### PR TITLE
fix(release): restore automatic main publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,9 @@ jobs:
 
   build:
     name: Build + Verify
-    if: github.event_name != 'workflow_dispatch' || github.run_attempt == 1
+    if: >-
+      (github.event_name != 'workflow_dispatch' || github.run_attempt == 1) &&
+      (github.event_name != 'push' || github.run_attempt == 1)
     needs: authorize-release
     runs-on: ubuntu-latest
     outputs:
@@ -191,6 +193,12 @@ jobs:
           print(f"{os.environ['BASE_VERSION']}.dev{pair(pair(int(os.environ['PR_NUMBER']), int(os.environ['GITHUB_RUN_NUMBER'])), int(os.environ['GITHUB_RUN_ATTEMPT']))}")
           PY
             )
+          elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+            CHANNEL="stable"
+            VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \
+              list-versions --registry pypi)
+            VERSION=$(uv run --no-sync python scripts/compute_main_release_version.py \
+              --base-version "$BASE_VERSION" <<< "$VERSIONS")
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
@@ -554,6 +562,308 @@ jobs:
           [[ -n "$wheel" ]]
           [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
 
+  publish-main-testpypi:
+    name: Verify main artifact on TestPyPI
+    if: >-
+      always() &&
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      github.event_name == 'push' &&
+      github.run_attempt == 1 &&
+      github.ref == 'refs/heads/main' &&
+      needs.build.result == 'success' &&
+      needs.build.outputs.channel == 'stable'
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.build.outputs.source_sha }}
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distributions
+          path: dist/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distribution-sha256
+      - name: Verify immutable build artifact
+        run: sha256sum --check distribution-sha256.txt
+      - name: Keep only the Guard release distribution
+        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
+      - name: Revalidate main source before TestPyPI
+        env:
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+        run: |
+          git fetch --no-tags origin "+refs/heads/main:refs/remotes/origin/main"
+          git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main
+      - name: Inspect TestPyPI release state
+        id: testpypi
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+            verify-release --registry testpypi --version "$VERSION" --dist-dir dist)
+          status=$(jq -r '.status' <<< "$result")
+          if [[ "$status" == "absent" ]]; then
+            echo "upload=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$status" == "exact" ]]; then
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unexpected TestPyPI status: $status" >&2
+            exit 1
+          fi
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        if: steps.testpypi.outputs.upload == 'true'
+        with:
+          repository-url: https://test.pypi.org/legacy/
+      - name: Download and verify exact TestPyPI artifacts
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          for attempt in {1..12}; do
+            if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+              verify-release --registry testpypi --version "$VERSION" --dist-dir dist \
+              --download-dir verified-testpypi); then
+              exit 1
+            fi
+            status=$(jq -r '.status' <<< "$result")
+            if [[ "$status" == "exact" ]]; then
+              break
+            fi
+            if [[ "$status" != "absent" || "$attempt" == "12" ]]; then
+              echo "TestPyPI did not expose the exact release artifacts" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
+          [[ -n "$wheel" ]]
+          [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
+
+  publish-main-pypi:
+    name: Publish main release to PyPI
+    if: >-
+      always() &&
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      github.event_name == 'push' &&
+      github.run_attempt == 1 &&
+      github.ref == 'refs/heads/main' &&
+      needs.build.result == 'success' &&
+      needs.publish-main-testpypi.result == 'success' &&
+      needs.build.outputs.channel == 'stable'
+    needs: [build, publish-main-testpypi]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.build.outputs.source_sha }}
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distributions
+          path: dist/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distribution-sha256
+      - name: Verify the TestPyPI-proven artifact
+        run: sha256sum --check distribution-sha256.txt
+      - name: Keep only the Guard release distribution
+        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
+      - name: Revalidate main publication
+        env:
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          git fetch --no-tags origin "+refs/heads/main:refs/remotes/origin/main"
+          git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main
+          BASE_VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          VERSIONS=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+            list-versions --registry pypi)
+          PRIOR_VERSIONS=$(jq --arg version "$VERSION" '[.[] | select(. != $version)]' <<< "$VERSIONS")
+          EXPECTED_VERSION=$(uv run --no-sync python scripts/compute_main_release_version.py \
+            --base-version "$BASE_VERSION" <<< "$PRIOR_VERSIONS")
+          if [[ "$EXPECTED_VERSION" != "$VERSION" ]]; then
+            echo "Main release version changed before publication" >&2
+            exit 1
+          fi
+          LATEST_VERSION=$(uv run --no-sync python scripts/compute_main_release_version.py \
+            --base-version "$BASE_VERSION" --latest-existing <<< "$PRIOR_VERSIONS")
+          if [[ -n "$LATEST_VERSION" ]]; then
+            git fetch --no-tags origin "+refs/tags/v${LATEST_VERSION}:refs/tags/v${LATEST_VERSION}"
+            if ! git merge-base --is-ancestor "v${LATEST_VERSION}^{commit}" "$SOURCE_SHA"; then
+              echo "Main release source predates the latest stable release" >&2
+              exit 1
+            fi
+          fi
+      - name: Inspect PyPI release state
+        id: pypi
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+            verify-release --registry pypi --version "$VERSION" --dist-dir dist)
+          status=$(jq -r '.status' <<< "$result")
+          if [[ "$status" == "absent" ]]; then
+            echo "upload=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$status" == "exact" ]]; then
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unexpected PyPI status: $status" >&2
+            exit 1
+          fi
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        if: steps.pypi.outputs.upload == 'true'
+      - name: Download and verify exact PyPI artifacts
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          for attempt in {1..12}; do
+            if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+              verify-release --registry pypi --version "$VERSION" --dist-dir dist \
+              --download-dir verified-pypi); then
+              exit 1
+            fi
+            status=$(jq -r '.status' <<< "$result")
+            if [[ "$status" == "exact" ]]; then
+              break
+            fi
+            if [[ "$status" != "absent" || "$attempt" == "12" ]]; then
+              echo "PyPI did not expose the exact release artifacts" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
+          [[ -n "$wheel" ]]
+          [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
+
+  release-main:
+    name: Create main GitHub release
+    if: >-
+      always() &&
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      github.event_name == 'push' &&
+      github.run_attempt == 1 &&
+      github.ref == 'refs/heads/main' &&
+      needs.build.result == 'success' &&
+      needs.publish-main-pypi.result == 'success' &&
+      needs.build.outputs.channel == 'stable'
+    needs: [build, publish-main-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.build.outputs.source_sha }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distributions
+          path: dist/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: distribution-sha256
+      - name: Download release toolchain SBOM
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: release-toolchain-sbom
+          path: dist/
+      - name: Verify and select release assets
+        run: |
+          sha256sum --check distribution-sha256.txt
+          rm -f dist/plugin_scanner-* dist/plugin-scanner-*
+      - name: Attest main release assets
+        id: provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-path: dist/*
+      - name: Materialize provenance bundle
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: cp "${{ steps.provenance.outputs.bundle-path }}" "dist/hol-guard-v${VERSION}.intoto.jsonl"
+      - name: Create discoverable main release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          tag="v${VERSION}"
+          remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
+          if [[ -z "$remote_tag_sha" ]]; then
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/${tag}" \
+              -f sha="$SOURCE_SHA" >/dev/null
+            remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/${tag}" | awk '{print $1}')
+          fi
+          if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
+            echo "Stable tag does not target the published source" >&2
+            exit 1
+          fi
+          if release_json=$(gh release view "$tag" --json isDraft,isPrerelease 2>/dev/null); then
+            if ! jq -e '.isDraft == false and .isPrerelease == false' <<< "$release_json" >/dev/null; then
+              echo "Existing stable release is a draft or prerelease" >&2
+              exit 1
+            fi
+            existing_dir=$(mktemp -d)
+            gh release download "$tag" --dir "$existing_dir"
+            mapfile -d '' local_files < <(find dist -maxdepth 1 -type f -print0 | sort -z)
+            mapfile -d '' remote_files < <(find "$existing_dir" -maxdepth 1 -type f -print0 | sort -z)
+            [[ "${#local_files[@]}" -gt 0 ]]
+            [[ "${#local_files[@]}" == "${#remote_files[@]}" ]]
+            for local_file in "${local_files[@]}"; do
+              remote_file="$existing_dir/$(basename "$local_file")"
+              [[ -f "$remote_file" ]]
+              if [[ "$remote_file" != *.intoto.jsonl ]]; then
+                cmp --silent "$local_file" "$remote_file"
+              fi
+            done
+            bundle="$existing_dir/hol-guard-v${VERSION}.intoto.jsonl"
+            [[ -s "$bundle" ]]
+            shopt -s nullglob
+            remote_guard_files=("$existing_dir"/hol_guard-*)
+            [[ "${#remote_guard_files[@]}" -gt 0 ]]
+            for remote_file in "${remote_guard_files[@]}"; do
+              gh attestation verify "$remote_file" --repo "$GITHUB_REPOSITORY" \
+                --bundle "$bundle" --source-digest "$SOURCE_SHA" >/dev/null
+            done
+            exit 0
+          fi
+          body_file=$(mktemp)
+          cat > "$body_file" <<EOF
+          Guard ${VERSION}
+
+          Install this release:
+
+          \`\`\`bash
+          uv tool install "hol-guard[cisco]==${VERSION}"
+          \`\`\`
+          EOF
+          mapfile -d '' ASSET_FILES < <(find dist -maxdepth 1 -type f -print0 | sort -z)
+          gh release create "$tag" \
+            --repo "${{ github.repository }}" \
+            --target "$SOURCE_SHA" \
+            --title "Guard ${VERSION}" \
+            --notes-file "$body_file" \
+            --verify-tag \
+            "${ASSET_FILES[@]}"
+
   release-alpha:
     name: Create alpha GitHub prerelease
     if: >-
@@ -663,13 +973,25 @@ jobs:
     if: >-
       always() &&
       vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      github.event_name == 'workflow_dispatch' &&
-      github.run_attempt == 1 &&
       needs.build.result == 'success' &&
-      needs.build.outputs.channel == 'alpha' &&
-      needs.publish-alpha-pypi.result == 'success' &&
-      needs.release-alpha.result == 'success'
-    needs: [build, publish-alpha-pypi, release-alpha]
+      (
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.run_attempt == 1 &&
+          needs.build.outputs.channel == 'alpha' &&
+          needs.publish-alpha-pypi.result == 'success' &&
+          needs.release-alpha.result == 'success'
+        ) ||
+        (
+          github.event_name == 'push' &&
+          github.run_attempt == 1 &&
+          github.ref == 'refs/heads/main' &&
+          needs.build.outputs.channel == 'stable' &&
+          needs.publish-main-pypi.result == 'success' &&
+          needs.release-main.result == 'success'
+        )
+      )
+    needs: [build, publish-alpha-pypi, publish-main-pypi, release-alpha, release-main]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -699,6 +1021,9 @@ jobs:
           {
             echo "value<<EOF"
             echo "${IMAGE_NAME}:${VERSION}"
+            if [[ "${{ needs.build.outputs.channel }}" == "stable" ]]; then
+              echo "${IMAGE_NAME}:latest"
+            fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5

--- a/scripts/compute_main_release_version.py
+++ b/scripts/compute_main_release_version.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Compute the next stable release version for a main-branch build."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable
+
+from packaging.version import InvalidVersion, Version
+
+
+def _canonical_stable(version_text: str, *, label: str) -> Version:
+    try:
+        version = Version(version_text)
+    except InvalidVersion as exc:
+        raise ValueError(f"{label} is not a valid PEP 440 version: {version_text!r}") from exc
+    if (
+        version_text != str(version)
+        or len(version.release) != 3
+        or version.pre is not None
+        or version.dev is not None
+        or version.post is not None
+        or version.local is not None
+    ):
+        raise ValueError(f"{label} must be a canonical X.Y.Z stable version")
+    return version
+
+
+def _stable_versions_for_line(base: Version, existing_versions: Iterable[str]) -> list[Version]:
+    same_line: list[Version] = []
+
+    for version_text in existing_versions:
+        try:
+            version = Version(version_text)
+        except InvalidVersion as exc:
+            raise ValueError(f"Registry version is invalid: {version_text!r}") from exc
+        if version_text != str(version) or version.local is not None:
+            raise ValueError(f"Registry version is not canonical: {version_text!r}")
+        if (
+            version.release[:2] == base.release[:2]
+            and len(version.release) == 3
+            and version.epoch == 0
+            and version.pre is None
+            and version.dev is None
+            and version.post is None
+        ):
+            same_line.append(version)
+
+    return same_line
+
+
+def latest_main_release_version(base_version: str, existing_versions: Iterable[str]) -> str | None:
+    base = _canonical_stable(base_version, label="Repository version")
+    same_line = _stable_versions_for_line(base, existing_versions)
+    return str(max(same_line)) if same_line else None
+
+
+def compute_main_release_version(base_version: str, existing_versions: Iterable[str]) -> str:
+    base = _canonical_stable(base_version, label="Repository version")
+    same_line = _stable_versions_for_line(base, existing_versions)
+
+    if not same_line:
+        return str(base)
+
+    latest = max(same_line)
+    next_registry = Version(f"{base.major}.{base.minor}.{latest.micro + 1}")
+    return str(max(base, next_registry))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    _ = parser.add_argument("--base-version", required=True)
+    _ = parser.add_argument("--latest-existing", action="store_true")
+    args = parser.parse_args()
+    base_version = str(args.base_version)
+    latest_existing = bool(args.latest_existing)
+
+    try:
+        payload = json.load(sys.stdin)
+        if not isinstance(payload, list) or not all(isinstance(item, str) for item in payload):
+            raise ValueError("Registry versions must be a JSON array of strings")
+        if latest_existing:
+            latest = latest_main_release_version(base_version, payload)
+            if latest is not None:
+                print(latest)
+        else:
+            print(compute_main_release_version(base_version, payload))
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_compute_main_release_version.py
+++ b/tests/test_compute_main_release_version.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+import pytest
+
+from scripts.compute_main_release_version import compute_main_release_version, latest_main_release_version, main
+
+
+@pytest.mark.parametrize(
+    ("base", "existing", "expected"),
+    [
+        ("2.0.1117", ["2.0.1116"], "2.0.1117"),
+        ("2.0.1117", ["2.0.1117"], "2.0.1118"),
+        ("2.0.1117", ["2.0.1120"], "2.0.1121"),
+        ("2.0.1117", ["2.0.1117.dev4", "2.2.0a1", "3.1.0a5"], "2.0.1117"),
+        ("3.1.0", ["2.0.2000", "3.1.0a5"], "3.1.0"),
+    ],
+)
+def test_computes_monotonic_version_for_repository_release_line(
+    base: str,
+    existing: list[str],
+    expected: str,
+) -> None:
+    assert compute_main_release_version(base, existing) == expected
+
+
+@pytest.mark.parametrize("base", ["2.0", "2.0.1a1", "2.0.1.dev1", "v2.0.1", "not-a-version"])
+def test_rejects_noncanonical_repository_versions(base: str) -> None:
+    with pytest.raises(ValueError, match="Repository version"):
+        compute_main_release_version(base, [])
+
+
+def test_rejects_noncanonical_registry_versions() -> None:
+    with pytest.raises(ValueError, match="Registry version"):
+        compute_main_release_version("2.0.1", ["2.0.01"])
+
+
+def test_reports_latest_stable_version_for_source_monotonicity() -> None:
+    assert latest_main_release_version("2.0.1117", ["2.0.1116", "2.0.1117.dev4", "3.1.0a5"]) == "2.0.1116"
+    assert latest_main_release_version("2.0.1117", ["2.2.0a1", "3.1.0a5"]) is None
+
+
+def test_cli_reports_latest_existing_stable(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["compute_main_release_version.py", "--base-version", "2.0.1117", "--latest-existing"],
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(["2.0.1116", "3.1.0a5"])))
+
+    assert main() == 0
+    assert capsys.readouterr().out == "2.0.1116\n"
+
+
+def test_cli_reads_registry_versions_from_stdin(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["compute_main_release_version.py", "--base-version", "2.0.1117"])
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(["2.0.1116"])))
+
+    assert main() == 0
+    assert capsys.readouterr().out == "2.0.1117\n"
+
+
+def test_cli_fails_closed_for_invalid_registry_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["compute_main_release_version.py", "--base-version", "2.0.1117"])
+    monkeypatch.setattr(sys, "stdin", io.StringIO('{"version":"2.0.1116"}'))
+
+    assert main() == 1
+    assert "JSON array of strings" in capsys.readouterr().err

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -39,7 +39,7 @@ def test_release_branches_run_ci_and_pr_canaries() -> None:
     assert "tags" not in publish[True]["push"]
 
 
-def test_ordinary_pushes_and_tag_pushes_cannot_publish() -> None:
+def test_main_pushes_publish_stable_while_tag_pushes_cannot_publish() -> None:
     workflow = _workflow(PUBLISH_WORKFLOW)
     jobs = workflow["jobs"]
 
@@ -50,17 +50,21 @@ def test_ordinary_pushes_and_tag_pushes_cannot_publish() -> None:
         "publish-container",
     ):
         assert "github.event_name == 'workflow_dispatch'" in jobs[job_name]["if"]
-    assert "publish-stable-testpypi" not in jobs
-    assert "publish-stable-pypi" not in jobs
-    assert "release" not in jobs
+    for job_name in ("publish-main-testpypi", "publish-main-pypi", "release-main"):
+        condition = jobs[job_name]["if"]
+        assert "github.event_name == 'push'" in condition
+        assert "github.run_attempt == 1" in condition
+        assert "github.ref == 'refs/heads/main'" in condition
+        assert "needs.build.outputs.channel == 'stable'" in condition
+    assert jobs["publish-main-pypi"]["needs"] == ["build", "publish-main-testpypi"]
+    assert jobs["release-main"]["needs"] == ["build", "publish-main-pypi"]
 
-    assert "sync-repository-version" not in jobs
     workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
-    assert "[skip release publish]" not in workflow_text
     assert "startsWith(github.ref, 'refs/tags/')" not in workflow_text
+    assert "github.ref == 'refs/heads/main'" in workflow_text
 
 
-def test_push_build_keeps_the_repository_version_without_restamping() -> None:
+def test_main_push_build_computes_a_registry_derived_stable_version() -> None:
     workflow = _workflow(PUBLISH_WORKFLOW)
     build_steps = workflow["jobs"]["build"]["steps"]
     compute_run = next(step["run"] for step in build_steps if step.get("name") == "Compute publish version")
@@ -70,7 +74,10 @@ def test_push_build_keeps_the_repository_version_without_restamping() -> None:
     assert 'VERSION="$BASE_VERSION"' in compute_run
     assert 'CHANNEL="integration"' in compute_run
     assert 'elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]' in compute_run
-    assert '[[ "$GITHUB_EVENT_NAME" == "push" ]]' not in compute_run
+    assert 'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]' in compute_run
+    assert 'CHANNEL="stable"' in compute_run
+    assert "verify_release_registry.py" in compute_run
+    assert "compute_main_release_version.py" in compute_run
     assert "if" not in stamp_step
     assert "sync_repo_version.py --check" in stamp_run
     assert '[[ "$CURRENT_VERSION" == "$VERSION" ]]' in stamp_run
@@ -125,7 +132,9 @@ def test_release_dispatch_binds_channel_train_version_and_sha() -> None:
     assert '"$GITHUB_REF" != "refs/heads/release/2.2"' in dispatch_gate["run"]
     assert '"$EXPECTED_SHA" != "$GITHUB_SHA"' in dispatch_gate["run"]
     assert jobs["build"]["needs"] == "authorize-release"
-    assert jobs["build"]["if"] == "github.event_name != 'workflow_dispatch' || github.run_attempt == 1"
+    build_condition = jobs["build"]["if"]
+    assert "github.event_name != 'workflow_dispatch' || github.run_attempt == 1" in build_condition
+    assert "github.event_name != 'push' || github.run_attempt == 1" in build_condition
     assert jobs["alpha-cross-platform"]["needs"] == "build"
     for job_name in (
         "alpha-cross-platform",
@@ -166,6 +175,8 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
     for job_name in (
         "publish-alpha-testpypi",
         "publish-alpha-pypi",
+        "publish-main-testpypi",
+        "publish-main-pypi",
     ):
         steps = jobs[job_name]["steps"]
         assert any(step.get("run") == "sha256sum --check distribution-sha256.txt" for step in steps)
@@ -185,10 +196,19 @@ def test_publish_jobs_use_channel_specific_protected_environments() -> None:
     assert jobs["publish-testpypi"]["environment"] == "testpypi"
     assert jobs["publish-alpha-testpypi"]["environment"] == "testpypi-alpha"
     assert jobs["publish-alpha-pypi"]["environment"] == "pypi-alpha"
+    assert jobs["publish-main-testpypi"]["environment"] == "testpypi"
+    assert jobs["publish-main-pypi"]["environment"] == "pypi"
     assert jobs["publish-testpypi"]["permissions"] == {"id-token": "write"}
     assert jobs["publish-alpha-testpypi"]["permissions"] == {"contents": "read", "id-token": "write"}
     assert jobs["publish-alpha-pypi"]["permissions"] == {"contents": "read", "id-token": "write"}
-    for job_name in ("publish-alpha-testpypi", "publish-alpha-pypi"):
+    assert jobs["publish-main-testpypi"]["permissions"] == {"contents": "read", "id-token": "write"}
+    assert jobs["publish-main-pypi"]["permissions"] == {"contents": "read", "id-token": "write"}
+    for job_name in (
+        "publish-alpha-testpypi",
+        "publish-alpha-pypi",
+        "publish-main-testpypi",
+        "publish-main-pypi",
+    ):
         assert "vars.RELEASE_PUBLISHING_ENABLED == 'true'" in jobs[job_name]["if"]
 
 
@@ -196,7 +216,7 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
     workflow = _workflow(PUBLISH_WORKFLOW)
     jobs = workflow["jobs"]
 
-    for job_name in ("publish-alpha-testpypi",):
+    for job_name in ("publish-alpha-testpypi", "publish-main-testpypi"):
         steps = jobs[job_name]["steps"]
         inspect_step = next(step for step in steps if step.get("name") == "Inspect TestPyPI release state")
         publish_step = next(step for step in steps if str(step.get("uses", "")).startswith("pypa/"))
@@ -208,6 +228,14 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
         assert 'status" == "exact"' in verify_step["run"]
         assert 'status" != "absent"' in verify_step["run"]
         assert '== "hol-guard $VERSION"' in verify_step["run"]
+
+    main_revalidation = next(
+        step["run"] for step in jobs["publish-main-pypi"]["steps"] if step.get("name") == "Revalidate main publication"
+    )
+    assert "compute_main_release_version.py" in main_revalidation
+    assert "--latest-existing" in main_revalidation
+    assert "refs/tags/v${LATEST_VERSION}" in main_revalidation
+    assert 'git merge-base --is-ancestor "v${LATEST_VERSION}^{commit}" "$SOURCE_SHA"' in main_revalidation
 
     alpha_run = next(
         step["run"]
@@ -223,7 +251,7 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
     workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
     assert 'for registry in ("pypi.org", "test.pypi.org")' not in workflow_text
 
-    for job_name in ("publish-alpha-pypi",):
+    for job_name in ("publish-alpha-pypi", "publish-main-pypi"):
         steps = jobs[job_name]["steps"]
         inspect_step = next(step for step in steps if step.get("name") == "Inspect PyPI release state")
         publish_step = next(step for step in steps if str(step.get("uses", "")).startswith("pypa/"))
@@ -272,22 +300,41 @@ def test_release_tags_are_bound_to_the_exact_published_source() -> None:
     assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in release_run
     assert "--verify-tag" in release_run
 
+    main_release_run = next(
+        step["run"] for step in jobs["release-main"]["steps"] if step.get("name") == "Create discoverable main release"
+    )
+    assert 'tag="v${VERSION}"' in main_release_run
+    assert 'gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs"' in main_release_run
+    assert '-f sha="$SOURCE_SHA"' in main_release_run
+    assert 'remote_tag_sha" != "$SOURCE_SHA"' in main_release_run
+    assert 'gh release view "$tag" --json isDraft,isPrerelease' in main_release_run
+    assert "Existing stable release is a draft or prerelease" in main_release_run
+    assert 'remote_guard_files=("$existing_dir"/hol_guard-*)' in main_release_run
+    assert '[[ "${#remote_guard_files[@]}" -gt 0 ]]' in main_release_run
+    assert 'gh attestation verify "$remote_file"' in main_release_run
+    assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in main_release_run
+    assert "--verify-tag" in main_release_run
 
-def test_release_22_has_no_stable_publication_surface() -> None:
+
+def test_release_22_dispatch_remains_alpha_only_while_main_is_stable() -> None:
     workflow = _workflow(PUBLISH_WORKFLOW)
     jobs = workflow["jobs"]
     workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
 
     assert "channel == 'alpha'" in jobs["release-alpha"]["if"]
-    assert "channel == 'stable'" not in jobs["publish-container"]["if"]
+    assert "github.event_name == 'workflow_dispatch'" in jobs["release-alpha"]["if"]
+    assert "channel == 'stable'" in jobs["publish-container"]["if"]
     assert jobs["publish-container"]["needs"] == [
         "build",
         "publish-alpha-pypi",
+        "publish-main-pypi",
         "release-alpha",
+        "release-main",
     ]
-    assert not {"publish-stable-testpypi", "publish-stable-pypi", "release"} & jobs.keys()
-    assert "testpypi-stable" not in workflow_text
-    assert "pypi-stable" not in workflow_text
-    assert "refs/tags/v${VERSION}" not in workflow_text
+    assert {"publish-main-testpypi", "publish-main-pypi", "release-main"} <= jobs.keys()
+    assert jobs["publish-main-testpypi"]["environment"] == "testpypi"
+    assert jobs["publish-main-pypi"]["environment"] == "pypi"
+    assert "refs/tags/${tag}" in workflow_text
     assert "--channel stable" not in workflow_text
-    assert "name: Create GitHub Release" not in workflow_text
+    inputs = workflow[True]["workflow_dispatch"]["inputs"]
+    assert inputs["release_channel"]["options"] == ["alpha"]


### PR DESCRIPTION
## Summary
- restore automatic stable version selection and publication for successful main pushes
- verify one hashed artifact through TestPyPI and PyPI before creating the source-bound release and container tags
- deny release reruns and prevent queued workflows from publishing an older source after a newer stable release

## Testing
- `actionlint .github/workflows/publish.yml`
- `uv run --no-sync python scripts/check_privileged_workflows.py`
- `uv run --no-sync pytest -q tests/test_compute_main_release_version.py tests/test_release_train_workflow.py tests/test_pr_testpypi_canary_workflow.py tests/test_validate_alpha_release.py tests/test_release_toolchain_sbom.py tests/test_sync_repo_version.py tests/test_privileged_workflow_policy.py`
- `uv build`
