### PR TITLE
fix(release): use registered TestPyPI publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -356,7 +356,7 @@ jobs:
       (needs.alpha-cross-platform.result == 'success' || needs.alpha-cross-platform.result == 'skipped')
     needs: [build, alpha-cross-platform]
     runs-on: ubuntu-latest
-    environment: testpypi-alpha
+    environment: testpypi
     permissions:
       contents: read
       id-token: write

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -178,12 +178,12 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
     assert "skip-existing" not in workflow_text
 
 
-def test_publish_jobs_use_channel_specific_protected_environments() -> None:
+def test_publish_jobs_use_registered_protected_environments() -> None:
     workflow = _workflow(PUBLISH_WORKFLOW)
     jobs = workflow["jobs"]
 
     assert jobs["publish-testpypi"]["environment"] == "testpypi"
-    assert jobs["publish-alpha-testpypi"]["environment"] == "testpypi-alpha"
+    assert jobs["publish-alpha-testpypi"]["environment"] == "testpypi"
     assert jobs["publish-alpha-pypi"]["environment"] == "pypi-alpha"
     assert jobs["publish-testpypi"]["permissions"] == {"id-token": "write"}
     assert jobs["publish-alpha-testpypi"]["permissions"] == {"contents": "read", "id-token": "write"}


### PR DESCRIPTION
## Summary

- run alpha TestPyPI publication through the existing `testpypi` GitHub environment
- align the alpha OIDC subject with the registered TestPyPI trusted publisher
- retain the separate `pypi-alpha` production publication environment
- update workflow regression coverage

## Root cause

Alpha build and platform suites passed, but TestPyPI rejected the OIDC token because the workflow emitted `environment:testpypi-alpha` while the trusted publisher is registered for `environment:testpypi`. The two GitHub environments currently have identical protection settings.

## Verification

- `uv run --no-sync pytest tests/test_release_train_workflow.py -q` (11 passed)
- `uv run --no-sync ruff check tests/test_release_train_workflow.py`
- focused Basedpyright retains the test module's pre-existing YAML object typing errors; this two-line expectation change adds no new typed surface