### PR TITLE
feat(guard): add bounded command activity rollups

### DIFF
--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -452,6 +452,11 @@ def load_guard_config(
         receipt_redaction_level=_coerce_loaded_receipt_redaction_level(
             merged.get("receipt_redaction_level"),
         ),
+        evidence_retain_days=_coerce_loaded_bounded_positive_int(
+            merged.get("evidence_retain_days"),
+            default=90,
+            maximum=3_650,
+        ),
         managed_policy_status=managed_state.status,
         managed_policy_hash=effective_managed_policy.content_hash if effective_managed_policy is not None else None,
         managed_locked_settings=tuple(sorted(effective_managed_policy.locked_settings))
@@ -634,6 +639,12 @@ def _coerce_loaded_non_negative_int(value: object, fallback: int) -> int:
 
 def _coerce_loaded_bounded_int(value: object, *, default: int, maximum: int) -> int:
     if isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= maximum:
+        return value
+    return default
+
+
+def _coerce_loaded_bounded_positive_int(value: object, *, default: int, maximum: int) -> int:
+    if isinstance(value, int) and not isinstance(value, bool) and 1 <= value <= maximum:
         return value
     return default
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5676,6 +5676,7 @@ class GuardDaemonServer:
         self._bundle_refresh_thread: threading.Thread | None = None
         self._command_queue_worker: CommandQueueWorker | None = None
         self._headless_cloud_sync_thread: threading.Thread | None = None
+        self._command_activity_maintenance_thread: threading.Thread | None = None
         self._live_request_sync_worker: LiveRequestSyncWorker | None = None
         self._thread: threading.Thread | None = None
         self._watchdog_thread: threading.Thread | None = None
@@ -5714,6 +5715,7 @@ class GuardDaemonServer:
         if self._headless_cloud_sync_thread is not None:
             self._headless_cloud_sync_thread.join(timeout=5)
             self._headless_cloud_sync_thread = None
+        self._join_command_activity_maintenance()
         self._command_queue_worker = stop_command_queue_worker(self._command_queue_worker)
         self._live_request_sync_worker = stop_cloud_sync_sync_worker(self._live_request_sync_worker)
 
@@ -5722,7 +5724,9 @@ class GuardDaemonServer:
             if self._aibom_refresh_thread.is_alive():
                 raise RuntimeError("AIBOM inventory refresh is still stopping")
             self._aibom_refresh_thread = None
+        self._require_command_activity_maintenance_stopped()
         self._shutdown_started.clear()
+        self._maintain_command_activity_best_effort()
         self._persist_aibom_inventory_context()
         self._server.last_activity_monotonic = time.monotonic()
         write_guard_daemon_state(
@@ -5752,6 +5756,54 @@ class GuardDaemonServer:
             self._server.store,
             self._live_request_sync_worker,
         )
+        self._start_command_activity_maintenance()
+
+    def _maintain_command_activity_best_effort(self) -> None:
+        now = datetime.now(timezone.utc)
+        try:
+            config = load_guard_config(
+                self._server.store.guard_home,
+            )
+            self._server.store.maintain_command_activity(
+                now=now,
+                detail_retain_days=config.evidence_retain_days,
+            )
+        except Exception:
+            with suppress(Exception):
+                self._server.store.record_command_activity_persistence_failure(
+                    error_code="maintenance_failed",
+                    occurred_at=now,
+                )
+
+    def _start_command_activity_maintenance(self) -> None:
+        if (
+            self._command_activity_maintenance_thread is not None
+            and self._command_activity_maintenance_thread.is_alive()
+        ):
+            return
+        self._command_activity_maintenance_thread = threading.Thread(
+            target=self._command_activity_maintenance_loop,
+            daemon=True,
+        )
+        self._command_activity_maintenance_thread.start()
+
+    def _require_command_activity_maintenance_stopped(self) -> None:
+        if self._command_activity_maintenance_thread is None:
+            return
+        if self._command_activity_maintenance_thread.is_alive():
+            raise RuntimeError("command activity maintenance is still stopping")
+        self._command_activity_maintenance_thread = None
+
+    def _join_command_activity_maintenance(self) -> None:
+        if self._command_activity_maintenance_thread is None:
+            return
+        self._command_activity_maintenance_thread.join(timeout=5)
+        if not self._command_activity_maintenance_thread.is_alive():
+            self._command_activity_maintenance_thread = None
+
+    def _command_activity_maintenance_loop(self) -> None:
+        while not self._shutdown_started.wait(3_600):
+            self._maintain_command_activity_best_effort()
 
     def _persist_aibom_inventory_context(self) -> None:
         workspace_id = self._server.store.get_cloud_workspace_id()

--- a/src/codex_plugin_scanner/guard/runtime/command_activity_privacy.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_activity_privacy.py
@@ -312,7 +312,9 @@ def _require_cloud_dimension_value(dimension: CloudAggregateDimension, value: st
         CloudAggregateDimension.EXECUTION_STATUS: frozenset(item.value for item in CommandExecutionStatus),
         CloudAggregateDimension.PROMPT_STATUS: frozenset({"prompted", "not_prompted"}),
         CloudAggregateDimension.PROOF_LEVEL: frozenset(item.value for item in CommandProofLevel),
-        CloudAggregateDimension.LATENCY: frozenset(item.value for item in ActivityLatencyBucket),
+        CloudAggregateDimension.LATENCY: frozenset(
+            f"{kind}.{bucket.value}" for kind in ("evaluation", "persistence") for bucket in ActivityLatencyBucket
+        ),
     }
     if value not in allowed[dimension]:
         raise ValueError("dimension_value must belong to the selected bounded aggregate dimension")

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -14,6 +14,7 @@ from .store_approval_facade import StoreApprovalsMixin
 from .store_cloud_events import StoreCloudEventsMixin
 from .store_command_activity import StoreCommandActivityMixin
 from .store_command_activity_lifecycle import StoreCommandActivityLifecycleMixin
+from .store_command_activity_maintenance import StoreCommandActivityMaintenanceMixin
 from .store_connection_schema import StoreConnectionSchemaMixin
 from .store_event_receipts import StoreEventReceiptsMixin
 from .store_evidence_facade import StoreEvidenceMixin
@@ -36,6 +37,7 @@ class GuardStore(
     StoreConnectionSchemaMixin,
     StoreCommandActivityMixin,
     StoreCommandActivityLifecycleMixin,
+    StoreCommandActivityMaintenanceMixin,
     StoreInventoryMixin,
     StorePolicyMixin,
     StorePolicyIntegrityAdminMixin,

--- a/src/codex_plugin_scanner/guard/store_command_activity.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity.py
@@ -15,6 +15,7 @@ from .runtime.command_activity_contract import (
     CommandActivityMatch,
     CorrelationHandle,
 )
+from .store_command_activity_rollups import record_command_activity_rollups
 
 
 class _ConnectionOwner(Protocol):
@@ -38,6 +39,14 @@ class StoreCommandActivityMixin:
             )
             if existing is not None:
                 _require_exact_replay(connection, evidence, existing)
+                return False
+            if (
+                connection.execute(
+                    "select 1 from command_activity_rollup_membership where activity_id = ?",
+                    (evidence.activity.activity_id,),
+                ).fetchone()
+                is not None
+            ):
                 return False
             connection.execute(
                 """
@@ -77,6 +86,7 @@ class StoreCommandActivityMixin:
                 """,
                 _correlation_values(evidence.activity),
             )
+            record_command_activity_rollups(connection, evidence)
             return True
 
     def count_command_activities(self: _ConnectionOwner) -> int:

--- a/src/codex_plugin_scanner/guard/store_command_activity_lifecycle.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_lifecycle.py
@@ -31,6 +31,7 @@ from .runtime.command_activity_contract import (
     validate_activity_transition,
 )
 from .runtime.effect_contract import UncertaintyKind
+from .store_command_activity_rollups import transition_command_activity_rollups
 
 _MAX_COUNTER: Final = 9_223_372_036_854_775_807
 _ERROR_CODE: Final = re.compile(r"[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*")
@@ -155,6 +156,7 @@ class StoreCommandActivityLifecycleMixin:
             )
             if result.rowcount != 1:
                 raise RuntimeError("command activity changed during lifecycle transition")
+            transition_command_activity_rollups(connection, previous, current)
             return True
 
     def record_command_activity_persistence_failure(

--- a/src/codex_plugin_scanner/guard/store_command_activity_maintenance.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_maintenance.py
@@ -1,0 +1,258 @@
+"""Bounded rollup reconciliation and retention for command activity."""
+
+# pyright: reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Final, Protocol, cast
+
+from .store_command_activity_rollups import (
+    CommandActivityRollupBackfillResult,
+    backfill_command_activity_rollups_batch,
+    command_activity_rollups_are_reconciled,
+    rebuild_command_activity_rollups,
+)
+
+COMMAND_ACTIVITY_AGGREGATE_MONTHS: Final = 13
+DEFAULT_COMMAND_ACTIVITY_MAINTENANCE_BATCH_SIZE: Final = 1_000
+_MAX_BATCH_SIZE: Final = 10_000
+_MAX_RETENTION_DAYS: Final = 3_650
+
+
+class _ConnectionOwner(Protocol):
+    def _connect(self) -> AbstractContextManager[sqlite3.Connection]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class CommandActivityMaintenanceResult:
+    ran: bool
+    completed: bool
+    backfilled_rows: int
+    detail_rows_deleted: int
+    correlation_rows_deleted: int
+    aggregate_rows_deleted: int
+
+
+class StoreCommandActivityMaintenanceMixin:
+    def maintain_command_activity(
+        self: _ConnectionOwner,
+        *,
+        now: datetime,
+        detail_retain_days: int,
+        batch_size: int = DEFAULT_COMMAND_ACTIVITY_MAINTENANCE_BATCH_SIZE,
+    ) -> CommandActivityMaintenanceResult:
+        """Run at most one crash-safe batch until today's work is complete."""
+
+        _validate_maintenance_inputs(now, detail_retain_days, batch_size)
+        today = now.date().isoformat()
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            state = cast(
+                sqlite3.Row,
+                connection.execute("select * from command_activity_maintenance where singleton = 1").fetchone(),
+            )
+            last_completed_day = str(state["last_completed_day"]) if state["last_completed_day"] is not None else None
+            pending = connection.execute("select 1 from command_activity_rollup_pending limit 1").fetchone()
+            if last_completed_day == today and pending is None:
+                return CommandActivityMaintenanceResult(False, True, 0, 0, 0, 0)
+
+            backfill = _backfill_batch(connection, state=state, batch_size=batch_size, now=now)
+            detail_deleted, correlations_deleted = _delete_retained_detail_batch(
+                connection,
+                cutoff=now - timedelta(days=detail_retain_days),
+                batch_size=batch_size,
+            )
+            aggregates_deleted = _delete_expired_aggregates(
+                connection,
+                now=now,
+                batch_size=batch_size,
+            )
+            completed = backfill.complete and detail_deleted < batch_size and aggregates_deleted < batch_size
+            connection.execute(
+                """
+                update command_activity_maintenance
+                set last_completed_day = case when ? then ? else last_completed_day end,
+                    last_run_at = ?, last_backfilled_rows = ?,
+                    last_detail_rows_deleted = ?, last_correlation_rows_deleted = ?,
+                    last_aggregate_rows_deleted = ?,
+                    detail_compaction_started_at = case
+                      when ? > 0 then coalesce(detail_compaction_started_at, ?)
+                      else detail_compaction_started_at end,
+                    rollup_backfill_cursor_occurred_at = ?,
+                    rollup_backfill_cursor_activity_id = ?,
+                    rollup_backfill_complete = ?
+                where singleton = 1
+                """,
+                (
+                    completed,
+                    today,
+                    now.isoformat(),
+                    backfill.rolled_rows,
+                    detail_deleted,
+                    correlations_deleted,
+                    aggregates_deleted,
+                    detail_deleted,
+                    now.isoformat(),
+                    backfill.cursor_occurred_at,
+                    backfill.cursor_activity_id,
+                    backfill.cursor_complete,
+                ),
+            )
+            return CommandActivityMaintenanceResult(
+                True,
+                completed,
+                backfill.rolled_rows,
+                detail_deleted,
+                correlations_deleted,
+                aggregates_deleted,
+            )
+
+    def rebuild_command_activity_rollups(
+        self: _ConnectionOwner,
+        *,
+        now: datetime,
+    ) -> None:
+        """Rebuild all retained-detail aggregates atomically for reconciliation."""
+
+        _require_utc(now)
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            rebuild_command_activity_rollups(connection, rebuilt_at=now)
+
+    def command_activity_rollups_are_reconciled(self: _ConnectionOwner) -> bool:
+        with self._connect() as connection:
+            return command_activity_rollups_are_reconciled(connection)
+
+
+def _delete_retained_detail_batch(
+    connection: sqlite3.Connection,
+    *,
+    cutoff: datetime,
+    batch_size: int,
+) -> tuple[int, int]:
+    rows = cast(
+        list[sqlite3.Row],
+        connection.execute(
+            """
+            select membership.activity_id from command_activity_rollup_membership as membership
+            join command_activity as activity on activity.activity_id = membership.activity_id
+            where membership.detail_present = 1 and membership.occurred_at < ?
+            order by membership.occurred_at, membership.activity_id limit ?
+            """,
+            (cutoff.isoformat(), batch_size),
+        ).fetchall(),
+    )
+    activity_ids = tuple(str(row["activity_id"]) for row in rows)
+    if not activity_ids:
+        return 0, 0
+    placeholders = ", ".join("?" for _ in activity_ids)
+    correlation_row = connection.execute(
+        f"select count(*) from command_activity_correlations where activity_id in ({placeholders})",
+        activity_ids,
+    ).fetchone()
+    correlations = int(correlation_row[0]) if correlation_row is not None else 0
+    result = connection.execute(
+        f"delete from command_activity where activity_id in ({placeholders})",
+        activity_ids,
+    )
+    return max(result.rowcount, 0), correlations
+
+
+def _backfill_batch(
+    connection: sqlite3.Connection,
+    *,
+    state: sqlite3.Row,
+    batch_size: int,
+    now: datetime,
+) -> CommandActivityRollupBackfillResult:
+    return backfill_command_activity_rollups_batch(
+        connection,
+        batch_size=batch_size,
+        rolled_at=now,
+        cursor_occurred_at=(
+            str(state["rollup_backfill_cursor_occurred_at"])
+            if state["rollup_backfill_cursor_occurred_at"] is not None
+            else None
+        ),
+        cursor_activity_id=(
+            str(state["rollup_backfill_cursor_activity_id"])
+            if state["rollup_backfill_cursor_activity_id"] is not None
+            else None
+        ),
+        cursor_complete=bool(state["rollup_backfill_complete"]),
+    )
+
+
+def _delete_expired_aggregates(
+    connection: sqlite3.Connection,
+    *,
+    now: datetime,
+    batch_size: int,
+) -> int:
+    cutoff = _aggregate_cutoff(now).isoformat()
+    rollups = connection.execute(
+        """
+        delete from command_activity_daily_rollups where rowid in (
+          select rowid from command_activity_daily_rollups
+          where day < ? order by day, dimension, dimension_value limit ?
+        )
+        """,
+        (cutoff, batch_size),
+    )
+    rollups_deleted = max(rollups.rowcount, 0)
+    remaining = batch_size - rollups_deleted
+    if remaining == 0:
+        return rollups_deleted
+    totals = connection.execute(
+        """
+        delete from command_activity_daily_totals where rowid in (
+          select rowid from command_activity_daily_totals where day < ? order by day limit ?
+        )
+        """,
+        (cutoff, remaining),
+    )
+    totals_deleted = max(totals.rowcount, 0)
+    remaining -= totals_deleted
+    if remaining == 0:
+        return rollups_deleted + totals_deleted
+    memberships = connection.execute(
+        """
+        delete from command_activity_rollup_membership where rowid in (
+          select rowid from command_activity_rollup_membership
+          where detail_present = 0 and day < ?
+          order by day, activity_id limit ?
+        )
+        """,
+        (cutoff, remaining),
+    )
+    return rollups_deleted + totals_deleted + max(memberships.rowcount, 0)
+
+
+def _aggregate_cutoff(now: datetime) -> date:
+    month_index = now.year * 12 + now.month - 1 - (COMMAND_ACTIVITY_AGGREGATE_MONTHS - 1)
+    return date(month_index // 12, month_index % 12 + 1, 1)
+
+
+def _validate_maintenance_inputs(now: datetime, detail_retain_days: int, batch_size: int) -> None:
+    _require_utc(now)
+    if isinstance(detail_retain_days, bool) or not 1 <= detail_retain_days <= _MAX_RETENTION_DAYS:
+        raise ValueError(f"detail_retain_days must be between 1 and {_MAX_RETENTION_DAYS}")
+    if isinstance(batch_size, bool) or not 1 <= batch_size <= _MAX_BATCH_SIZE:
+        raise ValueError(f"batch_size must be between 1 and {_MAX_BATCH_SIZE}")
+
+
+def _require_utc(value: datetime) -> None:
+    if value.tzinfo is None or value.utcoffset() != timedelta(0):
+        raise ValueError("now must be timezone-aware UTC")
+
+
+__all__ = [
+    "COMMAND_ACTIVITY_AGGREGATE_MONTHS",
+    "DEFAULT_COMMAND_ACTIVITY_MAINTENANCE_BATCH_SIZE",
+    "CommandActivityMaintenanceResult",
+    "StoreCommandActivityMaintenanceMixin",
+]

--- a/src/codex_plugin_scanner/guard/store_command_activity_maintenance_schema.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_maintenance_schema.py
@@ -1,0 +1,211 @@
+"""Schema for bounded command-activity rollup and retention maintenance."""
+
+# pyright: reportAny=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from typing import Final, cast
+
+COMMAND_ACTIVITY_MAINTENANCE_SCHEMA_MIGRATION_VERSION: Final = 12
+COMMAND_ACTIVITY_MAINTENANCE_SCHEMA_VERSION: Final = "guard.command-activity-maintenance.v1"
+
+
+def command_activity_maintenance_schema_statements() -> tuple[str, ...]:
+    return (
+        """
+        create table if not exists command_activity_rollup_membership (
+          activity_id text primary key,
+          day text not null,
+          occurred_at text not null,
+          rolled_at text not null,
+          detail_present integer not null default 1 check (detail_present in (0, 1))
+        )
+        """,
+        """
+        create index if not exists idx_command_activity_rollup_membership_day
+        on command_activity_rollup_membership (detail_present, day, activity_id)
+        """,
+        """
+        create index if not exists idx_command_activity_rollup_membership_occurred_at
+        on command_activity_rollup_membership (detail_present, occurred_at, activity_id)
+        """,
+        """
+        create table if not exists command_activity_rollup_pending (
+          activity_id text primary key,
+          occurred_at text not null
+        )
+        """,
+        """
+        create table if not exists command_activity_maintenance (
+          singleton integer primary key check (singleton = 1),
+          last_completed_day text,
+          last_run_at text,
+          detail_compaction_started_at text,
+          rollup_backfill_cursor_occurred_at text,
+          rollup_backfill_cursor_activity_id text,
+          rollup_backfill_complete integer not null default 0 check (rollup_backfill_complete in (0, 1)),
+          last_backfilled_rows integer not null default 0 check (last_backfilled_rows >= 0),
+          last_detail_rows_deleted integer not null default 0 check (last_detail_rows_deleted >= 0),
+          last_correlation_rows_deleted integer not null default 0 check (last_correlation_rows_deleted >= 0),
+          last_aggregate_rows_deleted integer not null default 0 check (last_aggregate_rows_deleted >= 0),
+          schema_version text not null
+        )
+        """,
+        """
+        create trigger if not exists trg_command_activity_rollup_membership_parent
+        before insert on command_activity_rollup_membership
+        when not exists (
+          select 1 from command_activity where activity_id = new.activity_id
+        )
+        begin
+          select raise(abort, 'command activity rollup membership parent is missing');
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_rollup_membership_detail_deleted
+        after delete on command_activity
+        begin
+          update command_activity_rollup_membership
+          set detail_present = 0 where activity_id = old.activity_id;
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_rollup_pending_parent_inserted
+        after insert on command_activity
+        begin
+          insert or ignore into command_activity_rollup_pending (activity_id, occurred_at)
+          values (new.activity_id, new.occurred_at);
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_rollup_pending_membership_inserted
+        after insert on command_activity_rollup_membership
+        begin
+          delete from command_activity_rollup_pending where activity_id = new.activity_id;
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_rollup_pending_parent_deleted
+        after delete on command_activity
+        begin
+          delete from command_activity_rollup_pending where activity_id = old.activity_id;
+        end
+        """,
+    )
+
+
+def ensure_command_activity_maintenance_schema(connection: sqlite3.Connection, *, applied_at: str) -> None:
+    """Apply and validate maintenance state in one savepoint."""
+
+    statements = command_activity_maintenance_schema_statements()
+    connection.execute("savepoint command_activity_maintenance_schema_v1")
+    try:
+        for statement in statements:
+            connection.execute(statement)
+        connection.execute(
+            """
+            insert or ignore into command_activity_maintenance (
+              singleton, last_completed_day, last_run_at, detail_compaction_started_at,
+              rollup_backfill_cursor_occurred_at, rollup_backfill_cursor_activity_id,
+              rollup_backfill_complete,
+              last_backfilled_rows,
+              last_detail_rows_deleted, last_correlation_rows_deleted,
+              last_aggregate_rows_deleted, schema_version
+            ) values (1, null, null, null, null, null, 0, 0, 0, 0, 0, ?)
+            """,
+            (COMMAND_ACTIVITY_MAINTENANCE_SCHEMA_VERSION,),
+        )
+        _validate_command_activity_maintenance_schema(connection, statements)
+        connection.execute(
+            "insert or ignore into schema_migrations (version, applied_at) values (?, ?)",
+            (COMMAND_ACTIVITY_MAINTENANCE_SCHEMA_MIGRATION_VERSION, applied_at),
+        )
+    except BaseException:
+        connection.execute("rollback to command_activity_maintenance_schema_v1")
+        connection.execute("release command_activity_maintenance_schema_v1")
+        raise
+    connection.execute("release command_activity_maintenance_schema_v1")
+
+
+def _validate_command_activity_maintenance_schema(
+    connection: sqlite3.Connection,
+    statements: tuple[str, ...],
+) -> None:
+    expected_columns = {
+        "command_activity_rollup_membership": {
+            "activity_id",
+            "day",
+            "occurred_at",
+            "rolled_at",
+            "detail_present",
+        },
+        "command_activity_maintenance": {
+            "singleton",
+            "last_completed_day",
+            "last_run_at",
+            "detail_compaction_started_at",
+            "rollup_backfill_cursor_occurred_at",
+            "rollup_backfill_cursor_activity_id",
+            "rollup_backfill_complete",
+            "last_backfilled_rows",
+            "last_detail_rows_deleted",
+            "last_correlation_rows_deleted",
+            "last_aggregate_rows_deleted",
+            "schema_version",
+        },
+        "command_activity_rollup_pending": {"activity_id", "occurred_at"},
+    }
+    for table, expected in expected_columns.items():
+        rows = cast(
+            list[tuple[int, str, str, int, object | None, int]],
+            connection.execute(f"pragma table_info({table})").fetchall(),
+        )
+        if {str(row[1]) for row in rows} != expected:
+            raise RuntimeError(f"incompatible {table} schema")
+        primary_key = tuple(str(row[1]) for row in sorted(rows, key=lambda item: int(item[5])) if int(row[5]) > 0)
+        expected_primary_key = ("singleton",) if table == "command_activity_maintenance" else ("activity_id",)
+        if primary_key != expected_primary_key:
+            raise RuntimeError(f"incompatible {table} primary key")
+    _validate_schema_object_sql(connection, statements)
+    row = cast(
+        sqlite3.Row | None,
+        connection.execute("select * from command_activity_maintenance where singleton = 1").fetchone(),
+    )
+    if row is None or str(row["schema_version"]) != COMMAND_ACTIVITY_MAINTENANCE_SCHEMA_VERSION:
+        raise RuntimeError("incompatible command_activity_maintenance singleton")
+
+
+def _validate_schema_object_sql(connection: sqlite3.Connection, statements: tuple[str, ...]) -> None:
+    expected: dict[str, str] = {}
+    for statement in statements:
+        canonical = _canonical_sql(statement)
+        match = re.match(r"create (?:table|trigger|index) if not exists ([a-z0-9_]+)", canonical)
+        if match is None:
+            raise RuntimeError("unrecognized command activity maintenance schema statement")
+        expected[match.group(1)] = canonical.replace(" if not exists", "", 1)
+    placeholders = ", ".join("?" for _ in expected)
+    rows = cast(
+        list[tuple[str, str]],
+        connection.execute(
+            f"select name, sql from sqlite_schema where name in ({placeholders})",
+            tuple(expected),
+        ).fetchall(),
+    )
+    actual = {name: _canonical_sql(sql) for name, sql in rows}
+    for name, expected_sql in expected.items():
+        if actual.get(name) != expected_sql:
+            raise RuntimeError(f"incompatible command activity maintenance schema object: {name}")
+
+
+def _canonical_sql(value: str) -> str:
+    return " ".join(value.strip().lower().split())
+
+
+__all__ = [
+    "COMMAND_ACTIVITY_MAINTENANCE_SCHEMA_MIGRATION_VERSION",
+    "COMMAND_ACTIVITY_MAINTENANCE_SCHEMA_VERSION",
+    "command_activity_maintenance_schema_statements",
+    "ensure_command_activity_maintenance_schema",
+]

--- a/src/codex_plugin_scanner/guard/store_command_activity_rollups.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_rollups.py
@@ -1,0 +1,470 @@
+"""Transactional daily rollups for privacy-safe command activity facts."""
+
+# pyright: reportAny=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Final, cast
+
+from .runtime.command_activity_contract import CommandActivity, CommandActivityEvidence, CommandActivityMatch
+
+COMMAND_ACTIVITY_ROLLUP_DIMENSIONS: Final = frozenset(
+    {
+        "harness",
+        "extension",
+        "rule",
+        "disposition",
+        "execution_status",
+        "prompt_status",
+        "proof_level",
+        "latency",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CommandActivityRollupBackfillResult:
+    examined_rows: int
+    rolled_rows: int
+    cursor_occurred_at: str | None
+    cursor_activity_id: str | None
+    cursor_complete: bool
+    complete: bool
+
+
+def record_command_activity_rollups(
+    connection: sqlite3.Connection,
+    evidence: CommandActivityEvidence,
+) -> bool:
+    """Add one activity to its daily cells exactly once in the caller transaction."""
+
+    activity = evidence.activity
+    day = activity.occurred_at.date().isoformat()
+    if not _claim_rollup_membership(
+        connection,
+        activity.activity_id,
+        day,
+        activity.occurred_at.isoformat(),
+        activity.occurred_at.isoformat(),
+    ):
+        return False
+    _increment_total(connection, day, 1)
+    _apply_dimension_deltas(connection, day, _activity_dimensions(activity, evidence.matches))
+    return True
+
+
+def transition_command_activity_rollups(
+    connection: sqlite3.Connection,
+    previous: CommandActivity,
+    current: CommandActivity,
+) -> None:
+    """Move mutable lifecycle cells without changing one-command totals."""
+
+    _ensure_persisted_activity_rolled(connection, previous)
+    day = previous.occurred_at.date().isoformat()
+    previous_dimensions = _base_activity_dimensions(previous)
+    current_dimensions = _base_activity_dimensions(current)
+    deltas: Counter[tuple[str, str]] = Counter()
+    for cell in previous_dimensions.keys() | current_dimensions.keys():
+        delta = current_dimensions[cell] - previous_dimensions[cell]
+        if delta:
+            deltas[cell] = delta
+    _apply_dimension_deltas(connection, day, deltas)
+
+
+def backfill_command_activity_rollups_batch(
+    connection: sqlite3.Connection,
+    *,
+    batch_size: int,
+    rolled_at: datetime,
+    cursor_occurred_at: str | None,
+    cursor_activity_id: str | None,
+    cursor_complete: bool,
+) -> CommandActivityRollupBackfillResult:
+    """Roll up at most one bounded batch of legacy detail rows."""
+
+    if batch_size < 1:
+        raise ValueError("batch_size must be positive")
+    if (cursor_occurred_at is None) != (cursor_activity_id is None):
+        raise ValueError("backfill cursor fields must both be present or absent")
+    legacy_budget = 0 if cursor_complete else max(1, batch_size // 2)
+    rows: list[sqlite3.Row] = []
+    if legacy_budget and cursor_occurred_at is None:
+        rows = cast(
+            list[sqlite3.Row],
+            connection.execute(
+                "select * from command_activity order by occurred_at, activity_id limit ?",
+                (legacy_budget,),
+            ).fetchall(),
+        )
+    elif legacy_budget:
+        rows = cast(
+            list[sqlite3.Row],
+            connection.execute(
+                """
+                select * from command_activity
+                where (occurred_at, activity_id) > (?, ?)
+                order by occurred_at, activity_id limit ?
+                """,
+                (cursor_occurred_at, cursor_activity_id, legacy_budget),
+            ).fetchall(),
+        )
+    legacy_complete = cursor_complete or len(rows) < legacy_budget
+    remaining = batch_size - len(rows)
+    pending_rows = cast(
+        list[sqlite3.Row],
+        connection.execute(
+            """
+            select activity.* from command_activity_rollup_pending as pending
+            join command_activity as activity on activity.activity_id = pending.activity_id
+            order by pending.activity_id limit ?
+            """,
+            (remaining,),
+        ).fetchall(),
+    )
+    processed = 0
+    for row in rows:
+        processed += int(_roll_raw_activity(connection, row, rolled_at=rolled_at))
+    for row in pending_rows:
+        processed += int(_roll_raw_activity(connection, row, rolled_at=rolled_at))
+        connection.execute(
+            "delete from command_activity_rollup_pending where activity_id = ?",
+            (str(row["activity_id"]),),
+        )
+    return CommandActivityRollupBackfillResult(
+        examined_rows=len(pending_rows) + len(rows),
+        rolled_rows=processed,
+        cursor_occurred_at=str(rows[-1]["occurred_at"]) if rows else cursor_occurred_at,
+        cursor_activity_id=str(rows[-1]["activity_id"]) if rows else cursor_activity_id,
+        cursor_complete=legacy_complete,
+        complete=len(pending_rows) < remaining and legacy_complete,
+    )
+
+
+def _roll_raw_activity(connection: sqlite3.Connection, row: sqlite3.Row, *, rolled_at: datetime) -> bool:
+    activity_id = str(row["activity_id"])
+    day = str(row["occurred_at"])[:10]
+    if not _claim_rollup_membership(
+        connection,
+        activity_id,
+        day,
+        str(row["occurred_at"]),
+        rolled_at.isoformat(),
+    ):
+        return False
+    _increment_total(connection, day, 1)
+    _apply_dimension_deltas(connection, day, _raw_activity_dimensions(connection, row))
+    return True
+
+
+def rebuild_command_activity_rollups(connection: sqlite3.Connection, *, rebuilt_at: datetime) -> None:
+    """Reconcile every aggregate from detail inside the caller transaction."""
+
+    if _detail_compaction_has_started(connection):
+        raise RuntimeError("rollups cannot be rebuilt after detail compaction")
+
+    connection.execute("delete from command_activity_daily_totals")
+    connection.execute("delete from command_activity_daily_rollups")
+    connection.execute("delete from command_activity_rollup_membership")
+    connection.execute(
+        """
+        insert into command_activity_daily_totals (day, total)
+        select substr(occurred_at, 1, 10), count(*)
+        from command_activity
+        group by substr(occurred_at, 1, 10)
+        """
+    )
+    connection.execute(
+        """
+        insert into command_activity_daily_rollups (day, dimension, dimension_value, count)
+        select day, dimension, dimension_value, count(*)
+        from (
+          select substr(occurred_at, 1, 10) as day, 'harness' as dimension,
+                 harness as dimension_value from command_activity
+          union all
+          select substr(occurred_at, 1, 10), 'disposition', policy_action
+                 from command_activity where policy_action is not null
+          union all
+          select substr(occurred_at, 1, 10), 'execution_status', execution_status
+                 from command_activity
+          union all
+          select substr(occurred_at, 1, 10), 'prompt_status',
+                 case when prompted = 1 then 'prompted' else 'not_prompted' end from command_activity
+          union all
+          select substr(occurred_at, 1, 10), 'proof_level', proof_level
+                 from command_activity
+          union all
+          select substr(occurred_at, 1, 10), 'latency',
+                 'evaluation.' || evaluation_latency_bucket
+                 from command_activity
+          union all
+          select substr(occurred_at, 1, 10), 'latency',
+                 'persistence.' || persistence_latency_bucket
+                 from command_activity
+          union all
+          select extension.day, 'extension', extension.extension_id from (
+            select distinct activity.activity_id, substr(activity.occurred_at, 1, 10) as day,
+                   matches.extension_id
+            from command_activity as activity
+            join command_activity_matches as matches on matches.activity_id = activity.activity_id
+          ) as extension
+          union all
+          select substr(activity.occurred_at, 1, 10), 'rule', matches.rule_id
+                 from command_activity as activity
+                 join command_activity_matches as matches on matches.activity_id = activity.activity_id
+        ) as cells
+        group by day, dimension, dimension_value
+        """
+    )
+    connection.execute(
+        """
+        insert into command_activity_rollup_membership (activity_id, day, occurred_at, rolled_at)
+        select activity_id, substr(occurred_at, 1, 10), occurred_at, ? from command_activity
+        """,
+        (rebuilt_at.isoformat(),),
+    )
+    connection.execute(
+        """
+        update command_activity_maintenance
+        set last_completed_day = null,
+            rollup_backfill_cursor_occurred_at = null,
+            rollup_backfill_cursor_activity_id = null,
+            rollup_backfill_complete = 1
+        where singleton = 1
+        """
+    )
+
+
+def command_activity_rollups_are_reconciled(connection: sqlite3.Connection) -> bool:
+    """Check exact total and per-dimension equality against retained detail."""
+
+    if _detail_compaction_has_started(connection):
+        return False
+
+    expected_totals = _query_count_map(
+        connection,
+        """
+        select substr(occurred_at, 1, 10) as day, count(*) as count
+        from command_activity group by substr(occurred_at, 1, 10)
+        """,
+        key_columns=("day",),
+    )
+    actual_totals = _query_count_map(
+        connection,
+        "select day, total as count from command_activity_daily_totals",
+        key_columns=("day",),
+    )
+    if actual_totals != expected_totals:
+        return False
+    expected_cells = _expected_dimension_cells(connection)
+    actual_cells = _query_count_map(
+        connection,
+        "select day, dimension, dimension_value, count from command_activity_daily_rollups",
+        key_columns=("day", "dimension", "dimension_value"),
+    )
+    return actual_cells == expected_cells
+
+
+def _detail_compaction_has_started(connection: sqlite3.Connection) -> bool:
+    row = connection.execute(
+        "select detail_compaction_started_at from command_activity_maintenance where singleton = 1"
+    ).fetchone()
+    return row is not None and row[0] is not None
+
+
+def _ensure_persisted_activity_rolled(connection: sqlite3.Connection, activity: CommandActivity) -> None:
+    day = activity.occurred_at.date().isoformat()
+    if not _claim_rollup_membership(
+        connection,
+        activity.activity_id,
+        day,
+        activity.occurred_at.isoformat(),
+        activity.occurred_at.isoformat(),
+    ):
+        return
+    _increment_total(connection, day, 1)
+    matches = cast(
+        list[sqlite3.Row],
+        connection.execute(
+            "select extension_id, rule_id from command_activity_matches where activity_id = ?",
+            (activity.activity_id,),
+        ).fetchall(),
+    )
+    dimensions = _base_activity_dimensions(activity)
+    for extension_id in {str(row["extension_id"]) for row in matches}:
+        dimensions[("extension", extension_id)] += 1
+    for row in matches:
+        dimensions[("rule", str(row["rule_id"]))] += 1
+    _apply_dimension_deltas(connection, day, dimensions)
+
+
+def _claim_rollup_membership(
+    connection: sqlite3.Connection,
+    activity_id: str,
+    day: str,
+    occurred_at: str,
+    rolled_at: str,
+) -> bool:
+    result = connection.execute(
+        """
+        insert or ignore into command_activity_rollup_membership (activity_id, day, occurred_at, rolled_at)
+        values (?, ?, ?, ?)
+        """,
+        (activity_id, day, occurred_at, rolled_at),
+    )
+    return result.rowcount == 1
+
+
+def _activity_dimensions(
+    activity: CommandActivity,
+    matches: Iterable[CommandActivityMatch],
+) -> Counter[tuple[str, str]]:
+    dimensions = _base_activity_dimensions(activity)
+    materialized = tuple(matches)
+    for extension_id in {match.identity.extension_id for match in materialized}:
+        dimensions[("extension", extension_id)] += 1
+    for match in materialized:
+        dimensions[("rule", match.identity.rule_id)] += 1
+    return dimensions
+
+
+def _base_activity_dimensions(activity: CommandActivity) -> Counter[tuple[str, str]]:
+    dimensions = Counter(
+        {
+            ("harness", activity.harness): 1,
+            ("execution_status", activity.execution_status.value): 1,
+            ("prompt_status", "prompted" if activity.prompted else "not_prompted"): 1,
+            ("proof_level", activity.proof_level.value): 1,
+            ("latency", f"evaluation.{activity.evaluation_latency_bucket.value}"): 1,
+            ("latency", f"persistence.{activity.persistence_latency_bucket.value}"): 1,
+        }
+    )
+    if activity.policy_action is not None:
+        dimensions[("disposition", activity.policy_action)] += 1
+    return dimensions
+
+
+def _raw_activity_dimensions(connection: sqlite3.Connection, row: sqlite3.Row) -> Counter[tuple[str, str]]:
+    dimensions: Counter[tuple[str, str]] = Counter(
+        {
+            ("harness", str(row["harness"])): 1,
+            ("execution_status", str(row["execution_status"])): 1,
+            ("prompt_status", "prompted" if bool(row["prompted"]) else "not_prompted"): 1,
+            ("proof_level", str(row["proof_level"])): 1,
+            ("latency", f"evaluation.{row['evaluation_latency_bucket']}"): 1,
+            ("latency", f"persistence.{row['persistence_latency_bucket']}"): 1,
+        }
+    )
+    if row["policy_action"] is not None:
+        dimensions[("disposition", str(row["policy_action"]))] += 1
+    matches = cast(
+        list[sqlite3.Row],
+        connection.execute(
+            "select extension_id, rule_id from command_activity_matches where activity_id = ?",
+            (str(row["activity_id"]),),
+        ).fetchall(),
+    )
+    for extension_id in {str(match["extension_id"]) for match in matches}:
+        dimensions[("extension", extension_id)] += 1
+    for match in matches:
+        dimensions[("rule", str(match["rule_id"]))] += 1
+    return dimensions
+
+
+def _increment_total(connection: sqlite3.Connection, day: str, delta: int) -> None:
+    connection.execute(
+        """
+        insert into command_activity_daily_totals (day, total) values (?, ?)
+        on conflict(day) do update set total = total + excluded.total
+        """,
+        (day, delta),
+    )
+
+
+def _apply_dimension_deltas(
+    connection: sqlite3.Connection,
+    day: str,
+    deltas: Counter[tuple[str, str]],
+) -> None:
+    positive_rows = tuple((day, dimension, value, count) for (dimension, value), count in deltas.items() if count > 0)
+    connection.executemany(
+        """
+        insert into command_activity_daily_rollups (day, dimension, dimension_value, count)
+        values (?, ?, ?, ?)
+        on conflict(day, dimension, dimension_value)
+        do update set count = count + excluded.count
+        """,
+        positive_rows,
+    )
+    for (dimension, value), count in deltas.items():
+        if count >= 0:
+            continue
+        result = connection.execute(
+            """
+            update command_activity_daily_rollups set count = count + ?
+            where day = ? and dimension = ? and dimension_value = ?
+            """,
+            (count, day, dimension, value),
+        )
+        if result.rowcount != 1:
+            raise RuntimeError("command activity rollup delta referenced a missing cell")
+    connection.execute("delete from command_activity_daily_rollups where day = ? and count = 0", (day,))
+    if connection.execute(
+        "select 1 from command_activity_daily_rollups where day = ? and count < 0 limit 1",
+        (day,),
+    ).fetchone():
+        raise RuntimeError("command activity rollup delta produced a negative count")
+
+
+def _expected_dimension_cells(connection: sqlite3.Connection) -> dict[tuple[str, ...], int]:
+    query = """
+        select day, dimension, dimension_value, count(*) as count from (
+          select substr(occurred_at, 1, 10) as day, 'harness' as dimension, harness as dimension_value
+            from command_activity
+          union all select substr(occurred_at, 1, 10), 'disposition', policy_action
+            from command_activity where policy_action is not null
+          union all select substr(occurred_at, 1, 10), 'execution_status', execution_status from command_activity
+          union all select substr(occurred_at, 1, 10), 'prompt_status',
+            case when prompted = 1 then 'prompted' else 'not_prompted' end from command_activity
+          union all select substr(occurred_at, 1, 10), 'proof_level', proof_level from command_activity
+          union all select substr(occurred_at, 1, 10), 'latency',
+            'evaluation.' || evaluation_latency_bucket from command_activity
+          union all select substr(occurred_at, 1, 10), 'latency',
+            'persistence.' || persistence_latency_bucket
+            from command_activity
+          union all select extension.day, 'extension', extension.extension_id from (
+            select distinct activity.activity_id, substr(activity.occurred_at, 1, 10) as day,
+              matches.extension_id
+            from command_activity activity join command_activity_matches matches using (activity_id)
+          ) as extension
+          union all select substr(activity.occurred_at, 1, 10), 'rule', matches.rule_id
+            from command_activity activity join command_activity_matches matches using (activity_id)
+        ) group by day, dimension, dimension_value
+    """
+    return _query_count_map(connection, query, key_columns=("day", "dimension", "dimension_value"))
+
+
+def _query_count_map(
+    connection: sqlite3.Connection,
+    query: str,
+    *,
+    key_columns: tuple[str, ...],
+) -> dict[tuple[str, ...], int]:
+    rows = cast(list[sqlite3.Row], connection.execute(query).fetchall())
+    return {tuple(str(row[column]) for column in key_columns): int(row["count"]) for row in rows}
+
+
+__all__ = [
+    "COMMAND_ACTIVITY_ROLLUP_DIMENSIONS",
+    "CommandActivityRollupBackfillResult",
+    "backfill_command_activity_rollups_batch",
+    "command_activity_rollups_are_reconciled",
+    "rebuild_command_activity_rollups",
+    "record_command_activity_rollups",
+    "transition_command_activity_rollups",
+]

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 # ruff: noqa: F403,F405
 from .store_base import *
 from .store_command_activity_health_schema import ensure_command_activity_health_schema
+from .store_command_activity_maintenance_schema import ensure_command_activity_maintenance_schema
 from .store_command_activity_schema import ensure_command_activity_schema
 from .store_live_request_outbox import ensure_live_request_outbox_schema, seed_live_request_outbox
 from .store_secret_policy_integrity import _POLICY_INTEGRITY_LOOKUP_UNSET
@@ -619,6 +620,7 @@ class StoreConnectionSchemaMixin:
                 connection.execute(statement)
             ensure_command_activity_schema(connection, applied_at=_now())
             ensure_command_activity_health_schema(connection, applied_at=_now())
+            ensure_command_activity_maintenance_schema(connection, applied_at=_now())
             ensure_evidence_schema(connection)
             if not self._schema_version_applied(connection, version=4):
                 self._record_schema_version(connection, version=4)

--- a/tests/test_guard_command_activity_maintenance_runtime.py
+++ b/tests/test_guard_command_activity_maintenance_runtime.py
@@ -1,0 +1,100 @@
+"""Daemon scheduling and config ownership for command activity maintenance."""
+
+# pyright: reportAny=false, reportMissingImports=false, reportPrivateUsage=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.config import load_guard_config
+from codex_plugin_scanner.guard.daemon import server as daemon_server
+
+
+class _SequencedEvent:
+    calls: int
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def wait(self, timeout: float) -> bool:
+        assert timeout == 3_600
+        self.calls += 1
+        return self.calls > 2
+
+
+@dataclass(frozen=True, slots=True)
+class _LoadedConfig:
+    evidence_retain_days: int
+
+
+class _FakeStore:
+    guard_home: Path = Path("/global-home")
+
+    def maintain_command_activity(self, **_kwargs: object) -> None:
+        return None
+
+    def record_command_activity_persistence_failure(self, **_kwargs: object) -> None:
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeServer:
+    store: _FakeStore
+
+
+class _ThreadStillStopping:
+    joined: bool = False
+
+    def join(self, timeout: float | None = None) -> None:
+        assert timeout == 5
+        self.joined = True
+
+    def is_alive(self) -> bool:
+        return True
+
+
+def test_long_lived_daemon_rechecks_daily_and_uses_global_retention(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = object.__new__(daemon_server.GuardDaemonServer)
+    service._shutdown_started = cast(threading.Event, cast(object, _SequencedEvent()))
+    maintenance_calls: list[int] = []
+    service._maintain_command_activity_best_effort = lambda: maintenance_calls.append(1)
+    service._command_activity_maintenance_loop()
+    assert len(maintenance_calls) == 2
+
+    loaded: list[tuple[Path, Path | None]] = []
+    object.__setattr__(service, "_server", _FakeServer(_FakeStore()))
+    service._aibom_workspace_dir = Path("/workspace")
+
+    def load(home: Path, workspace: Path | None = None) -> _LoadedConfig:
+        loaded.append((home, workspace))
+        return _LoadedConfig(evidence_retain_days=90)
+
+    monkeypatch.setattr(daemon_server, "load_guard_config", load)
+    daemon_server.GuardDaemonServer._maintain_command_activity_best_effort(service)
+    assert loaded == [(Path("/global-home"), None)]
+
+
+def test_daemon_restart_rejects_a_still_stopping_maintenance_worker() -> None:
+    service = object.__new__(daemon_server.GuardDaemonServer)
+    worker = _ThreadStillStopping()
+    service._command_activity_maintenance_thread = cast(threading.Thread, cast(object, worker))
+    service._join_command_activity_maintenance()
+    assert worker.joined is True
+    assert service._command_activity_maintenance_thread is not None
+    with pytest.raises(RuntimeError, match="still stopping"):
+        service._require_command_activity_maintenance_stopped()
+
+
+def test_global_evidence_retention_setting_is_bounded(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    config_path = guard_home / "config.toml"
+    config_path.write_text("evidence_retain_days = 45\n", encoding="utf-8")
+    assert load_guard_config(guard_home).evidence_retain_days == 45
+    config_path.write_text("evidence_retain_days = 0\n", encoding="utf-8")
+    assert load_guard_config(guard_home).evidence_retain_days == 90

--- a/tests/test_guard_command_activity_rollups.py
+++ b/tests/test_guard_command_activity_rollups.py
@@ -1,0 +1,418 @@
+"""Transactional rollup and bounded retention evidence for command activity."""
+
+# pyright: reportAny=false, reportMissingImports=false, reportPrivateUsage=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import replace
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard import store_command_activity as activity_store
+from codex_plugin_scanner.guard import store_command_activity_maintenance as activity_maintenance
+from codex_plugin_scanner.guard import store_command_activity_maintenance_schema as maintenance_schema
+from codex_plugin_scanner.guard.models import GuardAction
+from codex_plugin_scanner.guard.runtime.command_activity_contract import (
+    ActivityApprovalReuseStatus,
+    ActivityDecisionReason,
+    ActivityLatencyBucket,
+    ActivityMatchClass,
+    ActivityParseConfidence,
+    CommandActivity,
+    CommandActivityEvidence,
+    CommandActivityMatch,
+    CommandExecutionStatus,
+    CommandHookPhase,
+    CommandProofLevel,
+    CorrelationHandle,
+    CorrelationKind,
+    ReceiptLinkStatus,
+)
+from codex_plugin_scanner.guard.runtime.command_activity_privacy import (
+    MIN_CLOUD_AGGREGATE_COUNT,
+    CloudAggregateDimension,
+    CloudCommandActivityAggregate,
+)
+from codex_plugin_scanner.guard.runtime.effect_contract import EffectKind
+from codex_plugin_scanner.guard.runtime.extension_evidence import EvidenceSeverity, ExtensionRuleIdentity
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_command_activity_maintenance import CommandActivityMaintenanceResult
+from codex_plugin_scanner.guard.store_command_activity_rollups import COMMAND_ACTIVITY_ROLLUP_DIMENSIONS
+
+_NOW = datetime(2026, 7, 18, 20, 0, tzinfo=timezone.utc)
+
+
+def _evidence(
+    activity_id: str,
+    *,
+    occurred_at: datetime = _NOW,
+    action: GuardAction | None = "allow",
+    prompted: bool = False,
+    matches: int = 0,
+) -> CommandActivityEvidence:
+    unpaired = action is None
+    activity = CommandActivity(
+        activity_id=activity_id,
+        occurred_at=occurred_at,
+        harness="codex",
+        hook_phase=CommandHookPhase.POST_SUCCESS if unpaired else CommandHookPhase.PRE,
+        execution_status=(
+            CommandExecutionStatus.UNPAIRED_POST if unpaired else CommandExecutionStatus.ALLOWED_UNCONFIRMED
+        ),
+        proof_level=CommandProofLevel.UNPAIRED_POST if unpaired else CommandProofLevel.PRE_HOOK,
+        policy_action=action,
+        decision_reason_code=(
+            None if unpaired else ActivityDecisionReason.EXTENSION_MATCH if matches else ActivityDecisionReason.NO_MATCH
+        ),
+        controlling_rule_id="command.git.push" if matches else None,
+        parse_confidence=None if unpaired else ActivityParseConfidence.EXACT,
+        uncertainty_class=None,
+        match_count=matches,
+        prompted=False if unpaired else prompted,
+        approval_reuse_status=ActivityApprovalReuseStatus.NOT_APPLICABLE,
+        request_correlation=(
+            None
+            if unpaired
+            else CorrelationHandle(
+                CorrelationKind.REQUEST,
+                "codex",
+                "key.v1",
+                f"{int(activity_id.split(':')[-1]):064x}",
+            )
+        ),
+        session_correlation=None,
+        receipt_link_status=ReceiptLinkStatus.NOT_APPLICABLE,
+        receipt_id=None,
+        evaluation_latency_bucket=ActivityLatencyBucket.NOT_MEASURED if unpaired else ActivityLatencyBucket.LE_5_MS,
+        persistence_latency_bucket=ActivityLatencyBucket.LE_2_MS,
+    )
+    rule_hits = tuple(
+        CommandActivityMatch(
+            activity_id=activity_id,
+            ordinal=ordinal,
+            identity=ExtensionRuleIdentity(
+                "command.git",
+                "2.2.0",
+                "command.git.push" if ordinal == 0 else "command.git.force-push",
+                "1.0.0",
+            ),
+            match_class=ActivityMatchClass.UNSAFE,
+            severity=EvidenceSeverity.HIGH,
+            default_floor="review",
+            effect_claims=frozenset({EffectKind.REMOTE_STATE_MUTATION}),
+        )
+        for ordinal in range(matches)
+    )
+    return CommandActivityEvidence(activity, rule_hits)
+
+
+def _rollups(store: GuardStore) -> dict[tuple[str, str, str], int]:
+    with sqlite3.connect(store.path) as connection:
+        rows = connection.execute(
+            "select day, dimension, dimension_value, count from command_activity_daily_rollups"
+        ).fetchall()
+    return {(str(day), str(dimension), str(value)): int(count) for day, dimension, value, count in rows}
+
+
+def _total(store: GuardStore, day: str) -> int:
+    with sqlite3.connect(store.path) as connection:
+        row = connection.execute("select total from command_activity_daily_totals where day = ?", (day,)).fetchone()
+    return int(row[0]) if row is not None else 0
+
+
+def test_v12_schema_is_strict_atomic_and_rejects_orphan_membership(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    with sqlite3.connect(store.path) as connection:
+        version = connection.execute(
+            "select version from schema_migrations where version = ?",
+            (maintenance_schema.COMMAND_ACTIVITY_MAINTENANCE_SCHEMA_MIGRATION_VERSION,),
+        ).fetchone()
+        with pytest.raises(sqlite3.IntegrityError, match="parent is missing"):
+            connection.execute(
+                """
+                insert into command_activity_rollup_membership (activity_id, day, occurred_at, rolled_at)
+                values ('missing', '2026-07-18', ?, ?)
+                """,
+                (_NOW.isoformat(), _NOW.isoformat()),
+            )
+    assert version == (12,)
+
+
+def test_v12_schema_failure_rolls_back_objects_and_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "migration.db"
+    with sqlite3.connect(path) as connection:
+        connection.execute("create table schema_migrations (version integer primary key, applied_at text not null)")
+        connection.execute("create table command_activity (activity_id text primary key)")
+        statements = maintenance_schema.command_activity_maintenance_schema_statements()
+        monkeypatch.setattr(
+            maintenance_schema,
+            "command_activity_maintenance_schema_statements",
+            lambda: (statements[0], "create table"),
+        )
+        with pytest.raises(sqlite3.OperationalError):
+            maintenance_schema.ensure_command_activity_maintenance_schema(connection, applied_at=_NOW.isoformat())
+        table = connection.execute(
+            "select 1 from sqlite_schema where name = 'command_activity_rollup_membership'"
+        ).fetchone()
+        version = connection.execute("select 1 from schema_migrations where version = 12").fetchone()
+    assert table is None
+    assert version is None
+
+
+def test_record_and_transition_update_exact_bounded_cells_once(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    first = _evidence("activity:1", matches=2)
+    second = _evidence("activity:2", action=None)
+    third = _evidence("activity:3", prompted=True)
+    assert store.record_command_activity(first) is True
+    assert store.record_command_activity(first) is False
+    assert store.record_command_activity(second) is True
+    assert store.record_command_activity(third) is True
+
+    cells = _rollups(store)
+    day = _NOW.date().isoformat()
+    assert _total(store, day) == 3
+    assert cells[(day, "extension", "command.git")] == 1
+    assert cells[(day, "rule", "command.git.push")] == 1
+    assert cells[(day, "rule", "command.git.force-push")] == 1
+    assert (day, "disposition", "not_applicable") not in cells
+    assert cells[(day, "prompt_status", "not_prompted")] == 2
+    assert cells[(day, "prompt_status", "prompted")] == 1
+    assert cells[(day, "latency", "evaluation.le_5_ms")] == 2
+    assert cells[(day, "latency", "evaluation.not_measured")] == 1
+    assert cells[(day, "latency", "persistence.le_2_ms")] == 3
+    assert set(COMMAND_ACTIVITY_ROLLUP_DIMENSIONS) == {
+        item.value for item in CloudAggregateDimension if item is not CloudAggregateDimension.TOTAL
+    }
+
+    current = replace(
+        first.activity,
+        hook_phase=CommandHookPhase.POST_SUCCESS,
+        execution_status=CommandExecutionStatus.CONFIRMED_SUCCESS,
+        proof_level=CommandProofLevel.POST_HOOK,
+        persistence_latency_bucket=ActivityLatencyBucket.LE_5_MS,
+    )
+    assert store.transition_command_activity(current) is True
+    assert store.transition_command_activity(current) is False
+    transitioned = _rollups(store)
+    assert transitioned[(day, "execution_status", "confirmed_success")] == 1
+    assert transitioned[(day, "proof_level", "post_hook")] == 1
+    assert transitioned[(day, "latency", "evaluation.le_5_ms")] == 2
+    assert transitioned[(day, "latency", "persistence.le_2_ms")] == 2
+    assert transitioned[(day, "latency", "persistence.le_5_ms")] == 1
+    assert _total(store, day) == 3
+
+
+def test_latency_cells_have_explicit_bounded_cloud_semantics() -> None:
+    for value in ("evaluation.le_5_ms", "persistence.le_2_ms"):
+        aggregate = CloudCommandActivityAggregate(
+            day=_NOW.date(),
+            dimension=CloudAggregateDimension.LATENCY,
+            dimension_value=value,
+            count=MIN_CLOUD_AGGREGATE_COUNT,
+        )
+        assert aggregate.dimension_value == value
+    with pytest.raises(ValueError, match="bounded aggregate dimension"):
+        CloudCommandActivityAggregate(
+            day=_NOW.date(),
+            dimension=CloudAggregateDimension.LATENCY,
+            dimension_value="le_5_ms",
+            count=MIN_CLOUD_AGGREGATE_COUNT,
+        )
+
+
+def test_rollup_failure_rolls_back_parent_and_children(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+
+    def fail(_connection: sqlite3.Connection, _evidence: CommandActivityEvidence) -> bool:
+        raise RuntimeError("injected rollup failure")
+
+    monkeypatch.setattr(activity_store, "record_command_activity_rollups", fail)
+    with pytest.raises(RuntimeError, match="injected"):
+        store.record_command_activity(_evidence("activity:1", matches=2))
+    assert store.count_command_activities() == 0
+    assert store.count_command_activity_rule_hits() == 0
+
+
+def test_rebuild_reconciles_one_hundred_thousand_rows(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    template = _evidence("activity:1")
+    store.record_command_activity(template)
+    with sqlite3.connect(store.path) as connection:
+        row = list[object](connection.execute("select * from command_activity").fetchone() or ())
+        connection.execute("delete from command_activity")
+        connection.execute("delete from command_activity_rollup_membership")
+        connection.execute("delete from command_activity_daily_rollups")
+        connection.execute("delete from command_activity_daily_totals")
+        insert = "insert into command_activity values (" + ",".join("?" for _ in row) + ")"
+        for start in range(0, 100_000, 10_000):
+            batch: list[tuple[object, ...]] = []
+            for index in range(start, start + 10_000):
+                values = list(row)
+                values[0] = f"bulk:{index:06d}"
+                values[1] = (_NOW - timedelta(days=400 + index % 10)).isoformat()
+                batch.append(tuple(values))
+            connection.executemany(insert, batch)
+        detail_plan = connection.execute(
+            """
+            explain query plan select membership.activity_id
+            from command_activity_rollup_membership membership
+            join command_activity activity on activity.activity_id = membership.activity_id
+            where membership.detail_present = 1 and membership.occurred_at < ?
+            order by membership.occurred_at, membership.activity_id limit ?
+            """,
+            (_NOW.isoformat(), 1_000),
+        ).fetchall()
+        assert connection.execute("select count(*) from command_activity_rollup_membership").fetchone() == (0,)
+    assert any("idx_command_activity_rollup_membership_occurred_at" in str(item) for item in detail_plan)
+    assert not any("SCAN activity" in str(item) for item in detail_plan)
+
+    first_page = store.maintain_command_activity(now=_NOW, detail_retain_days=1_000, batch_size=1_000)
+    assert 0 < first_page.backfilled_rows <= 1_000
+    assert first_page.completed is False
+    with sqlite3.connect(store.path) as connection:
+        cursor = connection.execute(
+            """
+            select rollup_backfill_cursor_occurred_at, rollup_backfill_cursor_activity_id,
+                   rollup_backfill_complete
+            from command_activity_maintenance where singleton = 1
+            """
+        ).fetchone()
+        assert cursor is not None
+        plan = connection.execute(
+            """
+            explain query plan select * from command_activity
+            where (occurred_at, activity_id) > (?, ?)
+            order by occurred_at, activity_id limit ?
+            """,
+            (cursor[0], cursor[1], 1_000),
+        ).fetchall()
+    assert cursor[2] == 0
+    assert any("idx_command_activity_occurred_at" in str(row) for row in plan)
+
+    store.rebuild_command_activity_rollups(now=_NOW)
+    assert store.count_command_activities() == 100_000
+    assert store.command_activity_rollups_are_reconciled() is True
+    with sqlite3.connect(store.path) as connection:
+        assert connection.execute("select sum(total) from command_activity_daily_totals").fetchone() == (100_000,)
+        assert connection.execute("select count(*) from command_activity_rollup_membership").fetchone() == (100_000,)
+    retained = store.maintain_command_activity(now=_NOW, detail_retain_days=1_000, batch_size=1_000)
+    assert retained.completed is True
+    assert retained.detail_rows_deleted == 0
+    assert retained.aggregate_rows_deleted > 0
+    with sqlite3.connect(store.path) as connection:
+        assert connection.execute("select count(*) from command_activity_rollup_membership").fetchone() == (100_000,)
+        plan = connection.execute(
+            """
+            explain query plan select rowid from command_activity_rollup_membership
+            where detail_present = 0 and day < ? order by day, activity_id limit ?
+            """,
+            ("2025-07-01", 1_000),
+        ).fetchall()
+    assert any("idx_command_activity_rollup_membership_day" in str(row) for row in plan)
+
+    store.rebuild_command_activity_rollups(now=_NOW)
+    same_day = store.maintain_command_activity(now=_NOW, detail_retain_days=1_000, batch_size=1_000)
+    assert same_day.aggregate_rows_deleted > 0
+    values = list(row)
+    values[0] = "bulk:backdated"
+    values[1] = (_NOW - timedelta(days=500)).isoformat()
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(insert, tuple(values))
+        assert connection.execute("select count(*) from command_activity_rollup_pending").fetchone() == (1,)
+        pending_plan = connection.execute(
+            """explain query plan select activity.* from command_activity_rollup_pending pending
+            join command_activity activity on activity.activity_id = pending.activity_id
+            order by pending.activity_id limit 1000"""
+        ).fetchall()
+    assert not any("SCAN activity" in str(item) for item in pending_plan)
+    late = store.maintain_command_activity(now=_NOW, detail_retain_days=1_000, batch_size=1_000)
+    assert late.backfilled_rows == 1
+    assert late.completed is True
+
+    maintenance = store.maintain_command_activity(
+        now=_NOW + timedelta(days=1),
+        detail_retain_days=30,
+        batch_size=1_000,
+    )
+    assert maintenance.detail_rows_deleted == 1_000
+    assert maintenance.completed is False
+    assert store.count_command_activities() == 99_001
+
+
+def test_compaction_is_bounded_preserves_history_and_delayed_replay_dedupes(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    old = _NOW - timedelta(days=60)
+    for index in range(5):
+        store.record_command_activity(_evidence(f"activity:{index + 1}", occurred_at=old))
+    old_day = old.date().isoformat()
+
+    results: list[CommandActivityMaintenanceResult] = []
+    while not results or not results[-1].completed:
+        results.append(store.maintain_command_activity(now=_NOW, detail_retain_days=30, batch_size=2))
+    assert all(result.detail_rows_deleted <= 2 for result in results)
+    assert sum(result.correlation_rows_deleted for result in results) == 5
+    assert store.count_command_activities() == 0
+    assert _total(store, old_day) == 5
+    assert results[-1].completed is True
+    assert store.maintain_command_activity(now=_NOW, detail_retain_days=30, batch_size=2).ran is False
+    assert store.command_activity_rollups_are_reconciled() is False
+    with pytest.raises(RuntimeError, match="after detail compaction"):
+        store.rebuild_command_activity_rollups(now=_NOW)
+
+    assert store.record_command_activity(_evidence("activity:1", occurred_at=old)) is False
+    assert store.count_command_activities() == 0
+    assert _total(store, old_day) == 5
+
+
+def test_aggregate_and_membership_retention_is_thirteen_calendar_months_and_bounded(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    cutoff = date(2025, 7, 1)
+    with sqlite3.connect(store.path) as connection:
+        for index in range(7):
+            connection.execute(
+                "insert into command_activity_daily_rollups values (?, 'harness', ?, 1)",
+                ((cutoff - timedelta(days=index + 1)).isoformat(), f"old-{index}"),
+            )
+        connection.execute("insert into command_activity_daily_totals values ('2025-06-30', 7)")
+        connection.execute("insert into command_activity_daily_totals values ('2025-07-01', 1)")
+
+    deleted: list[int] = []
+    while True:
+        result = store.maintain_command_activity(now=_NOW, detail_retain_days=30, batch_size=3)
+        deleted.append(result.aggregate_rows_deleted)
+        if result.completed:
+            break
+    assert all(count <= 3 for count in deleted)
+    assert sum(deleted) == 8
+    assert _total(store, "2025-06-30") == 0
+    assert _total(store, "2025-07-01") == 1
+
+
+def test_maintenance_failure_rolls_back_all_mutations_and_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    old = _NOW - timedelta(days=60)
+    store.record_command_activity(_evidence("activity:1", occurred_at=old))
+
+    def fail_aggregate(
+        _connection: sqlite3.Connection,
+        *,
+        now: datetime,
+        batch_size: int,
+    ) -> int:
+        del now, batch_size
+        raise RuntimeError("injected aggregate failure")
+
+    monkeypatch.setattr(activity_maintenance, "_delete_expired_aggregates", fail_aggregate)
+    with pytest.raises(RuntimeError, match="injected"):
+        store.maintain_command_activity(now=_NOW, detail_retain_days=30, batch_size=2)
+    assert store.count_command_activities() == 1
+    assert _total(store, old.date().isoformat()) == 1


### PR DESCRIPTION
## Summary
- add transactional daily command-activity rollups with explicit evaluation and persistence latency buckets
- add crash-safe, bounded legacy reconciliation, detail compaction, correlation cleanup, and 13-month aggregate retention
- run startup and daily maintenance without interfering with Guard enforcement

## Testing
- `uv run --no-sync pytest -q tests/test_guard_command_activity_contract.py tests/test_guard_command_activity_correlation.py tests/test_guard_command_activity_cursor.py tests/test_guard_command_activity_hook_integration.py tests/test_guard_command_activity_lifecycle.py tests/test_guard_command_activity_lifecycle_store.py tests/test_guard_command_activity_orchestration.py tests/test_guard_command_activity_persistence.py tests/test_guard_command_activity_privacy.py tests/test_guard_command_activity_rollups.py tests/test_guard_command_activity_maintenance_runtime.py tests/test_guard_daemon_worker_isolation.py tests/test_guard_daemon_live_sync_lifecycle.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/config.py src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/runtime/command_activity_privacy.py src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/store_command_activity.py src/codex_plugin_scanner/guard/store_command_activity_lifecycle.py src/codex_plugin_scanner/guard/store_connection_schema.py src/codex_plugin_scanner/guard/store_command_activity_maintenance.py src/codex_plugin_scanner/guard/store_command_activity_maintenance_schema.py src/codex_plugin_scanner/guard/store_command_activity_rollups.py tests/test_guard_command_activity_rollups.py tests/test_guard_command_activity_maintenance_runtime.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/config.py src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/runtime/command_activity_privacy.py src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/store_command_activity.py src/codex_plugin_scanner/guard/store_command_activity_lifecycle.py src/codex_plugin_scanner/guard/store_connection_schema.py src/codex_plugin_scanner/guard/store_command_activity_maintenance.py src/codex_plugin_scanner/guard/store_command_activity_maintenance_schema.py src/codex_plugin_scanner/guard/store_command_activity_rollups.py tests/test_guard_command_activity_rollups.py tests/test_guard_command_activity_maintenance_runtime.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/runtime/command_activity_privacy.py src/codex_plugin_scanner/guard/store_command_activity_maintenance_schema.py src/codex_plugin_scanner/guard/store_command_activity_rollups.py src/codex_plugin_scanner/guard/store_command_activity_maintenance.py tests/test_guard_command_activity_rollups.py tests/test_guard_command_activity_maintenance_runtime.py`
- `git diff --check`
