### PR TITLE
fix(guard): preserve registered executable tamper errors

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/grok_executable.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok_executable.py
@@ -81,11 +81,11 @@ def resolve_trusted_grok_executable(context: HarnessContext) -> GrokExecutableRe
     registered = _registered_executable(context)
     if registered.executable is not None:
         return registered
+    if registered.error is not None:
+        return registered
 
     candidate = _which_grok()
     if candidate is None:
-        if registered.error is not None:
-            return registered
         return GrokExecutableResolution(None, "Grok executable was not found in a trusted installation location.")
     return _resolve_candidate(
         candidate,


### PR DESCRIPTION
## Summary
- preserve saved executable registration errors before considering ambient PATH candidates
- keep changed registered binaries fail-closed with the actionable re-selection message

## Testing
- `uv run pytest -q tests/test_guard_grok_executable_security.py`
- exact CI shard 3 selection: 2,630 passed, 4 skipped, 1 deselected
- `uv run ruff check src/codex_plugin_scanner/guard/adapters/grok_executable.py tests/test_guard_grok_executable_security.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/adapters/grok_executable.py tests/test_guard_grok_executable_security.py`
- `uv run basedpyright src/codex_plugin_scanner/guard/adapters/grok_executable.py`
