### PR TITLE
feat(policy): validate signed bundle v2

### DIFF
--- a/src/codex_plugin_scanner/guard/policy_bundle_trusted_keys.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_trusted_keys.py
@@ -6,6 +6,7 @@ import hashlib
 import importlib
 import time
 from dataclasses import dataclass
+from typing import Protocol, cast
 
 from .runtime.supply_chain_bundle_base import _parse_iso_timestamp
 
@@ -59,6 +60,21 @@ class PolicyBundleVerificationKey:
             state=normalized_state,
             valid_until=normalized_valid_until,
         )
+
+
+class _PolicyBundleV2Module(Protocol):
+    def validated_policy_bundle_v2_payload(
+        self,
+        policy_bundle: dict[str, object],
+        *,
+        trusted_verification_keys: tuple[PolicyBundleVerificationKey, ...],
+        anchored_verification_keys: tuple[PolicyBundleVerificationKey, ...],
+    ) -> tuple[dict[str, object] | None, str | None]: ...
+
+
+def _policy_bundle_v2_module() -> _PolicyBundleV2Module:
+    module = importlib.import_module(".policy_bundle_v2", __package__)
+    return cast(_PolicyBundleV2Module, cast(object, module))
 
 
 def policy_bundle_key_fingerprint(public_key_pem: str) -> str:
@@ -223,11 +239,20 @@ def validate_synced_policy_bundle(
         sync_payload=sync_payload,
         supply_chain_keyring=supply_chain_keyring,
     )
-    validated_bundle, rejection_reason = _policy_bundle_parser_module().validated_policy_bundle_payload(
-        policy_bundle,
-        trusted_verification_keys=trusted_keys,
-        anchored_verification_keys=anchored_keys,
-    )
+    if policy_bundle.get("contractVersion") == "guard-policy-bundle.v2":
+        validated_policy_bundle_v2_payload = _policy_bundle_v2_module().validated_policy_bundle_v2_payload
+
+        validated_bundle, rejection_reason = validated_policy_bundle_v2_payload(
+            policy_bundle,
+            trusted_verification_keys=trusted_keys,
+            anchored_verification_keys=anchored_keys,
+        )
+    else:
+        validated_bundle, rejection_reason = _policy_bundle_parser_module().validated_policy_bundle_payload(
+            policy_bundle,
+            trusted_verification_keys=trusted_keys,
+            anchored_verification_keys=anchored_keys,
+        )
     if validated_bundle is None:
         return None, rejection_reason, anchored_keys
     updated_keys = persistable_policy_bundle_keyring(

--- a/src/codex_plugin_scanner/guard/policy_bundle_trusted_keys.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_trusted_keys.py
@@ -11,6 +11,7 @@ from typing import Protocol, cast
 from .runtime.supply_chain_bundle_base import _parse_iso_timestamp
 
 _VERIFICATION_KEY_STATES = frozenset({"active", "grace", "revoked"})
+_POLICY_BUNDLE_V2_CONTRACT = "guard-policy-bundle.v2"
 
 
 def _policy_bundle_parser_module():
@@ -239,7 +240,7 @@ def validate_synced_policy_bundle(
         sync_payload=sync_payload,
         supply_chain_keyring=supply_chain_keyring,
     )
-    if policy_bundle.get("contractVersion") == "guard-policy-bundle.v2":
+    if policy_bundle.get("contractVersion") == _POLICY_BUNDLE_V2_CONTRACT:
         validated_policy_bundle_v2_payload = _policy_bundle_v2_module().validated_policy_bundle_v2_payload
 
         validated_bundle, rejection_reason = validated_policy_bundle_v2_payload(

--- a/src/codex_plugin_scanner/guard/policy_bundle_v2.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_v2.py
@@ -1,0 +1,434 @@
+"""Signed canonical Guard policy bundle v2 validation and state transitions."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+from datetime import datetime, timezone
+from typing import TypeGuard, cast
+
+from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+
+from .policy_bundle_trusted_keys import (
+    PolicyBundleVerificationKey,
+    resolve_policy_bundle_signing_key,
+    signing_key_is_current,
+    signing_key_is_trusted,
+)
+from .policy_document import JsonValue, canonical_json_bytes, canonical_policy_document_bytes
+from .policy_document_yaml import PolicyDocumentError, parse_policy_document_yaml
+
+POLICY_BUNDLE_V2_CONTRACT = "guard-policy-bundle.v2"
+POLICY_BUNDLE_V2_ENVELOPE_VERSION = 2
+POLICY_BUNDLE_V2_CAPABILITY = "guard-policy-bundle.v2"
+POLICY_BUNDLE_V2_CANONICALIZATION = {"algorithm": "rfc8785", "version": "1"}
+POLICY_BUNDLE_V2_ACK_STATUSES = frozenset({"received", "validated", "applied", "failed", "offline"})
+
+_MAX_BUNDLE_BYTES = 2_097_152
+_MAX_DEPTH = 40
+_MAX_COLLECTION_ITEMS = 2_048
+_MAX_STRING_LENGTH = 1_048_576
+_ALLOWED_TOP_LEVEL = frozenset(
+    {
+        "envelopeVersion",
+        "contractVersion",
+        "bundleVersion",
+        "bundleHash",
+        "payloadHash",
+        "issuedAt",
+        "expiresAt",
+        "workspaceId",
+        "canonicalization",
+        "verifier",
+        "payload",
+        "rollback",
+    }
+)
+_ALLOWED_ROLLBACK_KEYS = frozenset(
+    {
+        "rollbackOfBundleHash",
+        "rollbackOfBundleVersion",
+        "lastGoodBundleHash",
+        "lastGoodBundleVersion",
+        "reason",
+        "actor",
+        "createdAt",
+        "authorization",
+    }
+)
+_ALLOWED_VERIFIER_KEYS = frozenset({"algorithm", "keyId", "keyFingerprint", "publicKeyPem", "signature"})
+_ALLOWED_ACK_KEYS = frozenset(
+    {
+        "contractVersion",
+        "workspaceId",
+        "deviceId",
+        "bundleVersion",
+        "bundleHash",
+        "sequence",
+        "status",
+        "observedAt",
+        "errorCode",
+    }
+)
+_ALLOWED_ACK_TRANSITIONS = {
+    "received": frozenset({"received", "validated", "failed", "offline"}),
+    "validated": frozenset({"validated", "applied", "failed", "offline"}),
+    "applied": frozenset({"applied", "offline"}),
+    "failed": frozenset({"failed", "received", "offline"}),
+    "offline": frozenset({"offline", "received"}),
+}
+
+
+def _is_object_list(value: object) -> TypeGuard[list[object]]:
+    return isinstance(value, list)
+
+
+def _is_object_mapping(value: object) -> TypeGuard[dict[str, object]]:
+    if not isinstance(value, dict):
+        return False
+    return all(isinstance(key, str) for key in cast(dict[object, object], value))
+
+
+def _non_empty_string(value: object, *, maximum: int = _MAX_STRING_LENGTH) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized or len(value.encode("utf-8")) > maximum:
+        return None
+    return value
+
+
+def _strict_utc_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.removesuffix("Z") + "+00:00")
+    except ValueError:
+        return None
+    if parsed.tzinfo is None or parsed.utcoffset() != timezone.utc.utcoffset(parsed):
+        return None
+    return parsed
+
+
+def _json_value(value: object, *, depth: int = 0) -> JsonValue:
+    if depth > _MAX_DEPTH:
+        raise ValueError("limit_depth")
+    if value is None or isinstance(value, (bool, str)):
+        if isinstance(value, str) and len(value.encode("utf-8")) > _MAX_STRING_LENGTH:
+            raise ValueError("limit_string")
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        raise ValueError("unsupported_number")
+    if _is_object_list(value):
+        if len(value) > _MAX_COLLECTION_ITEMS:
+            raise ValueError("limit_collection")
+        return [_json_value(item, depth=depth + 1) for item in value]
+    if _is_object_mapping(value):
+        if len(value) > _MAX_COLLECTION_ITEMS:
+            raise ValueError("limit_collection")
+        result: dict[str, JsonValue] = {}
+        for key, item in value.items():
+            if len(key.encode("utf-8")) > 128:
+                raise ValueError("limit_key")
+            result[key] = _json_value(item, depth=depth + 1)
+        return result
+    raise ValueError("invalid_json_value")
+
+
+def _mapping(value: JsonValue) -> dict[str, JsonValue] | None:
+    return value if isinstance(value, dict) else None
+
+
+def _unsigned_bundle_core(policy_bundle: dict[str, object]) -> dict[str, JsonValue]:
+    normalized = _json_value(policy_bundle)
+    core = _mapping(normalized)
+    if core is None:
+        raise ValueError("invalid_bundle")
+    result = dict(core)
+    _ = result.pop("bundleHash", None)
+    verifier = _mapping(result.get("verifier"))
+    if verifier is None:
+        raise ValueError("invalid_verifier")
+    normalized_verifier = dict(verifier)
+    _ = normalized_verifier.pop("signature", None)
+    _ = normalized_verifier.pop("publicKeyPem", None)
+    result["verifier"] = normalized_verifier
+    return result
+
+
+def computed_policy_bundle_v2_hash(policy_bundle: dict[str, object]) -> str:
+    """Return the integrity hash for the signed v2 envelope core."""
+
+    digest = hashlib.sha256(canonical_json_bytes(_unsigned_bundle_core(policy_bundle))).hexdigest()
+    return f"sha256:{digest}"
+
+
+def canonical_policy_bundle_v2_payload(policy_bundle: dict[str, object]) -> bytes:
+    """Return the exact bytes covered by the v2 RSA-PSS signature."""
+
+    core = _unsigned_bundle_core(policy_bundle)
+    bundle_hash = _non_empty_string(policy_bundle.get("bundleHash"), maximum=128)
+    if bundle_hash is None:
+        raise ValueError("missing_bundle_hash")
+    return canonical_json_bytes({**core, "bundleHash": bundle_hash})
+
+
+def payload_hash_for_policy_bundle_v2(policy_bundle: dict[str, object]) -> str:
+    payload = policy_bundle.get("payload")
+    if not _is_object_mapping(payload):
+        raise ValueError("invalid_payload")
+    document = parse_policy_document_yaml(canonical_json_bytes(_json_value(payload)))
+    digest = hashlib.sha256(canonical_policy_document_bytes(document)).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _validate_keys(value: dict[str, object], allowed: frozenset[str]) -> bool:
+    return all(key in allowed or key.startswith("x-") for key in value)
+
+
+def _validate_rollback(value: object) -> str | None:
+    if value is None:
+        return None
+    if not _is_object_mapping(value) or not _validate_keys(value, _ALLOWED_ROLLBACK_KEYS):
+        return "invalid_rollback"
+    required_strings = (
+        "rollbackOfBundleHash",
+        "lastGoodBundleHash",
+        "reason",
+        "actor",
+        "createdAt",
+        "authorization",
+    )
+    if any(_non_empty_string(value.get(key)) is None for key in required_strings):
+        return "invalid_rollback"
+    versions = (value.get("rollbackOfBundleVersion"), value.get("lastGoodBundleVersion"))
+    if any(not isinstance(version, int) or isinstance(version, bool) or version < 1 for version in versions):
+        return "invalid_rollback"
+    if _strict_utc_timestamp(value.get("createdAt")) is None:
+        return "invalid_rollback"
+    return None
+
+
+def _verify_signature(
+    policy_bundle: dict[str, object],
+    *,
+    trusted_verification_keys: tuple[PolicyBundleVerificationKey, ...],
+    anchored_verification_keys: tuple[PolicyBundleVerificationKey, ...],
+) -> str | None:
+    verifier = policy_bundle.get("verifier")
+    if not _is_object_mapping(verifier) or not _validate_keys(verifier, _ALLOWED_VERIFIER_KEYS):
+        return "invalid_verifier"
+    if verifier.get("algorithm") != "rsa-pss-sha256":
+        return "invalid_verifier"
+    key_id = _non_empty_string(verifier.get("keyId"), maximum=128)
+    signature = _non_empty_string(verifier.get("signature"))
+    if key_id is None or signature is None:
+        return "invalid_verifier"
+    signing_key = resolve_policy_bundle_signing_key(key_id, trusted_verification_keys)
+    if signing_key is None:
+        return "untrusted_signing_key"
+    if anchored_verification_keys and not signing_key_is_trusted(signing_key, anchored_verification_keys):
+        return "untrusted_signing_key"
+    if not signing_key_is_current(signing_key):
+        return "untrusted_signing_key"
+    key_fingerprint = verifier.get("keyFingerprint")
+    if key_fingerprint is not None and key_fingerprint != signing_key.fingerprint_sha256:
+        return "untrusted_signing_key"
+    supplied_public_key = verifier.get("publicKeyPem")
+    if supplied_public_key is not None and supplied_public_key != signing_key.public_key_pem:
+        return "untrusted_signing_key"
+    try:
+        public_key = serialization.load_pem_public_key(signing_key.public_key_pem.encode("utf-8"))
+    except (UnsupportedAlgorithm, ValueError, TypeError):
+        return "invalid_verifier"
+    if not isinstance(public_key, RSAPublicKey):
+        return "invalid_verifier"
+    try:
+        signature_bytes = base64.b64decode(signature, validate=True)
+    except (binascii.Error, ValueError):
+        return "invalid_verifier"
+    try:
+        public_key.verify(
+            signature_bytes,
+            canonical_policy_bundle_v2_payload(policy_bundle),
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.AUTO),
+            hashes.SHA256(),
+        )
+    except (InvalidSignature, ValueError, TypeError):
+        return "bundle_signature_invalid"
+    return None
+
+
+def validated_policy_bundle_v2_payload(
+    policy_bundle: dict[str, object],
+    *,
+    trusted_verification_keys: tuple[PolicyBundleVerificationKey, ...] = (),
+    anchored_verification_keys: tuple[PolicyBundleVerificationKey, ...] = (),
+    now: datetime | None = None,
+) -> tuple[dict[str, object] | None, str | None]:
+    """Validate one bounded signed v2 envelope and its canonical policy document."""
+
+    try:
+        encoded = canonical_json_bytes(_json_value(policy_bundle))
+    except ValueError as error:
+        return None, str(error)
+    if len(encoded) > _MAX_BUNDLE_BYTES:
+        return None, "limit_bytes"
+    if not _validate_keys(policy_bundle, _ALLOWED_TOP_LEVEL):
+        return None, "unknown_field"
+    required = _ALLOWED_TOP_LEVEL - {"expiresAt", "rollback"}
+    if any(key not in policy_bundle for key in required):
+        return None, "missing_required_field"
+    if policy_bundle.get("envelopeVersion") != POLICY_BUNDLE_V2_ENVELOPE_VERSION:
+        return None, "unsupported_envelope_version"
+    if policy_bundle.get("contractVersion") != POLICY_BUNDLE_V2_CONTRACT:
+        return None, "unsupported_contract_version"
+    bundle_version = policy_bundle.get("bundleVersion")
+    if not isinstance(bundle_version, int) or isinstance(bundle_version, bool) or bundle_version < 1:
+        return None, "invalid_bundle_version"
+    if _non_empty_string(policy_bundle.get("workspaceId"), maximum=128) is None:
+        return None, "invalid_workspace_id"
+    canonicalization = policy_bundle.get("canonicalization")
+    if canonicalization != POLICY_BUNDLE_V2_CANONICALIZATION:
+        return None, "unsupported_canonicalization"
+    issued_at = _strict_utc_timestamp(policy_bundle.get("issuedAt"))
+    if issued_at is None:
+        return None, "invalid_issued_at"
+    expires_at_value = policy_bundle.get("expiresAt")
+    expires_at = None if expires_at_value is None else _strict_utc_timestamp(expires_at_value)
+    if expires_at_value is not None and expires_at is None:
+        return None, "invalid_expires_at"
+    if expires_at is not None and expires_at <= issued_at:
+        return None, "invalid_expires_at"
+    comparison_time = now or datetime.now(timezone.utc)
+    if expires_at is not None and expires_at <= comparison_time:
+        return None, "bundle_expired"
+    rollback_error = _validate_rollback(policy_bundle.get("rollback"))
+    if rollback_error is not None:
+        return None, rollback_error
+    try:
+        expected_payload_hash = payload_hash_for_policy_bundle_v2(policy_bundle)
+    except (PolicyDocumentError, ValueError):
+        return None, "invalid_policy_document"
+    if policy_bundle.get("payloadHash") != expected_payload_hash:
+        return None, "payload_hash_mismatch"
+    try:
+        expected_bundle_hash = computed_policy_bundle_v2_hash(policy_bundle)
+    except ValueError:
+        return None, "invalid_bundle"
+    if policy_bundle.get("bundleHash") != expected_bundle_hash:
+        return None, "bundle_hash_mismatch"
+    signature_error = _verify_signature(
+        policy_bundle,
+        trusted_verification_keys=trusted_verification_keys,
+        anchored_verification_keys=anchored_verification_keys,
+    )
+    if signature_error is not None:
+        return None, signature_error
+    return policy_bundle, None
+
+
+def validate_policy_bundle_v2_transition(
+    policy_bundle: dict[str, object],
+    *,
+    current_bundle_version: int | None,
+    current_bundle_hash: str | None,
+) -> str | None:
+    """Reject replay, same-version substitution, and unsigned rollback semantics."""
+
+    incoming_version = policy_bundle.get("bundleVersion")
+    incoming_hash = policy_bundle.get("bundleHash")
+    if not isinstance(incoming_version, int) or isinstance(incoming_version, bool):
+        return "invalid_bundle_version"
+    if not isinstance(incoming_hash, str):
+        return "invalid_bundle_hash"
+    if current_bundle_version is None:
+        return None
+    if current_bundle_hash is None:
+        return "missing_current_bundle_hash"
+    if incoming_version < current_bundle_version:
+        return "bundle_downgrade_rejected"
+    if incoming_version == current_bundle_version:
+        return None if incoming_hash == current_bundle_hash else "bundle_version_conflict"
+    rollback = policy_bundle.get("rollback")
+    if rollback is None:
+        return None
+    if not _is_object_mapping(rollback):
+        return "invalid_rollback"
+    if (
+        rollback.get("rollbackOfBundleHash") != current_bundle_hash
+        or rollback.get("rollbackOfBundleVersion") != current_bundle_version
+    ):
+        return "rollback_target_mismatch"
+    last_good_version = rollback.get("lastGoodBundleVersion")
+    if (
+        not isinstance(last_good_version, int)
+        or isinstance(last_good_version, bool)
+        or last_good_version >= current_bundle_version
+    ):
+        return "rollback_target_mismatch"
+    if _non_empty_string(rollback.get("lastGoodBundleHash"), maximum=128) is None:
+        return "rollback_target_mismatch"
+    if _non_empty_string(rollback.get("authorization")) is None:
+        return "rollback_authorization_missing"
+    return None
+
+
+def validated_policy_bundle_v2_acknowledgement(
+    acknowledgement: dict[str, object],
+    *,
+    previous: dict[str, object] | None = None,
+) -> tuple[dict[str, object] | None, str | None]:
+    """Validate a monotonic explicit device acknowledgement transition."""
+
+    if not _validate_keys(acknowledgement, _ALLOWED_ACK_KEYS):
+        return None, "unknown_field"
+    required = _ALLOWED_ACK_KEYS - {"errorCode"}
+    if any(key not in acknowledgement for key in required):
+        return None, "missing_required_field"
+    if acknowledgement.get("contractVersion") != POLICY_BUNDLE_V2_CONTRACT:
+        return None, "unsupported_contract_version"
+    string_fields = ("workspaceId", "deviceId", "bundleHash")
+    if any(_non_empty_string(acknowledgement.get(key), maximum=256) is None for key in string_fields):
+        return None, "invalid_acknowledgement"
+    bundle_version = acknowledgement.get("bundleVersion")
+    sequence = acknowledgement.get("sequence")
+    if (
+        not isinstance(bundle_version, int)
+        or isinstance(bundle_version, bool)
+        or bundle_version < 1
+        or not isinstance(sequence, int)
+        or isinstance(sequence, bool)
+        or sequence < 1
+    ):
+        return None, "invalid_acknowledgement"
+    status = acknowledgement.get("status")
+    if status not in POLICY_BUNDLE_V2_ACK_STATUSES:
+        return None, "invalid_acknowledgement_status"
+    if _strict_utc_timestamp(acknowledgement.get("observedAt")) is None:
+        return None, "invalid_acknowledgement"
+    error_code = acknowledgement.get("errorCode")
+    if error_code is not None and _non_empty_string(error_code, maximum=128) is None:
+        return None, "invalid_acknowledgement"
+    if previous is None:
+        return acknowledgement, None
+    identity_fields = ("workspaceId", "deviceId", "bundleVersion", "bundleHash")
+    if any(previous.get(key) != acknowledgement.get(key) for key in identity_fields):
+        return None, "acknowledgement_identity_mismatch"
+    previous_sequence = previous.get("sequence")
+    previous_status = previous.get("status")
+    if not isinstance(previous_sequence, int) or previous_status not in POLICY_BUNDLE_V2_ACK_STATUSES:
+        return None, "invalid_previous_acknowledgement"
+    if sequence < previous_sequence:
+        return None, "acknowledgement_replay"
+    if sequence == previous_sequence:
+        return (acknowledgement, None) if acknowledgement == previous else (None, "acknowledgement_sequence_conflict")
+    if status not in _ALLOWED_ACK_TRANSITIONS[str(previous_status)]:
+        return None, "acknowledgement_transition_rejected"
+    return acknowledgement, None

--- a/src/codex_plugin_scanner/guard/policy_bundle_v2.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_v2.py
@@ -24,7 +24,6 @@ from .policy_document_yaml import PolicyDocumentError, parse_policy_document_yam
 
 POLICY_BUNDLE_V2_CONTRACT = "guard-policy-bundle.v2"
 POLICY_BUNDLE_V2_ENVELOPE_VERSION = 2
-POLICY_BUNDLE_V2_CAPABILITY = "guard-policy-bundle.v2"
 POLICY_BUNDLE_V2_CANONICALIZATION = {"algorithm": "rfc8785", "version": "1"}
 POLICY_BUNDLE_V2_ACK_STATUSES = frozenset({"received", "validated", "applied", "failed", "offline"})
 
@@ -97,9 +96,9 @@ def _non_empty_string(value: object, *, maximum: int = _MAX_STRING_LENGTH) -> st
     if not isinstance(value, str):
         return None
     normalized = value.strip()
-    if not normalized or len(value.encode("utf-8")) > maximum:
+    if not normalized or normalized != value or len(value.encode("utf-8")) > maximum:
         return None
-    return value
+    return normalized
 
 
 def _strict_utc_timestamp(value: object) -> datetime | None:
@@ -233,7 +232,7 @@ def _verify_signature(
     signing_key = resolve_policy_bundle_signing_key(key_id, trusted_verification_keys)
     if signing_key is None:
         return "untrusted_signing_key"
-    if anchored_verification_keys and not signing_key_is_trusted(signing_key, anchored_verification_keys):
+    if not signing_key_is_trusted(signing_key, anchored_verification_keys):
         return "untrusted_signing_key"
     if not signing_key_is_current(signing_key):
         return "untrusted_signing_key"
@@ -253,11 +252,12 @@ def _verify_signature(
         signature_bytes = base64.b64decode(signature, validate=True)
     except (binascii.Error, ValueError):
         return "invalid_verifier"
+    salt_length = padding.calculate_max_pss_salt_length(public_key, hashes.SHA256())
     try:
         public_key.verify(
             signature_bytes,
             canonical_policy_bundle_v2_payload(policy_bundle),
-            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.AUTO),
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=salt_length),
             hashes.SHA256(),
         )
     except (InvalidSignature, ValueError, TypeError):

--- a/src/codex_plugin_scanner/guard/policy_document.py
+++ b/src/codex_plugin_scanner/guard/policy_document.py
@@ -44,6 +44,7 @@ POLICY_MATCH_FIELDS = (
 JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
 EncodedExtensions: TypeAlias = tuple[tuple[str, str], ...]
 
+
 def _mapping(value: object) -> dict[str, object]:
     if not isinstance(value, dict):
         raise TypeError("validated_policy_document_shape")
@@ -58,6 +59,7 @@ def _sequence(value: object) -> list[object]:
 
 def _json_value(value: object) -> JsonValue:
     return cast(JsonValue, value)
+
 
 def _canonical_json_text(value: JsonValue | object) -> str:
     if value is None:
@@ -76,22 +78,13 @@ def _canonical_json_text(value: JsonValue | object) -> str:
         items = cast(dict[str, object], value).items()
         ordered = sorted(items, key=lambda item: item[0].encode("utf-16-be"))
         return (
-            "{"
-            + ",".join(
-                f"{_canonical_json_text(key)}:{_canonical_json_text(item)}"
-                for key, item in ordered
-            )
-            + "}"
+            "{" + ",".join(f"{_canonical_json_text(key)}:{_canonical_json_text(item)}" for key, item in ordered) + "}"
         )
     raise TypeError("unsupported_canonical_json_value")
 
 
 def _encode_extensions(value: dict[str, object], known_fields: frozenset[str]) -> EncodedExtensions:
-    return tuple(
-        (key, _canonical_json_text(item))
-        for key, item in sorted(value.items())
-        if key not in known_fields
-    )
+    return tuple((key, _canonical_json_text(item)) for key, item in sorted(value.items()) if key not in known_fields)
 
 
 def _decode_extensions(value: EncodedExtensions) -> dict[str, JsonValue]:
@@ -153,11 +146,7 @@ class PolicyDefaults:
                 "syncEnabled",
             }
         )
-        values = tuple(
-            (key, _json_value(value[key]))
-            for key in sorted(known - {"mode"})
-            if key in value
-        )
+        values = tuple((key, _json_value(value[key])) for key in sorted(known - {"mode"}) if key in value)
         return cls(mode=str(value["mode"]), values=values, extensions=_encode_extensions(value, known))
 
     def to_mapping(self) -> dict[str, JsonValue]:
@@ -332,10 +321,16 @@ class GuardPolicyDocument:
         return _with_extensions(result, self.extensions)
 
 
+def canonical_json_bytes(value: JsonValue) -> bytes:
+    """Return canonical JSON bytes for the contract's integer-only number subset."""
+
+    return _canonical_json_text(value).encode("utf-8")
+
+
 def canonical_policy_document_bytes(document: GuardPolicyDocument) -> bytes:
     """Return RFC 8785-compatible JSON for the contract's integer-only number subset."""
 
-    return _canonical_json_text(document.to_mapping()).encode("utf-8")
+    return canonical_json_bytes(document.to_mapping())
 
 
 def policy_document_digest(document: GuardPolicyDocument) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -65,6 +65,10 @@ from ..policy_bundle_trusted_keys import (
     policy_bundle_keyring_payload,
     validate_synced_policy_bundle,
 )
+from ..policy_bundle_v2 import (
+    POLICY_BUNDLE_V2_CONTRACT,
+    validate_policy_bundle_v2_transition,
+)
 from ..redaction import redact_sensitive_text
 from ..shims import package_shim_cloud_coverage
 from ..store import GuardStore
@@ -1049,6 +1053,21 @@ def _policy_bundle_is_version_downgrade(
     existing_bundle: dict[str, object] | None,
     next_bundle: dict[str, object],
 ) -> bool:
+    if next_bundle.get("contractVersion") == POLICY_BUNDLE_V2_CONTRACT:
+        current_version = existing_bundle.get("bundleVersion") if isinstance(existing_bundle, dict) else None
+        current_hash = existing_bundle.get("bundleHash") if isinstance(existing_bundle, dict) else None
+        return (
+            validate_policy_bundle_v2_transition(
+                next_bundle,
+                current_bundle_version=(
+                    current_version
+                    if isinstance(current_version, int) and not isinstance(current_version, bool)
+                    else None
+                ),
+                current_bundle_hash=(current_hash if isinstance(current_hash, str) else None),
+            )
+            is not None
+        )
     if not isinstance(existing_bundle, dict) or not existing_bundle:
         return False
     existing_issued_at = non_empty_string(existing_bundle.get("issuedAt"))

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -18648,6 +18648,46 @@ def test_policy_bundle_downgrade_check_ignores_mixed_timezone_formats():
     )
 
 
+def test_policy_bundle_v2_downgrade_check_uses_monotonic_bundle_version():
+    current = {
+        "contractVersion": "guard-policy-bundle.v2",
+        "bundleVersion": 8,
+        "bundleHash": "a" * 64,
+        "issuedAt": "2026-06-05T13:30:00Z",
+    }
+
+    assert guard_runner_module._policy_bundle_is_version_downgrade(
+        current,
+        {
+            "contractVersion": "guard-policy-bundle.v2",
+            "bundleVersion": 7,
+            "bundleHash": "b" * 64,
+            "issuedAt": "2026-06-05T13:31:00Z",
+        },
+    )
+    assert guard_runner_module._policy_bundle_is_version_downgrade(
+        current,
+        {
+            "contractVersion": "guard-policy-bundle.v2",
+            "bundleVersion": 8,
+            "bundleHash": "b" * 64,
+            "issuedAt": "2026-06-05T13:31:00Z",
+        },
+    )
+    assert (
+        guard_runner_module._policy_bundle_is_version_downgrade(
+            current,
+            {
+                "contractVersion": "guard-policy-bundle.v2",
+                "bundleVersion": 9,
+                "bundleHash": "b" * 64,
+                "issuedAt": "2026-06-05T13:31:00Z",
+            },
+        )
+        is False
+    )
+
+
 def test_sync_receipts_uploads_policy_bundle_acknowledgement(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     _seed_guard_cloud(store)

--- a/tests/test_policy_bundle_v2.py
+++ b/tests/test_policy_bundle_v2.py
@@ -138,6 +138,24 @@ def test_shared_sync_validator_dispatches_v2_without_changing_v1_parser() -> Non
     assert persisted_keys == (verification_key,)
 
 
+def test_shared_sync_validator_rejects_sync_only_v2_signing_key() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    verification_key = _verification_key(private_key)
+    bundle = _signed_bundle(private_key, verification_key)
+
+    validated, reason, persisted_keys = validate_synced_policy_bundle(
+        bundle,
+        stored_keyring={},
+        sync_payload={
+            "policyBundleVerificationKeys": [verification_key.to_dict()],
+        },
+    )
+
+    assert validated is None
+    assert reason == "untrusted_signing_key"
+    assert persisted_keys == ()
+
+
 def test_v2_bundle_rejects_payload_tampering_before_apply() -> None:
     private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     verification_key = _verification_key(private_key)
@@ -177,6 +195,29 @@ def test_v2_bundle_rejects_invalid_signature() -> None:
     assert reason == "bundle_signature_invalid"
 
 
+def test_v2_bundle_rejects_non_contract_pss_salt_length() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    verification_key = _verification_key(private_key)
+    bundle = _signed_bundle(private_key, verification_key)
+    verifier = cast(dict[str, object], bundle["verifier"])
+    signature = private_key.sign(
+        canonical_policy_bundle_v2_payload(bundle),
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=8),
+        hashes.SHA256(),
+    )
+    verifier["signature"] = base64.b64encode(signature).decode("ascii")
+
+    validated, reason = validated_policy_bundle_v2_payload(
+        bundle,
+        trusted_verification_keys=(verification_key,),
+        anchored_verification_keys=(verification_key,),
+        now=datetime(2026, 7, 16, tzinfo=timezone.utc),
+    )
+
+    assert validated is None
+    assert reason == "bundle_signature_invalid"
+
+
 def test_v2_bundle_rejects_expired_envelope() -> None:
     private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     verification_key = _verification_key(private_key)
@@ -191,6 +232,23 @@ def test_v2_bundle_rejects_expired_envelope() -> None:
 
     assert validated is None
     assert reason == "bundle_expired"
+
+
+def test_v2_bundle_rejects_whitespace_padded_identifiers() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    verification_key = _verification_key(private_key)
+    bundle = _signed_bundle(private_key, verification_key)
+    bundle["workspaceId"] = " workspace-alpha "
+
+    validated, reason = validated_policy_bundle_v2_payload(
+        bundle,
+        trusted_verification_keys=(verification_key,),
+        anchored_verification_keys=(verification_key,),
+        now=datetime(2026, 7, 16, tzinfo=timezone.utc),
+    )
+
+    assert validated is None
+    assert reason == "invalid_workspace_id"
 
 
 def test_v2_bundle_rejects_unsigned_unknown_fields() -> None:

--- a/tests/test_policy_bundle_v2.py
+++ b/tests/test_policy_bundle_v2.py
@@ -1,0 +1,320 @@
+"""Signed canonical policy bundle v2 contract tests."""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+from codex_plugin_scanner.guard.policy_bundle_trusted_keys import (
+    PolicyBundleVerificationKey,
+    policy_bundle_verification_key_from_public_key,
+    validate_synced_policy_bundle,
+)
+from codex_plugin_scanner.guard.policy_bundle_v2 import (
+    POLICY_BUNDLE_V2_CANONICALIZATION,
+    POLICY_BUNDLE_V2_CONTRACT,
+    canonical_policy_bundle_v2_payload,
+    computed_policy_bundle_v2_hash,
+    payload_hash_for_policy_bundle_v2,
+    validate_policy_bundle_v2_transition,
+    validated_policy_bundle_v2_acknowledgement,
+    validated_policy_bundle_v2_payload,
+)
+from codex_plugin_scanner.guard.policy_document_yaml import load_policy_document
+
+_FIXTURE = Path(__file__).parents[1] / "spec" / "guard-policy" / "v1alpha1" / "fixtures" / "valid" / "basic.yaml"
+
+
+def _verification_key(
+    private_key: rsa.RSAPrivateKey,
+    *,
+    key_id: str = "policy-v2-key-1",
+) -> PolicyBundleVerificationKey:
+    public_key_pem = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
+    return policy_bundle_verification_key_from_public_key(
+        key_id=key_id,
+        public_key_pem=public_key_pem,
+    )
+
+
+def _signed_bundle(
+    private_key: rsa.RSAPrivateKey,
+    verification_key: PolicyBundleVerificationKey,
+    *,
+    bundle_version: int = 8,
+    rollback: dict[str, object] | None = None,
+) -> dict[str, object]:
+    document = load_policy_document(_FIXTURE)
+    bundle: dict[str, object] = {
+        "envelopeVersion": 2,
+        "contractVersion": POLICY_BUNDLE_V2_CONTRACT,
+        "bundleVersion": bundle_version,
+        "bundleHash": "",
+        "payloadHash": "",
+        "issuedAt": "2026-07-15T12:00:00Z",
+        "expiresAt": "2030-07-15T12:00:00Z",
+        "workspaceId": "workspace-alpha",
+        "canonicalization": POLICY_BUNDLE_V2_CANONICALIZATION,
+        "verifier": {
+            "algorithm": "rsa-pss-sha256",
+            "keyId": verification_key.key_id,
+            "keyFingerprint": verification_key.fingerprint_sha256,
+            "publicKeyPem": verification_key.public_key_pem,
+            "signature": "",
+        },
+        "payload": document.to_mapping(),
+        "rollback": rollback,
+    }
+    bundle["payloadHash"] = payload_hash_for_policy_bundle_v2(bundle)
+    bundle["bundleHash"] = computed_policy_bundle_v2_hash(bundle)
+    signature = private_key.sign(
+        canonical_policy_bundle_v2_payload(bundle),
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    verifier = bundle["verifier"]
+    assert isinstance(verifier, dict)
+    verifier["signature"] = base64.b64encode(signature).decode("ascii")
+    return bundle
+
+
+def _acknowledgement(
+    *,
+    sequence: int,
+    status: str,
+) -> dict[str, object]:
+    return {
+        "contractVersion": POLICY_BUNDLE_V2_CONTRACT,
+        "workspaceId": "workspace-alpha",
+        "deviceId": "device-alpha",
+        "bundleVersion": 8,
+        "bundleHash": "sha256:bundle-alpha",
+        "sequence": sequence,
+        "status": status,
+        "observedAt": "2026-07-15T12:01:00Z",
+    }
+
+
+def test_signed_v2_bundle_validates_canonical_document_and_rsa_pss_signature() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    verification_key = _verification_key(private_key)
+    bundle = _signed_bundle(private_key, verification_key)
+
+    validated, reason = validated_policy_bundle_v2_payload(
+        bundle,
+        trusted_verification_keys=(verification_key,),
+        anchored_verification_keys=(verification_key,),
+        now=datetime(2026, 7, 16, tzinfo=timezone.utc),
+    )
+
+    assert reason is None
+    assert validated == bundle
+
+
+def test_shared_sync_validator_dispatches_v2_without_changing_v1_parser() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    verification_key = _verification_key(private_key)
+    bundle = _signed_bundle(private_key, verification_key)
+
+    validated, reason, persisted_keys = validate_synced_policy_bundle(
+        bundle,
+        stored_keyring={"keys": [verification_key.to_dict()]},
+    )
+
+    assert reason is None
+    assert validated == bundle
+    assert persisted_keys == (verification_key,)
+
+
+def test_v2_bundle_rejects_payload_tampering_before_apply() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    verification_key = _verification_key(private_key)
+    bundle = _signed_bundle(private_key, verification_key)
+    payload = bundle["payload"]
+    assert isinstance(payload, dict)
+    metadata = cast(dict[str, object], payload["metadata"])
+    assert isinstance(metadata, dict)
+    metadata["revision"] = 99
+
+    validated, reason = validated_policy_bundle_v2_payload(
+        bundle,
+        trusted_verification_keys=(verification_key,),
+        anchored_verification_keys=(verification_key,),
+        now=datetime(2026, 7, 16, tzinfo=timezone.utc),
+    )
+
+    assert validated is None
+    assert reason == "payload_hash_mismatch"
+
+
+def test_v2_bundle_rejects_invalid_signature() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    verification_key = _verification_key(private_key)
+    bundle = _signed_bundle(private_key, verification_key)
+    verifier = cast(dict[str, object], bundle["verifier"])
+    verifier["signature"] = "AA=="
+
+    validated, reason = validated_policy_bundle_v2_payload(
+        bundle,
+        trusted_verification_keys=(verification_key,),
+        anchored_verification_keys=(verification_key,),
+        now=datetime(2026, 7, 16, tzinfo=timezone.utc),
+    )
+
+    assert validated is None
+    assert reason == "bundle_signature_invalid"
+
+
+def test_v2_bundle_rejects_expired_envelope() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    verification_key = _verification_key(private_key)
+    bundle = _signed_bundle(private_key, verification_key)
+
+    validated, reason = validated_policy_bundle_v2_payload(
+        bundle,
+        trusted_verification_keys=(verification_key,),
+        anchored_verification_keys=(verification_key,),
+        now=datetime(2031, 7, 16, tzinfo=timezone.utc),
+    )
+
+    assert validated is None
+    assert reason == "bundle_expired"
+
+
+def test_v2_bundle_rejects_unsigned_unknown_fields() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    verification_key = _verification_key(private_key)
+    bundle = _signed_bundle(private_key, verification_key)
+    bundle["unexpected"] = "unsigned"
+
+    validated, reason = validated_policy_bundle_v2_payload(
+        bundle,
+        trusted_verification_keys=(verification_key,),
+        anchored_verification_keys=(verification_key,),
+        now=datetime(2026, 7, 16, tzinfo=timezone.utc),
+    )
+
+    assert validated is None
+    assert reason == "unknown_field"
+
+
+def test_v2_bundle_rejects_unanchored_rotated_key() -> None:
+    first_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    first_key = _verification_key(first_private_key)
+    rotated_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    rotated_key = _verification_key(rotated_private_key, key_id="policy-v2-key-2")
+    bundle = _signed_bundle(rotated_private_key, rotated_key)
+
+    validated, reason = validated_policy_bundle_v2_payload(
+        bundle,
+        trusted_verification_keys=(first_key, rotated_key),
+        anchored_verification_keys=(first_key,),
+        now=datetime(2026, 7, 16, tzinfo=timezone.utc),
+    )
+
+    assert validated is None
+    assert reason == "untrusted_signing_key"
+
+
+def test_v2_transition_rejects_replay_and_same_version_substitution() -> None:
+    assert (
+        validate_policy_bundle_v2_transition(
+            {"bundleVersion": 7, "bundleHash": "sha256:old"},
+            current_bundle_version=8,
+            current_bundle_hash="sha256:current",
+        )
+        == "bundle_downgrade_rejected"
+    )
+    assert (
+        validate_policy_bundle_v2_transition(
+            {"bundleVersion": 8, "bundleHash": "sha256:different"},
+            current_bundle_version=8,
+            current_bundle_hash="sha256:current",
+        )
+        == "bundle_version_conflict"
+    )
+
+
+def test_v2_transition_accepts_only_authorized_monotonic_rollback() -> None:
+    rollback: dict[str, object] = {
+        "rollbackOfBundleHash": "sha256:current",
+        "rollbackOfBundleVersion": 8,
+        "lastGoodBundleHash": "sha256:historical-good",
+        "lastGoodBundleVersion": 6,
+        "reason": "Restore the last verified policy.",
+        "actor": "operator-alpha",
+        "createdAt": "2026-07-15T12:02:00Z",
+        "authorization": "approval-receipt-alpha",
+    }
+    incoming: dict[str, object] = {
+        "bundleVersion": 9,
+        "bundleHash": "sha256:rollback-envelope",
+        "rollback": rollback,
+    }
+
+    assert (
+        validate_policy_bundle_v2_transition(
+            incoming,
+            current_bundle_version=8,
+            current_bundle_hash="sha256:current",
+        )
+        is None
+    )
+    rollback["rollbackOfBundleHash"] = "sha256:other"
+    assert (
+        validate_policy_bundle_v2_transition(
+            incoming,
+            current_bundle_version=8,
+            current_bundle_hash="sha256:current",
+        )
+        == "rollback_target_mismatch"
+    )
+
+
+def test_v2_acknowledgement_enforces_sequence_and_state_transitions() -> None:
+    received = _acknowledgement(sequence=1, status="received")
+    validated = _acknowledgement(sequence=2, status="validated")
+    applied = _acknowledgement(sequence=3, status="applied")
+
+    assert validated_policy_bundle_v2_acknowledgement(received) == (received, None)
+    assert validated_policy_bundle_v2_acknowledgement(
+        validated,
+        previous=received,
+    ) == (validated, None)
+    assert validated_policy_bundle_v2_acknowledgement(
+        applied,
+        previous=validated,
+    ) == (applied, None)
+    replayed, reason = validated_policy_bundle_v2_acknowledgement(
+        received,
+        previous=applied,
+    )
+    assert replayed is None
+    assert reason == "acknowledgement_replay"
+
+
+def test_v2_acknowledgement_rejects_sequence_conflicts_and_terminal_reapply() -> None:
+    applied = _acknowledgement(sequence=3, status="applied")
+    conflict = {**applied, "status": "failed"}
+    retried = _acknowledgement(sequence=4, status="received")
+
+    assert validated_policy_bundle_v2_acknowledgement(
+        conflict,
+        previous=applied,
+    ) == (None, "acknowledgement_sequence_conflict")
+    assert validated_policy_bundle_v2_acknowledgement(
+        retried,
+        previous=applied,
+    ) == (None, "acknowledgement_transition_rejected")


### PR DESCRIPTION
## Summary
- add bounded canonical Guard Policy Bundle v2 envelope validation
- verify canonical payload and bundle hashes plus RSA-PSS signatures against anchored keyrings
- enforce monotonic bundle transitions, signed rollback metadata, and explicit acknowledgement sequencing
- preserve the existing v1 parser and byte contract through shared sync dispatch

## Verification
- `uv run pytest -q tests/test_policy_bundle_v2.py tests/test_policy_bundle_parser.py tests/test_policy_document_yaml.py` — 59 passed
- `uv run ruff check src/codex_plugin_scanner/guard/policy_bundle_v2.py src/codex_plugin_scanner/guard/policy_bundle_trusted_keys.py tests/test_policy_bundle_v2.py` — passed
- `uv run basedpyright src/codex_plugin_scanner/guard/policy_bundle_v2.py src/codex_plugin_scanner/guard/policy_bundle_trusted_keys.py tests/test_policy_bundle_v2.py` — 0 errors; 11 pre-existing warnings in trusted-key parsing
- public-surface infrastructure keyword scan — no matches

## Contract
- base: `feat/guard-policy-v3`
- no v1 serialization, signature, or parser changes
- no runtime capability advertisement until the portal v2 contract lands