### PR TITLE
fix(sync): emit V2 policy acknowledgements

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -4686,7 +4686,12 @@ def _receipt_sync_context(
         "syncHealth": sync_health,
     }
     if isinstance(policy_bundle_ack, dict) and policy_bundle_ack:
-        context["policyBundleAcknowledgement"] = policy_bundle_ack
+        acknowledgement_key = (
+            "policyBundleAcknowledgementV2"
+            if policy_bundle_ack.get("contractVersion") == POLICY_BUNDLE_V2_CONTRACT
+            else "policyBundleAcknowledgement"
+        )
+        context[acknowledgement_key] = policy_bundle_ack
     if runtime_synced_at is not None:
         context["lastRuntimeSyncAt"] = runtime_synced_at
     return context

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -18177,6 +18177,33 @@ def test_receipt_sync_context_uploads_policy_bundle_acknowledgement(tmp_path):
     }
 
 
+def test_receipt_sync_context_uploads_v2_policy_bundle_acknowledgement(tmp_path):
+    store = GuardStore(tmp_path / "guard-home")
+    acknowledgement = {
+        "contractVersion": "guard-policy-bundle.v2",
+        "workspaceId": "workspace-1",
+        "deviceId": "device-1",
+        "bundleVersion": 3,
+        "bundleHash": "a" * 64,
+        "sequence": 1,
+        "status": "applied",
+        "observedAt": "2026-04-19T00:00:11Z",
+    }
+    store.set_sync_payload(
+        "policy_bundle_ack",
+        acknowledgement,
+        "2026-04-19T00:00:11+00:00",
+    )
+
+    context = guard_runner_module._receipt_sync_context(
+        store,
+        local_guard_online_at="2026-04-19T00:01:00+00:00",
+    )
+
+    assert context["policyBundleAcknowledgementV2"] == acknowledgement
+    assert "policyBundleAcknowledgement" not in context
+
+
 def test_policy_bundle_validation_rejects_missing_rules_field():
     bundle = {
         "contractVersion": "guard-policy-bundle.v1",


### PR DESCRIPTION
## Summary
- send V2 policy acknowledgements under the V2 sync-context field
- preserve the legacy field for V1 policy acknowledgements
- cover both acknowledgement contracts with focused tests

## Verification
- `uv run pytest tests/test_guard_runtime.py -k 'receipt_sync_context_uploads' -q`
- `uv run pytest tests/test_cloud_exception_sync_proof.py -q`
- `uv run pytest tests/test_guard_cloud_local_sync.py -k 'sync_runtime_session_emits_package_manager_coverage_payload or local_runtime_session_advertises_enabled_policy_capabilities' -q`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/runner.py tests/test_guard_runtime.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/runtime/runner.py tests/test_guard_runtime.py`
