### PR TITLE
feat(guard): add command activity APIs

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/command_activity_api.py
+++ b/src/codex_plugin_scanner/guard/daemon/command_activity_api.py
@@ -9,6 +9,7 @@ import base64
 import hashlib
 import hmac
 import json
+import threading
 import time
 from collections.abc import Mapping
 from datetime import date, datetime, timezone
@@ -191,6 +192,7 @@ class _Writable(Protocol):
 
 class _ApiServer(Protocol):
     auth_token: str
+    shutdown_started: threading.Event
     store: GuardStore
 
 
@@ -300,7 +302,7 @@ def stream_command_activity_events(handler: object, cursor: int) -> None:
         target.end_headers()
         next_cursor = max(0, cursor)
         deadline = time.monotonic() + _COMMAND_ACTIVITY_STREAM_MAX_SECONDS
-        while time.monotonic() < deadline:
+        while time.monotonic() < deadline and not target.server.shutdown_started.is_set():
             target._touch_runtime_heartbeat("/v1/command-activity/events")
             page = target.server.store.list_command_activity_invalidations(next_cursor, limit=100)
             reset_required = page.get("reset_required")
@@ -338,7 +340,8 @@ def stream_command_activity_events(handler: object, cursor: int) -> None:
                     target.wfile.flush()
                 except (BrokenPipeError, ConnectionResetError):
                     return
-            time.sleep(0.5)
+            if target.server.shutdown_started.wait(0.5):
+                return
     finally:
         target._decrement_active_stream_clients()
 
@@ -425,15 +428,23 @@ def _verified_cursor(cursor: str, *, auth_token: str) -> dict[str, object]:
         if prefix != _CURSOR_PREFIX or not encoded or not signature:
             raise ValueError
         expected = hmac.new(auth_token.encode("utf-8"), encoded.encode("ascii"), hashlib.sha256).digest()
-        supplied = base64.urlsafe_b64decode(signature + "=" * (-len(signature) % 4))
+        supplied = _decode_base64url_canonical(signature)
         if not hmac.compare_digest(supplied, expected):
             raise ValueError
-        raw = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+        raw = _decode_base64url_canonical(encoded)
         decoded: object = json.loads(raw)
     except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as error:
         raise ValueError("invalid_cursor") from error
     if not _is_string_object_dict(decoded):
         raise ValueError("invalid_cursor")
+    return decoded
+
+
+def _decode_base64url_canonical(value: str) -> bytes:
+    decoded = base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+    canonical = base64.urlsafe_b64encode(decoded).decode("ascii").rstrip("=")
+    if not hmac.compare_digest(value, canonical):
+        raise ValueError
     return decoded
 
 

--- a/src/codex_plugin_scanner/guard/daemon/command_activity_api.py
+++ b/src/codex_plugin_scanner/guard/daemon/command_activity_api.py
@@ -1,0 +1,452 @@
+"""Validation and cursor helpers for local command-activity routes."""
+
+# pyright: reportAny=false, reportPrivateUsage=false, reportUnknownArgumentType=false
+# pyright: reportUnknownVariableType=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from collections.abc import Mapping
+from datetime import date, datetime, timezone
+from typing import Final, Protocol, TypeGuard, cast
+from urllib.parse import parse_qsl
+
+from ..runtime.command_activity_api_contract import (
+    COMMAND_ACTIVITY_API_SCHEMA_VERSION,
+    COMMAND_ACTIVITY_PAGE_DEFAULT,
+    CommandActivityAnalyticsQuery,
+    CommandActivityFeedbackLabel,
+    CommandActivityListQuery,
+)
+from ..runtime.command_extensions import (
+    BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+    COMMAND_EXTENSION_SCHEMA_VERSION,
+    CommandSafetyExtension,
+)
+from ..store import GuardStore
+from ..store_command_activity_api import CommandActivityNotFoundError
+
+_CURSOR_PREFIX: Final = "gca1"
+_LIST_QUERY_KEYS: Final = frozenset(
+    {
+        "limit",
+        "cursor",
+        "harness",
+        "execution_status",
+        "proof_level",
+        "prompted",
+        "approval_reuse_status",
+        "extension_id",
+        "rule_id",
+        "occurred_from",
+        "occurred_through",
+    }
+)
+_ANALYTICS_QUERY_KEYS: Final = frozenset({"days", "top_limit", "dimension", "dimension_value"})
+_EXTENSION_QUERY_KEYS: Final = frozenset({"limit", "cursor"})
+_EVENT_QUERY_KEYS: Final = frozenset({"cursor"})
+_COMMAND_ACTIVITY_STREAM_MAX_CLIENTS: Final = 8
+_COMMAND_ACTIVITY_STREAM_MAX_SECONDS: Final = 300.0
+
+
+def parse_command_activity_list_query(query_string: str) -> tuple[CommandActivityListQuery, str | None]:
+    query = _single_query_values(query_string, allowed=_LIST_QUERY_KEYS)
+    prompted = None
+    if "prompted" in query:
+        if query["prompted"] not in {"true", "false"}:
+            raise ValueError("invalid_prompted")
+        prompted = query["prompted"] == "true"
+    return (
+        CommandActivityListQuery(
+            limit=_bounded_int(query.get("limit"), default=COMMAND_ACTIVITY_PAGE_DEFAULT),
+            harness=query.get("harness"),
+            execution_status=query.get("execution_status"),
+            proof_level=query.get("proof_level"),
+            prompted=prompted,
+            approval_reuse_status=query.get("approval_reuse_status"),
+            extension_id=query.get("extension_id"),
+            rule_id=query.get("rule_id"),
+            occurred_from=_optional_date(query.get("occurred_from"), "invalid_occurred_from"),
+            occurred_through=_optional_date(query.get("occurred_through"), "invalid_occurred_through"),
+        ),
+        query.get("cursor"),
+    )
+
+
+def parse_command_activity_analytics_query(query_string: str) -> CommandActivityAnalyticsQuery:
+    query = _single_query_values(query_string, allowed=_ANALYTICS_QUERY_KEYS)
+    return CommandActivityAnalyticsQuery(
+        days=_bounded_int(query.get("days"), default=90),
+        top_limit=_bounded_int(query.get("top_limit"), default=10),
+        dimension=query.get("dimension"),
+        dimension_value=query.get("dimension_value"),
+    )
+
+
+def parse_command_activity_event_cursor(query_string: str, *, last_event_id: str | None) -> int:
+    query = _single_query_values(query_string, allowed=_EVENT_QUERY_KEYS)
+    candidate = (
+        last_event_id.strip() if isinstance(last_event_id, str) and last_event_id.strip() else query.get("cursor", "0")
+    )
+    if not candidate.isascii() or not candidate.isdigit():
+        raise ValueError("invalid_cursor")
+    cursor = int(candidate)
+    if cursor > 9_223_372_036_854_775_807:
+        raise ValueError("invalid_cursor")
+    return cursor
+
+
+def encode_activity_cursor(
+    marker: tuple[str, str],
+    *,
+    query: CommandActivityListQuery,
+    auth_token: str,
+) -> str:
+    payload: dict[str, object] = {
+        "binding": list(query.binding()),
+        "occurred_at": marker[0],
+        "activity_id": marker[1],
+        "version": COMMAND_ACTIVITY_API_SCHEMA_VERSION,
+    }
+    return _signed_cursor(payload, auth_token=auth_token)
+
+
+def decode_activity_cursor(
+    cursor: str,
+    *,
+    query: CommandActivityListQuery,
+    auth_token: str,
+) -> tuple[str, str]:
+    payload = _verified_cursor(cursor, auth_token=auth_token)
+    if (
+        payload.get("version") != COMMAND_ACTIVITY_API_SCHEMA_VERSION
+        or payload.get("binding") != list(query.binding())
+        or not isinstance(payload.get("occurred_at"), str)
+        or not isinstance(payload.get("activity_id"), str)
+    ):
+        raise ValueError("invalid_cursor")
+    return str(payload["occurred_at"]), str(payload["activity_id"])
+
+
+def command_extensions_page(query_string: str, *, auth_token: str) -> dict[str, object]:
+    query = _single_query_values(query_string, allowed=_EXTENSION_QUERY_KEYS)
+    limit = _bounded_int(query.get("limit"), default=50)
+    if not 1 <= limit <= 100:
+        raise ValueError("limit_out_of_range")
+    after = None
+    cursor = query.get("cursor")
+    if cursor is not None:
+        payload = _verified_cursor(cursor, auth_token=auth_token)
+        if payload.get("kind") != "extensions" or not isinstance(payload.get("after"), str):
+            raise ValueError("invalid_cursor")
+        after = str(payload["after"])
+    extensions = BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions
+    if after is not None:
+        extensions = tuple(extension for extension in extensions if extension.extension_id > after)
+    page = extensions[:limit]
+    next_cursor = None
+    if len(extensions) > limit and page:
+        next_cursor = _signed_cursor(
+            {"kind": "extensions", "after": page[-1].extension_id},
+            auth_token=auth_token,
+        )
+    return {
+        "schema_version": COMMAND_EXTENSION_SCHEMA_VERSION,
+        "source": "built-in",
+        "items": [_extension_payload(extension) for extension in page],
+        "next_cursor": next_cursor,
+    }
+
+
+def parse_feedback_payload(payload: dict[str, object]) -> tuple[str, CommandActivityFeedbackLabel]:
+    if set(payload) != {"activity_id", "label"}:
+        raise ValueError("invalid_feedback_payload")
+    activity_id = payload.get("activity_id")
+    label = payload.get("label")
+    if not isinstance(activity_id, str) or not activity_id or len(activity_id) > 256:
+        raise ValueError("invalid_activity_id")
+    if not isinstance(label, str):
+        raise ValueError("invalid_feedback_label")
+    try:
+        feedback_label = CommandActivityFeedbackLabel(label)
+    except ValueError as error:
+        raise ValueError("invalid_feedback_label") from error
+    return activity_id, feedback_label
+
+
+class _Writable(Protocol):
+    def write(self, value: bytes) -> object: ...
+
+    def flush(self) -> object: ...
+
+
+class _ApiServer(Protocol):
+    auth_token: str
+    store: GuardStore
+
+
+class _Handler(Protocol):
+    server: _ApiServer
+    wfile: _Writable
+
+    def _write_json(self, payload: dict[str, object], *, status: int = 200) -> None: ...
+
+    def _cors_headers_for_request(self, *, allow_methods: str = "GET, POST, OPTIONS") -> dict[str, str] | None: ...
+
+    def _validated_headers(self, extra_headers: dict[str, str] | None) -> dict[str, str]: ...
+
+    def _touch_runtime_heartbeat(self, path: str) -> None: ...
+
+    def _increment_active_stream_clients(self) -> None: ...
+
+    def _try_increment_active_stream_clients(self, maximum: int) -> bool: ...
+
+    def _decrement_active_stream_clients(self) -> None: ...
+
+    def send_response(self, code: int, message: str | None = None) -> None: ...
+
+    def send_header(self, keyword: str, value: str) -> None: ...
+
+    def end_headers(self) -> None: ...
+
+
+def handle_command_activity_list(handler: object, query_string: str) -> None:
+    target = cast(_Handler, handler)
+    try:
+        query, encoded_cursor = parse_command_activity_list_query(query_string)
+        cursor = (
+            decode_activity_cursor(encoded_cursor, query=query, auth_token=target.server.auth_token)
+            if encoded_cursor is not None
+            else None
+        )
+        page = target.server.store.list_command_activity_page(query, cursor=cursor)
+        marker = page.pop("next_marker", None)
+        if isinstance(marker, tuple) and len(marker) == 2 and all(isinstance(item, str) for item in marker):
+            typed_marker = (cast(str, marker[0]), cast(str, marker[1]))
+            page["next_cursor"] = encode_activity_cursor(
+                typed_marker,
+                query=query,
+                auth_token=target.server.auth_token,
+            )
+        else:
+            page["next_cursor"] = None
+    except ValueError as error:
+        target._write_json({"error": str(error)}, status=400)
+        return
+    target._write_json(page)
+
+
+def handle_command_activity_analytics(handler: object, query_string: str) -> None:
+    target = cast(_Handler, handler)
+    try:
+        query = parse_command_activity_analytics_query(query_string)
+        payload = target.server.store.command_activity_analytics(query, as_of=datetime.now(timezone.utc).date())
+    except ValueError as error:
+        target._write_json({"error": str(error)}, status=400)
+        return
+    target._write_json(payload)
+
+
+def handle_command_extensions(handler: object, query_string: str) -> None:
+    target = cast(_Handler, handler)
+    try:
+        payload = command_extensions_page(query_string, auth_token=target.server.auth_token)
+    except ValueError as error:
+        target._write_json({"error": str(error)}, status=400)
+        return
+    target._write_json(payload)
+
+
+def handle_command_activity_feedback(handler: object, payload: dict[str, object]) -> None:
+    target = cast(_Handler, handler)
+    try:
+        activity_id, label = parse_feedback_payload(payload)
+        response = target.server.store.record_command_activity_feedback(
+            activity_id=activity_id,
+            label=label,
+            recorded_at=datetime.now(timezone.utc),
+        )
+    except CommandActivityNotFoundError:
+        target._write_json({"error": "activity_not_found"}, status=404)
+        return
+    except ValueError as error:
+        target._write_json({"error": str(error)}, status=400)
+        return
+    target._write_json(response)
+
+
+def stream_command_activity_events(handler: object, cursor: int) -> None:
+    target = cast(_Handler, handler)
+    if not target._try_increment_active_stream_clients(_COMMAND_ACTIVITY_STREAM_MAX_CLIENTS):
+        target._write_json({"error": "too_many_streams"}, status=429)
+        return
+    try:
+        target.send_response(200)
+        target.send_header("Content-Type", "text/event-stream")
+        target.send_header("Cache-Control", "no-cache")
+        target.send_header("Connection", "keep-alive")
+        cors_headers = target._cors_headers_for_request(allow_methods="GET, OPTIONS")
+        for key, value in target._validated_headers(cors_headers).items():
+            target.send_header(key, value)
+        target.end_headers()
+        next_cursor = max(0, cursor)
+        deadline = time.monotonic() + _COMMAND_ACTIVITY_STREAM_MAX_SECONDS
+        while time.monotonic() < deadline:
+            target._touch_runtime_heartbeat("/v1/command-activity/events")
+            page = target.server.store.list_command_activity_invalidations(next_cursor, limit=100)
+            reset_required = page.get("reset_required")
+            reset_cursor = page.get("reset_cursor")
+            if reset_required is True and isinstance(reset_cursor, int):
+                next_cursor = reset_cursor
+                reset_body = json.dumps(
+                    {"event": "command_activity_reset", "reset_required": True},
+                    separators=(",", ":"),
+                )
+                try:
+                    target.wfile.write(
+                        f"id: {reset_cursor}\nevent: command_activity_reset\ndata: {reset_body}\n\n".encode()
+                    )
+                    target.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    return
+            items = page.get("items")
+            if not isinstance(items, list):
+                items = []
+            for item in items:
+                if not _is_string_object_dict(item):
+                    continue
+                sequence = item.get("sequence")
+                activity_id = item.get("activity_id")
+                if not isinstance(sequence, int) or not isinstance(activity_id, str):
+                    continue
+                next_cursor = sequence
+                body = json.dumps(
+                    {"event": "command_activity_invalidated", "activity_id": activity_id},
+                    separators=(",", ":"),
+                )
+                try:
+                    target.wfile.write(f"id: {sequence}\ndata: {body}\n\n".encode())
+                    target.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    return
+            time.sleep(0.5)
+    finally:
+        target._decrement_active_stream_clients()
+
+
+def _extension_payload(extension: CommandSafetyExtension) -> dict[str, object]:
+    return {
+        "extension_id": extension.extension_id,
+        "version": extension.version,
+        "name": extension.name,
+        "description": extension.description,
+        "enabled": True,
+        "required": extension.required,
+        "source": extension.source,
+        "dependencies": list(extension.dependencies),
+        "conflicts": list(extension.conflicts),
+        "delegated_protection": extension.delegated_protection,
+        "action_classes": list(extension.action_classes),
+        "risk_classes": list(extension.risk_classes),
+        "rule_count": len(extension.rules),
+        "rules": [
+            {
+                "rule_id": rule.rule_id,
+                "title": rule.title,
+                "description": rule.description,
+                "severity": rule.severity,
+                "risk_classes": list(rule.risk_classes),
+                "action_classes": list(rule.action_classes),
+                "default_mode": rule.default_mode,
+                "safe_variant_ids": [variant.variant_id for variant in rule.safe_variants],
+                "compatibility_fallback": rule.compatibility_fallback,
+            }
+            for rule in extension.rules
+        ],
+    }
+
+
+def _single_query_values(query_string: str, *, allowed: frozenset[str]) -> dict[str, str]:
+    if len(query_string) > 8_192:
+        raise ValueError("query_too_long")
+    values: dict[str, str] = {}
+    for key, value in parse_qsl(query_string, keep_blank_values=True, strict_parsing=False):
+        if key not in allowed:
+            raise ValueError("unknown_query_parameter")
+        if key in values or not value:
+            raise ValueError("invalid_query_parameter")
+        values[key] = value
+    return values
+
+
+def _bounded_int(value: str | None, *, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError as error:
+        raise ValueError("invalid_integer") from error
+
+
+def _optional_date(value: str | None, error_code: str) -> date | None:
+    if value is None:
+        return None
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as error:
+        raise ValueError(error_code) from error
+    if parsed.isoformat() != value:
+        raise ValueError(error_code)
+    return parsed
+
+
+def _signed_cursor(payload: Mapping[str, object], *, auth_token: str) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    encoded = base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+    signature = hmac.new(auth_token.encode("utf-8"), encoded.encode("ascii"), hashlib.sha256).digest()
+    encoded_signature = base64.urlsafe_b64encode(signature).decode("ascii").rstrip("=")
+    return f"{_CURSOR_PREFIX}.{encoded}.{encoded_signature}"
+
+
+def _verified_cursor(cursor: str, *, auth_token: str) -> dict[str, object]:
+    if len(cursor) > 2_048:
+        raise ValueError("invalid_cursor")
+    try:
+        prefix, encoded, signature = cursor.split(".")
+        if prefix != _CURSOR_PREFIX or not encoded or not signature:
+            raise ValueError
+        expected = hmac.new(auth_token.encode("utf-8"), encoded.encode("ascii"), hashlib.sha256).digest()
+        supplied = base64.urlsafe_b64decode(signature + "=" * (-len(signature) % 4))
+        if not hmac.compare_digest(supplied, expected):
+            raise ValueError
+        raw = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+        decoded: object = json.loads(raw)
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("invalid_cursor") from error
+    if not _is_string_object_dict(decoded):
+        raise ValueError("invalid_cursor")
+    return decoded
+
+
+def _is_string_object_dict(value: object) -> TypeGuard[dict[str, object]]:
+    return isinstance(value, dict) and all(isinstance(key, str) for key in value)
+
+
+__all__ = (
+    "command_extensions_page",
+    "decode_activity_cursor",
+    "encode_activity_cursor",
+    "handle_command_activity_analytics",
+    "handle_command_activity_feedback",
+    "handle_command_activity_list",
+    "handle_command_extensions",
+    "parse_command_activity_analytics_query",
+    "parse_command_activity_event_cursor",
+    "parse_command_activity_list_query",
+    "parse_feedback_payload",
+    "stream_command_activity_events",
+)

--- a/src/codex_plugin_scanner/guard/daemon/command_activity_api.py
+++ b/src/codex_plugin_scanner/guard/daemon/command_activity_api.py
@@ -144,7 +144,12 @@ def command_extensions_page(query_string: str, *, auth_token: str) -> dict[str, 
         if payload.get("kind") != "extensions" or not isinstance(payload.get("after"), str):
             raise ValueError("invalid_cursor")
         after = str(payload["after"])
-    extensions = BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions
+    extensions = tuple(
+        sorted(
+            BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions,
+            key=lambda extension: extension.extension_id,
+        )
+    )
     if after is not None:
         extensions = tuple(extension for extension in extensions if extension.extension_id > after)
     page = extensions[:limit]

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -178,6 +178,14 @@ from ..store_evidence import (
     export_evidence_json,
     list_evidence,
 )
+from .command_activity_api import (
+    handle_command_activity_analytics,
+    handle_command_activity_feedback,
+    handle_command_activity_list,
+    handle_command_extensions,
+    parse_command_activity_event_cursor,
+    stream_command_activity_events,
+)
 from .command_queue_worker import CommandQueueWorker, start_command_queue_worker, stop_command_queue_worker
 from .dashboard_update import merge_dashboard_update_progress, schedule_guard_dashboard_update
 from .discovery import (
@@ -1326,7 +1334,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         headers = self._cors_headers_for_request(
             allow_methods="GET, POST, DELETE, OPTIONS",
-            allow_headers="Authorization, Content-Type, X-Guard-Dashboard-Session, X-Guard-Token",
+            allow_headers=("Authorization, Content-Type, Last-Event-ID, X-Guard-Dashboard-Session, X-Guard-Token"),
         )
         if headers is None:
             self._write_empty(status=403)
@@ -1359,6 +1367,24 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 self._write_unauthorized(extra_headers=self._cors_headers_for_request())
                 return
             self._stream_events(_int_query_value(parsed.query, "cursor"))
+            return
+        if parsed.path == "/v1/command-activity/events":
+            if self._query_has_guard_token(parsed.query):
+                self._record_query_token_rejection()
+                self._write_unauthorized(extra_headers=self._cors_headers_for_request())
+                return
+            if not self._header_token_is_valid():
+                self._write_unauthorized(extra_headers=self._cors_headers_for_request())
+                return
+            try:
+                cursor = parse_command_activity_event_cursor(
+                    parsed.query,
+                    last_event_id=self.headers.get("Last-Event-ID"),
+                )
+            except ValueError as error:
+                self._write_json({"error": str(error)}, status=400)
+                return
+            stream_command_activity_events(self, cursor)
             return
         if parsed.path.startswith("/v1/") and not self._header_token_is_valid():
             self._write_unauthorized(extra_headers=self._cors_headers_for_request())
@@ -1476,6 +1502,15 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/v1/requests":
             self._handle_requests_list(parsed.query)
+            return
+        if parsed.path == "/v1/command-activity":
+            handle_command_activity_list(self, parsed.query)
+            return
+        if parsed.path == "/v1/command-activity/analytics":
+            handle_command_activity_analytics(self, parsed.query)
+            return
+        if parsed.path == "/v1/command-extensions":
+            handle_command_extensions(self, parsed.query)
             return
         if parsed.path == "/v1/connect/state":
             self._write_legacy_pairing_disabled()
@@ -1758,6 +1793,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/v1/initialize":
             self._handle_initialize(payload)
+            return
+        if parsed.path == "/v1/command-activity/feedback":
+            handle_command_activity_feedback(self, payload)
             return
         if len(path_parts) == 3 and path_parts[:2] == ["v1", "hooks"]:
             self._handle_runtime_hook(payload, parsed.query, default_harness=path_parts[2])
@@ -4775,6 +4813,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/settings/export",
             "/v1/events",
             "/v1/events/stream",
+            "/v1/command-activity",
+            "/v1/command-activity/analytics",
+            "/v1/command-activity/events",
+            "/v1/command-activity/feedback",
+            "/v1/command-extensions",
             "/v1/requests",
             "/v1/receipts",
             "/v1/receipts/analytics",
@@ -4996,6 +5039,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         with self.server.active_stream_clients_lock:  # type: ignore[attr-defined]
             self.server.active_stream_clients += 1  # type: ignore[attr-defined]
 
+    def _try_increment_active_stream_clients(self, maximum: int) -> bool:
+        with self.server.active_stream_clients_lock:  # type: ignore[attr-defined]
+            if self.server.active_stream_clients >= maximum:  # type: ignore[attr-defined]
+                return False
+            self.server.active_stream_clients += 1  # type: ignore[attr-defined]
+            return True
+
     def _decrement_active_stream_clients(self) -> None:
         with self.server.active_stream_clients_lock:  # type: ignore[attr-defined]
             self.server.active_stream_clients = max(0, self.server.active_stream_clients - 1)  # type: ignore[attr-defined]
@@ -5063,6 +5113,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/daemon/repair",
             "/v1/evidence",
             "/v1/evidence/export",
+            "/v1/command-activity",
+            "/v1/command-activity/analytics",
+            "/v1/command-activity/events",
+            "/v1/command-activity/feedback",
+            "/v1/command-extensions",
             "/v1/harnesses",
             "/v1/notifications/setup",
             "/v1/policy",
@@ -5478,6 +5533,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/cloud/connect",
             "/v1/notifications/setup",
             "/v1/update",
+            "/v1/command-activity/feedback",
         }:
             return True
         if len(path_parts) >= 3 and path_parts[:2] == ["v1", "hooks"]:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -283,6 +283,7 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
     start_monotonic: float
     active_stream_clients: int
     active_stream_clients_lock: threading.Lock
+    shutdown_started: threading.Event
     package_firewall_connect_state: dict[str, object] | None
     package_firewall_connect_state_lock: threading.Lock
     guard_cloud_connect_state: dict[str, object] | None
@@ -306,6 +307,7 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
         runtime_session_id: str,
         runtime_started_at: str,
         idle_timeout_seconds: float | None,
+        shutdown_started: threading.Event,
     ) -> None:
         super().__init__(server_address, handler_class)
         self.store = store
@@ -319,6 +321,7 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
         self.start_monotonic = time.monotonic()
         self.active_stream_clients = 0
         self.active_stream_clients_lock = threading.Lock()
+        self.shutdown_started = shutdown_started
         self.package_firewall_connect_state = None
         self.package_firewall_connect_state_lock = threading.Lock()
         self.guard_cloud_connect_state = None
@@ -5703,6 +5706,7 @@ class GuardDaemonServer:
         workspace_dir: Path | None = None,
     ) -> None:
         _validate_dashboard_bundle()
+        self._shutdown_started = threading.Event()
         self._server = _GuardDaemonHttpServer(
             (host, port),
             _GuardDaemonHandler,
@@ -5715,6 +5719,7 @@ class GuardDaemonServer:
                 store.guard_home,
                 idle_timeout_seconds=idle_timeout_seconds,
             ),
+            shutdown_started=self._shutdown_started,
         )
         self.port = self._server.daemon_port()
         self._bundle_refresh_backoff_seconds = bundle_refresh_backoff_seconds
@@ -5736,7 +5741,6 @@ class GuardDaemonServer:
         self._live_request_sync_worker: LiveRequestSyncWorker | None = None
         self._thread: threading.Thread | None = None
         self._watchdog_thread: threading.Thread | None = None
-        self._shutdown_started = threading.Event()
 
     def start(self) -> None:
         if self._thread is not None and self._thread.is_alive():

--- a/src/codex_plugin_scanner/guard/runtime/command_activity_api_contract.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_activity_api_contract.py
@@ -1,0 +1,135 @@
+"""Strict local API contracts for privacy-safe command activity."""
+
+# pyright: reportAny=false, reportUnnecessaryIsInstance=false
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+from typing import Final, cast
+
+from .command_activity_contract import (
+    COMMAND_ACTIVITY_HARNESSES,
+    ActivityApprovalReuseStatus,
+    CommandExecutionStatus,
+    CommandProofLevel,
+)
+
+COMMAND_ACTIVITY_API_SCHEMA_VERSION: Final = "guard.command-activity-api.v1"
+COMMAND_ACTIVITY_PAGE_DEFAULT: Final = 50
+COMMAND_ACTIVITY_PAGE_MAX: Final = 100
+COMMAND_ACTIVITY_ANALYTICS_DAYS_MAX: Final = 397
+COMMAND_ACTIVITY_ANALYTICS_TOP_MAX: Final = 50
+_STABLE_ID: Final[re.Pattern[str]] = re.compile(r"[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*")
+
+
+class CommandActivityFeedbackLabel(str, Enum):
+    SHOULD_NOT_HAVE_INTERRUPTED = "should_not_have_interrupted"
+    EXPECTED_GUARD_TO_STOP_THIS = "expected_guard_to_stop_this"
+
+
+@dataclass(frozen=True, slots=True)
+class CommandActivityListQuery:
+    limit: int = COMMAND_ACTIVITY_PAGE_DEFAULT
+    harness: str | None = None
+    execution_status: str | None = None
+    proof_level: str | None = None
+    prompted: bool | None = None
+    approval_reuse_status: str | None = None
+    extension_id: str | None = None
+    rule_id: str | None = None
+    occurred_from: date | None = None
+    occurred_through: date | None = None
+
+    def __post_init__(self) -> None:
+        if type(self.limit) is not int or not 1 <= self.limit <= COMMAND_ACTIVITY_PAGE_MAX:
+            raise ValueError("limit_out_of_range")
+        if self.harness is not None and self.harness not in COMMAND_ACTIVITY_HARNESSES:
+            raise ValueError("invalid_harness")
+        _require_optional_enum(self.execution_status, CommandExecutionStatus, "invalid_execution_status")
+        _require_optional_enum(self.proof_level, CommandProofLevel, "invalid_proof_level")
+        if self.prompted is not None and type(self.prompted) is not bool:
+            raise ValueError("invalid_prompted")
+        _require_optional_enum(
+            self.approval_reuse_status,
+            ActivityApprovalReuseStatus,
+            "invalid_approval_reuse_status",
+        )
+        _require_optional_stable_id(self.extension_id, "invalid_extension_id")
+        _require_optional_stable_id(self.rule_id, "invalid_rule_id")
+        if self.occurred_from is not None and type(cast(object, self.occurred_from)) is not date:
+            raise ValueError("invalid_occurred_from")
+        if self.occurred_through is not None and type(cast(object, self.occurred_through)) is not date:
+            raise ValueError("invalid_occurred_through")
+        if (
+            self.occurred_from is not None
+            and self.occurred_through is not None
+            and self.occurred_from > self.occurred_through
+        ):
+            raise ValueError("invalid_date_range")
+        if (
+            self.occurred_from is not None
+            and self.occurred_through is not None
+            and (self.occurred_through - self.occurred_from).days >= COMMAND_ACTIVITY_ANALYTICS_DAYS_MAX
+        ):
+            raise ValueError("date_range_out_of_range")
+
+    def binding(self) -> tuple[object, ...]:
+        return (
+            self.harness,
+            self.execution_status,
+            self.proof_level,
+            self.prompted,
+            self.approval_reuse_status,
+            self.extension_id,
+            self.rule_id,
+            self.occurred_from.isoformat() if self.occurred_from else None,
+            self.occurred_through.isoformat() if self.occurred_through else None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CommandActivityAnalyticsQuery:
+    days: int = 90
+    top_limit: int = 10
+    dimension: str | None = None
+    dimension_value: str | None = None
+
+    def __post_init__(self) -> None:
+        if type(self.days) is not int or not 1 <= self.days <= COMMAND_ACTIVITY_ANALYTICS_DAYS_MAX:
+            raise ValueError("days_out_of_range")
+        if type(self.top_limit) is not int or not 1 <= self.top_limit <= COMMAND_ACTIVITY_ANALYTICS_TOP_MAX:
+            raise ValueError("top_limit_out_of_range")
+        if (self.dimension is None) != (self.dimension_value is None):
+            raise ValueError("incomplete_dimension_filter")
+        if self.dimension is not None and self.dimension not in {"harness", "extension", "rule"}:
+            raise ValueError("invalid_dimension")
+        _require_optional_stable_id(self.dimension_value, "invalid_dimension_value")
+        if self.dimension == "harness" and self.dimension_value not in COMMAND_ACTIVITY_HARNESSES:
+            raise ValueError("invalid_harness")
+
+
+def _require_optional_enum(value: str | None, enum_type: type[Enum], error: str) -> None:
+    if value is None:
+        return
+    if not isinstance(value, str) or value not in {str(item.value) for item in enum_type}:
+        raise ValueError(error)
+
+
+def _require_optional_stable_id(value: str | None, error: str) -> None:
+    if value is not None and (not isinstance(value, str) or len(value) > 256 or _STABLE_ID.fullmatch(value) is None):
+        raise ValueError(error)
+
+
+__all__ = (
+    "COMMAND_ACTIVITY_ANALYTICS_DAYS_MAX",
+    "COMMAND_ACTIVITY_ANALYTICS_TOP_MAX",
+    "COMMAND_ACTIVITY_API_SCHEMA_VERSION",
+    "COMMAND_ACTIVITY_PAGE_DEFAULT",
+    "COMMAND_ACTIVITY_PAGE_MAX",
+    "CommandActivityAnalyticsQuery",
+    "CommandActivityFeedbackLabel",
+    "CommandActivityListQuery",
+)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -13,6 +13,7 @@ from .store_base import (
 from .store_approval_facade import StoreApprovalsMixin
 from .store_cloud_events import StoreCloudEventsMixin
 from .store_command_activity import StoreCommandActivityMixin
+from .store_command_activity_api import StoreCommandActivityApiMixin
 from .store_command_activity_lifecycle import StoreCommandActivityLifecycleMixin
 from .store_command_activity_maintenance import StoreCommandActivityMaintenanceMixin
 from .store_connection_schema import StoreConnectionSchemaMixin
@@ -36,6 +37,7 @@ class GuardStore(
     StoreSecretPolicyIntegrityMixin,
     StoreConnectionSchemaMixin,
     StoreCommandActivityMixin,
+    StoreCommandActivityApiMixin,
     StoreCommandActivityLifecycleMixin,
     StoreCommandActivityMaintenanceMixin,
     StoreInventoryMixin,

--- a/src/codex_plugin_scanner/guard/store_command_activity_api.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_api.py
@@ -1,0 +1,439 @@
+"""Bounded queries and feedback for the local command-activity API."""
+
+# pyright: reportAny=false, reportImplicitStringConcatenation=false, reportPrivateUsage=false
+# pyright: reportUnnecessaryIsInstance=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Sequence
+from contextlib import AbstractContextManager
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Protocol, cast
+
+from .runtime.command_activity_api_contract import (
+    COMMAND_ACTIVITY_API_SCHEMA_VERSION,
+    CommandActivityAnalyticsQuery,
+    CommandActivityFeedbackLabel,
+    CommandActivityListQuery,
+)
+
+
+class CommandActivityNotFoundError(ValueError):
+    pass
+
+
+class _ConnectionOwner(Protocol):
+    def _connect(self) -> AbstractContextManager[sqlite3.Connection]: ...
+
+
+class StoreCommandActivityApiMixin:
+    def list_command_activity_page(
+        self: _ConnectionOwner,
+        query: CommandActivityListQuery,
+        *,
+        cursor: tuple[str, str] | None = None,
+    ) -> dict[str, object]:
+        if not isinstance(cast(object, query), CommandActivityListQuery):
+            raise ValueError("invalid_query")
+        sql, params = _activity_page_query(query, cursor=cursor)
+        with self._connect() as connection:
+            connection.execute("begin")
+            rows = cast(list[sqlite3.Row], connection.execute(sql, params).fetchall())
+            page_rows = rows[: query.limit]
+            items = _activity_items(connection, page_rows)
+        next_marker = None
+        if len(rows) > query.limit and page_rows:
+            last = page_rows[-1]
+            next_marker = (str(last["occurred_at"]), str(last["activity_id"]))
+        return {
+            "schema_version": COMMAND_ACTIVITY_API_SCHEMA_VERSION,
+            "items": items,
+            "next_marker": next_marker,
+        }
+
+    def command_activity_analytics(
+        self: _ConnectionOwner,
+        query: CommandActivityAnalyticsQuery,
+        *,
+        as_of: date,
+    ) -> dict[str, object]:
+        if not isinstance(cast(object, query), CommandActivityAnalyticsQuery):
+            raise ValueError("invalid_query")
+        if type(cast(object, as_of)) is not date:
+            raise ValueError("invalid_as_of")
+        start = as_of - timedelta(days=query.days - 1)
+        with self._connect() as connection:
+            connection.execute("begin")
+            trend = _analytics_trend(connection, query, start=start, end=as_of)
+            dimensions = {
+                dimension: _top_dimension(
+                    connection,
+                    dimension,
+                    start=start,
+                    end=as_of,
+                    limit=query.top_limit,
+                )
+                for dimension in (
+                    "harness",
+                    "extension",
+                    "rule",
+                    "disposition",
+                    "execution_status",
+                    "prompt_status",
+                    "proof_level",
+                    "latency",
+                )
+            }
+            feedback = _feedback_counts(connection, query=query, start=start, end=as_of)
+            health = _health_payload(connection)
+        total = sum(cast(int, item["count"]) for item in trend)
+        return {
+            "schema_version": COMMAND_ACTIVITY_API_SCHEMA_VERSION,
+            "window": {"from": start.isoformat(), "through": as_of.isoformat(), "days": query.days},
+            "scope": {
+                "dimension": query.dimension,
+                "dimension_value": query.dimension_value,
+            },
+            "commands_checked": total,
+            "trend": trend,
+            "dimensions": dimensions,
+            "dimension_breakdowns_scope": "global",
+            "feedback": feedback,
+            "health": health,
+        }
+
+    def record_command_activity_feedback(
+        self: _ConnectionOwner,
+        *,
+        activity_id: str,
+        label: CommandActivityFeedbackLabel,
+        recorded_at: datetime,
+    ) -> dict[str, object]:
+        if not isinstance(activity_id, str) or not activity_id:
+            raise ValueError("invalid_activity_id")
+        if not isinstance(cast(object, label), CommandActivityFeedbackLabel):
+            raise ValueError("invalid_feedback_label")
+        if recorded_at.tzinfo is None or recorded_at.utcoffset() != timedelta(0):
+            raise ValueError("recorded_at_must_be_utc")
+        timestamp = recorded_at.isoformat()
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            if (
+                connection.execute(
+                    "select 1 from command_activity where activity_id = ?",
+                    (activity_id,),
+                ).fetchone()
+                is None
+            ):
+                raise CommandActivityNotFoundError(activity_id)
+            existing = cast(
+                sqlite3.Row | None,
+                connection.execute(
+                    "select label, created_at, updated_at from command_activity_feedback where activity_id = ?",
+                    (activity_id,),
+                ).fetchone(),
+            )
+            if existing is not None and str(existing["label"]) == label.value:
+                changed = False
+                created_at = str(existing["created_at"])
+                updated_at = str(existing["updated_at"])
+            else:
+                created_at = str(existing["created_at"]) if existing is not None else timestamp
+                updated_at = timestamp
+                connection.execute(
+                    """
+                    insert into command_activity_feedback (
+                      activity_id, label, created_at, updated_at, schema_version
+                    ) values (?, ?, ?, ?, ?)
+                    on conflict(activity_id) do update set
+                      label = excluded.label,
+                      updated_at = excluded.updated_at,
+                      schema_version = excluded.schema_version
+                    """,
+                    (activity_id, label.value, created_at, timestamp, COMMAND_ACTIVITY_API_SCHEMA_VERSION),
+                )
+                changed = True
+        return {
+            "schema_version": COMMAND_ACTIVITY_API_SCHEMA_VERSION,
+            "activity_id": activity_id,
+            "label": label.value,
+            "created_at": created_at,
+            "updated_at": updated_at,
+            "changed": changed,
+        }
+
+    def list_command_activity_invalidations(
+        self: _ConnectionOwner,
+        cursor: int,
+        *,
+        limit: int = 100,
+    ) -> dict[str, object]:
+        if type(cursor) is not int or cursor < 0:
+            raise ValueError("invalid_invalidation_cursor")
+        if type(limit) is not int or not 1 <= limit <= 100:
+            raise ValueError("invalid_invalidation_limit")
+        with self._connect() as connection:
+            connection.execute("begin")
+            bounds = cast(
+                sqlite3.Row,
+                connection.execute(
+                    "select min(sequence) as minimum, max(sequence) as maximum from command_activity_invalidations"
+                ).fetchone(),
+            )
+            minimum = int(bounds["minimum"]) if bounds["minimum"] is not None else None
+            maximum = int(bounds["maximum"]) if bounds["maximum"] is not None else None
+            reset_required = (minimum is None and cursor > 0) or (
+                minimum is not None and maximum is not None and (cursor < minimum - 1 or cursor > maximum)
+            )
+            if reset_required:
+                if minimum is None or maximum is None:
+                    effective_cursor = 0
+                elif cursor > maximum:
+                    effective_cursor = maximum
+                else:
+                    effective_cursor = minimum - 1
+            else:
+                effective_cursor = cursor
+            rows = cast(
+                list[sqlite3.Row],
+                connection.execute(
+                    """
+                    select sequence, activity_id from command_activity_invalidations
+                    where sequence > ? order by sequence limit ?
+                    """,
+                    (effective_cursor, limit),
+                ).fetchall(),
+            )
+        return {
+            "reset_required": reset_required,
+            "reset_cursor": effective_cursor if reset_required else None,
+            "items": [{"sequence": int(row["sequence"]), "activity_id": str(row["activity_id"])} for row in rows],
+        }
+
+
+def _activity_page_query(
+    query: CommandActivityListQuery,
+    *,
+    cursor: tuple[str, str] | None,
+) -> tuple[str, tuple[object, ...]]:
+    clauses: list[str] = []
+    params: list[object] = []
+    for column, value in (
+        ("activity.harness", query.harness),
+        ("activity.execution_status", query.execution_status),
+        ("activity.proof_level", query.proof_level),
+        ("activity.approval_reuse_status", query.approval_reuse_status),
+    ):
+        if value is not None:
+            clauses.append(f"{column} = ?")
+            params.append(value)
+    if query.prompted is not None:
+        clauses.append("activity.prompted = ?")
+        params.append(int(query.prompted))
+    if query.occurred_from is not None:
+        clauses.append("activity.occurred_at >= ?")
+        params.append(datetime.combine(query.occurred_from, time.min, tzinfo=timezone.utc).isoformat())
+    if query.occurred_through is not None:
+        if query.occurred_through == date.max:
+            clauses.append("activity.occurred_at <= ?")
+            params.append("9999-12-31T23:59:59.999999+00:00")
+        else:
+            clauses.append("activity.occurred_at < ?")
+            through_exclusive = query.occurred_through + timedelta(days=1)
+            params.append(datetime.combine(through_exclusive, time.min, tzinfo=timezone.utc).isoformat())
+    for column, value in (("extension_id", query.extension_id), ("rule_id", query.rule_id)):
+        if value is not None:
+            clauses.append(
+                f"activity.activity_id in (select match.activity_id from command_activity_matches as match "
+                f"where match.{column} = ?)"
+            )
+            params.append(value)
+    if cursor is not None:
+        clauses.append("(activity.occurred_at < ? or (activity.occurred_at = ? and activity.activity_id < ?))")
+        params.extend((cursor[0], cursor[0], cursor[1]))
+    where = " where " + " and ".join(clauses) if clauses else ""
+    sql = (
+        "select activity.*, feedback.label as feedback_label "
+        "from command_activity as activity "
+        "left join command_activity_feedback as feedback using (activity_id)"
+        f"{where} order by activity.occurred_at desc, activity.activity_id desc limit ?"
+    )
+    params.append(query.limit + 1)
+    return sql, tuple(params)
+
+
+def _activity_items(connection: sqlite3.Connection, rows: Sequence[sqlite3.Row]) -> list[dict[str, object]]:
+    if not rows:
+        return []
+    activity_ids = [str(row["activity_id"]) for row in rows]
+    placeholders = ",".join("?" for _ in activity_ids)
+    match_rows = cast(
+        list[sqlite3.Row],
+        connection.execute(
+            f"""
+            select matches.*, effects.effect_class from command_activity_matches as matches
+            left join command_activity_match_effects as effects
+              on effects.activity_id = matches.activity_id and effects.ordinal = matches.ordinal
+            where matches.activity_id in ({placeholders})
+            order by matches.activity_id, matches.ordinal, effects.effect_class
+            """,
+            tuple(activity_ids),
+        ).fetchall(),
+    )
+    matches_by_activity = _group_matches(match_rows)
+    return [_activity_row_payload(row, matches_by_activity.get(str(row["activity_id"]), [])) for row in rows]
+
+
+def _group_matches(rows: Sequence[sqlite3.Row]) -> dict[str, list[dict[str, object]]]:
+    grouped: dict[str, list[dict[str, object]]] = {}
+    keys: dict[tuple[str, int], dict[str, object]] = {}
+    for row in rows:
+        activity_id = str(row["activity_id"])
+        ordinal = int(row["ordinal"])
+        key = (activity_id, ordinal)
+        item: dict[str, object] | None = keys.get(key)
+        if item is None:
+            item = {
+                "ordinal": ordinal,
+                "extension_id": str(row["extension_id"]),
+                "extension_version": str(row["extension_version"]),
+                "rule_id": str(row["rule_id"]),
+                "rule_version": str(row["rule_version"]),
+                "match_class": str(row["match_class"]),
+                "severity": str(row["severity"]),
+                "default_floor": str(row["default_floor"]),
+                "safe_variant_id": str(row["safe_variant_id"]) if row["safe_variant_id"] is not None else None,
+                "effect_classes": [],
+                "schema_version": str(row["schema_version"]),
+            }
+            keys[key] = item
+            grouped.setdefault(activity_id, []).append(item)
+        effect = row["effect_class"]
+        if effect is not None:
+            cast(list[str], item["effect_classes"]).append(str(effect))
+    return grouped
+
+
+def _activity_row_payload(row: sqlite3.Row, matches: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "activity_id": str(row["activity_id"]),
+        "occurred_at": str(row["occurred_at"]),
+        "harness": str(row["harness"]),
+        "hook_phase": str(row["hook_phase"]),
+        "execution_status": str(row["execution_status"]),
+        "proof_level": str(row["proof_level"]),
+        "policy_action": str(row["policy_action"]) if row["policy_action"] is not None else None,
+        "decision_reason_code": str(row["decision_reason_code"]) if row["decision_reason_code"] is not None else None,
+        "controlling_rule_id": str(row["controlling_rule_id"]) if row["controlling_rule_id"] is not None else None,
+        "parse_confidence": str(row["parse_confidence"]) if row["parse_confidence"] is not None else None,
+        "uncertainty_class": str(row["uncertainty_class"]) if row["uncertainty_class"] is not None else None,
+        "match_count": int(row["match_count"]),
+        "prompted": bool(row["prompted"]),
+        "approval_reuse_status": str(row["approval_reuse_status"]),
+        "receipt_link_status": str(row["receipt_link_status"]),
+        "receipt_id": str(row["receipt_id"]) if row["receipt_id"] is not None else None,
+        "evaluation_latency_bucket": str(row["evaluation_latency_bucket"]),
+        "persistence_latency_bucket": str(row["persistence_latency_bucket"]),
+        "feedback_label": str(row["feedback_label"]) if row["feedback_label"] is not None else None,
+        "schema_version": str(row["schema_version"]),
+        "matches": matches,
+    }
+
+
+def _analytics_trend(
+    connection: sqlite3.Connection,
+    query: CommandActivityAnalyticsQuery,
+    *,
+    start: date,
+    end: date,
+) -> list[dict[str, object]]:
+    if query.dimension is None:
+        rows = connection.execute(
+            """select day, total as count from command_activity_daily_totals
+            where day between ? and ? order by day""",
+            (start.isoformat(), end.isoformat()),
+        ).fetchall()
+    else:
+        rows = connection.execute(
+            """select day, count from command_activity_daily_rollups
+            where day between ? and ? and dimension = ? and dimension_value = ? order by day""",
+            (start.isoformat(), end.isoformat(), query.dimension, query.dimension_value),
+        ).fetchall()
+    return [{"day": str(row["day"]), "count": int(row["count"])} for row in rows]
+
+
+def _top_dimension(
+    connection: sqlite3.Connection,
+    dimension: str,
+    *,
+    start: date,
+    end: date,
+    limit: int,
+) -> list[dict[str, object]]:
+    rows = connection.execute(
+        """
+        select dimension_value, sum(count) as total from command_activity_daily_rollups
+        where day between ? and ? and dimension = ?
+        group by dimension_value order by total desc, dimension_value limit ?
+        """,
+        (start.isoformat(), end.isoformat(), dimension, limit),
+    ).fetchall()
+    return [{"value": str(row["dimension_value"]), "count": int(row["total"])} for row in rows]
+
+
+def _feedback_counts(
+    connection: sqlite3.Connection,
+    *,
+    query: CommandActivityAnalyticsQuery,
+    start: date,
+    end: date,
+) -> list[dict[str, object]]:
+    end_exclusive = end + timedelta(days=1)
+    clauses = ["activity.occurred_at >= ?", "activity.occurred_at < ?"]
+    params: list[object] = [
+        datetime.combine(start, time.min, tzinfo=timezone.utc).isoformat(),
+        datetime.combine(end_exclusive, time.min, tzinfo=timezone.utc).isoformat(),
+    ]
+    if query.dimension == "harness":
+        clauses.append("activity.harness = ?")
+        params.append(query.dimension_value)
+    elif query.dimension in {"extension", "rule"}:
+        column = "extension_id" if query.dimension == "extension" else "rule_id"
+        clauses.append(
+            f"activity.activity_id in (select match.activity_id from command_activity_matches as match "
+            f"where match.{column} = ?)"
+        )
+        params.append(query.dimension_value)
+    rows = connection.execute(
+        f"""
+        select feedback.label, count(*) as total from command_activity_feedback as feedback
+        join command_activity as activity using (activity_id)
+        where {" and ".join(clauses)}
+        group by feedback.label order by feedback.label
+        """,
+        tuple(params),
+    ).fetchall()
+    return [{"label": str(row["label"]), "count": int(row["total"])} for row in rows]
+
+
+def _health_payload(connection: sqlite3.Connection) -> dict[str, object]:
+    row = cast(
+        sqlite3.Row | None,
+        connection.execute("select * from command_activity_health where singleton = 1").fetchone(),
+    )
+    if row is None:
+        return {"status": "degraded", "dropped_events": 0, "persistence_errors": 0}
+    return {
+        "status": ("degraded" if int(row["dropped_event_count"]) or int(row["persistence_error_count"]) else "healthy"),
+        "dropped_events": int(row["dropped_event_count"]),
+        "persistence_errors": int(row["persistence_error_count"]),
+        "last_error_class": str(row["last_error_code"]) if row["last_error_code"] is not None else None,
+        "last_error_at": str(row["last_error_at"]) if row["last_error_at"] is not None else None,
+    }
+
+
+__all__ = (
+    "CommandActivityNotFoundError",
+    "StoreCommandActivityApiMixin",
+)

--- a/src/codex_plugin_scanner/guard/store_command_activity_api_schema.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_api_schema.py
@@ -1,0 +1,188 @@
+"""Schema for command-activity API feedback and invalidation state."""
+
+# pyright: reportAny=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from typing import Final, cast
+
+COMMAND_ACTIVITY_API_SCHEMA_MIGRATION_VERSION: Final = 13
+COMMAND_ACTIVITY_INVALIDATION_LIMIT: Final = 10_000
+
+
+def command_activity_api_schema_statements() -> tuple[str, ...]:
+    return (
+        """
+        create table if not exists command_activity_feedback (
+          activity_id text primary key references command_activity(activity_id) on delete cascade,
+          label text not null check (
+            label in ('should_not_have_interrupted', 'expected_guard_to_stop_this')
+          ),
+          created_at text not null,
+          updated_at text not null,
+          schema_version text not null
+        )
+        """,
+        """
+        create table if not exists command_activity_invalidations (
+          sequence integer primary key autoincrement,
+          activity_id text not null
+        )
+        """,
+        """
+        create index if not exists idx_command_activity_feedback_label
+        on command_activity_feedback (label, updated_at desc, activity_id desc)
+        """,
+        """
+        create index if not exists idx_command_activity_execution_status_occurred_at
+        on command_activity (execution_status, occurred_at desc, activity_id desc)
+        """,
+        """
+        create index if not exists idx_command_activity_proof_level_occurred_at
+        on command_activity (proof_level, occurred_at desc, activity_id desc)
+        """,
+        """
+        create index if not exists idx_command_activity_approval_reuse_occurred_at
+        on command_activity (approval_reuse_status, occurred_at desc, activity_id desc)
+        """,
+        """
+        create index if not exists idx_command_activity_prompted_occurred_at
+        on command_activity (prompted, occurred_at desc, activity_id desc)
+        """,
+        """
+        create trigger if not exists trg_command_activity_invalidation_insert
+        after insert on command_activity
+        begin
+          insert into command_activity_invalidations (activity_id) values (new.activity_id);
+          delete from command_activity_invalidations
+          where sequence <= last_insert_rowid() - 10000;
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_invalidation_update
+        after update on command_activity
+        begin
+          insert into command_activity_invalidations (activity_id) values (new.activity_id);
+          delete from command_activity_invalidations
+          where sequence <= last_insert_rowid() - 10000;
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_invalidation_delete
+        after delete on command_activity
+        begin
+          insert into command_activity_invalidations (activity_id) values (old.activity_id);
+          delete from command_activity_invalidations
+          where sequence <= last_insert_rowid() - 10000;
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_feedback_invalidation_insert
+        after insert on command_activity_feedback
+        begin
+          insert into command_activity_invalidations (activity_id) values (new.activity_id);
+          delete from command_activity_invalidations
+          where sequence <= last_insert_rowid() - 10000;
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_feedback_invalidation_update
+        after update on command_activity_feedback
+        begin
+          insert into command_activity_invalidations (activity_id) values (new.activity_id);
+          delete from command_activity_invalidations
+          where sequence <= last_insert_rowid() - 10000;
+        end
+        """,
+        """
+        create trigger if not exists trg_command_activity_feedback_invalidation_delete
+        after delete on command_activity_feedback
+        begin
+          insert into command_activity_invalidations (activity_id) values (old.activity_id);
+          delete from command_activity_invalidations
+          where sequence <= last_insert_rowid() - 10000;
+        end
+        """,
+    )
+
+
+def ensure_command_activity_api_schema(connection: sqlite3.Connection, *, applied_at: str) -> None:
+    statements = command_activity_api_schema_statements()
+    connection.execute("savepoint command_activity_api_schema_v1")
+    try:
+        for statement in statements:
+            connection.execute(statement)
+        _validate_command_activity_api_schema(connection, statements)
+        connection.execute(
+            "insert or ignore into schema_migrations (version, applied_at) values (?, ?)",
+            (COMMAND_ACTIVITY_API_SCHEMA_MIGRATION_VERSION, applied_at),
+        )
+    except BaseException:
+        connection.execute("rollback to command_activity_api_schema_v1")
+        connection.execute("release command_activity_api_schema_v1")
+        raise
+    connection.execute("release command_activity_api_schema_v1")
+
+
+def _validate_command_activity_api_schema(
+    connection: sqlite3.Connection,
+    statements: tuple[str, ...],
+) -> None:
+    expected_columns = {
+        "command_activity_feedback": {
+            "activity_id",
+            "label",
+            "created_at",
+            "updated_at",
+            "schema_version",
+        },
+        "command_activity_invalidations": {"sequence", "activity_id"},
+    }
+    for table, columns in expected_columns.items():
+        rows = cast(list[sqlite3.Row], connection.execute(f"pragma table_info({table})").fetchall())
+        if {str(row["name"]) for row in rows} != columns:
+            raise RuntimeError(f"incompatible {table} schema")
+        primary_key = tuple(str(row["name"]) for row in sorted(rows, key=lambda row: int(row["pk"])) if row["pk"])
+        expected_primary_key = ("activity_id",) if table == "command_activity_feedback" else ("sequence",)
+        if primary_key != expected_primary_key:
+            raise RuntimeError(f"incompatible {table} primary key")
+
+    _validate_schema_object_sql(connection, statements)
+    if len(statements) != 13:
+        raise RuntimeError("incomplete command activity API schema")
+
+
+def _validate_schema_object_sql(connection: sqlite3.Connection, statements: tuple[str, ...]) -> None:
+    expected: dict[str, str] = {}
+    for statement in statements:
+        canonical = _canonical_sql(statement)
+        match = re.match(r"create (?:table|trigger|index) if not exists ([a-z0-9_]+)", canonical)
+        if match is None:
+            raise RuntimeError("unrecognized command activity API schema statement")
+        expected[match.group(1)] = canonical.replace(" if not exists", "", 1)
+    placeholders = ", ".join("?" for _ in expected)
+    rows = cast(
+        list[tuple[str, str]],
+        connection.execute(
+            f"select name, sql from sqlite_schema where name in ({placeholders})",
+            tuple(expected),
+        ).fetchall(),
+    )
+    actual = {name: _canonical_sql(sql) for name, sql in rows}
+    for name, expected_sql in expected.items():
+        if actual.get(name) != expected_sql:
+            raise RuntimeError(f"incompatible command activity API schema object: {name}")
+
+
+def _canonical_sql(value: str) -> str:
+    return " ".join(value.strip().lower().split())
+
+
+__all__ = (
+    "COMMAND_ACTIVITY_API_SCHEMA_MIGRATION_VERSION",
+    "COMMAND_ACTIVITY_INVALIDATION_LIMIT",
+    "command_activity_api_schema_statements",
+    "ensure_command_activity_api_schema",
+)

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 # ruff: noqa: F403,F405
 from .store_base import *
+from .store_command_activity_api_schema import ensure_command_activity_api_schema
 from .store_command_activity_health_schema import ensure_command_activity_health_schema
 from .store_command_activity_maintenance_schema import ensure_command_activity_maintenance_schema
 from .store_command_activity_schema import ensure_command_activity_schema
@@ -621,6 +622,7 @@ class StoreConnectionSchemaMixin:
             ensure_command_activity_schema(connection, applied_at=_now())
             ensure_command_activity_health_schema(connection, applied_at=_now())
             ensure_command_activity_maintenance_schema(connection, applied_at=_now())
+            ensure_command_activity_api_schema(connection, applied_at=_now())
             ensure_evidence_schema(connection)
             if not self._schema_version_applied(connection, version=4):
                 self._record_schema_version(connection, version=4)

--- a/tests/guard_command_activity_api_support.py
+++ b/tests/guard_command_activity_api_support.py
@@ -1,0 +1,141 @@
+"""Focused fixtures and HTTP helpers for command-activity API tests."""
+
+# pyright: reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.runtime.command_activity_contract import (
+    ActivityApprovalReuseStatus,
+    ActivityDecisionReason,
+    ActivityLatencyBucket,
+    ActivityMatchClass,
+    ActivityParseConfidence,
+    CommandActivity,
+    CommandActivityEvidence,
+    CommandActivityMatch,
+    CommandExecutionStatus,
+    CommandHookPhase,
+    CommandProofLevel,
+    ReceiptLinkStatus,
+)
+from codex_plugin_scanner.guard.runtime.effect_contract import EffectKind
+from codex_plugin_scanner.guard.runtime.extension_evidence import EvidenceSeverity, ExtensionRuleIdentity
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def evidence(
+    activity_id: str,
+    *,
+    minute: int,
+    prompted: bool = False,
+    harness: str = "codex",
+) -> CommandActivityEvidence:
+    activity = CommandActivity(
+        activity_id=activity_id,
+        occurred_at=datetime(2026, 7, 18, 20, minute, tzinfo=timezone.utc),
+        harness=harness,
+        hook_phase=CommandHookPhase.PRE,
+        execution_status=CommandExecutionStatus.ALLOWED_UNCONFIRMED,
+        proof_level=CommandProofLevel.PRE_HOOK,
+        policy_action="review" if prompted else "allow",
+        decision_reason_code=ActivityDecisionReason.EXTENSION_MATCH,
+        controlling_rule_id="command.git.push",
+        parse_confidence=ActivityParseConfidence.EXACT,
+        uncertainty_class=None,
+        match_count=1,
+        prompted=prompted,
+        approval_reuse_status=ActivityApprovalReuseStatus.NOT_APPLICABLE,
+        request_correlation=None,
+        session_correlation=None,
+        receipt_link_status=ReceiptLinkStatus.LINKED if prompted else ReceiptLinkStatus.NOT_APPLICABLE,
+        receipt_id=f"receipt:{activity_id}" if prompted else None,
+        evaluation_latency_bucket=ActivityLatencyBucket.LE_5_MS,
+        persistence_latency_bucket=ActivityLatencyBucket.LE_2_MS,
+    )
+    match = CommandActivityMatch(
+        activity_id=activity_id,
+        ordinal=0,
+        identity=ExtensionRuleIdentity("command.git", "2.2.0", "command.git.push", "1.0.0"),
+        match_class=ActivityMatchClass.UNSAFE,
+        severity=EvidenceSeverity.HIGH,
+        default_floor="review",
+        effect_claims=frozenset({EffectKind.REMOTE_STATE_MUTATION}),
+    )
+    return CommandActivityEvidence(activity, (match,))
+
+
+def seed(store: GuardStore) -> None:
+    for index in range(3):
+        store.record_command_activity(
+            evidence(
+                f"activity:{index + 1:02d}",
+                minute=index,
+                prompted=index == 1,
+            )
+        )
+
+
+def json_request(
+    daemon: GuardDaemonServer,
+    path: str,
+    *,
+    method: str = "GET",
+    token: str | None = None,
+    payload: dict[str, object] | None = None,
+    origin: str | None = None,
+    extra_headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, object], dict[str, str]]:
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if token is not None:
+        if token.startswith("gld1."):
+            headers["X-Guard-Dashboard-Session"] = token
+        else:
+            headers["X-Guard-Token"] = token
+    if origin is not None:
+        headers["Origin"] = origin
+    if extra_headers is not None:
+        headers.update(extra_headers)
+    data = None if method == "GET" else json.dumps(payload or {}).encode("utf-8")
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{daemon.port}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+    try:
+        response = urllib.request.urlopen(request, timeout=5)
+    except urllib.error.HTTPError as error:
+        body = json.loads(error.read().decode("utf-8"))
+        return error.code, body, dict(error.headers.items())
+    with response:
+        body = json.loads(response.read().decode("utf-8"))
+        return response.status, body, dict(response.headers.items())
+
+
+def raw_request(
+    daemon: GuardDaemonServer,
+    path: str,
+    *,
+    token: str,
+    origin: str | None = None,
+    last_event_id: str | None = None,
+) -> urllib.request.Request:
+    headers = {"X-Guard-Dashboard-Session": token}
+    if origin is not None:
+        headers["Origin"] = origin
+    if last_event_id is not None:
+        headers["Last-Event-ID"] = last_event_id
+    return urllib.request.Request(
+        f"http://127.0.0.1:{daemon.port}{path}",
+        headers=headers,
+        method="GET",
+    )
+
+
+__all__ = ("evidence", "json_request", "raw_request", "seed")

--- a/tests/guard_command_corpus_runner.py
+++ b/tests/guard_command_corpus_runner.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import TypedDict, cast
 
 EVALUATION_SHARD_COUNT = 4
-MAX_CONCURRENT_WORKERS = 2
+MAX_CONCURRENT_WORKERS = 1
 WORKER_TIMEOUT_SECONDS = 15
 REPO_ROOT = Path(__file__).parents[1]
 SYNTHETIC_CWD = REPO_ROOT / "workspace"

--- a/tests/guard_command_corpus_runner.py
+++ b/tests/guard_command_corpus_runner.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import TypedDict, cast
 
 EVALUATION_SHARD_COUNT = 4
-MAX_CONCURRENT_WORKERS = 1
+MAX_CONCURRENT_WORKERS = 2
 WORKER_TIMEOUT_SECONDS = 15
 REPO_ROOT = Path(__file__).parents[1]
 SYNTHETIC_CWD = REPO_ROOT / "workspace"
@@ -50,10 +50,27 @@ def peak_rss_mib() -> float:
         )
         return int(completed.stdout.strip()) / (1024 * 1024)
 
+    if sys.platform.startswith("linux"):
+        try:
+            return linux_peak_rss_mib_from_status(Path("/proc/self/status").read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            pass
+
     import resource
 
     rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
     return rss / (1024 * 1024 if sys.platform == "darwin" else 1024)
+
+
+def linux_peak_rss_mib_from_status(status: str) -> float:
+    for line in status.splitlines():
+        if not line.startswith("VmHWM:"):
+            continue
+        fields = line.split()
+        if len(fields) == 3 and fields[0] == "VmHWM:" and fields[2] == "kB":
+            return int(fields[1]) / 1024
+        break
+    raise ValueError("missing Linux VmHWM")
 
 
 def _install_evaluator_packages() -> None:

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -2618,7 +2618,7 @@ class TestGuardApprovals:
             daemon.stop()
 
         assert status == 200
-        assert allow_headers == "Authorization, Content-Type, X-Guard-Dashboard-Session, X-Guard-Token"
+        assert allow_headers == ("Authorization, Content-Type, Last-Event-ID, X-Guard-Dashboard-Session, X-Guard-Token")
 
     def test_guard_daemon_limits_request_resolution_to_local_dashboard_origin(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_command_activity_api.py
+++ b/tests/test_guard_command_activity_api.py
@@ -1,0 +1,247 @@
+"""Store and query contract tests for the command-activity API."""
+
+# pyright: reportAny=false, reportArgumentType=false, reportGeneralTypeIssues=false
+# pyright: reportIndexIssue=false, reportMissingImports=false, reportPrivateUsage=false
+# pyright: reportUnknownArgumentType=false, reportUnknownMemberType=false, reportUnknownVariableType=false
+# pyright: reportUnknownParameterType=false, reportUntypedFunctionDecorator=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard import store_command_activity_api_schema as api_schema
+from codex_plugin_scanner.guard.runtime.command_activity_api_contract import (
+    CommandActivityAnalyticsQuery,
+    CommandActivityFeedbackLabel,
+    CommandActivityListQuery,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_command_activity_api import (
+    CommandActivityNotFoundError,
+    _activity_page_query,
+)
+from tests.guard_command_activity_api_support import evidence, seed
+
+
+def test_api_schema_is_atomic_strict_and_reopens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    with sqlite3.connect(store.path) as connection:
+        tables = {
+            str(row[0]) for row in connection.execute("select name from sqlite_schema where type = 'table'").fetchall()
+        }
+        migration = connection.execute("select version from schema_migrations where version = 13").fetchone()
+    assert {"command_activity_feedback", "command_activity_invalidations"} <= tables
+    assert migration == (13,)
+    GuardStore(store.guard_home, prime_policy_integrity=False)
+
+    database = tmp_path / "failure.db"
+    with sqlite3.connect(database) as connection:
+        connection.row_factory = sqlite3.Row
+        connection.execute("create table schema_migrations (version integer primary key, applied_at text not null)")
+        connection.execute("create table command_activity (activity_id text primary key)")
+        statements = api_schema.command_activity_api_schema_statements()
+        monkeypatch.setattr(
+            api_schema,
+            "command_activity_api_schema_statements",
+            lambda: (statements[0], "create table"),
+        )
+        with pytest.raises(sqlite3.OperationalError):
+            api_schema.ensure_command_activity_api_schema(connection, applied_at="2026-07-18T20:00:00+00:00")
+        assert connection.execute("select 1 from schema_migrations where version = 13").fetchone() is None
+        assert (
+            connection.execute("select 1 from sqlite_schema where name = 'command_activity_feedback'").fetchone()
+            is None
+        )
+
+
+def test_activity_page_is_deterministic_filter_bounded_and_private(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+
+    first = store.list_command_activity_page(CommandActivityListQuery(limit=2))
+    assert [item["activity_id"] for item in first["items"]] == ["activity:03", "activity:02"]
+    assert first["next_marker"] == ("2026-07-18T20:01:00+00:00", "activity:02")
+    serialized = repr(first)
+    for forbidden in ("correlation", "digest", "command_text", "raw_command", "cwd", "environment"):
+        assert forbidden not in serialized
+
+    second = store.list_command_activity_page(
+        CommandActivityListQuery(limit=2),
+        cursor=("2026-07-18T20:01:00+00:00", "activity:02"),
+    )
+    assert [item["activity_id"] for item in second["items"]] == ["activity:01"]
+    prompted = store.list_command_activity_page(CommandActivityListQuery(prompted=True))
+    assert [item["activity_id"] for item in prompted["items"]] == ["activity:02"]
+    extension = store.list_command_activity_page(CommandActivityListQuery(extension_id="command.git"))
+    assert len(extension["items"]) == 3
+    missing_rule = store.list_command_activity_page(CommandActivityListQuery(rule_id="command.git.fetch"))
+    assert missing_rule["items"] == []
+    through_max = store.list_command_activity_page(CommandActivityListQuery(occurred_through=date.max))
+    assert len(through_max["items"]) == 3
+
+
+@pytest.mark.parametrize(
+    "kwargs,error",
+    [
+        ({"limit": 0}, "limit_out_of_range"),
+        ({"harness": "unknown"}, "invalid_harness"),
+        ({"execution_status": "executed"}, "invalid_execution_status"),
+        ({"proof_level": "guessed"}, "invalid_proof_level"),
+        ({"extension_id": "../../private"}, "invalid_extension_id"),
+        (
+            {"occurred_from": date(2026, 7, 19), "occurred_through": date(2026, 7, 18)},
+            "invalid_date_range",
+        ),
+        (
+            {"occurred_from": date(2025, 1, 1), "occurred_through": date(2026, 7, 18)},
+            "date_range_out_of_range",
+        ),
+    ],
+)
+def test_activity_query_rejects_unbounded_or_unknown_values(kwargs: dict[str, object], error: str) -> None:
+    with pytest.raises(ValueError, match=error):
+        CommandActivityListQuery(**kwargs)
+
+
+def test_analytics_reconciles_rollups_and_exposes_bounded_health(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+
+    payload = store.command_activity_analytics(
+        CommandActivityAnalyticsQuery(days=7, top_limit=5),
+        as_of=date(2026, 7, 18),
+    )
+    assert payload["commands_checked"] == 3
+    assert payload["trend"] == [{"day": "2026-07-18", "count": 3}]
+    assert payload["dimensions"]["harness"] == [{"value": "codex", "count": 3}]
+    assert payload["dimensions"]["extension"] == [{"value": "command.git", "count": 3}]
+    assert payload["health"] == {
+        "status": "healthy",
+        "dropped_events": 0,
+        "persistence_errors": 0,
+        "last_error_class": None,
+        "last_error_at": None,
+    }
+
+    filtered = store.command_activity_analytics(
+        CommandActivityAnalyticsQuery(days=7, dimension="harness", dimension_value="codex"),
+        as_of=date(2026, 7, 18),
+    )
+    assert filtered["commands_checked"] == 3
+    assert filtered["scope"] == {"dimension": "harness", "dimension_value": "codex"}
+
+
+def test_filtered_analytics_excludes_out_of_scope_feedback(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+    store.record_command_activity(evidence("activity:claude", minute=4, harness="claude-code"))
+    store.record_command_activity_feedback(
+        activity_id="activity:claude",
+        label=CommandActivityFeedbackLabel.EXPECTED_GUARD_TO_STOP_THIS,
+        recorded_at=datetime(2026, 7, 18, 21, 0, tzinfo=timezone.utc),
+    )
+
+    codex = store.command_activity_analytics(
+        CommandActivityAnalyticsQuery(days=7, dimension="harness", dimension_value="codex"),
+        as_of=date(2026, 7, 18),
+    )
+    claude = store.command_activity_analytics(
+        CommandActivityAnalyticsQuery(days=7, dimension="harness", dimension_value="claude-code"),
+        as_of=date(2026, 7, 18),
+    )
+    assert codex["feedback"] == []
+    assert claude["feedback"] == [{"label": "expected_guard_to_stop_this", "count": 1}]
+
+
+def test_feedback_is_fixed_vocabulary_idempotent_and_never_mutates_activity(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+    before = store.list_command_activity_page(CommandActivityListQuery())
+    recorded_at = datetime(2026, 7, 18, 21, 0, tzinfo=timezone.utc)
+
+    first = store.record_command_activity_feedback(
+        activity_id="activity:02",
+        label=CommandActivityFeedbackLabel.SHOULD_NOT_HAVE_INTERRUPTED,
+        recorded_at=recorded_at,
+    )
+    replay = store.record_command_activity_feedback(
+        activity_id="activity:02",
+        label=CommandActivityFeedbackLabel.SHOULD_NOT_HAVE_INTERRUPTED,
+        recorded_at=datetime(2026, 7, 18, 22, 0, tzinfo=timezone.utc),
+    )
+    assert first["changed"] is True
+    assert replay["changed"] is False
+    after = store.list_command_activity_page(CommandActivityListQuery())
+    before_item = next(item for item in before["items"] if item["activity_id"] == "activity:02")
+    after_item = next(item for item in after["items"] if item["activity_id"] == "activity:02")
+    assert {key: value for key, value in before_item.items() if key != "feedback_label"} == {
+        key: value for key, value in after_item.items() if key != "feedback_label"
+    }
+    assert after_item["feedback_label"] == "should_not_have_interrupted"
+
+    with pytest.raises(CommandActivityNotFoundError):
+        store.record_command_activity_feedback(
+            activity_id="activity:missing",
+            label=CommandActivityFeedbackLabel.EXPECTED_GUARD_TO_STOP_THIS,
+            recorded_at=recorded_at,
+        )
+
+
+def test_invalidation_log_is_capped_and_id_only(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+    initial_page = store.list_command_activity_invalidations(0)
+    items = initial_page["items"]
+    assert items
+    assert initial_page["reset_required"] is False
+    assert all(set(item) == {"sequence", "activity_id"} for item in items)
+    store.record_command_activity_feedback(
+        activity_id="activity:01",
+        label=CommandActivityFeedbackLabel.SHOULD_NOT_HAVE_INTERRUPTED,
+        recorded_at=datetime(2026, 7, 18, 21, 0, tzinfo=timezone.utc),
+    )
+    with sqlite3.connect(store.path) as connection:
+        connection.executemany(
+            "update command_activity_feedback set updated_at = ? where activity_id = 'activity:01'",
+            ((f"2026-07-19T00:00:{index:05d}+00:00",) for index in range(10_100)),
+        )
+        count = connection.execute("select count(*) from command_activity_invalidations").fetchone()
+    assert count is not None
+    assert count[0] <= api_schema.COMMAND_ACTIVITY_INVALIDATION_LIMIT
+    gap_page = store.list_command_activity_invalidations(0)
+    assert gap_page["reset_required"] is True
+    assert isinstance(gap_page["reset_cursor"], int)
+    assert gap_page["reset_cursor"] > 0
+
+
+def test_empty_invalidation_log_resets_an_ahead_cursor(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    page = store.list_command_activity_invalidations(42)
+    assert page == {"reset_required": True, "reset_cursor": 0, "items": []}
+
+
+def test_filtered_query_plans_are_index_driven(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    with sqlite3.connect(store.path) as connection:
+        status_sql, status_params = _activity_page_query(
+            CommandActivityListQuery(execution_status="confirmed_failure"),
+            cursor=None,
+        )
+        status_plan = " ".join(
+            str(row[3]) for row in connection.execute(f"explain query plan {status_sql}", status_params).fetchall()
+        )
+        rule_sql, rule_params = _activity_page_query(
+            CommandActivityListQuery(rule_id="command.git.missing"),
+            cursor=None,
+        )
+        rule_plan = " ".join(
+            str(row[3]) for row in connection.execute(f"explain query plan {rule_sql}", rule_params).fetchall()
+        )
+    assert "idx_command_activity_execution_status_occurred_at" in status_plan
+    assert "idx_command_activity_match_rule" in rule_plan
+    assert "SCAN activity USING INDEX idx_command_activity_occurred_at" not in status_plan
+    assert "SCAN activity USING INDEX idx_command_activity_occurred_at" not in rule_plan

--- a/tests/test_guard_command_activity_api_access.py
+++ b/tests/test_guard_command_activity_api_access.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import urllib.parse
 import urllib.request
@@ -100,7 +101,15 @@ def test_signed_cursor_rejects_tampering_and_filter_rebinding(tmp_path: Path) ->
             f"/v1/command-activity?limit=2&cursor={urllib.parse.quote(cursor)}",
             token=token,
         )
-        tampered = cursor[:-1] + ("A" if cursor[-1] != "A" else "B")
+        prefix, encoded, signature = cursor.split(".")
+        decoded_signature = base64.urlsafe_b64decode(signature + "=")
+        alias = next(
+            candidate
+            for character in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+            if (candidate := signature[:-1] + character) != signature
+            and base64.urlsafe_b64decode(candidate + "=") == decoded_signature
+        )
+        tampered = f"{prefix}.{encoded}.{alias}"
         tampered_status, tampered_body, _ = json_request(
             daemon,
             f"/v1/command-activity?limit=2&cursor={urllib.parse.quote(tampered)}",
@@ -248,6 +257,7 @@ def test_sse_emits_only_invalidation_type_and_activity_id(tmp_path: Path) -> Non
             response.close()
         daemon.stop()
 
+    assert daemon._server.active_stream_clients == 0
     assert query_token_status == 401
     assert event_id.startswith("id: ")
     assert payload == {"event": "command_activity_invalidated", "activity_id": "activity:01"}

--- a/tests/test_guard_command_activity_api_access.py
+++ b/tests/test_guard_command_activity_api_access.py
@@ -206,6 +206,10 @@ def test_analytics_and_extensions_are_paginated_bounded_contracts(tmp_path: Path
     assert analytics["scope"] == {"dimension": "harness", "dimension_value": "codex"}
     assert first_status == second_status == 200
     assert len(first["items"]) == len(second["items"]) == 2
+    first_extension_ids = [str(item["extension_id"]) for item in first["items"]]
+    second_extension_ids = [str(item["extension_id"]) for item in second["items"]]
+    extension_ids = first_extension_ids + second_extension_ids
+    assert extension_ids == sorted(extension_ids)
     assert {item["extension_id"] for item in first["items"]}.isdisjoint(
         {item["extension_id"] for item in second["items"]}
     )

--- a/tests/test_guard_command_activity_api_access.py
+++ b/tests/test_guard_command_activity_api_access.py
@@ -1,0 +1,358 @@
+"""Daemon authentication, CORS, cursor, and SSE tests for command activity."""
+
+# pyright: reportAny=false, reportArgumentType=false, reportGeneralTypeIssues=false
+# pyright: reportIndexIssue=false, reportPrivateUsage=false, reportUnknownArgumentType=false
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+from codex_plugin_scanner.guard.daemon.command_activity_api import stream_command_activity_events
+from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.local_dashboard_session import build_local_dashboard_session_token
+from codex_plugin_scanner.guard.store import GuardStore
+from tests.guard_command_activity_api_support import json_request, raw_request, seed
+
+
+def _dashboard_token(daemon: GuardDaemonServer, *, surface: str = "dashboard", **claims: object) -> str:
+    return build_local_dashboard_session_token(
+        auth_token=daemon._server.auth_token,
+        surface=surface,
+        extra_claims=dict(claims),
+    )
+
+
+def test_activity_routes_require_auth_and_exact_hosted_origin(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token(daemon)
+        unauthenticated, _, _ = json_request(daemon, "/v1/command-activity")
+        allowed, payload, headers = json_request(
+            daemon,
+            "/v1/command-activity",
+            token=token,
+            origin="https://hol.org",
+        )
+        forbidden, body, _ = json_request(
+            daemon,
+            "/v1/command-activity",
+            token=token,
+            origin="https://attacker.example",
+        )
+    finally:
+        daemon.stop()
+
+    assert unauthenticated == 401
+    assert allowed == 200
+    assert len(payload["items"]) == 3
+    assert headers["Access-Control-Allow-Origin"] == "https://hol.org"
+    assert forbidden == 403
+    assert body == {"error": "forbidden_origin"}
+
+
+def test_dashboard_session_scope_is_an_exact_path_allowlist(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        scoped = _dashboard_token(
+            daemon,
+            surface="command-action",
+            action_path="command_activity_read",
+            allowed_read_paths=["/v1/command-activity"],
+        )
+        allowed, _, _ = json_request(daemon, "/v1/command-activity", token=scoped)
+        analytics, _, _ = json_request(daemon, "/v1/command-activity/analytics", token=scoped)
+        feedback, _, _ = json_request(
+            daemon,
+            "/v1/command-activity/feedback",
+            method="POST",
+            token=scoped,
+            payload={"activity_id": "activity:01", "label": "should_not_have_interrupted"},
+        )
+    finally:
+        daemon.stop()
+
+    assert allowed == 200
+    assert analytics == 401
+    assert feedback == 401
+
+
+def test_signed_cursor_rejects_tampering_and_filter_rebinding(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token(daemon)
+        status, first, _ = json_request(daemon, "/v1/command-activity?limit=2", token=token)
+        cursor = str(first["next_cursor"])
+        second_status, second, _ = json_request(
+            daemon,
+            f"/v1/command-activity?limit=2&cursor={urllib.parse.quote(cursor)}",
+            token=token,
+        )
+        tampered = cursor[:-1] + ("A" if cursor[-1] != "A" else "B")
+        tampered_status, tampered_body, _ = json_request(
+            daemon,
+            f"/v1/command-activity?limit=2&cursor={urllib.parse.quote(tampered)}",
+            token=token,
+        )
+        rebound_status, rebound_body, _ = json_request(
+            daemon,
+            f"/v1/command-activity?limit=2&prompted=true&cursor={urllib.parse.quote(cursor)}",
+            token=token,
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert [item["activity_id"] for item in second["items"]] == ["activity:01"]
+    assert second_status == 200
+    assert tampered_status == 400
+    assert tampered_body == {"error": "invalid_cursor"}
+    assert rebound_status == 400
+    assert rebound_body == {"error": "invalid_cursor"}
+
+
+def test_query_and_feedback_payloads_fail_closed(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token(daemon)
+        cases = [
+            "/v1/command-activity?limit=101",
+            "/v1/command-activity?limit=1&limit=2",
+            "/v1/command-activity?unknown=value",
+            "/v1/command-activity?prompted=1",
+            "/v1/command-activity/analytics?days=398",
+            "/v1/command-activity/analytics?dimension=harness",
+            "/v1/command-extensions?limit=101",
+            "/v1/command-activity?cursor=" + "x" * 2_049,
+            "/v1/command-activity?extension_id=" + "a" * 8_193,
+            "/v1/command-activity/events?cursor=invalid",
+            "/v1/command-activity/events?cursor=0&cursor=1",
+        ]
+        statuses = [json_request(daemon, path, token=token)[0] for path in cases]
+        invalid_feedback = json_request(
+            daemon,
+            "/v1/command-activity/feedback",
+            method="POST",
+            token=token,
+            payload={
+                "activity_id": "activity:01",
+                "label": "should_not_have_interrupted",
+                "notes": "free form must never be accepted",
+            },
+        )
+        missing_feedback = json_request(
+            daemon,
+            "/v1/command-activity/feedback",
+            method="POST",
+            token=token,
+            payload={"activity_id": "activity:missing", "label": "expected_guard_to_stop_this"},
+        )
+        valid_feedback = json_request(
+            daemon,
+            "/v1/command-activity/feedback",
+            method="POST",
+            token=token,
+            payload={"activity_id": "activity:01", "label": "expected_guard_to_stop_this"},
+        )
+    finally:
+        daemon.stop()
+
+    assert statuses == [400] * len(cases)
+    assert invalid_feedback[:2] == (400, {"error": "invalid_feedback_payload"})
+    assert missing_feedback[:2] == (404, {"error": "activity_not_found"})
+    assert valid_feedback[0] == 200
+    assert valid_feedback[1]["label"] == "expected_guard_to_stop_this"
+
+
+def test_analytics_and_extensions_are_paginated_bounded_contracts(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token(daemon)
+        analytics_status, analytics, _ = json_request(
+            daemon,
+            "/v1/command-activity/analytics?days=7&dimension=harness&dimension_value=codex",
+            token=token,
+        )
+        first_status, first, _ = json_request(daemon, "/v1/command-extensions?limit=2", token=token)
+        cursor = urllib.parse.quote(str(first["next_cursor"]))
+        second_status, second, _ = json_request(
+            daemon,
+            f"/v1/command-extensions?limit=2&cursor={cursor}",
+            token=token,
+        )
+    finally:
+        daemon.stop()
+
+    assert analytics_status == 200
+    assert analytics["commands_checked"] == 3
+    assert analytics["scope"] == {"dimension": "harness", "dimension_value": "codex"}
+    assert first_status == second_status == 200
+    assert len(first["items"]) == len(second["items"]) == 2
+    assert {item["extension_id"] for item in first["items"]}.isdisjoint(
+        {item["extension_id"] for item in second["items"]}
+    )
+    serialized = json.dumps(first)
+    assert "reference_urls" not in serialized
+    assert "project_markers" not in serialized
+
+
+def test_sse_emits_only_invalidation_type_and_activity_id(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    response = None
+    try:
+        token = _dashboard_token(daemon)
+        query_token_status, _, _ = json_request(
+            daemon,
+            "/v1/command-activity/events?token=forbidden",
+            token=token,
+        )
+        response = urllib.request.urlopen(
+            raw_request(
+                daemon,
+                "/v1/command-activity/events?cursor=0",
+                token=token,
+                origin="https://hol.org",
+            ),
+            timeout=5,
+        )
+        event_id = response.readline().decode("utf-8").strip()
+        data_line = response.readline().decode("utf-8").strip()
+        payload = json.loads(data_line.removeprefix("data: "))
+    finally:
+        if response is not None:
+            response.close()
+        daemon.stop()
+
+    assert query_token_status == 401
+    assert event_id.startswith("id: ")
+    assert payload == {"event": "command_activity_invalidated", "activity_id": "activity:01"}
+    assert set(payload) == {"event", "activity_id"}
+
+
+def test_sse_last_event_id_resumes_without_replay(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    response = None
+    try:
+        token = _dashboard_token(daemon)
+        response = urllib.request.urlopen(
+            raw_request(
+                daemon,
+                "/v1/command-activity/events?cursor=0",
+                token=token,
+                last_event_id="2",
+            ),
+            timeout=5,
+        )
+        event_id = response.readline().decode("utf-8").strip()
+        data_line = response.readline().decode("utf-8").strip()
+        payload = json.loads(data_line.removeprefix("data: "))
+    finally:
+        if response is not None:
+            response.close()
+        daemon.stop()
+
+    assert event_id == "id: 3"
+    assert payload == {"event": "command_activity_invalidated", "activity_id": "activity:03"}
+
+
+def test_sse_retention_gap_emits_reset_before_retained_events(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+    with store._connect() as connection:
+        connection.execute("delete from command_activity_invalidations where sequence = 1")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    response = None
+    try:
+        token = _dashboard_token(daemon)
+        response = urllib.request.urlopen(
+            raw_request(daemon, "/v1/command-activity/events?cursor=0", token=token),
+            timeout=5,
+        )
+        reset_id = response.readline().decode("utf-8").strip()
+        reset_event = response.readline().decode("utf-8").strip()
+        reset_data = response.readline().decode("utf-8").strip()
+        reset_payload = json.loads(reset_data.removeprefix("data: "))
+    finally:
+        if response is not None:
+            response.close()
+        daemon.stop()
+
+    assert reset_id == "id: 1"
+    assert reset_event == "event: command_activity_reset"
+    assert reset_payload == {"event": "command_activity_reset", "reset_required": True}
+
+
+def test_sse_admission_is_capped(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token(daemon)
+        with daemon._server.active_stream_clients_lock:
+            daemon._server.active_stream_clients = 8
+        status, payload, _ = json_request(
+            daemon,
+            "/v1/command-activity/events?cursor=0",
+            token=token,
+        )
+    finally:
+        with daemon._server.active_stream_clients_lock:
+            daemon._server.active_stream_clients = 0
+        daemon.stop()
+
+    assert status == 429
+    assert payload == {"error": "too_many_streams"}
+
+
+def test_sse_header_failure_releases_admission_slot() -> None:
+    class FailingHeaderHandler:
+        active: int = 0
+
+        def _try_increment_active_stream_clients(self, maximum: int) -> bool:
+            assert maximum == 8
+            self.active += 1
+            return True
+
+        def _decrement_active_stream_clients(self) -> None:
+            self.active -= 1
+
+        def _write_json(self, payload: dict[str, object], *, status: int = 200) -> None:
+            raise AssertionError((payload, status))
+
+        def send_response(self, code: int, message: str | None = None) -> None:
+            raise ConnectionResetError((code, message))
+
+    handler = FailingHeaderHandler()
+    try:
+        stream_command_activity_events(handler, 0)
+    except ConnectionResetError:
+        pass
+    else:
+        raise AssertionError("header failure did not propagate")
+    assert handler.active == 0

--- a/tests/test_guard_command_corpus.py
+++ b/tests/test_guard_command_corpus.py
@@ -42,7 +42,7 @@ from tests.guard_command_corpus_oracle import (
     iter_adversarial_oracle,
     iter_benign_oracle,
 )
-from tests.guard_command_corpus_runner import peak_rss_mib
+from tests.guard_command_corpus_runner import linux_peak_rss_mib_from_status, peak_rss_mib
 
 _OPAQUE_ID = re.compile(r"c-[0-9a-f]{24}")
 _OWNERS = {f"CDX-06{index}" for index in range(7)}
@@ -342,6 +342,11 @@ def test_windows_peak_rss_uses_process_working_set(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     assert peak_rss_mib() == 128.0
+
+
+def test_linux_peak_rss_uses_fresh_process_high_water_mark() -> None:
+    status = "Name:\tpython\nVmPeak:\t1048576 kB\nVmHWM:\t131072 kB\n"
+    assert linux_peak_rss_mib_from_status(status) == 128.0
 
 
 def test_canonical_digests_are_stable_across_process_roots_hash_seed_timezone_and_locale(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add authenticated, bounded command activity, analytics, extension, feedback, and invalidation stream endpoints
- add signed filter-bound pagination and strict local feedback persistence without command or policy mutation
- enforce dashboard-session origin controls, bounded event streams, reset semantics, and ID-only invalidation payloads

## Testing

- `uv run --no-sync pytest -q tests/test_guard_command_activity_api.py tests/test_guard_command_activity_api_access.py --tb=short`
- `uv run --no-sync ruff check` on all changed Python files
- `uv run --no-sync ruff format --check` on all changed Python files
- `uv run --no-sync basedpyright` on the new API, store, schema, and test modules
- `git diff --check`