### PR TITLE
fix(release): ignore generated upload attestations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -195,8 +195,14 @@ jobs:
             )
           elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
             CHANNEL="stable"
-            VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \
+            PYPI_VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \
               list-versions --registry pypi)
+            TESTPYPI_VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \
+              list-versions --registry testpypi)
+            VERSIONS=$(jq -n \
+              --argjson pypi "$PYPI_VERSIONS" \
+              --argjson testpypi "$TESTPYPI_VERSIONS" \
+              '$pypi + $testpypi | unique')
             VERSION=$(uv run --no-sync python scripts/compute_main_release_version.py \
               --base-version "$BASE_VERSION" <<< "$VERSIONS")
           fi
@@ -423,6 +429,8 @@ jobs:
         if: steps.testpypi.outputs.upload == 'true'
         with:
           repository-url: https://test.pypi.org/legacy/
+      - name: Remove generated upload attestations
+        run: rm -f dist/*.publish.attestation
       - name: Download and verify exact TestPyPI artifacts
         env:
           VERSION: ${{ needs.build.outputs.version }}
@@ -538,6 +546,8 @@ jobs:
           uv run --with packaging==25.0 python scripts/validate_alpha_release.py "${validator_args[@]}"
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         if: steps.pypi.outputs.upload == 'true'
+      - name: Remove generated upload attestations
+        run: rm -f dist/*.publish.attestation
       - name: Download and verify exact PyPI artifacts
         env:
           VERSION: ${{ needs.build.outputs.version }}
@@ -623,6 +633,8 @@ jobs:
         if: steps.testpypi.outputs.upload == 'true'
         with:
           repository-url: https://test.pypi.org/legacy/
+      - name: Remove generated upload attestations
+        run: rm -f dist/*.publish.attestation
       - name: Download and verify exact TestPyPI artifacts
         env:
           VERSION: ${{ needs.build.outputs.version }}
@@ -691,17 +703,26 @@ jobs:
           git fetch --no-tags origin "+refs/heads/main:refs/remotes/origin/main"
           git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main
           BASE_VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
-          VERSIONS=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+          PYPI_VERSIONS=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
             list-versions --registry pypi)
-          PRIOR_VERSIONS=$(jq --arg version "$VERSION" '[.[] | select(. != $version)]' <<< "$VERSIONS")
+          TESTPYPI_VERSIONS=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+            list-versions --registry testpypi)
+          RELEASE_VERSIONS=$(jq -n \
+            --argjson pypi "$PYPI_VERSIONS" \
+            --argjson testpypi "$TESTPYPI_VERSIONS" \
+            '$pypi + $testpypi | unique')
+          PRIOR_RELEASE_VERSIONS=$(jq --arg version "$VERSION" \
+            '[.[] | select(. != $version)]' <<< "$RELEASE_VERSIONS")
           EXPECTED_VERSION=$(uv run --no-sync python scripts/compute_main_release_version.py \
-            --base-version "$BASE_VERSION" <<< "$PRIOR_VERSIONS")
+            --base-version "$BASE_VERSION" <<< "$PRIOR_RELEASE_VERSIONS")
           if [[ "$EXPECTED_VERSION" != "$VERSION" ]]; then
             echo "Main release version changed before publication" >&2
             exit 1
           fi
+          PRIOR_PYPI_VERSIONS=$(jq --arg version "$VERSION" \
+            '[.[] | select(. != $version)]' <<< "$PYPI_VERSIONS")
           LATEST_VERSION=$(uv run --no-sync python scripts/compute_main_release_version.py \
-            --base-version "$BASE_VERSION" --latest-existing <<< "$PRIOR_VERSIONS")
+            --base-version "$BASE_VERSION" --latest-existing <<< "$PRIOR_PYPI_VERSIONS")
           if [[ -n "$LATEST_VERSION" ]]; then
             git fetch --no-tags origin "+refs/tags/v${LATEST_VERSION}:refs/tags/v${LATEST_VERSION}"
             if ! git merge-base --is-ancestor "v${LATEST_VERSION}^{commit}" "$SOURCE_SHA"; then
@@ -727,6 +748,8 @@ jobs:
           fi
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         if: steps.pypi.outputs.upload == 'true'
+      - name: Remove generated upload attestations
+        run: rm -f dist/*.publish.attestation
       - name: Download and verify exact PyPI artifacts
         env:
           VERSION: ${{ needs.build.outputs.version }}

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -77,6 +77,9 @@ def test_main_push_build_computes_a_registry_derived_stable_version() -> None:
     assert 'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]' in compute_run
     assert 'CHANNEL="stable"' in compute_run
     assert "verify_release_registry.py" in compute_run
+    assert "list-versions --registry pypi" in compute_run
+    assert "list-versions --registry testpypi" in compute_run
+    assert "'$pypi + $testpypi | unique'" in compute_run
     assert "compute_main_release_version.py" in compute_run
     assert "if" not in stamp_step
     assert "sync_repo_version.py --check" in stamp_run
@@ -220,9 +223,12 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
         steps = jobs[job_name]["steps"]
         inspect_step = next(step for step in steps if step.get("name") == "Inspect TestPyPI release state")
         publish_step = next(step for step in steps if str(step.get("uses", "")).startswith("pypa/"))
+        cleanup_step = next(step for step in steps if step.get("name") == "Remove generated upload attestations")
         verify_step = next(step for step in steps if step.get("name") == "Download and verify exact TestPyPI artifacts")
         assert "verify-release --registry testpypi" in inspect_step["run"]
         assert publish_step["if"] == "steps.testpypi.outputs.upload == 'true'"
+        assert cleanup_step["run"] == "rm -f dist/*.publish.attestation"
+        assert steps.index(publish_step) < steps.index(cleanup_step) < steps.index(verify_step)
         assert "--download-dir verified-testpypi" in verify_step["run"]
         assert 'uv tool run --from "$wheel"' in verify_step["run"]
         assert 'status" == "exact"' in verify_step["run"]
@@ -233,7 +239,12 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
         step["run"] for step in jobs["publish-main-pypi"]["steps"] if step.get("name") == "Revalidate main publication"
     )
     assert "compute_main_release_version.py" in main_revalidation
+    assert "list-versions --registry pypi" in main_revalidation
+    assert "list-versions --registry testpypi" in main_revalidation
+    assert "'$pypi + $testpypi | unique'" in main_revalidation
+    assert '<<< "$PRIOR_RELEASE_VERSIONS"' in main_revalidation
     assert "--latest-existing" in main_revalidation
+    assert '<<< "$PRIOR_PYPI_VERSIONS"' in main_revalidation
     assert "refs/tags/v${LATEST_VERSION}" in main_revalidation
     assert 'git merge-base --is-ancestor "v${LATEST_VERSION}^{commit}" "$SOURCE_SHA"' in main_revalidation
 
@@ -255,9 +266,12 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
         steps = jobs[job_name]["steps"]
         inspect_step = next(step for step in steps if step.get("name") == "Inspect PyPI release state")
         publish_step = next(step for step in steps if str(step.get("uses", "")).startswith("pypa/"))
+        cleanup_step = next(step for step in steps if step.get("name") == "Remove generated upload attestations")
         verify_step = next(step for step in steps if step.get("name") == "Download and verify exact PyPI artifacts")
         assert "verify-release --registry pypi" in inspect_step["run"]
         assert publish_step["if"] == "steps.pypi.outputs.upload == 'true'"
+        assert cleanup_step["run"] == "rm -f dist/*.publish.attestation"
+        assert steps.index(publish_step) < steps.index(cleanup_step) < steps.index(verify_step)
         assert "--download-dir verified-pypi" in verify_step["run"]
         assert 'status" == "exact"' in verify_step["run"]
         assert 'status" != "absent"' in verify_step["run"]


### PR DESCRIPTION
## Summary
- remove trusted-publish action sidecars from the local distribution directory after upload
- keep upload attestations enabled while exact registry verification remains restricted to wheels and source distributions
- cover cleanup ordering across alpha and stable TestPyPI/PyPI paths

## Testing
- `actionlint .github/workflows/publish.yml`
- `uv run --no-sync python scripts/check_privileged_workflows.py`
- `uv run --no-sync pytest -q tests/test_release_train_workflow.py tests/test_pr_testpypi_canary_workflow.py tests/test_privileged_workflow_policy.py`
