### PR TITLE
feat(policy): complete canonical v3 rollout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -180,7 +180,6 @@ jobs:
           name: distributions
           path: dist/
       - name: Keep only the Guard canary distribution
-        if: github.event_name == 'pull_request'
         run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ hol-guard init
 
 `hol-guard init` discovers compatible AI agents, explains each setup change before applying it, and guides you through your first protected action.
 
-[Install guide](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/get-started.md) · [Supported agents](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/harness-support.md) · [Local vs. cloud](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/local-vs-cloud.md) · [Security policy](https://github.com/hashgraph-online/hol-guard/blob/main/SECURITY.md)
+[Install guide](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/get-started.md) · [GuardPolicy v1alpha1](https://github.com/hashgraph-online/hol-guard/blob/main/spec/guard-policy/v1alpha1/README.md) · [Supported agents](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/harness-support.md) · [Local vs. cloud](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/local-vs-cloud.md) · [Security policy](https://github.com/hashgraph-online/hol-guard/blob/main/SECURITY.md)
 
 ## What HOL Guard Protects
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "requests>=2.32,<3",
     "tomli>=2.0; python_version < '3.11'",
     "cisco-ai-skill-scanner~=2.0.11; python_version < '3.14'",
-    "mcp>=1.27.0,<2; python_version >= '3.10'",
+    "mcp>=1.28.1,<2; python_version >= '3.10'",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hol-guard"
-version = "2.0.1105"
+version = "2.0.1113"
 description = "Open-source antivirus and runtime protection for AI agents, tools, MCP servers, plugins, skills, and package installs."
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/sync_repo_version.py
+++ b/scripts/sync_repo_version.py
@@ -43,8 +43,8 @@ def _default_repo_root() -> Path:
 def _validate_version_token(version: str) -> str:
     try:
         Version(version)
-    except InvalidVersion:
-        raise ValueError(f"Unsupported version format: {version}")
+    except InvalidVersion as exc:
+        raise ValueError(f"Unsupported version format: {version}") from exc
     return version
 
 
@@ -124,9 +124,8 @@ def _replace_project_version(path: Path, version: str) -> tuple[str, bool]:
             break
         if not in_project_table:
             continue
-        replaced_line = _replace_matching_line(line, PYPROJECT_VERSION_LINE_PATTERN, version)
-        if replaced_line != line:
-            lines[index] = replaced_line
+        if PYPROJECT_VERSION_LINE_PATTERN.match(line.rstrip("\r\n")) is not None:
+            lines[index] = _replace_matching_line(line, PYPROJECT_VERSION_LINE_PATTERN, version)
             project_version_index = index
             break
 
@@ -143,9 +142,8 @@ def _replace_module_version(path: Path, version: str) -> tuple[str, bool]:
     module_version_index: int | None = None
 
     for index, line in enumerate(lines):
-        replaced_line = _replace_matching_line(line, MODULE_VERSION_LINE_PATTERN, version)
-        if replaced_line != line:
-            lines[index] = replaced_line
+        if MODULE_VERSION_LINE_PATTERN.match(line.rstrip("\r\n")) is not None:
+            lines[index] = _replace_matching_line(line, MODULE_VERSION_LINE_PATTERN, version)
             module_version_index = index
             break
 

--- a/spec/guard-policy/README.md
+++ b/spec/guard-policy/README.md
@@ -6,6 +6,7 @@
 - [v1alpha1 semantics](v1alpha1/semantics.md)
 - [v1alpha1 canonicalization](v1alpha1/canonicalization.md)
 - [v1alpha1 conformance fixtures](v1alpha1/fixtures)
+- [Deferred legacy removal PRD](legacy-removal-prd.md)
 
 Versions are additive during alpha. A consumer MUST reject an unknown `apiVersion`; it MUST NOT guess or silently downgrade. The public schema and fixtures are normative. The Python package carries an exact generated schema copy for installed CLI validation, and its contract test prevents drift.
 

--- a/spec/guard-policy/legacy-removal-prd.md
+++ b/spec/guard-policy/legacy-removal-prd.md
@@ -1,0 +1,58 @@
+# Guard policy legacy removal PRD
+
+## Status
+
+Deferred. This proposal must not be approved or implemented as part of the v1alpha1 compatibility rollout.
+
+## Goal
+
+Remove legacy policy fields and signed bundle v1 only after every supported Portal and HOL Guard version reads, writes, signs, acknowledges, and enforces the canonical policy contract.
+
+## Measured support window
+
+The window starts after canonical enforcement reaches 100% of production workspaces. It ends only when all of the following remain true for at least two supported client release cycles:
+
+- no active client negotiates only bundle v1;
+- no Portal canonical-read fallback is exercised;
+- no unexplained canonical-versus-legacy decision mismatch is observed;
+- rollback to the legacy authority remains exercised and successful during the observation window;
+- package telemetry confirms unsupported client versions are outside the published support policy.
+
+Calendar time alone does not complete the window.
+
+## Legacy reader and writer inventory
+
+The removal implementation must regenerate this inventory from current source and attach exact call sites to its PR. The v1alpha1 rollout intentionally retains these categories:
+
+- Portal JSONB `reviewDecisionRules`, `policyRules`, and graph projections;
+- Portal bundle v1 compiler, signer, API negotiation, acknowledgement, and receipt compatibility paths;
+- Portal canonical backfill, dual-write, shadow-read, and exact legacy fallback controls;
+- HOL Guard bundle v1 parser, signature verification, sync persistence, decision compiler, and acknowledgement paths;
+- HOL Guard local `PolicyDecision` SQLite rows and YAML import/export adapters;
+- frozen v1 payload, canonical signing-byte, signature, hash, precedence, Suggested Memory, undo, simulation, and sync fixtures.
+
+## Entry criteria
+
+1. GuardPolicy is stabilized beyond `v1alpha1` after independent interoperability and security review.
+2. Every canonical-read owner is converted and verified without partial canonical/legacy merges.
+3. Every active rule has exactly one semantic authority and one stable canonical identifier.
+4. Production cohort metrics and sampled receipts show no safety-affecting mismatch.
+5. The oldest supported Portal and HOL Guard releases understand canonical documents and signed bundle v2.
+6. A tested rollback artifact exists for the last release that still contains legacy readers.
+
+## Removal sequence
+
+1. Freeze a final legacy inventory and byte-level regression corpus.
+2. Stop legacy writes behind a reversible production flag; retain readers.
+3. Observe one full supported release cycle and exercise rollback.
+4. Stop bundle v1 negotiation for clients outside the support window; retain parser and last-known-good rollback data.
+5. Remove legacy readers, storage fields, and bundle v1 in separate repository PRs with cross-version tests.
+6. Remove compatibility flags only after rollback data expires under the published retention policy.
+
+## Stop conditions
+
+Any unexplained decision mismatch, signature or digest regression, stale client still inside support, lost Builder or Suggested Memory update, or failed rollback stops removal and restores the previous authority path.
+
+## Non-goals
+
+This document does not authorize deletion, schema migration, field removal, bundle v1 removal, or a reduced support window. Each requires a separately approved implementation plan and release evidence.

--- a/spec/guard-policy/v1alpha1/README.md
+++ b/spec/guard-policy/v1alpha1/README.md
@@ -9,7 +9,11 @@ GuardPolicy is HOL Guard's portable policy document. The alpha contract is inten
 - [`canonicalization.md`](canonicalization.md): YAML parsing profile, canonical JSON bytes, hashes, and signatures.
 - [`compatibility.md`](compatibility.md): alpha versioning, extension registration, unknown fields, and deprecation policy.
 - [`threat-model.md`](threat-model.md): trust boundaries, attacks, mitigations, and non-goals.
-- [`rfc.md`](rfc.md): open questions for action vocabulary, scope vocabulary, trust, and local precedence.
+- [`architecture-decision.md`](architecture-decision.md): accepted V3 alpha authority, transport, rollout, and compatibility decisions.
+- [`operator-runbook.md`](operator-runbook.md): validation, import, capability-gated rollout, observation, and stop conditions.
+- [`rollback-runbook.md`](rollback-runbook.md): legacy kill switch, previous-good restoration, and recovery verification.
+- [`schema-compatibility-runbook.md`](schema-compatibility-runbook.md): producer/consumer matrix, change procedure, and TestPyPI boundary.
+- [`rfc.md`](rfc.md): public alpha questions and stabilization criteria.
 - [`fixtures/manifest.json`](fixtures/manifest.json): valid, invalid, hash, and decision conformance vectors.
 
 ## Reference validation

--- a/spec/guard-policy/v1alpha1/README.md
+++ b/spec/guard-policy/v1alpha1/README.md
@@ -1,0 +1,34 @@
+# GuardPolicy v1alpha1
+
+GuardPolicy is HOL Guard's portable policy document. The alpha contract is intentionally narrow: YAML is the human interchange format, validated typed data is the semantic model, and RFC 8785 canonical JSON is the only representation hashed or signed.
+
+## Normative material
+
+- [`schema.json`](schema.json): accepted document shape and bounded extension values.
+- [`semantics.md`](semantics.md): effects, matchers, lifetime, provenance, authority, and precedence.
+- [`canonicalization.md`](canonicalization.md): YAML parsing profile, canonical JSON bytes, hashes, and signatures.
+- [`compatibility.md`](compatibility.md): alpha versioning, extension registration, unknown fields, and deprecation policy.
+- [`threat-model.md`](threat-model.md): trust boundaries, attacks, mitigations, and non-goals.
+- [`rfc.md`](rfc.md): open questions for action vocabulary, scope vocabulary, trust, and local precedence.
+- [`fixtures/manifest.json`](fixtures/manifest.json): valid, invalid, hash, and decision conformance vectors.
+
+## Reference validation
+
+The Python implementation in HOL Guard is independent of the Portal TypeScript implementation and consumes the same normative schema and fixtures.
+
+```bash
+hol-guard policy validate ./policy.yaml --json
+hol-guard policy fmt ./policy.yaml --check --json
+```
+
+Run its public conformance suite from a source checkout:
+
+```bash
+uv run pytest -q tests/test_policy_document_yaml.py tests/test_policy_document_io.py tests/test_policy_document_cli.py
+```
+
+A conforming implementation must reject every fixture listed under `invalid`, parse and reformat every fixture listed under `valid` deterministically, reproduce the published canonical JSON and SHA-256 vectors byte-for-byte, and preserve all valid `x-` extensions in canonical bytes.
+
+## Alpha status
+
+`v1alpha1` is suitable for interoperability testing, not a stability claim. Stabilization requires an independent implementation, fixture agreement, recorded ambiguity findings, and security review. Bundle v1 and legacy policy fields remain supported during the measured compatibility window; their removal requires a separate approved proposal.

--- a/spec/guard-policy/v1alpha1/architecture-decision.md
+++ b/spec/guard-policy/v1alpha1/architecture-decision.md
@@ -1,0 +1,36 @@
+# Architecture decision: canonical GuardPolicy document
+
+Status: accepted for V3 alpha integration
+
+## Context
+
+Portal Policy Builder, Suggested Memory, signed cloud bundles, and local HOL Guard previously represented policy through related but independently evolving payloads. Enforcement could combine those payloads, but identity, provenance, canonical hashing, capability negotiation, and rollback were not one explicit contract.
+
+## Decision
+
+- `guard.hashgraphonline.com/v1alpha1` is the shared portable policy contract.
+- YAML is human input and display only. Validated typed data is the semantic model.
+- RFC 8785 canonical JSON is the sole hashing and signing representation.
+- Stable rule IDs preserve identity across Builder, Suggested Memory, migration, sync, and local evaluation.
+- Portal remains the authority for cloud-owned policy; local policy retains its documented precedence and fallback behavior.
+- Bundle v2 signs the complete manifest and payload and activates only after capability negotiation, validation, shadow equivalence, and acknowledgement.
+- Bundle v1 and legacy fields remain available throughout the measured compatibility window.
+- Canonical and legacy last-known-good state is retained independently so rollback does not depend on the rejected candidate.
+- Rollout uses deterministic workspace-and-device cohorts and one legacy kill switch. Canonical enforcement is off by default in the V3 alpha artifact.
+
+## Consequences
+
+- Both implementations must consume the same schema and conformance fixtures.
+- Unsupported semantics fail closed rather than silently downgrade.
+- Policy parsing and compilation occur at write, import, or sync time rather than interception time.
+- Observability is limited to bounded reason codes, counts, versions, and hashes; raw policy content is excluded.
+- Promotion means merge into `feat/guard-policy-v3` plus TestPyPI verification. Integration into `main`, stable PyPI publication, and default runtime activation remain separate decisions.
+- Removing bundle v1, legacy reads, or legacy storage requires capability coverage, a clean observation window, exercised rollback, and a separately approved proposal.
+
+## Rejected alternatives
+
+- Hashing YAML bytes: presentation differences would change identity without changing semantics.
+- Treating Suggested Memory as an independent rule store: duplicate authorities would preserve drift and unstable identity.
+- Partial canonical cutover by rule: mixing an incomplete canonical subset with complete legacy policy can change enforcement.
+- Flag-only bundle selection: flags do not prove client parser, signature, acknowledgement, rollback, or snapshot support.
+- Destructive migration: it removes the exact rollback path required during alpha adoption.

--- a/spec/guard-policy/v1alpha1/compatibility.md
+++ b/spec/guard-policy/v1alpha1/compatibility.md
@@ -1,0 +1,37 @@
+# GuardPolicy compatibility policy
+
+## Version boundary
+
+`apiVersion: guard.hashgraphonline.com/v1alpha1` identifies one complete schema and semantic contract. Parsers must reject an unsupported `apiVersion` or `kind`; they must not guess, silently downgrade, or merge fields from another version.
+
+During alpha, additions are permitted only when old conforming readers already have an explicit behavior. New core fields therefore require a new API version unless they are optional and all supported readers have shipped support. A changed effect, matcher, precedence rule, canonical byte, or trust rule is incompatible and requires a new major API version.
+
+Deprecations are announced for at least one measured support window covering active Portal and Guard client versions. Legacy bundle v1 readers and writers remain available throughout that window. Removal of legacy fields, readers, writers, or bundle v1 is out of scope for this rollout and requires a separate approved proposal.
+
+## Unknown fields
+
+Unknown core fields are errors. Every object in `schema.json` closes `additionalProperties` except documented free-form string maps and recursively bounded extension values. Readers must not discard an unknown core field and continue enforcement.
+
+Extensions use names matching `^x-[a-z0-9][a-z0-9.-]{0,62}$`. Valid extension values are JSON scalars, arrays, or objects within the schema's size and depth limits. Extensions:
+
+- survive YAML format, import, export, and canonical JSON unchanged;
+- participate in the document digest and bundle signature;
+- never change core matching, effect, lifetime, authority, or precedence semantics unless separately registered;
+- may be ignored semantically by a reader that does not implement the registered extension, but may not be removed before hashing or forwarding.
+
+## Extension registration
+
+An extension proposal must publish:
+
+1. its globally unique `x-<owner>.<name>` key;
+2. allowed locations and value schema;
+3. deterministic semantics and failure behavior;
+4. security and privacy analysis;
+5. canonical fixtures and at least one consumer;
+6. a collision and retirement plan.
+
+Registration does not grant permission to weaken core policy. An extension that changes authority, precedence, signing, or rollback requires a new core API version.
+
+## Conformance and ambiguity
+
+Implementations report fixture mismatches against `fixtures/manifest.json` with the fixture path, expected result, observed result, implementation version, and platform. Ambiguity findings belong in the public RFC before stabilization. No alpha behavior becomes v1.0 solely because one implementation shipped it.

--- a/spec/guard-policy/v1alpha1/operator-runbook.md
+++ b/spec/guard-policy/v1alpha1/operator-runbook.md
@@ -1,0 +1,66 @@
+# GuardPolicy operator runbook
+
+## Scope
+
+This runbook covers validation, import, capability-gated bundle activation, observation, and rollback for `guard.hashgraphonline.com/v1alpha1`. It does not authorize a stable-schema claim or a production package release.
+
+## Preconditions
+
+- Keep bundle v1 available for clients that do not advertise bundle v2 support.
+- Keep `HOL_GUARD_POLICY_CANONICAL_ENFORCEMENT` at `0` or `legacy` until shadow comparison is clean.
+- Confirm the client advertises the required policy schema, bundle, signature, acknowledgement, rollback, and snapshot capabilities.
+- Retain the active legacy bundle plus canonical last-known-good and previous-good bundles.
+- Use bounded, aggregate metrics. Do not record policy documents, commands, prompts, paths, or secrets.
+
+## Validate a candidate
+
+```bash
+hol-guard policy validate ./guard-policy.yaml --json
+hol-guard policy fmt ./guard-policy.yaml --check --json
+hol-guard policy diff ./guard-policy.yaml --json
+hol-guard policy import ./guard-policy.yaml --merge --dry-run --json
+```
+
+Treat any parse, schema, semantic, signature, hash, downgrade, or unsupported matcher result as a stop condition. Resolve the document at its source; never weaken validation to make a candidate importable.
+
+## Apply a local document
+
+Use merge when the candidate intentionally augments current local policy. Use replace only when the candidate is a complete authoritative document.
+
+```bash
+hol-guard policy import ./guard-policy.yaml --merge --apply --json
+```
+
+After import, export the effective policy and compare its canonical digest with the validated candidate:
+
+```bash
+hol-guard policy export --output ./effective-policy.yaml --json
+hol-guard policy validate ./effective-policy.yaml --json
+```
+
+## Capability-gated bundle rollout
+
+1. Serve byte-identical bundle v1 to clients without complete v2 capability support.
+2. Send signed bundle v2 only when schema, signature, acknowledgement, rollback, and snapshot capabilities intersect.
+3. In shadow mode, validate and cache bundle v2 while continuing to enforce legacy decisions.
+4. Require a successful v2 acknowledgement with the expected version, hash, sequence, device, and workspace before promotion.
+5. Compare canonical and legacy decisions by bounded reason code. Zero unexplained mismatches is the promotion gate.
+6. Set `HOL_GUARD_POLICY_CANONICAL_ENFORCEMENT` to an integer from `1` through `99` for a deterministic workspace-and-device cohort. `true`, `on`, `canonical`, and `100` enable every eligible client.
+7. Expand only after the observation window remains inside the stop conditions below.
+
+## Observe
+
+Track aggregate counts and rates for:
+
+- canonical conversion attempted, succeeded, and incompatible;
+- shadow match and mismatch by reason code;
+- sync latency, retry exhaustion, queue depth, and dead letters;
+- client capability and selected bundle version;
+- signature, hash, transition, and acknowledgement failures;
+- last-known-good fallback and rollback activation.
+
+Stop expansion on any unexplained decision mismatch, invalid signature acceptance, anti-downgrade failure, acknowledgement sequence regression, repeated activation, loss of last-known-good state, or sensitive metric value.
+
+## Release boundary
+
+This alpha release is promoted only by merging the Guard change into `feat/guard-policy-v3` and verifying its artifact from TestPyPI against that V3 dependency chain. It must not merge directly into `main`, publish to stable PyPI, or enable canonical enforcement by default. Those actions belong to the later consolidated V3 release.

--- a/spec/guard-policy/v1alpha1/rfc.md
+++ b/spec/guard-policy/v1alpha1/rfc.md
@@ -1,0 +1,39 @@
+# RFC: GuardPolicy v1alpha1 interoperability
+
+Status: public alpha; comments requested through a GitHub issue or pull request against this document.
+
+## Proposal
+
+Adopt `guard.hashgraphonline.com/v1alpha1` as the shared human-authored policy contract for Portal and HOL Guard. YAML is input and display only. Validated typed data is canonicalized as RFC 8785 JSON for hashing and signing. Legacy bundle v1 remains available during the compatibility window.
+
+## Questions for implementers
+
+### Action vocabulary
+
+The core effects are `allow`, `block`, `review`, and `ignore`. Are these sufficient across shell, file, browser, MCP, package, skill, plugin, and remote-control actions? Should a future version distinguish advisory review from an enforcement pause without changing precedence?
+
+### Scope vocabulary
+
+The alpha matcher vocabulary covers operations, actors, agents, artifacts, commands, devices, domains, ecosystems, environments, harnesses, locations, MCPs, packages, paths, publishers, repositories, secret types, skills, tools, workspaces, and browser-specific fields. Which fields are ambiguous across runtimes? Which missing scopes cannot be expressed safely as a registered extension?
+
+### Trust
+
+A signed cloud bundle is accepted only through a local trusted-key registry. Is RSA-PSS/SHA-256 sufficient for the compatibility window? What rotation, revocation, offline grace, and emergency rollback evidence should a stable version require?
+
+### Local precedence
+
+Current precedence evaluates eligibility, local/remote authority, exactness/specificity, then recency. Does an exact local temporary decision always need to beat a broader remote rule? Which managed environments require an explicit non-overridable remote authority, and should that be a new API version rather than an extension?
+
+## Review evidence requested
+
+Implementers should run `fixtures/manifest.json`, report canonical byte/hash differences, and attach effective-decision results for local/remote, exact/broad, active/expired, and once/permanent cases. Reports must identify parser version and platform without including private policy content.
+
+## Stabilization criteria
+
+- at least two independent implementations agree on every fixture;
+- ambiguity findings are resolved in the normative semantics;
+- a security review covers YAML parsing, extensions, canonicalization, signing, trust, rollback, precedence, and secret handling;
+- staged production metrics show no unexplained legacy/canonical decision mismatch;
+- compatibility and deprecation windows are approved.
+
+Until those gates pass, the contract remains `v1alpha1`; incompatible changes use a new API version rather than silent reinterpretation.

--- a/spec/guard-policy/v1alpha1/rollback-runbook.md
+++ b/spec/guard-policy/v1alpha1/rollback-runbook.md
@@ -1,0 +1,49 @@
+# GuardPolicy rollback runbook
+
+## Trigger conditions
+
+Rollback immediately when any of these conditions occurs:
+
+- an unexplained canonical-versus-legacy decision mismatch;
+- a signature, hash, key-transition, or anti-downgrade invariant fails;
+- an acknowledgement version, hash, sequence, workspace, or device does not match;
+- the same bundle activates more than once;
+- canonical activation cannot preserve or restore last-known-good state;
+- an incompatible client receives a bundle or event it did not advertise;
+- an aggregate metric or audit event contains sensitive policy content.
+
+## Immediate rollback
+
+1. Set `HOL_GUARD_POLICY_CANONICAL_ENFORCEMENT=legacy` for the affected process or cohort.
+2. Restart or reconnect the affected Guard runtime through its normal lifecycle so the environment change is loaded.
+3. Confirm evaluation uses the cached legacy last-good bundle.
+4. Confirm canonical last-known-good and previous-good records remain intact for diagnosis; do not overwrite them with the rejected candidate.
+5. Confirm the portal continues to serve bundle v1 to clients that do not advertise complete v2 support.
+6. Pause cohort expansion and canonical read promotion.
+
+Do not edit SQLite rows manually, delete bundle caches, bypass signature verification, reset acknowledgement sequences, or weaken schema validation.
+
+## Restore a previous signed bundle
+
+A rollback candidate must be a previously accepted signed bundle with a trusted key and explicit transition metadata. Verify:
+
+- `bundleVersion` and `bundleHash` match the stored previous-good record;
+- `previousBundleVersion` describes the transition being reversed;
+- `policyRevision` does not violate the anti-downgrade contract;
+- the signature covers the complete canonical manifest and payload;
+- the acknowledgement returns the expected version, hash, and next sequence.
+
+Apply the candidate atomically. If activation fails, retain the current last-good bundle and continue legacy enforcement.
+
+## Verify recovery
+
+- Re-run the action corpus that exposed the mismatch.
+- Confirm canonical and legacy comparison emits no unexplained reason code.
+- Confirm retries do not produce duplicate activation or acknowledgement.
+- Confirm local YAML fallback still evaluates when cloud sync is unavailable.
+- Confirm raw documents, commands, prompts, paths, and secrets are absent from metrics and audit events.
+- Record the affected version, hash, bounded reason code, cohort size, and recovery timestamp.
+
+## Resume criteria
+
+Resume with a smaller deterministic cohort only after the root cause is fixed, conformance and rollback tests pass, the rejected bundle cannot reactivate, and the observation window is clean. Keep the legacy kill switch available for the full alpha compatibility window.

--- a/spec/guard-policy/v1alpha1/schema-compatibility-runbook.md
+++ b/spec/guard-policy/v1alpha1/schema-compatibility-runbook.md
@@ -1,0 +1,46 @@
+# GuardPolicy schema compatibility runbook
+
+## Supported contracts
+
+| Producer | Consumer capability | Contract | Behavior |
+|---|---|---|---|
+| Portal | No policy capability report | Bundle v1 | Preserve existing bytes and legacy evaluation. |
+| Portal | `v1alpha1` without complete v2 support | Bundle v1 | Preserve legacy delivery and acknowledgement. |
+| Portal | `v1alpha1` with complete v2 support | Signed bundle v2 | Validate and shadow-compare before enforcement. |
+| Local author | HOL Guard with `v1alpha1` parser | YAML input | Validate, canonicalize to JSON, then import. |
+| Local author | Older HOL Guard | Existing local policy | Do not send or import the unsupported document. |
+
+`apiVersion` selects semantics. Unknown major versions and unknown core fields are rejected. Additive alpha data is permitted only under registered `x-*` extension namespaces and remains covered by canonical hashing and v2 signatures.
+
+## Producer checklist
+
+- Emit `guard.hashgraphonline.com/v1alpha1` and `kind: GuardPolicy` exactly.
+- Emit stable rule IDs and deterministic priority ordering.
+- Normalize actions and durations before canonicalization.
+- Preserve user-authored fields, provenance, and valid extensions.
+- Reject unsupported actions, matchers, regex features, and environment interpolation.
+- Hash and sign RFC 8785 canonical JSON, never YAML bytes.
+- Preserve byte-identical bundle v1 output while any compatible client requires it.
+
+## Consumer checklist
+
+- Discover policy through the documented CLI, environment, workspace, user, and system precedence.
+- Parse YAML with the bounded safe profile.
+- Validate schema and semantics before compiling matchers.
+- Reject unknown core fields and unsupported versions without partial activation.
+- Verify the complete bundle v2 signature, trusted key, hash, transition, and anti-downgrade metadata.
+- Store canonical last-known-good and previous-good bundles before advancing activation state.
+- Acknowledge the exact version, hash, sequence, workspace, and device.
+
+## Change procedure
+
+1. Add or update shared fixtures before changing either implementation.
+2. Make Portal and Guard reproduce the same canonical JSON, digest, and decision vectors.
+3. Update the compatibility table and capability response.
+4. Preserve the legacy path until the measured compatibility window closes.
+5. Use a new API version for incompatible semantics; never silently reinterpret an existing field.
+6. Verify the Guard artifact from TestPyPI against `feat/guard-policy-v3`. The alpha artifact depends on that V3 integration branch and is not a stable `main` or PyPI release.
+
+## Deprecation gate
+
+Bundle v1, legacy policy fields, and legacy reads may be removed only after capability coverage is complete, the approved compatibility window has elapsed, canonical shadow comparison has no unexplained mismatch, rollback has been exercised, and a separate removal proposal is accepted.

--- a/spec/guard-policy/v1alpha1/schema.json
+++ b/spec/guard-policy/v1alpha1/schema.json
@@ -438,6 +438,23 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 256
+        },
+        "updatedAt": {
+          "$ref": "#/$defs/utcTimestamp"
+        },
+        "updatedBy": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "importSourceDigest": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "previousRuleRevision": {
+          "type": "integer",
+          "minimum": 1
         }
       },
       "patternProperties": {

--- a/spec/guard-policy/v1alpha1/threat-model.md
+++ b/spec/guard-policy/v1alpha1/threat-model.md
@@ -1,0 +1,41 @@
+# GuardPolicy v1alpha1 threat model
+
+## Assets and boundaries
+
+Protected assets are effective decisions, policy provenance, canonical bytes and hashes, signing keys, trusted verification keys, rollback state, local SQLite policy rows, and cloud synchronization acknowledgements.
+
+The YAML file is untrusted input. The Portal API, transport, local cache, and extension values are also untrusted until schema validation, canonicalization, signature verification, trust anchoring, and rollback checks complete. Local runtime enforcement remains authoritative when cloud policy is unavailable or invalid.
+
+## Threats and required controls
+
+| Threat | Required control |
+| --- | --- |
+| YAML aliases, merge keys, custom tags, duplicate keys, or parser differentials | Reject before semantic conversion; use the documented YAML subset and fixture suite. |
+| Oversized or deeply nested policy | Enforce byte, depth, collection, string, and rule-count limits before expensive work. |
+| Unknown core field or action | Fail closed for the document; never discard and continue enforcement. |
+| Extension collision or semantic smuggling | Restrict names to registered `x-` keys; include extension values in canonical bytes; extensions cannot override core semantics. |
+| Canonicalization disagreement | Hash and sign RFC 8785 canonical JSON only; verify published byte and digest vectors. |
+| Signature substitution or key injection | Verify RSA-PSS/SHA-256 with an independently trusted key registry; never trust an envelope's embedded key by itself. |
+| Replay, downgrade, or unauthorized rollback | Persist the last accepted version/hash, reject lower or conflicting versions, and require explicit signed rollback authorization. |
+| Partial cloud update or concurrent Portal writer | Use atomic compare-and-swap revision writes; never merge canonical and legacy authorities after validation. |
+| Expired temporary rule | Evaluate expiry before precedence and exclude expired rows. |
+| Broad remote policy eclipses exact local intent | Apply documented eligibility, authority, specificity, and recency precedence in that order. |
+| Secret disclosure through policy, diagnostics, or logs | Reject secret-bearing fields, redact parser errors, and log bounded reason codes rather than raw policy content. |
+| Client capability spoofing | Capability negotiation selects serialization only; it does not grant policy authority or weaken local trust checks. |
+| Availability loss during rollout | Preserve byte-identical bundle v1 fallback and last-known-good local policy; fail closed for unverified v2 without deleting the valid cache. |
+
+## Signing-key handling
+
+Portal private signing keys remain outside policy documents and source control. Bundles identify a key; Guard resolves that identifier through its trusted-key registry. Revocation and grace state are local trust decisions. Signatures cover the canonical envelope payload and all extension values.
+
+## Privacy
+
+Policy matchers may reveal repository, path, package, tool, device, or workspace identifiers. Implementations minimize transport and logs, never include raw secrets, and keep local-only rules local unless the user explicitly synchronizes them.
+
+## Non-goals
+
+The format does not make a malicious endpoint trustworthy, replace operating-system isolation, authorize cloud enrollment, or guarantee that every harness exposes every action. It standardizes policy meaning and transport for supported enforcement surfaces.
+
+## Residual risk and stabilization gate
+
+Parser bugs, implementation-specific Unicode behavior, incomplete harness coverage, and ambiguous new vocabularies remain alpha risks. v1.0 requires independent fixture agreement, no unexplained decision mismatch in staged production, and dedicated security review of parsing, signatures, rollback, precedence, and secret handling.

--- a/src/codex_plugin_scanner/guard/cli/approval_gate_prompt.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_gate_prompt.py
@@ -13,6 +13,7 @@ def prompt_for_approval_gate(
     guard_home: Path,
     *,
     use_cooldown: bool = True,
+    summary: str | None = None,
 ) -> ApprovalGateInput | None:
     gate = public_config(guard_home)
     if not gate.enabled:
@@ -22,6 +23,8 @@ def prompt_for_approval_gate(
             "approval_gate_interactive_required",
             "Approval password is required from an interactive terminal.",
         )
+    if summary:
+        print(summary, file=sys.stderr)
     password = getpass.getpass("Approval password: ")
     totp_code = getpass.getpass("Authenticator code: ") if gate.totp_enabled else None
     return ApprovalGateInput(

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_policy_document.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_policy_document.py
@@ -29,6 +29,7 @@ from ..store import GuardStore
 from ..store_policy_document import PolicyImportMode
 from .approval_gate_prompt import prompt_for_approval_gate
 
+
 _POLICY_IMPORT_FLAG = "HOL_GUARD_POLICY_YAML_IMPORT"
 
 
@@ -61,26 +62,6 @@ def _now() -> str:
 def _load_and_compile(path: Path):
     document = load_trusted_policy_document(path)
     return document, compile_policy_document(document)
-
-
-def _semantic_diff_payload(difference: PolicyDocumentDiff) -> dict[str, object]:
-    return {
-        "changed": difference.changed,
-        "diff": difference.text,
-        "additions": list(difference.additions),
-        "modifications": list(difference.modifications),
-        "removals": list(difference.removals),
-        "impacted_scopes": list(difference.impacted_scopes),
-        "impacted_harnesses": list(difference.impacted_harnesses),
-        "impacted_artifact_families": list(difference.impacted_artifact_families),
-        "conflict_warnings": list(difference.conflict_warnings),
-        "broadened_rules": list(difference.broadened_rules),
-        "narrowed_rules": list(difference.narrowed_rules),
-        "unchanged_rules": list(difference.unchanged_rules),
-        "effective_action_changes": list(difference.effective_action_changes),
-        "broad_relaxing_changes": list(difference.broad_relaxing_changes),
-        "requires_high_risk_approval": bool(difference.broad_relaxing_changes),
-    }
 
 
 def _run_guard_policy_document_command(
@@ -313,6 +294,26 @@ def _run_guard_policy_document_command(
             output_stream=output_stream,
         )
         return 4
+
+
+def _semantic_diff_payload(difference: PolicyDocumentDiff) -> dict[str, object]:
+    return {
+        "changed": difference.changed,
+        "diff": difference.text,
+        "additions": list(difference.additions),
+        "modifications": list(difference.modifications),
+        "removals": list(difference.removals),
+        "impacted_scopes": list(difference.impacted_scopes),
+        "impacted_harnesses": list(difference.impacted_harnesses),
+        "impacted_artifact_families": list(difference.impacted_artifact_families),
+        "conflict_warnings": list(difference.conflict_warnings),
+        "broadened_rules": list(difference.broadened_rules),
+        "narrowed_rules": list(difference.narrowed_rules),
+        "unchanged_rules": list(difference.unchanged_rules),
+        "effective_action_changes": list(difference.effective_action_changes),
+        "broad_relaxing_changes": list(difference.broad_relaxing_changes),
+        "requires_high_risk_approval": bool(difference.broad_relaxing_changes),
+    }
 
 
 __all__ = ["_run_guard_policy_document_command"]

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_policy_document.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_policy_document.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TextIO, cast
 
 from ..approval_gate import ApprovalGateError, require_high_risk
+from ..policy_authority import PolicyAuthorityError
 from ..policy_document import policy_document_digest
 from ..policy_document_io import (
     PolicyCompilationError,
@@ -244,7 +245,13 @@ def _run_guard_policy_document_command(
             return 0
 
         raise ValueError("unknown_policy_document_command")
-    except (ApprovalGateError, PolicyCompilationError, PolicyDocumentError, PolicyFileTrustError) as error:
+    except (
+        ApprovalGateError,
+        PolicyAuthorityError,
+        PolicyCompilationError,
+        PolicyDocumentError,
+        PolicyFileTrustError,
+    ) as error:
         code = getattr(error, "code", error.__class__.__name__)
         _write_payload(
             f"policy {command}",

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_policy_document.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_policy_document.py
@@ -15,6 +15,7 @@ from ..policy_authority import PolicyAuthorityError
 from ..policy_document import policy_document_digest
 from ..policy_document_io import (
     PolicyCompilationError,
+    PolicyDocumentDiff,
     PolicyFileTrustError,
     build_policy_document_from_rows,
     compile_policy_document,
@@ -60,6 +61,26 @@ def _now() -> str:
 def _load_and_compile(path: Path):
     document = load_trusted_policy_document(path)
     return document, compile_policy_document(document)
+
+
+def _semantic_diff_payload(difference: PolicyDocumentDiff) -> dict[str, object]:
+    return {
+        "changed": difference.changed,
+        "diff": difference.text,
+        "additions": list(difference.additions),
+        "modifications": list(difference.modifications),
+        "removals": list(difference.removals),
+        "impacted_scopes": list(difference.impacted_scopes),
+        "impacted_harnesses": list(difference.impacted_harnesses),
+        "impacted_artifact_families": list(difference.impacted_artifact_families),
+        "conflict_warnings": list(difference.conflict_warnings),
+        "broadened_rules": list(difference.broadened_rules),
+        "narrowed_rules": list(difference.narrowed_rules),
+        "unchanged_rules": list(difference.unchanged_rules),
+        "effective_action_changes": list(difference.effective_action_changes),
+        "broad_relaxing_changes": list(difference.broad_relaxing_changes),
+        "requires_high_risk_approval": bool(difference.broad_relaxing_changes),
+    }
 
 
 def _run_guard_policy_document_command(
@@ -121,15 +142,32 @@ def _run_guard_policy_document_command(
             candidate, _ = _load_and_compile(Path(args.file))
             base = build_policy_document_from_rows(store.list_policy_decisions(), include_provenance=True)
             difference = diff_policy_documents(base, candidate)
+            semantic_payload = _semantic_diff_payload(difference)
             if as_json:
                 _write_payload(
                     "policy diff",
-                    {"changed": difference.changed, "diff": difference.text},
+                    semantic_payload,
                     as_json=True,
                     output_stream=output_stream,
                 )
             else:
-                _write_document(difference.text or "No policy changes.", output_stream)
+                summary = (
+                    f"Semantic changes: {len(difference.additions)} additions, "
+                    f"{len(difference.modifications)} modifications, "
+                    f"{len(difference.removals)} removals.\n"
+                    f"Impacted scopes: {', '.join(difference.impacted_scopes) or 'none'}.\n"
+                    f"Impacted harnesses: {', '.join(difference.impacted_harnesses) or 'none'}.\n"
+                    "Impacted artifact families: "
+                    f"{', '.join(difference.impacted_artifact_families) or 'none'}.\n"
+                    f"Conflict warnings: {', '.join(difference.conflict_warnings) or 'none'}.\n\n"
+                    f"Broadened rules: {', '.join(difference.broadened_rules) or 'none'}.\n"
+                    f"Narrowed rules: {', '.join(difference.narrowed_rules) or 'none'}.\n"
+                    "Effective action changes: "
+                    f"{', '.join(difference.effective_action_changes) or 'none'}.\n"
+                    "Broad relaxing changes: "
+                    f"{', '.join(difference.broad_relaxing_changes) or 'none'}.\n\n"
+                )
+                _write_document(summary + (difference.text or "No policy changes."), output_stream)
             return 1 if difference.changed else 0
 
         if command == "export":
@@ -189,6 +227,11 @@ def _run_guard_policy_document_command(
                 return 4
             document, compiled = _load_and_compile(Path(args.file))
             mode = cast(PolicyImportMode, args.mode)
+            current_document = build_policy_document_from_rows(
+                store.list_policy_decisions(),
+                include_provenance=True,
+            )
+            difference = diff_policy_documents(current_document, document)
             plan = store.plan_policy_document_import(compiled, mode=mode)
             dry_run = bool(args.dry_run)
             if dry_run:
@@ -199,9 +242,10 @@ def _run_guard_policy_document_command(
                         "document_id": document.metadata.id,
                         "digest": policy_document_digest(document),
                         "compiled_rows": len(compiled),
-                        "additions": list(plan.additions),
-                        "replacements": list(plan.replacements),
-                        "removals": list(plan.removals),
+                        "import_additions": list(plan.additions),
+                        "import_replacements": list(plan.replacements),
+                        "import_removals": list(plan.removals),
+                        **_semantic_diff_payload(difference),
                         "message": (
                             f"Dry run: {len(plan.additions)} additions, "
                             f"{len(plan.replacements)} replacements, "
@@ -213,7 +257,16 @@ def _run_guard_policy_document_command(
                 )
                 return 0
 
-            gate_input = prompt_for_approval_gate(store.guard_home, use_cooldown=False)
+            gate_input = prompt_for_approval_gate(
+                store.guard_home,
+                use_cooldown=False,
+                summary=(
+                    f"Approve policy import: {len(plan.additions)} additions, "
+                    f"{len(plan.replacements)} replacements, "
+                    f"{len(plan.removals)} removals; "
+                    f"{len(difference.broad_relaxing_changes)} broad relaxing changes."
+                ),
+            )
             grant = require_high_risk(
                 store.guard_home,
                 purpose="policy_import",

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
@@ -44,7 +44,6 @@ def _configure_guard_policy_parsers(
     policy_diff_parser.add_argument("--json", action="store_true")
 
     policy_export_parser = policy_subparsers.add_parser("export", help="Export local policies")
-    policy_export_parser.add_argument("--format", choices=("yaml",), default="yaml")
     policy_export_parser.add_argument("--output")
     policy_export_parser.add_argument("--include-provenance", action="store_true")
     _add_guard_common_args(policy_export_parser)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -125,6 +125,8 @@ from ..policy_bundle_trusted_keys import (
     policy_bundle_keyring_payload,
     validate_synced_policy_bundle,
 )
+from ..policy_bundle_v2 import POLICY_BUNDLE_V2_CONTRACT
+from ..policy_document_io import PolicyCompilationError
 from ..receipts.manager import build_receipt
 from ..review_contracts import (
     GuardReviewContractError,
@@ -139,11 +141,13 @@ from ..runtime.runner import (
     GuardSyncNotAvailableError,
     GuardSyncNotConfiguredError,
     _build_policy_bundle_decisions,
+    _canonical_policy_enforcement_enabled,
     _daemon_version_supported,
     _guard_device_metadata,
     _persist_cloud_exceptions,
     _policy_bundle_acknowledgement_payload,
     _policy_bundle_is_version_downgrade,
+    _policy_shadow_mismatch_reason_codes,
     _resolve_guard_sync_auth_context,
     prepare_guard_cloud_connect_authorization,
     repair_guard_cloud_connect_storage,
@@ -2307,27 +2311,152 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             existing_policy_bundle = (
                 existing_policy_bundle_payload if isinstance(existing_policy_bundle_payload, dict) else None
             )
+            canonical_last_good = self.server.store.get_sync_payload(  # type: ignore[attr-defined]
+                "policy_bundle_canonical_last_good"
+            )
+            canonical_previous_good = self.server.store.get_sync_payload(  # type: ignore[attr-defined]
+                "policy_bundle_canonical_previous_good"
+            )
+            transition_baseline = existing_policy_bundle
+            if validated_policy_bundle is not None and (
+                validated_policy_bundle.get("contractVersion") == POLICY_BUNDLE_V2_CONTRACT
+            ):
+                if isinstance(canonical_last_good, dict):
+                    transition_baseline = canonical_last_good
             if validated_policy_bundle is None:
                 self._write_json({"error": rejection_reason or "invalid_policy_bundle"}, status=400)
                 return
             if not _daemon_version_supported(validated_policy_bundle):
                 self._write_json({"error": "unsupported_daemon_version"}, status=400)
                 return
-            if _policy_bundle_is_version_downgrade(existing_policy_bundle, validated_policy_bundle):
+            if _policy_bundle_is_version_downgrade(
+                transition_baseline,
+                validated_policy_bundle,
+                expected_last_good_bundle=(
+                    canonical_previous_good if isinstance(canonical_previous_good, dict) else None
+                ),
+            ):
                 self._write_json({"error": "bundle_version_downgrade"}, status=400)
                 return
             applied_at = _now()
-            self.server.store.set_sync_payload("policy_bundle", validated_policy_bundle, applied_at)  # type: ignore[attr-defined]
-            self.server.store.set_sync_payload("policy_bundle_last_good", validated_policy_bundle, applied_at)  # type: ignore[attr-defined]
+            device_id, device_name = _guard_device_metadata(self.server.store)  # type: ignore[attr-defined]
+            workspace_id = self.server.store.get_cloud_workspace_id() or ""  # type: ignore[attr-defined]
+            canonical_enforcement = _canonical_policy_enforcement_enabled(
+                workspace_id=workspace_id,
+                device_id=device_id,
+            )
+            bundle_is_v2 = validated_policy_bundle.get("contractVersion") == POLICY_BUNDLE_V2_CONTRACT
+            try:
+                if bundle_is_v2:
+                    canonical_decisions = _build_policy_bundle_decisions(
+                        validated_policy_bundle,
+                        device_id=device_id,
+                        device_name=device_name,
+                        canonical_enforcement=True,
+                    )
+                    legacy_payload = self.server.store.get_sync_payload(  # type: ignore[attr-defined]
+                        "policy_bundle_legacy_last_good"
+                    )
+                    if not isinstance(legacy_payload, dict):
+                        legacy_payload = (
+                            existing_policy_bundle
+                            if isinstance(existing_policy_bundle, dict)
+                            and existing_policy_bundle.get("contractVersion") != POLICY_BUNDLE_V2_CONTRACT
+                            else None
+                        )
+                    legacy_decisions = (
+                        _build_policy_bundle_decisions(
+                            legacy_payload,
+                            device_id=device_id,
+                            device_name=device_name,
+                        )
+                        if isinstance(legacy_payload, dict)
+                        else []
+                    )
+                    mismatch_reasons = _policy_shadow_mismatch_reason_codes(
+                        legacy_decisions,
+                        canonical_decisions,
+                    )
+                    if not legacy_decisions:
+                        mismatch_reasons = ("legacy_unavailable", *mismatch_reasons)[:4]
+                    candidate_policy_decisions = (
+                        canonical_decisions if canonical_enforcement and not mismatch_reasons else legacy_decisions
+                    )
+                    if mismatch_reasons:
+                        self.server.store.add_event(  # type: ignore[attr-defined]
+                            "policy_bundle/semantic_mismatch",
+                            {
+                                "canonicalRuleCount": len(canonical_decisions),
+                                "legacyRuleCount": len(legacy_decisions),
+                                "reasonCodes": mismatch_reasons,
+                                "schemaVersion": 1,
+                            },
+                            applied_at,
+                        )
+                    if canonical_enforcement and mismatch_reasons:
+                        self._write_json({"error": "canonical_shadow_mismatch"}, status=409)
+                        return
+                else:
+                    candidate_policy_decisions = _build_policy_bundle_decisions(
+                        validated_policy_bundle,
+                        device_id=device_id,
+                        device_name=device_name,
+                    )
+            except PolicyCompilationError as error:
+                self._write_json({"error": f"canonical_compile_{error.code}"}, status=400)
+                return
+            if bundle_is_v2:
+                if isinstance(canonical_last_good, dict) and canonical_last_good.get(
+                    "bundleHash"
+                ) != validated_policy_bundle.get("bundleHash"):
+                    self.server.store.set_sync_payload(  # type: ignore[attr-defined]
+                        "policy_bundle_canonical_previous_good",
+                        canonical_last_good,
+                        applied_at,
+                    )
+                self.server.store.set_sync_payload(  # type: ignore[attr-defined]
+                    "policy_bundle_canonical_last_good",
+                    validated_policy_bundle,
+                    applied_at,
+                )
+                if canonical_enforcement:
+                    self.server.store.set_sync_payload(  # type: ignore[attr-defined]
+                        "policy_bundle",
+                        validated_policy_bundle,
+                        applied_at,
+                    )
+                    self.server.store.set_sync_payload(  # type: ignore[attr-defined]
+                        "policy_bundle_last_good",
+                        validated_policy_bundle,
+                        applied_at,
+                    )
+            else:
+                self.server.store.set_sync_payload(  # type: ignore[attr-defined]
+                    "policy_bundle",
+                    validated_policy_bundle,
+                    applied_at,
+                )
+                self.server.store.set_sync_payload(  # type: ignore[attr-defined]
+                    "policy_bundle_last_good",
+                    validated_policy_bundle,
+                    applied_at,
+                )
+                self.server.store.set_sync_payload(  # type: ignore[attr-defined]
+                    "policy_bundle_legacy_last_good",
+                    validated_policy_bundle,
+                    applied_at,
+                )
             self.server.store.set_sync_payload(  # type: ignore[attr-defined]
                 "policy_bundle_keyring",
                 policy_bundle_keyring_payload(
                     trusted_policy_bundle_keys,
-                    workspace_id=self.server.store.get_cloud_workspace_id(),  # type: ignore[attr-defined]
+                    workspace_id=workspace_id,
                 ),
                 applied_at,
             )
-            device_id, device_name = _guard_device_metadata(self.server.store)  # type: ignore[attr-defined]
+            previous_policy_bundle_ack = self.server.store.get_sync_payload(  # type: ignore[attr-defined]
+                "policy_bundle_ack"
+            )
             self.server.store.set_sync_payload(  # type: ignore[attr-defined]
                 "policy_bundle_ack",
                 _policy_bundle_acknowledgement_payload(
@@ -2335,6 +2464,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     device_name=device_name,
                     policy_bundle=validated_policy_bundle,
                     synced_at=applied_at,
+                    status=("applied" if canonical_enforcement else "validated"),
+                    previous=(previous_policy_bundle_ack if isinstance(previous_policy_bundle_ack, dict) else None),
                 ),
                 applied_at,
             )
@@ -2357,13 +2488,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 if _is_decision_scope(scope := self._optional_string(item.get("scope")) or "")
                 if _is_guard_action(action := self._optional_string(item.get("action")) or "")
             ]
-            existing_remote_decisions.extend(
-                _build_policy_bundle_decisions(
-                    validated_policy_bundle,
-                    device_id=device_id,
-                    device_name=device_name,
-                )
-            )
+            existing_remote_decisions.extend(candidate_policy_decisions)
             self.server.store.replace_remote_policies(  # type: ignore[attr-defined]
                 existing_remote_decisions,
                 applied_at,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2318,11 +2318,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "policy_bundle_canonical_previous_good"
             )
             transition_baseline = existing_policy_bundle
-            if validated_policy_bundle is not None and (
-                validated_policy_bundle.get("contractVersion") == POLICY_BUNDLE_V2_CONTRACT
+            if (
+                validated_policy_bundle is not None
+                and validated_policy_bundle.get("contractVersion") == POLICY_BUNDLE_V2_CONTRACT
+                and isinstance(canonical_last_good, dict)
             ):
-                if isinstance(canonical_last_good, dict):
-                    transition_baseline = canonical_last_good
+                transition_baseline = canonical_last_good
             if validated_policy_bundle is None:
                 self._write_json({"error": rejection_reason or "invalid_policy_bundle"}, status=400)
                 return
@@ -2377,10 +2378,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                         legacy_decisions,
                         canonical_decisions,
                     )
-                    if not legacy_decisions:
-                        mismatch_reasons = ("legacy_unavailable", *mismatch_reasons)[:4]
+                    blocking_mismatch_reasons = tuple(
+                        reason for reason in mismatch_reasons if reason != "legacy_unavailable"
+                    )
                     candidate_policy_decisions = (
-                        canonical_decisions if canonical_enforcement and not mismatch_reasons else legacy_decisions
+                        canonical_decisions
+                        if canonical_enforcement and not blocking_mismatch_reasons
+                        else legacy_decisions
                     )
                     if mismatch_reasons:
                         self.server.store.add_event(  # type: ignore[attr-defined]
@@ -2393,7 +2397,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                             },
                             applied_at,
                         )
-                    if canonical_enforcement and mismatch_reasons:
+                    if canonical_enforcement and blocking_mismatch_reasons:
                         self._write_json({"error": "canonical_shadow_mismatch"}, status=409)
                         return
                 else:

--- a/src/codex_plugin_scanner/guard/policy_bundle_parser.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_parser.py
@@ -78,6 +78,47 @@ _POLICY_BUNDLE_RULE_MATCHER_FAMILIES = frozenset(
     {"file-read", "mcp", "mcp-tool", "package-request", "prompt", "prompt-env-read", "tool-action"}
 )
 _POLICY_BUNDLE_DEFAULT_ENVIRONMENTS = frozenset({"development"})
+_MAX_BUNDLE_BYTES = 2_097_152
+_MAX_DEPTH = 40
+_MAX_COLLECTION_ITEMS = 2_048
+_MAX_STRING_LENGTH = 1_048_576
+
+
+def _policy_bundle_resource_limit_error(value: object) -> str | None:
+    stack: list[tuple[object, int]] = [(value, 0)]
+    while stack:
+        current, depth = stack.pop()
+        if depth > _MAX_DEPTH:
+            return "limit_depth"
+        if isinstance(current, str):
+            if len(current.encode("utf-8")) > _MAX_STRING_LENGTH:
+                return "limit_string"
+            continue
+        if current is None or isinstance(current, (bool, int, float)):
+            continue
+        if isinstance(current, dict):
+            if len(current) > _MAX_COLLECTION_ITEMS:
+                return "limit_collection"
+            if not all(isinstance(key, str) for key in current):
+                return "invalid_json_value"
+            stack.extend((item, depth + 1) for item in current.values())
+            continue
+        if isinstance(current, list):
+            if len(current) > _MAX_COLLECTION_ITEMS:
+                return "limit_collection"
+            stack.extend((item, depth + 1) for item in current)
+            continue
+        return "invalid_json_value"
+    try:
+        encoded = json.dumps(
+            value,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (RecursionError, TypeError, ValueError):
+        return "invalid_json_value"
+    return "limit_bytes" if len(encoded) > _MAX_BUNDLE_BYTES else None
 
 
 def _stable_serialize(value: object) -> str:
@@ -282,6 +323,9 @@ def validated_policy_bundle_payload(
     trusted_verification_keys: tuple[PolicyBundleVerificationKey, ...] = (),
     anchored_verification_keys: tuple[PolicyBundleVerificationKey, ...] = (),
 ) -> tuple[dict[str, object] | None, str | None]:
+    resource_error = _policy_bundle_resource_limit_error(policy_bundle)
+    if resource_error is not None:
+        return None, resource_error
     required_top_level = (*_POLICY_BUNDLE_CORE_KEYS, "bundleHash", "acknowledgements")
     if any(key not in policy_bundle for key in required_top_level):
         return None, "missing_required_field"

--- a/src/codex_plugin_scanner/guard/policy_bundle_parser.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_parser.py
@@ -19,6 +19,12 @@ from .policy_bundle_trusted_keys import (
     signing_key_is_current,
     signing_key_is_trusted,
 )
+from .policy_bundle_v2 import (
+    POLICY_BUNDLE_MAX_BYTES,
+    POLICY_BUNDLE_MAX_COLLECTION_ITEMS,
+    POLICY_BUNDLE_MAX_DEPTH,
+    POLICY_BUNDLE_MAX_STRING_LENGTH,
+)
 
 _POLICY_BUNDLE_CORE_KEYS = (
     "contractVersion",
@@ -78,33 +84,29 @@ _POLICY_BUNDLE_RULE_MATCHER_FAMILIES = frozenset(
     {"file-read", "mcp", "mcp-tool", "package-request", "prompt", "prompt-env-read", "tool-action"}
 )
 _POLICY_BUNDLE_DEFAULT_ENVIRONMENTS = frozenset({"development"})
-_MAX_BUNDLE_BYTES = 2_097_152
-_MAX_DEPTH = 40
-_MAX_COLLECTION_ITEMS = 2_048
-_MAX_STRING_LENGTH = 1_048_576
 
 
 def _policy_bundle_resource_limit_error(value: object) -> str | None:
     stack: list[tuple[object, int]] = [(value, 0)]
     while stack:
         current, depth = stack.pop()
-        if depth > _MAX_DEPTH:
+        if depth > POLICY_BUNDLE_MAX_DEPTH:
             return "limit_depth"
         if isinstance(current, str):
-            if len(current.encode("utf-8")) > _MAX_STRING_LENGTH:
+            if len(current.encode("utf-8")) > POLICY_BUNDLE_MAX_STRING_LENGTH:
                 return "limit_string"
             continue
         if current is None or isinstance(current, (bool, int, float)):
             continue
         if isinstance(current, dict):
-            if len(current) > _MAX_COLLECTION_ITEMS:
+            if len(current) > POLICY_BUNDLE_MAX_COLLECTION_ITEMS:
                 return "limit_collection"
             if not all(isinstance(key, str) for key in current):
                 return "invalid_json_value"
             stack.extend((item, depth + 1) for item in current.values())
             continue
         if isinstance(current, list):
-            if len(current) > _MAX_COLLECTION_ITEMS:
+            if len(current) > POLICY_BUNDLE_MAX_COLLECTION_ITEMS:
                 return "limit_collection"
             stack.extend((item, depth + 1) for item in current)
             continue
@@ -118,7 +120,7 @@ def _policy_bundle_resource_limit_error(value: object) -> str | None:
         ).encode("utf-8")
     except (RecursionError, TypeError, ValueError):
         return "invalid_json_value"
-    return "limit_bytes" if len(encoded) > _MAX_BUNDLE_BYTES else None
+    return "limit_bytes" if len(encoded) > POLICY_BUNDLE_MAX_BYTES else None
 
 
 def _stable_serialize(value: object) -> str:

--- a/src/codex_plugin_scanner/guard/policy_bundle_v2.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_v2.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import binascii
 import hashlib
+import re
 from datetime import datetime, timezone
 from typing import TypeGuard, cast
 
@@ -31,6 +32,7 @@ _MAX_BUNDLE_BYTES = 2_097_152
 _MAX_DEPTH = 40
 _MAX_COLLECTION_ITEMS = 2_048
 _MAX_STRING_LENGTH = 1_048_576
+_SHA256_DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 _ALLOWED_TOP_LEVEL = frozenset(
     {
         "envelopeVersion",
@@ -191,6 +193,10 @@ def _validate_keys(value: dict[str, object], allowed: frozenset[str]) -> bool:
     return all(key in allowed or key.startswith("x-") for key in value)
 
 
+def _is_sha256_digest(value: object) -> bool:
+    return isinstance(value, str) and _SHA256_DIGEST_PATTERN.fullmatch(value) is not None
+
+
 def _validate_rollback(value: object) -> str | None:
     if value is None:
         return None
@@ -205,6 +211,10 @@ def _validate_rollback(value: object) -> str | None:
         "authorization",
     )
     if any(_non_empty_string(value.get(key)) is None for key in required_strings):
+        return "invalid_rollback"
+    if not _is_sha256_digest(value.get("rollbackOfBundleHash")) or not _is_sha256_digest(
+        value.get("lastGoodBundleHash")
+    ):
         return "invalid_rollback"
     versions = (value.get("rollbackOfBundleVersion"), value.get("lastGoodBundleVersion"))
     if any(not isinstance(version, int) or isinstance(version, bool) or version < 1 for version in versions):
@@ -339,6 +349,8 @@ def validate_policy_bundle_v2_transition(
     *,
     current_bundle_version: int | None,
     current_bundle_hash: str | None,
+    expected_last_good_bundle_version: int | None = None,
+    expected_last_good_bundle_hash: str | None = None,
 ) -> str | None:
     """Reject replay, same-version substitution, and unsigned rollback semantics."""
 
@@ -375,6 +387,11 @@ def validate_policy_bundle_v2_transition(
         return "rollback_target_mismatch"
     if _non_empty_string(rollback.get("lastGoodBundleHash"), maximum=128) is None:
         return "rollback_target_mismatch"
+    if expected_last_good_bundle_version is not None and last_good_version != expected_last_good_bundle_version:
+        return "rollback_last_good_mismatch"
+    last_good_hash = rollback.get("lastGoodBundleHash")
+    if expected_last_good_bundle_hash is not None and last_good_hash != expected_last_good_bundle_hash:
+        return "rollback_last_good_mismatch"
     if _non_empty_string(rollback.get("authorization")) is None:
         return "rollback_authorization_missing"
     return None

--- a/src/codex_plugin_scanner/guard/policy_bundle_v2.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_v2.py
@@ -28,10 +28,10 @@ POLICY_BUNDLE_V2_ENVELOPE_VERSION = 2
 POLICY_BUNDLE_V2_CANONICALIZATION = {"algorithm": "rfc8785", "version": "1"}
 POLICY_BUNDLE_V2_ACK_STATUSES = frozenset({"received", "validated", "applied", "failed", "offline"})
 
-_MAX_BUNDLE_BYTES = 2_097_152
-_MAX_DEPTH = 40
-_MAX_COLLECTION_ITEMS = 2_048
-_MAX_STRING_LENGTH = 1_048_576
+POLICY_BUNDLE_MAX_BYTES = 2_097_152
+POLICY_BUNDLE_MAX_DEPTH = 40
+POLICY_BUNDLE_MAX_COLLECTION_ITEMS = 2_048
+POLICY_BUNDLE_MAX_STRING_LENGTH = 1_048_576
 _SHA256_DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 _ALLOWED_TOP_LEVEL = frozenset(
     {
@@ -94,7 +94,7 @@ def _is_object_mapping(value: object) -> TypeGuard[dict[str, object]]:
     return all(isinstance(key, str) for key in cast(dict[object, object], value))
 
 
-def _non_empty_string(value: object, *, maximum: int = _MAX_STRING_LENGTH) -> str | None:
+def _non_empty_string(value: object, *, maximum: int = POLICY_BUNDLE_MAX_STRING_LENGTH) -> str | None:
     if not isinstance(value, str):
         return None
     normalized = value.strip()
@@ -116,10 +116,10 @@ def _strict_utc_timestamp(value: object) -> datetime | None:
 
 
 def _json_value(value: object, *, depth: int = 0) -> JsonValue:
-    if depth > _MAX_DEPTH:
+    if depth > POLICY_BUNDLE_MAX_DEPTH:
         raise ValueError("limit_depth")
     if value is None or isinstance(value, (bool, str)):
-        if isinstance(value, str) and len(value.encode("utf-8")) > _MAX_STRING_LENGTH:
+        if isinstance(value, str) and len(value.encode("utf-8")) > POLICY_BUNDLE_MAX_STRING_LENGTH:
             raise ValueError("limit_string")
         return value
     if isinstance(value, int):
@@ -127,11 +127,11 @@ def _json_value(value: object, *, depth: int = 0) -> JsonValue:
     if isinstance(value, float):
         raise ValueError("unsupported_number")
     if _is_object_list(value):
-        if len(value) > _MAX_COLLECTION_ITEMS:
+        if len(value) > POLICY_BUNDLE_MAX_COLLECTION_ITEMS:
             raise ValueError("limit_collection")
         return [_json_value(item, depth=depth + 1) for item in value]
     if _is_object_mapping(value):
-        if len(value) > _MAX_COLLECTION_ITEMS:
+        if len(value) > POLICY_BUNDLE_MAX_COLLECTION_ITEMS:
             raise ValueError("limit_collection")
         result: dict[str, JsonValue] = {}
         for key, item in value.items():
@@ -288,7 +288,7 @@ def validated_policy_bundle_v2_payload(
         encoded = canonical_json_bytes(_json_value(policy_bundle))
     except ValueError as error:
         return None, str(error)
-    if len(encoded) > _MAX_BUNDLE_BYTES:
+    if len(encoded) > POLICY_BUNDLE_MAX_BYTES:
         return None, "limit_bytes"
     if not _validate_keys(policy_bundle, _ALLOWED_TOP_LEVEL):
         return None, "unknown_field"

--- a/src/codex_plugin_scanner/guard/policy_document.py
+++ b/src/codex_plugin_scanner/guard/policy_document.py
@@ -201,6 +201,10 @@ class PolicyProvenance:
     receipt_ids: tuple[str, ...] = ()
     suggestion_id: str | None = None
     created_by: str | None = None
+    updated_at: str | None = None
+    updated_by: str | None = None
+    import_source_digest: str | None = None
+    previous_rule_revision: int | None = None
     extensions: EncodedExtensions = ()
 
     @classmethod
@@ -208,15 +212,35 @@ class PolicyProvenance:
         receipt_ids = value.get("receiptIds")
         suggestion_id = value.get("suggestionId")
         created_by = value.get("createdBy")
+        updated_at = value.get("updatedAt")
+        updated_by = value.get("updatedBy")
+        import_source_digest = value.get("importSourceDigest")
+        previous_rule_revision = value.get("previousRuleRevision")
         return cls(
             source=str(value["source"]),
             created_at=str(value["createdAt"]),
             receipt_ids=tuple(str(item) for item in _sequence(receipt_ids)) if isinstance(receipt_ids, list) else (),
             suggestion_id=suggestion_id if isinstance(suggestion_id, str) else None,
             created_by=created_by if isinstance(created_by, str) else None,
+            updated_at=updated_at if isinstance(updated_at, str) else None,
+            updated_by=updated_by if isinstance(updated_by, str) else None,
+            import_source_digest=import_source_digest if isinstance(import_source_digest, str) else None,
+            previous_rule_revision=previous_rule_revision if isinstance(previous_rule_revision, int) else None,
             extensions=_encode_extensions(
                 value,
-                frozenset({"source", "receiptIds", "suggestionId", "createdAt", "createdBy"}),
+                frozenset(
+                    {
+                        "source",
+                        "receiptIds",
+                        "suggestionId",
+                        "createdAt",
+                        "createdBy",
+                        "updatedAt",
+                        "updatedBy",
+                        "importSourceDigest",
+                        "previousRuleRevision",
+                    }
+                ),
             ),
         )
 
@@ -228,6 +252,14 @@ class PolicyProvenance:
             result["suggestionId"] = self.suggestion_id
         if self.created_by is not None:
             result["createdBy"] = self.created_by
+        if self.updated_at is not None:
+            result["updatedAt"] = self.updated_at
+        if self.updated_by is not None:
+            result["updatedBy"] = self.updated_by
+        if self.import_source_digest is not None:
+            result["importSourceDigest"] = self.import_source_digest
+        if self.previous_rule_revision is not None:
+            result["previousRuleRevision"] = self.previous_rule_revision
         return _with_extensions(result, self.extensions)
 
 

--- a/src/codex_plugin_scanner/guard/policy_document_io.py
+++ b/src/codex_plugin_scanner/guard/policy_document_io.py
@@ -271,12 +271,12 @@ def diff_policy_documents(
     return PolicyDocumentDiff(changed=bool(text), text=text)
 
 
-def _normalized_timestamp(value: object) -> str:
+def _normalized_timestamp(value: object, *, rule_id: str) -> str:
     if isinstance(value, str):
         candidate = value.strip().replace("+00:00", "Z")
         if _UTC_TIMESTAMP_RE.fullmatch(candidate):
             return candidate
-    return "1970-01-01T00:00:00Z"
+    raise PolicyCompilationError("invalid_local_policy_timestamp", rule_id)
 
 
 def _normalized_expiry(value: object, *, rule_id: str, code: str) -> str | None:
@@ -306,6 +306,8 @@ def _provenance_source(value: object) -> str:
         return value
     if value == "cloud-sync":
         return "cloud"
+    if value == _POLICY_IMPORT_SOURCE:
+        return "import"
     return "local"
 
 
@@ -345,7 +347,9 @@ def _rule_from_policy_row(row: Mapping[str, object], *, include_provenance: bool
     )
     provenance: dict[str, object] = {
         "source": _provenance_source(row.get("source")) if include_provenance else "export-redacted",
-        "createdAt": _normalized_timestamp(row.get("updated_at")) if include_provenance else _REDACTED_TIMESTAMP,
+        "createdAt": _normalized_timestamp(row.get("updated_at"), rule_id=rule_id)
+        if include_provenance
+        else _REDACTED_TIMESTAMP,
     }
     owner = _optional_string(row.get("owner"))
     if include_provenance and owner is not None:
@@ -423,15 +427,20 @@ def build_policy_document_from_rows(
     return GuardPolicyDocument.from_mapping(mapping)
 
 
-def _selector_values(match: Mapping[str, object], key: str) -> tuple[str | None, ...]:
+def _selector_values(
+    match: Mapping[str, object],
+    key: str,
+    *,
+    rule_id: str,
+) -> tuple[str | None, ...]:
     value = match.get(key)
     if value is None:
         return (None,)
     if not isinstance(value, list) or not value:
-        return (None,)
+        raise PolicyCompilationError("invalid_policy_match_selector", rule_id)
     items = cast(list[object], value)
-    if not all(isinstance(item, str) for item in items):
-        return (None,)
+    if not all(isinstance(item, str) and item for item in items):
+        raise PolicyCompilationError("invalid_policy_match_selector", rule_id)
     return tuple(cast(list[str], items))
 
 
@@ -496,10 +505,10 @@ def compile_policy_document(document: GuardPolicyDocument) -> tuple[CompiledPoli
         local_extension = raw_rule.get("x-hol-local")
         extension = local_extension if isinstance(local_extension, Mapping) else {}
         selectors = itertools.product(
-            _selector_values(match, "artifacts"),
-            _selector_values(match, "harnesses"),
-            _selector_values(match, "publishers"),
-            _selector_values(match, "workspaces"),
+            _selector_values(match, "artifacts", rule_id=rule_id),
+            _selector_values(match, "harnesses", rule_id=rule_id),
+            _selector_values(match, "publishers", rule_id=rule_id),
+            _selector_values(match, "workspaces", rule_id=rule_id),
         )
         provenance = raw_rule.get("provenance")
         provenance_mapping = provenance if isinstance(provenance, Mapping) else {}

--- a/src/codex_plugin_scanner/guard/policy_document_io.py
+++ b/src/codex_plugin_scanner/guard/policy_document_io.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Final, cast, final
 
 from .models import DecisionScope, GuardAction, PolicyDecision
-from .policy_document import GuardPolicyDocument
+from .policy_document import GuardPolicyDocument, PolicyRule
 from .policy_document_yaml import (
     MAX_POLICY_BYTES,
     format_policy_document_yaml,
@@ -77,10 +77,22 @@ class CompiledPolicyRow:
     provenance_json: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PolicyDocumentDiff:
     changed: bool
     text: str
+    additions: tuple[str, ...]
+    modifications: tuple[str, ...]
+    removals: tuple[str, ...]
+    impacted_scopes: tuple[str, ...]
+    impacted_harnesses: tuple[str, ...]
+    impacted_artifact_families: tuple[str, ...]
+    conflict_warnings: tuple[str, ...]
+    broadened_rules: tuple[str, ...] = ()
+    narrowed_rules: tuple[str, ...] = ()
+    unchanged_rules: tuple[str, ...] = ()
+    effective_action_changes: tuple[str, ...] = ()
+    broad_relaxing_changes: tuple[str, ...] = ()
 
 
 def _assert_trusted_parent_metadata(path: Path, metadata: os.stat_result) -> None:
@@ -252,6 +264,223 @@ def format_trusted_policy_file(source: Path, destination: Path) -> GuardPolicyDo
     return document
 
 
+def _artifact_family(value: str) -> str:
+    for separator in (":", "/"):
+        if separator in value:
+            return value.split(separator, 1)[0]
+    return value
+
+
+def _semantic_policy_diff(
+    baseline: GuardPolicyDocument,
+    candidate: GuardPolicyDocument,
+) -> tuple[
+    tuple[str, ...],
+    tuple[str, ...],
+    tuple[str, ...],
+    tuple[str, ...],
+    tuple[str, ...],
+    tuple[str, ...],
+    tuple[str, ...],
+]:
+    baseline_rules = {rule.id: rule for rule in baseline.rules}
+    candidate_rules = {rule.id: rule for rule in candidate.rules}
+    additions = tuple(sorted(candidate_rules.keys() - baseline_rules.keys()))
+    removals = tuple(sorted(baseline_rules.keys() - candidate_rules.keys()))
+    modifications = tuple(
+        sorted(
+            rule_id
+            for rule_id in baseline_rules.keys() & candidate_rules.keys()
+            if baseline_rules[rule_id].to_mapping() != candidate_rules[rule_id].to_mapping()
+        )
+    )
+    changed_ids = set(additions) | set(modifications) | set(removals)
+    impacted_rules = [
+        rule
+        for rule_id in sorted(changed_ids)
+        for rule in (candidate_rules.get(rule_id) or baseline_rules.get(rule_id),)
+        if rule is not None
+    ]
+    impacted_scopes = {field for rule in impacted_rules for field, values in rule.match.fields if values}
+    impacted_harnesses = {
+        value
+        for rule in impacted_rules
+        for field, values in rule.match.fields
+        if field == "harnesses"
+        for value in values
+    }
+    impacted_artifact_families = {
+        _artifact_family(value)
+        for rule in impacted_rules
+        for field, values in rule.match.fields
+        if field == "artifacts"
+        for value in values
+    }
+    enabled_candidate_rules = [rule for rule in candidate.rules if rule.enabled]
+    conflict_warnings = tuple(
+        sorted(
+            f"overlapping_effects:{left.id}:{right.id}"
+            for left, right in itertools.combinations(enabled_candidate_rules, 2)
+            if left.effect != right.effect and _matches_overlap(left, right)
+        )
+    )
+    return (
+        additions,
+        modifications,
+        removals,
+        tuple(sorted(impacted_scopes)),
+        tuple(sorted(impacted_harnesses)),
+        tuple(sorted(impacted_artifact_families)),
+        conflict_warnings,
+    )
+
+
+def _match_fields(rule: PolicyRule) -> dict[str, frozenset[str]]:
+    return {field: frozenset(values) for field, values in rule.match.fields if values}
+
+
+def _match_contains(container: PolicyRule, contained: PolicyRule) -> bool:
+    container_fields = _match_fields(container)
+    contained_fields = _match_fields(contained)
+    return all(
+        field in contained_fields and values.issuperset(contained_fields[field])
+        for field, values in container_fields.items()
+    )
+
+
+def _matches_overlap(left: PolicyRule, right: PolicyRule) -> bool:
+    left_fields = _match_fields(left)
+    right_fields = _match_fields(right)
+    return all(bool(left_fields[field] & right_fields[field]) for field in left_fields.keys() & right_fields.keys())
+
+
+def _restrictive_lifetime_relaxed(previous: PolicyRule, current: PolicyRule) -> bool:
+    if previous.lifetime == current.lifetime:
+        return False
+    if previous.lifetime.mode == "permanent":
+        return current.lifetime.mode != "permanent"
+    if current.lifetime.mode == "permanent":
+        return False
+    if previous.lifetime.mode != current.lifetime.mode:
+        return True
+    previous_expiry = previous.lifetime.expires_at
+    current_expiry = current.lifetime.expires_at
+    if previous_expiry is None:
+        return current_expiry is not None
+    return current_expiry is None or current_expiry < previous_expiry
+
+
+_DEFAULT_ENFORCEMENT_STRENGTH = {
+    "allow": 0,
+    "ignore": 0,
+    "observe": 0,
+    "warn": 1,
+    "review": 1,
+    "prompt": 1,
+    "require-reapproval": 2,
+    "block": 3,
+    "enforce": 3,
+}
+
+
+def _classify_default_changes(
+    baseline: GuardPolicyDocument,
+    candidate: GuardPolicyDocument,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    baseline_defaults = baseline.defaults.to_mapping()
+    candidate_defaults = candidate.defaults.to_mapping()
+    changes: list[str] = []
+    broad_relaxing: list[str] = []
+    for key in sorted(baseline_defaults.keys() | candidate_defaults.keys()):
+        previous = baseline_defaults.get(key)
+        current = candidate_defaults.get(key)
+        if previous == current:
+            continue
+        changes.append(f"defaults.{key}:{previous}->{current}")
+        previous_strength = _DEFAULT_ENFORCEMENT_STRENGTH.get(previous) if isinstance(previous, str) else None
+        current_strength = _DEFAULT_ENFORCEMENT_STRENGTH.get(current) if isinstance(current, str) else None
+        if previous_strength is not None and current_strength is not None and current_strength < previous_strength:
+            broad_relaxing.append(f"defaults.{key}")
+    return tuple(changes), tuple(broad_relaxing)
+
+
+def _classify_rule_changes(
+    baseline: GuardPolicyDocument,
+    candidate: GuardPolicyDocument,
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    baseline_rules = {rule.id: rule for rule in baseline.rules}
+    candidate_rules = {rule.id: rule for rule in candidate.rules}
+    shared_ids = baseline_rules.keys() & candidate_rules.keys()
+    broadened: list[str] = []
+    narrowed: list[str] = []
+    unchanged: list[str] = []
+    action_changes: list[str] = []
+    broad_relaxing: list[str] = []
+    restrictive_effects = frozenset({"block", "review"})
+    relaxing_effects = frozenset({"allow", "ignore"})
+
+    for rule_id in sorted(shared_ids):
+        previous = baseline_rules[rule_id]
+        current = candidate_rules[rule_id]
+        if previous.to_mapping() == current.to_mapping():
+            unchanged.append(rule_id)
+            continue
+        current_contains_previous = _match_contains(current, previous)
+        previous_contains_current = _match_contains(previous, current)
+        if current_contains_previous and not previous_contains_current:
+            broadened.append(rule_id)
+        elif previous_contains_current and not current_contains_previous:
+            narrowed.append(rule_id)
+        if previous.effect != current.effect or previous.enabled != current.enabled:
+            action_changes.append(
+                f"{rule_id}:{previous.effect if previous.enabled else 'disabled'}"
+                f"->{current.effect if current.enabled else 'disabled'}"
+            )
+        relaxes_effect = (
+            previous.enabled
+            and previous.effect in restrictive_effects
+            and (not current.enabled or current.effect in relaxing_effects)
+        )
+        relaxes_lifetime = (
+            previous.enabled
+            and current.enabled
+            and previous.effect in restrictive_effects
+            and current.effect in restrictive_effects
+            and _restrictive_lifetime_relaxed(previous, current)
+        )
+        if (
+            relaxes_effect
+            or relaxes_lifetime
+            or (
+                current.enabled
+                and current.effect in relaxing_effects
+                and current_contains_previous
+                and not previous_contains_current
+            )
+        ):
+            broad_relaxing.append(rule_id)
+
+    for rule_id in sorted(candidate_rules.keys() - baseline_rules.keys()):
+        current = candidate_rules[rule_id]
+        if current.enabled and current.effect in relaxing_effects:
+            broad_relaxing.append(rule_id)
+    for rule_id in sorted(baseline_rules.keys() - candidate_rules.keys()):
+        previous = baseline_rules[rule_id]
+        if previous.enabled and previous.effect in restrictive_effects:
+            broad_relaxing.append(rule_id)
+
+    default_changes, default_relaxing = _classify_default_changes(baseline, candidate)
+    action_changes.extend(default_changes)
+    broad_relaxing.extend(default_relaxing)
+    return (
+        tuple(broadened),
+        tuple(narrowed),
+        tuple(unchanged),
+        tuple(action_changes),
+        tuple(sorted(set(broad_relaxing))),
+    )
+
+
 def diff_policy_documents(
     baseline: GuardPolicyDocument,
     candidate: GuardPolicyDocument,
@@ -268,7 +497,38 @@ def diff_policy_documents(
         tofile=candidate_name,
     )
     text = "".join(lines)
-    return PolicyDocumentDiff(changed=bool(text), text=text)
+    (
+        additions,
+        modifications,
+        removals,
+        impacted_scopes,
+        impacted_harnesses,
+        impacted_artifact_families,
+        conflict_warnings,
+    ) = _semantic_policy_diff(baseline, candidate)
+    (
+        broadened_rules,
+        narrowed_rules,
+        unchanged_rules,
+        effective_action_changes,
+        broad_relaxing_changes,
+    ) = _classify_rule_changes(baseline, candidate)
+    return PolicyDocumentDiff(
+        changed=bool(text),
+        text=text,
+        additions=additions,
+        modifications=modifications,
+        removals=removals,
+        impacted_scopes=impacted_scopes,
+        impacted_harnesses=impacted_harnesses,
+        impacted_artifact_families=impacted_artifact_families,
+        conflict_warnings=conflict_warnings,
+        broadened_rules=broadened_rules,
+        narrowed_rules=narrowed_rules,
+        unchanged_rules=unchanged_rules,
+        effective_action_changes=effective_action_changes,
+        broad_relaxing_changes=broad_relaxing_changes,
+    )
 
 
 def _normalized_timestamp(value: object, *, rule_id: str) -> str:

--- a/src/codex_plugin_scanner/guard/policy_document_io.py
+++ b/src/codex_plugin_scanner/guard/policy_document_io.py
@@ -12,6 +12,7 @@ import secrets
 import stat
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Final, cast, final
 
@@ -367,7 +368,11 @@ def _restrictive_lifetime_relaxed(previous: PolicyRule, current: PolicyRule) -> 
     current_expiry = current.lifetime.expires_at
     if previous_expiry is None:
         return current_expiry is not None
-    return current_expiry is None or current_expiry < previous_expiry
+    if current_expiry is None:
+        return False
+    return datetime.fromisoformat(current_expiry.replace("Z", "+00:00")) < datetime.fromisoformat(
+        previous_expiry.replace("Z", "+00:00")
+    )
 
 
 _DEFAULT_ENFORCEMENT_STRENGTH = {

--- a/src/codex_plugin_scanner/guard/policy_document_yaml.py
+++ b/src/codex_plugin_scanner/guard/policy_document_yaml.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from functools import lru_cache
 from importlib import resources
 from pathlib import Path
-from typing import TypeAlias
+from typing import TypeAlias, cast
 
 import yaml
 from jsonschema import Draft202012Validator
@@ -41,6 +41,7 @@ MAX_DIAGNOSTICS = 20
 MAX_POLICY_TOKENS = 200_000
 
 JsonPath: TypeAlias = tuple[str | int, ...]
+JsonSchemaValue: TypeAlias = str | int | float | bool | None | list["JsonSchemaValue"] | dict[str, "JsonSchemaValue"]
 
 _JSON_BOOL = re.compile(r"^(?:true|false)$")
 _JSON_NULL = re.compile(r"^null$")
@@ -387,7 +388,7 @@ def _schema_diagnostics(text: str, value: object) -> tuple[PolicyDiagnostic, ...
         source_node = None
     diagnostics: list[PolicyDiagnostic] = []
     errors = sorted(
-        _policy_document_validator().iter_errors(value),
+        _policy_document_validator().iter_errors(cast(JsonSchemaValue, value)),
         key=lambda item: tuple(str(part) for part in item.path),
     )
     for error in errors[:MAX_DIAGNOSTICS]:

--- a/src/codex_plugin_scanner/guard/policy_document_yaml.py
+++ b/src/codex_plugin_scanner/guard/policy_document_yaml.py
@@ -38,6 +38,7 @@ MAX_POLICY_RULES = 1_000
 MAX_COLLECTION_ITEMS = 256
 MAX_STRING_LENGTH = 4_096
 MAX_DIAGNOSTICS = 20
+MAX_POLICY_TOKENS = 200_000
 
 JsonPath: TypeAlias = tuple[str | int, ...]
 
@@ -78,13 +79,13 @@ class PolicyDiagnostic:
 
 class PolicyDocumentError(ValueError):
     """Bounded policy diagnostics that never include policy values."""
+
     diagnostics: tuple[PolicyDiagnostic, ...]
 
     def __init__(self, diagnostics: tuple[PolicyDiagnostic, ...]):
         self.diagnostics = diagnostics[:MAX_DIAGNOSTICS]
         summary = "; ".join(
-            f"{item.code}@{_format_path(item.path)}:{item.line or 0}:{item.column or 0}"
-            for item in self.diagnostics
+            f"{item.code}@{_format_path(item.path)}:{item.line or 0}:{item.column or 0}" for item in self.diagnostics
         )
         super().__init__((summary or "invalid_policy_document")[:4_096])
 
@@ -93,10 +94,7 @@ def _format_path(path: JsonPath) -> str:
     if not path:
         return "$"
     return "$" + "".join(
-        f"[{item}]"
-        if isinstance(item, int)
-        else f"[{json.dumps(item[:80], ensure_ascii=True)}]"
-        for item in path
+        f"[{item}]" if isinstance(item, int) else f"[{json.dumps(item[:80], ensure_ascii=True)}]" for item in path
     )
 
 
@@ -191,8 +189,8 @@ _PolicyDumper.add_representer(str, _represent_policy_string)
 
 @lru_cache(maxsize=1)
 def _load_policy_document_schema() -> dict[str, object]:
-    schema_path = resources.files("codex_plugin_scanner.guard").joinpath("schemas").joinpath(
-        "guard-policy-v1alpha1.schema.json"
+    schema_path = (
+        resources.files("codex_plugin_scanner.guard").joinpath("schemas").joinpath("guard-policy-v1alpha1.schema.json")
     )
     value = json.loads(schema_path.read_text(encoding="utf-8"))
     if not isinstance(value, dict):
@@ -212,6 +210,7 @@ def _policy_document_validator() -> Draft202012Validator:
 
 def _scan_restricted_tokens(text: str) -> None:
     depth = 0
+    token_count = 0
     collection_starts = (
         BlockMappingStartToken,
         BlockSequenceStartToken,
@@ -221,6 +220,17 @@ def _scan_restricted_tokens(text: str) -> None:
     collection_ends = (BlockEndToken, FlowMappingEndToken, FlowSequenceEndToken)
     try:
         for token in yaml.scan(text, Loader=_PolicyLoader):
+            token_count += 1
+            if token_count > MAX_POLICY_TOKENS:
+                raise PolicyDocumentError(
+                    (
+                        PolicyDiagnostic(
+                            "limit_tokens",
+                            line=token.start_mark.line + 1,
+                            column=token.start_mark.column + 1,
+                        ),
+                    )
+                )
             if isinstance(token, collection_starts):
                 depth += 1
                 if depth > MAX_POLICY_DEPTH + 1:
@@ -246,11 +256,7 @@ def _scan_restricted_tokens(text: str) -> None:
                             ),
                         )
                     )
-                if (
-                    token.style is None
-                    and _JSON_INT.fullmatch(token.value)
-                    and len(token.value.removeprefix("-")) > 16
-                ):
+                if token.style is None and _JSON_INT.fullmatch(token.value) and len(token.value.removeprefix("-")) > 16:
                     raise PolicyDocumentError(
                         (
                             PolicyDiagnostic(

--- a/src/codex_plugin_scanner/guard/policy_integrity.py
+++ b/src/codex_plugin_scanner/guard/policy_integrity.py
@@ -13,7 +13,9 @@ POLICY_INTEGRITY_VERSION = 2
 POLICY_INTEGRITY_MAC_ALGORITHM = "hmac-sha256"
 _LEGACY_POLICY_INTEGRITY_VERSION = 1
 _SUPPORTED_POLICY_INTEGRITY_VERSIONS = frozenset({_LEGACY_POLICY_INTEGRITY_VERSION, POLICY_INTEGRITY_VERSION})
-REMOTE_POLICY_SOURCES = frozenset({"cloud-sync", "team-policy", "policy-bundle", "cloud-signed-memory"})
+REMOTE_POLICY_SOURCES = frozenset(
+    {"cloud-sync", "team-policy", "policy-bundle", "policy-bundle-canonical", "cloud-signed-memory"}
+)
 
 PolicyIntegrityStatus = Literal[
     "valid",

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1082,12 +1082,18 @@ def _policy_bundle_acknowledgement_payload(
         if status == "applied" or (matching_previous is not None and matching_previous.get("status") == "applied")
         else "validated"
     )
+    parsed_synced_at = _parse_iso_timestamp(synced_at)
+    observed_at = (
+        parsed_synced_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        if parsed_synced_at is not None
+        else synced_at
+    )
     acknowledgement = {
         "contractVersion": POLICY_BUNDLE_V2_CONTRACT,
         **candidate_identity,
         "sequence": previous_sequence + 1 if isinstance(previous_sequence, int) else 1,
         "status": resolved_status,
-        "observedAt": synced_at.removesuffix("+00:00") + "Z",
+        "observedAt": observed_at,
     }
     validated, error = validated_policy_bundle_v2_acknowledgement(
         acknowledgement,
@@ -1125,6 +1131,12 @@ def _policy_bundle_is_version_downgrade(
     if next_bundle.get("contractVersion") == POLICY_BUNDLE_V2_CONTRACT:
         current_version = existing_bundle.get("bundleVersion") if isinstance(existing_bundle, dict) else None
         current_hash = existing_bundle.get("bundleHash") if isinstance(existing_bundle, dict) else None
+        expected_version = (
+            expected_last_good_bundle.get("bundleVersion") if isinstance(expected_last_good_bundle, dict) else None
+        )
+        expected_hash = (
+            expected_last_good_bundle.get("bundleHash") if isinstance(expected_last_good_bundle, dict) else None
+        )
         return (
             validate_policy_bundle_v2_transition(
                 next_bundle,
@@ -1135,17 +1147,11 @@ def _policy_bundle_is_version_downgrade(
                 ),
                 current_bundle_hash=(current_hash if isinstance(current_hash, str) else None),
                 expected_last_good_bundle_version=(
-                    expected_last_good_bundle.get("bundleVersion")
-                    if isinstance(expected_last_good_bundle, dict)
-                    and isinstance(expected_last_good_bundle.get("bundleVersion"), int)
+                    expected_version
+                    if isinstance(expected_version, int) and not isinstance(expected_version, bool)
                     else None
                 ),
-                expected_last_good_bundle_hash=(
-                    expected_last_good_bundle.get("bundleHash")
-                    if isinstance(expected_last_good_bundle, dict)
-                    and isinstance(expected_last_good_bundle.get("bundleHash"), str)
-                    else None
-                ),
+                expected_last_good_bundle_hash=(expected_hash if isinstance(expected_hash, str) else None),
             )
             is not None
         )
@@ -1528,6 +1534,9 @@ def _policy_shadow_mismatch_reason_codes(
     legacy: list[PolicyDecision],
     canonical: list[PolicyDecision],
 ) -> tuple[str, ...]:
+    if not legacy:
+        return ("legacy_unavailable",)
+
     def keyed(
         decisions: list[PolicyDecision],
     ) -> dict[tuple[str, str, str | None, str | None, str | None, str | None], PolicyDecision]:
@@ -1934,17 +1943,15 @@ def sync_receipts(
                         legacy_decisions,
                         canonical_decisions,
                     )
-                    if not legacy_decisions:
-                        shadow_mismatch_reasons = (
-                            "legacy_unavailable",
-                            *shadow_mismatch_reasons,
-                        )[:4]
+                    blocking_shadow_mismatch_reasons = tuple(
+                        reason for reason in shadow_mismatch_reasons if reason != "legacy_unavailable"
+                    )
                     candidate_policy_decisions = (
                         canonical_decisions
-                        if canonical_enforcement and not shadow_mismatch_reasons
+                        if canonical_enforcement and not blocking_shadow_mismatch_reasons
                         else legacy_decisions
                     )
-                    if canonical_enforcement and shadow_mismatch_reasons:
+                    if canonical_enforcement and blocking_shadow_mismatch_reasons:
                         validated_policy_bundle = None
                         policy_bundle_rejection_reason = "canonical_shadow_mismatch"
                         canonical_enforcement = False

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -20,7 +20,7 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from cryptography.hazmat.primitives import hashes, serialization
@@ -68,7 +68,10 @@ from ..policy_bundle_trusted_keys import (
 from ..policy_bundle_v2 import (
     POLICY_BUNDLE_V2_CONTRACT,
     validate_policy_bundle_v2_transition,
+    validated_policy_bundle_v2_acknowledgement,
 )
+from ..policy_document import GuardPolicyDocument
+from ..policy_document_io import PolicyCompilationError, compile_policy_document
 from ..redaction import redact_sensitive_text
 from ..shims import package_shim_cloud_coverage
 from ..store import GuardStore
@@ -88,8 +91,35 @@ from .supply_chain_support import ecosystem_support_matrix
 
 _POLICY_DOCUMENT_VERSIONS = ("guard.hashgraphonline.com/v1alpha1",)
 _POLICY_BUNDLE_VERSIONS = ("guard-policy-bundle.v1", "guard-policy-bundle.v2")
+_POLICY_CONTRACTS = ("guard-policy-bundle/v1", "guard-policy-bundle/v2")
 _POLICY_YAML_IMPORT_ENV = "HOL_GUARD_POLICY_YAML_IMPORT"
 _POLICY_CANONICAL_ENFORCEMENT_ENV = "HOL_GUARD_POLICY_CANONICAL_ENFORCEMENT"
+
+
+def _canonical_policy_rollout_percentage() -> int:
+    raw = os.environ.get(_POLICY_CANONICAL_ENFORCEMENT_ENV, "").strip().lower()
+    if raw in {"", "0", "false", "off", "legacy"}:
+        return 0
+    if raw in {"1", "true", "on", "canonical"}:
+        return 100
+    try:
+        percentage = int(raw)
+    except ValueError:
+        return 0
+    return percentage if 1 <= percentage <= 100 else 0
+
+
+def _canonical_policy_enforcement_enabled(
+    *,
+    device_id: str,
+    workspace_id: str | None,
+) -> bool:
+    percentage = _canonical_policy_rollout_percentage()
+    if percentage in {0, 100}:
+        return percentage == 100
+    cohort_key = f"{workspace_id or 'local'}:{device_id}".encode()
+    cohort = int.from_bytes(hashlib.sha256(cohort_key).digest()[:8], "big") % 100
+    return cohort < percentage
 
 
 def detect_harness(harness: str, context: HarnessContext) -> HarnessDetection:
@@ -1021,15 +1051,51 @@ def _policy_bundle_acknowledgement_payload(
     device_name: str,
     policy_bundle: dict[str, object],
     synced_at: str,
+    status: Literal["validated", "applied"] = "applied",
+    previous: dict[str, object] | None = None,
 ) -> dict[str, object]:
-    return {
-        "appliedAt": synced_at,
-        "bundleHash": policy_bundle["bundleHash"],
-        "bundleVersion": policy_bundle["bundleVersion"],
+    if policy_bundle.get("contractVersion") != POLICY_BUNDLE_V2_CONTRACT:
+        return {
+            "appliedAt": synced_at,
+            "bundleHash": policy_bundle["bundleHash"],
+            "bundleVersion": policy_bundle["bundleVersion"],
+            "deviceId": device_id,
+            "deviceName": device_name,
+            "status": "synced",
+        }
+
+    identity_fields = ("workspaceId", "deviceId", "bundleVersion", "bundleHash")
+    candidate_identity = {
+        "workspaceId": policy_bundle["workspaceId"],
         "deviceId": device_id,
-        "deviceName": device_name,
-        "status": "synced",
+        "bundleVersion": policy_bundle["bundleVersion"],
+        "bundleHash": policy_bundle["bundleHash"],
     }
+    matching_previous = (
+        previous
+        if previous is not None and all(previous.get(field) == candidate_identity[field] for field in identity_fields)
+        else None
+    )
+    previous_sequence = matching_previous.get("sequence") if matching_previous is not None else None
+    resolved_status = (
+        "applied"
+        if status == "applied" or (matching_previous is not None and matching_previous.get("status") == "applied")
+        else "validated"
+    )
+    acknowledgement = {
+        "contractVersion": POLICY_BUNDLE_V2_CONTRACT,
+        **candidate_identity,
+        "sequence": previous_sequence + 1 if isinstance(previous_sequence, int) else 1,
+        "status": resolved_status,
+        "observedAt": synced_at.removesuffix("+00:00") + "Z",
+    }
+    validated, error = validated_policy_bundle_v2_acknowledgement(
+        acknowledgement,
+        previous=matching_previous,
+    )
+    if validated is None:
+        raise ValueError(error or "invalid_policy_bundle_acknowledgement")
+    return validated
 
 
 def _version_tuple(value: str) -> tuple[int, ...] | None:
@@ -1053,6 +1119,8 @@ def _daemon_version_supported(policy_bundle: dict[str, object]) -> bool:
 def _policy_bundle_is_version_downgrade(
     existing_bundle: dict[str, object] | None,
     next_bundle: dict[str, object],
+    *,
+    expected_last_good_bundle: dict[str, object] | None = None,
 ) -> bool:
     if next_bundle.get("contractVersion") == POLICY_BUNDLE_V2_CONTRACT:
         current_version = existing_bundle.get("bundleVersion") if isinstance(existing_bundle, dict) else None
@@ -1066,6 +1134,18 @@ def _policy_bundle_is_version_downgrade(
                     else None
                 ),
                 current_bundle_hash=(current_hash if isinstance(current_hash, str) else None),
+                expected_last_good_bundle_version=(
+                    expected_last_good_bundle.get("bundleVersion")
+                    if isinstance(expected_last_good_bundle, dict)
+                    and isinstance(expected_last_good_bundle.get("bundleVersion"), int)
+                    else None
+                ),
+                expected_last_good_bundle_hash=(
+                    expected_last_good_bundle.get("bundleHash")
+                    if isinstance(expected_last_good_bundle, dict)
+                    and isinstance(expected_last_good_bundle.get("bundleHash"), str)
+                    else None
+                ),
             )
             is not None
         )
@@ -1291,12 +1371,75 @@ def _policy_bundle_rule_has_browser_scope(rule: dict[str, object]) -> bool:
     return False
 
 
-def _build_policy_bundle_decisions(
+def _build_canonical_policy_bundle_decisions(
     policy_bundle: dict[str, object],
     *,
     device_id: str,
     device_name: str,
 ) -> list[PolicyDecision]:
+    payload = policy_bundle.get("payload")
+    if not isinstance(payload, dict):
+        raise PolicyCompilationError("missing_policy_bundle_payload", "policy-bundle")
+    local_document = json.loads(json.dumps(payload))
+    spec = local_document.get("spec")
+    if not isinstance(spec, dict):
+        raise PolicyCompilationError("invalid_policy_spec", "policy-bundle")
+    rules = spec.get("rules")
+    if not isinstance(rules, list):
+        raise PolicyCompilationError("invalid_policy_rules", "policy-bundle")
+    local_rules: list[object] = []
+    for raw_rule in rules:
+        if not isinstance(raw_rule, dict):
+            continue
+        match = raw_rule.get("match")
+        if not isinstance(match, dict):
+            local_rules.append(raw_rule)
+            continue
+        devices = match.get("devices")
+        if isinstance(devices, list) and devices:
+            device_selectors = {str(value) for value in devices}
+            if device_id not in device_selectors and device_name not in device_selectors:
+                continue
+            match.pop("devices", None)
+        local_rules.append(raw_rule)
+    spec["rules"] = local_rules
+    document = GuardPolicyDocument.from_mapping(local_document)
+    decisions: list[PolicyDecision] = []
+    for row in compile_policy_document(document):
+        decision = row.decision
+        decisions.append(
+            PolicyDecision(
+                harness=decision.harness,
+                scope=decision.scope,
+                action=decision.action,
+                artifact_id=decision.artifact_id,
+                artifact_hash=decision.artifact_hash,
+                workspace=decision.workspace,
+                publisher=decision.publisher,
+                reason=decision.reason,
+                owner=row.rule_id,
+                source="policy-bundle-canonical",
+                expires_at=decision.expires_at,
+            )
+        )
+    return decisions
+
+
+def _build_policy_bundle_decisions(
+    policy_bundle: dict[str, object],
+    *,
+    device_id: str,
+    device_name: str,
+    canonical_enforcement: bool = False,
+) -> list[PolicyDecision]:
+    if policy_bundle.get("contractVersion") == POLICY_BUNDLE_V2_CONTRACT:
+        if not canonical_enforcement:
+            return []
+        return _build_canonical_policy_bundle_decisions(
+            policy_bundle,
+            device_id=device_id,
+            device_name=device_name,
+        )
     decisions: list[PolicyDecision] = []
     rules = policy_bundle.get("rules")
     if not isinstance(rules, list):
@@ -1379,6 +1522,40 @@ def _build_policy_bundle_decisions(
                         )
                     )
     return decisions
+
+
+def _policy_shadow_mismatch_reason_codes(
+    legacy: list[PolicyDecision],
+    canonical: list[PolicyDecision],
+) -> tuple[str, ...]:
+    def keyed(
+        decisions: list[PolicyDecision],
+    ) -> dict[tuple[str, str, str | None, str | None, str | None, str | None], PolicyDecision]:
+        return {
+            (
+                decision.harness,
+                decision.scope,
+                decision.artifact_id,
+                decision.artifact_hash,
+                decision.workspace,
+                decision.publisher,
+            ): decision
+            for decision in decisions
+        }
+
+    reasons: list[str] = []
+    legacy_by_key = keyed(legacy)
+    canonical_by_key = keyed(canonical)
+    if len(legacy) != len(canonical):
+        reasons.append("row_count")
+    if legacy_by_key.keys() != canonical_by_key.keys():
+        reasons.append("selector_set")
+    shared_keys = legacy_by_key.keys() & canonical_by_key.keys()
+    if any(legacy_by_key[key].action != canonical_by_key[key].action for key in shared_keys):
+        reasons.append("action")
+    if any(legacy_by_key[key].expires_at != canonical_by_key[key].expires_at for key in shared_keys):
+        reasons.append("expiration")
+    return tuple(reasons[:4])
 
 
 def _parse_policy_simulation_timestamp(value: object) -> datetime | None:
@@ -1677,6 +1854,12 @@ def sync_receipts(
         store.set_sync_payload("policy", policy_payload, now)
     else:
         store.set_sync_payload("policy", {}, now)
+    cloud_workspace_id = store.get_cloud_workspace_id()
+    canonical_enforcement = _canonical_policy_enforcement_enabled(
+        device_id=device_id,
+        workspace_id=cloud_workspace_id,
+    )
+    candidate_policy_decisions: list[PolicyDecision] = []
     validated_policy_bundle: dict[str, object] | None = None
     if policy_bundle_payload is not None:
         validated_policy_bundle, policy_bundle_rejection_reason, trusted_policy_bundle_keys = (
@@ -1691,11 +1874,20 @@ def sync_receipts(
         existing_policy_bundle = (
             existing_policy_bundle_payload if isinstance(existing_policy_bundle_payload, dict) else None
         )
+        canonical_last_good_payload = store.get_sync_payload("policy_bundle_canonical_last_good")
+        canonical_previous_good_payload = store.get_sync_payload("policy_bundle_canonical_previous_good")
+        policy_bundle_for_version_check = (
+            canonical_last_good_payload if isinstance(canonical_last_good_payload, dict) else existing_policy_bundle
+        )
         if validated_policy_bundle is not None and not _daemon_version_supported(validated_policy_bundle):
             validated_policy_bundle = None
             policy_bundle_rejection_reason = "unsupported_daemon_version"
         if validated_policy_bundle is not None and _policy_bundle_is_version_downgrade(
-            existing_policy_bundle, validated_policy_bundle
+            policy_bundle_for_version_check,
+            validated_policy_bundle,
+            expected_last_good_bundle=(
+                canonical_previous_good_payload if isinstance(canonical_previous_good_payload, dict) else None
+            ),
         ):
             validated_policy_bundle = None
             policy_bundle_rejection_reason = "bundle_version_downgrade"
@@ -1711,9 +1903,105 @@ def sync_receipts(
         ):
             validated_policy_bundle = None
             policy_bundle_rejection_reason = "wrong_workspace"
+        shadow_mismatch_reasons: tuple[str, ...] = ()
+        shadow_legacy_rows = 0
+        shadow_canonical_rows = 0
+        validated_bundle_is_v2 = (
+            validated_policy_bundle is not None
+            and validated_policy_bundle.get("contractVersion") == POLICY_BUNDLE_V2_CONTRACT
+        )
         if validated_policy_bundle is not None:
-            store.set_sync_payload("policy_bundle", validated_policy_bundle, now)
-            store.set_sync_payload("policy_bundle_last_good", validated_policy_bundle, now)
+            try:
+                if validated_bundle_is_v2:
+                    canonical_decisions = _build_canonical_policy_bundle_decisions(
+                        validated_policy_bundle,
+                        device_id=device_id,
+                        device_name=device_name,
+                    )
+                    legacy_decisions = (
+                        _build_policy_bundle_decisions(
+                            existing_policy_bundle,
+                            device_id=device_id,
+                            device_name=device_name,
+                        )
+                        if isinstance(existing_policy_bundle, dict)
+                        and existing_policy_bundle.get("contractVersion") != POLICY_BUNDLE_V2_CONTRACT
+                        else []
+                    )
+                    shadow_legacy_rows = len(legacy_decisions)
+                    shadow_canonical_rows = len(canonical_decisions)
+                    shadow_mismatch_reasons = _policy_shadow_mismatch_reason_codes(
+                        legacy_decisions,
+                        canonical_decisions,
+                    )
+                    if not legacy_decisions:
+                        shadow_mismatch_reasons = (
+                            "legacy_unavailable",
+                            *shadow_mismatch_reasons,
+                        )[:4]
+                    candidate_policy_decisions = (
+                        canonical_decisions
+                        if canonical_enforcement and not shadow_mismatch_reasons
+                        else legacy_decisions
+                    )
+                    if canonical_enforcement and shadow_mismatch_reasons:
+                        validated_policy_bundle = None
+                        policy_bundle_rejection_reason = "canonical_shadow_mismatch"
+                        canonical_enforcement = False
+                else:
+                    candidate_policy_decisions = _build_policy_bundle_decisions(
+                        validated_policy_bundle,
+                        device_id=device_id,
+                        device_name=device_name,
+                    )
+            except PolicyCompilationError as error:
+                validated_policy_bundle = None
+                policy_bundle_rejection_reason = f"canonical_compile_{error.code}"
+        if shadow_mismatch_reasons:
+            store.add_event(
+                "policy_bundle/shadow_mismatch",
+                {
+                    "canonicalRows": shadow_canonical_rows,
+                    "legacyRows": shadow_legacy_rows,
+                    "reasonCodes": list(shadow_mismatch_reasons),
+                    "status": "mismatch",
+                },
+                now,
+            )
+        if validated_policy_bundle is not None:
+            if validated_bundle_is_v2:
+                if isinstance(canonical_last_good_payload, dict) and canonical_last_good_payload.get(
+                    "bundleHash"
+                ) != validated_policy_bundle.get("bundleHash"):
+                    store.set_sync_payload(
+                        "policy_bundle_canonical_previous_good",
+                        canonical_last_good_payload,
+                        now,
+                    )
+                store.set_sync_payload(
+                    "policy_bundle_canonical_last_good",
+                    validated_policy_bundle,
+                    now,
+                )
+                if canonical_enforcement:
+                    store.set_sync_payload("policy_bundle", validated_policy_bundle, now)
+                    store.set_sync_payload(
+                        "policy_bundle_last_good",
+                        validated_policy_bundle,
+                        now,
+                    )
+            else:
+                store.set_sync_payload("policy_bundle", validated_policy_bundle, now)
+                store.set_sync_payload(
+                    "policy_bundle_last_good",
+                    validated_policy_bundle,
+                    now,
+                )
+                store.set_sync_payload(
+                    "policy_bundle_legacy_last_good",
+                    validated_policy_bundle,
+                    now,
+                )
             store.set_sync_payload(
                 "policy_bundle_keyring",
                 policy_bundle_keyring_payload(
@@ -1735,19 +2023,30 @@ def sync_receipts(
                     level=cloud_redaction_level,
                     synced_at=now,
                 )
-            remote_decisions.update(
-                _build_policy_bundle_decisions(
-                    validated_policy_bundle,
-                    device_id=device_id,
-                    device_name=device_name,
-                )
-            )
+            remote_decisions.update(candidate_policy_decisions)
         else:
+            canonical_fallback = (
+                canonical_last_good_payload
+                if canonical_enforcement
+                and isinstance(canonical_last_good_payload, dict)
+                and canonical_last_good_payload
+                else None
+            )
+            legacy_last_good_payload = store.get_sync_payload("policy_bundle_legacy_last_good")
+            legacy_fallback = (
+                legacy_last_good_payload
+                if not canonical_enforcement and isinstance(legacy_last_good_payload, dict) and legacy_last_good_payload
+                else None
+            )
             last_good_bundle_payload = store.get_sync_payload("policy_bundle_last_good")
             preserved_bundle_payload = (
-                last_good_bundle_payload
-                if isinstance(last_good_bundle_payload, dict) and last_good_bundle_payload
-                else existing_policy_bundle
+                canonical_fallback
+                or legacy_fallback
+                or (
+                    last_good_bundle_payload
+                    if isinstance(last_good_bundle_payload, dict) and last_good_bundle_payload
+                    else existing_policy_bundle
+                )
             )
             if isinstance(preserved_bundle_payload, dict) and preserved_bundle_payload:
                 remote_decisions.update(
@@ -1755,7 +2054,24 @@ def sync_receipts(
                         preserved_bundle_payload,
                         device_id=device_id,
                         device_name=device_name,
+                        canonical_enforcement=canonical_enforcement,
                     )
+                )
+                store.add_event(
+                    "policy_bundle/rollback",
+                    {
+                        "reason": policy_bundle_rejection_reason or "invalid_policy_bundle",
+                        "restored": (
+                            "policy_bundle_canonical_last_good"
+                            if canonical_fallback is not None
+                            else (
+                                "policy_bundle_legacy_last_good"
+                                if legacy_fallback is not None
+                                else "policy_bundle_last_good"
+                            )
+                        ),
+                    },
+                    now,
                 )
             store.set_sync_payload(
                 "policy_bundle_last_error",
@@ -1769,12 +2085,25 @@ def sync_receipts(
             )
     else:
         existing_bundle_payload = store.get_sync_payload("policy_bundle")
+        canonical_cached_payload = store.get_sync_payload("policy_bundle_canonical_last_good")
+        legacy_cached_payload = store.get_sync_payload("policy_bundle_legacy_last_good")
+        if canonical_enforcement and isinstance(canonical_cached_payload, dict) and canonical_cached_payload:
+            existing_bundle_payload = canonical_cached_payload
+        elif (
+            not canonical_enforcement
+            and isinstance(existing_bundle_payload, dict)
+            and existing_bundle_payload.get("contractVersion") == POLICY_BUNDLE_V2_CONTRACT
+            and isinstance(legacy_cached_payload, dict)
+            and legacy_cached_payload
+        ):
+            existing_bundle_payload = legacy_cached_payload
         if isinstance(existing_bundle_payload, dict) and existing_bundle_payload:
             remote_decisions.update(
                 _build_policy_bundle_decisions(
                     existing_bundle_payload,
                     device_id=device_id,
                     device_name=device_name,
+                    canonical_enforcement=canonical_enforcement,
                 )
             )
     if not isinstance(store.get_sync_payload("policy_bundle_last_error"), dict):
@@ -1801,6 +2130,7 @@ def sync_receipts(
     try:
         store.replace_remote_policies(list(remote_decisions), now, remote_write_authorized=True)
         if validated_policy_bundle is not None:
+            previous_ack_payload = store.get_sync_payload("policy_bundle_ack")
             store.set_sync_payload(
                 "policy_bundle_ack",
                 _policy_bundle_acknowledgement_payload(
@@ -1808,6 +2138,8 @@ def sync_receipts(
                     device_name=device_name,
                     policy_bundle=validated_policy_bundle,
                     synced_at=now,
+                    status=("applied" if canonical_enforcement else "validated"),
+                    previous=(previous_ack_payload if isinstance(previous_ack_payload, dict) else None),
                 ),
                 now,
             )
@@ -2483,7 +2815,11 @@ def sync_runtime_session(
     return summary
 
 
-def _local_guard_runtime_session() -> dict[str, object]:
+def _local_guard_runtime_session(
+    *,
+    device_id: str = "local-machine",
+    workspace_id: str | None = None,
+) -> dict[str, object]:
     session: dict[str, object] = {
         "harness": "hol-guard",
         "surface": "cli",
@@ -2495,9 +2831,13 @@ def _local_guard_runtime_session() -> dict[str, object]:
         "capabilities": ["approval-center", "guard-cloud-sync", "local-daemon"],
         "policy_document_versions": list(_POLICY_DOCUMENT_VERSIONS),
         "policy_bundle_versions": list(_POLICY_BUNDLE_VERSIONS),
+        "policy_contracts": list(_POLICY_CONTRACTS),
         "yaml_import": os.environ.get(_POLICY_YAML_IMPORT_ENV) == "1",
     }
-    if os.environ.get(_POLICY_CANONICAL_ENFORCEMENT_ENV) == "1":
+    if _canonical_policy_enforcement_enabled(
+        device_id=device_id,
+        workspace_id=workspace_id,
+    ):
         session["canonical_policy_enforcement"] = True
     return session
 
@@ -2516,9 +2856,14 @@ def sync_local_guard_cloud_proof(
     with store.hold_cloud_sync_lock():
         reconcile_connect_state_with_oauth_entitlement(store, now=resolved_now)
         resolved_auth_context = auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
+        device_id = store.get_or_create_installation_id()
+        workspace_id = store.get_cloud_workspace_id()
         runtime_summary = sync_runtime_session(
             store,
-            session=_local_guard_runtime_session(),
+            session=_local_guard_runtime_session(
+                device_id=device_id,
+                workspace_id=workspace_id,
+            ),
             auth_context=resolved_auth_context,
         )
         receipts_summary = sync_receipts(
@@ -4585,6 +4930,7 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
     policy_bundle_versions = list(
         _string_items(session.get("policy_bundle_versions") or session.get("policyBundleVersions"))
     )
+    policy_contracts = list(_string_items(session.get("policy_contracts") or session.get("policyContracts")))
     yaml_import = session.get("yaml_import") is True or session.get("yamlImport") is True
     canonical_policy_enforcement = (
         session.get("canonical_policy_enforcement") is True or session.get("canonicalPolicyEnforcement") is True
@@ -4619,6 +4965,8 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
         payload["policyDocumentVersions"] = policy_document_versions
     if policy_bundle_versions:
         payload["policyBundleVersions"] = policy_bundle_versions
+    if policy_contracts:
+        payload["policyContracts"] = policy_contracts
     payload["yamlImport"] = yaml_import
     if canonical_policy_enforcement:
         payload["canonicalPolicyEnforcement"] = True

--- a/src/codex_plugin_scanner/guard/schemas/guard-policy-v1alpha1.schema.json
+++ b/src/codex_plugin_scanner/guard/schemas/guard-policy-v1alpha1.schema.json
@@ -438,6 +438,23 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 256
+        },
+        "updatedAt": {
+          "$ref": "#/$defs/utcTimestamp"
+        },
+        "updatedBy": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "importSourceDigest": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "previousRuleRevision": {
+          "type": "integer",
+          "minimum": 1
         }
       },
       "patternProperties": {

--- a/src/codex_plugin_scanner/guard/store_policy_document.py
+++ b/src/codex_plugin_scanner/guard/store_policy_document.py
@@ -85,7 +85,11 @@ class StorePolicyDocumentMixin:
                 if row.get("source") != "policy-yaml-import" or key in incoming_by_key:
                     continue
                 rule_id = row.get("policy_rule_id")
-                removals.append(str(rule_id) if rule_id is not None else f"local-{int(row.get('decision_id', 0))}")
+                decision_id = row.get("decision_id")
+                local_decision_id = (
+                    decision_id if isinstance(decision_id, int) and not isinstance(decision_id, bool) else 0
+                )
+                removals.append(str(rule_id) if rule_id is not None else f"local-{local_decision_id}")
         return PolicyDocumentImportPlan(
             additions=tuple(additions),
             replacements=tuple(replacements),

--- a/src/codex_plugin_scanner/version.py
+++ b/src/codex_plugin_scanner/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for tool version."""
 
-__version__ = "2.0.1105"
+__version__ = "2.0.1113"

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -910,6 +910,10 @@ def test_sync_runtime_session_emits_package_manager_coverage_payload(
         "guard-policy-bundle.v1",
         "guard-policy-bundle.v2",
     ]
+    assert session_payload["policyContracts"] == [
+        "guard-policy-bundle/v1",
+        "guard-policy-bundle/v2",
+    ]
     assert session_payload["yamlImport"] is False
     assert "canonicalPolicyEnforcement" not in session_payload
 
@@ -927,8 +931,36 @@ def test_local_runtime_session_advertises_enabled_policy_capabilities(
         "guard-policy-bundle.v1",
         "guard-policy-bundle.v2",
     ]
+    assert session["policy_contracts"] == [
+        "guard-policy-bundle/v1",
+        "guard-policy-bundle/v2",
+    ]
     assert session["yaml_import"] is True
     assert session["canonical_policy_enforcement"] is True
+
+
+def test_local_runtime_session_applies_stable_policy_rollout_cohorts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOL_GUARD_POLICY_CANONICAL_ENFORCEMENT", "25")
+
+    cohort = [
+        guard_runner_module._canonical_policy_enforcement_enabled(
+            device_id=f"device-{index}",
+            workspace_id="workspace-alpha",
+        )
+        for index in range(100)
+    ]
+
+    assert any(cohort)
+    assert not all(cohort)
+    assert cohort == [
+        guard_runner_module._canonical_policy_enforcement_enabled(
+            device_id=f"device-{index}",
+            workspace_id="workspace-alpha",
+        )
+        for index in range(100)
+    ]
 
 
 def test_sync_runtime_session_prefers_latest_sync_summary_for_package_manager_coverage_freshness(

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -2448,29 +2448,32 @@ def test_headless_policy_sync_accepts_policy_bundle_and_returns_bundle_metadata(
     assert store.resolve_policy("codex", "codex:project:package-request:abc", "hash") == "block"
 
 
+@pytest.mark.parametrize("legacy_available", [True, False])
 def test_headless_policy_sync_enforces_canonical_v2_bundle(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    legacy_available: bool,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_payload(
-        "policy_bundle_legacy_last_good",
-        {
-            "contractVersion": "guard-policy-bundle.v1",
-            "bundleVersion": "policy-2026-07-16.7",
-            "bundleHash": "sha256:legacy",
-            "issuedAt": "2026-07-16T09:59:00Z",
-            "rules": [
-                {
-                    "ruleId": "rule-1",
-                    "action": "block",
-                    "artifactId": "skill:hol/deploy",
-                    "scope": {},
-                }
-            ],
-        },
-        "2026-07-16T09:59:00Z",
-    )
+    if legacy_available:
+        store.set_sync_payload(
+            "policy_bundle_legacy_last_good",
+            {
+                "contractVersion": "guard-policy-bundle.v1",
+                "bundleVersion": "policy-2026-07-16.7",
+                "bundleHash": "sha256:legacy",
+                "issuedAt": "2026-07-16T09:59:00Z",
+                "rules": [
+                    {
+                        "ruleId": "rule-1",
+                        "action": "block",
+                        "artifactId": "skill:hol/deploy",
+                        "scope": {},
+                    }
+                ],
+            },
+            "2026-07-16T09:59:00Z",
+        )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     bundle: dict[str, object] = {

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -2448,6 +2448,156 @@ def test_headless_policy_sync_accepts_policy_bundle_and_returns_bundle_metadata(
     assert store.resolve_policy("codex", "codex:project:package-request:abc", "hash") == "block"
 
 
+def test_headless_policy_sync_enforces_canonical_v2_bundle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_payload(
+        "policy_bundle_legacy_last_good",
+        {
+            "contractVersion": "guard-policy-bundle.v1",
+            "bundleVersion": "policy-2026-07-16.7",
+            "bundleHash": "sha256:legacy",
+            "issuedAt": "2026-07-16T09:59:00Z",
+            "rules": [
+                {
+                    "ruleId": "rule-1",
+                    "action": "block",
+                    "artifactId": "skill:hol/deploy",
+                    "scope": {},
+                }
+            ],
+        },
+        "2026-07-16T09:59:00Z",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    bundle: dict[str, object] = {
+        "contractVersion": "guard-policy-bundle.v2",
+        "bundleVersion": 8,
+        "bundleHash": "sha256:canonical",
+        "issuedAt": "2026-07-16T10:00:00Z",
+        "workspaceId": "workspace-1",
+        "payload": {
+            "apiVersion": "guard.hashgraphonline.com/v1alpha1",
+            "kind": "GuardPolicy",
+            "metadata": {"id": "test-policy", "name": "Test policy", "revision": 1},
+            "spec": {
+                "defaults": {"mode": "prompt"},
+                "rules": [
+                    {
+                        "id": "rule-1",
+                        "enabled": True,
+                        "effect": "block",
+                        "match": {"artifacts": ["skill:hol/deploy"]},
+                        "lifetime": {"mode": "permanent", "expiresAt": None},
+                        "provenance": {
+                            "source": "import",
+                            "createdAt": "2026-07-16T10:00:00Z",
+                            "createdBy": "owner@example.com",
+                        },
+                    }
+                ],
+            },
+        },
+    }
+    monkeypatch.setenv("HOL_GUARD_POLICY_CANONICAL_ENFORCEMENT", "true")
+    monkeypatch.setattr(
+        daemon_server,
+        "validate_synced_policy_bundle",
+        lambda *_args, **_kwargs: (bundle, None, {}),
+    )
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/policy/sync",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "policy_sync",
+                    "policy_bundle": json.dumps(bundle),
+                },
+            ),
+        )
+        repeat_status, repeat_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/policy/sync",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "policy_sync",
+                    "policy_bundle": json.dumps(bundle),
+                },
+            ),
+        )
+        repeated_ack = store.get_sync_payload("policy_bundle_ack")
+        bundle["bundleVersion"] = 9
+        bundle["bundleHash"] = "sha256:higher"
+        higher_status, higher_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/policy/sync",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "policy_sync",
+                    "policy_bundle": json.dumps(bundle),
+                },
+            ),
+        )
+        previous_good = store.get_sync_payload("policy_bundle_canonical_previous_good")
+        bundle["bundleVersion"] = 7
+        bundle["bundleHash"] = "sha256:lower"
+        downgrade_status, downgrade_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/policy/sync",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "policy_sync",
+                    "policy_bundle": json.dumps(bundle),
+                },
+            ),
+        )
+        bundle["bundleVersion"] = 9
+        bundle["bundleHash"] = "sha256:substitution"
+        substitution_status, substitution_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/policy/sync",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "policy_sync",
+                    "policy_bundle": json.dumps(bundle),
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200, (payload, store.list_events())
+    assert payload["bundle_version"] == "8"
+    assert store.get_sync_payload("policy_bundle")["contractVersion"] == "guard-policy-bundle.v2"
+    decisions = store.list_policy_decisions()
+    assert [(decision["owner"], decision["source"]) for decision in decisions] == [
+        ("rule-1", "policy-bundle-canonical")
+    ]
+    assert repeat_status == 200, repeat_payload
+    assert repeated_ack["sequence"] == 2
+    assert higher_status == 200, higher_payload
+    assert previous_good["bundleVersion"] == 8
+    assert downgrade_status == 400
+    assert downgrade_payload["error"] == "bundle_version_downgrade"
+    assert substitution_status == 400
+    assert substitution_payload["error"] == "bundle_version_downgrade"
+
+
 def test_headless_policy_sync_rejects_unsupported_daemon_version(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -3645,6 +3645,18 @@ clearer UX and an implementation plan with technical references.
                 "client_version": guard_runner_module.__version__,
                 "workspace": "local-machine",
                 "capabilities": ["approval-center", "guard-cloud-sync", "local-daemon"],
+                "policy_bundle_versions": [
+                    "guard-policy-bundle.v1",
+                    "guard-policy-bundle.v2",
+                ],
+                "policy_contracts": [
+                    "guard-policy-bundle/v1",
+                    "guard-policy-bundle/v2",
+                ],
+                "policy_document_versions": [
+                    "guard.hashgraphonline.com/v1alpha1",
+                ],
+                "yaml_import": False,
             }
             return {
                 "synced_at": "2026-06-05T12:00:00+00:00",
@@ -18688,6 +18700,97 @@ def test_policy_bundle_v2_downgrade_check_uses_monotonic_bundle_version():
     )
 
 
+def test_policy_bundle_v2_acknowledgement_sequence_is_monotonic_per_bundle():
+    bundle = {
+        "contractVersion": "guard-policy-bundle.v2",
+        "workspaceId": "workspace-a",
+        "bundleVersion": 7,
+        "bundleHash": "a" * 64,
+    }
+    first = guard_runner_module._policy_bundle_acknowledgement_payload(
+        device_id="device-a",
+        device_name="Guard",
+        policy_bundle=bundle,
+        synced_at="2026-06-05T13:30:00+00:00",
+    )
+    second = guard_runner_module._policy_bundle_acknowledgement_payload(
+        device_id="device-a",
+        device_name="Guard",
+        policy_bundle=bundle,
+        synced_at="2026-06-05T13:31:00+00:00",
+        previous=first,
+    )
+
+    assert first == {
+        "contractVersion": "guard-policy-bundle.v2",
+        "workspaceId": "workspace-a",
+        "deviceId": "device-a",
+        "bundleVersion": 7,
+        "bundleHash": "a" * 64,
+        "sequence": 1,
+        "status": "applied",
+        "observedAt": "2026-06-05T13:30:00Z",
+    }
+    assert second["sequence"] == 2
+    assert second["observedAt"] == "2026-06-05T13:31:00Z"
+
+
+def test_policy_bundle_v2_acknowledgement_distinguishes_shadow_validation() -> None:
+    bundle = {
+        "contractVersion": "guard-policy-bundle.v2",
+        "workspaceId": "workspace-a",
+        "bundleVersion": 7,
+        "bundleHash": "a" * 64,
+    }
+    validated = guard_runner_module._policy_bundle_acknowledgement_payload(
+        device_id="device-a",
+        device_name="Guard",
+        policy_bundle=bundle,
+        synced_at="2026-06-05T13:30:00+00:00",
+        status="validated",
+    )
+    applied = guard_runner_module._policy_bundle_acknowledgement_payload(
+        device_id="device-a",
+        device_name="Guard",
+        policy_bundle=bundle,
+        synced_at="2026-06-05T13:31:00+00:00",
+        status="applied",
+        previous=validated,
+    )
+
+    assert validated["status"] == "validated"
+    assert applied["status"] == "applied"
+    assert applied["sequence"] == 2
+
+
+def test_policy_bundle_v2_acknowledgement_resets_sequence_for_new_bundle():
+    previous = {
+        "contractVersion": "guard-policy-bundle.v2",
+        "workspaceId": "workspace-a",
+        "deviceId": "device-a",
+        "bundleVersion": 7,
+        "bundleHash": "a" * 64,
+        "sequence": 8,
+        "status": "applied",
+        "observedAt": "2026-06-05T13:30:00Z",
+    }
+    acknowledgement = guard_runner_module._policy_bundle_acknowledgement_payload(
+        device_id="device-a",
+        device_name="Guard",
+        policy_bundle={
+            "contractVersion": "guard-policy-bundle.v2",
+            "workspaceId": "workspace-a",
+            "bundleVersion": 8,
+            "bundleHash": "b" * 64,
+        },
+        synced_at="2026-06-05T13:31:00+00:00",
+        previous=previous,
+    )
+
+    assert acknowledgement["sequence"] == 1
+    assert acknowledgement["bundleVersion"] == 8
+
+
 def test_sync_receipts_uploads_policy_bundle_acknowledgement(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     _seed_guard_cloud(store)
@@ -18903,6 +19006,308 @@ def test_sync_receipts_rejects_policy_bundle_for_the_wrong_workspace(tmp_path, m
     assert store.get_sync_payload("policy_bundle") is None
     assert store.get_sync_payload("policy_bundle_last_good") is None
     assert store.get_sync_payload("policy_bundle_last_error") == {"reason": "wrong_workspace"}
+
+
+def test_sync_receipts_rolls_back_to_last_good_bundle_on_canonical_compile_failure(
+    tmp_path,
+    monkeypatch,
+):
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-a")
+    monkeypatch.setenv("HOL_GUARD_POLICY_CANONICAL_ENFORCEMENT", "1")
+    last_good = {
+        "contractVersion": "guard-policy-bundle.v1",
+        "bundleVersion": "policy-2026-06-05.4",
+        "bundleHash": "sha256:last-good",
+        "issuedAt": "2026-06-05T13:29:00+00:00",
+        "rules": [
+            {
+                "ruleId": "legacy-last-good",
+                "action": "block",
+                "artifactId": "command:npm-test",
+                "scope": {"harnesses": ["codex"], "devices": []},
+            }
+        ],
+    }
+    store.set_sync_payload("policy_bundle", last_good, "2026-06-05T13:29:00+00:00")
+    store.set_sync_payload("policy_bundle_last_good", last_good, "2026-06-05T13:29:00+00:00")
+    candidate = {
+        "contractVersion": "guard-policy-bundle.v2",
+        "bundleVersion": 5,
+        "bundleHash": "sha256:candidate",
+        "issuedAt": "2026-06-05T13:30:00+00:00",
+        "workspaceId": "workspace-a",
+        "payload": {
+            "apiVersion": "guard.hashgraphonline.com/v1alpha1",
+            "kind": "GuardPolicy",
+            "metadata": {
+                "id": "policy.unsupported",
+                "name": "Unsupported policy",
+                "revision": 1,
+            },
+            "spec": {
+                "defaults": {"mode": "prompt", "defaultAction": "warn"},
+                "rules": [
+                    {
+                        "id": "rule.unsupported-operation",
+                        "enabled": True,
+                        "effect": "block",
+                        "match": {"operations": ["browser.navigate"]},
+                        "lifetime": {"mode": "permanent", "expiresAt": None},
+                        "provenance": {
+                            "source": "manual",
+                            "receiptIds": [],
+                            "createdAt": "2026-06-05T13:30:00Z",
+                            "createdBy": "owner-1",
+                        },
+                    }
+                ],
+            },
+        },
+    }
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        if request.full_url.endswith("/api/v1/guard/events"):
+            return _Response({"accepted": 0, "rejected": 0, "statuses": []})
+        return _Response(
+            {
+                "syncedAt": "2026-06-05T13:30:01+00:00",
+                "receiptsStored": 0,
+                "policyBundle": candidate,
+            }
+        )
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+    monkeypatch.setattr(
+        guard_runner_module,
+        "validate_synced_policy_bundle",
+        lambda *args, **kwargs: (candidate, None, ()),
+    )
+    monkeypatch.setattr(
+        guard_runner_module,
+        "sync_pain_signals",
+        lambda _store, auth_context=None: 0,
+    )
+
+    guard_runner_module.sync_receipts(store)
+
+    assert store.get_sync_payload("policy_bundle") == last_good
+    assert store.get_sync_payload("policy_bundle_last_good") == last_good
+    assert store.get_sync_payload("policy_bundle_last_error") == {
+        "reason": "canonical_compile_unsupported_policy_match"
+    }
+    assert [decision["owner"] for decision in store.list_policy_decisions()] == ["legacy-last-good"]
+    rollback_events = store.list_events(event_name="policy_bundle/rollback")
+    assert rollback_events[-1]["payload"] == {
+        "reason": "canonical_compile_unsupported_policy_match",
+        "restored": "policy_bundle_last_good",
+    }
+
+
+def test_sync_receipts_keeps_legacy_bundle_active_on_canonical_shadow_mismatch(
+    tmp_path,
+    monkeypatch,
+):
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-a")
+    monkeypatch.setenv("HOL_GUARD_POLICY_CANONICAL_ENFORCEMENT", "1")
+    legacy = {
+        "contractVersion": "guard-policy-bundle.v1",
+        "bundleVersion": "policy-2026-06-05.4",
+        "bundleHash": "sha256:legacy",
+        "issuedAt": "2026-06-05T13:29:00+00:00",
+        "rules": [
+            {
+                "ruleId": "legacy-rule",
+                "action": "block",
+                "artifactId": "skill:hol/deploy",
+                "scope": {"harnesses": ["codex"], "devices": []},
+            }
+        ],
+    }
+    store.set_sync_payload("policy_bundle", legacy, "2026-06-05T13:29:00+00:00")
+    store.set_sync_payload("policy_bundle_legacy_last_good", legacy, "2026-06-05T13:29:00+00:00")
+    candidate = {
+        "contractVersion": "guard-policy-bundle.v2",
+        "bundleVersion": 5,
+        "bundleHash": "a" * 64,
+        "issuedAt": "2026-06-05T13:30:00Z",
+        "workspaceId": "workspace-a",
+        "payload": {
+            "apiVersion": "guard.hashgraphonline.com/v1alpha1",
+            "kind": "GuardPolicy",
+            "metadata": {
+                "id": "policy.shadow-mismatch",
+                "name": "Shadow mismatch",
+                "revision": 1,
+            },
+            "spec": {
+                "defaults": {"mode": "prompt", "defaultAction": "warn"},
+                "rules": [
+                    {
+                        "id": "rule.canonical",
+                        "enabled": True,
+                        "effect": "allow",
+                        "match": {
+                            "artifacts": ["skill:hol/deploy"],
+                            "harnesses": ["codex"],
+                        },
+                        "lifetime": {"mode": "permanent", "expiresAt": None},
+                        "provenance": {
+                            "source": "manual",
+                            "receiptIds": [],
+                            "createdAt": "2026-06-05T13:30:00Z",
+                            "createdBy": "owner-1",
+                        },
+                    }
+                ],
+            },
+        },
+    }
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        if request.full_url.endswith("/api/v1/guard/events"):
+            return _Response({"accepted": 0, "rejected": 0, "statuses": []})
+        return _Response(
+            {
+                "syncedAt": "2026-06-05T13:30:01+00:00",
+                "receiptsStored": 0,
+                "policyBundle": candidate,
+            }
+        )
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+    monkeypatch.setattr(
+        guard_runner_module,
+        "validate_synced_policy_bundle",
+        lambda *args, **kwargs: (candidate, None, ()),
+    )
+    monkeypatch.setattr(
+        guard_runner_module,
+        "sync_pain_signals",
+        lambda _store, auth_context=None: 0,
+    )
+
+    guard_runner_module.sync_receipts(store)
+
+    assert store.get_sync_payload("policy_bundle") == legacy
+    assert store.get_sync_payload("policy_bundle_canonical_last_good") is None
+    assert store.get_sync_payload("policy_bundle_last_error") == {"reason": "canonical_shadow_mismatch"}
+    assert [decision["action"] for decision in store.list_policy_decisions()] == ["block"]
+    mismatch_events = store.list_events(event_name="policy_bundle/shadow_mismatch")
+    assert mismatch_events[-1]["payload"] == {
+        "canonicalRows": 1,
+        "legacyRows": 1,
+        "reasonCodes": ["action"],
+        "status": "mismatch",
+    }
+
+
+def test_sync_receipts_restores_legacy_last_good_when_canonical_flag_is_disabled(
+    tmp_path,
+    monkeypatch,
+):
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-a")
+    monkeypatch.delenv("HOL_GUARD_POLICY_CANONICAL_ENFORCEMENT", raising=False)
+    canonical_bundle = {
+        "contractVersion": "guard-policy-bundle.v2",
+        "bundleVersion": 5,
+        "bundleHash": "sha256:canonical",
+        "issuedAt": "2026-06-05T13:30:00+00:00",
+        "workspaceId": "workspace-a",
+        "payload": {
+            "apiVersion": "guard.hashgraphonline.com/v1alpha1",
+            "kind": "GuardPolicy",
+            "metadata": {
+                "id": "policy.canonical",
+                "name": "Canonical policy",
+                "revision": 5,
+            },
+            "spec": {"defaults": {"mode": "prompt", "defaultAction": "warn"}, "rules": []},
+        },
+    }
+    legacy_bundle = {
+        "contractVersion": "guard-policy-bundle.v1",
+        "bundleVersion": "policy-2026-06-05.4",
+        "bundleHash": "sha256:legacy",
+        "issuedAt": "2026-06-05T13:29:00+00:00",
+        "rules": [
+            {
+                "ruleId": "legacy-last-good",
+                "action": "block",
+                "artifactId": "command:npm-test",
+                "scope": {"harnesses": ["codex"], "devices": []},
+            }
+        ],
+    }
+    store.set_sync_payload("policy_bundle", canonical_bundle, "2026-06-05T13:30:00+00:00")
+    store.set_sync_payload(
+        "policy_bundle_canonical_last_good",
+        canonical_bundle,
+        "2026-06-05T13:30:00+00:00",
+    )
+    store.set_sync_payload(
+        "policy_bundle_legacy_last_good",
+        legacy_bundle,
+        "2026-06-05T13:29:00+00:00",
+    )
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "syncedAt": "2026-06-05T13:31:00+00:00",
+                    "receiptsStored": 0,
+                }
+            ).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        return _Response()
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+    monkeypatch.setattr(
+        guard_runner_module,
+        "sync_pain_signals",
+        lambda _store, auth_context=None: 0,
+    )
+
+    guard_runner_module.sync_receipts(store)
+
+    assert store.get_sync_payload("policy_bundle") == canonical_bundle
+    assert [decision["owner"] for decision in store.list_policy_decisions()] == ["legacy-last-good"]
 
 
 def test_policy_bundle_decision_resolves_before_receipt_persistence(tmp_path, monkeypatch):

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -18717,8 +18717,15 @@ def test_policy_bundle_v2_acknowledgement_sequence_is_monotonic_per_bundle():
         device_id="device-a",
         device_name="Guard",
         policy_bundle=bundle,
-        synced_at="2026-06-05T13:31:00+00:00",
+        synced_at="2026-06-05T14:31:00+01:00",
         previous=first,
+    )
+    third = guard_runner_module._policy_bundle_acknowledgement_payload(
+        device_id="device-a",
+        device_name="Guard",
+        policy_bundle=bundle,
+        synced_at="2026-06-05T13:32:00Z",
+        previous=second,
     )
 
     assert first == {
@@ -18733,6 +18740,8 @@ def test_policy_bundle_v2_acknowledgement_sequence_is_monotonic_per_bundle():
     }
     assert second["sequence"] == 2
     assert second["observedAt"] == "2026-06-05T13:31:00Z"
+    assert third["sequence"] == 3
+    assert third["observedAt"] == "2026-06-05T13:32:00Z"
 
 
 def test_policy_bundle_v2_acknowledgement_distinguishes_shadow_validation() -> None:

--- a/tests/test_policy_bundle_parser.py
+++ b/tests/test_policy_bundle_parser.py
@@ -203,6 +203,44 @@ def test_hgc072_invalid_schema_rejected() -> None:
     assert reason == "missing_required_field"
 
 
+def test_hgc072_rejects_policy_bundle_over_collection_limit() -> None:
+    bundle = _sample_policy_bundle()
+    bundle["acknowledgements"] = [{}] * 2_049
+
+    validated_bundle, reason = validated_policy_bundle_payload(bundle)
+
+    assert validated_bundle is None
+    assert reason == "limit_collection"
+
+
+def test_hgc072_rejects_policy_bundle_over_depth_limit() -> None:
+    bundle = _sample_policy_bundle()
+    nested: dict[str, object] = {}
+    cursor = nested
+    for index in range(41):
+        child: dict[str, object] = {}
+        cursor[f"level{index}"] = child
+        cursor = child
+    bundle["extension"] = nested
+
+    validated_bundle, reason = validated_policy_bundle_payload(bundle)
+
+    assert validated_bundle is None
+    assert reason == "limit_depth"
+
+
+def test_hgc072_rejects_policy_bundle_over_byte_limit() -> None:
+    bundle = _sample_policy_bundle()
+    defaults = bundle["policyDefaults"]
+    assert isinstance(defaults, dict)
+    defaults["extension"] = ["a" * 700_000, "b" * 700_000, "c" * 700_000]
+
+    validated_bundle, reason = validated_policy_bundle_payload(bundle)
+
+    assert validated_bundle is None
+    assert reason == "limit_bytes"
+
+
 def test_hgc073_tampered_hash_rejected() -> None:
     bundle = _sample_policy_bundle(bundle_hash="sha256:tampered")
 

--- a/tests/test_policy_bundle_v2.py
+++ b/tests/test_policy_bundle_v2.py
@@ -10,6 +10,7 @@ from typing import cast
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
+from codex_plugin_scanner.guard.models import PolicyDecision
 from codex_plugin_scanner.guard.policy_bundle_trusted_keys import (
     PolicyBundleVerificationKey,
     policy_bundle_verification_key_from_public_key,
@@ -26,6 +27,7 @@ from codex_plugin_scanner.guard.policy_bundle_v2 import (
     validated_policy_bundle_v2_payload,
 )
 from codex_plugin_scanner.guard.policy_document_yaml import load_policy_document
+from codex_plugin_scanner.guard.runtime import runner as guard_runner
 
 _FIXTURE = Path(__file__).parents[1] / "spec" / "guard-policy" / "v1alpha1" / "fixtures" / "valid" / "basic.yaml"
 
@@ -286,6 +288,37 @@ def test_v2_bundle_rejects_unanchored_rotated_key() -> None:
     assert reason == "untrusted_signing_key"
 
 
+def test_v2_bundle_rejects_malformed_rollback_hashes() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    verification_key = _verification_key(private_key)
+    rollback = {
+        "rollbackOfBundleHash": "sha256:not-a-digest",
+        "rollbackOfBundleVersion": 8,
+        "lastGoodBundleHash": f"sha256:{'a' * 64}",
+        "lastGoodBundleVersion": 6,
+        "reason": "Restore the last verified policy.",
+        "actor": "operator-alpha",
+        "createdAt": "2026-07-15T12:02:00Z",
+        "authorization": "approval-receipt-alpha",
+    }
+    bundle = _signed_bundle(
+        private_key,
+        verification_key,
+        bundle_version=9,
+        rollback=rollback,
+    )
+
+    validated, reason = validated_policy_bundle_v2_payload(
+        bundle,
+        trusted_verification_keys=(verification_key,),
+        anchored_verification_keys=(verification_key,),
+        now=datetime(2026, 7, 16, tzinfo=timezone.utc),
+    )
+
+    assert validated is None
+    assert reason == "invalid_rollback"
+
+
 def test_v2_transition_rejects_replay_and_same_version_substitution() -> None:
     assert (
         validate_policy_bundle_v2_transition(
@@ -330,6 +363,18 @@ def test_v2_transition_accepts_only_authorized_monotonic_rollback() -> None:
         )
         is None
     )
+    rollback["lastGoodBundleHash"] = "sha256:unexpected"
+    assert (
+        validate_policy_bundle_v2_transition(
+            incoming,
+            current_bundle_version=8,
+            current_bundle_hash="sha256:current",
+            expected_last_good_bundle_version=6,
+            expected_last_good_bundle_hash="sha256:historical-good",
+        )
+        == "rollback_last_good_mismatch"
+    )
+    rollback["lastGoodBundleHash"] = "sha256:historical-good"
     rollback["rollbackOfBundleHash"] = "sha256:other"
     assert (
         validate_policy_bundle_v2_transition(
@@ -376,3 +421,113 @@ def test_v2_acknowledgement_rejects_sequence_conflicts_and_terminal_reapply() ->
         retried,
         previous=applied,
     ) == (None, "acknowledgement_transition_rejected")
+
+
+def test_runtime_canonical_enforcement_compiles_signed_v2_payload() -> None:
+    policy_bundle = {
+        "contractVersion": POLICY_BUNDLE_V2_CONTRACT,
+        "payload": {
+            "apiVersion": "guard.hashgraphonline.com/v1alpha1",
+            "kind": "GuardPolicy",
+            "metadata": {
+                "id": "policy.runtime",
+                "name": "Runtime policy",
+                "revision": 1,
+            },
+            "spec": {
+                "defaults": {"mode": "prompt", "defaultAction": "warn"},
+                "rules": [
+                    {
+                        "id": "rule.block-command",
+                        "enabled": True,
+                        "effect": "block",
+                        "match": {
+                            "artifacts": ["command:npm-test"],
+                            "harnesses": ["codex"],
+                        },
+                        "lifetime": {"mode": "permanent", "expiresAt": None},
+                        "provenance": {
+                            "source": "suggested-memory",
+                            "receiptIds": ["receipt-1"],
+                            "suggestionId": "suggestion-1",
+                            "createdAt": "2026-07-15T12:00:00Z",
+                            "createdBy": "owner-1",
+                        },
+                    }
+                ],
+            },
+        },
+    }
+
+    legacy = guard_runner._build_policy_bundle_decisions(
+        policy_bundle,
+        device_id="device-1",
+        device_name="Mac",
+    )
+    canonical = guard_runner._build_policy_bundle_decisions(
+        policy_bundle,
+        device_id="device-1",
+        device_name="Mac",
+        canonical_enforcement=True,
+    )
+
+    assert legacy == []
+    assert [decision.to_dict() for decision in canonical] == [
+        {
+            "harness": "codex",
+            "scope": "artifact",
+            "action": "block",
+            "artifact_id": "command:npm-test",
+            "artifact_hash": None,
+            "workspace": None,
+            "publisher": None,
+            "reason": None,
+            "owner": "rule.block-command",
+            "source": "policy-bundle-canonical",
+            "expires_at": None,
+        }
+    ]
+
+
+def test_policy_shadow_comparison_uses_bounded_semantic_reason_codes() -> None:
+    legacy = [
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="block",
+            artifact_id="command:npm-test",
+            source="policy-bundle",
+        )
+    ]
+    equivalent = [
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="block",
+            artifact_id="command:npm-test",
+            source="policy-bundle-canonical",
+        )
+    ]
+    changed = [
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id="command:npm-test",
+            source="policy-bundle-canonical",
+        ),
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="block",
+            artifact_id="command:pnpm-test",
+            source="policy-bundle-canonical",
+        ),
+    ]
+
+    assert guard_runner._policy_shadow_mismatch_reason_codes(legacy, equivalent) == ()
+    assert guard_runner._policy_shadow_mismatch_reason_codes(legacy, changed) == (
+        "row_count",
+        "selector_set",
+        "action",
+    )

--- a/tests/test_policy_bundle_v2.py
+++ b/tests/test_policy_bundle_v2.py
@@ -525,6 +525,7 @@ def test_policy_shadow_comparison_uses_bounded_semantic_reason_codes() -> None:
         ),
     ]
 
+    assert guard_runner._policy_shadow_mismatch_reason_codes([], equivalent) == ("legacy_unavailable",)
     assert guard_runner._policy_shadow_mismatch_reason_codes(legacy, equivalent) == ()
     assert guard_runner._policy_shadow_mismatch_reason_codes(legacy, changed) == (
         "row_count",

--- a/tests/test_policy_document_cli.py
+++ b/tests/test_policy_document_cli.py
@@ -58,7 +58,23 @@ def test_policy_export_validate_format_and_diff(tmp_path: Path, capsys: pytest.C
     assert validate_payload["valid"] is True
     assert format_rc == 0
     assert diff_rc == 0
-    assert diff_payload == {"changed": False, "diff": ""}
+    assert diff_payload == {
+        "changed": False,
+        "diff": "",
+        "additions": [],
+        "modifications": [],
+        "removals": [],
+        "impacted_scopes": [],
+        "impacted_harnesses": [],
+        "impacted_artifact_families": [],
+        "conflict_warnings": [],
+        "broadened_rules": [],
+        "narrowed_rules": [],
+        "unchanged_rules": [],
+        "effective_action_changes": [],
+        "broad_relaxing_changes": [],
+        "requires_high_risk_approval": False,
+    }
 
 
 def test_policy_import_is_feature_gated_and_dry_run_by_default(
@@ -117,6 +133,11 @@ def test_policy_import_is_feature_gated_and_dry_run_by_default(
     assert disabled_payload["error"] == "policy_import_disabled"
     assert dry_run_rc == 0
     assert dry_run_payload["dry_run"] is True
+    assert dry_run_payload["changed"] is False
+    assert dry_run_payload["compiled_rows"] == 0
+    assert dry_run_payload["additions"] == []
+    assert dry_run_payload["impacted_scopes"] == []
+    assert dry_run_payload["import_additions"] == []
     assert GuardStore(home).list_policy_decisions() == []
 
 

--- a/tests/test_policy_document_cli.py
+++ b/tests/test_policy_document_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.cli import _resolve_legacy_args, main
+from codex_plugin_scanner.guard.policy_authority import PolicyAuthorityError
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -131,3 +132,61 @@ def test_policy_file_error_does_not_disclose_the_local_path(
     assert result == 4
     assert payload["error"] == "policy_parent_unavailable"
     assert str(missing) not in json.dumps(payload)
+
+
+def test_policy_import_reports_authority_errors(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    policy_file = tmp_path / "policy.yaml"
+    assert (
+        main(
+            [
+                "guard",
+                "policy",
+                "export",
+                "--home",
+                str(home),
+                "--output",
+                str(policy_file),
+                "--json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    monkeypatch.setenv("HOL_GUARD_POLICY_YAML_IMPORT", "1")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.commands_dispatch_policy_document.prompt_for_approval_gate",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.commands_dispatch_policy_document.require_high_risk",
+        lambda *_args, **_kwargs: object(),
+    )
+
+    def reject_import(*_args: object, **_kwargs: object) -> None:
+        raise PolicyAuthorityError("remote_policy_source_requires_validated_sync_path")
+
+    monkeypatch.setattr(GuardStore, "import_policy_document", reject_import)
+
+    result = main(
+        [
+            "guard",
+            "policy",
+            "import",
+            str(policy_file),
+            "--replace",
+            "--apply",
+            "--home",
+            str(home),
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert result == 4
+    assert payload["error"] == "PolicyAuthorityError"
+    assert payload["message"] == "remote_policy_source_requires_validated_sync_path"

--- a/tests/test_policy_document_io.py
+++ b/tests/test_policy_document_io.py
@@ -528,6 +528,37 @@ def test_document_diff_flags_shorter_restrictive_lifetime() -> None:
     assert difference.broad_relaxing_changes == ("rule-1",)
 
 
+def test_document_diff_compares_mixed_precision_lifetimes_chronologically() -> None:
+    baseline_mapping = _policy_document(effect="block").to_mapping()
+    baseline_spec = baseline_mapping["spec"]
+    assert isinstance(baseline_spec, dict)
+    baseline_rules = baseline_spec["rules"]
+    assert isinstance(baseline_rules, list)
+    baseline_rule = baseline_rules[0]
+    assert isinstance(baseline_rule, dict)
+    baseline_rule["lifetime"] = {
+        "mode": "until",
+        "expiresAt": "2026-07-17T10:00:00.500Z",
+    }
+    baseline = GuardPolicyDocument.from_mapping(baseline_mapping)
+    candidate_mapping = baseline.to_mapping()
+    candidate_spec = candidate_mapping["spec"]
+    assert isinstance(candidate_spec, dict)
+    candidate_rules = candidate_spec["rules"]
+    assert isinstance(candidate_rules, list)
+    candidate_rule = candidate_rules[0]
+    assert isinstance(candidate_rule, dict)
+    candidate_rule["lifetime"] = {
+        "mode": "until",
+        "expiresAt": "2026-07-17T10:00:00Z",
+    }
+    candidate = GuardPolicyDocument.from_mapping(candidate_mapping)
+
+    difference = diff_policy_documents(baseline, candidate)
+
+    assert difference.broad_relaxing_changes == ("rule-1",)
+
+
 def test_document_diff_flags_constrained_relaxing_addition() -> None:
     baseline = _policy_document(effect="block")
     candidate_mapping = baseline.to_mapping()

--- a/tests/test_policy_document_io.py
+++ b/tests/test_policy_document_io.py
@@ -444,3 +444,145 @@ def test_document_diff_is_deterministic() -> None:
     assert first == second
     assert "-    effect: allow" in first.text
     assert "+    effect: block" in first.text
+    assert first.additions == ()
+    assert first.modifications == ("rule-1",)
+    assert first.removals == ()
+    assert first.impacted_scopes == ("artifacts",)
+    assert first.impacted_harnesses == ()
+    assert first.impacted_artifact_families == ("skill",)
+    assert first.conflict_warnings == ()
+    assert first.effective_action_changes == ("rule-1:allow->block",)
+    assert first.broadened_rules == ()
+    assert first.narrowed_rules == ()
+    assert first.broad_relaxing_changes == ()
+
+
+def test_document_diff_flags_broad_relaxing_changes() -> None:
+    baseline = _policy_document(effect="block")
+    mapping = baseline.to_mapping()
+    spec = mapping["spec"]
+    assert isinstance(spec, dict)
+    rules = spec["rules"]
+    assert isinstance(rules, list)
+    rule = rules[0]
+    assert isinstance(rule, dict)
+    rule["effect"] = "allow"
+    rule["match"] = {}
+    candidate = GuardPolicyDocument.from_mapping(mapping)
+
+    difference = diff_policy_documents(baseline, candidate)
+
+    assert difference.broadened_rules == ("rule-1",)
+    assert difference.narrowed_rules == ()
+    assert difference.effective_action_changes == ("rule-1:block->allow",)
+    assert difference.broad_relaxing_changes == ("rule-1",)
+
+
+def test_document_diff_flags_relaxed_defaults() -> None:
+    baseline_mapping = _policy_document(effect="block").to_mapping()
+    baseline_spec = baseline_mapping["spec"]
+    assert isinstance(baseline_spec, dict)
+    baseline_defaults = baseline_spec["defaults"]
+    assert isinstance(baseline_defaults, dict)
+    baseline_defaults["defaultAction"] = "block"
+    baseline_defaults["unknownPublisherAction"] = "review"
+    baseline = GuardPolicyDocument.from_mapping(baseline_mapping)
+    candidate_mapping = baseline.to_mapping()
+    candidate_spec = candidate_mapping["spec"]
+    assert isinstance(candidate_spec, dict)
+    candidate_defaults = candidate_spec["defaults"]
+    assert isinstance(candidate_defaults, dict)
+    candidate_defaults["defaultAction"] = "allow"
+    candidate_defaults["unknownPublisherAction"] = "allow"
+    candidate = GuardPolicyDocument.from_mapping(candidate_mapping)
+
+    difference = diff_policy_documents(baseline, candidate)
+
+    assert difference.effective_action_changes == (
+        "defaults.defaultAction:block->allow",
+        "defaults.unknownPublisherAction:review->allow",
+    )
+    assert difference.broad_relaxing_changes == (
+        "defaults.defaultAction",
+        "defaults.unknownPublisherAction",
+    )
+
+
+def test_document_diff_flags_shorter_restrictive_lifetime() -> None:
+    baseline = _policy_document(effect="block")
+    candidate_mapping = baseline.to_mapping()
+    candidate_spec = candidate_mapping["spec"]
+    assert isinstance(candidate_spec, dict)
+    candidate_rules = candidate_spec["rules"]
+    assert isinstance(candidate_rules, list)
+    candidate_rule = candidate_rules[0]
+    assert isinstance(candidate_rule, dict)
+    candidate_rule["lifetime"] = {
+        "mode": "until",
+        "expiresAt": "2026-07-17T10:00:00Z",
+    }
+    candidate = GuardPolicyDocument.from_mapping(candidate_mapping)
+
+    difference = diff_policy_documents(baseline, candidate)
+
+    assert difference.broad_relaxing_changes == ("rule-1",)
+
+
+def test_document_diff_flags_constrained_relaxing_addition() -> None:
+    baseline = _policy_document(effect="block")
+    candidate_mapping = baseline.to_mapping()
+    candidate_spec = candidate_mapping["spec"]
+    assert isinstance(candidate_spec, dict)
+    candidate_rules = candidate_spec["rules"]
+    assert isinstance(candidate_rules, list)
+    candidate_rules.append(
+        {
+            "id": "rule-2",
+            "enabled": True,
+            "effect": "allow",
+            "match": {"artifacts": ["skill:hol/deploy"]},
+            "lifetime": {"mode": "permanent", "expiresAt": None},
+            "provenance": {
+                "source": "import",
+                "createdAt": "2026-07-16T10:00:00Z",
+                "createdBy": "owner@example.com",
+            },
+        }
+    )
+    candidate = GuardPolicyDocument.from_mapping(candidate_mapping)
+
+    difference = diff_policy_documents(baseline, candidate)
+
+    assert difference.broad_relaxing_changes == ("rule-2",)
+    assert difference.conflict_warnings == ("overlapping_effects:rule-1:rule-2",)
+
+
+def test_document_diff_reports_overlapping_effect_conflicts() -> None:
+    baseline = _policy_document(effect="allow")
+    mapping = baseline.to_mapping()
+    spec = mapping["spec"]
+    assert isinstance(spec, dict)
+    rules = spec["rules"]
+    assert isinstance(rules, list)
+    rules.append(
+        {
+            "id": "rule-2",
+            "enabled": True,
+            "effect": "block",
+            "match": {"artifacts": ["skill:hol/deploy"]},
+            "lifetime": {"mode": "permanent", "expiresAt": None},
+            "provenance": {
+                "source": "import",
+                "createdAt": "2026-07-16T10:00:00Z",
+                "createdBy": "owner@example.com",
+            },
+        }
+    )
+    candidate = GuardPolicyDocument.from_mapping(mapping)
+
+    difference = diff_policy_documents(baseline, candidate)
+
+    assert difference.additions == ("rule-2",)
+    assert difference.impacted_scopes == ("artifacts",)
+    assert difference.impacted_artifact_families == ("skill",)
+    assert difference.conflict_warnings == ("overlapping_effects:rule-1:rule-2",)

--- a/tests/test_policy_document_io.py
+++ b/tests/test_policy_document_io.py
@@ -169,6 +169,43 @@ def test_export_rejects_invalid_local_expiry() -> None:
         )
 
 
+def test_export_rejects_invalid_local_timestamp() -> None:
+    with pytest.raises(PolicyCompilationError, match="invalid_local_policy_timestamp"):
+        build_policy_document_from_rows(
+            [
+                {
+                    "decision_id": 10,
+                    "harness": "codex",
+                    "scope": "global",
+                    "action": "allow",
+                    "source": "review-decision",
+                    "updated_at": "not-a-timestamp",
+                }
+            ],
+            include_provenance=True,
+        )
+
+
+def test_export_identifies_yaml_import_provenance() -> None:
+    document = build_policy_document_from_rows(
+        [
+            {
+                "decision_id": 11,
+                "harness": "codex",
+                "scope": "global",
+                "action": "allow",
+                "source": "policy-yaml-import",
+                "updated_at": "2026-07-16T10:00:00Z",
+            }
+        ],
+        include_provenance=True,
+    )
+
+    rule = document.rules[0]
+    assert rule.provenance is not None
+    assert rule.provenance.source == "import"
+
+
 def test_export_order_is_stable_when_primary_fields_tie() -> None:
     rows = [
         {
@@ -204,6 +241,13 @@ def test_compile_rejects_match_not_supported_by_local_store() -> None:
     document = _policy_document(match={"commands": ["deploy"]})
 
     with pytest.raises(PolicyCompilationError, match="unsupported_policy_match"):
+        compile_policy_document(document)
+
+
+def test_compile_rejects_empty_selector_lists() -> None:
+    document = _policy_document(match={"artifacts": []})
+
+    with pytest.raises(PolicyCompilationError, match="invalid_policy_match_selector"):
         compile_policy_document(document)
 
 

--- a/tests/test_policy_document_yaml.py
+++ b/tests/test_policy_document_yaml.py
@@ -20,6 +20,7 @@ from codex_plugin_scanner.guard.policy_document import (
 )
 from codex_plugin_scanner.guard.policy_document_yaml import (
     MAX_POLICY_BYTES,
+    MAX_POLICY_TOKENS,
     PolicyDocumentError,
     format_policy_document_yaml,
     parse_policy_document_yaml,
@@ -69,6 +70,30 @@ def test_valid_conformance_fixtures_are_stable() -> None:
         assert format_policy_document_yaml(reparsed) == formatted
         assert canonical_policy_document_bytes(reparsed) == canonical_policy_document_bytes(document)
         assert policy_document_digest(reparsed) == policy_document_digest(document)
+
+
+def test_provenance_update_and_import_fields_round_trip() -> None:
+    mapping = _basic_mapping()
+    spec = mapping["spec"]
+    assert isinstance(spec, dict)
+    rules = spec["rules"]
+    assert isinstance(rules, list)
+    first_rule = rules[0]
+    assert isinstance(first_rule, dict)
+    provenance = first_rule["provenance"]
+    assert isinstance(provenance, dict)
+    provenance.update(
+        {
+            "updatedAt": "2026-07-16T12:00:00Z",
+            "updatedBy": "editor@example.com",
+            "importSourceDigest": "sha256:canonical-import",
+            "previousRuleRevision": 4,
+        }
+    )
+
+    document = parse_policy_document_yaml(_yaml(mapping))
+
+    assert document.rules[0].provenance.to_mapping() == provenance
 
 
 def test_yaml_11_ambiguous_scalars_remain_strings() -> None:
@@ -154,6 +179,15 @@ def test_encoded_size_limit_runs_before_yaml_parsing() -> None:
 
     assert error.value.diagnostics == (error.value.diagnostics[0],)
     assert error.value.diagnostics[0].code == "limit_bytes"
+
+
+def test_token_limit_stops_large_yaml_before_object_construction() -> None:
+    source = "items:\n" + ("- value\n" * (MAX_POLICY_TOKENS // 2 + 1))
+
+    with pytest.raises(PolicyDocumentError) as error:
+        parse_policy_document_yaml(source)
+
+    assert error.value.diagnostics[0].code == "limit_tokens"
 
 
 @pytest.mark.parametrize(
@@ -308,8 +342,6 @@ def test_canonical_object_keys_use_utf16_order() -> None:
     value = _basic_mapping()
     value["x-sort"] = {"\ue000": "bmp", "😀": "astral"}
 
-    canonical = canonical_policy_document_bytes(
-        parse_policy_document_yaml(_yaml(value))
-    ).decode("utf-8")
+    canonical = canonical_policy_document_bytes(parse_policy_document_yaml(_yaml(value))).decode("utf-8")
 
     assert canonical.index('"😀"') < canonical.index('"\ue000"')

--- a/tests/test_sync_repo_version.py
+++ b/tests/test_sync_repo_version.py
@@ -76,6 +76,18 @@ def test_sync_repo_version_updates_both_files(tmp_path: Path) -> None:
     assert state.module == "2.0.844"
     assert state.lockfile == "2.0.844"
 
+def test_sync_repo_version_is_idempotent(tmp_path: Path) -> None:
+    _write_repo_files(tmp_path, pyproject_version="2.0.844", module_version="2.0.844")
+
+    changed = SYNC_REPO_VERSION.sync_repo_version(tmp_path, "2.0.844")
+
+    assert changed is False
+    assert SYNC_REPO_VERSION.read_repo_version_state(tmp_path) == SYNC_REPO_VERSION.RepoVersionState(
+        pyproject="2.0.844",
+        module="2.0.844",
+        lockfile="2.0.844",
+    )
+
 
 def test_assert_repo_version_detects_mismatch(tmp_path: Path) -> None:
     _write_repo_files(tmp_path, pyproject_version="2.0.844", module_version="2.0.764")

--- a/uv.lock
+++ b/uv.lock
@@ -1171,7 +1171,7 @@ wheels = [
 
 [[package]]
 name = "hol-guard"
-version = "2.0.1105"
+version = "2.0.1113"
 source = { editable = "." }
 dependencies = [
     { name = "cisco-ai-skill-scanner" },

--- a/uv.lock
+++ b/uv.lock
@@ -1218,7 +1218,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "keyring", specifier = ">=25.0" },
     { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'cisco'", specifier = "==1.91.3" },
-    { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.27.0,<2" },
+    { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.28.1,<2" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pyinstaller", marker = "extra == 'mdm-build'", specifier = ">=6.16,<7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
@@ -1770,7 +1770,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.1"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1788,9 +1788,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- define the public Guard policy schema, YAML authoring model, deterministic normalization, and semantic diff classification
- validate signed policy bundle v2 envelopes, bounded inputs, rollback lineage, acknowledgement transitions, and canonical last-good history
- support canonical policy shadow comparison and controlled runtime enforcement across CLI and daemon sync paths
- expose policy capabilities, dry-run impact, provenance, source positions, and legacy-removal guidance

## Verification
- focused policy schema, YAML, parser, bundle v2, semantic diff, runtime, and daemon tests
- Ruff formatting and lint checks
- basedpyright: no errors
- package build completed for version 2.0.1113
