### PR TITLE
feat(guard): define command activity contracts

### DIFF
--- a/docs/guard/command-activity-privacy.md
+++ b/docs/guard/command-activity-privacy.md
@@ -1,0 +1,111 @@
+# Command Activity Privacy Contract
+
+## Scope
+
+Command activity is a local security-evidence domain. It records bounded facts about Guard decisions and proof,
+not command content. It is separate from receipts, matcher diagnostics, and command identities because those domains
+may contain user input.
+
+The default egress mode is `local_only`. Optional cloud egress accepts only rare-cell-suppressed daily aggregate
+counts through a separate type. Local activity rows, match rows, correlation handles, and receipt links cannot enter
+that type.
+
+## Lifecycle
+
+One logical activity row represents one command evaluation. A pre-hook row is created transactionally and moves
+from `attempted` to exactly one of:
+
+- `prevented`
+- `allowed_unconfirmed`
+
+When a permitted command later supplies strongly correlated native post-hook evidence, the same logical row may move
+from `allowed_unconfirmed` to `confirmed_success` or `confirmed_failure`. `prevented` is terminal. Replayed identical
+updates are idempotent; conflicting or out-of-order outcomes fail closed.
+
+A post hook without a strong request correlation produces `unpaired_post`. It cannot invent a policy decision,
+match, prompt, receipt, parse result, or controlling rule. Session-only correlation never proves execution.
+
+Inspection-only operations do not create command activity.
+
+## Stored Facts
+
+The versioned local schema permits only:
+
+- Opaque activity and optional receipt references
+- Canonical harness, phase, status, proof, action, and bounded reason values
+- Typed parse confidence and uncertainty classes
+- Prompt and approval-reuse states
+- Local keyed request/session correlation handles
+- Bounded evaluation and persistence latency buckets
+- Built-in extension/rule identities, versions, safe-variant outcomes, severity, floors, and effect classes
+
+Multi-rule commands produce one activity row and ordered match rows. A safe variant has its own analytics class and
+is never projected as unsafe. An unmatched ordinary command may have zero match rows and cannot name a controlling
+rule.
+
+Review-or-stronger decisions require a linked receipt reference. Analytics does not copy the receipt payload.
+
+## Forbidden Data
+
+The activity domain must never store, expose, log, or export:
+
+- Raw or normalized commands, arguments, shell fragments, substitutions, heredocs, or redirects
+- Paths, current directories, workspace or repository names, owners, remotes, hosts, or URLs
+- Package names or sources
+- Environment names or values
+- Matcher evidence or free-form reason text containing user input
+- Credentials, tokens, secrets, clipboard contents, or exception messages
+- Raw harness request or session identifiers
+- Installation identifiers or stable device identifiers
+- Command security identities, artifact hashes, fingerprints, reversible encodings, or unsalted hashes of forbidden data
+- Arbitrary metadata dictionaries
+
+Positive field allowlists and closed typed values enforce this boundary. Redaction is not sufficient.
+
+## Correlation
+
+Correlation requires a native unpredictable identifier attested by the harness adapter. Counters, timestamps,
+commands, digests of commands, and fallback IDs are not strong identifiers.
+
+Each installation uses an independent random key containing at least 32 bytes. Later persistence wiring must store
+that key through the protected local secret backend with restrictive access. It must not reuse an authentication,
+policy-integrity, dashboard, device, or installation key.
+
+The local handle is HMAC-SHA-256 over length-framed values:
+
+1. Correlation contract version
+2. Activity schema version
+3. Non-secret key rotation ID
+4. Canonical harness
+5. Identifier kind (`request` or `session`)
+6. Exact native identifier
+
+The raw identifier remains ephemeral. Handles are pseudonymous, not anonymous, and remain local. Key rotation creates
+a new correlation domain and cannot reinterpret old rows.
+
+## Cloud Boundary
+
+Cloud egress requires explicit `aggregate_only` opt-in. Its type contains exactly:
+
+- UTC calendar day
+- One bounded dimension
+- One value validated against that dimension's authoritative vocabulary
+- Integer count
+- Aggregate schema version
+
+Allowed dimensions are total, harness, built-in extension, built-in rule, disposition, execution status, prompt
+status, proof level, and latency bucket. A record carries only one dimension, preventing arbitrary multidimensional
+slices. Cells below the fixed privacy threshold are rejected.
+
+Cloud payloads cannot contain activity, receipt, correlation, installation, or device identifiers; exact timestamps;
+free-form text; local versions; or per-command rows. Creating local activity has no network callback. Later cloud
+transport must accept only the aggregate type and must reject unexpected or nested fields recursively.
+
+## Failure Model
+
+Activity persistence and aggregation failures never change Guard's enforcement result. Later wiring must increment
+bounded dropped-event or error counters and expose degraded evidence health without including user input.
+
+Tests must continue to cover the exhaustive phase/status/proof matrix, transitions, receipt requirements,
+safe-variant projection, schema drift, HMAC separation and rotation, forbidden-field canaries, cloud allowlists,
+rare-cell suppression, and enforcement independence from analytics failures.

--- a/src/codex_plugin_scanner/guard/runtime/command_activity_contract.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_activity_contract.py
@@ -1,0 +1,401 @@
+"""Versioned, privacy-safe contracts for local command activity evidence."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field, fields
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Final, cast
+
+from codex_plugin_scanner.guard.action_lattice import guard_action_severity, is_guard_action
+from codex_plugin_scanner.guard.adapters.contracts import HARNESS_CONTRACTS
+from codex_plugin_scanner.guard.models import GuardAction
+
+from .effect_contract import EffectKind, UncertaintyKind
+from .extension_evidence import EvidenceSeverity, ExtensionRuleIdentity
+
+COMMAND_ACTIVITY_SCHEMA_VERSION: Final = "1.0.0"
+_OPAQUE_ID: Final[re.Pattern[str]] = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+_STABLE_ID: Final[re.Pattern[str]] = re.compile(r"[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*")
+COMMAND_ACTIVITY_HARNESSES: Final = frozenset(contract.harness for contract in HARNESS_CONTRACTS)
+
+
+class CommandHookPhase(str, Enum):
+    PRE = "pre"
+    POST_SUCCESS = "post_success"
+    POST_FAILURE = "post_failure"
+
+
+class CommandExecutionStatus(str, Enum):
+    ATTEMPTED = "attempted"
+    PREVENTED = "prevented"
+    ALLOWED_UNCONFIRMED = "allowed_unconfirmed"
+    CONFIRMED_SUCCESS = "confirmed_success"
+    CONFIRMED_FAILURE = "confirmed_failure"
+    UNPAIRED_POST = "unpaired_post"
+
+
+class CommandProofLevel(str, Enum):
+    PRE_HOOK = "pre_hook"
+    POST_HOOK = "post_hook"
+    UNPAIRED_POST = "unpaired_post"
+
+
+class ActivityParseConfidence(str, Enum):
+    EXACT = "exact"
+    FALLBACK = "fallback"
+    UNCERTAIN = "uncertain"
+
+
+class ActivityDecisionReason(str, Enum):
+    NO_MATCH = "no_match"
+    EXTENSION_MATCH = "extension_match"
+    UNCERTAINTY = "uncertainty"
+    POLICY = "policy"
+    APPROVAL_REUSE = "approval_reuse"
+    CONTAINMENT = "containment"
+    CAPABILITY = "capability"
+
+
+class ActivityApprovalReuseStatus(str, Enum):
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    NOT_APPLICABLE = "not-applicable"
+
+
+class ReceiptLinkStatus(str, Enum):
+    NOT_APPLICABLE = "not_applicable"
+    LINKED = "linked"
+
+
+class ActivityMatchClass(str, Enum):
+    UNSAFE = "unsafe"
+    SAFE_VARIANT = "safe_variant"
+    UNCERTAINTY = "uncertainty"
+
+
+class ActivityLatencyBucket(str, Enum):
+    NOT_MEASURED = "not_measured"
+    LE_1_MS = "le_1_ms"
+    LE_2_MS = "le_2_ms"
+    LE_5_MS = "le_5_ms"
+    LE_10_MS = "le_10_ms"
+    LE_20_MS = "le_20_ms"
+    LE_50_MS = "le_50_ms"
+    LE_100_MS = "le_100_ms"
+    GT_100_MS = "gt_100_ms"
+
+
+class CorrelationKind(str, Enum):
+    REQUEST = "request"
+    SESSION = "session"
+
+
+@dataclass(frozen=True, slots=True)
+class CorrelationHandle:
+    """A local keyed handle. It is pseudonymous and must never leave the device."""
+
+    kind: CorrelationKind
+    harness: str
+    key_id: str
+    digest: str = field(repr=False)
+
+    def __post_init__(self) -> None:
+        _require_enum(self.kind, CorrelationKind, "kind")
+        _require_stable_id(self.harness, "harness")
+        _require_stable_id(self.key_id, "key_id")
+        if not isinstance(cast(object, self.digest), str) or re.fullmatch(r"[0-9a-f]{64}", self.digest) is None:
+            raise ValueError("digest must be a 256-bit lowercase hexadecimal HMAC")
+
+
+@dataclass(frozen=True, slots=True)
+class CommandActivity:
+    """One logical command row updated through the allowed lifecycle."""
+
+    activity_id: str
+    occurred_at: datetime
+    harness: str
+    hook_phase: CommandHookPhase
+    execution_status: CommandExecutionStatus
+    proof_level: CommandProofLevel
+    policy_action: GuardAction | None
+    decision_reason_code: ActivityDecisionReason | None
+    controlling_rule_id: str | None
+    parse_confidence: ActivityParseConfidence | None
+    uncertainty_class: UncertaintyKind | None
+    match_count: int
+    prompted: bool
+    approval_reuse_status: ActivityApprovalReuseStatus
+    request_correlation: CorrelationHandle | None
+    session_correlation: CorrelationHandle | None
+    receipt_link_status: ReceiptLinkStatus
+    receipt_id: str | None
+    evaluation_latency_bucket: ActivityLatencyBucket
+    persistence_latency_bucket: ActivityLatencyBucket
+    schema_version: str = COMMAND_ACTIVITY_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _require_opaque_id(self.activity_id, "activity_id")
+        _require_utc_datetime(self.occurred_at)
+        _require_stable_id(self.harness, "harness")
+        _require_enum(self.hook_phase, CommandHookPhase, "hook_phase")
+        _require_enum(self.execution_status, CommandExecutionStatus, "execution_status")
+        _require_enum(self.proof_level, CommandProofLevel, "proof_level")
+        _require_optional_guard_action(self.policy_action)
+        if self.decision_reason_code is not None:
+            _require_enum(self.decision_reason_code, ActivityDecisionReason, "decision_reason_code")
+        _require_optional_stable_id(self.controlling_rule_id, "controlling_rule_id")
+        if self.parse_confidence is not None:
+            _require_enum(self.parse_confidence, ActivityParseConfidence, "parse_confidence")
+        if self.uncertainty_class is not None:
+            _require_enum(self.uncertainty_class, UncertaintyKind, "uncertainty_class")
+        if type(self.match_count) is not int or self.match_count < 0:
+            raise ValueError("match_count must be a non-negative integer")
+        if type(self.prompted) is not bool:
+            raise ValueError("prompted must be a boolean")
+        _require_enum(self.approval_reuse_status, ActivityApprovalReuseStatus, "approval_reuse_status")
+        _require_optional_correlation(self.request_correlation, CorrelationKind.REQUEST, self.harness)
+        _require_optional_correlation(self.session_correlation, CorrelationKind.SESSION, self.harness)
+        _require_enum(self.receipt_link_status, ReceiptLinkStatus, "receipt_link_status")
+        if self.receipt_id is not None:
+            _require_opaque_id(self.receipt_id, "receipt_id")
+        _require_enum(self.evaluation_latency_bucket, ActivityLatencyBucket, "evaluation_latency_bucket")
+        _require_enum(self.persistence_latency_bucket, ActivityLatencyBucket, "persistence_latency_bucket")
+        _require_schema_version(self.schema_version)
+        _validate_activity_state(self)
+
+
+@dataclass(frozen=True, slots=True)
+class CommandActivityMatch:
+    activity_id: str
+    ordinal: int
+    identity: ExtensionRuleIdentity
+    match_class: ActivityMatchClass
+    severity: EvidenceSeverity
+    default_floor: GuardAction
+    effect_claims: frozenset[EffectKind]
+    safe_variant_id: str | None = None
+    schema_version: str = COMMAND_ACTIVITY_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        _require_opaque_id(self.activity_id, "activity_id")
+        if type(self.ordinal) is not int or self.ordinal < 0:
+            raise ValueError("ordinal must be a non-negative integer")
+        if not isinstance(cast(object, self.identity), ExtensionRuleIdentity):
+            raise ValueError("identity must be an ExtensionRuleIdentity")
+        _require_enum(self.match_class, ActivityMatchClass, "match_class")
+        _require_enum(self.severity, EvidenceSeverity, "severity")
+        if not is_guard_action(self.default_floor):
+            raise ValueError("default_floor must be a canonical GuardAction")
+        if not isinstance(cast(object, self.effect_claims), frozenset) or not self.effect_claims:
+            raise ValueError("effect_claims must be a non-empty frozenset")
+        if any(not isinstance(cast(object, item), EffectKind) for item in self.effect_claims):
+            raise ValueError("effect_claims members must be EffectKind values")
+        _require_optional_stable_id(self.safe_variant_id, "safe_variant_id")
+        if (self.match_class is ActivityMatchClass.SAFE_VARIANT) != (self.safe_variant_id is not None):
+            raise ValueError("safe_variant match class requires exactly one safe_variant_id")
+        _require_schema_version(self.schema_version)
+
+
+@dataclass(frozen=True, slots=True)
+class CommandActivityEvidence:
+    activity: CommandActivity
+    matches: tuple[CommandActivityMatch, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(cast(object, self.activity), CommandActivity):
+            raise ValueError("activity must be a CommandActivity")
+        if not isinstance(cast(object, self.matches), tuple) or any(
+            not isinstance(cast(object, item), CommandActivityMatch) for item in self.matches
+        ):
+            raise ValueError("matches must be a tuple of CommandActivityMatch values")
+        if self.activity.match_count != len(self.matches):
+            raise ValueError("match_count must equal the number of match rows")
+        if any(item.activity_id != self.activity.activity_id for item in self.matches):
+            raise ValueError("every match must reference the parent activity_id")
+        if tuple(item.ordinal for item in self.matches) != tuple(range(len(self.matches))):
+            raise ValueError("match ordinals must be unique, ordered, and contiguous from zero")
+        identities = tuple(item.identity for item in self.matches)
+        if len(identities) != len(set(identities)):
+            raise ValueError("an activity cannot repeat an extension rule identity")
+        rule_id_values = tuple(item.identity.rule_id for item in self.matches)
+        if len(rule_id_values) != len(set(rule_id_values)):
+            raise ValueError("an activity cannot repeat a logical rule_id across versions")
+        rule_ids = set(rule_id_values)
+        if self.activity.controlling_rule_id is not None and self.activity.controlling_rule_id not in rule_ids:
+            raise ValueError("controlling_rule_id must identify one of the activity matches")
+
+
+COMMAND_ACTIVITY_FIELDS: Final = tuple(field.name for field in fields(CommandActivity))
+COMMAND_ACTIVITY_MATCH_FIELDS: Final = tuple(field.name for field in fields(CommandActivityMatch))
+
+
+def validate_activity_transition(previous: CommandActivity, current: CommandActivity) -> None:
+    """Reject out-of-order, conflicting, or fact-changing lifecycle updates."""
+
+    if not isinstance(cast(object, previous), CommandActivity) or not isinstance(
+        cast(object, current), CommandActivity
+    ):
+        raise ValueError("activity transitions require exact CommandActivity values")
+    immutable_fields = (
+        "activity_id",
+        "occurred_at",
+        "harness",
+        "policy_action",
+        "decision_reason_code",
+        "controlling_rule_id",
+        "parse_confidence",
+        "uncertainty_class",
+        "match_count",
+        "prompted",
+        "approval_reuse_status",
+        "request_correlation",
+        "session_correlation",
+        "receipt_link_status",
+        "receipt_id",
+        "evaluation_latency_bucket",
+        "schema_version",
+    )
+    if any(getattr(previous, name) != getattr(current, name) for name in immutable_fields):
+        raise ValueError("activity transitions cannot change decision, identity, proof, or match facts")
+    if previous.execution_status is current.execution_status:
+        if previous != current:
+            raise ValueError("idempotent activity replay cannot change persisted fields")
+        return
+    allowed = {
+        CommandExecutionStatus.ATTEMPTED: {
+            CommandExecutionStatus.PREVENTED,
+            CommandExecutionStatus.ALLOWED_UNCONFIRMED,
+        },
+        CommandExecutionStatus.ALLOWED_UNCONFIRMED: {
+            CommandExecutionStatus.CONFIRMED_SUCCESS,
+            CommandExecutionStatus.CONFIRMED_FAILURE,
+        },
+    }
+    if current.execution_status not in allowed.get(previous.execution_status, set()):
+        raise ValueError("invalid or conflicting command activity lifecycle transition")
+
+
+def _validate_activity_state(activity: CommandActivity) -> None:
+    pre_statuses = {
+        CommandExecutionStatus.ATTEMPTED,
+        CommandExecutionStatus.PREVENTED,
+        CommandExecutionStatus.ALLOWED_UNCONFIRMED,
+    }
+    confirmed = {
+        CommandExecutionStatus.CONFIRMED_SUCCESS: CommandHookPhase.POST_SUCCESS,
+        CommandExecutionStatus.CONFIRMED_FAILURE: CommandHookPhase.POST_FAILURE,
+    }
+    if activity.execution_status in pre_statuses:
+        if activity.hook_phase is not CommandHookPhase.PRE or activity.proof_level is not CommandProofLevel.PRE_HOOK:
+            raise ValueError("pre-hook statuses require pre phase and pre-hook proof")
+    elif activity.execution_status in confirmed:
+        if (
+            activity.hook_phase is not confirmed[activity.execution_status]
+            or activity.proof_level is not CommandProofLevel.POST_HOOK
+        ):
+            raise ValueError("confirmed status requires its matching post phase and post-hook proof")
+        if activity.request_correlation is None:
+            raise ValueError("confirmed status requires one strong request correlation")
+    elif activity.execution_status is CommandExecutionStatus.UNPAIRED_POST:
+        if activity.hook_phase is CommandHookPhase.PRE or activity.proof_level is not CommandProofLevel.UNPAIRED_POST:
+            raise ValueError("unpaired post requires a post phase and unpaired-post proof")
+        if activity.request_correlation is not None:
+            raise ValueError("unpaired post cannot claim request correlation")
+        if any(
+            (
+                activity.policy_action is not None,
+                activity.decision_reason_code is not None,
+                activity.controlling_rule_id is not None,
+                activity.parse_confidence is not None,
+                activity.uncertainty_class is not None,
+                activity.match_count != 0,
+                activity.prompted,
+                activity.approval_reuse_status is not ActivityApprovalReuseStatus.NOT_APPLICABLE,
+                activity.receipt_link_status is not ReceiptLinkStatus.NOT_APPLICABLE,
+                activity.receipt_id is not None,
+                activity.evaluation_latency_bucket is not ActivityLatencyBucket.NOT_MEASURED,
+            )
+        ):
+            raise ValueError("unpaired post cannot invent pre-hook decision or match facts")
+    if activity.parse_confidence is ActivityParseConfidence.EXACT and activity.uncertainty_class is not None:
+        raise ValueError("exact parse confidence cannot carry uncertainty")
+    if (
+        activity.parse_confidence in {ActivityParseConfidence.FALLBACK, ActivityParseConfidence.UNCERTAIN}
+        and activity.uncertainty_class is None
+    ):
+        raise ValueError("non-exact parse confidence requires a bounded uncertainty class")
+    if activity.execution_status is not CommandExecutionStatus.UNPAIRED_POST and (
+        activity.policy_action is None or activity.decision_reason_code is None or activity.parse_confidence is None
+    ):
+        raise ValueError("pre and confirmed activity requires complete bounded decision facts")
+    if activity.match_count == 0 and activity.controlling_rule_id is not None:
+        raise ValueError("an activity without matches cannot name a controlling rule")
+    if activity.execution_status is not CommandExecutionStatus.UNPAIRED_POST and (
+        (activity.match_count == 0) != (activity.decision_reason_code is ActivityDecisionReason.NO_MATCH)
+    ):
+        raise ValueError("no-match reason must correspond exactly to an activity without matches")
+    if activity.receipt_link_status is ReceiptLinkStatus.LINKED and activity.receipt_id is None:
+        raise ValueError("linked receipt status requires receipt_id")
+    if activity.receipt_link_status is ReceiptLinkStatus.NOT_APPLICABLE and activity.receipt_id is not None:
+        raise ValueError("receipt_id requires linked receipt status")
+    if (
+        activity.policy_action is not None
+        and guard_action_severity(activity.policy_action) >= guard_action_severity("review")
+        and activity.receipt_link_status is not ReceiptLinkStatus.LINKED
+    ):
+        raise ValueError("review-or-stronger activity requires a linked receipt")
+
+
+def _require_schema_version(value: object) -> None:
+    if value != COMMAND_ACTIVITY_SCHEMA_VERSION:
+        raise ValueError("unsupported command activity schema version")
+
+
+def _require_utc_datetime(value: object) -> None:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() != timezone.utc.utcoffset(value):
+        raise ValueError("occurred_at must be a timezone-aware UTC datetime")
+
+
+def _require_opaque_id(value: object, label: str) -> None:
+    if not isinstance(value, str) or _OPAQUE_ID.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a bounded opaque identifier")
+
+
+def _require_stable_id(value: object, label: str) -> None:
+    if (
+        not isinstance(value, str)
+        or len(value) > 128
+        or _STABLE_ID.fullmatch(value) is None
+        or (label == "harness" and value not in COMMAND_ACTIVITY_HARNESSES)
+    ):
+        raise ValueError(f"{label} must be a stable lowercase identifier")
+
+
+def _require_optional_stable_id(value: object, label: str) -> None:
+    if value is not None:
+        _require_stable_id(value, label)
+
+
+def _require_enum(value: object, enum_type: type[Enum], label: str) -> None:
+    if not isinstance(value, enum_type):
+        raise ValueError(f"{label} must be an exact {enum_type.__name__} value")
+
+
+def _require_optional_guard_action(value: object) -> None:
+    if value is not None and not is_guard_action(value):
+        raise ValueError("policy_action must be a canonical GuardAction or None")
+
+
+def _require_optional_correlation(
+    value: object,
+    kind: CorrelationKind,
+    harness: str,
+) -> None:
+    if value is None:
+        return
+    if not isinstance(value, CorrelationHandle):
+        raise ValueError("correlation values must be exact CorrelationHandle values")
+    if value.kind is not kind or value.harness != harness:
+        raise ValueError("correlation kind and harness must match the activity")

--- a/src/codex_plugin_scanner/guard/runtime/command_activity_privacy.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_activity_privacy.py
@@ -1,0 +1,321 @@
+"""Privacy and egress contracts for command activity evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import re
+from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+from typing import Final, cast, final
+
+from typing_extensions import override
+
+from codex_plugin_scanner.guard.action_lattice import GUARD_ACTION_LATTICE
+
+from .command_activity_contract import (
+    COMMAND_ACTIVITY_FIELDS,
+    COMMAND_ACTIVITY_HARNESSES,
+    COMMAND_ACTIVITY_MATCH_FIELDS,
+    COMMAND_ACTIVITY_SCHEMA_VERSION,
+    ActivityLatencyBucket,
+    CommandExecutionStatus,
+    CommandProofLevel,
+    CorrelationHandle,
+    CorrelationKind,
+)
+from .command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+
+COMMAND_ACTIVITY_CORRELATION_VERSION: Final = "guard.command-activity-correlation.v1"
+COMMAND_ACTIVITY_CLOUD_SCHEMA_VERSION: Final = "guard.command-activity-aggregate.v1"
+MIN_CLOUD_AGGREGATE_COUNT: Final = 10
+_STABLE_ID: Final[re.Pattern[str]] = re.compile(r"[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*")
+_WEAK_IDENTIFIER: Final[re.Pattern[str]] = re.compile(
+    r"(?:[0-9]+|(?:request|req|session|sess|run|event)[._:-]?[0-9]+)",
+    re.IGNORECASE,
+)
+_OPAQUE_STRONG_IDENTIFIER: Final[re.Pattern[str]] = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{15,511}")
+_ISO_TIMESTAMP: Final[re.Pattern[str]] = re.compile(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}[Tt][0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]+)?(?:[Zz]|[+-][0-9]{2}:[0-9]{2})"
+)
+_CLOUD_EXTENSION_IDS: Final = frozenset(
+    extension.extension_id for extension in BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions
+)
+_CLOUD_RULE_IDS: Final = frozenset(
+    rule.rule_id for extension in BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions for rule in extension.rules
+)
+
+FORBIDDEN_ACTIVITY_FIELD_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "arguments",
+        "args",
+        "artifact_hash",
+        "clipboard",
+        "command",
+        "command_hash",
+        "command_security_identity",
+        "command_text",
+        "credential",
+        "credentials",
+        "cwd",
+        "environment",
+        "environment_names",
+        "environment_values",
+        "exception_message",
+        "hostname",
+        "installation_id",
+        "matcher_evidence",
+        "metadata",
+        "normalized_command",
+        "package_name",
+        "package_source",
+        "path",
+        "raw_arguments",
+        "raw_command",
+        "raw_request_id",
+        "raw_session_id",
+        "reason_text",
+        "repository_name",
+        "secret",
+        "secrets",
+        "security_identity",
+        "shell_fragment",
+        "token",
+        "tokens",
+        "url",
+        "workspace_name",
+    }
+)
+
+
+class ActivityEgressMode(str, Enum):
+    LOCAL_ONLY = "local_only"
+    AGGREGATE_ONLY = "aggregate_only"
+
+
+class CloudAggregateDimension(str, Enum):
+    TOTAL = "total"
+    HARNESS = "harness"
+    EXTENSION = "extension"
+    RULE = "rule"
+    DISPOSITION = "disposition"
+    EXECUTION_STATUS = "execution_status"
+    PROMPT_STATUS = "prompt_status"
+    PROOF_LEVEL = "proof_level"
+    LATENCY = "latency"
+
+
+@dataclass(frozen=True, slots=True)
+class CommandActivityPrivacyPolicy:
+    egress_mode: ActivityEgressMode = ActivityEgressMode.LOCAL_ONLY
+
+    def __post_init__(self) -> None:
+        if not isinstance(cast(object, self.egress_mode), ActivityEgressMode):
+            raise ValueError("egress_mode must be an exact ActivityEgressMode value")
+
+
+DEFAULT_COMMAND_ACTIVITY_PRIVACY_POLICY: Final = CommandActivityPrivacyPolicy()
+
+
+@final
+class InstallationCorrelationKey:
+    """Independent per-install HMAC material with a non-secret rotation ID."""
+
+    __slots__: tuple[str, ...] = ("_material", "key_id")
+    key_id: str
+    _material: bytes
+
+    def __init__(self, *, key_id: str, material: bytes) -> None:
+        _require_stable_id(key_id, "key_id")
+        if type(material) is not bytes or len(material) < 32:
+            raise ValueError("correlation key material must contain at least 32 random bytes")
+        self.key_id = key_id
+        self._material = bytes(material)
+
+    @override
+    def __repr__(self) -> str:
+        return f"InstallationCorrelationKey(key_id={self.key_id!r}, material=<hidden>)"
+
+    def derive(self, framed: bytes) -> str:
+        return hmac.new(self._material, framed, hashlib.sha256).hexdigest()
+
+
+@final
+class StrongHarnessIdentifier:
+    """A native unpredictable identifier attested by a harness adapter."""
+
+    __slots__: tuple[str, ...] = ("_value", "harness", "kind")
+    harness: str
+    kind: CorrelationKind
+    _value: str
+
+    def __init__(self, *, harness: str, kind: CorrelationKind, value: str) -> None:
+        _require_harness(harness)
+        if not isinstance(cast(object, kind), CorrelationKind):
+            raise ValueError("kind must be an exact CorrelationKind value")
+        if not isinstance(cast(object, value), str) or _OPAQUE_STRONG_IDENTIFIER.fullmatch(value) is None:
+            raise ValueError("strong harness identifier must be a bounded opaque native identifier")
+        identifier_alphabet = {character.lower() for character in value if character.isalnum()}
+        if (
+            _WEAK_IDENTIFIER.fullmatch(value) is not None
+            or _ISO_TIMESTAMP.fullmatch(value) is not None
+            or len(identifier_alphabet) < 6
+        ):
+            raise ValueError("predictable counters and timestamps are not strong harness identifiers")
+        self.harness = harness
+        self.kind = kind
+        self._value = value
+
+    @override
+    def __repr__(self) -> str:
+        return f"StrongHarnessIdentifier(harness={self.harness!r}, kind={self.kind!r}, value=<hidden>)"
+
+    def derive(self, key: InstallationCorrelationKey) -> CorrelationHandle:
+        framed = b"".join(
+            _frame(value)
+            for value in (
+                COMMAND_ACTIVITY_CORRELATION_VERSION.encode("ascii"),
+                COMMAND_ACTIVITY_SCHEMA_VERSION.encode("ascii"),
+                key.key_id.encode("ascii"),
+                self.harness.encode("utf-8"),
+                self.kind.value.encode("ascii"),
+                self._value.encode("utf-8"),
+            )
+        )
+        return CorrelationHandle(self.kind, self.harness, key.key_id, key.derive(framed))
+
+
+@dataclass(frozen=True, slots=True)
+class CloudCommandActivityAggregate:
+    """One rare-cell-suppressed daily count with exactly one bounded dimension."""
+
+    day: date
+    dimension: CloudAggregateDimension
+    dimension_value: str
+    count: int
+    schema_version: str = COMMAND_ACTIVITY_CLOUD_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if type(cast(object, self.day)) is not date:
+            raise ValueError("day must be a UTC calendar date")
+        if not isinstance(cast(object, self.dimension), CloudAggregateDimension):
+            raise ValueError("dimension must be an exact CloudAggregateDimension value")
+        _require_stable_id(self.dimension_value, "dimension_value")
+        _require_cloud_dimension_value(self.dimension, self.dimension_value)
+        if type(self.count) is not int or self.count < MIN_CLOUD_AGGREGATE_COUNT:
+            raise ValueError("rare cloud aggregate cells must be suppressed")
+        if self.schema_version != COMMAND_ACTIVITY_CLOUD_SCHEMA_VERSION:
+            raise ValueError("unsupported cloud command activity aggregate schema version")
+
+    def to_cloud_payload(self, policy: CommandActivityPrivacyPolicy) -> dict[str, object]:
+        if not isinstance(cast(object, policy), CommandActivityPrivacyPolicy):
+            raise ValueError("policy must be a CommandActivityPrivacyPolicy")
+        if policy.egress_mode is not ActivityEgressMode.AGGREGATE_ONLY:
+            raise ValueError("command activity egress is local-only unless aggregate mode is explicitly enabled")
+        return {
+            "day": self.day.isoformat(),
+            "dimension": self.dimension.value,
+            "dimension_value": self.dimension_value,
+            "count": self.count,
+            "schema_version": self.schema_version,
+        }
+
+
+def derive_correlation_handle(
+    identifier: StrongHarnessIdentifier,
+    key: InstallationCorrelationKey,
+) -> CorrelationHandle:
+    """Derive a local-only, domain-separated handle without retaining the raw ID."""
+
+    if not isinstance(cast(object, identifier), StrongHarnessIdentifier):
+        raise ValueError("identifier must be an exact StrongHarnessIdentifier")
+    if not isinstance(cast(object, key), InstallationCorrelationKey):
+        raise ValueError("key must be an exact InstallationCorrelationKey")
+    return identifier.derive(key)
+
+
+def validate_activity_schema_privacy() -> None:
+    """Prove the frozen activity schemas contain no forbidden storage fields."""
+
+    names = frozenset((*COMMAND_ACTIVITY_FIELDS, *COMMAND_ACTIVITY_MATCH_FIELDS))
+    overlap = names & FORBIDDEN_ACTIVITY_FIELD_NAMES
+    if overlap:
+        raise ValueError(f"command activity schema contains forbidden fields: {sorted(overlap)!r}")
+    if any(name in names for name in ("raw_request_id", "raw_session_id", "installation_id")):
+        raise ValueError("raw or installation identifiers cannot enter command activity schemas")
+
+
+def validate_cloud_payload(payload: object) -> None:
+    """Reject non-aggregate, nested, or unexpected cloud payload shapes."""
+
+    if not isinstance(payload, dict):
+        raise ValueError("cloud command activity payload must be a dictionary")
+    typed_payload = cast(dict[object, object], payload)
+    expected = {"day", "dimension", "dimension_value", "count", "schema_version"}
+    if set(typed_payload) != expected or any(
+        isinstance(value, (dict, list, tuple, set)) for value in typed_payload.values()
+    ):
+        raise ValueError("cloud command activity payload must use the exact flat aggregate allowlist")
+    forbidden = set(typed_payload) & FORBIDDEN_ACTIVITY_FIELD_NAMES
+    if forbidden:
+        raise ValueError("cloud command activity payload contains forbidden fields")
+    day_value = typed_payload["day"]
+    dimension_value = typed_payload["dimension"]
+    bounded_value = typed_payload["dimension_value"]
+    count = typed_payload["count"]
+    schema_version = typed_payload["schema_version"]
+    if (
+        type(day_value) is not str
+        or re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}", day_value) is None
+        or type(dimension_value) is not str
+        or type(bounded_value) is not str
+        or type(count) is not int
+        or type(schema_version) is not str
+    ):
+        raise ValueError("cloud command activity payload contains invalid scalar types")
+    try:
+        parsed_day = date.fromisoformat(day_value)
+        parsed_dimension = CloudAggregateDimension(dimension_value)
+    except ValueError as error:
+        raise ValueError("cloud command activity payload contains invalid bounded values") from error
+    _ = CloudCommandActivityAggregate(
+        day=parsed_day,
+        dimension=parsed_dimension,
+        dimension_value=bounded_value,
+        count=count,
+        schema_version=schema_version,
+    )
+
+
+def _frame(value: bytes) -> bytes:
+    return len(value).to_bytes(4, "big") + value
+
+
+def _require_stable_id(value: object, label: str) -> None:
+    if not isinstance(value, str) or len(value) > 128 or _STABLE_ID.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a stable lowercase identifier")
+
+
+def _require_harness(value: object) -> None:
+    if not isinstance(value, str) or value not in COMMAND_ACTIVITY_HARNESSES:
+        raise ValueError("harness must identify a supported Guard harness")
+
+
+def _require_cloud_dimension_value(dimension: CloudAggregateDimension, value: str) -> None:
+    allowed: dict[CloudAggregateDimension, frozenset[str]] = {
+        CloudAggregateDimension.TOTAL: frozenset({"all"}),
+        CloudAggregateDimension.HARNESS: COMMAND_ACTIVITY_HARNESSES,
+        CloudAggregateDimension.EXTENSION: _CLOUD_EXTENSION_IDS,
+        CloudAggregateDimension.RULE: _CLOUD_RULE_IDS,
+        CloudAggregateDimension.DISPOSITION: frozenset(GUARD_ACTION_LATTICE),
+        CloudAggregateDimension.EXECUTION_STATUS: frozenset(item.value for item in CommandExecutionStatus),
+        CloudAggregateDimension.PROMPT_STATUS: frozenset({"prompted", "not_prompted"}),
+        CloudAggregateDimension.PROOF_LEVEL: frozenset(item.value for item in CommandProofLevel),
+        CloudAggregateDimension.LATENCY: frozenset(item.value for item in ActivityLatencyBucket),
+    }
+    if value not in allowed[dimension]:
+        raise ValueError("dimension_value must belong to the selected bounded aggregate dimension")
+
+
+validate_activity_schema_privacy()

--- a/tests/test_guard_command_activity_contract.py
+++ b/tests/test_guard_command_activity_contract.py
@@ -1,0 +1,327 @@
+# pyright: reportUnusedCallResult=false
+from __future__ import annotations
+
+import itertools
+from dataclasses import FrozenInstanceError, replace
+from datetime import datetime, timezone
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.models import GuardAction
+from codex_plugin_scanner.guard.runtime.command_activity_contract import (
+    COMMAND_ACTIVITY_SCHEMA_VERSION,
+    ActivityApprovalReuseStatus,
+    ActivityDecisionReason,
+    ActivityLatencyBucket,
+    ActivityMatchClass,
+    ActivityParseConfidence,
+    CommandActivity,
+    CommandActivityEvidence,
+    CommandActivityMatch,
+    CommandExecutionStatus,
+    CommandHookPhase,
+    CommandProofLevel,
+    CorrelationHandle,
+    CorrelationKind,
+    ReceiptLinkStatus,
+    validate_activity_transition,
+)
+from codex_plugin_scanner.guard.runtime.effect_contract import EffectKind, UncertaintyKind
+from codex_plugin_scanner.guard.runtime.extension_evidence import EvidenceSeverity, ExtensionRuleIdentity
+
+
+def _identity(rule_id: str = "command.git.push") -> ExtensionRuleIdentity:
+    return ExtensionRuleIdentity("command.git", "2.2.0", rule_id, "1.0.0")
+
+
+def _correlation(kind: CorrelationKind = CorrelationKind.REQUEST, *, harness: str = "codex") -> CorrelationHandle:
+    return CorrelationHandle(kind, harness, "key.v1", "a" * 64)
+
+
+def _activity(
+    *,
+    status: CommandExecutionStatus = CommandExecutionStatus.ATTEMPTED,
+    phase: CommandHookPhase = CommandHookPhase.PRE,
+    proof: CommandProofLevel = CommandProofLevel.PRE_HOOK,
+    policy_action: GuardAction | None = "allow",
+    request_correlation: CorrelationHandle | None = None,
+    session_correlation: CorrelationHandle | None = None,
+    match_count: int = 1,
+    controlling_rule_id: str | None = "command.git.push",
+    decision_reason_code: ActivityDecisionReason | None = ActivityDecisionReason.EXTENSION_MATCH,
+    parse_confidence: ActivityParseConfidence | None = ActivityParseConfidence.EXACT,
+    uncertainty_class: UncertaintyKind | None = None,
+    receipt_link_status: ReceiptLinkStatus = ReceiptLinkStatus.NOT_APPLICABLE,
+    receipt_id: str | None = None,
+    schema_version: str = COMMAND_ACTIVITY_SCHEMA_VERSION,
+) -> CommandActivity:
+    return CommandActivity(
+        activity_id="activity:01",
+        occurred_at=datetime(2026, 7, 18, 20, 0, tzinfo=timezone.utc),
+        harness="codex",
+        hook_phase=phase,
+        execution_status=status,
+        proof_level=proof,
+        policy_action=policy_action,
+        decision_reason_code=decision_reason_code if policy_action is not None else None,
+        controlling_rule_id=controlling_rule_id,
+        parse_confidence=parse_confidence,
+        uncertainty_class=uncertainty_class,
+        match_count=match_count,
+        prompted=False,
+        approval_reuse_status=ActivityApprovalReuseStatus.NOT_APPLICABLE,
+        request_correlation=request_correlation,
+        session_correlation=session_correlation,
+        receipt_link_status=receipt_link_status,
+        receipt_id=receipt_id,
+        evaluation_latency_bucket=(
+            ActivityLatencyBucket.LE_5_MS
+            if status is not CommandExecutionStatus.UNPAIRED_POST
+            else ActivityLatencyBucket.NOT_MEASURED
+        ),
+        persistence_latency_bucket=ActivityLatencyBucket.LE_2_MS,
+        schema_version=schema_version,
+    )
+
+
+def _unpaired(phase: CommandHookPhase) -> CommandActivity:
+    return _activity(
+        status=CommandExecutionStatus.UNPAIRED_POST,
+        phase=phase,
+        proof=CommandProofLevel.UNPAIRED_POST,
+        policy_action=None,
+        match_count=0,
+        controlling_rule_id=None,
+        decision_reason_code=None,
+        parse_confidence=None,
+    )
+
+
+def _match(
+    ordinal: int = 0,
+    *,
+    identity: ExtensionRuleIdentity | None = None,
+    match_class: ActivityMatchClass = ActivityMatchClass.UNSAFE,
+    safe_variant_id: str | None = None,
+) -> CommandActivityMatch:
+    return CommandActivityMatch(
+        activity_id="activity:01",
+        ordinal=ordinal,
+        identity=identity or _identity(),
+        match_class=match_class,
+        severity=EvidenceSeverity.HIGH,
+        default_floor="review",
+        effect_claims=frozenset({EffectKind.REMOTE_STATE_MUTATION}),
+        safe_variant_id=safe_variant_id,
+    )
+
+
+def test_schema_is_versioned_immutable_and_uses_exact_typed_boundaries() -> None:
+    activity = _activity()
+
+    assert activity.schema_version == "1.0.0"
+    with pytest.raises(FrozenInstanceError):
+        activity.__setattr__("match_count", 2)
+    with pytest.raises(ValueError, match="schema version"):
+        _activity(schema_version="1.0.1")
+    with pytest.raises(ValueError, match="CommandExecutionStatus"):
+        replace(activity, execution_status=cast(CommandExecutionStatus, cast(object, "attempted")))
+    with pytest.raises(ValueError, match="UTC datetime"):
+        replace(activity, occurred_at=datetime(2026, 7, 18, 20, 0))
+
+
+def test_phase_status_proof_matrix_is_closed_and_exhaustive() -> None:
+    legal = {
+        (CommandHookPhase.PRE, status, CommandProofLevel.PRE_HOOK)
+        for status in (
+            CommandExecutionStatus.ATTEMPTED,
+            CommandExecutionStatus.PREVENTED,
+            CommandExecutionStatus.ALLOWED_UNCONFIRMED,
+        )
+    } | {
+        (
+            CommandHookPhase.POST_SUCCESS,
+            CommandExecutionStatus.CONFIRMED_SUCCESS,
+            CommandProofLevel.POST_HOOK,
+        ),
+        (
+            CommandHookPhase.POST_FAILURE,
+            CommandExecutionStatus.CONFIRMED_FAILURE,
+            CommandProofLevel.POST_HOOK,
+        ),
+        (
+            CommandHookPhase.POST_SUCCESS,
+            CommandExecutionStatus.UNPAIRED_POST,
+            CommandProofLevel.UNPAIRED_POST,
+        ),
+        (
+            CommandHookPhase.POST_FAILURE,
+            CommandExecutionStatus.UNPAIRED_POST,
+            CommandProofLevel.UNPAIRED_POST,
+        ),
+    }
+    for phase, status, proof in itertools.product(CommandHookPhase, CommandExecutionStatus, CommandProofLevel):
+        request = (
+            _correlation()
+            if status in {CommandExecutionStatus.CONFIRMED_SUCCESS, CommandExecutionStatus.CONFIRMED_FAILURE}
+            else None
+        )
+        factory = _unpaired if status is CommandExecutionStatus.UNPAIRED_POST else None
+        if (phase, status, proof) in legal:
+            result = (
+                factory(phase)
+                if factory is not None
+                else _activity(status=status, phase=phase, proof=proof, request_correlation=request)
+            )
+            assert result.execution_status is status
+        else:
+            with pytest.raises(ValueError):
+                _activity(status=status, phase=phase, proof=proof, request_correlation=request)
+
+
+def test_session_only_correlation_never_confirms_execution() -> None:
+    session = _correlation(CorrelationKind.SESSION)
+
+    with pytest.raises(ValueError, match="strong request correlation"):
+        _activity(
+            status=CommandExecutionStatus.CONFIRMED_SUCCESS,
+            phase=CommandHookPhase.POST_SUCCESS,
+            proof=CommandProofLevel.POST_HOOK,
+            session_correlation=session,
+        )
+    assert _unpaired(CommandHookPhase.POST_SUCCESS).execution_status is CommandExecutionStatus.UNPAIRED_POST
+    assert replace(_unpaired(CommandHookPhase.POST_SUCCESS), session_correlation=session).session_correlation == session
+
+
+def test_unpaired_post_cannot_invent_pre_hook_facts() -> None:
+    unpaired = _unpaired(CommandHookPhase.POST_FAILURE)
+
+    with pytest.raises(ValueError, match="cannot invent"):
+        replace(unpaired, match_count=1)
+    with pytest.raises(ValueError, match="cannot invent"):
+        replace(unpaired, policy_action="allow")
+    with pytest.raises(ValueError, match="cannot claim"):
+        replace(unpaired, request_correlation=_correlation())
+
+
+def test_lifecycle_transitions_are_idempotent_and_fail_closed() -> None:
+    request = _correlation()
+    attempted = _activity(request_correlation=request)
+    allowed = replace(
+        attempted,
+        execution_status=CommandExecutionStatus.ALLOWED_UNCONFIRMED,
+    )
+    confirmed = replace(
+        allowed,
+        hook_phase=CommandHookPhase.POST_SUCCESS,
+        execution_status=CommandExecutionStatus.CONFIRMED_SUCCESS,
+        proof_level=CommandProofLevel.POST_HOOK,
+    )
+    prevented = replace(attempted, execution_status=CommandExecutionStatus.PREVENTED)
+
+    validate_activity_transition(attempted, allowed)
+    validate_activity_transition(allowed, confirmed)
+    validate_activity_transition(confirmed, confirmed)
+    validate_activity_transition(attempted, prevented)
+    with pytest.raises(ValueError, match="invalid or conflicting"):
+        validate_activity_transition(prevented, confirmed)
+    conflicting = replace(
+        confirmed,
+        hook_phase=CommandHookPhase.POST_FAILURE,
+        execution_status=CommandExecutionStatus.CONFIRMED_FAILURE,
+    )
+    with pytest.raises(ValueError, match="invalid or conflicting"):
+        validate_activity_transition(confirmed, conflicting)
+    with pytest.raises(ValueError, match="cannot change"):
+        validate_activity_transition(allowed, replace(allowed, prompted=True))
+
+
+def test_review_or_stronger_activity_requires_exact_receipt_link() -> None:
+    with pytest.raises(ValueError, match="linked receipt"):
+        _activity(status=CommandExecutionStatus.PREVENTED, policy_action="review")
+
+    reviewed = _activity(
+        status=CommandExecutionStatus.PREVENTED,
+        policy_action="review",
+        receipt_link_status=ReceiptLinkStatus.LINKED,
+        receipt_id="receipt:01",
+    )
+    assert reviewed.receipt_id == "receipt:01"
+    with pytest.raises(ValueError, match="requires receipt_id"):
+        replace(reviewed, receipt_id=None)
+
+
+def test_non_exact_parse_requires_bounded_uncertainty() -> None:
+    with pytest.raises(ValueError, match="requires a bounded uncertainty"):
+        _activity(parse_confidence=ActivityParseConfidence.UNCERTAIN)
+    with pytest.raises(ValueError, match="exact parse"):
+        _activity(uncertainty_class=UncertaintyKind.PARTIAL_PARSE)
+
+    uncertain = _activity(
+        parse_confidence=ActivityParseConfidence.FALLBACK,
+        uncertainty_class=UncertaintyKind.PARTIAL_PARSE,
+    )
+    assert uncertain.uncertainty_class is UncertaintyKind.PARTIAL_PARSE
+
+
+def test_pre_and_confirmed_rows_require_complete_bounded_decision_facts() -> None:
+    activity = _activity()
+
+    with pytest.raises(ValueError, match="complete bounded decision facts"):
+        replace(activity, policy_action=None, decision_reason_code=None)
+    with pytest.raises(ValueError, match="no-match reason"):
+        replace(activity, decision_reason_code=ActivityDecisionReason.NO_MATCH)
+    with pytest.raises(ValueError, match="no-match reason"):
+        _activity(match_count=0, controlling_rule_id=None, decision_reason_code=ActivityDecisionReason.POLICY)
+
+
+def test_match_projection_distinguishes_safe_variants_and_rejects_untyped_evidence() -> None:
+    safe = _match(match_class=ActivityMatchClass.SAFE_VARIANT, safe_variant_id="dry.run")
+    assert safe.match_class is ActivityMatchClass.SAFE_VARIANT
+    with pytest.raises(ValueError, match="safe_variant_id"):
+        _match(match_class=ActivityMatchClass.SAFE_VARIANT)
+    with pytest.raises(ValueError, match="safe_variant_id"):
+        _match(safe_variant_id="dry.run")
+    with pytest.raises(ValueError, match="EffectKind"):
+        replace(
+            _match(),
+            effect_claims=frozenset({cast(EffectKind, cast(object, "remote-state-mutation"))}),
+        )
+
+
+def test_evidence_binds_one_activity_to_exact_ordered_unique_matches() -> None:
+    first = _match()
+    second = _match(1, identity=_identity("command.git.delete"))
+    activity = replace(_activity(), match_count=2)
+
+    evidence = CommandActivityEvidence(activity, (first, second))
+    assert evidence.activity.match_count == 2
+    with pytest.raises(ValueError, match="match_count"):
+        CommandActivityEvidence(_activity(), ())
+    with pytest.raises(ValueError, match="ordinals"):
+        CommandActivityEvidence(activity, (second, first))
+    with pytest.raises(ValueError, match="repeat"):
+        CommandActivityEvidence(activity, (first, replace(first, ordinal=1)))
+    version_duplicate = replace(
+        first,
+        ordinal=1,
+        identity=ExtensionRuleIdentity("command.git", "2.2.0", "command.git.push", "1.0.1"),
+    )
+    with pytest.raises(ValueError, match="logical rule_id"):
+        CommandActivityEvidence(activity, (first, version_duplicate))
+    with pytest.raises(ValueError, match="controlling_rule_id"):
+        CommandActivityEvidence(replace(_activity(), controlling_rule_id="command.git.other"), (first,))
+
+
+def test_unmatched_ordinary_command_has_one_activity_and_zero_match_rows() -> None:
+    activity = _activity(
+        match_count=0,
+        controlling_rule_id=None,
+        decision_reason_code=ActivityDecisionReason.NO_MATCH,
+    )
+
+    evidence = CommandActivityEvidence(activity, ())
+
+    assert evidence.activity.match_count == 0
+    assert evidence.matches == ()

--- a/tests/test_guard_command_activity_privacy.py
+++ b/tests/test_guard_command_activity_privacy.py
@@ -1,0 +1,191 @@
+# pyright: reportUnusedCallResult=false
+from __future__ import annotations
+
+from dataclasses import is_dataclass
+from datetime import date, datetime, timezone
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.command_activity_contract import CorrelationKind
+from codex_plugin_scanner.guard.runtime.command_activity_privacy import (
+    COMMAND_ACTIVITY_CLOUD_SCHEMA_VERSION,
+    DEFAULT_COMMAND_ACTIVITY_PRIVACY_POLICY,
+    MIN_CLOUD_AGGREGATE_COUNT,
+    ActivityEgressMode,
+    CloudAggregateDimension,
+    CloudCommandActivityAggregate,
+    CommandActivityPrivacyPolicy,
+    InstallationCorrelationKey,
+    StrongHarnessIdentifier,
+    derive_correlation_handle,
+    validate_activity_schema_privacy,
+    validate_cloud_payload,
+)
+
+
+def _identifier(
+    *,
+    harness: str = "codex",
+    kind: CorrelationKind = CorrelationKind.REQUEST,
+    value: str = "01J3ABCD9XYZ7NATIVEID",
+) -> StrongHarnessIdentifier:
+    return StrongHarnessIdentifier(harness=harness, kind=kind, value=value)
+
+
+def _key(*, key_id: str = "correlation.v1", byte: int = 7) -> InstallationCorrelationKey:
+    return InstallationCorrelationKey(key_id=key_id, material=bytes([byte]) * 32)
+
+
+def _aggregate(count: int = MIN_CLOUD_AGGREGATE_COUNT) -> CloudCommandActivityAggregate:
+    return CloudCommandActivityAggregate(
+        day=date(2026, 7, 18),
+        dimension=CloudAggregateDimension.TOTAL,
+        dimension_value="all",
+        count=count,
+    )
+
+
+def test_activity_detail_is_local_only_by_default() -> None:
+    assert DEFAULT_COMMAND_ACTIVITY_PRIVACY_POLICY.egress_mode is ActivityEgressMode.LOCAL_ONLY
+    with pytest.raises(ValueError, match="local-only"):
+        _aggregate().to_cloud_payload(DEFAULT_COMMAND_ACTIVITY_PRIVACY_POLICY)
+
+
+def test_cloud_aggregate_requires_explicit_opt_in_and_exact_allowlist() -> None:
+    policy = CommandActivityPrivacyPolicy(ActivityEgressMode.AGGREGATE_ONLY)
+    payload = _aggregate().to_cloud_payload(policy)
+
+    assert payload == {
+        "day": "2026-07-18",
+        "dimension": "total",
+        "dimension_value": "all",
+        "count": 10,
+        "schema_version": COMMAND_ACTIVITY_CLOUD_SCHEMA_VERSION,
+    }
+    validate_cloud_payload(payload)
+    with pytest.raises(ValueError, match="exact flat aggregate allowlist"):
+        validate_cloud_payload({**payload, "activity_id": "activity:01"})
+    with pytest.raises(ValueError, match="exact flat aggregate allowlist"):
+        validate_cloud_payload({**payload, "dimension_value": {"nested": "value"}})
+    with pytest.raises(ValueError, match="invalid scalar types"):
+        validate_cloud_payload(
+            {
+                "day": "raw-secret",
+                "dimension": "anything",
+                "dimension_value": "secret",
+                "count": 0,
+                "schema_version": "x",
+            }
+        )
+    with pytest.raises(ValueError, match="rare cloud aggregate"):
+        validate_cloud_payload({**payload, "count": MIN_CLOUD_AGGREGATE_COUNT - 1})
+
+
+def test_cloud_aggregate_suppresses_rare_cells_and_arbitrary_dimension_tuples() -> None:
+    with pytest.raises(ValueError, match="rare cloud aggregate"):
+        _aggregate(MIN_CLOUD_AGGREGATE_COUNT - 1)
+    with pytest.raises(ValueError, match="bounded aggregate dimension"):
+        CloudCommandActivityAggregate(
+            day=date(2026, 7, 18),
+            dimension=CloudAggregateDimension.TOTAL,
+            dimension_value="codex",
+            count=MIN_CLOUD_AGGREGATE_COUNT,
+        )
+    with pytest.raises(ValueError, match="UTC calendar date"):
+        CloudCommandActivityAggregate(
+            day=cast(date, datetime(2026, 7, 18, 12, 0, tzinfo=timezone.utc)),
+            dimension=CloudAggregateDimension.TOTAL,
+            dimension_value="all",
+            count=MIN_CLOUD_AGGREGATE_COUNT,
+        )
+    with pytest.raises(ValueError, match="bounded aggregate dimension"):
+        CloudCommandActivityAggregate(
+            day=date(2026, 7, 18),
+            dimension=CloudAggregateDimension.EXECUTION_STATUS,
+            dimension_value="repository.secret",
+            count=MIN_CLOUD_AGGREGATE_COUNT,
+        )
+    with pytest.raises(ValueError, match="schema version"):
+        CloudCommandActivityAggregate(
+            day=date(2026, 7, 18),
+            dimension=CloudAggregateDimension.HARNESS,
+            dimension_value="codex",
+            count=MIN_CLOUD_AGGREGATE_COUNT,
+            schema_version="guard.command-activity-aggregate.v2",
+        )
+
+
+def test_correlation_hmac_is_deterministic_and_domain_separated() -> None:
+    key = _key()
+    request = _identifier()
+    same = derive_correlation_handle(request, key)
+
+    assert same == derive_correlation_handle(request, key)
+    assert same != derive_correlation_handle(_identifier(value="01J3ABCD9XYZ7OTHERID"), key)
+    assert same.digest != derive_correlation_handle(_identifier(harness="cursor"), key).digest
+    assert same.digest != derive_correlation_handle(_identifier(kind=CorrelationKind.SESSION), key).digest
+    assert same.digest != derive_correlation_handle(request, _key(byte=8)).digest
+    assert same.digest != derive_correlation_handle(request, _key(key_id="correlation.v2")).digest
+    assert same.key_id == "correlation.v1"
+
+
+def test_key_rotation_cannot_reinterpret_old_handles() -> None:
+    identifier = _identifier()
+    first = derive_correlation_handle(identifier, _key(key_id="correlation.v1", byte=1))
+    rotated = derive_correlation_handle(identifier, _key(key_id="correlation.v2", byte=2))
+
+    assert first.key_id != rotated.key_id
+    assert first.digest != rotated.digest
+
+
+def test_raw_identifier_and_key_material_are_hidden_from_repr_and_contract_output() -> None:
+    raw_identifier = "01J3SECRET9XYZ7NATIVEID"
+    key_material = b"secret-key-material-that-is-32-bytes"
+    identifier = _identifier(value=raw_identifier)
+    key = InstallationCorrelationKey(key_id="correlation.v1", material=key_material)
+    handle = derive_correlation_handle(identifier, key)
+
+    assert raw_identifier not in repr(identifier)
+    assert key_material.decode("ascii") not in repr(key)
+    assert raw_identifier not in repr(handle)
+    assert handle.digest not in repr(handle)
+    assert not is_dataclass(identifier)
+    assert not is_dataclass(key)
+    assert raw_identifier not in handle.digest
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "1",
+        "123456789012345",
+        "request-1234567890123",
+        "request-123456789012345678901",
+        "session:1234567890",
+        "2026-07-18T20:00:00Z",
+        "aaaaaaaaaaaaaaaa",
+        "abababababababab",
+    ],
+)
+def test_predictable_identifiers_are_rejected(value: str) -> None:
+    with pytest.raises(ValueError):
+        _identifier(value=value)
+
+
+def test_short_keys_and_untyped_correlation_inputs_are_rejected() -> None:
+    with pytest.raises(ValueError, match="at least 32"):
+        InstallationCorrelationKey(key_id="correlation.v1", material=b"short")
+    with pytest.raises(ValueError, match="StrongHarnessIdentifier"):
+        derive_correlation_handle(cast(StrongHarnessIdentifier, cast(object, "raw-request-id")), _key())
+    with pytest.raises(ValueError, match="InstallationCorrelationKey"):
+        derive_correlation_handle(
+            _identifier(),
+            cast(InstallationCorrelationKey, cast(object, b"not-a-key")),
+        )
+    with pytest.raises(ValueError, match="supported Guard harness"):
+        _identifier(harness="repository.secret")
+
+
+def test_frozen_activity_schema_contains_no_forbidden_fields() -> None:
+    validate_activity_schema_privacy()


### PR DESCRIPTION
## Summary
- add immutable, versioned command activity and match contracts with closed lifecycle, proof, receipt, and safe-variant invariants
- define local-only HMAC correlation and an explicit opt-in, rare-cell-suppressed daily aggregate boundary
- document the command activity privacy model and cover adversarial lifecycle, correlation, and egress cases

## Testing
- `uv run --no-sync pytest -q tests/test_guard_effect_contract.py tests/test_guard_extension_evidence_contract.py tests/test_guard_command_activity_contract.py tests/test_guard_command_activity_privacy.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/runtime/command_activity_contract.py src/codex_plugin_scanner/guard/runtime/command_activity_privacy.py tests/test_guard_command_activity_contract.py tests/test_guard_command_activity_privacy.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/runtime/command_activity_contract.py src/codex_plugin_scanner/guard/runtime/command_activity_privacy.py tests/test_guard_command_activity_contract.py tests/test_guard_command_activity_privacy.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/runtime/command_activity_contract.py src/codex_plugin_scanner/guard/runtime/command_activity_privacy.py tests/test_guard_command_activity_contract.py tests/test_guard_command_activity_privacy.py`
- `uv run --isolated --python 3.10 --with pytest --with typing-extensions --with-editable . pytest -q tests/test_guard_command_activity_contract.py tests/test_guard_command_activity_privacy.py --tb=short`
- `git diff --check`
