### PR TITLE
feat(policy): add canonical YAML CLI

### DIFF
--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -259,6 +259,7 @@ def _resolve_legacy_args(
         "allow",
         "deny",
         "policies",
+        "policy",
         "trust",
         "settings",
         "exceptions",

--- a/src/codex_plugin_scanner/guard/approval_gate.py
+++ b/src/codex_plugin_scanner/guard/approval_gate.py
@@ -68,6 +68,8 @@ ApprovalGatePurpose = Literal[
     "approval_decision",
     "policy_write",
     "policy_clear",
+    "policy_import",
+    "policy_export_provenance",
     "queue_clear",
     "settings_write",
     "native_policy",

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_policy_document.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_policy_document.py
@@ -1,0 +1,258 @@
+"""Canonical Guard policy document CLI commands."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from argparse import Namespace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TextIO, cast
+
+from ..approval_gate import ApprovalGateError, require_high_risk
+from ..policy_document import policy_document_digest
+from ..policy_document_io import (
+    PolicyCompilationError,
+    PolicyFileTrustError,
+    build_policy_document_from_rows,
+    compile_policy_document,
+    diff_policy_documents,
+    load_trusted_policy_document,
+    read_trusted_policy_text,
+    write_private_policy_text,
+)
+from ..policy_document_yaml import PolicyDocumentError, format_policy_document_yaml
+from ..store import GuardStore
+from ..store_policy_document import PolicyImportMode
+from .approval_gate_prompt import prompt_for_approval_gate
+
+_POLICY_IMPORT_FLAG = "HOL_GUARD_POLICY_YAML_IMPORT"
+
+
+def _write_payload(
+    command: str,
+    payload: dict[str, object],
+    *,
+    as_json: bool,
+    output_stream: TextIO | None,
+) -> None:
+    stream = output_stream or sys.stdout
+    if as_json:
+        stream.write(json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n")
+        return
+    summary = payload.get("message")
+    stream.write(f"{summary if isinstance(summary, str) else command}\n")
+
+
+def _write_document(text: str, output_stream: TextIO | None) -> None:
+    stream = output_stream or sys.stdout
+    stream.write(text)
+    if not text.endswith("\n"):
+        stream.write("\n")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _load_and_compile(path: Path):
+    document = load_trusted_policy_document(path)
+    return document, compile_policy_document(document)
+
+
+def _run_guard_policy_document_command(
+    args: Namespace,
+    *,
+    store: GuardStore | None = None,
+    output_stream: TextIO | None = None,
+    **_kwargs: object,
+) -> int:
+    command = str(args.policy_command)
+    as_json = bool(getattr(args, "json", False))
+    try:
+        if command == "validate":
+            document, compiled = _load_and_compile(Path(args.file))
+            _write_payload(
+                "policy validate",
+                {
+                    "valid": True,
+                    "document_id": document.metadata.id,
+                    "digest": policy_document_digest(document),
+                    "compiled_rows": len(compiled),
+                    "message": f"Valid Guard policy: {document.metadata.id} ({len(compiled)} rows)",
+                },
+                as_json=as_json,
+                output_stream=output_stream,
+            )
+            return 0
+
+        if command == "fmt":
+            path = Path(args.file)
+            original = read_trusted_policy_text(path)
+            document, _compiled = _load_and_compile(path)
+            formatted = format_policy_document_yaml(document)
+            changed = original != formatted
+            if bool(args.check):
+                _write_payload(
+                    "policy fmt",
+                    {
+                        "changed": changed,
+                        "message": "Policy formatting differs." if changed else "Policy is canonically formatted.",
+                    },
+                    as_json=as_json,
+                    output_stream=output_stream,
+                )
+                return 1 if changed else 0
+            write_private_policy_text(path, formatted)
+            _write_payload(
+                "policy fmt",
+                {"changed": changed, "message": "Policy formatted canonically."},
+                as_json=as_json,
+                output_stream=output_stream,
+            )
+            return 0
+
+        if store is None:
+            raise RuntimeError("Guard policy command requires a policy store.")
+
+        if command == "diff":
+            candidate, _ = _load_and_compile(Path(args.file))
+            base = build_policy_document_from_rows(store.list_policy_decisions(), include_provenance=True)
+            difference = diff_policy_documents(base, candidate)
+            if as_json:
+                _write_payload(
+                    "policy diff",
+                    {"changed": difference.changed, "diff": difference.text},
+                    as_json=True,
+                    output_stream=output_stream,
+                )
+            else:
+                _write_document(difference.text or "No policy changes.", output_stream)
+            return 1 if difference.changed else 0
+
+        if command == "export":
+            include_provenance = bool(args.include_provenance)
+            if include_provenance:
+                gate_input = prompt_for_approval_gate(store.guard_home, use_cooldown=False)
+                require_high_risk(
+                    store.guard_home,
+                    purpose="policy_export_provenance",
+                    approval_gate_input=gate_input,
+                )
+            rows = store.list_policy_decisions()
+            document = build_policy_document_from_rows(rows, include_provenance=include_provenance)
+            formatted = format_policy_document_yaml(document)
+            output_value = getattr(args, "output", None)
+            payload: dict[str, object] = {
+                "rules": len(document.rules),
+                "digest": policy_document_digest(document),
+                "include_provenance": include_provenance,
+            }
+            if output_value is None:
+                if as_json:
+                    payload["yaml"] = formatted
+                    payload["message"] = f"Exported {len(document.rules)} policy rules."
+                    _write_payload(
+                        "policy export",
+                        payload,
+                        as_json=True,
+                        output_stream=output_stream,
+                    )
+                else:
+                    _write_document(formatted, output_stream)
+            else:
+                output = Path(output_value)
+                write_private_policy_text(output, formatted)
+                payload["written"] = str(output)
+                payload["message"] = f"Exported {len(document.rules)} policy rules."
+                _write_payload(
+                    "policy export",
+                    payload,
+                    as_json=as_json,
+                    output_stream=output_stream,
+                )
+            return 0
+
+        if command == "import":
+            if os.environ.get(_POLICY_IMPORT_FLAG) != "1":
+                _write_payload(
+                    "policy import",
+                    {
+                        "error": "policy_import_disabled",
+                        "message": f"Policy import requires {_POLICY_IMPORT_FLAG}=1.",
+                    },
+                    as_json=as_json,
+                    output_stream=output_stream,
+                )
+                return 4
+            document, compiled = _load_and_compile(Path(args.file))
+            mode = cast(PolicyImportMode, args.mode)
+            plan = store.plan_policy_document_import(compiled, mode=mode)
+            dry_run = bool(args.dry_run)
+            if dry_run:
+                _write_payload(
+                    "policy import",
+                    {
+                        "dry_run": True,
+                        "document_id": document.metadata.id,
+                        "digest": policy_document_digest(document),
+                        "compiled_rows": len(compiled),
+                        "additions": list(plan.additions),
+                        "replacements": list(plan.replacements),
+                        "removals": list(plan.removals),
+                        "message": (
+                            f"Dry run: {len(plan.additions)} additions, "
+                            f"{len(plan.replacements)} replacements, "
+                            f"{len(plan.removals)} removals; no changes written."
+                        ),
+                    },
+                    as_json=as_json,
+                    output_stream=output_stream,
+                )
+                return 0
+
+            gate_input = prompt_for_approval_gate(store.guard_home, use_cooldown=False)
+            grant = require_high_risk(
+                store.guard_home,
+                purpose="policy_import",
+                approval_gate_input=gate_input,
+            )
+            result = store.import_policy_document(
+                document,
+                compiled,
+                mode=mode,
+                now=_now(),
+                approval_gate_grant=grant,
+            )
+            _write_payload(
+                "policy import",
+                {
+                    "dry_run": False,
+                    "document_id": result.document_id,
+                    "digest": result.digest,
+                    "inserted": result.inserted,
+                    "replaced": result.replaced,
+                    "additions": list(plan.additions),
+                    "replacements": list(plan.replacements),
+                    "removals": list(plan.removals),
+                    "message": f"Imported {result.inserted} policy rows.",
+                },
+                as_json=as_json,
+                output_stream=output_stream,
+            )
+            return 0
+
+        raise ValueError("unknown_policy_document_command")
+    except (ApprovalGateError, PolicyCompilationError, PolicyDocumentError, PolicyFileTrustError) as error:
+        code = getattr(error, "code", error.__class__.__name__)
+        _write_payload(
+            f"policy {command}",
+            {"error": str(code), "message": str(error)},
+            as_json=as_json,
+            output_stream=output_stream,
+        )
+        return 4
+
+
+__all__ = ["_run_guard_policy_document_command"]

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
@@ -19,6 +19,48 @@ from .commands_parser_helpers import *
 def _configure_guard_policy_parsers(
     guard_subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
+    policy_parser = guard_subparsers.add_parser(
+        "policy",
+        help="Validate, format, diff, export, or import canonical Guard policy YAML",
+    )
+    policy_subparsers = policy_parser.add_subparsers(dest="policy_command", required=True)
+
+    policy_validate_parser = policy_subparsers.add_parser("validate", help="Validate a policy document")
+    policy_validate_parser.add_argument("file")
+    _add_guard_common_args(policy_validate_parser)
+    policy_validate_parser.add_argument("--json", action="store_true")
+
+    policy_fmt_parser = policy_subparsers.add_parser("fmt", help="Format a policy document canonically")
+    policy_fmt_parser.add_argument("file")
+    policy_fmt_parser.add_argument("--check", action="store_true")
+    _add_guard_common_args(policy_fmt_parser)
+    policy_fmt_parser.add_argument("--json", action="store_true")
+
+    policy_diff_parser = policy_subparsers.add_parser(
+        "diff", help="Diff a candidate document against active local policy"
+    )
+    policy_diff_parser.add_argument("file")
+    _add_guard_common_args(policy_diff_parser)
+    policy_diff_parser.add_argument("--json", action="store_true")
+
+    policy_export_parser = policy_subparsers.add_parser("export", help="Export local policies")
+    policy_export_parser.add_argument("--format", choices=("yaml",), default="yaml")
+    policy_export_parser.add_argument("--output")
+    policy_export_parser.add_argument("--include-provenance", action="store_true")
+    _add_guard_common_args(policy_export_parser)
+    policy_export_parser.add_argument("--json", action="store_true")
+
+    policy_import_parser = policy_subparsers.add_parser("import", help="Import a policy document")
+    policy_import_parser.add_argument("file")
+    import_mode = policy_import_parser.add_mutually_exclusive_group(required=True)
+    import_mode.add_argument("--merge", dest="mode", action="store_const", const="merge")
+    import_mode.add_argument("--replace", dest="mode", action="store_const", const="replace")
+    import_execution = policy_import_parser.add_mutually_exclusive_group()
+    import_execution.add_argument("--dry-run", dest="dry_run", action="store_true", default=True)
+    import_execution.add_argument("--apply", dest="dry_run", action="store_false")
+    _add_guard_common_args(policy_import_parser)
+    policy_import_parser.add_argument("--json", action="store_true")
+
     policies_parser = guard_subparsers.add_parser(
         "policies",
         help="List or clear remembered rules and synced Cloud policy rows",

--- a/src/codex_plugin_scanner/guard/cli/commands_router.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_router.py
@@ -53,6 +53,7 @@ _COMMON_HANDLERS = {
     "inventory": "_run_guard_inventory_command",
     "aibom": "_run_guard_aibom_command",
     "abom": "_run_guard_abom_command",
+    "policy": "_run_guard_policy_document_command",
     "policies": "_run_guard_policies_command",
     "trust": "_run_guard_trust_command",
     "settings": "_run_guard_settings_command",

--- a/src/codex_plugin_scanner/guard/cli/commands_support.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support.py
@@ -31,6 +31,7 @@ from . import commands_dispatch_local as _commands_dispatch_local
 from . import commands_dispatch_mdm as _commands_dispatch_mdm
 from . import commands_dispatch_proxy as _commands_dispatch_proxy
 from . import commands_dispatch_records as _commands_dispatch_records
+from . import commands_dispatch_policy_document as _commands_dispatch_policy_document
 from . import commands_dispatch_trust as _commands_dispatch_trust
 from . import commands_dispatch_admin as _commands_dispatch_admin
 from . import commands_dispatch_cloud as _commands_dispatch_cloud
@@ -66,6 +67,7 @@ _SOURCE_MODULES: tuple[ModuleType, ...] = (
     _commands_dispatch_mdm,
     _commands_dispatch_proxy,
     _commands_dispatch_records,
+    _commands_dispatch_policy_document,
     _commands_dispatch_trust,
     _commands_dispatch_admin,
     _commands_dispatch_cloud,

--- a/src/codex_plugin_scanner/guard/policy_document_io.py
+++ b/src/codex_plugin_scanner/guard/policy_document_io.py
@@ -1,0 +1,541 @@
+"""Trusted policy file I/O and local policy row adapters."""
+
+from __future__ import annotations
+
+import difflib
+import hashlib
+import itertools
+import json
+import os
+import re
+import secrets
+import stat
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, cast, final
+
+from .models import DecisionScope, GuardAction, PolicyDecision
+from .policy_document import GuardPolicyDocument
+from .policy_document_yaml import (
+    MAX_POLICY_BYTES,
+    format_policy_document_yaml,
+    parse_policy_document_yaml,
+)
+
+_POLICY_API_VERSION: Final = "guard.hashgraphonline.com/v1alpha1"
+_POLICY_KIND: Final = "GuardPolicy"
+_POLICY_IMPORT_SOURCE: Final = "policy-yaml-import"
+_POLICY_FILE_MODE: Final = 0o600
+_POLICY_DIRECTORY_MODE_MASK: Final = 0o022
+_MAX_COMPILED_ROWS: Final = 10_000
+_IDENTIFIER_RE: Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_UTC_TIMESTAMP_RE: Final = re.compile(
+    r"^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[01])T" + r"([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]{1,9})?Z$"
+)
+_REDACTED_TIMESTAMP: Final = "1970-01-01T00:00:00Z"
+_SUPPORTED_MATCH_KEYS: Final = frozenset({"artifacts", "harnesses", "publishers", "workspaces"})
+_LOCAL_SCOPES: Final = frozenset({"artifact", "workspace", "publisher", "harness", "global"})
+_PROVENANCE_SOURCES: Final = frozenset(
+    {
+        "suggested-memory",
+        "review-decision",
+        "builder",
+        "import",
+        "legacy",
+        "cloud",
+        "local",
+        "policy-bundle",
+    }
+)
+
+
+@final
+class PolicyFileTrustError(ValueError):
+    """Raised when a policy path cannot be trusted for local I/O."""
+
+    def __init__(self, code: str, path: Path) -> None:
+        self.code = code
+        self.path = path
+        super().__init__(code)
+
+
+@final
+class PolicyCompilationError(ValueError):
+    """Raised when a canonical rule cannot map to local PolicyDecision rows."""
+
+    def __init__(self, code: str, rule_id: str) -> None:
+        self.code = code
+        self.rule_id = rule_id
+        super().__init__(f"{code}: {rule_id}")
+
+
+@dataclass(frozen=True)
+class CompiledPolicyRow:
+    decision: PolicyDecision
+    rule_id: str
+    provenance_json: str
+
+
+@dataclass(frozen=True)
+class PolicyDocumentDiff:
+    changed: bool
+    text: str
+
+
+def _assert_trusted_parent_metadata(path: Path, metadata: os.stat_result) -> None:
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise PolicyFileTrustError("policy_parent_not_directory", path)
+    if metadata.st_uid != os.geteuid():
+        raise PolicyFileTrustError("policy_parent_not_owned", path)
+    if stat.S_IMODE(metadata.st_mode) & _POLICY_DIRECTORY_MODE_MASK:
+        raise PolicyFileTrustError("policy_parent_insecure_mode", path)
+
+
+def _open_trusted_parent(path: Path) -> int:
+    parent = path.parent
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor: int | None = None
+    try:
+        parts = parent.parts
+        if not parts:
+            raise OSError("policy parent has no path components")
+        descriptor = os.open(parts[0], flags)
+        for component in parts[1:]:
+            next_descriptor = os.open(component, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = next_descriptor
+        _assert_trusted_parent_metadata(parent, os.fstat(descriptor))
+        return descriptor
+    except PolicyFileTrustError:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise
+    except OSError as error:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise PolicyFileTrustError("policy_parent_unavailable", parent) from error
+
+
+def _assert_trusted_file_metadata(path: Path, metadata: os.stat_result) -> None:
+    if not stat.S_ISREG(metadata.st_mode):
+        raise PolicyFileTrustError("policy_file_not_regular", path)
+    if metadata.st_uid != os.geteuid():
+        raise PolicyFileTrustError("policy_file_not_owned", path)
+    if stat.S_IMODE(metadata.st_mode) & 0o022:
+        raise PolicyFileTrustError("policy_file_insecure_mode", path)
+    if metadata.st_nlink != 1:
+        raise PolicyFileTrustError("policy_file_link_count", path)
+
+
+def read_trusted_policy_bytes(path: Path, *, max_bytes: int = MAX_POLICY_BYTES) -> bytes:
+    """Read one bounded, owner-only regular file without following links."""
+
+    candidate = path.expanduser().absolute()
+    parent_descriptor = _open_trusted_parent(candidate)
+    try:
+        try:
+            before = os.stat(
+                candidate.name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+        except OSError as error:
+            raise PolicyFileTrustError("policy_file_unavailable", candidate) from error
+        _assert_trusted_file_metadata(candidate, before)
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(candidate.name, flags, dir_fd=parent_descriptor)
+        except OSError as error:
+            raise PolicyFileTrustError("policy_file_open_failed", candidate) from error
+        try:
+            opened = os.fstat(descriptor)
+            _assert_trusted_file_metadata(candidate, opened)
+            if (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino):
+                raise PolicyFileTrustError("policy_file_changed", candidate)
+            chunks: list[bytes] = []
+            remaining = max_bytes + 1
+            while remaining > 0:
+                chunk = os.read(descriptor, min(65_536, remaining))
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            payload = b"".join(chunks)
+            if len(payload) > max_bytes:
+                raise PolicyFileTrustError("policy_file_too_large", candidate)
+            return payload
+        finally:
+            os.close(descriptor)
+    finally:
+        os.close(parent_descriptor)
+
+
+def read_trusted_policy_text(path: Path, *, max_bytes: int = MAX_POLICY_BYTES) -> str:
+    payload = read_trusted_policy_bytes(path, max_bytes=max_bytes)
+    try:
+        return payload.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise PolicyFileTrustError("policy_file_not_utf8", path.expanduser().absolute()) from error
+
+
+def write_private_policy_text(path: Path, content: str) -> None:
+    """Atomically replace an owner-only policy file inside a private directory."""
+
+    candidate = path.expanduser().absolute()
+    payload = content.encode("utf-8")
+    if len(payload) > MAX_POLICY_BYTES:
+        raise PolicyFileTrustError("policy_output_too_large", candidate)
+    parent_descriptor = _open_trusted_parent(candidate)
+    temporary_name = f".{candidate.name}.{secrets.token_hex(12)}.tmp"
+    descriptor: int | None = None
+    try:
+        try:
+            existing = os.stat(
+                candidate.name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            existing = None
+        except OSError as error:
+            raise PolicyFileTrustError("policy_output_unavailable", candidate) from error
+        if existing is not None:
+            _assert_trusted_file_metadata(candidate, existing)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(
+            temporary_name,
+            flags,
+            _POLICY_FILE_MODE,
+            dir_fd=parent_descriptor,
+        )
+        os.fchmod(descriptor, _POLICY_FILE_MODE)
+        view = memoryview(payload)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("policy output write made no progress")
+            view = view[written:]
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
+        os.replace(
+            temporary_name,
+            candidate.name,
+            src_dir_fd=parent_descriptor,
+            dst_dir_fd=parent_descriptor,
+        )
+        os.fsync(parent_descriptor)
+    except PolicyFileTrustError:
+        raise
+    except OSError as error:
+        raise PolicyFileTrustError("policy_output_write_failed", candidate) from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        try:
+            os.unlink(temporary_name, dir_fd=parent_descriptor)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            pass
+        os.close(parent_descriptor)
+
+
+def load_trusted_policy_document(path: Path) -> GuardPolicyDocument:
+    return parse_policy_document_yaml(read_trusted_policy_text(path))
+
+
+def format_trusted_policy_file(source: Path, destination: Path) -> GuardPolicyDocument:
+    document = load_trusted_policy_document(source)
+    write_private_policy_text(destination, format_policy_document_yaml(document))
+    return document
+
+
+def diff_policy_documents(
+    baseline: GuardPolicyDocument,
+    candidate: GuardPolicyDocument,
+    *,
+    baseline_name: str = "baseline",
+    candidate_name: str = "candidate",
+) -> PolicyDocumentDiff:
+    baseline_text = format_policy_document_yaml(baseline)
+    candidate_text = format_policy_document_yaml(candidate)
+    lines = difflib.unified_diff(
+        baseline_text.splitlines(keepends=True),
+        candidate_text.splitlines(keepends=True),
+        fromfile=baseline_name,
+        tofile=candidate_name,
+    )
+    text = "".join(lines)
+    return PolicyDocumentDiff(changed=bool(text), text=text)
+
+
+def _normalized_timestamp(value: object) -> str:
+    if isinstance(value, str):
+        candidate = value.strip().replace("+00:00", "Z")
+        if _UTC_TIMESTAMP_RE.fullmatch(candidate):
+            return candidate
+    return "1970-01-01T00:00:00Z"
+
+
+def _normalized_expiry(value: object, *, rule_id: str, code: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise PolicyCompilationError(code, rule_id)
+    candidate = value.strip().replace("+00:00", "Z")
+    if not _UTC_TIMESTAMP_RE.fullmatch(candidate):
+        raise PolicyCompilationError(code, rule_id)
+    return candidate
+
+
+def _stable_rule_id(row: Mapping[str, object]) -> str:
+    policy_rule_id = row.get("policy_rule_id")
+    if isinstance(policy_rule_id, str) and _IDENTIFIER_RE.fullmatch(policy_rule_id):
+        return policy_rule_id
+    decision_id = row.get("decision_id")
+    if isinstance(decision_id, int) and not isinstance(decision_id, bool) and decision_id >= 0:
+        return f"local-{decision_id}"
+    encoded = json.dumps(dict(row), sort_keys=True, separators=(",", ":"), default=str).encode()
+    return f"local-{hashlib.sha256(encoded).hexdigest()[:24]}"
+
+
+def _provenance_source(value: object) -> str:
+    if isinstance(value, str) and value in _PROVENANCE_SOURCES:
+        return value
+    if value == "cloud-sync":
+        return "cloud"
+    return "local"
+
+
+def _optional_string(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _rule_match_from_row(row: Mapping[str, object], *, include_provenance: bool) -> dict[str, object]:
+    match: dict[str, object] = {}
+    artifact_id = _optional_string(row.get("artifact_id"))
+    harness = _optional_string(row.get("harness"))
+    publisher = _optional_string(row.get("publisher"))
+    workspace = _optional_string(row.get("workspace"))
+    if artifact_id is not None:
+        match["artifacts"] = [artifact_id]
+    if harness is not None and harness != "*":
+        match["harnesses"] = [harness]
+    if publisher is not None:
+        match["publishers"] = [publisher]
+    if include_provenance and workspace is not None:
+        match["workspaces"] = [workspace]
+    return match
+
+
+def _rule_from_policy_row(row: Mapping[str, object], *, include_provenance: bool) -> dict[str, object]:
+    rule_id = _stable_rule_id(row)
+    workspace = _optional_string(row.get("workspace"))
+    if workspace is not None and not include_provenance:
+        raise PolicyCompilationError("sensitive_local_policy_requires_provenance", rule_id)
+    action = row.get("action")
+    if action not in {"allow", "block"}:
+        raise PolicyCompilationError("unsupported_local_policy_action", rule_id)
+    expires_at = _normalized_expiry(
+        row.get("expires_at"),
+        rule_id=rule_id,
+        code="invalid_local_policy_expiry",
+    )
+    provenance: dict[str, object] = {
+        "source": _provenance_source(row.get("source")) if include_provenance else "export-redacted",
+        "createdAt": _normalized_timestamp(row.get("updated_at")) if include_provenance else _REDACTED_TIMESTAMP,
+    }
+    owner = _optional_string(row.get("owner"))
+    if include_provenance and owner is not None:
+        provenance["createdBy"] = owner[:256]
+    local_extension = {
+        "artifactHash": row.get("artifact_hash"),
+        "harness": row.get("harness"),
+        "publisher": row.get("publisher"),
+        "scope": row.get("scope"),
+    }
+    if include_provenance:
+        local_extension.update(
+            {
+                "owner": row.get("owner"),
+                "reason": row.get("reason"),
+                "source": row.get("source"),
+                "updatedAt": row.get("updated_at"),
+                "workspace": row.get("workspace"),
+            }
+        )
+    rule: dict[str, object] = {
+        "id": rule_id,
+        "enabled": True,
+        "effect": action,
+        "match": _rule_match_from_row(row, include_provenance=include_provenance),
+        "lifetime": {
+            "mode": "until" if expires_at is not None else "permanent",
+            "expiresAt": expires_at,
+        },
+        "provenance": provenance,
+        "x-hol-local": local_extension,
+    }
+    reason = _optional_string(row.get("reason"))
+    if include_provenance and reason is not None:
+        rule["description"] = reason[:4096]
+    return rule
+
+
+def _row_sort_decision_id(row: Mapping[str, object]) -> int:
+    value = row.get("decision_id")
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def build_policy_document_from_rows(
+    rows: Iterable[Mapping[str, object]],
+    *,
+    document_id: str = "local-policy",
+    name: str = "Local Guard policy",
+    revision: int = 0,
+    include_provenance: bool = False,
+) -> GuardPolicyDocument:
+    """Build a deterministic portable document from local policy rows."""
+
+    if not _IDENTIFIER_RE.fullmatch(document_id):
+        raise ValueError("policy_document_id_invalid")
+    ordered = sorted(
+        (dict(row) for row in rows),
+        key=lambda row: (
+            _row_sort_decision_id(row),
+            str(row.get("harness", "")),
+            str(row.get("scope", "")),
+            str(row.get("artifact_id", "")),
+            json.dumps(row, sort_keys=True, separators=(",", ":"), default=str),
+        ),
+    )
+    mapping: dict[str, object] = {
+        "apiVersion": _POLICY_API_VERSION,
+        "kind": _POLICY_KIND,
+        "metadata": {"id": document_id, "name": name[:256], "revision": revision},
+        "spec": {
+            "defaults": {"mode": "prompt"},
+            "rules": [_rule_from_policy_row(row, include_provenance=include_provenance) for row in ordered],
+        },
+    }
+    return GuardPolicyDocument.from_mapping(mapping)
+
+
+def _selector_values(match: Mapping[str, object], key: str) -> tuple[str | None, ...]:
+    value = match.get(key)
+    if value is None:
+        return (None,)
+    if not isinstance(value, list) or not value:
+        return (None,)
+    items = cast(list[object], value)
+    if not all(isinstance(item, str) for item in items):
+        return (None,)
+    return tuple(cast(list[str], items))
+
+
+def _local_scope(
+    extension: Mapping[str, object],
+    *,
+    artifact_id: str | None,
+    workspace: str | None,
+    publisher: str | None,
+    harness: str | None,
+) -> DecisionScope:
+    preferred = extension.get("scope")
+    if isinstance(preferred, str) and preferred in _LOCAL_SCOPES:
+        return cast(DecisionScope, preferred)
+    if artifact_id is not None:
+        return "artifact"
+    if workspace is not None:
+        return "workspace"
+    if publisher is not None:
+        return "publisher"
+    if harness is not None:
+        return "harness"
+    return "global"
+
+
+def compile_policy_document(document: GuardPolicyDocument) -> tuple[CompiledPolicyRow, ...]:
+    """Compile the portable subset representable by the local policy store."""
+
+    mapping = document.to_mapping()
+    spec = mapping.get("spec")
+    if not isinstance(spec, Mapping):
+        raise PolicyCompilationError("invalid_policy_spec", document.metadata.id)
+    rules = spec.get("rules")
+    if not isinstance(rules, list):
+        raise PolicyCompilationError("invalid_policy_rules", document.metadata.id)
+    compiled: list[CompiledPolicyRow] = []
+    for raw_rule in rules:
+        if not isinstance(raw_rule, Mapping):
+            raise PolicyCompilationError("invalid_policy_rule", document.metadata.id)
+        rule_id = str(raw_rule.get("id", "unknown"))
+        enabled = raw_rule.get("enabled")
+        if not isinstance(enabled, bool):
+            raise PolicyCompilationError("invalid_policy_enabled", rule_id)
+        if not enabled:
+            continue
+        effect = raw_rule.get("effect")
+        if effect not in {"allow", "block"}:
+            raise PolicyCompilationError("unsupported_policy_effect", rule_id)
+        lifetime = raw_rule.get("lifetime")
+        if not isinstance(lifetime, Mapping) or lifetime.get("mode") not in {"permanent", "until"}:
+            raise PolicyCompilationError("unsupported_policy_lifetime", rule_id)
+        match = raw_rule.get("match")
+        if not isinstance(match, Mapping):
+            raise PolicyCompilationError("unsupported_policy_match", rule_id)
+        unsupported = {
+            key
+            for key, value in match.items()
+            if not str(key).startswith("x-") and key not in _SUPPORTED_MATCH_KEYS and value not in (None, [])
+        }
+        if unsupported:
+            raise PolicyCompilationError("unsupported_policy_match", rule_id)
+        local_extension = raw_rule.get("x-hol-local")
+        extension = local_extension if isinstance(local_extension, Mapping) else {}
+        selectors = itertools.product(
+            _selector_values(match, "artifacts"),
+            _selector_values(match, "harnesses"),
+            _selector_values(match, "publishers"),
+            _selector_values(match, "workspaces"),
+        )
+        provenance = raw_rule.get("provenance")
+        provenance_mapping = provenance if isinstance(provenance, Mapping) else {}
+        provenance_json = json.dumps(dict(provenance_mapping), sort_keys=True, separators=(",", ":"))
+        expires_at = _normalized_expiry(
+            lifetime.get("expiresAt") if lifetime.get("mode") == "until" else None,
+            rule_id=rule_id,
+            code="invalid_policy_expiry",
+        )
+        for artifact_id, harness, publisher, workspace in selectors:
+            if len(compiled) >= _MAX_COMPILED_ROWS:
+                raise PolicyCompilationError("policy_compilation_limit", rule_id)
+            scope = _local_scope(
+                extension,
+                artifact_id=artifact_id,
+                workspace=workspace,
+                publisher=publisher,
+                harness=harness,
+            )
+            compiled.append(
+                CompiledPolicyRow(
+                    decision=PolicyDecision(
+                        harness=harness or "*",
+                        scope=scope,
+                        action=cast(GuardAction, effect),
+                        artifact_id=artifact_id,
+                        artifact_hash=_optional_string(extension.get("artifactHash")),
+                        workspace=workspace,
+                        publisher=publisher,
+                        reason=_optional_string(raw_rule.get("description")),
+                        owner=_optional_string(provenance_mapping.get("createdBy")),
+                        source=_POLICY_IMPORT_SOURCE,
+                        expires_at=_optional_string(expires_at),
+                    ),
+                    rule_id=rule_id,
+                    provenance_json=provenance_json,
+                )
+            )
+    return tuple(compiled)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -16,6 +16,7 @@ from .store_connection_schema import StoreConnectionSchemaMixin
 from .store_event_receipts import StoreEventReceiptsMixin
 from .store_evidence_facade import StoreEvidenceMixin
 from .store_inventory import StoreInventoryMixin
+from .store_policy_document import StorePolicyDocumentMixin
 from .store_live_request_outbox import StoreLiveRequestOutboxMixin
 from .store_oauth import StoreOAuthConnectMixin
 from .store_policy import StorePolicyMixin
@@ -43,6 +44,7 @@ class GuardStore(
     StoreOAuthConnectMixin,
     StoreSessionsMixin,
     StoreEvidenceMixin,
+    StorePolicyDocumentMixin,
     StoreReadStateMixin,
 ):
     """Local SQLite store for Guard state."""

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -250,6 +250,11 @@ class StoreConnectionSchemaMixin:
               owner text,
               source text not null default 'local',
               expires_at text,
+              policy_document_schema_version text,
+              policy_document_id text,
+              policy_document_digest text,
+              policy_rule_id text,
+              policy_provenance_json text,
               updated_at text not null
             )
             """,
@@ -490,6 +495,11 @@ class StoreConnectionSchemaMixin:
             self._ensure_policy_column(connection, "payload_mac", "text")
             self._ensure_policy_column(connection, "integrity_key_id", "text")
             self._ensure_policy_column(connection, "signed_at", "text")
+            self._ensure_policy_column(connection, "policy_document_schema_version", "text")
+            self._ensure_policy_column(connection, "policy_document_id", "text")
+            self._ensure_policy_column(connection, "policy_document_digest", "text")
+            self._ensure_policy_column(connection, "policy_rule_id", "text")
+            self._ensure_policy_column(connection, "policy_provenance_json", "text")
             self._ensure_runtime_receipts_column(connection, "capabilities_summary", "text not null default ''")
             self._ensure_runtime_receipts_column(connection, "scanner_evidence_json", "text not null default '[]'")
             self._ensure_runtime_receipts_column(connection, "diff_summary", "text")

--- a/src/codex_plugin_scanner/guard/store_policy_document.py
+++ b/src/codex_plugin_scanner/guard/store_policy_document.py
@@ -1,0 +1,238 @@
+"""Atomic canonical policy document persistence."""
+
+from __future__ import annotations
+
+# pyright: reportAttributeAccessIssue=false, reportUnknownMemberType=false
+from dataclasses import dataclass
+from typing import Literal
+
+from .approval_gate import ApprovalGateGrant, require_high_risk
+from .policy_authority import validate_policy_write_authority
+from .policy_document import GuardPolicyDocument, policy_document_digest
+from .policy_document_io import CompiledPolicyRow
+from .store_base import _validate_scoped_policy_artifact_target
+
+PolicyImportMode = Literal["merge", "replace"]
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDocumentImportResult:
+    document_id: str
+    digest: str
+    inserted: int
+    replaced: int
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyDocumentImportPlan:
+    additions: tuple[str, ...]
+    replacements: tuple[str, ...]
+    removals: tuple[str, ...]
+
+
+class StorePolicyDocumentMixin:
+    def plan_policy_document_import(
+        self,
+        compiled_rows: tuple[CompiledPolicyRow, ...],
+        *,
+        mode: PolicyImportMode,
+    ) -> PolicyDocumentImportPlan:
+        if mode not in {"merge", "replace"}:
+            raise ValueError("invalid_policy_import_mode")
+        current_rows = self.list_policy_decisions()
+        current_by_key: dict[
+            tuple[str, str, str | None, str | None, str | None, str | None],
+            dict[str, object],
+        ] = {}
+        for row in current_rows:
+            if row.get("source") != "policy-yaml-import":
+                continue
+            current_by_key[
+                (
+                    str(row.get("harness", "")),
+                    str(row.get("scope", "")),
+                    str(row["artifact_id"]) if row.get("artifact_id") is not None else None,
+                    str(row["artifact_hash"]) if row.get("artifact_hash") is not None else None,
+                    str(row["workspace"]) if row.get("workspace") is not None else None,
+                    str(row["publisher"]) if row.get("publisher") is not None else None,
+                )
+            ] = row
+
+        incoming_by_key: dict[
+            tuple[str, str, str | None, str | None, str | None, str | None],
+            str,
+        ] = {}
+        for compiled in compiled_rows:
+            decision = compiled.decision
+            artifact_id, artifact_hash, workspace, publisher = self._normalized_policy_keys(decision)
+            key = (
+                decision.harness,
+                decision.scope,
+                artifact_id,
+                artifact_hash,
+                workspace,
+                publisher,
+            )
+            if key in incoming_by_key:
+                raise ValueError(f"duplicate_policy_selector:{compiled.rule_id}")
+            incoming_by_key[key] = compiled.rule_id
+
+        additions = sorted(rule_id for key, rule_id in incoming_by_key.items() if key not in current_by_key)
+        replacements = sorted(rule_id for key, rule_id in incoming_by_key.items() if key in current_by_key)
+        removals: list[str] = []
+        if mode == "replace":
+            for key, row in current_by_key.items():
+                if row.get("source") != "policy-yaml-import" or key in incoming_by_key:
+                    continue
+                rule_id = row.get("policy_rule_id")
+                removals.append(str(rule_id) if rule_id is not None else f"local-{int(row.get('decision_id', 0))}")
+        return PolicyDocumentImportPlan(
+            additions=tuple(additions),
+            replacements=tuple(replacements),
+            removals=tuple(sorted(removals)),
+        )
+
+    def import_policy_document(
+        self,
+        document: GuardPolicyDocument,
+        compiled_rows: tuple[CompiledPolicyRow, ...],
+        *,
+        mode: PolicyImportMode,
+        now: str,
+        approval_gate_grant: ApprovalGateGrant | None,
+    ) -> PolicyDocumentImportResult:
+        """Persist one fully compiled document as an all-or-nothing local mutation."""
+        if mode not in {"merge", "replace"}:
+            raise ValueError("invalid_policy_import_mode")
+
+        normalized_rows: list[tuple[CompiledPolicyRow, str | None, str | None, str | None, str | None]] = []
+        seen_keys: set[tuple[str, str, str | None, str | None, str | None, str | None]] = set()
+        for compiled in compiled_rows:
+            decision = compiled.decision
+            validate_policy_write_authority(decision, remote_write_authorized=False)
+            _validate_scoped_policy_artifact_target(decision.scope, decision.artifact_id)
+            artifact_id, artifact_hash, workspace, publisher = self._normalized_policy_keys(decision)
+            key = (
+                decision.harness,
+                decision.scope,
+                artifact_id,
+                artifact_hash,
+                workspace,
+                publisher,
+            )
+            if key in seen_keys:
+                raise ValueError(f"duplicate_policy_selector:{compiled.rule_id}")
+            seen_keys.add(key)
+            normalized_rows.append((compiled, artifact_id, artifact_hash, workspace, publisher))
+
+        require_high_risk(
+            self.guard_home,
+            purpose="policy_import",
+            approval_gate_grant=approval_gate_grant,
+            now=now,
+        )
+
+        digest = policy_document_digest(document)
+        next_control_state: dict[str, object] | None = None
+        inserted_ids: set[int] = set()
+        replaced = 0
+        secret_material = self._policy_integrity_secret_material(create=True)
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            state = self._refresh_policy_integrity_state(
+                connection,
+                now=now,
+                create_key=True,
+                secret_material=secret_material,
+                allow_cutover_resign=False,
+            )
+            if mode == "replace":
+                cursor = connection.execute("delete from policy_decisions where source = 'policy-yaml-import'")
+                replaced += max(cursor.rowcount, 0)
+
+            for compiled, artifact_id, artifact_hash, workspace, publisher in normalized_rows:
+                decision = compiled.decision
+                if mode == "merge":
+                    cursor = connection.execute(
+                        """
+                        delete from policy_decisions
+                        where source = 'policy-yaml-import'
+                          and harness = ? and scope = ? and coalesce(artifact_id, '') = coalesce(?, '')
+                          and coalesce(artifact_hash, '') = coalesce(?, '')
+                          and coalesce(workspace, '') = coalesce(?, '')
+                          and coalesce(publisher, '') = coalesce(?, '')
+                        """,
+                        (
+                            decision.harness,
+                            decision.scope,
+                            artifact_id,
+                            artifact_hash,
+                            workspace,
+                            publisher,
+                        ),
+                    )
+                    replaced += max(cursor.rowcount, 0)
+                cursor = connection.execute(
+                    """
+                    insert into policy_decisions (
+                      harness, scope, artifact_id, artifact_hash, workspace, publisher, action, reason,
+                      owner, source, expires_at, policy_document_schema_version, policy_document_id,
+                      policy_document_digest, policy_rule_id, policy_provenance_json, updated_at,
+                      integrity_version, integrity_generation, payload_hash, payload_mac,
+                      integrity_key_id, signed_at
+                    )
+                    values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        decision.harness,
+                        decision.scope,
+                        artifact_id,
+                        artifact_hash,
+                        workspace,
+                        publisher,
+                        decision.action,
+                        decision.reason,
+                        decision.owner,
+                        decision.source,
+                        decision.expires_at,
+                        document.api_version,
+                        document.metadata.id,
+                        digest,
+                        compiled.rule_id,
+                        compiled.provenance_json,
+                        now,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    ),
+                )
+                if cursor.lastrowid is None:
+                    raise RuntimeError("Guard policy decision row was not inserted.")
+                inserted_ids.add(cursor.lastrowid)
+
+            if state.get("mode") == "protected":
+                key, key_id = secret_material
+                if key is not None and key_id is not None:
+                    trusted_state = self._load_policy_integrity_control_state(create=True)
+                    if trusted_state is not None:
+                        next_control_state = self._advance_policy_integrity_generation(
+                            connection,
+                            now=now,
+                            key=key,
+                            key_id=key_id,
+                            trusted_state=trusted_state,
+                            force_sign_decision_ids=inserted_ids,
+                        )
+            connection.commit()
+
+        if next_control_state is not None:
+            self._finalize_policy_integrity_control_state(next_control_state)
+        return PolicyDocumentImportResult(
+            document_id=document.metadata.id,
+            digest=digest,
+            inserted=len(inserted_ids),
+            replaced=replaced,
+        )

--- a/src/codex_plugin_scanner/guard/store_policy_integrity_runtime.py
+++ b/src/codex_plugin_scanner/guard/store_policy_integrity_runtime.py
@@ -43,8 +43,9 @@ class StorePolicyIntegrityAdminMixin:
     def list_policy_decisions(self, harness: str | None = None) -> list[dict[str, object]]:
         query = """
             select decision_id, harness, scope, artifact_id, artifact_hash, workspace, publisher,
-                   action, reason, owner, source, expires_at, updated_at, integrity_version,
-                   integrity_generation,
+                   action, reason, owner, source, expires_at, updated_at,
+                   policy_document_schema_version, policy_document_id, policy_document_digest,
+                   policy_rule_id, policy_provenance_json, integrity_version, integrity_generation,
                    payload_hash, payload_mac, integrity_key_id, signed_at
             from policy_decisions
         """
@@ -155,6 +156,16 @@ class StorePolicyIntegrityAdminMixin:
             "expires_at": row["expires_at"],
             "updated_at": str(row["updated_at"]),
         }
+        row_keys = set(row.keys())
+        for field in (
+            "policy_document_schema_version",
+            "policy_document_id",
+            "policy_document_digest",
+            "policy_rule_id",
+            "policy_provenance_json",
+        ):
+            if field in row_keys and row[field] is not None:
+                payload[field] = str(row[field])
         if row["integrity_version"] is not None:
             payload["integrity_version"] = int(row["integrity_version"])
         if row["integrity_generation"] is not None:

--- a/tests/test_policy_document_cli.py
+++ b/tests/test_policy_document_cli.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.cli import _resolve_legacy_args, main
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def test_hol_guard_routes_policy_as_a_top_level_command() -> None:
+    assert _resolve_legacy_args(
+        ["policy", "validate", "policy.yaml"],
+        program_mode="combined",
+        program_name="hol-guard",
+    ) == ["guard", "policy", "validate", "policy.yaml"]
+
+
+def test_policy_export_validate_format_and_diff(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    home = tmp_path / "home"
+    policy_file = tmp_path / "policy.yaml"
+
+    export_rc = main(
+        [
+            "guard",
+            "policy",
+            "export",
+            "--home",
+            str(home),
+            "--output",
+            str(policy_file),
+            "--json",
+        ]
+    )
+    export_payload = json.loads(capsys.readouterr().out)
+    validate_rc = main(["guard", "policy", "validate", str(policy_file), "--json"])
+    validate_payload = json.loads(capsys.readouterr().out)
+    format_rc = main(["guard", "policy", "fmt", str(policy_file), "--check", "--json"])
+    capsys.readouterr()
+    diff_rc = main(
+        [
+            "guard",
+            "policy",
+            "diff",
+            str(policy_file),
+            "--home",
+            str(home),
+            "--json",
+        ]
+    )
+    diff_payload = json.loads(capsys.readouterr().out)
+
+    assert export_rc == 0
+    assert export_payload["rules"] == 0
+    assert validate_rc == 0
+    assert validate_payload["valid"] is True
+    assert format_rc == 0
+    assert diff_rc == 0
+    assert diff_payload == {"changed": False, "diff": ""}
+
+
+def test_policy_import_is_feature_gated_and_dry_run_by_default(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    policy_file = tmp_path / "policy.yaml"
+    assert (
+        main(
+            [
+                "guard",
+                "policy",
+                "export",
+                "--home",
+                str(home),
+                "--output",
+                str(policy_file),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    disabled_rc = main(
+        [
+            "guard",
+            "policy",
+            "import",
+            str(policy_file),
+            "--home",
+            str(home),
+            "--replace",
+            "--json",
+        ]
+    )
+    disabled_payload = json.loads(capsys.readouterr().out)
+
+    monkeypatch.setenv("HOL_GUARD_POLICY_YAML_IMPORT", "1")
+    dry_run_rc = main(
+        [
+            "guard",
+            "policy",
+            "import",
+            str(policy_file),
+            "--home",
+            str(home),
+            "--replace",
+            "--json",
+        ]
+    )
+    dry_run_payload = json.loads(capsys.readouterr().out)
+
+    assert disabled_rc == 4
+    assert disabled_payload["error"] == "policy_import_disabled"
+    assert dry_run_rc == 0
+    assert dry_run_payload["dry_run"] is True
+    assert GuardStore(home).list_policy_decisions() == []
+
+
+def test_policy_file_error_does_not_disclose_the_local_path(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing = tmp_path / "sensitive-workspace" / "private-policy.yaml"
+
+    result = main(["guard", "policy", "validate", str(missing), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert result == 4
+    assert payload["error"] == "policy_parent_unavailable"
+    assert str(missing) not in json.dumps(payload)

--- a/tests/test_policy_document_import.py
+++ b/tests/test_policy_document_import.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.models import PolicyDecision
+from codex_plugin_scanner.guard.policy_document import GuardPolicyDocument, policy_document_digest
+from codex_plugin_scanner.guard.policy_document_io import (
+    CompiledPolicyRow,
+    build_policy_document_from_rows,
+    compile_policy_document,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _document(*, document_id: str = "policy-doc", rule_ids: tuple[str, ...] = ("rule-1",)) -> GuardPolicyDocument:
+    return GuardPolicyDocument.from_mapping(
+        {
+            "apiVersion": "guard.hol.org/v1alpha1",
+            "kind": "GuardPolicy",
+            "metadata": {
+                "id": document_id,
+                "name": "Imported policy",
+                "revision": 1,
+                "createdAt": "2026-07-16T12:00:00Z",
+                "updatedAt": "2026-07-16T12:00:00Z",
+            },
+            "spec": {
+                "defaults": {"mode": "prompt"},
+                "rules": [
+                    {
+                        "id": rule_id,
+                        "enabled": True,
+                        "match": {"artifacts": [f"skill:hol/{rule_id}"]},
+                        "effect": "allow",
+                        "reason": f"Imported {rule_id}",
+                        "lifetime": {"mode": "permanent"},
+                        "provenance": {
+                            "source": "cli-import",
+                            "createdAt": "2026-07-16T12:00:00Z",
+                        },
+                        "x-hol-local": {"harness": "codex", "scope": "artifact"},
+                    }
+                    for rule_id in rule_ids
+                ],
+            },
+        }
+    )
+
+
+def _rows(store: GuardStore) -> list[sqlite3.Row]:
+    with store._connect() as connection:
+        return connection.execute(
+            """
+            select source, policy_document_schema_version, policy_document_id,
+                   policy_document_digest, policy_rule_id, policy_provenance_json
+            from policy_decisions order by decision_id
+            """
+        ).fetchall()
+
+
+def test_import_persists_document_identity_and_provenance(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard")
+    document = _document()
+
+    result = store.import_policy_document(
+        document,
+        compile_policy_document(document),
+        mode="merge",
+        now="2026-07-16T12:00:00Z",
+        approval_gate_grant=None,
+    )
+
+    assert result.inserted == 1
+    assert result.replaced == 0
+    assert result.digest == policy_document_digest(document)
+    rows = _rows(store)
+    assert len(rows) == 1
+    assert dict(rows[0]) == {
+        "source": "policy-yaml-import",
+        "policy_document_schema_version": "guard.hol.org/v1alpha1",
+        "policy_document_id": "policy-doc",
+        "policy_document_digest": result.digest,
+        "policy_rule_id": "rule-1",
+        "policy_provenance_json": '{"createdAt":"2026-07-16T12:00:00Z","source":"cli-import"}',
+    }
+    listed = store.list_policy_decisions()
+    assert int(listed[0]["integrity_version"]) > 0
+    assert isinstance(listed[0]["integrity_key_id"], str)
+    assert isinstance(listed[0]["signed_at"], str)
+
+
+def test_replace_removes_only_prior_yaml_imports(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard")
+    first = _document(document_id="first", rule_ids=("rule-1",))
+    second = _document(document_id="second", rule_ids=("rule-2",))
+    store.import_policy_document(
+        first,
+        compile_policy_document(first),
+        mode="merge",
+        now="2026-07-16T12:00:00Z",
+        approval_gate_grant=None,
+    )
+
+    plan = store.plan_policy_document_import(
+        compile_policy_document(second),
+        mode="replace",
+    )
+    assert plan.additions == ("rule-2",)
+    assert plan.replacements == ()
+    assert plan.removals == ("rule-1",)
+
+    result = store.import_policy_document(
+        second,
+        compile_policy_document(second),
+        mode="replace",
+        now="2026-07-16T12:01:00Z",
+        approval_gate_grant=None,
+    )
+
+    assert result.inserted == 1
+    assert result.replaced == 1
+    assert [row["policy_document_id"] for row in _rows(store)] == ["second"]
+
+
+def test_merge_preserves_cloud_policy_with_the_same_selector(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard")
+    store.replace_remote_policies(
+        [
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                artifact_id="skill:hol/rule-1",
+                artifact_hash="sha256:rule-1",
+                workspace=None,
+                publisher=None,
+                action="block",
+                reason="cloud policy",
+                owner=None,
+                source="cloud-sync",
+            )
+        ],
+        now="2026-07-16T11:59:00Z",
+        remote_write_authorized=True,
+    )
+    document = _document(rule_ids=("rule-1",))
+
+    plan = store.plan_policy_document_import(compile_policy_document(document), mode="merge")
+    result = store.import_policy_document(
+        document,
+        compile_policy_document(document),
+        mode="merge",
+        now="2026-07-16T12:00:00Z",
+        approval_gate_grant=None,
+    )
+
+    with store._connect() as connection:
+        sources = [
+            str(row["source"])
+            for row in connection.execute("select source from policy_decisions order by source").fetchall()
+        ]
+    assert plan.additions == ("rule-1",)
+    assert plan.replacements == ()
+    assert result.replaced == 0
+    assert sources == ["cloud-sync", "policy-yaml-import"]
+
+
+def test_empty_replace_clears_prior_yaml_imports(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard")
+    first = _document(rule_ids=("rule-1",))
+    empty = _document(document_id="empty", rule_ids=())
+    store.import_policy_document(
+        first,
+        compile_policy_document(first),
+        mode="merge",
+        now="2026-07-16T12:00:00Z",
+        approval_gate_grant=None,
+    )
+
+    result = store.import_policy_document(
+        empty,
+        compile_policy_document(empty),
+        mode="replace",
+        now="2026-07-16T12:01:00Z",
+        approval_gate_grant=None,
+    )
+
+    assert result.inserted == 0
+    assert result.replaced == 1
+    assert _rows(store) == []
+
+
+def test_import_rolls_back_every_row_on_insert_failure(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard")
+    document = _document(rule_ids=("rule-1", "rule-2"))
+    with store._connect() as connection:
+        connection.execute(
+            """
+            create trigger reject_rule_two before insert on policy_decisions
+            when new.policy_rule_id = 'rule-2'
+            begin
+              select raise(abort, 'forced import failure');
+            end
+            """
+        )
+
+    with pytest.raises(sqlite3.IntegrityError, match="forced import failure"):
+        store.import_policy_document(
+            document,
+            compile_policy_document(document),
+            mode="merge",
+            now="2026-07-16T12:00:00Z",
+            approval_gate_grant=None,
+        )
+
+    assert _rows(store) == []
+
+
+def test_duplicate_compiled_selector_is_rejected_before_writes(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard")
+    document = _document(rule_ids=("rule-1", "rule-1"))
+
+    with pytest.raises(ValueError, match="duplicate_policy_selector"):
+        store.import_policy_document(
+            document,
+            compile_policy_document(document),
+            mode="merge",
+            now="2026-07-16T12:00:00Z",
+            approval_gate_grant=None,
+        )
+
+    assert _rows(store) == []
+
+
+def test_privileged_export_preserves_imported_rule_identity_and_semantics(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard")
+    document = _document(rule_ids=("rule-a", "rule-b"))
+    original_rows = compile_policy_document(document)
+
+    store.import_policy_document(
+        document,
+        original_rows,
+        mode="replace",
+        now="2026-07-16T12:00:00Z",
+        approval_gate_grant=None,
+    )
+    exported = build_policy_document_from_rows(
+        store.list_policy_decisions(),
+        include_provenance=True,
+    )
+    round_trip_rows = compile_policy_document(exported)
+
+    def semantic_row(row: CompiledPolicyRow) -> tuple[object, ...]:
+        decision = row.decision
+        return (
+            row.rule_id,
+            decision.harness,
+            decision.scope,
+            decision.action,
+            decision.artifact_id,
+            decision.artifact_hash,
+            decision.workspace,
+            decision.publisher,
+            decision.expires_at,
+        )
+
+    assert [semantic_row(row) for row in round_trip_rows] == [semantic_row(row) for row in original_rows]

--- a/tests/test_policy_document_io.py
+++ b/tests/test_policy_document_io.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.policy_document import (
+    GuardPolicyDocument,
+    policy_document_digest,
+)
+from codex_plugin_scanner.guard.policy_document_io import (
+    PolicyCompilationError,
+    PolicyFileTrustError,
+    build_policy_document_from_rows,
+    compile_policy_document,
+    diff_policy_documents,
+    load_trusted_policy_document,
+    read_trusted_policy_text,
+    write_private_policy_text,
+)
+from codex_plugin_scanner.guard.policy_document_yaml import (
+    MAX_POLICY_BYTES,
+    format_policy_document_yaml,
+)
+
+
+def _policy_document(*, effect: str = "allow", match: dict[str, object] | None = None) -> GuardPolicyDocument:
+    return GuardPolicyDocument.from_mapping(
+        {
+            "apiVersion": "guard.hashgraphonline.com/v1alpha1",
+            "kind": "GuardPolicy",
+            "metadata": {"id": "test-policy", "name": "Test policy", "revision": 1},
+            "spec": {
+                "defaults": {"mode": "prompt"},
+                "rules": [
+                    {
+                        "id": "rule-1",
+                        "enabled": True,
+                        "effect": effect,
+                        "match": match or {"artifacts": ["skill:hol/deploy"]},
+                        "lifetime": {"mode": "permanent", "expiresAt": None},
+                        "provenance": {
+                            "source": "import",
+                            "createdAt": "2026-07-16T10:00:00Z",
+                            "createdBy": "owner@example.com",
+                        },
+                    }
+                ],
+            },
+        }
+    )
+
+
+def _private_directory(path: Path) -> Path:
+    path.mkdir(mode=0o700)
+    path.chmod(0o700)
+    return path
+
+
+def test_local_rows_round_trip_through_canonical_document() -> None:
+    document = build_policy_document_from_rows(
+        [
+            {
+                "decision_id": 7,
+                "harness": "codex",
+                "scope": "artifact",
+                "artifact_id": "skill:hol/deploy",
+                "artifact_hash": "sha256:abc",
+                "workspace": "/workspace",
+                "publisher": "hashgraph-online",
+                "action": "allow",
+                "reason": "Approved deployment skill",
+                "owner": "owner@example.com",
+                "source": "review-decision",
+                "expires_at": None,
+                "updated_at": "2026-07-16T10:00:00+00:00",
+            }
+        ],
+        include_provenance=True,
+    )
+
+    compiled = compile_policy_document(document)
+
+    mapping = document.to_mapping()
+    spec = mapping["spec"]
+    assert isinstance(spec, dict)
+    rules = spec["rules"]
+    assert isinstance(rules, list)
+    first_rule = rules[0]
+    assert isinstance(first_rule, dict)
+    assert first_rule["id"] == "local-7"
+    assert len(compiled) == 1
+    assert compiled[0].rule_id == "local-7"
+    assert compiled[0].decision.harness == "codex"
+    assert compiled[0].decision.scope == "artifact"
+    assert compiled[0].decision.artifact_id == "skill:hol/deploy"
+    assert compiled[0].decision.artifact_hash == "sha256:abc"
+    assert compiled[0].decision.workspace == "/workspace"
+    assert compiled[0].decision.publisher == "hashgraph-online"
+    assert compiled[0].decision.action == "allow"
+
+
+def test_export_redacts_sensitive_provenance_by_default() -> None:
+    document = build_policy_document_from_rows(
+        [
+            {
+                "decision_id": 7,
+                "harness": "codex",
+                "scope": "global",
+                "action": "allow",
+                "reason": "Contains local context",
+                "owner": "owner@example.com",
+                "source": "review-decision",
+                "updated_at": "2026-07-16T10:00:00Z",
+            }
+        ]
+    )
+
+    formatted = format_policy_document_yaml(document)
+
+    assert "owner@example.com" not in formatted
+    assert "Contains local context" not in formatted
+    assert "review-decision" not in formatted
+    assert "export-redacted" in formatted
+
+
+def test_export_requires_privileged_intent_for_workspace_selectors() -> None:
+    with pytest.raises(PolicyCompilationError, match="sensitive_local_policy_requires_provenance"):
+        build_policy_document_from_rows(
+            [
+                {
+                    "decision_id": 8,
+                    "harness": "codex",
+                    "scope": "workspace",
+                    "workspace": "/Users/private/repository",
+                    "action": "allow",
+                }
+            ]
+        )
+
+
+def test_export_rejects_unsupported_local_actions() -> None:
+    with pytest.raises(PolicyCompilationError, match="unsupported_local_policy_action"):
+        build_policy_document_from_rows(
+            [
+                {
+                    "decision_id": 9,
+                    "harness": "codex",
+                    "scope": "global",
+                    "action": "prompt",
+                }
+            ]
+        )
+
+
+def test_export_rejects_invalid_local_expiry() -> None:
+    with pytest.raises(PolicyCompilationError, match="invalid_local_policy_expiry"):
+        build_policy_document_from_rows(
+            [
+                {
+                    "decision_id": 9,
+                    "harness": "codex",
+                    "scope": "global",
+                    "action": "allow",
+                    "expires_at": "not-a-timestamp",
+                }
+            ]
+        )
+
+
+def test_export_order_is_stable_when_primary_fields_tie() -> None:
+    rows = [
+        {
+            "harness": "codex",
+            "scope": "artifact",
+            "artifact_id": "skill:hol/deploy",
+            "publisher": "publisher-b",
+            "action": "block",
+        },
+        {
+            "harness": "codex",
+            "scope": "artifact",
+            "artifact_id": "skill:hol/deploy",
+            "publisher": "publisher-a",
+            "action": "allow",
+        },
+    ]
+
+    forward = build_policy_document_from_rows(rows)
+    reverse = build_policy_document_from_rows(reversed(rows))
+
+    assert policy_document_digest(forward) == policy_document_digest(reverse)
+
+
+def test_compile_rejects_effect_not_supported_by_local_store() -> None:
+    document = _policy_document(effect="review")
+
+    with pytest.raises(PolicyCompilationError, match="unsupported_policy_effect"):
+        compile_policy_document(document)
+
+
+def test_compile_rejects_match_not_supported_by_local_store() -> None:
+    document = _policy_document(match={"commands": ["deploy"]})
+
+    with pytest.raises(PolicyCompilationError, match="unsupported_policy_match"):
+        compile_policy_document(document)
+
+
+def test_compile_rejects_invalid_until_expiry() -> None:
+    mapping = _policy_document().to_mapping()
+    spec = mapping["spec"]
+    assert isinstance(spec, dict)
+    rules = spec["rules"]
+    assert isinstance(rules, list)
+    rule = rules[0]
+    assert isinstance(rule, dict)
+    rule["lifetime"] = {"mode": "until", "expiresAt": "not-a-timestamp"}
+    document = GuardPolicyDocument.from_mapping(mapping)
+
+    with pytest.raises(PolicyCompilationError, match="invalid_policy_expiry"):
+        compile_policy_document(document)
+
+
+def test_compile_rejects_selector_expansion_over_limit() -> None:
+    document = _policy_document(
+        match={
+            "artifacts": [f"artifact-{index}" for index in range(101)],
+            "workspaces": [f"workspace-{index}" for index in range(101)],
+        }
+    )
+
+    with pytest.raises(PolicyCompilationError, match="policy_compilation_limit"):
+        compile_policy_document(document)
+
+
+def test_trusted_file_round_trip_and_atomic_private_output(tmp_path: Path) -> None:
+    directory = _private_directory(tmp_path / "private")
+    source = directory / "source.yaml"
+    source.write_text(format_policy_document_yaml(_policy_document()), encoding="utf-8")
+    source.chmod(0o600)
+    destination = directory / "output.yaml"
+
+    document = load_trusted_policy_document(source)
+    write_private_policy_text(destination, format_policy_document_yaml(document))
+
+    assert policy_document_digest(load_trusted_policy_document(destination)) == policy_document_digest(document)
+    assert destination.stat().st_mode & 0o777 == 0o600
+
+
+def test_trusted_read_rejects_symlink(tmp_path: Path) -> None:
+    directory = _private_directory(tmp_path / "private")
+    target = directory / "target.yaml"
+    target.write_text(format_policy_document_yaml(_policy_document()), encoding="utf-8")
+    target.chmod(0o600)
+    link = directory / "link.yaml"
+    link.symlink_to(target)
+
+    with pytest.raises(PolicyFileTrustError, match="policy_file_not_regular"):
+        read_trusted_policy_text(link)
+
+
+def test_trusted_read_rejects_symlinked_ancestor(tmp_path: Path) -> None:
+    trusted = _private_directory(tmp_path / "trusted")
+    directory = _private_directory(trusted / "private")
+    source = directory / "policy.yaml"
+    source.write_text(format_policy_document_yaml(_policy_document()), encoding="utf-8")
+    source.chmod(0o600)
+    alias = tmp_path / "alias"
+    alias.symlink_to(trusted, target_is_directory=True)
+
+    with pytest.raises(PolicyFileTrustError, match="policy_parent_unavailable"):
+        read_trusted_policy_text(alias / "private" / source.name)
+
+
+def test_trusted_read_rejects_hardlink(tmp_path: Path) -> None:
+    directory = _private_directory(tmp_path / "private")
+    target = directory / "target.yaml"
+    target.write_text(format_policy_document_yaml(_policy_document()), encoding="utf-8")
+    target.chmod(0o600)
+    link = directory / "hardlink.yaml"
+    os.link(target, link)
+
+    with pytest.raises(PolicyFileTrustError, match="policy_file_link_count"):
+        read_trusted_policy_text(link)
+
+
+def test_trusted_read_rejects_group_writable_file(tmp_path: Path) -> None:
+    directory = _private_directory(tmp_path / "private")
+    source = directory / "policy.yaml"
+    source.write_text(format_policy_document_yaml(_policy_document()), encoding="utf-8")
+    source.chmod(0o620)
+
+    with pytest.raises(PolicyFileTrustError, match="policy_file_insecure_mode"):
+        read_trusted_policy_text(source)
+
+
+def test_trusted_read_rejects_world_writable_parent(tmp_path: Path) -> None:
+    directory = _private_directory(tmp_path / "private")
+    source = directory / "policy.yaml"
+    source.write_text(format_policy_document_yaml(_policy_document()), encoding="utf-8")
+    source.chmod(0o600)
+    directory.chmod(0o777)
+
+    with pytest.raises(PolicyFileTrustError, match="policy_parent_insecure_mode"):
+        read_trusted_policy_text(source)
+
+
+def test_trusted_read_rejects_oversized_file(tmp_path: Path) -> None:
+    directory = _private_directory(tmp_path / "private")
+    source = directory / "policy.yaml"
+    source.write_bytes(b"x" * (MAX_POLICY_BYTES + 1))
+    source.chmod(0o600)
+
+    with pytest.raises(PolicyFileTrustError, match="policy_file_too_large"):
+        read_trusted_policy_text(source)
+
+
+def test_private_output_rejects_oversized_content(tmp_path: Path) -> None:
+    directory = _private_directory(tmp_path / "private")
+    destination = directory / "policy.yaml"
+
+    with pytest.raises(PolicyFileTrustError, match="policy_output_too_large"):
+        write_private_policy_text(destination, "x" * (MAX_POLICY_BYTES + 1))
+
+    assert not destination.exists()
+
+
+def test_private_output_rejects_existing_symlink(tmp_path: Path) -> None:
+    directory = _private_directory(tmp_path / "private")
+    target = directory / "target.yaml"
+    target.write_text("target", encoding="utf-8")
+    target.chmod(0o600)
+    destination = directory / "policy.yaml"
+    destination.symlink_to(target)
+
+    with pytest.raises(PolicyFileTrustError, match="policy_file_not_regular"):
+        write_private_policy_text(destination, "replacement")
+
+    assert target.read_text(encoding="utf-8") == "target"
+
+
+def test_private_output_rejects_existing_hardlink(tmp_path: Path) -> None:
+    directory = _private_directory(tmp_path / "private")
+    target = directory / "target.yaml"
+    target.write_text("target", encoding="utf-8")
+    target.chmod(0o600)
+    destination = directory / "policy.yaml"
+    os.link(target, destination)
+
+    with pytest.raises(PolicyFileTrustError, match="policy_file_link_count"):
+        write_private_policy_text(destination, "replacement")
+
+    assert target.read_text(encoding="utf-8") == "target"
+
+
+def test_private_output_retries_short_writes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    directory = _private_directory(tmp_path / "private")
+    destination = directory / "policy.yaml"
+    original_write = os.write
+
+    def short_write(descriptor: int, payload: bytes | memoryview) -> int:
+        return original_write(descriptor, payload[:1])
+
+    monkeypatch.setattr(os, "write", short_write)
+
+    write_private_policy_text(destination, "complete")
+
+    assert destination.read_text(encoding="utf-8") == "complete"
+
+
+def test_atomic_output_preserves_existing_file_when_replace_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    directory = _private_directory(tmp_path / "private")
+    destination = directory / "policy.yaml"
+    destination.write_text("before", encoding="utf-8")
+    destination.chmod(0o600)
+
+    def fail_replace(_source: str, _destination: str, **_kwargs: int) -> None:
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+
+    with pytest.raises(PolicyFileTrustError, match="policy_output_write_failed"):
+        write_private_policy_text(destination, "after")
+
+    assert destination.read_text(encoding="utf-8") == "before"
+    assert not list(directory.glob(".*.tmp"))
+
+
+def test_document_diff_is_deterministic() -> None:
+    baseline = _policy_document(effect="allow")
+    candidate = _policy_document(effect="block")
+
+    first = diff_policy_documents(baseline, candidate)
+    second = diff_policy_documents(baseline, candidate)
+
+    assert first.changed is True
+    assert first == second
+    assert "-    effect: allow" in first.text
+    assert "+    effect: block" in first.text


### PR DESCRIPTION
## Summary
- add canonical Guard policy YAML validation, formatting, diff, export, and feature-gated import commands
- enforce trusted private file I/O, atomic writes, transactional merge/replace imports, approval gates, and signed policy integrity metadata
- preserve cloud policies alongside imported documents and expose deterministic dry-run plans

## Verification
- `uv run pytest -q tests/test_policy_document_cli.py tests/test_policy_document_import.py tests/test_policy_document_io.py` (34 passed)
- policy regression suites (238 passed)
- approval-gate suite (52 passed)
- `uv run ruff check` on changed source and tests
- `uv build`
- clean-wheel smoke: top-level policy export and validate
