### PR TITLE
fix(mdm): canonicalize health lease signatures

### DIFF
--- a/src/codex_plugin_scanner/guard/mdm/health_lease_contract.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_lease_contract.py
@@ -263,18 +263,33 @@ class HealthLeaseClaims:
         return HEALTH_LEASE_SIGNING_DOMAIN + canonical_json_bytes(self.to_dict())
 
 
+def _canonical_ecdsa_signature(signature: bytes) -> bytes:
+    try:
+        r, s = decode_dss_signature(signature)
+    except ValueError as exc:
+        raise ValueError("health_lease_invalid") from exc
+    if (
+        not 1 <= r < P256_ORDER
+        or not 1 <= s < P256_ORDER
+        or encode_dss_signature(r, s) != signature
+    ):
+        raise ValueError("health_lease_invalid")
+    return encode_dss_signature(r, min(s, P256_ORDER - s))
+
+
 @dataclass(frozen=True, slots=True)
 class SignedHealthLease:
     claims: HealthLeaseClaims
     signature: bytes
 
     def to_dict(self) -> dict[str, object]:
+        signature = _canonical_ecdsa_signature(self.signature)
         return {
             "claims": self.claims.to_dict(),
             "signature": {
                 "algorithm": SIGNATURE_ALGORITHM,
                 "encoding": SIGNATURE_ENCODING,
-                "value": base64.b64encode(self.signature).decode("ascii"),
+                "value": base64.b64encode(signature).decode("ascii"),
             },
         }
 
@@ -303,13 +318,11 @@ class SignedHealthLease:
             raise ValueError("health_lease_invalid")
         try:
             signature = base64.b64decode(value, validate=True)
-            r, s = decode_dss_signature(signature)
+            canonical_signature = _canonical_ecdsa_signature(signature)
         except (ValueError, TypeError) as exc:
             raise ValueError("health_lease_invalid") from exc
         if (
-            not 1 <= r < P256_ORDER
-            or not 1 <= s < P256_ORDER
-            or encode_dss_signature(r, s) != signature
+            canonical_signature != signature
             or base64.b64encode(signature).decode("ascii") != value
         ):
             raise ValueError("health_lease_invalid")

--- a/src/codex_plugin_scanner/guard/mdm/health_lease_contract.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_lease_contract.py
@@ -268,13 +268,11 @@ def _canonical_ecdsa_signature(signature: bytes) -> bytes:
         r, s = decode_dss_signature(signature)
     except ValueError as exc:
         raise ValueError("health_lease_invalid") from exc
-    if (
-        not 1 <= r < P256_ORDER
-        or not 1 <= s < P256_ORDER
-        or encode_dss_signature(r, s) != signature
-    ):
+    if not 1 <= r < P256_ORDER or not 1 <= s < P256_ORDER or encode_dss_signature(r, s) != signature:
         raise ValueError("health_lease_invalid")
-    return encode_dss_signature(r, min(s, P256_ORDER - s))
+    if s <= P256_ORDER // 2:
+        return signature
+    return encode_dss_signature(r, P256_ORDER - s)
 
 
 @dataclass(frozen=True, slots=True)
@@ -321,10 +319,7 @@ class SignedHealthLease:
             canonical_signature = _canonical_ecdsa_signature(signature)
         except (ValueError, TypeError) as exc:
             raise ValueError("health_lease_invalid") from exc
-        if (
-            canonical_signature != signature
-            or base64.b64encode(signature).decode("ascii") != value
-        ):
+        if canonical_signature != signature or base64.b64encode(signature).decode("ascii") != value:
             raise ValueError("health_lease_invalid")
         return cls(HealthLeaseClaims.parse(raw.get("claims")), signature)
 

--- a/tests/test_guard_mdm_health_lease.py
+++ b/tests/test_guard_mdm_health_lease.py
@@ -13,12 +13,14 @@ from typing import cast
 import pytest
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
 
 from codex_plugin_scanner.guard.mdm import continuity, health_lease
 from codex_plugin_scanner.guard.mdm.contracts import LocalIntegritySnapshot, MachinePaths
 from codex_plugin_scanner.guard.mdm.device_key import KeyGeneration
 from codex_plugin_scanner.guard.mdm.health_lease_contract import (
     HEALTH_LEASE_SCHEMA,
+    P256_ORDER,
     HealthLeaseBinding,
     HealthLeaseClaims,
     HealthLeaseOutbox,
@@ -192,6 +194,24 @@ def test_outbox_rejects_oversized_snapshot() -> None:
 
     with pytest.raises(ValueError, match="health_lease_outbox_invalid"):
         HealthLeaseOutbox(lease, snapshot).canonical_bytes()
+
+
+def test_signed_lease_emits_low_s_and_rejects_high_s() -> None:
+    private, key = _key()
+    claims = HealthLeaseClaims.parse(_claims(key.key_id))
+    signature = private.sign(claims.signing_payload(), ec.ECDSA(hashes.SHA256()))
+    r, s = decode_dss_signature(signature)
+    high_s_signature = encode_dss_signature(r, max(s, P256_ORDER - s))
+    lease = SignedHealthLease(claims, high_s_signature)
+    serialized = json.loads(lease.canonical_bytes())
+    serialized_signature = base64.b64decode(serialized["signature"]["value"], validate=True)
+    _, serialized_s = decode_dss_signature(serialized_signature)
+
+    assert serialized_s <= P256_ORDER // 2
+
+    serialized["signature"]["value"] = base64.b64encode(high_s_signature).decode("ascii")
+    with pytest.raises(ValueError, match="health_lease_invalid"):
+        SignedHealthLease.parse(canonical_json_bytes(serialized))
 
 
 @pytest.mark.parametrize("container", [None, "identifiers", "product", "components", "harnessCoverage", "continuity"])

--- a/tests/test_guard_mdm_health_lease_contract.py
+++ b/tests/test_guard_mdm_health_lease_contract.py
@@ -51,7 +51,11 @@ def _claims(key_id: str, **updates: object) -> dict[str, object]:
 
 def _signed_lease(private: ec.EllipticCurvePrivateKey, key_id: str) -> SignedHealthLease:
     claims = HealthLeaseClaims.parse(_claims(key_id))
-    return SignedHealthLease(claims, private.sign(claims.signing_payload(), ec.ECDSA(hashes.SHA256())))
+    signed = SignedHealthLease(
+        claims,
+        private.sign(claims.signing_payload(), ec.ECDSA(hashes.SHA256())),
+    )
+    return SignedHealthLease.parse(signed.canonical_bytes())
 
 
 def _snapshot() -> dict[str, object]:


### PR DESCRIPTION
## Summary
- canonicalize P-256 health lease signatures to low-S before serialization
- reject malleated high-S lease envelopes during parsing
- cover issuer normalization and verifier rejection behavior

## Verification
- `uv run pytest -q tests/test_guard_mdm_health_lease.py`
- `uv run ruff check src/codex_plugin_scanner/guard/mdm/health_lease_contract.py tests/test_guard_mdm_health_lease.py`
- `uv run basedpyright src/codex_plugin_scanner/guard/mdm/health_lease_contract.py` (0 errors)