### PR TITLE
feat(guard): record command activity lifecycle

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
@@ -311,6 +311,7 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "      {\n"
         '        hook_event_name: "PreToolUse",\n'
         "        config_path: GUARD_CONFIG_PATH,\n"
+        "        tool_call_id: event.toolCallId,\n"
         "        tool_name: event.toolName,\n"
         "        tool_input: toolInput,\n"
         "      },\n"
@@ -356,6 +357,7 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "    const guardPayload: Record<string, unknown> = {\n"
         '        hook_event_name: "PostToolUse",\n'
         "        config_path: GUARD_CONFIG_PATH,\n"
+        "        tool_call_id: event.toolCallId,\n"
         "        tool_name: event.toolName,\n"
         "        tool_input: toolInput,\n"
         "        stdout: toolOutput,\n"

--- a/src/codex_plugin_scanner/guard/cli/commands_hook.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
     from .commands_support_hook_payload import _hook_action_envelope, _load_hook_payload, _normalize_hook_payload
     from .commands_support_interaction import _emit
     from .commands_support_permission_store import (
+        _cursor_conversation_id,
+        _cursor_shell_command_from_payload,
         _discard_claude_pending_permissions,
         _persist_cursor_native_permission_after_shell,
     )
@@ -44,6 +46,11 @@ from .commands_hook_runtime_eval import _evaluate_runtime_artifact_hook
 from .commands_hook_runtime_finish import _finalize_runtime_artifact_hook
 from .commands_hook_runtime_review import _review_runtime_artifact_hook
 from .commands_parser_helpers import *
+from .commands_support_command_activity import (
+    hook_post_succeeded,
+    record_command_activity_failure_best_effort,
+    record_post_hook_command_activity_best_effort,
+)
 
 
 def _run_guard_hook_command(
@@ -98,6 +105,25 @@ def _run_guard_hook_command(
     }:
         if runtime_workspace is None:
             runtime_workspace = _workspace_from_cursor_project_dir()
+        from ..runtime.command_activity_cursor import cursor_command_activity_observer_trusted
+
+        cursor_conversation_id = _cursor_conversation_id(payload)
+        cursor_command = _cursor_shell_command_from_payload(payload)
+        try:
+            command_activity_observer_trusted = (
+                cursor_conversation_id is not None
+                and cursor_command is not None
+                and cursor_command_activity_observer_trusted(
+                    guard_home=context.guard_home,
+                    payload=payload,
+                    conversation_id=cursor_conversation_id,
+                    command=cursor_command,
+                    env=os.environ,
+                )
+            )
+        except Exception:
+            command_activity_observer_trusted = False
+            record_command_activity_failure_best_effort(store, "cursor_observer_verify_failed")
         saved = _persist_cursor_native_permission_after_shell(
             store=store,
             payload=payload,
@@ -107,6 +133,16 @@ def _run_guard_hook_command(
             workspace=runtime_workspace,
             hook_env=os.environ,
         )
+        if command_activity_observer_trusted:
+            event_name = _hook_event_name(payload) or "afterShellExecution"
+            _ = record_post_hook_command_activity_best_effort(
+                store=store,
+                guard_home=context.guard_home,
+                harness="cursor",
+                event=event_name,
+                payload=payload,
+                succeeded=hook_post_succeeded(event_name, payload),
+            )
         _emit(
             "hook",
             {
@@ -461,6 +497,15 @@ def _try_source_ref_fast_path(
     )
 
     response = engine.review(request)
+    event_name = _hook_event_name(payload) or "PostToolUse"
+    record_post_hook_command_activity_best_effort(
+        store=store,
+        guard_home=context.guard_home,
+        harness=_canonical_harness_name(args.harness),
+        event=event_name,
+        payload=payload,
+        succeeded=hook_post_succeeded(event_name, payload),
+    )
     _emit("hook", response.to_harness_json(), getattr(args, "json", False))
     return 0
 

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
@@ -29,8 +29,45 @@ if TYPE_CHECKING:
 
 
 from ..models import GuardAction
+from ..runtime.command_activity_contract import ActivityApprovalReuseStatus
 from ._commands_shared import *
 from .commands_parser_helpers import *
+from .commands_support_command_activity import (
+    command_activity_was_prompted,
+    record_pre_hook_command_activity_best_effort,
+)
+
+
+def _record_copilot_pre_activity(
+    *,
+    store: GuardStore,
+    context: HarnessContext,
+    event: str,
+    payload: Mapping[str, object],
+    policy_action: GuardAction,
+    receipt_id: str,
+    decision: ToolCallDecision,
+    runtime_workspace: Path | None,
+) -> None:
+    raw_reuse_status = decision.approval_reuse_status
+    reuse_status = (
+        ActivityApprovalReuseStatus(raw_reuse_status)
+        if raw_reuse_status in {item.value for item in ActivityApprovalReuseStatus}
+        else ActivityApprovalReuseStatus.NOT_APPLICABLE
+    )
+    _ = record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=context.guard_home,
+        harness="copilot",
+        event=event,
+        payload=payload,
+        policy_action=policy_action,
+        receipt_id=receipt_id,
+        prompted=command_activity_was_prompted(decision.current_action or policy_action, reuse_status),
+        approval_reuse_status=reuse_status,
+        cwd=runtime_workspace,
+        home_dir=context.home_dir,
+    )
 
 
 def _copilot_tool_decision_scanner_evidence(
@@ -237,8 +274,10 @@ def _run_hook_copilot_pretool(
                 store=store,
             )
         policy_action = "allow"
+    # Copilot review/reapproval continues to PermissionRequest, which owns that
+    # activity. PreToolUse records only decisions that terminate at this stage.
     if policy_action == "allow":
-        allow_tool_call(
+        receipt = allow_tool_call(
             store=store,
             artifact=runtime_artifact,
             artifact_hash=runtime_artifact_hash,
@@ -251,6 +290,16 @@ def _run_hook_copilot_pretool(
             additional_scanner_evidence=decision_scanner_evidence,
         )
         if _should_emit_copilot_hook_response(args):
+            _record_copilot_pre_activity(
+                store=store,
+                context=context,
+                event="preToolUse",
+                payload=payload,
+                policy_action=policy_action,
+                receipt_id=receipt.receipt_id,
+                decision=decision,
+                runtime_workspace=runtime_workspace,
+            )
             _record_harness_usage_for_hook(
                 store=store,
                 action_envelope=action_envelope,
@@ -267,7 +316,7 @@ def _run_hook_copilot_pretool(
             return 0
     else:
         if policy_action in {"block", "sandbox-required"}:
-            block_tool_call(
+            receipt = block_tool_call(
                 store=store,
                 artifact=runtime_artifact,
                 artifact_hash=runtime_artifact_hash,
@@ -279,6 +328,17 @@ def _run_hook_copilot_pretool(
                 additional_scanner_evidence=decision_scanner_evidence,
                 policy_action=policy_action,
             )
+            if _should_emit_copilot_hook_response(args):
+                _record_copilot_pre_activity(
+                    store=store,
+                    context=context,
+                    event="preToolUse",
+                    payload=payload,
+                    policy_action=policy_action,
+                    receipt_id=receipt.receipt_id,
+                    decision=decision,
+                    runtime_workspace=runtime_workspace,
+                )
         if _should_emit_copilot_hook_response(args):
             _record_harness_usage_for_hook(
                 store=store,
@@ -416,7 +476,7 @@ def _run_hook_copilot_permission_request(
         policy_action = "allow"
         response_payload["policy_action"] = "allow"
     if policy_action == "allow":
-        allow_tool_call(
+        receipt = allow_tool_call(
             store=store,
             artifact=runtime_artifact,
             artifact_hash=runtime_artifact_hash,
@@ -427,6 +487,16 @@ def _run_hook_copilot_permission_request(
             remember=False,
             arguments=runtime_arguments,
             additional_scanner_evidence=decision_scanner_evidence,
+        )
+        _record_copilot_pre_activity(
+            store=store,
+            context=context,
+            event="copilotPermissionRequest",
+            payload=payload,
+            policy_action=policy_action,
+            receipt_id=receipt.receipt_id,
+            decision=decision,
+            runtime_workspace=runtime_workspace,
         )
         if _should_emit_copilot_hook_response(args):
             _record_harness_usage_for_hook(
@@ -450,7 +520,7 @@ def _run_hook_copilot_permission_request(
         )
         _emit("hook", response_payload, getattr(args, "json", False))
         return 0
-    block_tool_call(
+    receipt = block_tool_call(
         store=store,
         artifact=runtime_artifact,
         artifact_hash=runtime_artifact_hash,
@@ -461,6 +531,16 @@ def _run_hook_copilot_permission_request(
         arguments=runtime_arguments,
         additional_scanner_evidence=decision_scanner_evidence,
         policy_action=policy_action,
+    )
+    _record_copilot_pre_activity(
+        store=store,
+        context=context,
+        event="copilotPermissionRequest",
+        payload=payload,
+        policy_action=policy_action,
+        receipt_id=receipt.receipt_id,
+        decision=decision,
+        runtime_workspace=runtime_workspace,
     )
     if terminal_action:
         response_payload["approval_requests"] = []

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -69,8 +69,17 @@ from ..runtime.approval_reuse import (
     ApprovalReuseValidationFailure,
     evaluate_approval_reuse,
 )
+from ..runtime.command_activity_contract import ActivityApprovalReuseStatus
 from ._commands_shared import *
 from .commands_parser_helpers import *
+from .commands_support_command_activity import (
+    command_activity_was_prompted,
+    hook_is_post_event,
+    hook_is_pre_event,
+    hook_post_succeeded,
+    record_post_hook_command_activity_best_effort,
+    record_pre_hook_command_activity_best_effort,
+)
 from .commands_support_runtime_policy import _runtime_hook_effective_policy_config
 
 # Bump when generic-hook classification or action-composition semantics change.
@@ -748,6 +757,7 @@ def _run_hook_generic_payload(
     effective_action_envelope = (
         action_envelope.with_pre_execution_result(policy_action) if action_envelope is not None else None
     )
+    command_activity_receipt_id: str | None = None
     if should_record_generic_hook_receipt:
         receipt = build_receipt(
             harness=args.harness,
@@ -770,12 +780,44 @@ def _run_hook_generic_payload(
             approval_source=("inline" if _optional_string(payload_map.get("user_override")) is not None else "policy"),
         )
         store.add_receipt(receipt, action_envelope=effective_action_envelope)
+        command_activity_receipt_id = receipt.receipt_id
     _record_harness_usage_for_hook(
         store=store,
         action_envelope=effective_action_envelope,
         payload=payload_map,
         policy_action=policy_action,
     )
+    if hook_is_post_event(hook_event_name):
+        record_post_hook_command_activity_best_effort(
+            store=store,
+            guard_home=store.guard_home,
+            harness=_canonical_harness_name(args.harness),
+            event=hook_event_name,
+            payload=payload_map,
+            succeeded=hook_post_succeeded(hook_event_name, payload_map),
+        )
+    elif hook_is_pre_event(hook_event_name):
+        command_activity_reuse_status = (
+            ActivityApprovalReuseStatus(approval_reuse.status)
+            if approval_reuse.status in {item.value for item in ActivityApprovalReuseStatus}
+            else ActivityApprovalReuseStatus.NOT_APPLICABLE
+        )
+        record_pre_hook_command_activity_best_effort(
+            store=store,
+            guard_home=store.guard_home,
+            harness=_canonical_harness_name(args.harness),
+            event=hook_event_name,
+            payload=payload_map,
+            policy_action=cast(GuardAction, policy_action),
+            receipt_id=command_activity_receipt_id,
+            prompted=command_activity_was_prompted(
+                cast(GuardAction, current_policy_action),
+                command_activity_reuse_status,
+            ),
+            approval_reuse_status=command_activity_reuse_status,
+            cwd=runtime_workspace,
+            home_dir=home_dir,
+        )
     if _should_emit_copilot_hook_response(args):
         _emit_copilot_hook_response(
             policy_action=policy_action,

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -848,6 +848,8 @@ def _evaluate_runtime_artifact_hook(
         decision_signals=tuple(decision_signals),
         decision_v2_payload=decision_v2_payload,
         event_name=event_name,
+        guard_home=context.guard_home,
+        hook_payload=payload_map,
         initial_policy_action=policy_action,
         package_evaluation=package_evaluation,
         policy_action=policy_action,

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_state.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_state.py
@@ -161,7 +161,10 @@ def _record_runtime_command_activity(state: RuntimeArtifactHookState, store: Gua
         payload=state.hook_payload,
         policy_action=state.receipt.policy_decision,
         receipt_id=state.receipt.receipt_id,
-        prompted=command_activity_was_prompted(state.initial_policy_action, approval_reuse_status),
+        prompted=command_activity_was_prompted(
+            normalize_guard_action(state.initial_policy_action),
+            approval_reuse_status,
+        ),
         approval_reuse_status=approval_reuse_status,
     )
 

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_state.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_state.py
@@ -7,11 +7,20 @@ from __future__ import annotations
 
 from ._commands_shared import *
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 
 from ..action_lattice import normalize_guard_action
 from ..models import GuardReceipt
+from ..runtime.command_activity_contract import ActivityApprovalReuseStatus
 from ..runtime.signals import RiskSignalV2
+from .commands_support_command_activity import (
+    command_activity_was_prompted,
+    hook_is_post_event,
+    hook_is_pre_event,
+    hook_post_succeeded,
+    record_post_hook_command_activity_best_effort,
+    record_pre_hook_command_activity_best_effort,
+)
 
 
 @dataclass
@@ -35,6 +44,8 @@ class RuntimeArtifactHookState:
     runtime_artifact_hash: str
     scanner_evidence_payload: list[dict[str, object]]
     stored_policy_action: str | None
+    guard_home: Path | None = None
+    hook_payload: dict[str, object] = field(default_factory=dict)
     receipt_recorded: bool = False
 
 
@@ -118,6 +129,41 @@ def record_runtime_artifact_hook_receipt(
     state.receipt_recorded = True
     state.response_payload["recorded"] = True
     state.response_payload["receipt_id"] = state.receipt.receipt_id
+    _record_runtime_command_activity(state, store)
+
+
+def _record_runtime_command_activity(state: RuntimeArtifactHookState, store: GuardStore) -> None:
+    if state.guard_home is None:
+        return
+    if hook_is_post_event(state.event_name):
+        record_post_hook_command_activity_best_effort(
+            store=store,
+            guard_home=state.guard_home,
+            harness=state.runtime_artifact.harness,
+            event=state.event_name,
+            payload=state.hook_payload,
+            succeeded=hook_post_succeeded(state.event_name, state.hook_payload),
+        )
+        return
+    if not hook_is_pre_event(state.event_name):
+        return
+    approval_reuse_status = ActivityApprovalReuseStatus.NOT_APPLICABLE
+    approval_reuse = state.response_payload.get("approval_reuse")
+    if isinstance(approval_reuse, dict):
+        status = approval_reuse.get("status")
+        if status in {item.value for item in ActivityApprovalReuseStatus}:
+            approval_reuse_status = ActivityApprovalReuseStatus(status)
+    record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=state.guard_home,
+        harness=state.runtime_artifact.harness,
+        event=state.event_name,
+        payload=state.hook_payload,
+        policy_action=state.receipt.policy_decision,
+        receipt_id=state.receipt.receipt_id,
+        prompted=command_activity_was_prompted(state.initial_policy_action, approval_reuse_status),
+        approval_reuse_status=approval_reuse_status,
+    )
 
 __all__ = [
     "RuntimeArtifactHookState",

--- a/src/codex_plugin_scanner/guard/cli/commands_support.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support.py
@@ -14,6 +14,7 @@ from . import _commands_shared as __commands_shared
 from . import commands_support_workspace as _commands_support_workspace
 from . import commands_support_interaction as _commands_support_interaction
 from . import commands_support_hook_state as _commands_support_hook_state
+from . import commands_support_command_activity as _commands_support_command_activity
 from . import commands_support_permission_store as _commands_support_permission_store
 from . import commands_support_claude_approval as _commands_support_claude_approval
 from . import commands_support_runtime_policy as _commands_support_runtime_policy
@@ -49,6 +50,7 @@ _SOURCE_MODULES: tuple[ModuleType, ...] = (
     _commands_support_workspace,
     _commands_support_interaction,
     _commands_support_hook_state,
+    _commands_support_command_activity,
     _commands_support_permission_store,
     _commands_support_claude_approval,
     _commands_support_runtime_policy,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
@@ -1,0 +1,258 @@
+"""Best-effort command activity recording at hook orchestration boundaries."""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import Mapping
+from contextlib import suppress
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+
+from ..action_lattice import guard_action_severity
+from ..models import GuardAction
+from ..runtime.command_activity_contract import (
+    ActivityApprovalReuseStatus,
+    ActivityDecisionReason,
+    CommandExecutionStatus,
+)
+from ..runtime.command_activity_correlation import (
+    derive_proven_request_correlation,
+    load_or_create_installation_correlation_key,
+)
+from ..runtime.command_activity_lifecycle import (
+    CommandActivityDecisionFacts,
+    build_correlated_post_activity,
+    build_pre_hook_evidence,
+    build_unpaired_post_evidence,
+)
+from ..runtime.command_evaluation import evaluate_command
+from ..runtime.secret_file_requests import extract_sensitive_tool_action_request
+from ..store import GuardStore
+
+_PRE_HOOK_EVENTS = frozenset({"PreToolUse", "preToolUse", "copilotPermissionRequest"})
+_POST_HOOK_EVENTS = frozenset(
+    {
+        "PostToolUse",
+        "PostToolUseFailure",
+        "postToolUse",
+        "afterShellExecution",
+        "afterMCPExecution",
+    }
+)
+
+
+def record_pre_hook_command_activity_best_effort(
+    *,
+    store: GuardStore,
+    guard_home: Path,
+    harness: str,
+    event: str,
+    payload: Mapping[str, object],
+    policy_action: GuardAction,
+    receipt_id: str | None,
+    prompted: bool,
+    approval_reuse_status: ActivityApprovalReuseStatus = ActivityApprovalReuseStatus.NOT_APPLICABLE,
+    cwd: Path | None = None,
+    home_dir: Path | None = None,
+) -> bool:
+    """Record matched pre-hook evidence without allowing analytics to affect enforcement."""
+
+    try:
+        if event not in _PRE_HOOK_EVENTS:
+            return False
+        evaluation = _evaluate_payload_command(payload, cwd=cwd, home_dir=home_dir)
+        if evaluation is None or not evaluation.matches:
+            return False
+        key = load_or_create_installation_correlation_key(guard_home)
+        correlation = derive_proven_request_correlation(
+            harness=harness,
+            event=event,
+            payload=payload,
+            key=key,
+        )
+        evidence = build_pre_hook_evidence(
+            evaluation,
+            CommandActivityDecisionFacts(
+                policy_action=policy_action,
+                decision_reason_code=(
+                    ActivityDecisionReason.EXTENSION_MATCH
+                    if evaluation.command.confidence == "exact"
+                    else ActivityDecisionReason.UNCERTAINTY
+                ),
+                prompted=prompted,
+                approval_reuse_status=approval_reuse_status,
+                receipt_id=receipt_id,
+            ),
+            activity_id=_activity_id(),
+            occurred_at=_utc_now(),
+            harness=harness,
+            request_correlation=correlation,
+        )
+        if correlation is not None and store.is_exact_command_activity_pre_replay(evidence):
+            return False
+        try:
+            return store.record_command_activity(evidence)
+        except Exception:
+            if correlation is not None and store.is_exact_command_activity_pre_replay(evidence):
+                return False
+            raise
+    except Exception:
+        _record_persistence_failure(store, "pre_record_failed")
+        return False
+
+
+def record_post_hook_command_activity_best_effort(
+    *,
+    store: GuardStore,
+    guard_home: Path,
+    harness: str,
+    event: str,
+    payload: Mapping[str, object],
+    succeeded: bool,
+) -> bool:
+    """Transition strong pairs or record a fact-minimal unpaired command post."""
+
+    try:
+        if event not in _POST_HOOK_EVENTS:
+            return False
+        key = load_or_create_installation_correlation_key(guard_home)
+        correlation = derive_proven_request_correlation(
+            harness=harness,
+            event=event,
+            payload=payload,
+            key=key,
+        )
+        if correlation is not None:
+            previous = store.get_command_activity_by_request_correlation(correlation)
+            if previous is not None:
+                expected_status = (
+                    CommandExecutionStatus.CONFIRMED_SUCCESS if succeeded else CommandExecutionStatus.CONFIRMED_FAILURE
+                )
+                if previous.execution_status is expected_status:
+                    return False
+                if previous.execution_status is not CommandExecutionStatus.ALLOWED_UNCONFIRMED:
+                    raise ValueError("post-hook proof conflicts with persisted command lifecycle")
+                current = build_correlated_post_activity(
+                    previous,
+                    request_correlation=correlation,
+                    succeeded=succeeded,
+                )
+                return store.transition_command_activity(current)
+        if _payload_command_text(payload) is None:
+            return False
+        evidence = build_unpaired_post_evidence(
+            activity_id=_activity_id(),
+            occurred_at=_utc_now(),
+            harness=harness,
+            succeeded=succeeded,
+        )
+        return store.record_command_activity(evidence)
+    except Exception:
+        _record_persistence_failure(store, "post_record_failed")
+        return False
+
+
+def hook_post_succeeded(event: str, payload: Mapping[str, object]) -> bool:
+    """Interpret only bounded native failure signals; absence means success."""
+
+    if "failure" in event.strip().lower():
+        return False
+    for key in ("is_error", "isError", "failed"):
+        if payload.get(key) is True:
+            return False
+    if payload.get("success") is False:
+        return False
+    exit_code = payload.get("exit_code", payload.get("exitCode"))
+    return not (type(exit_code) is int and exit_code != 0)
+
+
+def hook_is_post_event(event: str) -> bool:
+    return event in _POST_HOOK_EVENTS
+
+
+def hook_is_pre_event(event: str) -> bool:
+    return event in _PRE_HOOK_EVENTS
+
+
+def command_activity_was_prompted(
+    initial_policy_action: GuardAction,
+    approval_reuse_status: ActivityApprovalReuseStatus,
+) -> bool:
+    """Report an actual prompt, excluding approvals reused without interaction."""
+
+    return approval_reuse_status is not ActivityApprovalReuseStatus.ACCEPTED and guard_action_severity(
+        initial_policy_action
+    ) >= guard_action_severity("review")
+
+
+def record_command_activity_failure_best_effort(store: GuardStore, error_code: str) -> None:
+    """Count an analytics-boundary failure without affecting hook enforcement."""
+
+    _record_persistence_failure(store, error_code)
+
+
+def _evaluate_payload_command(
+    payload: Mapping[str, object],
+    *,
+    cwd: Path | None,
+    home_dir: Path | None,
+):
+    arguments = payload.get("tool_input", payload.get("arguments"))
+    request = extract_sensitive_tool_action_request(
+        payload.get("tool_name"),
+        arguments,
+        cwd=cwd,
+        home_dir=home_dir,
+    )
+    if request is not None:
+        command_text = request.raw_command_text or request.command_text
+        return evaluate_command(
+            command_text,
+            canonical_command=(request.canonical_command if request.raw_command_text is None else None),
+            compatibility_action_class=request.action_class,
+            compatibility_reason=request.reason,
+        )
+    command_text = _payload_command_text(payload)
+    if command_text is None:
+        return None
+    return evaluate_command(command_text)
+
+
+def _payload_command_text(payload: Mapping[str, object]) -> str | None:
+    arguments = payload.get("tool_input", payload.get("arguments"))
+    if isinstance(arguments, Mapping):
+        command_arguments = cast(Mapping[object, object], arguments)
+        for key in ("command", "cmd", "shell_command", "shellCommand"):
+            value = command_arguments.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+    for key in ("command", "cmd"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _record_persistence_failure(store: GuardStore, error_code: str) -> None:
+    with suppress(Exception):
+        store.record_command_activity_persistence_failure(error_code=error_code, occurred_at=_utc_now())
+
+
+def _activity_id() -> str:
+    return f"activity:{secrets.token_hex(16)}"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+__all__ = [
+    "command_activity_was_prompted",
+    "hook_is_post_event",
+    "hook_is_pre_event",
+    "hook_post_succeeded",
+    "record_command_activity_failure_best_effort",
+    "record_post_hook_command_activity_best_effort",
+    "record_pre_hook_command_activity_best_effort",
+]

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker.py
@@ -17,6 +17,10 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ..cli.commands_support_command_activity import (
+    hook_post_succeeded,
+    record_post_hook_command_activity_best_effort,
+)
 from ..config import load_guard_config
 from ..runtime.hook_content_scanner import ContentScanner
 from ..runtime.hook_decision_cache import HookDecisionCache
@@ -105,6 +109,14 @@ class HookWorker:
             workspace=workspace,
         )
         response = self.engine.review(request)
+        record_post_hook_command_activity_best_effort(
+            store=self.store,
+            guard_home=self.guard_home,
+            harness=harness,
+            event=event_name,
+            payload=payload,
+            succeeded=hook_post_succeeded(event_name, payload),
+        )
         return _harness_json_from_review_response(harness, event_name, response)
 
     def _runtime_harness(self, params: Mapping[str, list[str]]) -> str | None:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5127,6 +5127,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         uptime = round(time.monotonic() - self.server.start_monotonic, 1)  # type: ignore[attr-defined]
         store = self.server.store  # type: ignore[attr-defined]
         pending_approvals = store.count_approval_requests()
+        activity_health = store.get_command_activity_persistence_health()
         return {
             "ok": True,
             "receipts": len(store.list_receipts(limit=500)),
@@ -5138,6 +5139,16 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "compatibility_version": GUARD_DAEMON_COMPATIBILITY_VERSION,
             "package_version": __version__,
             "guard_home": str(store.guard_home.resolve()),
+            "command_activity_evidence": {
+                "state": "degraded" if activity_health.persistence_error_count else "healthy",
+                "dropped_event_count": activity_health.dropped_event_count,
+                "persistence_error_count": activity_health.persistence_error_count,
+                "last_error_code": activity_health.last_error_code,
+                "last_error_at": (
+                    activity_health.last_error_at.isoformat() if activity_health.last_error_at is not None else None
+                ),
+                "schema_version": activity_health.schema_version,
+            },
         }
 
     @staticmethod

--- a/src/codex_plugin_scanner/guard/runtime/command_activity_contract.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_activity_contract.py
@@ -155,6 +155,8 @@ class CommandActivity:
         if type(self.prompted) is not bool:
             raise ValueError("prompted must be a boolean")
         _require_enum(self.approval_reuse_status, ActivityApprovalReuseStatus, "approval_reuse_status")
+        if self.prompted and self.approval_reuse_status is ActivityApprovalReuseStatus.ACCEPTED:
+            raise ValueError("accepted approval reuse cannot claim a prompt")
         _require_optional_correlation(self.request_correlation, CorrelationKind.REQUEST, self.harness)
         _require_optional_correlation(self.session_correlation, CorrelationKind.SESSION, self.harness)
         _require_enum(self.receipt_link_status, ReceiptLinkStatus, "receipt_link_status")

--- a/src/codex_plugin_scanner/guard/runtime/command_activity_correlation.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_activity_correlation.py
@@ -1,0 +1,218 @@
+# pyright: reportPrivateUsage=false
+"""Private correlation-key lifecycle and proven request-ID adapters."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import stat
+import tempfile
+from collections.abc import Mapping
+from contextlib import suppress
+from pathlib import Path
+from typing import Final, cast
+
+from .command_activity_contract import CorrelationHandle, CorrelationKind
+from .command_activity_privacy import (
+    InstallationCorrelationKey,
+    StrongHarnessIdentifier,
+    derive_correlation_handle,
+)
+
+COMMAND_ACTIVITY_CORRELATION_KEY_SCHEMA_VERSION: Final = "guard.command-activity-correlation-key.v1"
+COMMAND_ACTIVITY_CORRELATION_KEY_FILE: Final = "command-activity-correlation-key.json"
+_PRIVATE_FILE_MODE: Final = 0o600
+_PRIVATE_DIRECTORY_MODE: Final = 0o700
+_KEY_BYTES: Final = 32
+
+# Only native, top-level request identifiers documented by these hook adapters
+# can pair pre- and post-execution evidence. Content and session fields are absent.
+_PROVEN_REQUEST_ID_FIELDS: Final[dict[tuple[str, str], str]] = {
+    ("codex", "PreToolUse"): "tool_call_id",
+    ("codex", "PostToolUse"): "tool_call_id",
+    ("codex", "PostToolUseFailure"): "tool_call_id",
+    ("claude-code", "PreToolUse"): "tool_use_id",
+    ("claude-code", "PostToolUse"): "tool_use_id",
+    ("claude-code", "PostToolUseFailure"): "tool_use_id",
+    ("cursor", "PreToolUse"): "generation_id",
+    ("cursor", "afterShellExecution"): "generation_id",
+    ("cursor", "afterMCPExecution"): "generation_id",
+    ("pi", "PreToolUse"): "tool_call_id",
+    ("pi", "PostToolUse"): "tool_call_id",
+}
+
+
+def load_or_create_installation_correlation_key(guard_home: Path) -> InstallationCorrelationKey:
+    """Load one per-install key, creating it without exposing partial contents."""
+
+    key_path = _prepare_key_path(guard_home)
+    try:
+        return _read_key(key_path)
+    except FileNotFoundError:
+        pass
+
+    generated = _new_key()
+    temporary_path = _write_private_temporary(key_path, _serialize_key(generated))
+    try:
+        try:
+            os.link(temporary_path, key_path)
+            _set_private_mode(key_path)
+            _fsync_directory(key_path.parent)
+            return generated
+        except FileExistsError:
+            return _read_key(key_path)
+    finally:
+        with suppress(OSError):
+            temporary_path.unlink()
+
+
+def rotate_installation_correlation_key(guard_home: Path) -> InstallationCorrelationKey:
+    """Atomically replace the active key and return its new versioned identity."""
+
+    key_path = _prepare_key_path(guard_home)
+    generated = _new_key()
+    temporary_path = _write_private_temporary(key_path, _serialize_key(generated))
+    try:
+        os.replace(temporary_path, key_path)
+        _set_private_mode(key_path)
+        _fsync_directory(key_path.parent)
+    finally:
+        with suppress(OSError):
+            temporary_path.unlink()
+    return generated
+
+
+def derive_proven_request_correlation(
+    *,
+    harness: str,
+    event: str,
+    payload: Mapping[str, object],
+    key: InstallationCorrelationKey,
+) -> CorrelationHandle | None:
+    """Derive a handle only from an allowlisted native top-level request ID."""
+
+    field = _PROVEN_REQUEST_ID_FIELDS.get((harness, event))
+    if field is None:
+        return None
+    if (
+        harness == "cursor"
+        and event == "PreToolUse"
+        and payload.get("cursor_source_hook_event")
+        not in {
+            "beforeShellExecution",
+            "beforeMCPExecution",
+        }
+    ):
+        return None
+    value = payload.get(field)
+    if value is None:
+        return None
+    if type(value) is not str:
+        raise ValueError(f"{harness} {event} {field} must be an exact string")
+    identifier = StrongHarnessIdentifier(
+        harness=harness,
+        kind=CorrelationKind.REQUEST,
+        value=value,
+    )
+    return derive_correlation_handle(identifier, key)
+
+
+def _prepare_key_path(guard_home: Path) -> Path:
+    guard_home.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_DIRECTORY_MODE)
+    if not guard_home.is_dir():
+        raise ValueError("guard_home must be a directory")
+    return guard_home / COMMAND_ACTIVITY_CORRELATION_KEY_FILE
+
+
+def _new_key() -> InstallationCorrelationKey:
+    material = secrets.token_bytes(_KEY_BYTES)
+    fingerprint = hashlib.sha256(material).hexdigest()[:16]
+    return InstallationCorrelationKey(key_id=f"correlation.v1.{fingerprint}", material=material)
+
+
+def _serialize_key(key: InstallationCorrelationKey) -> bytes:
+    material = key._material
+    payload = {
+        "schema_version": COMMAND_ACTIVITY_CORRELATION_KEY_SCHEMA_VERSION,
+        "key_id": key.key_id,
+        "material": base64.b64encode(material).decode("ascii"),
+    }
+    return (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode("ascii")
+
+
+def _read_key(path: Path) -> InstallationCorrelationKey:
+    file_stat = path.lstat()
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise ValueError("command activity correlation key must be a regular file")
+    _set_private_mode(path)
+    try:
+        raw_payload = cast(object, json.loads(path.read_text(encoding="ascii")))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError("invalid command activity correlation key file") from error
+    if not isinstance(raw_payload, dict):
+        raise ValueError("invalid command activity correlation key file shape")
+    payload = cast(dict[object, object], raw_payload)
+    if set(payload) != {"schema_version", "key_id", "material"}:
+        raise ValueError("invalid command activity correlation key file shape")
+    if payload["schema_version"] != COMMAND_ACTIVITY_CORRELATION_KEY_SCHEMA_VERSION:
+        raise ValueError("unsupported command activity correlation key schema")
+    key_id = payload["key_id"]
+    encoded_material = payload["material"]
+    if type(key_id) is not str or type(encoded_material) is not str:
+        raise ValueError("invalid command activity correlation key fields")
+    try:
+        material = base64.b64decode(encoded_material, validate=True)
+    except ValueError as error:
+        raise ValueError("invalid command activity correlation key material") from error
+    key = InstallationCorrelationKey(key_id=key_id, material=material)
+    expected_id = f"correlation.v1.{hashlib.sha256(material).hexdigest()[:16]}"
+    if key.key_id != expected_id:
+        raise ValueError("command activity correlation key identity does not match its material")
+    return key
+
+
+def _write_private_temporary(path: Path, payload: bytes) -> Path:
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        if os.name != "nt":
+            os.fchmod(descriptor, _PRIVATE_FILE_MODE)
+        with os.fdopen(descriptor, "wb") as handle:
+            descriptor = -1
+            _ = handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        return temporary_path
+    except BaseException:
+        if descriptor >= 0:
+            os.close(descriptor)
+        with suppress(OSError):
+            temporary_path.unlink()
+        raise
+
+
+def _set_private_mode(path: Path) -> None:
+    if os.name != "nt":
+        os.chmod(path, _PRIVATE_FILE_MODE, follow_symlinks=False)
+
+
+def _fsync_directory(path: Path) -> None:
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+__all__ = [
+    "COMMAND_ACTIVITY_CORRELATION_KEY_FILE",
+    "COMMAND_ACTIVITY_CORRELATION_KEY_SCHEMA_VERSION",
+    "derive_proven_request_correlation",
+    "load_or_create_installation_correlation_key",
+    "rotate_installation_correlation_key",
+]

--- a/src/codex_plugin_scanner/guard/runtime/command_activity_cursor.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_activity_cursor.py
@@ -1,0 +1,50 @@
+"""Trust boundary for Cursor command-activity post observers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from ..adapters.cursor_native_approval import (
+    after_shell_proof_from_env,
+    cursor_observer_event_for_payload,
+    ensure_cursor_hook_attestation_secret,
+    managed_cursor_hook_invocation,
+    normalize_cursor_shell_command,
+    resolve_cursor_approval_binding,
+    verify_cursor_after_observer_proof,
+)
+from .harness_attribution import cursor_runtime_detected
+
+
+def cursor_command_activity_observer_trusted(
+    *,
+    guard_home: Path,
+    payload: Mapping[str, object],
+    conversation_id: str,
+    command: str,
+    env: Mapping[str, str],
+) -> bool:
+    """Verify a managed Cursor observer without requiring a pending approval."""
+
+    if not managed_cursor_hook_invocation(env) or not cursor_runtime_detected(env):
+        return False
+    approval_binding = resolve_cursor_approval_binding(payload, env=env)
+    proof = after_shell_proof_from_env(env)
+    if approval_binding is None or proof is None:
+        return False
+    try:
+        secret = ensure_cursor_hook_attestation_secret(guard_home)
+    except OSError:
+        return False
+    return verify_cursor_after_observer_proof(
+        secret=secret,
+        conversation_id=conversation_id,
+        command=normalize_cursor_shell_command(command),
+        approval_binding=approval_binding,
+        proof=proof,
+        observer_event=cursor_observer_event_for_payload(payload),
+    )
+
+
+__all__ = ["cursor_command_activity_observer_trusted"]

--- a/src/codex_plugin_scanner/guard/runtime/command_activity_lifecycle.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_activity_lifecycle.py
@@ -1,0 +1,261 @@
+"""Pure construction of privacy-safe command activity lifecycle evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime
+from types import MappingProxyType
+from typing import Final, cast
+
+from codex_plugin_scanner.guard.action_lattice import guard_action_severity, is_guard_action
+from codex_plugin_scanner.guard.models import GuardAction
+
+from .command_activity_contract import (
+    ActivityApprovalReuseStatus,
+    ActivityDecisionReason,
+    ActivityLatencyBucket,
+    ActivityMatchClass,
+    ActivityParseConfidence,
+    CommandActivity,
+    CommandActivityEvidence,
+    CommandActivityMatch,
+    CommandExecutionStatus,
+    CommandHookPhase,
+    CommandProofLevel,
+    CorrelationHandle,
+    ReceiptLinkStatus,
+)
+from .command_evaluation import CompositeCommandEvaluation, OwnedCommandRuleMatch
+from .command_rules import CommandRuleMode
+from .effect_contract import EffectKind, UncertaintyKind
+from .extension_evidence import EvidenceSeverity, ExtensionRuleIdentity
+
+
+@dataclass(frozen=True, slots=True)
+class CommandActivityDecisionFacts:
+    """Authoritative final decision facts supplied by the hook orchestrator."""
+
+    policy_action: GuardAction
+    decision_reason_code: ActivityDecisionReason
+    prompted: bool
+    approval_reuse_status: ActivityApprovalReuseStatus
+    receipt_id: str | None
+
+    def __post_init__(self) -> None:
+        if not is_guard_action(self.policy_action):
+            raise ValueError("policy_action must be a canonical GuardAction")
+        if not isinstance(cast(object, self.decision_reason_code), ActivityDecisionReason):
+            raise ValueError("decision_reason_code must be an ActivityDecisionReason")
+        if type(self.prompted) is not bool:
+            raise ValueError("prompted must be a boolean")
+        if not isinstance(cast(object, self.approval_reuse_status), ActivityApprovalReuseStatus):
+            raise ValueError("approval_reuse_status must be an ActivityApprovalReuseStatus")
+
+
+_RISK_EFFECTS: Final = MappingProxyType(
+    {
+        "credential_exfiltration": frozenset({EffectKind.CREDENTIAL_OR_SECRET_OPERATION}),
+        "data_flow_exfiltration": frozenset({EffectKind.NETWORK_WRITE}),
+        "destructive_shell": frozenset({EffectKind.DESTRUCTIVE_OR_IRREVERSIBLE_OPERATION}),
+        "encoded_execution": frozenset({EffectKind.PROCESS_EXECUTION}),
+        "execution": frozenset({EffectKind.PROCESS_EXECUTION}),
+        "local_secret_read": frozenset({EffectKind.SENSITIVE_READ}),
+        "network_egress": frozenset({EffectKind.NETWORK_WRITE}),
+        "policy_bypass": frozenset({EffectKind.GUARD_CONTROL_OPERATION}),
+        "supply_chain": frozenset({EffectKind.PACKAGE_OR_SOURCE_INSTALLATION}),
+    }
+)
+_RULE_MODE_FLOOR: Final[dict[CommandRuleMode, GuardAction]] = {
+    "disabled": "allow",
+    "monitor": "warn",
+    "review": "review",
+    "enforce": "block",
+    "required": "review",
+}
+_SEVERITY: Final = {
+    "low": EvidenceSeverity.LOW,
+    "medium": EvidenceSeverity.MEDIUM,
+    "high": EvidenceSeverity.HIGH,
+    "critical": EvidenceSeverity.CRITICAL,
+}
+_UNCERTAINTY_REASON: Final = MappingProxyType(
+    {
+        "command_byte_limit_exceeded": UncertaintyKind.PARSER_BUDGET_EXHAUSTED,
+        "command_segment_limit_exceeded": UncertaintyKind.PARSER_BUDGET_EXHAUSTED,
+        "command_token_limit_exceeded": UncertaintyKind.PARSER_BUDGET_EXHAUSTED,
+        "embedded_command_limit_exceeded": UncertaintyKind.PARSER_BUDGET_EXHAUSTED,
+        "malformed_shell_quoting": UncertaintyKind.MALFORMED_INPUT,
+        "wrapper_normalization_limit_exceeded": UncertaintyKind.PARSER_BUDGET_EXHAUSTED,
+    }
+)
+
+
+def build_pre_hook_evidence(
+    evaluation: CompositeCommandEvaluation,
+    decision: CommandActivityDecisionFacts,
+    *,
+    activity_id: str,
+    occurred_at: datetime,
+    harness: str,
+    request_correlation: CorrelationHandle | None = None,
+    session_correlation: CorrelationHandle | None = None,
+    evaluation_latency_bucket: ActivityLatencyBucket = ActivityLatencyBucket.NOT_MEASURED,
+    persistence_latency_bucket: ActivityLatencyBucket = ActivityLatencyBucket.NOT_MEASURED,
+) -> CommandActivityEvidence:
+    """Build final pre-hook evidence without evaluating, persisting, or mutating policy."""
+
+    if not isinstance(cast(object, evaluation), CompositeCommandEvaluation):
+        raise ValueError("evaluation must be a CompositeCommandEvaluation")
+    matches = tuple(_activity_match(activity_id, ordinal, owned) for ordinal, owned in enumerate(evaluation.matches))
+    _validate_reason_matches(decision.decision_reason_code, matches)
+    receipt_status = ReceiptLinkStatus.LINKED if decision.receipt_id is not None else ReceiptLinkStatus.NOT_APPLICABLE
+    activity = CommandActivity(
+        activity_id=activity_id,
+        occurred_at=occurred_at,
+        harness=harness,
+        hook_phase=CommandHookPhase.PRE,
+        execution_status=(
+            CommandExecutionStatus.PREVENTED
+            if guard_action_severity(decision.policy_action) >= guard_action_severity("review")
+            else CommandExecutionStatus.ALLOWED_UNCONFIRMED
+        ),
+        proof_level=CommandProofLevel.PRE_HOOK,
+        policy_action=decision.policy_action,
+        decision_reason_code=decision.decision_reason_code,
+        controlling_rule_id=evaluation.controlling_rule_id,
+        parse_confidence=ActivityParseConfidence(evaluation.command.confidence),
+        uncertainty_class=_uncertainty_kind(evaluation),
+        match_count=len(matches),
+        prompted=decision.prompted,
+        approval_reuse_status=decision.approval_reuse_status,
+        request_correlation=request_correlation,
+        session_correlation=session_correlation,
+        receipt_link_status=receipt_status,
+        receipt_id=decision.receipt_id,
+        evaluation_latency_bucket=evaluation_latency_bucket,
+        persistence_latency_bucket=persistence_latency_bucket,
+    )
+    return CommandActivityEvidence(activity=activity, matches=matches)
+
+
+def build_correlated_post_evidence(
+    previous: CommandActivityEvidence,
+    *,
+    request_correlation: CorrelationHandle,
+    succeeded: bool,
+    persistence_latency_bucket: ActivityLatencyBucket = ActivityLatencyBucket.NOT_MEASURED,
+) -> CommandActivityEvidence:
+    """Promote an evidence value while preserving its immutable rule matches."""
+
+    activity = build_correlated_post_activity(
+        previous.activity,
+        request_correlation=request_correlation,
+        succeeded=succeeded,
+        persistence_latency_bucket=persistence_latency_bucket,
+    )
+    return CommandActivityEvidence(activity=activity, matches=previous.matches)
+
+
+def build_correlated_post_activity(
+    previous: CommandActivity,
+    *,
+    request_correlation: CorrelationHandle,
+    succeeded: bool,
+    persistence_latency_bucket: ActivityLatencyBucket = ActivityLatencyBucket.NOT_MEASURED,
+) -> CommandActivity:
+    """Promote a stored parent row only when the exact strong request handle matches."""
+
+    if previous.execution_status is not CommandExecutionStatus.ALLOWED_UNCONFIRMED:
+        raise ValueError("only allowed-unconfirmed activity can receive post-hook proof")
+    if previous.request_correlation is None or previous.request_correlation != request_correlation:
+        raise ValueError("post-hook proof requires the exact pre-hook request correlation")
+    return replace(
+        previous,
+        hook_phase=CommandHookPhase.POST_SUCCESS if succeeded else CommandHookPhase.POST_FAILURE,
+        execution_status=(
+            CommandExecutionStatus.CONFIRMED_SUCCESS if succeeded else CommandExecutionStatus.CONFIRMED_FAILURE
+        ),
+        proof_level=CommandProofLevel.POST_HOOK,
+        persistence_latency_bucket=persistence_latency_bucket,
+    )
+
+
+def build_unpaired_post_evidence(
+    *,
+    activity_id: str,
+    occurred_at: datetime,
+    harness: str,
+    succeeded: bool,
+    session_correlation: CorrelationHandle | None = None,
+    persistence_latency_bucket: ActivityLatencyBucket = ActivityLatencyBucket.NOT_MEASURED,
+) -> CommandActivityEvidence:
+    """Build explicit post-hook evidence that claims no pre-hook decision or command facts."""
+
+    activity = CommandActivity(
+        activity_id=activity_id,
+        occurred_at=occurred_at,
+        harness=harness,
+        hook_phase=CommandHookPhase.POST_SUCCESS if succeeded else CommandHookPhase.POST_FAILURE,
+        execution_status=CommandExecutionStatus.UNPAIRED_POST,
+        proof_level=CommandProofLevel.UNPAIRED_POST,
+        policy_action=None,
+        decision_reason_code=None,
+        controlling_rule_id=None,
+        parse_confidence=None,
+        uncertainty_class=None,
+        match_count=0,
+        prompted=False,
+        approval_reuse_status=ActivityApprovalReuseStatus.NOT_APPLICABLE,
+        request_correlation=None,
+        session_correlation=session_correlation,
+        receipt_link_status=ReceiptLinkStatus.NOT_APPLICABLE,
+        receipt_id=None,
+        evaluation_latency_bucket=ActivityLatencyBucket.NOT_MEASURED,
+        persistence_latency_bucket=persistence_latency_bucket,
+    )
+    return CommandActivityEvidence(activity=activity, matches=())
+
+
+def _activity_match(activity_id: str, ordinal: int, owned: OwnedCommandRuleMatch) -> CommandActivityMatch:
+    effects: set[EffectKind] = set()
+    for risk_class in owned.match.rule.risk_classes:
+        mapped = _RISK_EFFECTS.get(risk_class)
+        if mapped is None:
+            raise ValueError(f"unsupported command risk class: {risk_class}")
+        effects.update(mapped)
+    rule = owned.match.rule
+    default_floor = _RULE_MODE_FLOOR[rule.default_mode]
+    if owned.extension.required:
+        default_floor = "block" if rule.severity == "critical" else "review"
+    return CommandActivityMatch(
+        activity_id=activity_id,
+        ordinal=ordinal,
+        identity=ExtensionRuleIdentity(
+            extension_id=owned.extension.extension_id,
+            extension_version=owned.extension.version,
+            rule_id=rule.rule_id,
+            rule_version=owned.extension.version,
+        ),
+        match_class=ActivityMatchClass.UNSAFE,
+        severity=_SEVERITY[rule.severity],
+        default_floor=default_floor,
+        effect_claims=frozenset(effects),
+    )
+
+
+def _uncertainty_kind(evaluation: CompositeCommandEvaluation) -> UncertaintyKind | None:
+    command = evaluation.command
+    if command.confidence == "exact":
+        return None
+    reason = command.uncertainty_reason
+    if reason is not None and reason.startswith("unsupported_"):
+        return UncertaintyKind.UNSUPPORTED_INPUT
+    return _UNCERTAINTY_REASON.get(reason or "", UncertaintyKind.PARTIAL_PARSE)
+
+
+def _validate_reason_matches(
+    reason: ActivityDecisionReason,
+    matches: tuple[CommandActivityMatch, ...],
+) -> None:
+    if (not matches) != (reason is ActivityDecisionReason.NO_MATCH):
+        raise ValueError("no-match decision reason must correspond exactly to no rule matches")

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -13,6 +13,7 @@ from .store_base import (
 from .store_approval_facade import StoreApprovalsMixin
 from .store_cloud_events import StoreCloudEventsMixin
 from .store_command_activity import StoreCommandActivityMixin
+from .store_command_activity_lifecycle import StoreCommandActivityLifecycleMixin
 from .store_connection_schema import StoreConnectionSchemaMixin
 from .store_event_receipts import StoreEventReceiptsMixin
 from .store_evidence_facade import StoreEvidenceMixin
@@ -34,6 +35,7 @@ class GuardStore(
     StoreSecretPolicyIntegrityMixin,
     StoreConnectionSchemaMixin,
     StoreCommandActivityMixin,
+    StoreCommandActivityLifecycleMixin,
     StoreInventoryMixin,
     StorePolicyMixin,
     StorePolicyIntegrityAdminMixin,

--- a/src/codex_plugin_scanner/guard/store_command_activity_health_schema.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_health_schema.py
@@ -1,0 +1,92 @@
+"""Schema migration for bounded command activity persistence health."""
+
+# pyright: reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from typing import Final, cast
+
+COMMAND_ACTIVITY_HEALTH_MIGRATION_VERSION: Final = 11
+COMMAND_ACTIVITY_HEALTH_SCHEMA_VERSION: Final = "1.0.0"
+_HEALTH_TABLE_SQL: Final = """
+create table if not exists command_activity_health (
+  singleton integer primary key check (singleton = 1),
+  dropped_event_count integer not null check (dropped_event_count between 0 and 9223372036854775807),
+  persistence_error_count integer not null check (persistence_error_count between 0 and 9223372036854775807),
+  last_error_code text check (last_error_code is null or length(last_error_code) between 1 and 64),
+  last_error_at text,
+  schema_version text not null
+)
+"""
+
+
+def ensure_command_activity_health_schema(connection: sqlite3.Connection, *, applied_at: str) -> None:
+    """Create and validate v11 atomically, including its singleton seed row."""
+
+    connection.execute("savepoint command_activity_health_schema_v1")
+    try:
+        connection.execute(_HEALTH_TABLE_SQL)
+        _validate_health_schema(connection)
+        connection.execute(
+            """
+            insert or ignore into command_activity_health (
+              singleton, dropped_event_count, persistence_error_count,
+              last_error_code, last_error_at, schema_version
+            ) values (1, 0, 0, null, null, ?)
+            """,
+            (COMMAND_ACTIVITY_HEALTH_SCHEMA_VERSION,),
+        )
+        _validate_health_row(connection)
+        connection.execute(
+            "insert or ignore into schema_migrations (version, applied_at) values (?, ?)",
+            (COMMAND_ACTIVITY_HEALTH_MIGRATION_VERSION, applied_at),
+        )
+    except BaseException:
+        connection.execute("rollback to command_activity_health_schema_v1")
+        connection.execute("release command_activity_health_schema_v1")
+        raise
+    connection.execute("release command_activity_health_schema_v1")
+
+
+def _validate_health_schema(connection: sqlite3.Connection) -> None:
+    rows = cast(
+        list[tuple[int, str, str, int, object | None, int]],
+        connection.execute("pragma table_info(command_activity_health)").fetchall(),
+    )
+    expected_columns = {
+        "singleton",
+        "dropped_event_count",
+        "persistence_error_count",
+        "last_error_code",
+        "last_error_at",
+        "schema_version",
+    }
+    if {str(row[1]) for row in rows} != expected_columns:
+        raise RuntimeError("incompatible command_activity_health schema")
+    primary_key = tuple(str(row[1]) for row in rows if int(row[5]) > 0)
+    if primary_key != ("singleton",):
+        raise RuntimeError("incompatible command_activity_health primary key")
+    row = cast(
+        tuple[str] | None,
+        connection.execute(
+            "select sql from sqlite_schema where type = 'table' and name = 'command_activity_health'"
+        ).fetchone(),
+    )
+    expected_sql = _canonical_sql(_HEALTH_TABLE_SQL).replace(" if not exists", "", 1)
+    if row is None or _canonical_sql(row[0]) != expected_sql:
+        raise RuntimeError("incompatible command_activity_health schema object")
+
+
+def _validate_health_row(connection: sqlite3.Connection) -> None:
+    row = cast(
+        tuple[int, int, int, str | None, str | None, str] | None,
+        connection.execute("select * from command_activity_health where singleton = 1").fetchone(),
+    )
+    if row is None or row[5] != COMMAND_ACTIVITY_HEALTH_SCHEMA_VERSION:
+        raise RuntimeError("incompatible command_activity_health singleton")
+
+
+def _canonical_sql(value: str) -> str:
+    return " ".join(re.sub(r"\s+", " ", value.strip().lower()).split())

--- a/src/codex_plugin_scanner/guard/store_command_activity_lifecycle.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_lifecycle.py
@@ -1,0 +1,319 @@
+"""Lifecycle updates and bounded persistence health for command activity."""
+
+# pyright: reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Final, Protocol, TypeVar, cast
+
+from codex_plugin_scanner.guard.models import GuardAction
+
+from .runtime.command_activity_contract import (
+    ActivityApprovalReuseStatus,
+    ActivityDecisionReason,
+    ActivityLatencyBucket,
+    ActivityParseConfidence,
+    CommandActivity,
+    CommandActivityEvidence,
+    CommandActivityMatch,
+    CommandExecutionStatus,
+    CommandHookPhase,
+    CommandProofLevel,
+    CorrelationHandle,
+    CorrelationKind,
+    ReceiptLinkStatus,
+    validate_activity_transition,
+)
+from .runtime.effect_contract import UncertaintyKind
+
+_MAX_COUNTER: Final = 9_223_372_036_854_775_807
+_ERROR_CODE: Final = re.compile(r"[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*")
+_EnumT = TypeVar("_EnumT", bound=Enum)
+
+
+class _ConnectionOwner(Protocol):
+    def _connect(self) -> AbstractContextManager[sqlite3.Connection]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class CommandActivityPersistenceHealth:
+    dropped_event_count: int
+    persistence_error_count: int
+    last_error_code: str | None
+    last_error_at: datetime | None
+    schema_version: str
+
+
+class StoreCommandActivityLifecycleMixin:
+    def is_exact_command_activity_pre_replay(
+        self: _ConnectionOwner,
+        evidence: CommandActivityEvidence,
+    ) -> bool:
+        """Return true for one existing logical pre delivery; reject fact conflicts."""
+
+        correlation = evidence.activity.request_correlation
+        if correlation is None:
+            return False
+        _require_request_correlation(correlation)
+        with self._connect() as connection:
+            row = _select_by_request_correlation(connection, correlation)
+            if row is None:
+                return False
+            previous = _activity_from_row(connection, row)
+            persisted_matches = tuple(
+                tuple(item)
+                for item in connection.execute(
+                    """
+                    select ordinal, extension_id, extension_version, rule_id, rule_version,
+                           match_class, severity, default_floor, safe_variant_id, schema_version
+                    from command_activity_matches where activity_id = ? order by ordinal
+                    """,
+                    (previous.activity_id,),
+                ).fetchall()
+            )
+            persisted_effects = tuple(
+                tuple(item)
+                for item in connection.execute(
+                    """
+                    select ordinal, effect_class from command_activity_match_effects
+                    where activity_id = ? order by ordinal, effect_class
+                    """,
+                    (previous.activity_id,),
+                ).fetchall()
+            )
+        expected_matches = tuple(_pre_replay_match_values(item) for item in evidence.matches)
+        expected_effects = tuple(
+            (match.ordinal, effect.value)
+            for match in evidence.matches
+            for effect in sorted(match.effect_claims, key=lambda item: item.value)
+        )
+        if (
+            _pre_replay_activity_values(previous) != _pre_replay_activity_values(evidence.activity)
+            or persisted_matches != expected_matches
+            or persisted_effects != expected_effects
+        ):
+            raise ValueError("conflicting command activity replay")
+        return True
+
+    def get_command_activity_by_request_correlation(
+        self: _ConnectionOwner,
+        correlation: CorrelationHandle,
+    ) -> CommandActivity | None:
+        """Resolve one logical command by an exact, strong request handle."""
+
+        _require_request_correlation(correlation)
+        with self._connect() as connection:
+            row = _select_by_request_correlation(connection, correlation)
+            return _activity_from_row(connection, row) if row is not None else None
+
+    def transition_command_activity(self: _ConnectionOwner, current: CommandActivity) -> bool:
+        """Atomically advance one correlated activity; return false for an exact replay."""
+
+        if not isinstance(cast(object, current), CommandActivity):
+            raise ValueError("current must be a CommandActivity")
+        correlation = current.request_correlation
+        if correlation is None:
+            raise ValueError("lifecycle transitions require request correlation")
+        _require_request_correlation(correlation)
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            row = _select_by_request_correlation(connection, correlation)
+            if row is None:
+                raise ValueError("command activity correlation does not identify a pre-hook record")
+            previous = _activity_from_row(connection, row)
+            if previous.activity_id != current.activity_id:
+                raise ValueError("command activity correlation conflicts with activity identity")
+            validate_activity_transition(previous, current)
+            if previous == current:
+                return False
+            result = connection.execute(
+                """
+                update command_activity
+                set hook_phase = ?, execution_status = ?, proof_level = ?,
+                    persistence_latency_bucket = ?
+                where activity_id = ? and hook_phase = ?
+                  and execution_status = ? and proof_level = ?
+                  and persistence_latency_bucket = ?
+                """,
+                (
+                    current.hook_phase.value,
+                    current.execution_status.value,
+                    current.proof_level.value,
+                    current.persistence_latency_bucket.value,
+                    current.activity_id,
+                    previous.hook_phase.value,
+                    previous.execution_status.value,
+                    previous.proof_level.value,
+                    previous.persistence_latency_bucket.value,
+                ),
+            )
+            if result.rowcount != 1:
+                raise RuntimeError("command activity changed during lifecycle transition")
+            return True
+
+    def record_command_activity_persistence_failure(
+        self: _ConnectionOwner,
+        *,
+        error_code: str,
+        occurred_at: datetime,
+    ) -> None:
+        """Count one dropped event and persistence error without unbounded details."""
+
+        _require_error_code(error_code)
+        _require_utc_datetime(occurred_at)
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            connection.execute(
+                """
+                update command_activity_health
+                set dropped_event_count = min(dropped_event_count + 1, ?),
+                    persistence_error_count = min(persistence_error_count + 1, ?),
+                    last_error_code = ?, last_error_at = ?
+                where singleton = 1
+                """,
+                (_MAX_COUNTER, _MAX_COUNTER, error_code, occurred_at.isoformat()),
+            )
+
+    def get_command_activity_persistence_health(
+        self: _ConnectionOwner,
+    ) -> CommandActivityPersistenceHealth:
+        with self._connect() as connection:
+            row = cast(
+                sqlite3.Row | None,
+                connection.execute("select * from command_activity_health where singleton = 1").fetchone(),
+            )
+        if row is None:
+            raise RuntimeError("command activity persistence health is unavailable")
+        last_error_at = str(row["last_error_at"]) if row["last_error_at"] is not None else None
+        return CommandActivityPersistenceHealth(
+            dropped_event_count=int(row["dropped_event_count"]),
+            persistence_error_count=int(row["persistence_error_count"]),
+            last_error_code=str(row["last_error_code"]) if row["last_error_code"] is not None else None,
+            last_error_at=datetime.fromisoformat(last_error_at) if last_error_at is not None else None,
+            schema_version=str(row["schema_version"]),
+        )
+
+
+def _select_by_request_correlation(
+    connection: sqlite3.Connection,
+    correlation: CorrelationHandle,
+) -> sqlite3.Row | None:
+    return cast(
+        sqlite3.Row | None,
+        connection.execute(
+            """
+            select activity.* from command_activity as activity
+            join command_activity_correlations as correlation
+              on correlation.activity_id = activity.activity_id
+            where correlation.kind = 'request' and correlation.harness = ?
+              and correlation.key_id = ? and correlation.digest = ?
+            """,
+            (correlation.harness, correlation.key_id, correlation.digest),
+        ).fetchone(),
+    )
+
+
+def _activity_from_row(connection: sqlite3.Connection, row: sqlite3.Row) -> CommandActivity:
+    correlations = cast(
+        list[sqlite3.Row],
+        connection.execute(
+            "select kind, harness, key_id, digest from command_activity_correlations where activity_id = ?",
+            (str(row["activity_id"]),),
+        ).fetchall(),
+    )
+    handles = {
+        CorrelationKind(str(item["kind"])): CorrelationHandle(
+            CorrelationKind(str(item["kind"])),
+            str(item["harness"]),
+            str(item["key_id"]),
+            str(item["digest"]),
+        )
+        for item in correlations
+    }
+    return CommandActivity(
+        activity_id=str(row["activity_id"]),
+        occurred_at=datetime.fromisoformat(str(row["occurred_at"])),
+        harness=str(row["harness"]),
+        hook_phase=CommandHookPhase(str(row["hook_phase"])),
+        execution_status=CommandExecutionStatus(str(row["execution_status"])),
+        proof_level=CommandProofLevel(str(row["proof_level"])),
+        policy_action=cast(GuardAction | None, row["policy_action"]),
+        decision_reason_code=_optional_enum(ActivityDecisionReason, row["decision_reason_code"]),
+        controlling_rule_id=str(row["controlling_rule_id"]) if row["controlling_rule_id"] is not None else None,
+        parse_confidence=_optional_enum(ActivityParseConfidence, row["parse_confidence"]),
+        uncertainty_class=_optional_enum(UncertaintyKind, row["uncertainty_class"]),
+        match_count=int(row["match_count"]),
+        prompted=bool(row["prompted"]),
+        approval_reuse_status=ActivityApprovalReuseStatus(str(row["approval_reuse_status"])),
+        request_correlation=handles.get(CorrelationKind.REQUEST),
+        session_correlation=handles.get(CorrelationKind.SESSION),
+        receipt_link_status=ReceiptLinkStatus(str(row["receipt_link_status"])),
+        receipt_id=str(row["receipt_id"]) if row["receipt_id"] is not None else None,
+        evaluation_latency_bucket=ActivityLatencyBucket(str(row["evaluation_latency_bucket"])),
+        persistence_latency_bucket=ActivityLatencyBucket(str(row["persistence_latency_bucket"])),
+        schema_version=str(row["schema_version"]),
+    )
+
+
+def _optional_enum(enum_type: type[_EnumT], value: object) -> _EnumT | None:
+    return enum_type(str(value)) if value is not None else None
+
+
+def _pre_replay_activity_values(activity: CommandActivity) -> tuple[object, ...]:
+    return (
+        activity.harness,
+        activity.policy_action,
+        activity.decision_reason_code,
+        activity.controlling_rule_id,
+        activity.parse_confidence,
+        activity.uncertainty_class,
+        activity.match_count,
+        activity.prompted,
+        activity.approval_reuse_status,
+        activity.request_correlation,
+        activity.session_correlation,
+        activity.receipt_link_status,
+        activity.evaluation_latency_bucket,
+        activity.schema_version,
+    )
+
+
+def _pre_replay_match_values(match: CommandActivityMatch) -> tuple[object, ...]:
+    return (
+        match.ordinal,
+        match.identity.extension_id,
+        match.identity.extension_version,
+        match.identity.rule_id,
+        match.identity.rule_version,
+        match.match_class.value,
+        match.severity.value,
+        match.default_floor,
+        match.safe_variant_id,
+        match.schema_version,
+    )
+
+
+def _require_request_correlation(correlation: CorrelationHandle) -> None:
+    if not isinstance(cast(object, correlation), CorrelationHandle) or correlation.kind is not CorrelationKind.REQUEST:
+        raise ValueError("correlation must be an exact request CorrelationHandle")
+
+
+def _require_error_code(value: str) -> None:
+    if not isinstance(cast(object, value), str) or len(value) > 64 or _ERROR_CODE.fullmatch(value) is None:
+        raise ValueError("error_code must be a bounded stable identifier")
+
+
+def _require_utc_datetime(value: datetime) -> None:
+    if not isinstance(cast(object, value), datetime) or value.tzinfo is None:
+        raise ValueError("occurred_at must be timezone-aware")
+    offset = value.utcoffset()
+    if offset is None:
+        raise ValueError("occurred_at must be timezone-aware")
+    if offset.total_seconds() != 0:
+        raise ValueError("occurred_at must be UTC")

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 # ruff: noqa: F403,F405
 from .store_base import *
+from .store_command_activity_health_schema import ensure_command_activity_health_schema
 from .store_command_activity_schema import ensure_command_activity_schema
 from .store_live_request_outbox import ensure_live_request_outbox_schema, seed_live_request_outbox
 from .store_secret_policy_integrity import _POLICY_INTEGRITY_LOOKUP_UNSET
@@ -617,6 +618,7 @@ class StoreConnectionSchemaMixin:
             for statement in statements:
                 connection.execute(statement)
             ensure_command_activity_schema(connection, applied_at=_now())
+            ensure_command_activity_health_schema(connection, applied_at=_now())
             ensure_evidence_schema(connection)
             if not self._schema_version_applied(connection, version=4):
                 self._record_schema_version(connection, version=4)

--- a/tests/test_guard_command_activity_contract.py
+++ b/tests/test_guard_command_activity_contract.py
@@ -54,6 +54,8 @@ def _activity(
     uncertainty_class: UncertaintyKind | None = None,
     receipt_link_status: ReceiptLinkStatus = ReceiptLinkStatus.NOT_APPLICABLE,
     receipt_id: str | None = None,
+    prompted: bool = False,
+    approval_reuse_status: ActivityApprovalReuseStatus = ActivityApprovalReuseStatus.NOT_APPLICABLE,
     schema_version: str = COMMAND_ACTIVITY_SCHEMA_VERSION,
 ) -> CommandActivity:
     return CommandActivity(
@@ -69,8 +71,8 @@ def _activity(
         parse_confidence=parse_confidence,
         uncertainty_class=uncertainty_class,
         match_count=match_count,
-        prompted=False,
-        approval_reuse_status=ActivityApprovalReuseStatus.NOT_APPLICABLE,
+        prompted=prompted,
+        approval_reuse_status=approval_reuse_status,
         request_correlation=request_correlation,
         session_correlation=session_correlation,
         receipt_link_status=receipt_link_status,
@@ -250,6 +252,14 @@ def test_review_or_stronger_activity_requires_exact_receipt_link() -> None:
     assert reviewed.receipt_id == "receipt:01"
     with pytest.raises(ValueError, match="requires receipt_id"):
         replace(reviewed, receipt_id=None)
+
+
+def test_accepted_approval_reuse_cannot_claim_a_prompt() -> None:
+    with pytest.raises(ValueError, match="accepted approval reuse cannot claim a prompt"):
+        _activity(
+            prompted=True,
+            approval_reuse_status=ActivityApprovalReuseStatus.ACCEPTED,
+        )
 
 
 def test_non_exact_parse_requires_bounded_uncertainty() -> None:

--- a/tests/test_guard_command_activity_correlation.py
+++ b/tests/test_guard_command_activity_correlation.py
@@ -1,0 +1,261 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import json
+import os
+import stat
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
+from codex_plugin_scanner.guard.runtime.command_activity_correlation import (
+    COMMAND_ACTIVITY_CORRELATION_KEY_FILE,
+    COMMAND_ACTIVITY_CORRELATION_KEY_SCHEMA_VERSION,
+    derive_proven_request_correlation,
+    load_or_create_installation_correlation_key,
+    rotate_installation_correlation_key,
+)
+from codex_plugin_scanner.guard.runtime.command_activity_privacy import InstallationCorrelationKey
+
+_STRONG_ID = "01J3ABCD9XYZ7NATIVEID"
+
+
+def _fixed_key() -> InstallationCorrelationKey:
+    return InstallationCorrelationKey(key_id="correlation.v1.test", material=b"k" * 32)
+
+
+def test_key_is_private_versioned_and_reused_deterministically(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard"
+    first = load_or_create_installation_correlation_key(guard_home)
+    second = load_or_create_installation_correlation_key(guard_home)
+    key_path = guard_home / COMMAND_ACTIVITY_CORRELATION_KEY_FILE
+    raw_payload = cast(object, json.loads(key_path.read_text(encoding="ascii")))
+    assert isinstance(raw_payload, dict)
+    payload = cast(dict[object, object], raw_payload)
+
+    assert first.key_id == second.key_id
+    assert first.derive(b"probe") == second.derive(b"probe")
+    assert first.key_id.startswith("correlation.v1.")
+    assert payload["schema_version"] == COMMAND_ACTIVITY_CORRELATION_KEY_SCHEMA_VERSION
+    assert payload["key_id"] == first.key_id
+    if os.name != "nt":
+        assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+
+def test_existing_key_permissions_are_repaired(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard"
+    original = load_or_create_installation_correlation_key(guard_home)
+    key_path = guard_home / COMMAND_ACTIVITY_CORRELATION_KEY_FILE
+    if os.name == "nt":
+        pytest.skip("POSIX permission modes are not available")
+    key_path.chmod(0o644)
+
+    loaded = load_or_create_installation_correlation_key(guard_home)
+
+    assert loaded.key_id == original.key_id
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+
+def test_rotation_atomically_changes_key_identity(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard"
+    original = load_or_create_installation_correlation_key(guard_home)
+
+    rotated = rotate_installation_correlation_key(guard_home)
+    loaded = load_or_create_installation_correlation_key(guard_home)
+
+    assert rotated.key_id == loaded.key_id
+    assert rotated.key_id != original.key_id
+    assert rotated.derive(b"probe") != original.derive(b"probe")
+
+
+def test_concurrent_creation_converges_on_one_key(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard"
+
+    def load_key(_: int) -> InstallationCorrelationKey:
+        return load_or_create_installation_correlation_key(guard_home)
+
+    with ThreadPoolExecutor(max_workers=12) as executor:
+        keys = list(executor.map(load_key, range(48)))
+
+    assert len({key.key_id for key in keys}) == 1
+    assert len({key.derive(b"probe") for key in keys}) == 1
+    assert not list(guard_home.glob(f".{COMMAND_ACTIVITY_CORRELATION_KEY_FILE}.*"))
+
+
+@pytest.mark.parametrize(
+    ("harness", "event", "field"),
+    [
+        ("codex", "PreToolUse", "tool_call_id"),
+        ("codex", "PostToolUse", "tool_call_id"),
+        ("codex", "PostToolUseFailure", "tool_call_id"),
+        ("claude-code", "PreToolUse", "tool_use_id"),
+        ("claude-code", "PostToolUse", "tool_use_id"),
+        ("claude-code", "PostToolUseFailure", "tool_use_id"),
+        ("pi", "PreToolUse", "tool_call_id"),
+        ("pi", "PostToolUse", "tool_call_id"),
+    ],
+)
+def test_adapter_allowlist_derives_only_native_request_ids(harness: str, event: str, field: str) -> None:
+    key = _fixed_key()
+
+    result = derive_proven_request_correlation(
+        harness=harness,
+        event=event,
+        payload={field: _STRONG_ID},
+        key=key,
+    )
+
+    assert result is not None
+    assert result.harness == harness
+    assert result.key_id == key.key_id
+
+
+@pytest.mark.parametrize(
+    "source_event",
+    ["beforeShellExecution", "beforeMCPExecution", "afterShellExecution", "afterMCPExecution"],
+)
+def test_cursor_allowlist_uses_prepared_event_provenance(source_event: str) -> None:
+    prepared = prepare_cursor_hook_payload(
+        {
+            "hook_event_name": source_event,
+            "generation_id": _STRONG_ID,
+            "command": "true",
+        }
+    )
+    event = prepared.get("hook_event_name")
+    assert isinstance(event, str)
+
+    result = derive_proven_request_correlation(
+        harness="cursor",
+        event=event,
+        payload=prepared,
+        key=_fixed_key(),
+    )
+
+    assert result is not None
+    assert result.harness == "cursor"
+
+
+def test_cursor_generic_pretool_event_cannot_claim_generation_proof() -> None:
+    assert (
+        derive_proven_request_correlation(
+            harness="cursor",
+            event="PreToolUse",
+            payload={"generation_id": _STRONG_ID},
+            key=_fixed_key(),
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("event", ["preToolUse", "postToolUse", "postToolUseFailure"])
+def test_copilot_has_no_documented_per_tool_proof_identifier(event: str) -> None:
+    assert (
+        derive_proven_request_correlation(
+            harness="copilot",
+            event=event,
+            payload={
+                "sessionId": _STRONG_ID,
+                "tool_call_id": _STRONG_ID,
+                "toolCallId": _STRONG_ID,
+            },
+            key=_fixed_key(),
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("harness", "event"),
+    [
+        ("opencode", "PreToolUse"),
+        ("gemini", "BeforeTool"),
+        ("hermes", "PreToolUse"),
+        ("openclaw", "PreToolUse"),
+        ("antigravity", "PreToolUse"),
+        ("kimi", "PreToolUse"),
+        ("grok", "PreToolUse"),
+        ("zcode", "PreToolUse"),
+    ],
+)
+def test_harnesses_without_native_proof_return_none(harness: str, event: str) -> None:
+    assert (
+        derive_proven_request_correlation(
+            harness=harness,
+            event=event,
+            payload={"tool_call_id": _STRONG_ID},
+            key=_fixed_key(),
+        )
+        is None
+    )
+
+
+def test_missing_or_wrong_event_proof_returns_none() -> None:
+    key = _fixed_key()
+    assert derive_proven_request_correlation(harness="codex", event="PreToolUse", payload={}, key=key) is None
+    assert (
+        derive_proven_request_correlation(
+            harness="codex",
+            event="PermissionRequest",
+            payload={"tool_call_id": _STRONG_ID},
+            key=key,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("value", ["1", "request-123456789012345678901", "2026-07-18T20:00:00Z", "aaaaaaaaaaaaaaaa"])
+def test_allowlisted_weak_identifiers_are_rejected(value: str) -> None:
+    with pytest.raises(ValueError, match="strong harness identifier"):
+        _ = derive_proven_request_correlation(
+            harness="codex",
+            event="PreToolUse",
+            payload={"tool_call_id": value},
+            key=_fixed_key(),
+        )
+
+
+def test_adapter_never_guesses_from_content_sessions_or_nested_fields() -> None:
+    payload: dict[str, object] = {
+        "command": _STRONG_ID,
+        "content": _STRONG_ID,
+        "session_id": _STRONG_ID,
+        "request_id": _STRONG_ID,
+        "tool_input": {"tool_call_id": _STRONG_ID},
+    }
+
+    assert (
+        derive_proven_request_correlation(
+            harness="codex",
+            event="PreToolUse",
+            payload=payload,
+            key=_fixed_key(),
+        )
+        is None
+    )
+
+
+def test_invalid_key_file_is_not_silently_replaced(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard"
+    guard_home.mkdir()
+    key_path = guard_home / COMMAND_ACTIVITY_CORRELATION_KEY_FILE
+    _ = key_path.write_text("{}", encoding="ascii")
+
+    with pytest.raises(ValueError, match="key file shape"):
+        _ = load_or_create_installation_correlation_key(guard_home)
+
+
+def test_key_file_symlink_is_rejected(tmp_path: Path) -> None:
+    if os.name == "nt":
+        pytest.skip("symlink creation is not generally available")
+    guard_home = tmp_path / "guard"
+    guard_home.mkdir()
+    target = tmp_path / "target"
+    _ = target.write_text("secret", encoding="ascii")
+    (guard_home / COMMAND_ACTIVITY_CORRELATION_KEY_FILE).symlink_to(target)
+
+    with pytest.raises(ValueError, match="regular file"):
+        _ = load_or_create_installation_correlation_key(guard_home)

--- a/tests/test_guard_command_activity_cursor.py
+++ b/tests/test_guard_command_activity_cursor.py
@@ -1,0 +1,78 @@
+"""Cursor post-observer trust tests for command activity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.cursor_native_approval import (
+    compute_cursor_after_observer_proof,
+    ensure_cursor_hook_attestation_secret,
+)
+from codex_plugin_scanner.guard.runtime.command_activity_cursor import (
+    cursor_command_activity_observer_trusted,
+)
+
+
+@pytest.mark.parametrize("event", ("afterShellExecution", "afterMCPExecution"))
+def test_managed_cursor_observer_is_trusted_without_pending_approval(tmp_path: Path, event: str) -> None:
+    guard_home = tmp_path / "guard-home"
+    conversation_id = "conversation_abcdef1234567890"
+    generation_id = "generation_abcdef1234567890"
+    command = "git status"
+    secret = ensure_cursor_hook_attestation_secret(guard_home)
+    proof = compute_cursor_after_observer_proof(
+        secret=secret,
+        conversation_id=conversation_id,
+        command=command,
+        approval_binding=generation_id,
+        observer_event=event,
+    )
+    payload: dict[str, object] = {
+        "hook_event_name": event,
+        "generation_id": generation_id,
+        "conversation_id": conversation_id,
+        "command": command,
+    }
+    env = {
+        "HOL_GUARD_MANAGED_CURSOR_HOOK": "1",
+        "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF": proof,
+        "HOL_GUARD_CURSOR_APPROVAL_BINDING": generation_id,
+        "CURSOR_VERSION": "test",
+    }
+
+    assert cursor_command_activity_observer_trusted(
+        guard_home=guard_home,
+        payload=payload,
+        conversation_id=conversation_id,
+        command=command,
+        env=env,
+    )
+
+
+def test_cursor_observer_rejects_forged_or_unmanaged_proof(tmp_path: Path) -> None:
+    payload: dict[str, object] = {
+        "hook_event_name": "afterShellExecution",
+        "generation_id": "generation_abcdef1234567890",
+    }
+    base_env = {
+        "HOL_GUARD_MANAGED_CURSOR_HOOK": "1",
+        "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF": "0" * 64,
+        "HOL_GUARD_CURSOR_APPROVAL_BINDING": "generation_abcdef1234567890",
+        "CURSOR_VERSION": "test",
+    }
+    assert not cursor_command_activity_observer_trusted(
+        guard_home=tmp_path / "guard-home",
+        payload=payload,
+        conversation_id="conversation_abcdef1234567890",
+        command="git status",
+        env=base_env,
+    )
+    assert not cursor_command_activity_observer_trusted(
+        guard_home=tmp_path / "guard-home",
+        payload=payload,
+        conversation_id="conversation_abcdef1234567890",
+        command="git status",
+        env={key: value for key, value in base_env.items() if key != "HOL_GUARD_MANAGED_CURSOR_HOOK"},
+    )

--- a/tests/test_guard_command_activity_hook_integration.py
+++ b/tests/test_guard_command_activity_hook_integration.py
@@ -1,0 +1,447 @@
+"""Hook-boundary integration and non-interference tests for command activity."""
+
+# pyright: reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.cli.commands_support_command_activity import (
+    hook_post_succeeded,
+    record_post_hook_command_activity_best_effort,
+    record_pre_hook_command_activity_best_effort,
+)
+from codex_plugin_scanner.guard.runtime.command_activity_contract import (
+    COMMAND_ACTIVITY_HARNESSES,
+    CommandExecutionStatus,
+)
+from codex_plugin_scanner.guard.runtime.command_activity_correlation import (
+    derive_proven_request_correlation,
+    load_or_create_installation_correlation_key,
+)
+from codex_plugin_scanner.guard.runtime.secret_file_requests import (
+    build_tool_action_request_artifact,
+    extract_sensitive_tool_action_request,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _command_payload(*, request_id: str | None = "toolcall_abcdef1234567890") -> dict[str, object]:
+    payload: dict[str, object] = {
+        "tool_name": "Shell",
+        "tool_input": {"command": "git push origin release/2.2 --force"},
+    }
+    if request_id is not None:
+        payload["tool_call_id"] = request_id
+    return payload
+
+
+def _store(guard_home: Path) -> GuardStore:
+    return GuardStore(guard_home, prime_policy_integrity=False)
+
+
+def test_codex_pre_and_post_transition_one_matched_activity(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = _store(guard_home)
+    payload = _command_payload()
+
+    assert record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PreToolUse",
+        payload=payload,
+        policy_action="allow",
+        receipt_id=None,
+        prompted=False,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+    assert not record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PreToolUse",
+        payload=payload,
+        policy_action="allow",
+        receipt_id=None,
+        prompted=False,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+    assert store.count_command_activities() == 1
+    assert store.count_command_activity_rule_hits() >= 1
+
+    assert record_post_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PostToolUse",
+        payload=payload,
+        succeeded=True,
+    )
+    key = load_or_create_installation_correlation_key(guard_home)
+    correlation = derive_proven_request_correlation(
+        harness="codex",
+        event="PostToolUse",
+        payload=payload,
+        key=key,
+    )
+    assert correlation is not None
+    activity = store.get_command_activity_by_request_correlation(correlation)
+    assert activity is not None
+    assert activity.execution_status is CommandExecutionStatus.CONFIRMED_SUCCESS
+    assert store.count_command_activities() == 1
+    assert not record_post_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PostToolUse",
+        payload=payload,
+        succeeded=True,
+    )
+    health = store.get_command_activity_persistence_health()
+    assert health.dropped_event_count == 0
+    assert health.persistence_error_count == 0
+
+
+def test_every_supported_harness_records_matched_pre_hook_evidence(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = _store(guard_home)
+    for harness in sorted(COMMAND_ACTIVITY_HARNESSES):
+        payload = _command_payload(request_id=None)
+        event = "preToolUse" if harness == "copilot" else "PreToolUse"
+        if harness in {"codex", "pi"}:
+            payload["tool_call_id"] = f"{harness}_toolcall_abcdef1234567890"
+        elif harness == "claude-code":
+            payload["tool_use_id"] = "claude_tooluse_abcdef1234567890"
+        elif harness == "cursor":
+            payload["generation_id"] = "cursor_generation_abcdef1234567890"
+            payload["cursor_source_hook_event"] = "beforeShellExecution"
+        assert record_pre_hook_command_activity_best_effort(
+            store=store,
+            guard_home=guard_home,
+            harness=harness,
+            event=event,
+            payload=payload,
+            policy_action="allow",
+            receipt_id=None,
+            prompted=False,
+        )
+    assert store.count_command_activities() == len(COMMAND_ACTIVITY_HARNESSES)
+
+
+def test_same_request_id_with_changed_decision_is_a_counted_conflict(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = _store(guard_home)
+    payload = _command_payload()
+    assert record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PreToolUse",
+        payload=payload,
+        policy_action="allow",
+        receipt_id=None,
+        prompted=False,
+    )
+    assert not record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PreToolUse",
+        payload=payload,
+        policy_action="warn",
+        receipt_id=None,
+        prompted=False,
+    )
+    assert store.count_command_activities() == 1
+    health = store.get_command_activity_persistence_health()
+    assert health.dropped_event_count == 1
+    assert health.last_error_code == "pre_record_failed"
+
+
+def test_persisted_rule_ids_match_authoritative_runtime_artifact_evaluation(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = _store(guard_home)
+    command = "sudo --command-timeout 10 git push origin main --force"
+    payload: dict[str, object] = {
+        "tool_name": "Shell",
+        "tool_input": {"command": command},
+        "tool_call_id": "toolcall_wrapped_abcdef1234567890",
+    }
+    request = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+    assert request is not None
+    artifact = build_tool_action_request_artifact(
+        "codex",
+        request,
+        config_path="config.toml",
+        source_scope="project",
+    )
+    authoritative_matches = artifact.metadata["command_rule_matches"]
+    assert isinstance(authoritative_matches, list)
+    authoritative_rule_ids: set[str] = set()
+    for raw_item in cast(list[object], authoritative_matches):
+        if not isinstance(raw_item, dict):
+            continue
+        item = cast(dict[object, object], raw_item)
+        rule_id = item.get("rule_id")
+        if isinstance(rule_id, str):
+            authoritative_rule_ids.add(rule_id)
+
+    assert record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PreToolUse",
+        payload=payload,
+        policy_action="allow",
+        receipt_id=None,
+        prompted=False,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+    with sqlite3.connect(store.path) as connection:
+        rows = cast(
+            list[tuple[str]],
+            connection.execute("select rule_id from command_activity_matches").fetchall(),
+        )
+        persisted_rule_ids = {row[0] for row in rows}
+    assert persisted_rule_ids == authoritative_rule_ids
+
+
+def test_failure_post_transitions_with_same_native_identifier(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = _store(guard_home)
+    payload = _command_payload()
+    assert record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PreToolUse",
+        payload=payload,
+        policy_action="allow",
+        receipt_id=None,
+        prompted=False,
+    )
+
+    assert record_post_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PostToolUseFailure",
+        payload=payload,
+        succeeded=False,
+    )
+    key = load_or_create_installation_correlation_key(guard_home)
+    correlation = derive_proven_request_correlation(
+        harness="codex",
+        event="PostToolUseFailure",
+        payload=payload,
+        key=key,
+    )
+    assert correlation is not None
+    activity = store.get_command_activity_by_request_correlation(correlation)
+    assert activity is not None
+    assert activity.execution_status is CommandExecutionStatus.CONFIRMED_FAILURE
+
+
+def test_strong_post_pairs_without_repeated_command_content(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = _store(guard_home)
+    payload = _command_payload()
+    assert record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PreToolUse",
+        payload=payload,
+        policy_action="allow",
+        receipt_id=None,
+        prompted=False,
+    )
+    assert record_post_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PostToolUse",
+        payload={"tool_call_id": payload["tool_call_id"]},
+        succeeded=True,
+    )
+    assert store.count_command_activities() == 1
+
+
+def test_conflicting_terminal_post_is_counted_without_creating_unpaired_evidence(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = _store(guard_home)
+    payload = _command_payload()
+    assert record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PreToolUse",
+        payload=payload,
+        policy_action="allow",
+        receipt_id=None,
+        prompted=False,
+    )
+    assert record_post_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PostToolUse",
+        payload=payload,
+        succeeded=True,
+    )
+    assert not record_post_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PostToolUseFailure",
+        payload=payload,
+        succeeded=False,
+    )
+    assert store.count_command_activities() == 1
+    health = store.get_command_activity_persistence_health()
+    assert health.dropped_event_count == 1
+    assert health.last_error_code == "post_record_failed"
+
+
+def test_non_hook_command_event_does_not_create_pre_evidence(tmp_path: Path) -> None:
+    store = _store(tmp_path / "guard-home")
+    assert not record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=store.guard_home,
+        harness="codex",
+        event="UserPromptSubmit",
+        payload=_command_payload(),
+        policy_action="allow",
+        receipt_id=None,
+        prompted=False,
+    )
+    assert store.count_command_activities() == 0
+
+
+def test_cursor_before_and_trusted_after_events_pair_by_generation_id(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = _store(guard_home)
+    payload = {
+        **_command_payload(request_id=None),
+        "generation_id": "generation_abcdef1234567890",
+        "cursor_source_hook_event": "beforeShellExecution",
+    }
+    assert record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="cursor",
+        event="PreToolUse",
+        payload=payload,
+        policy_action="allow",
+        receipt_id=None,
+        prompted=False,
+    )
+    payload.pop("cursor_source_hook_event")
+    assert record_post_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="cursor",
+        event="afterShellExecution",
+        payload=payload,
+        succeeded=True,
+    )
+    assert store.count_command_activities() == 1
+
+
+def test_unsupported_post_is_explicitly_unpaired(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = _store(guard_home)
+
+    assert record_post_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="kimi",
+        event="PostToolUse",
+        payload=_command_payload(request_id=None),
+        succeeded=True,
+    )
+    with sqlite3.connect(store.path) as connection:
+        row = cast(
+            tuple[str, str, int] | None,
+            connection.execute("select execution_status, proof_level, match_count from command_activity").fetchone(),
+        )
+    assert row is not None
+    assert tuple(row) == ("unpaired_post", "unpaired_post", 0)
+
+
+def test_persistence_failure_is_counted_without_escaping(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = _store(guard_home)
+
+    def fail_record(_evidence: object) -> bool:
+        raise RuntimeError("fixture-only persistence failure")
+
+    monkeypatch.setattr(store, "record_command_activity", fail_record)
+    assert not record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PreToolUse",
+        payload=_command_payload(),
+        policy_action="allow",
+        receipt_id=None,
+        prompted=False,
+    )
+    health = store.get_command_activity_persistence_health()
+    assert health.dropped_event_count == 1
+    assert health.persistence_error_count == 1
+    assert health.last_error_code == "pre_record_failed"
+
+
+def test_primary_and_health_failures_are_both_non_interfering(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path / "guard-home")
+
+    def fail(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("fixture-only failure")
+
+    monkeypatch.setattr(store, "record_command_activity", fail)
+    monkeypatch.setattr(store, "record_command_activity_persistence_failure", fail)
+    assert not record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=store.guard_home,
+        harness="codex",
+        event="PreToolUse",
+        payload=_command_payload(),
+        policy_action="allow",
+        receipt_id=None,
+        prompted=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("event", "payload", "expected"),
+    (
+        ("PostToolUse", {}, True),
+        ("PostToolUseFailure", {}, False),
+        ("PostToolUse", {"is_error": True}, False),
+        ("postToolUse", {"success": False}, False),
+        ("afterShellExecution", {"exitCode": 7}, False),
+    ),
+)
+def test_post_success_interpretation_is_closed(
+    event: str,
+    payload: dict[str, object],
+    expected: bool,
+) -> None:
+    assert hook_post_succeeded(event, payload) is expected

--- a/tests/test_guard_command_activity_lifecycle.py
+++ b/tests/test_guard_command_activity_lifecycle.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+
+import pytest
+
+from codex_plugin_scanner.guard.models import GuardAction
+from codex_plugin_scanner.guard.runtime.command_activity_contract import (
+    ActivityApprovalReuseStatus,
+    ActivityDecisionReason,
+    ActivityLatencyBucket,
+    ActivityParseConfidence,
+    CommandExecutionStatus,
+    CommandHookPhase,
+    CommandProofLevel,
+    CorrelationHandle,
+    CorrelationKind,
+    ReceiptLinkStatus,
+    validate_activity_transition,
+)
+from codex_plugin_scanner.guard.runtime.command_activity_lifecycle import (
+    CommandActivityDecisionFacts,
+    build_correlated_post_activity,
+    build_correlated_post_evidence,
+    build_pre_hook_evidence,
+    build_unpaired_post_evidence,
+)
+from codex_plugin_scanner.guard.runtime.command_evaluation import evaluate_command
+from codex_plugin_scanner.guard.runtime.effect_contract import EffectKind, UncertaintyKind
+
+NOW = datetime(2026, 7, 18, 20, 0, tzinfo=timezone.utc)
+
+
+def _correlation(kind: CorrelationKind = CorrelationKind.REQUEST, *, digest: str = "a" * 64) -> CorrelationHandle:
+    return CorrelationHandle(kind=kind, harness="codex", key_id="key.v1", digest=digest)
+
+
+def _decision(
+    *,
+    action: GuardAction = "allow",
+    reason: ActivityDecisionReason = ActivityDecisionReason.EXTENSION_MATCH,
+    receipt_id: str | None = None,
+) -> CommandActivityDecisionFacts:
+    return CommandActivityDecisionFacts(
+        policy_action=action,
+        decision_reason_code=reason,
+        prompted=action == "review",
+        approval_reuse_status=ActivityApprovalReuseStatus.NOT_APPLICABLE,
+        receipt_id=receipt_id,
+    )
+
+
+def test_pre_hook_uses_only_authoritative_evaluation_and_final_decision_facts() -> None:
+    evaluation = evaluate_command("rm -rf ./generated-output")
+    request = _correlation()
+    evidence = build_pre_hook_evidence(
+        evaluation,
+        _decision(action="review", receipt_id="receipt:01"),
+        activity_id="activity:01",
+        occurred_at=NOW,
+        harness="codex",
+        request_correlation=request,
+        evaluation_latency_bucket=ActivityLatencyBucket.LE_2_MS,
+    )
+
+    activity = evidence.activity
+    match = evidence.matches[0]
+    assert activity.execution_status is CommandExecutionStatus.PREVENTED
+    assert activity.policy_action == "review"
+    assert activity.prompted is True
+    assert activity.receipt_link_status is ReceiptLinkStatus.LINKED
+    assert activity.receipt_id == "receipt:01"
+    assert activity.controlling_rule_id == "command.filesystem.recursive-delete"
+    assert activity.parse_confidence is ActivityParseConfidence.EXACT
+    assert activity.request_correlation == request
+    assert match.identity.extension_id == "command.filesystem"
+    assert match.identity.extension_version == "1.0.0"
+    assert match.identity.rule_id == "command.filesystem.recursive-delete"
+    assert match.identity.rule_version == "1.0.0"
+    assert match.effect_claims == frozenset({EffectKind.DESTRUCTIVE_OR_IRREVERSIBLE_OPERATION})
+    assert match.default_floor == "review"
+
+
+def test_allow_and_warn_are_allowed_unconfirmed_while_review_or_stronger_is_prevented() -> None:
+    evaluation = evaluate_command("rm -rf ./generated-output")
+    for action in ("allow", "warn"):
+        evidence = build_pre_hook_evidence(
+            evaluation,
+            _decision(action=action),
+            activity_id=f"activity:{action}",
+            occurred_at=NOW,
+            harness="codex",
+        )
+        assert evidence.activity.execution_status is CommandExecutionStatus.ALLOWED_UNCONFIRMED
+    for action in ("review", "require-reapproval", "sandbox-required", "block"):
+        evidence = build_pre_hook_evidence(
+            evaluation,
+            _decision(action=action, receipt_id=f"receipt:{action}"),
+            activity_id=f"activity:{action}",
+            occurred_at=NOW,
+            harness="codex",
+        )
+        assert evidence.activity.execution_status is CommandExecutionStatus.PREVENTED
+
+
+def test_required_critical_rule_retains_the_evaluators_block_floor() -> None:
+    evidence = build_pre_hook_evidence(
+        evaluate_command("mkfs /dev/example"),
+        _decision(action="block", receipt_id="receipt:critical"),
+        activity_id="activity:critical",
+        occurred_at=NOW,
+        harness="codex",
+    )
+
+    assert evidence.matches[0].default_floor == "block"
+
+
+def test_no_match_reason_is_exact_and_does_not_invent_rule_evidence() -> None:
+    evaluation = evaluate_command("printf routine")
+    evidence = build_pre_hook_evidence(
+        evaluation,
+        _decision(reason=ActivityDecisionReason.NO_MATCH),
+        activity_id="activity:no-match",
+        occurred_at=NOW,
+        harness="codex",
+    )
+
+    assert evidence.matches == ()
+    assert evidence.activity.match_count == 0
+    assert evidence.activity.controlling_rule_id is None
+    with pytest.raises(ValueError, match="no-match"):
+        _ = build_pre_hook_evidence(
+            evaluation,
+            _decision(),
+            activity_id="activity:bad-reason",
+            occurred_at=NOW,
+            harness="codex",
+        )
+
+
+def test_parser_uncertainty_is_bounded_without_storing_parser_input() -> None:
+    exact = evaluate_command("rm -rf ./generated-output")
+    uncertain_command = replace(
+        exact.command,
+        confidence="uncertain",
+        uncertainty_reason="command_token_limit_exceeded",
+    )
+    uncertain = replace(exact, command=uncertain_command)
+    evidence = build_pre_hook_evidence(
+        uncertain,
+        _decision(reason=ActivityDecisionReason.UNCERTAINTY),
+        activity_id="activity:uncertain",
+        occurred_at=NOW,
+        harness="codex",
+    )
+
+    assert evidence.activity.parse_confidence is ActivityParseConfidence.UNCERTAIN
+    assert evidence.activity.uncertainty_class is UncertaintyKind.PARSER_BUDGET_EXHAUSTED
+    assert "generated-output" not in repr(evidence)
+
+
+def test_correlated_success_and_failure_preserve_pre_hook_facts() -> None:
+    request = _correlation()
+    pre = build_pre_hook_evidence(
+        evaluate_command("rm -rf ./generated-output"),
+        _decision(),
+        activity_id="activity:paired",
+        occurred_at=NOW,
+        harness="codex",
+        request_correlation=request,
+    )
+
+    for succeeded, phase, status in (
+        (True, CommandHookPhase.POST_SUCCESS, CommandExecutionStatus.CONFIRMED_SUCCESS),
+        (False, CommandHookPhase.POST_FAILURE, CommandExecutionStatus.CONFIRMED_FAILURE),
+    ):
+        post = build_correlated_post_evidence(
+            pre,
+            request_correlation=request,
+            succeeded=succeeded,
+            persistence_latency_bucket=ActivityLatencyBucket.LE_5_MS,
+        )
+        assert post.activity.hook_phase is phase
+        assert post.activity.execution_status is status
+        assert post.activity.proof_level is CommandProofLevel.POST_HOOK
+        assert post.matches == pre.matches
+        validate_activity_transition(pre.activity, post.activity)
+
+
+def test_correlated_post_activity_accepts_the_parent_row_returned_by_storage() -> None:
+    request = _correlation()
+    pre = build_pre_hook_evidence(
+        evaluate_command("rm -rf ./generated-output"),
+        _decision(),
+        activity_id="activity:stored",
+        occurred_at=NOW,
+        harness="codex",
+        request_correlation=request,
+    )
+
+    post = build_correlated_post_activity(
+        pre.activity,
+        request_correlation=request,
+        succeeded=True,
+    )
+
+    assert post.execution_status is CommandExecutionStatus.CONFIRMED_SUCCESS
+    assert post.activity_id == pre.activity.activity_id
+    validate_activity_transition(pre.activity, post)
+
+
+def test_correlated_post_rejects_missing_mismatched_or_prevented_pre_hook() -> None:
+    request = _correlation()
+    allowed = build_pre_hook_evidence(
+        evaluate_command("rm -rf ./generated-output"),
+        _decision(),
+        activity_id="activity:paired",
+        occurred_at=NOW,
+        harness="codex",
+        request_correlation=request,
+    )
+    with pytest.raises(ValueError, match="exact pre-hook"):
+        _ = build_correlated_post_evidence(
+            allowed,
+            request_correlation=_correlation(digest="b" * 64),
+            succeeded=True,
+        )
+    without_request = replace(allowed, activity=replace(allowed.activity, request_correlation=None))
+    with pytest.raises(ValueError, match="exact pre-hook"):
+        _ = build_correlated_post_evidence(without_request, request_correlation=request, succeeded=True)
+    prevented = build_pre_hook_evidence(
+        evaluate_command("rm -rf ./generated-output"),
+        _decision(action="review", receipt_id="receipt:01"),
+        activity_id="activity:prevented",
+        occurred_at=NOW,
+        harness="codex",
+        request_correlation=request,
+    )
+    with pytest.raises(ValueError, match="allowed-unconfirmed"):
+        _ = build_correlated_post_evidence(prevented, request_correlation=request, succeeded=True)
+
+
+def test_unpaired_post_claims_no_decision_match_receipt_or_request_proof() -> None:
+    session = _correlation(CorrelationKind.SESSION)
+    evidence = build_unpaired_post_evidence(
+        activity_id="activity:unpaired",
+        occurred_at=NOW,
+        harness="codex",
+        succeeded=False,
+        session_correlation=session,
+    )
+
+    activity = evidence.activity
+    assert activity.execution_status is CommandExecutionStatus.UNPAIRED_POST
+    assert activity.hook_phase is CommandHookPhase.POST_FAILURE
+    assert activity.proof_level is CommandProofLevel.UNPAIRED_POST
+    assert activity.policy_action is None
+    assert activity.request_correlation is None
+    assert activity.session_correlation == session
+    assert activity.receipt_id is None
+    assert activity.match_count == 0
+    assert evidence.matches == ()
+
+
+def test_runtime_construction_exposes_no_command_or_matcher_content_fields() -> None:
+    evaluation = evaluate_command("rm -rf /private/forbidden-sentinel")
+    evidence = build_pre_hook_evidence(
+        evaluation,
+        _decision(),
+        activity_id="activity:privacy",
+        occurred_at=NOW,
+        harness="codex",
+    )
+
+    serialized = repr(evidence)
+    for forbidden in ("forbidden-sentinel", "raw_text", "normalized_text", "matcher_evidence"):
+        assert forbidden not in serialized

--- a/tests/test_guard_command_activity_lifecycle_store.py
+++ b/tests/test_guard_command_activity_lifecycle_store.py
@@ -1,0 +1,245 @@
+"""Transactional lifecycle and health tests for command activity persistence."""
+
+# pyright: reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard import store_command_activity_health_schema as health_schema
+from codex_plugin_scanner.guard.runtime.command_activity_contract import (
+    ActivityApprovalReuseStatus,
+    ActivityDecisionReason,
+    ActivityLatencyBucket,
+    ActivityParseConfidence,
+    CommandActivity,
+    CommandActivityEvidence,
+    CommandExecutionStatus,
+    CommandHookPhase,
+    CommandProofLevel,
+    CorrelationHandle,
+    CorrelationKind,
+    ReceiptLinkStatus,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+_NOW = datetime(2026, 7, 18, 22, 0, tzinfo=timezone.utc)
+
+
+def _request(digest: str = "a" * 64) -> CorrelationHandle:
+    return CorrelationHandle(CorrelationKind.REQUEST, "codex", "key.v1", digest)
+
+
+def _activity(
+    *,
+    activity_id: str = "activity:01",
+    request: CorrelationHandle | None = None,
+) -> CommandActivity:
+    return CommandActivity(
+        activity_id=activity_id,
+        occurred_at=_NOW,
+        harness="codex",
+        hook_phase=CommandHookPhase.PRE,
+        execution_status=CommandExecutionStatus.ALLOWED_UNCONFIRMED,
+        proof_level=CommandProofLevel.PRE_HOOK,
+        policy_action="allow",
+        decision_reason_code=ActivityDecisionReason.NO_MATCH,
+        controlling_rule_id=None,
+        parse_confidence=ActivityParseConfidence.EXACT,
+        uncertainty_class=None,
+        match_count=0,
+        prompted=False,
+        approval_reuse_status=ActivityApprovalReuseStatus.NOT_APPLICABLE,
+        request_correlation=request or _request(),
+        session_correlation=None,
+        receipt_link_status=ReceiptLinkStatus.NOT_APPLICABLE,
+        receipt_id=None,
+        evaluation_latency_bucket=ActivityLatencyBucket.LE_2_MS,
+        persistence_latency_bucket=ActivityLatencyBucket.LE_1_MS,
+    )
+
+
+def _confirmed(activity: CommandActivity, *, succeeded: bool) -> CommandActivity:
+    return replace(
+        activity,
+        hook_phase=CommandHookPhase.POST_SUCCESS if succeeded else CommandHookPhase.POST_FAILURE,
+        execution_status=(
+            CommandExecutionStatus.CONFIRMED_SUCCESS if succeeded else CommandExecutionStatus.CONFIRMED_FAILURE
+        ),
+        proof_level=CommandProofLevel.POST_HOOK,
+        persistence_latency_bucket=ActivityLatencyBucket.LE_2_MS,
+    )
+
+
+def _attempt_transition(guard_home: Path, current: CommandActivity) -> str:
+    store = GuardStore(guard_home, prime_policy_integrity=False)
+    try:
+        return "updated" if store.transition_command_activity(current) else "replayed"
+    except ValueError:
+        return "rejected"
+
+
+def test_health_migration_is_v11_atomic_and_reopens(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    first = GuardStore(guard_home, prime_policy_integrity=False)
+    initial = first.get_command_activity_persistence_health()
+    reopened = GuardStore(guard_home, prime_policy_integrity=False)
+
+    with sqlite3.connect(first.path) as connection:
+        migration = connection.execute(
+            "select version from schema_migrations where version = ?",
+            (health_schema.COMMAND_ACTIVITY_HEALTH_MIGRATION_VERSION,),
+        ).fetchone()
+
+    assert migration == (11,)
+    assert initial == reopened.get_command_activity_persistence_health()
+    assert initial.dropped_event_count == 0
+    assert initial.schema_version == health_schema.COMMAND_ACTIVITY_HEALTH_SCHEMA_VERSION
+
+
+def test_health_migration_failure_rolls_back_table_and_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "migration.db"
+    with sqlite3.connect(path) as connection:
+        connection.execute("create table schema_migrations (version integer primary key, applied_at text not null)")
+        monkeypatch.setattr(health_schema, "_HEALTH_TABLE_SQL", "create table")
+        with pytest.raises(sqlite3.OperationalError):
+            health_schema.ensure_command_activity_health_schema(connection, applied_at=_NOW.isoformat())
+
+        tables = connection.execute("select name from sqlite_schema where name = 'command_activity_health'").fetchall()
+        migration = connection.execute("select version from schema_migrations where version = 11").fetchone()
+
+    assert tables == []
+    assert migration is None
+
+
+def test_health_migration_rejects_weakened_existing_schema(tmp_path: Path) -> None:
+    path = tmp_path / "incompatible.db"
+    weakened = health_schema._HEALTH_TABLE_SQL.replace(
+        " check (dropped_event_count between 0 and 9223372036854775807)",
+        "",
+    )
+    with sqlite3.connect(path) as connection:
+        connection.execute("create table schema_migrations (version integer primary key, applied_at text not null)")
+        connection.execute(weakened)
+
+        with pytest.raises(RuntimeError, match="incompatible command_activity_health schema object"):
+            health_schema.ensure_command_activity_health_schema(connection, applied_at=_NOW.isoformat())
+
+        migration = connection.execute("select version from schema_migrations where version = 11").fetchone()
+
+    assert migration is None
+
+
+def test_health_migration_rejects_incompatible_existing_singleton(tmp_path: Path) -> None:
+    path = tmp_path / "incompatible-row.db"
+    with sqlite3.connect(path) as connection:
+        connection.execute("create table schema_migrations (version integer primary key, applied_at text not null)")
+        connection.execute(health_schema._HEALTH_TABLE_SQL)
+        connection.execute(
+            """
+            insert into command_activity_health values (1, 0, 0, null, null, '0.0.0')
+            """
+        )
+        with pytest.raises(RuntimeError, match="incompatible command_activity_health singleton"):
+            health_schema.ensure_command_activity_health_schema(connection, applied_at=_NOW.isoformat())
+        migration = connection.execute("select version from schema_migrations where version = 11").fetchone()
+
+    assert migration is None
+
+
+def test_lookup_requires_exact_request_handle_and_hides_activity_id_lookup(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    activity = _activity()
+    store.record_command_activity(CommandActivityEvidence(activity, ()))
+
+    assert store.get_command_activity_by_request_correlation(_request()) == activity
+    assert store.get_command_activity_by_request_correlation(_request("b" * 64)) is None
+    with pytest.raises(ValueError, match="request CorrelationHandle"):
+        store.get_command_activity_by_request_correlation(
+            CorrelationHandle(CorrelationKind.SESSION, "codex", "key.v1", "b" * 64)
+        )
+
+
+def test_transition_is_atomic_idempotent_and_rejects_conflicting_terminal(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    activity = _activity()
+    succeeded = _confirmed(activity, succeeded=True)
+    failed = _confirmed(activity, succeeded=False)
+    store.record_command_activity(CommandActivityEvidence(activity, ()))
+
+    assert store.transition_command_activity(succeeded) is True
+    assert store.transition_command_activity(succeeded) is False
+    with pytest.raises(ValueError, match="invalid or conflicting"):
+        store.transition_command_activity(failed)
+    assert store.get_command_activity_by_request_correlation(_request()) == succeeded
+
+
+def test_competing_terminal_transitions_commit_exactly_one_outcome(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home, prime_policy_integrity=False)
+    activity = _activity()
+    store.record_command_activity(CommandActivityEvidence(activity, ()))
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        success = executor.submit(_attempt_transition, guard_home, _confirmed(activity, succeeded=True))
+        failure = executor.submit(_attempt_transition, guard_home, _confirmed(activity, succeeded=False))
+        outcomes = (success.result(), failure.result())
+
+    assert sorted(outcomes) == ["rejected", "updated"]
+    persisted = store.get_command_activity_by_request_correlation(_request())
+    assert persisted is not None
+    assert persisted.execution_status in {
+        CommandExecutionStatus.CONFIRMED_SUCCESS,
+        CommandExecutionStatus.CONFIRMED_FAILURE,
+    }
+
+
+def test_transition_rejects_fact_changes_and_unknown_correlations(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    activity = _activity()
+    store.record_command_activity(CommandActivityEvidence(activity, ()))
+
+    with pytest.raises(ValueError, match="cannot change"):
+        store.transition_command_activity(
+            replace(_confirmed(activity, succeeded=True), occurred_at=_NOW + timedelta(seconds=1))
+        )
+    unknown = _activity(activity_id="activity:02", request=_request("b" * 64))
+    with pytest.raises(ValueError, match="does not identify"):
+        store.transition_command_activity(_confirmed(unknown, succeeded=True))
+
+
+def test_health_failure_counts_are_bounded_and_store_no_error_details(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    store.record_command_activity_persistence_failure(error_code="sqlite.busy", occurred_at=_NOW)
+
+    health = store.get_command_activity_persistence_health()
+    assert health.dropped_event_count == 1
+    assert health.persistence_error_count == 1
+    assert health.last_error_code == "sqlite.busy"
+    assert health.last_error_at == _NOW
+
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            """
+            update command_activity_health
+            set dropped_event_count = 9223372036854775807,
+                persistence_error_count = 9223372036854775807
+            where singleton = 1
+            """
+        )
+    store.record_command_activity_persistence_failure(error_code="store.failure", occurred_at=_NOW)
+    saturated = store.get_command_activity_persistence_health()
+    assert saturated.dropped_event_count == 9_223_372_036_854_775_807
+    assert saturated.persistence_error_count == 9_223_372_036_854_775_807
+
+    with pytest.raises(ValueError, match="bounded stable identifier"):
+        store.record_command_activity_persistence_failure(error_code="raw /private/path", occurred_at=_NOW)

--- a/tests/test_guard_command_activity_orchestration.py
+++ b/tests/test_guard_command_activity_orchestration.py
@@ -1,0 +1,303 @@
+"""End-to-end orchestration regressions for command activity ownership."""
+
+# pyright: reportPrivateUsage=false, reportUnknownArgumentType=false, reportUnknownLambdaType=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.cli import commands_hook as hook_command
+from codex_plugin_scanner.guard.cli import commands_hook_copilot as copilot_hook
+from codex_plugin_scanner.guard.cli.commands_support_command_activity import command_activity_was_prompted
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.mcp_tool_calls import ToolCallDecision
+from codex_plugin_scanner.guard.models import GuardAction, GuardArtifact
+from codex_plugin_scanner.guard.runtime import command_activity_cursor
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def _artifact(tmp_path: Path) -> GuardArtifact:
+    return GuardArtifact(
+        artifact_id="copilot:project:tool-action:partition",
+        name="Copilot partition tool call",
+        harness="copilot",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(tmp_path / ".vscode" / "mcp.json"),
+        command="git push origin release/2.2 --force",
+    )
+
+
+def _decision(action: GuardAction) -> ToolCallDecision:
+    return ToolCallDecision(
+        action=action,
+        source="heuristic",
+        signals=("fixture signal",),
+        summary="Fixture decision.",
+        risk_categories=("destructive_mutation",),
+    )
+
+
+def _args() -> argparse.Namespace:
+    return argparse.Namespace(harness="copilot", json=False)
+
+
+@pytest.mark.parametrize(
+    ("reuse_status", "expected"),
+    (
+        ("accepted", False),
+        ("rejected", True),
+        ("not-applicable", True),
+    ),
+)
+def test_prompt_attribution_excludes_accepted_approval_reuse(
+    reuse_status: str,
+    expected: bool,
+) -> None:
+    from codex_plugin_scanner.guard.runtime.command_activity_contract import ActivityApprovalReuseStatus
+
+    assert command_activity_was_prompted("review", ActivityApprovalReuseStatus(reuse_status)) is expected
+
+
+@pytest.mark.parametrize(
+    ("current_action", "expected"),
+    (("allow", False), ("review", True)),
+)
+def test_copilot_prompt_attribution_uses_pre_reuse_action(
+    current_action: GuardAction,
+    expected: bool,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    captured: list[bool] = []
+    monkeypatch.setattr(
+        copilot_hook,
+        "record_pre_hook_command_activity_best_effort",
+        lambda **kwargs: captured.append(bool(kwargs["prompted"])),
+    )
+    decision = ToolCallDecision(
+        action="block",
+        source="policy",
+        signals=("fixture signal",),
+        summary="Fixture decision.",
+        approval_reuse_status="rejected",
+        current_action=current_action,
+        saved_action="block",
+    )
+
+    copilot_hook._record_copilot_pre_activity(
+        store=GuardStore(context.guard_home),
+        context=context,
+        event="preToolUse",
+        payload={"tool_name": "Shell", "tool_input": {"command": "git push origin main --force"}},
+        policy_action="block",
+        receipt_id="guard-receipt-fixture",
+        decision=decision,
+        runtime_workspace=context.workspace_dir,
+    )
+
+    assert captured == [expected]
+
+
+def test_copilot_orchestrators_assign_one_owner_for_each_valid_stage_flow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    artifact = _artifact(tmp_path)
+    store = GuardStore(context.guard_home)
+    recorded_events: list[str] = []
+    current_decision = [_decision("allow")]
+    monkeypatch.setattr(copilot_hook, "evaluate_tool_call", lambda **_kwargs: current_decision[0])
+    monkeypatch.setattr(
+        copilot_hook,
+        "_record_copilot_pre_activity",
+        lambda **kwargs: recorded_events.append(str(kwargs["event"])),
+    )
+    monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
+    monkeypatch.setattr(copilot_hook, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(
+        copilot_hook,
+        "load_guard_surface_daemon_client",
+        lambda _guard_home: (_ for _ in ()).throw(RuntimeError("fixture offline")),
+    )
+    monkeypatch.setattr(copilot_hook, "queue_blocked_approvals", lambda **_kwargs: [])
+    payload = {
+        "tool_name": "Shell",
+        "tool_input": {"command": "git push origin release/2.2 --force"},
+    }
+    runtime_call = (artifact, "partition-hash", payload["tool_input"])
+
+    actions: tuple[GuardAction, ...] = ("allow", "block")
+    for action in actions:
+        current_decision[0] = _decision(action)
+        result = copilot_hook._run_hook_copilot_pretool(
+            _args(),
+            action_envelope=None,
+            config=GuardConfig(context.guard_home, context.workspace_dir, mode="prompt"),
+            context=context,
+            copilot_hook_stage="pretooluse",
+            copilot_runtime_tool_call=runtime_call,
+            output_stream=io.StringIO(),
+            payload=payload,
+            runtime_workspace=context.workspace_dir,
+            store=store,
+        )
+        assert result == 0
+
+    current_decision[0] = _decision("review")
+    pretool_result = copilot_hook._run_hook_copilot_pretool(
+        _args(),
+        action_envelope=None,
+        config=GuardConfig(context.guard_home, context.workspace_dir, mode="prompt"),
+        context=context,
+        copilot_hook_stage="pretooluse",
+        copilot_runtime_tool_call=runtime_call,
+        output_stream=io.StringIO(),
+        payload=payload,
+        runtime_workspace=context.workspace_dir,
+        store=store,
+    )
+    assert pretool_result == 0
+    assert recorded_events == ["preToolUse", "preToolUse"]
+
+    permission_result = copilot_hook._run_hook_copilot_permission_request(
+        _args(),
+        action_envelope=None,
+        config=GuardConfig(context.guard_home, context.workspace_dir, mode="prompt"),
+        context=context,
+        copilot_permission_request=runtime_call,
+        guard_home=context.guard_home,
+        managed_install=None,
+        output_stream=io.StringIO(),
+        payload=payload,
+        runtime_workspace=context.workspace_dir,
+        store=store,
+    )
+    assert permission_result == 0
+    assert recorded_events == ["preToolUse", "preToolUse", "copilotPermissionRequest"]
+
+
+def test_repeated_native_pre_hook_with_new_receipt_is_one_logical_activity(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    home_dir.mkdir()
+    workspace_dir.mkdir()
+    (home_dir / "config.toml").write_text("approval_wait_timeout_seconds = 0\n", encoding="utf-8")
+    event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Shell",
+        "tool_input": {"command": "git push origin release/2.2 --force"},
+        "tool_call_id": "toolcall_replayed_abcdef1234567890",
+    }
+    command = [
+        "guard",
+        "hook",
+        "--home",
+        str(home_dir),
+        "--workspace",
+        str(workspace_dir),
+        "--harness",
+        "codex",
+        "--policy-action",
+        "block",
+    ]
+
+    for _ in range(2):
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+        assert main(command) == 0
+        _ = capsys.readouterr()
+
+    store = GuardStore(home_dir)
+    receipts = store.list_receipts(limit=10)
+    assert len(receipts) == 2
+    assert receipts[0]["receipt_id"] != receipts[1]["receipt_id"]
+    assert store.count_command_activities() == 1
+    health = store.get_command_activity_persistence_health()
+    assert health.dropped_event_count == 0
+    assert health.persistence_error_count == 0
+
+
+def test_cursor_observer_verifier_failure_preserves_exact_hook_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(context.guard_home, context.workspace_dir)
+    args = argparse.Namespace(
+        artifact_id=None,
+        artifact_name=None,
+        event_file=None,
+        harness="cursor",
+        json=True,
+        policy_action=None,
+        runtime_harness=None,
+    )
+    payload = json.dumps(
+        {
+            "hook_event_name": "afterShellExecution",
+            "conversation_id": "cursor-conversation-abcdef",
+            "generation_id": "cursor-generation-abcdef",
+            "command": "git push origin release/2.2 --force",
+            "cwd": str(context.workspace_dir),
+        }
+    )
+    monkeypatch.setattr(hook_command, "_persist_cursor_native_permission_after_shell", lambda **_kwargs: True)
+    monkeypatch.setattr(command_activity_cursor, "cursor_command_activity_observer_trusted", lambda **_kwargs: False)
+    baseline = io.StringIO()
+    baseline_rc = hook_command._run_guard_hook_command(
+        args,
+        guard_home=context.guard_home,
+        workspace=context.workspace_dir,
+        context=context,
+        store=store,
+        config=config,
+        input_text=payload,
+        output_stream=baseline,
+    )
+
+    def fail_verification(**_kwargs: object) -> bool:
+        raise RuntimeError("fixture verifier failure")
+
+    monkeypatch.setattr(command_activity_cursor, "cursor_command_activity_observer_trusted", fail_verification)
+    failed = io.StringIO()
+    failed_rc = hook_command._run_guard_hook_command(
+        args,
+        guard_home=context.guard_home,
+        workspace=context.workspace_dir,
+        context=context,
+        store=store,
+        config=config,
+        input_text=payload,
+        output_stream=failed,
+    )
+
+    assert failed_rc == baseline_rc == 0
+    assert failed.getvalue() == baseline.getvalue()
+    health = store.get_command_activity_persistence_health()
+    assert health.dropped_event_count == 1
+    assert health.last_error_code == "cursor_observer_verify_failed"

--- a/tests/test_guard_daemon_registry.py
+++ b/tests/test_guard_daemon_registry.py
@@ -155,6 +155,28 @@ class TestHealthzEndpoint:
         finally:
             server.stop()
 
+    def test_healthz_details_exposes_bounded_command_activity_degradation(self, tmp_path: Path) -> None:
+        url, server = self._start_server(tmp_path)
+        try:
+            store = server._server.store
+            store.record_command_activity_persistence_failure(
+                error_code="fixture_failure",
+                occurred_at=datetime.now(timezone.utc),
+            )
+            payload = self._get_healthz_details(url, server)
+            evidence = payload["command_activity_evidence"]
+            assert evidence == {
+                "state": "degraded",
+                "dropped_event_count": 1,
+                "persistence_error_count": 1,
+                "last_error_code": "fixture_failure",
+                "last_error_at": evidence["last_error_at"],
+                "schema_version": "1.0.0",
+            }
+            assert isinstance(evidence["last_error_at"], str)
+        finally:
+            server.stop()
+
     def test_healthz_details_requires_auth(self, tmp_path: Path) -> None:
         url, server = self._start_server(tmp_path)
         try:

--- a/tests/test_pi_tool_call_id_adapter.py
+++ b/tests/test_pi_tool_call_id_adapter.py
@@ -1,0 +1,27 @@
+"""Pi managed-extension request-correlation contract tests."""
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters.pi_extension_source import managed_extension_source
+
+
+def _managed_source(tmp_path: Path) -> str:
+    return managed_extension_source(
+        guard_home=tmp_path / "guard-home",
+        home_dir=tmp_path / "home",
+        settings_path=tmp_path / "home" / ".pi" / "agent" / "settings.json",
+    )
+
+
+def test_pi_pre_tool_payload_forwards_native_tool_call_id(tmp_path: Path) -> None:
+    source = _managed_source(tmp_path)
+    pre_handler = source.split('pi.on("tool_call"', maxsplit=1)[1].split('pi.on("message_end"', maxsplit=1)[0]
+
+    assert "tool_call_id: event.toolCallId," in pre_handler
+
+
+def test_pi_post_tool_payload_forwards_native_tool_call_id(tmp_path: Path) -> None:
+    source = _managed_source(tmp_path)
+    post_handler = source.split('pi.on("tool_result"', maxsplit=1)[1]
+
+    assert "tool_call_id: event.toolCallId," in post_handler


### PR DESCRIPTION
## Summary
- record privacy-preserving command activity evidence at supported hook boundaries
- pair proven pre- and post-execution events while retaining unsupported observations as unpaired evidence
- persist lifecycle transitions, bounded persistence health, and authenticated health details without affecting enforcement outcomes
- forward Pi native tool-call identifiers and partition Copilot pretool and permission-request ownership

## Testing
- `uv run --no-sync pytest -q tests/test_guard_command_activity_*.py tests/test_pi_tool_call_id_adapter.py tests/test_guard_hook_saved_block_terminal.py --tb=short` (134 passed)
- `uv run --no-sync pytest -q tests/test_cursor_hooks.py tests/test_guard_daemon_registry.py --tb=short` (70 passed with the adjacent hook suite)
- `uv run --no-sync pytest -q tests/test_guard_runtime.py --tb=short` (658 passed)
- `uv run --no-sync ruff check` on all changed command-activity Python files
- `uv run --no-sync ruff format --check` on all changed command-activity Python files
- `uv run --no-sync basedpyright` on all command-activity modules and tests (0 errors, 0 warnings)
- `git diff --check`