### PR TITLE
fix(guard): refine structured command parsing

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_backup_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_backup_extensions.py
@@ -7,6 +7,7 @@ from .command_extension_specs import CommandExtensionSpec
 from .command_rules import AnyMatcher, CommandSafetyRule, CommandSafeVariant
 
 _RCLONE_GLOBAL_OPTIONS = frozenset({"--config", "--log-file", "--log-level", "--password-command", "--rc-addr"})
+_RCLONE_GLOBAL_FLAGS = frozenset({"--dry-run", "--quiet", "--verbose", "-n", "-q", "-v"})
 _RESTIC_GLOBAL_OPTIONS = frozenset(
     {
         "--cacert",
@@ -30,8 +31,12 @@ _RESTIC_GLOBAL_OPTIONS = frozenset(
         "-r",
     }
 )
+_RESTIC_GLOBAL_FLAGS = frozenset({"--quiet", "--verbose", "-q", "-v"})
 _BORG_GLOBAL_OPTIONS = frozenset(
     {
+        "-P",
+        "-a",
+        "-e",
         "-r",
         "--repo",
         "--debug-profile",
@@ -46,6 +51,7 @@ _BORG_GLOBAL_OPTIONS = frozenset(
         "--upload-ratelimit",
     }
 )
+_BORG_GLOBAL_FLAGS = frozenset({"--debug", "--show-rc", "--show-version", "--verbose", "-n", "-v"})
 _VELERO_GLOBAL_OPTIONS = frozenset(
     {
         "--features",
@@ -88,6 +94,7 @@ _RCLONE_MUTATION = AnyMatcher(
             command,
             allow_leading_options=True,
             leading_options_with_values=_RCLONE_GLOBAL_OPTIONS,
+            global_flags=_RCLONE_GLOBAL_FLAGS,
             fail_secure_unknown_options=True,
         )
         for command in ("delete", "deletefile", "purge", "rmdirs", "sync", "move", "moveto", "bisync")
@@ -100,6 +107,7 @@ _RESTIC_MUTATION = AnyMatcher(
             "forget",
             allow_leading_options=True,
             leading_options_with_values=_RESTIC_GLOBAL_OPTIONS,
+            global_flags=_RESTIC_GLOBAL_FLAGS,
             fail_secure_unknown_options=True,
         ),
         executable_matcher(
@@ -107,6 +115,7 @@ _RESTIC_MUTATION = AnyMatcher(
             "prune",
             allow_leading_options=True,
             leading_options_with_values=_RESTIC_GLOBAL_OPTIONS,
+            global_flags=_RESTIC_GLOBAL_FLAGS,
             fail_secure_unknown_options=True,
         ),
         executable_matcher(
@@ -115,6 +124,7 @@ _RESTIC_MUTATION = AnyMatcher(
             required_flags=frozenset({"--forget"}),
             allow_leading_options=True,
             leading_options_with_values=_RESTIC_GLOBAL_OPTIONS,
+            global_flags=_RESTIC_GLOBAL_FLAGS,
             fail_secure_unknown_options=True,
         ),
     )
@@ -126,6 +136,7 @@ _BORG_MUTATION = AnyMatcher(
             command,
             allow_leading_options=True,
             leading_options_with_values=_BORG_GLOBAL_OPTIONS,
+            global_flags=_BORG_GLOBAL_FLAGS,
             fail_secure_unknown_options=True,
         )
         for command in ("delete", "prune", "recreate")
@@ -138,6 +149,7 @@ _BORG_DRY_RUN = AnyMatcher(
             command,
             allow_leading_options=True,
             leading_options_with_values=_BORG_GLOBAL_OPTIONS,
+            global_flags=_BORG_GLOBAL_FLAGS,
             fail_secure_unknown_options=True,
         )
         for command in ("prune", "recreate")

--- a/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
@@ -80,6 +80,8 @@ _GIT_FORCE_REFSPEC = SubcommandOperandPrefixMatcher(
     operand_prefixes=frozenset({"+"}),
     leading_options_with_values=_GIT_GLOBAL_OPTIONS_WITH_VALUES,
     options_with_values=_GIT_SUBCOMMAND_OPTIONS_WITH_VALUES["push"],
+    leading_operands_to_skip=1,
+    options_supplying_leading_operands=frozenset({"--repo"}),
 )
 
 
@@ -296,7 +298,12 @@ BUILT_IN_COMMAND_RULES = (
             CommandSafeVariant(
                 variant_id="dry-run",
                 title="Git push preview",
-                matcher=_git_matcher("push", required_flags=frozenset({"--dry-run"})),
+                matcher=AnyMatcher(
+                    matchers=(
+                        _git_matcher("push", required_flags=frozenset({"-n"})),
+                        _git_matcher("push", required_flags=frozenset({"--dry-run"})),
+                    )
+                ),
             ),
         ),
     ),

--- a/src/codex_plugin_scanner/guard/runtime/command_curl_parsing.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_curl_parsing.py
@@ -1,0 +1,244 @@
+"""Structured curl operation parsing for command safety matchers."""
+
+from __future__ import annotations
+
+CURL_SHORT_OPTIONS_WITH_VALUES = frozenset(
+    {
+        "A",
+        "b",
+        "c",
+        "C",
+        "d",
+        "D",
+        "e",
+        "E",
+        "F",
+        "H",
+        "K",
+        "m",
+        "o",
+        "P",
+        "Q",
+        "r",
+        "t",
+        "T",
+        "u",
+        "U",
+        "w",
+        "x",
+        "X",
+        "y",
+        "Y",
+        "z",
+    }
+)
+CURL_LONG_OPTIONS_WITH_VALUES = frozenset(
+    {
+        "--abstract-unix-socket",
+        "--alt-svc",
+        "--aws-sigv4",
+        "--cacert",
+        "--capath",
+        "--cert",
+        "--cert-type",
+        "--ciphers",
+        "--config",
+        "--connect-timeout",
+        "--connect-to",
+        "--cookie",
+        "--cookie-jar",
+        "--create-file-mode",
+        "--crlfile",
+        "--curves",
+        "--data",
+        "--data-ascii",
+        "--data-binary",
+        "--data-raw",
+        "--data-urlencode",
+        "--delegation",
+        "--dns-interface",
+        "--dns-ipv4-addr",
+        "--dns-ipv6-addr",
+        "--dns-servers",
+        "--doh-url",
+        "--dump-header",
+        "--ech",
+        "--egd-file",
+        "--engine",
+        "--etag-compare",
+        "--etag-save",
+        "--expect100-timeout",
+        "--form",
+        "--form-string",
+        "--ftp-account",
+        "--ftp-alternative-to-user",
+        "--ftp-method",
+        "--ftp-port",
+        "--ftp-ssl-ccc-mode",
+        "--happy-eyeballs-timeout-ms",
+        "--haproxy-clientip",
+        "--header",
+        "--hostpubmd5",
+        "--hostpubsha256",
+        "--hsts",
+        "--interface",
+        "--ip-tos",
+        "--ipfs-gateway",
+        "--json",
+        "--keepalive-time",
+        "--keepalive-cnt",
+        "--key",
+        "--key-type",
+        "--krb",
+        "--libcurl",
+        "--limit-rate",
+        "--local-port",
+        "--login-options",
+        "--mail-auth",
+        "--mail-from",
+        "--mail-rcpt",
+        "--max-filesize",
+        "--max-redirs",
+        "--max-time",
+        "--netrc-file",
+        "--noproxy",
+        "--oauth2-bearer",
+        "--output",
+        "--output-dir",
+        "--parallel-max",
+        "--parallel-max-host",
+        "--pass",
+        "--pinnedpubkey",
+        "--preproxy",
+        "--proto",
+        "--proto-default",
+        "--proto-redir",
+        "--proxy",
+        "--proxy-cacert",
+        "--proxy-capath",
+        "--proxy-cert",
+        "--proxy-cert-type",
+        "--proxy-ciphers",
+        "--proxy-crlfile",
+        "--proxy-header",
+        "--proxy-key",
+        "--proxy-key-type",
+        "--proxy-pass",
+        "--proxy-pinnedpubkey",
+        "--proxy-service-name",
+        "--proxy-tls13-ciphers",
+        "--proxy-tlsauthtype",
+        "--proxy-tlspassword",
+        "--proxy-tlsuser",
+        "--proxy-user",
+        "--proxy1.0",
+        "--pubkey",
+        "--quote",
+        "--random-file",
+        "--range",
+        "--rate",
+        "--referer",
+        "--request-target",
+        "--resolve",
+        "--retry",
+        "--retry-delay",
+        "--retry-max-time",
+        "--sasl-authzid",
+        "--service-name",
+        "--speed-limit",
+        "--speed-time",
+        "--socks4",
+        "--socks4a",
+        "--socks5",
+        "--socks5-hostname",
+        "--socks5-gssapi-service",
+        "--stderr",
+        "--telnet-option",
+        "--tftp-blksize",
+        "--tls-max",
+        "--tls-earlydata",
+        "--tls13-ciphers",
+        "--tlsauthtype",
+        "--tlspassword",
+        "--tlsuser",
+        "--time-cond",
+        "--trace",
+        "--trace-ascii",
+        "--trace-config",
+        "--unix-socket",
+        "--upload-file",
+        "--upload-flags",
+        "--user",
+        "--user-agent",
+        "--url-query",
+        "--variable",
+        "--vlan-priority",
+        "--write-out",
+    }
+)
+
+
+def curl_operations(arguments: tuple[str, ...]) -> tuple[tuple[str | None, tuple[str, ...]], ...]:
+    """Return request methods and URL targets grouped by curl operation."""
+
+    operations: list[tuple[str | None, tuple[str, ...]]] = []
+    method: str | None = None
+    targets: list[str] = []
+    index = 0
+    parse_options = True
+    while index < len(arguments):
+        argument = arguments[index]
+        lowered = argument.lower()
+        if parse_options and argument == "--":
+            parse_options = False
+            index += 1
+            continue
+        if not parse_options:
+            targets.append(argument.strip("'\""))
+            index += 1
+            continue
+        if lowered == "--next":
+            operations.append((method, tuple(targets)))
+            method = None
+            targets = []
+            index += 1
+            continue
+        if lowered == "--request" and index + 1 < len(arguments):
+            method = arguments[index + 1].lower()
+            index += 2
+            continue
+        if lowered.startswith("--request="):
+            method = argument.split("=", 1)[1].lower()
+            index += 1
+            continue
+        if lowered == "--url" and index + 1 < len(arguments):
+            targets.append(arguments[index + 1].strip("'\""))
+            index += 2
+            continue
+        if lowered.startswith("--url="):
+            targets.append(argument.split("=", 1)[1].strip("'\""))
+            index += 1
+            continue
+        long_option = lowered.split("=", 1)[0]
+        if long_option in CURL_LONG_OPTIONS_WITH_VALUES:
+            index += 1 if "=" in argument else 2
+            continue
+        if argument.startswith("-") and not argument.startswith("--") and len(argument) > 1:
+            consumed_next = False
+            for offset, short_option in enumerate(argument[1:], start=1):
+                if short_option not in CURL_SHORT_OPTIONS_WITH_VALUES:
+                    continue
+                attached_value = argument[offset + 1 :]
+                if not attached_value and index + 1 < len(arguments):
+                    attached_value = arguments[index + 1]
+                    consumed_next = True
+                if short_option == "X":
+                    method = attached_value.lower()
+                break
+            index += 2 if consumed_next else 1
+            continue
+        if not argument.startswith("-"):
+            targets.append(argument.strip("'\""))
+        index += 1
+    operations.append((method, tuple(targets)))
+    return tuple(operations)

--- a/src/codex_plugin_scanner/guard/runtime/command_model.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_model.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from .command_segment_parsing import shell_tokens_without_redirects
 from .command_structure import (
     CommandRedirect,
     EmbeddedCommand,
@@ -36,22 +37,6 @@ MAX_COMMAND_SEGMENTS = 128
 MAX_COMMAND_TOKENS = 2_048
 
 _SHELL_SCRIPT_EXECUTABLES = frozenset({"ash", "bash", "dash", "sh", "zsh"})
-
-
-def _shell_tokens_without_redirects(
-    command: str,
-    *,
-    source_offset: int,
-    redirects: tuple[CommandRedirect, ...],
-) -> tuple[str, ...]:
-    masked = list(command)
-    for redirect in redirects:
-        local_start = redirect.start - source_offset
-        local_end = redirect.end - source_offset
-        if local_start < 0 or local_end > len(masked):
-            continue
-        masked[local_start:local_end] = " " * (local_end - local_start)
-    return shell_tokens("".join(masked))[0]
 
 
 @dataclass(frozen=True, slots=True)
@@ -252,7 +237,7 @@ def parse_shell_command(
             start = min(cursor, len(normalized_text))
         end = min(start + len(segment_text), len(normalized_text))
         cursor = end
-        command_tokens = _shell_tokens_without_redirects(
+        command_tokens = shell_tokens_without_redirects(
             segment_text,
             source_offset=start,
             redirects=command_redirects,
@@ -482,7 +467,7 @@ def _segments_for_embedded(
         context_prefix=execution_context,
     ):
         tokens, _exact = shell_tokens(segment_text)
-        command_tokens = _shell_tokens_without_redirects(
+        command_tokens = shell_tokens_without_redirects(
             segment_text,
             source_offset=local_offset,
             redirects=redirects,

--- a/src/codex_plugin_scanner/guard/runtime/command_model.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_model.py
@@ -17,6 +17,7 @@ from .data_flow import (
     ShellHeredoc,
     extract_command_segments,
     extract_command_substitution_spans,
+    extract_expanded_heredoc_substitution_spans,
     extract_heredocs,
     extract_pipes,
     mask_heredoc_bodies,
@@ -342,6 +343,7 @@ def _embedded_execution(
                     embedded=embedded,
                     segments=segments,
                     depth=0,
+                    expanded_heredoc=True,
                 )
             continue
         context = f"heredoc:{index}"
@@ -382,10 +384,12 @@ def _append_substitution_execution(
     embedded: list[EmbeddedCommand],
     segments: list[CommandSegment],
     depth: int,
+    expanded_heredoc: bool = False,
 ) -> None:
     if depth >= 4:
         return
-    for index, substitution in enumerate(extract_command_substitution_spans(command)):
+    extractor = extract_expanded_heredoc_substitution_spans if expanded_heredoc else extract_command_substitution_spans
+    for index, substitution in enumerate(extractor(command)):
         absolute_start = source_offset + substitution.body_start
         if any(start <= absolute_start < end for start, end in excluded_ranges):
             continue

--- a/src/codex_plugin_scanner/guard/runtime/command_model.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_model.py
@@ -260,6 +260,8 @@ def parse_shell_command(
         normalized_text,
         heredocs=heredocs,
         top_level_segments=tuple(segments),
+        cwd=cwd,
+        home_dir=home_dir,
     )
     segments.extend(embedded_segments)
     if len(segments) > MAX_COMMAND_SEGMENTS or sum(len(segment.tokens) for segment in segments) > MAX_COMMAND_TOKENS:
@@ -314,6 +316,8 @@ def _embedded_execution(
     *,
     heredocs: tuple[ShellHeredoc, ...],
     top_level_segments: tuple[CommandSegment, ...],
+    cwd: Path | None,
+    home_dir: Path | None,
 ) -> tuple[tuple[EmbeddedCommand, ...], tuple[CommandSegment, ...]]:
     embedded: list[EmbeddedCommand] = []
     segments: list[CommandSegment] = []
@@ -325,6 +329,8 @@ def _embedded_execution(
         embedded=embedded,
         segments=segments,
         depth=0,
+        cwd=cwd,
+        home_dir=home_dir,
     )
 
     for index, heredoc in enumerate(heredocs):
@@ -344,6 +350,8 @@ def _embedded_execution(
                     segments=segments,
                     depth=0,
                     expanded_heredoc=True,
+                    cwd=cwd,
+                    home_dir=home_dir,
                 )
             continue
         context = f"heredoc:{index}"
@@ -361,6 +369,8 @@ def _embedded_execution(
                 heredoc.body,
                 execution_context=context,
                 source_offset=heredoc.body_start,
+                cwd=cwd,
+                home_dir=home_dir,
             )
         )
         _append_substitution_execution(
@@ -371,6 +381,8 @@ def _embedded_execution(
             embedded=embedded,
             segments=segments,
             depth=0,
+            cwd=cwd,
+            home_dir=home_dir,
         )
     return tuple(embedded), tuple(segments)
 
@@ -384,6 +396,8 @@ def _append_substitution_execution(
     embedded: list[EmbeddedCommand],
     segments: list[CommandSegment],
     depth: int,
+    cwd: Path | None,
+    home_dir: Path | None,
     expanded_heredoc: bool = False,
 ) -> None:
     if depth >= 4:
@@ -408,6 +422,8 @@ def _append_substitution_execution(
                 substitution.body,
                 execution_context=context,
                 source_offset=absolute_start,
+                cwd=cwd,
+                home_dir=home_dir,
             )
         )
         _append_substitution_execution(
@@ -418,6 +434,8 @@ def _append_substitution_execution(
             embedded=embedded,
             segments=segments,
             depth=depth + 1,
+            cwd=cwd,
+            home_dir=home_dir,
         )
 
 
@@ -426,17 +444,21 @@ def _segments_for_embedded(
     *,
     execution_context: str,
     source_offset: int,
+    cwd: Path | None,
+    home_dir: Path | None,
 ) -> tuple[CommandSegment, ...]:
     results: list[CommandSegment] = []
+    normalization = normalize_transparent_shell_command(command, cwd=cwd, home_dir=home_dir)
     for context, pipeline_index, segment_text, local_offset in _execution_segment_texts(
-        command,
+        normalization.normalized_command,
         context_prefix=execution_context,
     ):
         tokens, _exact = shell_tokens(segment_text)
         environment_names, executable_index, wrappers = leading_environment(tokens)
         executable = tokens[executable_index] if executable_index < len(tokens) else None
         arguments = tokens[executable_index + 1 :] if executable is not None else ()
-        start = source_offset + local_offset
+        original_offset = command.find(segment_text)
+        start = source_offset + (original_offset if original_offset >= 0 else local_offset)
         results.append(
             CommandSegment(
                 text=segment_text,
@@ -444,7 +466,7 @@ def _segments_for_embedded(
                 executable=executable,
                 arguments=arguments,
                 environment_names=environment_names,
-                wrapper_chain=wrappers,
+                wrapper_chain=(*normalization.wrapper_chain, *wrappers),
                 path_overridden="PATH" in environment_names,
                 execution_context=context,
                 pipeline_index=pipeline_index,

--- a/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
@@ -19,7 +19,7 @@ class _ParseOutcome(Enum):
 @dataclass(frozen=True, slots=True)
 class _OptionTransition:
     advance: int
-    flags: frozenset[str] = frozenset()
+    flag_assignments: frozenset[tuple[str, bool]] = frozenset()
 
 
 @dataclass(frozen=True, slots=True)
@@ -142,8 +142,8 @@ def _flag_parse_outcome(
     options_with_values: frozenset[str],
     known_flags: frozenset[str],
 ) -> _ParseOutcome:
-    pending = [(0, False)]
-    visited: set[tuple[int, bool]] = set()
+    pending: list[tuple[int, bool | None]] = [(0, None)]
+    visited: set[tuple[int, bool | None]] = set()
     found_terminal = False
     while pending:
         state = pending.pop()
@@ -152,28 +152,27 @@ def _flag_parse_outcome(
         if len(visited) >= _MAX_OPTION_PARSE_STATES:
             return _ParseOutcome.UNCERTAIN
         visited.add(state)
-        argument_index, seen = state
+        argument_index, final_assignment = state
         if argument_index >= len(arguments) or arguments[argument_index] == "--":
-            if not seen:
+            if final_assignment is not True:
                 return _ParseOutcome.NO_MATCH
             found_terminal = True
             continue
         argument = arguments[argument_index]
         if not _is_option(argument):
-            pending.append((argument_index + 1, seen))
+            pending.append((argument_index + 1, final_assignment))
             continue
         shape = _option_shape(
             argument,
             options_with_values=options_with_values,
             known_flags=known_flags,
         )
-        pending.extend(
-            (
-                argument_index + transition.advance,
-                seen or required_flag in transition.flags,
-            )
-            for transition in shape.transitions
-        )
+        for transition in shape.transitions:
+            next_assignment = final_assignment
+            for flag, enabled in transition.flag_assignments:
+                if flag == required_flag:
+                    next_assignment = enabled
+            pending.append((argument_index + transition.advance, next_assignment))
     return _ParseOutcome.MATCH if found_terminal else _ParseOutcome.NO_MATCH
 
 
@@ -189,10 +188,9 @@ def _option_shape(
             advance = 1 if separator else 2
             return _OptionShape((_OptionTransition(advance),), fully_known=True)
         if option_name in known_flags:
-            flags = {argument}
-            if long_flag_assignment_is_enabled(argument):
-                flags.add(option_name)
-            return _OptionShape((_OptionTransition(1, frozenset(flags)),), fully_known=True)
+            enabled = long_flag_assignment_is_enabled(argument)
+            assignments = frozenset({(argument, True), (option_name, enabled)})
+            return _OptionShape((_OptionTransition(1, assignments),), fully_known=True)
         if separator:
             return _OptionShape((_OptionTransition(1),), fully_known=True)
         return _OptionShape((_OptionTransition(1), _OptionTransition(2)), fully_known=False)
@@ -216,16 +214,19 @@ def _short_option_shape(
         short_option = f"-{character}"
         if short_option in options_with_values:
             advance = 1 if index + 1 < len(argument) else 2
-            transitions.add(_OptionTransition(advance, frozenset(flags)))
+            assignments = frozenset((flag, True) for flag in flags)
+            transitions.add(_OptionTransition(advance, assignments))
             return _OptionShape(tuple(transitions), fully_known=fully_known)
         if short_option in known_flags:
             flags.add(short_option)
             continue
         fully_known = False
-        transitions.add(_OptionTransition(1, frozenset(flags)))
+        assignments = frozenset((flag, True) for flag in flags)
+        transitions.add(_OptionTransition(1, assignments))
         if index + 1 == len(argument):
-            transitions.add(_OptionTransition(2, frozenset(flags)))
-    transitions.add(_OptionTransition(1, frozenset(flags)))
+            transitions.add(_OptionTransition(2, assignments))
+    assignments = frozenset((flag, True) for flag in flags)
+    transitions.add(_OptionTransition(1, assignments))
     return _OptionShape(tuple(transitions), fully_known=fully_known)
 
 

--- a/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
@@ -2,7 +2,29 @@
 
 from __future__ import annotations
 
-from functools import cache
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Final
+
+_MAX_OPTION_PARSE_STATES: Final = 16_384
+
+
+class _ParseOutcome(Enum):
+    MATCH = auto()
+    NO_MATCH = auto()
+    UNCERTAIN = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class _OptionTransition:
+    advance: int
+    flags: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True, slots=True)
+class _OptionShape:
+    transitions: tuple[_OptionTransition, ...]
+    fully_known: bool
 
 
 def matches_subcommands_conservatively(
@@ -12,38 +34,15 @@ def matches_subcommands_conservatively(
     options_with_values: frozenset[str],
     known_flags: frozenset[str],
 ) -> bool:
-    """Match a destructive prefix under any plausible unknown-option shape."""
+    """Match a destructive prefix, including when bounded parsing is uncertain."""
 
-    @cache
-    def matches(argument_index: int, subcommand_index: int) -> bool:
-        if subcommand_index == len(subcommands):
-            return True
-        if argument_index >= len(arguments):
-            return False
-        argument = arguments[argument_index]
-        if argument == "--":
-            remaining = len(subcommands) - subcommand_index
-            return arguments[argument_index + 1 : argument_index + 1 + remaining] == subcommands[subcommand_index:]
-        if _is_option(argument):
-            option_name = argument.split("=", 1)[0]
-            attached_short_option = _attached_short_value_option(argument, options_with_values)
-            last_short_is_known_flag = _last_short_option_is_known_flag(argument, known_flags)
-            if option_name in options_with_values:
-                advance = 1 if "=" in argument else 2
-                return matches(argument_index + advance, subcommand_index)
-            if attached_short_option is not None or "=" in argument or last_short_is_known_flag:
-                return matches(argument_index + 1, subcommand_index)
-            if option_name in known_flags:
-                return matches(argument_index + 1, subcommand_index)
-            return matches(argument_index + 1, subcommand_index) or matches(
-                argument_index + 2,
-                subcommand_index,
-            )
-        if argument != subcommands[subcommand_index]:
-            return False
-        return matches(argument_index + 1, subcommand_index + 1)
-
-    return matches(0, 0)
+    outcome = _subcommand_parse_outcome(
+        arguments,
+        subcommands,
+        options_with_values=options_with_values,
+        known_flags=known_flags,
+    )
+    return outcome is not _ParseOutcome.NO_MATCH
 
 
 def flags_present_in_all_option_parses(
@@ -53,76 +52,171 @@ def flags_present_in_all_option_parses(
     options_with_values: frozenset[str],
     known_flags: frozenset[str],
 ) -> bool:
-    """Return whether every plausible option parse contains each required flag."""
+    """Return whether every bounded parse certainly contains each required flag."""
 
     return all(
-        _flag_present_in_all_option_parses(
+        _flag_parse_outcome(
             arguments,
             required_flag,
             options_with_values=options_with_values,
             known_flags=known_flags,
         )
+        is _ParseOutcome.MATCH
         for required_flag in required_flags
     )
 
 
-def _flag_present_in_all_option_parses(
+def known_option_advance(
+    argument: str,
+    *,
+    options_with_values: frozenset[str],
+    known_flags: frozenset[str],
+) -> int | None:
+    """Return the deterministic token advance for a fully known option shape."""
+
+    if not _is_option(argument):
+        return None
+    shape = _option_shape(
+        argument,
+        options_with_values=options_with_values,
+        known_flags=known_flags,
+    )
+    advances = {transition.advance for transition in shape.transitions}
+    if not shape.fully_known or len(advances) != 1:
+        return None
+    return advances.pop()
+
+
+def _subcommand_parse_outcome(
+    arguments: tuple[str, ...],
+    subcommands: tuple[str, ...],
+    *,
+    options_with_values: frozenset[str],
+    known_flags: frozenset[str],
+) -> _ParseOutcome:
+    pending = [(0, 0)]
+    visited: set[tuple[int, int]] = set()
+    while pending:
+        state = pending.pop()
+        if state in visited:
+            continue
+        if len(visited) >= _MAX_OPTION_PARSE_STATES:
+            return _ParseOutcome.UNCERTAIN
+        visited.add(state)
+        argument_index, subcommand_index = state
+        if subcommand_index == len(subcommands):
+            return _ParseOutcome.MATCH
+        if argument_index >= len(arguments):
+            continue
+        argument = arguments[argument_index]
+        if argument == "--":
+            remaining = len(subcommands) - subcommand_index
+            if arguments[argument_index + 1 : argument_index + 1 + remaining] == subcommands[subcommand_index:]:
+                return _ParseOutcome.MATCH
+            continue
+        if _is_option(argument):
+            shape = _option_shape(
+                argument,
+                options_with_values=options_with_values,
+                known_flags=known_flags,
+            )
+            pending.extend((argument_index + transition.advance, subcommand_index) for transition in shape.transitions)
+            continue
+        if argument == subcommands[subcommand_index]:
+            pending.append((argument_index + 1, subcommand_index + 1))
+    return _ParseOutcome.NO_MATCH
+
+
+def _flag_parse_outcome(
     arguments: tuple[str, ...],
     required_flag: str,
     *,
     options_with_values: frozenset[str],
     known_flags: frozenset[str],
-) -> bool:
-    @cache
-    def present(argument_index: int, seen: bool) -> bool:
-        if argument_index >= len(arguments):
-            return seen
+) -> _ParseOutcome:
+    pending = [(0, False)]
+    visited: set[tuple[int, bool]] = set()
+    found_terminal = False
+    while pending:
+        state = pending.pop()
+        if state in visited:
+            continue
+        if len(visited) >= _MAX_OPTION_PARSE_STATES:
+            return _ParseOutcome.UNCERTAIN
+        visited.add(state)
+        argument_index, seen = state
+        if argument_index >= len(arguments) or arguments[argument_index] == "--":
+            if not seen:
+                return _ParseOutcome.NO_MATCH
+            found_terminal = True
+            continue
         argument = arguments[argument_index]
-        if argument == "--":
-            return seen
         if not _is_option(argument):
-            return present(argument_index + 1, seen)
-        option_name = argument.split("=", 1)[0]
-        attached_short_option = _attached_short_value_option(argument, options_with_values)
-        if option_name in options_with_values:
-            advance = 1 if "=" in argument else 2
-            return present(argument_index + advance, seen)
-        if attached_short_option is not None:
-            return present(argument_index + 1, seen)
-        token_flags = _flags_in_option_token(argument, options_with_values)
-        next_seen = seen or required_flag in token_flags
-        if option_name in known_flags or "=" in argument or _last_short_option_is_known_flag(argument, known_flags):
-            return present(argument_index + 1, next_seen)
-        return present(argument_index + 1, next_seen) and present(argument_index + 2, seen)
+            pending.append((argument_index + 1, seen))
+            continue
+        shape = _option_shape(
+            argument,
+            options_with_values=options_with_values,
+            known_flags=known_flags,
+        )
+        pending.extend(
+            (
+                argument_index + transition.advance,
+                seen or required_flag in transition.flags,
+            )
+            for transition in shape.transitions
+        )
+    return _ParseOutcome.MATCH if found_terminal else _ParseOutcome.NO_MATCH
 
-    return present(0, False)
+
+def _option_shape(
+    argument: str,
+    *,
+    options_with_values: frozenset[str],
+    known_flags: frozenset[str],
+) -> _OptionShape:
+    if argument.startswith("--"):
+        option_name, separator, _value = argument.partition("=")
+        if option_name in options_with_values:
+            advance = 1 if separator else 2
+            return _OptionShape((_OptionTransition(advance),), fully_known=True)
+        if option_name in known_flags:
+            return _OptionShape((_OptionTransition(1, frozenset({option_name, argument})),), fully_known=True)
+        if separator:
+            return _OptionShape((_OptionTransition(1),), fully_known=True)
+        return _OptionShape((_OptionTransition(1), _OptionTransition(2)), fully_known=False)
+    return _short_option_shape(
+        argument,
+        options_with_values=options_with_values,
+        known_flags=known_flags,
+    )
+
+
+def _short_option_shape(
+    argument: str,
+    *,
+    options_with_values: frozenset[str],
+    known_flags: frozenset[str],
+) -> _OptionShape:
+    transitions: set[_OptionTransition] = set()
+    flags: set[str] = set()
+    fully_known = True
+    for index, character in enumerate(argument[1:], start=1):
+        short_option = f"-{character}"
+        if short_option in options_with_values:
+            advance = 1 if index + 1 < len(argument) else 2
+            transitions.add(_OptionTransition(advance, frozenset(flags)))
+            return _OptionShape(tuple(transitions), fully_known=fully_known)
+        if short_option in known_flags:
+            flags.add(short_option)
+            continue
+        fully_known = False
+        transitions.add(_OptionTransition(1, frozenset(flags)))
+        if index + 1 == len(argument):
+            transitions.add(_OptionTransition(2, frozenset(flags)))
+    transitions.add(_OptionTransition(1, frozenset(flags)))
+    return _OptionShape(tuple(transitions), fully_known=fully_known)
 
 
 def _is_option(argument: str) -> bool:
     return len(argument) > 1 and argument.startswith("-")
-
-
-def _attached_short_value_option(argument: str, options_with_values: frozenset[str]) -> str | None:
-    if len(argument) <= 2 or not argument.startswith("-") or argument.startswith("--"):
-        return None
-    option = argument[:2]
-    return option if option in options_with_values else None
-
-
-def _last_short_option_is_known_flag(argument: str, known_flags: frozenset[str]) -> bool:
-    return len(argument) > 2 and not argument.startswith("--") and f"-{argument[-1]}" in known_flags
-
-
-def _flags_in_option_token(argument: str, options_with_values: frozenset[str]) -> frozenset[str]:
-    flags = {argument}
-    if "=" in argument:
-        flags.add(argument.split("=", 1)[0])
-    if argument.startswith("-") and not argument.startswith("--") and len(argument) > 2:
-        for character in argument[1:]:
-            if not character.isalnum():
-                continue
-            short_flag = f"-{character}"
-            flags.add(short_flag)
-            if short_flag in options_with_values:
-                break
-    return frozenset(flags)

--- a/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
@@ -7,6 +7,7 @@ from enum import Enum, auto
 from typing import Final
 
 _MAX_OPTION_PARSE_STATES: Final = 16_384
+_TRUTHY_FLAG_VALUES: Final = frozenset({"1", "on", "true", "yes"})
 
 
 class _ParseOutcome(Enum):
@@ -85,6 +86,13 @@ def known_option_advance(
     if not shape.fully_known or len(advances) != 1:
         return None
     return advances.pop()
+
+
+def long_flag_assignment_is_enabled(argument: str) -> bool:
+    """Return whether a long flag is bare or explicitly assigned a truthy value."""
+
+    _option_name, separator, value = argument.partition("=")
+    return not separator or value.lower() in _TRUTHY_FLAG_VALUES
 
 
 def _subcommand_parse_outcome(
@@ -181,7 +189,10 @@ def _option_shape(
             advance = 1 if separator else 2
             return _OptionShape((_OptionTransition(advance),), fully_known=True)
         if option_name in known_flags:
-            return _OptionShape((_OptionTransition(1, frozenset({option_name, argument})),), fully_known=True)
+            flags = {argument}
+            if long_flag_assignment_is_enabled(argument):
+                flags.add(option_name)
+            return _OptionShape((_OptionTransition(1, frozenset(flags)),), fully_known=True)
         if separator:
             return _OptionShape((_OptionTransition(1),), fully_known=True)
         return _OptionShape((_OptionTransition(1), _OptionTransition(2)), fully_known=False)

--- a/src/codex_plugin_scanner/guard/runtime/command_remote_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_remote_extensions.py
@@ -60,6 +60,7 @@ _SSH_CONFIGURED_EXECUTION = AnyMatcher(
             value_keys=frozenset({"knownhostscommand", "proxycommand", "remotecommand"}),
             forbidden_flags=frozenset({"-G", "-O", "-Q", "-V"}),
             ignored_values=frozenset({"none"}),
+            cluster_options_with_values=_SSH_OPTIONS_WITH_VALUES,
         ),
         OptionValueKeyMatcher(
             executables=executable_names("ssh"),
@@ -68,6 +69,7 @@ _SSH_CONFIGURED_EXECUTION = AnyMatcher(
             forbidden_flags=frozenset({"-G", "-O", "-Q", "-V"}),
             ignored_values=frozenset({"none"}),
             required_key_values=(("permitlocalcommand", "yes"),),
+            cluster_options_with_values=_SSH_OPTIONS_WITH_VALUES,
         ),
     )
 )

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -7,7 +7,11 @@ from typing import Literal, final
 
 from .command_matcher_contracts import CommandMatcher, MatcherEvidence
 from .command_model import CanonicalCommand, CommandSegment
-from .command_option_parsing import flags_present_in_all_option_parses, matches_subcommands_conservatively
+from .command_option_parsing import (
+    flags_present_in_all_option_parses,
+    known_option_advance,
+    matches_subcommands_conservatively,
+)
 
 CommandRuleSeverity = Literal["critical", "high", "medium", "low"]
 CommandRuleMode = Literal["required", "enforce", "review", "monitor", "disabled"]
@@ -78,6 +82,7 @@ class ExecutableMatcher:
                 subcommand_arguments = _after_leading_options(
                     subcommand_arguments,
                     self.leading_options_with_values,
+                    self.interspersed_flags,
                 )
             if (
                 self.subcommands
@@ -435,7 +440,11 @@ def _present_flags(
     return frozenset(flags)
 
 
-def _after_leading_options(arguments: tuple[str, ...], options_with_values: frozenset[str]) -> tuple[str, ...]:
+def _after_leading_options(
+    arguments: tuple[str, ...],
+    options_with_values: frozenset[str],
+    flags: frozenset[str],
+) -> tuple[str, ...]:
     index = 0
     while index < len(arguments):
         argument = arguments[index]
@@ -443,11 +452,12 @@ def _after_leading_options(arguments: tuple[str, ...], options_with_values: froz
             return arguments[index + 1 :]
         if not argument.startswith("-"):
             return arguments[index:]
-        option_name = argument.split("=", 1)[0]
-        if option_name in options_with_values and "=" not in argument:
-            index += 2
-        else:
-            index += 1
+        advance = known_option_advance(
+            argument,
+            options_with_values=options_with_values,
+            known_flags=flags,
+        )
+        index += advance if advance is not None else 1
     return ()
 
 
@@ -465,19 +475,14 @@ def _without_options(
         if argument == "--":
             retained.extend(arguments[index + 1 :])
             break
-        option_name = argument.split("=", 1)[0]
-        attached_short_option = (
-            argument[:2]
-            if len(argument) > 2 and argument[0] == "-" and argument[1] != "-" and argument[:2] in options_with_values
-            else None
+        advance = known_option_advance(
+            argument,
+            options_with_values=options_with_values,
+            known_flags=flags,
         )
-        if option_name in flags:
-            index += 1
-            continue
-        if option_name not in options_with_values and attached_short_option is None:
+        if advance is None:
             retained.append(argument)
             index += 1
             continue
-        is_attached_short = attached_short_option is not None and option_name not in options_with_values
-        index += 1 if "=" in argument or is_attached_short else 2
+        index += advance
     return tuple(retained)

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -10,6 +10,7 @@ from .command_model import CanonicalCommand, CommandSegment
 from .command_option_parsing import (
     flags_present_in_all_option_parses,
     known_option_advance,
+    long_flag_assignment_is_enabled,
     matches_subcommands_conservatively,
 )
 
@@ -19,7 +20,6 @@ CommandRuleMode = Literal["required", "enforce", "review", "monitor", "disabled"
 _VALID_SEVERITIES = frozenset({"critical", "high", "medium", "low"})
 _VALID_MODES = frozenset({"required", "enforce", "review", "monitor", "disabled"})
 _EMPTY_STRING_SET: frozenset[str] = frozenset()
-_TRUTHY_FLAG_VALUES = frozenset({"1", "on", "true", "yes"})
 
 
 @final
@@ -435,7 +435,7 @@ def _present_flags(
         index += 2 if option_name in options_with_values and "=" not in argument else 1
     for option_name, (argument, option_value, is_value_option) in effective_long_options.items():
         flags.add(argument)
-        if is_value_option or option_value is None or option_value in _TRUTHY_FLAG_VALUES:
+        if is_value_option or option_value is None or long_flag_assignment_is_enabled(argument):
             flags.add(option_name)
     return frozenset(flags)
 

--- a/src/codex_plugin_scanner/guard/runtime/command_search_messaging_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_search_messaging_extensions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from urllib.parse import urlsplit
 
+from .command_curl_parsing import curl_operations
 from .command_database_matchers import LeadingSubcommandMatcher
 from .command_extension_matchers import executable_names, safe_flag_variant
 from .command_extension_specs import CommandExtensionSpec
@@ -18,180 +19,6 @@ from .command_rules import (
 )
 
 _CURL_EXECUTABLES = executable_names("curl")
-_CURL_SHORT_OPTIONS_WITH_VALUES = frozenset(
-    {
-        "A",
-        "b",
-        "c",
-        "C",
-        "d",
-        "D",
-        "e",
-        "E",
-        "F",
-        "H",
-        "K",
-        "m",
-        "o",
-        "P",
-        "Q",
-        "r",
-        "t",
-        "T",
-        "u",
-        "U",
-        "w",
-        "x",
-        "X",
-        "y",
-        "Y",
-        "z",
-    }
-)
-_CURL_LONG_OPTIONS_WITH_VALUES = frozenset(
-    {
-        "--abstract-unix-socket",
-        "--alt-svc",
-        "--aws-sigv4",
-        "--cacert",
-        "--capath",
-        "--cert",
-        "--cert-type",
-        "--ciphers",
-        "--config",
-        "--connect-timeout",
-        "--connect-to",
-        "--cookie",
-        "--cookie-jar",
-        "--create-file-mode",
-        "--crlfile",
-        "--curves",
-        "--data",
-        "--data-ascii",
-        "--data-binary",
-        "--data-raw",
-        "--data-urlencode",
-        "--delegation",
-        "--dns-interface",
-        "--dns-ipv4-addr",
-        "--dns-ipv6-addr",
-        "--dns-servers",
-        "--doh-url",
-        "--dump-header",
-        "--ech",
-        "--egd-file",
-        "--engine",
-        "--etag-compare",
-        "--etag-save",
-        "--expect100-timeout",
-        "--form",
-        "--form-string",
-        "--ftp-account",
-        "--ftp-alternative-to-user",
-        "--ftp-method",
-        "--ftp-port",
-        "--ftp-ssl-ccc-mode",
-        "--happy-eyeballs-timeout-ms",
-        "--haproxy-clientip",
-        "--header",
-        "--hostpubmd5",
-        "--hostpubsha256",
-        "--hsts",
-        "--interface",
-        "--ip-tos",
-        "--ipfs-gateway",
-        "--json",
-        "--keepalive-time",
-        "--keepalive-cnt",
-        "--key",
-        "--key-type",
-        "--krb",
-        "--libcurl",
-        "--limit-rate",
-        "--local-port",
-        "--login-options",
-        "--mail-auth",
-        "--mail-from",
-        "--mail-rcpt",
-        "--max-filesize",
-        "--max-redirs",
-        "--max-time",
-        "--netrc-file",
-        "--noproxy",
-        "--oauth2-bearer",
-        "--output",
-        "--output-dir",
-        "--parallel-max",
-        "--parallel-max-host",
-        "--pass",
-        "--pinnedpubkey",
-        "--preproxy",
-        "--proto",
-        "--proto-default",
-        "--proto-redir",
-        "--proxy",
-        "--proxy-cacert",
-        "--proxy-capath",
-        "--proxy-cert",
-        "--proxy-cert-type",
-        "--proxy-ciphers",
-        "--proxy-crlfile",
-        "--proxy-header",
-        "--proxy-key",
-        "--proxy-key-type",
-        "--proxy-pass",
-        "--proxy-pinnedpubkey",
-        "--proxy-service-name",
-        "--proxy-tls13-ciphers",
-        "--proxy-tlsauthtype",
-        "--proxy-tlspassword",
-        "--proxy-tlsuser",
-        "--proxy-user",
-        "--proxy1.0",
-        "--pubkey",
-        "--quote",
-        "--random-file",
-        "--range",
-        "--rate",
-        "--referer",
-        "--request-target",
-        "--resolve",
-        "--retry",
-        "--retry-delay",
-        "--retry-max-time",
-        "--sasl-authzid",
-        "--service-name",
-        "--speed-limit",
-        "--speed-time",
-        "--socks4",
-        "--socks4a",
-        "--socks5",
-        "--socks5-hostname",
-        "--socks5-gssapi-service",
-        "--stderr",
-        "--telnet-option",
-        "--tftp-blksize",
-        "--tls-max",
-        "--tls-earlydata",
-        "--tls13-ciphers",
-        "--tlsauthtype",
-        "--tlspassword",
-        "--tlsuser",
-        "--time-cond",
-        "--trace",
-        "--trace-ascii",
-        "--trace-config",
-        "--unix-socket",
-        "--upload-file",
-        "--upload-flags",
-        "--user",
-        "--user-agent",
-        "--url-query",
-        "--variable",
-        "--vlan-priority",
-        "--write-out",
-    }
-)
 _RABBITMQ_OPTIONS_WITH_VALUES = frozenset({"-n", "--node", "-t", "--timeout", "--formatter", "--erlang-cookie"})
 _NATS_OPTIONS_WITH_VALUES = frozenset(
     {
@@ -229,7 +56,7 @@ class CurlElasticsearchDeleteMatcher:
             executable = (segment.executable or "").replace("\\", "/").rsplit("/", 1)[-1].lower()
             if executable not in self.executables:
                 continue
-            operations = _curl_operations(segment.arguments)
+            operations = curl_operations(segment.arguments)
             if not any(
                 method == "delete" and any(self._matches_target(target) for target in targets)
                 for method, targets in operations
@@ -259,70 +86,6 @@ class CurlElasticsearchDeleteMatcher:
         recognizable_host = port in self.service_ports or "elasticsearch" in hostname.split(".")
         supported_scheme = parsed.scheme in {"http", "https"} if explicit_scheme else not parsed.scheme
         return supported_scheme and recognizable_host and parsed.path not in {"", "/"}
-
-
-def _curl_operations(arguments: tuple[str, ...]) -> tuple[tuple[str | None, tuple[str, ...]], ...]:
-    operations: list[tuple[str | None, tuple[str, ...]]] = []
-    method: str | None = None
-    targets: list[str] = []
-    index = 0
-    parse_options = True
-    while index < len(arguments):
-        argument = arguments[index]
-        lowered = argument.lower()
-        if parse_options and argument == "--":
-            parse_options = False
-            index += 1
-            continue
-        if not parse_options:
-            targets.append(argument.strip("'\""))
-            index += 1
-            continue
-        if lowered == "--next":
-            operations.append((method, tuple(targets)))
-            method = None
-            targets = []
-            index += 1
-            continue
-        if lowered == "--request" and index + 1 < len(arguments):
-            method = arguments[index + 1].lower()
-            index += 2
-            continue
-        if lowered.startswith("--request="):
-            method = argument.split("=", 1)[1].lower()
-            index += 1
-            continue
-        if lowered == "--url" and index + 1 < len(arguments):
-            targets.append(arguments[index + 1].strip("'\""))
-            index += 2
-            continue
-        if lowered.startswith("--url="):
-            targets.append(argument.split("=", 1)[1].strip("'\""))
-            index += 1
-            continue
-        long_option = lowered.split("=", 1)[0]
-        if long_option in _CURL_LONG_OPTIONS_WITH_VALUES:
-            index += 1 if "=" in argument else 2
-            continue
-        if argument.startswith("-") and not argument.startswith("--") and len(argument) > 1:
-            consumed_next = False
-            for offset, short_option in enumerate(argument[1:], start=1):
-                if short_option not in _CURL_SHORT_OPTIONS_WITH_VALUES:
-                    continue
-                attached_value = argument[offset + 1 :]
-                if not attached_value and index + 1 < len(arguments):
-                    attached_value = arguments[index + 1]
-                    consumed_next = True
-                if short_option == "X":
-                    method = attached_value.lower()
-                break
-            index += 2 if consumed_next else 1
-            continue
-        if not argument.startswith("-"):
-            targets.append(argument.strip("'\""))
-        index += 1
-    operations.append((method, tuple(targets)))
-    return tuple(operations)
 
 
 def _safe_flag_variant(

--- a/src/codex_plugin_scanner/guard/runtime/command_search_messaging_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_search_messaging_extensions.py
@@ -18,6 +18,180 @@ from .command_rules import (
 )
 
 _CURL_EXECUTABLES = executable_names("curl")
+_CURL_SHORT_OPTIONS_WITH_VALUES = frozenset(
+    {
+        "A",
+        "b",
+        "c",
+        "C",
+        "d",
+        "D",
+        "e",
+        "E",
+        "F",
+        "H",
+        "K",
+        "m",
+        "o",
+        "P",
+        "Q",
+        "r",
+        "t",
+        "T",
+        "u",
+        "U",
+        "w",
+        "x",
+        "X",
+        "y",
+        "Y",
+        "z",
+    }
+)
+_CURL_LONG_OPTIONS_WITH_VALUES = frozenset(
+    {
+        "--abstract-unix-socket",
+        "--alt-svc",
+        "--aws-sigv4",
+        "--cacert",
+        "--capath",
+        "--cert",
+        "--cert-type",
+        "--ciphers",
+        "--config",
+        "--connect-timeout",
+        "--connect-to",
+        "--cookie",
+        "--cookie-jar",
+        "--create-file-mode",
+        "--crlfile",
+        "--curves",
+        "--data",
+        "--data-ascii",
+        "--data-binary",
+        "--data-raw",
+        "--data-urlencode",
+        "--delegation",
+        "--dns-interface",
+        "--dns-ipv4-addr",
+        "--dns-ipv6-addr",
+        "--dns-servers",
+        "--doh-url",
+        "--dump-header",
+        "--ech",
+        "--egd-file",
+        "--engine",
+        "--etag-compare",
+        "--etag-save",
+        "--expect100-timeout",
+        "--form",
+        "--form-string",
+        "--ftp-account",
+        "--ftp-alternative-to-user",
+        "--ftp-method",
+        "--ftp-port",
+        "--ftp-ssl-ccc-mode",
+        "--happy-eyeballs-timeout-ms",
+        "--haproxy-clientip",
+        "--header",
+        "--hostpubmd5",
+        "--hostpubsha256",
+        "--hsts",
+        "--interface",
+        "--ip-tos",
+        "--ipfs-gateway",
+        "--json",
+        "--keepalive-time",
+        "--keepalive-cnt",
+        "--key",
+        "--key-type",
+        "--krb",
+        "--libcurl",
+        "--limit-rate",
+        "--local-port",
+        "--login-options",
+        "--mail-auth",
+        "--mail-from",
+        "--mail-rcpt",
+        "--max-filesize",
+        "--max-redirs",
+        "--max-time",
+        "--netrc-file",
+        "--noproxy",
+        "--oauth2-bearer",
+        "--output",
+        "--output-dir",
+        "--parallel-max",
+        "--parallel-max-host",
+        "--pass",
+        "--pinnedpubkey",
+        "--preproxy",
+        "--proto",
+        "--proto-default",
+        "--proto-redir",
+        "--proxy",
+        "--proxy-cacert",
+        "--proxy-capath",
+        "--proxy-cert",
+        "--proxy-cert-type",
+        "--proxy-ciphers",
+        "--proxy-crlfile",
+        "--proxy-header",
+        "--proxy-key",
+        "--proxy-key-type",
+        "--proxy-pass",
+        "--proxy-pinnedpubkey",
+        "--proxy-service-name",
+        "--proxy-tls13-ciphers",
+        "--proxy-tlsauthtype",
+        "--proxy-tlspassword",
+        "--proxy-tlsuser",
+        "--proxy-user",
+        "--proxy1.0",
+        "--pubkey",
+        "--quote",
+        "--random-file",
+        "--range",
+        "--rate",
+        "--referer",
+        "--request-target",
+        "--resolve",
+        "--retry",
+        "--retry-delay",
+        "--retry-max-time",
+        "--sasl-authzid",
+        "--service-name",
+        "--speed-limit",
+        "--speed-time",
+        "--socks4",
+        "--socks4a",
+        "--socks5",
+        "--socks5-hostname",
+        "--socks5-gssapi-service",
+        "--stderr",
+        "--telnet-option",
+        "--tftp-blksize",
+        "--tls-max",
+        "--tls-earlydata",
+        "--tls13-ciphers",
+        "--tlsauthtype",
+        "--tlspassword",
+        "--tlsuser",
+        "--time-cond",
+        "--trace",
+        "--trace-ascii",
+        "--trace-config",
+        "--unix-socket",
+        "--upload-file",
+        "--upload-flags",
+        "--user",
+        "--user-agent",
+        "--url-query",
+        "--variable",
+        "--vlan-priority",
+        "--write-out",
+    }
+)
 _RABBITMQ_OPTIONS_WITH_VALUES = frozenset({"-n", "--node", "-t", "--timeout", "--formatter", "--erlang-cookie"})
 _NATS_OPTIONS_WITH_VALUES = frozenset(
     {
@@ -55,8 +229,11 @@ class CurlElasticsearchDeleteMatcher:
             executable = (segment.executable or "").replace("\\", "/").rsplit("/", 1)[-1].lower()
             if executable not in self.executables:
                 continue
-            method, targets = _curl_method_and_targets(segment.arguments)
-            if method != "delete" or not any(self._matches_target(target) for target in targets):
+            operations = _curl_operations(segment.arguments)
+            if not any(
+                method == "delete" and any(self._matches_target(target) for target in targets)
+                for method, targets in operations
+            ):
                 continue
             evidence.append(
                 MatcherEvidence(
@@ -84,22 +261,36 @@ class CurlElasticsearchDeleteMatcher:
         return supported_scheme and recognizable_host and parsed.path not in {"", "/"}
 
 
-def _curl_method_and_targets(arguments: tuple[str, ...]) -> tuple[str | None, tuple[str, ...]]:
+def _curl_operations(arguments: tuple[str, ...]) -> tuple[tuple[str | None, tuple[str, ...]], ...]:
+    operations: list[tuple[str | None, tuple[str, ...]]] = []
     method: str | None = None
     targets: list[str] = []
     index = 0
+    parse_options = True
     while index < len(arguments):
         argument = arguments[index]
         lowered = argument.lower()
-        if argument == "-x" or lowered == "--proxy":
-            index += 2
-            continue
-        if (argument.startswith("-x") and len(argument) > 2) or lowered.startswith("--proxy="):
+        if parse_options and argument == "--":
+            parse_options = False
             index += 1
             continue
-        if (argument == "-X" or lowered == "--request") and index + 1 < len(arguments):
+        if not parse_options:
+            targets.append(argument.strip("'\""))
+            index += 1
+            continue
+        if lowered == "--next":
+            operations.append((method, tuple(targets)))
+            method = None
+            targets = []
+            index += 1
+            continue
+        if lowered == "--request" and index + 1 < len(arguments):
             method = arguments[index + 1].lower()
             index += 2
+            continue
+        if lowered.startswith("--request="):
+            method = argument.split("=", 1)[1].lower()
+            index += 1
             continue
         if lowered == "--url" and index + 1 < len(arguments):
             targets.append(arguments[index + 1].strip("'\""))
@@ -109,14 +300,29 @@ def _curl_method_and_targets(arguments: tuple[str, ...]) -> tuple[str | None, tu
             targets.append(argument.split("=", 1)[1].strip("'\""))
             index += 1
             continue
-        if lowered.startswith("--request="):
-            method = lowered.split("=", 1)[1]
-        elif argument.startswith("-X") and len(argument) > 2:
-            method = argument[2:].lower()
+        long_option = lowered.split("=", 1)[0]
+        if long_option in _CURL_LONG_OPTIONS_WITH_VALUES:
+            index += 1 if "=" in argument else 2
+            continue
+        if argument.startswith("-") and not argument.startswith("--") and len(argument) > 1:
+            consumed_next = False
+            for offset, short_option in enumerate(argument[1:], start=1):
+                if short_option not in _CURL_SHORT_OPTIONS_WITH_VALUES:
+                    continue
+                attached_value = argument[offset + 1 :]
+                if not attached_value and index + 1 < len(arguments):
+                    attached_value = arguments[index + 1]
+                    consumed_next = True
+                if short_option == "X":
+                    method = attached_value.lower()
+                break
+            index += 2 if consumed_next else 1
+            continue
         if not argument.startswith("-"):
             targets.append(argument.strip("'\""))
         index += 1
-    return method, tuple(targets)
+    operations.append((method, tuple(targets)))
+    return tuple(operations)
 
 
 def _safe_flag_variant(

--- a/src/codex_plugin_scanner/guard/runtime/command_segment_parsing.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_segment_parsing.py
@@ -1,0 +1,24 @@
+"""Shared token helpers for canonical command segments."""
+
+from __future__ import annotations
+
+from .command_structure import CommandRedirect
+from .command_tokens import shell_tokens
+
+
+def shell_tokens_without_redirects(
+    command: str,
+    *,
+    source_offset: int,
+    redirects: tuple[CommandRedirect, ...],
+) -> tuple[str, ...]:
+    """Tokenize a command after masking redirects owned by its segment."""
+
+    masked = list(command)
+    for redirect in redirects:
+        local_start = redirect.start - source_offset
+        local_end = redirect.end - source_offset
+        if local_start < 0 or local_end > len(masked):
+            continue
+        masked[local_start:local_end] = " " * (local_end - local_start)
+    return shell_tokens("".join(masked))[0]

--- a/src/codex_plugin_scanner/guard/runtime/command_structured_matchers.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_structured_matchers.py
@@ -66,6 +66,8 @@ class SubcommandOperandPrefixMatcher:
     operand_prefixes: frozenset[str]
     leading_options_with_values: frozenset[str] = frozenset()
     options_with_values: frozenset[str] = frozenset()
+    leading_operands_to_skip: int = 0
+    options_supplying_leading_operands: frozenset[str] = frozenset()
 
     def __post_init__(self) -> None:
         normalized_executables = frozenset(value.strip().lower() for value in self.executables if value.strip())
@@ -73,6 +75,8 @@ class SubcommandOperandPrefixMatcher:
         normalized_prefixes = frozenset(value for value in self.operand_prefixes if value)
         if not normalized_executables or not normalized_subcommands or not normalized_prefixes:
             raise ValueError("SubcommandOperandPrefixMatcher requires executables, subcommands, and prefixes")
+        if self.leading_operands_to_skip < 0:
+            raise ValueError("SubcommandOperandPrefixMatcher cannot skip a negative operand count")
         object.__setattr__(self, "executables", normalized_executables)
         object.__setattr__(self, "subcommands", normalized_subcommands)
         object.__setattr__(self, "operand_prefixes", normalized_prefixes)
@@ -89,10 +93,20 @@ class SubcommandOperandPrefixMatcher:
             lowered = tuple(value.lower() for value in leading_operands)
             if lowered[: len(self.subcommands)] != self.subcommands:
                 continue
+            subcommand_arguments = leading_operands[len(self.subcommands) :]
             operands = _operands_without_options(
-                leading_operands[len(self.subcommands) :],
+                subcommand_arguments,
                 options_with_values=self.options_with_values,
             )
+            supplied_leading_operands = (
+                present_flags(
+                    subcommand_arguments,
+                    options_with_values=self.options_with_values,
+                )
+                & self.options_supplying_leading_operands
+            )
+            if not supplied_leading_operands:
+                operands = operands[self.leading_operands_to_skip :]
             if not any(
                 len(operand) > len(prefix) and operand.startswith(prefix)
                 for operand in operands
@@ -120,6 +134,7 @@ class OptionValueKeyMatcher:
     forbidden_flags: frozenset[str] = frozenset()
     ignored_values: frozenset[str] = frozenset()
     required_key_values: tuple[tuple[str, str], ...] = ()
+    cluster_options_with_values: frozenset[str] = frozenset()
 
     def __post_init__(self) -> None:
         normalized_executables = frozenset(value.strip().lower() for value in self.executables if value.strip())
@@ -142,17 +157,27 @@ class OptionValueKeyMatcher:
         object.__setattr__(self, "forbidden_flags", normalized_forbidden)
         object.__setattr__(self, "ignored_values", normalized_ignored)
         object.__setattr__(self, "required_key_values", normalized_required)
+        object.__setattr__(
+            self,
+            "cluster_options_with_values",
+            frozenset(value.strip() for value in self.cluster_options_with_values if value.strip()),
+        )
 
     def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
         evidence: list[MatcherEvidence] = []
         for index, segment in enumerate(command.segments):
             if not _segment_matches_executable(segment, self.executables):
                 continue
-            matched_flags = present_flags(segment.arguments, options_with_values=self.option_names)
+            all_value_options = self.option_names | self.cluster_options_with_values
+            matched_flags = present_flags(segment.arguments, options_with_values=all_value_options)
             if self.forbidden_flags & matched_flags:
                 continue
             settings: dict[str, str] = {}
-            for option_value in _option_values(segment.arguments, self.option_names):
+            for option_value in _option_values(
+                segment.arguments,
+                self.option_names,
+                cluster_options_with_values=all_value_options,
+            ):
                 key, value = _split_option_setting(option_value)
                 if key:
                     settings.setdefault(key, value)
@@ -278,7 +303,12 @@ def leading_flags_and_operands(
     return frozenset(flags), arguments[index:]
 
 
-def _option_values(arguments: tuple[str, ...], option_names: frozenset[str]) -> tuple[str, ...]:
+def _option_values(
+    arguments: tuple[str, ...],
+    option_names: frozenset[str],
+    *,
+    cluster_options_with_values: frozenset[str] | None = None,
+) -> tuple[str, ...]:
     values: list[str] = []
     ordered_options = sorted(option_names, key=len, reverse=True)
     index = 0
@@ -292,16 +322,20 @@ def _option_values(arguments: tuple[str, ...], option_names: frozenset[str]) -> 
             ),
             None,
         )
-        clustered_match = _clustered_short_value(argument, option_names)
+        clustered_match = _clustered_short_value(
+            argument,
+            cluster_options_with_values or option_names,
+        )
         if matched_option is None:
             if clustered_match is not None:
-                _option, value = clustered_match
-                if value:
-                    values.append(value)
-                elif index + 1 < len(arguments):
-                    values.append(arguments[index + 1])
-                    index += 2
-                    continue
+                option, value = clustered_match
+                if option in option_names:
+                    if value:
+                        values.append(value)
+                    elif index + 1 < len(arguments):
+                        values.append(arguments[index + 1])
+                        index += 2
+                        continue
             index += 1
             continue
         if argument == matched_option:

--- a/src/codex_plugin_scanner/guard/runtime/data_flow.py
+++ b/src/codex_plugin_scanner/guard/runtime/data_flow.py
@@ -24,6 +24,9 @@ from .shell_structure import (
     extract_command_substitutions as extract_command_substitutions,
 )
 from .shell_structure import (
+    extract_expanded_heredoc_substitution_spans as extract_expanded_heredoc_substitution_spans,
+)
+from .shell_structure import (
     extract_heredocs as extract_heredocs,
 )
 from .shell_structure import (

--- a/src/codex_plugin_scanner/guard/runtime/shell_structure.py
+++ b/src/codex_plugin_scanner/guard/runtime/shell_structure.py
@@ -161,6 +161,20 @@ def extract_command_substitutions(command: str) -> tuple[str, ...]:
 def extract_command_substitution_spans(command: str) -> tuple[ShellCommandSubstitution, ...]:
     """Return top-level substitutions with exact source spans."""
 
+    return _extract_command_substitution_spans(command, respect_quotes=True)
+
+
+def extract_expanded_heredoc_substitution_spans(command: str) -> tuple[ShellCommandSubstitution, ...]:
+    """Return substitutions expanded by an unquoted heredoc delimiter."""
+
+    return _extract_command_substitution_spans(command, respect_quotes=False)
+
+
+def _extract_command_substitution_spans(
+    command: str,
+    *,
+    respect_quotes: bool,
+) -> tuple[ShellCommandSubstitution, ...]:
     substitutions: list[ShellCommandSubstitution] = []
     index = 0
     quote: str | None = None
@@ -169,19 +183,19 @@ def extract_command_substitution_spans(command: str) -> tuple[ShellCommandSubsti
         if char == "\\":
             index += 2
             continue
-        if char == "'" and quote is None:
+        if respect_quotes and char == "'" and quote is None:
             quote = "'"
             index += 1
             continue
-        if char == "'" and quote == "'":
+        if respect_quotes and char == "'" and quote == "'":
             quote = None
             index += 1
             continue
-        if char == '"' and quote is None:
+        if respect_quotes and char == '"' and quote is None:
             quote = '"'
             index += 1
             continue
-        if char == '"' and quote == '"':
+        if respect_quotes and char == '"' and quote == '"':
             quote = None
             index += 1
             continue

--- a/tests/test_guard_command_backup_extensions.py
+++ b/tests/test_guard_command_backup_extensions.py
@@ -52,6 +52,16 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.backup.rclone.mutation",
         ),
         (
+            "rclone purge remote:archive --dry-run --dry-run=false",
+            "Rclone destructive command",
+            "command.backup.rclone.mutation",
+        ),
+        (
+            "rclone purge remote:archive --dry-run=true --dry-run=false",
+            "Rclone destructive command",
+            "command.backup.rclone.mutation",
+        ),
+        (
             "rclone -ab value purge remote:archive",
             "Rclone destructive command",
             "command.backup.rclone.mutation",
@@ -84,6 +94,11 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
         ),
         (
             "restic -qrs3:archive forget latest --prune",
+            "Restic destructive command",
+            "command.backup.restic.mutation",
+        ),
+        (
+            "restic forget latest --dry-run --dry-run=false",
             "Restic destructive command",
             "command.backup.restic.mutation",
         ),
@@ -132,6 +147,11 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "Borg destructive command",
             "command.backup.borg.mutation",
         ),
+        (
+            "borg prune --keep-daily 7 /archive --dry-run --dry-run=false",
+            "Borg destructive command",
+            "command.backup.borg.mutation",
+        ),
         ("velero backup delete release-1", "Velero destructive command", "command.backup.velero.deletion"),
         (
             "velero --namespace prod backup delete release-1",
@@ -146,6 +166,11 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
         ("velero -nprod schedule delete nightly", "Velero destructive command", "command.backup.velero.deletion"),
         (
             "velero -vnprod backup delete release-1",
+            "Velero destructive command",
+            "command.backup.velero.deletion",
+        ),
+        (
+            "velero backup delete release-1 --help --help=false",
             "Velero destructive command",
             "command.backup.velero.deletion",
         ),
@@ -193,6 +218,8 @@ def test_backup_rules_feed_runtime_hooks(
         "rclone sync source: destination: --dry-run",
         "rclone purge remote:archive --dry-run=true",
         "rclone purge remote:archive --dry-run=1",
+        "rclone purge remote:archive --dry-run=false --dry-run",
+        "rclone purge remote:archive --dry-run=false --dry-run=true",
         "rclone -n purge remote:archive",
         "restic -r s3:archive forget latest --dry-run",
         "restic rewrite --forget latest --dry-run",
@@ -212,15 +239,18 @@ def test_backup_rules_feed_runtime_hooks(
         "restic --compression max snapshots",
         "restic -qr forget snapshots",
         "restic -qrforget snapshots",
+        "restic forget latest --dry-run=false --dry-run",
         "borg list /archive",
         "borg --remote-ratelimit 1000 list /archive",
         "borg prune -Pfoo -n --keep-daily 7 /archive",
         "borg prune -afoo -n --keep-daily 7 /archive",
         "borg recreate -efoo -n /archive",
         "borg -vr prune list",
+        "borg prune --keep-daily 7 /archive --dry-run=false --dry-run",
         "velero backup describe release-1",
         "velero --future-global-option cluster backup describe release-1",
         "velero -vnprod backup describe release-1",
+        "velero backup delete release-1 --help=false --help",
         "grep 'rclone sync|restic forget|borg prune|velero backup delete' docs",
     ],
 )

--- a/tests/test_guard_command_backup_extensions.py
+++ b/tests/test_guard_command_backup_extensions.py
@@ -6,8 +6,13 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard.runtime import command_option_parsing
 from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
+from codex_plugin_scanner.guard.runtime.command_option_parsing import (
+    flags_present_in_all_option_parses,
+    matches_subcommands_conservatively,
+)
 from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
 
 
@@ -62,6 +67,16 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "Restic destructive command",
             "command.backup.restic.mutation",
         ),
+        (
+            "restic -qr repository forget latest --prune",
+            "Restic destructive command",
+            "command.backup.restic.mutation",
+        ),
+        (
+            "restic -qrs3:archive forget latest --prune",
+            "Restic destructive command",
+            "command.backup.restic.mutation",
+        ),
         ("restic rewrite --forget latest", "Restic destructive command", "command.backup.restic.mutation"),
         ("borg.cmd prune --keep-daily 7 /archive", "Borg destructive command", "command.backup.borg.mutation"),
         ("borg delete /archive::old", "Borg destructive command", "command.backup.borg.mutation"),
@@ -82,6 +97,31 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "Borg destructive command",
             "command.backup.borg.mutation",
         ),
+        (
+            "borg -Pfoo-n prune --keep-daily 7 /archive",
+            "Borg destructive command",
+            "command.backup.borg.mutation",
+        ),
+        (
+            "borg -afoo-n prune --keep-daily 7 /archive",
+            "Borg destructive command",
+            "command.backup.borg.mutation",
+        ),
+        (
+            "borg -efoo-n recreate /archive",
+            "Borg destructive command",
+            "command.backup.borg.mutation",
+        ),
+        (
+            "borg -vr /archive prune --keep-daily 7",
+            "Borg destructive command",
+            "command.backup.borg.mutation",
+        ),
+        (
+            "borg -vr/archive prune --keep-daily 7",
+            "Borg destructive command",
+            "command.backup.borg.mutation",
+        ),
         ("velero backup delete release-1", "Velero destructive command", "command.backup.velero.deletion"),
         (
             "velero --namespace prod backup delete release-1",
@@ -94,6 +134,11 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.backup.velero.deletion",
         ),
         ("velero -nprod schedule delete nightly", "Velero destructive command", "command.backup.velero.deletion"),
+        (
+            "velero -vnprod backup delete release-1",
+            "Velero destructive command",
+            "command.backup.velero.deletion",
+        ),
         (
             "velero --future-global-option cluster backup delete release-1",
             "Velero destructive command",
@@ -150,12 +195,20 @@ def test_backup_rules_feed_runtime_hooks(
         "rclone lsl remote:archive",
         "rclone --log-level DEBUG lsl remote:archive",
         "rclone -ab value lsl remote:archive",
+        "rclone -vn purge remote:archive",
         "restic snapshots",
         "restic --compression max snapshots",
+        "restic -qr forget snapshots",
+        "restic -qrforget snapshots",
         "borg list /archive",
         "borg --remote-ratelimit 1000 list /archive",
+        "borg prune -Pfoo -n --keep-daily 7 /archive",
+        "borg prune -afoo -n --keep-daily 7 /archive",
+        "borg recreate -efoo -n /archive",
+        "borg -vr prune list",
         "velero backup describe release-1",
         "velero --future-global-option cluster backup describe release-1",
+        "velero -vnprod backup describe release-1",
         "grep 'rclone sync|restic forget|borg prune|velero backup delete' docs",
     ],
 )
@@ -179,6 +232,50 @@ def test_backup_interactive_mode_remains_reviewable(tmp_path: Path) -> None:
 
     assert payload["status"] == "review"
     assert payload["controlling_rule_id"] == "command.backup.rclone.mutation"
+
+
+def test_backup_option_parsing_handles_deep_option_sequences(tmp_path: Path) -> None:
+    repeated_options = " ".join("--x=y" for _ in range(1200))
+    destructive_command = f"rclone {repeated_options} purge remote:archive"
+    safe_command = f"rclone {repeated_options} -n purge remote:archive"
+
+    destructive_payload = inspect_command(destructive_command, cwd=tmp_path, home_dir=tmp_path)
+    destructive_runtime = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": destructive_command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+    safe_payload = inspect_command(safe_command, cwd=tmp_path, home_dir=tmp_path)
+    safe_runtime = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": safe_command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert destructive_payload["status"] == "review"
+    assert destructive_runtime is not None
+    assert safe_payload["status"] == "no_match"
+    assert safe_runtime is None
+
+
+def test_backup_option_parse_limit_fails_secure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(command_option_parsing, "_MAX_OPTION_PARSE_STATES", 1)
+    arguments = ("--future=value", "purge", "remote:archive")
+
+    assert matches_subcommands_conservatively(
+        arguments,
+        ("purge",),
+        options_with_values=frozenset(),
+        known_flags=frozenset({"-n"}),
+    )
+    assert not flags_present_in_all_option_parses(
+        arguments,
+        frozenset({"-n"}),
+        options_with_values=frozenset(),
+        known_flags=frozenset({"-n"}),
+    )
 
 
 def test_backup_extensions_publish_official_references() -> None:

--- a/tests/test_guard_command_backup_extensions.py
+++ b/tests/test_guard_command_backup_extensions.py
@@ -42,6 +42,16 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.backup.rclone.mutation",
         ),
         (
+            "rclone purge remote:archive --dry-run=false",
+            "Rclone destructive command",
+            "command.backup.rclone.mutation",
+        ),
+        (
+            "rclone purge remote:archive --dry-run=0",
+            "Rclone destructive command",
+            "command.backup.rclone.mutation",
+        ),
+        (
             "rclone -ab value purge remote:archive",
             "Rclone destructive command",
             "command.backup.rclone.mutation",
@@ -181,6 +191,8 @@ def test_backup_rules_feed_runtime_hooks(
     "command",
     [
         "rclone sync source: destination: --dry-run",
+        "rclone purge remote:archive --dry-run=true",
+        "rclone purge remote:archive --dry-run=1",
         "rclone -n purge remote:archive",
         "restic -r s3:archive forget latest --dry-run",
         "restic rewrite --forget latest --dry-run",

--- a/tests/test_guard_command_cloud_extensions.py
+++ b/tests/test_guard_command_cloud_extensions.py
@@ -102,6 +102,21 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.cloud.azure.resource-deletion",
         ),
         (
+            "aws ec2 terminate-instances --instance-ids i-123 --dry-run --dry-run=false",
+            "AWS destructive command",
+            "command.cloud.aws.resource-deletion",
+        ),
+        (
+            "gcloud compute instances delete api-1 --help --help=false",
+            "Google Cloud destructive command",
+            "command.cloud.gcp.resource-deletion",
+        ),
+        (
+            "az vm delete --resource-group app --name api-1 --help --help=false",
+            "Azure destructive command",
+            "command.cloud.azure.resource-deletion",
+        ),
+        (
             "aws.exe ec2 --region us-east-1 terminate-instances --instance-ids i-123",
             "AWS destructive command",
             "command.cloud.aws.resource-deletion",
@@ -221,6 +236,9 @@ def test_cloud_rules_feed_inspection_and_runtime_hooks(
         "aws --future-global-option account ec2 terminate-instances --instance-ids i-123 --dry-run",
         "gcloud --future-global-option account compute instances delete api-1 --help",
         "az --future-global-option tenant vm delete --resource-group app --name api-1 --help",
+        "aws ec2 terminate-instances --instance-ids i-123 --dry-run=false --dry-run",
+        "gcloud compute instances delete api-1 --help=false --help",
+        "az vm delete --resource-group app --name api-1 --help=false --help",
         "aws ec2 describe-instances --instance-ids i-123",
         "aws --future-global-option account ec2 describe-instances --instance-ids i-123",
         "gcloud compute instances describe api-1",

--- a/tests/test_guard_command_specialized_variants.py
+++ b/tests/test_guard_command_specialized_variants.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
 from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
 
@@ -84,6 +86,66 @@ def test_unquoted_data_heredoc_expands_substitutions_despite_body_quotes(body: s
     assert payload["status"] == "review"
     assert payload["controlling_rule_id"] == "command.filesystem.recursive-delete"
     assert match is not None
+
+
+@pytest.mark.parametrize(
+    "substitution",
+    [
+        "$(sh -c 'rm -rf ./build')",
+        '$(sh -c "rm -rf ./build")',
+        "$(sh -c 'sh -c \"rm -rf ./build\"')",
+    ],
+)
+def test_heredoc_substitution_shell_wrappers_feed_cli_and_runtime_classification(
+    substitution: str,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    command = f"cat <<EOF\n{substitution}\nEOF"
+
+    exit_code = main(["guard", "command", "test", "--json", command])
+    payload = json.loads(capsys.readouterr().out)
+    match = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert exit_code == 0
+    assert payload["status"] == "review"
+    assert payload["classification"]["matched"] is True
+    assert payload["classification"]["action_class"] == "filesystem destructive command"
+    assert payload["controlling_rule_id"] == "command.filesystem.recursive-delete"
+    assert match is not None
+    assert match.action_class == "filesystem destructive command"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat <<'EOF'\n$(sh -c 'rm -rf ./build')\nEOF",
+        "cat <<EOF\n\\$(sh -c 'rm -rf ./build')\nEOF",
+    ],
+)
+def test_literal_shell_wrapped_heredoc_substitutions_remain_safe_at_cli_and_runtime_boundaries(
+    command: str,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = main(["guard", "command", "test", "--json", command])
+    payload = json.loads(capsys.readouterr().out)
+    match = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert exit_code == 0
+    assert payload["status"] == "no_match"
+    assert payload["classification"]["matched"] is False
+    assert match is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_command_specialized_variants.py
+++ b/tests/test_guard_command_specialized_variants.py
@@ -11,13 +11,43 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
 
 
 @pytest.mark.parametrize(
-    "command",
+    ("command", "rule_id", "action_class"),
     [
-        "git push origin +main",
-        "git push origin +refs/heads/main:refs/heads/main",
+        ("git push origin +main", "command.git.force-push", "git destructive command"),
+        (
+            "git push origin +refs/heads/main:refs/heads/main",
+            "command.git.force-push",
+            "git destructive command",
+        ),
+        ("git push --repo origin +main", "command.git.force-push", "git destructive command"),
+        (
+            "curl -X DELETE localhost:9200/customer-index --next -X GET https://api.example.test/items",
+            "command.search.elasticsearch.delete",
+            "Elasticsearch destructive command",
+        ),
+        (
+            "curl -sXDELETE localhost:9200/customer-index",
+            "command.search.elasticsearch.delete",
+            "Elasticsearch destructive command",
+        ),
+        (
+            "ssh -voProxyCommand='sh -c id' host.example",
+            "command.remote.ssh.configured-execution",
+            "SSH configured execution command",
+        ),
+        (
+            "ssh -4oRemoteCommand='id' host.example",
+            "command.remote.ssh.configured-execution",
+            "SSH configured execution command",
+        ),
     ],
 )
-def test_git_force_push_refspecs_feed_runtime_classification(command: str, tmp_path: Path) -> None:
+def test_specialized_variants_feed_runtime_classification(
+    command: str,
+    rule_id: str,
+    action_class: str,
+    tmp_path: Path,
+) -> None:
     payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
     match = extract_sensitive_tool_action_request(
         "Shell",
@@ -27,6 +57,78 @@ def test_git_force_push_refspecs_feed_runtime_classification(command: str, tmp_p
     )
 
     assert payload["status"] == "review"
-    assert payload["controlling_rule_id"] == "command.git.force-push"
+    assert payload["controlling_rule_id"] == rule_id
     assert match is not None
-    assert match.action_class == "git destructive command"
+    assert match.action_class == action_class
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "'$(rm -rf ./build)'",
+        '"$(rm -rf ./build)"',
+        "prefix 'quoted text' $(rm -rf ./build)",
+        "'`rm -rf ./build`'",
+    ],
+)
+def test_unquoted_data_heredoc_expands_substitutions_despite_body_quotes(body: str, tmp_path: Path) -> None:
+    command = f"cat <<EOF\n{body}\nEOF"
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+    match = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert payload["status"] == "review"
+    assert payload["controlling_rule_id"] == "command.filesystem.recursive-delete"
+    assert match is not None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat <<'EOF'\n'$(rm -rf ./build)'\nEOF",
+        "cat <<EOF\n\\$(rm -rf ./build)\nEOF",
+        "cat <<EOF\n\\`rm -rf ./build\\`\nEOF",
+        "curl -X DELETE https://api.example.test/items --next -X GET localhost:9200/customer-index",
+        "curl -sXGET localhost:9200/customer-index",
+        "curl -X DELETE --data localhost:9200/customer-index https://api.example.test/items",
+        "curl -X DELETE --data=localhost:9200/customer-index https://api.example.test/items",
+        "curl -X DELETE --output localhost:9200/customer-index https://api.example.test/items",
+        "curl -X DELETE --header localhost:9200/customer-index https://api.example.test/items",
+        "curl -X DELETE -Hlocalhost:9200/customer-index https://api.example.test/items",
+        "curl -X DELETE --user localhost:9200/customer-index https://api.example.test/items",
+        "curl -X DELETE --cert localhost:9200/customer-index https://api.example.test/items",
+        "curl -X DELETE --key localhost:9200/customer-index https://api.example.test/items",
+        "curl -X DELETE --cacert localhost:9200/customer-index https://api.example.test/items",
+        "curl -X DELETE --proxy-user localhost:9200/customer-index https://api.example.test/items",
+        "curl -X DELETE --url-query localhost:9200/customer-index https://api.example.test/items",
+        "curl -X DELETE -o localhost:9200/customer-index https://api.example.test/items",
+        "curl -oXDELETE localhost:9200/customer-index",
+        "ssh -pvoProxyCommand='sh -c id' host.example",
+        "ssh -FvoProxyCommand='sh -c id' host.example",
+        "ssh -v4 host.example",
+        "git push +origin",
+        "git push --repo +origin main",
+        "git push --repo=+origin main",
+        "git push --push-option +audit origin main",
+        "git push --push-option=+audit origin main",
+        "git push -o +audit origin main",
+        "git push -o+audit origin main",
+        "git push -n origin +main",
+        "git push origin +main -n",
+    ],
+)
+def test_specialized_literal_observer_and_option_value_variants_remain_safe(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+    match = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert payload["status"] == "no_match"
+    assert match is None


### PR DESCRIPTION
## Summary
- refine structured parsing for option-heavy command invocations
- preserve benign command variants while improving destructive-action classification

## Testing
- `python3 -m pytest -q tests/test_guard_command*.py --tb=short`
- `python3 -m pytest -q tests/test_guard_command_specialized_variants.py tests/test_guard_command_model.py tests/test_guard_command_extensions.py tests/test_guard_command_remote_extensions.py tests/test_guard_command_search_messaging_extensions.py --tb=short`
- `python3 -m ruff check` on changed source and test files
- `python3 -m build --wheel`
