### PR TITLE
fix(guard): harden policy document CLI

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_policy_document.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_policy_document.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TextIO, cast
 
 from ..approval_gate import ApprovalGateError, require_high_risk
+from ..policy_authority import PolicyAuthorityError
 from ..policy_document import policy_document_digest
 from ..policy_document_io import (
     PolicyCompilationError,
@@ -244,7 +245,13 @@ def _run_guard_policy_document_command(
             return 0
 
         raise ValueError("unknown_policy_document_command")
-    except (ApprovalGateError, PolicyCompilationError, PolicyDocumentError, PolicyFileTrustError) as error:
+    except (
+        ApprovalGateError,
+        PolicyAuthorityError,
+        PolicyCompilationError,
+        PolicyDocumentError,
+        PolicyFileTrustError,
+    ) as error:
         code = getattr(error, "code", error.__class__.__name__)
         _write_payload(
             f"policy {command}",

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
@@ -44,7 +44,6 @@ def _configure_guard_policy_parsers(
     policy_diff_parser.add_argument("--json", action="store_true")
 
     policy_export_parser = policy_subparsers.add_parser("export", help="Export local policies")
-    policy_export_parser.add_argument("--format", choices=("yaml",), default="yaml")
     policy_export_parser.add_argument("--output")
     policy_export_parser.add_argument("--include-provenance", action="store_true")
     _add_guard_common_args(policy_export_parser)

--- a/src/codex_plugin_scanner/guard/policy_document_io.py
+++ b/src/codex_plugin_scanner/guard/policy_document_io.py
@@ -271,12 +271,12 @@ def diff_policy_documents(
     return PolicyDocumentDiff(changed=bool(text), text=text)
 
 
-def _normalized_timestamp(value: object) -> str:
+def _normalized_timestamp(value: object, *, rule_id: str) -> str:
     if isinstance(value, str):
         candidate = value.strip().replace("+00:00", "Z")
         if _UTC_TIMESTAMP_RE.fullmatch(candidate):
             return candidate
-    return "1970-01-01T00:00:00Z"
+    raise PolicyCompilationError("invalid_local_policy_timestamp", rule_id)
 
 
 def _normalized_expiry(value: object, *, rule_id: str, code: str) -> str | None:
@@ -306,6 +306,8 @@ def _provenance_source(value: object) -> str:
         return value
     if value == "cloud-sync":
         return "cloud"
+    if value == _POLICY_IMPORT_SOURCE:
+        return "import"
     return "local"
 
 
@@ -345,7 +347,9 @@ def _rule_from_policy_row(row: Mapping[str, object], *, include_provenance: bool
     )
     provenance: dict[str, object] = {
         "source": _provenance_source(row.get("source")) if include_provenance else "export-redacted",
-        "createdAt": _normalized_timestamp(row.get("updated_at")) if include_provenance else _REDACTED_TIMESTAMP,
+        "createdAt": _normalized_timestamp(row.get("updated_at"), rule_id=rule_id)
+        if include_provenance
+        else _REDACTED_TIMESTAMP,
     }
     owner = _optional_string(row.get("owner"))
     if include_provenance and owner is not None:
@@ -423,15 +427,20 @@ def build_policy_document_from_rows(
     return GuardPolicyDocument.from_mapping(mapping)
 
 
-def _selector_values(match: Mapping[str, object], key: str) -> tuple[str | None, ...]:
+def _selector_values(
+    match: Mapping[str, object],
+    key: str,
+    *,
+    rule_id: str,
+) -> tuple[str | None, ...]:
     value = match.get(key)
     if value is None:
         return (None,)
     if not isinstance(value, list) or not value:
-        return (None,)
+        raise PolicyCompilationError("invalid_policy_match_selector", rule_id)
     items = cast(list[object], value)
-    if not all(isinstance(item, str) for item in items):
-        return (None,)
+    if not all(isinstance(item, str) and item for item in items):
+        raise PolicyCompilationError("invalid_policy_match_selector", rule_id)
     return tuple(cast(list[str], items))
 
 
@@ -496,10 +505,10 @@ def compile_policy_document(document: GuardPolicyDocument) -> tuple[CompiledPoli
         local_extension = raw_rule.get("x-hol-local")
         extension = local_extension if isinstance(local_extension, Mapping) else {}
         selectors = itertools.product(
-            _selector_values(match, "artifacts"),
-            _selector_values(match, "harnesses"),
-            _selector_values(match, "publishers"),
-            _selector_values(match, "workspaces"),
+            _selector_values(match, "artifacts", rule_id=rule_id),
+            _selector_values(match, "harnesses", rule_id=rule_id),
+            _selector_values(match, "publishers", rule_id=rule_id),
+            _selector_values(match, "workspaces", rule_id=rule_id),
         )
         provenance = raw_rule.get("provenance")
         provenance_mapping = provenance if isinstance(provenance, Mapping) else {}

--- a/tests/test_policy_document_cli.py
+++ b/tests/test_policy_document_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.cli import _resolve_legacy_args, main
+from codex_plugin_scanner.guard.policy_authority import PolicyAuthorityError
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -131,3 +132,61 @@ def test_policy_file_error_does_not_disclose_the_local_path(
     assert result == 4
     assert payload["error"] == "policy_parent_unavailable"
     assert str(missing) not in json.dumps(payload)
+
+
+def test_policy_import_reports_authority_errors(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    policy_file = tmp_path / "policy.yaml"
+    assert (
+        main(
+            [
+                "guard",
+                "policy",
+                "export",
+                "--home",
+                str(home),
+                "--output",
+                str(policy_file),
+                "--json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    monkeypatch.setenv("HOL_GUARD_POLICY_YAML_IMPORT", "1")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.commands_dispatch_policy_document.prompt_for_approval_gate",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.commands_dispatch_policy_document.require_high_risk",
+        lambda *_args, **_kwargs: object(),
+    )
+
+    def reject_import(*_args: object, **_kwargs: object) -> None:
+        raise PolicyAuthorityError("remote_policy_source_requires_validated_sync_path")
+
+    monkeypatch.setattr(GuardStore, "import_policy_document", reject_import)
+
+    result = main(
+        [
+            "guard",
+            "policy",
+            "import",
+            str(policy_file),
+            "--replace",
+            "--apply",
+            "--home",
+            str(home),
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert result == 4
+    assert payload["error"] == "PolicyAuthorityError"
+    assert payload["message"] == "remote_policy_source_requires_validated_sync_path"

--- a/tests/test_policy_document_io.py
+++ b/tests/test_policy_document_io.py
@@ -169,6 +169,43 @@ def test_export_rejects_invalid_local_expiry() -> None:
         )
 
 
+def test_export_rejects_invalid_local_timestamp() -> None:
+    with pytest.raises(PolicyCompilationError, match="invalid_local_policy_timestamp"):
+        build_policy_document_from_rows(
+            [
+                {
+                    "decision_id": 10,
+                    "harness": "codex",
+                    "scope": "global",
+                    "action": "allow",
+                    "source": "review-decision",
+                    "updated_at": "not-a-timestamp",
+                }
+            ],
+            include_provenance=True,
+        )
+
+
+def test_export_identifies_yaml_import_provenance() -> None:
+    document = build_policy_document_from_rows(
+        [
+            {
+                "decision_id": 11,
+                "harness": "codex",
+                "scope": "global",
+                "action": "allow",
+                "source": "policy-yaml-import",
+                "updated_at": "2026-07-16T10:00:00Z",
+            }
+        ],
+        include_provenance=True,
+    )
+
+    rule = document.rules[0]
+    assert rule.provenance is not None
+    assert rule.provenance.source == "import"
+
+
 def test_export_order_is_stable_when_primary_fields_tie() -> None:
     rows = [
         {
@@ -204,6 +241,13 @@ def test_compile_rejects_match_not_supported_by_local_store() -> None:
     document = _policy_document(match={"commands": ["deploy"]})
 
     with pytest.raises(PolicyCompilationError, match="unsupported_policy_match"):
+        compile_policy_document(document)
+
+
+def test_compile_rejects_empty_selector_lists() -> None:
+    document = _policy_document(match={"artifacts": []})
+
+    with pytest.raises(PolicyCompilationError, match="invalid_policy_match_selector"):
         compile_policy_document(document)
 
 


### PR DESCRIPTION
## Summary
- report policy authority violations as structured CLI errors
- reject empty selectors and invalid provenance timestamps
- preserve imported-policy provenance and remove the unused export format flag

## Verification
- `uv run pytest -q tests/test_policy_document_cli.py tests/test_policy_document_io.py tests/test_policy_document_import.py`
- focused Ruff lint and format checks
- `uv run basedpyright src`