### PR TITLE
feat(mdm): add signed health lease continuity

### DIFF
--- a/scripts/mdm/macos/device-key-helper.swift
+++ b/scripts/mdm/macos/device-key-helper.swift
@@ -1,10 +1,18 @@
 import Foundation
 import Security
+import CryptoKit
 
 private let labelPrefix = "org.hol.guard.device-key."
 private let systemKeychainPath = "/Library/Keychains/System.keychain"
 private let installedHelperPath = "/Library/Application Support/HOL Guard/hol-guard-device-key"
 private let generationPattern = try! NSRegularExpression(pattern: "^[0-9a-f]{32}$")
+private let digestPattern = try! NSRegularExpression(pattern: "^[0-9a-f]{64}$")
+private let keyIdPattern = try! NSRegularExpression(pattern: "^[A-Za-z0-9_-]{43}$")
+private let timestampPattern = try! NSRegularExpression(pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+private let safeIdPattern = try! NSRegularExpression(pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+private let healthLeaseDomain = Data("HOL-GUARD-HEALTH-LEASE-V1\0".utf8)
+private let maximumClaimsBytes = 4096
+private let p256IntegerBytes = 32
 
 private enum HelperError: Error {
     case denied
@@ -23,6 +31,13 @@ private struct PublicResult: Encodable {
     let reasonCode: String
 }
 
+private struct SignatureResult: Encodable {
+    let ok: Bool
+    let signature: String
+    let signatureAlgorithm: String
+    let signatureEncoding: String
+}
+
 private func emit(_ result: PublicResult, exitCode: Int32) -> Never {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.sortedKeys]
@@ -31,6 +46,19 @@ private func emit(_ result: PublicResult, exitCode: Int32) -> Never {
         FileHandle.standardOutput.write(Data([0x0A]))
     }
     exit(exitCode)
+}
+
+private func emitSignature(_ signature: Data) -> Never {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let result = SignatureResult(ok: true, signature: signature.base64EncodedString(),
+                                 signatureAlgorithm: "ecdsa-p256-sha256", signatureEncoding: "asn1-der")
+    guard let data = try? encoder.encode(result) else {
+        fail("device_key_probe_failed")
+    }
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data([0x0A]))
+    exit(0)
 }
 
 private func fail(_ reason: String) -> Never {
@@ -44,6 +72,108 @@ private func validatedGeneration(_ value: String) throws -> String {
         throw HelperError.invalidRequest
     }
     return value
+}
+
+private func matches(_ value: String, pattern: NSRegularExpression) -> Bool {
+    let range = NSRange(value.startIndex..<value.endIndex, in: value)
+    return pattern.firstMatch(in: value, range: range)?.range == range
+}
+
+private func requiredString(_ claims: [String: Any], _ key: String, maximumLength: Int,
+                            pattern: NSRegularExpression? = nil) throws -> String {
+    guard let value = claims[key] as? String, !value.isEmpty, value.utf8.count <= maximumLength else {
+        throw HelperError.invalidRequest
+    }
+    if let requiredPattern = pattern, !matches(value, pattern: requiredPattern) {
+        throw HelperError.invalidRequest
+    }
+    return value
+}
+
+private func signingKeyId(publicKeyX963: Data) throws -> String {
+    let spkiPrefix = Data([0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01,
+                           0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00])
+    guard publicKeyX963.count == 65, publicKeyX963.first == 0x04 else { throw HelperError.keyInvalid }
+    let digest = Data(SHA256.hash(data: spkiPrefix + publicKeyX963))
+    return digest.base64EncodedString().replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: "=", with: "")
+}
+
+private func validateCanonicalHealthLeaseClaims(_ data: Data, expectedSigningKeyId: String) throws {
+    guard !data.isEmpty, data.count <= maximumClaimsBytes,
+          let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        throw HelperError.invalidRequest
+    }
+    let expectedKeys: Set<String> = [
+        "deviceId", "installationGeneration", "issuedAt", "leaseExpiresAt", "machineInstallationId",
+        "previousLeaseDigest", "previousLeaseKeyId", "schemaVersion", "sequence", "signingKeyId",
+        "snapshotDigest", "snapshotSchemaVersion", "workspaceId",
+    ]
+    guard Set(object.keys) == expectedKeys,
+          object["schemaVersion"] as? String == "hol-guard-health-lease.v1",
+          object["snapshotSchemaVersion"] as? String == "local-integrity-snapshot.v1" else {
+        throw HelperError.invalidRequest
+    }
+    _ = try requiredString(object, "workspaceId", maximumLength: 128, pattern: safeIdPattern)
+    _ = try requiredString(object, "deviceId", maximumLength: 128, pattern: safeIdPattern)
+    _ = try requiredString(object, "machineInstallationId", maximumLength: 32, pattern: generationPattern)
+    _ = try requiredString(object, "installationGeneration", maximumLength: 32, pattern: generationPattern)
+    let issuedText = try requiredString(object, "issuedAt", maximumLength: 20, pattern: timestampPattern)
+    let expiresText = try requiredString(object, "leaseExpiresAt", maximumLength: 20, pattern: timestampPattern)
+    _ = try requiredString(object, "snapshotDigest", maximumLength: 64, pattern: digestPattern)
+    let claimedSigningKeyId = try requiredString(object, "signingKeyId", maximumLength: 43, pattern: keyIdPattern)
+    guard claimedSigningKeyId == expectedSigningKeyId else { throw HelperError.invalidRequest }
+    guard let maximumSequence = Decimal(string: "18446744073709551615"),
+          let sequence = object["sequence"] as? NSNumber,
+          CFGetTypeID(sequence) != CFBooleanGetTypeID(), sequence.decimalValue >= 1,
+          sequence.decimalValue <= maximumSequence,
+          sequence.decimalValue == Decimal(sequence.uint64Value) else {
+        throw HelperError.invalidRequest
+    }
+    let timestampFormatter = DateFormatter()
+    timestampFormatter.locale = Locale(identifier: "en_US_POSIX")
+    timestampFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+    timestampFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+    timestampFormatter.isLenient = false
+    guard let issuedAt = timestampFormatter.date(from: issuedText),
+          let expiresAt = timestampFormatter.date(from: expiresText),
+          expiresAt.timeIntervalSince(issuedAt) > 0,
+          expiresAt.timeIntervalSince(issuedAt) <= 3600 else {
+        throw HelperError.invalidRequest
+    }
+    let previousDigest = object["previousLeaseDigest"]
+    let previousKeyId = object["previousLeaseKeyId"]
+    if sequence.uint64Value == 1 {
+        guard previousDigest is NSNull, previousKeyId is NSNull else { throw HelperError.invalidRequest }
+    } else {
+        guard let digest = previousDigest as? String, matches(digest, pattern: digestPattern),
+              let keyId = previousKeyId as? String, matches(keyId, pattern: keyIdPattern) else {
+            throw HelperError.invalidRequest
+        }
+    }
+    // Every v1 string claim is ASCII-only. Comparing the exact bytes supplied by Python keeps
+    // the helper and verifier on one canonical representation; a broader schema requires v2.
+    let canonical = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
+    guard canonical == data else { throw HelperError.invalidRequest }
+}
+
+private func validateCanonicalDERSignature(_ signature: Data) throws {
+    let bytes = [UInt8](signature)
+    guard bytes.count >= 8, bytes.count <= 72, bytes[0] == 0x30,
+          Int(bytes[1]) == bytes.count - 2 else { throw HelperError.keyInvalid }
+    var offset = 2
+    for _ in 0..<2 {
+        guard offset + 2 <= bytes.count, bytes[offset] == 0x02 else { throw HelperError.keyInvalid }
+        let length = Int(bytes[offset + 1])
+        offset += 2
+        guard length >= 1, length <= p256IntegerBytes + 1, offset + length <= bytes.count,
+              bytes[offset] & 0x80 == 0,
+              !(length > 1 && bytes[offset] == 0 && bytes[offset + 1] & 0x80 == 0),
+              !(length == 1 && bytes[offset] == 0) else { throw HelperError.keyInvalid }
+        if length == p256IntegerBytes + 1 && bytes[offset] != 0 { throw HelperError.keyInvalid }
+        offset += length
+    }
+    guard offset == bytes.count else { throw HelperError.keyInvalid }
 }
 
 private func openSystemKeychain() throws -> SecKeychain {
@@ -194,6 +324,23 @@ private func createKey(generation: String, keychain: SecKeychain) throws -> SecK
     return key
 }
 
+private func signHealthLease(_ privateKey: SecKey, publicKeyX963: Data) throws -> Data {
+    guard let claims = try FileHandle.standardInput.read(upToCount: maximumClaimsBytes + 1),
+          claims.count <= maximumClaimsBytes else {
+        throw HelperError.invalidRequest
+    }
+    try validateCanonicalHealthLeaseClaims(claims, expectedSigningKeyId: try signingKeyId(publicKeyX963: publicKeyX963))
+    var message = healthLeaseDomain
+    message.append(claims)
+    guard SecKeyIsAlgorithmSupported(privateKey, .sign, .ecdsaSignatureMessageX962SHA256),
+          let signature = SecKeyCreateSignature(privateKey, .ecdsaSignatureMessageX962SHA256,
+                                                message as CFData, nil) as Data? else {
+        throw HelperError.operationFailed
+    }
+    try validateCanonicalDERSignature(signature)
+    return signature
+}
+
 private func run() throws -> PublicResult {
     guard geteuid() == 0, CommandLine.arguments.count == 3 else {
         throw HelperError.denied
@@ -218,12 +365,15 @@ private func run() throws -> PublicResult {
         } catch HelperError.keyAbsent {
             privateKey = try createKey(generation: generation, keychain: keychain)
         }
-    } else if verb == "inspect" {
+    } else if verb == "inspect" || verb == "sign-health-lease" {
         privateKey = try copyPrivateKey(generation: generation, keychain: keychain)
     } else {
         throw HelperError.invalidRequest
     }
     let publicKey = try inspectKey(privateKey)
+    if verb == "sign-health-lease" {
+        emitSignature(try signHealthLease(privateKey, publicKeyX963: publicKey))
+    }
     return PublicResult(ok: true, state: "active", protectionLevel: "os-protected",
                         publicKeyX963: publicKey.base64EncodedString(), reasonCode: "device_key_active")
 }

--- a/scripts/mdm/windows/device-key-helper.ps1
+++ b/scripts/mdm/windows/device-key-helper.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet('create', 'inspect', 'delete')]
+    [ValidateSet('create', 'inspect', 'delete', 'sign-health-lease')]
     [string]$Verb,
     [Parameter(Mandatory = $true)]
     [ValidatePattern('^[0-9a-f]{32}$')]
@@ -15,6 +15,8 @@ $KeyName = $KeyPrefix + $Generation
 $PlatformProvider = 'Microsoft Platform Crypto Provider'
 $SoftwareProvider = 'Microsoft Software Key Storage Provider'
 $ProtectedSddl = 'O:SYG:SYD:P(A;;FA;;;SY)(A;;FA;;;BA)'
+$HealthLeaseDomain = [System.Text.Encoding]::UTF8.GetBytes("HOL-GUARD-HEALTH-LEASE-V1`0")
+$MaximumClaimsBytes = 4096
 
 function Emit-Result {
     param(
@@ -33,6 +35,126 @@ function Emit-Result {
         reasonCode = $ReasonCode
     } | ConvertTo-Json -Compress
     exit $ExitCode
+}
+
+function Emit-SignatureResult {
+    param([byte[]]$Signature)
+    [ordered]@{
+        ok = $true
+        signature = [Convert]::ToBase64String($Signature)
+        signatureAlgorithm = 'ecdsa-p256-sha256'
+        signatureEncoding = 'asn1-der'
+    } | ConvertTo-Json -Compress
+    exit 0
+}
+
+function Convert-P1363ToDer {
+    param([byte[]]$Signature)
+    if ($Signature.Length -ne 64) { throw 'invalid' }
+    $EncodedIntegers = [System.Collections.Generic.List[byte]]::new()
+    foreach ($Offset in @(0, 32)) {
+        $First = $Offset
+        while ($First -lt ($Offset + 31) -and $Signature[$First] -eq 0) { $First++ }
+        $Length = ($Offset + 32) - $First
+        $NeedsPositivePrefix = ($Signature[$First] -band 0x80) -ne 0
+        $EncodedIntegers.Add(0x02)
+        $EncodedIntegers.Add([byte]($Length + $(if ($NeedsPositivePrefix) { 1 } else { 0 })))
+        if ($NeedsPositivePrefix) { $EncodedIntegers.Add(0) }
+        for ($Index = $First; $Index -lt ($Offset + 32); $Index++) {
+            $EncodedIntegers.Add($Signature[$Index])
+        }
+    }
+    if ($EncodedIntegers.Count -gt 127) { throw 'invalid' }
+    $Der = [System.Collections.Generic.List[byte]]::new()
+    $Der.Add(0x30)
+    $Der.Add([byte]$EncodedIntegers.Count)
+    $Der.AddRange($EncodedIntegers)
+    return $Der.ToArray()
+}
+
+function Get-SigningKeyId {
+    param([string]$PublicKeyX963)
+    $SpkiPrefix = [byte[]]@(
+        0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01,
+        0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00
+    )
+    $PublicBytes = [Convert]::FromBase64String($PublicKeyX963)
+    if ($PublicBytes.Length -ne 65 -or $PublicBytes[0] -ne 4) { throw 'invalid' }
+    $Spki = [byte[]]::new($SpkiPrefix.Length + $PublicBytes.Length)
+    [Array]::Copy($SpkiPrefix, 0, $Spki, 0, $SpkiPrefix.Length)
+    [Array]::Copy($PublicBytes, 0, $Spki, $SpkiPrefix.Length, $PublicBytes.Length)
+    $Hasher = [System.Security.Cryptography.SHA256]::Create()
+    try { $Digest = $Hasher.ComputeHash($Spki) } finally { $Hasher.Dispose() }
+    return [Convert]::ToBase64String($Digest).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}
+
+function Read-HealthLeaseClaims {
+    param([string]$ExpectedSigningKeyId)
+    $Buffer = [char[]]::new($MaximumClaimsBytes + 1)
+    $Count = [Console]::In.ReadBlock($Buffer, 0, $Buffer.Length)
+    if ($Count -eq 0 -or $Count -gt $MaximumClaimsBytes) { throw 'invalid' }
+    $Text = [string]::new($Buffer, 0, $Count)
+    $Utf8 = [System.Text.UTF8Encoding]::new($false, $true)
+    if ($Utf8.GetByteCount($Text) -gt $MaximumClaimsBytes) { throw 'invalid' }
+    $Claims = $Text | ConvertFrom-Json
+    $SequenceMatch = [regex]::Match($Text, '"sequence":([0-9]{1,20}),')
+    if (-not $SequenceMatch.Success) { throw 'invalid' }
+    $SequenceText = $SequenceMatch.Groups[1].Value
+    $Sequence = [decimal]::Parse($SequenceText, [Globalization.CultureInfo]::InvariantCulture)
+    $ExpectedKeys = @(
+        'deviceId', 'installationGeneration', 'issuedAt', 'leaseExpiresAt', 'machineInstallationId',
+        'previousLeaseDigest', 'previousLeaseKeyId', 'schemaVersion', 'sequence', 'signingKeyId',
+        'snapshotDigest', 'snapshotSchemaVersion', 'workspaceId'
+    )
+    $ActualKeys = @($Claims.PSObject.Properties.Name)
+    if (@(Compare-Object $ActualKeys $ExpectedKeys).Count -ne 0) { throw 'invalid' }
+    if ($Claims.schemaVersion -ne 'hol-guard-health-lease.v1' -or
+        $Claims.snapshotSchemaVersion -ne 'local-integrity-snapshot.v1' -or
+        $Claims.workspaceId -notmatch '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$' -or
+        $Claims.deviceId -notmatch '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$' -or
+        $Claims.machineInstallationId -notmatch '^[0-9a-f]{32}$' -or
+        $Claims.installationGeneration -notmatch '^[0-9a-f]{32}$' -or
+        $Claims.issuedAt -notmatch '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' -or
+        $Claims.leaseExpiresAt -notmatch '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' -or
+        $Claims.snapshotDigest -notmatch '^[0-9a-f]{64}$' -or
+        $Claims.signingKeyId -notmatch '^[A-Za-z0-9_-]{43}$' -or $Claims.signingKeyId -ne $ExpectedSigningKeyId -or
+        $Sequence -lt 1 -or
+        $Sequence -gt [decimal]::Parse('18446744073709551615', [Globalization.CultureInfo]::InvariantCulture)) {
+        throw 'invalid'
+    }
+    $TimestampStyle = [Globalization.DateTimeStyles]::AssumeUniversal -bor [Globalization.DateTimeStyles]::AdjustToUniversal
+    $IssuedAt = [DateTime]::ParseExact(
+        $Claims.issuedAt, "yyyy-MM-dd'T'HH:mm:ss'Z'", [Globalization.CultureInfo]::InvariantCulture, $TimestampStyle
+    )
+    $ExpiresAt = [DateTime]::ParseExact(
+        $Claims.leaseExpiresAt, "yyyy-MM-dd'T'HH:mm:ss'Z'", [Globalization.CultureInfo]::InvariantCulture, $TimestampStyle
+    )
+    $LeaseSeconds = ($ExpiresAt - $IssuedAt).TotalSeconds
+    if ($LeaseSeconds -le 0 -or $LeaseSeconds -gt 3600) { throw 'invalid' }
+    if ($Sequence -eq 1) {
+        if ($null -ne $Claims.previousLeaseDigest -or $null -ne $Claims.previousLeaseKeyId) { throw 'invalid' }
+    } elseif ($Claims.previousLeaseDigest -notmatch '^[0-9a-f]{64}$' -or
+              $Claims.previousLeaseKeyId -notmatch '^[A-Za-z0-9_-]{43}$') {
+        throw 'invalid'
+    }
+    $Canonical = [ordered]@{
+        deviceId = $Claims.deviceId
+        installationGeneration = $Claims.installationGeneration
+        issuedAt = $Claims.issuedAt
+        leaseExpiresAt = $Claims.leaseExpiresAt
+        machineInstallationId = $Claims.machineInstallationId
+        previousLeaseDigest = $Claims.previousLeaseDigest
+        previousLeaseKeyId = $Claims.previousLeaseKeyId
+        schemaVersion = $Claims.schemaVersion
+        sequence = '!HOL_GUARD_SEQUENCE!'
+        signingKeyId = $Claims.signingKeyId
+        snapshotDigest = $Claims.snapshotDigest
+        snapshotSchemaVersion = $Claims.snapshotSchemaVersion
+        workspaceId = $Claims.workspaceId
+    } | ConvertTo-Json -Compress
+    $Canonical = $Canonical.Replace('"!HOL_GUARD_SEQUENCE!"', $SequenceText)
+    if (-not [string]::Equals($Canonical, $Text, [System.StringComparison]::Ordinal)) { throw 'invalid' }
+    return [System.Text.Encoding]::UTF8.GetBytes($Text)
 }
 
 function Get-SecurityDescriptorBytes {
@@ -162,10 +284,30 @@ try {
         $ProviderName = $Found.Provider
         $ProtectionLevel = if ($ProviderName -eq $PlatformProvider) { 'hardware-backed' } else { 'os-protected' }
     }
+    $HealthLeaseSignature = $null
     try {
         $PublicKey = Inspect-Key $Key $ProviderName
+        if ($Verb -eq 'sign-health-lease') {
+            $ClaimsBytes = Read-HealthLeaseClaims (Get-SigningKeyId $PublicKey)
+            $Message = [byte[]]::new($HealthLeaseDomain.Length + $ClaimsBytes.Length)
+            [Array]::Copy($HealthLeaseDomain, 0, $Message, 0, $HealthLeaseDomain.Length)
+            [Array]::Copy($ClaimsBytes, 0, $Message, $HealthLeaseDomain.Length, $ClaimsBytes.Length)
+            $Signer = [System.Security.Cryptography.ECDsaCng]::new($Key)
+            try {
+                $P1363 = $Signer.SignData($Message, [System.Security.Cryptography.HashAlgorithmName]::SHA256)
+                if (-not $Signer.VerifyData($Message, $P1363, [System.Security.Cryptography.HashAlgorithmName]::SHA256)) {
+                    throw 'invalid'
+                }
+                $HealthLeaseSignature = Convert-P1363ToDer $P1363
+            } finally {
+                $Signer.Dispose()
+            }
+        }
     } finally {
         $Key.Dispose()
+    }
+    if ($null -ne $HealthLeaseSignature) {
+        Emit-SignatureResult $HealthLeaseSignature
     }
     Emit-Result $true 'active' $ProtectionLevel $PublicKey 'device_key_active' 0
 } catch {

--- a/src/codex_plugin_scanner/guard/mdm/continuity.py
+++ b/src/codex_plugin_scanner/guard/mdm/continuity.py
@@ -41,6 +41,7 @@ class InstallationContinuityRecord:
     last_lease_boot_session_id: str | None
     last_lease_monotonic_uptime_ns: int | None
     updated_at: str
+    last_lease_key_id: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -53,6 +54,7 @@ class InstallationContinuityRecord:
             "lastLeaseDigest": self.last_lease_digest,
             "lastLeaseBootSessionId": self.last_lease_boot_session_id,
             "lastLeaseMonotonicUptimeNs": self.last_lease_monotonic_uptime_ns,
+            "lastLeaseKeyId": self.last_lease_key_id,
             "updatedAt": self.updated_at,
         }
 
@@ -162,9 +164,10 @@ def _parse_record(payload: bytes) -> InstallationContinuityRecord:
     boot_id = _optional_bounded_string(raw.get("lastLeaseBootSessionId"))
     uptime_raw = raw.get("lastLeaseMonotonicUptimeNs")
     uptime = None if uptime_raw is None else _uint64(uptime_raw)
-    if sequence == 0 and any(value is not None for value in (digest, boot_id, uptime)):
+    lease_key_id = _optional_bounded_string(raw.get("lastLeaseKeyId"))
+    if sequence == 0 and any(value is not None for value in (digest, boot_id, uptime, lease_key_id)):
         raise ValueError("installation_identity_invalid")
-    if sequence > 0 and any(value is None for value in (digest, boot_id, uptime)):
+    if sequence > 0 and any(value is None for value in (digest, boot_id, uptime, lease_key_id)):
         raise ValueError("installation_identity_invalid")
     key_id = raw.get("keyIdAtGenerationCreation")
     if not isinstance(key_id, str) or not key_id or len(key_id) > 256:
@@ -179,6 +182,7 @@ def _parse_record(payload: bytes) -> InstallationContinuityRecord:
         boot_id,
         uptime,
         _timestamp(raw.get("updatedAt")),
+        lease_key_id,
     )
 
 

--- a/src/codex_plugin_scanner/guard/mdm/device_key.py
+++ b/src/codex_plugin_scanner/guard/mdm/device_key.py
@@ -21,15 +21,9 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
 from .contracts import KeyProtectionLevel, KeyProtectionStatus, MachinePaths, default_machine_paths
-from .device_key_native import (
-    NativeKeyEvidence,
-)
-from .device_key_native import (
-    require_machine_context as require_machine_device_context,
-)
-from .device_key_native import (
-    run_helper as _run_helper,
-)
+from .device_key_native import NativeKeyEvidence
+from .device_key_native import require_machine_context as require_machine_device_context
+from .device_key_native import run_helper as _run_helper
 
 _METADATA_SCHEMA = "hol-guard-device-key.v1"
 _METADATA_NAME = "device-key.json"

--- a/src/codex_plugin_scanner/guard/mdm/device_key_access.py
+++ b/src/codex_plugin_scanner/guard/mdm/device_key_access.py
@@ -1,0 +1,28 @@
+"""Narrow verified access to machine key generations for fixed signing protocols."""
+
+from __future__ import annotations
+
+from .contracts import MachinePaths
+from .device_key import KeyGeneration, _read_metadata, verified_machine_device_key_ids
+
+
+def verified_machine_device_key_by_id(
+    paths: MachinePaths,
+    key_id: str | None = None,
+    *,
+    system_name: str | None = None,
+) -> KeyGeneration:
+    active_key_id, verified_ids = verified_machine_device_key_ids(paths, system_name=system_name)
+    requested = key_id or active_key_id
+    if requested not in verified_ids:
+        raise OSError("device_key_public_mismatch")
+    metadata = _read_metadata(paths)
+    if metadata is None or metadata.state != "active":
+        raise OSError("device_key_rotation_incomplete")
+    for generation in (metadata.active, metadata.previous):
+        if generation is not None and generation.key_id == requested:
+            return generation
+    raise OSError("device_key_rotation_incomplete")
+
+
+__all__ = ["verified_machine_device_key_by_id"]

--- a/src/codex_plugin_scanner/guard/mdm/device_key_native.py
+++ b/src/codex_plugin_scanner/guard/mdm/device_key_native.py
@@ -7,15 +7,36 @@ import ctypes
 import json
 import ntpath
 import os
+import re
 import subprocess
 from dataclasses import dataclass
 from typing import Literal, cast
 
+from cryptography.hazmat.primitives.asymmetric import utils
+
 from .contracts import KeyProtectionLevel, MachinePaths
 
 _MAX_HELPER_OUTPUT_BYTES = 16 * 1024
+_MAX_HELPER_STDERR_BYTES = 4096
+_MAX_HEALTH_LEASE_CLAIMS_BYTES = 4096
 _HELPER_TIMEOUT_SECONDS = 15
 _SYSTEM_SID = "S-1-5-18"
+_P256_ORDER = int("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551", 16)
+_HEALTH_LEASE_KEYS = {
+    "deviceId",
+    "installationGeneration",
+    "issuedAt",
+    "leaseExpiresAt",
+    "machineInstallationId",
+    "previousLeaseDigest",
+    "previousLeaseKeyId",
+    "schemaVersion",
+    "sequence",
+    "signingKeyId",
+    "snapshotDigest",
+    "snapshotSchemaVersion",
+    "workspaceId",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,6 +47,51 @@ class NativeKeyEvidence:
     reason_code: str
 
 
+@dataclass(frozen=True, slots=True)
+class NativeHealthLeaseSignature:
+    signature: bytes
+    algorithm: Literal["ecdsa-p256-sha256"] = "ecdsa-p256-sha256"
+    encoding: Literal["asn1-der"] = "asn1-der"
+
+
+def _validated_canonical_health_lease_claims(claims: bytes) -> str:
+    if not claims or len(claims) > _MAX_HEALTH_LEASE_CLAIMS_BYTES:
+        raise ValueError("health_lease_claims_invalid")
+    try:
+        text = claims.decode("utf-8")
+        decoded = cast(object, json.loads(text))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("health_lease_claims_invalid") from exc
+    if not isinstance(decoded, dict):
+        raise ValueError("health_lease_claims_invalid")
+    payload = cast(dict[str, object], decoded)
+    if set(payload) != _HEALTH_LEASE_KEYS:
+        raise ValueError("health_lease_claims_invalid")
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    if canonical != text:
+        raise ValueError("health_lease_claims_invalid")
+    from .health_lease_contract import HealthLeaseClaims
+
+    try:
+        HealthLeaseClaims.parse(payload)
+    except ValueError as exc:
+        raise ValueError("health_lease_claims_invalid") from exc
+    return text
+
+
+def _validated_der_signature(encoded: object) -> bytes:
+    if not isinstance(encoded, str) or len(encoded) > 128:
+        raise OSError("device_key_probe_failed")
+    try:
+        signature = base64.b64decode(encoded, validate=True)
+        r, s = utils.decode_dss_signature(signature)
+    except (ValueError, TypeError) as exc:
+        raise OSError("device_key_probe_failed") from exc
+    if not 0 < r < _P256_ORDER or not 0 < s < _P256_ORDER or utils.encode_dss_signature(r, s) != signature:
+        raise OSError("device_key_probe_failed")
+    return signature
+
+
 def windows_directory() -> str:
     buffer = ctypes.create_unicode_buffer(32_768)
     length = int(ctypes.windll.kernel32.GetSystemWindowsDirectoryW(buffer, len(buffer)))
@@ -34,9 +100,9 @@ def windows_directory() -> str:
     return ntpath.normpath(str(buffer.value))
 
 
-def run_helper(paths: MachinePaths, verb: str, generation: str, *, system_name: str) -> NativeKeyEvidence:
-    if verb not in {"create", "inspect", "delete"}:
-        raise ValueError("device_key_request_invalid")
+def _helper_invocation(
+    paths: MachinePaths, verb: str, generation: str, system_name: str
+) -> tuple[list[str], dict[str, str], str]:
     if system_name == "Darwin":
         command = [str(paths.runtime_root / "hol-guard-device-key"), verb, generation]
         environment = {
@@ -74,7 +140,16 @@ def run_helper(paths: MachinePaths, verb: str, generation: str, *, system_name: 
         }
         cwd = system_directory
     else:
+        raise OSError("device_key_platform_unsupported")
+    return command, environment, cwd
+
+
+def run_helper(paths: MachinePaths, verb: str, generation: str, *, system_name: str) -> NativeKeyEvidence:
+    if verb not in {"create", "inspect", "delete"}:
+        raise ValueError("device_key_request_invalid")
+    if system_name not in {"Darwin", "Windows"}:
         return NativeKeyEvidence("unknown", "unavailable", None, "device_key_platform_unsupported")
+    command, environment, cwd = _helper_invocation(paths, verb, generation, system_name)
     result = subprocess.run(
         command,
         check=False,
@@ -85,7 +160,10 @@ def run_helper(paths: MachinePaths, verb: str, generation: str, *, system_name: 
         text=True,
         timeout=_HELPER_TIMEOUT_SECONDS,
     )
-    if len(result.stdout.encode("utf-8")) > _MAX_HELPER_OUTPUT_BYTES or len(result.stderr.encode("utf-8")) > 4096:
+    if (
+        len(result.stdout.encode("utf-8")) > _MAX_HELPER_OUTPUT_BYTES
+        or len(result.stderr.encode("utf-8")) > _MAX_HELPER_STDERR_BYTES
+    ):
         raise OSError("device_key_probe_failed")
     try:
         payload = json.loads(result.stdout)
@@ -149,6 +227,44 @@ def run_helper(paths: MachinePaths, verb: str, generation: str, *, system_name: 
     )
 
 
+def sign_health_lease(
+    paths: MachinePaths, generation: str, canonical_claims: bytes, *, system_name: str
+) -> NativeHealthLeaseSignature:
+    if re.fullmatch(r"[0-9a-f]{32}", generation) is None:
+        raise ValueError("device_key_request_invalid")
+    claims_text = _validated_canonical_health_lease_claims(canonical_claims)
+    command, environment, cwd = _helper_invocation(paths, "sign-health-lease", generation, system_name)
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        cwd=cwd,
+        env=environment,
+        input=claims_text,
+        text=True,
+        timeout=_HELPER_TIMEOUT_SECONDS,
+    )
+    if (
+        len(result.stdout.encode("utf-8")) > _MAX_HELPER_OUTPUT_BYTES
+        or len(result.stderr.encode("utf-8")) > _MAX_HELPER_STDERR_BYTES
+    ):
+        raise OSError("device_key_probe_failed")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise OSError("device_key_probe_failed") from exc
+    if (
+        result.returncode != 0
+        or not isinstance(payload, dict)
+        or set(payload) != {"ok", "signature", "signatureAlgorithm", "signatureEncoding"}
+        or payload.get("ok") is not True
+        or payload.get("signatureAlgorithm") != "ecdsa-p256-sha256"
+        or payload.get("signatureEncoding") != "asn1-der"
+    ):
+        raise OSError("device_key_probe_failed")
+    return NativeHealthLeaseSignature(_validated_der_signature(payload.get("signature")))
+
+
 def windows_current_user_sid() -> str:
     from ctypes import wintypes
 
@@ -187,4 +303,11 @@ def require_machine_context(system_name: str) -> None:
     raise OSError("device_key_platform_unsupported")
 
 
-__all__ = ["NativeKeyEvidence", "require_machine_context", "run_helper", "windows_current_user_sid"]
+__all__ = [
+    "NativeHealthLeaseSignature",
+    "NativeKeyEvidence",
+    "require_machine_context",
+    "run_helper",
+    "sign_health_lease",
+    "windows_current_user_sid",
+]

--- a/src/codex_plugin_scanner/guard/mdm/health_lease.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_lease.py
@@ -1,0 +1,308 @@
+"""Crash-consistent local health-lease issuance with a single protected outbox."""
+
+from __future__ import annotations
+
+import base64
+import errno
+import hashlib
+import os
+import platform
+import secrets
+import stat
+from collections.abc import Callable, Mapping
+from contextlib import suppress
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from .continuity import (
+    InstallationContinuityRecord,
+    _atomic_write,
+    _continuity_lock,
+    _read_record,
+    observe_boot,
+)
+from .contracts import LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION, LocalIntegritySnapshot, MachinePaths
+from .device_key import KeyGeneration
+from .device_key_access import verified_machine_device_key_by_id
+from .health_lease_contract import (
+    MAX_LEASE_SECONDS,
+    MAX_OUTBOX_BYTES,
+    MAX_SNAPSHOT_BYTES,
+    HealthLeaseBinding,
+    HealthLeaseClaims,
+    HealthLeaseOutbox,
+    SignedHealthLease,
+    canonical_json_bytes,
+    canonical_timestamp,
+)
+from .integrity import machine_integrity_snapshot
+
+_OUTBOX_NAME = "health-lease-outbox.json"
+SnapshotFactory = Callable[[], LocalIntegritySnapshot]
+LeaseSigner = Callable[[MachinePaths, KeyGeneration, HealthLeaseClaims, str], bytes]
+CrashHook = Callable[[str], None]
+
+
+def _outbox_path(paths: MachinePaths) -> Path:
+    return paths.state_root / _OUTBOX_NAME
+
+
+def _private_regular_file(metadata: os.stat_result) -> bool:
+    return stat.S_ISREG(metadata.st_mode) and (
+        os.name == "nt" or (metadata.st_uid == 0 and not stat.S_IMODE(metadata.st_mode) & 0o077)
+    )
+
+
+def _read_bounded(path: Path) -> bytes:
+    try:
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0))
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            raise PermissionError("health_lease_outbox_acl_invalid") from exc
+        raise
+    try:
+        before = os.fstat(descriptor)
+        if before.st_size > MAX_OUTBOX_BYTES or not _private_regular_file(before):
+            raise PermissionError("health_lease_outbox_acl_invalid")
+        payload = os.read(descriptor, MAX_OUTBOX_BYTES + 1)
+        after = os.fstat(descriptor)
+        before_identity = (before.st_dev, before.st_ino, before.st_size, before.st_ctime_ns)
+        after_identity = (after.st_dev, after.st_ino, after.st_size, after.st_ctime_ns)
+        if len(payload) != before.st_size or before_identity != after_identity:
+            raise OSError("health_lease_outbox_invalid")
+        return payload
+    finally:
+        os.close(descriptor)
+
+
+def _atomic_outbox_write(paths: MachinePaths, outbox: HealthLeaseOutbox) -> None:
+    parent = paths.state_root
+    if parent.is_symlink() or not parent.is_dir():
+        raise OSError("health_lease_state_root_invalid")
+    target = _outbox_path(paths)
+    if target.exists() or target.is_symlink():
+        raise FileExistsError("health_lease_pending_conflict")
+    temporary = parent / f".{target.name}.{secrets.token_hex(16)}.tmp"
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb", closefd=True) as handle:
+            handle.write(outbox.canonical_bytes())
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o600)
+        os.link(temporary, target, follow_symlinks=False)
+        if os.name != "nt":
+            parent_descriptor = os.open(parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+            try:
+                os.fsync(parent_descriptor)
+            finally:
+                os.close(parent_descriptor)
+    finally:
+        with suppress(FileNotFoundError):
+            temporary.unlink()
+
+
+def _load_pending(paths: MachinePaths) -> HealthLeaseOutbox | None:
+    try:
+        return HealthLeaseOutbox.parse(_read_bounded(_outbox_path(paths)))
+    except FileNotFoundError:
+        return None
+
+
+def load_pending_health_lease(paths: MachinePaths) -> HealthLeaseOutbox | None:
+    """Read an exact pending artifact without changing continuity state."""
+
+    return _load_pending(paths)
+
+
+def _normalized_snapshot(
+    snapshot: Mapping[str, object], binding: HealthLeaseBinding, record: InstallationContinuityRecord
+) -> bytes:
+    if snapshot.get("schemaVersion") != LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION:
+        raise ValueError("health_lease_snapshot_invalid")
+    identifiers = snapshot.get("identifiers")
+    continuity = snapshot.get("continuity")
+    if not isinstance(identifiers, dict) or not isinstance(continuity, dict):
+        raise ValueError("health_lease_snapshot_invalid")
+    for key, expected in (
+        ("machineInstallationId", record.machine_installation_id),
+        ("installationGeneration", record.installation_generation),
+    ):
+        if identifiers.get(key) != expected:
+            raise ValueError("health_lease_snapshot_invalid")
+    if identifiers.get("workspaceId") not in {None, binding.workspace_id}:
+        raise ValueError("health_lease_snapshot_invalid")
+    if identifiers.get("deviceId") not in {None, binding.device_id}:
+        raise ValueError("health_lease_snapshot_invalid")
+    if continuity.get("sequence") != record.last_issued_sequence:
+        raise ValueError("health_lease_snapshot_invalid")
+    if continuity.get("previousLeaseDigest") != record.last_lease_digest:
+        raise ValueError("health_lease_snapshot_invalid")
+    normalized = dict(snapshot)
+    normalized["identifiers"] = {
+        **identifiers,
+        "workspaceId": binding.workspace_id,
+        "deviceId": binding.device_id,
+    }
+    payload = canonical_json_bytes(normalized)
+    if not payload or len(payload) > MAX_SNAPSHOT_BYTES:
+        raise ValueError("health_lease_snapshot_invalid")
+    return payload
+
+
+def _verify_signature(generation: KeyGeneration, claims: HealthLeaseClaims, signature: bytes) -> None:
+    try:
+        public_key = serialization.load_der_public_key(base64.b64decode(generation.public_key_spki, validate=True))
+        if not isinstance(public_key, ec.EllipticCurvePublicKey) or not isinstance(public_key.curve, ec.SECP256R1):
+            raise ValueError("health_lease_signing_key_invalid")
+        public_key.verify(signature, claims.signing_payload(), ec.ECDSA(hashes.SHA256()))
+    except (ValueError, InvalidSignature) as exc:
+        raise OSError("health_lease_signature_invalid") from exc
+
+
+def _default_signer(
+    paths: MachinePaths, generation: KeyGeneration, claims: HealthLeaseClaims, system_name: str
+) -> bytes:
+    from .device_key_native import sign_health_lease
+
+    result = sign_health_lease(
+        paths,
+        generation.generation,
+        canonical_json_bytes(claims.to_dict()),
+        system_name=system_name,
+    )
+    return result.signature
+
+
+def _validate_pending(
+    pending: HealthLeaseOutbox,
+    binding: HealthLeaseBinding,
+    record: InstallationContinuityRecord,
+) -> bool:
+    claims = pending.lease.claims
+    if (
+        claims.workspace_id != binding.workspace_id
+        or claims.device_id != binding.device_id
+        or claims.machine_installation_id != record.machine_installation_id
+        or claims.installation_generation != record.installation_generation
+    ):
+        raise OSError("health_lease_pending_conflict")
+    if claims.sequence == record.last_issued_sequence:
+        if record.last_lease_digest != pending.lease.digest or record.last_lease_key_id != claims.signing_key_id:
+            raise OSError("health_lease_pending_conflict")
+        return False
+    if claims.sequence != record.last_issued_sequence + 1:
+        raise OSError("health_lease_pending_conflict")
+    if (
+        claims.previous_lease_digest != record.last_lease_digest
+        or claims.previous_lease_key_id != record.last_lease_key_id
+    ):
+        raise OSError("health_lease_pending_conflict")
+    return True
+
+
+def _advanced_record(
+    record: InstallationContinuityRecord,
+    lease: SignedHealthLease,
+    *,
+    system_name: str,
+    now: datetime,
+) -> InstallationContinuityRecord:
+    observation = observe_boot(system_name=system_name)
+    return replace(
+        record,
+        last_issued_sequence=lease.claims.sequence,
+        last_lease_digest=lease.digest,
+        last_lease_boot_session_id=observation.boot_session_id,
+        last_lease_monotonic_uptime_ns=observation.monotonic_uptime_ns,
+        last_lease_key_id=lease.claims.signing_key_id,
+        updated_at=now.astimezone(timezone.utc).isoformat(),
+    )
+
+
+def issue_or_load_pending_health_lease(
+    paths: MachinePaths,
+    binding: HealthLeaseBinding,
+    *,
+    now: datetime | None = None,
+    lease_seconds: int = 900,
+    system_name: str | None = None,
+    snapshot_factory: SnapshotFactory = machine_integrity_snapshot,
+    signer: LeaseSigner = _default_signer,
+    crash_hook: CrashHook | None = None,
+) -> HealthLeaseOutbox:
+    """Issue one lease or recover the exact pending artifact after a crash."""
+
+    requested_now = now or datetime.now(timezone.utc)
+    if requested_now.tzinfo is None or requested_now.utcoffset() is None:
+        raise ValueError("health_lease_time_invalid")
+    resolved_now = requested_now.astimezone(timezone.utc).replace(microsecond=0)
+    resolved_system = system_name or platform.system()
+    if not 1 <= lease_seconds <= MAX_LEASE_SECONDS:
+        raise ValueError("health_lease_duration_invalid")
+    with _continuity_lock(paths):
+        record = _read_record(paths)
+        if record is None:
+            raise OSError("installation_identity_absent")
+        pending = _load_pending(paths)
+        if pending is not None:
+            requires_recovery = _validate_pending(pending, binding, record)
+            generation = verified_machine_device_key_by_id(
+                paths,
+                pending.lease.claims.signing_key_id,
+                system_name=resolved_system,
+            )
+            _verify_signature(generation, pending.lease.claims, pending.lease.signature)
+            if requires_recovery:
+                recovered = _advanced_record(record, pending.lease, system_name=resolved_system, now=resolved_now)
+                _atomic_write(paths, recovered)
+            expires = datetime.strptime(pending.lease.claims.lease_expires_at, "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+            if resolved_now >= expires:
+                # Only an authenticated Cloud ACK may retire pending evidence. Local expiry
+                # must fail closed instead of erasing proof and silently advancing the chain.
+                raise OSError("health_lease_pending_expired")
+            return pending
+        if record.last_issued_sequence == (1 << 64) - 1:
+            raise OSError("lease_continuity_sequence_exhausted")
+        if record.last_issued_sequence > 0:
+            raise OSError("health_lease_outbox_absent")
+        generation = verified_machine_device_key_by_id(paths, system_name=resolved_system)
+        snapshot_bytes = _normalized_snapshot(snapshot_factory(), binding, record)
+        claims = HealthLeaseClaims.parse(
+            {
+                "schemaVersion": "hol-guard-health-lease.v1",
+                "workspaceId": binding.workspace_id,
+                "deviceId": binding.device_id,
+                "machineInstallationId": record.machine_installation_id,
+                "installationGeneration": record.installation_generation,
+                "sequence": record.last_issued_sequence + 1,
+                "issuedAt": canonical_timestamp(resolved_now),
+                "leaseExpiresAt": canonical_timestamp(resolved_now + timedelta(seconds=lease_seconds)),
+                "snapshotSchemaVersion": LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION,
+                "snapshotDigest": hashlib.sha256(snapshot_bytes).hexdigest(),
+                "previousLeaseDigest": record.last_lease_digest,
+                "previousLeaseKeyId": record.last_lease_key_id,
+                "signingKeyId": generation.key_id,
+            }
+        )
+        signature = signer(paths, generation, claims, resolved_system)
+        lease = SignedHealthLease.parse(SignedHealthLease(claims, signature).canonical_bytes())
+        _verify_signature(generation, claims, lease.signature)
+        outbox = HealthLeaseOutbox(lease, snapshot_bytes)
+        _atomic_outbox_write(paths, outbox)
+        if crash_hook is not None:
+            crash_hook("outbox-durable")
+        _atomic_write(paths, _advanced_record(record, lease, system_name=resolved_system, now=resolved_now))
+        if crash_hook is not None:
+            crash_hook("continuity-durable")
+        return outbox
+
+
+__all__ = ["issue_or_load_pending_health_lease", "load_pending_health_lease"]

--- a/src/codex_plugin_scanner/guard/mdm/health_lease_contract.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_lease_contract.py
@@ -1,0 +1,476 @@
+"""Strict, versioned contract for machine health leases."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Final, get_args
+
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
+
+from .contracts import (
+    LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION,
+    AssuranceLevel,
+    InstallOwner,
+    IntegrityReasonCode,
+    IntegrityState,
+    KeyProtectionLevel,
+    RemediationClass,
+    SupervisorState,
+)
+
+HEALTH_LEASE_SCHEMA: Final = "hol-guard-health-lease.v1"
+HEALTH_LEASE_OUTBOX_SCHEMA: Final = "hol-guard-health-lease-outbox.v1"
+HEALTH_LEASE_SIGNING_DOMAIN: Final = b"HOL-GUARD-HEALTH-LEASE-V1\x00"
+SIGNATURE_ALGORITHM: Final = "ecdsa-p256-sha256"
+SIGNATURE_ENCODING: Final = "asn1-der"
+MAX_LEASE_BYTES: Final = 32 * 1024
+MAX_SNAPSHOT_BYTES: Final = 256 * 1024
+MAX_OUTBOX_BYTES: Final = 4 * ((MAX_SNAPSHOT_BYTES + 2) // 3) + MAX_LEASE_BYTES + 4096
+MAX_LEASE_SECONDS: Final = 3600
+MAX_UINT64: Final = (1 << 64) - 1
+P256_ORDER: Final = int("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551", 16)
+
+_SAFE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}\Z")
+_HEX_32 = re.compile(r"[0-9a-f]{32}\Z")
+_HEX_64 = re.compile(r"[0-9a-f]{64}\Z")
+_KEY_ID = re.compile(r"[A-Za-z0-9_-]{43}\Z")
+_TIMESTAMP = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\Z")
+_CLAIM_KEYS = {
+    "schemaVersion",
+    "workspaceId",
+    "deviceId",
+    "machineInstallationId",
+    "installationGeneration",
+    "sequence",
+    "issuedAt",
+    "leaseExpiresAt",
+    "snapshotSchemaVersion",
+    "snapshotDigest",
+    "previousLeaseDigest",
+    "previousLeaseKeyId",
+    "signingKeyId",
+}
+_SNAPSHOT_KEYS = {
+    "schemaVersion",
+    "generatedAt",
+    "scope",
+    "healthy",
+    "assuranceLevel",
+    "installOwner",
+    "platform",
+    "architecture",
+    "identifiers",
+    "product",
+    "components",
+    "harnessCoverage",
+    "continuity",
+    "reasonCodes",
+    "remediationClass",
+}
+_IDENTIFIER_KEYS = {"workspaceId", "deviceId", "machineInstallationId", "installationGeneration"}
+_PRODUCT_KEYS = {"version", "buildId", "sourceCommit", "packageIdentity", "manifestHash", "policyHash"}
+_COMPONENT_KEYS = {
+    "manifest",
+    "nativePackage",
+    "managedPolicy",
+    "ownershipAndAcl",
+    "supervisor",
+    "deviceKey",
+    "harnessCoverage",
+    "installationIdentity",
+    "leaseContinuity",
+    "daemon",
+    "commandShadowing",
+    "update",
+}
+_HARNESS_KEYS = {"required", "protected", "degraded", "missing"}
+_CONTINUITY_KEYS = {"monotonicUptimeSeconds", "sequence", "previousLeaseDigest", "bootSessionId"}
+_BASIC_COMPONENT_KEYS = {"state", "healthy", "reasonCode"}
+_INTEGRITY_STATES = frozenset(get_args(IntegrityState))
+_SUPERVISOR_STATES = frozenset(get_args(SupervisorState))
+_KEY_LEVELS = frozenset(get_args(KeyProtectionLevel))
+_REASON_CODES = frozenset(get_args(IntegrityReasonCode))
+
+
+def canonical_json_bytes(payload: dict[str, object]) -> bytes:
+    try:
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("health_lease_json_invalid") from exc
+    return encoded.encode("utf-8")
+
+
+def canonical_timestamp(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("health_lease_invalid")
+    normalized = value.astimezone(timezone.utc).replace(microsecond=0)
+    return normalized.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_timestamp(value: object) -> datetime:
+    if not isinstance(value, str) or _TIMESTAMP.fullmatch(value) is None:
+        raise ValueError("health_lease_invalid")
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        raise ValueError("health_lease_invalid") from exc
+
+
+def _strict_json(payload: bytes, *, maximum: int, reason: str) -> dict[str, object]:
+    if not payload or len(payload) > maximum:
+        raise ValueError(reason)
+    try:
+        decoded = payload.decode("utf-8")
+        raw = json.loads(decoded, parse_constant=_reject_json_constant)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(reason) from exc
+    if not isinstance(raw, dict) or canonical_json_bytes(raw) != payload:
+        raise ValueError(reason)
+    return raw
+
+
+def _reject_json_constant(_value: str) -> None:
+    raise ValueError("health_lease_json_invalid")
+
+
+def _exact_keys(raw: dict[str, object], expected: set[str], reason: str = "health_lease_invalid") -> None:
+    if set(raw) != expected:
+        raise ValueError(reason)
+
+
+def _safe_id(value: object) -> str:
+    if not isinstance(value, str) or _SAFE_ID.fullmatch(value) is None:
+        raise ValueError("health_lease_invalid")
+    return value
+
+
+def _match(value: object, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str) or pattern.fullmatch(value) is None:
+        raise ValueError("health_lease_invalid")
+    return value
+
+
+def _bounded_string(value: object, *, maximum: int, nullable: bool = False) -> str | None:
+    if value is None and nullable:
+        return None
+    if not isinstance(value, str) or not value or len(value.encode("utf-8")) > maximum:
+        raise ValueError("health_lease_outbox_invalid")
+    return value
+
+
+def _optional_uint64(value: object) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= MAX_UINT64:
+        raise ValueError("health_lease_outbox_invalid")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class HealthLeaseBinding:
+    workspace_id: str
+    device_id: str
+
+    def __post_init__(self) -> None:
+        _safe_id(self.workspace_id)
+        _safe_id(self.device_id)
+
+
+@dataclass(frozen=True, slots=True)
+class HealthLeaseClaims:
+    workspace_id: str
+    device_id: str
+    machine_installation_id: str
+    installation_generation: str
+    sequence: int
+    issued_at: str
+    lease_expires_at: str
+    snapshot_schema_version: str
+    snapshot_digest: str
+    previous_lease_digest: str | None
+    previous_lease_key_id: str | None
+    signing_key_id: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schemaVersion": HEALTH_LEASE_SCHEMA,
+            "workspaceId": self.workspace_id,
+            "deviceId": self.device_id,
+            "machineInstallationId": self.machine_installation_id,
+            "installationGeneration": self.installation_generation,
+            "sequence": self.sequence,
+            "issuedAt": self.issued_at,
+            "leaseExpiresAt": self.lease_expires_at,
+            "snapshotSchemaVersion": self.snapshot_schema_version,
+            "snapshotDigest": self.snapshot_digest,
+            "previousLeaseDigest": self.previous_lease_digest,
+            "previousLeaseKeyId": self.previous_lease_key_id,
+            "signingKeyId": self.signing_key_id,
+        }
+
+    @classmethod
+    def parse(cls, raw: object) -> HealthLeaseClaims:
+        if not isinstance(raw, dict):
+            raise ValueError("health_lease_invalid")
+        _exact_keys(raw, _CLAIM_KEYS)
+        if raw.get("schemaVersion") != HEALTH_LEASE_SCHEMA:
+            raise ValueError("health_lease_invalid")
+        sequence = raw.get("sequence")
+        if not isinstance(sequence, int) or isinstance(sequence, bool) or not 1 <= sequence <= MAX_UINT64:
+            raise ValueError("health_lease_invalid")
+        previous_digest = raw.get("previousLeaseDigest")
+        previous_key = raw.get("previousLeaseKeyId")
+        if sequence == 1:
+            if previous_digest is not None or previous_key is not None:
+                raise ValueError("health_lease_invalid")
+        elif previous_digest is None or previous_key is None:
+            raise ValueError("health_lease_invalid")
+        issued = _parse_timestamp(raw.get("issuedAt"))
+        expires = _parse_timestamp(raw.get("leaseExpiresAt"))
+        duration = (expires - issued).total_seconds()
+        if duration <= 0 or duration > MAX_LEASE_SECONDS:
+            raise ValueError("health_lease_invalid")
+        if raw.get("snapshotSchemaVersion") != LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION:
+            raise ValueError("health_lease_invalid")
+        return cls(
+            _safe_id(raw.get("workspaceId")),
+            _safe_id(raw.get("deviceId")),
+            _match(raw.get("machineInstallationId"), _HEX_32),
+            _match(raw.get("installationGeneration"), _HEX_32),
+            sequence,
+            canonical_timestamp(issued),
+            canonical_timestamp(expires),
+            LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION,
+            _match(raw.get("snapshotDigest"), _HEX_64),
+            None if previous_digest is None else _match(previous_digest, _HEX_64),
+            None if previous_key is None else _match(previous_key, _KEY_ID),
+            _match(raw.get("signingKeyId"), _KEY_ID),
+        )
+
+    def signing_payload(self) -> bytes:
+        return HEALTH_LEASE_SIGNING_DOMAIN + canonical_json_bytes(self.to_dict())
+
+
+@dataclass(frozen=True, slots=True)
+class SignedHealthLease:
+    claims: HealthLeaseClaims
+    signature: bytes
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "claims": self.claims.to_dict(),
+            "signature": {
+                "algorithm": SIGNATURE_ALGORITHM,
+                "encoding": SIGNATURE_ENCODING,
+                "value": base64.b64encode(self.signature).decode("ascii"),
+            },
+        }
+
+    def canonical_bytes(self) -> bytes:
+        payload = canonical_json_bytes(self.to_dict())
+        if len(payload) > MAX_LEASE_BYTES:
+            raise ValueError("health_lease_invalid")
+        return payload
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.canonical_bytes()).hexdigest()
+
+    @classmethod
+    def parse(cls, payload: bytes) -> SignedHealthLease:
+        raw = _strict_json(payload, maximum=MAX_LEASE_BYTES, reason="health_lease_invalid")
+        _exact_keys(raw, {"claims", "signature"})
+        signature_raw = raw.get("signature")
+        if not isinstance(signature_raw, dict):
+            raise ValueError("health_lease_invalid")
+        _exact_keys(signature_raw, {"algorithm", "encoding", "value"})
+        if signature_raw.get("algorithm") != SIGNATURE_ALGORITHM or signature_raw.get("encoding") != SIGNATURE_ENCODING:
+            raise ValueError("health_lease_invalid")
+        value = signature_raw.get("value")
+        if not isinstance(value, str) or len(value) > 128:
+            raise ValueError("health_lease_invalid")
+        try:
+            signature = base64.b64decode(value, validate=True)
+            r, s = decode_dss_signature(signature)
+        except (ValueError, TypeError) as exc:
+            raise ValueError("health_lease_invalid") from exc
+        if (
+            not 1 <= r < P256_ORDER
+            or not 1 <= s < P256_ORDER
+            or encode_dss_signature(r, s) != signature
+            or base64.b64encode(signature).decode("ascii") != value
+        ):
+            raise ValueError("health_lease_invalid")
+        return cls(HealthLeaseClaims.parse(raw.get("claims")), signature)
+
+
+@dataclass(frozen=True, slots=True)
+class HealthLeaseOutbox:
+    lease: SignedHealthLease
+    snapshot_bytes: bytes
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schemaVersion": HEALTH_LEASE_OUTBOX_SCHEMA,
+            "lease": self.lease.to_dict(),
+            "leaseDigest": self.lease.digest,
+            "snapshot": base64.b64encode(self.snapshot_bytes).decode("ascii"),
+        }
+
+    def canonical_bytes(self) -> bytes:
+        _validate_snapshot_binding(self.snapshot_bytes, self.lease.claims)
+        payload = canonical_json_bytes(self.to_dict())
+        if len(payload) > MAX_OUTBOX_BYTES:
+            raise ValueError("health_lease_outbox_invalid")
+        return payload
+
+    @classmethod
+    def parse(cls, payload: bytes) -> HealthLeaseOutbox:
+        raw = _strict_json(payload, maximum=MAX_OUTBOX_BYTES, reason="health_lease_outbox_invalid")
+        _exact_keys(raw, {"schemaVersion", "lease", "leaseDigest", "snapshot"}, "health_lease_outbox_invalid")
+        if raw.get("schemaVersion") != HEALTH_LEASE_OUTBOX_SCHEMA:
+            raise ValueError("health_lease_outbox_invalid")
+        lease_raw = raw.get("lease")
+        if not isinstance(lease_raw, dict):
+            raise ValueError("health_lease_outbox_invalid")
+        lease = SignedHealthLease.parse(canonical_json_bytes(lease_raw))
+        snapshot_raw = raw.get("snapshot")
+        if not isinstance(snapshot_raw, str):
+            raise ValueError("health_lease_outbox_invalid")
+        try:
+            snapshot = base64.b64decode(snapshot_raw, validate=True)
+        except ValueError as exc:
+            raise ValueError("health_lease_outbox_invalid") from exc
+        snapshot_digest = hashlib.sha256(snapshot).hexdigest()
+        if not snapshot or len(snapshot) > MAX_SNAPSHOT_BYTES or snapshot_digest != lease.claims.snapshot_digest:
+            raise ValueError("health_lease_outbox_invalid")
+        if raw.get("leaseDigest") != lease.digest:
+            raise ValueError("health_lease_outbox_invalid")
+        outbox = cls(lease, snapshot)
+        _validate_snapshot_binding(snapshot, lease.claims)
+        return outbox
+
+
+def _validate_snapshot_binding(snapshot: bytes, claims: HealthLeaseClaims) -> None:
+    raw = _strict_json(snapshot, maximum=MAX_SNAPSHOT_BYTES, reason="health_lease_outbox_invalid")
+    _exact_keys(raw, _SNAPSHOT_KEYS, "health_lease_outbox_invalid")
+    if raw.get("schemaVersion") != claims.snapshot_schema_version:
+        raise ValueError("health_lease_outbox_invalid")
+    identifiers = raw.get("identifiers")
+    product = raw.get("product")
+    components = raw.get("components")
+    harness = raw.get("harnessCoverage")
+    continuity = raw.get("continuity")
+    if not all(isinstance(value, dict) for value in (identifiers, product, components, harness, continuity)):
+        raise ValueError("health_lease_outbox_invalid")
+    assert isinstance(identifiers, dict)
+    assert isinstance(product, dict)
+    assert isinstance(components, dict)
+    assert isinstance(harness, dict)
+    assert isinstance(continuity, dict)
+    for value, keys in (
+        (identifiers, _IDENTIFIER_KEYS),
+        (product, _PRODUCT_KEYS),
+        (components, _COMPONENT_KEYS),
+        (harness, _HARNESS_KEYS),
+        (continuity, _CONTINUITY_KEYS),
+    ):
+        _exact_keys(value, keys, "health_lease_outbox_invalid")
+    for name, component in components.items():
+        if not isinstance(component, dict):
+            raise ValueError("health_lease_outbox_invalid")
+        expected = _BASIC_COMPONENT_KEYS | ({"level"} if name == "deviceKey" else set())
+        _exact_keys(component, expected, "health_lease_outbox_invalid")
+        allowed_states = _SUPERVISOR_STATES if name == "supervisor" else _INTEGRITY_STATES
+        state = component.get("state")
+        reason_code = component.get("reasonCode")
+        level = component.get("level")
+        if (
+            not isinstance(state, str)
+            or state not in allowed_states
+            or not isinstance(component.get("healthy"), bool)
+            or not isinstance(reason_code, str)
+            or reason_code not in _REASON_CODES
+            or (name == "deviceKey" and (not isinstance(level, str) or level not in _KEY_LEVELS))
+        ):
+            raise ValueError("health_lease_outbox_invalid")
+    generated_at = raw.get("generatedAt")
+    if not isinstance(generated_at, str):
+        raise ValueError("health_lease_outbox_invalid")
+    try:
+        generated = datetime.fromisoformat(generated_at)
+    except ValueError as exc:
+        raise ValueError("health_lease_outbox_invalid") from exc
+    reason_codes = raw.get("reasonCodes")
+    if (
+        generated.tzinfo is None
+        or len(generated_at.encode("utf-8")) > 64
+        or raw.get("scope") != "machine"
+        or not isinstance(raw.get("healthy"), bool)
+        or raw.get("assuranceLevel") not in get_args(AssuranceLevel)
+        or raw.get("installOwner") not in get_args(InstallOwner)
+        or raw.get("remediationClass") not in get_args(RemediationClass)
+        or not isinstance(reason_codes, list)
+        or len(reason_codes) > 128
+        or any(not isinstance(reason, str) or reason not in _REASON_CODES for reason in reason_codes)
+        or reason_codes != sorted(set(reason_codes))
+    ):
+        raise ValueError("health_lease_outbox_invalid")
+    _bounded_string(raw.get("platform"), maximum=64)
+    _bounded_string(raw.get("architecture"), maximum=64)
+    _bounded_string(product.get("version"), maximum=128)
+    _bounded_string(product.get("buildId"), maximum=256, nullable=True)
+    _bounded_string(product.get("sourceCommit"), maximum=256, nullable=True)
+    _bounded_string(product.get("packageIdentity"), maximum=256)
+    for name in ("manifestHash", "policyHash"):
+        value = product.get(name)
+        if value is not None:
+            _match(value, _HEX_64)
+    for value in harness.values():
+        _optional_uint64(value)
+    uptime = continuity.get("monotonicUptimeSeconds")
+    if uptime is not None and (
+        not isinstance(uptime, (int, float)) or isinstance(uptime, bool) or not math.isfinite(uptime) or uptime < 0
+    ):
+        raise ValueError("health_lease_outbox_invalid")
+    _optional_uint64(continuity.get("sequence"))
+    previous = continuity.get("previousLeaseDigest")
+    if previous is not None:
+        _match(previous, _HEX_64)
+    _bounded_string(continuity.get("bootSessionId"), maximum=256, nullable=True)
+    expected_identifiers = {
+        "workspaceId": claims.workspace_id,
+        "deviceId": claims.device_id,
+        "machineInstallationId": claims.machine_installation_id,
+        "installationGeneration": claims.installation_generation,
+    }
+    if any(identifiers.get(key) != value for key, value in expected_identifiers.items()):
+        raise ValueError("health_lease_outbox_invalid")
+    if (
+        continuity.get("sequence") != claims.sequence - 1
+        or continuity.get("previousLeaseDigest") != claims.previous_lease_digest
+    ):
+        raise ValueError("health_lease_outbox_invalid")
+
+
+__all__ = [
+    "HEALTH_LEASE_SIGNING_DOMAIN",
+    "HealthLeaseBinding",
+    "HealthLeaseClaims",
+    "HealthLeaseOutbox",
+    "SignedHealthLease",
+    "canonical_json_bytes",
+    "canonical_timestamp",
+]

--- a/tests/test_guard_mdm_continuity.py
+++ b/tests/test_guard_mdm_continuity.py
@@ -67,6 +67,22 @@ def test_continuity_provision_is_idempotent_and_snapshot_read_is_immutable(
     assert verification.record is not None and verification.record.last_issued_sequence == 0
 
 
+def test_uninitialized_v1_state_without_lease_key_id_remains_compatible(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _prepare(tmp_path, monkeypatch)
+    continuity.provision_machine_continuity()
+    state_path = paths.state_root / "installation-continuity.json"
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    del payload["lastLeaseKeyId"]
+    state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = continuity.verify_installation_continuity(paths, system_name="Darwin")
+
+    assert result.healthy is True
+    assert result.record is not None and result.record.last_lease_key_id is None
+
+
 def test_missing_state_creates_a_fresh_generation_without_inheriting_identity(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -149,6 +165,7 @@ def test_continuity_detects_same_boot_monotonic_regression(tmp_path: Path, monke
         lastLeaseDigest="a" * 64,
         lastLeaseBootSessionId="boot-a",
         lastLeaseMonotonicUptimeNs=20_000_000_000,
+        lastLeaseKeyId="active-key",
     )
     state_path.write_text(json.dumps(payload), encoding="utf-8")
 
@@ -169,6 +186,7 @@ def test_continuity_allows_lower_uptime_after_reboot(tmp_path: Path, monkeypatch
         lastLeaseDigest="a" * 64,
         lastLeaseBootSessionId="boot-before",
         lastLeaseMonotonicUptimeNs=20_000_000_000,
+        lastLeaseKeyId="active-key",
     )
     state_path.write_text(json.dumps(payload), encoding="utf-8")
 
@@ -223,6 +241,7 @@ def test_maximum_sequence_is_degraded_not_healthy(tmp_path: Path, monkeypatch: p
         lastLeaseDigest="a" * 64,
         lastLeaseBootSessionId="boot-before",
         lastLeaseMonotonicUptimeNs=1,
+        lastLeaseKeyId="active-key",
     )
     state_path.write_text(json.dumps(payload), encoding="utf-8")
 

--- a/tests/test_guard_mdm_device_key_signing.py
+++ b/tests/test_guard_mdm_device_key_signing.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import utils
+
+from codex_plugin_scanner.guard.mdm import device_key_native
+from codex_plugin_scanner.guard.mdm.contracts import MachinePaths
+
+
+def _paths(root: Path) -> MachinePaths:
+    return MachinePaths(
+        runtime_root=root / "runtime",
+        state_root=root / "state",
+        policy_path=root / "policy.json",
+        log_root=root / "logs",
+        manifest_path=root / "runtime" / "release-manifest.json",
+    )
+
+
+def _canonical_claims(**changes: object) -> bytes:
+    claims: dict[str, object] = {
+        "schemaVersion": "hol-guard-health-lease.v1",
+        "workspaceId": "workspace-1",
+        "deviceId": "device-1",
+        "machineInstallationId": "a" * 32,
+        "installationGeneration": "b" * 32,
+        "sequence": 1,
+        "issuedAt": "2026-07-18T12:00:00Z",
+        "leaseExpiresAt": "2026-07-18T12:05:00Z",
+        "snapshotSchemaVersion": "local-integrity-snapshot.v1",
+        "snapshotDigest": "c" * 64,
+        "previousLeaseDigest": None,
+        "previousLeaseKeyId": None,
+        "signingKeyId": "A" * 43,
+    }
+    claims.update(changes)
+    return json.dumps(claims, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _successful_result(signature: bytes) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        ["helper"],
+        0,
+        json.dumps(
+            {
+                "ok": True,
+                "signature": base64.b64encode(signature).decode(),
+                "signatureAlgorithm": "ecdsa-p256-sha256",
+                "signatureEncoding": "asn1-der",
+            }
+        ),
+        "",
+    )
+
+
+def test_health_lease_signing_uses_only_purpose_bound_native_operation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    signature = utils.encode_dss_signature(1, 2)
+    run = Mock(return_value=_successful_result(signature))
+    monkeypatch.setattr(device_key_native.subprocess, "run", run)
+    claims = _canonical_claims()
+
+    result = device_key_native.sign_health_lease(_paths(tmp_path), "d" * 32, claims, system_name="Darwin")
+
+    assert result.signature == signature
+    assert result.algorithm == "ecdsa-p256-sha256"
+    assert result.encoding == "asn1-der"
+    assert run.call_args.args[0] == [
+        str(tmp_path / "runtime" / "hol-guard-device-key"),
+        "sign-health-lease",
+        "d" * 32,
+    ]
+    assert run.call_args.kwargs["input"] == claims.decode()
+    with pytest.raises(ValueError, match="device_key_request_invalid"):
+        device_key_native.run_helper(_paths(tmp_path), "sign", "d" * 32, system_name="Darwin")
+
+
+def test_health_lease_signing_accepts_uint64_sequence_boundary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    signature = utils.encode_dss_signature(1, 2)
+    monkeypatch.setattr(device_key_native.subprocess, "run", Mock(return_value=_successful_result(signature)))
+    claims = _canonical_claims(
+        sequence=(1 << 64) - 1,
+        previousLeaseDigest="e" * 64,
+        previousLeaseKeyId="B" * 43,
+    )
+
+    result = device_key_native.sign_health_lease(_paths(tmp_path), "d" * 32, claims, system_name="Darwin")
+
+    assert result.signature == signature
+
+
+@pytest.mark.parametrize(
+    "claims",
+    [
+        b"x" * 4097,
+        _canonical_claims(unexpected=True),
+        b'{"schemaVersion":"hol-guard-health-lease.v1"}',
+        _canonical_claims() + b"\n",
+    ],
+)
+def test_health_lease_signing_rejects_oversized_unknown_or_noncanonical_claims(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, claims: bytes
+) -> None:
+    run = Mock()
+    monkeypatch.setattr(device_key_native.subprocess, "run", run)
+
+    with pytest.raises(ValueError, match="health_lease_claims_invalid"):
+        device_key_native.sign_health_lease(_paths(tmp_path), "d" * 32, claims, system_name="Darwin")
+
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "claims",
+    [
+        _canonical_claims(workspaceId=""),
+        _canonical_claims(deviceId="contains a space"),
+        _canonical_claims(sequence=0),
+        _canonical_claims(sequence=True),
+        _canonical_claims(issuedAt="2026-02-30T12:00:00Z"),
+        _canonical_claims(leaseExpiresAt="2026-07-18T13:00:01Z"),
+        _canonical_claims(snapshotSchemaVersion="hol-guard-local-integrity.v1"),
+        _canonical_claims(signingKeyId="short"),
+    ],
+)
+def test_health_lease_signing_revalidates_claim_values_before_native_execution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, claims: bytes
+) -> None:
+    run = Mock()
+    monkeypatch.setattr(device_key_native.subprocess, "run", run)
+
+    with pytest.raises(ValueError, match="health_lease_claims_invalid"):
+        device_key_native.sign_health_lease(_paths(tmp_path), "d" * 32, claims, system_name="Darwin")
+
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "response_mutation",
+    [
+        {"extra": True},
+        {"signatureAlgorithm": "ecdsa-p256"},
+        {"signatureEncoding": "p1363"},
+        {"signature": "not-base64"},
+    ],
+)
+def test_health_lease_signing_rejects_noncontractual_helper_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, response_mutation: dict[str, object]
+) -> None:
+    payload: dict[str, object] = {
+        "ok": True,
+        "signature": base64.b64encode(utils.encode_dss_signature(1, 2)).decode(),
+        "signatureAlgorithm": "ecdsa-p256-sha256",
+        "signatureEncoding": "asn1-der",
+    }
+    payload.update(response_mutation)
+    monkeypatch.setattr(
+        device_key_native.subprocess,
+        "run",
+        Mock(return_value=subprocess.CompletedProcess(["helper"], 0, json.dumps(payload), "")),
+    )
+
+    with pytest.raises(OSError, match="device_key_probe_failed"):
+        device_key_native.sign_health_lease(_paths(tmp_path), "d" * 32, _canonical_claims(), system_name="Darwin")
+
+
+def test_health_lease_signing_rejects_oversized_helper_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        device_key_native.subprocess,
+        "run",
+        Mock(return_value=subprocess.CompletedProcess(["helper"], 0, "x" * (16 * 1024 + 1), "")),
+    )
+
+    with pytest.raises(OSError, match="device_key_probe_failed"):
+        device_key_native.sign_health_lease(_paths(tmp_path), "d" * 32, _canonical_claims(), system_name="Darwin")
+
+
+@pytest.mark.parametrize(
+    "signature",
+    [
+        b"\x30\x06\x02\x01\x01\x02\x01\x02\x00",
+        b"\x30\x07\x02\x02\x00\x01\x02\x01\x02",
+        utils.encode_dss_signature(0, 2),
+    ],
+)
+def test_health_lease_signing_rejects_noncanonical_or_out_of_range_der(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, signature: bytes
+) -> None:
+    monkeypatch.setattr(device_key_native.subprocess, "run", Mock(return_value=_successful_result(signature)))
+
+    with pytest.raises(OSError, match="device_key_probe_failed"):
+        device_key_native.sign_health_lease(_paths(tmp_path), "d" * 32, _canonical_claims(), system_name="Darwin")
+
+
+def test_native_helpers_bind_health_lease_domain_and_exact_claim_contract() -> None:
+    macos = Path("scripts/mdm/macos/device-key-helper.swift").read_text(encoding="utf-8")
+    windows = Path("scripts/mdm/windows/device-key-helper.ps1").read_text(encoding="utf-8")
+
+    for source in (macos, windows):
+        assert "HOL-GUARD-HEALTH-LEASE-V1" in source
+        assert "hol-guard-health-lease.v1" in source
+        assert "local-integrity-snapshot.v1" in source
+        assert "sign-health-lease" in source
+        assert "sign-message" not in source
+        assert "sign-digest" not in source
+    assert "ecdsaSignatureMessageX962SHA256" in macos
+    assert "SHA256.hash(data: spkiPrefix + publicKeyX963)" in macos
+    assert "claimedSigningKeyId == expectedSigningKeyId" in macos
+    assert "Convert-P1363ToDer" in windows
+    assert "Get-SigningKeyId $PublicKey" in windows
+    assert "$Claims.signingKeyId -ne $ExpectedSigningKeyId" in windows
+
+
+@pytest.mark.skipif(os.name != "nt", reason="PowerShell helper conversion requires Windows")
+@pytest.mark.parametrize(
+    ("r", "s"),
+    [
+        (1, 1),
+        (0x7F, 0x80 << 248),
+        (0x80, (1 << 256) - 1),
+    ],
+)
+def test_windows_p1363_to_der_conversion_vectors(r: int, s: int) -> None:
+    powershell = Path(os.environ["SYSTEMROOT"]) / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
+    helper = Path("scripts/mdm/windows/device-key-helper.ps1").resolve()
+    p1363 = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+    program = (
+        "$tokens=$null;$errors=$null;"
+        "$ast=[System.Management.Automation.Language.Parser]::ParseFile($args[0],[ref]$tokens,[ref]$errors);"
+        "$fn=$ast.Find({param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] "
+        "-and $node.Name -eq 'Convert-P1363ToDer'},$true);"
+        "Invoke-Expression $fn.Extent.Text;"
+        "$raw=[Convert]::FromBase64String($args[1]);"
+        "[Convert]::ToBase64String((Convert-P1363ToDer $raw))"
+    )
+    result = subprocess.run(
+        [
+            str(powershell),
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            program,
+            str(helper),
+            base64.b64encode(p1363).decode(),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert base64.b64decode(result.stdout.strip(), validate=True) == utils.encode_dss_signature(r, s)

--- a/tests/test_guard_mdm_health_lease.py
+++ b/tests/test_guard_mdm_health_lease.py
@@ -1,0 +1,469 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from threading import Barrier
+from typing import cast
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from codex_plugin_scanner.guard.mdm import continuity, health_lease
+from codex_plugin_scanner.guard.mdm.contracts import LocalIntegritySnapshot, MachinePaths
+from codex_plugin_scanner.guard.mdm.device_key import KeyGeneration
+from codex_plugin_scanner.guard.mdm.health_lease_contract import (
+    HEALTH_LEASE_SCHEMA,
+    HealthLeaseBinding,
+    HealthLeaseClaims,
+    HealthLeaseOutbox,
+    SignedHealthLease,
+    canonical_json_bytes,
+)
+
+_NOW = datetime(2026, 7, 18, 14, 0, tzinfo=timezone.utc)
+_INSTALLATION_ID = "1" * 32
+_GENERATION_ID = "2" * 32
+
+
+def _paths(root: Path) -> MachinePaths:
+    return MachinePaths(
+        runtime_root=root / "runtime",
+        state_root=root / "state",
+        policy_path=root / "policy.json",
+        log_root=root / "logs",
+        manifest_path=root / "runtime" / "release-manifest.json",
+    )
+
+
+def _key() -> tuple[ec.EllipticCurvePrivateKey, KeyGeneration]:
+    private = ec.generate_private_key(ec.SECP256R1())
+    public = private.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    key_id = base64.urlsafe_b64encode(hashlib.sha256(public).digest()).decode("ascii").rstrip("=")
+    return private, KeyGeneration(
+        generation="3" * 32,
+        key_id=key_id,
+        public_key_spki=base64.b64encode(public).decode("ascii"),
+        protection_level="os-protected",
+        created_at="2026-07-18T13:00:00+00:00",
+    )
+
+
+def _claims(key_id: str, **updates: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schemaVersion": HEALTH_LEASE_SCHEMA,
+        "workspaceId": "workspace-a",
+        "deviceId": "device-a",
+        "machineInstallationId": _INSTALLATION_ID,
+        "installationGeneration": _GENERATION_ID,
+        "sequence": 1,
+        "issuedAt": "2026-07-18T14:00:00Z",
+        "leaseExpiresAt": "2026-07-18T14:15:00Z",
+        "snapshotSchemaVersion": "local-integrity-snapshot.v1",
+        "snapshotDigest": "4" * 64,
+        "previousLeaseDigest": None,
+        "previousLeaseKeyId": None,
+        "signingKeyId": key_id,
+    }
+    payload.update(updates)
+    return payload
+
+
+def _snapshot(sequence: int = 0, previous_digest: str | None = None) -> LocalIntegritySnapshot:
+    component = {"state": "healthy", "healthy": True, "reasonCode": "release_manifest_valid"}
+    components = {
+        name: dict(component)
+        for name in (
+            "manifest",
+            "nativePackage",
+            "managedPolicy",
+            "ownershipAndAcl",
+            "supervisor",
+            "harnessCoverage",
+            "installationIdentity",
+            "leaseContinuity",
+            "daemon",
+            "commandShadowing",
+            "update",
+        )
+    }
+    components["deviceKey"] = {**component, "level": "os-protected"}
+    components["supervisor"] = {**component, "state": "running"}
+    return cast(
+        LocalIntegritySnapshot,
+        cast(
+            object,
+            {
+                "schemaVersion": "local-integrity-snapshot.v1",
+                "generatedAt": "2026-07-18T14:00:00+00:00",
+                "scope": "machine",
+                "healthy": True,
+                "assuranceLevel": "mdm-managed",
+                "installOwner": "mdm",
+                "platform": "Darwin",
+                "architecture": "arm64",
+                "identifiers": {
+                    "workspaceId": None,
+                    "deviceId": None,
+                    "machineInstallationId": _INSTALLATION_ID,
+                    "installationGeneration": _GENERATION_ID,
+                },
+                "product": {
+                    "version": "3.1.0a1",
+                    "buildId": None,
+                    "sourceCommit": None,
+                    "packageIdentity": "test",
+                    "manifestHash": None,
+                    "policyHash": None,
+                },
+                "components": components,
+                "harnessCoverage": {"required": 0, "protected": 0, "degraded": 0, "missing": 0},
+                "continuity": {
+                    "monotonicUptimeSeconds": 10.0,
+                    "sequence": sequence,
+                    "previousLeaseDigest": previous_digest,
+                    "bootSessionId": "boot-a",
+                },
+                "reasonCodes": [],
+                "remediationClass": "none",
+            },
+        ),
+    )
+
+
+def _prepare(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[MachinePaths, ec.EllipticCurvePrivateKey, KeyGeneration]:
+    paths = _paths(tmp_path)
+    paths.state_root.mkdir(parents=True)
+    private, key = _key()
+    monkeypatch.setattr(continuity, "_private_regular_file", lambda _metadata: True)
+    monkeypatch.setattr(health_lease, "_private_regular_file", lambda _metadata: True)
+    monkeypatch.setattr(health_lease, "verified_machine_device_key_by_id", lambda *_args, **_kwargs: key)
+    monkeypatch.setattr(
+        health_lease,
+        "observe_boot",
+        lambda **_kwargs: continuity.BootObservation("boot-a", 10_000_000_000),
+    )
+    record = continuity.InstallationContinuityRecord(
+        machine_installation_id=_INSTALLATION_ID,
+        installation_generation=_GENERATION_ID,
+        generation_created_at="2026-07-18T13:00:00+00:00",
+        key_id_at_generation_creation=key.key_id,
+        last_issued_sequence=0,
+        last_lease_digest=None,
+        last_lease_boot_session_id=None,
+        last_lease_monotonic_uptime_ns=None,
+        updated_at="2026-07-18T13:00:00+00:00",
+        last_lease_key_id=None,
+    )
+    continuity._atomic_write(paths, record)
+    return paths, private, key
+
+
+def _signer(private: ec.EllipticCurvePrivateKey) -> health_lease.LeaseSigner:
+    def sign(
+        _paths: MachinePaths,
+        _generation: KeyGeneration,
+        claims: HealthLeaseClaims,
+        _system_name: str,
+    ) -> bytes:
+        return private.sign(claims.signing_payload(), ec.ECDSA(hashes.SHA256()))
+
+    return sign
+
+
+def test_outbox_rejects_oversized_snapshot() -> None:
+    private, key = _key()
+    snapshot = b"x" * (256 * 1024 + 1)
+    claims = HealthLeaseClaims.parse(_claims(key.key_id, snapshotDigest=hashlib.sha256(snapshot).hexdigest()))
+    lease = SignedHealthLease(
+        claims,
+        private.sign(claims.signing_payload(), ec.ECDSA(hashes.SHA256())),
+    )
+
+    with pytest.raises(ValueError, match="health_lease_outbox_invalid"):
+        HealthLeaseOutbox(lease, snapshot).canonical_bytes()
+
+
+@pytest.mark.parametrize("container", [None, "identifiers", "product", "components", "harnessCoverage", "continuity"])
+def test_outbox_rejects_unknown_snapshot_fields(container: str | None) -> None:
+    private, key = _key()
+    snapshot = cast(dict[str, object], cast(object, _snapshot()))
+    identifiers = cast(dict[str, object], snapshot["identifiers"])
+    identifiers.update(workspaceId="workspace-a", deviceId="device-a")
+    target = snapshot if container is None else cast(dict[str, object], snapshot[container])
+    target["unexpected"] = True
+    snapshot_bytes = canonical_json_bytes(snapshot)
+    claims = HealthLeaseClaims.parse(_claims(key.key_id, snapshotDigest=hashlib.sha256(snapshot_bytes).hexdigest()))
+    lease = SignedHealthLease(claims, private.sign(claims.signing_payload(), ec.ECDSA(hashes.SHA256())))
+
+    with pytest.raises(ValueError, match="health_lease_outbox_invalid"):
+        HealthLeaseOutbox(lease, snapshot_bytes).canonical_bytes()
+
+
+def test_snapshot_canonicalization_rejects_non_finite_numbers() -> None:
+    snapshot = cast(dict[str, object], cast(object, _snapshot()))
+    continuity_payload = cast(dict[str, object], snapshot["continuity"])
+    continuity_payload["monotonicUptimeSeconds"] = float("nan")
+
+    with pytest.raises(ValueError, match="health_lease_json_invalid"):
+        canonical_json_bytes(snapshot)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda snapshot: cast(dict[str, object], cast(dict[str, object], snapshot["components"])["manifest"]).update(
+            state={}
+        ),
+        lambda snapshot: cast(list[object], snapshot["reasonCodes"]).append({}),
+        lambda snapshot: cast(dict[str, object], snapshot["harnessCoverage"]).update(required=True),
+        lambda snapshot: cast(dict[str, object], snapshot["product"]).update(version="x" * 129),
+        lambda snapshot: cast(dict[str, object], snapshot["continuity"]).update(monotonicUptimeSeconds=-1),
+    ],
+)
+def test_outbox_rejects_malformed_snapshot_values(mutation: object) -> None:
+    private, key = _key()
+    snapshot = cast(dict[str, object], cast(object, _snapshot()))
+    cast(dict[str, object], snapshot["identifiers"]).update(workspaceId="workspace-a", deviceId="device-a")
+    assert callable(mutation)
+    mutation(snapshot)
+    snapshot_bytes = canonical_json_bytes(snapshot)
+    claims = HealthLeaseClaims.parse(_claims(key.key_id, snapshotDigest=hashlib.sha256(snapshot_bytes).hexdigest()))
+    lease = SignedHealthLease(claims, private.sign(claims.signing_payload(), ec.ECDSA(hashes.SHA256())))
+
+    with pytest.raises(ValueError, match="health_lease_outbox_invalid"):
+        HealthLeaseOutbox(lease, snapshot_bytes).canonical_bytes()
+
+
+def test_sequence_requires_complete_prior_lease_chain() -> None:
+    _, key = _key()
+    chained = HealthLeaseClaims.parse(
+        _claims(
+            key.key_id,
+            sequence=2,
+            previousLeaseDigest="5" * 64,
+            previousLeaseKeyId=key.key_id,
+        )
+    )
+
+    assert chained.sequence == 2
+    for field in ("previousLeaseDigest", "previousLeaseKeyId"):
+        invalid = _claims(
+            key.key_id,
+            sequence=2,
+            previousLeaseDigest="5" * 64,
+            previousLeaseKeyId=key.key_id,
+        )
+        invalid[field] = None
+        with pytest.raises(ValueError, match="health_lease_invalid"):
+            HealthLeaseClaims.parse(invalid)
+
+
+def test_issue_binds_exact_normalized_snapshot_digest_and_verifies_signature(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, private, key = _prepare(tmp_path, monkeypatch)
+
+    outbox = health_lease.issue_or_load_pending_health_lease(
+        paths,
+        HealthLeaseBinding("workspace-a", "device-a"),
+        now=_NOW,
+        system_name="Darwin",
+        snapshot_factory=_snapshot,
+        signer=_signer(private),
+    )
+
+    decoded_snapshot = json.loads(outbox.snapshot_bytes)
+    assert decoded_snapshot["identifiers"]["workspaceId"] == "workspace-a"
+    assert decoded_snapshot["identifiers"]["deviceId"] == "device-a"
+    assert outbox.lease.claims.snapshot_digest == hashlib.sha256(outbox.snapshot_bytes).hexdigest()
+    private.public_key().verify(
+        outbox.lease.signature,
+        outbox.lease.claims.signing_payload(),
+        ec.ECDSA(hashes.SHA256()),
+    )
+    assert outbox.lease.claims.signing_key_id == key.key_id
+
+
+def test_issue_rejects_signature_from_an_unrelated_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths, _private, _key_generation = _prepare(tmp_path, monkeypatch)
+    attacker = ec.generate_private_key(ec.SECP256R1())
+
+    with pytest.raises(OSError, match="health_lease_signature_invalid"):
+        health_lease.issue_or_load_pending_health_lease(
+            paths,
+            HealthLeaseBinding("workspace-a", "device-a"),
+            now=_NOW,
+            system_name="Darwin",
+            snapshot_factory=_snapshot,
+            signer=_signer(attacker),
+        )
+
+    assert not (paths.state_root / "health-lease-outbox.json").exists()
+
+
+def test_missing_pending_after_issuance_fails_without_reusing_sequence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, private, _key = _prepare(tmp_path, monkeypatch)
+    first = health_lease.issue_or_load_pending_health_lease(
+        paths,
+        HealthLeaseBinding("workspace-a", "device-a"),
+        now=_NOW,
+        system_name="Darwin",
+        snapshot_factory=_snapshot,
+        signer=_signer(private),
+    )
+    (paths.state_root / "health-lease-outbox.json").unlink()
+
+    with pytest.raises(OSError, match="health_lease_outbox_absent"):
+        health_lease.issue_or_load_pending_health_lease(
+            paths,
+            HealthLeaseBinding("workspace-a", "device-a"),
+            now=_NOW + timedelta(minutes=1),
+            system_name="Darwin",
+            snapshot_factory=lambda: _snapshot(1, first.lease.digest),
+            signer=_signer(private),
+        )
+
+    record = continuity._read_record(paths)
+    assert record is not None and record.last_issued_sequence == 1
+    assert record.last_lease_digest == first.lease.digest
+
+
+def test_crash_after_outbox_write_recovers_byte_identical_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, private, _key_generation = _prepare(tmp_path, monkeypatch)
+
+    def crash(stage: str) -> None:
+        assert stage == "outbox-durable"
+        raise RuntimeError("simulated-crash")
+
+    with pytest.raises(RuntimeError, match="simulated-crash"):
+        health_lease.issue_or_load_pending_health_lease(
+            paths,
+            HealthLeaseBinding("workspace-a", "device-a"),
+            now=_NOW,
+            system_name="Darwin",
+            snapshot_factory=_snapshot,
+            signer=_signer(private),
+            crash_hook=crash,
+        )
+    outbox_path = paths.state_root / "health-lease-outbox.json"
+    before = outbox_path.read_bytes()
+    initial_record = continuity._read_record(paths)
+    assert initial_record is not None and initial_record.last_issued_sequence == 0
+
+    recovered = health_lease.issue_or_load_pending_health_lease(
+        paths,
+        HealthLeaseBinding("workspace-a", "device-a"),
+        now=_NOW + timedelta(seconds=1),
+        system_name="Darwin",
+        snapshot_factory=lambda: pytest.fail("snapshot must not be recollected"),
+        signer=lambda *_args, **_kwargs: pytest.fail("lease must not be resigned"),
+    )
+
+    assert recovered.canonical_bytes() == HealthLeaseOutbox.parse(before).canonical_bytes()
+    assert outbox_path.read_bytes() == before
+    record = continuity._read_record(paths)
+    assert record is not None and record.last_issued_sequence == 1
+    assert record.last_lease_digest == recovered.lease.digest
+
+
+def test_pending_binding_conflict_and_expiry_fail_without_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, private, _key_generation = _prepare(tmp_path, monkeypatch)
+    issued = health_lease.issue_or_load_pending_health_lease(
+        paths,
+        HealthLeaseBinding("workspace-a", "device-a"),
+        now=_NOW,
+        system_name="Darwin",
+        snapshot_factory=_snapshot,
+        signer=_signer(private),
+    )
+    outbox_path = paths.state_root / "health-lease-outbox.json"
+    before = outbox_path.read_bytes()
+
+    with pytest.raises(OSError, match="health_lease_pending_conflict"):
+        health_lease.issue_or_load_pending_health_lease(
+            paths,
+            HealthLeaseBinding("workspace-b", "device-a"),
+            now=_NOW + timedelta(seconds=1),
+            system_name="Darwin",
+        )
+    with pytest.raises(OSError, match="health_lease_pending_expired"):
+        health_lease.issue_or_load_pending_health_lease(
+            paths,
+            HealthLeaseBinding("workspace-a", "device-a"),
+            now=_NOW + timedelta(minutes=15),
+            system_name="Darwin",
+        )
+
+    assert outbox_path.read_bytes() == before
+    assert health_lease.load_pending_health_lease(paths) == issued
+
+
+def test_malformed_and_symlink_outbox_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths, _private, _key_generation = _prepare(tmp_path, monkeypatch)
+    outbox_path = paths.state_root / "health-lease-outbox.json"
+    outbox_path.write_bytes(b'{"schemaVersion":"wrong"}')
+
+    with pytest.raises(ValueError, match="health_lease_outbox_invalid"):
+        health_lease.load_pending_health_lease(paths)
+
+    outbox_path.unlink()
+    target = tmp_path / "attacker-controlled"
+    target.write_text("{}", encoding="utf-8")
+    outbox_path.symlink_to(target)
+    with pytest.raises(PermissionError, match="health_lease_outbox_acl_invalid"):
+        health_lease.load_pending_health_lease(paths)
+
+
+def test_concurrent_issuance_creates_only_one_pending_lease(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths, private, _key_generation = _prepare(tmp_path, monkeypatch)
+    barrier = Barrier(2)
+
+    def issue() -> HealthLeaseOutbox:
+        barrier.wait()
+        return health_lease.issue_or_load_pending_health_lease(
+            paths,
+            HealthLeaseBinding("workspace-a", "device-a"),
+            now=_NOW,
+            system_name="Darwin",
+            snapshot_factory=_snapshot,
+            signer=_signer(private),
+        )
+
+    results: list[HealthLeaseOutbox] = []
+    conflicts: list[BlockingIOError] = []
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        for future in (executor.submit(issue), executor.submit(issue)):
+            try:
+                results.append(future.result())
+            except BlockingIOError as exc:
+                conflicts.append(exc)
+
+    assert results
+    assert len(results) + len(conflicts) == 2
+    retry = health_lease.issue_or_load_pending_health_lease(
+        paths,
+        HealthLeaseBinding("workspace-a", "device-a"),
+        now=_NOW,
+        system_name="Darwin",
+    )
+    assert all(result.canonical_bytes() == retry.canonical_bytes() for result in results)
+    assert os.stat(paths.state_root / "health-lease-outbox.json").st_mode & 0o777 == 0o600
+    record = continuity._read_record(paths)
+    assert record is not None and record.last_issued_sequence == 1

--- a/tests/test_guard_mdm_health_lease_contract.py
+++ b/tests/test_guard_mdm_health_lease_contract.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from typing import cast
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from codex_plugin_scanner.guard.mdm.health_lease_contract import (
+    HEALTH_LEASE_SCHEMA,
+    MAX_LEASE_BYTES,
+    HealthLeaseClaims,
+    HealthLeaseOutbox,
+    SignedHealthLease,
+    canonical_json_bytes,
+)
+
+
+def _key() -> tuple[ec.EllipticCurvePrivateKey, str]:
+    private = ec.generate_private_key(ec.SECP256R1())
+    public = private.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    key_id = base64.urlsafe_b64encode(hashlib.sha256(public).digest()).decode("ascii").rstrip("=")
+    return private, key_id
+
+
+def _claims(key_id: str, **updates: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schemaVersion": HEALTH_LEASE_SCHEMA,
+        "workspaceId": "workspace-a",
+        "deviceId": "device-a",
+        "machineInstallationId": "1" * 32,
+        "installationGeneration": "2" * 32,
+        "sequence": 1,
+        "issuedAt": "2026-07-18T14:00:00Z",
+        "leaseExpiresAt": "2026-07-18T14:15:00Z",
+        "snapshotSchemaVersion": "local-integrity-snapshot.v1",
+        "snapshotDigest": "4" * 64,
+        "previousLeaseDigest": None,
+        "previousLeaseKeyId": None,
+        "signingKeyId": key_id,
+    }
+    payload.update(updates)
+    return payload
+
+
+def _signed_lease(private: ec.EllipticCurvePrivateKey, key_id: str) -> SignedHealthLease:
+    claims = HealthLeaseClaims.parse(_claims(key_id))
+    return SignedHealthLease(claims, private.sign(claims.signing_payload(), ec.ECDSA(hashes.SHA256())))
+
+
+def _snapshot() -> dict[str, object]:
+    component = {"state": "healthy", "healthy": True, "reasonCode": "release_manifest_valid"}
+    components = {
+        name: dict(component)
+        for name in (
+            "manifest",
+            "nativePackage",
+            "managedPolicy",
+            "ownershipAndAcl",
+            "supervisor",
+            "harnessCoverage",
+            "installationIdentity",
+            "leaseContinuity",
+            "daemon",
+            "commandShadowing",
+            "update",
+        )
+    }
+    components["deviceKey"] = {**component, "level": "os-protected"}
+    components["supervisor"] = {**component, "state": "running"}
+    return {
+        "schemaVersion": "local-integrity-snapshot.v1",
+        "generatedAt": "2026-07-18T14:00:00+00:00",
+        "scope": "machine",
+        "healthy": True,
+        "assuranceLevel": "mdm-managed",
+        "installOwner": "mdm",
+        "platform": "Darwin",
+        "architecture": "arm64",
+        "identifiers": {
+            "workspaceId": "workspace-a",
+            "deviceId": "device-a",
+            "machineInstallationId": "1" * 32,
+            "installationGeneration": "2" * 32,
+        },
+        "product": {
+            "version": "3.1.0a1",
+            "buildId": None,
+            "sourceCommit": None,
+            "packageIdentity": "test",
+            "manifestHash": None,
+            "policyHash": None,
+        },
+        "components": components,
+        "harnessCoverage": {"required": 0, "protected": 0, "degraded": 0, "missing": 0},
+        "continuity": {
+            "monotonicUptimeSeconds": 10.0,
+            "sequence": 0,
+            "previousLeaseDigest": None,
+            "bootSessionId": "boot-a",
+        },
+        "reasonCodes": [],
+        "remediationClass": "none",
+    }
+
+
+def _outbox(snapshot: dict[str, object]) -> HealthLeaseOutbox:
+    private, key_id = _key()
+    snapshot_bytes = canonical_json_bytes(snapshot)
+    claims = HealthLeaseClaims.parse(_claims(key_id, snapshotDigest=hashlib.sha256(snapshot_bytes).hexdigest()))
+    lease = SignedHealthLease(claims, private.sign(claims.signing_payload(), ec.ECDSA(hashes.SHA256())))
+    return HealthLeaseOutbox(lease, snapshot_bytes)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda payload: payload.update(unexpected=True),
+        lambda payload: payload.update(sequence=True),
+        lambda payload: payload.update(workspaceId="../escape"),
+        lambda payload: payload.update(workspaceId="wörkspace"),
+        lambda payload: payload.update(leaseExpiresAt="2026-07-18T15:00:01Z"),
+        lambda payload: payload.update(previousLeaseDigest="5" * 64),
+        lambda payload: payload.update(signingKeyId="not-a-key-id"),
+    ],
+)
+def test_claims_reject_unknown_malformed_and_inconsistent_fields(mutation: object) -> None:
+    _, key_id = _key()
+    payload = _claims(key_id)
+    assert callable(mutation)
+    mutation(payload)
+
+    with pytest.raises(ValueError, match="health_lease_invalid"):
+        HealthLeaseClaims.parse(payload)
+
+
+def test_signed_lease_requires_exact_canonical_json_and_bounded_input() -> None:
+    private, key_id = _key()
+    lease = _signed_lease(private, key_id)
+    canonical = lease.canonical_bytes()
+
+    assert SignedHealthLease.parse(canonical) == lease
+    with pytest.raises(ValueError, match="health_lease_invalid"):
+        SignedHealthLease.parse(json.dumps(lease.to_dict(), indent=2).encode())
+    with pytest.raises(ValueError, match="health_lease_invalid"):
+        unexpected = lease.to_dict()
+        unexpected["unexpected"] = True
+        SignedHealthLease.parse(canonical_json_bytes(unexpected))
+    with pytest.raises(ValueError, match="health_lease_invalid"):
+        SignedHealthLease.parse(b"{" + b" " * MAX_LEASE_BYTES + b"}")
+
+
+def test_signed_lease_parser_rejects_invalid_base64() -> None:
+    private, key_id = _key()
+    payload = _signed_lease(private, key_id).to_dict()
+    cast(dict[str, object], payload["signature"])["value"] = "***"
+
+    with pytest.raises(ValueError, match="health_lease_invalid"):
+        SignedHealthLease.parse(canonical_json_bytes(payload))
+
+
+def test_outbox_rejects_oversized_snapshot() -> None:
+    private, key_id = _key()
+    snapshot = b"x" * (256 * 1024 + 1)
+    claims = HealthLeaseClaims.parse(_claims(key_id, snapshotDigest=hashlib.sha256(snapshot).hexdigest()))
+    lease = SignedHealthLease(claims, private.sign(claims.signing_payload(), ec.ECDSA(hashes.SHA256())))
+
+    with pytest.raises(ValueError, match="health_lease_outbox_invalid"):
+        HealthLeaseOutbox(lease, snapshot).canonical_bytes()
+
+
+@pytest.mark.parametrize("container", [None, "identifiers", "product", "components", "harnessCoverage", "continuity"])
+def test_outbox_rejects_unknown_snapshot_fields(container: str | None) -> None:
+    snapshot = _snapshot()
+    target = snapshot if container is None else cast(dict[str, object], snapshot[container])
+    target["unexpected"] = True
+
+    with pytest.raises(ValueError, match="health_lease_outbox_invalid"):
+        _outbox(snapshot).canonical_bytes()
+
+
+def test_snapshot_canonicalization_rejects_non_finite_numbers() -> None:
+    snapshot = _snapshot()
+    cast(dict[str, object], snapshot["continuity"])["monotonicUptimeSeconds"] = float("nan")
+
+    with pytest.raises(ValueError, match="health_lease_json_invalid"):
+        canonical_json_bytes(snapshot)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda snapshot: cast(dict[str, object], cast(dict[str, object], snapshot["components"])["manifest"]).update(
+            state={}
+        ),
+        lambda snapshot: cast(list[object], snapshot["reasonCodes"]).append({}),
+        lambda snapshot: cast(dict[str, object], snapshot["harnessCoverage"]).update(required=True),
+        lambda snapshot: cast(dict[str, object], snapshot["product"]).update(version="x" * 129),
+        lambda snapshot: cast(dict[str, object], snapshot["continuity"]).update(monotonicUptimeSeconds=-1),
+    ],
+)
+def test_outbox_rejects_malformed_snapshot_values(mutation: object) -> None:
+    snapshot = _snapshot()
+    assert callable(mutation)
+    mutation(snapshot)
+
+    with pytest.raises(ValueError, match="health_lease_outbox_invalid"):
+        _outbox(snapshot).canonical_bytes()
+
+
+def test_sequence_requires_complete_prior_lease_chain() -> None:
+    _, key_id = _key()
+    chained = HealthLeaseClaims.parse(
+        _claims(key_id, sequence=2, previousLeaseDigest="5" * 64, previousLeaseKeyId=key_id)
+    )
+
+    assert chained.sequence == 2
+    for field in ("previousLeaseDigest", "previousLeaseKeyId"):
+        invalid = _claims(key_id, sequence=2, previousLeaseDigest="5" * 64, previousLeaseKeyId=key_id)
+        invalid[field] = None
+        with pytest.raises(ValueError, match="health_lease_invalid"):
+            HealthLeaseClaims.parse(invalid)


### PR DESCRIPTION
## Summary
- add a strict, bounded health-lease and snapshot contract bound to workspace, device, installation generation, sequence, prior lease, and key identity
- add purpose-bound P-256 signing through macOS System Keychain and Windows machine CNG keys without exposing a generic signing operation
- persist one protected pending lease with crash-consistent recovery and fail-closed replay, conflict, expiry, deletion, and rotation handling

## Verification
- `uv run pytest -q tests/test_guard_mdm_*.py` (246 passed, 7 skipped)
- touched-file Ruff checks
- full basedpyright (0 errors)
- macOS Swift helper typecheck and production link command
- independent security review: no unresolved findings

Windows-native runtime vectors remain platform-gated and will run in Windows CI.