### PR TITLE
feat(mdm): run health leases on machine cadence

### DIFF
--- a/scripts/mdm/macos/org.hol.guard.machine-health.plist
+++ b/scripts/mdm/macos/org.hol.guard.machine-health.plist
@@ -7,7 +7,7 @@
   <array>
     <string>/Library/Application Support/HOL Guard/hol-guard/hol-guard</string>
     <string>mdm</string>
-    <string>integrity-snapshot</string>
+    <string>health-report</string>
     <string>--scope</string>
     <string>machine</string>
     <string>--json</string>

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_mdm.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_mdm.py
@@ -14,6 +14,7 @@ from ..mdm.device_key import (
     revoke_machine_device_key,
     rotate_machine_device_key,
 )
+from ..mdm.health_reporter import run_machine_health_cadence
 from ..mdm.integrity import machine_integrity_snapshot
 from ..mdm.lifecycle import (
     activate_user,
@@ -68,6 +69,8 @@ def _run_guard_mdm_command(
             }
         elif command == "integrity-snapshot":
             payload = dict(machine_integrity_snapshot())
+        elif command == "health-report":
+            payload = run_machine_health_cadence()
         elif command == "supervisor-install":
             payload = install_machine_supervisor()
         elif command == "supervisor-remove":

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_mdm.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_mdm.py
@@ -35,6 +35,12 @@ def _configure_guard_mdm_parsers(
         "--json", required=True, action="store_true", help="Emit the versioned JSON automation contract"
     )
 
+    health_report = commands.add_parser("health-report", help=argparse.SUPPRESS)
+    health_report.add_argument("--scope", required=True, choices=("machine",))
+    health_report.add_argument(
+        "--json", required=True, action="store_true", help="Emit the versioned JSON automation contract"
+    )
+
     for name in ("supervisor-install", "supervisor-remove"):
         supervisor = commands.add_parser(name, help=argparse.SUPPRESS)
         _add_json(supervisor)

--- a/src/codex_plugin_scanner/guard/mdm/health_reporter.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_reporter.py
@@ -1,0 +1,76 @@
+"""Machine-context health cadence independent of user and harness activity."""
+
+from __future__ import annotations
+
+import platform
+from collections.abc import Callable, Mapping
+from typing import cast
+
+from .contracts import MachinePaths, ManagedPolicyState, default_machine_paths
+from .health_lease import issue_or_load_pending_health_lease
+from .health_lease_contract import HealthLeaseBinding, HealthLeaseOutbox
+from .policy import load_managed_policy
+
+_WORKSPACE_LOCK = "selfProtection.workspaceId"
+_DEVICE_LOCK = "selfProtection.deviceId"
+
+PolicyLoader = Callable[..., ManagedPolicyState]
+LeaseIssuer = Callable[..., HealthLeaseOutbox]
+
+
+def _machine_binding(policy_state: ManagedPolicyState) -> HealthLeaseBinding:
+    policy = policy_state.policy
+    if policy is None:
+        raise OSError(policy_state.reason_code or "health_reporter_managed_policy_absent")
+    if policy.install_owner != "mdm":
+        raise PermissionError("health_reporter_machine_management_required")
+    required_locks = {_WORKSPACE_LOCK, _DEVICE_LOCK}
+    if not required_locks.issubset(policy.locked_settings):
+        raise PermissionError("health_reporter_binding_unlocked")
+    protection_raw = policy.settings.get("selfProtection")
+    if not isinstance(protection_raw, dict):
+        raise ValueError("health_reporter_binding_invalid")
+    protection = cast(Mapping[str, object], protection_raw)
+    workspace_id = protection.get("workspaceId")
+    device_id = protection.get("deviceId")
+    if not isinstance(workspace_id, str) or not isinstance(device_id, str):
+        raise ValueError("health_reporter_binding_invalid")
+    try:
+        return HealthLeaseBinding(workspace_id, device_id)
+    except ValueError as exc:
+        raise ValueError("health_reporter_binding_invalid") from exc
+
+
+def run_machine_health_cadence(
+    *,
+    paths: MachinePaths | None = None,
+    system_name: str | None = None,
+    policy_loader: PolicyLoader = load_managed_policy,
+    lease_issuer: LeaseIssuer = issue_or_load_pending_health_lease,
+) -> dict[str, object]:
+    """Issue or recover the current signed lease from protected machine state."""
+
+    resolved_system = system_name or platform.system()
+    resolved_paths = paths or default_machine_paths(system_name=resolved_system)
+    policy_state = policy_loader(system_name=resolved_system)
+    binding = _machine_binding(policy_state)
+    outbox = lease_issuer(resolved_paths, binding, system_name=resolved_system)
+    claims = outbox.lease.claims
+    return {
+        "schemaVersion": "hol-guard-mdm-status.v1",
+        "operation": "health-report",
+        "healthy": True,
+        "state": "lease-ready",
+        "reasonCodes": ["health_lease_ready"],
+        "workspaceId": claims.workspace_id,
+        "deviceId": claims.device_id,
+        "machineInstallationId": claims.machine_installation_id,
+        "installationGeneration": claims.installation_generation,
+        "sequence": claims.sequence,
+        "issuedAt": claims.issued_at,
+        "leaseExpiresAt": claims.lease_expires_at,
+        "leaseDigest": outbox.lease.digest,
+    }
+
+
+__all__ = ["run_machine_health_cadence"]

--- a/src/codex_plugin_scanner/guard/mdm/supervisor.py
+++ b/src/codex_plugin_scanner/guard/mdm/supervisor.py
@@ -19,7 +19,7 @@ _MACOS_LABEL = "org.hol.guard.machine-health"
 _MACOS_PLIST = Path(f"/Library/LaunchDaemons/{_MACOS_LABEL}.plist")
 _WINDOWS_TASK_NAME = r"\HOL Guard\Machine Health"
 _TASK_NAMESPACE = "http://schemas.microsoft.com/windows/2004/02/mit/task"
-_HEALTH_ARGUMENTS = "mdm integrity-snapshot --scope machine --json"
+_HEALTH_ARGUMENTS = "mdm health-report --scope machine --json"
 _WINDOWS_TASK_START_BOUNDARY = "2000-01-01T00:00:00"
 _WINDOWS_TASK_SECURITY_DESCRIPTOR = "D:P(A;;FA;;;SY)(A;;FA;;;BA)"
 _MAX_REGISTRATION_BYTES = 256 * 1024
@@ -74,7 +74,7 @@ def _macos_registration_status(paths: MachinePaths, plist_path: Path) -> Supervi
     expected_arguments = [
         str(machine_executable(paths, "Darwin")),
         "mdm",
-        "integrity-snapshot",
+        "health-report",
         "--scope",
         "machine",
         "--json",
@@ -153,7 +153,7 @@ def _launchctl_arguments(output: str) -> list[str] | None:
 
 def _macos_loaded_status(paths: MachinePaths, output: str) -> SupervisorStatus | None:
     expected_executable = str(machine_executable(paths, "Darwin"))
-    expected_arguments = [expected_executable, "mdm", "integrity-snapshot", "--scope", "machine", "--json"]
+    expected_arguments = [expected_executable, "mdm", "health-report", "--scope", "machine", "--json"]
     if _launchctl_scalar(output, "path") != str(_MACOS_PLIST):
         return SupervisorStatus("stopped", "supervisor_registration_invalid")
     if _launchctl_scalar(output, "program") != expected_executable:

--- a/tests/test_guard_mdm_health_reporter.py
+++ b/tests/test_guard_mdm_health_reporter.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner import cli
+from codex_plugin_scanner.guard.cli import commands_dispatch_mdm
+from codex_plugin_scanner.guard.mdm.contracts import (
+    MDM_POLICY_SCHEMA_VERSION,
+    InstallOwner,
+    MachinePaths,
+    ManagedPolicy,
+    ManagedPolicyState,
+    ManagedUpdatePolicy,
+)
+from codex_plugin_scanner.guard.mdm.health_lease_contract import HealthLeaseBinding, HealthLeaseOutbox
+from codex_plugin_scanner.guard.mdm.health_reporter import run_machine_health_cadence
+
+
+def _paths(root: Path) -> MachinePaths:
+    return MachinePaths(root / "runtime", root / "state", root / "policy", root / "logs", root / "manifest")
+
+
+def _policy(*, owner: str = "mdm", locked: bool = True) -> ManagedPolicyState:
+    locks = frozenset({"selfProtection.workspaceId", "selfProtection.deviceId"}) if locked else frozenset()
+    return ManagedPolicyState(
+        "active",
+        "native",
+        ManagedPolicy(
+            schema_version=MDM_POLICY_SCHEMA_VERSION,
+            settings={"selfProtection": {"workspaceId": "workspace-a", "deviceId": "device-a"}},
+            locked_settings=locks,
+            update=ManagedUpdatePolicy(owner=cast(InstallOwner, owner)),
+        ),
+        reason_code="managed_policy_active",
+    )
+
+
+def _outbox() -> HealthLeaseOutbox:
+    claims = SimpleNamespace(
+        workspace_id="workspace-a",
+        device_id="device-a",
+        machine_installation_id="1" * 32,
+        installation_generation="2" * 32,
+        sequence=7,
+        issued_at="2026-07-18T18:00:00Z",
+        lease_expires_at="2026-07-18T18:15:00Z",
+    )
+    lease = SimpleNamespace(claims=claims, digest="3" * 64)
+    return cast(HealthLeaseOutbox, SimpleNamespace(lease=lease))
+
+
+def test_machine_cadence_uses_only_locked_machine_policy_binding(tmp_path: Path) -> None:
+    calls: list[tuple[MachinePaths, HealthLeaseBinding, str]] = []
+
+    def issue(paths: MachinePaths, binding: HealthLeaseBinding, *, system_name: str) -> HealthLeaseOutbox:
+        calls.append((paths, binding, system_name))
+        return _outbox()
+
+    paths = _paths(tmp_path)
+    result = run_machine_health_cadence(
+        paths=paths,
+        system_name="Darwin",
+        policy_loader=lambda **_kwargs: _policy(),
+        lease_issuer=issue,
+    )
+
+    assert calls == [(paths, HealthLeaseBinding("workspace-a", "device-a"), "Darwin")]
+    assert result == {
+        "schemaVersion": "hol-guard-mdm-status.v1",
+        "operation": "health-report",
+        "healthy": True,
+        "state": "lease-ready",
+        "reasonCodes": ["health_lease_ready"],
+        "workspaceId": "workspace-a",
+        "deviceId": "device-a",
+        "machineInstallationId": "1" * 32,
+        "installationGeneration": "2" * 32,
+        "sequence": 7,
+        "issuedAt": "2026-07-18T18:00:00Z",
+        "leaseExpiresAt": "2026-07-18T18:15:00Z",
+        "leaseDigest": "3" * 64,
+    }
+    assert "signature" not in result
+    assert "snapshot" not in result
+
+
+@pytest.mark.parametrize(
+    ("state", "reason"),
+    [
+        (ManagedPolicyState("absent", "native", reason_code="managed_policy_absent"), "managed_policy_absent"),
+        (_policy(locked=False), "health_reporter_binding_unlocked"),
+        (_policy(owner="user"), "health_reporter_machine_management_required"),
+    ],
+)
+def test_machine_cadence_fails_closed_without_managed_locked_binding(
+    tmp_path: Path, state: ManagedPolicyState, reason: str
+) -> None:
+    with pytest.raises((OSError, PermissionError), match=reason):
+        run_machine_health_cadence(
+            paths=_paths(tmp_path),
+            system_name="Darwin",
+            policy_loader=lambda **_kwargs: state,
+            lease_issuer=lambda *_args, **_kwargs: pytest.fail("lease issuer must not run"),
+        )
+
+
+def test_health_report_cli_is_machine_only_and_emits_bounded_status(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    expected = {
+        "schemaVersion": "hol-guard-mdm-status.v1",
+        "operation": "health-report",
+        "healthy": True,
+        "reasonCodes": ["health_lease_ready"],
+    }
+    monkeypatch.setattr(commands_dispatch_mdm, "run_machine_health_cadence", lambda: expected)
+
+    assert cli.main(["mdm", "health-report", "--scope", "machine", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out) == expected

--- a/tests/test_guard_mdm_health_reporter.py
+++ b/tests/test_guard_mdm_health_reporter.py
@@ -25,14 +25,20 @@ def _paths(root: Path) -> MachinePaths:
     return MachinePaths(root / "runtime", root / "state", root / "policy", root / "logs", root / "manifest")
 
 
-def _policy(*, owner: str = "mdm", locked: bool = True) -> ManagedPolicyState:
+def _policy(
+    *,
+    owner: str = "mdm",
+    locked: bool = True,
+    workspace_id: str = "workspace-a",
+    device_id: str = "device-a",
+) -> ManagedPolicyState:
     locks = frozenset({"selfProtection.workspaceId", "selfProtection.deviceId"}) if locked else frozenset()
     return ManagedPolicyState(
         "active",
         "native",
         ManagedPolicy(
             schema_version=MDM_POLICY_SCHEMA_VERSION,
-            settings={"selfProtection": {"workspaceId": "workspace-a", "deviceId": "device-a"}},
+            settings={"selfProtection": {"workspaceId": workspace_id, "deviceId": device_id}},
             locked_settings=locks,
             update=ManagedUpdatePolicy(owner=cast(InstallOwner, owner)),
         ),
@@ -95,12 +101,13 @@ def test_machine_cadence_uses_only_locked_machine_policy_binding(tmp_path: Path)
         (ManagedPolicyState("absent", "native", reason_code="managed_policy_absent"), "managed_policy_absent"),
         (_policy(locked=False), "health_reporter_binding_unlocked"),
         (_policy(owner="user"), "health_reporter_machine_management_required"),
+        (_policy(workspace_id="   "), "health_reporter_binding_invalid"),
     ],
 )
 def test_machine_cadence_fails_closed_without_managed_locked_binding(
     tmp_path: Path, state: ManagedPolicyState, reason: str
 ) -> None:
-    with pytest.raises((OSError, PermissionError), match=reason):
+    with pytest.raises((OSError, PermissionError, ValueError), match=reason):
         run_machine_health_cadence(
             paths=_paths(tmp_path),
             system_name="Darwin",

--- a/tests/test_guard_mdm_native.py
+++ b/tests/test_guard_mdm_native.py
@@ -175,7 +175,7 @@ def test_macos_installer_registers_machine_health_launch_daemon() -> None:
     assert '"${STAGE}/Library/LaunchDaemons"' in build
     assert "org.hol.guard.machine-health.plist" in build
     assert payload["StartInterval"] == 300
-    assert payload["ProgramArguments"][-5:] == ["mdm", "integrity-snapshot", "--scope", "machine", "--json"]
+    assert payload["ProgramArguments"][-5:] == ["mdm", "health-report", "--scope", "machine", "--json"]
     assert "/bin/launchctl bootstrap system" in postinstall
     assert "/bin/launchctl bootout" not in preinstall
     assert 'install -o root -g wheel -m 0600 "${LAUNCH_DAEMON}" "${ROLLBACK_PLIST}"' in preinstall

--- a/tests/test_guard_mdm_supervisor.py
+++ b/tests/test_guard_mdm_supervisor.py
@@ -47,7 +47,7 @@ def _launchctl_print(paths: MachinePaths) -> str:
     arguments = {{
         {executable}
         mdm
-        integrity-snapshot
+        health-report
         --scope
         machine
         --json


### PR DESCRIPTION
## Summary
- replace the protected five-minute snapshot action with a dedicated machine health lease cadence
- require workspace and device bindings to be MDM-managed and locked before lease issuance
- keep scheduled output bounded to lease metadata while preserving the signed outbox for delivery

## Security properties
- runs from the existing root/SYSTEM supervisor with an absolute machine-owned executable and bounded environment
- does not depend on user sessions, receipts, harness activity, or user-scoped credentials
- fails closed for absent, user-owned, unlocked, or malformed machine bindings
- emits neither raw snapshots nor signatures to supervisor logs

## Verification
- `uv run pytest -q tests/test_guard_mdm*.py` (345 passed, 7 skipped)
- focused isolated Docker suite on Python 3.10, 3.12, and 3.13 (89 passed each)
- `uv run ruff check` on changed Python files
- `uv run basedpyright src/codex_plugin_scanner/guard/mdm/health_reporter.py` (0 errors, 0 warnings)