### PR TITLE
feat(mdm): harden managed removal authorization

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_mdm.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_mdm.py
@@ -22,7 +22,6 @@ from ..mdm.lifecycle import (
     machine_status,
     repair_user,
     user_status,
-    validate_removal_authorization,
     validate_user_home,
 )
 from ..mdm.network import diagnose_endpoint
@@ -46,7 +45,11 @@ def _run_guard_mdm_command(
     try:
         if command == "authorize-deactivation":
             payload = authorize_deactivation(
-                Path(str(args.home)).resolve(), str(args.user), token_name=getattr(args, "token_name", None)
+                Path(str(args.home)).resolve(),
+                str(args.user),
+                actor=str(args.actor),
+                reason=str(args.reason),
+                token_name=getattr(args, "token_name", None),
             )
         elif command == "network-diagnose":
             policy_state = load_managed_policy()
@@ -101,10 +104,11 @@ def _run_guard_mdm_command(
             elif command == "deactivate":
                 if not args.authorization_file:
                     raise PermissionError("mdm_removal_authorization_required")
-                authorization_fingerprint = validate_removal_authorization(
-                    Path(str(args.authorization_file)), home=home, user=str(args.user)
+                payload = deactivate_user(
+                    home,
+                    user=str(args.user),
+                    authorization_file=Path(str(args.authorization_file)),
                 )
-                payload = deactivate_user(home, authorization_fingerprint=authorization_fingerprint)
             else:
                 raise ValueError("mdm_command_invalid")
     except (OSError, RuntimeError, ValueError, PermissionError) as exc:

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_mdm.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_mdm.py
@@ -58,6 +58,8 @@ def _configure_guard_mdm_parsers(
         "authorize-deactivation", help="Create a short-lived machine-owned user removal authorization"
     )
     _add_user(authorize, require_user=True)
+    authorize.add_argument("--actor", required=True, help="Auditable MDM actor identity")
+    authorize.add_argument("--reason", required=True, help="Bounded removal reason")
     authorize.add_argument("--token-name", help="Machine-state token filename selected by the MDM wrapper")
 
     network = commands.add_parser("network-diagnose", help="Test managed DNS, proxy, and TLS without prompts")

--- a/src/codex_plugin_scanner/guard/mdm/lifecycle.py
+++ b/src/codex_plugin_scanner/guard/mdm/lifecycle.py
@@ -3,18 +3,15 @@
 from __future__ import annotations
 
 import getpass
-import hashlib
 import json
 import logging
 import os
 import platform
-import re
-import secrets
 import shutil
 import stat
 from collections.abc import Iterator
 from contextlib import contextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
@@ -26,6 +23,11 @@ from .contracts import MDM_STATUS_SCHEMA_VERSION, default_machine_paths
 from .manifest import verify_release_manifest
 from .native import NativeInstallVerification, verify_native_install
 from .policy import load_managed_policy
+from .removal import (
+    authorize_deactivation,
+    record_removal_tombstone,
+    validate_removal_authorization,
+)
 
 
 def _now() -> str:
@@ -74,140 +76,24 @@ def validate_user_home(home: str, user: str | None = None) -> Path:
     return resolved
 
 
-def _is_administrator() -> bool:
-    if platform.system() != "Windows":
-        return os.geteuid() == 0
-    import ctypes
-
-    return bool(ctypes.windll.shell32.IsUserAnAdmin())
-
-
-def authorize_deactivation(home: Path, user: str, *, token_name: str | None = None) -> dict[str, object]:
-    """Create machine-owned authority without putting authorization material in arguments."""
-
-    if not _is_administrator():
-        raise PermissionError("mdm_administrator_context_required")
-    if not home.is_absolute() or not home.is_dir():
-        raise ValueError("mdm_home_not_found")
-    if platform.system() != "Windows":
-        import pwd
-
-        try:
-            account = pwd.getpwnam(user)
-        except KeyError as exc:
-            raise ValueError("mdm_user_not_found") from exc
-        if home.resolve().stat().st_uid != account.pw_uid:
-            raise ValueError("mdm_home_owner_mismatch")
-    root = default_machine_paths().state_root / "removal-authorizations"
-    root.mkdir(mode=0o700, parents=True, exist_ok=True)
-    root.chmod(0o700)
-    now = datetime.now(timezone.utc)
-    resolved_name = token_name or f"{user}-{secrets.token_hex(8)}.json"
-    if re.fullmatch(r"[A-Za-z0-9_.-]{1,128}\.json", resolved_name) is None:
-        raise ValueError("mdm_removal_authorization_name_invalid")
-    target = root / resolved_name
-    target.write_text(
-        json.dumps(
-            {
-                "operation": "deactivate",
-                "user": user,
-                "home": str(home.resolve()),
-                "nonce": secrets.token_urlsafe(24),
-                "issuedAt": now.isoformat(),
-                "expiresAt": (now + timedelta(minutes=2)).isoformat(),
-            },
-            sort_keys=True,
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    target.chmod(0o644)
-    _audit(
-        default_machine_paths().log_root / "mdm-lifecycle.log",
-        operation="authorize-deactivation",
-        status="authorized",
-        scope="machine",
-    )
-    payload = _base("authorize-deactivation")
-    payload.update(
-        {
-            "scope": "user",
-            "home": str(home.resolve()),
-            "user": user,
-            "authorizationPath": str(target),
-        }
-    )
-    return payload
-
-
-def validate_removal_authorization(
-    path: Path,
-    *,
-    home: Path,
-    user: str,
-    authorization_root: Path | None = None,
-) -> str:
-    """Validate a root/MDM-owned, short-lived, user-bound removal authorization."""
-
-    resolved_root = authorization_root or default_machine_paths().state_root / "removal-authorizations"
-    try:
-        resolved = path.resolve(strict=True)
-    except FileNotFoundError as exc:
-        raise ValueError("mdm_removal_authorization_consumed_or_missing") from exc
-    if not resolved.is_relative_to(resolved_root.resolve()) or not resolved.is_file():
-        raise ValueError("mdm_removal_authorization_wrong_scope")
-    metadata = resolved.stat()
-    if metadata.st_size > 16 * 1024:
-        raise ValueError("mdm_removal_authorization_invalid")
-    if platform.system() != "Windows" and (metadata.st_uid != 0 or metadata.st_mode & 0o022):
-        raise ValueError("mdm_removal_authorization_untrusted_owner")
-    payload = json.loads(resolved.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError("mdm_removal_authorization_invalid")
-    if payload.get("operation") != "deactivate" or payload.get("user") != user:
-        raise ValueError("mdm_removal_authorization_wrong_scope")
-    if payload.get("home") != str(home):
-        raise ValueError("mdm_removal_authorization_wrong_scope")
-    nonce = payload.get("nonce")
-    issued_raw = payload.get("issuedAt")
-    expires_raw = payload.get("expiresAt")
-    if not all(isinstance(value, str) and value for value in (nonce, issued_raw, expires_raw)):
-        raise ValueError("mdm_removal_authorization_invalid")
-    try:
-        issued = datetime.fromisoformat(str(issued_raw))
-        expires = datetime.fromisoformat(str(expires_raw))
-    except ValueError as exc:
-        raise ValueError("mdm_removal_authorization_invalid") from exc
-    now = datetime.now(timezone.utc)
-    if issued.tzinfo is None or expires.tzinfo is None or issued > now or expires <= now:
-        raise ValueError("mdm_removal_authorization_expired")
-    if (expires - issued).total_seconds() > 300 or (now - issued).total_seconds() > 300:
-        raise ValueError("mdm_removal_authorization_expired")
-    fingerprint = hashlib.sha256(resolved.read_bytes()).hexdigest()
-    try:
-        resolved.unlink()
-    except OSError as exc:
-        raise PermissionError("mdm_removal_authorization_not_consumable") from exc
-    return fingerprint
-
-
 @contextmanager
 def _activation_lock(guard_home: Path) -> Iterator[None]:
     guard_home.mkdir(mode=0o700, parents=True, exist_ok=True)
     lock_path = guard_home / "mdm-activation.lock"
     descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
     try:
-        if platform.system() == "Windows":
-            import msvcrt
+        try:
+            if platform.system() == "Windows":
+                import msvcrt
 
-            msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
-        else:
-            import fcntl
+                msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
 
-            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (BlockingIOError, OSError) as exc:
+            raise RuntimeError("mdm_activation_in_progress") from exc
         yield
-    except (BlockingIOError, OSError) as exc:
-        raise RuntimeError("mdm_activation_in_progress") from exc
     finally:
         os.close(descriptor)
 
@@ -379,17 +265,34 @@ def repair_user(home: Path, user: str | None = None) -> dict[str, object]:
     return activate_user(home, user or getpass.getuser()) | {"operation": "repair"}
 
 
-def deactivate_user(home: Path, *, authorization_fingerprint: str | None = None) -> dict[str, object]:
-    if authorization_fingerprint is None:
+def deactivate_user(
+    home: Path,
+    *,
+    user: str,
+    authorization_file: Path | None = None,
+) -> dict[str, object]:
+    if authorization_file is None:
         raise PermissionError("mdm_removal_authorization_required")
+    paths = default_machine_paths()
+    evidence = validate_removal_authorization(
+        authorization_file,
+        home=home,
+        user=user,
+    )
+    _ = record_removal_tombstone(evidence, status="started", machine_paths=paths)
     guard_home = home / ".hol-guard"
-    with _activation_lock(guard_home):
-        context = HarnessContext(home_dir=home, workspace_dir=None, guard_home=guard_home)
-        store = GuardStore(guard_home)
-        retired_pids = retire_all_guard_daemons_for_home(guard_home)
-        result = apply_managed_install("uninstall", None, True, context, store, None, _now())
-        (guard_home / "mdm-activation.json").unlink(missing_ok=True)
-        _audit(guard_home / "logs" / "mdm-lifecycle.log", operation="deactivate", status="complete", scope="user")
+    try:
+        with _activation_lock(guard_home):
+            context = HarnessContext(home_dir=home, workspace_dir=None, guard_home=guard_home)
+            store = GuardStore(guard_home)
+            retired_pids = retire_all_guard_daemons_for_home(guard_home)
+            result = apply_managed_install("uninstall", None, True, context, store, None, _now())
+            (guard_home / "mdm-activation.json").unlink(missing_ok=True)
+            _audit(guard_home / "logs" / "mdm-lifecycle.log", operation="deactivate", status="complete", scope="user")
+    except (OSError, RuntimeError, ValueError):
+        _ = record_removal_tombstone(evidence, status="failed", machine_paths=paths)
+        raise
+    _ = record_removal_tombstone(evidence, status="completed", machine_paths=paths)
     payload = _base("deactivate")
     payload.update(
         {
@@ -397,6 +300,9 @@ def deactivate_user(home: Path, *, authorization_fingerprint: str | None = None)
             "home": str(home),
             "changed": True,
             "retiredDaemonCount": len(retired_pids),
+            "authorizationFingerprint": evidence.fingerprint,
+            "machineInstallationId": evidence.machine_installation_id,
+            "installationGeneration": evidence.installation_generation,
             "result": result,
         }
     )

--- a/src/codex_plugin_scanner/guard/mdm/removal.py
+++ b/src/codex_plugin_scanner/guard/mdm/removal.py
@@ -1,0 +1,367 @@
+"""Generation-bound managed removal authorization and tombstone evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import re
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import cast
+
+from .acl import verify_protected_ownership_and_acl
+from .continuity import verify_installation_continuity
+from .contracts import MDM_STATUS_SCHEMA_VERSION, MachinePaths, default_machine_paths
+
+_AUTHORIZATION_KEYS = {
+    "actor",
+    "expiresAt",
+    "home",
+    "installationGeneration",
+    "issuedAt",
+    "machineInstallationId",
+    "nonce",
+    "operation",
+    "reason",
+    "user",
+}
+_IDENTIFIER = re.compile(r"^[0-9a-f]{32}$")
+_ACTOR = re.compile(r"^[A-Za-z0-9][A-Za-z0-9@._:-]{0,127}$")
+_MAX_TOMBSTONES = 4096
+_TOMBSTONE_TRANSITIONS: dict[str | None, frozenset[str]] = {
+    None: frozenset({"issued", "started"}),
+    "issued": frozenset({"started"}),
+    "started": frozenset({"completed", "failed"}),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class RemovalAuthorizationEvidence:
+    fingerprint: str
+    actor: str
+    reason: str
+    machine_installation_id: str
+    installation_generation: str
+    issued_at: str
+    expires_at: str
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _fsync_directory(path: Path) -> None:
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _active_binding(paths: MachinePaths) -> tuple[str, str]:
+    verification = verify_installation_continuity(paths)
+    record = verification.record
+    if record is None or verification.identity_reason_code != "installation_identity_active":
+        raise ValueError("mdm_removal_authorization_installation_unavailable")
+    return record.machine_installation_id, record.installation_generation
+
+
+def _is_administrator() -> bool:
+    if platform.system() != "Windows":
+        return os.geteuid() == 0
+    import ctypes
+
+    return bool(ctypes.windll.shell32.IsUserAnAdmin())
+
+
+def _authorization_owner_is_trusted(metadata: os.stat_result) -> bool:
+    return platform.system() == "Windows" or (metadata.st_uid == 0 and metadata.st_mode & 0o022 == 0)
+
+
+def _authorization_root_is_trusted(paths: MachinePaths) -> bool:
+    return verify_protected_ownership_and_acl(paths).healthy
+
+
+def _validate_actor_reason(actor: str, reason: str) -> None:
+    if _ACTOR.fullmatch(actor) is None:
+        raise ValueError("mdm_removal_authorization_actor_invalid")
+    if not 1 <= len(reason) <= 256 or any(ord(character) < 32 for character in reason):
+        raise ValueError("mdm_removal_authorization_reason_invalid")
+
+
+def _required_string(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError("mdm_removal_authorization_invalid")
+    return value
+
+
+def authorize_deactivation(
+    home: Path,
+    user: str,
+    *,
+    actor: str,
+    reason: str,
+    token_name: str | None = None,
+) -> dict[str, object]:
+    if not _is_administrator():
+        raise PermissionError("mdm_administrator_context_required")
+    if not home.is_absolute() or not home.is_dir():
+        raise ValueError("mdm_home_not_found")
+    if platform.system() != "Windows":
+        import pwd
+
+        try:
+            account = pwd.getpwnam(user)
+        except KeyError as exc:
+            raise ValueError("mdm_user_not_found") from exc
+        if home.resolve().stat().st_uid != account.pw_uid:
+            raise ValueError("mdm_home_owner_mismatch")
+    _validate_actor_reason(actor, reason)
+    paths = default_machine_paths()
+    machine_installation_id, installation_generation = _active_binding(paths)
+    if not _authorization_root_is_trusted(paths):
+        raise ValueError("mdm_removal_authorization_untrusted_root")
+    root = paths.state_root / "removal-authorizations"
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    root.chmod(0o700)
+    now = _now()
+    issued_at = now.isoformat()
+    expires_at = (now + timedelta(minutes=2)).isoformat()
+    resolved_name = token_name or f"{user}-{secrets.token_hex(8)}.json"
+    if re.fullmatch(r"[A-Za-z0-9_.-]{1,128}\.json", resolved_name) is None:
+        raise ValueError("mdm_removal_authorization_name_invalid")
+    target = root / resolved_name
+    descriptor = os.open(target, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+        json.dump(
+            {
+                "actor": actor,
+                "expiresAt": expires_at,
+                "home": str(home.resolve()),
+                "installationGeneration": installation_generation,
+                "issuedAt": issued_at,
+                "machineInstallationId": machine_installation_id,
+                "nonce": secrets.token_urlsafe(24),
+                "operation": "deactivate",
+                "reason": reason,
+                "user": user,
+            },
+            stream,
+            sort_keys=True,
+        )
+        _ = stream.write("\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    target.chmod(0o600)
+    _fsync_directory(root)
+    fingerprint = hashlib.sha256(target.read_bytes()).hexdigest()
+    evidence = RemovalAuthorizationEvidence(
+        fingerprint,
+        actor,
+        reason,
+        machine_installation_id,
+        installation_generation,
+        issued_at,
+        expires_at,
+    )
+    try:
+        _ = record_removal_tombstone(evidence, status="issued", machine_paths=paths)
+    except OSError:
+        target.unlink(missing_ok=True)
+        _fsync_directory(root)
+        raise
+    return {
+        "schemaVersion": MDM_STATUS_SCHEMA_VERSION,
+        "operation": "authorize-deactivation",
+        "generatedAt": now.isoformat(),
+        "scope": "user",
+        "home": str(home.resolve()),
+        "user": user,
+        "authorizationPath": str(target),
+        "authorizationFingerprint": fingerprint,
+        "machineInstallationId": machine_installation_id,
+        "installationGeneration": installation_generation,
+    }
+
+
+def validate_removal_authorization(
+    path: Path,
+    *,
+    home: Path,
+    user: str,
+) -> RemovalAuthorizationEvidence:
+    paths = default_machine_paths()
+    if not _authorization_root_is_trusted(paths):
+        raise ValueError("mdm_removal_authorization_untrusted_root")
+    resolved_root = paths.state_root / "removal-authorizations"
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ValueError("mdm_removal_authorization_consumed_or_missing") from exc
+    if not resolved.is_relative_to(resolved_root.resolve()) or not resolved.is_file():
+        raise ValueError("mdm_removal_authorization_wrong_scope")
+    metadata = resolved.stat()
+    if metadata.st_size > 16 * 1024:
+        raise ValueError("mdm_removal_authorization_invalid")
+    if not _authorization_owner_is_trusted(metadata):
+        raise ValueError("mdm_removal_authorization_untrusted_owner")
+    try:
+        raw_payload: object = json.loads(resolved.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError("mdm_removal_authorization_invalid") from exc
+    if not isinstance(raw_payload, dict):
+        raise ValueError("mdm_removal_authorization_invalid")
+    payload = cast(dict[str, object], raw_payload)
+    if set(payload) != _AUTHORIZATION_KEYS:
+        raise ValueError("mdm_removal_authorization_invalid")
+    if payload.get("operation") != "deactivate" or payload.get("user") != user:
+        raise ValueError("mdm_removal_authorization_wrong_scope")
+    if payload.get("home") != str(home):
+        raise ValueError("mdm_removal_authorization_wrong_scope")
+    actor = _required_string(payload, "actor")
+    reason = _required_string(payload, "reason")
+    machine_installation_id = _required_string(payload, "machineInstallationId")
+    installation_generation = _required_string(payload, "installationGeneration")
+    _ = _required_string(payload, "nonce")
+    issued_raw = _required_string(payload, "issuedAt")
+    expires_raw = _required_string(payload, "expiresAt")
+    if _IDENTIFIER.fullmatch(machine_installation_id) is None:
+        raise ValueError("mdm_removal_authorization_invalid")
+    if _IDENTIFIER.fullmatch(installation_generation) is None:
+        raise ValueError("mdm_removal_authorization_invalid")
+    _validate_actor_reason(actor, reason)
+    try:
+        issued = datetime.fromisoformat(issued_raw)
+        expires = datetime.fromisoformat(expires_raw)
+    except ValueError as exc:
+        raise ValueError("mdm_removal_authorization_invalid") from exc
+    now = _now()
+    if issued.tzinfo is None or expires.tzinfo is None or issued > now or expires <= now:
+        raise ValueError("mdm_removal_authorization_expired")
+    if (expires - issued).total_seconds() > 300 or (now - issued).total_seconds() > 300:
+        raise ValueError("mdm_removal_authorization_expired")
+    if (machine_installation_id, installation_generation) != _active_binding(paths):
+        raise ValueError("mdm_removal_authorization_wrong_generation")
+    fingerprint = hashlib.sha256(resolved.read_bytes()).hexdigest()
+    try:
+        resolved.unlink()
+        _fsync_directory(resolved.parent)
+    except OSError as exc:
+        raise PermissionError("mdm_removal_authorization_not_consumable") from exc
+    return RemovalAuthorizationEvidence(
+        fingerprint,
+        actor,
+        reason,
+        machine_installation_id,
+        installation_generation,
+        issued_raw,
+        expires_raw,
+    )
+
+
+def record_removal_tombstone(
+    evidence: RemovalAuthorizationEvidence,
+    *,
+    status: str,
+    machine_paths: MachinePaths | None = None,
+) -> Path:
+    if status not in {"issued", "started", "completed", "failed"}:
+        raise ValueError("mdm_removal_tombstone_status_invalid")
+    paths = machine_paths or default_machine_paths()
+    root = paths.state_root / "removal-tombstones"
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    root.chmod(0o700)
+    target = root / f"{evidence.fingerprint}.json"
+    if not target.exists() and sum(1 for item in root.iterdir() if item.is_file()) >= _MAX_TOMBSTONES:
+        raise OSError("mdm_removal_tombstone_capacity_exceeded")
+    static_payload = {
+        "actor": evidence.actor,
+        "authorizationExpiresAt": evidence.expires_at,
+        "authorizationFingerprint": evidence.fingerprint,
+        "authorizationIssuedAt": evidence.issued_at,
+        "installationGeneration": evidence.installation_generation,
+        "machineInstallationId": evidence.machine_installation_id,
+        "operation": "deactivate",
+        "reason": evidence.reason,
+        "schemaVersion": "hol-guard-removal-tombstone.v1",
+    }
+    events: list[dict[str, str]] = []
+    previous_status: str | None = None
+    if target.exists():
+        try:
+            existing_raw: object = json.loads(target.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise ValueError("mdm_removal_tombstone_invalid") from exc
+        if not isinstance(existing_raw, dict):
+            raise ValueError("mdm_removal_tombstone_invalid")
+        existing = cast(dict[str, object], existing_raw)
+        if set(existing) != set(static_payload) | {"events", "status", "updatedAt"}:
+            raise ValueError("mdm_removal_tombstone_invalid")
+        if any(existing.get(key) != value for key, value in static_payload.items()):
+            raise ValueError("mdm_removal_tombstone_identity_mismatch")
+        existing_events_raw = existing.get("events")
+        if not isinstance(existing_events_raw, list):
+            raise ValueError("mdm_removal_tombstone_invalid")
+        existing_events = cast(list[object], existing_events_raw)
+        if not 1 <= len(existing_events) <= 3:
+            raise ValueError("mdm_removal_tombstone_invalid")
+        event_previous_status: str | None = None
+        event_previous_time: datetime | None = None
+        for event_raw in existing_events:
+            if not isinstance(event_raw, dict):
+                raise ValueError("mdm_removal_tombstone_invalid")
+            event = cast(dict[str, object], event_raw)
+            if set(event) != {"at", "status"}:
+                raise ValueError("mdm_removal_tombstone_invalid")
+            event_status = event.get("status")
+            event_at = event.get("at")
+            if not isinstance(event_status, str) or not isinstance(event_at, str):
+                raise ValueError("mdm_removal_tombstone_invalid")
+            try:
+                event_time = datetime.fromisoformat(event_at)
+            except ValueError as exc:
+                raise ValueError("mdm_removal_tombstone_invalid") from exc
+            if event_time.tzinfo is None or (event_previous_time is not None and event_time < event_previous_time):
+                raise ValueError("mdm_removal_tombstone_invalid")
+            if event_status not in _TOMBSTONE_TRANSITIONS.get(event_previous_status, frozenset()):
+                raise ValueError("mdm_removal_tombstone_invalid")
+            events.append({"at": event_at, "status": event_status})
+            event_previous_status = event_status
+            event_previous_time = event_time
+        previous_status = events[-1]["status"]
+        if existing.get("status") != previous_status or existing.get("updatedAt") != events[-1]["at"]:
+            raise ValueError("mdm_removal_tombstone_invalid")
+    if status not in _TOMBSTONE_TRANSITIONS.get(previous_status, frozenset()):
+        raise ValueError("mdm_removal_tombstone_transition_invalid")
+    updated_at = _now().isoformat()
+    events.append({"at": updated_at, "status": status})
+    payload = static_payload | {"events": events, "status": status, "updatedAt": updated_at}
+    temporary = root / f".{evidence.fingerprint}.{secrets.token_hex(8)}.tmp"
+    descriptor = os.open(temporary, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, sort_keys=True)
+            _ = stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, target)
+        target.chmod(0o600)
+        _fsync_directory(root)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return target
+
+
+__all__ = [
+    "RemovalAuthorizationEvidence",
+    "authorize_deactivation",
+    "record_removal_tombstone",
+    "validate_removal_authorization",
+]

--- a/src/codex_plugin_scanner/guard/mdm/removal.py
+++ b/src/codex_plugin_scanner/guard/mdm/removal.py
@@ -81,7 +81,7 @@ def _is_administrator() -> bool:
 
 
 def _authorization_owner_is_trusted(metadata: os.stat_result) -> bool:
-    return platform.system() == "Windows" or (metadata.st_uid == 0 and metadata.st_mode & 0o022 == 0)
+    return platform.system() == "Windows" or (metadata.st_uid == 0 and metadata.st_mode & 0o077 == 0)
 
 
 def _authorization_root_is_trusted(paths: MachinePaths) -> bool:
@@ -173,7 +173,7 @@ def authorize_deactivation(
     )
     try:
         _ = record_removal_tombstone(evidence, status="issued", machine_paths=paths)
-    except OSError:
+    except (OSError, ValueError):
         target.unlink(missing_ok=True)
         _fsync_directory(root)
         raise
@@ -207,14 +207,18 @@ def validate_removal_authorization(
         raise ValueError("mdm_removal_authorization_consumed_or_missing") from exc
     if not resolved.is_relative_to(resolved_root.resolve()) or not resolved.is_file():
         raise ValueError("mdm_removal_authorization_wrong_scope")
-    metadata = resolved.stat()
-    if metadata.st_size > 16 * 1024:
+    try:
+        content_bytes = resolved.read_bytes()
+        metadata = resolved.stat()
+    except OSError as exc:
+        raise ValueError("mdm_removal_authorization_invalid") from exc
+    if len(content_bytes) > 16 * 1024 or metadata.st_size != len(content_bytes):
         raise ValueError("mdm_removal_authorization_invalid")
     if not _authorization_owner_is_trusted(metadata):
         raise ValueError("mdm_removal_authorization_untrusted_owner")
     try:
-        raw_payload: object = json.loads(resolved.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raw_payload: object = json.loads(content_bytes.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
         raise ValueError("mdm_removal_authorization_invalid") from exc
     if not isinstance(raw_payload, dict):
         raise ValueError("mdm_removal_authorization_invalid")
@@ -249,7 +253,7 @@ def validate_removal_authorization(
         raise ValueError("mdm_removal_authorization_expired")
     if (machine_installation_id, installation_generation) != _active_binding(paths):
         raise ValueError("mdm_removal_authorization_wrong_generation")
-    fingerprint = hashlib.sha256(resolved.read_bytes()).hexdigest()
+    fingerprint = hashlib.sha256(content_bytes).hexdigest()
     try:
         resolved.unlink()
         _fsync_directory(resolved.parent)
@@ -279,8 +283,11 @@ def record_removal_tombstone(
     root.mkdir(mode=0o700, parents=True, exist_ok=True)
     root.chmod(0o700)
     target = root / f"{evidence.fingerprint}.json"
-    if not target.exists() and sum(1 for item in root.iterdir() if item.is_file()) >= _MAX_TOMBSTONES:
-        raise OSError("mdm_removal_tombstone_capacity_exceeded")
+    if not target.exists():
+        with os.scandir(root) as entries:
+            file_count = sum(1 for entry in entries if entry.is_file(follow_symlinks=False))
+        if file_count >= _MAX_TOMBSTONES:
+            raise OSError("mdm_removal_tombstone_capacity_exceeded")
     static_payload = {
         "actor": evidence.actor,
         "authorizationExpiresAt": evidence.expires_at,

--- a/tests/test_guard_mdm_cli.py
+++ b/tests/test_guard_mdm_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner import cli
+from codex_plugin_scanner.guard.cli import commands_dispatch_mdm
 
 
 def test_user_status_cli_is_versioned_read_only_and_nonhealthy(
@@ -46,3 +47,65 @@ def test_cli_cannot_claim_managed_authority_from_a_policy_argument(tmp_path: Pat
             ]
         )
     assert error.value.code == 2
+
+
+def test_authorize_deactivation_cli_requires_auditable_actor_and_reason(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as error:
+        cli.main(
+            [
+                "mdm",
+                "authorize-deactivation",
+                "--home",
+                str(tmp_path),
+                "--user",
+                "developer",
+                "--json",
+            ]
+        )
+    assert error.value.code == 2
+
+
+def test_authorize_deactivation_cli_forwards_auditable_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    captured: dict[str, object] = {}
+
+    def authorize(
+        home: Path,
+        user: str,
+        *,
+        actor: str,
+        reason: str,
+        token_name: str | None = None,
+    ) -> dict[str, object]:
+        captured.update(home=home, user=user, actor=actor, reason=reason, token_name=token_name)
+        return {"schemaVersion": "hol-guard-mdm-status.v1", "operation": "authorize-deactivation"}
+
+    monkeypatch.setattr(commands_dispatch_mdm, "authorize_deactivation", authorize)
+    exit_code = cli.main(
+        [
+            "mdm",
+            "authorize-deactivation",
+            "--home",
+            str(tmp_path),
+            "--user",
+            "developer",
+            "--actor",
+            "mdm-admin@example.test",
+            "--reason",
+            "approved retirement",
+            "--token-name",
+            "developer.json",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["operation"] == "authorize-deactivation"
+    assert captured == {
+        "home": tmp_path,
+        "user": "developer",
+        "actor": "mdm-admin@example.test",
+        "reason": "approved retirement",
+        "token_name": "developer.json",
+    }

--- a/tests/test_guard_mdm_lifecycle.py
+++ b/tests/test_guard_mdm_lifecycle.py
@@ -12,8 +12,42 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from jsonschema import Draft202012Validator
 
-from codex_plugin_scanner.guard.mdm import lifecycle
+from codex_plugin_scanner.guard.mdm import lifecycle, removal
 from codex_plugin_scanner.guard.mdm.contracts import MDM_STATUS_SCHEMA_VERSION, MachinePaths
+
+MACHINE_INSTALLATION_ID = "1" * 32
+INSTALLATION_GENERATION = "2" * 32
+
+
+def _machine_paths(root: Path) -> MachinePaths:
+    return MachinePaths(root / "runtime", root / "state", None, root / "logs", root / "manifest")
+
+
+def _patch_machine_paths(monkeypatch: pytest.MonkeyPatch, paths: MachinePaths) -> None:
+    monkeypatch.setattr(removal, "default_machine_paths", lambda: paths)
+    monkeypatch.setattr(lifecycle, "default_machine_paths", lambda: paths)
+
+
+def _write_removal_authorization(root: Path, home: Path, *, generation: str = INSTALLATION_GENERATION) -> Path:
+    now = datetime.now(timezone.utc)
+    token = root / "token.json"
+    token.write_text(
+        json.dumps(
+            {
+                "actor": "mdm-admin@example.test",
+                "expiresAt": (now + timedelta(minutes=2)).isoformat(),
+                "home": str(home),
+                "installationGeneration": generation,
+                "issuedAt": now.isoformat(),
+                "machineInstallationId": MACHINE_INSTALLATION_ID,
+                "nonce": "unique-removal-nonce",
+                "operation": "deactivate",
+                "reason": "approved device retirement",
+                "user": "developer",
+            }
+        )
+    )
+    return token
 
 
 def _write_signed_runtime(runtime: Path, key: Ed25519PrivateKey) -> None:
@@ -148,16 +182,75 @@ def test_deactivation_restores_integrations_and_removes_marker(tmp_path: Path, m
         return {"managed_installs": []}
 
     monkeypatch.setattr(lifecycle, "apply_managed_install", fake_install)
-    payload = lifecycle.deactivate_user(tmp_path, authorization_fingerprint="consumed-token")
+    monkeypatch.setattr(removal, "_authorization_owner_is_trusted", lambda _metadata: True)
+    monkeypatch.setattr(removal, "_authorization_root_is_trusted", lambda _paths: True)
+    monkeypatch.setattr(removal, "_active_binding", lambda _paths: (MACHINE_INSTALLATION_ID, INSTALLATION_GENERATION))
+    paths = _machine_paths(tmp_path)
+    _patch_machine_paths(monkeypatch, paths)
+    authorization_root = paths.state_root / "removal-authorizations"
+    authorization_root.mkdir(parents=True)
+    token = _write_removal_authorization(authorization_root, tmp_path)
+    payload = lifecycle.deactivate_user(
+        tmp_path,
+        user="developer",
+        authorization_file=token,
+    )
 
     assert commands == ["uninstall"]
     assert payload["operation"] == "deactivate"
+    assert payload["installationGeneration"] == INSTALLATION_GENERATION
     assert not (guard_home / "mdm-activation.json").exists()
+    tombstones = list((paths.state_root / "removal-tombstones").glob("*.json"))
+    assert len(tombstones) == 1
+    tombstone = json.loads(tombstones[0].read_text())
+    assert tombstone["status"] == "completed"
+    assert [event["status"] for event in tombstone["events"]] == ["started", "completed"]
+    assert tombstone["installationGeneration"] == INSTALLATION_GENERATION
+    assert "home" not in tombstone
+    assert "user" not in tombstone
+    assert "nonce" not in tombstone
+    lifecycle.activate_user(tmp_path, "developer")
+    assert commands == ["uninstall", "install"]
+    assert tombstones[0].is_file()
 
 
 def test_deactivation_requires_machine_authorization(tmp_path: Path) -> None:
     with pytest.raises(PermissionError, match="mdm_removal_authorization_required"):
-        lifecycle.deactivate_user(tmp_path)
+        lifecycle.deactivate_user(tmp_path, user="developer")
+
+
+def test_failed_deactivation_consumes_authorization_and_preserves_failure_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    guard_home = tmp_path / ".hol-guard"
+    guard_home.mkdir()
+    paths = _machine_paths(tmp_path)
+    _patch_machine_paths(monkeypatch, paths)
+    authorization_root = paths.state_root / "removal-authorizations"
+    authorization_root.mkdir(parents=True)
+    token = _write_removal_authorization(authorization_root, tmp_path)
+    monkeypatch.setattr(removal, "_authorization_owner_is_trusted", lambda _metadata: True)
+    monkeypatch.setattr(removal, "_authorization_root_is_trusted", lambda _paths: True)
+    monkeypatch.setattr(removal, "_active_binding", lambda _paths: (MACHINE_INSTALLATION_ID, INSTALLATION_GENERATION))
+
+    def fail_install(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise OSError("uninstall failed")
+
+    monkeypatch.setattr(lifecycle, "apply_managed_install", fail_install)
+
+    with pytest.raises(OSError, match="uninstall failed"):
+        lifecycle.deactivate_user(
+            tmp_path,
+            user="developer",
+            authorization_file=token,
+        )
+
+    assert not token.exists()
+    tombstones = list((paths.state_root / "removal-tombstones").glob("*.json"))
+    assert len(tombstones) == 1
+    tombstone = json.loads(tombstones[0].read_text())
+    assert tombstone["status"] == "failed"
+    assert [event["status"] for event in tombstone["events"]] == ["started", "failed"]
 
 
 def test_status_schema_accepts_stable_user_contract(tmp_path: Path) -> None:
@@ -169,39 +262,55 @@ def test_status_schema_accepts_stable_user_contract(tmp_path: Path) -> None:
 def test_removal_authorization_is_scoped_short_lived_and_single_use(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    authorization_root = tmp_path / "authorizations"
-    authorization_root.mkdir()
+    paths = _machine_paths(tmp_path)
+    monkeypatch.setattr(removal, "default_machine_paths", lambda: paths)
+    authorization_root = paths.state_root / "removal-authorizations"
+    authorization_root.mkdir(parents=True)
     home = tmp_path / "home"
     home.mkdir()
-    now = datetime.now(timezone.utc)
-    token = authorization_root / "token.json"
-    token.write_text(
-        json.dumps(
-            {
-                "operation": "deactivate",
-                "user": "developer",
-                "home": str(home),
-                "nonce": "unique-removal-nonce",
-                "issuedAt": now.isoformat(),
-                "expiresAt": (now + timedelta(minutes=2)).isoformat(),
-            }
-        )
-    )
-    monkeypatch.setattr(lifecycle.platform, "system", lambda: "Windows")
+    token = _write_removal_authorization(authorization_root, home)
+    monkeypatch.setattr(removal.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(removal, "_authorization_root_is_trusted", lambda _paths: True)
+    monkeypatch.setattr(removal, "_active_binding", lambda _paths: (MACHINE_INSTALLATION_ID, INSTALLATION_GENERATION))
 
-    fingerprint = lifecycle.validate_removal_authorization(
-        token, home=home, user="developer", authorization_root=authorization_root
+    evidence = lifecycle.validate_removal_authorization(
+        token,
+        home=home,
+        user="developer",
     )
-    assert len(fingerprint) == 64
+    assert len(evidence.fingerprint) == 64
+    assert evidence.installation_generation == INSTALLATION_GENERATION
     assert not token.exists()
 
     with pytest.raises(ValueError, match="mdm_removal_authorization_consumed_or_missing"):
+        lifecycle.validate_removal_authorization(token, home=home, user="developer")
+
+
+def test_removal_authorization_rejects_stale_generation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths = _machine_paths(tmp_path)
+    monkeypatch.setattr(removal, "default_machine_paths", lambda: paths)
+    authorization_root = paths.state_root / "removal-authorizations"
+    authorization_root.mkdir(parents=True)
+    home = tmp_path / "home"
+    home.mkdir()
+    token = _write_removal_authorization(authorization_root, home, generation="3" * 32)
+    monkeypatch.setattr(removal.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(removal, "_authorization_root_is_trusted", lambda _paths: True)
+    monkeypatch.setattr(removal, "_active_binding", lambda _paths: (MACHINE_INSTALLATION_ID, INSTALLATION_GENERATION))
+
+    with pytest.raises(ValueError, match="mdm_removal_authorization_wrong_generation"):
         lifecycle.validate_removal_authorization(
-            token, home=home, user="developer", authorization_root=authorization_root
+            token,
+            home=home,
+            user="developer",
         )
+    assert token.exists()
 
 
-def test_removal_authorization_rejects_arbitrary_path(tmp_path: Path) -> None:
+def test_removal_authorization_rejects_arbitrary_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths = _machine_paths(tmp_path / "machine")
+    monkeypatch.setattr(removal, "default_machine_paths", lambda: paths)
+    monkeypatch.setattr(removal, "_authorization_root_is_trusted", lambda _paths: True)
     token = tmp_path / "token.json"
     token.write_text("{}")
     with pytest.raises(ValueError, match="mdm_removal_authorization_wrong_scope"):
@@ -209,20 +318,90 @@ def test_removal_authorization_rejects_arbitrary_path(tmp_path: Path) -> None:
             token,
             home=tmp_path,
             user="developer",
-            authorization_root=tmp_path / "trusted",
         )
 
 
-def test_authorization_creation_requires_admin_and_safe_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    paths = MachinePaths(tmp_path, tmp_path / "state", None, tmp_path / "logs", tmp_path / "manifest")
-    monkeypatch.setattr(lifecycle, "default_machine_paths", lambda: paths)
-    monkeypatch.setattr(lifecycle, "_is_administrator", lambda: False)
-    with pytest.raises(PermissionError, match="mdm_administrator_context_required"):
-        lifecycle.authorize_deactivation(tmp_path, "developer")
+def test_removal_authorization_rejects_untrusted_machine_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _machine_paths(tmp_path)
+    monkeypatch.setattr(removal, "default_machine_paths", lambda: paths)
+    monkeypatch.setattr(removal, "_authorization_root_is_trusted", lambda _paths: False)
+    token = paths.state_root / "removal-authorizations" / "token.json"
+    token.parent.mkdir(parents=True)
+    token.write_text("{}")
+    with pytest.raises(ValueError, match="mdm_removal_authorization_untrusted_root"):
+        lifecycle.validate_removal_authorization(token, home=tmp_path, user="developer")
+    assert token.exists()
 
-    monkeypatch.setattr(lifecycle, "_is_administrator", lambda: True)
-    monkeypatch.setattr(lifecycle.platform, "system", lambda: "Windows")
+
+def test_authorization_creation_requires_admin_and_safe_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths = _machine_paths(tmp_path)
+    monkeypatch.setattr(removal, "default_machine_paths", lambda: paths)
+    monkeypatch.setattr(removal, "_active_binding", lambda _paths: (MACHINE_INSTALLATION_ID, INSTALLATION_GENERATION))
+    monkeypatch.setattr(removal, "_is_administrator", lambda: False)
+    with pytest.raises(PermissionError, match="mdm_administrator_context_required"):
+        lifecycle.authorize_deactivation(
+            tmp_path, "developer", actor="mdm-admin@example.test", reason="approved retirement"
+        )
+
+    monkeypatch.setattr(removal, "_is_administrator", lambda: True)
+    monkeypatch.setattr(removal.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(removal, "_authorization_root_is_trusted", lambda _paths: True)
     with pytest.raises(ValueError, match="mdm_removal_authorization_name_invalid"):
-        lifecycle.authorize_deactivation(tmp_path, "developer", token_name="../escape.json")
-    payload = lifecycle.authorize_deactivation(tmp_path, "developer", token_name="developer.json")
+        lifecycle.authorize_deactivation(
+            tmp_path,
+            "developer",
+            actor="mdm-admin@example.test",
+            reason="approved retirement",
+            token_name="../escape.json",
+        )
+    payload = lifecycle.authorize_deactivation(
+        tmp_path,
+        "developer",
+        actor="mdm-admin@example.test",
+        reason="approved retirement",
+        token_name="developer.json",
+    )
     assert Path(str(payload["authorizationPath"])).is_file()
+    token = json.loads(Path(str(payload["authorizationPath"])).read_text())
+    assert token["installationGeneration"] == INSTALLATION_GENERATION
+    assert token["actor"] == "mdm-admin@example.test"
+    tombstone = paths.state_root / "removal-tombstones" / f"{payload['authorizationFingerprint']}.json"
+    assert json.loads(tombstone.read_text())["status"] == "issued"
+    evidence = removal.validate_removal_authorization(
+        Path(str(payload["authorizationPath"])),
+        home=tmp_path,
+        user="developer",
+    )
+    _ = removal.record_removal_tombstone(evidence, status="started", machine_paths=paths)
+    _ = removal.record_removal_tombstone(evidence, status="completed", machine_paths=paths)
+    completed = json.loads(tombstone.read_text())
+    assert [event["status"] for event in completed["events"]] == ["issued", "started", "completed"]
+    with pytest.raises(ValueError, match="mdm_removal_tombstone_transition_invalid"):
+        removal.record_removal_tombstone(evidence, status="failed", machine_paths=paths)
+
+
+def test_authorization_creation_removes_token_when_tombstone_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _machine_paths(tmp_path)
+    monkeypatch.setattr(removal, "default_machine_paths", lambda: paths)
+    monkeypatch.setattr(removal, "_active_binding", lambda _paths: (MACHINE_INSTALLATION_ID, INSTALLATION_GENERATION))
+    monkeypatch.setattr(removal, "_is_administrator", lambda: True)
+    monkeypatch.setattr(removal.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(removal, "_authorization_root_is_trusted", lambda _paths: True)
+
+    def fail_tombstone(*_args: object, **_kwargs: object) -> Path:
+        raise OSError("audit unavailable")
+
+    monkeypatch.setattr(removal, "record_removal_tombstone", fail_tombstone)
+    with pytest.raises(OSError, match="audit unavailable"):
+        lifecycle.authorize_deactivation(
+            tmp_path,
+            "developer",
+            actor="mdm-admin@example.test",
+            reason="approved retirement",
+            token_name="developer.json",
+        )
+    assert not (paths.state_root / "removal-authorizations" / "developer.json").exists()

--- a/tests/test_guard_mdm_lifecycle.py
+++ b/tests/test_guard_mdm_lifecycle.py
@@ -382,8 +382,9 @@ def test_authorization_creation_requires_admin_and_safe_name(tmp_path: Path, mon
         removal.record_removal_tombstone(evidence, status="failed", machine_paths=paths)
 
 
+@pytest.mark.parametrize("failure", [OSError("audit unavailable"), ValueError("audit unavailable")])
 def test_authorization_creation_removes_token_when_tombstone_fails(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure: Exception
 ) -> None:
     paths = _machine_paths(tmp_path)
     monkeypatch.setattr(removal, "default_machine_paths", lambda: paths)
@@ -393,10 +394,10 @@ def test_authorization_creation_removes_token_when_tombstone_fails(
     monkeypatch.setattr(removal, "_authorization_root_is_trusted", lambda _paths: True)
 
     def fail_tombstone(*_args: object, **_kwargs: object) -> Path:
-        raise OSError("audit unavailable")
+        raise failure
 
     monkeypatch.setattr(removal, "record_removal_tombstone", fail_tombstone)
-    with pytest.raises(OSError, match="audit unavailable"):
+    with pytest.raises((OSError, ValueError), match="audit unavailable"):
         lifecycle.authorize_deactivation(
             tmp_path,
             "developer",


### PR DESCRIPTION
## Summary

- bind managed deactivation authority to the active machine installation and generation
- consume short-lived authorizations atomically inside deactivation and reject untrusted machine state
- preserve a bounded, redacted issued/started/completed-or-failed tombstone across user repair and reactivation

## Security properties

- canonical machine paths only; callers cannot override the authorization trust root
- exact-key validation, root/MDM ownership, protected ACL verification, five-minute maximum age, and single-use consumption
- exclusive 0600 creation plus file and directory fsync for durable authorization and lifecycle evidence
- tombstones exclude usernames, home paths, nonces, tokens, and command content

## Verification

- `uv run pytest tests/test_guard_mdm_*.py -q` — 273 passed, 7 skipped
- targeted Ruff checks — passed
- targeted basedpyright — 0 errors
- `git diff --check` — passed