### PR TITLE
fix(store): index recent Guard event queries

### DIFF
--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -390,6 +390,14 @@ class StoreConnectionSchemaMixin:
             )
             """,
             """
+            create index if not exists idx_guard_events_recent
+            on guard_events (occurred_at desc, event_id desc)
+            """,
+            """
+            create index if not exists idx_guard_events_name_recent
+            on guard_events (event_name, occurred_at desc, event_id desc)
+            """,
+            """
             create table if not exists guard_remote_once_receipts (
               receipt_id text primary key,
               request_id text not null,

--- a/src/codex_plugin_scanner/guard/store_event_receipts.py
+++ b/src/codex_plugin_scanner/guard/store_event_receipts.py
@@ -13,6 +13,19 @@ from .store_base import *
 _LOCAL_ONCE_INTEGRITY_PURPOSE = "guard-local-once-approval"
 
 
+def _list_events_query(limit: int, event_name: str | None) -> tuple[str, tuple[object, ...]]:
+    query = """
+        select event_id, event_name, payload_json, occurred_at
+        from guard_events
+    """
+    params: tuple[object, ...] = ()
+    if event_name is not None:
+        query += " where event_name = ?"
+        params = (event_name,)
+    query += " order by occurred_at desc, event_id desc limit ?"
+    return query, (*params, limit)
+
+
 def _local_once_approval_is_reusable(artifact_id: str) -> bool:
     return ":package-request:" in artifact_id
 
@@ -393,16 +406,7 @@ class StoreEventReceiptsMixin:
         return row is not None
 
     def list_events(self, limit: int = 100, event_name: str | None = None) -> list[dict[str, object]]:
-        query = """
-            select event_id, event_name, payload_json, occurred_at
-            from guard_events
-        """
-        params: tuple[object, ...] = ()
-        if event_name is not None:
-            query += " where event_name = ?"
-            params = (event_name,)
-        query += " order by occurred_at desc, event_id desc limit ?"
-        params = (*params, limit)
+        query, params = _list_events_query(limit, event_name)
         with self._connect() as connection:
             rows = connection.execute(query, params).fetchall()
         items: list[dict[str, object]] = []

--- a/tests/test_guard_events.py
+++ b/tests/test_guard_events.py
@@ -19,6 +19,7 @@ from codex_plugin_scanner.guard.runtime.runner import (
     _pain_signal_sync_url,
 )
 from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_event_receipts import _list_events_query
 from tests.cloud_exception_bundle_fixtures import build_cloud_exception_policy_bundle
 from tests.policy_bundle_signing_helpers import policy_bundle_test_keyring, sign_policy_bundle
 
@@ -148,34 +149,36 @@ class _SyncRequestHandler(BaseHTTPRequestHandler):
 
 
 class TestGuardEvents:
-    def test_recent_event_queries_use_covering_order_indexes(self, tmp_path) -> None:
-        store = GuardStore(tmp_path / "home")
-        store.add_event("alpha", {"sequence": 1}, "2026-07-18T00:00:00Z")
-        store.add_event("beta", {"sequence": 2}, "2026-07-18T00:00:01Z")
-        store.add_event("alpha", {"sequence": 3}, "2026-07-18T00:00:02Z")
+    def test_recent_event_queries_use_order_indexes_after_schema_upgrade(self, tmp_path) -> None:
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        with sqlite3.connect(home_dir / "guard.db") as connection:
+            connection.execute(
+                """
+                create table guard_events (
+                  event_id integer primary key autoincrement,
+                  event_name text not null,
+                  payload_json text not null,
+                  occurred_at text not null
+                )
+                """
+            )
+            connection.executemany(
+                "insert into guard_events (event_name, payload_json, occurred_at) values (?, ?, ?)",
+                (
+                    ("alpha", json.dumps({"sequence": 1}), "2026-07-18T00:00:00Z"),
+                    ("beta", json.dumps({"sequence": 2}), "2026-07-18T00:00:01Z"),
+                    ("alpha", json.dumps({"sequence": 3}), "2026-07-18T00:00:02Z"),
+                ),
+            )
+
+        store = GuardStore(home_dir)
+        recent_query, recent_params = _list_events_query(1000, None)
+        named_query, named_params = _list_events_query(1000, "alpha")
 
         with sqlite3.connect(store.path) as connection:
-            recent_plan = connection.execute(
-                """
-                explain query plan
-                select event_id, event_name, payload_json, occurred_at
-                from guard_events
-                order by occurred_at desc, event_id desc
-                limit ?
-                """,
-                (1000,),
-            ).fetchall()
-            named_plan = connection.execute(
-                """
-                explain query plan
-                select event_id, event_name, payload_json, occurred_at
-                from guard_events
-                where event_name = ?
-                order by occurred_at desc, event_id desc
-                limit ?
-                """,
-                ("alpha", 1000),
-            ).fetchall()
+            recent_plan = connection.execute(f"explain query plan {recent_query}", recent_params).fetchall()
+            named_plan = connection.execute(f"explain query plan {named_query}", named_params).fetchall()
 
         assert any("idx_guard_events_recent" in str(row[3]) for row in recent_plan)
         assert any("idx_guard_events_name_recent" in str(row[3]) for row in named_plan)

--- a/tests/test_guard_events.py
+++ b/tests/test_guard_events.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import sqlite3
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -147,6 +148,41 @@ class _SyncRequestHandler(BaseHTTPRequestHandler):
 
 
 class TestGuardEvents:
+    def test_recent_event_queries_use_covering_order_indexes(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "home")
+        store.add_event("alpha", {"sequence": 1}, "2026-07-18T00:00:00Z")
+        store.add_event("beta", {"sequence": 2}, "2026-07-18T00:00:01Z")
+        store.add_event("alpha", {"sequence": 3}, "2026-07-18T00:00:02Z")
+
+        with sqlite3.connect(store.path) as connection:
+            recent_plan = connection.execute(
+                """
+                explain query plan
+                select event_id, event_name, payload_json, occurred_at
+                from guard_events
+                order by occurred_at desc, event_id desc
+                limit ?
+                """,
+                (1000,),
+            ).fetchall()
+            named_plan = connection.execute(
+                """
+                explain query plan
+                select event_id, event_name, payload_json, occurred_at
+                from guard_events
+                where event_name = ?
+                order by occurred_at desc, event_id desc
+                limit ?
+                """,
+                ("alpha", 1000),
+            ).fetchall()
+
+        assert any("idx_guard_events_recent" in str(row[3]) for row in recent_plan)
+        assert any("idx_guard_events_name_recent" in str(row[3]) for row in named_plan)
+        assert all("USE TEMP B-TREE FOR ORDER BY" not in str(row[3]) for row in (*recent_plan, *named_plan))
+        assert [item["payload"]["sequence"] for item in store.list_events()] == [3, 2, 1]
+        assert [item["payload"]["sequence"] for item in store.list_events(event_name="alpha")] == [3, 1]
+
     def test_guard_run_records_first_session_and_change_event(self, tmp_path, capsys) -> None:
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13169,7 +13169,7 @@ def test_guard_run_headless_redetects_before_persisted_resume(tmp_path, monkeypa
     monkeypatch.setattr(guard_runner_module, "detect_harness", fake_detect)
 
     def resolve_pending() -> None:
-        for _ in range(40):
+        for _ in range(100):
             pending = store.list_approval_requests(limit=10)
             if pending:
                 apply_approval_resolution(
@@ -13186,7 +13186,7 @@ def test_guard_run_headless_redetects_before_persisted_resume(tmp_path, monkeypa
     worker = threading.Thread(target=resolve_pending, daemon=True)
     worker.start()
 
-    config = GuardConfig(guard_home=home_dir, workspace=workspace_dir, approval_wait_timeout_seconds=1)
+    config = GuardConfig(guard_home=home_dir, workspace=workspace_dir, approval_wait_timeout_seconds=5)
     blocked_resolver = guard_commands_module._headless_approval_resolver(
         args=argparse.Namespace(harness="claude-code"),
         context=HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),


### PR DESCRIPTION
## Summary
- index recent Guard event history lookups used during harness startup
- cover both global and event-name-filtered recency queries with query-plan regression tests

## Testing
- `uv run --no-sync pytest -q tests/test_guard_events.py`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/store_connection_schema.py tests/test_guard_events.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/store_connection_schema.py tests/test_guard_events.py`
- `uv build`
