### PR TITLE
test: synchronize cloud reconnect completion

### DIFF
--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -555,6 +555,14 @@ def test_supply_chain_package_firewall_connect_repairs_local_auth_and_unlocks_pa
             workspace_id="workspace-1",
         ),
     )
+    credentials_persisted = threading.Event()
+    persist_oauth_local_credentials = daemon_server._persist_oauth_local_credentials
+
+    def persist_and_signal(**kwargs: object) -> None:
+        persist_oauth_local_credentials(**kwargs)
+        credentials_persisted.set()
+
+    monkeypatch.setattr(daemon_server, "_persist_oauth_local_credentials", persist_and_signal)
 
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -585,30 +593,19 @@ def test_supply_chain_package_firewall_connect_repairs_local_auth_and_unlocks_pa
         assert connect_flow["state"] in {"idle", "running"}
         if connect_flow["state"] == "running":
             assert connect_flow["authorize_url"] == "https://hol.org/mock-authorize"
-        deadline = time.monotonic() + 10.0
-        refreshed: dict[str, object] = {}
-        while time.monotonic() < deadline:
-            status, refreshed = _read_json_response(
-                _request(
-                    daemon.port,
-                    "/v1/supply-chain/package-shims",
-                    method="GET",
-                    token=token,
-                ),
-            )
-            if refreshed["entitlement"]["allowed"] is True:
-                assert status == 200
-                assert refreshed["entitlement"]["reason"] == "paid_oauth_entitlement_active"
-                assert refreshed["connect_flow"] is None
-                break
-            connect_flow = refreshed.get("connect_flow")
-            if isinstance(connect_flow, dict) and connect_flow.get("state") == "failed":
-                pytest.fail(f"Guard Cloud connect failed: {connect_flow.get('detail', 'unknown error')}")
-            time.sleep(0.1)
-        else:
-            raise AssertionError(
-                f"package firewall status never unlocked after local connect repair: last response={refreshed!r}"
-            )
+        assert credentials_persisted.wait(timeout=30), "Guard Cloud connect did not persist repaired credentials"
+        status, refreshed = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims",
+                method="GET",
+                token=token,
+            ),
+        )
+        assert status == 200
+        assert refreshed["entitlement"]["allowed"] is True
+        assert refreshed["entitlement"]["reason"] == "paid_oauth_entitlement_active"
+        assert refreshed["connect_flow"] is None
     finally:
         daemon.stop()
 

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -555,14 +555,18 @@ def test_supply_chain_package_firewall_connect_repairs_local_auth_and_unlocks_pa
             workspace_id="workspace-1",
         ),
     )
-    credentials_persisted = threading.Event()
-    persist_oauth_local_credentials = daemon_server._persist_oauth_local_credentials
+    connect_finalized = threading.Event()
+    set_guard_cloud_connect_state = daemon_server._set_guard_cloud_connect_state
 
-    def persist_and_signal(**kwargs: object) -> None:
-        persist_oauth_local_credentials(**kwargs)
-        credentials_persisted.set()
+    def set_state_and_signal(
+        server: daemon_server._GuardDaemonHttpServer,
+        state: dict[str, object] | None,
+    ) -> None:
+        set_guard_cloud_connect_state(server, state)
+        if state is None:
+            connect_finalized.set()
 
-    monkeypatch.setattr(daemon_server, "_persist_oauth_local_credentials", persist_and_signal)
+    monkeypatch.setattr(daemon_server, "_set_guard_cloud_connect_state", set_state_and_signal)
 
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -593,7 +597,7 @@ def test_supply_chain_package_firewall_connect_repairs_local_auth_and_unlocks_pa
         assert connect_flow["state"] in {"idle", "running"}
         if connect_flow["state"] == "running":
             assert connect_flow["authorize_url"] == "https://hol.org/mock-authorize"
-        assert credentials_persisted.wait(timeout=30), "Guard Cloud connect did not persist repaired credentials"
+        assert connect_finalized.wait(timeout=30), "Guard Cloud connect did not finalize repaired credentials"
         status, refreshed = _read_json_response(
             _request(
                 daemon.port,


### PR DESCRIPTION
## Summary
- synchronize the reconnect test on the exact credential-persistence event
- avoid repeatedly running expensive credential-health verification while the repair worker is still persisting credentials
- retain a bounded failure timeout and assert the final package-firewall entitlement contract

## Verification
- focused reconnect test passes
- Ruff passes for the changed test
- diff whitespace check passes