### PR TITLE
fix(release): use release/3.1 alpha cycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [main, feat/guard-policy-v3]
+    branches: [main, release/3.1]
   pull_request:
-    branches: [main, feat/guard-policy-v3]
+    branches: [main, release/3.1]
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -234,7 +234,7 @@ jobs:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
-          uv-version: "0.9.26"
+          version: "0.9.26"
           enable-cache: true
       - run: uv sync --frozen --extra dev --python 3.12
       - name: Run Linux release suite

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -294,7 +294,7 @@ jobs:
           github.event.inputs.publish_target == 'pypi' &&
           (
             (needs.build.outputs.channel == 'stable' && github.ref == 'refs/heads/main') ||
-            (needs.build.outputs.channel == 'alpha' && github.ref == 'refs/heads/feat/guard-policy-v3')
+            (needs.build.outputs.channel == 'alpha' && github.ref == 'refs/heads/release/3.1')
           )
         )
       )
@@ -321,7 +321,7 @@ jobs:
       github.event_name == 'workflow_dispatch' &&
       github.event.inputs.publish_target == 'pypi' &&
       needs.build.outputs.channel == 'alpha' &&
-      github.ref == 'refs/heads/feat/guard-policy-v3'
+      github.ref == 'refs/heads/release/3.1'
     needs: [build, publish-pypi]
     runs-on: ubuntu-latest
     permissions:

--- a/docs/guard/release-checklist.md
+++ b/docs/guard/release-checklist.md
@@ -36,15 +36,15 @@ When running Guard scans against untrusted content in a container, keep the runt
 Guard uses two isolated release lines:
 
 - `main` remains the stable 2.x source. Stable manual publishes are accepted only from `main`; normal installation continues to select the latest 2.x release.
-- `feat/guard-policy-v3` is the long-lived 3.x integration branch until the 3.x compatibility gates are closed. It receives 2.x fixes by regular forward merges from `main`, never by backporting unfinished 3.x behavior into `main`.
+- `release/3.1` is the long-lived 3.x alpha release branch until the 3.x compatibility gates are closed. It receives compatible 2.x fixes by regular forward merges from `main`, never by backporting unfinished 3.x behavior into `main`.
 - PyPI 3.x alpha versions use public PEP 440 versions such as `3.0.0a1`. Package installers ignore these prereleases unless users opt in with an exact version or an explicit prerelease flag.
 - `plugin-scanner` remains on its stable release line during Guard 3.x alpha publishing. The alpha workflow removes its distributions before upload.
 
 ### Publish a 3.x alpha
 
-1. Merge the intended changes and the latest `main` into `feat/guard-policy-v3`.
+1. Merge the intended changes and the latest compatible `main` fixes into `release/3.1`.
 2. Wait for the standard Linux and cross-platform CI jobs on the branch to pass.
-3. Run the `Publish to PyPI` workflow from `feat/guard-policy-v3` with `publish_target=pypi`, `release_channel=alpha`, and a new `alpha_version` such as `3.0.0a1`.
+3. Run the `Publish to PyPI` workflow from `release/3.1` with `publish_target=pypi`, `release_channel=alpha`, and a new `alpha_version` such as `3.1.0a1`.
 4. Confirm the workflow's Linux suite, Windows suite, package checks, and PyPI trusted publish all pass.
 5. Verify the generated `alpha/v<VERSION>` GitHub prerelease and install the exact version in a clean environment.
 6. Record compatibility findings against the alpha without changing the default 2.x installer path.
@@ -54,7 +54,7 @@ The workflow rejects alpha versions outside the 3.x line, rejects non-alpha prer
 ### Continue 2.x maintenance
 
 1. Land compatible fixes on `main` and publish them through the existing stable path.
-2. Forward-merge `main` into `feat/guard-policy-v3`. Resolve behavior conflicts in favor of the fixed 2.x invariant while preserving the 3.x contract.
+2. Forward-merge compatible `main` fixes into `release/3.1`. Resolve behavior conflicts in favor of the fixed 2.x invariant while preserving the 3.x contract.
 3. Let both branch CI matrices pass before the next alpha.
 
 ### Promote 3.x later

--- a/scripts/validate_alpha_release.py
+++ b/scripts/validate_alpha_release.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from packaging.version import Version
 
-ALPHA_BRANCHES = ("refs/heads/feat/guard-policy-v3", "refs/heads/release/3.1-policy-v3")
+ALPHA_BRANCHES = ("refs/heads/release/3.1",)
 
 
 @dataclass(frozen=True)

--- a/spec/guard-policy/v1alpha1/architecture-decision.md
+++ b/spec/guard-policy/v1alpha1/architecture-decision.md
@@ -24,7 +24,7 @@ Portal Policy Builder, Suggested Memory, signed cloud bundles, and local HOL Gua
 - Unsupported semantics fail closed rather than silently downgrade.
 - Policy parsing and compilation occur at write, import, or sync time rather than interception time.
 - Observability is limited to bounded reason codes, counts, versions, and hashes; raw policy content is excluded.
-- Promotion means merge into `feat/guard-policy-v3` plus TestPyPI verification. Integration into `main`, stable PyPI publication, and default runtime activation remain separate decisions.
+- Promotion means merge into `release/3.1` plus alpha artifact verification. Integration into `main`, stable PyPI publication, and default runtime activation remain separate decisions.
 - Removing bundle v1, legacy reads, or legacy storage requires capability coverage, a clean observation window, exercised rollback, and a separately approved proposal.
 
 ## Rejected alternatives

--- a/spec/guard-policy/v1alpha1/operator-runbook.md
+++ b/spec/guard-policy/v1alpha1/operator-runbook.md
@@ -63,4 +63,4 @@ Stop expansion on any unexplained decision mismatch, invalid signature acceptanc
 
 ## Release boundary
 
-This alpha release is promoted only by merging the Guard change into `feat/guard-policy-v3` and verifying its artifact from TestPyPI against that V3 dependency chain. It must not merge directly into `main`, publish to stable PyPI, or enable canonical enforcement by default. Those actions belong to the later consolidated V3 release.
+This alpha release is promoted only by merging the Guard change into `release/3.1` and verifying its published alpha artifact against that release branch. It must not merge directly into `main`, publish a stable release, or enable canonical enforcement by default. Those actions belong to the later consolidated V3 release.

--- a/spec/guard-policy/v1alpha1/schema-compatibility-runbook.md
+++ b/spec/guard-policy/v1alpha1/schema-compatibility-runbook.md
@@ -39,7 +39,7 @@
 3. Update the compatibility table and capability response.
 4. Preserve the legacy path until the measured compatibility window closes.
 5. Use a new API version for incompatible semantics; never silently reinterpret an existing field.
-6. Verify the Guard artifact from TestPyPI against `feat/guard-policy-v3`. The alpha artifact depends on that V3 integration branch and is not a stable `main` or PyPI release.
+6. Verify the Guard alpha artifact against `release/3.1`. The alpha artifact depends on that V3 release branch and is not a stable `main` release.
 
 ## Deprecation gate
 

--- a/tests/test_validate_alpha_release.py
+++ b/tests/test_validate_alpha_release.py
@@ -35,13 +35,13 @@ def test_rejects_versions_that_are_not_public_guard_3_alphas(version: str) -> No
 
 
 def test_rejects_alpha_release_from_any_other_branch() -> None:
-    with pytest.raises(ValueError, match="feat/guard-policy-v3"):
+    with pytest.raises(ValueError, match=r"release/3\.1"):
         validate_alpha_release("3.0.0a1", "refs/heads/main")
 
 
-def test_accepts_release_31_policy_branch() -> None:
-    release = validate_alpha_release("3.0.0a1", "refs/heads/release/3.1-policy-v3")
-    assert release.git_ref == "refs/heads/release/3.1-policy-v3"
+def test_accepts_release_31_branch() -> None:
+    release = validate_alpha_release("3.0.0a1", "refs/heads/release/3.1")
+    assert release.git_ref == "refs/heads/release/3.1"
 
 
 def test_cli_reports_invalid_alpha_without_traceback(
@@ -72,7 +72,7 @@ def test_release_workflows_keep_stable_and_alpha_channels_isolated() -> None:
     alpha_matrix = jobs["alpha-cross-platform"]["strategy"]["matrix"]["os"]
     assert alpha_matrix == ["ubuntu-latest", "windows-latest"]
     publish_if = jobs["publish-pypi"]["if"]
-    assert any(branch in publish_if for branch in ("feat/guard-policy-v3", "release/3.1-policy-v3"))
+    assert "release/3.1" in publish_if
     assert jobs["publish-pypi"]["needs"] == ["build", "alpha-cross-platform"]
     assert jobs["release-alpha"]["needs"] == ["build", "publish-pypi"]
 
@@ -84,11 +84,11 @@ def test_release_workflows_keep_stable_and_alpha_channels_isolated() -> None:
     assert "plugin_scanner" in prune_step["run"]
 
 
-def test_v3_branch_runs_standard_cross_platform_ci() -> None:
+def test_release_31_branch_runs_standard_cross_platform_ci() -> None:
     root = Path(__file__).parent.parent
     ci = yaml.safe_load((root / ".github/workflows/ci.yml").read_text(encoding="utf-8"))
 
     on_section = ci.get(True) or ci.get("on")
-    assert "feat/guard-policy-v3" in on_section["push"]["branches"]
-    assert "feat/guard-policy-v3" in on_section["pull_request"]["branches"]
+    assert "release/3.1" in on_section["push"]["branches"]
+    assert "release/3.1" in on_section["pull_request"]["branches"]
     assert "windows-latest" in ci["jobs"]["cross-platform"]["strategy"]["matrix"]["os"]


### PR DESCRIPTION
## Summary
- make `release/3.1` the sole Guard 3 alpha CI and publishing branch
- align alpha validation, workflow assertions, and release guidance with the official release branch

## Testing
- `uv run pytest tests/test_validate_alpha_release.py -q`
- `uv run ruff check scripts/validate_alpha_release.py tests/test_validate_alpha_release.py`