### PR TITLE
fix(release): tolerate registry propagation lag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -435,7 +435,7 @@ jobs:
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          for attempt in {1..12}; do
+          for attempt in {1..60}; do
             if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
               verify-release --registry testpypi --version "$VERSION" --dist-dir dist \
               --download-dir verified-testpypi); then
@@ -445,7 +445,7 @@ jobs:
             if [[ "$status" == "exact" ]]; then
               break
             fi
-            if [[ "$status" != "absent" || "$attempt" == "12" ]]; then
+            if [[ "$status" != "absent" || "$attempt" == "60" ]]; then
               echo "TestPyPI did not expose the exact release artifacts" >&2
               exit 1
             fi
@@ -552,7 +552,7 @@ jobs:
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          for attempt in {1..12}; do
+          for attempt in {1..60}; do
             if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
               verify-release --registry pypi --version "$VERSION" --dist-dir dist \
               --download-dir verified-pypi); then
@@ -562,7 +562,7 @@ jobs:
             if [[ "$status" == "exact" ]]; then
               break
             fi
-            if [[ "$status" != "absent" || "$attempt" == "12" ]]; then
+            if [[ "$status" != "absent" || "$attempt" == "60" ]]; then
               echo "PyPI did not expose the exact release artifacts" >&2
               exit 1
             fi
@@ -639,7 +639,7 @@ jobs:
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          for attempt in {1..12}; do
+          for attempt in {1..60}; do
             if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
               verify-release --registry testpypi --version "$VERSION" --dist-dir dist \
               --download-dir verified-testpypi); then
@@ -649,7 +649,7 @@ jobs:
             if [[ "$status" == "exact" ]]; then
               break
             fi
-            if [[ "$status" != "absent" || "$attempt" == "12" ]]; then
+            if [[ "$status" != "absent" || "$attempt" == "60" ]]; then
               echo "TestPyPI did not expose the exact release artifacts" >&2
               exit 1
             fi
@@ -708,15 +708,14 @@ jobs:
           TESTPYPI_VERSIONS=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
             list-versions --registry testpypi)
           RELEASE_VERSIONS=$(jq -n \
+            --arg version "$VERSION" \
             --argjson pypi "$PYPI_VERSIONS" \
             --argjson testpypi "$TESTPYPI_VERSIONS" \
-            '$pypi + $testpypi | unique')
-          PRIOR_RELEASE_VERSIONS=$(jq --arg version "$VERSION" \
-            '[.[] | select(. != $version)]' <<< "$RELEASE_VERSIONS")
-          EXPECTED_VERSION=$(uv run --with packaging==25.0 python scripts/compute_main_release_version.py \
-            --base-version "$BASE_VERSION" <<< "$PRIOR_RELEASE_VERSIONS")
-          if [[ "$EXPECTED_VERSION" != "$VERSION" ]]; then
-            echo "Main release version changed before publication" >&2
+            '$pypi + $testpypi + [$version] | unique')
+          LATEST_RELEASE_VERSION=$(uv run --with packaging==25.0 python scripts/compute_main_release_version.py \
+            --base-version "$BASE_VERSION" --latest-existing <<< "$RELEASE_VERSIONS")
+          if [[ "$LATEST_RELEASE_VERSION" != "$VERSION" ]]; then
+            echo "A newer main release candidate exists before publication" >&2
             exit 1
           fi
           PRIOR_PYPI_VERSIONS=$(jq --arg version "$VERSION" \
@@ -754,7 +753,7 @@ jobs:
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          for attempt in {1..12}; do
+          for attempt in {1..60}; do
             if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
               verify-release --registry pypi --version "$VERSION" --dist-dir dist \
               --download-dir verified-pypi); then
@@ -764,7 +763,7 @@ jobs:
             if [[ "$status" == "exact" ]]; then
               break
             fi
-            if [[ "$status" != "absent" || "$attempt" == "12" ]]; then
+            if [[ "$status" != "absent" || "$attempt" == "60" ]]; then
               echo "PyPI did not expose the exact release artifacts" >&2
               exit 1
             fi

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -233,6 +233,8 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
         assert 'uv tool run --from "$wheel"' in verify_step["run"]
         assert 'status" == "exact"' in verify_step["run"]
         assert 'status" != "absent"' in verify_step["run"]
+        assert "for attempt in {1..60}" in verify_step["run"]
+        assert 'attempt" == "60"' in verify_step["run"]
         assert '== "hol-guard $VERSION"' in verify_step["run"]
 
     main_revalidation = next(
@@ -243,8 +245,9 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
     assert "uv run --no-sync" not in main_revalidation
     assert "list-versions --registry pypi" in main_revalidation
     assert "list-versions --registry testpypi" in main_revalidation
-    assert "'$pypi + $testpypi | unique'" in main_revalidation
-    assert '<<< "$PRIOR_RELEASE_VERSIONS"' in main_revalidation
+    assert "'$pypi + $testpypi + [$version] | unique'" in main_revalidation
+    assert '<<< "$RELEASE_VERSIONS"' in main_revalidation
+    assert '[[ "$LATEST_RELEASE_VERSION" != "$VERSION" ]]' in main_revalidation
     assert "--latest-existing" in main_revalidation
     assert '<<< "$PRIOR_PYPI_VERSIONS"' in main_revalidation
     assert "refs/tags/v${LATEST_VERSION}" in main_revalidation
@@ -277,6 +280,8 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
         assert "--download-dir verified-pypi" in verify_step["run"]
         assert 'status" == "exact"' in verify_step["run"]
         assert 'status" != "absent"' in verify_step["run"]
+        assert "for attempt in {1..60}" in verify_step["run"]
+        assert 'attempt" == "60"' in verify_step["run"]
         assert '== "hol-guard $VERSION"' in verify_step["run"]
 
 


### PR DESCRIPTION
## Summary
- allow bounded package-index propagation before exact artifact verification
- keep stable publication monotonic without relying on an eventually consistent exact-next snapshot

## Testing
- `uv run --no-sync pytest -q tests/test_compute_main_release_version.py tests/test_release_train_workflow.py`
- `actionlint .github/workflows/publish.yml`
- `uv run --no-sync ruff check tests/test_release_train_workflow.py`
- `uv run --no-sync ruff format --check tests/test_release_train_workflow.py`
- `uv run --with pyyaml==6.0.3 python scripts/check_privileged_workflows.py`
