### PR TITLE
feat(policy): add versioned policy document schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dependencies = [
     "cryptography>=49.0.0",
     "keyring>=25.0",
     "packaging>=24.0",
+    "jsonschema>=4.26.0",
+    "pyyaml>=6.0.3",
     "requests>=2.32,<3",
     "tomli>=2.0; python_version < '3.11'",
     "cisco-ai-skill-scanner~=2.0.11; python_version < '3.14'",
@@ -61,8 +63,6 @@ cisco = [
 dev = [
     "basedpyright>=1.39.8",
     "build>=1.5.0",
-    "jsonschema>=4.26.0",
-    "pyyaml>=6.0.3",
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
     "ruff>=0.15.15",
@@ -118,7 +118,10 @@ line-length = 120
 packages = ["src/codex_plugin_scanner"]
 
 [tool.hatch.build]
-artifacts = ["src/codex_plugin_scanner/guard/daemon/static/**"]
+artifacts = [
+    "src/codex_plugin_scanner/guard/daemon/static/**",
+    "src/codex_plugin_scanner/guard/schemas/**",
+]
 exclude = [
     ".guard-live/**",
     ".guard-package-venv/**",

--- a/spec/guard-policy/README.md
+++ b/spec/guard-policy/README.md
@@ -1,0 +1,12 @@
+# GuardPolicy specification
+
+`GuardPolicy` is HOL Guard's portable policy source format.
+
+- [v1alpha1 JSON Schema](v1alpha1/schema.json)
+- [v1alpha1 semantics](v1alpha1/semantics.md)
+- [v1alpha1 canonicalization](v1alpha1/canonicalization.md)
+- [v1alpha1 conformance fixtures](v1alpha1/fixtures)
+
+Versions are additive during alpha. A consumer MUST reject an unknown `apiVersion`; it MUST NOT guess or silently downgrade. The public schema and fixtures are normative. The Python package carries an exact generated schema copy for installed CLI validation, and its contract test prevents drift.
+
+The format is repository-neutral. Private endpoints, infrastructure names, credentials, internal topology, and deployment details do not belong in this directory or its fixtures.

--- a/spec/guard-policy/v1alpha1/canonicalization.md
+++ b/spec/guard-policy/v1alpha1/canonicalization.md
@@ -43,7 +43,7 @@ The deterministic formatter emits block-style YAML, stable core-field order, UTF
 
 The signing/hash input is UTF-8 canonical JSON of the complete normalized document:
 
-1. object keys sorted lexicographically by Unicode code point;
+1. object keys sorted lexicographically by UTF-16 code units, as required by RFC 8785;
 2. no insignificant whitespace;
 3. JSON string escaping with unescaped non-ASCII Unicode;
 4. integer numbers only;

--- a/spec/guard-policy/v1alpha1/canonicalization.md
+++ b/spec/guard-policy/v1alpha1/canonicalization.md
@@ -1,0 +1,59 @@
+# GuardPolicy v1alpha1 canonicalization
+
+## Accepted YAML subset
+
+The parser accepts exactly one UTF-8 YAML document using YAML 1.2 JSON-compatible implicit scalars:
+
+- implicit booleans: only `true` and `false`;
+- implicit null: only `null`;
+- implicit integers: JSON decimal integers; finite decimal/exponent floats are recognized and then rejected as `unsupported_float`;
+- every other plain scalar, including `yes`, `no`, `on`, `off`, `~`, `0123`, sexagesimal forms, `.inf`, `.nan`, and timestamp-looking text, is a string.
+
+Anchors, aliases, merge keys, explicit tags, custom tags, duplicate mapping keys, and multiple documents are rejected. Empty matcher arrays are rejected. Empty `match` means an explicit global rule.
+
+Unknown core fields are rejected. `x-*` extensions are allowed at the documented object boundaries, preserved, and signed. Expressions are not a schema feature: no core field evaluates templates, environment variables, code, regular expressions, or arbitrary predicates.
+
+## Resource limits
+
+Validation happens before compilation:
+
+- maximum encoded document size: 1,048,576 bytes;
+- maximum nesting depth: 32;
+- maximum rules: 1,000;
+- maximum entries in any other collection: 256;
+- maximum scalar string length: 4,096 Unicode code points;
+- maximum mapping-key length: 128 Unicode code points;
+- maximum returned diagnostics: 20.
+
+A producer SHOULD use materially smaller documents. Limits are interoperability ceilings, not targets.
+
+## Normalized model
+
+Formatting and hashing operate on the typed normalized model, not YAML syntax. The model:
+
+- preserves rule order and matcher-value order;
+- sorts labels and extension keys;
+- emits explicit `expiresAt: null` for non-expiring lifetimes;
+- preserves all `x-*` values as bounded JSON data, excluding floating-point numbers;
+- rejects duplicate rule IDs before construction.
+
+The deterministic formatter emits block-style YAML, stable core-field order, UTF-8 text, LF line endings, one trailing newline, and quotes YAML-ambiguous strings. Reformatting a formatted document is byte-stable. Parsing before and after formatting produces the same normalized model and digest.
+
+## Canonical JSON and digest
+
+The signing/hash input is UTF-8 canonical JSON of the complete normalized document:
+
+1. object keys sorted lexicographically by Unicode code point;
+2. no insignificant whitespace;
+3. JSON string escaping with unescaped non-ASCII Unicode;
+4. integer numbers only;
+5. all extensions included;
+6. no transport wrapper, signature, or digest field included.
+
+The schema permits only integer core numeric values, and semantic validation applies the same rule to extensions. This avoids cross-runtime floating-point serialization drift. The digest is lowercase hexadecimal `SHA-256(canonical_json_bytes)`.
+
+This digest is independent from legacy `guard-policy-bundle.v1` `bundleHash` and `payloadHash`. Those legacy projections remain byte-for-byte unchanged until negotiated v2 activation. A consumer MUST report a disagreement between advertised and computed legacy hashes; it MUST NOT rewrite either hash as part of YAML formatting.
+
+## Diagnostics
+
+Diagnostics expose only a bounded stable code, JSON-style path, line, and column. Messages never echo scalar values. Callers may add filename context but MUST NOT log policy source text, secrets, credentials, authorization headers, or raw provenance payloads.

--- a/spec/guard-policy/v1alpha1/fixtures/decisions/precedence.json
+++ b/spec/guard-policy/v1alpha1/fixtures/decisions/precedence.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "description": "Frozen current-runtime precedence; representation changes must not alter these outcomes.",
+  "vectors": [
+    {
+      "name": "exact artifact beats newer global",
+      "request": { "harness": "codex", "artifactId": "pkg:npm/example" },
+      "persisted": [
+        { "id": "global-new", "scope": "global", "action": "allow", "source": "local", "updatedAt": "2026-07-15T12:05:00Z" },
+        { "id": "artifact-old", "scope": "artifact", "artifactId": "pkg:npm/example", "action": "block", "source": "policy-bundle", "updatedAt": "2026-07-15T12:00:00Z" }
+      ],
+      "expected": "artifact-old"
+    },
+    {
+      "name": "expired exact row is excluded",
+      "request": { "harness": "codex", "artifactId": "pkg:npm/example", "now": "2026-07-15T12:10:00Z" },
+      "persisted": [
+        { "id": "artifact-expired", "scope": "artifact", "artifactId": "pkg:npm/example", "action": "block", "source": "policy-bundle", "updatedAt": "2026-07-15T12:00:00Z", "expiresAt": "2026-07-15T12:09:00Z" },
+        { "id": "global-active", "scope": "global", "action": "allow", "source": "local", "updatedAt": "2026-07-15T12:05:00Z" }
+      ],
+      "expected": "global-active"
+    },
+    {
+      "name": "eligible local once beats persisted",
+      "request": { "harness": "codex", "artifactId": "pkg:npm/example" },
+      "once": { "id": "once-local", "scope": "once", "action": "allow", "source": "local" },
+      "persisted": [
+        { "id": "artifact-cloud", "scope": "artifact", "artifactId": "pkg:npm/example", "action": "block", "source": "policy-bundle", "updatedAt": "2026-07-15T12:05:00Z" }
+      ],
+      "expected": "once-local"
+    },
+    {
+      "name": "newer remote wins equal specificity",
+      "request": { "harness": "codex", "artifactId": "pkg:npm/example" },
+      "persisted": [
+        { "id": "local-old", "scope": "artifact", "artifactId": "pkg:npm/example", "action": "allow", "source": "local", "updatedAt": "2026-07-15T12:00:00Z" },
+        { "id": "remote-new", "scope": "artifact", "artifactId": "pkg:npm/example", "action": "review", "source": "policy-bundle", "updatedAt": "2026-07-15T12:05:00Z" }
+      ],
+      "expected": "remote-new"
+    },
+    {
+      "name": "newer local wins equal specificity",
+      "request": { "harness": "codex", "artifactId": "pkg:npm/example" },
+      "persisted": [
+        { "id": "remote-old", "scope": "artifact", "artifactId": "pkg:npm/example", "action": "block", "source": "policy-bundle", "updatedAt": "2026-07-15T12:00:00Z" },
+        { "id": "local-new", "scope": "artifact", "artifactId": "pkg:npm/example", "action": "allow", "source": "local", "updatedAt": "2026-07-15T12:05:00Z" }
+      ],
+      "expected": "local-new"
+    }
+  ]
+}

--- a/spec/guard-policy/v1alpha1/fixtures/hashes/basic.json
+++ b/spec/guard-policy/v1alpha1/fixtures/hashes/basic.json
@@ -1,0 +1,5 @@
+{
+  "source": "../valid/basic.yaml",
+  "sha256": "2124d2a66ab9db1270737cd23bb85cce2376aa31e05bca2b6c0d5c820947de3f",
+  "canonicalJson": "{\"apiVersion\":\"guard.hashgraphonline.com/v1alpha1\",\"kind\":\"GuardPolicy\",\"metadata\":{\"id\":\"policy.team-defaults\",\"labels\":{\"environment\":\"production\"},\"name\":\"Team defaults\",\"revision\":7},\"spec\":{\"defaults\":{\"defaultAction\":\"warn\",\"mode\":\"prompt\"},\"rolloutState\":\"draft\",\"rules\":[{\"description\":\"Block untrusted package installs\",\"effect\":\"block\",\"enabled\":true,\"id\":\"rule.block-untrusted-install\",\"lifetime\":{\"expiresAt\":null,\"mode\":\"permanent\"},\"match\":{\"harnesses\":[\"claude-code\",\"codex\"],\"operations\":[\"package.install\"],\"packages\":[\"bad-package\"],\"repositories\":[\"team/example\"]},\"provenance\":{\"createdAt\":\"2026-07-15T12:00:00Z\",\"createdBy\":\"user-001\",\"receiptIds\":[\"receipt-001\"],\"source\":\"suggested-memory\",\"suggestionId\":\"suggestion-001\"}}]}}"
+}

--- a/spec/guard-policy/v1alpha1/fixtures/hashes/legacy-bundle-v1.json
+++ b/spec/guard-policy/v1alpha1/fixtures/hashes/legacy-bundle-v1.json
@@ -1,0 +1,33 @@
+{
+  "payload": {
+    "contractVersion": "guard-policy-bundle.v1",
+    "bundleVersion": "bundle-7",
+    "issuedAt": "2026-07-15T12:00:00Z",
+    "expiresAt": null,
+    "verifier": {
+      "algorithm": "hmac-sha256",
+      "keyId": "test-key",
+      "signature": "fixture-signature"
+    },
+    "rolloutState": "draft",
+    "policyDefaults": {
+      "mode": "prompt",
+      "defaultAction": "warn"
+    },
+    "rules": [
+      {
+        "id": "rule-1",
+        "action": "block",
+        "matcherFamily": "package-request",
+        "reason": "fixture"
+      }
+    ],
+    "receiptRedactionLevel": "metadata",
+    "workspaceId": "workspace-1",
+    "acknowledgements": [],
+    "minDaemonVersion": "0.1.0"
+  },
+  "bundleHash": "sha256:f8472211770d67339012aa409753ac855328278ae9019996c217299e15a0f16b",
+  "payloadHash": "64c2485090dc77e4084679ee643b3004efce8d51d3576ba871c5102ba60c7ca7",
+  "canonicalSigningPayload": "{\"acknowledgements\":[],\"bundleVersion\":\"bundle-7\",\"contractVersion\":\"guard-policy-bundle.v1\",\"expiresAt\":null,\"issuedAt\":\"2026-07-15T12:00:00Z\",\"minDaemonVersion\":\"0.1.0\",\"policyDefaults\":{\"defaultAction\":\"warn\",\"mode\":\"prompt\"},\"receiptRedactionLevel\":\"metadata\",\"rolloutState\":\"draft\",\"rules\":[{\"action\":\"block\",\"id\":\"rule-1\",\"matcherFamily\":\"package-request\",\"reason\":\"fixture\"}],\"verifier\":{\"algorithm\":\"hmac-sha256\",\"keyId\":\"test-key\",\"signature\":null},\"workspaceId\":\"workspace-1\"}"
+}

--- a/spec/guard-policy/v1alpha1/fixtures/invalid/anchor-alias.yaml
+++ b/spec/guard-policy/v1alpha1/fixtures/invalid/anchor-alias.yaml
@@ -1,0 +1,11 @@
+apiVersion: guard.hashgraphonline.com/v1alpha1
+kind: GuardPolicy
+metadata: &metadata
+  id: policy.invalid
+  name: Invalid
+  revision: 1
+spec:
+  defaults:
+    mode: prompt
+  rules: []
+x-copy: *metadata

--- a/spec/guard-policy/v1alpha1/fixtures/invalid/custom-tag.yaml
+++ b/spec/guard-policy/v1alpha1/fixtures/invalid/custom-tag.yaml
@@ -1,0 +1,10 @@
+apiVersion: guard.hashgraphonline.com/v1alpha1
+kind: GuardPolicy
+metadata:
+  id: policy.invalid
+  name: !custom Invalid
+  revision: 1
+spec:
+  defaults:
+    mode: prompt
+  rules: []

--- a/spec/guard-policy/v1alpha1/fixtures/invalid/duplicate-key.yaml
+++ b/spec/guard-policy/v1alpha1/fixtures/invalid/duplicate-key.yaml
@@ -1,0 +1,11 @@
+apiVersion: guard.hashgraphonline.com/v1alpha1
+kind: GuardPolicy
+kind: GuardPolicy
+metadata:
+  id: policy.invalid
+  name: Invalid
+  revision: 1
+spec:
+  defaults:
+    mode: prompt
+  rules: []

--- a/spec/guard-policy/v1alpha1/fixtures/invalid/duplicate-rule-id.yaml
+++ b/spec/guard-policy/v1alpha1/fixtures/invalid/duplicate-rule-id.yaml
@@ -1,0 +1,28 @@
+apiVersion: guard.hashgraphonline.com/v1alpha1
+kind: GuardPolicy
+metadata:
+  id: policy.invalid
+  name: Invalid
+  revision: 1
+spec:
+  defaults:
+    mode: prompt
+  rules:
+    - id: duplicate
+      enabled: true
+      effect: allow
+      match: {}
+      lifetime:
+        mode: permanent
+      provenance:
+        source: import
+        createdAt: 2026-07-15T12:00:00Z
+    - id: duplicate
+      enabled: true
+      effect: block
+      match: {}
+      lifetime:
+        mode: permanent
+      provenance:
+        source: import
+        createdAt: 2026-07-15T12:00:00Z

--- a/spec/guard-policy/v1alpha1/fixtures/invalid/empty-matcher-array.yaml
+++ b/spec/guard-policy/v1alpha1/fixtures/invalid/empty-matcher-array.yaml
@@ -1,0 +1,20 @@
+apiVersion: guard.hashgraphonline.com/v1alpha1
+kind: GuardPolicy
+metadata:
+  id: policy.invalid
+  name: Invalid
+  revision: 1
+spec:
+  defaults:
+    mode: prompt
+  rules:
+    - id: rule.invalid
+      enabled: true
+      effect: block
+      match:
+        packages: []
+      lifetime:
+        mode: permanent
+      provenance:
+        source: import
+        createdAt: 2026-07-15T12:00:00Z

--- a/spec/guard-policy/v1alpha1/fixtures/invalid/invalid-timestamp.yaml
+++ b/spec/guard-policy/v1alpha1/fixtures/invalid/invalid-timestamp.yaml
@@ -1,0 +1,20 @@
+apiVersion: guard.hashgraphonline.com/v1alpha1
+kind: GuardPolicy
+metadata:
+  id: policy.invalid
+  name: Invalid
+  revision: 1
+spec:
+  defaults:
+    mode: prompt
+  rules:
+    - id: rule.invalid
+      enabled: true
+      effect: allow
+      match: {}
+      lifetime:
+        mode: until
+        expiresAt: 2026-02-31T12:00:00Z
+      provenance:
+        source: import
+        createdAt: 2026-07-15T12:00:00Z

--- a/spec/guard-policy/v1alpha1/fixtures/invalid/merge-key.yaml
+++ b/spec/guard-policy/v1alpha1/fixtures/invalid/merge-key.yaml
@@ -1,0 +1,11 @@
+apiVersion: guard.hashgraphonline.com/v1alpha1
+kind: GuardPolicy
+metadata:
+  <<:
+    id: policy.invalid
+    name: Invalid
+    revision: 1
+spec:
+  defaults:
+    mode: prompt
+  rules: []

--- a/spec/guard-policy/v1alpha1/fixtures/invalid/raw-secret.yaml
+++ b/spec/guard-policy/v1alpha1/fixtures/invalid/raw-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: guard.hashgraphonline.com/v1alpha1
+kind: GuardPolicy
+metadata:
+  id: policy.invalid
+  name: Invalid
+  revision: 1
+spec:
+  defaults:
+    mode: prompt
+  rules:
+    - id: rule.invalid
+      enabled: true
+      effect: block
+      match:
+        secretValue: redacted-fixture-value
+      lifetime:
+        mode: permanent
+      provenance:
+        source: import
+        createdAt: 2026-07-15T12:00:00Z

--- a/spec/guard-policy/v1alpha1/fixtures/invalid/unknown-core-field.yaml
+++ b/spec/guard-policy/v1alpha1/fixtures/invalid/unknown-core-field.yaml
@@ -1,0 +1,11 @@
+apiVersion: guard.hashgraphonline.com/v1alpha1
+kind: GuardPolicy
+metadata:
+  id: policy.invalid
+  name: Invalid
+  revision: 1
+spec:
+  defaults:
+    mode: prompt
+    surprise: true
+  rules: []

--- a/spec/guard-policy/v1alpha1/fixtures/manifest.json
+++ b/spec/guard-policy/v1alpha1/fixtures/manifest.json
@@ -1,0 +1,17 @@
+{
+  "valid": [
+    "valid/basic.yaml",
+    "valid/extensions-and-scalars.yaml"
+  ],
+  "invalid": {
+    "invalid/anchor-alias.yaml": "yaml_anchor",
+    "invalid/custom-tag.yaml": "yaml_tag",
+    "invalid/duplicate-key.yaml": "yaml_duplicate_key",
+    "invalid/duplicate-rule-id.yaml": "duplicate_rule_id",
+    "invalid/empty-matcher-array.yaml": "schema_minItems",
+    "invalid/invalid-timestamp.yaml": "invalid_timestamp",
+    "invalid/merge-key.yaml": "yaml_merge_key",
+    "invalid/raw-secret.yaml": "forbidden_sensitive_field",
+    "invalid/unknown-core-field.yaml": "schema_additionalProperties"
+  }
+}

--- a/spec/guard-policy/v1alpha1/fixtures/valid/basic.yaml
+++ b/spec/guard-policy/v1alpha1/fixtures/valid/basic.yaml
@@ -1,0 +1,38 @@
+apiVersion: guard.hashgraphonline.com/v1alpha1
+kind: GuardPolicy
+metadata:
+  id: policy.team-defaults
+  name: Team defaults
+  revision: 7
+  labels:
+    environment: production
+spec:
+  defaults:
+    mode: prompt
+    defaultAction: warn
+  rolloutState: draft
+  rules:
+    - id: rule.block-untrusted-install
+      description: Block untrusted package installs
+      enabled: true
+      effect: block
+      match:
+        operations:
+          - package.install
+        harnesses:
+          - claude-code
+          - codex
+        packages:
+          - bad-package
+        repositories:
+          - team/example
+      lifetime:
+        mode: permanent
+        expiresAt: null
+      provenance:
+        source: suggested-memory
+        receiptIds:
+          - receipt-001
+        suggestionId: suggestion-001
+        createdAt: 2026-07-15T12:00:00Z
+        createdBy: user-001

--- a/spec/guard-policy/v1alpha1/fixtures/valid/extensions-and-scalars.yaml
+++ b/spec/guard-policy/v1alpha1/fixtures/valid/extensions-and-scalars.yaml
@@ -1,0 +1,40 @@
+apiVersion: guard.hashgraphonline.com/v1alpha1
+kind: GuardPolicy
+metadata:
+  id: policy.scalar-fixtures
+  name: YAML 1.2 scalar fixtures
+  revision: 1
+  labels:
+    yes-value: yes
+    no-value: no
+    on-value: on
+    off-value: off
+    tilde-value: ~
+    leading-zero: 0123
+    sexagesimal: 12:34:56
+    infinity: .inf
+    not-a-number: .nan
+    timestamp-text: 2026-07-15
+  x-owner-context:
+    display: portable
+spec:
+  defaults:
+    mode: observe
+    x-mode-note: yes
+  rules:
+    - id: rule.allow-once
+      enabled: true
+      effect: allow
+      match: {}
+      lifetime:
+        mode: once
+      provenance:
+        source: import
+        createdAt: 2026-07-15T12:00:00Z
+      x-editor:
+        node:
+          x: 120
+          y: 80
+  x-layout:
+    direction: horizontal
+x-document-note: on

--- a/spec/guard-policy/v1alpha1/schema.json
+++ b/spec/guard-policy/v1alpha1/schema.json
@@ -1,0 +1,533 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://guard.hashgraphonline.com/schema/policy/v1alpha1",
+  "title": "GuardPolicy v1alpha1",
+  "description": "Canonical, portable HOL Guard policy document.",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "const": "guard.hashgraphonline.com/v1alpha1"
+    },
+    "kind": {
+      "const": "GuardPolicy"
+    },
+    "metadata": {
+      "$ref": "#/$defs/metadata"
+    },
+    "spec": {
+      "$ref": "#/$defs/spec"
+    }
+  },
+  "patternProperties": {
+    "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+      "$ref": "#/$defs/extensionValue"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "boundedString": {
+      "type": "string",
+      "maxLength": 4096
+    },
+    "utcTimestamp": {
+      "type": "string",
+      "maxLength": 32,
+      "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]{1,9})?Z$"
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "revision"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "revision": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 2147483647
+        },
+        "labels": {
+          "type": "object",
+          "maxProperties": 64,
+          "propertyNames": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64
+          },
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 256
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+          "$ref": "#/$defs/extensionValue"
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "type": "object",
+      "required": [
+        "defaults",
+        "rules"
+      ],
+      "properties": {
+        "defaults": {
+          "$ref": "#/$defs/defaults"
+        },
+        "rolloutState": {
+          "enum": [
+            "draft",
+            "simulated",
+            "pending_approval",
+            "enforcing",
+            "enforced",
+            "rollback_available"
+          ]
+        },
+        "rules": {
+          "type": "array",
+          "maxItems": 1000,
+          "items": {
+            "$ref": "#/$defs/rule"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+          "$ref": "#/$defs/extensionValue"
+        }
+      },
+      "additionalProperties": false
+    },
+    "defaults": {
+      "type": "object",
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "mode": {
+          "enum": [
+            "observe",
+            "prompt",
+            "enforce"
+          ]
+        },
+        "defaultAction": {
+          "enum": [
+            "allow",
+            "warn",
+            "block"
+          ]
+        },
+        "unknownPublisherAction": {
+          "enum": [
+            "allow",
+            "review",
+            "block"
+          ]
+        },
+        "changedHashAction": {
+          "enum": [
+            "allow",
+            "warn",
+            "require-reapproval",
+            "block"
+          ]
+        },
+        "newNetworkDomainAction": {
+          "enum": [
+            "allow",
+            "warn",
+            "block"
+          ]
+        },
+        "subprocessAction": {
+          "enum": [
+            "allow",
+            "warn",
+            "block"
+          ]
+        },
+        "telemetryEnabled": {
+          "type": "boolean"
+        },
+        "syncEnabled": {
+          "type": "boolean"
+        }
+      },
+      "patternProperties": {
+        "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+          "$ref": "#/$defs/extensionValue"
+        }
+      },
+      "additionalProperties": false
+    },
+    "stringSet": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 256,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 512
+      }
+    },
+    "match": {
+      "type": "object",
+      "properties": {
+        "operations": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "actors": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "agents": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "artifacts": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "commands": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "devices": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "domains": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "ecosystems": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "environments": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "harnesses": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "locations": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "mcps": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "packages": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "paths": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "publishers": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "repositories": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "secretTypes": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "skills": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "tools": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "workspaces": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "browserIntents": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "browser.navigation",
+              "browser.inspect",
+              "browser.interact",
+              "browser.transfer",
+              "browser.privileged"
+            ]
+          }
+        },
+        "browserOperations": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "browserProfiles": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "isolated",
+              "dedicated",
+              "shared",
+              "remote-debugging",
+              "unknown"
+            ]
+          }
+        },
+        "origins": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "pathPrefixes": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "sensitiveSurfaces": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "cookies",
+              "storage",
+              "auth-headers",
+              "raw-cdp",
+              "script-eval",
+              "network-intercept",
+              "upload",
+              "download",
+              "clipboard",
+              "password-fields"
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+          "$ref": "#/$defs/extensionValue"
+        }
+      },
+      "additionalProperties": false
+    },
+    "lifetime": {
+      "type": "object",
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "mode": {
+          "enum": [
+            "once",
+            "session",
+            "project",
+            "machine",
+            "workspace",
+            "team",
+            "permanent",
+            "until"
+          ]
+        },
+        "expiresAt": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/utcTimestamp"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "patternProperties": {
+        "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+          "$ref": "#/$defs/extensionValue"
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "mode": {
+                "const": "until"
+              }
+            },
+            "required": [
+              "mode"
+            ]
+          },
+          "then": {
+            "required": [
+              "expiresAt"
+            ],
+            "properties": {
+              "expiresAt": {
+                "$ref": "#/$defs/utcTimestamp"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "expiresAt": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "provenance": {
+      "type": "object",
+      "required": [
+        "source",
+        "createdAt"
+      ],
+      "properties": {
+        "source": {
+          "enum": [
+            "suggested-memory",
+            "review-decision",
+            "builder",
+            "import",
+            "legacy",
+            "cloud",
+            "local",
+            "policy-bundle"
+          ]
+        },
+        "receiptIds": {
+          "type": "array",
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/identifier"
+          }
+        },
+        "suggestionId": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/identifier"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "createdAt": {
+          "$ref": "#/$defs/utcTimestamp"
+        },
+        "createdBy": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      },
+      "patternProperties": {
+        "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+          "$ref": "#/$defs/extensionValue"
+        }
+      },
+      "additionalProperties": false
+    },
+    "rule": {
+      "type": "object",
+      "required": [
+        "id",
+        "enabled",
+        "effect",
+        "match",
+        "lifetime",
+        "provenance"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "description": {
+          "$ref": "#/$defs/boundedString"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "effect": {
+          "enum": [
+            "allow",
+            "block",
+            "review",
+            "ignore"
+          ]
+        },
+        "match": {
+          "$ref": "#/$defs/match"
+        },
+        "lifetime": {
+          "$ref": "#/$defs/lifetime"
+        },
+        "provenance": {
+          "$ref": "#/$defs/provenance"
+        }
+      },
+      "patternProperties": {
+        "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+          "$ref": "#/$defs/extensionValue"
+        }
+      },
+      "additionalProperties": false
+    },
+    "extensionValue": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
+        },
+        {
+          "type": "string",
+          "maxLength": 4096
+        },
+        {
+          "type": "array",
+          "maxItems": 256,
+          "items": {
+            "$ref": "#/$defs/extensionValue"
+          }
+        },
+        {
+          "type": "object",
+          "maxProperties": 256,
+          "propertyNames": {
+            "type": "string",
+            "maxLength": 128
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/extensionValue"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/spec/guard-policy/v1alpha1/semantics.md
+++ b/spec/guard-policy/v1alpha1/semantics.md
@@ -1,0 +1,69 @@
+# GuardPolicy v1alpha1 semantics
+
+`GuardPolicy` is the portable semantic source. Portal graph state is editor metadata; signed Cloud bundles and local SQLite rows are compiled projections. A projection MUST reject a rule it cannot represent without changing meaning.
+
+## Action compatibility
+
+| Canonical effect | Portal `GuardPolicyRule` | Cloud bundle v1 | Local `PolicyDecision` | Classification |
+|---|---|---|---|---|
+| `allow` | `allow` | `allow` | `allow` | Lossless when scope is representable |
+| `block` | `block` | `block` | `block` | Lossless when scope is representable |
+| `review` | `review` | `review` | `review` | Lossless; remains an approval gate, never downgraded to `warn` |
+| `ignore` | `ignore` | `ignore` | no row | Lossless inert projection; never compiled as `allow` |
+
+Runtime-only actions are not rule effects: local `warn`, `sandbox-required`, and `require-reapproval`; bundle default `warn`; and changed-hash `warn`/`require-reapproval`. They remain typed defaults or legacy runtime results. Importing one as a rule effect is unsupported.
+
+## Status, mode, rollout, and lifetime
+
+- Portal `active`/`disabled` maps losslessly to `enabled: true/false`.
+- Cloud modes `observe`, `prompt`, and `enforce` map losslessly to `spec.defaults.mode`.
+- Cloud rollout states map losslessly to `spec.rolloutState`.
+- `once`, `session`, `project`, `machine`, `workspace`, `team`, and `permanent` preserve Portal review durations. `30d` and `90d` normalize to `until` plus an absolute UTC `expiresAt` at creation time.
+- A local null `expires_at` maps to `permanent`; a non-null UTC expiration maps to `until`. Consumed local one-shot approvals map to `once` but remain execution state rather than durable policy rows.
+- `until` requires `expiresAt`. Every other mode has a null or omitted `expiresAt` and MUST NOT invent an expiration.
+
+## Matcher compatibility
+
+| Canonical matcher | Existing projection | Classification |
+|---|---|---|
+| `actors` | Portal `actor` | Lossless |
+| `harnesses` | Portal `harness`; Cloud `harnesses`; local `harness` | Lossless |
+| `tools`, `paths`, `repositories`, `commands`, `mcps`, `skills`, `packages`, `domains`, `secretTypes` | Corresponding Portal scope | Lossless in Portal; Cloud/local compiler MUST reject unless its fixed matcher-family projection is exact |
+| `agents`, `devices`, `ecosystems`, `environments`, `locations` | Corresponding Cloud bundle scope | Lossless |
+| `artifacts`, `publishers`, `workspaces` | Local artifact/publisher/workspace decision keys | Lossless for exact singleton values; multi-value rules fan out deterministically |
+| `browserIntents`, `browserOperations`, `browserProfiles`, `origins`, `pathPrefixes`, `sensitiveSurfaces` | Portal browser scope and Cloud browser scope | Lossless in signed bundle; unsupported in SQLite because a row would broaden the rule |
+| `operations` | Cloud matcher families (`file-read`, `mcp`, `mcp-tool`, `package-request`, `prompt`, `prompt-env-read`, `tool-action`) or a typed Portal operation such as `package.install` | Lossless only through an explicit registered mapping; unknown operations are unsupported |
+| empty `match` | Global rule | Lossless; an empty individual matcher array is invalid |
+
+Cloud bundle v1 uses singular browser keys and plural fleet keys. The canonical adapters use the plural names in the schema and MUST perform a named field mapping; unknown keys never pass through as core matchers.
+
+## Defaults compatibility
+
+`defaultAction`, `unknownPublisherAction`, `changedHashAction`, `newNetworkDomainAction`, `subprocessAction`, `telemetryEnabled`, and `syncEnabled` preserve the current signed bundle values. Portal defaults that do not exist in bundle v1 are unsupported until capability negotiation. Local SQLite has no independent defaults projection.
+
+## Provenance
+
+Provenance is immutable semantic data. Suggested Memory emits `source: suggested-memory`, stable `receiptIds`, `suggestionId`, `createdAt`, and `createdBy`. User export MAY redact IDs but MUST record that redaction in an `x-*` extension. Raw secrets, credentials, authorization headers, and secret values are forbidden; `secretTypes` contains categories only.
+
+## Merge and identity
+
+Files are never merged implicitly. An explicit import assembles an ordered effective set, then fails if any rule ID appears more than once, including byte-identical rules. Document IDs identify documents; they do not scope rule IDs. Rule order is presentation order and does not resolve conflicts.
+
+Suggested Memory rule IDs are deterministic from immutable suggestion identity plus the semantic rule digest. Retries reuse the same ID. Editing content does not silently mint a second rule.
+
+## Current runtime precedence (frozen)
+
+This representation release does not change runtime precedence:
+
+1. An eligible local one-shot approval is atomically claimed first.
+2. Active persisted rows are ordered by scope: artifact, workspace, publisher, harness, global.
+3. Within workspace/harness/global, an artifact-constrained row precedes an unconstrained row.
+4. Remaining ties use `updated_at` descending. Source is not a tie-breaker: a local and remote row at the same specificity follow the same timestamp rule.
+5. Expired rows do not participate. Integrity-invalid local rows are skipped; a valid next candidate may win.
+6. A signed Cloud `block` or `review` does not receive absolute priority over a more-specific or newer local `allow`; changing that rule requires a separate safety contract.
+
+The decision fixtures freeze exact-vs-broad, active-vs-expired, once-vs-permanent, and local-vs-remote outcomes. Compilers and representation changes MUST preserve them.
+
+## Extensions
+
+An object may contain keys matching `x-[a-z0-9][a-z0-9.-]{0,62}`. Extensions are preserved and participate in canonical hashing/signing. Core enforcement ignores them unless both producer and consumer negotiated that extension contract. An unnegotiated extension cannot affect matching, action, precedence, or lifetime.

--- a/src/codex_plugin_scanner/guard/policy_document.py
+++ b/src/codex_plugin_scanner/guard/policy_document.py
@@ -1,0 +1,353 @@
+"""Typed GuardPolicy v1alpha1 documents and canonical JSON hashing."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TypeAlias, cast
+
+POLICY_API_VERSION = "guard.hashgraphonline.com/v1alpha1"
+POLICY_KIND = "GuardPolicy"
+POLICY_RULE_EFFECTS = ("allow", "block", "review", "ignore")
+POLICY_MODES = ("observe", "prompt", "enforce")
+POLICY_LIFETIME_MODES = ("once", "session", "project", "machine", "workspace", "team", "permanent", "until")
+POLICY_MATCH_FIELDS = (
+    "operations",
+    "actors",
+    "agents",
+    "artifacts",
+    "commands",
+    "devices",
+    "domains",
+    "ecosystems",
+    "environments",
+    "harnesses",
+    "locations",
+    "mcps",
+    "packages",
+    "paths",
+    "publishers",
+    "repositories",
+    "secretTypes",
+    "skills",
+    "tools",
+    "workspaces",
+    "browserIntents",
+    "browserOperations",
+    "browserProfiles",
+    "origins",
+    "pathPrefixes",
+    "sensitiveSurfaces",
+)
+
+JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+EncodedExtensions: TypeAlias = tuple[tuple[str, str], ...]
+
+def _mapping(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise TypeError("validated_policy_document_shape")
+    return cast(dict[str, object], value)
+
+
+def _sequence(value: object) -> list[object]:
+    if not isinstance(value, list):
+        raise TypeError("validated_policy_document_shape")
+    return cast(list[object], value)
+
+
+def _json_value(value: object) -> JsonValue:
+    return cast(JsonValue, value)
+
+def _canonical_json_text(value: JsonValue | object) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    if isinstance(value, list):
+        return "[" + ",".join(_canonical_json_text(item) for item in value) + "]"
+    if isinstance(value, dict):
+        items = cast(dict[str, object], value).items()
+        ordered = sorted(items, key=lambda item: item[0].encode("utf-16-be"))
+        return (
+            "{"
+            + ",".join(
+                f"{_canonical_json_text(key)}:{_canonical_json_text(item)}"
+                for key, item in ordered
+            )
+            + "}"
+        )
+    raise TypeError("unsupported_canonical_json_value")
+
+
+def _encode_extensions(value: dict[str, object], known_fields: frozenset[str]) -> EncodedExtensions:
+    return tuple(
+        (key, _canonical_json_text(item))
+        for key, item in sorted(value.items())
+        if key not in known_fields
+    )
+
+
+def _decode_extensions(value: EncodedExtensions) -> dict[str, JsonValue]:
+    return {key: json.loads(encoded) for key, encoded in value}
+
+
+def _with_extensions(core: dict[str, JsonValue], extensions: EncodedExtensions) -> dict[str, JsonValue]:
+    core.update(_decode_extensions(extensions))
+    return core
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyMetadata:
+    id: str
+    name: str
+    revision: int
+    labels: tuple[tuple[str, str], ...] = ()
+    extensions: EncodedExtensions = ()
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, object]) -> PolicyMetadata:
+        labels_value = value.get("labels")
+        labels = _mapping(labels_value) if labels_value is not None else {}
+        revision = value["revision"]
+        if not isinstance(revision, int) or isinstance(revision, bool):
+            raise TypeError("validated_policy_document_shape")
+        return cls(
+            id=str(value["id"]),
+            name=str(value["name"]),
+            revision=revision,
+            labels=tuple(sorted((key, str(item)) for key, item in labels.items())),
+            extensions=_encode_extensions(value, frozenset({"id", "name", "revision", "labels"})),
+        )
+
+    def to_mapping(self) -> dict[str, JsonValue]:
+        result: dict[str, JsonValue] = {"id": self.id, "name": self.name, "revision": self.revision}
+        if self.labels:
+            result["labels"] = dict(self.labels)
+        return _with_extensions(result, self.extensions)
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDefaults:
+    mode: str
+    values: tuple[tuple[str, JsonValue], ...] = ()
+    extensions: EncodedExtensions = ()
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, object]) -> PolicyDefaults:
+        known = frozenset(
+            {
+                "mode",
+                "defaultAction",
+                "unknownPublisherAction",
+                "changedHashAction",
+                "newNetworkDomainAction",
+                "subprocessAction",
+                "telemetryEnabled",
+                "syncEnabled",
+            }
+        )
+        values = tuple(
+            (key, _json_value(value[key]))
+            for key in sorted(known - {"mode"})
+            if key in value
+        )
+        return cls(mode=str(value["mode"]), values=values, extensions=_encode_extensions(value, known))
+
+    def to_mapping(self) -> dict[str, JsonValue]:
+        result: dict[str, JsonValue] = {"mode": self.mode}
+        result.update(self.values)
+        return _with_extensions(result, self.extensions)
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyMatch:
+    fields: tuple[tuple[str, tuple[str, ...]], ...] = ()
+    extensions: EncodedExtensions = ()
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, object]) -> PolicyMatch:
+        fields = tuple(
+            (key, tuple(str(item) for item in _sequence(value[key])))
+            for key in POLICY_MATCH_FIELDS
+            if isinstance(value.get(key), list)
+        )
+        return cls(fields=fields, extensions=_encode_extensions(value, frozenset(POLICY_MATCH_FIELDS)))
+
+    def to_mapping(self) -> dict[str, JsonValue]:
+        result: dict[str, JsonValue] = {key: list(values) for key, values in self.fields}
+        return _with_extensions(result, self.extensions)
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyLifetime:
+    mode: str
+    expires_at: str | None = None
+    extensions: EncodedExtensions = ()
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, object]) -> PolicyLifetime:
+        expires_at = value.get("expiresAt")
+        return cls(
+            mode=str(value["mode"]),
+            expires_at=expires_at if isinstance(expires_at, str) else None,
+            extensions=_encode_extensions(value, frozenset({"mode", "expiresAt"})),
+        )
+
+    def to_mapping(self) -> dict[str, JsonValue]:
+        result: dict[str, JsonValue] = {"mode": self.mode, "expiresAt": self.expires_at}
+        return _with_extensions(result, self.extensions)
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyProvenance:
+    source: str
+    created_at: str
+    receipt_ids: tuple[str, ...] = ()
+    suggestion_id: str | None = None
+    created_by: str | None = None
+    extensions: EncodedExtensions = ()
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, object]) -> PolicyProvenance:
+        receipt_ids = value.get("receiptIds")
+        suggestion_id = value.get("suggestionId")
+        created_by = value.get("createdBy")
+        return cls(
+            source=str(value["source"]),
+            created_at=str(value["createdAt"]),
+            receipt_ids=tuple(str(item) for item in _sequence(receipt_ids)) if isinstance(receipt_ids, list) else (),
+            suggestion_id=suggestion_id if isinstance(suggestion_id, str) else None,
+            created_by=created_by if isinstance(created_by, str) else None,
+            extensions=_encode_extensions(
+                value,
+                frozenset({"source", "receiptIds", "suggestionId", "createdAt", "createdBy"}),
+            ),
+        )
+
+    def to_mapping(self) -> dict[str, JsonValue]:
+        result: dict[str, JsonValue] = {"source": self.source, "createdAt": self.created_at}
+        if self.receipt_ids:
+            result["receiptIds"] = list(self.receipt_ids)
+        if self.suggestion_id is not None:
+            result["suggestionId"] = self.suggestion_id
+        if self.created_by is not None:
+            result["createdBy"] = self.created_by
+        return _with_extensions(result, self.extensions)
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyRule:
+    id: str
+    enabled: bool
+    effect: str
+    match: PolicyMatch
+    lifetime: PolicyLifetime
+    provenance: PolicyProvenance
+    description: str | None = None
+    extensions: EncodedExtensions = ()
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, object]) -> PolicyRule:
+        description = value.get("description")
+        return cls(
+            id=str(value["id"]),
+            description=description if isinstance(description, str) else None,
+            enabled=bool(value["enabled"]),
+            effect=str(value["effect"]),
+            match=PolicyMatch.from_mapping(_mapping(value["match"])),
+            lifetime=PolicyLifetime.from_mapping(_mapping(value["lifetime"])),
+            provenance=PolicyProvenance.from_mapping(_mapping(value["provenance"])),
+            extensions=_encode_extensions(
+                value,
+                frozenset({"id", "description", "enabled", "effect", "match", "lifetime", "provenance"}),
+            ),
+        )
+
+    def to_mapping(self) -> dict[str, JsonValue]:
+        result: dict[str, JsonValue] = {"id": self.id}
+        if self.description is not None:
+            result["description"] = self.description
+        result.update(
+            {
+                "enabled": self.enabled,
+                "effect": self.effect,
+                "match": self.match.to_mapping(),
+                "lifetime": self.lifetime.to_mapping(),
+                "provenance": self.provenance.to_mapping(),
+            }
+        )
+        return _with_extensions(result, self.extensions)
+
+
+@dataclass(frozen=True, slots=True)
+class GuardPolicyDocument:
+    metadata: PolicyMetadata
+    defaults: PolicyDefaults
+    rules: tuple[PolicyRule, ...]
+    rollout_state: str | None = None
+    api_version: str = POLICY_API_VERSION
+    kind: str = POLICY_KIND
+    spec_extensions: EncodedExtensions = ()
+    extensions: EncodedExtensions = ()
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, object]) -> GuardPolicyDocument:
+        metadata = _mapping(value["metadata"])
+        spec = _mapping(value["spec"])
+        defaults = _mapping(spec["defaults"])
+        rules = _sequence(spec["rules"])
+        rollout_state = spec.get("rolloutState")
+        return cls(
+            api_version=str(value["apiVersion"]),
+            kind=str(value["kind"]),
+            metadata=PolicyMetadata.from_mapping(metadata),
+            defaults=PolicyDefaults.from_mapping(defaults),
+            rules=tuple(PolicyRule.from_mapping(_mapping(rule)) for rule in rules),
+            rollout_state=rollout_state if isinstance(rollout_state, str) else None,
+            spec_extensions=_encode_extensions(spec, frozenset({"defaults", "rolloutState", "rules"})),
+            extensions=_encode_extensions(value, frozenset({"apiVersion", "kind", "metadata", "spec"})),
+        )
+
+    def to_mapping(self) -> dict[str, JsonValue]:
+        spec: dict[str, JsonValue] = {
+            "defaults": self.defaults.to_mapping(),
+            "rules": [rule.to_mapping() for rule in self.rules],
+        }
+        if self.rollout_state is not None:
+            spec["rolloutState"] = self.rollout_state
+        spec = _with_extensions(spec, self.spec_extensions)
+        result: dict[str, JsonValue] = {
+            "apiVersion": self.api_version,
+            "kind": self.kind,
+            "metadata": self.metadata.to_mapping(),
+            "spec": spec,
+        }
+        return _with_extensions(result, self.extensions)
+
+
+def canonical_policy_document_bytes(document: GuardPolicyDocument) -> bytes:
+    """Return RFC 8785-compatible JSON for the contract's integer-only number subset."""
+
+    return _canonical_json_text(document.to_mapping()).encode("utf-8")
+
+
+def policy_document_digest(document: GuardPolicyDocument) -> str:
+    return hashlib.sha256(canonical_policy_document_bytes(document)).hexdigest()
+
+
+def validate_effective_rule_ids(documents: tuple[GuardPolicyDocument, ...]) -> None:
+    """Reject duplicate rule IDs across an explicitly assembled effective set."""
+
+    seen: set[str] = set()
+    for document in documents:
+        for rule in document.rules:
+            if rule.id in seen:
+                raise ValueError("duplicate_effective_rule_id")
+            seen.add(rule.id)

--- a/src/codex_plugin_scanner/guard/policy_document_yaml.py
+++ b/src/codex_plugin_scanner/guard/policy_document_yaml.py
@@ -1,0 +1,487 @@
+"""Strict YAML 1.2 parsing and deterministic formatting for GuardPolicy documents."""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from functools import lru_cache
+from importlib import resources
+from pathlib import Path
+from typing import TypeAlias
+
+import yaml
+from jsonschema import Draft202012Validator
+from yaml.nodes import MappingNode, Node, SequenceNode
+from yaml.tokens import (
+    AliasToken,
+    AnchorToken,
+    BlockEndToken,
+    BlockMappingStartToken,
+    BlockSequenceStartToken,
+    FlowMappingEndToken,
+    FlowMappingStartToken,
+    FlowSequenceEndToken,
+    FlowSequenceStartToken,
+    ScalarToken,
+    TagToken,
+)
+
+from .policy_document import GuardPolicyDocument
+
+MAX_POLICY_BYTES = 1_048_576
+MAX_POLICY_DEPTH = 32
+MAX_POLICY_RULES = 1_000
+MAX_COLLECTION_ITEMS = 256
+MAX_STRING_LENGTH = 4_096
+MAX_DIAGNOSTICS = 20
+
+JsonPath: TypeAlias = tuple[str | int, ...]
+
+_JSON_BOOL = re.compile(r"^(?:true|false)$")
+_JSON_NULL = re.compile(r"^null$")
+_JSON_INT = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
+_JSON_FLOAT = re.compile(r"^-?(?:(?:0|[1-9][0-9]*)\.[0-9]+|(?:0|[1-9][0-9]*)(?:\.[0-9]+)?[eE][+-]?[0-9]+)$")
+_AMBIGUOUS_STRING = re.compile(
+    r"^(?:null|true|false|yes|no|on|off|~|[-+]?\.(?:inf|nan)|[-+]?0[0-9]+|[-+]?[0-9]+(?::[0-9]+)+)$",
+    re.IGNORECASE,
+)
+_TIMESTAMP_LIKE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}(?:[Tt ]|$)")
+_SENSITIVE_KEY_NAMES = frozenset(
+    {
+        "apikey",
+        "authorization",
+        "authheader",
+        "credential",
+        "credentials",
+        "password",
+        "privatekey",
+        "rawcredential",
+        "secretvalue",
+        "token",
+        "accesstoken",
+        "refreshtoken",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDiagnostic:
+    code: str
+    path: JsonPath = ()
+    line: int | None = None
+    column: int | None = None
+
+
+class PolicyDocumentError(ValueError):
+    """Bounded policy diagnostics that never include policy values."""
+    diagnostics: tuple[PolicyDiagnostic, ...]
+
+    def __init__(self, diagnostics: tuple[PolicyDiagnostic, ...]):
+        self.diagnostics = diagnostics[:MAX_DIAGNOSTICS]
+        summary = "; ".join(
+            f"{item.code}@{_format_path(item.path)}:{item.line or 0}:{item.column or 0}"
+            for item in self.diagnostics
+        )
+        super().__init__((summary or "invalid_policy_document")[:4_096])
+
+
+def _format_path(path: JsonPath) -> str:
+    if not path:
+        return "$"
+    return "$" + "".join(
+        f"[{item}]"
+        if isinstance(item, int)
+        else f"[{json.dumps(item[:80], ensure_ascii=True)}]"
+        for item in path
+    )
+
+
+class _PolicyLoader(yaml.SafeLoader):
+    pass
+
+
+_PolicyLoader.yaml_implicit_resolvers = copy.deepcopy(yaml.SafeLoader.yaml_implicit_resolvers)
+for first_character, resolvers in tuple(_PolicyLoader.yaml_implicit_resolvers.items()):
+    _PolicyLoader.yaml_implicit_resolvers[first_character] = [
+        (tag, expression)
+        for tag, expression in resolvers
+        if tag
+        not in {
+            "tag:yaml.org,2002:bool",
+            "tag:yaml.org,2002:float",
+            "tag:yaml.org,2002:int",
+            "tag:yaml.org,2002:merge",
+            "tag:yaml.org,2002:null",
+            "tag:yaml.org,2002:timestamp",
+        }
+    ]
+
+_PolicyLoader.add_implicit_resolver("tag:yaml.org,2002:bool", _JSON_BOOL, list("tf"))
+_PolicyLoader.add_implicit_resolver("tag:yaml.org,2002:null", _JSON_NULL, ["n"])
+_PolicyLoader.add_implicit_resolver("tag:yaml.org,2002:int", _JSON_INT, list("-0123456789"))
+_PolicyLoader.add_implicit_resolver("tag:yaml.org,2002:float", _JSON_FLOAT, list("-0123456789"))
+
+
+def _construct_unique_mapping(loader: _PolicyLoader, node: MappingNode, deep: bool = False) -> dict[object, object]:
+    result: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key == "<<":
+            raise PolicyDocumentError(
+                (
+                    PolicyDiagnostic(
+                        "yaml_merge_key",
+                        line=key_node.start_mark.line + 1,
+                        column=key_node.start_mark.column + 1,
+                    ),
+                )
+            )
+        try:
+            duplicate = key in result
+        except TypeError as error:
+            raise PolicyDocumentError(
+                (
+                    PolicyDiagnostic(
+                        "yaml_unhashable_key",
+                        line=key_node.start_mark.line + 1,
+                        column=key_node.start_mark.column + 1,
+                    ),
+                )
+            ) from error
+        if duplicate:
+            raise PolicyDocumentError(
+                (
+                    PolicyDiagnostic(
+                        "yaml_duplicate_key",
+                        line=key_node.start_mark.line + 1,
+                        column=key_node.start_mark.column + 1,
+                    ),
+                )
+            )
+        result[key] = loader.construct_object(value_node, deep=deep)
+    return result
+
+
+_PolicyLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_unique_mapping)
+
+
+class _PolicyDumper(yaml.SafeDumper):
+    pass
+
+
+def _represent_policy_string(dumper: _PolicyDumper, value: str) -> yaml.ScalarNode:
+    style = None
+    if (
+        not value
+        or value != value.strip()
+        or _AMBIGUOUS_STRING.fullmatch(value)
+        or _TIMESTAMP_LIKE.match(value)
+        or "\n" in value
+    ):
+        style = "'"
+    return dumper.represent_scalar("tag:yaml.org,2002:str", value, style=style)
+
+
+_PolicyDumper.add_representer(str, _represent_policy_string)
+
+
+@lru_cache(maxsize=1)
+def _load_policy_document_schema() -> dict[str, object]:
+    schema_path = resources.files("codex_plugin_scanner.guard").joinpath("schemas").joinpath(
+        "guard-policy-v1alpha1.schema.json"
+    )
+    value = json.loads(schema_path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise RuntimeError("invalid_packaged_policy_schema")
+    Draft202012Validator.check_schema(value)
+    return value
+
+
+def policy_document_schema() -> dict[str, object]:
+    return copy.deepcopy(_load_policy_document_schema())
+
+
+@lru_cache(maxsize=1)
+def _policy_document_validator() -> Draft202012Validator:
+    return Draft202012Validator(_load_policy_document_schema())
+
+
+def _scan_restricted_tokens(text: str) -> None:
+    depth = 0
+    collection_starts = (
+        BlockMappingStartToken,
+        BlockSequenceStartToken,
+        FlowMappingStartToken,
+        FlowSequenceStartToken,
+    )
+    collection_ends = (BlockEndToken, FlowMappingEndToken, FlowSequenceEndToken)
+    try:
+        for token in yaml.scan(text, Loader=_PolicyLoader):
+            if isinstance(token, collection_starts):
+                depth += 1
+                if depth > MAX_POLICY_DEPTH + 1:
+                    raise PolicyDocumentError(
+                        (
+                            PolicyDiagnostic(
+                                "limit_depth",
+                                line=token.start_mark.line + 1,
+                                column=token.start_mark.column + 1,
+                            ),
+                        )
+                    )
+            elif isinstance(token, collection_ends):
+                depth = max(0, depth - 1)
+            elif isinstance(token, ScalarToken):
+                if len(token.value) > MAX_STRING_LENGTH:
+                    raise PolicyDocumentError(
+                        (
+                            PolicyDiagnostic(
+                                "limit_string",
+                                line=token.start_mark.line + 1,
+                                column=token.start_mark.column + 1,
+                            ),
+                        )
+                    )
+                if (
+                    token.style is None
+                    and _JSON_INT.fullmatch(token.value)
+                    and len(token.value.removeprefix("-")) > 16
+                ):
+                    raise PolicyDocumentError(
+                        (
+                            PolicyDiagnostic(
+                                "limit_integer",
+                                line=token.start_mark.line + 1,
+                                column=token.start_mark.column + 1,
+                            ),
+                        )
+                    )
+            if isinstance(token, AliasToken):
+                code = "yaml_alias"
+            elif isinstance(token, AnchorToken):
+                code = "yaml_anchor"
+            elif isinstance(token, TagToken):
+                code = "yaml_tag"
+            else:
+                continue
+            raise PolicyDocumentError(
+                (PolicyDiagnostic(code, line=token.start_mark.line + 1, column=token.start_mark.column + 1),)
+            )
+    except PolicyDocumentError:
+        raise
+    except (RecursionError, ValueError) as error:
+        raise PolicyDocumentError((PolicyDiagnostic("yaml_resource_limit"),)) from error
+    except yaml.YAMLError as error:
+        mark = getattr(error, "problem_mark", None)
+        raise PolicyDocumentError(
+            (
+                PolicyDiagnostic(
+                    "yaml_syntax",
+                    line=mark.line + 1 if mark is not None else None,
+                    column=mark.column + 1 if mark is not None else None,
+                ),
+            )
+        ) from error
+
+
+def _load_yaml(text: str) -> object:
+    _scan_restricted_tokens(text)
+    try:
+        documents = list(yaml.load_all(text, Loader=_PolicyLoader))
+    except PolicyDocumentError:
+        raise
+    except (RecursionError, ValueError) as error:
+        raise PolicyDocumentError((PolicyDiagnostic("yaml_resource_limit"),)) from error
+    except yaml.YAMLError as error:
+        mark = getattr(error, "problem_mark", None)
+        raise PolicyDocumentError(
+            (
+                PolicyDiagnostic(
+                    "yaml_syntax",
+                    line=mark.line + 1 if mark is not None else None,
+                    column=mark.column + 1 if mark is not None else None,
+                ),
+            )
+        ) from error
+    if len(documents) != 1:
+        raise PolicyDocumentError((PolicyDiagnostic("yaml_document_count"),))
+    return documents[0]
+
+
+def _contains_surrogate(value: str) -> bool:
+    return any(0xD800 <= ord(character) <= 0xDFFF for character in value)
+
+
+def _validate_bounds(value: object, path: JsonPath = (), depth: int = 0) -> None:
+    if depth > MAX_POLICY_DEPTH:
+        raise PolicyDocumentError((PolicyDiagnostic("limit_depth", path),))
+    if isinstance(value, str):
+        if _contains_surrogate(value):
+            raise PolicyDocumentError((PolicyDiagnostic("invalid_unicode", path),))
+        if len(value) > MAX_STRING_LENGTH:
+            raise PolicyDocumentError((PolicyDiagnostic("limit_string", path),))
+        return
+    if isinstance(value, float):
+        code = "non_finite_number" if not math.isfinite(value) else "unsupported_float"
+        raise PolicyDocumentError((PolicyDiagnostic(code, path),))
+    if isinstance(value, list):
+        limit = MAX_POLICY_RULES if path == ("spec", "rules") else MAX_COLLECTION_ITEMS
+        if len(value) > limit:
+            raise PolicyDocumentError((PolicyDiagnostic("limit_collection", path),))
+        for index, item in enumerate(value):
+            _validate_bounds(item, (*path, index), depth + 1)
+        return
+    if isinstance(value, dict):
+        if len(value) > MAX_COLLECTION_ITEMS:
+            raise PolicyDocumentError((PolicyDiagnostic("limit_collection", path),))
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise PolicyDocumentError((PolicyDiagnostic("mapping_key_type", path),))
+            if _contains_surrogate(key):
+                raise PolicyDocumentError((PolicyDiagnostic("invalid_unicode", (*path, key)),))
+            if len(key) > 128:
+                raise PolicyDocumentError((PolicyDiagnostic("limit_key", (*path, key)),))
+            normalized_key = re.sub(r"[^a-z0-9]", "", key.lower())
+            if normalized_key in _SENSITIVE_KEY_NAMES and not any(
+                isinstance(part, str) and part.startswith("x-") for part in path
+            ):
+                raise PolicyDocumentError((PolicyDiagnostic("forbidden_sensitive_field", (*path, key)),))
+            _validate_bounds(item, (*path, key), depth + 1)
+
+
+def _node_for_path(node: Node | None, path: JsonPath) -> Node | None:
+    current = node
+    for part in path:
+        if isinstance(part, int):
+            if not isinstance(current, SequenceNode) or part >= len(current.value):
+                return current
+            current = current.value[part]
+            continue
+        if not isinstance(current, MappingNode):
+            return current
+        selected: Node | None = None
+        for key_node, value_node in current.value:
+            if key_node.value == part:
+                selected = value_node
+                break
+        if selected is None:
+            return current
+        current = selected
+    return current
+
+
+def _schema_diagnostics(text: str, value: object) -> tuple[PolicyDiagnostic, ...]:
+    try:
+        source_node = yaml.compose(text, Loader=_PolicyLoader)
+    except yaml.YAMLError:
+        source_node = None
+    diagnostics: list[PolicyDiagnostic] = []
+    errors = sorted(
+        _policy_document_validator().iter_errors(value),
+        key=lambda item: tuple(str(part) for part in item.path),
+    )
+    for error in errors[:MAX_DIAGNOSTICS]:
+        path: JsonPath = tuple(error.absolute_path)
+        node = _node_for_path(source_node, path)
+        diagnostics.append(
+            PolicyDiagnostic(
+                f"schema_{error.validator}",
+                path,
+                line=node.start_mark.line + 1 if node is not None else None,
+                column=node.start_mark.column + 1 if node is not None else None,
+            )
+        )
+    return tuple(diagnostics)
+
+
+def _validate_rule_ids(value: dict[str, object]) -> None:
+    spec = value.get("spec")
+    if not isinstance(spec, dict):
+        return
+    rules = spec.get("rules")
+    if not isinstance(rules, list):
+        return
+    seen: set[str] = set()
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            continue
+        rule_id = rule.get("id")
+        if not isinstance(rule_id, str):
+            continue
+        if rule_id in seen:
+            raise PolicyDocumentError((PolicyDiagnostic("duplicate_rule_id", ("spec", "rules", index, "id")),))
+        seen.add(rule_id)
+
+
+def _validate_timestamps(value: dict[str, object]) -> None:
+    spec = value.get("spec")
+    if not isinstance(spec, dict):
+        return
+    rules = spec.get("rules")
+    if not isinstance(rules, list):
+        return
+    timestamp_paths: list[tuple[JsonPath, object]] = []
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            continue
+        lifetime = rule.get("lifetime")
+        provenance = rule.get("provenance")
+        if isinstance(lifetime, dict) and lifetime.get("expiresAt") is not None:
+            timestamp_paths.append((("spec", "rules", index, "lifetime", "expiresAt"), lifetime.get("expiresAt")))
+        if isinstance(provenance, dict):
+            timestamp_paths.append((("spec", "rules", index, "provenance", "createdAt"), provenance.get("createdAt")))
+    for path, timestamp in timestamp_paths:
+        if not isinstance(timestamp, str):
+            continue
+        try:
+            datetime.fromisoformat(timestamp.removesuffix("Z") + "+00:00")
+        except ValueError as error:
+            raise PolicyDocumentError((PolicyDiagnostic("invalid_timestamp", path),)) from error
+
+
+def parse_policy_document_yaml(source: str | bytes) -> GuardPolicyDocument:
+    """Parse and validate one strict GuardPolicy YAML document."""
+
+    try:
+        encoded = source.encode("utf-8") if isinstance(source, str) else source
+    except UnicodeEncodeError as error:
+        raise PolicyDocumentError((PolicyDiagnostic("invalid_utf8"),)) from error
+    if len(encoded) > MAX_POLICY_BYTES:
+        raise PolicyDocumentError((PolicyDiagnostic("limit_bytes"),))
+    try:
+        text = encoded.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise PolicyDocumentError((PolicyDiagnostic("invalid_utf8"),)) from error
+    value = _load_yaml(text)
+    _validate_bounds(value)
+    diagnostics = _schema_diagnostics(text, value)
+    if diagnostics:
+        raise PolicyDocumentError(diagnostics)
+    if not isinstance(value, dict):
+        raise PolicyDocumentError((PolicyDiagnostic("schema_type"),))
+    _validate_rule_ids(value)
+    _validate_timestamps(value)
+    return GuardPolicyDocument.from_mapping(value)
+
+
+def load_policy_document(path: Path) -> GuardPolicyDocument:
+    return parse_policy_document_yaml(path.read_bytes())
+
+
+def format_policy_document_yaml(document: GuardPolicyDocument) -> str:
+    """Render stable, human-readable YAML that round-trips through the strict parser."""
+
+    return yaml.dump(
+        document.to_mapping(),
+        Dumper=_PolicyDumper,
+        allow_unicode=True,
+        default_flow_style=False,
+        explicit_end=False,
+        explicit_start=False,
+        sort_keys=False,
+        width=100,
+    )

--- a/src/codex_plugin_scanner/guard/schemas/guard-policy-v1alpha1.schema.json
+++ b/src/codex_plugin_scanner/guard/schemas/guard-policy-v1alpha1.schema.json
@@ -1,0 +1,533 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://guard.hashgraphonline.com/schema/policy/v1alpha1",
+  "title": "GuardPolicy v1alpha1",
+  "description": "Canonical, portable HOL Guard policy document.",
+  "type": "object",
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "const": "guard.hashgraphonline.com/v1alpha1"
+    },
+    "kind": {
+      "const": "GuardPolicy"
+    },
+    "metadata": {
+      "$ref": "#/$defs/metadata"
+    },
+    "spec": {
+      "$ref": "#/$defs/spec"
+    }
+  },
+  "patternProperties": {
+    "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+      "$ref": "#/$defs/extensionValue"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+    },
+    "boundedString": {
+      "type": "string",
+      "maxLength": 4096
+    },
+    "utcTimestamp": {
+      "type": "string",
+      "maxLength": 32,
+      "pattern": "^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]{1,9})?Z$"
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "revision"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "revision": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 2147483647
+        },
+        "labels": {
+          "type": "object",
+          "maxProperties": 64,
+          "propertyNames": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64
+          },
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 256
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+          "$ref": "#/$defs/extensionValue"
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "type": "object",
+      "required": [
+        "defaults",
+        "rules"
+      ],
+      "properties": {
+        "defaults": {
+          "$ref": "#/$defs/defaults"
+        },
+        "rolloutState": {
+          "enum": [
+            "draft",
+            "simulated",
+            "pending_approval",
+            "enforcing",
+            "enforced",
+            "rollback_available"
+          ]
+        },
+        "rules": {
+          "type": "array",
+          "maxItems": 1000,
+          "items": {
+            "$ref": "#/$defs/rule"
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+          "$ref": "#/$defs/extensionValue"
+        }
+      },
+      "additionalProperties": false
+    },
+    "defaults": {
+      "type": "object",
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "mode": {
+          "enum": [
+            "observe",
+            "prompt",
+            "enforce"
+          ]
+        },
+        "defaultAction": {
+          "enum": [
+            "allow",
+            "warn",
+            "block"
+          ]
+        },
+        "unknownPublisherAction": {
+          "enum": [
+            "allow",
+            "review",
+            "block"
+          ]
+        },
+        "changedHashAction": {
+          "enum": [
+            "allow",
+            "warn",
+            "require-reapproval",
+            "block"
+          ]
+        },
+        "newNetworkDomainAction": {
+          "enum": [
+            "allow",
+            "warn",
+            "block"
+          ]
+        },
+        "subprocessAction": {
+          "enum": [
+            "allow",
+            "warn",
+            "block"
+          ]
+        },
+        "telemetryEnabled": {
+          "type": "boolean"
+        },
+        "syncEnabled": {
+          "type": "boolean"
+        }
+      },
+      "patternProperties": {
+        "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+          "$ref": "#/$defs/extensionValue"
+        }
+      },
+      "additionalProperties": false
+    },
+    "stringSet": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 256,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 512
+      }
+    },
+    "match": {
+      "type": "object",
+      "properties": {
+        "operations": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "actors": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "agents": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "artifacts": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "commands": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "devices": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "domains": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "ecosystems": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "environments": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "harnesses": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "locations": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "mcps": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "packages": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "paths": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "publishers": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "repositories": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "secretTypes": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "skills": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "tools": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "workspaces": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "browserIntents": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "browser.navigation",
+              "browser.inspect",
+              "browser.interact",
+              "browser.transfer",
+              "browser.privileged"
+            ]
+          }
+        },
+        "browserOperations": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "browserProfiles": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "isolated",
+              "dedicated",
+              "shared",
+              "remote-debugging",
+              "unknown"
+            ]
+          }
+        },
+        "origins": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "pathPrefixes": {
+          "$ref": "#/$defs/stringSet"
+        },
+        "sensitiveSurfaces": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "cookies",
+              "storage",
+              "auth-headers",
+              "raw-cdp",
+              "script-eval",
+              "network-intercept",
+              "upload",
+              "download",
+              "clipboard",
+              "password-fields"
+            ]
+          }
+        }
+      },
+      "patternProperties": {
+        "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+          "$ref": "#/$defs/extensionValue"
+        }
+      },
+      "additionalProperties": false
+    },
+    "lifetime": {
+      "type": "object",
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "mode": {
+          "enum": [
+            "once",
+            "session",
+            "project",
+            "machine",
+            "workspace",
+            "team",
+            "permanent",
+            "until"
+          ]
+        },
+        "expiresAt": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/utcTimestamp"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "patternProperties": {
+        "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+          "$ref": "#/$defs/extensionValue"
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "mode": {
+                "const": "until"
+              }
+            },
+            "required": [
+              "mode"
+            ]
+          },
+          "then": {
+            "required": [
+              "expiresAt"
+            ],
+            "properties": {
+              "expiresAt": {
+                "$ref": "#/$defs/utcTimestamp"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "expiresAt": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "provenance": {
+      "type": "object",
+      "required": [
+        "source",
+        "createdAt"
+      ],
+      "properties": {
+        "source": {
+          "enum": [
+            "suggested-memory",
+            "review-decision",
+            "builder",
+            "import",
+            "legacy",
+            "cloud",
+            "local",
+            "policy-bundle"
+          ]
+        },
+        "receiptIds": {
+          "type": "array",
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/identifier"
+          }
+        },
+        "suggestionId": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/identifier"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "createdAt": {
+          "$ref": "#/$defs/utcTimestamp"
+        },
+        "createdBy": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      },
+      "patternProperties": {
+        "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+          "$ref": "#/$defs/extensionValue"
+        }
+      },
+      "additionalProperties": false
+    },
+    "rule": {
+      "type": "object",
+      "required": [
+        "id",
+        "enabled",
+        "effect",
+        "match",
+        "lifetime",
+        "provenance"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/identifier"
+        },
+        "description": {
+          "$ref": "#/$defs/boundedString"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "effect": {
+          "enum": [
+            "allow",
+            "block",
+            "review",
+            "ignore"
+          ]
+        },
+        "match": {
+          "$ref": "#/$defs/match"
+        },
+        "lifetime": {
+          "$ref": "#/$defs/lifetime"
+        },
+        "provenance": {
+          "$ref": "#/$defs/provenance"
+        }
+      },
+      "patternProperties": {
+        "^x-[a-z0-9][a-z0-9.-]{0,62}$": {
+          "$ref": "#/$defs/extensionValue"
+        }
+      },
+      "additionalProperties": false
+    },
+    "extensionValue": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
+        },
+        {
+          "type": "string",
+          "maxLength": 4096
+        },
+        {
+          "type": "array",
+          "maxItems": 256,
+          "items": {
+            "$ref": "#/$defs/extensionValue"
+          }
+        },
+        {
+          "type": "object",
+          "maxProperties": 256,
+          "propertyNames": {
+            "type": "string",
+            "maxLength": 128
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/extensionValue"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_policy_document_yaml.py
+++ b/tests/test_policy_document_yaml.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from importlib import resources
+from pathlib import Path
+
+import pytest
+import yaml
+
+from codex_plugin_scanner.guard.policy_bundle_parser import (
+    canonical_policy_bundle_payload,
+    computed_policy_bundle_hash,
+    payload_hash_for_policy_bundle,
+)
+from codex_plugin_scanner.guard.policy_document import (
+    canonical_policy_document_bytes,
+    policy_document_digest,
+    validate_effective_rule_ids,
+)
+from codex_plugin_scanner.guard.policy_document_yaml import (
+    MAX_POLICY_BYTES,
+    PolicyDocumentError,
+    format_policy_document_yaml,
+    parse_policy_document_yaml,
+    policy_document_schema,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = ROOT / "spec" / "guard-policy" / "v1alpha1"
+FIXTURES = SPEC / "fixtures"
+
+
+def _basic_mapping() -> dict[str, object]:
+    document = parse_policy_document_yaml((FIXTURES / "valid" / "basic.yaml").read_bytes())
+    return json.loads(canonical_policy_document_bytes(document))
+
+
+def _yaml(value: dict[str, object]) -> str:
+    return yaml.safe_dump(value, allow_unicode=True, sort_keys=False)
+
+
+def test_normative_and_packaged_schema_are_identical() -> None:
+    normative = (SPEC / "schema.json").read_bytes()
+    packaged = (
+        resources.files("codex_plugin_scanner.guard")
+        .joinpath("schemas")
+        .joinpath("guard-policy-v1alpha1.schema.json")
+        .read_bytes()
+    )
+
+    assert packaged == normative
+    assert policy_document_schema()["$id"] == "https://guard.hashgraphonline.com/schema/policy/v1alpha1"
+
+    mutable_copy = policy_document_schema()
+    mutable_copy.clear()
+    assert policy_document_schema()["$id"] == "https://guard.hashgraphonline.com/schema/policy/v1alpha1"
+
+
+def test_valid_conformance_fixtures_are_stable() -> None:
+    manifest = json.loads((FIXTURES / "manifest.json").read_text(encoding="utf-8"))
+
+    for relative_path in manifest["valid"]:
+        document = parse_policy_document_yaml((FIXTURES / relative_path).read_bytes())
+        formatted = format_policy_document_yaml(document)
+        reparsed = parse_policy_document_yaml(formatted)
+
+        assert reparsed == document
+        assert format_policy_document_yaml(reparsed) == formatted
+        assert canonical_policy_document_bytes(reparsed) == canonical_policy_document_bytes(document)
+        assert policy_document_digest(reparsed) == policy_document_digest(document)
+
+
+def test_yaml_11_ambiguous_scalars_remain_strings() -> None:
+    document = parse_policy_document_yaml((FIXTURES / "valid" / "extensions-and-scalars.yaml").read_bytes())
+
+    labels = dict(document.metadata.labels)
+    assert labels == {
+        "infinity": ".inf",
+        "leading-zero": "0123",
+        "no-value": "no",
+        "not-a-number": ".nan",
+        "off-value": "off",
+        "on-value": "on",
+        "sexagesimal": "12:34:56",
+        "tilde-value": "~",
+        "timestamp-text": "2026-07-15",
+        "yes-value": "yes",
+    }
+
+
+def test_invalid_conformance_fixtures_have_bounded_codes() -> None:
+    manifest = json.loads((FIXTURES / "manifest.json").read_text(encoding="utf-8"))
+
+    for relative_path, expected_code in manifest["invalid"].items():
+        source = (FIXTURES / relative_path).read_bytes()
+        with pytest.raises(PolicyDocumentError) as error:
+            parse_policy_document_yaml(source)
+
+        assert error.value.diagnostics[0].code == expected_code
+        assert len(error.value.diagnostics) <= 20
+        assert "redacted-fixture-value" not in str(error.value)
+
+
+def test_extensions_are_preserved_and_signed() -> None:
+    source = (FIXTURES / "valid" / "extensions-and-scalars.yaml").read_bytes()
+    document = parse_policy_document_yaml(source)
+    changed = replace(document, extensions=(("x-document-note", '"changed"'),))
+
+    assert "x-document-note" in document.to_mapping()
+    assert policy_document_digest(changed) != policy_document_digest(document)
+
+
+def test_duplicate_rule_ids_fail_across_explicit_document_set() -> None:
+    document = parse_policy_document_yaml((FIXTURES / "valid" / "basic.yaml").read_bytes())
+
+    with pytest.raises(ValueError, match="duplicate_effective_rule_id"):
+        validate_effective_rule_ids((document, document))
+
+
+def test_canonical_hash_vector_is_cross_language_stable() -> None:
+    vector = json.loads((FIXTURES / "hashes" / "basic.json").read_text(encoding="utf-8"))
+    document = parse_policy_document_yaml((FIXTURES / "valid" / "basic.yaml").read_bytes())
+
+    assert canonical_policy_document_bytes(document).decode("utf-8") == vector["canonicalJson"]
+    assert policy_document_digest(document) == vector["sha256"]
+
+
+def test_legacy_bundle_v1_hash_projection_is_unchanged() -> None:
+    vector = json.loads((FIXTURES / "hashes" / "legacy-bundle-v1.json").read_text(encoding="utf-8"))
+    payload = vector["payload"]
+
+    assert computed_policy_bundle_hash(payload) == vector["bundleHash"]
+    assert payload_hash_for_policy_bundle(payload) == vector["payloadHash"]
+    assert canonical_policy_bundle_payload(payload).decode("utf-8") == vector["canonicalSigningPayload"]
+
+
+def test_precedence_vectors_cover_required_collision_families() -> None:
+    fixture = json.loads((FIXTURES / "decisions" / "precedence.json").read_text(encoding="utf-8"))
+    names = {vector["name"] for vector in fixture["vectors"]}
+
+    assert names == {
+        "eligible local once beats persisted",
+        "exact artifact beats newer global",
+        "expired exact row is excluded",
+        "newer local wins equal specificity",
+        "newer remote wins equal specificity",
+    }
+
+
+def test_encoded_size_limit_runs_before_yaml_parsing() -> None:
+    with pytest.raises(PolicyDocumentError) as error:
+        parse_policy_document_yaml(b"x" * (MAX_POLICY_BYTES + 1))
+
+    assert error.value.diagnostics == (error.value.diagnostics[0],)
+    assert error.value.diagnostics[0].code == "limit_bytes"
+
+
+@pytest.mark.parametrize(
+    ("test_case", "expected_code"),
+    (
+        ("depth", "limit_depth"),
+        ("rules", "limit_collection"),
+        ("matcher-values", "limit_collection"),
+        ("string", "limit_string"),
+        ("float", "unsupported_float"),
+        ("expression", "schema_additionalProperties"),
+    ),
+)
+def test_structural_limits_and_expression_fields_fail(test_case: str, expected_code: str) -> None:
+    value = _basic_mapping()
+    spec = value["spec"]
+    assert isinstance(spec, dict)
+    rules = spec["rules"]
+    assert isinstance(rules, list)
+    rule = rules[0]
+    assert isinstance(rule, dict)
+
+    if test_case == "depth":
+        nested: object = "leaf"
+        for _ in range(34):
+            nested = [nested]
+        value["x-deep"] = nested
+    elif test_case == "rules":
+        spec["rules"] = [json.loads(json.dumps(rule)) for _ in range(1_001)]
+    elif test_case == "matcher-values":
+        match = rule["match"]
+        assert isinstance(match, dict)
+        match["packages"] = [f"package-{index}" for index in range(257)]
+    elif test_case == "string":
+        value["x-long"] = "x" * 4_097
+    elif test_case == "float":
+        value["x-float"] = 1.5
+    else:
+        match = rule["match"]
+        assert isinstance(match, dict)
+        match["expression"] = "artifact.startsWith('pkg:')"
+
+    with pytest.raises(PolicyDocumentError) as error:
+        parse_policy_document_yaml(_yaml(value))
+
+    assert error.value.diagnostics[0].code == expected_code
+
+
+def test_multiple_yaml_documents_fail() -> None:
+    source = (FIXTURES / "valid" / "basic.yaml").read_text(encoding="utf-8")
+
+    with pytest.raises(PolicyDocumentError) as error:
+        parse_policy_document_yaml(f"{source}---\n{source}")
+
+    assert error.value.diagnostics[0].code == "yaml_document_count"
+
+
+def test_diagnostic_does_not_echo_unknown_value() -> None:
+    source = """apiVersion: guard.hashgraphonline.com/v1alpha1
+kind: GuardPolicy
+metadata:
+  id: policy.invalid
+  name: Invalid
+  revision: 1
+spec:
+  defaults:
+    mode: prompt
+    unknown: do-not-log-this
+  rules: []
+"""
+
+    with pytest.raises(PolicyDocumentError) as error:
+        parse_policy_document_yaml(source)
+
+    assert "do-not-log-this" not in str(error.value)
+    assert error.value.diagnostics[0].line is not None
+    assert error.value.diagnostics[0].column is not None
+
+
+def test_extension_objects_may_use_sensitive_looking_keys_without_secret_values() -> None:
+    value = _basic_mapping()
+    value["x-vendor"] = {
+        "authorization": False,
+        "credentials": None,
+        "token": "disabled",
+    }
+
+    document = parse_policy_document_yaml(_yaml(value))
+
+    assert document.to_mapping()["x-vendor"] == value["x-vendor"]
+
+
+def test_deep_yaml_and_huge_integers_return_bounded_diagnostics() -> None:
+    basic = _yaml(_basic_mapping())
+    deep = f"{basic}\nx-deep: {'[' * 40}null{']' * 40}\n"
+    huge_integer = f"{basic}\nx-integer: {'9' * 10_000}\n"
+
+    for source in (deep, huge_integer):
+        with pytest.raises(PolicyDocumentError) as error:
+            parse_policy_document_yaml(source)
+
+        assert len(str(error.value)) <= 4_096
+        assert error.value.diagnostics[0].code.startswith("limit_")
+
+
+def test_unpaired_surrogate_returns_invalid_utf8() -> None:
+    with pytest.raises(PolicyDocumentError) as error:
+        parse_policy_document_yaml("\ud800")
+
+    assert error.value.diagnostics[0].code == "invalid_utf8"
+
+
+def test_diagnostic_paths_escape_attacker_controlled_mapping_keys() -> None:
+    value = _basic_mapping()
+    value["line\nbreak"] = True
+
+    with pytest.raises(PolicyDocumentError) as error:
+        parse_policy_document_yaml(_yaml(value))
+
+    assert "line\nbreak" not in str(error.value)
+    assert len(str(error.value)) <= 4_096
+
+
+def test_extension_integers_are_limited_to_cross_language_safe_range() -> None:
+    value = _basic_mapping()
+    value["x-integer"] = 9_007_199_254_740_992
+
+    with pytest.raises(PolicyDocumentError) as error:
+        parse_policy_document_yaml(_yaml(value))
+
+    assert error.value.diagnostics[0].code == "schema_oneOf"
+
+
+def test_quoted_digit_string_is_not_treated_as_an_integer_limit() -> None:
+    source = _yaml(_basic_mapping()) + 'x-string: "12345678901234567"\n'
+
+    document = parse_policy_document_yaml(source)
+
+    assert document.to_mapping()["x-string"] == "12345678901234567"
+
+
+def test_yaml_escaped_surrogate_is_rejected_before_canonicalization() -> None:
+    source = _yaml(_basic_mapping()) + 'x-bad: "\\uD800"\n'
+
+    with pytest.raises(PolicyDocumentError) as error:
+        parse_policy_document_yaml(source)
+
+    assert error.value.diagnostics[0].code == "invalid_unicode"
+
+
+def test_canonical_object_keys_use_utf16_order() -> None:
+    value = _basic_mapping()
+    value["x-sort"] = {"\ue000": "bmp", "😀": "astral"}
+
+    canonical = canonical_policy_document_bytes(
+        parse_policy_document_yaml(_yaml(value))
+    ).decode("utf-8")
+
+    assert canonical.index('"😀"') < canonical.index('"\ue000"')

--- a/uv.lock
+++ b/uv.lock
@@ -1176,9 +1176,11 @@ source = { editable = "." }
 dependencies = [
     { name = "cisco-ai-skill-scanner" },
     { name = "cryptography" },
+    { name = "jsonschema" },
     { name = "keyring" },
     { name = "mcp" },
     { name = "packaging" },
+    { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -1191,10 +1193,8 @@ cisco = [
 dev = [
     { name = "basedpyright" },
     { name = "build" },
-    { name = "jsonschema" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pyyaml" },
     { name = "ruff" },
 ]
 mdm-build = [
@@ -1215,7 +1215,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "cisco-ai-skill-scanner", marker = "python_full_version < '3.14'", specifier = "~=2.0.11" },
     { name = "cryptography", specifier = ">=49.0.0" },
-    { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.26.0" },
+    { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "keyring", specifier = ">=25.0" },
     { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'cisco'", specifier = "==1.91.3" },
     { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.27.0,<2" },
@@ -1223,7 +1223,7 @@ requires-dist = [
     { name = "pyinstaller", marker = "extra == 'mdm-build'", specifier = ">=6.16,<7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
-    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.3" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "requests", specifier = ">=2.32,<3" },
     { name = "rich", specifier = ">=14.0,<15" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.15" },


### PR DESCRIPTION
## Summary
- define the `guard.hashgraphonline.com/v1alpha1` Guard Policy JSON Schema and semantic contract
- add strict bounded YAML parsing, deterministic RFC 8785-compatible canonicalization, and SHA-256 digests
- package the schema with the Python distribution and freeze valid, invalid, precedence, and legacy hash fixtures

## Verification
- `uv run pytest -q tests/test_policy_document_yaml.py tests/test_policy.py tests/test_policy_bundle_parser.py tests/test_policy_decision_source_context.py tests/test_sync_repo_version.py tests/test_guard_store_migrations.py tests/test_guard_evidence_store.py tests/test_guard_approval_store_dedup.py tests/test_guard_approval_store_phase14.py tests/test_guard_approval_store_scale.py` (231 passed)
- `uv run ruff check src/codex_plugin_scanner/guard/policy_document.py src/codex_plugin_scanner/guard/policy_document_yaml.py tests/test_policy_document_yaml.py`
- `uv run --extra dev basedpyright src/codex_plugin_scanner/guard/policy_document.py src/codex_plugin_scanner/guard/policy_document_yaml.py` (warnings only)
- `uv build`