### PR TITLE
Allow proven GitHub PR maintenance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "requests>=2.32,<3",
     "tomli>=2.0; python_version < '3.11'",
     "cisco-ai-skill-scanner~=2.0.11; python_version < '3.14'",
-    "mcp>=1.27.0,<2; python_version >= '3.10'",
+    "mcp>=1.28.1,<2; python_version >= '3.10'",
 ]
 
 [project.optional-dependencies]

--- a/src/codex_plugin_scanner/guard/runtime/github_command_capabilities.py
+++ b/src/codex_plugin_scanner/guard/runtime/github_command_capabilities.py
@@ -77,7 +77,6 @@ _MUTATING_SUBCOMMANDS: dict[str, frozenset[str]] = {
     "workflow": frozenset({"disable", "enable", "run"}),
 }
 _MAINTENANCE_SUBCOMMANDS: dict[str, frozenset[str]] = {"pr": frozenset({"merge"})}
-_MAINTENANCE_GRAPHQL_MUTATIONS = frozenset({"resolveReviewThread", "unresolveReviewThread"})
 
 _ALWAYS_MUTATING_GROUPS = frozenset({"cache", "codespace", "gpg-key", "label", "secret", "ssh-key", "variable"})
 _READ_ONLY_TOP_LEVEL = frozenset({"search", "status"})
@@ -109,8 +108,6 @@ _API_OPTIONS_WITH_VALUES = frozenset(
 _API_BOOLEAN_OPTIONS = frozenset({"--include", "--paginate", "--silent", "--slurp", "--verbose", "-i"})
 _METHOD_OVERRIDE_HEADER = re.compile(r"\Ax-http-method-override\s*:", re.IGNORECASE)
 _STATIC_ENDPOINT = re.compile(r"\A[A-Za-z0-9_./{}:+,@=-]+\Z")
-_GRAPHQL_NAME = re.compile(r"\b[_A-Za-z][_0-9A-Za-z]*\b")
-_GRAPHQL_ALIAS = re.compile(r"\b(?P<name>[_A-Za-z][_0-9A-Za-z]*)\s*:")
 
 
 def classify_github_cli(args: Sequence[str]) -> GitHubCommandAssessment:
@@ -170,7 +167,9 @@ def classify_github_cli(args: Sequence[str]) -> GitHubCommandAssessment:
                 "github.command.proven-read",
                 "The command is a known read-only GitHub operation.",
             )
-        if subcommand in _MAINTENANCE_SUBCOMMANDS.get(top_level, frozenset()):
+        if subcommand in _MAINTENANCE_SUBCOMMANDS.get(top_level, frozenset()) and not any(
+            token == "--admin" or token.startswith("--admin=") for token in normalized[2:]
+        ):
             return _assessment(
                 "maintain_remote",
                 "github.command.pr-maintenance",
@@ -376,192 +375,10 @@ def _classify_graphql(parsed: _ApiArguments, *, method: str | None) -> GitHubCom
 
 
 def _classify_graphql_document(document: str) -> GitHubCommandAssessment:
-    sanitized = _strip_graphql_strings_and_comments(document)
-    suspicious_aliases = [
-        match.group("name")
-        for match in _GRAPHQL_ALIAS.finditer(sanitized)
-        if "mutation" in match.group("name").lower() or "subscription" in match.group("name").lower()
-    ]
-    if suspicious_aliases:
-        return _assessment(
-            "unknown",
-            "github.graphql.suspicious-alias",
-            "A GraphQL alias resembles an operation type and is not classified automatically.",
-        )
-    operations = _top_level_graphql_operations(sanitized)
-    if operations is None:
-        return _assessment("unknown", "github.graphql.invalid-document", "The GraphQL document is not balanced.")
-    if not operations:
-        return _assessment("unknown", "github.graphql.missing-operation", "No static GraphQL operation was found.")
-    if len(operations) != 1:
-        return _assessment(
-            "unknown",
-            "github.graphql.multiple-operations",
-            "Multiple GraphQL operations or a batched document cannot be classified automatically.",
-        )
-    operation = operations[0]
-    if operation == "mutation":
-        root_fields = _graphql_root_fields(sanitized)
-        if root_fields and frozenset(root_fields) <= _MAINTENANCE_GRAPHQL_MUTATIONS:
-            return _assessment(
-                "maintain_remote",
-                "github.graphql.proven-maintenance",
-                "The GraphQL mutation performs only statically proven review-thread maintenance.",
-            )
-        return _assessment(
-            "mutate_remote",
-            "github.graphql.remote-mutation",
-            "The GraphQL operation can change GitHub-hosted state.",
-        )
-    if operation == "subscription":
-        return _assessment(
-            "mutate_remote",
-            "github.graphql.remote-mutation",
-            "The GraphQL operation can change or subscribe to GitHub-hosted state.",
-        )
-    return _assessment("read_remote", "github.graphql.proven-query", "The GraphQL document is a single static query.")
+    from .github_graphql_capabilities import classify_graphql_document
 
-
-def _graphql_root_fields(document: str) -> tuple[str, ...] | None:
-    selection_start = _graphql_selection_start(document)
-    if selection_start is None:
-        return None
-    fields: list[str] = []
-    depth = 1
-    parenthesis_depth = 0
-    index = selection_start + 1
-    while index < len(document) and depth > 0:
-        character = document[index]
-        if character == "(":
-            parenthesis_depth += 1
-            index += 1
-            continue
-        if character == ")":
-            if parenthesis_depth == 0:
-                return None
-            parenthesis_depth -= 1
-            index += 1
-            continue
-        if character == "{":
-            depth += 1
-            index += 1
-            continue
-        if character == "}":
-            depth -= 1
-            index += 1
-            continue
-        if depth != 1 or parenthesis_depth != 0 or character.isspace() or character == ",":
-            index += 1
-            continue
-        if document.startswith("...", index):
-            return None
-        name_match = _GRAPHQL_NAME.match(document, index)
-        if name_match is None:
-            return None
-        field_name = name_match.group(0)
-        index = name_match.end()
-        while index < len(document) and document[index].isspace():
-            index += 1
-        if index < len(document) and document[index] == ":":
-            index += 1
-            while index < len(document) and document[index].isspace():
-                index += 1
-            field_match = _GRAPHQL_NAME.match(document, index)
-            if field_match is None:
-                return None
-            field_name = field_match.group(0)
-            index = field_match.end()
-        fields.append(field_name)
-    if depth != 0 or parenthesis_depth != 0:
-        return None
-    return tuple(fields)
-
-
-def _graphql_selection_start(document: str) -> int | None:
-    parenthesis_depth = 0
-    for index, character in enumerate(document):
-        if character == "(":
-            parenthesis_depth += 1
-        elif character == ")":
-            if parenthesis_depth == 0:
-                return None
-            parenthesis_depth -= 1
-        elif character == "{" and parenthesis_depth == 0:
-            return index
-    return None
-
-
-def _top_level_graphql_operations(document: str) -> list[str] | None:
-    operations: list[str] = []
-    depth = 0
-    pending_definition = False
-    index = 0
-    while index < len(document):
-        character = document[index]
-        if character == "{":
-            if depth == 0:
-                if not pending_definition:
-                    operations.append("query")
-                pending_definition = False
-            depth += 1
-            index += 1
-            continue
-        if character == "}":
-            if depth == 0:
-                return None
-            depth -= 1
-            index += 1
-            continue
-        if depth == 0:
-            name_match = _GRAPHQL_NAME.match(document, index)
-            if name_match is not None:
-                name = name_match.group(0).lower()
-                if name in {"query", "mutation", "subscription"}:
-                    operations.append(name)
-                    pending_definition = True
-                elif name == "fragment":
-                    pending_definition = True
-                index = name_match.end()
-                continue
-        index += 1
-    return operations if depth == 0 else None
-
-
-def _strip_graphql_strings_and_comments(document: str) -> str:
-    output: list[str] = []
-    index = 0
-    while index < len(document):
-        if document.startswith('"""', index):
-            end = document.find('"""', index + 3)
-            if end == -1:
-                return ""
-            output.extend(" " * (end + 3 - index))
-            index = end + 3
-            continue
-        character = document[index]
-        if character == '"':
-            output.append(" ")
-            index += 1
-            escaped = False
-            while index < len(document):
-                current = document[index]
-                output.append(" ")
-                index += 1
-                if escaped:
-                    escaped = False
-                elif current == "\\":
-                    escaped = True
-                elif current == '"':
-                    break
-            continue
-        if character == "#":
-            while index < len(document) and document[index] not in "\r\n":
-                output.append(" ")
-                index += 1
-            continue
-        output.append(character)
-        index += 1
-    return "".join(output)
+    capability, reason_code, detail = classify_graphql_document(document)
+    return _assessment(capability, reason_code, detail)
 
 
 def _field_value_is_external(value: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/github_command_capabilities.py
+++ b/src/codex_plugin_scanner/guard/runtime/github_command_capabilities.py
@@ -15,6 +15,7 @@ from typing import Literal
 GitHubCommandCapability = Literal[
     "read_local",
     "read_remote",
+    "maintain_remote",
     "mutate_remote",
     "write_local",
     "unknown",
@@ -75,6 +76,8 @@ _MUTATING_SUBCOMMANDS: dict[str, frozenset[str]] = {
     "run": frozenset({"cancel", "delete", "rerun"}),
     "workflow": frozenset({"disable", "enable", "run"}),
 }
+_MAINTENANCE_SUBCOMMANDS: dict[str, frozenset[str]] = {"pr": frozenset({"merge"})}
+_MAINTENANCE_GRAPHQL_MUTATIONS = frozenset({"resolveReviewThread", "unresolveReviewThread"})
 
 _ALWAYS_MUTATING_GROUPS = frozenset({"cache", "codespace", "gpg-key", "label", "secret", "ssh-key", "variable"})
 _READ_ONLY_TOP_LEVEL = frozenset({"search", "status"})
@@ -166,6 +169,12 @@ def classify_github_cli(args: Sequence[str]) -> GitHubCommandAssessment:
                 "read_remote",
                 "github.command.proven-read",
                 "The command is a known read-only GitHub operation.",
+            )
+        if subcommand in _MAINTENANCE_SUBCOMMANDS.get(top_level, frozenset()):
+            return _assessment(
+                "maintain_remote",
+                "github.command.pr-maintenance",
+                "The command performs a statically proven pull-request maintenance operation.",
             )
         if subcommand in _MUTATING_SUBCOMMANDS[top_level]:
             return _assessment(
@@ -391,13 +400,95 @@ def _classify_graphql_document(document: str) -> GitHubCommandAssessment:
             "Multiple GraphQL operations or a batched document cannot be classified automatically.",
         )
     operation = operations[0]
-    if operation in {"mutation", "subscription"}:
+    if operation == "mutation":
+        root_fields = _graphql_root_fields(sanitized)
+        if root_fields and frozenset(root_fields) <= _MAINTENANCE_GRAPHQL_MUTATIONS:
+            return _assessment(
+                "maintain_remote",
+                "github.graphql.proven-maintenance",
+                "The GraphQL mutation performs only statically proven review-thread maintenance.",
+            )
+        return _assessment(
+            "mutate_remote",
+            "github.graphql.remote-mutation",
+            "The GraphQL operation can change GitHub-hosted state.",
+        )
+    if operation == "subscription":
         return _assessment(
             "mutate_remote",
             "github.graphql.remote-mutation",
             "The GraphQL operation can change or subscribe to GitHub-hosted state.",
         )
     return _assessment("read_remote", "github.graphql.proven-query", "The GraphQL document is a single static query.")
+
+
+def _graphql_root_fields(document: str) -> tuple[str, ...] | None:
+    selection_start = _graphql_selection_start(document)
+    if selection_start is None:
+        return None
+    fields: list[str] = []
+    depth = 1
+    parenthesis_depth = 0
+    index = selection_start + 1
+    while index < len(document) and depth > 0:
+        character = document[index]
+        if character == "(":
+            parenthesis_depth += 1
+            index += 1
+            continue
+        if character == ")":
+            if parenthesis_depth == 0:
+                return None
+            parenthesis_depth -= 1
+            index += 1
+            continue
+        if character == "{":
+            depth += 1
+            index += 1
+            continue
+        if character == "}":
+            depth -= 1
+            index += 1
+            continue
+        if depth != 1 or parenthesis_depth != 0 or character.isspace() or character == ",":
+            index += 1
+            continue
+        if document.startswith("...", index):
+            return None
+        name_match = _GRAPHQL_NAME.match(document, index)
+        if name_match is None:
+            return None
+        field_name = name_match.group(0)
+        index = name_match.end()
+        while index < len(document) and document[index].isspace():
+            index += 1
+        if index < len(document) and document[index] == ":":
+            index += 1
+            while index < len(document) and document[index].isspace():
+                index += 1
+            field_match = _GRAPHQL_NAME.match(document, index)
+            if field_match is None:
+                return None
+            field_name = field_match.group(0)
+            index = field_match.end()
+        fields.append(field_name)
+    if depth != 0 or parenthesis_depth != 0:
+        return None
+    return tuple(fields)
+
+
+def _graphql_selection_start(document: str) -> int | None:
+    parenthesis_depth = 0
+    for index, character in enumerate(document):
+        if character == "(":
+            parenthesis_depth += 1
+        elif character == ")":
+            if parenthesis_depth == 0:
+                return None
+            parenthesis_depth -= 1
+        elif character == "{" and parenthesis_depth == 0:
+            return index
+    return None
 
 
 def _top_level_graphql_operations(document: str) -> list[str] | None:

--- a/src/codex_plugin_scanner/guard/runtime/github_graphql_capabilities.py
+++ b/src/codex_plugin_scanner/guard/runtime/github_graphql_capabilities.py
@@ -1,0 +1,204 @@
+"""Conservative capability classification for static GitHub GraphQL documents."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+GitHubGraphQLCapability = Literal["read_remote", "maintain_remote", "mutate_remote", "unknown"]
+GitHubGraphQLAssessment = tuple[GitHubGraphQLCapability, str, str]
+
+_GRAPHQL_NAME = re.compile(r"\b[_A-Za-z][_0-9A-Za-z]*\b")
+_GRAPHQL_ALIAS = re.compile(r"\b(?P<name>[_A-Za-z][_0-9A-Za-z]*)\s*:")
+_MAINTENANCE_MUTATIONS = frozenset({"resolveReviewThread", "unresolveReviewThread"})
+
+
+def classify_graphql_document(document: str) -> GitHubGraphQLAssessment:
+    """Classify one static GraphQL document, allowing only narrow review maintenance."""
+
+    sanitized = _strip_strings_and_comments(document)
+    suspicious_aliases = [
+        match.group("name")
+        for match in _GRAPHQL_ALIAS.finditer(sanitized)
+        if "mutation" in match.group("name").lower() or "subscription" in match.group("name").lower()
+    ]
+    if suspicious_aliases:
+        return (
+            "unknown",
+            "github.graphql.suspicious-alias",
+            "A GraphQL alias resembles an operation type and is not classified automatically.",
+        )
+    operations = _top_level_operations(sanitized)
+    if operations is None:
+        return "unknown", "github.graphql.invalid-document", "The GraphQL document is not balanced."
+    if not operations:
+        return "unknown", "github.graphql.missing-operation", "No static GraphQL operation was found."
+    if len(operations) != 1:
+        return (
+            "unknown",
+            "github.graphql.multiple-operations",
+            "Multiple GraphQL operations or a batched document cannot be classified automatically.",
+        )
+    operation = operations[0]
+    if operation == "mutation":
+        root_fields = _root_fields(sanitized)
+        if root_fields and frozenset(root_fields) <= _MAINTENANCE_MUTATIONS:
+            return (
+                "maintain_remote",
+                "github.graphql.proven-maintenance",
+                "The GraphQL mutation performs only statically proven review-thread maintenance.",
+            )
+        return (
+            "mutate_remote",
+            "github.graphql.remote-mutation",
+            "The GraphQL operation can change GitHub-hosted state.",
+        )
+    if operation == "subscription":
+        return (
+            "mutate_remote",
+            "github.graphql.remote-mutation",
+            "The GraphQL operation can change or subscribe to GitHub-hosted state.",
+        )
+    return "read_remote", "github.graphql.proven-query", "The GraphQL document is a single static query."
+
+
+def _root_fields(document: str) -> tuple[str, ...] | None:
+    selection_start = _selection_start(document)
+    if selection_start is None:
+        return None
+    fields: list[str] = []
+    depth = 1
+    parenthesis_depth = 0
+    index = selection_start + 1
+    while index < len(document) and depth > 0:
+        character = document[index]
+        if character == "(":
+            parenthesis_depth += 1
+            index += 1
+            continue
+        if character == ")":
+            if parenthesis_depth == 0:
+                return None
+            parenthesis_depth -= 1
+            index += 1
+            continue
+        if character == "{":
+            depth += 1
+            index += 1
+            continue
+        if character == "}":
+            depth -= 1
+            index += 1
+            continue
+        if depth != 1 or parenthesis_depth != 0 or character.isspace() or character == ",":
+            index += 1
+            continue
+        if document.startswith("...", index):
+            return None
+        name_match = _GRAPHQL_NAME.match(document, index)
+        if name_match is None:
+            return None
+        field_name = name_match.group(0)
+        index = name_match.end()
+        while index < len(document) and document[index].isspace():
+            index += 1
+        if index < len(document) and document[index] == ":":
+            index += 1
+            while index < len(document) and document[index].isspace():
+                index += 1
+            field_match = _GRAPHQL_NAME.match(document, index)
+            if field_match is None:
+                return None
+            field_name = field_match.group(0)
+            index = field_match.end()
+        fields.append(field_name)
+    if depth != 0 or parenthesis_depth != 0:
+        return None
+    return tuple(fields)
+
+
+def _selection_start(document: str) -> int | None:
+    parenthesis_depth = 0
+    for index, character in enumerate(document):
+        if character == "(":
+            parenthesis_depth += 1
+        elif character == ")":
+            if parenthesis_depth == 0:
+                return None
+            parenthesis_depth -= 1
+        elif character == "{" and parenthesis_depth == 0:
+            return index
+    return None
+
+
+def _top_level_operations(document: str) -> list[str] | None:
+    operations: list[str] = []
+    depth = 0
+    pending_definition = False
+    index = 0
+    while index < len(document):
+        character = document[index]
+        if character == "{":
+            if depth == 0:
+                if not pending_definition:
+                    operations.append("query")
+                pending_definition = False
+            depth += 1
+            index += 1
+            continue
+        if character == "}":
+            if depth == 0:
+                return None
+            depth -= 1
+            index += 1
+            continue
+        if depth == 0:
+            name_match = _GRAPHQL_NAME.match(document, index)
+            if name_match is not None:
+                name = name_match.group(0).lower()
+                if name in {"query", "mutation", "subscription"}:
+                    operations.append(name)
+                    pending_definition = True
+                elif name == "fragment":
+                    pending_definition = True
+                index = name_match.end()
+                continue
+        index += 1
+    return operations if depth == 0 else None
+
+
+def _strip_strings_and_comments(document: str) -> str:
+    output: list[str] = []
+    index = 0
+    while index < len(document):
+        if document.startswith('"""', index):
+            end = document.find('"""', index + 3)
+            if end == -1:
+                return ""
+            output.extend(" " * (end + 3 - index))
+            index = end + 3
+            continue
+        character = document[index]
+        if character == '"':
+            output.append(" ")
+            index += 1
+            escaped = False
+            while index < len(document):
+                current = document[index]
+                output.append(" ")
+                index += 1
+                if escaped:
+                    escaped = False
+                elif current == "\\":
+                    escaped = True
+                elif current == '"':
+                    break
+            continue
+        if character == "#":
+            while index < len(document) and document[index] not in "\r\n":
+                output.append(" ")
+                index += 1
+            continue
+        output.append(character)
+        index += 1
+    return "".join(output)

--- a/src/codex_plugin_scanner/guard/runtime/github_graphql_capabilities.py
+++ b/src/codex_plugin_scanner/guard/runtime/github_graphql_capabilities.py
@@ -28,6 +28,13 @@ def classify_graphql_document(document: str) -> GitHubGraphQLAssessment:
             "github.graphql.suspicious-alias",
             "A GraphQL alias resembles an operation type and is not classified automatically.",
         )
+    has_fragment_definition = re.search(r"\bfragment\b", sanitized) is not None
+    if has_fragment_definition and re.search(r"\bmutation\b", sanitized) is not None:
+        return (
+            "mutate_remote",
+            "github.graphql.remote-mutation",
+            "GraphQL mutations with fragment definitions require confirmation.",
+        )
     operations = _top_level_operations(sanitized)
     if operations is None:
         return "unknown", "github.graphql.invalid-document", "The GraphQL document is not balanced."
@@ -42,7 +49,7 @@ def classify_graphql_document(document: str) -> GitHubGraphQLAssessment:
     operation = operations[0]
     if operation == "mutation":
         root_fields = _root_fields(sanitized)
-        if root_fields and frozenset(root_fields) <= _MAINTENANCE_MUTATIONS:
+        if not has_fragment_definition and root_fields and frozenset(root_fields) <= _MAINTENANCE_MUTATIONS:
             return (
                 "maintain_remote",
                 "github.graphql.proven-maintenance",

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -1286,7 +1286,7 @@ def _github_shell_capability_assessment(
             if command_name != "gh" or command_index is None:
                 continue
             assessment = _classify_github_shell_segment(segment, command_index)
-            if assessment.capability not in {"read_local", "read_remote"}:
+            if assessment.capability not in {"read_local", "read_remote", "maintain_remote"}:
                 return assessment
             contains_github_read = True
         if not contains_github_read or len(pipeline) < 2:

--- a/tests/test_guard_github_command_capabilities.py
+++ b/tests/test_guard_github_command_capabilities.py
@@ -29,6 +29,19 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "read_remote",
             "github.graphql.proven-query",
         ),
+        (
+            (
+                "api",
+                "graphql",
+                "-f",
+                "query=mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id}}}",
+                "-f",
+                "threadId=PRRT_example",
+            ),
+            "maintain_remote",
+            "github.graphql.proven-maintenance",
+        ),
+        (("pr", "merge", "17", "--squash", "--delete-branch"), "maintain_remote", "github.command.pr-maintenance"),
         (("pr", "edit", "17", "--title", "updated"), "mutate_remote", "github.command.remote-mutation"),
         (
             ("api", "repos/example/project", "-f", "name=updated"),
@@ -96,6 +109,12 @@ def test_classify_github_cli_rejects_ambiguous_graphql_inputs(args):
         "gh api repos/example/project -X GET -f per_page=1 --jq '.name'",
         "gh api graphql -f 'query=query { viewer { login } }' | jq -r '.data.viewer.login'",
         (
+            "gh api graphql -f "
+            "'query=mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id}}}' "
+            "-f threadId=PRRT_example"
+        ),
+        "gh pr merge 17 --repo example/project --squash --delete-branch",
+        (
             "gh api graphql -f 'query=query { viewer { login } }' 2>&1 | "
             "python3 -c \"import json,sys; print(json.load(sys.stdin)['data']['viewer']['login'])\""
         ),
@@ -116,6 +135,12 @@ def test_guard_keeps_proven_github_reads_prompt_free(tmp_path, command):
         ),
         (
             "gh api graphql -f 'query=mutation { updateThing(input: {}) { id } }' | jq -r '.data'",
+            "GitHub remote mutation command",
+        ),
+        (
+            "gh api graphql -f "
+            "'query=mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id}} "
+            "deleteRepository(input:{repositoryId:$threadId}){repository{id}}}' -f threadId=R_123",
             "GitHub remote mutation command",
         ),
         ("gh pr edit 17 --title updated | jq -r '.'", "GitHub remote mutation command"),

--- a/tests/test_guard_github_command_capabilities.py
+++ b/tests/test_guard_github_command_capabilities.py
@@ -60,6 +60,18 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "github.graphql.remote-mutation",
         ),
         (
+            (
+                "api",
+                "graphql",
+                "-f",
+                "query=fragment Maint on Mutation { resolveReviewThread(input: {threadId: \"T_1\"}) "
+                "{ thread { id } } } mutation { deleteRepository(input: {repositoryId: \"R_1\"}) "
+                "{ repository { id } } }",
+            ),
+            "mutate_remote",
+            "github.graphql.remote-mutation",
+        ),
+        (
             ("api", "graphql", "-f", "query=subscription { eventStream { id } }"),
             "mutate_remote",
             "github.graphql.remote-mutation",

--- a/tests/test_guard_github_command_capabilities.py
+++ b/tests/test_guard_github_command_capabilities.py
@@ -42,6 +42,7 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "github.graphql.proven-maintenance",
         ),
         (("pr", "merge", "17", "--squash", "--delete-branch"), "maintain_remote", "github.command.pr-maintenance"),
+        (("pr", "merge", "17", "--admin"), "mutate_remote", "github.command.remote-mutation"),
         (("pr", "edit", "17", "--title", "updated"), "mutate_remote", "github.command.remote-mutation"),
         (
             ("api", "repos/example/project", "-f", "name=updated"),
@@ -60,6 +61,17 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
         ),
         (
             ("api", "graphql", "-f", "query=subscription { eventStream { id } }"),
+            "mutate_remote",
+            "github.graphql.remote-mutation",
+        ),
+        (
+            (
+                "api",
+                "graphql",
+                "-f",
+                "query=mutation { resolveReviewThread(input: {threadId: \"T_1\"}) { thread { id } } "
+                "deleteRepository(input: {repositoryId: \"R_1\"}) { repository { id } } }",
+            ),
             "mutate_remote",
             "github.graphql.remote-mutation",
         ),
@@ -144,6 +156,7 @@ def test_guard_keeps_proven_github_reads_prompt_free(tmp_path, command):
             "GitHub remote mutation command",
         ),
         ("gh pr edit 17 --title updated | jq -r '.'", "GitHub remote mutation command"),
+        ("gh pr merge 17 --admin", "GitHub remote mutation command"),
         ("env GH_HOST=github.example command gh pr edit 17 --title updated", "GitHub remote mutation command"),
         ("sh -c 'gh pr edit 17 --title updated | jq -r .'", "GitHub remote mutation command"),
         ("gh project-alias | jq -r '.'", "Unverified GitHub command capability"),

--- a/uv.lock
+++ b/uv.lock
@@ -1218,7 +1218,7 @@ requires-dist = [
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.26.0" },
     { name = "keyring", specifier = ">=25.0" },
     { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'cisco'", specifier = "==1.91.3" },
-    { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.27.0,<2" },
+    { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.28.1,<2" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pyinstaller", marker = "extra == 'mdm-build'", specifier = ">=6.16,<7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -1770,7 +1770,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.1"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1788,9 +1788,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- classify statically proven pull-request maintenance separately from arbitrary remote mutations
- keep routine pull-request completion and review-thread state updates prompt-free
- preserve review requirements for mixed or arbitrary GraphQL mutations and destructive administration

## Testing

- `uv run pytest tests/test_guard_github_command_capabilities.py -q`
- `uv run pytest tests/test_guard_runtime_actions.py tests/test_guard_runtime_actions_phase14.py -q`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/github_command_capabilities.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_github_command_capabilities.py`
- `uv run --with basedpyright basedpyright src/codex_plugin_scanner/guard/runtime/github_command_capabilities.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py --level error`
- `uv build`
