### PR TITLE
fix(runtime): calibrate bounded source inspection

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_commands.py
@@ -142,7 +142,7 @@ def _codex_command_parts_are_git_grep(parts: list[str]) -> bool:
     return bool(parts) and Path(parts[0]).name.lower() == "git" and _git_grep_search_args(parts[1:]) is not None
 
 def _codex_command_part_is_local_reader(parts: list[str], index: int, *, cwd: Path | None) -> bool:
-    local_read_commands = {"cat", "grep", "head", "rg", "sed", "tail"}
+    local_read_commands = {"cat", "grep", "head", "nl", "rg", "sed", "tail", "wc", "yq"}
     executable = Path(parts[index]).name.lower()
     if executable not in local_read_commands:
         return False
@@ -209,9 +209,9 @@ def _codex_post_tool_command_texts(payload: dict[str, object]) -> tuple[str, ...
 
 _CODEX_READ_ONLY_SEARCH_COMMANDS = frozenset({"fd", "rg", "grep", "egrep", "fgrep"})
 
-_CODEX_READ_ONLY_VIEW_COMMANDS = frozenset({"cat", "head", "tail", "sed"})
+_CODEX_READ_ONLY_VIEW_COMMANDS = frozenset({"cat", "head", "nl", "tail", "sed", "wc", "yq"})
 
-_CODEX_READ_ONLY_PIPE_FILTERS = frozenset({"head", "tail", "sed"})
+_CODEX_READ_ONLY_PIPE_FILTERS = frozenset({"head", "nl", "tail", "sed", "wc"})
 
 _CODEX_READ_ONLY_SEARCH_WRAPPERS = frozenset({"bash", "sh", "zsh"})
 

--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_reads.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_reads.py
@@ -53,6 +53,15 @@ def _codex_source_inspection_target_tokens(parts: list[str]) -> tuple[str, ...]:
         if executable in {"head", "tail"}:
             targets, valid, skip_next = _parse_codex_head_tail_args(args)
             return tuple(targets) if valid and not skip_next else ()
+        if executable == "nl":
+            targets = _codex_nl_targets(args)
+            return targets if targets is not None else ()
+        if executable == "wc":
+            targets = _codex_wc_targets(args)
+            return targets if targets is not None else ()
+        if executable == "yq":
+            parsed = _codex_yq_expression_and_targets(args)
+            return parsed[1] if parsed is not None else ()
         return tuple(_codex_cat_targets(args))
     if executable in _CODEX_READ_ONLY_SEARCH_COMMANDS:
         if executable == "fd":
@@ -225,8 +234,17 @@ def _split_codex_safe_read_only_chain(command: str) -> list[str] | None:
             index += 2
             start = index
             continue
-        if command.startswith("||", index) or char in {";", "&"}:
+        if command.startswith("||", index) or char == "&":
             return None
+        if char == ";":
+            segment = command[start:index].strip()
+            if not segment or command.startswith(";;", index):
+                return None
+            segments.append(segment)
+            found_chain = True
+            index += 1
+            start = index
+            continue
         index += 1
     if quote is not None or escaped or not found_chain:
         return None
@@ -395,6 +413,10 @@ def _codex_command_is_bounded_read_only_filter(command_text: str) -> bool:
         return False
     if executable == "sed":
         return _codex_sed_args_are_bounded_filter(parts[1:])
+    if executable == "nl":
+        return _codex_nl_targets(parts[1:]) == ()
+    if executable == "wc":
+        return _codex_wc_targets(parts[1:]) == ()
     return _codex_head_tail_args_are_bounded_filter(parts[1:])
 
 
@@ -424,7 +446,164 @@ def _codex_command_is_read_only_source_view(
         return _codex_sed_targets_are_read_only_source_like(parts[1:], cwd=cwd, home_dir=home_dir)
     if executable in {"head", "tail"}:
         return _codex_head_tail_targets_are_source_like(parts[1:], cwd=cwd, home_dir=home_dir)
+    if executable == "nl":
+        targets = _codex_nl_targets(parts[1:])
+        return (
+            targets is not None
+            and bool(targets)
+            and all(_codex_search_target_is_source_like(target, cwd=cwd, home_dir=home_dir) for target in targets)
+        )
+    if executable == "wc":
+        targets = _codex_wc_targets(parts[1:])
+        return (
+            targets is not None
+            and bool(targets)
+            and all(_codex_search_target_is_source_like(target, cwd=cwd, home_dir=home_dir) for target in targets)
+        )
+    if executable == "yq":
+        parsed = _codex_yq_expression_and_targets(parts[1:])
+        return parsed is not None and all(
+            _codex_search_target_is_source_like(target, cwd=cwd, home_dir=home_dir) for target in parsed[1]
+        )
     return _codex_cat_targets_are_source_like(parts[1:], cwd=cwd, home_dir=home_dir)
+
+
+_CODEX_NL_VALUE_OPTIONS = frozenset(
+    {
+        "-b",
+        "--body-numbering",
+        "-d",
+        "--section-delimiter",
+        "-f",
+        "--footer-numbering",
+        "-h",
+        "--header-numbering",
+        "-i",
+        "--line-increment",
+        "-l",
+        "--join-blank-lines",
+        "-n",
+        "--number-format",
+        "-s",
+        "--number-separator",
+        "-v",
+        "--starting-line-number",
+        "-w",
+        "--number-width",
+    }
+)
+
+_CODEX_WC_BOOLEAN_OPTIONS = frozenset(
+    {"-c", "--bytes", "-m", "--chars", "-l", "--lines", "-L", "--max-line-length", "-w", "--words"}
+)
+
+_CODEX_YQ_BOOLEAN_OPTIONS = frozenset(
+    {
+        "-C",
+        "--colors",
+        "-e",
+        "--exit-status",
+        "-M",
+        "--no-colors",
+        "-N",
+        "--no-doc",
+        "-n",
+        "--null-input",
+        "-P",
+        "--prettyPrint",
+        "-r",
+        "--unwrapScalar",
+    }
+)
+
+_CODEX_YQ_VALUE_OPTIONS = frozenset({"-I", "--indent", "-o", "--output-format"})
+
+_CODEX_YQ_EXTERNAL_READ_PATTERN = re.compile(
+    r"(?i)(?:\$ENV(?:\.|\b)|(?:^|[^A-Za-z0-9_])(?:env|strenv|envsubst|eval|load(?:_[A-Za-z0-9_]+)?)\s*\()"
+)
+
+
+def _codex_nl_targets(args: list[str]) -> tuple[str, ...] | None:
+    targets: list[str] = []
+    skip_value = False
+    after_options = False
+    for arg in args:
+        if skip_value:
+            skip_value = False
+            continue
+        if after_options:
+            targets.append(arg)
+            continue
+        if arg == "--":
+            after_options = True
+            continue
+        if arg in _CODEX_NL_VALUE_OPTIONS:
+            skip_value = True
+            continue
+        if any(arg.startswith(f"{option}=") for option in _CODEX_NL_VALUE_OPTIONS if option.startswith("--")):
+            continue
+        if re.fullmatch(r"-[bdfhilnsvw].+", arg):
+            continue
+        if arg == "-" or arg.startswith("-"):
+            return None
+        targets.append(arg)
+    if skip_value or len(targets) > 1:
+        return None
+    return tuple(targets)
+
+
+def _codex_wc_targets(args: list[str]) -> tuple[str, ...] | None:
+    targets: list[str] = []
+    after_options = False
+    for arg in args:
+        if after_options:
+            targets.append(arg)
+            continue
+        if arg == "--":
+            after_options = True
+            continue
+        if arg in _CODEX_WC_BOOLEAN_OPTIONS or re.fullmatch(r"-[cmlLw]+", arg):
+            continue
+        if arg == "-" or arg.startswith("-"):
+            return None
+        targets.append(arg)
+    return tuple(targets)
+
+
+def _codex_yq_expression_and_targets(args: list[str]) -> tuple[str, tuple[str, ...]] | None:
+    positional: list[str] = []
+    skip_value = False
+    after_options = False
+    for arg in args:
+        if skip_value:
+            skip_value = False
+            continue
+        if after_options:
+            positional.append(arg)
+            continue
+        if arg == "--":
+            after_options = True
+            continue
+        if arg in _CODEX_YQ_BOOLEAN_OPTIONS:
+            continue
+        if arg in _CODEX_YQ_VALUE_OPTIONS:
+            skip_value = True
+            continue
+        if any(arg.startswith(f"{option}=") for option in _CODEX_YQ_VALUE_OPTIONS if option.startswith("--")):
+            continue
+        if re.fullmatch(r"-(?:I\d+|o(?:json|props|xml|yaml))", arg):
+            continue
+        if arg.startswith("-"):
+            return None
+        positional.append(arg)
+    if skip_value or len(positional) < 2:
+        return None
+    expression, *targets = positional
+    if not expression.startswith(".") or _CODEX_YQ_EXTERNAL_READ_PATTERN.search(expression):
+        return None
+    if any(target == "-" for target in targets):
+        return None
+    return expression, tuple(targets)
 
 
 def _codex_command_is_read_only_source_search(

--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_reads.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_reads.py
@@ -599,7 +599,11 @@ def _codex_yq_expression_and_targets(args: list[str]) -> tuple[str, tuple[str, .
     if skip_value or len(positional) < 2:
         return None
     expression, *targets = positional
-    if not expression.startswith(".") or _CODEX_YQ_EXTERNAL_READ_PATTERN.search(expression):
+    if (
+        not expression.startswith(".")
+        or any(marker in expression for marker in ("#", "\n", "\r"))
+        or _CODEX_YQ_EXTERNAL_READ_PATTERN.search(expression)
+    ):
         return None
     if any(target == "-" for target in targets):
         return None

--- a/src/codex_plugin_scanner/guard/runtime/source_paths.py
+++ b/src/codex_plugin_scanner/guard/runtime/source_paths.py
@@ -50,6 +50,17 @@ _EXTERNAL_SOURCE_SENSITIVE_PARTS = _SENSITIVE_SEARCH_BASENAMES | frozenset(
 )
 _SOURCE_SEARCH_PREFIXES = tuple(f"{part}/" for part in sorted(SOURCE_INSPECTION_PARTS))
 _SOURCE_SEARCH_EXTENSIONS = SOURCE_INSPECTION_EXTENSIONS
+_WORKFLOW_SOURCE_PREFIX = (".github", "workflows")
+
+
+def _hidden_parts_are_allowed_source(parts: list[str]) -> bool:
+    hidden_parts = [part for part in parts if part.startswith(".")]
+    if not hidden_parts:
+        return True
+    if all(part in _BENIGN_SOURCE_DOTFILES for part in hidden_parts):
+        return True
+    has_workflow_prefix = any(tuple(parts[index : index + 2]) == _WORKFLOW_SOURCE_PREFIX for index in range(len(parts)))
+    return has_workflow_prefix and hidden_parts == [".github"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -254,8 +265,7 @@ def source_path_is_allowed(
                 _external_source_filename_is_sensitive(candidate)
             ):
                 return SourcePathDecision(allowed=False, reason_code="sensitive_basename")
-            hidden_parts = [part for part in lowered_parts if part.startswith(".")]
-            if hidden_parts and not all(part in _BENIGN_SOURCE_DOTFILES for part in hidden_parts):
+            if not _hidden_parts_are_allowed_source(lowered_parts):
                 return SourcePathDecision(allowed=False, reason_code="unsafe_hidden_dir")
             normalized = "/".join(parts)
             if not (
@@ -301,8 +311,7 @@ def source_path_is_allowed(
     if any(part in _SENSITIVE_SEARCH_BASENAMES for part in lowered_parts):
         return SourcePathDecision(allowed=False, reason_code="sensitive_basename")
 
-    hidden_parts = [part for part in lowered_parts if part.startswith(".")]
-    if hidden_parts and not all(part in _BENIGN_SOURCE_DOTFILES for part in hidden_parts):
+    if not _hidden_parts_are_allowed_source(lowered_parts):
         return SourcePathDecision(allowed=False, reason_code="unsafe_hidden_dir")
 
     normalized = "/".join(parts)
@@ -362,8 +371,7 @@ def absolute_source_target_is_source_like(target_path: Path) -> bool:
     lowered_parts = [part.lower() for part in parts]
     if any(part in _SENSITIVE_SEARCH_BASENAMES for part in lowered_parts):
         return False
-    hidden_parts = [part for part in lowered_parts if part.startswith(".")]
-    if hidden_parts and not all(part in _BENIGN_SOURCE_DOTFILES for part in hidden_parts):
+    if not _hidden_parts_are_allowed_source(lowered_parts):
         return False
     normalized = "/".join(parts)
     if any(f"/{prefix}" in f"/{normalized}" for prefix in _SOURCE_SEARCH_PREFIXES):

--- a/tests/test_command_keys_and_uri_schemes.py
+++ b/tests/test_command_keys_and_uri_schemes.py
@@ -232,6 +232,7 @@ def test_semicolon_chain_requires_every_segment_to_be_read_only(tmp_path):
         "yq -i '.jobs' .github/workflows/publish.yml",
         "yq --inplace '.jobs' .github/workflows/publish.yml",
         "yq 'load(\"src/example.ts\")' .github/workflows/publish.yml",
+        "yq '.jobs | load_str # comment\n(\"src/example.ts\")' .github/workflows/publish.yml",
         "yq 'eval(\".jobs\")' .github/workflows/publish.yml",
         "yq 'strenv(API_TOKEN)' .github/workflows/publish.yml",
         "yq --from-file src/expression.txt .github/workflows/publish.yml",

--- a/tests/test_command_keys_and_uri_schemes.py
+++ b/tests/test_command_keys_and_uri_schemes.py
@@ -6,8 +6,11 @@ Verifies:
 3. _read_only_lookup_filter_grep_args_are_safe distinguishes patterns from file operands
 """
 
+import pytest
+
 from codex_plugin_scanner.guard.cli._commands_shared import _hook_command_text
 from codex_plugin_scanner.guard.cli.commands_support_codex_commands import (
+    _codex_command_is_read_only_source_inspection,
     _codex_post_tool_command_texts,
 )
 from codex_plugin_scanner.guard.cli.commands_support_native_search import native_post_tool_search_is_read_only
@@ -148,6 +151,109 @@ def test_native_grep_rejects_wildcard_target(tmp_path):
     }
 
     assert native_post_tool_search_is_read_only(payload=payload, cwd=None, home_dir=None) is False
+
+
+def test_yq_environment_lookup_is_not_read_only_source_inspection(tmp_path):
+    workflow = tmp_path / ".github" / "workflows" / "publish.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("jobs: {}\n", encoding="utf-8")
+
+    assert (
+        _codex_command_is_read_only_source_inspection(
+            "yq 'env(API_TOKEN)' .github/workflows/publish.yml",
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is False
+    )
+
+    assert (
+        _codex_command_is_read_only_source_inspection(
+            "yq '.value // $ENV.API_TOKEN' .github/workflows/publish.yml",
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is False
+    )
+
+
+def test_common_readers_are_read_only_source_inspection(tmp_path):
+    source_file = tmp_path / "src" / "example.ts"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("export const value = 1;\n", encoding="utf-8")
+    workflow = tmp_path / ".github" / "workflows" / "publish.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("jobs: {}\n", encoding="utf-8")
+
+    commands = (
+        "rg -n 'value' src/example.ts; sed -n '1,20p' src/example.ts",
+        "nl -ba src/example.ts | sed -n '1,20p'",
+        "wc -l src/example.ts",
+        "yq '.jobs' .github/workflows/publish.yml",
+    )
+
+    for command in commands:
+        assert _codex_command_is_read_only_source_inspection(
+            command,
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+
+
+def test_semicolon_chain_requires_every_segment_to_be_read_only(tmp_path):
+    source_file = tmp_path / "src" / "example.ts"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("export const value = 1;\n", encoding="utf-8")
+
+    assert (
+        _codex_command_is_read_only_source_inspection(
+            "sed -n '1,20p' src/example.ts; rm src/example.ts",
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "rg -n value src/example.ts; cat .env",
+        "rg -n value src/example.ts; curl https://example.test",
+        "rg -n value src/example.ts || sed -n '1,20p' src/example.ts",
+        "rg -n value src/example.ts & sed -n '1,20p' src/example.ts",
+        "rg -n value src/example.ts > output.txt",
+        'rg -n "$(printenv API_TOKEN)" src/example.ts',
+        "./nl -ba src/example.ts",
+        "./wc -l src/example.ts",
+        "nl -ba .env",
+        "wc -l .env",
+        "wc --files0-from=src/files.txt",
+        "yq -i '.jobs' .github/workflows/publish.yml",
+        "yq --inplace '.jobs' .github/workflows/publish.yml",
+        "yq 'load(\"src/example.ts\")' .github/workflows/publish.yml",
+        "yq 'eval(\".jobs\")' .github/workflows/publish.yml",
+        "yq 'strenv(API_TOKEN)' .github/workflows/publish.yml",
+        "yq --from-file src/expression.txt .github/workflows/publish.yml",
+        "yq '.jobs' -",
+    ),
+)
+def test_common_reader_unsafe_variants_are_not_source_inspection(tmp_path, command):
+    source_file = tmp_path / "src" / "example.ts"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text("export const value = 1;\n", encoding="utf-8")
+    (tmp_path / "src" / "files.txt").write_text("src/example.ts\n", encoding="utf-8")
+    (tmp_path / "src" / "expression.txt").write_text(".jobs\n", encoding="utf-8")
+    (tmp_path / ".env").write_text("API_TOKEN=fixture\n", encoding="utf-8")
+    workflow = tmp_path / ".github" / "workflows" / "publish.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("jobs: {}\n", encoding="utf-8")
+
+    assert not _codex_command_is_read_only_source_inspection(
+        command,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
 
 
 def test_command_from_payload_preserves_command_priority():

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1555,6 +1555,107 @@ clearer UX and an implementation plan with technical references.
         assert output["recorded"] is True
         assert "approval_requests" not in output
 
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "rg -n 'SMTP_TOKEN' src/example.ts; sed -n '1,20p' src/example.ts",
+            "nl -ba src/example.ts | sed -n '1,20p'",
+            "wc -l src/example.ts; sed -n '1,20p' src/example.ts",
+            ("yq '.jobs.build.steps[] | select(.name == \"Compute publish version\")' .github/workflows/publish.yml"),
+        ),
+    )
+    def test_codex_post_tool_use_allows_common_read_only_source_inspection(
+        self,
+        command,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        _write_text(workspace_dir / "src" / "example.ts", "const SMTP_TOKEN = process.env.SMTP_TOKEN;\n")
+        _write_text(
+            workspace_dir / ".github" / "workflows" / "publish.yml",
+            "jobs:\n  build:\n    steps:\n      - name: Compute publish version\n",
+        )
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {"stdout": "const SMTP_TOKEN = process.env.SMTP_TOKEN;\n"},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recorded"] is True
+        assert "approval_requests" not in output
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "sed -n '1,20p' src/example.ts; rm src/example.ts",
+            "nl -ba .env",
+        ),
+    )
+    def test_codex_post_tool_use_keeps_unsafe_source_inspection_guarded(
+        self,
+        command,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        _write_text(workspace_dir / "src" / "example.ts", "const SMTP_TOKEN = process.env.SMTP_TOKEN;\n")
+        _write_text(workspace_dir / ".github" / "workflows" / "publish.yml", "jobs: {}\n")
+        _write_text(workspace_dir / ".env", "API_TOKEN=fixture-only\n")
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {"stdout": "API_TOKEN=fixture-only\n"},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "tool_action_request"
+        assert output["policy_action"] in {"block", "require-reapproval"}
+        assert output["approval_requests"]
+
     def test_codex_post_tool_use_allows_absolute_source_view_with_secret_like_output(
         self,
         monkeypatch,
@@ -22903,10 +23004,22 @@ def test_codex_read_only_source_inspection_allows_tilde_worktree_targets(tmp_pat
     assert artifact is None
 
 
-def test_codex_read_only_source_inspection_still_blocks_value_like_secret_output(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "command",
+    (
+        "rg -n \"token\" src | sed -n '1,40p'",
+        "nl -ba src/config.ts | sed -n '1,40p'",
+        "wc -l src/config.ts; sed -n '1,40p' src/config.ts",
+        "yq '.jobs' .github/workflows/publish.yml",
+    ),
+)
+def test_codex_read_only_source_inspection_still_blocks_value_like_secret_output(
+    command: str,
+    tmp_path: Path,
+) -> None:
     workspace_dir = tmp_path / "workspace"
     _write_text(workspace_dir / "src" / "config.ts", "export const label = 'token';\n")
-    command = "rg -n \"token\" src | sed -n '1,40p'"
+    _write_text(workspace_dir / ".github" / "workflows" / "publish.yml", "jobs: {}\n")
 
     artifact = guard_commands_module._codex_post_tool_output_artifact(
         payload={
@@ -23545,7 +23658,7 @@ def test_codex_read_only_source_inspection_rejects_malformed_chains(tmp_path: Pa
         "sed -n '1,10p' src/safe.ts &&",
         "sed -n '1,10p' src/safe.ts && && cat src/safe.ts",
         "sed -n '1,10p' src/safe.ts || cat src/safe.ts",
-        "sed -n '1,10p' src/safe.ts; cat src/safe.ts",
+        "sed -n '1,10p' src/safe.ts;; cat src/safe.ts",
     ]
 
     for command in commands:

--- a/tests/test_hook_source_paths.py
+++ b/tests/test_hook_source_paths.py
@@ -93,6 +93,50 @@ class TestSourcePathIsAllowed:
         assert not decision.allowed
         assert decision.reason_code == "unsafe_hidden_dir"
 
+    def test_workflow_source_file_allowed(self, workspace: Path, home_dir: Path) -> None:
+        workflow = workspace / ".github" / "workflows" / "publish.yml"
+        workflow.parent.mkdir(parents=True)
+        workflow.write_text("jobs: {}\n")
+
+        decision = source_path_is_allowed(
+            ".github/workflows/publish.yml",
+            cwd=workspace,
+            home_dir=home_dir,
+        )
+
+        assert decision.allowed
+        assert decision.reason_code == "source_extension"
+
+    def test_other_hidden_github_source_file_rejected(self, workspace: Path, home_dir: Path) -> None:
+        hidden_source = workspace / ".github" / "private" / "config.yml"
+        hidden_source.parent.mkdir(parents=True)
+        hidden_source.write_text("token: fixture\n")
+
+        decision = source_path_is_allowed(
+            ".github/private/config.yml",
+            cwd=workspace,
+            home_dir=home_dir,
+        )
+
+        assert not decision.allowed
+        assert decision.reason_code == "unsafe_hidden_dir"
+
+    def test_workflow_source_symlink_rejected(self, workspace: Path, home_dir: Path, tmp_path: Path) -> None:
+        outside = tmp_path / "outside.yml"
+        outside.write_text("token: fixture\n")
+        workflow = workspace / ".github" / "workflows" / "publish.yml"
+        workflow.parent.mkdir(parents=True)
+        workflow.symlink_to(outside)
+
+        decision = source_path_is_allowed(
+            ".github/workflows/publish.yml",
+            cwd=workspace,
+            home_dir=home_dir,
+        )
+
+        assert not decision.allowed
+        assert decision.reason_code == "symlink_in_path"
+
     def test_benign_dotfile_allowed(self, workspace: Path, home_dir: Path) -> None:
         (workspace / ".nvmrc").write_text("20")
         decision = source_path_is_allowed(".nvmrc", cwd=workspace, home_dir=home_dir)
@@ -132,9 +176,7 @@ class TestSourcePathIsAllowed:
         assert decision.allowed
         assert decision.reason_code == "external_source_path"
 
-    def test_external_source_path_under_sibling_git_directory_allowed(
-        self, workspace: Path, home_dir: Path
-    ) -> None:
+    def test_external_source_path_under_sibling_git_directory_allowed(self, workspace: Path, home_dir: Path) -> None:
         source_root = home_dir / "sibling-repository"
         source_file = (source_root / "src" / "main.py").resolve()
         source_file.parent.mkdir(parents=True)
@@ -170,9 +212,7 @@ class TestSourcePathIsAllowed:
         assert not decision.allowed
         assert decision.reason_code == "external_target_not_sibling_git_checkout"
 
-    def test_external_source_path_outside_home_rejected(
-        self, workspace: Path, home_dir: Path, tmp_path: Path
-    ) -> None:
+    def test_external_source_path_outside_home_rejected(self, workspace: Path, home_dir: Path, tmp_path: Path) -> None:
         source_file = (tmp_path / "outside-home" / "scripts" / "guard-test").resolve()
         source_file.parent.mkdir(parents=True)
         source_file.write_text("#!/bin/sh\n")
@@ -187,9 +227,7 @@ class TestSourcePathIsAllowed:
         assert not decision.allowed
         assert decision.reason_code == "external_target_outside_home"
 
-    def test_external_source_path_without_home_rejected(
-        self, workspace: Path, home_dir: Path
-    ) -> None:
+    def test_external_source_path_without_home_rejected(self, workspace: Path, home_dir: Path) -> None:
         source_file = (home_dir / "sibling-source" / "scripts" / "guard-test").resolve()
         source_file.parent.mkdir(parents=True)
         source_file.write_text("#!/bin/sh\n")
@@ -302,9 +340,7 @@ class TestSourcePathIsAllowed:
         assert decision.allowed
         assert decision.reason_code == "external_source_path"
 
-    def test_external_symlinked_source_path_rejected(
-        self, workspace: Path, home_dir: Path, tmp_path: Path
-    ) -> None:
+    def test_external_symlinked_source_path_rejected(self, workspace: Path, home_dir: Path, tmp_path: Path) -> None:
         source_root = (home_dir / "sibling-source").resolve()
         real_file = source_root / "scripts" / "guard-test"
         real_file.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- recognize bounded source-view commands and independently safe read chains
- permit workflow source inspection while rejecting environment and external reads
- preserve review for hidden targets, mutations, and high-confidence secret output

## Verification
- 119 parser and source-path tests
- 84 post-tool runtime tests
- built-wheel hook verification
- isolated Guard CLI hook verification