### PR TITLE
docs(policy): publish v1alpha1 interoperability spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ hol-guard init
 
 `hol-guard init` discovers compatible AI agents, explains each setup change before applying it, and guides you through your first protected action.
 
-[Install guide](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/get-started.md) · [Supported agents](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/harness-support.md) · [Local vs. cloud](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/local-vs-cloud.md) · [Security policy](https://github.com/hashgraph-online/hol-guard/blob/main/SECURITY.md)
+[Install guide](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/get-started.md) · [GuardPolicy v1alpha1](https://github.com/hashgraph-online/hol-guard/blob/main/spec/guard-policy/v1alpha1/README.md) · [Supported agents](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/harness-support.md) · [Local vs. cloud](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/local-vs-cloud.md) · [Security policy](https://github.com/hashgraph-online/hol-guard/blob/main/SECURITY.md)
 
 ## What HOL Guard Protects
 

--- a/spec/guard-policy/v1alpha1/README.md
+++ b/spec/guard-policy/v1alpha1/README.md
@@ -1,0 +1,34 @@
+# GuardPolicy v1alpha1
+
+GuardPolicy is HOL Guard's portable policy document. The alpha contract is intentionally narrow: YAML is the human interchange format, validated typed data is the semantic model, and RFC 8785 canonical JSON is the only representation hashed or signed.
+
+## Normative material
+
+- [`schema.json`](schema.json): accepted document shape and bounded extension values.
+- [`semantics.md`](semantics.md): effects, matchers, lifetime, provenance, authority, and precedence.
+- [`canonicalization.md`](canonicalization.md): YAML parsing profile, canonical JSON bytes, hashes, and signatures.
+- [`compatibility.md`](compatibility.md): alpha versioning, extension registration, unknown fields, and deprecation policy.
+- [`threat-model.md`](threat-model.md): trust boundaries, attacks, mitigations, and non-goals.
+- [`rfc.md`](rfc.md): open questions for action vocabulary, scope vocabulary, trust, and local precedence.
+- [`fixtures/manifest.json`](fixtures/manifest.json): valid, invalid, hash, and decision conformance vectors.
+
+## Reference validation
+
+The Python implementation in HOL Guard is independent of the Portal TypeScript implementation and consumes the same normative schema and fixtures.
+
+```bash
+hol-guard policy validate ./policy.yaml --json
+hol-guard policy fmt ./policy.yaml --check --json
+```
+
+Run its public conformance suite from a source checkout:
+
+```bash
+uv run pytest -q tests/test_policy_document_yaml.py tests/test_policy_document_io.py tests/test_policy_document_cli.py
+```
+
+A conforming implementation must reject every fixture listed under `invalid`, parse and reformat every fixture listed under `valid` deterministically, reproduce the published canonical JSON and SHA-256 vectors byte-for-byte, and preserve all valid `x-` extensions in canonical bytes.
+
+## Alpha status
+
+`v1alpha1` is suitable for interoperability testing, not a stability claim. Stabilization requires an independent implementation, fixture agreement, recorded ambiguity findings, and security review. Bundle v1 and legacy policy fields remain supported during the measured compatibility window; their removal requires a separate approved proposal.

--- a/spec/guard-policy/v1alpha1/compatibility.md
+++ b/spec/guard-policy/v1alpha1/compatibility.md
@@ -1,0 +1,37 @@
+# GuardPolicy compatibility policy
+
+## Version boundary
+
+`apiVersion: guard.hashgraphonline.com/v1alpha1` identifies one complete schema and semantic contract. Parsers must reject an unsupported `apiVersion` or `kind`; they must not guess, silently downgrade, or merge fields from another version.
+
+During alpha, additions are permitted only when old conforming readers already have an explicit behavior. New core fields therefore require a new API version unless they are optional and all supported readers have shipped support. A changed effect, matcher, precedence rule, canonical byte, or trust rule is incompatible and requires a new major API version.
+
+Deprecations are announced for at least one measured support window covering active Portal and Guard client versions. Legacy bundle v1 readers and writers remain available throughout that window. Removal of legacy fields, readers, writers, or bundle v1 is out of scope for this rollout and requires a separate approved proposal.
+
+## Unknown fields
+
+Unknown core fields are errors. Every object in `schema.json` closes `additionalProperties` except documented free-form string maps and recursively bounded extension values. Readers must not discard an unknown core field and continue enforcement.
+
+Extensions use names matching `^x-[a-z0-9][a-z0-9.-]{0,62}$`. Valid extension values are JSON scalars, arrays, or objects within the schema's size and depth limits. Extensions:
+
+- survive YAML format, import, export, and canonical JSON unchanged;
+- participate in the document digest and bundle signature;
+- never change core matching, effect, lifetime, authority, or precedence semantics unless separately registered;
+- may be ignored semantically by a reader that does not implement the registered extension, but may not be removed before hashing or forwarding.
+
+## Extension registration
+
+An extension proposal must publish:
+
+1. its globally unique `x-<owner>.<name>` key;
+2. allowed locations and value schema;
+3. deterministic semantics and failure behavior;
+4. security and privacy analysis;
+5. canonical fixtures and at least one consumer;
+6. a collision and retirement plan.
+
+Registration does not grant permission to weaken core policy. An extension that changes authority, precedence, signing, or rollback requires a new core API version.
+
+## Conformance and ambiguity
+
+Implementations report fixture mismatches against `fixtures/manifest.json` with the fixture path, expected result, observed result, implementation version, and platform. Ambiguity findings belong in the public RFC before stabilization. No alpha behavior becomes v1.0 solely because one implementation shipped it.

--- a/spec/guard-policy/v1alpha1/rfc.md
+++ b/spec/guard-policy/v1alpha1/rfc.md
@@ -1,0 +1,39 @@
+# RFC: GuardPolicy v1alpha1 interoperability
+
+Status: public alpha; comments requested through a GitHub issue or pull request against this document.
+
+## Proposal
+
+Adopt `guard.hashgraphonline.com/v1alpha1` as the shared human-authored policy contract for Portal and HOL Guard. YAML is input and display only. Validated typed data is canonicalized as RFC 8785 JSON for hashing and signing. Legacy bundle v1 remains available during the compatibility window.
+
+## Questions for implementers
+
+### Action vocabulary
+
+The core effects are `allow`, `block`, `review`, and `ignore`. Are these sufficient across shell, file, browser, MCP, package, skill, plugin, and remote-control actions? Should a future version distinguish advisory review from an enforcement pause without changing precedence?
+
+### Scope vocabulary
+
+The alpha matcher vocabulary covers operations, actors, agents, artifacts, commands, devices, domains, ecosystems, environments, harnesses, locations, MCPs, packages, paths, publishers, repositories, secret types, skills, tools, workspaces, and browser-specific fields. Which fields are ambiguous across runtimes? Which missing scopes cannot be expressed safely as a registered extension?
+
+### Trust
+
+A signed cloud bundle is accepted only through a local trusted-key registry. Is RSA-PSS/SHA-256 sufficient for the compatibility window? What rotation, revocation, offline grace, and emergency rollback evidence should a stable version require?
+
+### Local precedence
+
+Current precedence evaluates eligibility, local/remote authority, exactness/specificity, then recency. Does an exact local temporary decision always need to beat a broader remote rule? Which managed environments require an explicit non-overridable remote authority, and should that be a new API version rather than an extension?
+
+## Review evidence requested
+
+Implementers should run `fixtures/manifest.json`, report canonical byte/hash differences, and attach effective-decision results for local/remote, exact/broad, active/expired, and once/permanent cases. Reports must identify parser version and platform without including private policy content.
+
+## Stabilization criteria
+
+- at least two independent implementations agree on every fixture;
+- ambiguity findings are resolved in the normative semantics;
+- a security review covers YAML parsing, extensions, canonicalization, signing, trust, rollback, precedence, and secret handling;
+- staged production metrics show no unexplained legacy/canonical decision mismatch;
+- compatibility and deprecation windows are approved.
+
+Until those gates pass, the contract remains `v1alpha1`; incompatible changes use a new API version rather than silent reinterpretation.

--- a/spec/guard-policy/v1alpha1/threat-model.md
+++ b/spec/guard-policy/v1alpha1/threat-model.md
@@ -1,0 +1,41 @@
+# GuardPolicy v1alpha1 threat model
+
+## Assets and boundaries
+
+Protected assets are effective decisions, policy provenance, canonical bytes and hashes, signing keys, trusted verification keys, rollback state, local SQLite policy rows, and cloud synchronization acknowledgements.
+
+The YAML file is untrusted input. The Portal API, transport, local cache, and extension values are also untrusted until schema validation, canonicalization, signature verification, trust anchoring, and rollback checks complete. Local runtime enforcement remains authoritative when cloud policy is unavailable or invalid.
+
+## Threats and required controls
+
+| Threat | Required control |
+| --- | --- |
+| YAML aliases, merge keys, custom tags, duplicate keys, or parser differentials | Reject before semantic conversion; use the documented YAML subset and fixture suite. |
+| Oversized or deeply nested policy | Enforce byte, depth, collection, string, and rule-count limits before expensive work. |
+| Unknown core field or action | Fail closed for the document; never discard and continue enforcement. |
+| Extension collision or semantic smuggling | Restrict names to registered `x-` keys; include extension values in canonical bytes; extensions cannot override core semantics. |
+| Canonicalization disagreement | Hash and sign RFC 8785 canonical JSON only; verify published byte and digest vectors. |
+| Signature substitution or key injection | Verify RSA-PSS/SHA-256 with an independently trusted key registry; never trust an envelope's embedded key by itself. |
+| Replay, downgrade, or unauthorized rollback | Persist the last accepted version/hash, reject lower or conflicting versions, and require explicit signed rollback authorization. |
+| Partial cloud update or concurrent Portal writer | Use atomic compare-and-swap revision writes; never merge canonical and legacy authorities after validation. |
+| Expired temporary rule | Evaluate expiry before precedence and exclude expired rows. |
+| Broad remote policy eclipses exact local intent | Apply documented eligibility, authority, specificity, and recency precedence in that order. |
+| Secret disclosure through policy, diagnostics, or logs | Reject secret-bearing fields, redact parser errors, and log bounded reason codes rather than raw policy content. |
+| Client capability spoofing | Capability negotiation selects serialization only; it does not grant policy authority or weaken local trust checks. |
+| Availability loss during rollout | Preserve byte-identical bundle v1 fallback and last-known-good local policy; fail closed for unverified v2 without deleting the valid cache. |
+
+## Signing-key handling
+
+Portal private signing keys remain outside policy documents and source control. Bundles identify a key; Guard resolves that identifier through its trusted-key registry. Revocation and grace state are local trust decisions. Signatures cover the canonical envelope payload and all extension values.
+
+## Privacy
+
+Policy matchers may reveal repository, path, package, tool, device, or workspace identifiers. Implementations minimize transport and logs, never include raw secrets, and keep local-only rules local unless the user explicitly synchronizes them.
+
+## Non-goals
+
+The format does not make a malicious endpoint trustworthy, replace operating-system isolation, authorize cloud enrollment, or guarantee that every harness exposes every action. It standardizes policy meaning and transport for supported enforcement surfaces.
+
+## Residual risk and stabilization gate
+
+Parser bugs, implementation-specific Unicode behavior, incomplete harness coverage, and ambiguous new vocabularies remain alpha risks. v1.0 requires independent fixture agreement, no unexplained decision mismatch in staged production, and dedicated security review of parsing, signatures, rollback, precedence, and secret handling.


### PR DESCRIPTION
## Summary
- publish the Guard policy v1alpha1 schema, semantics, canonicalization, compatibility, and threat model as one public interoperability surface
- document parser and decision conformance vectors
- define the alpha RFC lifecycle and compatibility guarantees

## Verification
- `uv run pytest -q tests/test_policy_document_yaml.py tests/test_policy_document_io.py tests/test_policy_document_cli.py` — 53 passed
- public-surface leakage and infrastructure keyword scan — clean
- `git diff --cached --check` — clean