### PR TITLE
feat(policy): advertise YAML capabilities

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -82,7 +82,7 @@ from .supply_chain_bundle import (
 from .supply_chain_bundle_models import SupplyChainVerificationKey
 from .supply_chain_support import ecosystem_support_matrix
 
-_POLICY_DOCUMENT_VERSIONS = ("guard.hol.org/v1alpha1",)
+_POLICY_DOCUMENT_VERSIONS = ("guard.hashgraphonline.com/v1alpha1",)
 _POLICY_YAML_IMPORT_ENV = "HOL_GUARD_POLICY_YAML_IMPORT"
 _POLICY_CANONICAL_ENFORCEMENT_ENV = "HOL_GUARD_POLICY_CANONICAL_ENFORCEMENT"
 

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -82,6 +82,10 @@ from .supply_chain_bundle import (
 from .supply_chain_bundle_models import SupplyChainVerificationKey
 from .supply_chain_support import ecosystem_support_matrix
 
+_POLICY_DOCUMENT_VERSIONS = ("guard.hol.org/v1alpha1",)
+_POLICY_YAML_IMPORT_ENV = "HOL_GUARD_POLICY_YAML_IMPORT"
+_POLICY_CANONICAL_ENFORCEMENT_ENV = "HOL_GUARD_POLICY_CANONICAL_ENFORCEMENT"
+
 
 def detect_harness(harness: str, context: HarnessContext) -> HarnessDetection:
     from ..consumer import detect_harness as _detect_harness
@@ -2460,7 +2464,7 @@ def sync_runtime_session(
 
 
 def _local_guard_runtime_session() -> dict[str, object]:
-    return {
+    session: dict[str, object] = {
         "harness": "hol-guard",
         "surface": "cli",
         "status": "active",
@@ -2469,7 +2473,12 @@ def _local_guard_runtime_session() -> dict[str, object]:
         "client_version": __version__,
         "workspace": "local-machine",
         "capabilities": ["approval-center", "guard-cloud-sync", "local-daemon"],
+        "policy_document_versions": list(_POLICY_DOCUMENT_VERSIONS),
+        "yaml_import": os.environ.get(_POLICY_YAML_IMPORT_ENV) == "1",
     }
+    if os.environ.get(_POLICY_CANONICAL_ENFORCEMENT_ENV) == "1":
+        session["canonical_policy_enforcement"] = True
+    return session
 
 
 def sync_local_guard_cloud_proof(
@@ -4549,13 +4558,20 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
     created_at = _optional_string(session.get("created_at") or session.get("createdAt")) or _now()
     updated_at = _optional_string(session.get("updated_at") or session.get("updatedAt")) or created_at
     capabilities = list(_string_items(session.get("capabilities")))
+    policy_document_versions = list(
+        _string_items(session.get("policy_document_versions") or session.get("policyDocumentVersions"))
+    )
+    yaml_import = session.get("yaml_import") is True or session.get("yamlImport") is True
+    canonical_policy_enforcement = (
+        session.get("canonical_policy_enforcement") is True or session.get("canonicalPolicyEnforcement") is True
+    )
     package_manager_coverage = _cloud_package_manager_coverage(
         store,
         workspace=workspace,
         generated_at=updated_at,
     )
     local_identity = _cloud_local_identity_payload(observed_at=updated_at)
-    return {
+    payload: dict[str, object] = {
         "sessionId": session_id,
         "harness": _optional_string(session.get("harness")) or "hol-guard",
         "surface": _optional_string(session.get("surface")) or "cli",
@@ -4575,6 +4591,12 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
         "createdAt": created_at,
         "updatedAt": updated_at,
     }
+    if policy_document_versions:
+        payload["policyDocumentVersions"] = policy_document_versions
+    payload["yamlImport"] = yaml_import
+    if canonical_policy_enforcement:
+        payload["canonicalPolicyEnforcement"] = True
+    return payload
 
 
 def _cloud_local_identity_payload(*, observed_at: str) -> dict[str, object]:

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -875,9 +875,7 @@ def test_sync_runtime_session_emits_package_manager_coverage_payload(
     guard_runner_module.sync_runtime_session(
         store,
         session={
-            "harness": "codex",
-            "surface": "cli",
-            "status": "active",
+            **guard_runner_module._local_guard_runtime_session(),
             "updatedAt": "2026-04-24T00:01:00+00:00",
             "workspace": str(workspace_dir),
         },
@@ -905,6 +903,22 @@ def test_sync_runtime_session_emits_package_manager_coverage_payload(
             "nextRefreshAt": "2026-04-24T00:15:00+00:00",
         },
     }
+    assert session_payload["policyDocumentVersions"] == ["guard.hol.org/v1alpha1"]
+    assert session_payload["yamlImport"] is False
+    assert "canonicalPolicyEnforcement" not in session_payload
+
+
+def test_local_runtime_session_advertises_enabled_policy_capabilities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOL_GUARD_POLICY_YAML_IMPORT", "1")
+    monkeypatch.setenv("HOL_GUARD_POLICY_CANONICAL_ENFORCEMENT", "1")
+
+    session = guard_runner_module._local_guard_runtime_session()
+
+    assert session["policy_document_versions"] == ["guard.hol.org/v1alpha1"]
+    assert session["yaml_import"] is True
+    assert session["canonical_policy_enforcement"] is True
 
 
 def test_sync_runtime_session_prefers_latest_sync_summary_for_package_manager_coverage_freshness(

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -838,6 +838,8 @@ def test_sync_runtime_session_emits_package_manager_coverage_payload(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.delenv("HOL_GUARD_POLICY_YAML_IMPORT", raising=False)
+    monkeypatch.delenv("HOL_GUARD_POLICY_CANONICAL_ENFORCEMENT", raising=False)
     store = GuardStore(tmp_path / "guard-home")
     _seed_guard_cloud(store, workspace_id="workspace-alpha")
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -905,7 +905,7 @@ def test_sync_runtime_session_emits_package_manager_coverage_payload(
             "nextRefreshAt": "2026-04-24T00:15:00+00:00",
         },
     }
-    assert session_payload["policyDocumentVersions"] == ["guard.hol.org/v1alpha1"]
+    assert session_payload["policyDocumentVersions"] == ["guard.hashgraphonline.com/v1alpha1"]
     assert session_payload["yamlImport"] is False
     assert "canonicalPolicyEnforcement" not in session_payload
 
@@ -918,7 +918,7 @@ def test_local_runtime_session_advertises_enabled_policy_capabilities(
 
     session = guard_runner_module._local_guard_runtime_session()
 
-    assert session["policy_document_versions"] == ["guard.hol.org/v1alpha1"]
+    assert session["policy_document_versions"] == ["guard.hashgraphonline.com/v1alpha1"]
     assert session["yaml_import"] is True
     assert session["canonical_policy_enforcement"] is True
 

--- a/tests/test_policy_document_import.py
+++ b/tests/test_policy_document_import.py
@@ -18,7 +18,7 @@ from codex_plugin_scanner.guard.store import GuardStore
 def _document(*, document_id: str = "policy-doc", rule_ids: tuple[str, ...] = ("rule-1",)) -> GuardPolicyDocument:
     return GuardPolicyDocument.from_mapping(
         {
-            "apiVersion": "guard.hol.org/v1alpha1",
+            "apiVersion": "guard.hashgraphonline.com/v1alpha1",
             "kind": "GuardPolicy",
             "metadata": {
                 "id": document_id,
@@ -80,7 +80,7 @@ def test_import_persists_document_identity_and_provenance(tmp_path: Path) -> Non
     assert len(rows) == 1
     assert dict(rows[0]) == {
         "source": "policy-yaml-import",
-        "policy_document_schema_version": "guard.hol.org/v1alpha1",
+        "policy_document_schema_version": "guard.hashgraphonline.com/v1alpha1",
         "policy_document_id": "policy-doc",
         "policy_document_digest": result.digest,
         "policy_rule_id": "rule-1",


### PR DESCRIPTION
## Summary
- advertise supported policy document contract versions in the existing runtime sync handshake
- report YAML import capability state while keeping canonical enforcement absent until explicitly enabled
- preserve compatibility with servers that ignore the additive fields

## Verification
- `uv run pytest -q tests/test_guard_cloud_local_sync.py` (31 passed)
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/runner.py tests/test_guard_cloud_local_sync.py`
