### PR TITLE
fix(release): ignore local attestation sidecars

### DIFF
--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -270,9 +270,7 @@ def compute_local_distribution_hashes(
             if path.name.startswith(("hol_guard-", "hol-guard-")):
                 raise RegistryVerificationError("Local Guard distributions cannot be symbolic links")
             continue
-        if not path.is_file():
-            continue
-        if _is_publish_attestation(path.name, version):
+        if not path.is_file() or _is_publish_attestation(path.name, version):
             continue
         try:
             name, file_version = _distribution_identity(path.name)

--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -272,6 +272,8 @@ def compute_local_distribution_hashes(
             continue
         if not path.is_file():
             continue
+        if _is_publish_attestation(path.name, version):
+            continue
         try:
             name, file_version = _distribution_identity(path.name)
         except RegistryVerificationError:

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -271,6 +271,31 @@ def test_computes_local_guard_wheel_and_sdist_hashes(tmp_path: Path) -> None:
     }
 
 
+def test_computes_local_hashes_while_ignoring_publish_attestations(
+    tmp_path: Path,
+) -> None:
+    dist = _local_dist(tmp_path)
+    (dist / f"{WHEEL}.publish.attestation").write_bytes(b"wheel-attestation")
+    (dist / f"{SDIST}.publish.attestation.publish.attestation").write_bytes(
+        b"nested-sdist-attestation"
+    )
+
+    assert compute_local_distribution_hashes(dist, VERSION) == {
+        SDIST: _sha(SDIST_BYTES),
+        WHEEL: _sha(WHEEL_BYTES),
+    }
+
+
+def test_local_hashes_reject_attestation_for_invalid_distribution(
+    tmp_path: Path,
+) -> None:
+    dist = _local_dist(tmp_path)
+    (dist / "not-a-distribution.publish.attestation").write_bytes(b"invalid")
+
+    with pytest.raises(RegistryVerificationError, match="Invalid distribution filename"):
+        compute_local_distribution_hashes(dist, VERSION)
+
+
 def test_verify_testpypi_accepts_absent_release(tmp_path: Path) -> None:
     dist = _local_dist(tmp_path)
     url = _release_url(Registry.TESTPYPI)

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -235,7 +235,7 @@ def test_inspect_release_rejects_release_with_only_publish_attestation_sidecars(
         inspect_release(Registry.TESTPYPI, VERSION, fetcher=fetcher)
 
 
-def test_inspect_release_rejects_publish_attestation_for_invalid_distribution() -> None:
+def test_rejects_publish_attestation_for_invalid_distribution(tmp_path: Path) -> None:
     attestation = "not-a-distribution.publish.attestation"
     payload = _release_payload(
         Registry.TESTPYPI,
@@ -245,6 +245,10 @@ def test_inspect_release_rejects_publish_attestation_for_invalid_distribution() 
 
     with pytest.raises(RegistryVerificationError, match="Invalid distribution filename"):
         inspect_release(Registry.TESTPYPI, VERSION, fetcher=fetcher)
+    dist = _local_dist(tmp_path)
+    (dist / attestation).write_bytes(b"invalid")
+    with pytest.raises(RegistryVerificationError, match="Invalid distribution filename"):
+        compute_local_distribution_hashes(dist, VERSION)
 
 
 def test_inspect_release_rejects_an_invalid_distribution_port() -> None:
@@ -264,36 +268,14 @@ def test_inspect_release_rejects_an_invalid_distribution_port() -> None:
 def test_computes_local_guard_wheel_and_sdist_hashes(tmp_path: Path) -> None:
     dist = _local_dist(tmp_path)
     (dist / f"plugin_scanner-{VERSION}-py3-none-any.whl").write_bytes(b"scanner")
-
-    assert compute_local_distribution_hashes(dist, VERSION) == {
-        SDIST: _sha(SDIST_BYTES),
-        WHEEL: _sha(WHEEL_BYTES),
-    }
-
-
-def test_computes_local_hashes_while_ignoring_publish_attestations(
-    tmp_path: Path,
-) -> None:
-    dist = _local_dist(tmp_path)
     (dist / f"{WHEEL}.publish.attestation").write_bytes(b"wheel-attestation")
     (dist / f"{SDIST}.publish.attestation.publish.attestation").write_bytes(
         b"nested-sdist-attestation"
     )
-
     assert compute_local_distribution_hashes(dist, VERSION) == {
         SDIST: _sha(SDIST_BYTES),
         WHEEL: _sha(WHEEL_BYTES),
     }
-
-
-def test_local_hashes_reject_attestation_for_invalid_distribution(
-    tmp_path: Path,
-) -> None:
-    dist = _local_dist(tmp_path)
-    (dist / "not-a-distribution.publish.attestation").write_bytes(b"invalid")
-
-    with pytest.raises(RegistryVerificationError, match="Invalid distribution filename"):
-        compute_local_distribution_hashes(dist, VERSION)
 
 
 def test_verify_testpypi_accepts_absent_release(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- ignore validated publish-attestation sidecars when hashing downloaded build artifacts
- preserve fail-closed behavior for malformed sidecar names
- cover regular and nested sidecars with regression tests

## Verification

- `uv run pytest -q tests/test_verify_release_registry.py` (33 passed)
- `uv run ruff check scripts/verify_release_registry.py tests/test_verify_release_registry.py`