### PR TITLE
fix(guard): complete canonical policy CLI integrity

### DIFF
--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -285,7 +285,7 @@ def _resolve_legacy_args(
         "cursor-mcp-proxy",
         "hermes-mcp-proxy",
     }
-    if program_mode == "combined" and argv[0] in _guard_subcommands and "--format" not in argv:
+    if program_mode == "combined" and argv[0] in _guard_subcommands and ("--format" not in argv or argv[0] == "policy"):
         return ["guard", *argv]
     if not should_default_to_scan_target(argv[0], known_commands=known_commands):
         return argv

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_policy_document.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_policy_document.py
@@ -159,7 +159,7 @@ def _run_guard_policy_document_command(
                 _write_document(summary + (difference.text or "No policy changes."), output_stream)
             return 1 if difference.changed else 0
 
-        if command == "export":
+        if command in {"export", "show"}:
             include_provenance = bool(args.include_provenance)
             if include_provenance:
                 gate_input = prompt_for_approval_gate(store.guard_home, use_cooldown=False)
@@ -171,7 +171,7 @@ def _run_guard_policy_document_command(
             rows = store.list_policy_decisions()
             document = build_policy_document_from_rows(rows, include_provenance=include_provenance)
             formatted = format_policy_document_yaml(document)
-            output_value = getattr(args, "output", None)
+            output_value = getattr(args, "output", None) if command == "export" else None
             payload: dict[str, object] = {
                 "rules": len(document.rules),
                 "digest": policy_document_digest(document),
@@ -200,6 +200,37 @@ def _run_guard_policy_document_command(
                     as_json=as_json,
                     output_stream=output_stream,
                 )
+            return 0
+        if command == "explain":
+            document = build_policy_document_from_rows(
+                store.list_policy_decisions(),
+                include_provenance=True,
+            )
+            compiled = compile_policy_document(document)
+            actions: dict[str, int] = {}
+            scopes: dict[str, int] = {}
+            for row in compiled:
+                action = row.decision.action
+                scope = row.decision.scope
+                actions[action] = actions.get(action, 0) + 1
+                scopes[scope] = scopes.get(scope, 0) + 1
+            _write_payload(
+                "policy explain",
+                {
+                    "document_id": document.metadata.id,
+                    "digest": policy_document_digest(document),
+                    "rules": len(document.rules),
+                    "compiled_rows": len(compiled),
+                    "actions": dict(sorted(actions.items())),
+                    "scopes": dict(sorted(scopes.items())),
+                    "message": (
+                        f"Active policy has {len(document.rules)} canonical rules "
+                        f"compiled into {len(compiled)} local rows."
+                    ),
+                },
+                as_json=as_json,
+                output_stream=output_stream,
+            )
             return 0
 
         if command == "import":

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
@@ -21,7 +21,7 @@ def _configure_guard_policy_parsers(
 ) -> None:
     policy_parser = guard_subparsers.add_parser(
         "policy",
-        help="Validate, format, diff, export, or import canonical Guard policy YAML",
+        help="Inspect, validate, format, diff, export, or import canonical Guard policy YAML",
     )
     policy_subparsers = policy_parser.add_subparsers(dest="policy_command", required=True)
 
@@ -43,7 +43,21 @@ def _configure_guard_policy_parsers(
     _add_guard_common_args(policy_diff_parser)
     policy_diff_parser.add_argument("--json", action="store_true")
 
+    policy_show_parser = policy_subparsers.add_parser(
+        "show", help="Show the active local policy as canonical YAML"
+    )
+    policy_show_parser.add_argument("--include-provenance", action="store_true")
+    _add_guard_common_args(policy_show_parser)
+    policy_show_parser.add_argument("--json", action="store_true")
+
+    policy_explain_parser = policy_subparsers.add_parser(
+        "explain", help="Explain the active local policy compilation"
+    )
+    _add_guard_common_args(policy_explain_parser)
+    policy_explain_parser.add_argument("--json", action="store_true")
+
     policy_export_parser = policy_subparsers.add_parser("export", help="Export local policies")
+    policy_export_parser.add_argument("--format", choices=("yaml",), default="yaml")
     policy_export_parser.add_argument("--output")
     policy_export_parser.add_argument("--include-provenance", action="store_true")
     _add_guard_common_args(policy_export_parser)

--- a/src/codex_plugin_scanner/guard/policy_bundle_parser.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_parser.py
@@ -664,7 +664,7 @@ def validated_policy_bundle_payload(
     canonical_payload = canonical_policy_bundle_payload(policy_bundle)
     payload_hash = _non_empty_string(policy_bundle.get("payloadHash"))
     computed_payload_hash = hashlib.sha256(canonical_payload).hexdigest()
-    if payload_hash is None:
+    if payload_hash is None or payload_hash != payload_hash.strip():
         return None, "invalid_payload_hash"
     if payload_hash.lower() not in {computed_payload_hash, f"sha256:{computed_payload_hash}"}:
         return None, "payload_hash_mismatch"

--- a/tests/test_policy_bundle_integrity.py
+++ b/tests/test_policy_bundle_integrity.py
@@ -1,0 +1,105 @@
+"""Signed policy bundle integrity validation tests."""
+
+from __future__ import annotations
+
+import base64
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+from codex_plugin_scanner.guard.policy_bundle_parser import (
+    canonical_policy_bundle_payload,
+    computed_policy_bundle_hash,
+    payload_hash_for_policy_bundle,
+    validated_policy_bundle_payload,
+)
+from codex_plugin_scanner.guard.policy_bundle_trusted_keys import (
+    policy_bundle_verification_key_from_public_key,
+)
+
+
+def _signed_policy_bundle() -> tuple[dict[str, object], tuple[object, ...]]:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key_pem = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
+    trusted_key = policy_bundle_verification_key_from_public_key(
+        key_id="guard-policy-bundle-test-key",
+        public_key_pem=public_key_pem,
+    )
+    bundle: dict[str, object] = {
+        "contractVersion": "guard-policy-bundle.v1",
+        "workspaceId": "workspace-1",
+        "bundleVersion": "policy-2026-04-19.1",
+        "bundleHash": "",
+        "issuedAt": "2026-04-19T00:00:10+00:00",
+        "expiresAt": None,
+        "verifier": {
+            "algorithm": "rsa-pss-sha256",
+            "keyId": trusted_key.key_id,
+            "publicKeyPem": public_key_pem,
+            "signature": None,
+        },
+        "rolloutState": "enforcing",
+        "policyDefaults": {
+            "mode": "enforce",
+            "defaultAction": "warn",
+            "unknownPublisherAction": "review",
+            "changedHashAction": "require-reapproval",
+            "newNetworkDomainAction": "warn",
+            "subprocessAction": "block",
+            "telemetryEnabled": False,
+            "syncEnabled": True,
+        },
+        "rules": [],
+        "acknowledgements": [],
+    }
+    bundle["bundleHash"] = computed_policy_bundle_hash(bundle)
+    bundle["payloadHash"] = payload_hash_for_policy_bundle(bundle)
+    verifier = dict(bundle["verifier"])
+    verifier["signature"] = base64.b64encode(
+        private_key.sign(
+            canonical_policy_bundle_payload(bundle),
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+    ).decode("utf-8")
+    bundle["verifier"] = verifier
+    return bundle, (trusted_key,)
+
+
+def test_hgc073_signed_policy_bundle_rejects_payload_hash_mismatch() -> None:
+    bundle, trusted_keys = _signed_policy_bundle()
+    bundle["payloadHash"] = f"sha256:{'0' * 64}"
+
+    validated_bundle, reason = validated_policy_bundle_payload(
+        bundle,
+        trusted_verification_keys=trusted_keys,
+        anchored_verification_keys=trusted_keys,
+    )
+
+    assert validated_bundle is None
+    assert reason == "payload_hash_mismatch"
+
+
+def test_hgc073_signed_policy_bundle_rejects_invalid_payload_hash() -> None:
+    for payload_hash in (None, "", 123):
+        bundle, trusted_keys = _signed_policy_bundle()
+        bundle["payloadHash"] = payload_hash
+
+        validated_bundle, reason = validated_policy_bundle_payload(
+            bundle,
+            trusted_verification_keys=trusted_keys,
+            anchored_verification_keys=trusted_keys,
+        )
+
+        assert validated_bundle is None
+        assert reason == "payload_hash_invalid"

--- a/tests/test_policy_bundle_integrity.py
+++ b/tests/test_policy_bundle_integrity.py
@@ -84,6 +84,7 @@ def test_hgc073_signed_policy_bundle_rejects_payload_hash_mismatch() -> None:
         bundle,
         trusted_verification_keys=trusted_keys,
         anchored_verification_keys=trusted_keys,
+        expected_workspace_id="workspace-1",
     )
 
     assert validated_bundle is None
@@ -91,7 +92,7 @@ def test_hgc073_signed_policy_bundle_rejects_payload_hash_mismatch() -> None:
 
 
 def test_hgc073_signed_policy_bundle_rejects_invalid_payload_hash() -> None:
-    for payload_hash in (None, "", 123):
+    for payload_hash in (None, "", 123, f" sha256:{'0' * 64}"):
         bundle, trusted_keys = _signed_policy_bundle()
         bundle["payloadHash"] = payload_hash
 
@@ -99,7 +100,8 @@ def test_hgc073_signed_policy_bundle_rejects_invalid_payload_hash() -> None:
             bundle,
             trusted_verification_keys=trusted_keys,
             anchored_verification_keys=trusted_keys,
+            expected_workspace_id="workspace-1",
         )
 
         assert validated_bundle is None
-        assert reason == "payload_hash_invalid"
+        assert reason == "invalid_payload_hash"

--- a/tests/test_policy_bundle_parser.py
+++ b/tests/test_policy_bundle_parser.py
@@ -166,6 +166,35 @@ def test_hgc071_signed_policy_bundle_parses() -> None:
     assert verifier["algorithm"] == "rsa-pss-sha256"
 
 
+def test_hgc073_signed_policy_bundle_rejects_payload_hash_mismatch() -> None:
+    bundle, trusted_keys = _signed_policy_bundle()
+    bundle["payloadHash"] = f"sha256:{'0' * 64}"
+
+    validated_bundle, reason = validated_policy_bundle_payload(
+        bundle,
+        trusted_verification_keys=trusted_keys,
+        anchored_verification_keys=trusted_keys,
+    )
+
+    assert validated_bundle is None
+    assert reason == "payload_hash_mismatch"
+
+
+def test_hgc073_signed_policy_bundle_rejects_invalid_payload_hash() -> None:
+    for payload_hash in (None, "", 123):
+        bundle, trusted_keys = _signed_policy_bundle()
+        bundle["payloadHash"] = payload_hash
+
+        validated_bundle, reason = validated_policy_bundle_payload(
+            bundle,
+            trusted_verification_keys=trusted_keys,
+            anchored_verification_keys=trusted_keys,
+        )
+
+        assert validated_bundle is None
+        assert reason == "payload_hash_invalid"
+
+
 def test_hgc073_signed_policy_bundle_rejects_invalid_signature() -> None:
     bundle, trusted_keys = _signed_policy_bundle()
     verifier = dict(bundle["verifier"]) if isinstance(bundle["verifier"], dict) else {}

--- a/tests/test_policy_bundle_parser.py
+++ b/tests/test_policy_bundle_parser.py
@@ -166,35 +166,6 @@ def test_hgc071_signed_policy_bundle_parses() -> None:
     assert verifier["algorithm"] == "rsa-pss-sha256"
 
 
-def test_hgc073_signed_policy_bundle_rejects_payload_hash_mismatch() -> None:
-    bundle, trusted_keys = _signed_policy_bundle()
-    bundle["payloadHash"] = f"sha256:{'0' * 64}"
-
-    validated_bundle, reason = validated_policy_bundle_payload(
-        bundle,
-        trusted_verification_keys=trusted_keys,
-        anchored_verification_keys=trusted_keys,
-    )
-
-    assert validated_bundle is None
-    assert reason == "payload_hash_mismatch"
-
-
-def test_hgc073_signed_policy_bundle_rejects_invalid_payload_hash() -> None:
-    for payload_hash in (None, "", 123):
-        bundle, trusted_keys = _signed_policy_bundle()
-        bundle["payloadHash"] = payload_hash
-
-        validated_bundle, reason = validated_policy_bundle_payload(
-            bundle,
-            trusted_verification_keys=trusted_keys,
-            anchored_verification_keys=trusted_keys,
-        )
-
-        assert validated_bundle is None
-        assert reason == "payload_hash_invalid"
-
-
 def test_hgc073_signed_policy_bundle_rejects_invalid_signature() -> None:
     bundle, trusted_keys = _signed_policy_bundle()
     verifier = dict(bundle["verifier"]) if isinstance(bundle["verifier"], dict) else {}

--- a/tests/test_policy_document_cli.py
+++ b/tests/test_policy_document_cli.py
@@ -18,6 +18,14 @@ def test_hol_guard_routes_policy_as_a_top_level_command() -> None:
     ) == ["guard", "policy", "validate", "policy.yaml"]
 
 
+def test_hol_guard_routes_policy_export_format_as_a_top_level_command() -> None:
+    assert _resolve_legacy_args(
+        ["policy", "export", "--format", "yaml"],
+        program_mode="combined",
+        program_name="hol-guard",
+    ) == ["guard", "policy", "export", "--format", "yaml"]
+
+
 def test_policy_export_validate_format_and_diff(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     home = tmp_path / "home"
     policy_file = tmp_path / "policy.yaml"
@@ -27,6 +35,8 @@ def test_policy_export_validate_format_and_diff(tmp_path: Path, capsys: pytest.C
             "guard",
             "policy",
             "export",
+            "--format",
+            "yaml",
             "--home",
             str(home),
             "--output",
@@ -75,6 +85,26 @@ def test_policy_export_validate_format_and_diff(tmp_path: Path, capsys: pytest.C
         "broad_relaxing_changes": [],
         "requires_high_risk_approval": False,
     }
+
+
+def test_policy_show_and_explain_active_document(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home = tmp_path / "home"
+
+    show_rc = main(["guard", "policy", "show", "--home", str(home)])
+    shown_policy = capsys.readouterr().out
+    explain_rc = main(["guard", "policy", "explain", "--home", str(home), "--json"])
+    explanation = json.loads(capsys.readouterr().out)
+
+    assert show_rc == 0
+    assert "apiVersion: guard.hashgraphonline.com/v1alpha1" in shown_policy
+    assert explain_rc == 0
+    assert explanation["rules"] == 0
+    assert explanation["compiled_rows"] == 0
+    assert explanation["actions"] == {}
+    assert explanation["scopes"] == {}
 
 
 def test_policy_import_is_feature_gated_and_dry_run_by_default(


### PR DESCRIPTION
## Summary
- complete the canonical policy CLI with `show`, `explain`, and explicit YAML export format support
- fail closed when a signed V1 bundle advertises a malformed or mismatched `payloadHash`
- preserve combined CLI routing for `policy export --format yaml`

## Verification
- `uv run ruff format --check` on changed files
- `uv run ruff check` on changed files
- 128 focused policy tests passed
- reviewer re-check: no residual findings