### PR TITLE
fix(policy): compile canonical tool selectors

### DIFF
--- a/src/codex_plugin_scanner/guard/policy_document_io.py
+++ b/src/codex_plugin_scanner/guard/policy_document_io.py
@@ -35,7 +35,18 @@ _UTC_TIMESTAMP_RE: Final = re.compile(
     r"^[0-9]{4}-(0[1-9]|1[0-2])-([0-2][0-9]|3[01])T" + r"([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]{1,9})?Z$"
 )
 _REDACTED_TIMESTAMP: Final = "1970-01-01T00:00:00Z"
-_SUPPORTED_MATCH_KEYS: Final = frozenset({"artifacts", "harnesses", "publishers", "workspaces"})
+_SUPPORTED_MATCH_KEYS: Final = frozenset({"artifacts", "harnesses", "publishers", "tools", "workspaces"})
+_TOOL_SELECTOR_FAMILIES: Final = {
+    "file-read": "file-read",
+    "mcp": "mcp",
+    "mcp-tool": "mcp-tool",
+    "package-request": "package-request",
+    "prompt": "prompt",
+    "prompt-env-read": "prompt-env-read",
+    "prompt-file": "prompt-file",
+    "shell": "tool-action",
+    "tool-action": "tool-action",
+}
 _LOCAL_SCOPES: Final = frozenset({"artifact", "workspace", "publisher", "harness", "global"})
 _PROVENANCE_SOURCES: Final = frozenset(
     {
@@ -708,6 +719,25 @@ def _selector_values(
         raise PolicyCompilationError("invalid_policy_match_selector", rule_id)
     return tuple(cast(list[str], items))
 
+def _artifact_selector_values(
+    match: Mapping[str, object],
+    *,
+    rule_id: str,
+) -> tuple[str | None, ...]:
+    artifacts = _selector_values(match, "artifacts", rule_id=rule_id)
+    tools = _selector_values(match, "tools", rule_id=rule_id)
+    if artifacts != (None,) and tools != (None,):
+        raise PolicyCompilationError("unsupported_policy_match", rule_id)
+    if tools == (None,):
+        return artifacts
+    families: list[str] = []
+    for tool in tools:
+        family = _TOOL_SELECTOR_FAMILIES.get(cast(str, tool).lower())
+        if family is None:
+            raise PolicyCompilationError("unsupported_policy_match", rule_id)
+        families.append(f"family:{family}")
+    return tuple(families)
+
 
 def _local_scope(
     extension: Mapping[str, object],
@@ -720,6 +750,8 @@ def _local_scope(
     preferred = extension.get("scope")
     if isinstance(preferred, str) and preferred in _LOCAL_SCOPES:
         return cast(DecisionScope, preferred)
+    if artifact_id is not None and artifact_id.startswith("family:"):
+        return "workspace" if workspace is not None else "harness"
     if artifact_id is not None:
         return "artifact"
     if workspace is not None:
@@ -770,7 +802,7 @@ def compile_policy_document(document: GuardPolicyDocument) -> tuple[CompiledPoli
         local_extension = raw_rule.get("x-hol-local")
         extension = local_extension if isinstance(local_extension, Mapping) else {}
         selectors = itertools.product(
-            _selector_values(match, "artifacts", rule_id=rule_id),
+            _artifact_selector_values(match, rule_id=rule_id),
             _selector_values(match, "harnesses", rule_id=rule_id),
             _selector_values(match, "publishers", rule_id=rule_id),
             _selector_values(match, "workspaces", rule_id=rule_id),

--- a/src/codex_plugin_scanner/guard/policy_document_io.py
+++ b/src/codex_plugin_scanner/guard/policy_document_io.py
@@ -719,6 +719,7 @@ def _selector_values(
         raise PolicyCompilationError("invalid_policy_match_selector", rule_id)
     return tuple(cast(list[str], items))
 
+
 def _artifact_selector_values(
     match: Mapping[str, object],
     *,

--- a/src/codex_plugin_scanner/guard/policy_document_io.py
+++ b/src/codex_plugin_scanner/guard/policy_document_io.py
@@ -729,6 +729,8 @@ def _artifact_selector_values(
     tools = _selector_values(match, "tools", rule_id=rule_id)
     if artifacts != (None,) and tools != (None,):
         raise PolicyCompilationError("unsupported_policy_match", rule_id)
+    if tools != (None,) and "publishers" in match:
+        raise PolicyCompilationError("unsupported_policy_match", rule_id)
     if tools == (None,):
         return artifacts
     families: list[str] = []

--- a/src/codex_plugin_scanner/guard/policy_document_io.py
+++ b/src/codex_plugin_scanner/guard/policy_document_io.py
@@ -750,11 +750,11 @@ def _local_scope(
     publisher: str | None,
     harness: str | None,
 ) -> DecisionScope:
+    if artifact_id is not None and artifact_id.startswith("family:"):
+        return "workspace" if workspace is not None else "harness"
     preferred = extension.get("scope")
     if isinstance(preferred, str) and preferred in _LOCAL_SCOPES:
         return cast(DecisionScope, preferred)
-    if artifact_id is not None and artifact_id.startswith("family:"):
-        return "workspace" if workspace is not None else "harness"
     if artifact_id is not None:
         return "artifact"
     if workspace is not None:

--- a/src/codex_plugin_scanner/guard/store_policy.py
+++ b/src/codex_plugin_scanner/guard/store_policy.py
@@ -326,7 +326,7 @@ class StorePolicyMixin:
                   or (
                     scope = 'workspace' and (workspace = ? or workspace = ?) and (
                       artifact_id is null or (
-                        artifact_id = ? and (
+                        (artifact_id = ? or artifact_id = ?) and (
                           artifact_hash is null or (? is not null and artifact_hash = ?)
                         )
                       )
@@ -365,6 +365,7 @@ class StorePolicyMixin:
                     workspace_key,
                     workspace,
                     artifact_id,
+                    action_family_key,
                     artifact_hash,
                     artifact_hash,
                     publisher,

--- a/tests/test_policy_document_import.py
+++ b/tests/test_policy_document_import.py
@@ -140,6 +140,58 @@ def test_imported_tool_family_matches_only_the_selected_harness(tmp_path: Path) 
     assert matching["decision"]["action"] == "allow"
     assert nonmatching["decision"] is None
 
+
+def test_imported_tool_family_respects_workspace_selector(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard")
+    document = GuardPolicyDocument.from_mapping(
+        {
+            "apiVersion": "guard.hashgraphonline.com/v1alpha1",
+            "kind": "GuardPolicy",
+            "metadata": {"id": "workspace-tool-policy", "name": "Workspace tool policy", "revision": 1},
+            "spec": {
+                "defaults": {"mode": "prompt"},
+                "rules": [
+                    {
+                        "id": "allow-workspace-mcp",
+                        "enabled": True,
+                        "match": {"tools": ["mcp"], "workspaces": ["project"]},
+                        "effect": "allow",
+                        "lifetime": {"mode": "permanent"},
+                        "provenance": {
+                            "source": "cli-import",
+                            "createdAt": "2026-07-16T12:00:00Z",
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    store.import_policy_document(
+        document,
+        compile_policy_document(document),
+        mode="merge",
+        now="2026-07-16T12:00:00Z",
+        approval_gate_grant=None,
+    )
+
+    matching = store.resolve_policy_decision_lookup(
+        "codex",
+        "codex:project:mcp:safe-read",
+        workspace="project",
+        now="2026-07-16T12:01:00Z",
+    )
+    nonmatching = store.resolve_policy_decision_lookup(
+        "codex",
+        "codex:other:mcp:safe-read",
+        workspace="other",
+        now="2026-07-16T12:01:00Z",
+    )
+
+    assert matching["decision"] is not None
+    assert matching["decision"]["action"] == "allow"
+    assert nonmatching["decision"] is None
+
+
 def test_replace_removes_only_prior_yaml_imports(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard")
     first = _document(document_id="first", rule_ids=("rule-1",))

--- a/tests/test_policy_document_import.py
+++ b/tests/test_policy_document_import.py
@@ -92,6 +92,54 @@ def test_import_persists_document_identity_and_provenance(tmp_path: Path) -> Non
     assert isinstance(listed[0]["signed_at"], str)
 
 
+def test_imported_tool_family_matches_only_the_selected_harness(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard")
+    document = GuardPolicyDocument.from_mapping(
+        {
+            "apiVersion": "guard.hashgraphonline.com/v1alpha1",
+            "kind": "GuardPolicy",
+            "metadata": {"id": "tool-policy", "name": "Tool policy", "revision": 1},
+            "spec": {
+                "defaults": {"mode": "prompt"},
+                "rules": [
+                    {
+                        "id": "allow-mcp",
+                        "enabled": True,
+                        "match": {"tools": ["mcp"], "harnesses": ["codex"]},
+                        "effect": "allow",
+                        "lifetime": {"mode": "permanent"},
+                        "provenance": {
+                            "source": "cli-import",
+                            "createdAt": "2026-07-16T12:00:00Z",
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    store.import_policy_document(
+        document,
+        compile_policy_document(document),
+        mode="merge",
+        now="2026-07-16T12:00:00Z",
+        approval_gate_grant=None,
+    )
+
+    matching = store.resolve_policy_decision_lookup(
+        "codex",
+        "codex:project:mcp:safe-read",
+        now="2026-07-16T12:01:00Z",
+    )
+    nonmatching = store.resolve_policy_decision_lookup(
+        "cursor",
+        "cursor:project:mcp:safe-read",
+        now="2026-07-16T12:01:00Z",
+    )
+
+    assert matching["decision"] is not None
+    assert matching["decision"]["action"] == "allow"
+    assert nonmatching["decision"] is None
+
 def test_replace_removes_only_prior_yaml_imports(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard")
     first = _document(document_id="first", rule_ids=("rule-1",))

--- a/tests/test_policy_document_io.py
+++ b/tests/test_policy_document_io.py
@@ -29,7 +29,7 @@ def _policy_document(
     *,
     effect: str = "allow",
     match: dict[str, object] | None = None,
-    extensions: dict[str, object] | None = None,
+    local_extension: dict[str, object] | None = None,
 ) -> GuardPolicyDocument:
     return GuardPolicyDocument.from_mapping(
         {
@@ -44,7 +44,7 @@ def _policy_document(
                         "enabled": True,
                         "effect": effect,
                         "match": match or {"artifacts": ["skill:hol/deploy"]},
-                        **({"extensions": extensions} if extensions is not None else {}),
+                        **({"x-hol-local": local_extension} if local_extension is not None else {}),
                         "lifetime": {"mode": "permanent", "expiresAt": None},
                         "provenance": {
                             "source": "import",
@@ -318,9 +318,8 @@ def test_compile_rejects_invalid_until_expiry() -> None:
 def test_compile_ignores_artifact_scope_override_for_tool_family() -> None:
     document = _policy_document(
         match={"tools": ["mcp"]},
-        extensions={"x-hol-local": {"scope": "artifact"}},
+        local_extension={"scope": "artifact"},
     )
-
     compiled = compile_policy_document(document)
 
     assert compiled[0].decision.artifact_id == "family:mcp"

--- a/tests/test_policy_document_io.py
+++ b/tests/test_policy_document_io.py
@@ -25,7 +25,12 @@ from codex_plugin_scanner.guard.policy_document_yaml import (
 )
 
 
-def _policy_document(*, effect: str = "allow", match: dict[str, object] | None = None) -> GuardPolicyDocument:
+def _policy_document(
+    *,
+    effect: str = "allow",
+    match: dict[str, object] | None = None,
+    extensions: dict[str, object] | None = None,
+) -> GuardPolicyDocument:
     return GuardPolicyDocument.from_mapping(
         {
             "apiVersion": "guard.hashgraphonline.com/v1alpha1",
@@ -39,6 +44,7 @@ def _policy_document(*, effect: str = "allow", match: dict[str, object] | None =
                         "enabled": True,
                         "effect": effect,
                         "match": match or {"artifacts": ["skill:hol/deploy"]},
+                        **({"extensions": extensions} if extensions is not None else {}),
                         "lifetime": {"mode": "permanent", "expiresAt": None},
                         "provenance": {
                             "source": "import",
@@ -295,6 +301,7 @@ def test_compile_rejects_empty_selector_lists() -> None:
 
 def test_compile_rejects_invalid_until_expiry() -> None:
     mapping = _policy_document().to_mapping()
+
     spec = mapping["spec"]
     assert isinstance(spec, dict)
     rules = spec["rules"]
@@ -306,6 +313,18 @@ def test_compile_rejects_invalid_until_expiry() -> None:
 
     with pytest.raises(PolicyCompilationError, match="invalid_policy_expiry"):
         compile_policy_document(document)
+
+
+def test_compile_ignores_artifact_scope_override_for_tool_family() -> None:
+    document = _policy_document(
+        match={"tools": ["mcp"]},
+        extensions={"x-hol-local": {"scope": "artifact"}},
+    )
+
+    compiled = compile_policy_document(document)
+
+    assert compiled[0].decision.artifact_id == "family:mcp"
+    assert compiled[0].decision.scope == "harness"
 
 
 def test_compile_rejects_selector_expansion_over_limit() -> None:

--- a/tests/test_policy_document_io.py
+++ b/tests/test_policy_document_io.py
@@ -243,6 +243,7 @@ def test_compile_rejects_match_not_supported_by_local_store() -> None:
     with pytest.raises(PolicyCompilationError, match="unsupported_policy_match"):
         compile_policy_document(document)
 
+
 @pytest.mark.parametrize(
     ("tool", "family"),
     (("mcp", "mcp"), ("shell", "tool-action"), ("tool-action", "tool-action")),
@@ -256,9 +257,7 @@ def test_compile_maps_portable_tool_selectors_to_local_families(tool: str, famil
 
 
 def test_compile_preserves_harness_for_tool_family_selector() -> None:
-    compiled = compile_policy_document(
-        _policy_document(match={"tools": ["mcp"], "harnesses": ["codex"]})
-    )
+    compiled = compile_policy_document(_policy_document(match={"tools": ["mcp"], "harnesses": ["codex"]}))
 
     assert len(compiled) == 1
     assert compiled[0].decision.harness == "codex"
@@ -274,9 +273,14 @@ def test_compile_rejects_unknown_tool_family() -> None:
 
 
 def test_compile_rejects_artifact_and_tool_selector_combination() -> None:
-    document = _policy_document(
-        match={"artifacts": ["skill:hol/deploy"], "tools": ["mcp"]}
-    )
+    document = _policy_document(match={"artifacts": ["skill:hol/deploy"], "tools": ["mcp"]})
+
+    with pytest.raises(PolicyCompilationError, match="unsupported_policy_match"):
+        compile_policy_document(document)
+
+
+def test_compile_rejects_tool_and_publisher_selector_combination() -> None:
+    document = _policy_document(match={"tools": ["mcp"], "publishers": ["hashgraph-online"]})
 
     with pytest.raises(PolicyCompilationError, match="unsupported_policy_match"):
         compile_policy_document(document)

--- a/tests/test_policy_document_io.py
+++ b/tests/test_policy_document_io.py
@@ -243,6 +243,44 @@ def test_compile_rejects_match_not_supported_by_local_store() -> None:
     with pytest.raises(PolicyCompilationError, match="unsupported_policy_match"):
         compile_policy_document(document)
 
+@pytest.mark.parametrize(
+    ("tool", "family"),
+    (("mcp", "mcp"), ("shell", "tool-action"), ("tool-action", "tool-action")),
+)
+def test_compile_maps_portable_tool_selectors_to_local_families(tool: str, family: str) -> None:
+    compiled = compile_policy_document(_policy_document(match={"tools": [tool]}))
+
+    assert len(compiled) == 1
+    assert compiled[0].decision.scope == "harness"
+    assert compiled[0].decision.artifact_id == f"family:{family}"
+
+
+def test_compile_preserves_harness_for_tool_family_selector() -> None:
+    compiled = compile_policy_document(
+        _policy_document(match={"tools": ["mcp"], "harnesses": ["codex"]})
+    )
+
+    assert len(compiled) == 1
+    assert compiled[0].decision.harness == "codex"
+    assert compiled[0].decision.scope == "harness"
+    assert compiled[0].decision.artifact_id == "family:mcp"
+
+
+def test_compile_rejects_unknown_tool_family() -> None:
+    document = _policy_document(match={"tools": ["unknown-tool"]})
+
+    with pytest.raises(PolicyCompilationError, match="unsupported_policy_match"):
+        compile_policy_document(document)
+
+
+def test_compile_rejects_artifact_and_tool_selector_combination() -> None:
+    document = _policy_document(
+        match={"artifacts": ["skill:hol/deploy"], "tools": ["mcp"]}
+    )
+
+    with pytest.raises(PolicyCompilationError, match="unsupported_policy_match"):
+        compile_policy_document(document)
+
 
 def test_compile_rejects_empty_selector_lists() -> None:
     document = _policy_document(match={"artifacts": []})


### PR DESCRIPTION
## Summary
- compile canonical `match.tools` selectors into local artifact-family decisions
- preserve harness and workspace scoping for family selectors
- reject unsupported or ambiguous tool selectors

## Verification
- `uv run ruff check src/codex_plugin_scanner/guard/policy_document_io.py tests/test_policy_document_io.py tests/test_policy_document_import.py`
- `uv run pytest tests/test_policy_document_io.py tests/test_policy_document_import.py -q` (46 passed)
- isolated policy-routing integration: canonical V2 bundle applied and acknowledged; MCP allow and shell block routes enforced