### PR TITLE
ci(release): add isolated Guard 3 alpha channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [main, feat/guard-policy-v3]
   pull_request:
-    branches: [main]
+    branches: [main, feat/guard-policy-v3]
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -313,13 +313,13 @@ jobs:
           Install this exact alpha:
 
           \`\`\`bash
-          uv tool install --force "hol-guard==$VERSION"
+          pipx install --force "hol-guard==$VERSION"
           \`\`\`
 
           Return to the stable channel:
 
           \`\`\`bash
-          uv tool install --force "hol-guard<3"
+          pipx install --force "hol-guard<3"
           \`\`\`
           EOF
           gh release create "alpha/v${VERSION}" --repo "${{ github.repository }}" --target "$GITHUB_SHA" --title "Guard ${VERSION} alpha" --notes-file "$body_file" --prerelease

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,18 @@ on:
         options:
           - testpypi
           - pypi
+      release_channel:
+        description: "Release channel"
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - alpha
+      alpha_version:
+        description: "Required for alpha releases (for example 3.0.0a1)"
+        required: false
+        type: string
   push:
     branches: [main]
     tags: ["v*"]
@@ -32,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      channel: ${{ steps.version.outputs.channel }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -54,10 +67,22 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_CHANNEL: ${{ github.event.inputs.release_channel }}
+          ALPHA_VERSION: ${{ github.event.inputs.alpha_version }}
         run: |
           BASE_VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
           VERSION="$BASE_VERSION"
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+          CHANNEL="${RELEASE_CHANNEL:-stable}"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$CHANNEL" == "alpha" ]]; then
+            if [[ -z "$ALPHA_VERSION" ]]; then
+              echo "alpha_version is required for alpha releases" >&2
+              exit 1
+            fi
+            VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py --version "$ALPHA_VERSION" --git-ref "$GITHUB_REF")
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "Stable manual releases must run from refs/heads/main" >&2
+            exit 1
+          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             VERSION=$(BASE_VERSION="$BASE_VERSION" PR_NUMBER="$PR_NUMBER" GITHUB_RUN_NUMBER="$GITHUB_RUN_NUMBER" GITHUB_RUN_ATTEMPT="$GITHUB_RUN_ATTEMPT" python - <<'PY'
@@ -104,7 +129,8 @@ jobs:
             fi
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Computed version: $VERSION"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "Computed $CHANNEL version: $VERSION"
       - name: Stamp package version
         env:
           VERSION: ${{ steps.version.outputs.version }}
@@ -166,10 +192,42 @@ jobs:
           name: distributions
           path: dist/
 
+  alpha-cross-platform:
+    name: Alpha release tests (${{ matrix.os }})
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_channel == 'alpha'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          uv-version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Run Linux release suite
+        if: runner.os == 'Linux'
+        run: uv run --no-sync pytest --tb=short
+      - name: Run Windows release suite
+        if: runner.os == 'Windows'
+        run: uv run --no-sync pytest tests/test_cli.py tests/test_verification.py tests/test_action_runner.py tests/test_policy_document_cli.py tests/test_policy_document_contract.py --tb=short
+
   publish-testpypi:
     name: Publish to TestPyPI (Manual)
-    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-    needs: build
+    if: >-
+      always() &&
+      needs.build.result == 'success' &&
+      (needs.alpha-cross-platform.result == 'success' || needs.alpha-cross-platform.result == 'skipped') &&
+      (
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi') ||
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      )
+    needs: [build, alpha-cross-platform]
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -197,8 +255,23 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi')
-    needs: build
+    if: >-
+      always() &&
+      needs.build.result == 'success' &&
+      (needs.alpha-cross-platform.result == 'success' || needs.alpha-cross-platform.result == 'skipped') &&
+      (
+        github.ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/tags/') ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.publish_target == 'pypi' &&
+          (
+            (needs.build.outputs.channel == 'stable' && github.ref == 'refs/heads/main') ||
+            (needs.build.outputs.channel == 'alpha' && github.ref == 'refs/heads/feat/guard-policy-v3')
+          )
+        )
+      )
+    needs: [build, alpha-cross-platform]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -208,9 +281,48 @@ jobs:
         with:
           name: distributions
           path: dist/
+      - name: Keep only the Guard alpha distribution
+        if: needs.build.outputs.channel == 'alpha'
+        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           skip-existing: true
+
+  release-alpha:
+    name: Create alpha GitHub prerelease
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.publish_target == 'pypi' &&
+      needs.build.outputs.channel == 'alpha' &&
+      github.ref == 'refs/heads/feat/guard-policy-v3'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - name: Create discoverable alpha prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          body_file=$(mktemp)
+          cat > "$body_file" <<EOF
+          Guard 3.x alpha for opt-in evaluation. Stable installations remain on Guard 2.x.
+
+          Install this exact alpha:
+
+          \`\`\`bash
+          uv tool install --force "hol-guard==$VERSION"
+          \`\`\`
+
+          Return to the stable channel:
+
+          \`\`\`bash
+          uv tool install --force "hol-guard<3"
+          \`\`\`
+          EOF
+          gh release create "alpha/v${VERSION}" --repo "${{ github.repository }}" --target "$GITHUB_SHA" --title "Guard ${VERSION} alpha" --notes-file "$body_file" --prerelease
 
   release:
     name: Create GitHub Release

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ hol-guard init
 
 `hol-guard init` discovers compatible AI agents, explains each setup change before applying it, and guides you through your first protected action.
 
+Guard 3.x alphas are opt-in and do not replace the stable 2.x release selected by normal installers. To evaluate a published alpha, pin its exact version from the [GitHub prereleases](https://github.com/hashgraph-online/hol-guard/releases):
+
+```bash
+uv tool install --force "hol-guard==3.0.0a1"
+```
+
+Return to the stable 2.x channel with `uv tool install --force "hol-guard<3"`.
+
 [Install guide](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/get-started.md) · [GuardPolicy v1alpha1](https://github.com/hashgraph-online/hol-guard/blob/main/spec/guard-policy/v1alpha1/README.md) · [Supported agents](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/harness-support.md) · [Local vs. cloud](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/local-vs-cloud.md) · [Security policy](https://github.com/hashgraph-online/hol-guard/blob/main/SECURITY.md)
 
 ## What HOL Guard Protects

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ hol-guard init
 Guard 3.x alphas are opt-in and do not replace the stable 2.x release selected by normal installers. To evaluate a published alpha, pin its exact version from the [GitHub prereleases](https://github.com/hashgraph-online/hol-guard/releases):
 
 ```bash
-uv tool install --force "hol-guard==3.0.0a1"
+pipx install --force "hol-guard==3.0.0a1"
 ```
 
-Return to the stable 2.x channel with `uv tool install --force "hol-guard<3"`.
+Return to the stable 2.x channel with `pipx install --force "hol-guard<3"`.
 
 [Install guide](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/get-started.md) · [GuardPolicy v1alpha1](https://github.com/hashgraph-online/hol-guard/blob/main/spec/guard-policy/v1alpha1/README.md) · [Supported agents](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/harness-support.md) · [Local vs. cloud](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/local-vs-cloud.md) · [Security policy](https://github.com/hashgraph-online/hol-guard/blob/main/SECURITY.md)
 

--- a/docs/guard/release-checklist.md
+++ b/docs/guard/release-checklist.md
@@ -16,3 +16,33 @@ When running Guard scans against untrusted content in a container, keep the runt
 - drop ambient privileges with `--cap-drop=ALL` and `--security-opt=no-new-privileges`
 - set explicit `--memory`, `--cpus`, and `--pids-limit` caps
 - use a writable `tmpfs` only for the minimal paths the scan needs, such as `/tmp`
+
+## Release channels
+
+Guard uses two isolated release lines:
+
+- `main` remains the stable 2.x source. Stable manual publishes are accepted only from `main`; normal installation continues to select the latest 2.x release.
+- `feat/guard-policy-v3` is the long-lived 3.x integration branch until the 3.x compatibility gates are closed. It receives 2.x fixes by regular forward merges from `main`, never by backporting unfinished 3.x behavior into `main`.
+- PyPI 3.x alpha versions use public PEP 440 versions such as `3.0.0a1`. Package installers ignore these prereleases unless users opt in with an exact version or an explicit prerelease flag.
+- `plugin-scanner` remains on its stable release line during Guard 3.x alpha publishing. The alpha workflow removes its distributions before upload.
+
+### Publish a 3.x alpha
+
+1. Merge the intended changes and the latest `main` into `feat/guard-policy-v3`.
+2. Wait for the standard Linux and cross-platform CI jobs on the branch to pass.
+3. Run the `Publish to PyPI` workflow from `feat/guard-policy-v3` with `publish_target=pypi`, `release_channel=alpha`, and a new `alpha_version` such as `3.0.0a1`.
+4. Confirm the workflow's Linux suite, Windows suite, package checks, and PyPI trusted publish all pass.
+5. Verify the generated `alpha/v<VERSION>` GitHub prerelease and install the exact version in a clean environment.
+6. Record compatibility findings against the alpha without changing the default 2.x installer path.
+
+The workflow rejects alpha versions outside the 3.x line, rejects non-alpha prerelease types, rejects alpha publishes from any other branch, and prevents alpha artifacts from entering the stable repository-version synchronization flow.
+
+### Continue 2.x maintenance
+
+1. Land compatible fixes on `main` and publish them through the existing stable path.
+2. Forward-merge `main` into `feat/guard-policy-v3`. Resolve behavior conflicts in favor of the fixed 2.x invariant while preserving the 3.x contract.
+3. Let both branch CI matrices pass before the next alpha.
+
+### Promote 3.x later
+
+Promotion is a separate decision. Do not merge the 3.x branch into `main` or publish `3.0.0` until compatibility, migration, telemetry, and rollback gates are explicitly approved. At promotion, merge the proven branch, publish the stable `3.0.0` version from `main`, and retain the latest 2.x tag as the rollback installation target.

--- a/scripts/validate_alpha_release.py
+++ b/scripts/validate_alpha_release.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import cast
+
+from packaging.version import Version
+
+ALPHA_BRANCH = "refs/heads/feat/guard-policy-v3"
+
+
+@dataclass(frozen=True)
+class AlphaRelease:
+    version: str
+    git_ref: str
+
+
+def validate_alpha_release(version_text: str, git_ref: str) -> AlphaRelease:
+    if git_ref != ALPHA_BRANCH:
+        raise ValueError(f"Alpha releases must run from {ALPHA_BRANCH}")
+
+    version = Version(version_text)
+    if (
+        version.major != 3
+        or version.pre is None
+        or version.pre[0] != "a"
+        or version.dev is not None
+        or version.post is not None
+        or version.local is not None
+    ):
+        raise ValueError("Alpha releases require a public PEP 440 3.x alpha version such as 3.0.0a1")
+
+    return AlphaRelease(version=str(version), git_ref=git_ref)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate a Guard 3.x alpha release request")
+    _ = parser.add_argument("--version", required=True)
+    _ = parser.add_argument("--git-ref", required=True)
+    args = parser.parse_args()
+    version_text = cast(str, args.version)
+    git_ref = cast(str, args.git_ref)
+    release = validate_alpha_release(version_text, git_ref)
+    print(release.version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_alpha_release.py
+++ b/scripts/validate_alpha_release.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from dataclasses import dataclass
-from typing import cast
 
 from packaging.version import Version
 
@@ -21,7 +21,8 @@ def validate_alpha_release(version_text: str, git_ref: str) -> AlphaRelease:
 
     version = Version(version_text)
     if (
-        version.major != 3
+        version.epoch != 0
+        or version.major != 3
         or version.pre is None
         or version.pre[0] != "a"
         or version.dev is not None
@@ -38,9 +39,15 @@ def main() -> int:
     _ = parser.add_argument("--version", required=True)
     _ = parser.add_argument("--git-ref", required=True)
     args = parser.parse_args()
-    version_text = cast(str, args.version)
-    git_ref = cast(str, args.git_ref)
-    release = validate_alpha_release(version_text, git_ref)
+    version_text = getattr(args, "version", None)
+    git_ref = getattr(args, "git_ref", None)
+    if not isinstance(version_text, str) or not isinstance(git_ref, str):
+        parser.error("--version and --git-ref must be strings")
+    try:
+        release = validate_alpha_release(version_text, git_ref)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
     print(release.version)
     return 0
 

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_policy_document.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_policy_document.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import json
 import os
 import sys
-from argparse import Namespace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TextIO, cast
+from typing import Protocol, TextIO, cast
 
 from ..approval_gate import ApprovalGateError, require_high_risk
 from ..policy_authority import PolicyAuthorityError
@@ -29,8 +28,17 @@ from ..store import GuardStore
 from ..store_policy_document import PolicyImportMode
 from .approval_gate_prompt import prompt_for_approval_gate
 
-
 _POLICY_IMPORT_FLAG = "HOL_GUARD_POLICY_YAML_IMPORT"
+
+
+class PolicyDocumentCommandArgs(Protocol):
+    policy_command: str
+    file: str
+    check: bool
+    include_provenance: bool
+    mode: str
+    dry_run: bool
+    json: bool
 
 
 def _write_payload(
@@ -65,7 +73,7 @@ def _load_and_compile(path: Path):
 
 
 def _run_guard_policy_document_command(
-    args: Namespace,
+    args: PolicyDocumentCommandArgs,
     *,
     store: GuardStore | None = None,
     output_stream: TextIO | None = None,

--- a/tests/test_validate_alpha_release.py
+++ b/tests/test_validate_alpha_release.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.validate_alpha_release import ALPHA_BRANCH, validate_alpha_release
+
+
+def test_accepts_public_guard_3_alpha_version_from_v3_branch() -> None:
+    release = validate_alpha_release("3.0.0a1", ALPHA_BRANCH)
+
+    assert release.version == "3.0.0a1"
+    assert release.git_ref == ALPHA_BRANCH
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "2.1.0a1",
+        "3.0.0b1",
+        "3.0.0rc1",
+        "3.0.0",
+        "3.0.0a1.dev1",
+        "3.0.0a1.post1",
+        "3.0.0a1+local",
+    ],
+)
+def test_rejects_versions_that_are_not_public_guard_3_alphas(version: str) -> None:
+    with pytest.raises(ValueError, match=r"3\.x alpha"):
+        validate_alpha_release(version, ALPHA_BRANCH)
+
+
+def test_rejects_alpha_release_from_any_other_branch() -> None:
+    with pytest.raises(ValueError, match="feat/guard-policy-v3"):
+        validate_alpha_release("3.0.0a1", "refs/heads/main")
+
+
+def test_release_workflows_keep_stable_and_alpha_channels_isolated() -> None:
+    root = Path(__file__).parent.parent
+    publish = yaml.safe_load((root / ".github/workflows/publish.yml").read_text(encoding="utf-8"))
+    inputs = publish[True]["workflow_dispatch"]["inputs"]
+
+    assert inputs["release_channel"]["options"] == ["stable", "alpha"]
+    assert inputs["alpha_version"]["required"] is False
+
+    jobs = publish["jobs"]
+    alpha_matrix = jobs["alpha-cross-platform"]["strategy"]["matrix"]["os"]
+    assert alpha_matrix == ["ubuntu-latest", "windows-latest"]
+    assert "refs/heads/feat/guard-policy-v3" in jobs["publish-pypi"]["if"]
+    assert jobs["publish-pypi"]["needs"] == ["build", "alpha-cross-platform"]
+    assert jobs["release-alpha"]["needs"] == ["build", "publish-pypi"]
+
+    alpha_publish_steps = jobs["publish-pypi"]["steps"]
+    prune_step = next(
+        step for step in alpha_publish_steps if step.get("name") == "Keep only the Guard alpha distribution"
+    )
+    assert prune_step["if"] == "needs.build.outputs.channel == 'alpha'"
+    assert "plugin_scanner" in prune_step["run"]
+
+
+def test_v3_branch_runs_standard_cross_platform_ci() -> None:
+    root = Path(__file__).parent.parent
+    ci = yaml.safe_load((root / ".github/workflows/ci.yml").read_text(encoding="utf-8"))
+
+    assert "feat/guard-policy-v3" in ci[True]["push"]["branches"]
+    assert "feat/guard-policy-v3" in ci[True]["pull_request"]["branches"]
+    assert "windows-latest" in ci["jobs"]["cross-platform"]["strategy"]["matrix"]["os"]

--- a/tests/test_validate_alpha_release.py
+++ b/tests/test_validate_alpha_release.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
 import yaml
 
-from scripts.validate_alpha_release import ALPHA_BRANCH, validate_alpha_release
+from scripts.validate_alpha_release import ALPHA_BRANCH, main, validate_alpha_release
 
 
 def test_accepts_public_guard_3_alpha_version_from_v3_branch() -> None:
@@ -18,6 +19,7 @@ def test_accepts_public_guard_3_alpha_version_from_v3_branch() -> None:
 @pytest.mark.parametrize(
     "version",
     [
+        "1!3.0.0a1",
         "2.1.0a1",
         "3.0.0b1",
         "3.0.0rc1",
@@ -37,10 +39,26 @@ def test_rejects_alpha_release_from_any_other_branch() -> None:
         validate_alpha_release("3.0.0a1", "refs/heads/main")
 
 
+def test_cli_reports_invalid_alpha_without_traceback(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["validate_alpha_release.py", "--version", "3.0.0", "--git-ref", ALPHA_BRANCH],
+    )
+
+    assert main() == 1
+    captured = capsys.readouterr()
+    assert "Error: Alpha releases require" in captured.err
+    assert "Traceback" not in captured.err
+
+
 def test_release_workflows_keep_stable_and_alpha_channels_isolated() -> None:
     root = Path(__file__).parent.parent
     publish = yaml.safe_load((root / ".github/workflows/publish.yml").read_text(encoding="utf-8"))
-    inputs = publish[True]["workflow_dispatch"]["inputs"]
+    on_section = publish.get(True) or publish.get("on")
+    inputs = on_section["workflow_dispatch"]["inputs"]
 
     assert inputs["release_channel"]["options"] == ["stable", "alpha"]
     assert inputs["alpha_version"]["required"] is False
@@ -64,6 +82,7 @@ def test_v3_branch_runs_standard_cross_platform_ci() -> None:
     root = Path(__file__).parent.parent
     ci = yaml.safe_load((root / ".github/workflows/ci.yml").read_text(encoding="utf-8"))
 
-    assert "feat/guard-policy-v3" in ci[True]["push"]["branches"]
-    assert "feat/guard-policy-v3" in ci[True]["pull_request"]["branches"]
+    on_section = ci.get(True) or ci.get("on")
+    assert "feat/guard-policy-v3" in on_section["push"]["branches"]
+    assert "feat/guard-policy-v3" in on_section["pull_request"]["branches"]
     assert "windows-latest" in ci["jobs"]["cross-platform"]["strategy"]["matrix"]["os"]


### PR DESCRIPTION
## Summary
- keep `main` as the stable Guard 2.x release line
- add opt-in PEP 440 Guard 3.x alpha publishing from `feat/guard-policy-v3`
- gate alpha publication on Linux and Windows release suites
- publish only `hol-guard` for alpha releases; keep `plugin-scanner` stable
- document exact-version installation, 2.x rollback, forward-merge maintenance, and later 3.x promotion

## Safety invariants
- stable manual publishing is accepted only from `main`
- alpha publishing is accepted only from `feat/guard-policy-v3`
- alpha versions must be public 3.x `aN` versions
- normal package installation continues selecting stable 2.x
- alpha publishing does not merge V3 into `main`

## Verification
- 24 focused release/version tests passed
- Ruff passed
- actionlint passed for CI and publish workflows
- isolated build produced `hol_guard-3.0.0a1-py3-none-any.whl` with metadata `Version: 3.0.0a1`
- public forbidden-term scan passed
