### PR TITLE
feat(mdm): add fail-honest integrity snapshot

### DIFF
--- a/docs/guard/schemas/local-integrity-snapshot-v1.schema.json
+++ b/docs/guard/schemas/local-integrity-snapshot-v1.schema.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hol.org/schemas/guard/local-integrity-snapshot-v1.schema.json",
+  "title": "HOL Guard local integrity snapshot v1",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "generatedAt",
+    "scope",
+    "healthy",
+    "assuranceLevel",
+    "installOwner",
+    "platform",
+    "architecture",
+    "identifiers",
+    "product",
+    "components",
+    "harnessCoverage",
+    "continuity",
+    "reasonCodes",
+    "remediationClass"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "local-integrity-snapshot.v1"},
+    "generatedAt": {"type": "string", "format": "date-time"},
+    "scope": {"const": "machine"},
+    "healthy": {"type": "boolean"},
+    "assuranceLevel": {"enum": ["user-managed", "mdm-managed-unverified", "mdm-managed"]},
+    "installOwner": {"enum": ["user", "mdm"]},
+    "platform": {"type": "string", "minLength": 1, "maxLength": 64},
+    "architecture": {"type": "string", "minLength": 1, "maxLength": 64},
+    "identifiers": {
+      "type": "object",
+      "required": ["workspaceId", "deviceId", "machineInstallationId", "installationGeneration"],
+      "properties": {
+        "workspaceId": {"type": ["string", "null"], "maxLength": 256},
+        "deviceId": {"type": ["string", "null"], "maxLength": 256},
+        "machineInstallationId": {"type": ["string", "null"], "maxLength": 256},
+        "installationGeneration": {"type": ["string", "null"], "maxLength": 256}
+      },
+      "additionalProperties": false
+    },
+    "product": {
+      "type": "object",
+      "required": ["version", "buildId", "sourceCommit", "packageIdentity", "manifestHash", "policyHash"],
+      "properties": {
+        "version": {"type": "string", "minLength": 1, "maxLength": 128},
+        "buildId": {"type": ["string", "null"], "maxLength": 256},
+        "sourceCommit": {"type": ["string", "null"], "maxLength": 128},
+        "packageIdentity": {"type": "string", "minLength": 1, "maxLength": 256},
+        "manifestHash": {"type": ["string", "null"], "pattern": "^[a-f0-9]{64}$"},
+        "policyHash": {"type": ["string", "null"], "pattern": "^[a-f0-9]{64}$"}
+      },
+      "additionalProperties": false
+    },
+    "components": {
+      "type": "object",
+      "required": [
+        "manifest",
+        "nativePackage",
+        "managedPolicy",
+        "ownershipAndAcl",
+        "supervisor",
+        "deviceKey",
+        "harnessCoverage",
+        "installationIdentity",
+        "leaseContinuity",
+        "daemon",
+        "commandShadowing",
+        "update"
+      ],
+      "properties": {
+        "manifest": {"$ref": "#/$defs/component"},
+        "nativePackage": {"$ref": "#/$defs/component"},
+        "managedPolicy": {"$ref": "#/$defs/component"},
+        "ownershipAndAcl": {"$ref": "#/$defs/component"},
+        "supervisor": {"$ref": "#/$defs/component"},
+        "deviceKey": {
+          "$ref": "#/$defs/keyComponent"
+        },
+        "harnessCoverage": {"$ref": "#/$defs/component"},
+        "installationIdentity": {"$ref": "#/$defs/component"},
+        "leaseContinuity": {"$ref": "#/$defs/component"},
+        "daemon": {"$ref": "#/$defs/component"},
+        "commandShadowing": {"$ref": "#/$defs/component"},
+        "update": {"$ref": "#/$defs/component"}
+      },
+      "additionalProperties": false
+    },
+    "harnessCoverage": {
+      "type": "object",
+      "required": ["required", "protected", "degraded", "missing"],
+      "properties": {
+        "required": {"type": ["integer", "null"], "minimum": 0},
+        "protected": {"type": ["integer", "null"], "minimum": 0},
+        "degraded": {"type": ["integer", "null"], "minimum": 0},
+        "missing": {"type": ["integer", "null"], "minimum": 0}
+      },
+      "additionalProperties": false
+    },
+    "continuity": {
+      "type": "object",
+      "required": ["monotonicUptimeSeconds", "sequence", "previousLeaseDigest", "bootSessionId"],
+      "properties": {
+        "monotonicUptimeSeconds": {"type": ["number", "null"], "minimum": 0},
+        "sequence": {"type": ["integer", "null"], "minimum": 0},
+        "previousLeaseDigest": {"type": ["string", "null"], "pattern": "^[a-f0-9]{64}$"},
+        "bootSessionId": {"type": ["string", "null"], "maxLength": 256}
+      },
+      "additionalProperties": false
+    },
+    "reasonCodes": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/reasonCode"}
+    },
+    "remediationClass": {"enum": ["none", "user-reinstall", "mdm-repair", "administrator-action"]}
+  },
+  "$defs": {
+    "component": {
+      "type": "object",
+      "required": ["state", "healthy", "reasonCode"],
+      "properties": {
+        "state": {"enum": ["healthy", "degraded", "absent", "tampered", "unsupported", "unknown", "running", "stopped", "disabled"]},
+        "healthy": {"type": "boolean"},
+        "reasonCode": {"$ref": "#/$defs/reasonCode"}
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {"properties": {"state": {"enum": ["healthy", "running"]}}, "required": ["state"]},
+          "then": {"properties": {"healthy": {"const": true}}},
+          "else": {"properties": {"healthy": {"const": false}}}
+        }
+      ]
+    },
+    "keyComponent": {
+      "type": "object",
+      "required": ["state", "healthy", "reasonCode", "level"],
+      "properties": {
+        "state": {"enum": ["healthy", "degraded", "absent", "tampered", "unsupported", "unknown"]},
+        "healthy": {"type": "boolean"},
+        "reasonCode": {"$ref": "#/$defs/reasonCode"},
+        "level": {"enum": ["hardware-backed", "os-protected", "file-backed", "unavailable", "unknown"]}
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {"properties": {"state": {"const": "healthy"}}, "required": ["state"]},
+          "then": {"properties": {"healthy": {"const": true}}},
+          "else": {"properties": {"healthy": {"const": false}}}
+        }
+      ]
+    },
+    "healthyComponent": {
+      "type": "object",
+      "required": ["healthy"],
+      "properties": {"healthy": {"const": true}}
+    },
+    "reasonCode": {
+      "enum": [
+        "release_manifest_absent",
+        "release_manifest_architecture_mismatch",
+        "release_manifest_hash_mismatch",
+        "release_manifest_insecure_permissions",
+        "release_manifest_invalid",
+        "release_manifest_path_escape",
+        "release_manifest_platform_mismatch",
+        "release_manifest_unsigned",
+        "release_manifest_untrusted_key",
+        "release_manifest_valid",
+        "release_manifest_wrong_owner",
+        "release_runtime_insecure_permissions",
+        "release_runtime_wrong_owner",
+        "native_install_valid",
+        "native_package_identity_absent",
+        "native_package_receipt_absent",
+        "native_platform_unsupported",
+        "native_publisher_signature_invalid",
+        "managed_policy_active",
+        "managed_policy_absent",
+        "managed_policy_cache_invalid",
+        "managed_policy_cache_tampered",
+        "managed_policy_inaccessible",
+        "managed_policy_invalid",
+        "managed_policy_profile_removed_cached",
+        "ownership_acl_verification_unavailable",
+        "supervisor_verification_unavailable",
+        "device_key_verification_unavailable",
+        "harness_coverage_verification_unavailable",
+        "installation_identity_verification_unavailable",
+        "lease_continuity_verification_unavailable",
+        "daemon_verification_unavailable",
+        "command_shadowing_verification_unavailable",
+        "update_verification_unavailable",
+        "integrity_reason_unrecognized",
+        "release_manifest_probe_failed",
+        "native_install_probe_failed",
+        "managed_policy_probe_failed"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {"properties": {"healthy": {"const": true}}, "required": ["healthy"]},
+      "then": {
+        "properties": {
+          "components": {
+            "properties": {
+              "manifest": {"$ref": "#/$defs/healthyComponent"},
+              "nativePackage": {"$ref": "#/$defs/healthyComponent"},
+              "managedPolicy": {"$ref": "#/$defs/healthyComponent"},
+              "ownershipAndAcl": {"$ref": "#/$defs/healthyComponent"},
+              "supervisor": {"$ref": "#/$defs/healthyComponent"},
+              "deviceKey": {"$ref": "#/$defs/healthyComponent"},
+              "harnessCoverage": {"$ref": "#/$defs/healthyComponent"},
+              "installationIdentity": {"$ref": "#/$defs/healthyComponent"},
+              "leaseContinuity": {"$ref": "#/$defs/healthyComponent"},
+              "daemon": {"$ref": "#/$defs/healthyComponent"},
+              "commandShadowing": {"$ref": "#/$defs/healthyComponent"},
+              "update": {"$ref": "#/$defs/healthyComponent"}
+            }
+          },
+          "reasonCodes": {"maxItems": 0},
+          "remediationClass": {"const": "none"}
+        }
+      }
+    }
+  ]
+}

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_mdm.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_mdm.py
@@ -6,6 +6,7 @@ import argparse
 import json
 from pathlib import Path
 
+from ..mdm.integrity import machine_integrity_snapshot
 from ..mdm.lifecycle import (
     activate_user,
     authorize_deactivation,
@@ -52,6 +53,8 @@ def _run_guard_mdm_command(
             payload["healthy"] = all(
                 isinstance(result, dict) and result.get("reasonCode") == "endpoint_reachable" for result in results
             )
+        elif command == "integrity-snapshot":
+            payload = machine_integrity_snapshot()
         elif command == "status" and args.scope == "machine":
             root = Path(args.machine_root).resolve() if getattr(args, "machine_root", None) else None
             payload = machine_status(machine_root=root)

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_mdm.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_mdm.py
@@ -27,6 +27,14 @@ def _configure_guard_mdm_parsers(
     status.add_argument("--machine-root", help="Machine runtime root override for test and remediation scripts")
     _add_json(status)
 
+    integrity_snapshot = commands.add_parser(
+        "integrity-snapshot", help="Read a fail-honest local machine integrity snapshot"
+    )
+    integrity_snapshot.add_argument("--scope", required=True, choices=("machine",))
+    integrity_snapshot.add_argument(
+        "--json", required=True, action="store_true", help="Emit the versioned JSON automation contract"
+    )
+
     for name in ("activate", "repair"):
         command = commands.add_parser(name, help=f"Idempotently {name} Guard for one user")
         _add_user(command, require_user=True)

--- a/src/codex_plugin_scanner/guard/mdm/__init__.py
+++ b/src/codex_plugin_scanner/guard/mdm/__init__.py
@@ -1,6 +1,7 @@
 """Enterprise MDM contracts for machine-owned HOL Guard installations."""
 
 from .contracts import (
+    LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION,
     MDM_POLICY_SCHEMA_VERSION,
     MDM_STATUS_SCHEMA_VERSION,
     RELEASE_MANIFEST_SCHEMA_VERSION,
@@ -9,10 +10,12 @@ from .contracts import (
     ManagedPolicyState,
     default_machine_paths,
 )
+from .integrity import machine_integrity_snapshot
 from .manifest import verify_release_manifest
 from .policy import apply_managed_policy, load_managed_policy
 
 __all__ = [
+    "LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION",
     "MDM_POLICY_SCHEMA_VERSION",
     "MDM_STATUS_SCHEMA_VERSION",
     "RELEASE_MANIFEST_SCHEMA_VERSION",
@@ -22,5 +25,6 @@ __all__ = [
     "apply_managed_policy",
     "default_machine_paths",
     "load_managed_policy",
+    "machine_integrity_snapshot",
     "verify_release_manifest",
 ]

--- a/src/codex_plugin_scanner/guard/mdm/contracts.py
+++ b/src/codex_plugin_scanner/guard/mdm/contracts.py
@@ -7,15 +7,192 @@ import json
 import platform
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
+from typing import Literal, TypedDict
 
 MDM_POLICY_SCHEMA_VERSION = "hol-guard-mdm-policy.v1"
 MDM_STATUS_SCHEMA_VERSION = "hol-guard-mdm-status.v1"
 RELEASE_MANIFEST_SCHEMA_VERSION = "hol-guard-release-manifest.v1"
+LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION = "local-integrity-snapshot.v1"
 
 InstallOwner = Literal["user", "mdm"]
 ProxyMode = Literal["system", "explicit", "none"]
 ManagedPolicyStatus = Literal["absent", "active", "invalid", "inaccessible", "tampered"]
+AssuranceLevel = Literal["user-managed", "mdm-managed-unverified", "mdm-managed"]
+IntegrityState = Literal["healthy", "degraded", "absent", "tampered", "unsupported", "unknown"]
+KeyProtectionLevel = Literal["hardware-backed", "os-protected", "file-backed", "unavailable", "unknown"]
+SupervisorState = Literal["running", "stopped", "disabled", "absent", "unsupported", "unknown"]
+RemediationClass = Literal["none", "user-reinstall", "mdm-repair", "administrator-action"]
+IntegrityReasonCode = Literal[
+    "release_manifest_absent",
+    "release_manifest_architecture_mismatch",
+    "release_manifest_hash_mismatch",
+    "release_manifest_insecure_permissions",
+    "release_manifest_invalid",
+    "release_manifest_path_escape",
+    "release_manifest_platform_mismatch",
+    "release_manifest_unsigned",
+    "release_manifest_untrusted_key",
+    "release_manifest_valid",
+    "release_manifest_wrong_owner",
+    "release_runtime_insecure_permissions",
+    "release_runtime_wrong_owner",
+    "native_install_valid",
+    "native_package_identity_absent",
+    "native_package_receipt_absent",
+    "native_platform_unsupported",
+    "native_publisher_signature_invalid",
+    "managed_policy_active",
+    "managed_policy_absent",
+    "managed_policy_cache_invalid",
+    "managed_policy_cache_tampered",
+    "managed_policy_inaccessible",
+    "managed_policy_invalid",
+    "managed_policy_profile_removed_cached",
+    "ownership_acl_verification_unavailable",
+    "supervisor_verification_unavailable",
+    "device_key_verification_unavailable",
+    "harness_coverage_verification_unavailable",
+    "installation_identity_verification_unavailable",
+    "lease_continuity_verification_unavailable",
+    "daemon_verification_unavailable",
+    "command_shadowing_verification_unavailable",
+    "update_verification_unavailable",
+    "integrity_reason_unrecognized",
+    "release_manifest_probe_failed",
+    "native_install_probe_failed",
+    "managed_policy_probe_failed",
+]
+
+
+class SnapshotComponent(TypedDict):
+    state: IntegrityState
+    healthy: bool
+    reasonCode: IntegrityReasonCode
+
+
+class SnapshotKeyComponent(TypedDict):
+    state: IntegrityState
+    healthy: bool
+    level: KeyProtectionLevel
+    reasonCode: IntegrityReasonCode
+
+
+class SnapshotSupervisorComponent(TypedDict):
+    state: SupervisorState
+    healthy: bool
+    reasonCode: IntegrityReasonCode
+
+
+@dataclass(frozen=True, slots=True)
+class IntegrityComponent:
+    state: IntegrityState
+    reason_code: IntegrityReasonCode
+
+    @property
+    def healthy(self) -> bool:
+        return self.state == "healthy"
+
+    def to_dict(self) -> SnapshotComponent:
+        return {"state": self.state, "healthy": self.healthy, "reasonCode": self.reason_code}
+
+
+@dataclass(frozen=True, slots=True)
+class KeyProtectionStatus:
+    state: IntegrityState
+    level: KeyProtectionLevel
+    reason_code: IntegrityReasonCode
+
+    @property
+    def healthy(self) -> bool:
+        return self.state == "healthy"
+
+    def to_dict(self) -> SnapshotKeyComponent:
+        return {
+            "state": self.state,
+            "healthy": self.healthy,
+            "level": self.level,
+            "reasonCode": self.reason_code,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SupervisorStatus:
+    state: SupervisorState
+    reason_code: IntegrityReasonCode
+
+    @property
+    def healthy(self) -> bool:
+        return self.state == "running"
+
+    def to_dict(self) -> SnapshotSupervisorComponent:
+        return {
+            "state": self.state,
+            "healthy": self.healthy,
+            "reasonCode": self.reason_code,
+        }
+
+
+class SnapshotProduct(TypedDict):
+    version: str
+    buildId: str | None
+    sourceCommit: str | None
+    packageIdentity: str
+    manifestHash: str | None
+    policyHash: str | None
+
+
+class SnapshotIdentifiers(TypedDict):
+    workspaceId: str | None
+    deviceId: str | None
+    machineInstallationId: str | None
+    installationGeneration: str | None
+
+
+class SnapshotContinuity(TypedDict):
+    monotonicUptimeSeconds: float | None
+    sequence: int | None
+    previousLeaseDigest: str | None
+    bootSessionId: str | None
+
+
+class HarnessCoverage(TypedDict):
+    required: int | None
+    protected: int | None
+    degraded: int | None
+    missing: int | None
+
+
+class SnapshotComponents(TypedDict):
+    manifest: SnapshotComponent
+    nativePackage: SnapshotComponent
+    managedPolicy: SnapshotComponent
+    ownershipAndAcl: SnapshotComponent
+    supervisor: SnapshotSupervisorComponent
+    deviceKey: SnapshotKeyComponent
+    harnessCoverage: SnapshotComponent
+    installationIdentity: SnapshotComponent
+    leaseContinuity: SnapshotComponent
+    daemon: SnapshotComponent
+    commandShadowing: SnapshotComponent
+    update: SnapshotComponent
+
+
+class LocalIntegritySnapshot(TypedDict):
+    schemaVersion: Literal["local-integrity-snapshot.v1"]
+    generatedAt: str
+    scope: Literal["machine"]
+    healthy: bool
+    assuranceLevel: AssuranceLevel
+    installOwner: InstallOwner
+    platform: str
+    architecture: str
+    identifiers: SnapshotIdentifiers
+    product: SnapshotProduct
+    components: SnapshotComponents
+    harnessCoverage: HarnessCoverage
+    continuity: SnapshotContinuity
+    reasonCodes: list[IntegrityReasonCode]
+    remediationClass: RemediationClass
 
 
 @dataclass(frozen=True, slots=True)
@@ -162,15 +339,34 @@ def canonical_payload_hash(payload: dict[str, object]) -> str:
 
 
 __all__ = [
+    "LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION",
     "MDM_POLICY_SCHEMA_VERSION",
     "MDM_STATUS_SCHEMA_VERSION",
     "RELEASE_MANIFEST_SCHEMA_VERSION",
+    "AssuranceLevel",
+    "HarnessCoverage",
     "InstallOwner",
+    "IntegrityComponent",
+    "IntegrityReasonCode",
+    "IntegrityState",
+    "KeyProtectionLevel",
+    "KeyProtectionStatus",
+    "LocalIntegritySnapshot",
     "MachinePaths",
     "ManagedNetworkPolicy",
     "ManagedPolicy",
     "ManagedPolicyState",
     "ManagedUpdatePolicy",
+    "RemediationClass",
+    "SnapshotComponent",
+    "SnapshotComponents",
+    "SnapshotContinuity",
+    "SnapshotIdentifiers",
+    "SnapshotKeyComponent",
+    "SnapshotProduct",
+    "SnapshotSupervisorComponent",
+    "SupervisorState",
+    "SupervisorStatus",
     "canonical_payload_hash",
     "default_machine_paths",
 ]

--- a/src/codex_plugin_scanner/guard/mdm/integrity.py
+++ b/src/codex_plugin_scanner/guard/mdm/integrity.py
@@ -51,14 +51,25 @@ def _assurance_level(*, update_owner: str) -> AssuranceLevel:
     return "user-managed"
 
 
-def _remediation_class(assurance_level: AssuranceLevel, states: list[str]) -> RemediationClass:
-    if all(state == "healthy" for state in states):
+def _remediation_class(assurance_level: AssuranceLevel, healthy: bool, states: list[str]) -> RemediationClass:
+    if healthy:
         return "none"
     if "tampered" in states:
         return "administrator-action"
     if assurance_level != "user-managed":
         return "mdm-repair"
     return "user-reinstall"
+
+
+def _trusted_product_version(
+    manifest: ManifestVerification,
+    native: NativeInstallVerification,
+) -> str:
+    if manifest.healthy and manifest.version is not None:
+        return manifest.version
+    if native.healthy and native.version is not None:
+        return native.version
+    return __version__
 
 
 def _bounded_file_hash(path: Path) -> str | None:
@@ -115,6 +126,8 @@ def machine_integrity_snapshot() -> LocalIntegritySnapshot:
     manifest_component = _component(manifest.status, manifest.reason_code)
     native_component = _component(native.status, native.reason_code)
     policy_state = "healthy" if policy.status == "active" else policy.status
+    if policy_state in {"invalid", "inaccessible"}:
+        policy_state = "degraded"
     if policy.reason_code == "managed_policy_profile_removed_cached":
         policy_state = "degraded"
     policy_component = _component(
@@ -177,7 +190,7 @@ def machine_integrity_snapshot() -> LocalIntegritySnapshot:
         list[IntegrityReasonCode],
         sorted({component.reason_code for component in component_results if not component.healthy}),
     )
-    healthy = all(state == "healthy" for state in states)
+    healthy = all(component.healthy for component in component_results)
     return {
         "schemaVersion": LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION,
         "generatedAt": _now(),
@@ -194,13 +207,7 @@ def machine_integrity_snapshot() -> LocalIntegritySnapshot:
             "installationGeneration": None,
         },
         "product": {
-            "version": (
-                manifest.version
-                if manifest.healthy and manifest.version is not None
-                else native.version
-                if native.healthy and native.version is not None
-                else __version__
-            ),
+            "version": _trusted_product_version(manifest, native),
             "buildId": manifest.build_id if manifest.healthy else None,
             "sourceCommit": None,
             "packageIdentity": native.package_identity,
@@ -216,7 +223,7 @@ def machine_integrity_snapshot() -> LocalIntegritySnapshot:
             "bootSessionId": None,
         },
         "reasonCodes": reason_codes,
-        "remediationClass": _remediation_class(assurance_level, states),
+        "remediationClass": _remediation_class(assurance_level, healthy, states),
     }
 
 

--- a/src/codex_plugin_scanner/guard/mdm/integrity.py
+++ b/src/codex_plugin_scanner/guard/mdm/integrity.py
@@ -1,0 +1,223 @@
+"""Fail-honest, read-only local integrity snapshot construction."""
+
+from __future__ import annotations
+
+import hashlib
+import platform
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast, get_args
+
+from ...version import __version__
+from .contracts import (
+    LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION,
+    AssuranceLevel,
+    IntegrityComponent,
+    IntegrityReasonCode,
+    IntegrityState,
+    KeyProtectionStatus,
+    LocalIntegritySnapshot,
+    MachinePaths,
+    ManagedPolicyState,
+    RemediationClass,
+    SnapshotComponents,
+    SupervisorStatus,
+    default_machine_paths,
+)
+from .lifecycle import load_trusted_keys
+from .manifest import ManifestVerification, verify_release_manifest
+from .native import NativeInstallVerification, verify_native_install
+from .policy import load_managed_policy
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _component(state: str, reason_code: str) -> IntegrityComponent:
+    normalized = (
+        state if state in {"healthy", "degraded", "absent", "tampered", "unsupported", "unknown"} else "unknown"
+    )
+    normalized_reason = reason_code if reason_code in get_args(IntegrityReasonCode) else "integrity_reason_unrecognized"
+    return IntegrityComponent(
+        cast(IntegrityState, normalized),
+        cast(IntegrityReasonCode, normalized_reason),
+    )
+
+
+def _assurance_level(*, update_owner: str) -> AssuranceLevel:
+    if update_owner == "mdm":
+        return "mdm-managed-unverified"
+    return "user-managed"
+
+
+def _remediation_class(assurance_level: AssuranceLevel, states: list[str]) -> RemediationClass:
+    if all(state == "healthy" for state in states):
+        return "none"
+    if "tampered" in states:
+        return "administrator-action"
+    if assurance_level != "user-managed":
+        return "mdm-repair"
+    return "user-reinstall"
+
+
+def _bounded_file_hash(path: Path) -> str | None:
+    try:
+        if path.is_symlink() or not path.is_file() or path.stat().st_size > 1024 * 1024:
+            return None
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _verify_manifest(paths: MachinePaths, trusted_keys: dict[str, bytes]) -> ManifestVerification:
+    try:
+        return verify_release_manifest(
+            paths.manifest_path,
+            paths.runtime_root,
+            trusted_keys=trusted_keys,
+            expected_platform={"Darwin": "macos", "Windows": "windows"}.get(platform.system()),
+            expected_architecture=platform.machine().lower(),
+            expected_owner_uid=0 if platform.system() != "Windows" else None,
+        )
+    except Exception:
+        return ManifestVerification("unknown", "release_manifest_probe_failed")
+
+
+def _verify_native(runtime_root: Path) -> NativeInstallVerification:
+    try:
+        return verify_native_install(runtime_root)
+    except Exception:
+        return NativeInstallVerification("unknown", "native_install_probe_failed", "unknown", "unknown")
+
+
+def _load_policy() -> ManagedPolicyState:
+    try:
+        return load_managed_policy(write_cache=False)
+    except Exception:
+        return ManagedPolicyState("inaccessible", "native", reason_code="managed_policy_probe_failed")
+
+
+def machine_integrity_snapshot() -> LocalIntegritySnapshot:
+    """Return bounded machine evidence without trusting environment path overrides."""
+
+    paths = default_machine_paths()
+    runtime_root = paths.runtime_root
+    trusted_keys = load_trusted_keys(runtime_root / "release-trusted-keys.json")
+    manifest = _verify_manifest(paths, trusted_keys)
+    native = _verify_native(runtime_root)
+    policy = _load_policy()
+    update_owner = policy.policy.install_owner if policy.policy is not None else "user"
+    if policy.policy is None and policy.status in {"invalid", "inaccessible", "tampered"}:
+        update_owner = "mdm"
+    assurance_level = _assurance_level(update_owner=update_owner)
+
+    manifest_component = _component(manifest.status, manifest.reason_code)
+    native_component = _component(native.status, native.reason_code)
+    policy_state = "healthy" if policy.status == "active" else policy.status
+    if policy.reason_code == "managed_policy_profile_removed_cached":
+        policy_state = "degraded"
+    policy_component = _component(
+        policy_state,
+        policy.reason_code or ("managed_policy_active" if policy.status == "active" else "managed_policy_absent"),
+    )
+    ownership_acl = IntegrityComponent("unsupported", "ownership_acl_verification_unavailable")
+    supervisor = SupervisorStatus("unsupported", "supervisor_verification_unavailable")
+    device_key = KeyProtectionStatus("unsupported", "unavailable", "device_key_verification_unavailable")
+    harness_coverage = IntegrityComponent("unsupported", "harness_coverage_verification_unavailable")
+    installation_identity = IntegrityComponent("unsupported", "installation_identity_verification_unavailable")
+    lease_continuity = IntegrityComponent("unsupported", "lease_continuity_verification_unavailable")
+    daemon = IntegrityComponent("unsupported", "daemon_verification_unavailable")
+    command_shadowing = IntegrityComponent("unsupported", "command_shadowing_verification_unavailable")
+    update = IntegrityComponent("unsupported", "update_verification_unavailable")
+
+    components: SnapshotComponents = {
+        "manifest": manifest_component.to_dict(),
+        "nativePackage": native_component.to_dict(),
+        "managedPolicy": policy_component.to_dict(),
+        "ownershipAndAcl": ownership_acl.to_dict(),
+        "supervisor": supervisor.to_dict(),
+        "deviceKey": device_key.to_dict(),
+        "harnessCoverage": harness_coverage.to_dict(),
+        "installationIdentity": installation_identity.to_dict(),
+        "leaseContinuity": lease_continuity.to_dict(),
+        "daemon": daemon.to_dict(),
+        "commandShadowing": command_shadowing.to_dict(),
+        "update": update.to_dict(),
+    }
+    states = [
+        manifest_component.state,
+        native_component.state,
+        policy_component.state,
+        ownership_acl.state,
+        supervisor.state,
+        device_key.state,
+        harness_coverage.state,
+        installation_identity.state,
+        lease_continuity.state,
+        daemon.state,
+        command_shadowing.state,
+        update.state,
+    ]
+    component_results = (
+        manifest_component,
+        native_component,
+        policy_component,
+        ownership_acl,
+        supervisor,
+        device_key,
+        harness_coverage,
+        installation_identity,
+        lease_continuity,
+        daemon,
+        command_shadowing,
+        update,
+    )
+    reason_codes = cast(
+        list[IntegrityReasonCode],
+        sorted({component.reason_code for component in component_results if not component.healthy}),
+    )
+    healthy = all(state == "healthy" for state in states)
+    return {
+        "schemaVersion": LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION,
+        "generatedAt": _now(),
+        "scope": "machine",
+        "healthy": healthy,
+        "assuranceLevel": assurance_level,
+        "installOwner": update_owner,
+        "platform": platform.system().lower(),
+        "architecture": platform.machine().lower(),
+        "identifiers": {
+            "workspaceId": None,
+            "deviceId": None,
+            "machineInstallationId": None,
+            "installationGeneration": None,
+        },
+        "product": {
+            "version": (
+                manifest.version
+                if manifest.healthy and manifest.version is not None
+                else native.version
+                if native.healthy and native.version is not None
+                else __version__
+            ),
+            "buildId": manifest.build_id if manifest.healthy else None,
+            "sourceCommit": None,
+            "packageIdentity": native.package_identity,
+            "manifestHash": _bounded_file_hash(paths.manifest_path),
+            "policyHash": policy.policy.content_hash if policy.policy is not None else None,
+        },
+        "components": components,
+        "harnessCoverage": {"required": None, "protected": None, "degraded": None, "missing": None},
+        "continuity": {
+            "monotonicUptimeSeconds": None,
+            "sequence": None,
+            "previousLeaseDigest": None,
+            "bootSessionId": None,
+        },
+        "reasonCodes": reason_codes,
+        "remediationClass": _remediation_class(assurance_level, states),
+    }
+
+
+__all__ = ["machine_integrity_snapshot"]

--- a/src/codex_plugin_scanner/guard/mdm/integrity.py
+++ b/src/codex_plugin_scanner/guard/mdm/integrity.py
@@ -65,6 +65,8 @@ def _trusted_product_version(
     manifest: ManifestVerification,
     native: NativeInstallVerification,
 ) -> str:
+    """Return public installed-version metadata only after its verification boundary passes."""
+
     if manifest.healthy and manifest.version is not None:
         return manifest.version
     if native.healthy and native.version is not None:

--- a/src/codex_plugin_scanner/guard/mdm/integrity.py
+++ b/src/codex_plugin_scanner/guard/mdm/integrity.py
@@ -24,7 +24,7 @@ from .contracts import (
     SupervisorStatus,
     default_machine_paths,
 )
-from .lifecycle import load_trusted_keys
+from .lifecycle import load_trusted_public_keys
 from .manifest import ManifestVerification, verify_release_manifest
 from .native import NativeInstallVerification, verify_native_install
 from .policy import load_managed_policy
@@ -81,12 +81,13 @@ def _bounded_file_hash(path: Path) -> str | None:
         return None
 
 
-def _verify_manifest(paths: MachinePaths, trusted_keys: dict[str, bytes]) -> ManifestVerification:
+def _verify_manifest(paths: MachinePaths) -> ManifestVerification:
     try:
+        trusted_public_keys = load_trusted_public_keys(paths.runtime_root / "release-trusted-keys.json")
         return verify_release_manifest(
             paths.manifest_path,
             paths.runtime_root,
-            trusted_keys=trusted_keys,
+            trusted_keys=trusted_public_keys,
             expected_platform={"Darwin": "macos", "Windows": "windows"}.get(platform.system()),
             expected_architecture=platform.machine().lower(),
             expected_owner_uid=0 if platform.system() != "Windows" else None,
@@ -114,8 +115,7 @@ def machine_integrity_snapshot() -> LocalIntegritySnapshot:
 
     paths = default_machine_paths()
     runtime_root = paths.runtime_root
-    trusted_keys = load_trusted_keys(runtime_root / "release-trusted-keys.json")
-    manifest = _verify_manifest(paths, trusted_keys)
+    manifest = _verify_manifest(paths)
     native = _verify_native(runtime_root)
     policy = _load_policy()
     update_owner = policy.policy.install_owner if policy.policy is not None else "user"

--- a/src/codex_plugin_scanner/guard/mdm/lifecycle.py
+++ b/src/codex_plugin_scanner/guard/mdm/lifecycle.py
@@ -213,7 +213,7 @@ def _activation_lock(guard_home: Path) -> Iterator[None]:
         os.close(descriptor)
 
 
-def load_trusted_keys(path: Path) -> dict[str, bytes]:
+def load_trusted_public_keys(path: Path) -> dict[str, bytes]:
     trusted_keys: dict[str, bytes] = {}
     try:
         if not path.is_file() or path.is_symlink() or path.stat().st_size > 64 * 1024:
@@ -240,7 +240,7 @@ def machine_status(
     runtime_root = (machine_root or paths.runtime_root).resolve()
     manifest_path = runtime_root / "release-manifest.json"
     trusted_keys_path = runtime_root / "release-trusted-keys.json"
-    trusted_keys = load_trusted_keys(trusted_keys_path)
+    trusted_keys = load_trusted_public_keys(trusted_keys_path)
     expected_platform = {"Darwin": "macos", "Windows": "windows"}.get(platform.system())
     verification = verify_release_manifest(
         manifest_path,
@@ -415,7 +415,7 @@ __all__ = [
     "activate_user",
     "authorize_deactivation",
     "deactivate_user",
-    "load_trusted_keys",
+    "load_trusted_public_keys",
     "machine_status",
     "repair_user",
     "user_status",

--- a/src/codex_plugin_scanner/guard/mdm/lifecycle.py
+++ b/src/codex_plugin_scanner/guard/mdm/lifecycle.py
@@ -213,11 +213,11 @@ def _activation_lock(guard_home: Path) -> Iterator[None]:
         os.close(descriptor)
 
 
-def _load_trusted_keys(path: Path) -> dict[str, bytes]:
+def load_trusted_keys(path: Path) -> dict[str, bytes]:
     trusted_keys: dict[str, bytes] = {}
-    if not path.is_file():
-        return trusted_keys
     try:
+        if not path.is_file() or path.is_symlink() or path.stat().st_size > 64 * 1024:
+            return trusted_keys
         raw_keys = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return trusted_keys
@@ -240,7 +240,7 @@ def machine_status(
     runtime_root = (machine_root or paths.runtime_root).resolve()
     manifest_path = runtime_root / "release-manifest.json"
     trusted_keys_path = runtime_root / "release-trusted-keys.json"
-    trusted_keys = _load_trusted_keys(trusted_keys_path)
+    trusted_keys = load_trusted_keys(trusted_keys_path)
     expected_platform = {"Darwin": "macos", "Windows": "windows"}.get(platform.system())
     verification = verify_release_manifest(
         manifest_path,
@@ -415,6 +415,7 @@ __all__ = [
     "activate_user",
     "authorize_deactivation",
     "deactivate_user",
+    "load_trusted_keys",
     "machine_status",
     "repair_user",
     "user_status",

--- a/src/codex_plugin_scanner/guard/mdm/policy.py
+++ b/src/codex_plugin_scanner/guard/mdm/policy.py
@@ -231,7 +231,12 @@ def _load_policy_cache(system_name: str) -> ManagedPolicyState | None:
         )
 
 
-def load_managed_policy(*, policy_path: Path | None = None, system_name: str | None = None) -> ManagedPolicyState:
+def load_managed_policy(
+    *,
+    policy_path: Path | None = None,
+    system_name: str | None = None,
+    write_cache: bool = True,
+) -> ManagedPolicyState:
     """Load machine authority only from an explicit test path or native machine source."""
 
     resolved_system = system_name or platform.system()
@@ -256,7 +261,7 @@ def load_managed_policy(*, policy_path: Path | None = None, system_name: str | N
                 return cached or ManagedPolicyState("absent", source, reason_code="managed_policy_absent")
             payload = _read_policy_file(native_path)
         policy = parse_managed_policy(payload)
-        if policy_path is None:
+        if policy_path is None and write_cache:
             _write_policy_cache(payload, resolved_system)
         return ManagedPolicyState("active", source, policy=policy)
     except PermissionError:

--- a/tests/test_guard_mdm_integrity.py
+++ b/tests/test_guard_mdm_integrity.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from codex_plugin_scanner import cli
+from codex_plugin_scanner.guard.cli import commands_dispatch_mdm
+from codex_plugin_scanner.guard.mdm import integrity
+from codex_plugin_scanner.guard.mdm.contracts import (
+    MDM_POLICY_SCHEMA_VERSION,
+    MachinePaths,
+    ManagedPolicy,
+    ManagedPolicyState,
+    ManagedUpdatePolicy,
+)
+from codex_plugin_scanner.guard.mdm.manifest import ManifestVerification
+from codex_plugin_scanner.guard.mdm.native import NativeInstallVerification
+from codex_plugin_scanner.version import __version__
+
+
+@pytest.fixture(autouse=True)
+def _isolate_host_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        integrity,
+        "load_managed_policy",
+        lambda **_kwargs: ManagedPolicyState("absent", "native", reason_code="managed_policy_absent"),
+    )
+
+
+def _paths(root: Path) -> MachinePaths:
+    return MachinePaths(
+        runtime_root=root / "runtime",
+        state_root=root / "state",
+        policy_path=root / "policy.json",
+        log_root=root / "logs",
+        manifest_path=root / "runtime" / "release-manifest.json",
+    )
+
+
+def test_snapshot_is_fail_honest_and_schema_valid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(integrity, "default_machine_paths", lambda: _paths(tmp_path))
+    snapshot = integrity.machine_integrity_snapshot()
+
+    schema_path = Path(__file__).parents[1] / "docs" / "guard" / "schemas" / "local-integrity-snapshot-v1.schema.json"
+    schema = json.loads(schema_path.read_text())
+    Draft202012Validator(schema).validate(snapshot)
+
+    assert snapshot["healthy"] is False
+    assert snapshot["assuranceLevel"] == "user-managed"
+    components = snapshot["components"]
+    assert isinstance(components, dict)
+    assert components["ownershipAndAcl"]["state"] == "unsupported"
+    assert components["supervisor"]["state"] == "unsupported"
+    assert components["deviceKey"]["level"] == "unavailable"
+    assert snapshot["reasonCodes"] == sorted(snapshot["reasonCodes"])
+
+    contradictory = json.loads(json.dumps(snapshot))
+    contradictory["components"]["manifest"]["healthy"] = True
+    assert list(Draft202012Validator(schema).iter_errors(contradictory))
+
+    contradictory = json.loads(json.dumps(snapshot))
+    contradictory["healthy"] = True
+    contradictory["reasonCodes"] = []
+    contradictory["remediationClass"] = "none"
+    assert list(Draft202012Validator(schema).iter_errors(contradictory))
+
+
+def test_snapshot_never_upgrades_incomplete_managed_evidence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(integrity, "default_machine_paths", lambda: _paths(tmp_path))
+    monkeypatch.setattr(
+        integrity,
+        "verify_release_manifest",
+        lambda *_args, **_kwargs: ManifestVerification("healthy", "release_manifest_valid", "3.1.0a1", "b1"),
+    )
+    monkeypatch.setattr(
+        integrity,
+        "verify_native_install",
+        lambda *_args, **_kwargs: NativeInstallVerification(
+            "healthy", "native_install_valid", "org.hol.guard", "valid", "3.1.0a1"
+        ),
+    )
+    monkeypatch.setattr(
+        integrity,
+        "load_managed_policy",
+        lambda **_kwargs: ManagedPolicyState("absent", "native", reason_code="managed_policy_absent"),
+    )
+
+    snapshot = integrity.machine_integrity_snapshot()
+
+    assert snapshot["assuranceLevel"] == "user-managed"
+    assert snapshot["healthy"] is False
+    assert snapshot["remediationClass"] == "user-reinstall"
+
+
+def test_snapshot_preserves_cached_managed_authority(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    managed_policy = ManagedPolicy(
+        schema_version=MDM_POLICY_SCHEMA_VERSION,
+        settings={},
+        locked_settings=frozenset(),
+        update=ManagedUpdatePolicy(owner="mdm"),
+    )
+    monkeypatch.setattr(integrity, "default_machine_paths", lambda: _paths(tmp_path))
+    monkeypatch.setattr(
+        integrity,
+        "load_managed_policy",
+        lambda **_kwargs: ManagedPolicyState(
+            "active",
+            "native-cache",
+            policy=managed_policy,
+            reason_code="managed_policy_profile_removed_cached",
+        ),
+    )
+
+    snapshot = integrity.machine_integrity_snapshot()
+
+    assert snapshot["installOwner"] == "mdm"
+    assert snapshot["assuranceLevel"] == "mdm-managed-unverified"
+    assert snapshot["remediationClass"] == "mdm-repair"
+    assert "managed_policy_profile_removed_cached" in snapshot["reasonCodes"]
+
+
+def test_snapshot_normalizes_probe_failures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(integrity, "default_machine_paths", lambda: _paths(tmp_path))
+    monkeypatch.setattr(integrity, "verify_release_manifest", lambda *_args, **_kwargs: 1 / 0)
+    monkeypatch.setattr(integrity, "verify_native_install", lambda *_args, **_kwargs: 1 / 0)
+    monkeypatch.setattr(integrity, "load_managed_policy", lambda **_kwargs: 1 / 0)
+
+    snapshot = integrity.machine_integrity_snapshot()
+
+    assert snapshot["schemaVersion"] == "local-integrity-snapshot.v1"
+    assert snapshot["healthy"] is False
+    assert "release_manifest_probe_failed" in snapshot["reasonCodes"]
+    assert "native_install_probe_failed" in snapshot["reasonCodes"]
+    assert "managed_policy_probe_failed" in snapshot["reasonCodes"]
+    assert snapshot["installOwner"] == "mdm"
+
+
+def test_snapshot_loads_policy_without_writing_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_load_policy(**kwargs: object) -> ManagedPolicyState:
+        calls.append(kwargs)
+        return ManagedPolicyState("absent", "native", reason_code="managed_policy_absent")
+
+    monkeypatch.setattr(integrity, "default_machine_paths", lambda: _paths(tmp_path))
+    monkeypatch.setattr(integrity, "load_managed_policy", fake_load_policy)
+
+    integrity.machine_integrity_snapshot()
+
+    assert calls == [{"write_cache": False}]
+
+
+def test_snapshot_does_not_promote_unverified_manifest_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(integrity, "default_machine_paths", lambda: _paths(tmp_path))
+    monkeypatch.setattr(
+        integrity,
+        "verify_release_manifest",
+        lambda *_args, **_kwargs: ManifestVerification(
+            "tampered",
+            "release_manifest_unsigned",
+            "999.0.0",
+            "attacker-build",
+        ),
+    )
+    monkeypatch.setattr(
+        integrity,
+        "verify_native_install",
+        lambda *_args, **_kwargs: NativeInstallVerification(
+            "absent", "native_package_receipt_absent", "org.hol.guard", "unknown"
+        ),
+    )
+
+    snapshot = integrity.machine_integrity_snapshot()
+
+    assert snapshot["product"]["version"] == __version__
+    assert snapshot["product"]["buildId"] is None
+
+
+def test_integrity_snapshot_cli_is_read_only_and_redacted(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(integrity, "default_machine_paths", lambda: _paths(tmp_path))
+    exit_code = cli.main(["mdm", "integrity-snapshot", "--scope", "machine", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    serialized = json.dumps(payload, sort_keys=True)
+
+    assert exit_code == 1
+    assert payload["schemaVersion"] == "local-integrity-snapshot.v1"
+    assert str(tmp_path) not in serialized
+    assert "home" not in serialized.casefold()
+    assert "username" not in serialized.casefold()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_integrity_snapshot_cli_does_not_accept_machine_path_override(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as error:
+        cli.main(
+            [
+                "mdm",
+                "integrity-snapshot",
+                "--scope",
+                "machine",
+                "--machine-root",
+                str(tmp_path),
+                "--json",
+            ]
+        )
+    assert error.value.code == 2
+
+
+def test_integrity_snapshot_cli_requires_json() -> None:
+    with pytest.raises(SystemExit) as error:
+        cli.main(["mdm", "integrity-snapshot", "--scope", "machine"])
+    assert error.value.code == 2
+
+
+def test_cli_dispatch_emits_snapshot_contract(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    expected = {
+        "schemaVersion": "local-integrity-snapshot.v1",
+        "healthy": False,
+        "reasonCodes": ["supervisor_verification_unavailable"],
+    }
+    monkeypatch.setattr(commands_dispatch_mdm, "machine_integrity_snapshot", lambda: expected)
+
+    exit_code = cli.main(["mdm", "integrity-snapshot", "--scope", "machine", "--json"])
+
+    assert exit_code == 1
+    assert json.loads(capsys.readouterr().out) == expected

--- a/tests/test_guard_mdm_integrity.py
+++ b/tests/test_guard_mdm_integrity.py
@@ -94,6 +94,7 @@ def test_snapshot_never_upgrades_incomplete_managed_evidence(tmp_path: Path, mon
     assert snapshot["assuranceLevel"] == "user-managed"
     assert snapshot["healthy"] is False
     assert snapshot["remediationClass"] == "user-reinstall"
+    assert snapshot["product"]["version"] == "3.1.0a1"
 
 
 def test_snapshot_preserves_cached_managed_authority(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_guard_mdm_integrity.py
+++ b/tests/test_guard_mdm_integrity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 from pathlib import Path
 
@@ -200,6 +201,20 @@ def test_integrity_snapshot_cli_is_read_only_and_redacted(
     assert "home" not in serialized.casefold()
     assert "username" not in serialized.casefold()
     assert list(tmp_path.iterdir()) == []
+
+
+def test_snapshot_never_serializes_release_verification_keys(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths = _paths(tmp_path)
+    paths.runtime_root.mkdir(parents=True)
+    public_key = base64.b64encode(b"public-verification-key").decode()
+    (paths.runtime_root / "release-trusted-keys.json").write_text(json.dumps({"release-1": public_key}))
+    monkeypatch.setattr(integrity, "default_machine_paths", lambda: paths)
+
+    snapshot = integrity.machine_integrity_snapshot()
+    serialized = json.dumps(snapshot, sort_keys=True)
+
+    assert public_key not in serialized
+    assert "release-1" not in serialized
 
 
 def test_integrity_snapshot_cli_does_not_accept_machine_path_override(tmp_path: Path) -> None:

--- a/tests/test_guard_mdm_integrity.py
+++ b/tests/test_guard_mdm_integrity.py
@@ -136,6 +136,7 @@ def test_snapshot_normalizes_probe_failures(tmp_path: Path, monkeypatch: pytest.
     assert "native_install_probe_failed" in snapshot["reasonCodes"]
     assert "managed_policy_probe_failed" in snapshot["reasonCodes"]
     assert snapshot["installOwner"] == "mdm"
+    assert snapshot["components"]["managedPolicy"]["state"] == "degraded"
 
 
 def test_snapshot_loads_policy_without_writing_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -151,6 +152,10 @@ def test_snapshot_loads_policy_without_writing_cache(tmp_path: Path, monkeypatch
     integrity.machine_integrity_snapshot()
 
     assert calls == [{"write_cache": False}]
+
+
+def test_running_supervisor_counts_as_healthy_for_remediation() -> None:
+    assert integrity._remediation_class("mdm-managed", True, ["healthy", "running"]) == "none"
 
 
 def test_snapshot_does_not_promote_unverified_manifest_identity(

--- a/tests/test_guard_mdm_lifecycle.py
+++ b/tests/test_guard_mdm_lifecycle.py
@@ -170,7 +170,7 @@ def test_trusted_key_loader_skips_only_malformed_entries(tmp_path: Path) -> None
     path = tmp_path / "release-trusted-keys.json"
     path.write_text(json.dumps({"valid": "a2V5", "invalid": "%%%"}))
 
-    assert lifecycle.load_trusted_keys(path) == {"valid": b"key"}
+    assert lifecycle.load_trusted_public_keys(path) == {"valid": b"key"}
 
 
 def test_trusted_key_loader_rejects_symlinks_and_oversized_files(tmp_path: Path) -> None:
@@ -181,5 +181,5 @@ def test_trusted_key_loader_rejects_symlinks_and_oversized_files(tmp_path: Path)
     oversized = tmp_path / "oversized.json"
     oversized.write_bytes(b"x" * (64 * 1024 + 1))
 
-    assert lifecycle.load_trusted_keys(symlink) == {}
-    assert lifecycle.load_trusted_keys(oversized) == {}
+    assert lifecycle.load_trusted_public_keys(symlink) == {}
+    assert lifecycle.load_trusted_public_keys(oversized) == {}

--- a/tests/test_guard_mdm_lifecycle.py
+++ b/tests/test_guard_mdm_lifecycle.py
@@ -170,4 +170,16 @@ def test_trusted_key_loader_skips_only_malformed_entries(tmp_path: Path) -> None
     path = tmp_path / "release-trusted-keys.json"
     path.write_text(json.dumps({"valid": "a2V5", "invalid": "%%%"}))
 
-    assert lifecycle._load_trusted_keys(path) == {"valid": b"key"}
+    assert lifecycle.load_trusted_keys(path) == {"valid": b"key"}
+
+
+def test_trusted_key_loader_rejects_symlinks_and_oversized_files(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    target.write_text(json.dumps({"valid": "a2V5"}))
+    symlink = tmp_path / "keys.json"
+    symlink.symlink_to(target)
+    oversized = tmp_path / "oversized.json"
+    oversized.write_bytes(b"x" * (64 * 1024 + 1))
+
+    assert lifecycle.load_trusted_keys(symlink) == {}
+    assert lifecycle.load_trusted_keys(oversized) == {}

--- a/tests/test_guard_mdm_policy.py
+++ b/tests/test_guard_mdm_policy.py
@@ -228,3 +228,23 @@ def test_removed_profile_retains_last_valid_machine_floor(tmp_path: Path, monkey
     assert cached.reason_code == "managed_policy_profile_removed_cached"
     assert cached.policy is not None
     assert cached.policy.content_hash == active.policy.content_hash
+
+
+def test_read_only_policy_load_does_not_refresh_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    native_path = tmp_path / "managed-policy.json"
+    paths = MachinePaths(
+        tmp_path / "runtime",
+        tmp_path / "state",
+        native_path,
+        tmp_path / "logs",
+        tmp_path / "manifest",
+    )
+    writes: list[tuple[dict[str, object], str]] = []
+    native_path.write_text(json.dumps(_policy()))
+    monkeypatch.setattr(policy_module, "default_machine_paths", lambda **_kwargs: paths)
+    monkeypatch.setattr(policy_module, "_write_policy_cache", lambda payload, system: writes.append((payload, system)))
+
+    state = load_managed_policy(system_name="Linux", write_cache=False)
+
+    assert state.status == "active"
+    assert writes == []


### PR DESCRIPTION
## Summary
- add a versioned, typed machine integrity snapshot with closed component states and reason codes
- expose `hol-guard mdm integrity-snapshot --scope machine --json` as a fail-honest, read-only command
- preserve managed-policy removal evidence while preventing unverified package identity from becoming trusted output

## Testing
- `uv run pytest -q tests/test_guard_mdm_integrity.py tests/test_guard_mdm_cli.py tests/test_guard_mdm_manifest.py tests/test_guard_mdm_native.py tests/test_guard_mdm_policy.py tests/test_guard_mdm_lifecycle.py`
- `uv run ruff check src/codex_plugin_scanner/guard/mdm/contracts.py src/codex_plugin_scanner/guard/mdm/integrity.py src/codex_plugin_scanner/guard/mdm/lifecycle.py src/codex_plugin_scanner/guard/mdm/policy.py src/codex_plugin_scanner/guard/mdm/__init__.py src/codex_plugin_scanner/guard/cli/commands_parser_mdm.py src/codex_plugin_scanner/guard/cli/commands_dispatch_mdm.py tests/test_guard_mdm_integrity.py tests/test_guard_mdm_lifecycle.py tests/test_guard_mdm_policy.py`
- `uv run basedpyright src/codex_plugin_scanner/guard/mdm/integrity.py src/codex_plugin_scanner/guard/mdm/contracts.py`
