### PR TITLE
ci(release): publish 3.1 alpha channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [main, "release/3.1"]
   pull_request:
-    branches: [main]
+    branches: [main, "release/3.1"]
 
 permissions:
   contents: read

--- a/.github/workflows/create-python-release.yml
+++ b/.github/workflows/create-python-release.yml
@@ -34,11 +34,13 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      - name: Download release distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ inputs.distribution_artifact }}
           path: dist/
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      - name: Download release toolchain SBOM
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ inputs.sbom_artifact }}
           path: dist/

--- a/.github/workflows/create-python-release.yml
+++ b/.github/workflows/create-python-release.yml
@@ -1,0 +1,146 @@
+name: Create Python Release
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      channel:
+        required: true
+        type: string
+      distribution_artifact:
+        required: true
+        type: string
+      sbom_artifact:
+        required: true
+        type: string
+      provenance_prefix:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Create ${{ inputs.channel }} GitHub release
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: ${{ inputs.distribution_artifact }}
+          path: dist/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: ${{ inputs.sbom_artifact }}
+          path: dist/
+      - name: Validate release channel
+        env:
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          if [[ "$CHANNEL" != "stable" && "$CHANNEL" != "alpha" ]]; then
+            echo "Unsupported release channel: $CHANNEL" >&2
+            exit 1
+          fi
+      - name: Skip if release already exists
+        id: release_exists
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          TAG="v${VERSION}"
+          if [[ "$CHANNEL" == "alpha" ]]; then
+            TAG="alpha/v${VERSION}"
+          fi
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Generate release notes
+        if: steps.release_exists.outputs.exists == 'false'
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ "$CHANNEL" == "alpha" ]]; then
+            cat > release-notes.md <<EOF
+          Guard 3.1 alpha for opt-in evaluation. Stable installations remain on the stable channel.
+
+          Install this exact alpha:
+
+          \`\`\`bash
+          uv tool install --force "hol-guard==$VERSION"
+          \`\`\`
+          EOF
+            exit 0
+          fi
+
+          LAST_TAG=$(git describe --tags --abbrev=0 --exclude="v${VERSION}" 2>/dev/null || echo "")
+          if [[ -n "$LAST_TAG" ]]; then
+            LOG=$(git log "${LAST_TAG}..HEAD" --pretty=format:"- %s (%h)" --no-merges)
+          else
+            LOG=$(git log --pretty=format:"- %s (%h)" --no-merges -20)
+          fi
+          cat > release-notes.md <<EOF
+          ## v${VERSION}
+
+          ### What's Changed
+          ${LOG}
+
+          ### Installation
+          \`\`\`bash
+          uv tool install hol-guard==${VERSION}
+          uv tool install plugin-scanner==${VERSION}
+          \`\`\`
+
+          Full Cisco coverage on Python 3.11+:
+          \`\`\`bash
+          uv tool install "hol-guard[cisco]==${VERSION}"
+          uv tool install "plugin-scanner[cisco]==${VERSION}"
+          \`\`\`
+
+          \`\`\`bash
+          docker pull ghcr.io/hashgraph-online/hol-guard:${VERSION}
+          \`\`\`
+
+          **Full Changelog**: https://github.com/hashgraph-online/hol-guard/compare/${LAST_TAG}...v${VERSION}
+          EOF
+      - name: Attest release assets
+        if: steps.release_exists.outputs.exists == 'false'
+        id: provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-path: dist/*
+      - name: Materialize provenance bundle
+        if: steps.release_exists.outputs.exists == 'false'
+        env:
+          PROVENANCE_PREFIX: ${{ inputs.provenance_prefix }}
+          VERSION: ${{ inputs.version }}
+        run: cp "${{ steps.provenance.outputs.bundle-path }}" "dist/${PROVENANCE_PREFIX}-v${VERSION}.intoto.jsonl"
+      - name: Create release
+        if: steps.release_exists.outputs.exists == 'false'
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          mapfile -d '' files < <(find dist -maxdepth 1 -type f -print0 | sort -z)
+          if [[ "${#files[@]}" -eq 0 ]]; then
+            echo "No release assets found" >&2
+            exit 1
+          fi
+          if [[ "$CHANNEL" == "alpha" ]]; then
+            gh release create "alpha/v${VERSION}" --target "$GITHUB_SHA" --title "Guard ${VERSION} alpha" --notes-file release-notes.md --prerelease "${files[@]}"
+          else
+            gh release create "v${VERSION}" --target main --title "v${VERSION}" --notes-file release-notes.md "${files[@]}"
+          fi

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -1,22 +1,17 @@
 name: Publish 3.1 Alpha
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      publish_target:
-        description: "Target repository"
-        required: true
-        default: pypi
-        type: choice
-        options:
-          - testpypi
-          - pypi
       alpha_version:
         description: "Public alpha version, for example 3.1.0a1"
-        required: true
+        required: false
+        default: ""
         type: string
-  pull_request:
-    branches: ["release/3.1"]
+    outputs:
+      version:
+        description: "Computed alpha package version"
+        value: ${{ jobs.build.outputs.version }}
 
 permissions:
   contents: read
@@ -28,7 +23,6 @@ concurrency:
 jobs:
   build:
     name: Build 3.1 Alpha
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -57,7 +51,7 @@ jobs:
       - name: Compute alpha version
         id: version
         env:
-          ALPHA_VERSION: ${{ github.event.inputs.alpha_version }}
+          ALPHA_VERSION: ${{ inputs.alpha_version }}
           EVENT_NAME: ${{ github.event_name }}
           GIT_REF: ${{ github.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -134,75 +128,3 @@ jobs:
       - name: Run Windows release suite
         if: runner.os == 'Windows'
         run: uv run --no-sync pytest tests/test_cli.py tests/test_verification.py tests/test_action_runner.py tests/test_policy_document_yaml.py tests/test_policy_bundle_v2.py --tb=short
-
-  publish-testpypi:
-    name: Publish alpha to TestPyPI
-    if: >-
-      always() &&
-      needs.build.result == 'success' &&
-      (needs.release-tests.result == 'success' || needs.release-tests.result == 'skipped') &&
-      (
-        github.event_name == 'pull_request' ||
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi')
-      )
-    needs: [build, release-tests]
-    uses: ./.github/workflows/publish.yml
-    with:
-      alpha_publish_target: testpypi
-      alpha_version: ${{ needs.build.outputs.version }}
-    permissions:
-      contents: read
-      id-token: write
-
-  publish-pypi:
-    name: Publish 3.1 alpha to PyPI
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi'
-    needs: [build, release-tests]
-    uses: ./.github/workflows/publish.yml
-    with:
-      alpha_publish_target: pypi
-      alpha_version: ${{ needs.build.outputs.version }}
-    permissions:
-      contents: read
-      id-token: write
-
-  release-alpha:
-    name: Create 3.1 alpha prerelease
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi'
-    needs: [build, publish-pypi]
-    runs-on: ubuntu-latest
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: alpha-distribution
-          path: dist/
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: alpha-toolchain-sbom
-          path: dist/
-      - name: Attest alpha release assets
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
-        with:
-          subject-path: dist/*
-      - name: Create discoverable alpha prerelease
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          body_file=$(mktemp)
-          cat > "$body_file" <<EOF
-          Guard 3.1 alpha for opt-in evaluation. Stable installations remain on the stable channel.
-
-          Install this exact alpha:
-
-          \`\`\`bash
-          uv tool install --force "hol-guard==$VERSION"
-          \`\`\`
-          EOF
-          mapfile -d '' files < <(find dist -maxdepth 1 -type f -print0 | sort -z)
-          gh release create "alpha/v${VERSION}" --repo "${{ github.repository }}" --target "$GITHUB_SHA" --title "Guard ${VERSION} alpha" --notes-file "$body_file" --prerelease "${files[@]}"

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -8,6 +8,17 @@ on:
         required: false
         default: ""
         type: string
+      git_ref:
+        required: true
+        type: string
+      pr_number:
+        required: false
+        default: 0
+        type: number
+      run_release_tests:
+        required: false
+        default: false
+        type: boolean
     outputs:
       version:
         description: "Computed alpha package version"
@@ -52,15 +63,18 @@ jobs:
         id: version
         env:
           ALPHA_VERSION: ${{ inputs.alpha_version }}
-          EVENT_NAME: ${{ github.event_name }}
-          GIT_REF: ${{ github.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GIT_REF: ${{ inputs.git_ref }}
+          PR_NUMBER: ${{ inputs.pr_number }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
           RUN_NUMBER: ${{ github.run_number }}
         run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+          if [[ -n "$ALPHA_VERSION" ]]; then
             VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py --version "$ALPHA_VERSION" --git-ref "$GIT_REF")
           else
+            if [[ "$PR_NUMBER" -le 0 ]]; then
+              echo "An explicit alpha_version is required for a public alpha release" >&2
+              exit 1
+            fi
             VERSION=$(PR_NUMBER="$PR_NUMBER" RUN_NUMBER="$RUN_NUMBER" RUN_ATTEMPT="$RUN_ATTEMPT" python - <<'PY'
           import os
 
@@ -106,7 +120,7 @@ jobs:
 
   release-tests:
     name: Alpha release tests (${{ matrix.os }})
-    if: github.event_name == 'workflow_dispatch'
+    if: inputs.run_release_tests
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -1,0 +1,225 @@
+name: Publish 3.1 Alpha
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_target:
+        description: "Target repository"
+        required: true
+        default: pypi
+        type: choice
+        options:
+          - testpypi
+          - pypi
+      alpha_version:
+        description: "Public alpha version, for example 3.1.0a1"
+        required: true
+        type: string
+  pull_request:
+    branches: ["release/3.1"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hol-guard-alpha-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build 3.1 Alpha
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - name: Verify release uv before dependency install
+        env:
+          EXPECTED_UV_VERSION: "0.9.26"
+          SETUP_UV_ACTION_REF: fac544c07dec837d0ccb6301d7b5580bf5edae39
+        run: |
+          python3 scripts/write_release_toolchain_sbom.py \
+            --output "$RUNNER_TEMP/hol-guard-release-toolchain-preflight.cdx.json" \
+            --release-version preflight \
+            --expected-uv-version "$EXPECTED_UV_VERSION" \
+            --setup-action-ref "$SETUP_UV_ACTION_REF"
+      - run: uv sync --frozen --extra dev --extra publish --extra cisco
+      - name: Compute alpha version
+        id: version
+        env:
+          ALPHA_VERSION: ${{ github.event.inputs.alpha_version }}
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_REF: ${{ github.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py --version "$ALPHA_VERSION" --git-ref "$GIT_REF")
+          else
+            VERSION=$(PR_NUMBER="$PR_NUMBER" RUN_NUMBER="$RUN_NUMBER" RUN_ATTEMPT="$RUN_ATTEMPT" python - <<'PY'
+          import os
+
+          def pair(left: int, right: int) -> int:
+              total = left + right
+              return total * (total + 1) // 2 + right
+
+          serial = pair(pair(int(os.environ["PR_NUMBER"]), int(os.environ["RUN_NUMBER"])), int(os.environ["RUN_ATTEMPT"]))
+          print(f"3.1.0a0.dev{serial}")
+          PY
+            )
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Computed alpha version: $VERSION"
+      - name: Write release toolchain SBOM
+        env:
+          EXPECTED_UV_VERSION: "0.9.26"
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          SETUP_UV_ACTION_REF: fac544c07dec837d0ccb6301d7b5580bf5edae39
+        run: |
+          python3 scripts/write_release_toolchain_sbom.py \
+            --output "release-metadata/hol-guard-v${RELEASE_VERSION}.toolchain.cdx.json" \
+            --release-version "$RELEASE_VERSION" \
+            --expected-uv-version "$EXPECTED_UV_VERSION" \
+            --setup-action-ref "$SETUP_UV_ACTION_REF"
+      - name: Stamp package version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: uv run --no-sync python scripts/sync_repo_version.py --version "$VERSION"
+      - name: Build Guard distribution
+        run: uv run --no-sync python -m build
+      - run: uv run --no-sync twine check dist/*
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: alpha-distribution
+          path: dist/hol_guard-*
+          if-no-files-found: error
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: alpha-toolchain-sbom
+          path: release-metadata/*.cdx.json
+          if-no-files-found: error
+
+  release-tests:
+    name: Alpha release tests (${{ matrix.os }})
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Run Linux release suite
+        if: runner.os == 'Linux'
+        run: uv run --no-sync pytest --tb=short
+      - name: Run Windows release suite
+        if: runner.os == 'Windows'
+        run: uv run --no-sync pytest tests/test_cli.py tests/test_verification.py tests/test_action_runner.py tests/test_policy_document_yaml.py tests/test_policy_bundle_v2.py --tb=short
+
+  publish-testpypi:
+    name: Publish alpha to TestPyPI
+    if: >-
+      always() &&
+      needs.build.result == 'success' &&
+      (needs.release-tests.result == 'success' || needs.release-tests.result == 'skipped') &&
+      (
+        github.event_name == 'pull_request' ||
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi')
+      )
+    needs: [build, release-tests]
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: alpha-distribution
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+      - name: Show canary install command
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          echo "## TestPyPI canary" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
+          echo "uv tool install --force --index https://test.pypi.org/simple --default-index https://pypi.org/simple 'hol-guard==$VERSION'" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+
+  publish-pypi:
+    name: Publish 3.1 alpha to PyPI
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi'
+    needs: [build, release-tests]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: alpha-distribution
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+
+  release-alpha:
+    name: Create 3.1 alpha prerelease
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: alpha-distribution
+          path: dist/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: alpha-toolchain-sbom
+          path: dist/
+      - name: Attest alpha release assets
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-path: dist/*
+      - name: Create discoverable alpha prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          body_file=$(mktemp)
+          cat > "$body_file" <<EOF
+          Guard 3.1 alpha for opt-in evaluation. Stable installations remain on the stable channel.
+
+          Install this exact alpha:
+
+          \`\`\`bash
+          uv tool install --force "hol-guard==$VERSION"
+          \`\`\`
+          EOF
+          mapfile -d '' files < <(find dist -maxdepth 1 -type f -print0 | sort -z)
+          gh release create "alpha/v${VERSION}" --repo "${{ github.repository }}" --target "$GITHUB_SHA" --title "Guard ${VERSION} alpha" --notes-file "$body_file" --prerelease "${files[@]}"

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -146,42 +146,25 @@ jobs:
         (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi')
       )
     needs: [build, release-tests]
-    runs-on: ubuntu-latest
-    environment: testpypi
+    uses: ./.github/workflows/publish.yml
+    with:
+      alpha_publish_target: testpypi
+      alpha_version: ${{ needs.build.outputs.version }}
     permissions:
+      contents: read
       id-token: write
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: alpha-distribution
-          path: dist/
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-      - name: Show canary install command
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          echo "## TestPyPI canary" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
-          echo "uv tool install --force --index https://test.pypi.org/simple --default-index https://pypi.org/simple 'hol-guard==$VERSION'" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
 
   publish-pypi:
     name: Publish 3.1 alpha to PyPI
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi'
     needs: [build, release-tests]
-    runs-on: ubuntu-latest
-    environment: pypi
+    uses: ./.github/workflows/publish.yml
+    with:
+      alpha_publish_target: pypi
+      alpha_version: ${{ needs.build.outputs.version }}
     permissions:
+      contents: read
       id-token: write
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: alpha-distribution
-          path: dist/
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
   release-alpha:
     name: Create 3.1 alpha prerelease

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,23 +11,11 @@ on:
         options:
           - testpypi
           - pypi
-      release_channel:
-        description: "Release channel"
-        required: true
-        default: stable
-        type: choice
-        options:
-          - stable
-          - alpha
-      alpha_version:
-        description: "Required for alpha releases (for example 3.1.0a1)"
-        required: false
-        type: string
   push:
     branches: [main]
     tags: ["v*"]
   pull_request:
-    branches: [main, "release/3.1"]
+    branches: [main]
 
 permissions:
   contents: read
@@ -43,7 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
-      channel: ${{ steps.version.outputs.channel }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -76,22 +63,10 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_CHANNEL: ${{ github.event.inputs.release_channel }}
-          ALPHA_VERSION: ${{ github.event.inputs.alpha_version }}
         run: |
           BASE_VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
           VERSION="$BASE_VERSION"
-          CHANNEL="${RELEASE_CHANNEL:-stable}"
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$CHANNEL" == "alpha" ]]; then
-            if [[ -z "$ALPHA_VERSION" ]]; then
-              echo "alpha_version is required for alpha releases" >&2
-              exit 1
-            fi
-            VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py --version "$ALPHA_VERSION" --git-ref "$GITHUB_REF")
-          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$GITHUB_REF" != "refs/heads/main" ]]; then
-            echo "Stable manual releases must run from refs/heads/main" >&2
-            exit 1
-          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             VERSION=$(BASE_VERSION="$BASE_VERSION" PR_NUMBER="$PR_NUMBER" GITHUB_RUN_NUMBER="$GITHUB_RUN_NUMBER" GITHUB_RUN_ATTEMPT="$GITHUB_RUN_ATTEMPT" python - <<'PY'
@@ -138,8 +113,7 @@ jobs:
             fi
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
-          echo "Computed $CHANNEL version: $VERSION"
+          echo "Computed version: $VERSION"
       - name: Verify release toolchain and write SBOM
         env:
           EXPECTED_UV_VERSION: "0.9.26"
@@ -218,42 +192,10 @@ jobs:
           path: release-metadata/*.cdx.json
           if-no-files-found: error
 
-  alpha-cross-platform:
-    name: Alpha release tests (${{ matrix.os }})
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_channel == 'alpha'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        with:
-          python-version: "3.12"
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
-        with:
-          version: "0.9.26"
-          enable-cache: true
-      - run: uv sync --frozen --extra dev --python 3.12
-      - name: Run Linux release suite
-        if: runner.os == 'Linux'
-        run: uv run --no-sync pytest --tb=short
-      - name: Run Windows release suite
-        if: runner.os == 'Windows'
-        run: uv run --no-sync pytest tests/test_cli.py tests/test_verification.py tests/test_action_runner.py tests/test_policy_document_yaml.py tests/test_policy_bundle_v2.py --tb=short
-
   publish-testpypi:
     name: Publish to TestPyPI (Manual)
-    if: >-
-      always() &&
-      needs.build.result == 'success' &&
-      (needs.alpha-cross-platform.result == 'success' || needs.alpha-cross-platform.result == 'skipped') &&
-      (
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi') ||
-        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-      )
-    needs: [build, alpha-cross-platform]
+    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    needs: build
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -282,23 +224,8 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    if: >-
-      always() &&
-      needs.build.result == 'success' &&
-      (needs.alpha-cross-platform.result == 'success' || needs.alpha-cross-platform.result == 'skipped') &&
-      (
-        github.ref == 'refs/heads/main' ||
-        startsWith(github.ref, 'refs/tags/') ||
-        (
-          github.event_name == 'workflow_dispatch' &&
-          github.event.inputs.publish_target == 'pypi' &&
-          (
-            (needs.build.outputs.channel == 'stable' && github.ref == 'refs/heads/main') ||
-            (needs.build.outputs.channel == 'alpha' && github.ref == 'refs/heads/release/3.1')
-          )
-        )
-      )
-    needs: [build, alpha-cross-platform]
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi')
+    needs: build
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -308,48 +235,9 @@ jobs:
         with:
           name: distributions
           path: dist/
-      - name: Keep only the Guard alpha distribution
-        if: needs.build.outputs.channel == 'alpha'
-        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           skip-existing: true
-
-  release-alpha:
-    name: Create alpha GitHub prerelease
-    if: >-
-      github.event_name == 'workflow_dispatch' &&
-      github.event.inputs.publish_target == 'pypi' &&
-      needs.build.outputs.channel == 'alpha' &&
-      github.ref == 'refs/heads/release/3.1'
-    needs: [build, publish-pypi]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - name: Create discoverable alpha prerelease
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          body_file=$(mktemp)
-          cat > "$body_file" <<EOF
-          Guard 3.1 alpha for opt-in evaluation. Stable installations remain on the stable channel.
-
-          Install this exact alpha:
-
-          \`\`\`bash
-          uv tool install --force "hol-guard==$VERSION"
-          \`\`\`
-
-          Return to the stable channel:
-
-          \`\`\`bash
-          uv tool install --force "hol-guard<3"
-          \`\`\`
-          EOF
-          gh release create "alpha/v${VERSION}" --repo "${{ github.repository }}" --target "$GITHUB_SHA" --title "Guard ${VERSION} alpha" --notes-file "$body_file" --prerelease
 
   release:
     name: Create GitHub Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,11 +11,23 @@ on:
         options:
           - testpypi
           - pypi
+      release_channel:
+        description: "Release channel"
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - alpha
+      alpha_version:
+        description: "Required for alpha releases (for example 3.1.0a1)"
+        required: false
+        type: string
   push:
     branches: [main]
     tags: ["v*"]
   pull_request:
-    branches: [main]
+    branches: [main, "release/3.1"]
 
 permissions:
   contents: read
@@ -31,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      channel: ${{ steps.version.outputs.channel }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -63,10 +76,22 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_CHANNEL: ${{ github.event.inputs.release_channel }}
+          ALPHA_VERSION: ${{ github.event.inputs.alpha_version }}
         run: |
           BASE_VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
           VERSION="$BASE_VERSION"
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+          CHANNEL="${RELEASE_CHANNEL:-stable}"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$CHANNEL" == "alpha" ]]; then
+            if [[ -z "$ALPHA_VERSION" ]]; then
+              echo "alpha_version is required for alpha releases" >&2
+              exit 1
+            fi
+            VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py --version "$ALPHA_VERSION" --git-ref "$GITHUB_REF")
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "Stable manual releases must run from refs/heads/main" >&2
+            exit 1
+          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             VERSION=$(BASE_VERSION="$BASE_VERSION" PR_NUMBER="$PR_NUMBER" GITHUB_RUN_NUMBER="$GITHUB_RUN_NUMBER" GITHUB_RUN_ATTEMPT="$GITHUB_RUN_ATTEMPT" python - <<'PY'
@@ -113,7 +138,8 @@ jobs:
             fi
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Computed version: $VERSION"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "Computed $CHANNEL version: $VERSION"
       - name: Verify release toolchain and write SBOM
         env:
           EXPECTED_UV_VERSION: "0.9.26"
@@ -192,10 +218,42 @@ jobs:
           path: release-metadata/*.cdx.json
           if-no-files-found: error
 
+  alpha-cross-platform:
+    name: Alpha release tests (${{ matrix.os }})
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_channel == 'alpha'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Run Linux release suite
+        if: runner.os == 'Linux'
+        run: uv run --no-sync pytest --tb=short
+      - name: Run Windows release suite
+        if: runner.os == 'Windows'
+        run: uv run --no-sync pytest tests/test_cli.py tests/test_verification.py tests/test_action_runner.py tests/test_policy_document_yaml.py tests/test_policy_bundle_v2.py --tb=short
+
   publish-testpypi:
     name: Publish to TestPyPI (Manual)
-    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-    needs: build
+    if: >-
+      always() &&
+      needs.build.result == 'success' &&
+      (needs.alpha-cross-platform.result == 'success' || needs.alpha-cross-platform.result == 'skipped') &&
+      (
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi') ||
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      )
+    needs: [build, alpha-cross-platform]
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -224,8 +282,23 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi')
-    needs: build
+    if: >-
+      always() &&
+      needs.build.result == 'success' &&
+      (needs.alpha-cross-platform.result == 'success' || needs.alpha-cross-platform.result == 'skipped') &&
+      (
+        github.ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/tags/') ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.publish_target == 'pypi' &&
+          (
+            (needs.build.outputs.channel == 'stable' && github.ref == 'refs/heads/main') ||
+            (needs.build.outputs.channel == 'alpha' && github.ref == 'refs/heads/release/3.1')
+          )
+        )
+      )
+    needs: [build, alpha-cross-platform]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -235,9 +308,48 @@ jobs:
         with:
           name: distributions
           path: dist/
+      - name: Keep only the Guard alpha distribution
+        if: needs.build.outputs.channel == 'alpha'
+        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           skip-existing: true
+
+  release-alpha:
+    name: Create alpha GitHub prerelease
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.publish_target == 'pypi' &&
+      needs.build.outputs.channel == 'alpha' &&
+      github.ref == 'refs/heads/release/3.1'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - name: Create discoverable alpha prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          body_file=$(mktemp)
+          cat > "$body_file" <<EOF
+          Guard 3.1 alpha for opt-in evaluation. Stable installations remain on the stable channel.
+
+          Install this exact alpha:
+
+          \`\`\`bash
+          uv tool install --force "hol-guard==$VERSION"
+          \`\`\`
+
+          Return to the stable channel:
+
+          \`\`\`bash
+          uv tool install --force "hol-guard<3"
+          \`\`\`
+          EOF
+          gh release create "alpha/v${VERSION}" --repo "${{ github.repository }}" --target "$GITHUB_SHA" --title "Guard ${VERSION} alpha" --notes-file "$body_file" --prerelease
 
   release:
     name: Create GitHub Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,16 @@
 name: Publish to PyPI
 
 on:
+  workflow_call:
+    inputs:
+      alpha_publish_target:
+        description: "Trusted publisher target for an artifact built by publish-alpha.yml"
+        required: true
+        type: string
+      alpha_version:
+        description: "Alpha version being published"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       publish_target:
@@ -27,7 +37,7 @@ concurrency:
 jobs:
   build:
     name: Build + Verify
-    if: github.event_name != 'push' || github.ref != 'refs/heads/main' || !contains(github.event.head_commit.message, '[skip release publish]')
+    if: inputs.alpha_publish_target == '' && (github.event_name != 'push' || github.ref != 'refs/heads/main' || !contains(github.event.head_commit.message, '[skip release publish]'))
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -191,6 +201,45 @@ jobs:
           name: release-toolchain-sbom
           path: release-metadata/*.cdx.json
           if-no-files-found: error
+
+  publish-alpha-testpypi:
+    name: Publish alpha artifact to TestPyPI
+    if: inputs.alpha_publish_target == 'testpypi'
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: alpha-distribution
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+      - name: Show canary install command
+        env:
+          VERSION: ${{ inputs.alpha_version }}
+        run: |
+          echo "## TestPyPI canary" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
+          echo "uv tool install --force --index https://test.pypi.org/simple --default-index https://pypi.org/simple 'hol-guard==$VERSION'" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+
+  publish-alpha-pypi:
+    name: Publish alpha artifact to PyPI
+    if: inputs.alpha_publish_target == 'pypi'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: alpha-distribution
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
   publish-testpypi:
     name: Publish to TestPyPI (Manual)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,6 @@
 name: Publish to PyPI
 
 on:
-  workflow_call:
-    inputs:
-      alpha_publish_target:
-        description: "Trusted publisher target for an artifact built by publish-alpha.yml"
-        required: true
-        type: string
-      alpha_version:
-        description: "Alpha version being published"
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       publish_target:
@@ -21,11 +11,15 @@ on:
         options:
           - testpypi
           - pypi
+      alpha_version:
+        description: "Required on release/3.1; for example 3.1.0a1"
+        required: false
+        type: string
   push:
     branches: [main]
     tags: ["v*"]
   pull_request:
-    branches: [main]
+    branches: [main, "release/3.1"]
 
 permissions:
   contents: read
@@ -37,7 +31,10 @@ concurrency:
 jobs:
   build:
     name: Build + Verify
-    if: inputs.alpha_publish_target == '' && (github.event_name != 'push' || github.ref != 'refs/heads/main' || !contains(github.event.head_commit.message, '[skip release publish]'))
+    if: >-
+      (github.event_name != 'pull_request' || github.base_ref != 'release/3.1') &&
+      (github.event_name != 'workflow_dispatch' || github.ref != 'refs/heads/release/3.1') &&
+      (github.event_name != 'push' || github.ref != 'refs/heads/main' || !contains(github.event.head_commit.message, '[skip release publish]'))
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -202,9 +199,27 @@ jobs:
           path: release-metadata/*.cdx.json
           if-no-files-found: error
 
+  build-alpha:
+    name: Build + test 3.1 alpha
+    if: >-
+      (github.event_name == 'pull_request' && github.base_ref == 'release/3.1' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/release/3.1')
+    uses: ./.github/workflows/publish-alpha.yml
+    with:
+      alpha_version: ${{ github.event.inputs.alpha_version || '' }}
+    permissions:
+      contents: read
+
   publish-alpha-testpypi:
-    name: Publish alpha artifact to TestPyPI
-    if: inputs.alpha_publish_target == 'testpypi'
+    name: Publish 3.1 alpha to TestPyPI
+    if: >-
+      always() &&
+      needs.build-alpha.result == 'success' &&
+      (
+        (github.event_name == 'pull_request' && github.base_ref == 'release/3.1') ||
+        (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/release/3.1' && github.event.inputs.publish_target == 'testpypi')
+      )
+    needs: build-alpha
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -220,7 +235,7 @@ jobs:
           skip-existing: true
       - name: Show canary install command
         env:
-          VERSION: ${{ inputs.alpha_version }}
+          VERSION: ${{ needs.build-alpha.outputs.version }}
         run: |
           echo "## TestPyPI canary" >> "$GITHUB_STEP_SUMMARY"
           echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
@@ -228,8 +243,12 @@ jobs:
           echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
 
   publish-alpha-pypi:
-    name: Publish alpha artifact to PyPI
-    if: inputs.alpha_publish_target == 'pypi'
+    name: Publish 3.1 alpha to PyPI
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/release/3.1' &&
+      github.event.inputs.publish_target == 'pypi'
+    needs: build-alpha
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -273,7 +292,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     needs: build
     runs-on: ubuntu-latest
     environment: pypi
@@ -292,131 +311,40 @@ jobs:
     name: Create GitHub Release
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     needs: [build, publish-pypi]
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/create-python-release.yml
+    with:
+      version: ${{ needs.build.outputs.version }}
+      channel: stable
+      distribution_artifact: distributions
+      sbom_artifact: release-toolchain-sbom
+      provenance_prefix: plugin-scanner
     permissions:
       attestations: write
       contents: write
       id-token: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distributions
-          path: dist/
-      - name: Download release toolchain SBOM
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: release-toolchain-sbom
-          path: dist/
-      - name: Skip if release already exists
-        id: release_exists
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          if gh release view "v${VERSION}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Generate changelog
-        if: steps.release_exists.outputs.exists == 'false'
-        id: changelog
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          # Get the range of commits since last tag
-          LAST_TAG=$(git describe --tags --abbrev=0 --exclude="v${VERSION}" 2>/dev/null || echo "")
 
-          if [ -n "$LAST_TAG" ]; then
-            LOG=$(git log ${LAST_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges)
-          else
-            LOG=$(git log --pretty=format:"- %s (%h)" --no-merges -20)
-          fi
-
-          # Build release notes
-          cat > release-notes.md << EOF
-          ## v${VERSION}
-
-          ### What's Changed
-          ${LOG}
-
-          ### Installation
-          Base install:
-          \`\`\`bash
-          uv tool install hol-guard==${VERSION}
-          \`\`\`
-
-          \`\`\`bash
-          uv tool install plugin-scanner==${VERSION}
-          \`\`\`
-
-          Full Cisco coverage on Python 3.11+:
-          \`\`\`bash
-          uv tool install "hol-guard[cisco]==${VERSION}"
-          \`\`\`
-
-          \`\`\`bash
-          uv tool install "plugin-scanner[cisco]==${VERSION}"
-          \`\`\`
-
-          \`\`\`bash
-          docker pull ghcr.io/hashgraph-online/hol-guard:${VERSION}
-          \`\`\`
-
-          **Full Changelog**: https://github.com/hashgraph-online/hol-guard/compare/${LAST_TAG}...v${VERSION}
-          EOF
-
-          echo "notes_path=release-notes.md" >> $GITHUB_OUTPUT
-      - name: Attest GitHub release assets
-        if: steps.release_exists.outputs.exists == 'false'
-        id: provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
-        with:
-          subject-path: |
-            dist/*
-      - name: Materialize provenance bundle
-        if: steps.release_exists.outputs.exists == 'false'
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          cp "${{ steps.provenance.outputs.bundle-path }}" "dist/plugin-scanner-v${VERSION}.intoto.jsonl"
-      - name: Collect release asset files
-        if: steps.release_exists.outputs.exists == 'false'
-        id: release_assets
-        run: |
-          mapfile -d '' ASSET_FILES < <(find dist -maxdepth 1 -type f -print0 | sort -z)
-          if [ "${#ASSET_FILES[@]}" -eq 0 ]; then
-            echo "No release asset files found in dist/" >&2
-            exit 1
-          fi
-          {
-            echo "files<<EOF"
-            for asset in "${ASSET_FILES[@]}"; do
-              printf '%s\n' "$asset"
-            done
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-      - name: Create release
-        if: steps.release_exists.outputs.exists == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          mapfile -t RELEASE_ASSETS <<'EOF'
-          ${{ steps.release_assets.outputs.files }}
-          EOF
-          gh release create "v${VERSION}" \
-            --title "v${VERSION}" \
-            --target main \
-            --notes-file ${{ steps.changelog.outputs.notes_path }} \
-            "${RELEASE_ASSETS[@]}"
+  release-alpha:
+    name: Create 3.1 alpha prerelease
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/release/3.1' &&
+      github.event.inputs.publish_target == 'pypi'
+    needs: [build-alpha, publish-alpha-pypi]
+    uses: ./.github/workflows/create-python-release.yml
+    with:
+      version: ${{ needs.build-alpha.outputs.version }}
+      channel: alpha
+      distribution_artifact: alpha-distribution
+      sbom_artifact: alpha-toolchain-sbom
+      provenance_prefix: hol-guard
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
 
   publish-container:
     name: Publish container image
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     needs: [build, publish-pypi]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,4 @@
 name: Publish to PyPI
-
 on:
   workflow_dispatch:
     inputs:
@@ -20,14 +19,11 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main, "release/3.1"]
-
 permissions:
   contents: read
-
 concurrency:
   group: hol-guard-publish-${{ github.ref }}
   cancel-in-progress: false
-
 jobs:
   build:
     name: Build + Verify
@@ -198,7 +194,6 @@ jobs:
           name: release-toolchain-sbom
           path: release-metadata/*.cdx.json
           if-no-files-found: error
-
   build-alpha:
     name: Build + test 3.1 alpha
     if: >-
@@ -207,6 +202,9 @@ jobs:
     uses: ./.github/workflows/publish-alpha.yml
     with:
       alpha_version: ${{ github.event.inputs.alpha_version || '' }}
+      git_ref: ${{ github.ref }}
+      pr_number: ${{ github.event.pull_request.number || 0 }}
+      run_release_tests: ${{ github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: read
 
@@ -262,7 +260,9 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI (Manual)
-    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    if: >-
+      (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/release/3.1' && github.event.inputs.publish_target == 'testpypi') ||
+      (github.event_name == 'pull_request' && github.base_ref != 'release/3.1' && github.event.pull_request.head.repo.full_name == github.repository)
     needs: build
     runs-on: ubuntu-latest
     environment: testpypi

--- a/scripts/validate_alpha_release.py
+++ b/scripts/validate_alpha_release.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+
+from packaging.version import Version
+
+ALPHA_BRANCH = "refs/heads/release/3.1"
+ALPHA_RELEASE = (3, 1, 0)
+
+
+@dataclass(frozen=True)
+class AlphaRelease:
+    version: str
+    git_ref: str
+
+
+def validate_alpha_release(version_text: str, git_ref: str) -> AlphaRelease:
+    if git_ref != ALPHA_BRANCH:
+        raise ValueError(f"Alpha releases must run from {ALPHA_BRANCH}")
+
+    version = Version(version_text)
+    if (
+        version.epoch != 0
+        or version.release != ALPHA_RELEASE
+        or version.pre is None
+        or version.pre[0] != "a"
+        or version.dev is not None
+        or version.post is not None
+        or version.local is not None
+    ):
+        raise ValueError("Alpha releases require a public PEP 440 3.1.0 alpha version such as 3.1.0a1")
+
+    return AlphaRelease(version=str(version), git_ref=git_ref)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate a Guard 3.1 alpha release request")
+    _ = parser.add_argument("--version", required=True)
+    _ = parser.add_argument("--git-ref", required=True)
+    args = parser.parse_args()
+    version_text = getattr(args, "version", None)
+    git_ref = getattr(args, "git_ref", None)
+    if not isinstance(version_text, str) or not isinstance(git_ref, str):
+        parser.error("--version and --git-ref must be strings")
+    try:
+        release = validate_alpha_release(version_text, git_ref)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    print(release.version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_alpha_release.py
+++ b/scripts/validate_alpha_release.py
@@ -19,6 +19,8 @@ class AlphaRelease:
 def validate_alpha_release(version_text: str, git_ref: str) -> AlphaRelease:
     if git_ref != ALPHA_BRANCH:
         raise ValueError(f"Alpha releases must run from {ALPHA_BRANCH}")
+    if not version_text.strip():
+        raise ValueError("Alpha releases require an explicit version such as 3.1.0a1")
 
     version = Version(version_text)
     if (

--- a/tests/test_cisco_install_surfaces.py
+++ b/tests/test_cisco_install_surfaces.py
@@ -82,6 +82,7 @@ def test_readme_distinguishes_baseline_and_full_cisco_installs() -> None:
 def test_repo_controlled_surfaces_prefer_cisco_extra_where_supported() -> None:
     ci_workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
     publish_workflow = (ROOT / ".github/workflows/publish.yml").read_text(encoding="utf-8")
+    release_workflow = (ROOT / ".github/workflows/create-python-release.yml").read_text(encoding="utf-8")
     dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
     contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
     docker_requirements = (ROOT / "docker-requirements.txt").read_text(encoding="utf-8")
@@ -91,7 +92,7 @@ def test_repo_controlled_surfaces_prefer_cisco_extra_where_supported() -> None:
     assert "uv sync --frozen --extra dev --extra cisco --group cisco-mcp --python 3.13" in ci_workflow
     assert "uv sync --frozen --extra dev --python ${{ matrix.python-version }}" in ci_workflow
     assert "uv sync --frozen --extra dev --extra publish --extra cisco" in publish_workflow
-    assert 'uv tool install "hol-guard[cisco]==' in publish_workflow
+    assert 'uv tool install "hol-guard[cisco]==' in release_workflow
     assert "COPY docker-requirements.txt LICENSE README.md /app/" in dockerfile
     assert "FROM python:3.13-slim@" in dockerfile
     assert "FROM python:3.14-slim" not in dockerfile

--- a/tests/test_pr_testpypi_canary_workflow.py
+++ b/tests/test_pr_testpypi_canary_workflow.py
@@ -11,11 +11,12 @@ def test_pr_canary_uses_trusted_publishing_for_same_repository_prs() -> None:
     workflow_path = ROOT / ".github/workflows/publish.yml"
     workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
 
-    assert workflow[True]["pull_request"] == {"branches": ["main"]}
+    assert workflow[True]["pull_request"] == {"branches": ["main", "release/3.1"]}
     assert workflow["permissions"] == {"contents": "read"}
     job = workflow["jobs"]["publish-testpypi"]
     assert job["permissions"] == {"id-token": "write"}
     assert "github.event.pull_request.head.repo.full_name == github.repository" in job["if"]
+    assert "github.base_ref != 'release/3.1'" in job["if"]
     assert job["environment"] == "testpypi"
     assert "github.event_name == 'pull_request'" in job["if"]
     publish_step = next(

--- a/tests/test_release_toolchain_sbom.py
+++ b/tests/test_release_toolchain_sbom.py
@@ -59,9 +59,12 @@ def test_release_toolchain_sbom_rejects_runtime_version_mismatch(tmp_path: Path)
 
 def test_publish_workflow_attests_toolchain_sbom_without_sending_it_to_pypi() -> None:
     workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8"))
+    release_workflow = yaml.safe_load(
+        (ROOT / ".github" / "workflows" / "create-python-release.yml").read_text(encoding="utf-8")
+    )
     jobs = workflow["jobs"]
     build_steps = jobs["build"]["steps"]
-    release_steps = jobs["release"]["steps"]
+    release_steps = release_workflow["jobs"]["release"]["steps"]
 
     preflight_index = next(
         index
@@ -71,6 +74,8 @@ def test_publish_workflow_attests_toolchain_sbom_without_sending_it_to_pypi() ->
     install_index = next(index for index, step in enumerate(build_steps) if step.get("name") == "Install dependencies")
     assert preflight_index < install_index
     assert any(step.get("name") == "Upload release toolchain SBOM" for step in build_steps)
+    assert jobs["release"]["uses"] == "./.github/workflows/create-python-release.yml"
+    assert jobs["release"]["with"]["sbom_artifact"] == "release-toolchain-sbom"
     assert any(step.get("name") == "Download release toolchain SBOM" for step in release_steps)
     assert all(
         step.get("name") != "Download release toolchain SBOM"

--- a/tests/test_validate_alpha_release.py
+++ b/tests/test_validate_alpha_release.py
@@ -57,27 +57,24 @@ def test_cli_reports_invalid_alpha_without_traceback(
 
 def test_release_workflow_keeps_stable_and_3_1_alpha_channels_isolated() -> None:
     root = Path(__file__).parent.parent
-    publish = yaml.safe_load((root / ".github/workflows/publish.yml").read_text(encoding="utf-8"))
+    publish = yaml.safe_load((root / ".github/workflows/publish-alpha.yml").read_text(encoding="utf-8"))
     on_section = publish.get(True) or publish.get("on")
     inputs = on_section["workflow_dispatch"]["inputs"]
 
-    assert inputs["release_channel"]["options"] == ["stable", "alpha"]
-    assert inputs["alpha_version"]["required"] is False
+    assert inputs["publish_target"]["options"] == ["testpypi", "pypi"]
+    assert inputs["alpha_version"]["required"] is True
     assert "release/3.1" in on_section["pull_request"]["branches"]
 
     jobs = publish["jobs"]
-    alpha_matrix = jobs["alpha-cross-platform"]["strategy"]["matrix"]["os"]
+    alpha_matrix = jobs["release-tests"]["strategy"]["matrix"]["os"]
     assert alpha_matrix == ["ubuntu-latest", "windows-latest"]
-    assert "refs/heads/release/3.1" in jobs["publish-pypi"]["if"]
-    assert jobs["publish-pypi"]["needs"] == ["build", "alpha-cross-platform"]
+    assert jobs["publish-pypi"]["needs"] == ["build", "release-tests"]
     assert jobs["release-alpha"]["needs"] == ["build", "publish-pypi"]
+    assert "publish-container" not in jobs
 
-    alpha_publish_steps = jobs["publish-pypi"]["steps"]
-    prune_step = next(
-        step for step in alpha_publish_steps if step.get("name") == "Keep only the Guard alpha distribution"
-    )
-    assert prune_step["if"] == "needs.build.outputs.channel == 'alpha'"
-    assert "plugin_scanner" in prune_step["run"]
+    stable_publish = yaml.safe_load((root / ".github/workflows/publish.yml").read_text(encoding="utf-8"))
+    stable_on = stable_publish.get(True) or stable_publish.get("on")
+    assert stable_on["pull_request"]["branches"] == ["main"]
 
 
 def test_release_branch_runs_standard_cross_platform_ci() -> None:

--- a/tests/test_validate_alpha_release.py
+++ b/tests/test_validate_alpha_release.py
@@ -57,24 +57,32 @@ def test_cli_reports_invalid_alpha_without_traceback(
 
 def test_release_workflow_keeps_stable_and_3_1_alpha_channels_isolated() -> None:
     root = Path(__file__).parent.parent
-    publish = yaml.safe_load((root / ".github/workflows/publish-alpha.yml").read_text(encoding="utf-8"))
+    publish_path = root / ".github/workflows/publish.yml"
+    publish_text = publish_path.read_text(encoding="utf-8")
+    publish = yaml.safe_load(publish_text)
     on_section = publish.get(True) or publish.get("on")
     inputs = on_section["workflow_dispatch"]["inputs"]
 
     assert inputs["publish_target"]["options"] == ["testpypi", "pypi"]
-    assert inputs["alpha_version"]["required"] is True
+    assert inputs["alpha_version"]["required"] is False
     assert "release/3.1" in on_section["pull_request"]["branches"]
 
     jobs = publish["jobs"]
-    alpha_matrix = jobs["release-tests"]["strategy"]["matrix"]["os"]
-    assert alpha_matrix == ["ubuntu-latest", "windows-latest"]
-    assert jobs["publish-pypi"]["needs"] == ["build", "release-tests"]
-    assert jobs["release-alpha"]["needs"] == ["build", "publish-pypi"]
-    assert "publish-container" not in jobs
+    assert jobs["build-alpha"]["uses"] == "./.github/workflows/publish-alpha.yml"
+    assert jobs["publish-alpha-pypi"]["needs"] == "build-alpha"
+    assert jobs["release"]["uses"] == "./.github/workflows/create-python-release.yml"
+    assert jobs["release"]["with"]["provenance_prefix"] == "plugin-scanner"
+    assert jobs["release-alpha"]["needs"] == ["build-alpha", "publish-alpha-pypi"]
+    assert jobs["release-alpha"]["with"]["provenance_prefix"] == "hol-guard"
+    assert "workflow_dispatch" not in jobs["publish-container"]["if"]
+    assert len(publish_text.splitlines()) <= 500
 
-    stable_publish = yaml.safe_load((root / ".github/workflows/publish.yml").read_text(encoding="utf-8"))
-    stable_on = stable_publish.get(True) or stable_publish.get("on")
-    assert stable_on["pull_request"]["branches"] == ["main"]
+    alpha = yaml.safe_load((root / ".github/workflows/publish-alpha.yml").read_text(encoding="utf-8"))
+    alpha_on = alpha.get(True) or alpha.get("on")
+    assert alpha_on["workflow_call"]["inputs"]["alpha_version"]["required"] is False
+    assert set(alpha["jobs"]) == {"build", "release-tests"}
+    alpha_matrix = alpha["jobs"]["release-tests"]["strategy"]["matrix"]["os"]
+    assert alpha_matrix == ["ubuntu-latest", "windows-latest"]
 
 
 def test_release_branch_runs_standard_cross_platform_ci() -> None:

--- a/tests/test_validate_alpha_release.py
+++ b/tests/test_validate_alpha_release.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.validate_alpha_release import ALPHA_BRANCH, main, validate_alpha_release
+
+
+def test_accepts_public_guard_3_1_alpha_from_release_branch() -> None:
+    release = validate_alpha_release("3.1.0a1", ALPHA_BRANCH)
+
+    assert release.version == "3.1.0a1"
+    assert release.git_ref == ALPHA_BRANCH
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "1!3.1.0a1",
+        "3.0.0a1",
+        "3.1.1a1",
+        "3.1.0b1",
+        "3.1.0rc1",
+        "3.1.0",
+        "3.1.0a1.dev1",
+        "3.1.0a1.post1",
+        "3.1.0a1+local",
+    ],
+)
+def test_rejects_versions_outside_public_guard_3_1_alpha_line(version: str) -> None:
+    with pytest.raises(ValueError, match=r"3\.1\.0 alpha"):
+        validate_alpha_release(version, ALPHA_BRANCH)
+
+
+def test_rejects_alpha_release_from_any_other_branch() -> None:
+    with pytest.raises(ValueError, match=r"release/3\.1"):
+        validate_alpha_release("3.1.0a1", "refs/heads/main")
+
+
+def test_cli_reports_invalid_alpha_without_traceback(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["validate_alpha_release.py", "--version", "3.1.0", "--git-ref", ALPHA_BRANCH],
+    )
+
+    assert main() == 1
+    captured = capsys.readouterr()
+    assert "Error: Alpha releases require" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_release_workflow_keeps_stable_and_3_1_alpha_channels_isolated() -> None:
+    root = Path(__file__).parent.parent
+    publish = yaml.safe_load((root / ".github/workflows/publish.yml").read_text(encoding="utf-8"))
+    on_section = publish.get(True) or publish.get("on")
+    inputs = on_section["workflow_dispatch"]["inputs"]
+
+    assert inputs["release_channel"]["options"] == ["stable", "alpha"]
+    assert inputs["alpha_version"]["required"] is False
+    assert "release/3.1" in on_section["pull_request"]["branches"]
+
+    jobs = publish["jobs"]
+    alpha_matrix = jobs["alpha-cross-platform"]["strategy"]["matrix"]["os"]
+    assert alpha_matrix == ["ubuntu-latest", "windows-latest"]
+    assert "refs/heads/release/3.1" in jobs["publish-pypi"]["if"]
+    assert jobs["publish-pypi"]["needs"] == ["build", "alpha-cross-platform"]
+    assert jobs["release-alpha"]["needs"] == ["build", "publish-pypi"]
+
+    alpha_publish_steps = jobs["publish-pypi"]["steps"]
+    prune_step = next(
+        step for step in alpha_publish_steps if step.get("name") == "Keep only the Guard alpha distribution"
+    )
+    assert prune_step["if"] == "needs.build.outputs.channel == 'alpha'"
+    assert "plugin_scanner" in prune_step["run"]
+
+
+def test_release_branch_runs_standard_cross_platform_ci() -> None:
+    root = Path(__file__).parent.parent
+    ci = yaml.safe_load((root / ".github/workflows/ci.yml").read_text(encoding="utf-8"))
+
+    on_section = ci.get(True) or ci.get("on")
+    assert "release/3.1" in on_section["push"]["branches"]
+    assert "release/3.1" in on_section["pull_request"]["branches"]
+    assert "windows-latest" in ci["jobs"]["cross-platform"]["strategy"]["matrix"]["os"]

--- a/tests/test_validate_alpha_release.py
+++ b/tests/test_validate_alpha_release.py
@@ -40,13 +40,19 @@ def test_rejects_alpha_release_from_any_other_branch() -> None:
         validate_alpha_release("3.1.0a1", "refs/heads/main")
 
 
+def test_rejects_empty_alpha_version_with_clear_error() -> None:
+    with pytest.raises(ValueError, match="explicit version"):
+        validate_alpha_release("", ALPHA_BRANCH)
+
+
+@pytest.mark.parametrize("version", ["3.1.0", ""])
 def test_cli_reports_invalid_alpha_without_traceback(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], version: str
 ) -> None:
     monkeypatch.setattr(
         sys,
         "argv",
-        ["validate_alpha_release.py", "--version", "3.1.0", "--git-ref", ALPHA_BRANCH],
+        ["validate_alpha_release.py", "--version", version, "--git-ref", ALPHA_BRANCH],
     )
 
     assert main() == 1
@@ -80,7 +86,9 @@ def test_release_workflow_keeps_stable_and_3_1_alpha_channels_isolated() -> None
     alpha = yaml.safe_load((root / ".github/workflows/publish-alpha.yml").read_text(encoding="utf-8"))
     alpha_on = alpha.get(True) or alpha.get("on")
     assert alpha_on["workflow_call"]["inputs"]["alpha_version"]["required"] is False
+    assert alpha_on["workflow_call"]["inputs"]["run_release_tests"]["type"] == "boolean"
     assert set(alpha["jobs"]) == {"build", "release-tests"}
+    assert alpha["jobs"]["release-tests"]["if"] == "inputs.run_release_tests"
     alpha_matrix = alpha["jobs"]["release-tests"]["strategy"]["matrix"]["os"]
     assert alpha_matrix == ["ubuntu-latest", "windows-latest"]
 


### PR DESCRIPTION
## Summary
- add an isolated, branch-bound PyPI alpha channel for the 3.1 release line
- publish pull-request canaries and require Linux/Windows release tests before alpha publication
- validate exact PEP 440 versions and keep stable publishing behavior unchanged

## Testing
- `uv run pytest tests/test_validate_alpha_release.py -q`
- `uv run ruff check scripts/validate_alpha_release.py tests/test_validate_alpha_release.py`
- `uv run python -c 'import pathlib,yaml; [yaml.safe_load(pathlib.Path(p).read_text()) for p in (".github/workflows/ci.yml", ".github/workflows/publish.yml")]'`
- `actionlint .github/workflows/ci.yml .github/workflows/publish.yml`
