### PR TITLE
feat(guard): persist command activity evidence

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -12,6 +12,7 @@ from .store_base import (
 )
 from .store_approval_facade import StoreApprovalsMixin
 from .store_cloud_events import StoreCloudEventsMixin
+from .store_command_activity import StoreCommandActivityMixin
 from .store_connection_schema import StoreConnectionSchemaMixin
 from .store_event_receipts import StoreEventReceiptsMixin
 from .store_evidence_facade import StoreEvidenceMixin
@@ -32,6 +33,7 @@ from .store_sessions import StoreSessionsMixin
 class GuardStore(
     StoreSecretPolicyIntegrityMixin,
     StoreConnectionSchemaMixin,
+    StoreCommandActivityMixin,
     StoreInventoryMixin,
     StorePolicyMixin,
     StorePolicyIntegrityAdminMixin,

--- a/src/codex_plugin_scanner/guard/store_command_activity.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity.py
@@ -1,0 +1,216 @@
+"""Transactional persistence for command activity evidence."""
+
+# pyright: reportPrivateUsage=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Sequence
+from contextlib import AbstractContextManager
+from typing import Protocol, cast
+
+from .runtime.command_activity_contract import (
+    CommandActivity,
+    CommandActivityEvidence,
+    CommandActivityMatch,
+    CorrelationHandle,
+)
+
+
+class _ConnectionOwner(Protocol):
+    def _connect(self) -> AbstractContextManager[sqlite3.Connection]: ...
+
+
+class StoreCommandActivityMixin:
+    def record_command_activity(self: _ConnectionOwner, evidence: CommandActivityEvidence) -> bool:
+        """Persist one logical command and its rule hits; return false for an exact replay."""
+
+        if not isinstance(cast(object, evidence), CommandActivityEvidence):
+            raise ValueError("evidence must be a CommandActivityEvidence")
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            existing = cast(
+                sqlite3.Row | None,
+                connection.execute(
+                    "select * from command_activity where activity_id = ?",
+                    (evidence.activity.activity_id,),
+                ).fetchone(),
+            )
+            if existing is not None:
+                _require_exact_replay(connection, evidence, existing)
+                return False
+            connection.execute(
+                """
+                insert into command_activity (
+                  activity_id, occurred_at, harness, hook_phase, execution_status,
+                  proof_level, policy_action, decision_reason_code, controlling_rule_id,
+                  parse_confidence, uncertainty_class, match_count, prompted,
+                  approval_reuse_status, receipt_link_status, receipt_id,
+                  evaluation_latency_bucket, persistence_latency_bucket, schema_version
+                ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                _activity_values(evidence.activity),
+            )
+            connection.executemany(
+                """
+                insert into command_activity_matches (
+                  activity_id, ordinal, extension_id, extension_version, rule_id,
+                  rule_version, match_class, severity, default_floor,
+                  safe_variant_id, schema_version
+                ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                tuple(_match_values(item) for item in evidence.matches),
+            )
+            connection.executemany(
+                """
+                insert into command_activity_match_effects (
+                  activity_id, ordinal, effect_class
+                ) values (?, ?, ?)
+                """,
+                _effect_values(evidence),
+            )
+            connection.executemany(
+                """
+                insert into command_activity_correlations (
+                  activity_id, kind, harness, key_id, digest
+                ) values (?, ?, ?, ?, ?)
+                """,
+                _correlation_values(evidence.activity),
+            )
+            return True
+
+    def count_command_activities(self: _ConnectionOwner) -> int:
+        with self._connect() as connection:
+            row = cast(
+                tuple[int] | None,
+                connection.execute("select count(*) from command_activity").fetchone(),
+            )
+        return int(row[0]) if row is not None else 0
+
+    def count_command_activity_rule_hits(self: _ConnectionOwner, rule_id: str | None = None) -> int:
+        with self._connect() as connection:
+            if rule_id is None:
+                row = cast(
+                    tuple[int] | None,
+                    connection.execute("select count(*) from command_activity_matches").fetchone(),
+                )
+            else:
+                row = cast(
+                    tuple[int] | None,
+                    connection.execute(
+                        "select count(*) from command_activity_matches where rule_id = ?",
+                        (rule_id,),
+                    ).fetchone(),
+                )
+        return int(row[0]) if row is not None else 0
+
+
+def _require_exact_replay(
+    connection: sqlite3.Connection,
+    evidence: CommandActivityEvidence,
+    existing: sqlite3.Row,
+) -> None:
+    persisted_activity = _row_values(existing)
+    persisted_matches = _query_values(
+        connection,
+        "select * from command_activity_matches where activity_id = ? order by ordinal",
+        evidence.activity.activity_id,
+    )
+    persisted_correlations = _query_values(
+        connection,
+        "select * from command_activity_correlations where activity_id = ? order by kind",
+        evidence.activity.activity_id,
+    )
+    persisted_effects = _query_values(
+        connection,
+        """
+        select * from command_activity_match_effects
+        where activity_id = ? order by ordinal, effect_class
+        """,
+        evidence.activity.activity_id,
+    )
+    expected_matches = tuple(_match_values(item) for item in evidence.matches)
+    expected_effects = _effect_values(evidence)
+    expected_correlations = tuple(sorted(_correlation_values(evidence.activity), key=lambda item: str(item[1])))
+    if (
+        persisted_activity != _activity_values(evidence.activity)
+        or persisted_matches != expected_matches
+        or persisted_effects != expected_effects
+        or persisted_correlations != expected_correlations
+    ):
+        raise ValueError("conflicting command activity replay")
+
+
+def _query_values(
+    connection: sqlite3.Connection,
+    query: str,
+    activity_id: str,
+) -> tuple[tuple[object, ...], ...]:
+    rows = cast(
+        list[sqlite3.Row],
+        connection.execute(query, (activity_id,)).fetchall(),
+    )
+    return tuple(_row_values(row) for row in rows)
+
+
+def _row_values(row: sqlite3.Row) -> tuple[object, ...]:
+    return tuple(cast(Sequence[object], row))
+
+
+def _activity_values(activity: CommandActivity) -> tuple[object, ...]:
+    return (
+        activity.activity_id,
+        activity.occurred_at.isoformat(),
+        activity.harness,
+        activity.hook_phase.value,
+        activity.execution_status.value,
+        activity.proof_level.value,
+        activity.policy_action,
+        activity.decision_reason_code.value if activity.decision_reason_code is not None else None,
+        activity.controlling_rule_id,
+        activity.parse_confidence.value if activity.parse_confidence is not None else None,
+        activity.uncertainty_class.value if activity.uncertainty_class is not None else None,
+        activity.match_count,
+        int(activity.prompted),
+        activity.approval_reuse_status.value,
+        activity.receipt_link_status.value,
+        activity.receipt_id,
+        activity.evaluation_latency_bucket.value,
+        activity.persistence_latency_bucket.value,
+        activity.schema_version,
+    )
+
+
+def _match_values(match: CommandActivityMatch) -> tuple[object, ...]:
+    return (
+        match.activity_id,
+        match.ordinal,
+        match.identity.extension_id,
+        match.identity.extension_version,
+        match.identity.rule_id,
+        match.identity.rule_version,
+        match.match_class.value,
+        match.severity.value,
+        match.default_floor,
+        match.safe_variant_id,
+        match.schema_version,
+    )
+
+
+def _effect_values(evidence: CommandActivityEvidence) -> tuple[tuple[object, ...], ...]:
+    return tuple(
+        (match.activity_id, match.ordinal, effect.value)
+        for match in evidence.matches
+        for effect in sorted(match.effect_claims, key=lambda item: item.value)
+    )
+
+
+def _correlation_values(activity: CommandActivity) -> tuple[tuple[object, ...], ...]:
+    handles = tuple(
+        handle for handle in (activity.request_correlation, activity.session_correlation) if handle is not None
+    )
+    return tuple(_correlation_value(activity.activity_id, handle) for handle in handles)
+
+
+def _correlation_value(activity_id: str, handle: CorrelationHandle) -> tuple[object, ...]:
+    return (activity_id, handle.kind.value, handle.harness, handle.key_id, handle.digest)

--- a/src/codex_plugin_scanner/guard/store_command_activity_schema.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_schema.py
@@ -1,0 +1,360 @@
+"""Schema migration for privacy-safe command activity evidence."""
+
+# pyright: reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from typing import cast
+
+COMMAND_ACTIVITY_SCHEMA_MIGRATION_VERSION = 10
+
+
+def command_activity_schema_statements() -> tuple[str, ...]:
+    return (
+        """
+        create table if not exists command_activity (
+          activity_id text primary key,
+          occurred_at text not null,
+          harness text not null,
+          hook_phase text not null,
+          execution_status text not null,
+          proof_level text not null,
+          policy_action text,
+          decision_reason_code text,
+          controlling_rule_id text,
+          parse_confidence text,
+          uncertainty_class text,
+          match_count integer not null check (match_count >= 0),
+          prompted integer not null check (prompted in (0, 1)),
+          approval_reuse_status text not null,
+          receipt_link_status text not null,
+          receipt_id text,
+          evaluation_latency_bucket text not null,
+          persistence_latency_bucket text not null,
+          schema_version text not null
+        )
+        """,
+        """
+        create table if not exists command_activity_matches (
+          activity_id text not null references command_activity(activity_id) on delete cascade,
+          ordinal integer not null check (ordinal >= 0),
+          extension_id text not null,
+          extension_version text not null,
+          rule_id text not null,
+          rule_version text not null,
+          match_class text not null,
+          severity text not null,
+          default_floor text not null,
+          safe_variant_id text,
+          schema_version text not null,
+          primary key (activity_id, ordinal),
+          unique (activity_id, rule_id)
+        )
+        """,
+        """
+        create table if not exists command_activity_match_effects (
+          activity_id text not null,
+          ordinal integer not null,
+          effect_class text not null,
+          primary key (activity_id, ordinal, effect_class),
+          foreign key (activity_id, ordinal)
+            references command_activity_matches(activity_id, ordinal) on delete cascade
+        )
+        """,
+        """
+        create table if not exists command_activity_correlations (
+          activity_id text not null references command_activity(activity_id) on delete cascade,
+          kind text not null,
+          harness text not null,
+          key_id text not null,
+          digest text not null,
+          primary key (activity_id, kind)
+        )
+        """,
+        """
+        create table if not exists command_activity_daily_totals (
+          day text primary key,
+          total integer not null default 0 check (total >= 0)
+        )
+        """,
+        """
+        create table if not exists command_activity_daily_rollups (
+          day text not null,
+          dimension text not null,
+          dimension_value text not null,
+          count integer not null default 0 check (count >= 0),
+          primary key (day, dimension, dimension_value)
+        )
+        """,
+        """
+        create index if not exists idx_command_activity_occurred_at
+        on command_activity (occurred_at desc, activity_id desc)
+        """,
+        """
+        create index if not exists idx_command_activity_harness_occurred_at
+        on command_activity (harness, occurred_at desc, activity_id desc)
+        """,
+        """
+        create index if not exists idx_command_activity_match_rule
+        on command_activity_matches (rule_id, activity_id)
+        """,
+        """
+        create index if not exists idx_command_activity_match_extension
+        on command_activity_matches (extension_id, activity_id)
+        """,
+        """
+        create index if not exists idx_command_activity_correlation_lookup
+        on command_activity_correlations (kind, harness, key_id, digest)
+        """,
+        """
+        create unique index if not exists idx_command_activity_request_correlation_unique
+        on command_activity_correlations (harness, key_id, digest)
+        where kind = 'request'
+        """,
+        """
+        create trigger if not exists trg_command_activity_matches_parent
+        before insert on command_activity_matches
+        when not exists (
+          select 1 from command_activity where activity_id = new.activity_id
+        )
+        begin
+          select raise(abort, 'command activity match requires parent activity');
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_effects_parent
+        before insert on command_activity_match_effects
+        when not exists (
+          select 1 from command_activity_matches
+          where activity_id = new.activity_id and ordinal = new.ordinal
+        )
+        begin
+          select raise(abort, 'command activity effect requires parent match');
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_correlations_parent
+        before insert on command_activity_correlations
+        when not exists (
+          select 1 from command_activity where activity_id = new.activity_id
+        )
+        begin
+          select raise(abort, 'command activity correlation requires parent activity');
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_delete_children
+        after delete on command_activity
+        begin
+          delete from command_activity_correlations where activity_id = old.activity_id;
+          delete from command_activity_matches where activity_id = old.activity_id;
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_match_delete_effects
+        after delete on command_activity_matches
+        begin
+          delete from command_activity_match_effects
+          where activity_id = old.activity_id and ordinal = old.ordinal;
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_id_immutable
+        before update of activity_id on command_activity
+        when new.activity_id != old.activity_id
+        begin
+          select raise(abort, 'command activity identity is immutable');
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_match_parent_immutable
+        before update of activity_id, ordinal on command_activity_matches
+        when new.activity_id != old.activity_id or new.ordinal != old.ordinal
+        begin
+          select raise(abort, 'command activity match parent is immutable');
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_effect_parent_immutable
+        before update of activity_id, ordinal on command_activity_match_effects
+        when new.activity_id != old.activity_id or new.ordinal != old.ordinal
+        begin
+          select raise(abort, 'command activity effect parent is immutable');
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_correlation_parent_immutable
+        before update of activity_id on command_activity_correlations
+        when new.activity_id != old.activity_id
+        begin
+          select raise(abort, 'command activity correlation parent is immutable');
+        end
+        """,
+    )
+
+
+def ensure_command_activity_schema(connection: sqlite3.Connection, *, applied_at: str) -> None:
+    """Apply and version the complete v1 schema as one crash-safe migration."""
+
+    connection.execute("savepoint command_activity_schema_v1")
+    try:
+        for statement in command_activity_schema_statements():
+            connection.execute(statement)
+        _validate_command_activity_schema(connection, command_activity_schema_statements())
+        connection.execute(
+            "insert or ignore into schema_migrations (version, applied_at) values (?, ?)",
+            (COMMAND_ACTIVITY_SCHEMA_MIGRATION_VERSION, applied_at),
+        )
+    except BaseException:
+        connection.execute("rollback to command_activity_schema_v1")
+        connection.execute("release command_activity_schema_v1")
+        raise
+    connection.execute("release command_activity_schema_v1")
+
+
+def _validate_command_activity_schema(
+    connection: sqlite3.Connection,
+    statements: tuple[str, ...],
+) -> None:
+    expected_columns = {
+        "command_activity": {
+            "activity_id",
+            "occurred_at",
+            "harness",
+            "hook_phase",
+            "execution_status",
+            "proof_level",
+            "policy_action",
+            "decision_reason_code",
+            "controlling_rule_id",
+            "parse_confidence",
+            "uncertainty_class",
+            "match_count",
+            "prompted",
+            "approval_reuse_status",
+            "receipt_link_status",
+            "receipt_id",
+            "evaluation_latency_bucket",
+            "persistence_latency_bucket",
+            "schema_version",
+        },
+        "command_activity_matches": {
+            "activity_id",
+            "ordinal",
+            "extension_id",
+            "extension_version",
+            "rule_id",
+            "rule_version",
+            "match_class",
+            "severity",
+            "default_floor",
+            "safe_variant_id",
+            "schema_version",
+        },
+        "command_activity_match_effects": {"activity_id", "ordinal", "effect_class"},
+        "command_activity_correlations": {"activity_id", "kind", "harness", "key_id", "digest"},
+        "command_activity_daily_totals": {"day", "total"},
+        "command_activity_daily_rollups": {"day", "dimension", "dimension_value", "count"},
+    }
+    expected_primary_keys = {
+        "command_activity": ("activity_id",),
+        "command_activity_matches": ("activity_id", "ordinal"),
+        "command_activity_match_effects": ("activity_id", "ordinal", "effect_class"),
+        "command_activity_correlations": ("activity_id", "kind"),
+        "command_activity_daily_totals": ("day",),
+        "command_activity_daily_rollups": ("day", "dimension", "dimension_value"),
+    }
+    for table, expected in expected_columns.items():
+        rows = cast(
+            list[tuple[int, str, str, int, object | None, int]],
+            connection.execute(f"pragma table_info({table})").fetchall(),
+        )
+        actual = {str(row[1]) for row in rows}
+        if actual != expected:
+            raise RuntimeError(f"incompatible {table} schema")
+        primary_key = tuple(str(row[1]) for row in sorted(rows, key=lambda item: int(item[5])) if int(row[5]) > 0)
+        if primary_key != expected_primary_keys[table]:
+            raise RuntimeError(f"incompatible {table} primary key")
+    expected_indexes = {
+        "idx_command_activity_occurred_at": ("command_activity", ("occurred_at", "activity_id"), 0, 0),
+        "idx_command_activity_harness_occurred_at": (
+            "command_activity",
+            ("harness", "occurred_at", "activity_id"),
+            0,
+            0,
+        ),
+        "idx_command_activity_match_rule": (
+            "command_activity_matches",
+            ("rule_id", "activity_id"),
+            0,
+            0,
+        ),
+        "idx_command_activity_match_extension": (
+            "command_activity_matches",
+            ("extension_id", "activity_id"),
+            0,
+            0,
+        ),
+        "idx_command_activity_correlation_lookup": (
+            "command_activity_correlations",
+            ("kind", "harness", "key_id", "digest"),
+            0,
+            0,
+        ),
+        "idx_command_activity_request_correlation_unique": (
+            "command_activity_correlations",
+            ("harness", "key_id", "digest"),
+            1,
+            1,
+        ),
+    }
+    actual_indexes: dict[str, tuple[str, tuple[str, ...], int, int]] = {}
+    for table in ("command_activity", "command_activity_matches", "command_activity_correlations"):
+        rows = cast(
+            list[tuple[int, str, int, str, int]],
+            connection.execute(f"pragma index_list({table})").fetchall(),
+        )
+        for _, name, unique, _, partial in rows:
+            columns = cast(
+                list[tuple[int, int, str]],
+                connection.execute(f"pragma index_info({name})").fetchall(),
+            )
+            actual_indexes[name] = (table, tuple(row[2] for row in columns), unique, partial)
+    for name, expected in expected_indexes.items():
+        if actual_indexes.get(name) != expected:
+            raise RuntimeError(f"incompatible command activity index: {name}")
+    _validate_schema_object_sql(connection, statements)
+
+
+def _validate_schema_object_sql(
+    connection: sqlite3.Connection,
+    statements: tuple[str, ...],
+) -> None:
+    expected: dict[str, str] = {}
+    for statement in statements:
+        canonical = _canonical_sql(statement)
+        match = re.match(
+            r"create (?:unique )?(?:table|index|trigger) if not exists ([a-z0-9_]+)",
+            canonical,
+        )
+        if match is None:
+            raise RuntimeError("unrecognized command activity schema statement")
+        expected[match.group(1)] = canonical.replace(" if not exists", "", 1)
+    placeholders = ", ".join("?" for _ in expected)
+    rows = cast(
+        list[tuple[str, str]],
+        connection.execute(
+            f"select name, sql from sqlite_schema where name in ({placeholders})",
+            tuple(expected),
+        ).fetchall(),
+    )
+    actual = {name: _canonical_sql(sql) for name, sql in rows}
+    for name, expected_sql in expected.items():
+        if actual.get(name) != expected_sql:
+            raise RuntimeError(f"incompatible command activity schema object: {name}")
+
+
+def _canonical_sql(value: str) -> str:
+    return " ".join(value.strip().lower().split())

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 # ruff: noqa: F403,F405
 from .store_base import *
+from .store_command_activity_schema import ensure_command_activity_schema
 from .store_live_request_outbox import ensure_live_request_outbox_schema, seed_live_request_outbox
 from .store_secret_policy_integrity import _POLICY_INTEGRITY_LOOKUP_UNSET
 
@@ -615,6 +616,7 @@ class StoreConnectionSchemaMixin:
         with self._connect() as connection:
             for statement in statements:
                 connection.execute(statement)
+            ensure_command_activity_schema(connection, applied_at=_now())
             ensure_evidence_schema(connection)
             if not self._schema_version_applied(connection, version=4):
                 self._record_schema_version(connection, version=4)

--- a/tests/test_guard_command_activity_persistence.py
+++ b/tests/test_guard_command_activity_persistence.py
@@ -1,0 +1,377 @@
+"""Migration and idempotency tests for command activity persistence."""
+
+# pyright: reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import replace
+from datetime import datetime, timezone
+from multiprocessing import get_context
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard import store_command_activity_schema as activity_schema
+from codex_plugin_scanner.guard.runtime.command_activity_contract import (
+    ActivityApprovalReuseStatus,
+    ActivityDecisionReason,
+    ActivityLatencyBucket,
+    ActivityMatchClass,
+    ActivityParseConfidence,
+    CommandActivity,
+    CommandActivityEvidence,
+    CommandActivityMatch,
+    CommandExecutionStatus,
+    CommandHookPhase,
+    CommandProofLevel,
+    CorrelationHandle,
+    CorrelationKind,
+    ReceiptLinkStatus,
+)
+from codex_plugin_scanner.guard.runtime.command_activity_privacy import FORBIDDEN_ACTIVITY_FIELD_NAMES
+from codex_plugin_scanner.guard.runtime.effect_contract import EffectKind
+from codex_plugin_scanner.guard.runtime.extension_evidence import EvidenceSeverity, ExtensionRuleIdentity
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _correlation(kind: CorrelationKind, digest: str) -> CorrelationHandle:
+    return CorrelationHandle(kind, "codex", "key.v1", digest)
+
+
+def _evidence(
+    *,
+    activity_id: str = "activity:01",
+    two_matches: bool = True,
+    request_digest: str = "a" * 64,
+    session_digest: str = "b" * 64,
+) -> CommandActivityEvidence:
+    activity = CommandActivity(
+        activity_id=activity_id,
+        occurred_at=datetime(2026, 7, 18, 20, 0, tzinfo=timezone.utc),
+        harness="codex",
+        hook_phase=CommandHookPhase.PRE,
+        execution_status=CommandExecutionStatus.ALLOWED_UNCONFIRMED,
+        proof_level=CommandProofLevel.PRE_HOOK,
+        policy_action="allow",
+        decision_reason_code=ActivityDecisionReason.EXTENSION_MATCH,
+        controlling_rule_id="command.git.push",
+        parse_confidence=ActivityParseConfidence.EXACT,
+        uncertainty_class=None,
+        match_count=2 if two_matches else 1,
+        prompted=False,
+        approval_reuse_status=ActivityApprovalReuseStatus.NOT_APPLICABLE,
+        request_correlation=_correlation(CorrelationKind.REQUEST, request_digest),
+        session_correlation=_correlation(CorrelationKind.SESSION, session_digest),
+        receipt_link_status=ReceiptLinkStatus.NOT_APPLICABLE,
+        receipt_id=None,
+        evaluation_latency_bucket=ActivityLatencyBucket.LE_5_MS,
+        persistence_latency_bucket=ActivityLatencyBucket.LE_2_MS,
+    )
+    matches = [
+        CommandActivityMatch(
+            activity_id=activity_id,
+            ordinal=0,
+            identity=ExtensionRuleIdentity("command.git", "2.2.0", "command.git.push", "1.0.0"),
+            match_class=ActivityMatchClass.UNSAFE,
+            severity=EvidenceSeverity.HIGH,
+            default_floor="review",
+            effect_claims=frozenset({EffectKind.REMOTE_STATE_MUTATION}),
+        )
+    ]
+    if two_matches:
+        matches.append(
+            CommandActivityMatch(
+                activity_id=activity_id,
+                ordinal=1,
+                identity=ExtensionRuleIdentity(
+                    "command.package",
+                    "2.2.0",
+                    "command.package.install",
+                    "1.0.0",
+                ),
+                match_class=ActivityMatchClass.UNSAFE,
+                severity=EvidenceSeverity.CRITICAL,
+                default_floor="require-reapproval",
+                effect_claims=frozenset({EffectKind.PACKAGE_OR_SOURCE_INSTALLATION}),
+            )
+        )
+    return CommandActivityEvidence(activity, tuple(matches))
+
+
+def _table_names(path: Path) -> set[str]:
+    with sqlite3.connect(path) as connection:
+        return {
+            str(row[0]) for row in connection.execute("select name from sqlite_schema where type = 'table'").fetchall()
+        }
+
+
+def _record_in_process(guard_home: str, evidence: CommandActivityEvidence) -> bool:
+    store = GuardStore(Path(guard_home), prime_policy_integrity=False)
+    return store.record_command_activity(evidence)
+
+
+def test_command_activity_migration_is_forward_safe_and_reopens(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    with sqlite3.connect(guard_home / "guard.db") as connection:
+        connection.execute("create table schema_migrations (version integer primary key, applied_at text not null)")
+        connection.execute("insert into schema_migrations values (9, '2026-07-17T20:00:00+00:00')")
+    first = GuardStore(guard_home, prime_policy_integrity=False)
+    expected = {
+        "command_activity",
+        "command_activity_matches",
+        "command_activity_match_effects",
+        "command_activity_correlations",
+        "command_activity_daily_totals",
+        "command_activity_daily_rollups",
+    }
+
+    assert expected.issubset(_table_names(first.path))
+    with sqlite3.connect(first.path) as connection:
+        version = connection.execute(
+            "select version from schema_migrations where version = ?",
+            (activity_schema.COMMAND_ACTIVITY_SCHEMA_MIGRATION_VERSION,),
+        ).fetchone()
+    assert version == (activity_schema.COMMAND_ACTIVITY_SCHEMA_MIGRATION_VERSION,)
+
+    evidence = _evidence()
+    first.record_command_activity(evidence)
+    reopened = GuardStore(guard_home, prime_policy_integrity=False)
+    assert expected.issubset(_table_names(reopened.path))
+    assert reopened.record_command_activity(evidence) is False
+    assert reopened.count_command_activities() == 1
+
+
+def test_command_activity_migration_repairs_a_missing_table_on_reopen(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home, prime_policy_integrity=False)
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("drop table command_activity_daily_rollups")
+
+    GuardStore(guard_home, prime_policy_integrity=False)
+
+    assert "command_activity_daily_rollups" in _table_names(store.path)
+
+
+def test_command_activity_migration_failure_rolls_back_schema_and_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database_path = tmp_path / "migration.db"
+    with sqlite3.connect(database_path) as connection:
+        connection.execute("create table schema_migrations (version integer primary key, applied_at text not null)")
+        statements = activity_schema.command_activity_schema_statements()
+        monkeypatch.setattr(
+            activity_schema,
+            "command_activity_schema_statements",
+            lambda: (statements[0], "create table"),
+        )
+        with pytest.raises(sqlite3.OperationalError):
+            activity_schema.ensure_command_activity_schema(connection, applied_at="2026-07-18T20:00:00+00:00")
+        tables = {
+            str(row[0]) for row in connection.execute("select name from sqlite_schema where type = 'table'").fetchall()
+        }
+        version = connection.execute(
+            "select version from schema_migrations where version = ?",
+            (activity_schema.COMMAND_ACTIVITY_SCHEMA_MIGRATION_VERSION,),
+        ).fetchone()
+
+        monkeypatch.setattr(activity_schema, "command_activity_schema_statements", lambda: statements)
+        activity_schema.ensure_command_activity_schema(connection, applied_at="2026-07-18T20:01:00+00:00")
+        recovered_version = connection.execute(
+            "select version from schema_migrations where version = ?",
+            (activity_schema.COMMAND_ACTIVITY_SCHEMA_MIGRATION_VERSION,),
+        ).fetchone()
+
+    assert "command_activity" not in tables
+    assert version is None
+    assert recovered_version == (activity_schema.COMMAND_ACTIVITY_SCHEMA_MIGRATION_VERSION,)
+
+
+def test_command_activity_migration_rejects_an_incompatible_existing_schema(tmp_path: Path) -> None:
+    database_path = tmp_path / "incompatible.db"
+    statements = activity_schema.command_activity_schema_statements()
+    incompatible_activity = statements[0].replace(
+        "match_count integer not null check (match_count >= 0)",
+        "match_count integer not null",
+    )
+    with sqlite3.connect(database_path) as connection:
+        connection.execute("create table schema_migrations (version integer primary key, applied_at text not null)")
+        connection.execute(incompatible_activity)
+
+        with pytest.raises(RuntimeError, match="incompatible command activity schema object"):
+            activity_schema.ensure_command_activity_schema(connection, applied_at="2026-07-18T20:00:00+00:00")
+
+        version = connection.execute(
+            "select version from schema_migrations where version = ?",
+            (activity_schema.COMMAND_ACTIVITY_SCHEMA_MIGRATION_VERSION,),
+        ).fetchone()
+
+    assert version is None
+
+
+def test_activity_persistence_counts_one_command_and_each_rule_hit(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    evidence = _evidence()
+
+    assert store.record_command_activity(evidence) is True
+    assert store.count_command_activities() == 1
+    assert store.count_command_activity_rule_hits() == 2
+    assert store.count_command_activity_rule_hits("command.git.push") == 1
+    assert store.count_command_activity_rule_hits("command.package.install") == 1
+
+
+def test_exact_activity_replay_is_an_idempotent_noop(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    evidence = _evidence()
+
+    assert store.record_command_activity(evidence) is True
+    assert store.record_command_activity(evidence) is False
+    assert store.count_command_activities() == 1
+    assert store.count_command_activity_rule_hits() == 2
+
+
+def test_two_processes_cannot_duplicate_one_activity(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    first = GuardStore(guard_home, prime_policy_integrity=False)
+    evidence = _evidence()
+
+    with ProcessPoolExecutor(max_workers=2, mp_context=get_context("spawn")) as executor:
+        futures = [executor.submit(_record_in_process, str(guard_home), evidence) for _ in range(2)]
+        results = [future.result(timeout=20) for future in futures]
+
+    assert sorted(results) == [False, True]
+    assert first.count_command_activities() == 1
+    assert first.count_command_activity_rule_hits() == 2
+
+
+def test_request_correlation_is_unique_but_session_correlation_is_shareable(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    store.record_command_activity(_evidence(activity_id="activity:01"))
+
+    with pytest.raises(sqlite3.IntegrityError):
+        store.record_command_activity(_evidence(activity_id="activity:02", session_digest="c" * 64))
+    assert store.record_command_activity(
+        _evidence(activity_id="activity:03", request_digest="c" * 64),
+    )
+
+    assert store.count_command_activities() == 2
+    assert store.count_command_activity_rule_hits() == 4
+
+
+def test_conflicting_activity_replay_is_rejected_without_mutation(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    evidence = _evidence()
+    store.record_command_activity(evidence)
+    conflicts = (
+        CommandActivityEvidence(replace(evidence.activity, prompted=True), evidence.matches),
+        CommandActivityEvidence(
+            evidence.activity,
+            (replace(evidence.matches[0], severity=EvidenceSeverity.LOW), evidence.matches[1]),
+        ),
+        CommandActivityEvidence(
+            evidence.activity,
+            (
+                replace(evidence.matches[0], effect_claims=frozenset({EffectKind.NETWORK_WRITE})),
+                evidence.matches[1],
+            ),
+        ),
+        CommandActivityEvidence(
+            replace(
+                evidence.activity,
+                request_correlation=_correlation(CorrelationKind.REQUEST, "c" * 64),
+            ),
+            evidence.matches,
+        ),
+    )
+
+    for conflicting in conflicts:
+        with pytest.raises(ValueError, match="conflicting command activity replay"):
+            store.record_command_activity(conflicting)
+
+    assert store.count_command_activities() == 1
+    assert store.count_command_activity_rule_hits() == 2
+
+
+def test_match_failure_rolls_back_the_parent_activity(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            """
+            create trigger fail_command_activity_match
+            before insert on command_activity_matches
+            begin
+              select raise(abort, 'injected match failure');
+            end
+            """
+        )
+
+    with pytest.raises(sqlite3.IntegrityError, match="injected match failure"):
+        store.record_command_activity(_evidence())
+
+    assert store.count_command_activities() == 0
+    assert store.count_command_activity_rule_hits() == 0
+
+
+def test_command_activity_integrity_rejects_orphans_and_cascades(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    evidence = _evidence()
+    store.record_command_activity(evidence)
+
+    with store._connect() as connection:
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(
+                """
+                insert into command_activity_match_effects (activity_id, ordinal, effect_class)
+                values ('missing', 0, 'network-write')
+                """
+            )
+        connection.execute("delete from command_activity where activity_id = ?", (evidence.activity.activity_id,))
+
+    with sqlite3.connect(store.path) as connection:
+        child_counts = tuple(
+            int(connection.execute(f"select count(*) from {table}").fetchone()[0])
+            for table in (
+                "command_activity_matches",
+                "command_activity_match_effects",
+                "command_activity_correlations",
+            )
+        )
+    assert child_counts == (0, 0, 0)
+
+
+def test_command_activity_parent_keys_cannot_be_updated(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    evidence = _evidence()
+    store.record_command_activity(evidence)
+
+    updates = (
+        "update command_activity set activity_id = 'moved' where activity_id = 'activity:01'",
+        "update command_activity_matches set activity_id = 'moved' where activity_id = 'activity:01'",
+        "update command_activity_match_effects set ordinal = 9 where activity_id = 'activity:01'",
+        "update command_activity_correlations set activity_id = 'moved' where activity_id = 'activity:01'",
+    )
+    for statement in updates:
+        with store._connect() as connection, pytest.raises(sqlite3.IntegrityError, match="immutable"):
+            connection.execute(statement)
+
+    assert store.count_command_activities() == 1
+    assert store.count_command_activity_rule_hits() == 2
+
+
+def test_activity_schema_has_no_forbidden_privacy_columns(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    tables = (
+        "command_activity",
+        "command_activity_matches",
+        "command_activity_match_effects",
+        "command_activity_correlations",
+    )
+    with sqlite3.connect(store.path) as connection:
+        columns = {
+            str(row[1]) for table in tables for row in connection.execute(f"pragma table_info({table})").fetchall()
+        }
+
+    assert columns.isdisjoint(FORBIDDEN_ACTIVITY_FIELD_NAMES)


### PR DESCRIPTION
## Summary

- add a crash-safe versioned migration for normalized command activity, rule match, effect, correlation, and daily rollup tables
- add transactional cross-process idempotent persistence with one command total and exact per-rule hit rows
- reject incompatible schema objects, orphaned child rows, conflicting replays, and mutable linkage keys
- preserve legacy store behavior with scoped command activity integrity triggers

## Verification

- `uv run --no-sync pytest -q tests/test_guard_approval_store_dedup.py tests/test_guard_approval_store_phase14.py tests/test_guard_approval_store_scale.py tests/test_guard_evidence_store.py tests/test_guard_store_migrations.py tests/test_guard_receipt_persistence.py tests/test_guard_receipt_command_detail_backfill.py tests/test_guard_receipt_p5_fields.py tests/test_guard_command_activity_contract.py tests/test_guard_command_activity_privacy.py tests/test_guard_command_activity_persistence.py --tb=short`
- `uv run --no-sync ruff check` and `ruff format --check` on all changed Python files
- `uv run --no-sync basedpyright` on the new persistence, schema, and test modules
- Python 3.10 isolated contract, privacy, and persistence suite
- independent adversarial review: SHIP
