### PR TITLE
fix(release): run existing Windows policy tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -215,7 +215,7 @@ jobs:
         run: uv run --no-sync pytest --tb=short
       - name: Run Windows release suite
         if: runner.os == 'Windows'
-        run: uv run --no-sync pytest tests/test_cli.py tests/test_verification.py tests/test_action_runner.py tests/test_policy_document_cli.py tests/test_policy_document_contract.py --tb=short
+        run: uv run --no-sync pytest tests/test_cli.py tests/test_verification.py tests/test_action_runner.py tests/test_policy_document_cli.py tests/test_policy_document_yaml.py tests/test_policy_bundle_v2.py --tb=short
 
   publish-testpypi:
     name: Publish to TestPyPI (Manual)


### PR DESCRIPTION
## Summary
- replace a nonexistent Windows release-test path with existing policy YAML and bundle suites
- keep the alpha publication fail-closed until Windows and Linux verification pass

## Verification
- actionlint passed
- the six-file release test selection collected 135 tests locally; three unrelated CLI score assertions were affected by the workstation's globally installed Guard copy
- the same clean-runner CLI suite passed in branch CI before this path-only correction
- public forbidden-term scan remains clean
