### PR TITLE
feat(guard): define command effect contracts

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/effect_contract.py
+++ b/src/codex_plugin_scanner/guard/runtime/effect_contract.py
@@ -1,0 +1,497 @@
+"""Pure contracts for Guard command effects, proof routes, and truthful states."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Final, TypeVar, cast
+
+from codex_plugin_scanner.guard.action_lattice import (
+    guard_action_severity,
+    is_guard_action,
+    most_restrictive_guard_action,
+)
+from codex_plugin_scanner.guard.models import GuardAction
+
+EFFECT_CONTRACT_SCHEMA_VERSION: Final = "1.0.0"
+_T = TypeVar("_T")
+
+
+class EffectKind(str, Enum):
+    WORKSPACE_OR_PUBLIC_READ = "workspace-or-public-read"
+    SENSITIVE_READ = "sensitive-read"
+    WORKSPACE_WRITE = "workspace-write"
+    EXTERNAL_FILESYSTEM_WRITE = "external-filesystem-write"
+    PROCESS_EXECUTION = "process-execution"
+    NETWORK_READ = "network-read"
+    NETWORK_WRITE = "network-write"
+    REMOTE_STATE_READ = "remote-state-read"
+    REMOTE_STATE_MUTATION = "remote-state-mutation"
+    PERMISSION_OR_ACCESS_CHANGE = "permission-or-access-change"
+    CREDENTIAL_OR_SECRET_OPERATION = "credential-or-secret-operation"
+    SYSTEM_OR_PRIVILEGE_OPERATION = "system-or-privilege-operation"
+    PACKAGE_OR_SOURCE_INSTALLATION = "package-or-source-installation"
+    DESTRUCTIVE_OR_IRREVERSIBLE_OPERATION = "destructive-or-irreversible-operation"
+    GUARD_CONTROL_OPERATION = "guard-control-operation"
+
+
+class EffectTargetScope(str, Enum):
+    PUBLIC_RESOURCE = "public-resource"
+    WORKSPACE = "workspace"
+    SENSITIVE_LOCAL = "sensitive-local"
+    EXTERNAL_LOCAL = "external-local"
+    NETWORK_ENDPOINT = "network-endpoint"
+    REMOTE_RESOURCE = "remote-resource"
+    SYSTEM = "system"
+    GUARD = "guard"
+    UNKNOWN = "unknown"
+
+
+class EffectReversibility(str, Enum):
+    REVERSIBLE = "reversible"
+    TRIVIALLY_RECOVERABLE = "trivially-recoverable"
+    RECOVERABLE_WITH_REVIEW = "recoverable-with-review"
+    IRREVERSIBLE = "irreversible"
+    UNKNOWN = "unknown"
+
+
+class EffectBlastRadius(str, Enum):
+    SINGLE_RESOURCE = "single-resource"
+    WORKSPACE = "workspace"
+    MULTIPLE_RESOURCES = "multiple-resources"
+    SYSTEM_WIDE = "system-wide"
+    CATASTROPHIC = "catastrophic"
+    UNKNOWN = "unknown"
+
+
+class EffectEvidenceSource(str, Enum):
+    PARSER = "parser"
+    EXTENSION = "extension"
+    LAUNCH_IDENTITY = "launch-identity"
+    MANIFEST = "manifest"
+    LOCKFILE = "lockfile"
+    CONFIGURATION = "configuration"
+    POLICY = "policy"
+    CONTAINMENT = "containment"
+    CAPABILITY = "capability"
+    RUNTIME = "runtime"
+
+
+class EffectConfidence(str, Enum):
+    EXACT = "exact"
+    STRONG = "strong"
+    PARTIAL = "partial"
+    DYNAMIC = "dynamic"
+    UNKNOWN = "unknown"
+
+
+class ContainmentRequirement(str, Enum):
+    NONE = "none"
+    ELIGIBLE = "eligible"
+    REQUIRED = "required"
+    NOT_ELIGIBLE = "not-eligible"
+
+
+class ProofRequirement(str, Enum):
+    OPERATION_AND_TARGETS = "operation-and-targets"
+    WORKSPACE_IDENTITY = "workspace-identity"
+    REPOSITORY_IDENTITY = "repository-identity"
+    REMOTE_RESOURCE_IDENTITY = "remote-resource-identity"
+    WORKING_DIRECTORY_IDENTITY = "working-directory-identity"
+    EXECUTABLE_IDENTITY = "executable-identity"
+    LAUNCH_CHAIN = "launch-chain"
+    DEPENDENCY_PROVENANCE = "dependency-provenance"
+    CONFIGURATION_IDENTITY = "configuration-identity"
+    SHELL_DATA_FLOW = "shell-data-flow"
+    PARSER_CONFIDENCE = "parser-confidence"
+    EXPECTED_EFFECTS = "expected-effects"
+    CONTAINMENT_IDENTITY = "containment-identity"
+    CAPABILITY_CONSTRAINTS = "capability-constraints"
+
+
+class ProofRoute(str, Enum):
+    VERIFIED = "verified"
+    CONTAINED = "contained"
+    WORKFLOW_AUTHORIZED = "workflow-authorized"
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionBasis:
+    action_floor: GuardAction
+    proof_route: ProofRoute | None
+
+    def __post_init__(self) -> None:
+        action_floor = _require_guard_action(self.action_floor, "action_floor")
+        if self.proof_route is not None:
+            _require_enum(self.proof_route, ProofRoute, "proof_route")
+        if guard_action_severity(action_floor) < guard_action_severity("review") and self.proof_route is None:
+            raise ValueError("permissive action floors require a positive proof route")
+
+
+class UncertaintyKind(str, Enum):
+    PARTIAL_PARSE = "partial-parse"
+    DYNAMIC_INPUT = "dynamic-input"
+    UNSUPPORTED_INPUT = "unsupported-input"
+    MALFORMED_INPUT = "malformed-input"
+    PARSER_BUDGET_EXHAUSTED = "parser-budget-exhausted"
+    MATCHER_FAILURE = "matcher-failure"
+    PARSER_FAILURE = "parser-failure"
+    UNRESOLVED_LAUNCH_IDENTITY = "unresolved-launch-identity"
+    UNKNOWN_EFFECT = "unknown-effect"
+    DEGRADED_CONTAINMENT = "degraded-containment"
+    PROTECTION_HEALTH_DEGRADED = "protection-health-degraded"
+    POLICY_VERSION_MISMATCH = "policy-version-mismatch"
+    MALFORMED_BOUNDARY_VERSION = "malformed-boundary-version"
+    UNKNOWN_BOUNDARY_VERSION = "unknown-boundary-version"
+    ROLLBACK_BOUNDARY_VERSION = "rollback-boundary-version"
+
+
+UNCERTAINTY_FLOOR: Final[Mapping[UncertaintyKind, GuardAction]] = MappingProxyType(
+    {
+        UncertaintyKind.PARTIAL_PARSE: "review",
+        UncertaintyKind.DYNAMIC_INPUT: "review",
+        UncertaintyKind.UNSUPPORTED_INPUT: "review",
+        UncertaintyKind.MALFORMED_INPUT: "review",
+        UncertaintyKind.PARSER_BUDGET_EXHAUSTED: "require-reapproval",
+        UncertaintyKind.MATCHER_FAILURE: "block",
+        UncertaintyKind.PARSER_FAILURE: "block",
+        UncertaintyKind.UNRESOLVED_LAUNCH_IDENTITY: "require-reapproval",
+        UncertaintyKind.UNKNOWN_EFFECT: "require-reapproval",
+        UncertaintyKind.DEGRADED_CONTAINMENT: "block",
+        UncertaintyKind.PROTECTION_HEALTH_DEGRADED: "block",
+        UncertaintyKind.POLICY_VERSION_MISMATCH: "block",
+        UncertaintyKind.MALFORMED_BOUNDARY_VERSION: "block",
+        UncertaintyKind.UNKNOWN_BOUNDARY_VERSION: "block",
+        UncertaintyKind.ROLLBACK_BOUNDARY_VERSION: "block",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class EffectAssessment:
+    kind: EffectKind
+    target_scope: EffectTargetScope
+    reversibility: EffectReversibility
+    blast_radius: EffectBlastRadius
+    evidence_source: EffectEvidenceSource
+    confidence: EffectConfidence
+    containment: ContainmentRequirement
+    proof_requirements: frozenset[ProofRequirement]
+    uncertainty_reasons: tuple[UncertaintyKind, ...] = ()
+    schema_version: str = EFFECT_CONTRACT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _require_enum(self.kind, EffectKind, "kind")
+        _require_enum(self.target_scope, EffectTargetScope, "target_scope")
+        _require_enum(self.reversibility, EffectReversibility, "reversibility")
+        _require_enum(self.blast_radius, EffectBlastRadius, "blast_radius")
+        _require_enum(self.evidence_source, EffectEvidenceSource, "evidence_source")
+        _require_enum(self.confidence, EffectConfidence, "confidence")
+        _require_enum(self.containment, ContainmentRequirement, "containment")
+        if self.schema_version != EFFECT_CONTRACT_SCHEMA_VERSION:
+            raise ValueError("unsupported effect contract schema version")
+        _require_enum_frozenset(self.proof_requirements, ProofRequirement, "proof_requirements")
+        _require_enum_tuple(self.uncertainty_reasons, UncertaintyKind, "uncertainty_reasons")
+        uncertain_confidence = self.confidence in {
+            EffectConfidence.PARTIAL,
+            EffectConfidence.DYNAMIC,
+            EffectConfidence.UNKNOWN,
+        }
+        if uncertain_confidence and not self.uncertainty_reasons:
+            raise ValueError("partial, dynamic, and unknown effects require an uncertainty reason")
+        if self.confidence is EffectConfidence.EXACT and self.uncertainty_reasons:
+            raise ValueError("exact effects cannot carry uncertainty reasons")
+        has_unknown_dimension = (
+            self.target_scope is EffectTargetScope.UNKNOWN
+            or self.reversibility is EffectReversibility.UNKNOWN
+            or self.blast_radius is EffectBlastRadius.UNKNOWN
+        )
+        if has_unknown_dimension and (self.confidence is EffectConfidence.EXACT or not self.uncertainty_reasons):
+            raise ValueError("unknown effect dimensions require non-exact confidence and typed uncertainty")
+        if (
+            self.containment is ContainmentRequirement.REQUIRED
+            and ProofRequirement.CONTAINMENT_IDENTITY not in self.proof_requirements
+        ):
+            raise ValueError("required containment must bind containment identity")
+
+
+def maximum_action_floor(floors: Iterable[GuardAction]) -> GuardAction:
+    return most_restrictive_guard_action(*tuple(floors))
+
+
+def apply_uncertainty_floor(current: GuardAction, uncertainties: Iterable[UncertaintyKind]) -> GuardAction:
+    typed_uncertainties = _require_uncertainties(uncertainties)
+    return maximum_action_floor((current, *(UNCERTAINTY_FLOOR[item] for item in typed_uncertainties)))
+
+
+class TruthfulState(str, Enum):
+    PROTECTED = "protected"
+    PARTIAL = "partial"
+    DEGRADED = "degraded"
+    CHECKED = "checked"
+    PERMITTED = "permitted"
+    ALLOWED_UNCONFIRMED = "allowed-unconfirmed"
+    CONFIRMED_SUCCESS = "confirmed-success"
+    CONFIRMED_FAILURE = "confirmed-failure"
+    INTERRUPTED = "interrupted"
+    BLOCKED = "blocked"
+
+
+@dataclass(frozen=True, slots=True)
+class TruthfulStateTerm:
+    label: str
+    meaning: str
+
+
+TRUTHFUL_STATE_GLOSSARY: Final[Mapping[TruthfulState, TruthfulStateTerm]] = MappingProxyType(
+    {
+        TruthfulState.PROTECTED: TruthfulStateTerm(
+            "Protected",
+            "Required hooks, services, policy, containment, tamper checks, and evidence health all pass.",
+        ),
+        TruthfulState.PARTIAL: TruthfulStateTerm(
+            "Partial",
+            "Core enforcement checks pass, but complete local evidence health cannot be proven.",
+        ),
+        TruthfulState.DEGRADED: TruthfulStateTerm(
+            "Degraded",
+            "One or more required protection checks do not pass.",
+        ),
+        TruthfulState.CHECKED: TruthfulStateTerm(
+            "Checked",
+            "Guard evaluated the command; this label does not classify it as a threat.",
+        ),
+        TruthfulState.PERMITTED: TruthfulStateTerm(
+            "Permitted",
+            "Guard permitted the command; this does not prove execution.",
+        ),
+        TruthfulState.ALLOWED_UNCONFIRMED: TruthfulStateTerm(
+            "Allowed — unconfirmed",
+            "Guard permitted the command but has no correlated post-execution proof.",
+        ),
+        TruthfulState.CONFIRMED_SUCCESS: TruthfulStateTerm(
+            "Confirmed success",
+            "Strongly correlated post-execution evidence reports successful completion.",
+        ),
+        TruthfulState.CONFIRMED_FAILURE: TruthfulStateTerm(
+            "Confirmed failure",
+            "Strongly correlated post-execution evidence reports failed completion.",
+        ),
+        TruthfulState.INTERRUPTED: TruthfulStateTerm(
+            "Interrupted",
+            "Guard required review or reapproval before execution could continue.",
+        ),
+        TruthfulState.BLOCKED: TruthfulStateTerm(
+            "Blocked",
+            "Guard prevented the command from proceeding.",
+        ),
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProtectionHealth:
+    required_hooks: bool
+    daemon_and_policy: bool
+    rules_and_containment: bool
+    tamper_checks: bool
+    evidence_health: bool
+
+    def __post_init__(self) -> None:
+        if any(type(cast(object, getattr(self, field))) is not bool for field in self.__slots__):
+            raise ValueError("ProtectionHealth fields must be booleans")
+
+
+class EnforcementOutcome(str, Enum):
+    CHECKED = "checked"
+    PERMITTED = "permitted"
+    INTERRUPTED = "interrupted"
+    BLOCKED = "blocked"
+
+
+class PostProofEligibility(str, Enum):
+    INELIGIBLE = "ineligible"
+    STRONG_CORRELATION = "strong-correlation"
+
+
+class PostExecutionOutcome(str, Enum):
+    SUCCESS = "success"
+    FAILURE = "failure"
+
+
+@dataclass(frozen=True, slots=True)
+class PostExecutionProof:
+    eligibility: PostProofEligibility
+    outcome: PostExecutionOutcome | None
+
+    def __post_init__(self) -> None:
+        _require_enum(self.eligibility, PostProofEligibility, "eligibility")
+        if self.outcome is not None:
+            _require_enum(self.outcome, PostExecutionOutcome, "outcome")
+        if self.eligibility is PostProofEligibility.INELIGIBLE and self.outcome is not None:
+            raise ValueError("ineligible post-execution proof cannot claim an outcome")
+        if self.eligibility is PostProofEligibility.STRONG_CORRELATION and self.outcome is None:
+            raise ValueError("strongly correlated post-execution proof requires an outcome")
+
+
+def derive_protection_state(health: ProtectionHealth) -> TruthfulState:
+    health = _require_instance(health, ProtectionHealth, "health")
+    core_healthy = (
+        health.required_hooks and health.daemon_and_policy and health.rules_and_containment and health.tamper_checks
+    )
+    if not core_healthy:
+        return TruthfulState.DEGRADED
+    if not health.evidence_health:
+        return TruthfulState.PARTIAL
+    return TruthfulState.PROTECTED
+
+
+def derive_activity_state(outcome: EnforcementOutcome, proof: PostExecutionProof) -> TruthfulState:
+    _require_enum(outcome, EnforcementOutcome, "outcome")
+    proof = _require_instance(proof, PostExecutionProof, "proof")
+    if outcome is not EnforcementOutcome.PERMITTED:
+        if proof.outcome is not None:
+            raise ValueError("only a permitted command may consume post-execution proof")
+        return {
+            EnforcementOutcome.CHECKED: TruthfulState.CHECKED,
+            EnforcementOutcome.INTERRUPTED: TruthfulState.INTERRUPTED,
+            EnforcementOutcome.BLOCKED: TruthfulState.BLOCKED,
+        }[outcome]
+    if proof.outcome is PostExecutionOutcome.SUCCESS:
+        return TruthfulState.CONFIRMED_SUCCESS
+    if proof.outcome is PostExecutionOutcome.FAILURE:
+        return TruthfulState.CONFIRMED_FAILURE
+    return TruthfulState.ALLOWED_UNCONFIRMED
+
+
+class BoundaryVersionStatus(str, Enum):
+    CURRENT = "current"
+    MALFORMED = "malformed"
+    UNKNOWN = "unknown"
+    ROLLBACK = "rollback"
+
+
+@dataclass(frozen=True, slots=True)
+class BoundaryVersionClassification:
+    status: BoundaryVersionStatus
+    version: str | None
+    expected_version: str
+    uncertainty: UncertaintyKind | None
+    action_floor: GuardAction | None
+
+    def __post_init__(self) -> None:
+        expected = _parse_boundary_version(self.expected_version)
+        received = _parse_boundary_version(self.version)
+        _require_enum(self.status, BoundaryVersionStatus, "status")
+        if expected is None:
+            raise ValueError("invalid boundary version classification")
+        failure = {
+            BoundaryVersionStatus.MALFORMED: UncertaintyKind.MALFORMED_BOUNDARY_VERSION,
+            BoundaryVersionStatus.UNKNOWN: UncertaintyKind.UNKNOWN_BOUNDARY_VERSION,
+            BoundaryVersionStatus.ROLLBACK: UncertaintyKind.ROLLBACK_BOUNDARY_VERSION,
+        }.get(self.status)
+        if self.status is BoundaryVersionStatus.CURRENT:
+            valid = (received, self.uncertainty, self.action_floor) == (expected, None, None)
+        elif failure is None or self.uncertainty is not failure or self.action_floor != "block":
+            valid = False
+        elif self.status is BoundaryVersionStatus.MALFORMED:
+            valid = self.version is None
+        else:
+            valid = received is not None and (
+                (self.status is BoundaryVersionStatus.UNKNOWN and received > expected)
+                or (self.status is BoundaryVersionStatus.ROLLBACK and received < expected)
+            )
+        if not valid:
+            raise ValueError("invalid boundary version classification")
+
+
+def decode_boundary_version(
+    value: object,
+    *,
+    current_version: str = EFFECT_CONTRACT_SCHEMA_VERSION,
+) -> BoundaryVersionClassification:
+    current = _parse_boundary_version(current_version)
+    if current is None:
+        raise ValueError("current_version must be a canonical semantic boundary version")
+    received = _parse_boundary_version(value)
+    if received is None:
+        return _boundary_version_failure(BoundaryVersionStatus.MALFORMED, None, current_version)
+    received_version = value if isinstance(value, str) else None
+    if received == current:
+        return BoundaryVersionClassification(
+            BoundaryVersionStatus.CURRENT, received_version, current_version, None, None
+        )
+    if received < current:
+        return _boundary_version_failure(BoundaryVersionStatus.ROLLBACK, received_version, current_version)
+    return _boundary_version_failure(BoundaryVersionStatus.UNKNOWN, received_version, current_version)
+
+
+def _boundary_version_failure(
+    status: BoundaryVersionStatus, version: str | None, expected_version: str
+) -> BoundaryVersionClassification:
+    uncertainty = UncertaintyKind(f"{status.value}-boundary-version")
+    return BoundaryVersionClassification(status, version, expected_version, uncertainty, UNCERTAINTY_FLOOR[uncertainty])
+
+
+def _parse_boundary_version(value: object) -> tuple[int, int, int] | None:
+    if not isinstance(value, str) or len(value) > 32:
+        return None
+    parts = value.split(".")
+    if len(parts) != 3 or any(
+        not part.isascii() or not part.isdigit() or len(part) > 9 or (len(part) > 1 and part.startswith("0"))
+        for part in parts
+    ):
+        return None
+    return int(parts[0]), int(parts[1]), int(parts[2])
+
+
+def _require_guard_action(value: object, label: str) -> GuardAction:
+    if not is_guard_action(value):
+        raise ValueError(f"{label} must be a canonical GuardAction")
+    return value
+
+
+def _require_enum(value: object, enum_type: type[Enum], label: str) -> None:
+    if not isinstance(value, enum_type):
+        raise ValueError(f"{label} must be an exact {enum_type.__name__} value")
+
+
+def _require_instance(value: object, expected_type: type[_T], label: str) -> _T:
+    if not isinstance(value, expected_type):
+        raise ValueError(f"{label} must be a {expected_type.__name__}")
+    return value
+
+
+def _require_uncertainties(values: Iterable[object]) -> tuple[UncertaintyKind, ...]:
+    items = tuple(values)
+    if any(not isinstance(item, UncertaintyKind) for item in items):
+        raise ValueError("uncertainties must contain exact UncertaintyKind values")
+    return cast(tuple[UncertaintyKind, ...], items)
+
+
+def _require_enum_frozenset(value: object, enum_type: type[Enum], label: str) -> None:
+    items = _require_non_empty_frozenset(value, label)
+    if any(not isinstance(item, enum_type) for item in items):
+        raise ValueError(f"{label} members must be {enum_type.__name__} values")
+
+
+def _require_enum_tuple(value: object, enum_type: type[Enum], label: str) -> None:
+    items = _require_tuple(value, label)
+    if any(not isinstance(item, enum_type) for item in items):
+        raise ValueError(f"{label} members must be {enum_type.__name__} values")
+    if len(items) != len(set(items)):
+        raise ValueError(f"{label} cannot contain duplicates")
+
+
+def _require_non_empty_frozenset(value: object, label: str) -> frozenset[object]:
+    if not isinstance(value, frozenset) or not value:
+        raise ValueError(f"{label} must be a non-empty frozenset")
+    return value
+
+
+def _require_tuple(value: object, label: str) -> tuple[object, ...]:
+    if not isinstance(value, tuple):
+        raise ValueError(f"{label} must be a tuple")
+    return cast(tuple[object, ...], value)

--- a/src/codex_plugin_scanner/guard/runtime/extension_evidence.py
+++ b/src/codex_plugin_scanner/guard/runtime/extension_evidence.py
@@ -1,0 +1,273 @@
+"""Immutable, lossless evidence contract for command safety extensions."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Final, cast
+
+from codex_plugin_scanner.guard.action_lattice import guard_action_severity, is_guard_action
+from codex_plugin_scanner.guard.models import GuardAction
+
+from .effect_contract import (
+    UNCERTAINTY_FLOOR,
+    EffectKind,
+    ProofRequirement,
+    UncertaintyKind,
+    maximum_action_floor,
+)
+
+_STABLE_ID: Final[re.Pattern[str]] = re.compile(r"[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*")
+_SEMANTIC_VERSION: Final[re.Pattern[str]] = re.compile(
+    r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+    + r"(?:-[0-9a-z]+(?:[.-][0-9a-z]+)*)?(?:\+[0-9a-z]+(?:[.-][0-9a-z]+)*)?"
+)
+_CANONICAL_REFERENCE: Final[re.Pattern[str]] = re.compile(r"[a-z][a-z0-9_-]*:[a-z0-9][a-z0-9._/-]*")
+EXTENSION_EVIDENCE_SCHEMA_VERSION: Final = "1.0.0"
+
+
+class ExtensionMatchClass(str, Enum):
+    UNSAFE = "unsafe"
+    UNCERTAINTY = "uncertainty"
+
+
+class EvidenceSeverity(str, Enum):
+    INFO = "info"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class SafeVariantOutcome(str, Enum):
+    OWNED_RULE_NOT_RAISED = "owned-rule-not-raised"
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionRuleIdentity:
+    extension_id: str
+    extension_version: str
+    rule_id: str
+    rule_version: str
+
+    def __post_init__(self) -> None:
+        _require_stable_id(self.extension_id, "extension_id")
+        _require_stable_id(self.rule_id, "rule_id")
+        _require_stable_version(self.extension_version, "extension_version")
+        _require_stable_version(self.rule_version, "rule_version")
+        if not self.rule_id.startswith(f"{self.extension_id}."):
+            raise ValueError("rule_id must be owned by extension_id")
+
+
+@dataclass(frozen=True, slots=True)
+class OwnedSafeVariant:
+    """A safe outcome that can neutralize only its exact owning rule match."""
+
+    identity: ExtensionRuleIdentity
+    safe_variant_id: str
+    outcome: SafeVariantOutcome
+
+    def __post_init__(self) -> None:
+        _require_identity(self.identity, "safe_variant.identity")
+        _require_stable_id(self.safe_variant_id, "safe_variant.safe_variant_id")
+        _require_enum(self.outcome, SafeVariantOutcome, "safe_variant.outcome")
+
+
+SemanticEvidenceKey = tuple[
+    str,
+    str,
+    str,
+    str,
+    str,
+    str,
+    str,
+    str,
+    str,
+    str,
+    tuple[str, ...],
+    tuple[str, ...],
+    tuple[str, ...],
+    tuple[str, str, str, str, str, str, str],
+    str,
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionEvidence:
+    """One owned base rule match and its optional owned safe outcome."""
+
+    identity: ExtensionRuleIdentity
+    match_class: ExtensionMatchClass
+    severity: EvidenceSeverity
+    declared_floor: GuardAction
+    base_fact: str
+    segment_ref: str
+    operation_ref: str
+    effect_claims: frozenset[EffectKind]
+    proof_requirements: frozenset[ProofRequirement]
+    uncertainty_reasons: tuple[UncertaintyKind, ...] = ()
+    safe_variant: OwnedSafeVariant | None = None
+    schema_version: str = EXTENSION_EVIDENCE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _require_identity(self.identity, "identity")
+        _require_enum(self.match_class, ExtensionMatchClass, "match_class")
+        _require_enum(self.severity, EvidenceSeverity, "severity")
+        if self.schema_version != EXTENSION_EVIDENCE_SCHEMA_VERSION:
+            raise ValueError("unsupported extension evidence schema version")
+        _require_stable_id(self.base_fact, "base_fact")
+        _require_reference(self.segment_ref, "segment_ref")
+        _require_reference(self.operation_ref, "operation_ref")
+        _require_enum_frozenset(self.effect_claims, EffectKind, "effect_claims")
+        _require_enum_frozenset(self.proof_requirements, ProofRequirement, "proof_requirements")
+        _require_enum_tuple(self.uncertainty_reasons, UncertaintyKind, "uncertainty_reasons")
+        declared_floor = _require_guard_action(self.declared_floor, "declared_floor")
+        if self.safe_variant is not None:
+            safe_variant = _require_safe_variant(self.safe_variant)
+            if safe_variant.identity != self.identity:
+                raise ValueError("safe variant must be owned by the exact matched rule identity")
+        if self.match_class is ExtensionMatchClass.UNCERTAINTY:
+            if self.safe_variant is not None:
+                raise ValueError("uncertainty evidence cannot declare a safe variant")
+            if not self.uncertainty_reasons:
+                raise ValueError("uncertainty evidence requires at least one uncertainty reason")
+            required_floor = maximum_action_floor(UNCERTAINTY_FLOOR[item] for item in self.uncertainty_reasons)
+            if guard_action_severity(declared_floor) < guard_action_severity(required_floor):
+                raise ValueError("uncertainty evidence cannot understate its canonical uncertainty floor")
+        elif self.uncertainty_reasons:
+            raise ValueError("unsafe evidence must use a separate uncertainty observation")
+        elif guard_action_severity(declared_floor) < guard_action_severity("review"):
+            raise ValueError("unsafe evidence must declare a review-or-stronger floor")
+
+    @property
+    def effective_floor(self) -> GuardAction | None:
+        """Return no floor only when this exact owned match has a safe outcome."""
+
+        if self.safe_variant is not None:
+            return None
+        return self.declared_floor
+
+    @property
+    def semantic_key(self) -> SemanticEvidenceKey:
+        """Return a canonical, lossless key for equality, dedupe, and ordering."""
+
+        safe_key = ("0", "", "", "", "", "", "")
+        if self.safe_variant is not None:
+            safe_key = (
+                "1",
+                self.safe_variant.identity.extension_id,
+                self.safe_variant.identity.extension_version,
+                self.safe_variant.identity.rule_id,
+                self.safe_variant.identity.rule_version,
+                self.safe_variant.safe_variant_id,
+                self.safe_variant.outcome.value,
+            )
+        return (
+            self.identity.extension_id,
+            self.identity.extension_version,
+            self.identity.rule_id,
+            self.identity.rule_version,
+            self.segment_ref,
+            self.operation_ref,
+            self.match_class.value,
+            self.severity.value,
+            self.declared_floor,
+            self.base_fact,
+            tuple(sorted(item.value for item in self.effect_claims)),
+            tuple(sorted(item.value for item in self.proof_requirements)),
+            tuple(sorted(item.value for item in self.uncertainty_reasons)),
+            safe_key,
+            self.schema_version,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionEvidenceBatch:
+    """Canonical evidence order with permutation-independent floor composition."""
+
+    evidence: tuple[ExtensionEvidence, ...]
+
+    def __post_init__(self) -> None:
+        observations = _require_tuple(self.evidence, "evidence")
+        if any(not isinstance(item, ExtensionEvidence) for item in observations):
+            raise ValueError("evidence members must be ExtensionEvidence values")
+        ordered = tuple(sorted(self.evidence, key=lambda item: item.semantic_key))
+        keys = tuple(item.semantic_key for item in ordered)
+        if len(keys) != len(set(keys)):
+            raise ValueError("duplicate extension evidence is not allowed")
+        object.__setattr__(self, "evidence", ordered)
+
+    def evidence_floor(self) -> GuardAction | None:
+        """Compose effective floors without inventing a floor for neutralized evidence."""
+
+        floors: list[GuardAction] = []
+        for item in self.evidence:
+            if (floor := item.effective_floor) is not None:
+                floors.append(floor)
+        if not floors:
+            return None
+        return maximum_action_floor(floors)
+
+
+def _require_stable_id(value: object, label: str) -> None:
+    if not isinstance(value, str) or len(value) > 128 or _STABLE_ID.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a stable lowercase identifier")
+
+
+def _require_stable_version(value: object, label: str) -> None:
+    if not isinstance(value, str) or _SEMANTIC_VERSION.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a stable semantic version")
+
+
+def _require_reference(value: object, label: str) -> None:
+    if not isinstance(value, str) or len(value) > 256 or _CANONICAL_REFERENCE.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a canonical reference")
+
+
+def _require_non_empty_frozenset(value: object, label: str) -> frozenset[object]:
+    if not isinstance(value, frozenset) or not value:
+        raise ValueError(f"{label} must be a non-empty frozenset")
+    return value
+
+
+def _require_enum_tuple(value: object, enum_type: type[Enum], label: str) -> None:
+    items = _require_tuple(value, label)
+    if any(not isinstance(item, enum_type) for item in items):
+        raise ValueError(f"{label} members must be {enum_type.__name__} values")
+    if len(items) != len(set(items)):
+        raise ValueError(f"{label} cannot contain duplicates")
+
+
+def _require_tuple(value: object, label: str) -> tuple[object, ...]:
+    if not isinstance(value, tuple):
+        raise ValueError(f"{label} must be a tuple")
+    return cast(tuple[object, ...], value)
+
+
+def _require_guard_action(value: object, label: str) -> GuardAction:
+    if not is_guard_action(value):
+        raise ValueError(f"{label} must be a canonical GuardAction")
+    return value
+
+
+def _require_identity(value: object, label: str) -> None:
+    if not isinstance(value, ExtensionRuleIdentity):
+        raise ValueError(f"{label} must be an ExtensionRuleIdentity")
+
+
+def _require_safe_variant(value: object) -> OwnedSafeVariant:
+    if not isinstance(value, OwnedSafeVariant):
+        raise ValueError("safe_variant must be an OwnedSafeVariant")
+    return value
+
+
+def _require_enum(value: object, enum_type: type[Enum], label: str) -> None:
+    if not isinstance(value, enum_type):
+        raise ValueError(f"{label} must be an exact {enum_type.__name__} value")
+
+
+def _require_enum_frozenset(value: object, enum_type: type[Enum], label: str) -> None:
+    items = _require_non_empty_frozenset(value, label)
+    if any(not isinstance(item, enum_type) for item in items):
+        raise ValueError(f"{label} members must be {enum_type.__name__} values")

--- a/tests/test_guard_effect_contract.py
+++ b/tests/test_guard_effect_contract.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import itertools
+from dataclasses import FrozenInstanceError, replace
+
+import pytest
+
+from codex_plugin_scanner.guard.action_lattice import GUARD_ACTION_LATTICE, GUARD_ACTION_SEVERITY
+from codex_plugin_scanner.guard.runtime.effect_contract import (
+    EFFECT_CONTRACT_SCHEMA_VERSION,
+    TRUTHFUL_STATE_GLOSSARY,
+    UNCERTAINTY_FLOOR,
+    BoundaryVersionClassification,
+    BoundaryVersionStatus,
+    ContainmentRequirement,
+    DecisionBasis,
+    EffectAssessment,
+    EffectBlastRadius,
+    EffectConfidence,
+    EffectEvidenceSource,
+    EffectKind,
+    EffectReversibility,
+    EffectTargetScope,
+    EnforcementOutcome,
+    PostExecutionOutcome,
+    PostExecutionProof,
+    PostProofEligibility,
+    ProofRequirement,
+    ProofRoute,
+    ProtectionHealth,
+    TruthfulState,
+    UncertaintyKind,
+    apply_uncertainty_floor,
+    decode_boundary_version,
+    derive_activity_state,
+    derive_protection_state,
+    maximum_action_floor,
+)
+
+
+def _effect(
+    *,
+    target_scope: EffectTargetScope = EffectTargetScope.WORKSPACE,
+    reversibility: EffectReversibility = EffectReversibility.TRIVIALLY_RECOVERABLE,
+    blast_radius: EffectBlastRadius = EffectBlastRadius.WORKSPACE,
+    confidence: EffectConfidence = EffectConfidence.EXACT,
+    uncertainty_reasons: tuple[UncertaintyKind, ...] = (),
+    proof_requirements: frozenset[ProofRequirement] | None = None,
+    schema_version: str = EFFECT_CONTRACT_SCHEMA_VERSION,
+) -> EffectAssessment:
+    return EffectAssessment(
+        kind=EffectKind.PROCESS_EXECUTION,
+        target_scope=target_scope,
+        reversibility=reversibility,
+        blast_radius=blast_radius,
+        evidence_source=EffectEvidenceSource.LAUNCH_IDENTITY,
+        confidence=confidence,
+        containment=ContainmentRequirement.REQUIRED,
+        proof_requirements=proof_requirements
+        or frozenset({ProofRequirement.EXECUTABLE_IDENTITY, ProofRequirement.CONTAINMENT_IDENTITY}),
+        uncertainty_reasons=uncertainty_reasons,
+        schema_version=schema_version,
+    )
+
+
+def test_effect_taxonomy_is_complete_and_versioned() -> None:
+    assert EFFECT_CONTRACT_SCHEMA_VERSION == "1.0.0"
+    assert {effect.value for effect in EffectKind} == {
+        "workspace-or-public-read",
+        "sensitive-read",
+        "workspace-write",
+        "external-filesystem-write",
+        "process-execution",
+        "network-read",
+        "network-write",
+        "remote-state-read",
+        "remote-state-mutation",
+        "permission-or-access-change",
+        "credential-or-secret-operation",
+        "system-or-privilege-operation",
+        "package-or-source-installation",
+        "destructive-or-irreversible-operation",
+        "guard-control-operation",
+    }
+
+
+def test_effect_assessment_is_immutable_and_binds_required_containment() -> None:
+    assessment = _effect()
+
+    with pytest.raises(FrozenInstanceError):
+        assessment.kind = EffectKind.NETWORK_WRITE  # type: ignore[misc]
+    with pytest.raises(ValueError, match="containment identity"):
+        _effect(proof_requirements=frozenset({ProofRequirement.EXECUTABLE_IDENTITY}))
+    with pytest.raises(ValueError, match="schema version"):
+        _effect(schema_version="2.0.0")
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("kind", "process-execution", "EffectKind"),
+        ("target_scope", object(), "EffectTargetScope"),
+        ("reversibility", "reversible", "EffectReversibility"),
+        ("blast_radius", "workspace", "EffectBlastRadius"),
+        ("evidence_source", "parser", "EffectEvidenceSource"),
+        ("confidence", "exact", "EffectConfidence"),
+        ("containment", "required", "ContainmentRequirement"),
+        ("proof_requirements", frozenset({"launch-chain"}), "proof_requirements members"),
+        ("uncertainty_reasons", ("parser-failure",), "uncertainty_reasons members"),
+    ],
+)
+def test_effect_assessment_rejects_untyped_enum_boundaries(field: str, value: object, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        replace(_effect(), **{field: value})
+
+
+@pytest.mark.parametrize("confidence", [EffectConfidence.PARTIAL, EffectConfidence.DYNAMIC, EffectConfidence.UNKNOWN])
+def test_non_exact_confidence_requires_typed_uncertainty(confidence: EffectConfidence) -> None:
+    with pytest.raises(ValueError, match="require an uncertainty reason"):
+        _effect(confidence=confidence)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("target_scope", EffectTargetScope.UNKNOWN),
+        ("reversibility", EffectReversibility.UNKNOWN),
+        ("blast_radius", EffectBlastRadius.UNKNOWN),
+    ],
+)
+def test_unknown_effect_dimensions_require_non_exact_typed_uncertainty(field: str, value: object) -> None:
+    arguments: dict[str, object] = {field: value}
+    with pytest.raises(ValueError, match="unknown effect dimensions"):
+        _effect(**arguments)  # type: ignore[arg-type]
+
+    arguments.update(
+        confidence=EffectConfidence.PARTIAL,
+        uncertainty_reasons=(UncertaintyKind.UNKNOWN_EFFECT,),
+    )
+    assert _effect(**arguments).uncertainty_reasons == (UncertaintyKind.UNKNOWN_EFFECT,)  # type: ignore[arg-type]
+
+
+def test_canonical_guard_action_floor_is_used_and_absence_reviews() -> None:
+    assert maximum_action_floor(()) == "review"
+    for left, right in itertools.product(GUARD_ACTION_LATTICE, repeat=2):
+        result = maximum_action_floor((left, right))
+        assert GUARD_ACTION_SEVERITY[result] >= GUARD_ACTION_SEVERITY[left]
+        assert GUARD_ACTION_SEVERITY[result] >= GUARD_ACTION_SEVERITY[right]
+
+
+def test_proof_route_is_separate_from_canonical_action_floor() -> None:
+    bases = {DecisionBasis("allow", route) for route in ProofRoute}
+
+    assert {basis.action_floor for basis in bases} == {"allow"}
+    assert {basis.proof_route for basis in bases} == set(ProofRoute)
+    with pytest.raises(ValueError, match="positive proof route"):
+        DecisionBasis("allow", None)
+    with pytest.raises(ValueError, match="canonical GuardAction"):
+        DecisionBasis("invalid-action", ProofRoute.VERIFIED)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="ProofRoute"):
+        DecisionBasis("allow", "verified")  # type: ignore[arg-type]
+
+
+def test_every_typed_uncertainty_retains_or_raises_every_canonical_floor() -> None:
+    assert set(UNCERTAINTY_FLOOR) == set(UncertaintyKind)
+    for current, uncertainty in itertools.product(GUARD_ACTION_LATTICE, UncertaintyKind):
+        result = apply_uncertainty_floor(current, (uncertainty,))
+        assert GUARD_ACTION_SEVERITY[result] >= GUARD_ACTION_SEVERITY[current]
+        assert GUARD_ACTION_SEVERITY[result] >= GUARD_ACTION_SEVERITY[UNCERTAINTY_FLOOR[uncertainty]]
+    with pytest.raises(ValueError, match="exact UncertaintyKind"):
+        apply_uncertainty_floor("review", ("parser-failure",))  # type: ignore[arg-type]
+
+
+def test_protection_state_is_derived_from_typed_health() -> None:
+    healthy = ProtectionHealth(True, True, True, True, True)
+    partial = ProtectionHealth(True, True, True, True, False)
+    degraded = ProtectionHealth(False, True, True, True, True)
+
+    assert derive_protection_state(healthy) is TruthfulState.PROTECTED
+    assert derive_protection_state(partial) is TruthfulState.PARTIAL
+    assert derive_protection_state(degraded) is TruthfulState.DEGRADED
+    assert TRUTHFUL_STATE_GLOSSARY[TruthfulState.PARTIAL].label == "Partial"
+    with pytest.raises(ValueError, match="ProtectionHealth fields must be booleans"):
+        ProtectionHealth("false", True, True, True, True)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "health",
+    [
+        {"required_hooks": True},
+        "healthy",
+        type("DuckHealth", (), {"required_hooks": True})(),
+    ],
+)
+def test_protection_state_rejects_non_contract_health_objects(health: object) -> None:
+    with pytest.raises(ValueError, match="health must be a ProtectionHealth"):
+        derive_protection_state(health)  # type: ignore[arg-type]
+
+
+def test_confirmed_states_require_strong_correlated_post_execution_proof() -> None:
+    absent = PostExecutionProof(PostProofEligibility.INELIGIBLE, None)
+    success = PostExecutionProof(PostProofEligibility.STRONG_CORRELATION, PostExecutionOutcome.SUCCESS)
+    failure = PostExecutionProof(PostProofEligibility.STRONG_CORRELATION, PostExecutionOutcome.FAILURE)
+
+    assert derive_activity_state(EnforcementOutcome.PERMITTED, absent) is TruthfulState.ALLOWED_UNCONFIRMED
+    assert derive_activity_state(EnforcementOutcome.PERMITTED, success) is TruthfulState.CONFIRMED_SUCCESS
+    assert derive_activity_state(EnforcementOutcome.PERMITTED, failure) is TruthfulState.CONFIRMED_FAILURE
+    with pytest.raises(ValueError, match="ineligible"):
+        PostExecutionProof(PostProofEligibility.INELIGIBLE, PostExecutionOutcome.SUCCESS)
+    with pytest.raises(ValueError, match="only a permitted"):
+        derive_activity_state(EnforcementOutcome.BLOCKED, success)
+    with pytest.raises(ValueError, match="PostProofEligibility"):
+        PostExecutionProof("ineligible", None)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="PostExecutionOutcome"):
+        PostExecutionProof(PostProofEligibility.STRONG_CORRELATION, "success")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="EnforcementOutcome"):
+        derive_activity_state("permitted", absent)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "proof",
+    [
+        {"outcome": None},
+        "success",
+        type("DuckProof", (), {"outcome": None})(),
+    ],
+)
+def test_activity_state_rejects_non_contract_proof_objects(proof: object) -> None:
+    with pytest.raises(ValueError, match="proof must be a PostExecutionProof"):
+        derive_activity_state(EnforcementOutcome.PERMITTED, proof)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("value", "status", "uncertainty"),
+    [
+        ("1.0.0", BoundaryVersionStatus.CURRENT, None),
+        (None, BoundaryVersionStatus.MALFORMED, UncertaintyKind.MALFORMED_BOUNDARY_VERSION),
+        ("1.0", BoundaryVersionStatus.MALFORMED, UncertaintyKind.MALFORMED_BOUNDARY_VERSION),
+        ("01.0.0", BoundaryVersionStatus.MALFORMED, UncertaintyKind.MALFORMED_BOUNDARY_VERSION),
+        ("\u0661.\u0660.\u0660", BoundaryVersionStatus.MALFORMED, UncertaintyKind.MALFORMED_BOUNDARY_VERSION),
+        ("2.0.0", BoundaryVersionStatus.UNKNOWN, UncertaintyKind.UNKNOWN_BOUNDARY_VERSION),
+        ("0.9.0", BoundaryVersionStatus.ROLLBACK, UncertaintyKind.ROLLBACK_BOUNDARY_VERSION),
+    ],
+)
+def test_boundary_version_decoder_classifies_drift_fail_closed(
+    value: object,
+    status: BoundaryVersionStatus,
+    uncertainty: UncertaintyKind | None,
+) -> None:
+    classification = decode_boundary_version(value)
+
+    assert classification.status is status
+    assert classification.uncertainty is uncertainty
+    assert classification.action_floor is (None if uncertainty is None else "block")
+
+
+def test_boundary_version_decoder_bounds_numeric_input_before_integer_conversion() -> None:
+    classification = decode_boundary_version(f"1.{('9' * 5000)}.0")
+
+    assert classification.status is BoundaryVersionStatus.MALFORMED
+    assert classification.uncertainty is UncertaintyKind.MALFORMED_BOUNDARY_VERSION
+    assert classification.action_floor == "block"
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        (BoundaryVersionStatus.CURRENT, "2.0.0", "1.0.0", None, None),
+        (
+            BoundaryVersionStatus.CURRENT,
+            "1.0.0",
+            "1.0.0",
+            UncertaintyKind.UNKNOWN_BOUNDARY_VERSION,
+            "block",
+        ),
+        (
+            BoundaryVersionStatus.MALFORMED,
+            "invalid",
+            "1.0.0",
+            UncertaintyKind.MALFORMED_BOUNDARY_VERSION,
+            "block",
+        ),
+        (
+            BoundaryVersionStatus.UNKNOWN,
+            "0.9.0",
+            "1.0.0",
+            UncertaintyKind.UNKNOWN_BOUNDARY_VERSION,
+            "block",
+        ),
+        (
+            BoundaryVersionStatus.ROLLBACK,
+            "2.0.0",
+            "1.0.0",
+            UncertaintyKind.ROLLBACK_BOUNDARY_VERSION,
+            "block",
+        ),
+        (BoundaryVersionStatus.UNKNOWN, "2.0.0", "1.0.0", "unknown-boundary-version", "allow"),
+        ("current", "1.0.0", "1.0.0", None, None),
+        (BoundaryVersionStatus.CURRENT, "1.0.0", "invalid", None, None),
+    ],
+)
+def test_boundary_version_classification_rejects_direct_forgery(arguments: tuple[object, ...]) -> None:
+    with pytest.raises(ValueError):
+        BoundaryVersionClassification(*arguments)  # type: ignore[arg-type]

--- a/tests/test_guard_extension_evidence_contract.py
+++ b/tests/test_guard_extension_evidence_contract.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import itertools
+from dataclasses import FrozenInstanceError, replace
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.effect_contract import EffectKind, ProofRequirement, UncertaintyKind
+from codex_plugin_scanner.guard.runtime.extension_evidence import (
+    EXTENSION_EVIDENCE_SCHEMA_VERSION,
+    EvidenceSeverity,
+    ExtensionEvidence,
+    ExtensionEvidenceBatch,
+    ExtensionMatchClass,
+    ExtensionRuleIdentity,
+    OwnedSafeVariant,
+    SafeVariantOutcome,
+)
+
+
+def _identity(
+    *,
+    rule_id: str = "command.git.force-push",
+    extension_version: str = "2.2.0",
+    rule_version: str = "1.0.0",
+) -> ExtensionRuleIdentity:
+    return ExtensionRuleIdentity(
+        extension_id="command.git",
+        extension_version=extension_version,
+        rule_id=rule_id,
+        rule_version=rule_version,
+    )
+
+
+def _safe(identity: ExtensionRuleIdentity | None = None) -> OwnedSafeVariant:
+    return OwnedSafeVariant(
+        identity=identity or _identity(),
+        safe_variant_id="dry-run",
+        outcome=SafeVariantOutcome.OWNED_RULE_NOT_RAISED,
+    )
+
+
+def _evidence(
+    *,
+    identity: ExtensionRuleIdentity | None = None,
+    match_class: ExtensionMatchClass = ExtensionMatchClass.UNSAFE,
+    severity: EvidenceSeverity = EvidenceSeverity.HIGH,
+    declared_floor: str = "review",
+    base_fact: str = "remote-mutation",
+    effect_claims: frozenset[EffectKind] | None = None,
+    proof_requirements: frozenset[ProofRequirement] | None = None,
+    uncertainty_reasons: tuple[UncertaintyKind, ...] = (),
+    safe_variant: OwnedSafeVariant | None = None,
+    schema_version: str = EXTENSION_EVIDENCE_SCHEMA_VERSION,
+) -> ExtensionEvidence:
+    return ExtensionEvidence(
+        identity=identity or _identity(),
+        match_class=match_class,
+        severity=severity,
+        declared_floor=declared_floor,  # type: ignore[arg-type]
+        base_fact=base_fact,
+        segment_ref="segment:0",
+        operation_ref="operation:git-push",
+        effect_claims=(effect_claims if effect_claims is not None else frozenset({EffectKind.REMOTE_STATE_MUTATION})),
+        proof_requirements=(
+            proof_requirements
+            if proof_requirements is not None
+            else frozenset({ProofRequirement.OPERATION_AND_TARGETS, ProofRequirement.EXECUTABLE_IDENTITY})
+        ),
+        uncertainty_reasons=uncertainty_reasons,
+        safe_variant=safe_variant,
+        schema_version=schema_version,
+    )
+
+
+def test_owned_rule_match_retains_declared_fact_floor_and_effective_floor() -> None:
+    evidence = _evidence(declared_floor="require-reapproval")
+
+    assert evidence.base_fact == "remote-mutation"
+    assert evidence.declared_floor == "require-reapproval"
+    assert evidence.effective_floor == "require-reapproval"
+    assert evidence.schema_version == "1.0.0"
+    with pytest.raises(FrozenInstanceError):
+        evidence.severity = EvidenceSeverity.LOW  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("extension_id", "Command Git"),
+        ("extension_version", "2.2"),
+        ("rule_id", "command/git"),
+        ("rule_version", ""),
+    ],
+)
+def test_identity_requires_stable_semver_and_rule_ownership(field: str, value: str) -> None:
+    values = {
+        "extension_id": "command.git",
+        "extension_version": "2.2.0",
+        "rule_id": "command.git.force-push",
+        "rule_version": "1.0.0",
+    }
+    values[field] = value
+    with pytest.raises(ValueError, match=field):
+        ExtensionRuleIdentity(**values)
+
+    with pytest.raises(ValueError, match="owned by extension_id"):
+        _identity(rule_id="command.filesystem.remove")
+
+
+def test_safe_variant_neutralizes_only_its_exact_owned_observation() -> None:
+    safe_match = _evidence(safe_variant=_safe())
+    sibling = _evidence(
+        identity=_identity(rule_id="command.git.force-delete"),
+        declared_floor="block",
+        base_fact="remote-delete",
+    )
+
+    assert safe_match.declared_floor == "review"
+    assert safe_match.effective_floor is None
+    assert ExtensionEvidenceBatch((safe_match,)).evidence_floor() is None
+    assert ExtensionEvidenceBatch((safe_match, sibling)).evidence_floor() == "block"
+
+    with pytest.raises(ValueError, match="exact matched rule"):
+        _evidence(safe_variant=_safe(_identity(rule_id="command.git.other-rule")))
+
+
+@pytest.mark.parametrize(
+    "safe_identity",
+    [
+        _identity(extension_version="2.2.1"),
+        _identity(rule_version="1.0.1"),
+    ],
+)
+def test_safe_variant_requires_the_full_exact_rule_identity(safe_identity: ExtensionRuleIdentity) -> None:
+    with pytest.raises(ValueError, match="exact matched rule identity"):
+        _evidence(safe_variant=_safe(safe_identity))
+
+
+def test_safe_variant_rejects_untyped_outcomes() -> None:
+    with pytest.raises(ValueError, match="SafeVariantOutcome"):
+        replace(_safe(), outcome="owned-rule-not-raised")  # type: ignore[arg-type]
+
+
+def test_safe_variant_cannot_erase_uncertainty_or_unrelated_floor() -> None:
+    safe_match = _evidence(safe_variant=_safe())
+    uncertainty = _evidence(
+        identity=_identity(rule_id="command.git.parser-health"),
+        match_class=ExtensionMatchClass.UNCERTAINTY,
+        declared_floor="block",
+        base_fact="parser-failure",
+        uncertainty_reasons=(UncertaintyKind.PARSER_FAILURE,),
+    )
+
+    assert ExtensionEvidenceBatch((safe_match, uncertainty)).evidence_floor() == "block"
+    with pytest.raises(ValueError, match="uncertainty evidence cannot declare a safe variant"):
+        _evidence(
+            match_class=ExtensionMatchClass.UNCERTAINTY,
+            declared_floor="block",
+            base_fact="parser-failure",
+            uncertainty_reasons=(UncertaintyKind.PARSER_FAILURE,),
+            safe_variant=_safe(),
+        )
+
+
+def test_unsafe_evidence_requires_a_valid_review_or_stronger_floor() -> None:
+    with pytest.raises(ValueError, match="review-or-stronger"):
+        _evidence(declared_floor="allow")
+    with pytest.raises(ValueError, match="canonical GuardAction"):
+        _evidence(declared_floor="invalid-action")
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("identity", object(), "identity must be an ExtensionRuleIdentity"),
+        ("match_class", "unsafe", "ExtensionMatchClass"),
+        ("severity", "high", "EvidenceSeverity"),
+        ("effect_claims", frozenset({"remote-state-mutation"}), "effect_claims members"),
+        ("proof_requirements", frozenset({"operation-and-targets"}), "proof_requirements members"),
+        ("uncertainty_reasons", ("parser-failure",), "uncertainty_reasons members"),
+    ],
+)
+def test_extension_evidence_rejects_untyped_semantic_boundaries(field: str, value: object, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        replace(_evidence(), **{field: value})
+
+
+def test_uncertainty_cannot_understate_its_canonical_floor() -> None:
+    with pytest.raises(ValueError, match="understate"):
+        _evidence(
+            match_class=ExtensionMatchClass.UNCERTAINTY,
+            declared_floor="review",
+            uncertainty_reasons=(UncertaintyKind.UNRESOLVED_LAUNCH_IDENTITY,),
+        )
+    with pytest.raises(ValueError, match="requires at least one"):
+        _evidence(match_class=ExtensionMatchClass.UNCERTAINTY)
+
+
+def test_semantic_key_is_lossless_for_every_security_relevant_field() -> None:
+    base = _evidence()
+    variants = (
+        replace(base, severity=EvidenceSeverity.CRITICAL),
+        replace(base, declared_floor="block"),
+        replace(base, base_fact="remote-delete"),
+        replace(base, effect_claims=frozenset({EffectKind.DESTRUCTIVE_OR_IRREVERSIBLE_OPERATION})),
+        replace(base, proof_requirements=frozenset({ProofRequirement.REMOTE_RESOURCE_IDENTITY})),
+        replace(
+            base,
+            match_class=ExtensionMatchClass.UNCERTAINTY,
+            declared_floor="block",
+            uncertainty_reasons=(UncertaintyKind.MATCHER_FAILURE,),
+        ),
+        replace(base, safe_variant=_safe()),
+    )
+
+    assert len({base.semantic_key, *(variant.semantic_key for variant in variants)}) == len(variants) + 1
+
+
+def test_batch_order_and_floor_are_permutation_independent() -> None:
+    items = (
+        _evidence(safe_variant=_safe()),
+        _evidence(
+            identity=_identity(rule_id="command.git.force-delete"),
+            declared_floor="block",
+            base_fact="remote-delete",
+        ),
+        _evidence(
+            identity=_identity(rule_id="command.git.remote-write"),
+            declared_floor="require-reapproval",
+            base_fact="remote-write",
+        ),
+    )
+
+    canonical_orders = {
+        tuple(item.semantic_key for item in ExtensionEvidenceBatch(order).evidence)
+        for order in itertools.permutations(items)
+    }
+    floors = {ExtensionEvidenceBatch(order).evidence_floor() for order in itertools.permutations(items)}
+
+    assert len(canonical_orders) == 1
+    assert floors == {"block"}
+
+
+def test_mixed_safe_and_unsafe_observations_have_a_canonical_sort_order() -> None:
+    unsafe = _evidence()
+    safe = _evidence(safe_variant=_safe())
+
+    forward = ExtensionEvidenceBatch((unsafe, safe))
+    reverse = ExtensionEvidenceBatch((safe, unsafe))
+
+    assert forward.evidence == reverse.evidence
+    assert forward.evidence_floor() == "review"
+
+
+def test_duplicate_and_malformed_payloads_fail_closed() -> None:
+    evidence = _evidence()
+    with pytest.raises(ValueError, match="duplicate"):
+        ExtensionEvidenceBatch((evidence, evidence))
+    with pytest.raises(ValueError, match="schema version"):
+        _evidence(schema_version="2.0.0")
+    with pytest.raises(ValueError, match="effect_claims"):
+        _evidence(effect_claims=frozenset())
+    with pytest.raises(ValueError, match="canonical reference"):
+        replace(evidence, segment_ref="../../raw/path")


### PR DESCRIPTION
## Summary

- define a versioned command-effect and proof-route contract using Guard's canonical action lattice
- add lossless, version-bound extension evidence with rule-owned safe variants and deterministic composition
- add proof-gated protection/activity states and fail-closed boundary-version classification

This slice introduces pure contract primitives only; it does not change runtime enforcement.

## Verification

- 137 focused and adjacent tests passed
- Ruff lint and format checks passed
- basedpyright: 0 errors, 0 warnings
- independent adversarial constructor and composition probes passed
- diff/whitespace checks passed