### PR TITLE
Treat patch payloads as file content

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -900,6 +900,8 @@ def extract_sensitive_tool_action_request(
 
     command_texts = _candidate_command_texts(arguments)
     normalized_tool_name = _normalize_tool_name(tool_name)
+    if normalized_tool_name in _FILE_WRITE_TOOL_NAMES:
+        return None
     if normalized_tool_name is None and not command_texts:
         return None
     requested_tool_name = str(tool_name).strip() if isinstance(tool_name, str) and str(tool_name).strip() else "Shell"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14187,6 +14187,18 @@ def test_guard_runtime_allows_apply_patch_to_non_sensitive_source_file(tmp_path)
     assert match is None
 
 
+def test_guard_runtime_does_not_execute_classify_apply_patch_content(tmp_path):
+    patch = """*** Begin Patch
+*** Update File: docs/notes.md
+@@
++Routine maintenance uses `gh pr merge 17 --squash --delete-branch`.
+*** End Patch"""
+
+    match = extract_sensitive_tool_action_request("apply_patch", patch, cwd=tmp_path)
+
+    assert match is None
+
+
 def test_guard_runtime_blocks_apply_patch_to_sensitive_file(tmp_path):
     patch = """*** Begin Patch
 *** Update File: .env


### PR DESCRIPTION
## Summary

- keep file-write payload content out of shell-command execution classification
- continue applying sensitive target-path protections to patch operations
- add regression coverage for documentation patches containing shell examples in Markdown code spans

## Testing

- `uv run pytest tests/test_guard_runtime.py -q -k 'apply_patch'`
- `uv run pytest tests/test_guard_runtime_actions.py tests/test_guard_runtime_actions_phase14.py -q`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_runtime.py`
- `uv run --with basedpyright basedpyright src/codex_plugin_scanner/guard/runtime/secret_file_requests.py --level error`
- `uv build`
