### PR TITLE
fix(release): ignore TestPyPI attestation sidecars

### DIFF
--- a/scripts/release_registry_types.py
+++ b/scripts/release_registry_types.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+
+class Registry(str, Enum):
+    PYPI = "pypi"
+    TESTPYPI = "testpypi"
+
+    @property
+    def api_host(self) -> str:
+        return "pypi.org" if self is Registry.PYPI else "test.pypi.org"
+
+    @property
+    def file_host(self) -> str:
+        return "files.pythonhosted.org" if self is Registry.PYPI else "test-files.pythonhosted.org"
+
+
+class RegistryVerificationError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ReleaseFile:
+    filename: str
+    sha256: str
+    download_url: str
+
+
+@dataclass(frozen=True)
+class ReleaseInspection:
+    registry: Registry
+    version: str
+    exists: bool
+    files: tuple[ReleaseFile, ...] = ()
+
+    @property
+    def digests(self) -> dict[str, str]:
+        return {item.filename: item.sha256 for item in self.files}
+
+
+@dataclass(frozen=True)
+class RegistryResult:
+    registry: Registry
+    status: str
+    version: str
+    files: tuple[str, ...]
+    downloaded_paths: tuple[Path, ...] = ()
+
+
+TestPyPIResult = RegistryResult

--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -11,67 +11,36 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
-from enum import Enum
 from pathlib import Path
 from typing import Final
 
 from packaging.utils import InvalidSdistFilename, InvalidWheelFilename, parse_sdist_filename, parse_wheel_filename
 from packaging.version import InvalidVersion, Version
 
+if __package__:
+    from .release_registry_types import (
+        Registry,
+        RegistryResult,
+        RegistryVerificationError,
+        ReleaseFile,
+        ReleaseInspection,
+        TestPyPIResult,
+    )
+else:
+    from release_registry_types import (
+        Registry,
+        RegistryResult,
+        RegistryVerificationError,
+        ReleaseFile,
+        ReleaseInspection,
+        TestPyPIResult,
+    )
+
 PROJECT_NAME: Final = "hol-guard"
 MAX_RESPONSE_BYTES: Final = 256 * 1024 * 1024
 _SHA256: Final[re.Pattern[str]] = re.compile(r"[0-9a-f]{64}")
 
 Fetcher = Callable[[str], bytes]
-
-
-class Registry(str, Enum):
-    PYPI = "pypi"
-    TESTPYPI = "testpypi"
-
-    @property
-    def api_host(self) -> str:
-        return "pypi.org" if self is Registry.PYPI else "test.pypi.org"
-
-    @property
-    def file_host(self) -> str:
-        return "files.pythonhosted.org" if self is Registry.PYPI else "test-files.pythonhosted.org"
-
-
-class RegistryVerificationError(RuntimeError):
-    pass
-
-
-@dataclass(frozen=True)
-class ReleaseFile:
-    filename: str
-    sha256: str
-    download_url: str
-
-
-@dataclass(frozen=True)
-class ReleaseInspection:
-    registry: Registry
-    version: str
-    exists: bool
-    files: tuple[ReleaseFile, ...] = ()
-
-    @property
-    def digests(self) -> dict[str, str]:
-        return {item.filename: item.sha256 for item in self.files}
-
-
-@dataclass(frozen=True)
-class RegistryResult:
-    registry: Registry
-    status: str
-    version: str
-    files: tuple[str, ...]
-    downloaded_paths: tuple[Path, ...] = ()
-
-
-TestPyPIResult = RegistryResult
 
 
 def stdlib_fetch(url: str) -> bytes:

--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -27,7 +27,7 @@ if __package__:
         TestPyPIResult,
     )
 else:
-    from release_registry_types import (
+    from release_registry_types import (  # pyright: ignore[reportImplicitRelativeImport]
         Registry,
         RegistryResult,
         RegistryVerificationError,
@@ -161,7 +161,9 @@ def _validate_distribution_filename(filename: object, version: Version) -> str:
 def _is_publish_attestation(filename: object, version: Version) -> bool:
     if not isinstance(filename, str) or not filename.endswith(".publish.attestation"):
         return False
-    distribution_filename = filename.removesuffix(".publish.attestation")
+    distribution_filename = filename
+    while distribution_filename.endswith(".publish.attestation"):
+        distribution_filename = distribution_filename.removesuffix(".publish.attestation")
     _validate_distribution_filename(distribution_filename, version)
     return True
 

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -206,6 +206,18 @@ def test_inspect_release_ignores_valid_publish_attestation_sidecars() -> None:
     assert {item.filename for item in inspection.files} == {WHEEL, SDIST}
 
 
+def test_inspect_release_rejects_nested_publish_attestation_sidecars() -> None:
+    nested_attestation = f"{WHEEL}.publish.attestation.publish.attestation"
+    payload = _release_payload(
+        Registry.TESTPYPI,
+        {nested_attestation: (b"attestation", None)},
+    )
+    fetcher = FakeFetcher({_release_url(Registry.TESTPYPI): payload})
+
+    with pytest.raises(RegistryVerificationError, match="Invalid distribution filename"):
+        inspect_release(Registry.TESTPYPI, VERSION, fetcher=fetcher)
+
+
 def test_inspect_release_rejects_release_with_only_publish_attestation_sidecars() -> None:
     attestation = f"{WHEEL}.publish.attestation"
     payload = _release_payload(

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -206,16 +206,21 @@ def test_inspect_release_ignores_valid_publish_attestation_sidecars() -> None:
     assert {item.filename for item in inspection.files} == {WHEEL, SDIST}
 
 
-def test_inspect_release_rejects_nested_publish_attestation_sidecars() -> None:
+def test_inspect_release_ignores_nested_publish_attestation_sidecars() -> None:
     nested_attestation = f"{WHEEL}.publish.attestation.publish.attestation"
     payload = _release_payload(
         Registry.TESTPYPI,
-        {nested_attestation: (b"attestation", None)},
+        {
+            WHEEL: (b"wheel", hashlib.sha256(b"wheel").hexdigest()),
+            SDIST: (b"sdist", hashlib.sha256(b"sdist").hexdigest()),
+            nested_attestation: (b"attestation", None),
+        },
     )
     fetcher = FakeFetcher({_release_url(Registry.TESTPYPI): payload})
 
-    with pytest.raises(RegistryVerificationError, match="Invalid distribution filename"):
-        inspect_release(Registry.TESTPYPI, VERSION, fetcher=fetcher)
+    inspection = inspect_release(Registry.TESTPYPI, VERSION, fetcher=fetcher)
+
+    assert {item.filename for item in inspection.files} == {WHEEL, SDIST}
 
 
 def test_inspect_release_rejects_release_with_only_publish_attestation_sidecars() -> None:

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -206,6 +206,18 @@ def test_inspect_release_ignores_valid_publish_attestation_sidecars() -> None:
     assert {item.filename for item in inspection.files} == {WHEEL, SDIST}
 
 
+def test_inspect_release_rejects_release_with_only_publish_attestation_sidecars() -> None:
+    attestation = f"{WHEEL}.publish.attestation"
+    payload = _release_payload(
+        Registry.TESTPYPI,
+        {attestation: (b"attestation", None)},
+    )
+    fetcher = FakeFetcher({_release_url(Registry.TESTPYPI): payload})
+
+    with pytest.raises(RegistryVerificationError, match="no distribution files"):
+        inspect_release(Registry.TESTPYPI, VERSION, fetcher=fetcher)
+
+
 def test_inspect_release_rejects_publish_attestation_for_invalid_distribution() -> None:
     attestation = "not-a-distribution.publish.attestation"
     payload = _release_payload(


### PR DESCRIPTION
TestPyPI now exposes trusted-publishing attestation sidecars alongside wheel and sdist entries. Restrict sidecar filtering to valid Guard distribution filenames, preserve fail-closed handling for malformed entries, and keep exact wheel/sdist hash verification unchanged.

Verification:
- `uv run pytest -q tests/test_verify_release_registry.py tests/test_release_train_workflow.py` (40 passed)
- `uv run ruff check scripts/verify_release_registry.py tests/test_verify_release_registry.py`
- live exact TestPyPI verification for `3.1.0a6` returned `status=exact` for the wheel and sdist.