### PR TITLE
fix(release): ignore registry attestation sidecars

### DIFF
--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -189,6 +189,14 @@ def _validate_distribution_filename(filename: object, version: Version) -> str:
     return filename
 
 
+def _is_publish_attestation(filename: object, version: Version) -> bool:
+    if not isinstance(filename, str) or not filename.endswith(".publish.attestation"):
+        return False
+    distribution_filename = filename.removesuffix(".publish.attestation")
+    _validate_distribution_filename(distribution_filename, version)
+    return True
+
+
 def _validated_download_url(url: object, filename: str, registry: Registry) -> str:
     if not isinstance(url, str):
         raise RegistryVerificationError("Registry distribution URL must be a string")
@@ -243,6 +251,8 @@ def inspect_release(
     for item in urls:
         if not isinstance(item, dict):
             raise RegistryVerificationError("Registry release file entry must be an object")
+        if _is_publish_attestation(item.get("filename"), version):
+            continue
         filename = _validate_distribution_filename(item.get("filename"), version)
         if filename in seen:
             raise RegistryVerificationError(f"Registry release repeats distribution filename: {filename}")
@@ -255,6 +265,8 @@ def inspect_release(
             raise RegistryVerificationError(f"Registry release has an invalid SHA-256 for {filename}")
         download_url = _validated_download_url(item.get("url"), filename, registry)
         files.append(ReleaseFile(filename=filename, sha256=sha256, download_url=download_url))
+    if not files:
+        raise RegistryVerificationError("Existing registry release has no distribution files")
     return ReleaseInspection(
         registry=registry,
         version=str(version),

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -189,6 +189,35 @@ def test_inspects_exact_release_without_exposing_urls_in_cli(capsys: pytest.Capt
     assert "pythonhosted.org" not in output
 
 
+def test_inspect_release_ignores_valid_publish_attestation_sidecars() -> None:
+    attestation = f"{WHEEL}.publish.attestation"
+    payload = _release_payload(
+        Registry.TESTPYPI,
+        {
+            WHEEL: (WHEEL_BYTES, None),
+            SDIST: (SDIST_BYTES, None),
+            attestation: (b"signed-attestation", None),
+        },
+    )
+    fetcher = FakeFetcher({_release_url(Registry.TESTPYPI): payload})
+
+    inspection = inspect_release(Registry.TESTPYPI, VERSION, fetcher=fetcher)
+
+    assert {item.filename for item in inspection.files} == {WHEEL, SDIST}
+
+
+def test_inspect_release_rejects_publish_attestation_for_invalid_distribution() -> None:
+    attestation = "not-a-distribution.publish.attestation"
+    payload = _release_payload(
+        Registry.TESTPYPI,
+        {attestation: (b"signed-attestation", None)},
+    )
+    fetcher = FakeFetcher({_release_url(Registry.TESTPYPI): payload})
+
+    with pytest.raises(RegistryVerificationError, match="Invalid distribution filename"):
+        inspect_release(Registry.TESTPYPI, VERSION, fetcher=fetcher)
+
+
 def test_inspect_release_rejects_an_invalid_distribution_port() -> None:
     document = json.loads(
         _release_payload(


### PR DESCRIPTION
## Summary
- ignore only valid `.publish.attestation` sidecars when reconciling registry distributions
- validate each sidecar's underlying wheel or sdist filename before exclusion
- fail closed when a release contains no actual distributions

## Verification
- 42 focused release workflow and registry tests passed
- Ruff passed
- live TestPyPI reconciliation for `3.1.0a6` returned exact wheel and sdist hashes
- Pyright reports no script errors; the focused invocation retains one existing unresolved pytest import in the test file