### PR TITLE
fix(release): harden release train publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [main, release/2.2]
   pull_request:
-    branches: [main]
+    branches: [main, release/2.2]
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -832,13 +832,23 @@ jobs:
           if release_json=$(gh release view "$tag" --json isDraft,isPrerelease 2>/dev/null); then
             jq -e '.isDraft == false and .isPrerelease == true' <<< "$release_json" >/dev/null
             existing_dir=$(mktemp -d)
-            gh release download "$tag" --pattern 'hol_guard-*' --dir "$existing_dir"
-            mapfile -d '' local_files < <(find dist -maxdepth 1 -type f -name 'hol_guard-*' -print0 | sort -z)
-            mapfile -d '' remote_files < <(find "$existing_dir" -maxdepth 1 -type f -name 'hol_guard-*' -print0 | sort -z)
+            gh release download "$tag" --dir "$existing_dir"
+            mapfile -d '' local_files < <(find dist -maxdepth 1 -type f -print0 | sort -z)
+            mapfile -d '' remote_files < <(find "$existing_dir" -maxdepth 1 -type f -print0 | sort -z)
             [[ "${#local_files[@]}" -gt 0 ]]
             [[ "${#local_files[@]}" == "${#remote_files[@]}" ]]
             for local_file in "${local_files[@]}"; do
-              cmp --silent "$local_file" "$existing_dir/$(basename "$local_file")"
+              remote_file="$existing_dir/$(basename "$local_file")"
+              [[ -f "$remote_file" ]]
+              if [[ "$remote_file" != *.intoto.jsonl ]]; then
+                cmp --silent "$local_file" "$remote_file"
+              fi
+            done
+            bundle="$existing_dir/hol-guard-v${VERSION}.intoto.jsonl"
+            [[ -s "$bundle" ]]
+            for remote_file in "$existing_dir"/hol_guard-*; do
+              gh attestation verify "$remote_file" --repo "$GITHUB_REPOSITORY" \
+                --bundle "$bundle" --source-digest "$SOURCE_SHA" >/dev/null
             done
             exit 0
           fi
@@ -978,13 +988,23 @@ jobs:
           if release_json=$(gh release view "$tag" --json isDraft,isPrerelease 2>/dev/null); then
             jq -e '.isDraft == false and .isPrerelease == false' <<< "$release_json" >/dev/null
             existing_dir=$(mktemp -d)
-            gh release download "$tag" --pattern 'hol_guard-*' --dir "$existing_dir"
-            mapfile -d '' local_files < <(find dist -maxdepth 1 -type f -name 'hol_guard-*' -print0 | sort -z)
-            mapfile -d '' remote_files < <(find "$existing_dir" -maxdepth 1 -type f -name 'hol_guard-*' -print0 | sort -z)
+            gh release download "$tag" --dir "$existing_dir"
+            mapfile -d '' local_files < <(find dist -maxdepth 1 -type f -print0 | sort -z)
+            mapfile -d '' remote_files < <(find "$existing_dir" -maxdepth 1 -type f -print0 | sort -z)
             [[ "${#local_files[@]}" -gt 0 ]]
             [[ "${#local_files[@]}" == "${#remote_files[@]}" ]]
             for local_file in "${local_files[@]}"; do
-              cmp --silent "$local_file" "$existing_dir/$(basename "$local_file")"
+              remote_file="$existing_dir/$(basename "$local_file")"
+              [[ -f "$remote_file" ]]
+              if [[ "$remote_file" != *.intoto.jsonl ]]; then
+                cmp --silent "$local_file" "$remote_file"
+              fi
+            done
+            bundle="$existing_dir/hol-guard-v${VERSION}.intoto.jsonl"
+            [[ -s "$bundle" ]]
+            for remote_file in "$existing_dir"/hol_guard-*; do
+              gh attestation verify "$remote_file" --repo "$GITHUB_REPOSITORY" \
+                --bundle "$bundle" --source-digest "$SOURCE_SHA" >/dev/null
             done
             exit 0
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,22 +3,40 @@ name: Publish to PyPI
 on:
   workflow_dispatch:
     inputs:
-      publish_target:
-        description: "Target repository"
+      release_channel:
+        description: "Release channel"
         required: true
-        default: pypi
+        default: alpha
         type: choice
         options:
-          - testpypi
-          - pypi
+          - alpha
+          - stable
+      release_train:
+        description: "Authorized release train"
+        required: true
+        type: choice
+        options:
+          - "2.2"
+      release_version:
+        description: "Exact canonical release version"
+        required: true
+        type: string
+      expected_sha:
+        description: "Exact source commit authorized for publication"
+        required: true
+        type: string
+      promotion_pr:
+        description: "Merged release-to-main PR number (required for stable)"
+        required: false
+        type: string
   push:
-    branches: [main]
-    tags: ["v*"]
+    branches: [main, release/2.2]
   pull_request:
-    branches: [main]
+    branches: [main, release/2.2]
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: hol-guard-publish-${{ github.ref }}
@@ -27,10 +45,12 @@ concurrency:
 jobs:
   build:
     name: Build + Verify
-    if: github.event_name != 'push' || github.ref != 'refs/heads/main' || !contains(github.event.head_commit.message, '[skip release publish]')
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      channel: ${{ steps.version.outputs.channel }}
+      release_train: ${{ steps.version.outputs.release_train }}
+      source_sha: ${{ steps.version.outputs.source_sha }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -63,12 +83,101 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_CHANNEL: ${{ github.event.inputs.release_channel }}
+          RELEASE_TRAIN: ${{ github.event.inputs.release_train }}
+          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+          EXPECTED_SHA: ${{ github.event.inputs.expected_sha }}
+          PROMOTION_PR: ${{ github.event.inputs.promotion_pr }}
+          RELEASE_PUBLISHING_ENABLED: ${{ vars.RELEASE_PUBLISHING_ENABLED }}
         run: |
           BASE_VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
           VERSION="$BASE_VERSION"
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
+          CHANNEL="integration"
+          TRAIN=""
+          SOURCE_SHA=$(git rev-parse 'HEAD^{commit}')
+
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ "$RELEASE_PUBLISHING_ENABLED" != "true" ]]; then
+              echo "Release publishing is disabled until protected environments are verified" >&2
+              exit 1
+            fi
+            CHANNEL="$RELEASE_CHANNEL"
+            TRAIN="$RELEASE_TRAIN"
+            TRAIN_REF="refs/heads/release/${TRAIN}"
+
+            if [[ "$CHANNEL" == "alpha" ]]; then
+              if [[ "$GITHUB_REF" != "$TRAIN_REF" ]]; then
+                echo "Alpha releases must run from ${TRAIN_REF}" >&2
+                exit 1
+              fi
+            elif [[ "$CHANNEL" == "stable" ]]; then
+              if [[ "$GITHUB_REF" != "refs/tags/v${RELEASE_VERSION}" ]]; then
+                echo "Stable releases must run from the exact protected version tag" >&2
+                exit 1
+              fi
+              if [[ "$BASE_VERSION" != "$RELEASE_VERSION" ]]; then
+                echo "Stable source metadata must already equal ${RELEASE_VERSION}" >&2
+                exit 1
+              fi
+              if [[ -z "$PROMOTION_PR" ]]; then
+                echo "Stable releases require the merged promotion PR number" >&2
+                exit 1
+              fi
+              git fetch --no-tags origin \
+                "+refs/heads/main:refs/remotes/origin/main" \
+                "+${TRAIN_REF}:refs/remotes/origin/release/${TRAIN}"
+              if ! git merge-base --is-ancestor "refs/remotes/origin/release/${TRAIN}" "$SOURCE_SHA"; then
+                echo "Stable source must contain the complete reviewed release train" >&2
+                exit 1
+              fi
+              if ! git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main; then
+                echo "Stable source must be contained by the protected main branch" >&2
+                exit 1
+              fi
+              remote_tag_sha=$(git ls-remote origin "refs/tags/v${RELEASE_VERSION}^{}" | awk '{print $1}' || true)
+              if [[ -z "$remote_tag_sha" ]]; then
+                remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/v${RELEASE_VERSION}" | awk '{print $1}')
+              fi
+              if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
+                echo "Protected stable tag must target the authorized promotion SHA" >&2
+                exit 1
+              fi
+              promotion_json=$(gh pr view "$PROMOTION_PR" --repo "$GITHUB_REPOSITORY" \
+                --json state,baseRefName,headRefName,mergeCommit)
+              if ! jq -e \
+                --arg train "release/${TRAIN}" \
+                --arg sha "$SOURCE_SHA" \
+                '.state == "MERGED" and .baseRefName == "main" and .headRefName == $train and .mergeCommit.oid == $sha' \
+                <<< "$promotion_json" >/dev/null; then
+                echo "Stable source must equal the reviewed release-to-main promotion commit" >&2
+                exit 1
+              fi
+            else
+              echo "Unsupported release channel: ${CHANNEL}" >&2
+              exit 1
+            fi
+
+            EXISTING_VERSION_FILE=$(mktemp)
+            uv run --no-sync python scripts/verify_release_registry.py \
+              list-versions --registry pypi | jq -r '.[]' > "$EXISTING_VERSION_FILE"
+            git tag --list 'alpha/v*' | sed 's#^alpha/v##' >> "$EXISTING_VERSION_FILE"
+            mapfile -t EXISTING_VERSIONS < <(
+              awk -v candidate="$RELEASE_VERSION" '$0 != candidate' "$EXISTING_VERSION_FILE"
+            )
+            VALIDATOR_ARGS=(
+              --channel "$CHANNEL"
+              --version "$RELEASE_VERSION"
+              --git-ref "$TRAIN_REF"
+              --actual-ref "$GITHUB_REF"
+              --github-sha "$SOURCE_SHA"
+              --expected-sha "$EXPECTED_SHA"
+            )
+            for existing_version in "${EXISTING_VERSIONS[@]}"; do
+              VALIDATOR_ARGS+=(--existing-version "$existing_version")
+            done
+            VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py "${VALIDATOR_ARGS[@]}")
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            CHANNEL="canary"
             VERSION=$(BASE_VERSION="$BASE_VERSION" PR_NUMBER="$PR_NUMBER" GITHUB_RUN_NUMBER="$GITHUB_RUN_NUMBER" GITHUB_RUN_ATTEMPT="$GITHUB_RUN_ATTEMPT" python - <<'PY'
           import os
 
@@ -79,41 +188,12 @@ jobs:
           print(f"{os.environ['BASE_VERSION']}.dev{pair(pair(int(os.environ['PR_NUMBER']), int(os.environ['GITHUB_RUN_NUMBER'])), int(os.environ['GITHUB_RUN_ATTEMPT']))}")
           PY
             )
-          elif [[ ("$GITHUB_EVENT_NAME" == "push" || "$GITHUB_EVENT_NAME" == "workflow_dispatch") && "$GITHUB_REF" == "refs/heads/main" ]]; then
-            # Check git tags first
-            LAST_TAG=$(git tag --list 'v*' --sort=-version:refname 2>/dev/null | head -n1)
-            LAST_TAG_VERSION="${LAST_TAG#v}"
-
-            # Also check GitHub releases (they may exist without corresponding git tags)
-            # GH_TOKEN provided via env block above
-            # Null-safe: returns empty if no releases exist
-            # Fetch all releases (--limit 100) and pick max semver
-            # Filter to strict semver tags (vX.Y.Z) to exclude non-semver like "nightly" or "rc"
-            GH_RELEASES=$(gh release list --limit 100 --json tagName --jq '.[].tagName' 2>/dev/null | \
-              grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -V 2>/dev/null || echo "")
-            GH_RELEASE_VERSION=$(echo "$GH_RELEASES" | grep -v '^$' | tail -n1)
-
-            # Use whichever version is higher
-            if [[ -n "$GH_RELEASE_VERSION" && -n "$LAST_TAG_VERSION" ]]; then
-              COMPARE=$(printf '%s\n%s\n' "$LAST_TAG_VERSION" "$GH_RELEASE_VERSION" | sort -V | tail -n1)
-              HIGHEST="$COMPARE"
-            elif [[ -n "$GH_RELEASE_VERSION" ]]; then
-              HIGHEST="$GH_RELEASE_VERSION"
-            elif [[ -n "$LAST_TAG_VERSION" ]]; then
-              HIGHEST="$LAST_TAG_VERSION"
-            fi
-
-            if [[ -n "$HIGHEST" ]]; then
-              IFS=. read -r MAJOR MINOR PATCH <<< "$HIGHEST"
-              if [[ -z "$MAJOR" || -z "$MINOR" || -z "$PATCH" ]]; then
-                echo "Unsupported release tag format: $HIGHEST" >&2
-                exit 1
-              fi
-              VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
-            fi
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Computed version: $VERSION"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "release_train=$TRAIN" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+          echo "Computed $CHANNEL version: $VERSION"
       - name: Verify release toolchain and write SBOM
         env:
           EXPECTED_UV_VERSION: "0.9.26"
@@ -180,11 +260,19 @@ jobs:
           mv pyproject.toml.bak pyproject.toml
       - name: Verify distributions
         run: uv run --no-sync twine check dist/*
+      - name: Record immutable distribution hashes
+        run: |
+          find dist -maxdepth 1 -type f -print0 | sort -z | xargs -0 sha256sum > distribution-sha256.txt
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: distributions
           path: dist/
+      - name: Upload distribution hashes
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: distribution-sha256
+          path: distribution-sha256.txt
       - name: Upload release toolchain SBOM
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -192,9 +280,34 @@ jobs:
           path: release-metadata/*.cdx.json
           if-no-files-found: error
 
+  alpha-cross-platform:
+    name: Alpha release tests (${{ matrix.os }})
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_channel == 'alpha'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Run Linux release suite
+        if: runner.os == 'Linux'
+        run: uv run --no-sync pytest --tb=short
+      - name: Run Windows release suite
+        if: runner.os == 'Windows'
+        run: uv run --no-sync pytest tests/test_cli.py tests/test_verification.py tests/test_action_runner.py tests/test_policy_document_yaml.py tests/test_policy_bundle_v2.py --tb=short
+
   publish-testpypi:
-    name: Publish to TestPyPI (Manual)
-    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    name: Publish PR canary to TestPyPI
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: build
     runs-on: ubuntu-latest
     environment: testpypi
@@ -206,14 +319,11 @@ jobs:
           name: distributions
           path: dist/
       - name: Keep only the Guard canary distribution
-        if: github.event_name == 'pull_request'
         run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
       - name: Show canary install command
-        if: github.event_name == 'pull_request'
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
@@ -222,27 +332,543 @@ jobs:
           echo "uv tool install --force --index https://pypi.org/simple --find-links https://test.pypi.org/simple/hol-guard/ 'hol-guard==$VERSION'" >> "$GITHUB_STEP_SUMMARY"
           echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
 
-  publish-pypi:
-    name: Publish to PyPI
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi')
-    needs: build
+  publish-alpha-testpypi:
+    name: Verify alpha artifact on TestPyPI
+    if: >-
+      always() &&
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.release_channel == 'alpha' &&
+      needs.build.result == 'success' &&
+      (needs.alpha-cross-platform.result == 'success' || needs.alpha-cross-platform.result == 'skipped')
+    needs: [build, alpha-cross-platform]
     runs-on: ubuntu-latest
-    environment: pypi
+    environment: testpypi-alpha
     permissions:
+      contents: read
       id-token: write
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ needs.build.outputs.source_sha }}
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: distributions
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          skip-existing: true
+          name: distribution-sha256
+      - name: Verify immutable build artifact
+        run: sha256sum --check distribution-sha256.txt
+      - name: Keep only the Guard release distribution
+        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
+      - name: Revalidate alpha source before TestPyPI
+        env:
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+          TRAIN: ${{ needs.build.outputs.release_train }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          train_ref="refs/heads/release/${TRAIN}"
+          remote_train_sha=$(git ls-remote --exit-code origin "$train_ref" | awk '{print $1}')
+          if [[ "$remote_train_sha" != "$SOURCE_SHA" ]]; then
+            echo "Alpha publication source is no longer the release train head" >&2
+            exit 1
+          fi
+          remote_alpha_tag_sha=$(git ls-remote origin "refs/tags/alpha/v${VERSION}" | awk '{print $1}')
+          if [[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]; then
+            echo "Alpha tag targets a different source" >&2
+            exit 1
+          fi
+      - name: Inspect TestPyPI release state
+        id: testpypi
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+            verify-release --registry testpypi --version "$VERSION" --dist-dir dist)
+          status=$(jq -r '.status' <<< "$result")
+          if [[ "$status" == "absent" ]]; then
+            echo "upload=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$status" == "exact" ]]; then
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unexpected TestPyPI status: $status" >&2
+            exit 1
+          fi
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        if: steps.testpypi.outputs.upload == 'true'
+        with:
+          repository-url: https://test.pypi.org/legacy/
+      - name: Download and verify exact TestPyPI artifacts
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          for attempt in {1..12}; do
+            if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+              verify-release --registry testpypi --version "$VERSION" --dist-dir dist \
+              --download-dir verified-testpypi); then
+              exit 1
+            fi
+            status=$(jq -r '.status' <<< "$result")
+            if [[ "$status" == "exact" ]]; then
+              break
+            fi
+            if [[ "$status" != "absent" || "$attempt" == "12" ]]; then
+              echo "TestPyPI did not expose the exact release artifacts" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
+          [[ -n "$wheel" ]]
+          [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
+
+  publish-alpha-pypi:
+    name: Publish alpha to PyPI
+    if: >-
+      always() &&
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.release_channel == 'alpha' &&
+      needs.build.result == 'success' &&
+      needs.publish-alpha-testpypi.result == 'success' &&
+      (needs.alpha-cross-platform.result == 'success' || needs.alpha-cross-platform.result == 'skipped')
+    needs: [build, alpha-cross-platform, publish-alpha-testpypi]
+    runs-on: ubuntu-latest
+    environment: pypi-alpha
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.build.outputs.source_sha }}
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distributions
+          path: dist/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distribution-sha256
+      - name: Verify the TestPyPI-proven artifact
+        run: sha256sum --check distribution-sha256.txt
+      - name: Keep only the Guard release distribution
+        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
+      - name: Inspect PyPI release state
+        id: pypi
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+            verify-release --registry pypi --version "$VERSION" --dist-dir dist)
+          status=$(jq -r '.status' <<< "$result")
+          if [[ "$status" == "absent" ]]; then
+            echo "upload=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$status" == "exact" ]]; then
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unexpected PyPI status: $status" >&2
+            exit 1
+          fi
+      - name: Revalidate alpha publication authorization
+        env:
+          ACTUAL_REF: ${{ github.ref }}
+          EXPECTED_SHA: ${{ github.event.inputs.expected_sha }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+          TRAIN: ${{ needs.build.outputs.release_train }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          train_ref="refs/heads/release/${TRAIN}"
+          remote_train_sha=$(git ls-remote --exit-code origin "$train_ref" | awk '{print $1}')
+          if [[ "$remote_train_sha" != "$SOURCE_SHA" ]]; then
+            echo "Alpha publication source is no longer the release train head" >&2
+            exit 1
+          fi
+          remote_alpha_tag_sha=$(git ls-remote origin "refs/tags/alpha/v${VERSION}" | awk '{print $1}')
+          if [[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]; then
+            echo "Alpha tag targets a different source" >&2
+            exit 1
+          fi
+          versions=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+            list-versions --registry pypi)
+          mapfile -t existing_versions < <(jq -r --arg version "$VERSION" '.[] | select(. != $version)' <<< "$versions")
+          mapfile -t alpha_tags < <(
+            git tag --list 'alpha/v*' | sed 's#^alpha/v##' | awk -v candidate="$VERSION" '$0 != candidate'
+          )
+          validator_args=(
+            --channel alpha
+            --version "$VERSION"
+            --git-ref "$train_ref"
+            --actual-ref "$ACTUAL_REF"
+            --github-sha "$SOURCE_SHA"
+            --expected-sha "$EXPECTED_SHA"
+          )
+          for existing_version in "${existing_versions[@]}" "${alpha_tags[@]}"; do
+            [[ -z "$existing_version" ]] || validator_args+=(--existing-version "$existing_version")
+          done
+          uv run --with packaging==25.0 python scripts/validate_alpha_release.py "${validator_args[@]}"
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        if: steps.pypi.outputs.upload == 'true'
+      - name: Download and verify exact PyPI artifacts
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          for attempt in {1..12}; do
+            if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+              verify-release --registry pypi --version "$VERSION" --dist-dir dist \
+              --download-dir verified-pypi); then
+              exit 1
+            fi
+            status=$(jq -r '.status' <<< "$result")
+            if [[ "$status" == "exact" ]]; then
+              break
+            fi
+            if [[ "$status" != "absent" || "$attempt" == "12" ]]; then
+              echo "PyPI did not expose the exact release artifacts" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
+          [[ -n "$wheel" ]]
+          [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
+
+  publish-stable-testpypi:
+    name: Verify stable artifact on TestPyPI
+    if: >-
+      always() &&
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.release_channel == 'stable' &&
+      needs.build.result == 'success' &&
+      needs.alpha-cross-platform.result == 'skipped'
+    needs: [build, alpha-cross-platform]
+    runs-on: ubuntu-latest
+    environment: testpypi-stable
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.build.outputs.source_sha }}
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distributions
+          path: dist/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distribution-sha256
+      - name: Verify immutable build artifact
+        run: sha256sum --check distribution-sha256.txt
+      - name: Keep only the Guard release distribution
+        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
+      - name: Revalidate stable source before TestPyPI
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROMOTION_PR: ${{ github.event.inputs.promotion_pr }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+          TRAIN: ${{ needs.build.outputs.release_train }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          train_ref="refs/heads/release/${TRAIN}"
+          git fetch --no-tags origin \
+            "+refs/heads/main:refs/remotes/origin/main" \
+            "+${train_ref}:refs/remotes/origin/release/${TRAIN}"
+          remote_tag_sha=$(git ls-remote origin "refs/tags/v${VERSION}^{}" | awk '{print $1}' || true)
+          if [[ -z "$remote_tag_sha" ]]; then
+            remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/v${VERSION}" | awk '{print $1}')
+          fi
+          [[ "$remote_tag_sha" == "$SOURCE_SHA" ]]
+          git merge-base --is-ancestor "refs/remotes/origin/release/${TRAIN}" "$SOURCE_SHA"
+          git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main
+          promotion_json=$(gh pr view "$PROMOTION_PR" --repo "$GITHUB_REPOSITORY" \
+            --json state,baseRefName,headRefName,mergeCommit)
+          jq -e \
+            --arg train "release/${TRAIN}" \
+            --arg sha "$SOURCE_SHA" \
+            '.state == "MERGED" and .baseRefName == "main" and .headRefName == $train and .mergeCommit.oid == $sha' \
+            <<< "$promotion_json" >/dev/null
+      - name: Inspect TestPyPI release state
+        id: testpypi
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+            verify-release --registry testpypi --version "$VERSION" --dist-dir dist)
+          status=$(jq -r '.status' <<< "$result")
+          if [[ "$status" == "absent" ]]; then
+            echo "upload=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$status" == "exact" ]]; then
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unexpected TestPyPI status: $status" >&2
+            exit 1
+          fi
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        if: steps.testpypi.outputs.upload == 'true'
+        with:
+          repository-url: https://test.pypi.org/legacy/
+      - name: Download and verify exact TestPyPI artifacts
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          for attempt in {1..12}; do
+            if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+              verify-release --registry testpypi --version "$VERSION" --dist-dir dist \
+              --download-dir verified-testpypi); then
+              exit 1
+            fi
+            status=$(jq -r '.status' <<< "$result")
+            if [[ "$status" == "exact" ]]; then
+              break
+            fi
+            if [[ "$status" != "absent" || "$attempt" == "12" ]]; then
+              echo "TestPyPI did not expose the exact release artifacts" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
+          [[ -n "$wheel" ]]
+          [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
+
+  publish-stable-pypi:
+    name: Publish stable to PyPI
+    if: >-
+      always() &&
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.release_channel == 'stable' &&
+      needs.build.result == 'success' &&
+      needs.publish-stable-testpypi.result == 'success' &&
+      needs.alpha-cross-platform.result == 'skipped'
+    needs: [build, alpha-cross-platform, publish-stable-testpypi]
+    runs-on: ubuntu-latest
+    environment: pypi-stable
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.build.outputs.source_sha }}
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distributions
+          path: dist/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distribution-sha256
+      - name: Verify the TestPyPI-proven artifact
+        run: sha256sum --check distribution-sha256.txt
+      - name: Keep only the Guard release distribution
+        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
+      - name: Inspect PyPI release state
+        id: pypi
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+            verify-release --registry pypi --version "$VERSION" --dist-dir dist)
+          status=$(jq -r '.status' <<< "$result")
+          if [[ "$status" == "absent" ]]; then
+            echo "upload=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$status" == "exact" ]]; then
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unexpected PyPI status: $status" >&2
+            exit 1
+          fi
+      - name: Revalidate stable publication authorization
+        env:
+          ACTUAL_REF: ${{ github.ref }}
+          EXPECTED_SHA: ${{ github.event.inputs.expected_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROMOTION_PR: ${{ github.event.inputs.promotion_pr }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+          TRAIN: ${{ needs.build.outputs.release_train }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          train_ref="refs/heads/release/${TRAIN}"
+          git fetch --no-tags origin \
+            "+refs/heads/main:refs/remotes/origin/main" \
+            "+${train_ref}:refs/remotes/origin/release/${TRAIN}"
+          remote_tag_sha=$(git ls-remote origin "refs/tags/v${VERSION}^{}" | awk '{print $1}' || true)
+          if [[ -z "$remote_tag_sha" ]]; then
+            remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/v${VERSION}" | awk '{print $1}')
+          fi
+          if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
+            echo "Protected stable tag moved after build authorization" >&2
+            exit 1
+          fi
+          git merge-base --is-ancestor "refs/remotes/origin/release/${TRAIN}" "$SOURCE_SHA"
+          git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main
+          promotion_json=$(gh pr view "$PROMOTION_PR" --repo "$GITHUB_REPOSITORY" \
+            --json state,baseRefName,headRefName,mergeCommit)
+          jq -e \
+            --arg train "release/${TRAIN}" \
+            --arg sha "$SOURCE_SHA" \
+            '.state == "MERGED" and .baseRefName == "main" and .headRefName == $train and .mergeCommit.oid == $sha' \
+            <<< "$promotion_json" >/dev/null
+          versions=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+            list-versions --registry pypi)
+          mapfile -t existing_versions < <(jq -r --arg version "$VERSION" '.[] | select(. != $version)' <<< "$versions")
+          validator_args=(
+            --channel stable
+            --version "$VERSION"
+            --git-ref "$train_ref"
+            --actual-ref "$ACTUAL_REF"
+            --github-sha "$SOURCE_SHA"
+            --expected-sha "$EXPECTED_SHA"
+          )
+          for existing_version in "${existing_versions[@]}"; do
+            validator_args+=(--existing-version "$existing_version")
+          done
+          uv run --with packaging==25.0 python scripts/validate_alpha_release.py "${validator_args[@]}"
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        if: steps.pypi.outputs.upload == 'true'
+      - name: Download and verify exact PyPI artifacts
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          for attempt in {1..12}; do
+            if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+              verify-release --registry pypi --version "$VERSION" --dist-dir dist \
+              --download-dir verified-pypi); then
+              exit 1
+            fi
+            status=$(jq -r '.status' <<< "$result")
+            if [[ "$status" == "exact" ]]; then
+              break
+            fi
+            if [[ "$status" != "absent" || "$attempt" == "12" ]]; then
+              echo "PyPI did not expose the exact release artifacts" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
+          [[ -n "$wheel" ]]
+          [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
+
+  release-alpha:
+    name: Create alpha GitHub prerelease
+    if: >-
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      github.event_name == 'workflow_dispatch' &&
+      needs.build.outputs.channel == 'alpha'
+    needs: [build, publish-alpha-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.build.outputs.source_sha }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distributions
+          path: dist/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distribution-sha256
+      - name: Download release toolchain SBOM
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: release-toolchain-sbom
+          path: dist/
+      - name: Verify and select release assets
+        run: |
+          sha256sum --check distribution-sha256.txt
+          rm -f dist/plugin_scanner-* dist/plugin-scanner-*
+      - name: Attest alpha release assets
+        id: provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-path: dist/*
+      - name: Materialize provenance bundle
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: cp "${{ steps.provenance.outputs.bundle-path }}" "dist/hol-guard-v${VERSION}.intoto.jsonl"
+      - name: Create discoverable alpha prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          tag="alpha/v${VERSION}"
+          remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
+          if [[ -z "$remote_tag_sha" ]]; then
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/${tag}" \
+              -f sha="$SOURCE_SHA" >/dev/null
+            remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/${tag}" | awk '{print $1}')
+          fi
+          if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
+            echo "Alpha tag does not target the published source" >&2
+            exit 1
+          fi
+          if release_json=$(gh release view "$tag" --json isDraft,isPrerelease 2>/dev/null); then
+            jq -e '.isDraft == false and .isPrerelease == true' <<< "$release_json" >/dev/null
+            existing_dir=$(mktemp -d)
+            gh release download "$tag" --pattern 'hol_guard-*' --dir "$existing_dir"
+            mapfile -d '' local_files < <(find dist -maxdepth 1 -type f -name 'hol_guard-*' -print0 | sort -z)
+            mapfile -d '' remote_files < <(find "$existing_dir" -maxdepth 1 -type f -name 'hol_guard-*' -print0 | sort -z)
+            [[ "${#local_files[@]}" -gt 0 ]]
+            [[ "${#local_files[@]}" == "${#remote_files[@]}" ]]
+            for local_file in "${local_files[@]}"; do
+              cmp --silent "$local_file" "$existing_dir/$(basename "$local_file")"
+            done
+            exit 0
+          fi
+          body_file=$(mktemp)
+          cat > "$body_file" <<EOF
+          Guard ${VERSION} is an opt-in prerelease. Stable installations remain on the stable channel.
+
+          Install this exact alpha:
+
+          \`\`\`bash
+          uv tool install --force "hol-guard==${VERSION}"
+          \`\`\`
+          EOF
+          mapfile -d '' ASSET_FILES < <(find dist -maxdepth 1 -type f -print0 | sort -z)
+          gh release create "$tag" \
+            --repo "${{ github.repository }}" \
+            --target "$SOURCE_SHA" \
+            --title "Guard ${VERSION} alpha" \
+            --notes-file "$body_file" \
+            --prerelease \
+            --verify-tag \
+            "${ASSET_FILES[@]}"
 
   release:
     name: Create GitHub Release
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
-    needs: [build, publish-pypi]
+    if: >-
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      github.event_name == 'workflow_dispatch' &&
+      needs.build.outputs.channel == 'stable'
+    needs: [build, publish-stable-pypi]
     runs-on: ubuntu-latest
     permissions:
       attestations: write
@@ -261,19 +887,14 @@ jobs:
         with:
           name: release-toolchain-sbom
           path: dist/
-      - name: Skip if release already exists
-        id: release_exists
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.build.outputs.version }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distribution-sha256
+      - name: Verify and select release assets
         run: |
-          if gh release view "v${VERSION}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+          sha256sum --check distribution-sha256.txt
+          rm -f dist/plugin_scanner-* dist/plugin-scanner-*
       - name: Generate changelog
-        if: steps.release_exists.outputs.exists == 'false'
         id: changelog
         env:
           VERSION: ${{ needs.build.outputs.version }}
@@ -300,17 +921,9 @@ jobs:
           uv tool install hol-guard==${VERSION}
           \`\`\`
 
-          \`\`\`bash
-          uv tool install plugin-scanner==${VERSION}
-          \`\`\`
-
           Full Cisco coverage on Python 3.11+:
           \`\`\`bash
           uv tool install "hol-guard[cisco]==${VERSION}"
-          \`\`\`
-
-          \`\`\`bash
-          uv tool install "plugin-scanner[cisco]==${VERSION}"
           \`\`\`
 
           \`\`\`bash
@@ -322,20 +935,17 @@ jobs:
 
           echo "notes_path=release-notes.md" >> $GITHUB_OUTPUT
       - name: Attest GitHub release assets
-        if: steps.release_exists.outputs.exists == 'false'
         id: provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-path: |
             dist/*
       - name: Materialize provenance bundle
-        if: steps.release_exists.outputs.exists == 'false'
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          cp "${{ steps.provenance.outputs.bundle-path }}" "dist/plugin-scanner-v${VERSION}.intoto.jsonl"
+          cp "${{ steps.provenance.outputs.bundle-path }}" "dist/hol-guard-v${VERSION}.intoto.jsonl"
       - name: Collect release asset files
-        if: steps.release_exists.outputs.exists == 'false'
         id: release_assets
         run: |
           mapfile -d '' ASSET_FILES < <(find dist -maxdepth 1 -type f -print0 | sort -z)
@@ -351,24 +961,62 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
       - name: Create release
-        if: steps.release_exists.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
+          remote_tag_sha=$(git ls-remote origin "refs/tags/v${VERSION}^{}" | awk '{print $1}' || true)
+          if [[ -z "$remote_tag_sha" ]]; then
+            remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/v${VERSION}" | awk '{print $1}')
+          fi
+          if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
+            echo "Protected stable tag no longer targets the validated source SHA" >&2
+            exit 1
+          fi
+          tag="v${VERSION}"
+          if release_json=$(gh release view "$tag" --json isDraft,isPrerelease 2>/dev/null); then
+            jq -e '.isDraft == false and .isPrerelease == false' <<< "$release_json" >/dev/null
+            existing_dir=$(mktemp -d)
+            gh release download "$tag" --pattern 'hol_guard-*' --dir "$existing_dir"
+            mapfile -d '' local_files < <(find dist -maxdepth 1 -type f -name 'hol_guard-*' -print0 | sort -z)
+            mapfile -d '' remote_files < <(find "$existing_dir" -maxdepth 1 -type f -name 'hol_guard-*' -print0 | sort -z)
+            [[ "${#local_files[@]}" -gt 0 ]]
+            [[ "${#local_files[@]}" == "${#remote_files[@]}" ]]
+            for local_file in "${local_files[@]}"; do
+              cmp --silent "$local_file" "$existing_dir/$(basename "$local_file")"
+            done
+            exit 0
+          fi
           mapfile -t RELEASE_ASSETS <<'EOF'
           ${{ steps.release_assets.outputs.files }}
           EOF
-          gh release create "v${VERSION}" \
+          gh release create "$tag" \
             --title "v${VERSION}" \
-            --target main \
+            --verify-tag \
             --notes-file ${{ steps.changelog.outputs.notes_path }} \
             "${RELEASE_ASSETS[@]}"
 
   publish-container:
     name: Publish container image
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi')
-    needs: [build, publish-pypi]
+    if: >-
+      always() &&
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      github.event_name == 'workflow_dispatch' &&
+      needs.build.result == 'success' &&
+      (
+        (
+          needs.build.outputs.channel == 'alpha' &&
+          needs.publish-alpha-pypi.result == 'success' &&
+          needs.release-alpha.result == 'success'
+        ) ||
+        (
+          needs.build.outputs.channel == 'stable' &&
+          needs.publish-stable-pypi.result == 'success' &&
+          needs.release.result == 'success'
+        )
+      )
+    needs: [build, publish-alpha-pypi, publish-stable-pypi, release-alpha, release]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -416,108 +1064,3 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.build.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
-
-  sync-repository-version:
-    name: Sync repository version
-    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip release publish]') && needs.build.result == 'success' && needs.publish-pypi.result == 'success' && contains(fromJSON('["success","skipped"]'), needs.release.result) && contains(fromJSON('["success","skipped"]'), needs.publish-container.result)
-    needs: [build, publish-pypi, release, publish-container]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          ref: main
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Prepare main branch
-        run: |
-          git checkout -B main origin/main
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        with:
-          python-version: "3.12"
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
-        with:
-          version: "0.9.26"
-      - name: Sync locked release tooling
-        run: |
-          uv sync --frozen
-      - name: Sync repository version files
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          uv run --no-sync python scripts/sync_repo_version.py --version "$VERSION"
-      - name: Open repository version sync PR
-        env:
-          ACTION_REPO_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
-          GH_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          if git diff --quiet -- pyproject.toml src/codex_plugin_scanner/version.py uv.lock; then
-            echo "Repository version already synced."
-            exit 0
-          fi
-          if [[ -z "$ACTION_REPO_TOKEN" ]]; then
-            echo "ACTION_REPO_TOKEN must be configured to sync repository version files after publish." >&2
-            exit 1
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/${{ github.repository }}.git"
-          branch="release/sync-repository-version-v${VERSION}"
-          head_ref="${{ github.repository_owner }}:${branch}"
-          title="chore(release): sync repository version to ${VERSION} [skip release publish]"
-          body_file="$(mktemp)"
-          trap 'rm -f "$body_file"' EXIT
-          cat > "$body_file" <<EOF
-          ## Summary
-          - sync repository version files to ${VERSION} after publish
-          - keep repo-visible version metadata aligned with the released package artifacts
-
-          ## Testing
-          - \`uv sync --frozen && uv run --no-sync python scripts/sync_repo_version.py --version "${VERSION}"\`
-          EOF
-          git checkout -B "$branch"
-          git add pyproject.toml src/codex_plugin_scanner/version.py uv.lock
-          changed_files="$(git diff --cached --name-only)"
-          unexpected_files="$(printf '%s\n' "$changed_files" | grep -Ev '^(pyproject.toml|src/codex_plugin_scanner/version.py|uv.lock)$' || true)"
-          if [[ -n "$unexpected_files" ]]; then
-            echo "Unexpected files staged for repository version sync:" >&2
-            printf '%s\n' "$unexpected_files" >&2
-            exit 1
-          fi
-          git commit -m "chore(release): sync repository version to ${VERSION} [skip release publish]"
-          lease_ref="refs/heads/$branch"
-          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-            if ! git fetch --no-tags origin "+$lease_ref:refs/remotes/origin/$branch"; then
-              if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-                exit 1
-              fi
-            fi
-          fi
-          expected_remote=""
-          if remote_head="$(git ls-remote --exit-code --heads origin "$branch" | awk '{print $1}')" && [[ -n "$remote_head" ]]; then
-            expected_remote="$remote_head"
-          fi
-          if [[ -n "$expected_remote" ]]; then
-            git push --force-with-lease="$lease_ref:$expected_remote" --set-upstream origin "$branch"
-          else
-            git push --force-with-lease="$lease_ref:" --set-upstream origin "$branch"
-          fi
-          head_sha="$(git rev-parse HEAD)"
-          pr_number="$(gh pr list --repo ${{ github.repository }} --base main --head "$head_ref" --state open --json number --jq '.[0].number // empty')"
-          if [[ -n "$pr_number" ]]; then
-            gh pr edit "$pr_number" --repo ${{ github.repository }} --title "$title" --body-file "$body_file"
-          else
-            pr_url="$(gh pr create --repo ${{ github.repository }} --base main --head "$branch" --title "$title" --body-file "$body_file")"
-            pr_number="${pr_url##*/}"
-          fi
-          if [[ -z "$pr_number" ]]; then
-            echo "Failed to create or locate repository version sync PR." >&2
-            exit 1
-          fi
-          if [[ "$(gh api repos/${{ github.repository }} --jq .allow_auto_merge)" != "true" ]]; then
-            echo "Repository auto-merge is disabled; leaving PR #${pr_number} open for manual merge after checks." >&2
-            exit 1
-          fi
-          gh pr merge "$pr_number" --repo ${{ github.repository }} --auto --squash --delete-branch --match-head-commit "$head_sha" --subject "chore(release): sync repository version to ${VERSION} [skip release publish]" --body ""

--- a/scripts/validate_alpha_release.py
+++ b/scripts/validate_alpha_release.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Final
+
+from packaging.version import InvalidVersion, Version
+
+
+@dataclass(frozen=True)
+class ReleaseTrain:
+    git_ref: str
+    major: int
+    minor: int
+    patch: int = 0
+
+    @property
+    def version_prefix(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
+@dataclass(frozen=True)
+class AlphaRelease:
+    version: str
+    git_ref: str
+
+
+class ReleaseChannel(str, Enum):
+    ALPHA = "alpha"
+    STABLE = "stable"
+
+
+@dataclass(frozen=True)
+class ValidatedRelease:
+    version: str
+    git_ref: str
+    source_ref: str
+    channel: ReleaseChannel
+    source_sha: str | None
+
+
+RELEASE_TRAINS: Final[Mapping[str, ReleaseTrain]] = MappingProxyType(
+    {
+        "refs/heads/release/2.2": ReleaseTrain(
+            git_ref="refs/heads/release/2.2",
+            major=2,
+            minor=2,
+        ),
+        "refs/heads/release/3.1": ReleaseTrain(
+            git_ref="refs/heads/release/3.1",
+            major=3,
+            minor=1,
+        ),
+    }
+)
+ALPHA_BRANCHES: Final[tuple[str, ...]] = tuple(RELEASE_TRAINS)
+_CANONICAL_GIT_SHA: Final[re.Pattern[str]] = re.compile(r"[0-9a-f]{40}")
+
+
+def _parse_version(version_text: str, *, label: str) -> Version:
+    try:
+        return Version(version_text)
+    except InvalidVersion as exc:
+        raise ValueError(f"{label} is not a valid PEP 440 version: {version_text!r}") from exc
+
+
+def _is_train_alpha(version: Version, train: ReleaseTrain) -> bool:
+    return (
+        version.epoch == 0
+        and version.release == (train.major, train.minor, train.patch)
+        and version.pre is not None
+        and version.pre[0] == "a"
+        and version.pre[1] >= 1
+        and version.dev is None
+        and version.post is None
+        and version.local is None
+    )
+
+
+def _is_train_stable(version: Version, train: ReleaseTrain) -> bool:
+    return (
+        version.epoch == 0
+        and version.release == (train.major, train.minor, train.patch)
+        and version.pre is None
+        and version.dev is None
+        and version.post is None
+        and version.local is None
+    )
+
+
+def _parse_channel(channel: ReleaseChannel | str) -> ReleaseChannel:
+    try:
+        return ReleaseChannel(channel)
+    except ValueError as exc:
+        allowed = ", ".join(item.value for item in ReleaseChannel)
+        raise ValueError(f"Release channel must be one of: {allowed}") from exc
+
+
+def _validate_source_sha(
+    *,
+    github_sha: str | None,
+    expected_sha: str | None,
+) -> str | None:
+    if github_sha is None and expected_sha is None:
+        return None
+    if github_sha is None or expected_sha is None:
+        raise ValueError("--github-sha and --expected-sha must be provided together")
+    if _CANONICAL_GIT_SHA.fullmatch(github_sha) is None:
+        raise ValueError("GitHub SHA must be exactly 40 lowercase hexadecimal characters")
+    if _CANONICAL_GIT_SHA.fullmatch(expected_sha) is None:
+        raise ValueError("Expected SHA must be exactly 40 lowercase hexadecimal characters")
+    if github_sha != expected_sha:
+        raise ValueError("GitHub SHA does not match the expected release SHA")
+    return github_sha
+
+
+def _validate_source_ref(
+    *,
+    version: Version,
+    train: ReleaseTrain,
+    channel: ReleaseChannel,
+    actual_ref: str | None,
+) -> str:
+    expected_ref = train.git_ref if channel is ReleaseChannel.ALPHA else f"refs/tags/v{version}"
+    if actual_ref is None:
+        if channel is ReleaseChannel.STABLE:
+            raise ValueError("Stable releases require the exact protected version tag ref")
+        return expected_ref
+    if actual_ref != expected_ref:
+        raise ValueError(f"{channel.value.title()} releases require source ref {expected_ref}")
+    return actual_ref
+
+
+def validate_release_train(
+    version_text: str,
+    git_ref: str,
+    channel: ReleaseChannel | str,
+    *,
+    existing_versions: Iterable[str] = (),
+    actual_ref: str | None = None,
+    github_sha: str | None = None,
+    expected_sha: str | None = None,
+) -> ValidatedRelease:
+    parsed_channel = _parse_channel(channel)
+    train = RELEASE_TRAINS.get(git_ref)
+    if train is None:
+        raise ValueError(f"Releases must run from one of: {', '.join(ALPHA_BRANCHES)}")
+
+    source_sha = _validate_source_sha(github_sha=github_sha, expected_sha=expected_sha)
+    version = _parse_version(version_text, label="Requested version")
+    valid_for_channel = (
+        _is_train_alpha(version, train) if parsed_channel is ReleaseChannel.ALPHA else _is_train_stable(version, train)
+    )
+    if version_text != str(version) or not valid_for_channel:
+        example = f"{train.version_prefix}a1" if parsed_channel is ReleaseChannel.ALPHA else train.version_prefix
+        raise ValueError(
+            f"{git_ref} requires a canonical public PEP 440 {parsed_channel.value} version "
+            f"for its exact release train, such as {example}"
+        )
+
+    source_ref = _validate_source_ref(
+        version=version,
+        train=train,
+        channel=parsed_channel,
+        actual_ref=actual_ref,
+    )
+
+    parsed_existing = [_parse_version(existing_text, label="Existing version") for existing_text in existing_versions]
+    if version in parsed_existing:
+        raise ValueError(f"{parsed_channel.value.title()} version {version} already exists")
+
+    if parsed_channel is ReleaseChannel.ALPHA:
+        train_alphas = [existing for existing in parsed_existing if _is_train_alpha(existing, train)]
+        if train_alphas:
+            latest = max(train_alphas)
+            if version <= latest:
+                raise ValueError(f"Alpha version {version} must be newer than existing {git_ref} alpha {latest}")
+
+    return ValidatedRelease(
+        version=str(version),
+        git_ref=git_ref,
+        source_ref=source_ref,
+        channel=parsed_channel,
+        source_sha=source_sha,
+    )
+
+
+def validate_release_train_alpha(
+    version_text: str,
+    git_ref: str,
+    *,
+    existing_versions: Iterable[str] = (),
+) -> AlphaRelease:
+    release = validate_release_train(
+        version_text,
+        git_ref,
+        ReleaseChannel.ALPHA,
+        existing_versions=existing_versions,
+    )
+    return AlphaRelease(version=release.version, git_ref=release.git_ref)
+
+
+def validate_alpha_release(
+    version_text: str,
+    git_ref: str,
+    *,
+    existing_versions: Iterable[str] = (),
+) -> AlphaRelease:
+    """Compatibility wrapper for existing release workflow callers."""
+
+    return validate_release_train_alpha(
+        version_text,
+        git_ref,
+        existing_versions=existing_versions,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate a Guard release-train request")
+    _ = parser.add_argument("--version", required=True)
+    _ = parser.add_argument("--git-ref", required=True)
+    _ = parser.add_argument(
+        "--channel",
+        choices=[channel.value for channel in ReleaseChannel],
+        default=ReleaseChannel.ALPHA.value,
+    )
+    _ = parser.add_argument("--github-sha")
+    _ = parser.add_argument("--expected-sha")
+    _ = parser.add_argument("--actual-ref")
+    _ = parser.add_argument(
+        "--existing-version",
+        action="append",
+        default=[],
+        help="Previously published version; repeat for every known version",
+    )
+    args = parser.parse_args()
+    version_text = getattr(args, "version", None)
+    git_ref = getattr(args, "git_ref", None)
+    channel = getattr(args, "channel", None)
+    github_sha = getattr(args, "github_sha", None)
+    expected_sha = getattr(args, "expected_sha", None)
+    actual_ref = getattr(args, "actual_ref", None)
+    existing_versions = getattr(args, "existing_version", None)
+    if (
+        not isinstance(version_text, str)
+        or not isinstance(git_ref, str)
+        or not isinstance(channel, str)
+        or (github_sha is not None and not isinstance(github_sha, str))
+        or (expected_sha is not None and not isinstance(expected_sha, str))
+        or (actual_ref is not None and not isinstance(actual_ref, str))
+        or not isinstance(existing_versions, list)
+        or not all(isinstance(value, str) for value in existing_versions)
+    ):
+        parser.error("release validator arguments must be strings")
+    try:
+        if channel == ReleaseChannel.STABLE.value and (
+            github_sha is None or expected_sha is None or actual_ref is None
+        ):
+            raise ValueError("Stable releases require --actual-ref, --github-sha, and --expected-sha")
+        release = validate_release_train(
+            version_text,
+            git_ref,
+            channel,
+            existing_versions=existing_versions,
+            actual_ref=actual_ref,
+            github_sha=github_sha,
+            expected_sha=expected_sha,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    print(release.version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -187,10 +187,14 @@ def _validated_download_url(url: object, filename: str, registry: Registry) -> s
         raise RegistryVerificationError("Registry distribution URL must be a string")
     parsed = urllib.parse.urlsplit(url)
     remote_filename = urllib.parse.unquote(parsed.path.rsplit("/", 1)[-1])
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise RegistryVerificationError("Registry distribution URL has an invalid port") from exc
     if (
         parsed.scheme != "https"
         or parsed.hostname != registry.file_host
-        or parsed.port not in (None, 443)
+        or port not in (None, 443)
         or parsed.username is not None
         or parsed.password is not None
         or parsed.query

--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -1,0 +1,505 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Final
+
+from packaging.utils import InvalidSdistFilename, InvalidWheelFilename, parse_sdist_filename, parse_wheel_filename
+from packaging.version import InvalidVersion, Version
+
+PROJECT_NAME: Final = "hol-guard"
+MAX_RESPONSE_BYTES: Final = 256 * 1024 * 1024
+_SHA256: Final[re.Pattern[str]] = re.compile(r"[0-9a-f]{64}")
+
+Fetcher = Callable[[str], bytes]
+
+
+class Registry(str, Enum):
+    PYPI = "pypi"
+    TESTPYPI = "testpypi"
+
+    @property
+    def api_host(self) -> str:
+        return "pypi.org" if self is Registry.PYPI else "test.pypi.org"
+
+    @property
+    def file_host(self) -> str:
+        return "files.pythonhosted.org" if self is Registry.PYPI else "test-files.pythonhosted.org"
+
+
+class RegistryVerificationError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ReleaseFile:
+    filename: str
+    sha256: str
+    download_url: str
+
+
+@dataclass(frozen=True)
+class ReleaseInspection:
+    registry: Registry
+    version: str
+    exists: bool
+    files: tuple[ReleaseFile, ...] = ()
+
+    @property
+    def digests(self) -> dict[str, str]:
+        return {item.filename: item.sha256 for item in self.files}
+
+
+@dataclass(frozen=True)
+class RegistryResult:
+    registry: Registry
+    status: str
+    version: str
+    files: tuple[str, ...]
+    downloaded_paths: tuple[Path, ...] = ()
+
+
+TestPyPIResult = RegistryResult
+
+
+def stdlib_fetch(url: str) -> bytes:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "hol-guard-release-registry-verifier"},
+    )
+    with urllib.request.urlopen(request, timeout=20) as response:
+        declared_length = response.headers.get("Content-Length")
+        if declared_length is not None:
+            try:
+                parsed_length = int(declared_length)
+            except ValueError as exc:
+                raise RegistryVerificationError("Registry response has an invalid content length") from exc
+            if parsed_length < 0 or parsed_length > MAX_RESPONSE_BYTES:
+                raise RegistryVerificationError("Registry response exceeds the maximum allowed size")
+        payload = response.read(MAX_RESPONSE_BYTES + 1)
+    if len(payload) > MAX_RESPONSE_BYTES:
+        raise RegistryVerificationError("Registry response exceeds the maximum allowed size")
+    return payload
+
+
+def _project_url(registry: Registry) -> str:
+    return f"https://{registry.api_host}/pypi/{PROJECT_NAME}/json"
+
+
+def _release_url(registry: Registry, version: str) -> str:
+    quoted_version = urllib.parse.quote(version, safe="")
+    return f"https://{registry.api_host}/pypi/{PROJECT_NAME}/{quoted_version}/json"
+
+
+def _fetch_payload(
+    url: str,
+    *,
+    fetcher: Fetcher,
+    allow_not_found: bool = False,
+) -> bytes | None:
+    try:
+        return fetcher(url)
+    except urllib.error.HTTPError as exc:
+        if allow_not_found and exc.code == 404:
+            return None
+        raise RegistryVerificationError(f"Registry request failed with HTTP {exc.code}") from exc
+    except RegistryVerificationError:
+        raise
+    except (OSError, TimeoutError, urllib.error.URLError) as exc:
+        raise RegistryVerificationError("Registry request failed") from exc
+
+
+def _decode_object(payload: bytes, *, label: str) -> dict[str, object]:
+    try:
+        decoded = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RegistryVerificationError(f"{label} returned invalid JSON") from exc
+    if not isinstance(decoded, dict) or not all(isinstance(key, str) for key in decoded):
+        raise RegistryVerificationError(f"{label} must be a JSON object")
+    return {str(key): value for key, value in decoded.items()}
+
+
+def _canonical_public_version(version_text: object, *, label: str) -> Version:
+    if not isinstance(version_text, str):
+        raise RegistryVerificationError(f"{label} must be a string")
+    try:
+        version = Version(version_text)
+    except InvalidVersion as exc:
+        raise RegistryVerificationError(f"{label} is not a valid PEP 440 version") from exc
+    if version_text != str(version) or version.local is not None:
+        raise RegistryVerificationError(f"{label} is not a canonical public PEP 440 version")
+    return version
+
+
+def list_registry_versions(
+    registry: Registry,
+    *,
+    fetcher: Fetcher = stdlib_fetch,
+) -> tuple[str, ...]:
+    payload = _fetch_payload(_project_url(registry), fetcher=fetcher)
+    if payload is None:
+        raise RegistryVerificationError("Registry project response was unexpectedly absent")
+    document = _decode_object(payload, label="Registry project response")
+    releases = document.get("releases")
+    if not isinstance(releases, dict):
+        raise RegistryVerificationError("Registry project response is missing the releases object")
+
+    versions: list[Version] = []
+    for version_text in releases:
+        versions.append(_canonical_public_version(version_text, label="Registry version"))
+    return tuple(str(version) for version in sorted(versions))
+
+
+def _distribution_identity(filename: str) -> tuple[str, Version]:
+    try:
+        if filename.endswith(".whl"):
+            name, version, _build, _tags = parse_wheel_filename(filename)
+            return name, version
+        name, version = parse_sdist_filename(filename)
+        return name, version
+    except (InvalidWheelFilename, InvalidSdistFilename) as exc:
+        raise RegistryVerificationError(f"Invalid distribution filename: {filename}") from exc
+
+
+def _validate_distribution_filename(filename: object, version: Version) -> str:
+    if not isinstance(filename, str) or not filename or Path(filename).name != filename:
+        raise RegistryVerificationError("Registry distribution filename is invalid")
+    name, file_version = _distribution_identity(filename)
+    if name != PROJECT_NAME or file_version != version:
+        raise RegistryVerificationError("Registry returned a distribution for the wrong project or version")
+    return filename
+
+
+def _validated_download_url(url: object, filename: str, registry: Registry) -> str:
+    if not isinstance(url, str):
+        raise RegistryVerificationError("Registry distribution URL must be a string")
+    parsed = urllib.parse.urlsplit(url)
+    remote_filename = urllib.parse.unquote(parsed.path.rsplit("/", 1)[-1])
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != registry.file_host
+        or parsed.port not in (None, 443)
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or remote_filename != filename
+    ):
+        raise RegistryVerificationError("Registry distribution URL is not an approved file URL")
+    return url
+
+
+def inspect_release(
+    registry: Registry,
+    version_text: str,
+    *,
+    fetcher: Fetcher = stdlib_fetch,
+) -> ReleaseInspection:
+    version = _canonical_public_version(version_text, label="Requested version")
+    payload = _fetch_payload(
+        _release_url(registry, str(version)),
+        fetcher=fetcher,
+        allow_not_found=True,
+    )
+    if payload is None:
+        return ReleaseInspection(registry=registry, version=str(version), exists=False)
+
+    document = _decode_object(payload, label="Registry release response")
+    info = document.get("info")
+    if not isinstance(info, dict):
+        raise RegistryVerificationError("Registry release response is missing package information")
+    info_version = _canonical_public_version(info.get("version"), label="Registry release version")
+    if info_version != version:
+        raise RegistryVerificationError("Registry release response returned the wrong version")
+    urls = document.get("urls")
+    if not isinstance(urls, list) or not urls:
+        raise RegistryVerificationError("Existing registry release has no distribution files")
+
+    files: list[ReleaseFile] = []
+    seen: set[str] = set()
+    for item in urls:
+        if not isinstance(item, dict):
+            raise RegistryVerificationError("Registry release file entry must be an object")
+        filename = _validate_distribution_filename(item.get("filename"), version)
+        if filename in seen:
+            raise RegistryVerificationError(f"Registry release repeats distribution filename: {filename}")
+        seen.add(filename)
+        digests = item.get("digests")
+        if not isinstance(digests, dict):
+            raise RegistryVerificationError(f"Registry release is missing a digest for {filename}")
+        sha256 = digests.get("sha256")
+        if not isinstance(sha256, str) or _SHA256.fullmatch(sha256) is None:
+            raise RegistryVerificationError(f"Registry release has an invalid SHA-256 for {filename}")
+        download_url = _validated_download_url(item.get("url"), filename, registry)
+        files.append(ReleaseFile(filename=filename, sha256=sha256, download_url=download_url))
+    return ReleaseInspection(
+        registry=registry,
+        version=str(version),
+        exists=True,
+        files=tuple(sorted(files, key=lambda item: item.filename)),
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def compute_local_distribution_hashes(
+    dist_dir: Path,
+    version_text: str,
+) -> dict[str, str]:
+    version = _canonical_public_version(version_text, label="Requested version")
+    if not dist_dir.is_dir():
+        raise RegistryVerificationError("Distribution directory does not exist")
+
+    hashes: dict[str, str] = {}
+    found_wheel = False
+    found_sdist = False
+    for path in sorted(dist_dir.iterdir()):
+        if path.is_symlink():
+            if path.name.startswith(("hol_guard-", "hol-guard-")):
+                raise RegistryVerificationError("Local Guard distributions cannot be symbolic links")
+            continue
+        if not path.is_file():
+            continue
+        try:
+            name, file_version = _distribution_identity(path.name)
+        except RegistryVerificationError:
+            if path.name.startswith(("hol_guard-", "hol-guard-")):
+                raise
+            continue
+        if name != PROJECT_NAME:
+            continue
+        if file_version != version:
+            raise RegistryVerificationError("Local Guard distribution has the wrong version")
+        if path.name in hashes:
+            raise RegistryVerificationError("Local Guard distribution filename is duplicated")
+        hashes[path.name] = _sha256_file(path)
+        found_wheel = found_wheel or path.name.endswith(".whl")
+        found_sdist = found_sdist or not path.name.endswith(".whl")
+
+    if not hashes or not found_wheel or not found_sdist:
+        raise RegistryVerificationError("Local release requires both a Guard wheel and sdist")
+    return hashes
+
+
+def _compare_digest_sets(
+    local_hashes: Mapping[str, str],
+    remote_hashes: Mapping[str, str],
+    *,
+    registry: Registry,
+) -> None:
+    local_names = set(local_hashes)
+    remote_names = set(remote_hashes)
+    if local_names != remote_names:
+        missing = sorted(local_names - remote_names)
+        extra = sorted(remote_names - local_names)
+        details: list[str] = []
+        if missing:
+            details.append(f"missing={','.join(missing)}")
+        if extra:
+            details.append(f"extra={','.join(extra)}")
+        raise RegistryVerificationError(
+            f"{registry.value} distribution set does not match the local build ({'; '.join(details)})"
+        )
+    mismatched = sorted(filename for filename, digest in local_hashes.items() if remote_hashes[filename] != digest)
+    if mismatched:
+        raise RegistryVerificationError(f"{registry.value} distribution digest mismatch: {','.join(mismatched)}")
+
+
+def download_verified_release(
+    inspection: ReleaseInspection,
+    destination: Path,
+    *,
+    fetcher: Fetcher = stdlib_fetch,
+) -> tuple[Path, ...]:
+    if not inspection.exists or not inspection.files:
+        raise RegistryVerificationError("Cannot download an absent registry release")
+    destination.mkdir(parents=True, exist_ok=True)
+    downloaded: list[Path] = []
+    with tempfile.TemporaryDirectory(dir=destination) as temporary_dir_text:
+        temporary_dir = Path(temporary_dir_text)
+        staged: list[tuple[Path, Path]] = []
+        for item in inspection.files:
+            payload = _fetch_payload(item.download_url, fetcher=fetcher)
+            if payload is None:
+                raise RegistryVerificationError(f"Registry distribution was absent: {item.filename}")
+            actual_digest = hashlib.sha256(payload).hexdigest()
+            if actual_digest != item.sha256:
+                raise RegistryVerificationError(f"Downloaded distribution digest mismatch: {item.filename}")
+            staged_path = temporary_dir / item.filename
+            _ = staged_path.write_bytes(payload)
+            staged.append((staged_path, destination / item.filename))
+        for staged_path, target in staged:
+            os.replace(staged_path, target)
+            downloaded.append(target)
+    return tuple(downloaded)
+
+
+def verify_registry_release(
+    registry: Registry,
+    version_text: str,
+    dist_dir: Path,
+    *,
+    download_dir: Path | None = None,
+    fetcher: Fetcher = stdlib_fetch,
+) -> RegistryResult:
+    local_hashes = compute_local_distribution_hashes(dist_dir, version_text)
+    inspection = inspect_release(registry, version_text, fetcher=fetcher)
+    if not inspection.exists:
+        return RegistryResult(
+            registry=registry,
+            status="absent",
+            version=inspection.version,
+            files=tuple(sorted(local_hashes)),
+        )
+    _compare_digest_sets(local_hashes, inspection.digests, registry=registry)
+    downloaded = (
+        download_verified_release(inspection, download_dir, fetcher=fetcher) if download_dir is not None else ()
+    )
+    return RegistryResult(
+        registry=registry,
+        status="exact",
+        version=inspection.version,
+        files=tuple(sorted(local_hashes)),
+        downloaded_paths=downloaded,
+    )
+
+
+def verify_testpypi_release(
+    version_text: str,
+    dist_dir: Path,
+    *,
+    download_dir: Path | None = None,
+    fetcher: Fetcher = stdlib_fetch,
+) -> TestPyPIResult:
+    """Compatibility wrapper for existing TestPyPI workflow callers."""
+
+    return verify_registry_release(
+        Registry.TESTPYPI,
+        version_text,
+        dist_dir,
+        download_dir=download_dir,
+        fetcher=fetcher,
+    )
+
+
+def assert_pypi_release_absent(
+    version_text: str,
+    *,
+    fetcher: Fetcher = stdlib_fetch,
+) -> None:
+    inspection = inspect_release(Registry.PYPI, version_text, fetcher=fetcher)
+    if inspection.exists:
+        raise RegistryVerificationError(f"PyPI release {inspection.version} already exists")
+
+
+def _inspection_output(inspection: ReleaseInspection) -> dict[str, object]:
+    return {
+        "registry": inspection.registry.value,
+        "version": inspection.version,
+        "status": "present" if inspection.exists else "absent",
+        "files": [{"filename": item.filename, "sha256": item.sha256} for item in inspection.files],
+    }
+
+
+def _result_output(result: RegistryResult) -> dict[str, object]:
+    return {
+        "registry": result.registry.value,
+        "version": result.version,
+        "status": result.status,
+        "files": list(result.files),
+        "install_paths": [str(path) for path in result.downloaded_paths],
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Verify Guard release registry state")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list-versions")
+    _ = list_parser.add_argument("--registry", choices=[item.value for item in Registry], required=True)
+
+    inspect_parser = subparsers.add_parser("inspect-release")
+    _ = inspect_parser.add_argument("--registry", choices=[item.value for item in Registry], required=True)
+    _ = inspect_parser.add_argument("--version", required=True)
+
+    verify_parser = subparsers.add_parser("verify-testpypi")
+    _ = verify_parser.add_argument("--version", required=True)
+    _ = verify_parser.add_argument("--dist-dir", type=Path, required=True)
+    _ = verify_parser.add_argument("--download-dir", type=Path)
+
+    generic_verify_parser = subparsers.add_parser("verify-release")
+    _ = generic_verify_parser.add_argument("--registry", choices=[item.value for item in Registry], required=True)
+    _ = generic_verify_parser.add_argument("--version", required=True)
+    _ = generic_verify_parser.add_argument("--dist-dir", type=Path, required=True)
+    _ = generic_verify_parser.add_argument("--download-dir", type=Path)
+
+    absent_parser = subparsers.add_parser("assert-pypi-absent")
+    _ = absent_parser.add_argument("--version", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None, *, fetcher: Fetcher = stdlib_fetch) -> int:
+    args = _parser().parse_args(argv)
+    command = getattr(args, "command", None)
+    try:
+        if command == "list-versions":
+            registry = Registry(args.registry)
+            output: object = list_registry_versions(registry, fetcher=fetcher)
+        elif command == "inspect-release":
+            registry = Registry(args.registry)
+            inspection = inspect_release(
+                registry,
+                args.version,
+                fetcher=fetcher,
+            )
+            output = _inspection_output(inspection)
+        elif command == "verify-testpypi":
+            result = verify_testpypi_release(
+                args.version,
+                args.dist_dir,
+                download_dir=args.download_dir,
+                fetcher=fetcher,
+            )
+            output = _result_output(result)
+        elif command == "verify-release":
+            result = verify_registry_release(
+                Registry(args.registry),
+                args.version,
+                args.dist_dir,
+                download_dir=args.download_dir,
+                fetcher=fetcher,
+            )
+            output = _result_output(result)
+        elif command == "assert-pypi-absent":
+            version = args.version
+            assert_pypi_release_absent(version, fetcher=fetcher)
+            output = {"registry": Registry.PYPI.value, "version": version, "status": "absent"}
+        else:
+            raise RegistryVerificationError("Unsupported registry verification command")
+    except RegistryVerificationError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(output, separators=(",", ":"), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -88,10 +88,17 @@ def stdlib_fetch(url: str) -> bytes:
                 raise RegistryVerificationError("Registry response has an invalid content length") from exc
             if parsed_length < 0 or parsed_length > MAX_RESPONSE_BYTES:
                 raise RegistryVerificationError("Registry response exceeds the maximum allowed size")
-        payload = response.read(MAX_RESPONSE_BYTES + 1)
-    if len(payload) > MAX_RESPONSE_BYTES:
-        raise RegistryVerificationError("Registry response exceeds the maximum allowed size")
-    return payload
+        chunks: list[bytes] = []
+        total_bytes = 0
+        while True:
+            chunk = response.read(min(1024 * 1024, MAX_RESPONSE_BYTES - total_bytes + 1))
+            if not chunk:
+                break
+            total_bytes += len(chunk)
+            if total_bytes > MAX_RESPONSE_BYTES:
+                raise RegistryVerificationError("Registry response exceeds the maximum allowed size")
+            chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _project_url(registry: Registry) -> str:

--- a/tests/test_pr_testpypi_canary_workflow.py
+++ b/tests/test_pr_testpypi_canary_workflow.py
@@ -11,8 +11,8 @@ def test_pr_canary_uses_trusted_publishing_for_same_repository_prs() -> None:
     workflow_path = ROOT / ".github/workflows/publish.yml"
     workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
 
-    assert workflow[True]["pull_request"] == {"branches": ["main"]}
-    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow[True]["pull_request"] == {"branches": ["main", "release/2.2"]}
+    assert workflow["permissions"] == {"contents": "read", "pull-requests": "read"}
     job = workflow["jobs"]["publish-testpypi"]
     assert job["permissions"] == {"id-token": "write"}
     assert "github.event.pull_request.head.repo.full_name == github.repository" in job["if"]

--- a/tests/test_release_toolchain_sbom.py
+++ b/tests/test_release_toolchain_sbom.py
@@ -74,23 +74,27 @@ def test_publish_workflow_attests_toolchain_sbom_without_sending_it_to_pypi() ->
     assert any(step.get("name") == "Download release toolchain SBOM" for step in release_steps)
     assert all(
         step.get("name") != "Download release toolchain SBOM"
-        for job_name in ("publish-testpypi", "publish-pypi")
+        for job_name in (
+            "publish-testpypi",
+            "publish-alpha-testpypi",
+            "publish-alpha-pypi",
+            "publish-stable-testpypi",
+            "publish-stable-pypi",
+        )
         for step in jobs[job_name]["steps"]
     )
     provenance_step = next(step for step in release_steps if step.get("id") == "provenance")
     assert "dist/*" in provenance_step["with"]["subject-path"]
 
 
-def test_publish_workflow_limits_ambient_credentials_for_build_and_version_sync() -> None:
+def test_publish_workflow_limits_ambient_credentials_and_has_no_version_sync() -> None:
     workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8"))
     jobs = workflow["jobs"]
-    sync_job = jobs["sync-repository-version"]
 
-    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["permissions"] == {"contents": "read", "pull-requests": "read"}
     assert "permissions" not in jobs["build"]
-    assert sync_job["permissions"] == {"contents": "read"}
-    token_steps = [step.get("name") for step in sync_job["steps"] if "ACTION_REPO_TOKEN" in (step.get("env") or {})]
-    assert token_steps == ["Open repository version sync PR"]
+    assert "sync-repository-version" not in jobs
+    assert "ACTION_REPO_TOKEN" not in (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
 
     publish_uv_versions = {
         step["with"]["version"]

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -232,12 +232,18 @@ def test_release_tags_are_bound_to_the_exact_published_source() -> None:
     assert 'gh release view "$tag" --json isDraft,isPrerelease' in release_run
     assert 'gh release download "$tag"' in release_run
     assert 'cmp --silent "$local_file"' in release_run
+    assert "mapfile -d '' local_files" in release_run
+    assert 'gh attestation verify "$remote_file"' in release_run
+    assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in release_run
     assert "--verify-tag" in release_run
 
     stable_release_run = next(step["run"] for step in jobs["release"]["steps"] if step.get("name") == "Create release")
     assert 'gh release view "$tag" --json isDraft,isPrerelease' in stable_release_run
     assert 'gh release download "$tag"' in stable_release_run
     assert 'cmp --silent "$local_file"' in stable_release_run
+    assert "mapfile -d '' local_files" in stable_release_run
+    assert 'gh attestation verify "$remote_file"' in stable_release_run
+    assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in stable_release_run
     assert "--verify-tag" in stable_release_run
 
 

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -1,0 +1,256 @@
+"""Security contracts for release-train publishing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "publish.yml"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+RELEASE_BRANCHES = ["main", "release/2.2"]
+
+
+def _workflow(path: Path) -> dict[object, object]:
+    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def test_release_branches_run_ci_and_pr_canaries() -> None:
+    ci = _workflow(CI_WORKFLOW)
+    publish = _workflow(PUBLISH_WORKFLOW)
+
+    assert ci[True]["push"]["branches"] == RELEASE_BRANCHES
+    assert ci[True]["pull_request"]["branches"] == RELEASE_BRANCHES
+    assert publish[True]["push"]["branches"] == RELEASE_BRANCHES
+    assert publish[True]["pull_request"]["branches"] == RELEASE_BRANCHES
+    assert "tags" not in publish[True]["push"]
+
+
+def test_ordinary_pushes_and_tag_pushes_cannot_publish() -> None:
+    workflow = _workflow(PUBLISH_WORKFLOW)
+    jobs = workflow["jobs"]
+
+    for job_name in (
+        "publish-alpha-testpypi",
+        "publish-alpha-pypi",
+        "publish-stable-testpypi",
+        "publish-stable-pypi",
+        "release-alpha",
+        "release",
+        "publish-container",
+    ):
+        assert "github.event_name == 'workflow_dispatch'" in jobs[job_name]["if"]
+
+    assert "sync-repository-version" not in jobs
+    workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+    assert "[skip release publish]" not in workflow_text
+    assert "startsWith(github.ref, 'refs/tags/')" not in workflow_text
+
+
+def test_release_dispatch_binds_channel_train_version_and_sha() -> None:
+    workflow = _workflow(PUBLISH_WORKFLOW)
+    inputs = workflow[True]["workflow_dispatch"]["inputs"]
+
+    assert inputs["release_channel"]["options"] == ["alpha", "stable"]
+    assert inputs["release_train"]["options"] == ["2.2"]
+    assert inputs["release_version"]["required"] is True
+    assert inputs["expected_sha"]["required"] is True
+    assert inputs["promotion_pr"]["required"] is False
+
+    workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+    assert '--github-sha "$SOURCE_SHA"' in workflow_text
+    assert '--expected-sha "$EXPECTED_SHA"' in workflow_text
+    assert '--actual-ref "$GITHUB_REF"' in workflow_text
+    assert "refs/tags/v${RELEASE_VERSION}" in workflow_text
+    assert "git merge-base --is-ancestor" in workflow_text
+    assert 'gh pr view "$PROMOTION_PR"' in workflow_text
+    assert "RELEASE_PUBLISHING_ENABLED" in workflow_text
+    assert 'awk -v candidate="$RELEASE_VERSION"' in workflow_text
+    assert "$0 != candidate" in workflow_text
+
+
+def test_release_publication_reuses_one_hashed_build_artifact() -> None:
+    workflow = _workflow(PUBLISH_WORKFLOW)
+    jobs = workflow["jobs"]
+
+    assert "distribution-sha256" in {
+        step.get("with", {}).get("name") for step in jobs["build"]["steps"] if isinstance(step, dict)
+    }
+    assert jobs["publish-alpha-pypi"]["needs"] == [
+        "build",
+        "alpha-cross-platform",
+        "publish-alpha-testpypi",
+    ]
+    assert jobs["publish-stable-pypi"]["needs"] == [
+        "build",
+        "alpha-cross-platform",
+        "publish-stable-testpypi",
+    ]
+    for job_name in (
+        "publish-alpha-testpypi",
+        "publish-alpha-pypi",
+        "publish-stable-testpypi",
+        "publish-stable-pypi",
+    ):
+        steps = jobs[job_name]["steps"]
+        assert any(step.get("run") == "sha256sum --check distribution-sha256.txt" for step in steps)
+        assert any(
+            step.get("name") == "Keep only the Guard release distribution" and "plugin_scanner" in step.get("run", "")
+            for step in steps
+        )
+
+    workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+    assert "skip-existing" not in workflow_text
+
+
+def test_publish_jobs_use_channel_specific_protected_environments() -> None:
+    workflow = _workflow(PUBLISH_WORKFLOW)
+    jobs = workflow["jobs"]
+
+    assert jobs["publish-testpypi"]["environment"] == "testpypi"
+    assert jobs["publish-alpha-testpypi"]["environment"] == "testpypi-alpha"
+    assert jobs["publish-alpha-pypi"]["environment"] == "pypi-alpha"
+    assert jobs["publish-stable-testpypi"]["environment"] == "testpypi-stable"
+    assert jobs["publish-stable-pypi"]["environment"] == "pypi-stable"
+    assert jobs["publish-testpypi"]["permissions"] == {"id-token": "write"}
+    assert jobs["publish-alpha-testpypi"]["permissions"] == {"contents": "read", "id-token": "write"}
+    assert jobs["publish-alpha-pypi"]["permissions"] == {"contents": "read", "id-token": "write"}
+    assert jobs["publish-stable-testpypi"]["permissions"] == {
+        "contents": "read",
+        "id-token": "write",
+        "pull-requests": "read",
+    }
+    assert jobs["publish-stable-pypi"]["permissions"] == {
+        "contents": "read",
+        "id-token": "write",
+        "pull-requests": "read",
+    }
+    for job_name in (
+        "publish-alpha-testpypi",
+        "publish-alpha-pypi",
+        "publish-stable-testpypi",
+        "publish-stable-pypi",
+    ):
+        assert "vars.RELEASE_PUBLISHING_ENABLED == 'true'" in jobs[job_name]["if"]
+
+
+def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
+    workflow = _workflow(PUBLISH_WORKFLOW)
+    jobs = workflow["jobs"]
+
+    for job_name in ("publish-alpha-testpypi", "publish-stable-testpypi"):
+        steps = jobs[job_name]["steps"]
+        inspect_step = next(step for step in steps if step.get("name") == "Inspect TestPyPI release state")
+        publish_step = next(step for step in steps if str(step.get("uses", "")).startswith("pypa/"))
+        verify_step = next(step for step in steps if step.get("name") == "Download and verify exact TestPyPI artifacts")
+        assert "verify-release --registry testpypi" in inspect_step["run"]
+        assert publish_step["if"] == "steps.testpypi.outputs.upload == 'true'"
+        assert "--download-dir verified-testpypi" in verify_step["run"]
+        assert 'uv tool run --from "$wheel"' in verify_step["run"]
+        assert 'status" == "exact"' in verify_step["run"]
+        assert 'status" != "absent"' in verify_step["run"]
+        assert '== "hol-guard $VERSION"' in verify_step["run"]
+
+    alpha_run = next(
+        step["run"]
+        for step in jobs["publish-alpha-pypi"]["steps"]
+        if step.get("name") == "Revalidate alpha publication authorization"
+    )
+    assert "list-versions --registry pypi" in alpha_run
+    assert "git ls-remote --exit-code origin" in alpha_run
+    assert "validate_alpha_release.py" in alpha_run
+    assert "refs/tags/alpha/v${VERSION}" in alpha_run
+    assert 'awk -v candidate="$VERSION"' in alpha_run
+
+    stable_run = next(
+        step["run"]
+        for step in jobs["publish-stable-pypi"]["steps"]
+        if step.get("name") == "Revalidate stable publication authorization"
+    )
+    assert "list-versions --registry pypi" in stable_run
+    assert "refs/tags/v${VERSION}^{}" in stable_run
+    assert "git merge-base --is-ancestor" in stable_run
+    assert 'gh pr view "$PROMOTION_PR"' in stable_run
+    assert "validate_alpha_release.py" in stable_run
+
+    workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+    assert 'for registry in ("pypi.org", "test.pypi.org")' not in workflow_text
+
+    for job_name in ("publish-alpha-pypi", "publish-stable-pypi"):
+        steps = jobs[job_name]["steps"]
+        inspect_step = next(step for step in steps if step.get("name") == "Inspect PyPI release state")
+        publish_step = next(step for step in steps if str(step.get("uses", "")).startswith("pypa/"))
+        verify_step = next(step for step in steps if step.get("name") == "Download and verify exact PyPI artifacts")
+        assert "verify-release --registry pypi" in inspect_step["run"]
+        assert publish_step["if"] == "steps.pypi.outputs.upload == 'true'"
+        assert "--download-dir verified-pypi" in verify_step["run"]
+        assert 'status" == "exact"' in verify_step["run"]
+        assert 'status" != "absent"' in verify_step["run"]
+        assert '== "hol-guard $VERSION"' in verify_step["run"]
+
+
+def test_release_tags_are_bound_to_the_exact_published_source() -> None:
+    workflow = _workflow(PUBLISH_WORKFLOW)
+    jobs = workflow["jobs"]
+
+    alpha_test_run = next(
+        step["run"]
+        for step in jobs["publish-alpha-testpypi"]["steps"]
+        if step.get("name") == "Revalidate alpha source before TestPyPI"
+    )
+    assert 'git ls-remote --exit-code origin "$train_ref"' in alpha_test_run
+    assert "refs/tags/alpha/v${VERSION}" in alpha_test_run
+    assert '[[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]' in alpha_test_run
+
+    alpha_pypi_run = next(
+        step["run"]
+        for step in jobs["publish-alpha-pypi"]["steps"]
+        if step.get("name") == "Revalidate alpha publication authorization"
+    )
+    assert '[[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]' in alpha_pypi_run
+
+    stable_test_run = next(
+        step["run"]
+        for step in jobs["publish-stable-testpypi"]["steps"]
+        if step.get("name") == "Revalidate stable source before TestPyPI"
+    )
+    assert "refs/tags/v${VERSION}^{}" in stable_test_run
+    assert "git merge-base --is-ancestor" in stable_test_run
+    assert 'gh pr view "$PROMOTION_PR"' in stable_test_run
+
+    release_run = next(
+        step["run"]
+        for step in jobs["release-alpha"]["steps"]
+        if step.get("name") == "Create discoverable alpha prerelease"
+    )
+    assert 'gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs"' in release_run
+    assert '-f ref="refs/tags/${tag}"' in release_run
+    assert 'remote_tag_sha" != "$SOURCE_SHA"' in release_run
+    assert 'gh release view "$tag" --json isDraft,isPrerelease' in release_run
+    assert 'gh release download "$tag"' in release_run
+    assert 'cmp --silent "$local_file"' in release_run
+    assert "--verify-tag" in release_run
+
+    stable_release_run = next(step["run"] for step in jobs["release"]["steps"] if step.get("name") == "Create release")
+    assert 'gh release view "$tag" --json isDraft,isPrerelease' in stable_release_run
+    assert 'gh release download "$tag"' in stable_release_run
+    assert 'cmp --silent "$local_file"' in stable_release_run
+    assert "--verify-tag" in stable_release_run
+
+
+def test_alpha_and_stable_release_paths_are_distinct() -> None:
+    workflow = _workflow(PUBLISH_WORKFLOW)
+    jobs = workflow["jobs"]
+
+    assert "channel == 'alpha'" in jobs["release-alpha"]["if"]
+    assert "channel == 'stable'" in jobs["release"]["if"]
+    assert jobs["publish-container"]["needs"] == [
+        "build",
+        "publish-alpha-pypi",
+        "publish-stable-pypi",
+        "release-alpha",
+        "release",
+    ]

--- a/tests/test_validate_alpha_release.py
+++ b/tests/test_validate_alpha_release.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from scripts.validate_alpha_release import (
+    ALPHA_BRANCHES,
+    RELEASE_TRAINS,
+    ReleaseChannel,
+    ValidatedRelease,
+    main,
+    validate_alpha_release,
+    validate_release_train,
+    validate_release_train_alpha,
+)
+
+GITHUB_SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+@pytest.mark.parametrize(
+    ("git_ref", "version"),
+    [
+        ("refs/heads/release/2.2", "2.2.0a1"),
+        ("refs/heads/release/2.2", "2.2.0a37"),
+        ("refs/heads/release/3.1", "3.1.0a5"),
+    ],
+)
+def test_accepts_exact_canonical_release_train_alphas(git_ref: str, version: str) -> None:
+    release = validate_release_train_alpha(version, git_ref)
+
+    assert release.version == version
+    assert release.git_ref == git_ref
+
+
+def test_generic_alpha_validator_returns_typed_sha_bound_release() -> None:
+    release = validate_release_train(
+        "2.2.0a2",
+        "refs/heads/release/2.2",
+        "alpha",
+        existing_versions=["2.2.0a1"],
+        github_sha=GITHUB_SHA,
+        expected_sha=GITHUB_SHA,
+    )
+
+    assert release == ValidatedRelease(
+        version="2.2.0a2",
+        git_ref="refs/heads/release/2.2",
+        source_ref="refs/heads/release/2.2",
+        channel=ReleaseChannel.ALPHA,
+        source_sha=GITHUB_SHA,
+    )
+
+
+def test_registry_preserves_release_31_and_adds_release_22() -> None:
+    assert ALPHA_BRANCHES == (
+        "refs/heads/release/2.2",
+        "refs/heads/release/3.1",
+    )
+    assert RELEASE_TRAINS["refs/heads/release/2.2"].version_prefix == "2.2.0"
+    assert RELEASE_TRAINS["refs/heads/release/3.1"].version_prefix == "3.1.0"
+
+
+@pytest.mark.parametrize(
+    ("git_ref", "version"),
+    [
+        ("refs/heads/release/2.2", "2.2.0"),
+        ("refs/heads/release/3.1", "3.1.0"),
+    ],
+)
+def test_accepts_exact_stable_candidates_with_bound_source_sha(git_ref: str, version: str) -> None:
+    release = validate_release_train(
+        version,
+        git_ref,
+        ReleaseChannel.STABLE,
+        actual_ref=f"refs/tags/v{version}",
+        github_sha=GITHUB_SHA,
+        expected_sha=GITHUB_SHA,
+    )
+
+    assert release == ValidatedRelease(
+        version=version,
+        git_ref=git_ref,
+        source_ref=f"refs/tags/v{version}",
+        channel=ReleaseChannel.STABLE,
+        source_sha=GITHUB_SHA,
+    )
+
+
+@pytest.mark.parametrize(
+    ("git_ref", "version"),
+    [
+        ("refs/heads/release/2.2", "2.2.0a1"),
+        ("refs/heads/release/2.2", "2.2.0b1"),
+        ("refs/heads/release/2.2", "2.2.0rc1"),
+        ("refs/heads/release/2.2", "2.2.1"),
+        ("refs/heads/release/2.2", "3.1.0"),
+        ("refs/heads/release/3.1", "3.0.0"),
+        ("refs/heads/release/3.1", "3.2.0"),
+        ("refs/heads/release/3.1", "3.1.0.dev1"),
+        ("refs/heads/release/3.1", "3.1.0.post1"),
+        ("refs/heads/release/3.1", "3.1.0+local"),
+        ("refs/heads/release/2.2", "v2.2.0"),
+        ("refs/heads/release/2.2", " 2.2.0 "),
+        ("refs/heads/release/2.2", "2.2"),
+    ],
+)
+def test_rejects_noncanonical_or_wrong_train_stable_candidates(git_ref: str, version: str) -> None:
+    with pytest.raises(ValueError, match="canonical public PEP 440 stable"):
+        validate_release_train(version, git_ref, ReleaseChannel.STABLE)
+
+
+@pytest.mark.parametrize(
+    ("git_ref", "version"),
+    [
+        ("refs/heads/release/2.2", "2.1.0a1"),
+        ("refs/heads/release/2.2", "2.3.0a1"),
+        ("refs/heads/release/2.2", "3.1.0a1"),
+        ("refs/heads/release/2.2", "2.2.1a1"),
+        ("refs/heads/release/3.1", "3.0.0a9"),
+        ("refs/heads/release/3.1", "3.2.0a1"),
+        ("refs/heads/release/3.1", "2.2.0a1"),
+        ("refs/heads/release/3.1", "3.1.1a1"),
+    ],
+)
+def test_rejects_wrong_train_major_minor_or_patch(git_ref: str, version: str) -> None:
+    with pytest.raises(ValueError, match="exact release train"):
+        validate_release_train_alpha(version, git_ref)
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "1!2.2.0a1",
+        "2.2.0a0",
+        "2.2.0b1",
+        "2.2.0rc1",
+        "2.2.0",
+        "2.2.0a1.dev1",
+        "2.2.0a1.post1",
+        "2.2.0a1+local",
+        "v2.2.0a1",
+        " 2.2.0a1 ",
+        "2.2a1",
+        "2.2.0a01",
+        "2.2.0-alpha1",
+    ],
+)
+def test_rejects_non_public_or_noncanonical_alpha_versions(version: str) -> None:
+    with pytest.raises(ValueError, match="canonical public PEP 440"):
+        validate_release_train_alpha(version, "refs/heads/release/2.2")
+
+
+def test_rejects_malformed_requested_version() -> None:
+    with pytest.raises(ValueError, match="Requested version is not a valid PEP 440 version"):
+        validate_release_train_alpha("not-a-version", "refs/heads/release/2.2")
+
+
+@pytest.mark.parametrize(
+    "git_ref",
+    [
+        "refs/heads/main",
+        "refs/heads/release/2.3",
+        "refs/tags/alpha/v2.2.0a1",
+        "refs/pull/123/merge",
+    ],
+)
+def test_rejects_unregistered_source_refs(git_ref: str) -> None:
+    with pytest.raises(ValueError, match=r"release/2\.2.*release/3\.1"):
+        validate_release_train_alpha("2.2.0a1", git_ref)
+
+
+def test_rejects_unknown_release_channel() -> None:
+    with pytest.raises(ValueError, match="alpha, stable"):
+        validate_release_train("2.2.0a1", "refs/heads/release/2.2", "preview")
+
+
+@pytest.mark.parametrize(
+    ("channel", "version", "actual_ref", "expected"),
+    [
+        (ReleaseChannel.ALPHA, "2.2.0a1", "refs/heads/main", "refs/heads/release/2.2"),
+        (ReleaseChannel.STABLE, "2.2.0", None, "exact protected version tag"),
+        (ReleaseChannel.STABLE, "2.2.0", "refs/heads/main", "refs/tags/v2.2.0"),
+        (ReleaseChannel.STABLE, "2.2.0", "refs/tags/v2.2.1", "refs/tags/v2.2.0"),
+    ],
+)
+def test_rejects_wrong_or_missing_actual_source_ref(
+    channel: ReleaseChannel,
+    version: str,
+    actual_ref: str | None,
+    expected: str,
+) -> None:
+    with pytest.raises(ValueError, match=expected):
+        validate_release_train(
+            version,
+            "refs/heads/release/2.2",
+            channel,
+            actual_ref=actual_ref,
+        )
+
+
+@pytest.mark.parametrize(
+    ("github_sha", "expected_sha", "error"),
+    [
+        (GITHUB_SHA, None, "provided together"),
+        (None, GITHUB_SHA, "provided together"),
+        ("abc123", "abc123", "GitHub SHA must be exactly 40"),
+        (GITHUB_SHA.upper(), GITHUB_SHA.upper(), "GitHub SHA must be exactly 40"),
+        (GITHUB_SHA, "abc123", "Expected SHA must be exactly 40"),
+        (GITHUB_SHA, "f" * 40, "does not match"),
+    ],
+)
+def test_rejects_missing_noncanonical_or_mismatched_source_sha(
+    github_sha: str | None, expected_sha: str | None, error: str
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        validate_release_train(
+            "2.2.0a1",
+            "refs/heads/release/2.2",
+            ReleaseChannel.ALPHA,
+            github_sha=github_sha,
+            expected_sha=expected_sha,
+        )
+
+
+def test_rejects_duplicate_alpha_across_normalized_existing_versions() -> None:
+    with pytest.raises(ValueError, match="already exists"):
+        validate_release_train_alpha(
+            "2.2.0a2",
+            "refs/heads/release/2.2",
+            existing_versions=["2.2.0-alpha2"],
+        )
+
+
+def test_rejects_duplicate_stable_candidate() -> None:
+    with pytest.raises(ValueError, match=r"Stable version 2\.2\.0 already exists"):
+        validate_release_train(
+            "2.2.0",
+            "refs/heads/release/2.2",
+            ReleaseChannel.STABLE,
+            existing_versions=["2.2.0"],
+            actual_ref="refs/tags/v2.2.0",
+        )
+
+
+def test_rejects_non_monotonic_alpha() -> None:
+    with pytest.raises(ValueError, match=r"must be newer than.*2\.2\.0a3"):
+        validate_release_train_alpha(
+            "2.2.0a2",
+            "refs/heads/release/2.2",
+            existing_versions=["2.2.0a1", "2.2.0a3"],
+        )
+
+
+def test_accepts_next_alpha_and_ignores_other_trains() -> None:
+    release = validate_release_train_alpha(
+        "2.2.0a4",
+        "refs/heads/release/2.2",
+        existing_versions=["2.2.0a3", "3.1.0a99", "2.1.0a200"],
+    )
+
+    assert release.version == "2.2.0a4"
+
+
+def test_rejects_malformed_existing_version() -> None:
+    with pytest.raises(ValueError, match="Existing version is not a valid PEP 440 version"):
+        validate_release_train_alpha(
+            "2.2.0a2",
+            "refs/heads/release/2.2",
+            existing_versions=["not-a-version"],
+        )
+
+
+def test_compatibility_wrapper_uses_generic_validator() -> None:
+    release = validate_alpha_release(
+        "3.1.0a5",
+        "refs/heads/release/3.1",
+        existing_versions=["3.1.0a4"],
+    )
+
+    assert release.version == "3.1.0a5"
+
+
+def test_cli_accepts_repeated_existing_versions(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "validate_alpha_release.py",
+            "--version",
+            "2.2.0a3",
+            "--git-ref",
+            "refs/heads/release/2.2",
+            "--existing-version",
+            "2.2.0a1",
+            "--existing-version",
+            "2.2.0a2",
+        ],
+    )
+
+    assert main() == 0
+    captured = capsys.readouterr()
+    assert captured.out == "2.2.0a3\n"
+    assert captured.err == ""
+
+
+def test_cli_reports_duplicate_without_traceback(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "validate_alpha_release.py",
+            "--version",
+            "2.2.0a2",
+            "--git-ref",
+            "refs/heads/release/2.2",
+            "--existing-version",
+            "2.2.0a2",
+        ],
+    )
+
+    assert main() == 1
+    captured = capsys.readouterr()
+    assert "Error: Alpha version 2.2.0a2 already exists" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_cli_accepts_stable_candidate_with_matching_sha_pair(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "validate_alpha_release.py",
+            "--version",
+            "2.2.0",
+            "--git-ref",
+            "refs/heads/release/2.2",
+            "--channel",
+            "stable",
+            "--actual-ref",
+            "refs/tags/v2.2.0",
+            "--github-sha",
+            GITHUB_SHA,
+            "--expected-sha",
+            GITHUB_SHA,
+        ],
+    )
+
+    assert main() == 0
+    captured = capsys.readouterr()
+    assert captured.out == "2.2.0\n"
+    assert captured.err == ""
+
+
+def test_cli_requires_sha_pair_for_stable_candidate(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "validate_alpha_release.py",
+            "--version",
+            "2.2.0",
+            "--git-ref",
+            "refs/heads/release/2.2",
+            "--channel",
+            "stable",
+        ],
+    )
+
+    assert main() == 1
+    captured = capsys.readouterr()
+    assert "Stable releases require --actual-ref, --github-sha, and --expected-sha" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+import scripts.verify_release_registry as registry_module
 from scripts.verify_release_registry import (
     Registry,
     RegistryVerificationError,
@@ -20,6 +21,22 @@ from scripts.verify_release_registry import (
     verify_registry_release,
     verify_testpypi_release,
 )
+
+
+class ChunkedResponse:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = iter(chunks)
+        self.headers = Message()
+
+    def __enter__(self) -> ChunkedResponse:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, _size: int) -> bytes:
+        return next(self._chunks, b"")
+
 
 VERSION = "2.2.0a1"
 WHEEL = f"hol_guard-{VERSION}-py3-none-any.whl"
@@ -122,6 +139,15 @@ def test_listing_registry_versions_fails_closed_on_network_error() -> None:
 
     with pytest.raises(RegistryVerificationError, match="Registry request failed"):
         list_registry_versions(Registry.PYPI, fetcher=fetcher)
+
+
+def test_stdlib_fetch_rejects_oversized_chunked_responses(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = ChunkedResponse([b"1234", b"5678", b"9"])
+    monkeypatch.setattr(registry_module, "MAX_RESPONSE_BYTES", 8)
+    monkeypatch.setattr(registry_module.urllib.request, "urlopen", lambda *_args, **_kwargs: response)
+
+    with pytest.raises(RegistryVerificationError, match="maximum allowed size"):
+        registry_module.stdlib_fetch("https://pypi.org/pypi/hol-guard/json")
 
 
 def test_inspect_release_reports_absent_only_for_404() -> None:

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -163,6 +163,20 @@ def test_inspects_exact_release_without_exposing_urls_in_cli(capsys: pytest.Capt
     assert "pythonhosted.org" not in output
 
 
+def test_inspect_release_rejects_an_invalid_distribution_port() -> None:
+    document = json.loads(
+        _release_payload(
+            Registry.TESTPYPI,
+            {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+        )
+    )
+    document["urls"][0]["url"] = f"https://test-files.pythonhosted.org:invalid/{WHEEL}"
+    fetcher = FakeFetcher({_release_url(Registry.TESTPYPI): json.dumps(document).encode()})
+
+    with pytest.raises(RegistryVerificationError, match="invalid port"):
+        inspect_release(Registry.TESTPYPI, VERSION, fetcher=fetcher)
+
+
 def test_computes_local_guard_wheel_and_sdist_hashes(tmp_path: Path) -> None:
     dist = _local_dist(tmp_path)
     (dist / f"plugin_scanner-{VERSION}-py3-none-any.whl").write_bytes(b"scanner")

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import urllib.error
+from email.message import Message
+from pathlib import Path
+
+import pytest
+
+from scripts.verify_release_registry import (
+    Registry,
+    RegistryVerificationError,
+    assert_pypi_release_absent,
+    compute_local_distribution_hashes,
+    inspect_release,
+    list_registry_versions,
+    main,
+    verify_registry_release,
+    verify_testpypi_release,
+)
+
+VERSION = "2.2.0a1"
+WHEEL = f"hol_guard-{VERSION}-py3-none-any.whl"
+SDIST = f"hol_guard-{VERSION}.tar.gz"
+WHEEL_BYTES = b"wheel-content"
+SDIST_BYTES = b"sdist-content"
+
+
+class FakeFetcher:
+    def __init__(self, responses: dict[str, bytes | Exception]) -> None:
+        self.responses = responses
+        self.calls: list[str] = []
+
+    def __call__(self, url: str) -> bytes:
+        self.calls.append(url)
+        response = self.responses.get(url)
+        if response is None:
+            raise AssertionError(f"Unexpected fetch: {url}")
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def _project_url(registry: Registry) -> str:
+    return f"https://{registry.api_host}/pypi/hol-guard/json"
+
+
+def _release_url(registry: Registry, version: str = VERSION) -> str:
+    return f"https://{registry.api_host}/pypi/hol-guard/{version}/json"
+
+
+def _file_url(registry: Registry, filename: str) -> str:
+    return f"https://{registry.file_host}/packages/{filename}"
+
+
+def _http_error(url: str, code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(url, code, "failure", Message(), io.BytesIO())
+
+
+def _sha(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _release_payload(
+    registry: Registry,
+    files: dict[str, tuple[bytes, str | None]],
+    *,
+    version: str = VERSION,
+) -> bytes:
+    urls = []
+    for filename, (payload, override_digest) in files.items():
+        urls.append(
+            {
+                "filename": filename,
+                "digests": {"sha256": override_digest or _sha(payload)},
+                "url": _file_url(registry, filename),
+            }
+        )
+    return json.dumps({"info": {"version": version}, "urls": urls}).encode()
+
+
+def _local_dist(tmp_path: Path) -> Path:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / WHEEL).write_bytes(WHEEL_BYTES)
+    (dist / SDIST).write_bytes(SDIST_BYTES)
+    return dist
+
+
+def test_lists_sorted_canonical_registry_versions() -> None:
+    fetcher = FakeFetcher(
+        {_project_url(Registry.PYPI): json.dumps({"releases": {"2.2.0a2": [], "2.1.0": [], "2.2.0a1": []}}).encode()}
+    )
+
+    assert list_registry_versions(Registry.PYPI, fetcher=fetcher) == (
+        "2.1.0",
+        "2.2.0a1",
+        "2.2.0a2",
+    )
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        b"not-json",
+        json.dumps([]).encode(),
+        json.dumps({}).encode(),
+        json.dumps({"releases": {"v2.2.0a1": []}}).encode(),
+    ],
+)
+def test_listing_registry_versions_fails_closed_on_invalid_data(response: bytes) -> None:
+    fetcher = FakeFetcher({_project_url(Registry.PYPI): response})
+
+    with pytest.raises(RegistryVerificationError):
+        list_registry_versions(Registry.PYPI, fetcher=fetcher)
+
+
+def test_listing_registry_versions_fails_closed_on_network_error() -> None:
+    fetcher = FakeFetcher({_project_url(Registry.PYPI): urllib.error.URLError("offline")})
+
+    with pytest.raises(RegistryVerificationError, match="Registry request failed"):
+        list_registry_versions(Registry.PYPI, fetcher=fetcher)
+
+
+def test_inspect_release_reports_absent_only_for_404() -> None:
+    url = _release_url(Registry.TESTPYPI)
+    fetcher = FakeFetcher({url: _http_error(url, 404)})
+
+    inspection = inspect_release(Registry.TESTPYPI, VERSION, fetcher=fetcher)
+
+    assert inspection.exists is False
+    assert inspection.files == ()
+
+
+def test_inspect_release_fails_closed_for_non_404_http_error() -> None:
+    url = _release_url(Registry.TESTPYPI)
+    fetcher = FakeFetcher({url: _http_error(url, 503)})
+
+    with pytest.raises(RegistryVerificationError, match="HTTP 503"):
+        inspect_release(Registry.TESTPYPI, VERSION, fetcher=fetcher)
+
+
+def test_inspects_exact_release_without_exposing_urls_in_cli(capsys: pytest.CaptureFixture[str]) -> None:
+    payload = _release_payload(
+        Registry.TESTPYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = FakeFetcher({_release_url(Registry.TESTPYPI): payload})
+
+    assert (
+        main(
+            ["inspect-release", "--registry", "testpypi", "--version", VERSION],
+            fetcher=fetcher,
+        )
+        == 0
+    )
+    output = capsys.readouterr().out
+    decoded = json.loads(output)
+    assert decoded["status"] == "present"
+    assert {item["filename"] for item in decoded["files"]} == {WHEEL, SDIST}
+    assert "pythonhosted.org" not in output
+
+
+def test_computes_local_guard_wheel_and_sdist_hashes(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    (dist / f"plugin_scanner-{VERSION}-py3-none-any.whl").write_bytes(b"scanner")
+
+    assert compute_local_distribution_hashes(dist, VERSION) == {
+        SDIST: _sha(SDIST_BYTES),
+        WHEEL: _sha(WHEEL_BYTES),
+    }
+
+
+def test_verify_testpypi_accepts_absent_release(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    url = _release_url(Registry.TESTPYPI)
+    fetcher = FakeFetcher({url: _http_error(url, 404)})
+
+    result = verify_testpypi_release(VERSION, dist, fetcher=fetcher)
+
+    assert result.status == "absent"
+    assert set(result.files) == {WHEEL, SDIST}
+
+
+@pytest.mark.parametrize("registry", [Registry.PYPI, Registry.TESTPYPI])
+def test_generic_registry_reconciliation_reports_absent(tmp_path: Path, registry: Registry) -> None:
+    dist = _local_dist(tmp_path)
+    url = _release_url(registry)
+    fetcher = FakeFetcher({url: _http_error(url, 404)})
+
+    result = verify_registry_release(registry, VERSION, dist, fetcher=fetcher)
+
+    assert result.registry is registry
+    assert result.status == "absent"
+    assert set(result.files) == {WHEEL, SDIST}
+
+
+def test_verify_testpypi_accepts_exact_release_and_downloads_installable_paths(
+    tmp_path: Path,
+) -> None:
+    dist = _local_dist(tmp_path)
+    payload = _release_payload(
+        Registry.TESTPYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = FakeFetcher(
+        {
+            _release_url(Registry.TESTPYPI): payload,
+            _file_url(Registry.TESTPYPI, WHEEL): WHEEL_BYTES,
+            _file_url(Registry.TESTPYPI, SDIST): SDIST_BYTES,
+        }
+    )
+
+    result = verify_testpypi_release(
+        VERSION,
+        dist,
+        download_dir=tmp_path / "verified",
+        fetcher=fetcher,
+    )
+
+    assert result.status == "exact"
+    assert {path.name for path in result.downloaded_paths} == {WHEEL, SDIST}
+    assert all(path.is_file() for path in result.downloaded_paths)
+    assert {path.name: path.read_bytes() for path in result.downloaded_paths} == {
+        WHEEL: WHEEL_BYTES,
+        SDIST: SDIST_BYTES,
+    }
+
+
+@pytest.mark.parametrize("registry", [Registry.PYPI, Registry.TESTPYPI])
+def test_generic_registry_reconciliation_accepts_exact_and_downloads(tmp_path: Path, registry: Registry) -> None:
+    dist = _local_dist(tmp_path)
+    payload = _release_payload(
+        registry,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = FakeFetcher(
+        {
+            _release_url(registry): payload,
+            _file_url(registry, WHEEL): WHEEL_BYTES,
+            _file_url(registry, SDIST): SDIST_BYTES,
+        }
+    )
+
+    result = verify_registry_release(
+        registry,
+        VERSION,
+        dist,
+        download_dir=tmp_path / f"verified-{registry.value}",
+        fetcher=fetcher,
+    )
+
+    assert result.registry is registry
+    assert result.status == "exact"
+    assert {path.name for path in result.downloaded_paths} == {WHEEL, SDIST}
+    assert all(path.is_file() for path in result.downloaded_paths)
+
+
+def test_verify_release_cli_reconciles_pypi_without_exposing_urls(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dist = _local_dist(tmp_path)
+    payload = _release_payload(
+        Registry.PYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = FakeFetcher({_release_url(Registry.PYPI): payload})
+
+    assert (
+        main(
+            [
+                "verify-release",
+                "--registry",
+                "pypi",
+                "--version",
+                VERSION,
+                "--dist-dir",
+                str(dist),
+            ],
+            fetcher=fetcher,
+        )
+        == 0
+    )
+    output = capsys.readouterr().out
+    decoded = json.loads(output)
+    assert decoded["registry"] == "pypi"
+    assert decoded["status"] == "exact"
+    assert "pythonhosted.org" not in output
+
+
+@pytest.mark.parametrize(
+    "files",
+    [
+        {WHEEL: (b"different", None), SDIST: (SDIST_BYTES, None)},
+        {WHEEL: (WHEEL_BYTES, None)},
+        {
+            WHEEL: (WHEEL_BYTES, None),
+            SDIST: (SDIST_BYTES, None),
+            f"hol_guard-{VERSION}-py2-none-any.whl": (b"extra", None),
+        },
+    ],
+)
+def test_verify_testpypi_rejects_mismatch_partial_and_extra(
+    tmp_path: Path,
+    files: dict[str, tuple[bytes, str | None]],
+) -> None:
+    dist = _local_dist(tmp_path)
+    fetcher = FakeFetcher({_release_url(Registry.TESTPYPI): _release_payload(Registry.TESTPYPI, files)})
+
+    with pytest.raises(RegistryVerificationError):
+        verify_testpypi_release(VERSION, dist, fetcher=fetcher)
+
+
+def test_generic_pypi_reconciliation_rejects_digest_mismatch(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    payload = _release_payload(
+        Registry.PYPI,
+        {WHEEL: (b"different", None), SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = FakeFetcher({_release_url(Registry.PYPI): payload})
+
+    with pytest.raises(RegistryVerificationError, match="pypi distribution digest mismatch"):
+        verify_registry_release(Registry.PYPI, VERSION, dist, fetcher=fetcher)
+
+
+def test_download_rejects_tampered_bytes_without_writing_target(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    payload = _release_payload(
+        Registry.TESTPYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    download_dir = tmp_path / "verified"
+    fetcher = FakeFetcher(
+        {
+            _release_url(Registry.TESTPYPI): payload,
+            _file_url(Registry.TESTPYPI, WHEEL): b"tampered",
+            _file_url(Registry.TESTPYPI, SDIST): SDIST_BYTES,
+        }
+    )
+
+    with pytest.raises(RegistryVerificationError, match="Downloaded distribution digest mismatch"):
+        verify_testpypi_release(
+            VERSION,
+            dist,
+            download_dir=download_dir,
+            fetcher=fetcher,
+        )
+    assert not (download_dir / WHEEL).exists()
+
+
+def test_download_is_all_or_nothing_when_later_file_is_tampered(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    payload = _release_payload(
+        Registry.TESTPYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    download_dir = tmp_path / "verified"
+    fetcher = FakeFetcher(
+        {
+            _release_url(Registry.TESTPYPI): payload,
+            _file_url(Registry.TESTPYPI, WHEEL): WHEEL_BYTES,
+            _file_url(Registry.TESTPYPI, SDIST): b"tampered",
+        }
+    )
+
+    with pytest.raises(RegistryVerificationError, match="Downloaded distribution digest mismatch"):
+        verify_testpypi_release(
+            VERSION,
+            dist,
+            download_dir=download_dir,
+            fetcher=fetcher,
+        )
+    assert not (download_dir / WHEEL).exists()
+    assert not (download_dir / SDIST).exists()
+
+
+def test_pypi_duplicate_is_detectable_and_fatal() -> None:
+    payload = _release_payload(
+        Registry.PYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = FakeFetcher({_release_url(Registry.PYPI): payload})
+
+    with pytest.raises(RegistryVerificationError, match="already exists"):
+        assert_pypi_release_absent(VERSION, fetcher=fetcher)
+
+
+def test_pypi_absence_passes() -> None:
+    url = _release_url(Registry.PYPI)
+    fetcher = FakeFetcher({url: _http_error(url, 404)})
+
+    assert_pypi_release_absent(VERSION, fetcher=fetcher)


### PR DESCRIPTION
## Summary
- bind 2.2 alpha and stable publication to canonical versions, exact refs, source commits, and reviewed promotion state
- reconcile exact package artifacts across test and production registries, including safe retries and verified local installation
- run CI and canary builds for the 2.2 release branch while keeping ordinary pushes build-only

## Testing
- `actionlint .github/workflows/publish.yml .github/workflows/ci.yml`
- `uv run --no-sync ruff check scripts/validate_alpha_release.py scripts/verify_release_registry.py tests/test_validate_alpha_release.py tests/test_verify_release_registry.py tests/test_release_train_workflow.py tests/test_pr_testpypi_canary_workflow.py tests/test_release_toolchain_sbom.py`
- `uv run --no-sync basedpyright --level error scripts/validate_alpha_release.py scripts/verify_release_registry.py tests/test_validate_alpha_release.py tests/test_verify_release_registry.py`
- `uv run --no-sync pytest tests/test_validate_alpha_release.py tests/test_verify_release_registry.py tests/test_release_train_workflow.py tests/test_pr_testpypi_canary_workflow.py tests/test_privileged_workflow_policy.py tests/test_release_toolchain_sbom.py --tb=short`
- built the wheel and source distribution, ran `twine check`, and verified the wheel reports `hol-guard 2.0.1116`
