### PR TITLE
fix(release): provision revalidation dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -702,7 +702,7 @@ jobs:
         run: |
           git fetch --no-tags origin "+refs/heads/main:refs/remotes/origin/main"
           git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main
-          BASE_VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          BASE_VERSION=$(uv run --with packaging==25.0 python scripts/sync_repo_version.py --check)
           PYPI_VERSIONS=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
             list-versions --registry pypi)
           TESTPYPI_VERSIONS=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
@@ -713,7 +713,7 @@ jobs:
             '$pypi + $testpypi | unique')
           PRIOR_RELEASE_VERSIONS=$(jq --arg version "$VERSION" \
             '[.[] | select(. != $version)]' <<< "$RELEASE_VERSIONS")
-          EXPECTED_VERSION=$(uv run --no-sync python scripts/compute_main_release_version.py \
+          EXPECTED_VERSION=$(uv run --with packaging==25.0 python scripts/compute_main_release_version.py \
             --base-version "$BASE_VERSION" <<< "$PRIOR_RELEASE_VERSIONS")
           if [[ "$EXPECTED_VERSION" != "$VERSION" ]]; then
             echo "Main release version changed before publication" >&2
@@ -721,7 +721,7 @@ jobs:
           fi
           PRIOR_PYPI_VERSIONS=$(jq --arg version "$VERSION" \
             '[.[] | select(. != $version)]' <<< "$PYPI_VERSIONS")
-          LATEST_VERSION=$(uv run --no-sync python scripts/compute_main_release_version.py \
+          LATEST_VERSION=$(uv run --with packaging==25.0 python scripts/compute_main_release_version.py \
             --base-version "$BASE_VERSION" --latest-existing <<< "$PRIOR_PYPI_VERSIONS")
           if [[ -n "$LATEST_VERSION" ]]; then
             git fetch --no-tags origin "+refs/tags/v${LATEST_VERSION}:refs/tags/v${LATEST_VERSION}"

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -239,6 +239,8 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
         step["run"] for step in jobs["publish-main-pypi"]["steps"] if step.get("name") == "Revalidate main publication"
     )
     assert "compute_main_release_version.py" in main_revalidation
+    assert main_revalidation.count("uv run --with packaging==25.0") == 5
+    assert "uv run --no-sync" not in main_revalidation
     assert "list-versions --registry pypi" in main_revalidation
     assert "list-versions --registry testpypi" in main_revalidation
     assert "'$pypi + $testpypi | unique'" in main_revalidation


### PR DESCRIPTION
## Summary
- provision the pinned version parser in the fresh stable-publication boundary
- verify every revalidation helper runs without relying on a project environment

## Testing
- `uv run --no-sync pytest -q tests/test_compute_main_release_version.py tests/test_release_train_workflow.py`
- `actionlint .github/workflows/publish.yml`
- `uv run --no-sync ruff check tests/test_release_train_workflow.py`
- `uv run --no-sync ruff format --check tests/test_release_train_workflow.py`
- `uv run --with pyyaml==6.0.3 python scripts/check_privileged_workflows.py`
- `uv run --isolated --no-project --with packaging==25.0 python scripts/sync_repo_version.py --check`
