### PR TITLE
fix(release): enforce alpha-only 2.2 train

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hashgraph-online/core
+* @kantorcodes @deep-purple-boots

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ on:
         type: choice
         options:
           - alpha
-          - stable
       release_train:
         description: "Authorized release train"
         required: true
@@ -24,10 +23,6 @@ on:
       expected_sha:
         description: "Exact source commit authorized for publication"
         required: true
-        type: string
-      promotion_pr:
-        description: "Merged release-to-main PR number (required for stable)"
-        required: false
         type: string
   push:
     branches: [main, release/2.2]
@@ -43,8 +38,47 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  authorize-release:
+    name: Authorize release dispatch
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Enforce alpha release authority
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GITHUB_ACTOR_ID: ${{ github.actor_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_SHA: ${{ github.sha }}
+          RELEASE_CHANNEL: ${{ github.event.inputs.release_channel }}
+          RELEASE_TRAIN: ${{ github.event.inputs.release_train }}
+          EXPECTED_SHA: ${{ github.event.inputs.expected_sha }}
+        run: |
+          if [[ "$GITHUB_RUN_ATTEMPT" != "1" ]]; then
+            echo "Release workflow reruns are denied; create a fresh authorized dispatch" >&2
+            exit 1
+          fi
+          if [[ "$GITHUB_ACTOR_ID" != "6068672" && "$GITHUB_ACTOR_ID" != "301892678" ]]; then
+            echo "Release dispatch actor is not an authorized maintainer" >&2
+            exit 1
+          fi
+          if [[ "$RELEASE_CHANNEL" != "alpha" || "$RELEASE_TRAIN" != "2.2" ]]; then
+            echo "Only the release/2.2 alpha train is authorized" >&2
+            exit 1
+          fi
+          if [[ "$GITHUB_REF" != "refs/heads/release/2.2" ]]; then
+            echo "Alpha releases must run from refs/heads/release/2.2" >&2
+            exit 1
+          fi
+          if [[ "$EXPECTED_SHA" != "$GITHUB_SHA" ]]; then
+            echo "Expected source SHA does not match the dispatch source" >&2
+            exit 1
+          fi
+
   build:
     name: Build + Verify
+    if: github.event_name != 'workflow_dispatch' || github.run_attempt == 1
+    needs: authorize-release
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -82,12 +116,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_ACTOR_ID: ${{ github.actor_id }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_CHANNEL: ${{ github.event.inputs.release_channel }}
           RELEASE_TRAIN: ${{ github.event.inputs.release_train }}
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
           EXPECTED_SHA: ${{ github.event.inputs.expected_sha }}
-          PROMOTION_PR: ${{ github.event.inputs.promotion_pr }}
           RELEASE_PUBLISHING_ENABLED: ${{ vars.RELEASE_PUBLISHING_ENABLED }}
         run: |
           BASE_VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
@@ -101,59 +135,28 @@ jobs:
               echo "Release publishing is disabled until protected environments are verified" >&2
               exit 1
             fi
+            if [[ "$GITHUB_RUN_ATTEMPT" != "1" ]]; then
+              echo "Release workflow reruns are denied; create a fresh authorized dispatch" >&2
+              exit 1
+            fi
+            if [[ "$GITHUB_ACTOR_ID" != "6068672" && "$GITHUB_ACTOR_ID" != "301892678" ]]; then
+              echo "Release dispatch actor is not an authorized maintainer" >&2
+              exit 1
+            fi
             CHANNEL="$RELEASE_CHANNEL"
             TRAIN="$RELEASE_TRAIN"
+            if [[ "$TRAIN" != "2.2" ]]; then
+              echo "Unsupported release train: ${TRAIN}" >&2
+              exit 1
+            fi
             TRAIN_REF="refs/heads/release/${TRAIN}"
 
-            if [[ "$CHANNEL" == "alpha" ]]; then
-              if [[ "$GITHUB_REF" != "$TRAIN_REF" ]]; then
-                echo "Alpha releases must run from ${TRAIN_REF}" >&2
-                exit 1
-              fi
-            elif [[ "$CHANNEL" == "stable" ]]; then
-              if [[ "$GITHUB_REF" != "refs/tags/v${RELEASE_VERSION}" ]]; then
-                echo "Stable releases must run from the exact protected version tag" >&2
-                exit 1
-              fi
-              if [[ "$BASE_VERSION" != "$RELEASE_VERSION" ]]; then
-                echo "Stable source metadata must already equal ${RELEASE_VERSION}" >&2
-                exit 1
-              fi
-              if [[ -z "$PROMOTION_PR" ]]; then
-                echo "Stable releases require the merged promotion PR number" >&2
-                exit 1
-              fi
-              git fetch --no-tags origin \
-                "+refs/heads/main:refs/remotes/origin/main" \
-                "+${TRAIN_REF}:refs/remotes/origin/release/${TRAIN}"
-              if ! git merge-base --is-ancestor "refs/remotes/origin/release/${TRAIN}" "$SOURCE_SHA"; then
-                echo "Stable source must contain the complete reviewed release train" >&2
-                exit 1
-              fi
-              if ! git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main; then
-                echo "Stable source must be contained by the protected main branch" >&2
-                exit 1
-              fi
-              remote_tag_sha=$(git ls-remote origin "refs/tags/v${RELEASE_VERSION}^{}" | awk '{print $1}' || true)
-              if [[ -z "$remote_tag_sha" ]]; then
-                remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/v${RELEASE_VERSION}" | awk '{print $1}')
-              fi
-              if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
-                echo "Protected stable tag must target the authorized promotion SHA" >&2
-                exit 1
-              fi
-              promotion_json=$(gh pr view "$PROMOTION_PR" --repo "$GITHUB_REPOSITORY" \
-                --json state,baseRefName,headRefName,mergeCommit)
-              if ! jq -e \
-                --arg train "release/${TRAIN}" \
-                --arg sha "$SOURCE_SHA" \
-                '.state == "MERGED" and .baseRefName == "main" and .headRefName == $train and .mergeCommit.oid == $sha' \
-                <<< "$promotion_json" >/dev/null; then
-                echo "Stable source must equal the reviewed release-to-main promotion commit" >&2
-                exit 1
-              fi
-            else
-              echo "Unsupported release channel: ${CHANNEL}" >&2
+            if [[ "$CHANNEL" != "alpha" ]]; then
+              echo "The release/2.2 train is alpha-only" >&2
+              exit 1
+            fi
+            if [[ "$GITHUB_REF" != "$TRAIN_REF" ]]; then
+              echo "Alpha releases must run from ${TRAIN_REF}" >&2
               exit 1
             fi
 
@@ -287,7 +290,11 @@ jobs:
 
   alpha-cross-platform:
     name: Alpha release tests (${{ matrix.os }})
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_channel == 'alpha'
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.run_attempt == 1 &&
+      github.event.inputs.release_channel == 'alpha'
+    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -343,6 +350,7 @@ jobs:
       always() &&
       vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
       github.event_name == 'workflow_dispatch' &&
+      github.run_attempt == 1 &&
       github.event.inputs.release_channel == 'alpha' &&
       needs.build.result == 'success' &&
       (needs.alpha-cross-platform.result == 'success' || needs.alpha-cross-platform.result == 'skipped')
@@ -437,6 +445,7 @@ jobs:
       always() &&
       vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
       github.event_name == 'workflow_dispatch' &&
+      github.run_attempt == 1 &&
       github.event.inputs.release_channel == 'alpha' &&
       needs.build.result == 'success' &&
       needs.publish-alpha-testpypi.result == 'success' &&
@@ -545,240 +554,12 @@ jobs:
           [[ -n "$wheel" ]]
           [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
 
-  publish-stable-testpypi:
-    name: Verify stable artifact on TestPyPI
-    if: >-
-      always() &&
-      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      github.event_name == 'workflow_dispatch' &&
-      github.event.inputs.release_channel == 'stable' &&
-      needs.build.result == 'success' &&
-      needs.alpha-cross-platform.result == 'skipped'
-    needs: [build, alpha-cross-platform]
-    runs-on: ubuntu-latest
-    environment: testpypi-stable
-    permissions:
-      contents: read
-      id-token: write
-      pull-requests: read
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.build.outputs.source_sha }}
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
-        with:
-          version: "0.9.26"
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distributions
-          path: dist/
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distribution-sha256
-      - name: Verify immutable build artifact
-        run: sha256sum --check distribution-sha256.txt
-      - name: Keep only the Guard release distribution
-        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
-      - name: Revalidate stable source before TestPyPI
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PROMOTION_PR: ${{ github.event.inputs.promotion_pr }}
-          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-          TRAIN: ${{ needs.build.outputs.release_train }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          train_ref="refs/heads/release/${TRAIN}"
-          git fetch --no-tags origin \
-            "+refs/heads/main:refs/remotes/origin/main" \
-            "+${train_ref}:refs/remotes/origin/release/${TRAIN}"
-          remote_tag_sha=$(git ls-remote origin "refs/tags/v${VERSION}^{}" | awk '{print $1}' || true)
-          if [[ -z "$remote_tag_sha" ]]; then
-            remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/v${VERSION}" | awk '{print $1}')
-          fi
-          [[ "$remote_tag_sha" == "$SOURCE_SHA" ]]
-          git merge-base --is-ancestor "refs/remotes/origin/release/${TRAIN}" "$SOURCE_SHA"
-          git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main
-          promotion_json=$(gh pr view "$PROMOTION_PR" --repo "$GITHUB_REPOSITORY" \
-            --json state,baseRefName,headRefName,mergeCommit)
-          jq -e \
-            --arg train "release/${TRAIN}" \
-            --arg sha "$SOURCE_SHA" \
-            '.state == "MERGED" and .baseRefName == "main" and .headRefName == $train and .mergeCommit.oid == $sha' \
-            <<< "$promotion_json" >/dev/null
-      - name: Inspect TestPyPI release state
-        id: testpypi
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-            verify-release --registry testpypi --version "$VERSION" --dist-dir dist)
-          status=$(jq -r '.status' <<< "$result")
-          if [[ "$status" == "absent" ]]; then
-            echo "upload=true" >> "$GITHUB_OUTPUT"
-          elif [[ "$status" == "exact" ]]; then
-            echo "upload=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Unexpected TestPyPI status: $status" >&2
-            exit 1
-          fi
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-        if: steps.testpypi.outputs.upload == 'true'
-        with:
-          repository-url: https://test.pypi.org/legacy/
-      - name: Download and verify exact TestPyPI artifacts
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          for attempt in {1..12}; do
-            if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-              verify-release --registry testpypi --version "$VERSION" --dist-dir dist \
-              --download-dir verified-testpypi); then
-              exit 1
-            fi
-            status=$(jq -r '.status' <<< "$result")
-            if [[ "$status" == "exact" ]]; then
-              break
-            fi
-            if [[ "$status" != "absent" || "$attempt" == "12" ]]; then
-              echo "TestPyPI did not expose the exact release artifacts" >&2
-              exit 1
-            fi
-            sleep 5
-          done
-          wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
-          [[ -n "$wheel" ]]
-          [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
-
-  publish-stable-pypi:
-    name: Publish stable to PyPI
-    if: >-
-      always() &&
-      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      github.event_name == 'workflow_dispatch' &&
-      github.event.inputs.release_channel == 'stable' &&
-      needs.build.result == 'success' &&
-      needs.publish-stable-testpypi.result == 'success' &&
-      needs.alpha-cross-platform.result == 'skipped'
-    needs: [build, alpha-cross-platform, publish-stable-testpypi]
-    runs-on: ubuntu-latest
-    environment: pypi-stable
-    permissions:
-      contents: read
-      id-token: write
-      pull-requests: read
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.build.outputs.source_sha }}
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
-        with:
-          version: "0.9.26"
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distributions
-          path: dist/
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distribution-sha256
-      - name: Verify the TestPyPI-proven artifact
-        run: sha256sum --check distribution-sha256.txt
-      - name: Keep only the Guard release distribution
-        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
-      - name: Inspect PyPI release state
-        id: pypi
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-            verify-release --registry pypi --version "$VERSION" --dist-dir dist)
-          status=$(jq -r '.status' <<< "$result")
-          if [[ "$status" == "absent" ]]; then
-            echo "upload=true" >> "$GITHUB_OUTPUT"
-          elif [[ "$status" == "exact" ]]; then
-            echo "upload=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Unexpected PyPI status: $status" >&2
-            exit 1
-          fi
-      - name: Revalidate stable publication authorization
-        env:
-          ACTUAL_REF: ${{ github.ref }}
-          EXPECTED_SHA: ${{ github.event.inputs.expected_sha }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PROMOTION_PR: ${{ github.event.inputs.promotion_pr }}
-          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-          TRAIN: ${{ needs.build.outputs.release_train }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          train_ref="refs/heads/release/${TRAIN}"
-          git fetch --no-tags origin \
-            "+refs/heads/main:refs/remotes/origin/main" \
-            "+${train_ref}:refs/remotes/origin/release/${TRAIN}"
-          remote_tag_sha=$(git ls-remote origin "refs/tags/v${VERSION}^{}" | awk '{print $1}' || true)
-          if [[ -z "$remote_tag_sha" ]]; then
-            remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/v${VERSION}" | awk '{print $1}')
-          fi
-          if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
-            echo "Protected stable tag moved after build authorization" >&2
-            exit 1
-          fi
-          git merge-base --is-ancestor "refs/remotes/origin/release/${TRAIN}" "$SOURCE_SHA"
-          git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main
-          promotion_json=$(gh pr view "$PROMOTION_PR" --repo "$GITHUB_REPOSITORY" \
-            --json state,baseRefName,headRefName,mergeCommit)
-          jq -e \
-            --arg train "release/${TRAIN}" \
-            --arg sha "$SOURCE_SHA" \
-            '.state == "MERGED" and .baseRefName == "main" and .headRefName == $train and .mergeCommit.oid == $sha' \
-            <<< "$promotion_json" >/dev/null
-          versions=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-            list-versions --registry pypi)
-          mapfile -t existing_versions < <(jq -r --arg version "$VERSION" '.[] | select(. != $version)' <<< "$versions")
-          validator_args=(
-            --channel stable
-            --version "$VERSION"
-            --git-ref "$train_ref"
-            --actual-ref "$ACTUAL_REF"
-            --github-sha "$SOURCE_SHA"
-            --expected-sha "$EXPECTED_SHA"
-          )
-          for existing_version in "${existing_versions[@]}"; do
-            validator_args+=(--existing-version "$existing_version")
-          done
-          uv run --with packaging==25.0 python scripts/validate_alpha_release.py "${validator_args[@]}"
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-        if: steps.pypi.outputs.upload == 'true'
-      - name: Download and verify exact PyPI artifacts
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          for attempt in {1..12}; do
-            if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-              verify-release --registry pypi --version "$VERSION" --dist-dir dist \
-              --download-dir verified-pypi); then
-              exit 1
-            fi
-            status=$(jq -r '.status' <<< "$result")
-            if [[ "$status" == "exact" ]]; then
-              break
-            fi
-            if [[ "$status" != "absent" || "$attempt" == "12" ]]; then
-              echo "PyPI did not expose the exact release artifacts" >&2
-              exit 1
-            fi
-            sleep 5
-          done
-          wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
-          [[ -n "$wheel" ]]
-          [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
-
   release-alpha:
     name: Create alpha GitHub prerelease
     if: >-
       vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
       github.event_name == 'workflow_dispatch' &&
+      github.run_attempt == 1 &&
       needs.build.outputs.channel == 'alpha'
     needs: [build, publish-alpha-pypi]
     runs-on: ubuntu-latest
@@ -877,171 +658,18 @@ jobs:
             --verify-tag \
             "${ASSET_FILES[@]}"
 
-  release:
-    name: Create GitHub Release
-    if: >-
-      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      github.event_name == 'workflow_dispatch' &&
-      needs.build.outputs.channel == 'stable'
-    needs: [build, publish-stable-pypi]
-    runs-on: ubuntu-latest
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distributions
-          path: dist/
-      - name: Download release toolchain SBOM
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: release-toolchain-sbom
-          path: dist/
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distribution-sha256
-      - name: Verify and select release assets
-        run: |
-          sha256sum --check distribution-sha256.txt
-          rm -f dist/plugin_scanner-* dist/plugin-scanner-*
-      - name: Generate changelog
-        id: changelog
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          # Get the range of commits since last tag
-          LAST_TAG=$(git describe --tags --abbrev=0 --exclude="v${VERSION}" 2>/dev/null || echo "")
-
-          if [ -n "$LAST_TAG" ]; then
-            LOG=$(git log ${LAST_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges)
-          else
-            LOG=$(git log --pretty=format:"- %s (%h)" --no-merges -20)
-          fi
-
-          # Build release notes
-          cat > release-notes.md << EOF
-          ## v${VERSION}
-
-          ### What's Changed
-          ${LOG}
-
-          ### Installation
-          Base install:
-          \`\`\`bash
-          uv tool install hol-guard==${VERSION}
-          \`\`\`
-
-          Full Cisco coverage on Python 3.11+:
-          \`\`\`bash
-          uv tool install "hol-guard[cisco]==${VERSION}"
-          \`\`\`
-
-          \`\`\`bash
-          docker pull ghcr.io/hashgraph-online/hol-guard:${VERSION}
-          \`\`\`
-
-          **Full Changelog**: https://github.com/hashgraph-online/hol-guard/compare/${LAST_TAG}...v${VERSION}
-          EOF
-
-          echo "notes_path=release-notes.md" >> $GITHUB_OUTPUT
-      - name: Attest GitHub release assets
-        id: provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
-        with:
-          subject-path: |
-            dist/*
-      - name: Materialize provenance bundle
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          cp "${{ steps.provenance.outputs.bundle-path }}" "dist/hol-guard-v${VERSION}.intoto.jsonl"
-      - name: Collect release asset files
-        id: release_assets
-        run: |
-          mapfile -d '' ASSET_FILES < <(find dist -maxdepth 1 -type f -print0 | sort -z)
-          if [ "${#ASSET_FILES[@]}" -eq 0 ]; then
-            echo "No release asset files found in dist/" >&2
-            exit 1
-          fi
-          {
-            echo "files<<EOF"
-            for asset in "${ASSET_FILES[@]}"; do
-              printf '%s\n' "$asset"
-            done
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-      - name: Create release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          remote_tag_sha=$(git ls-remote origin "refs/tags/v${VERSION}^{}" | awk '{print $1}' || true)
-          if [[ -z "$remote_tag_sha" ]]; then
-            remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/v${VERSION}" | awk '{print $1}')
-          fi
-          if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
-            echo "Protected stable tag no longer targets the validated source SHA" >&2
-            exit 1
-          fi
-          tag="v${VERSION}"
-          if release_json=$(gh release view "$tag" --json isDraft,isPrerelease 2>/dev/null); then
-            jq -e '.isDraft == false and .isPrerelease == false' <<< "$release_json" >/dev/null
-            existing_dir=$(mktemp -d)
-            gh release download "$tag" --dir "$existing_dir"
-            mapfile -d '' local_files < <(find dist -maxdepth 1 -type f -print0 | sort -z)
-            mapfile -d '' remote_files < <(find "$existing_dir" -maxdepth 1 -type f -print0 | sort -z)
-            [[ "${#local_files[@]}" -gt 0 ]]
-            [[ "${#local_files[@]}" == "${#remote_files[@]}" ]]
-            for local_file in "${local_files[@]}"; do
-              remote_file="$existing_dir/$(basename "$local_file")"
-              [[ -f "$remote_file" ]]
-              if [[ "$remote_file" != *.intoto.jsonl ]]; then
-                cmp --silent "$local_file" "$remote_file"
-              fi
-            done
-            bundle="$existing_dir/hol-guard-v${VERSION}.intoto.jsonl"
-            [[ -s "$bundle" ]]
-            for remote_file in "$existing_dir"/hol_guard-*; do
-              gh attestation verify "$remote_file" --repo "$GITHUB_REPOSITORY" \
-                --bundle "$bundle" --source-digest "$SOURCE_SHA" >/dev/null
-            done
-            exit 0
-          fi
-          mapfile -t RELEASE_ASSETS <<'EOF'
-          ${{ steps.release_assets.outputs.files }}
-          EOF
-          gh release create "$tag" \
-            --title "v${VERSION}" \
-            --verify-tag \
-            --notes-file ${{ steps.changelog.outputs.notes_path }} \
-            "${RELEASE_ASSETS[@]}"
-
   publish-container:
     name: Publish container image
     if: >-
       always() &&
       vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
       github.event_name == 'workflow_dispatch' &&
+      github.run_attempt == 1 &&
       needs.build.result == 'success' &&
-      (
-        (
-          needs.build.outputs.channel == 'alpha' &&
-          needs.publish-alpha-pypi.result == 'success' &&
-          needs.release-alpha.result == 'success'
-        ) ||
-        (
-          needs.build.outputs.channel == 'stable' &&
-          needs.publish-stable-pypi.result == 'success' &&
-          needs.release.result == 'success'
-        )
-      )
-    needs: [build, publish-alpha-pypi, publish-stable-pypi, release-alpha, release]
+      needs.build.outputs.channel == 'alpha' &&
+      needs.publish-alpha-pypi.result == 'success' &&
+      needs.release-alpha.result == 'success'
+    needs: [build, publish-alpha-pypi, release-alpha]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -645,7 +645,7 @@ jobs:
           Install this exact alpha:
 
           \`\`\`bash
-          uv tool install --force "hol-guard==${VERSION}"
+          uv tool install "hol-guard[cisco]==${VERSION}"
           \`\`\`
           EOF
           mapfile -d '' ASSET_FILES < <(find dist -maxdepth 1 -type f -print0 | sort -z)

--- a/scripts/validate_alpha_release.py
+++ b/scripts/validate_alpha_release.py
@@ -18,6 +18,7 @@ class ReleaseTrain:
     major: int
     minor: int
     patch: int = 0
+    stable_enabled: bool = False
 
     @property
     def version_prefix(self) -> str:
@@ -55,6 +56,7 @@ RELEASE_TRAINS: Final[Mapping[str, ReleaseTrain]] = MappingProxyType(
             git_ref="refs/heads/release/3.1",
             major=3,
             minor=1,
+            stable_enabled=True,
         ),
     }
 )
@@ -150,6 +152,8 @@ def validate_release_train(
     train = RELEASE_TRAINS.get(git_ref)
     if train is None:
         raise ValueError(f"Releases must run from one of: {', '.join(ALPHA_BRANCHES)}")
+    if parsed_channel is ReleaseChannel.STABLE and not train.stable_enabled:
+        raise ValueError(f"{git_ref} is alpha-only; stable releases are disabled")
 
     source_sha = _validate_source_sha(github_sha=github_sha, expected_sha=expected_sha)
     version = _parse_version(version_text, label="Requested version")

--- a/tests/test_release_toolchain_sbom.py
+++ b/tests/test_release_toolchain_sbom.py
@@ -61,7 +61,7 @@ def test_publish_workflow_attests_toolchain_sbom_without_sending_it_to_pypi() ->
     workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8"))
     jobs = workflow["jobs"]
     build_steps = jobs["build"]["steps"]
-    release_steps = jobs["release"]["steps"]
+    release_steps = jobs["release-alpha"]["steps"]
 
     preflight_index = next(
         index
@@ -78,8 +78,6 @@ def test_publish_workflow_attests_toolchain_sbom_without_sending_it_to_pypi() ->
             "publish-testpypi",
             "publish-alpha-testpypi",
             "publish-alpha-pypi",
-            "publish-stable-testpypi",
-            "publish-stable-pypi",
         )
         for step in jobs[job_name]["steps"]
     )

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -9,13 +9,23 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "publish.yml"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+CODEOWNERS = ROOT / ".github" / "CODEOWNERS"
 RELEASE_BRANCHES = ["main", "release/2.2"]
+RELEASE_MAINTAINERS = {"@kantorcodes", "@deep-purple-boots"}
 
 
 def _workflow(path: Path) -> dict[object, object]:
     workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
     assert isinstance(workflow, dict)
     return workflow
+
+
+def test_release_codeowners_are_the_two_named_maintainers() -> None:
+    pattern, *owners = CODEOWNERS.read_text(encoding="utf-8").split()
+
+    assert pattern == "*"
+    assert set(owners) == RELEASE_MAINTAINERS
+    assert len(owners) == len(RELEASE_MAINTAINERS)
 
 
 def test_release_branches_run_ci_and_pr_canaries() -> None:
@@ -36,13 +46,13 @@ def test_ordinary_pushes_and_tag_pushes_cannot_publish() -> None:
     for job_name in (
         "publish-alpha-testpypi",
         "publish-alpha-pypi",
-        "publish-stable-testpypi",
-        "publish-stable-pypi",
         "release-alpha",
-        "release",
         "publish-container",
     ):
         assert "github.event_name == 'workflow_dispatch'" in jobs[job_name]["if"]
+    assert "publish-stable-testpypi" not in jobs
+    assert "publish-stable-pypi" not in jobs
+    assert "release" not in jobs
 
     assert "sync-repository-version" not in jobs
     workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
@@ -70,13 +80,15 @@ def test_push_build_keeps_the_repository_version_without_restamping() -> None:
     assert stamp_run.index(condition) < stamp_run.index("--version")
 
 
-def test_stable_noop_and_pr_alpha_version_stamping_contracts() -> None:
+def test_alpha_only_dispatch_and_pr_version_stamping_contracts() -> None:
     workflow = _workflow(PUBLISH_WORKFLOW)
     build_steps = workflow["jobs"]["build"]["steps"]
     compute_run = next(step["run"] for step in build_steps if step.get("name") == "Compute publish version")
     stamp_run = next(step["run"] for step in build_steps if step.get("name") == "Stamp package version when needed")
 
-    assert 'if [[ "$BASE_VERSION" != "$RELEASE_VERSION" ]]' in compute_run
+    assert 'if [[ "$CHANNEL" != "alpha" ]]' in compute_run
+    assert "The release/2.2 train is alpha-only" in compute_run
+    assert 'elif [[ "$CHANNEL" == "stable" ]]' not in compute_run
     assert "VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py" in compute_run
     assert 'VERSION=$(BASE_VERSION="$BASE_VERSION" PR_NUMBER="$PR_NUMBER"' in compute_run
     assert 'sync_repo_version.py --version "$VERSION"' in stamp_run
@@ -85,20 +97,55 @@ def test_stable_noop_and_pr_alpha_version_stamping_contracts() -> None:
 def test_release_dispatch_binds_channel_train_version_and_sha() -> None:
     workflow = _workflow(PUBLISH_WORKFLOW)
     inputs = workflow[True]["workflow_dispatch"]["inputs"]
+    jobs = workflow["jobs"]
+    build_steps = workflow["jobs"]["build"]["steps"]
 
-    assert inputs["release_channel"]["options"] == ["alpha", "stable"]
+    assert inputs["release_channel"]["options"] == ["alpha"]
     assert inputs["release_train"]["options"] == ["2.2"]
     assert inputs["release_version"]["required"] is True
     assert inputs["expected_sha"]["required"] is True
-    assert inputs["promotion_pr"]["required"] is False
+    assert "promotion_pr" not in inputs
 
     workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
     assert '--github-sha "$SOURCE_SHA"' in workflow_text
     assert '--expected-sha "$EXPECTED_SHA"' in workflow_text
     assert '--actual-ref "$GITHUB_REF"' in workflow_text
-    assert "refs/tags/v${RELEASE_VERSION}" in workflow_text
-    assert "git merge-base --is-ancestor" in workflow_text
-    assert 'gh pr view "$PROMOTION_PR"' in workflow_text
+    authorize_job = jobs["authorize-release"]
+    assert authorize_job["permissions"] == {}
+    assert len(authorize_job["steps"]) == 1
+    dispatch_gate = authorize_job["steps"][0]
+    assert dispatch_gate["name"] == "Enforce alpha release authority"
+    assert dispatch_gate["if"] == "github.event_name == 'workflow_dispatch'"
+    assert not any("uses" in step for step in authorize_job["steps"])
+    assert '"$GITHUB_RUN_ATTEMPT" != "1"' in dispatch_gate["run"]
+    assert '"$GITHUB_ACTOR_ID" != "6068672"' in dispatch_gate["run"]
+    assert '"$GITHUB_ACTOR_ID" != "301892678"' in dispatch_gate["run"]
+    assert '"$RELEASE_CHANNEL" != "alpha"' in dispatch_gate["run"]
+    assert '"$RELEASE_TRAIN" != "2.2"' in dispatch_gate["run"]
+    assert '"$GITHUB_REF" != "refs/heads/release/2.2"' in dispatch_gate["run"]
+    assert '"$EXPECTED_SHA" != "$GITHUB_SHA"' in dispatch_gate["run"]
+    assert jobs["build"]["needs"] == "authorize-release"
+    assert jobs["build"]["if"] == "github.event_name != 'workflow_dispatch' || github.run_attempt == 1"
+    assert jobs["alpha-cross-platform"]["needs"] == "build"
+    for job_name in (
+        "alpha-cross-platform",
+        "publish-alpha-testpypi",
+        "publish-alpha-pypi",
+        "release-alpha",
+        "publish-container",
+    ):
+        assert "github.run_attempt == 1" in jobs[job_name]["if"]
+    compute_run = next(step["run"] for step in build_steps if step.get("name") == "Compute publish version")
+    assert 'if [[ "$CHANNEL" != "alpha" ]]' in compute_run
+    assert 'if [[ "$TRAIN" != "2.2" ]]' in compute_run
+    assert 'if [[ "$GITHUB_REF" != "$TRAIN_REF" ]]' in compute_run
+    assert '"$GITHUB_RUN_ATTEMPT" != "1"' in compute_run
+    assert '"$GITHUB_ACTOR_ID" != "6068672"' in compute_run
+    assert '"$GITHUB_ACTOR_ID" != "301892678"' in compute_run
+    assert compute_run.index('"$GITHUB_RUN_ATTEMPT" != "1"') < compute_run.index("VALIDATOR_ARGS=(")
+    for job_name in ("publish-alpha-testpypi", "publish-alpha-pypi", "release-alpha"):
+        assert "build" in workflow["jobs"][job_name]["needs"]
+        assert workflow["jobs"][job_name]["permissions"]["id-token"] == "write"
     assert "RELEASE_PUBLISHING_ENABLED" in workflow_text
     assert 'awk -v candidate="$RELEASE_VERSION"' in workflow_text
     assert "$0 != candidate" in workflow_text
@@ -116,16 +163,9 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
         "alpha-cross-platform",
         "publish-alpha-testpypi",
     ]
-    assert jobs["publish-stable-pypi"]["needs"] == [
-        "build",
-        "alpha-cross-platform",
-        "publish-stable-testpypi",
-    ]
     for job_name in (
         "publish-alpha-testpypi",
         "publish-alpha-pypi",
-        "publish-stable-testpypi",
-        "publish-stable-pypi",
     ):
         steps = jobs[job_name]["steps"]
         assert any(step.get("run") == "sha256sum --check distribution-sha256.txt" for step in steps)
@@ -145,27 +185,10 @@ def test_publish_jobs_use_channel_specific_protected_environments() -> None:
     assert jobs["publish-testpypi"]["environment"] == "testpypi"
     assert jobs["publish-alpha-testpypi"]["environment"] == "testpypi-alpha"
     assert jobs["publish-alpha-pypi"]["environment"] == "pypi-alpha"
-    assert jobs["publish-stable-testpypi"]["environment"] == "testpypi-stable"
-    assert jobs["publish-stable-pypi"]["environment"] == "pypi-stable"
     assert jobs["publish-testpypi"]["permissions"] == {"id-token": "write"}
     assert jobs["publish-alpha-testpypi"]["permissions"] == {"contents": "read", "id-token": "write"}
     assert jobs["publish-alpha-pypi"]["permissions"] == {"contents": "read", "id-token": "write"}
-    assert jobs["publish-stable-testpypi"]["permissions"] == {
-        "contents": "read",
-        "id-token": "write",
-        "pull-requests": "read",
-    }
-    assert jobs["publish-stable-pypi"]["permissions"] == {
-        "contents": "read",
-        "id-token": "write",
-        "pull-requests": "read",
-    }
-    for job_name in (
-        "publish-alpha-testpypi",
-        "publish-alpha-pypi",
-        "publish-stable-testpypi",
-        "publish-stable-pypi",
-    ):
+    for job_name in ("publish-alpha-testpypi", "publish-alpha-pypi"):
         assert "vars.RELEASE_PUBLISHING_ENABLED == 'true'" in jobs[job_name]["if"]
 
 
@@ -173,7 +196,7 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
     workflow = _workflow(PUBLISH_WORKFLOW)
     jobs = workflow["jobs"]
 
-    for job_name in ("publish-alpha-testpypi", "publish-stable-testpypi"):
+    for job_name in ("publish-alpha-testpypi",):
         steps = jobs[job_name]["steps"]
         inspect_step = next(step for step in steps if step.get("name") == "Inspect TestPyPI release state")
         publish_step = next(step for step in steps if str(step.get("uses", "")).startswith("pypa/"))
@@ -197,21 +220,10 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
     assert "refs/tags/alpha/v${VERSION}" in alpha_run
     assert 'awk -v candidate="$VERSION"' in alpha_run
 
-    stable_run = next(
-        step["run"]
-        for step in jobs["publish-stable-pypi"]["steps"]
-        if step.get("name") == "Revalidate stable publication authorization"
-    )
-    assert "list-versions --registry pypi" in stable_run
-    assert "refs/tags/v${VERSION}^{}" in stable_run
-    assert "git merge-base --is-ancestor" in stable_run
-    assert 'gh pr view "$PROMOTION_PR"' in stable_run
-    assert "validate_alpha_release.py" in stable_run
-
     workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
     assert 'for registry in ("pypi.org", "test.pypi.org")' not in workflow_text
 
-    for job_name in ("publish-alpha-pypi", "publish-stable-pypi"):
+    for job_name in ("publish-alpha-pypi",):
         steps = jobs[job_name]["steps"]
         inspect_step = next(step for step in steps if step.get("name") == "Inspect PyPI release state")
         publish_step = next(step for step in steps if str(step.get("uses", "")).startswith("pypa/"))
@@ -244,15 +256,6 @@ def test_release_tags_are_bound_to_the_exact_published_source() -> None:
     )
     assert '[[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]' in alpha_pypi_run
 
-    stable_test_run = next(
-        step["run"]
-        for step in jobs["publish-stable-testpypi"]["steps"]
-        if step.get("name") == "Revalidate stable source before TestPyPI"
-    )
-    assert "refs/tags/v${VERSION}^{}" in stable_test_run
-    assert "git merge-base --is-ancestor" in stable_test_run
-    assert 'gh pr view "$PROMOTION_PR"' in stable_test_run
-
     release_run = next(
         step["run"]
         for step in jobs["release-alpha"]["steps"]
@@ -269,26 +272,22 @@ def test_release_tags_are_bound_to_the_exact_published_source() -> None:
     assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in release_run
     assert "--verify-tag" in release_run
 
-    stable_release_run = next(step["run"] for step in jobs["release"]["steps"] if step.get("name") == "Create release")
-    assert 'gh release view "$tag" --json isDraft,isPrerelease' in stable_release_run
-    assert 'gh release download "$tag"' in stable_release_run
-    assert 'cmp --silent "$local_file"' in stable_release_run
-    assert "mapfile -d '' local_files" in stable_release_run
-    assert 'gh attestation verify "$remote_file"' in stable_release_run
-    assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in stable_release_run
-    assert "--verify-tag" in stable_release_run
 
-
-def test_alpha_and_stable_release_paths_are_distinct() -> None:
+def test_release_22_has_no_stable_publication_surface() -> None:
     workflow = _workflow(PUBLISH_WORKFLOW)
     jobs = workflow["jobs"]
+    workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
 
     assert "channel == 'alpha'" in jobs["release-alpha"]["if"]
-    assert "channel == 'stable'" in jobs["release"]["if"]
+    assert "channel == 'stable'" not in jobs["publish-container"]["if"]
     assert jobs["publish-container"]["needs"] == [
         "build",
         "publish-alpha-pypi",
-        "publish-stable-pypi",
         "release-alpha",
-        "release",
     ]
+    assert not {"publish-stable-testpypi", "publish-stable-pypi", "release"} & jobs.keys()
+    assert "testpypi-stable" not in workflow_text
+    assert "pypi-stable" not in workflow_text
+    assert "refs/tags/v${VERSION}" not in workflow_text
+    assert "--channel stable" not in workflow_text
+    assert "name: Create GitHub Release" not in workflow_text

--- a/tests/test_validate_alpha_release.py
+++ b/tests/test_validate_alpha_release.py
@@ -58,13 +58,13 @@ def test_registry_preserves_release_31_and_adds_release_22() -> None:
         "refs/heads/release/3.1",
     )
     assert RELEASE_TRAINS["refs/heads/release/2.2"].version_prefix == "2.2.0"
+    assert RELEASE_TRAINS["refs/heads/release/2.2"].stable_enabled is False
     assert RELEASE_TRAINS["refs/heads/release/3.1"].version_prefix == "3.1.0"
 
 
 @pytest.mark.parametrize(
     ("git_ref", "version"),
     [
-        ("refs/heads/release/2.2", "2.2.0"),
         ("refs/heads/release/3.1", "3.1.0"),
     ],
 )
@@ -87,22 +87,34 @@ def test_accepts_exact_stable_candidates_with_bound_source_sha(git_ref: str, ver
     )
 
 
+def test_release_22_rejects_stable_channel_even_with_exact_tag_and_sha() -> None:
+    with pytest.raises(ValueError, match=r"release/2\.2 is alpha-only"):
+        validate_release_train(
+            "2.2.0",
+            "refs/heads/release/2.2",
+            ReleaseChannel.STABLE,
+            actual_ref="refs/tags/v2.2.0",
+            github_sha=GITHUB_SHA,
+            expected_sha=GITHUB_SHA,
+        )
+
+
 @pytest.mark.parametrize(
     ("git_ref", "version"),
     [
-        ("refs/heads/release/2.2", "2.2.0a1"),
-        ("refs/heads/release/2.2", "2.2.0b1"),
-        ("refs/heads/release/2.2", "2.2.0rc1"),
-        ("refs/heads/release/2.2", "2.2.1"),
-        ("refs/heads/release/2.2", "3.1.0"),
+        ("refs/heads/release/3.1", "3.1.0a1"),
+        ("refs/heads/release/3.1", "3.1.0b1"),
+        ("refs/heads/release/3.1", "3.1.0rc1"),
+        ("refs/heads/release/3.1", "3.1.1"),
+        ("refs/heads/release/3.1", "2.2.0"),
         ("refs/heads/release/3.1", "3.0.0"),
         ("refs/heads/release/3.1", "3.2.0"),
         ("refs/heads/release/3.1", "3.1.0.dev1"),
         ("refs/heads/release/3.1", "3.1.0.post1"),
         ("refs/heads/release/3.1", "3.1.0+local"),
-        ("refs/heads/release/2.2", "v2.2.0"),
-        ("refs/heads/release/2.2", " 2.2.0 "),
-        ("refs/heads/release/2.2", "2.2"),
+        ("refs/heads/release/3.1", "v3.1.0"),
+        ("refs/heads/release/3.1", " 3.1.0 "),
+        ("refs/heads/release/3.1", "3.1"),
     ],
 )
 def test_rejects_noncanonical_or_wrong_train_stable_candidates(git_ref: str, version: str) -> None:
@@ -176,24 +188,43 @@ def test_rejects_unknown_release_channel() -> None:
 
 
 @pytest.mark.parametrize(
-    ("channel", "version", "actual_ref", "expected"),
+    ("channel", "version", "git_ref", "actual_ref", "expected"),
     [
-        (ReleaseChannel.ALPHA, "2.2.0a1", "refs/heads/main", "refs/heads/release/2.2"),
-        (ReleaseChannel.STABLE, "2.2.0", None, "exact protected version tag"),
-        (ReleaseChannel.STABLE, "2.2.0", "refs/heads/main", "refs/tags/v2.2.0"),
-        (ReleaseChannel.STABLE, "2.2.0", "refs/tags/v2.2.1", "refs/tags/v2.2.0"),
+        (
+            ReleaseChannel.ALPHA,
+            "2.2.0a1",
+            "refs/heads/release/2.2",
+            "refs/heads/main",
+            "refs/heads/release/2.2",
+        ),
+        (ReleaseChannel.STABLE, "3.1.0", "refs/heads/release/3.1", None, "exact protected version tag"),
+        (
+            ReleaseChannel.STABLE,
+            "3.1.0",
+            "refs/heads/release/3.1",
+            "refs/heads/main",
+            "refs/tags/v3.1.0",
+        ),
+        (
+            ReleaseChannel.STABLE,
+            "3.1.0",
+            "refs/heads/release/3.1",
+            "refs/tags/v3.1.1",
+            "refs/tags/v3.1.0",
+        ),
     ],
 )
 def test_rejects_wrong_or_missing_actual_source_ref(
     channel: ReleaseChannel,
     version: str,
+    git_ref: str,
     actual_ref: str | None,
     expected: str,
 ) -> None:
     with pytest.raises(ValueError, match=expected):
         validate_release_train(
             version,
-            "refs/heads/release/2.2",
+            git_ref,
             channel,
             actual_ref=actual_ref,
         )
@@ -233,13 +264,13 @@ def test_rejects_duplicate_alpha_across_normalized_existing_versions() -> None:
 
 
 def test_rejects_duplicate_stable_candidate() -> None:
-    with pytest.raises(ValueError, match=r"Stable version 2\.2\.0 already exists"):
+    with pytest.raises(ValueError, match=r"Stable version 3\.1\.0 already exists"):
         validate_release_train(
-            "2.2.0",
-            "refs/heads/release/2.2",
+            "3.1.0",
+            "refs/heads/release/3.1",
             ReleaseChannel.STABLE,
-            existing_versions=["2.2.0"],
-            actual_ref="refs/tags/v2.2.0",
+            existing_versions=["3.1.0"],
+            actual_ref="refs/tags/v3.1.0",
         )
 
 
@@ -338,13 +369,13 @@ def test_cli_accepts_stable_candidate_with_matching_sha_pair(
         [
             "validate_alpha_release.py",
             "--version",
-            "2.2.0",
+            "3.1.0",
             "--git-ref",
-            "refs/heads/release/2.2",
+            "refs/heads/release/3.1",
             "--channel",
             "stable",
             "--actual-ref",
-            "refs/tags/v2.2.0",
+            "refs/tags/v3.1.0",
             "--github-sha",
             GITHUB_SHA,
             "--expected-sha",
@@ -354,7 +385,7 @@ def test_cli_accepts_stable_candidate_with_matching_sha_pair(
 
     assert main() == 0
     captured = capsys.readouterr()
-    assert captured.out == "2.2.0\n"
+    assert captured.out == "3.1.0\n"
     assert captured.err == ""
 
 
@@ -367,9 +398,9 @@ def test_cli_requires_sha_pair_for_stable_candidate(
         [
             "validate_alpha_release.py",
             "--version",
-            "2.2.0",
+            "3.1.0",
             "--git-ref",
-            "refs/heads/release/2.2",
+            "refs/heads/release/3.1",
             "--channel",
             "stable",
         ],


### PR DESCRIPTION
## Summary

- assign release ownership to the two repository administrators responsible for 2.2 approvals
- make the 2.2 train alpha-only and remove stable publishing, tag, and release paths
- bind fresh release dispatches to immutable maintainer identities, exact train/ref/SHA inputs, and deny workflow reruns
- serialize all release jobs behind the no-permission authorization gate

## Testing

- `actionlint .github/workflows/publish.yml`
- `uv run --no-sync ruff check scripts/validate_alpha_release.py tests/test_release_train_workflow.py tests/test_validate_alpha_release.py`
- `uv run --no-sync ruff format --check scripts/validate_alpha_release.py tests/test_release_train_workflow.py tests/test_validate_alpha_release.py`
- `uv run --no-sync pytest -q tests/test_release_train_workflow.py tests/test_validate_alpha_release.py tests/test_pr_testpypi_canary_workflow.py tests/test_privileged_workflow_policy.py`
- `uv run --no-sync python scripts/check_privileged_workflows.py`
