### PR TITLE
feat(mdm): deliver challenge-bound protection leases

### DIFF
--- a/docs/guard/mdm-deployment.md
+++ b/docs/guard/mdm-deployment.md
@@ -32,6 +32,19 @@ On Unix platforms the native policy file and every path component must be root-o
 
 The machine-status JSON reports only whether this trust is configured, its workspace, and its key count. Public keys and fingerprints are not included in status output. The package's `release-trusted-keys.json` is a separate Ed25519 release-manifest trust domain and must not be used as policy-bundle signing authority.
 
+### Machine health Cloud enrollment
+
+Signed health delivery uses a dedicated machine-owned OAuth/DPoP profile. It never borrows credentials from a logged-in user. After the package and locked `selfProtection.workspaceId` / `selfProtection.deviceId` policy are deployed, an endpoint administrator completes device authorization once in root/SYSTEM context with the machine Cloud directory:
+
+- macOS: `hol-guard connect --guard-home "/Library/Application Support/HOL Guard State/cloud" --source machine-health --headless`
+- Windows: `hol-guard connect --guard-home "C:\ProgramData\HOL Guard\cloud" --source machine-health --headless`
+
+The administrator completes the displayed authorization URL using an identity permitted to enroll that organization’s device. MDM may orchestrate this command and collect only its bounded enrollment status; it must not place refresh tokens, DPoP private keys, or bearer tokens in managed policy. The resulting credential store is machine-owned and the scheduled reporter can refresh it without a user session.
+
+Each cadence registers the current non-exportable P-256 health key idempotently, submits one canonical `protection-lease.v1` outbox item, persists the authenticated acknowledgement, then polls only the fixed pending-attestation-challenge endpoint. A pending challenge can produce only a new signed lease bound to its exact nonce, lifetime, workspace, device, installation, and generation. Unknown fields and command-shaped responses are rejected.
+
+`mdm health-report --scope machine --json` exposes bounded diagnostics: snapshot duration, lease age, delivery latency, rejection reason, queue depth, and key-storage health. Cloud or proxy failure reports `delivery-failed` while retaining the current outbox and leaves local enforcement unchanged. A missing machine OAuth profile reports `lease-ready`; it never falls back to user credentials.
+
 ## Intune adapter example
 
 - macOS install: `/usr/sbin/installer -pkg hol-guard.pkg -target /`

--- a/scripts/mdm/macos/device-key-helper.swift
+++ b/scripts/mdm/macos/device-key-helper.swift
@@ -11,6 +11,7 @@ private let keyIdPattern = try! NSRegularExpression(pattern: "^[A-Za-z0-9_-]{43}
 private let timestampPattern = try! NSRegularExpression(pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
 private let safeIdPattern = try! NSRegularExpression(pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 private let healthLeaseDomain = Data("HOL-GUARD-HEALTH-LEASE-V1\0".utf8)
+private let healthKeyRegistrationDomain = Data("HOL-GUARD-HEALTH-KEY-REGISTRATION-V1\0".utf8)
 private let maximumClaimsBytes = 4096
 private let p256IntegerBytes = 32
 
@@ -153,6 +154,67 @@ private func validateCanonicalHealthLeaseClaims(_ data: Data, expectedSigningKey
     }
     // Every v1 string claim is ASCII-only. Comparing the exact bytes supplied by Python keeps
     // the helper and verifier on one canonical representation; a broader schema requires v2.
+    let canonical = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
+    guard canonical == data else { throw HelperError.invalidRequest }
+}
+
+private func validateCanonicalProtectionLease(_ data: Data, expectedSigningKeyId: String) throws {
+    guard !data.isEmpty, data.count <= maximumClaimsBytes,
+          let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+          Set(object.keys) == ["claims", "schemaVersion"],
+          object["schemaVersion"] as? String == "protection-lease.v1",
+          let claims = object["claims"] as? [String: Any] else {
+        throw HelperError.invalidRequest
+    }
+    let expectedClaimKeys: Set<String> = [
+        "challenge", "deviceId", "installationGeneration", "issuedAt", "machineInstallationId",
+        "previousLeaseDigest", "sequence", "signingKeyId", "snapshotDigest",
+        "snapshotSchemaVersion", "validForSeconds", "workspaceId",
+    ]
+    guard Set(claims.keys) == expectedClaimKeys,
+          claims["snapshotSchemaVersion"] as? String == "local-integrity-snapshot.v1",
+          try requiredString(claims, "signingKeyId", maximumLength: 43, pattern: keyIdPattern)
+            == expectedSigningKeyId else {
+        throw HelperError.invalidRequest
+    }
+    _ = try requiredString(claims, "workspaceId", maximumLength: 128, pattern: safeIdPattern)
+    _ = try requiredString(claims, "deviceId", maximumLength: 128, pattern: safeIdPattern)
+    _ = try requiredString(claims, "machineInstallationId", maximumLength: 32, pattern: generationPattern)
+    _ = try requiredString(claims, "installationGeneration", maximumLength: 32, pattern: generationPattern)
+    _ = try requiredString(claims, "issuedAt", maximumLength: 20, pattern: timestampPattern)
+    _ = try requiredString(claims, "snapshotDigest", maximumLength: 64, pattern: digestPattern)
+    guard let sequence = claims["sequence"] as? NSNumber,
+          CFGetTypeID(sequence) != CFBooleanGetTypeID(), sequence.uint64Value >= 1,
+          let validForSeconds = claims["validForSeconds"] as? NSNumber,
+          CFGetTypeID(validForSeconds) != CFBooleanGetTypeID(),
+          validForSeconds.intValue >= 180, validForSeconds.intValue <= 1800 else {
+        throw HelperError.invalidRequest
+    }
+    let canonical = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
+    guard canonical == data else { throw HelperError.invalidRequest }
+}
+
+private func validateCanonicalHealthKeyRegistration(_ data: Data, expectedSigningKeyId: String) throws {
+    guard !data.isEmpty, data.count <= maximumClaimsBytes,
+          let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        throw HelperError.invalidRequest
+    }
+    let expectedKeys: Set<String> = [
+        "algorithm", "deviceId", "installationGeneration", "keyId", "machineInstallationId",
+        "previousInstallationGeneration", "publicKeySpki", "registeredAt", "schemaVersion", "workspaceId",
+    ]
+    guard Set(object.keys) == expectedKeys,
+          object["schemaVersion"] as? String == "hol-guard-health-key-registration.v1",
+          object["algorithm"] as? String == "ecdsa-p256-sha256",
+          try requiredString(object, "keyId", maximumLength: 43, pattern: keyIdPattern) == expectedSigningKeyId else {
+        throw HelperError.invalidRequest
+    }
+    _ = try requiredString(object, "workspaceId", maximumLength: 128, pattern: safeIdPattern)
+    _ = try requiredString(object, "deviceId", maximumLength: 128, pattern: safeIdPattern)
+    _ = try requiredString(object, "machineInstallationId", maximumLength: 32, pattern: generationPattern)
+    _ = try requiredString(object, "installationGeneration", maximumLength: 32, pattern: generationPattern)
+    _ = try requiredString(object, "registeredAt", maximumLength: 20, pattern: timestampPattern)
+    _ = try requiredString(object, "publicKeySpki", maximumLength: 1024)
     let canonical = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
     guard canonical == data else { throw HelperError.invalidRequest }
 }
@@ -341,6 +403,41 @@ private func signHealthLease(_ privateKey: SecKey, publicKeyX963: Data) throws -
     return signature
 }
 
+private func signProtectionLease(_ privateKey: SecKey, publicKeyX963: Data) throws -> Data {
+    guard let lease = try FileHandle.standardInput.read(upToCount: maximumClaimsBytes + 1),
+          lease.count <= maximumClaimsBytes else {
+        throw HelperError.invalidRequest
+    }
+    try validateCanonicalProtectionLease(lease, expectedSigningKeyId: try signingKeyId(publicKeyX963: publicKeyX963))
+    guard SecKeyIsAlgorithmSupported(privateKey, .sign, .ecdsaSignatureMessageX962SHA256),
+          let signature = SecKeyCreateSignature(privateKey, .ecdsaSignatureMessageX962SHA256,
+                                                lease as CFData, nil) as Data? else {
+        throw HelperError.operationFailed
+    }
+    try validateCanonicalDERSignature(signature)
+    return signature
+}
+
+private func signHealthKeyRegistration(_ privateKey: SecKey, publicKeyX963: Data) throws -> Data {
+    guard let registration = try FileHandle.standardInput.read(upToCount: maximumClaimsBytes + 1),
+          registration.count <= maximumClaimsBytes else {
+        throw HelperError.invalidRequest
+    }
+    try validateCanonicalHealthKeyRegistration(
+        registration,
+        expectedSigningKeyId: try signingKeyId(publicKeyX963: publicKeyX963)
+    )
+    var message = healthKeyRegistrationDomain
+    message.append(registration)
+    guard SecKeyIsAlgorithmSupported(privateKey, .sign, .ecdsaSignatureMessageX962SHA256),
+          let signature = SecKeyCreateSignature(privateKey, .ecdsaSignatureMessageX962SHA256,
+                                                message as CFData, nil) as Data? else {
+        throw HelperError.operationFailed
+    }
+    try validateCanonicalDERSignature(signature)
+    return signature
+}
+
 private func run() throws -> PublicResult {
     guard geteuid() == 0, CommandLine.arguments.count == 3 else {
         throw HelperError.denied
@@ -365,7 +462,8 @@ private func run() throws -> PublicResult {
         } catch HelperError.keyAbsent {
             privateKey = try createKey(generation: generation, keychain: keychain)
         }
-    } else if verb == "inspect" || verb == "sign-health-lease" {
+    } else if verb == "inspect" || verb == "sign-health-lease" || verb == "sign-protection-lease"
+        || verb == "sign-health-key-registration" {
         privateKey = try copyPrivateKey(generation: generation, keychain: keychain)
     } else {
         throw HelperError.invalidRequest
@@ -373,6 +471,12 @@ private func run() throws -> PublicResult {
     let publicKey = try inspectKey(privateKey)
     if verb == "sign-health-lease" {
         emitSignature(try signHealthLease(privateKey, publicKeyX963: publicKey))
+    }
+    if verb == "sign-protection-lease" {
+        emitSignature(try signProtectionLease(privateKey, publicKeyX963: publicKey))
+    }
+    if verb == "sign-health-key-registration" {
+        emitSignature(try signHealthKeyRegistration(privateKey, publicKeyX963: publicKey))
     }
     return PublicResult(ok: true, state: "active", protectionLevel: "os-protected",
                         publicKeyX963: publicKey.base64EncodedString(), reasonCode: "device_key_active")

--- a/scripts/mdm/windows/device-key-helper.ps1
+++ b/scripts/mdm/windows/device-key-helper.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet('create', 'inspect', 'delete', 'sign-health-lease')]
+    [ValidateSet('create', 'inspect', 'delete', 'sign-health-lease', 'sign-protection-lease', 'sign-health-key-registration')]
     [string]$Verb,
     [Parameter(Mandatory = $true)]
     [ValidatePattern('^[0-9a-f]{32}$')]
@@ -16,6 +16,7 @@ $PlatformProvider = 'Microsoft Platform Crypto Provider'
 $SoftwareProvider = 'Microsoft Software Key Storage Provider'
 $ProtectedSddl = 'O:SYG:SYD:P(A;;FA;;;SY)(A;;FA;;;BA)'
 $HealthLeaseDomain = [System.Text.Encoding]::UTF8.GetBytes("HOL-GUARD-HEALTH-LEASE-V1`0")
+$HealthKeyRegistrationDomain = [System.Text.Encoding]::UTF8.GetBytes("HOL-GUARD-HEALTH-KEY-REGISTRATION-V1`0")
 $MaximumClaimsBytes = 4096
 
 function Emit-Result {
@@ -157,6 +158,96 @@ function Read-HealthLeaseClaims {
     return [System.Text.Encoding]::UTF8.GetBytes($Text)
 }
 
+function Read-ProtectionLease {
+    param([string]$ExpectedSigningKeyId)
+    $Buffer = [char[]]::new($MaximumClaimsBytes + 1)
+    $Count = [Console]::In.ReadBlock($Buffer, 0, $Buffer.Length)
+    if ($Count -eq 0 -or $Count -gt $MaximumClaimsBytes) { throw 'invalid' }
+    $Text = [string]::new($Buffer, 0, $Count)
+    $Utf8 = [System.Text.UTF8Encoding]::new($false, $true)
+    if ($Utf8.GetByteCount($Text) -gt $MaximumClaimsBytes) { throw 'invalid' }
+    $Lease = $Text | ConvertFrom-Json
+    if (@(Compare-Object @($Lease.PSObject.Properties.Name) @('claims', 'schemaVersion')).Count -ne 0 -or
+        $Lease.schemaVersion -ne 'protection-lease.v1') { throw 'invalid' }
+    $Claims = $Lease.claims
+    $ExpectedClaimKeys = @(
+        'challenge', 'deviceId', 'installationGeneration', 'issuedAt', 'machineInstallationId',
+        'previousLeaseDigest', 'sequence', 'signingKeyId', 'snapshotDigest', 'snapshotSchemaVersion',
+        'validForSeconds', 'workspaceId'
+    )
+    if (@(Compare-Object @($Claims.PSObject.Properties.Name) $ExpectedClaimKeys).Count -ne 0 -or
+        $Claims.snapshotSchemaVersion -ne 'local-integrity-snapshot.v1' -or
+        $Claims.workspaceId -notmatch '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$' -or
+        $Claims.deviceId -notmatch '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$' -or
+        $Claims.machineInstallationId -notmatch '^[0-9a-f]{32}$' -or
+        $Claims.installationGeneration -notmatch '^[0-9a-f]{32}$' -or
+        $Claims.issuedAt -notmatch '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' -or
+        $Claims.snapshotDigest -notmatch '^[0-9a-f]{64}$' -or
+        $Claims.signingKeyId -notmatch '^[A-Za-z0-9_-]{43}$' -or
+        $Claims.signingKeyId -ne $ExpectedSigningKeyId -or
+        $Claims.sequence -lt 1 -or $Claims.validForSeconds -lt 180 -or $Claims.validForSeconds -gt 1800) {
+        throw 'invalid'
+    }
+    $Canonical = [ordered]@{
+        claims = [ordered]@{
+            challenge = $Claims.challenge
+            deviceId = $Claims.deviceId
+            installationGeneration = $Claims.installationGeneration
+            issuedAt = $Claims.issuedAt
+            machineInstallationId = $Claims.machineInstallationId
+            previousLeaseDigest = $Claims.previousLeaseDigest
+            sequence = $Claims.sequence
+            signingKeyId = $Claims.signingKeyId
+            snapshotDigest = $Claims.snapshotDigest
+            snapshotSchemaVersion = $Claims.snapshotSchemaVersion
+            validForSeconds = $Claims.validForSeconds
+            workspaceId = $Claims.workspaceId
+        }
+        schemaVersion = $Lease.schemaVersion
+    } | ConvertTo-Json -Compress -Depth 5
+    if (-not [string]::Equals($Canonical, $Text, [System.StringComparison]::Ordinal)) { throw 'invalid' }
+    return [System.Text.Encoding]::UTF8.GetBytes($Text)
+}
+
+function Read-HealthKeyRegistration {
+    param([string]$ExpectedSigningKeyId)
+    $Buffer = [char[]]::new($MaximumClaimsBytes + 1)
+    $Count = [Console]::In.ReadBlock($Buffer, 0, $Buffer.Length)
+    if ($Count -eq 0 -or $Count -gt $MaximumClaimsBytes) { throw 'invalid' }
+    $Text = [string]::new($Buffer, 0, $Count)
+    $Registration = $Text | ConvertFrom-Json
+    $ExpectedKeys = @(
+        'algorithm', 'deviceId', 'installationGeneration', 'keyId', 'machineInstallationId',
+        'previousInstallationGeneration', 'publicKeySpki', 'registeredAt', 'schemaVersion', 'workspaceId'
+    )
+    if (@(Compare-Object @($Registration.PSObject.Properties.Name) $ExpectedKeys).Count -ne 0 -or
+        $Registration.schemaVersion -ne 'hol-guard-health-key-registration.v1' -or
+        $Registration.algorithm -ne 'ecdsa-p256-sha256' -or
+        $Registration.workspaceId -notmatch '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$' -or
+        $Registration.deviceId -notmatch '^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$' -or
+        $Registration.machineInstallationId -notmatch '^[0-9a-f]{32}$' -or
+        $Registration.installationGeneration -notmatch '^[0-9a-f]{32}$' -or
+        $Registration.keyId -notmatch '^[A-Za-z0-9_-]{43}$' -or
+        $Registration.keyId -ne $ExpectedSigningKeyId -or
+        $Registration.registeredAt -notmatch '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$') {
+        throw 'invalid'
+    }
+    $Canonical = [ordered]@{
+        algorithm = $Registration.algorithm
+        deviceId = $Registration.deviceId
+        installationGeneration = $Registration.installationGeneration
+        keyId = $Registration.keyId
+        machineInstallationId = $Registration.machineInstallationId
+        previousInstallationGeneration = $Registration.previousInstallationGeneration
+        publicKeySpki = $Registration.publicKeySpki
+        registeredAt = $Registration.registeredAt
+        schemaVersion = $Registration.schemaVersion
+        workspaceId = $Registration.workspaceId
+    } | ConvertTo-Json -Compress
+    if (-not [string]::Equals($Canonical, $Text, [System.StringComparison]::Ordinal)) { throw 'invalid' }
+    return [System.Text.Encoding]::UTF8.GetBytes($Text)
+}
+
 function Get-SecurityDescriptorBytes {
     $Descriptor = [System.Security.AccessControl.RawSecurityDescriptor]::new($ProtectedSddl)
     $Bytes = [byte[]]::new($Descriptor.BinaryLength)
@@ -287,11 +378,23 @@ try {
     $HealthLeaseSignature = $null
     try {
         $PublicKey = Inspect-Key $Key $ProviderName
-        if ($Verb -eq 'sign-health-lease') {
-            $ClaimsBytes = Read-HealthLeaseClaims (Get-SigningKeyId $PublicKey)
-            $Message = [byte[]]::new($HealthLeaseDomain.Length + $ClaimsBytes.Length)
-            [Array]::Copy($HealthLeaseDomain, 0, $Message, 0, $HealthLeaseDomain.Length)
-            [Array]::Copy($ClaimsBytes, 0, $Message, $HealthLeaseDomain.Length, $ClaimsBytes.Length)
+        if ($Verb -eq 'sign-health-lease' -or $Verb -eq 'sign-protection-lease' -or
+            $Verb -eq 'sign-health-key-registration') {
+            if ($Verb -eq 'sign-health-lease') {
+                $ClaimsBytes = Read-HealthLeaseClaims (Get-SigningKeyId $PublicKey)
+                $Message = [byte[]]::new($HealthLeaseDomain.Length + $ClaimsBytes.Length)
+                [Array]::Copy($HealthLeaseDomain, 0, $Message, 0, $HealthLeaseDomain.Length)
+                [Array]::Copy($ClaimsBytes, 0, $Message, $HealthLeaseDomain.Length, $ClaimsBytes.Length)
+            } elseif ($Verb -eq 'sign-protection-lease') {
+                $Message = Read-ProtectionLease (Get-SigningKeyId $PublicKey)
+            } else {
+                $RegistrationBytes = Read-HealthKeyRegistration (Get-SigningKeyId $PublicKey)
+                $Message = [byte[]]::new($HealthKeyRegistrationDomain.Length + $RegistrationBytes.Length)
+                [Array]::Copy($HealthKeyRegistrationDomain, 0, $Message, 0, $HealthKeyRegistrationDomain.Length)
+                [Array]::Copy(
+                    $RegistrationBytes, 0, $Message, $HealthKeyRegistrationDomain.Length, $RegistrationBytes.Length
+                )
+            }
             $Signer = [System.Security.Cryptography.ECDsaCng]::new($Key)
             try {
                 $P1363 = $Signer.SignData($Message, [System.Security.Cryptography.HashAlgorithmName]::SHA256)

--- a/src/codex_plugin_scanner/guard/mdm/device_key_native.py
+++ b/src/codex_plugin_scanner/guard/mdm/device_key_native.py
@@ -107,7 +107,7 @@ def _validated_canonical_protection_lease(unsigned_lease: bytes) -> str:
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
     if canonical != text:
         raise ValueError("health_lease_claims_invalid")
-    from .health_lease_contract import ProtectionLeaseClaims
+    from .protection_lease_contract import ProtectionLeaseClaims
 
     try:
         ProtectionLeaseClaims.parse(payload.get("claims"))

--- a/src/codex_plugin_scanner/guard/mdm/device_key_native.py
+++ b/src/codex_plugin_scanner/guard/mdm/device_key_native.py
@@ -37,6 +37,18 @@ _HEALTH_LEASE_KEYS = {
     "snapshotSchemaVersion",
     "workspaceId",
 }
+_HEALTH_KEY_REGISTRATION_KEYS = {
+    "algorithm",
+    "deviceId",
+    "installationGeneration",
+    "keyId",
+    "machineInstallationId",
+    "previousInstallationGeneration",
+    "publicKeySpki",
+    "registeredAt",
+    "schemaVersion",
+    "workspaceId",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,6 +88,57 @@ def _validated_canonical_health_lease_claims(claims: bytes) -> str:
         HealthLeaseClaims.parse(payload)
     except ValueError as exc:
         raise ValueError("health_lease_claims_invalid") from exc
+    return text
+
+
+def _validated_canonical_protection_lease(unsigned_lease: bytes) -> str:
+    if not unsigned_lease or len(unsigned_lease) > _MAX_HEALTH_LEASE_CLAIMS_BYTES:
+        raise ValueError("health_lease_claims_invalid")
+    try:
+        text = unsigned_lease.decode("utf-8")
+        decoded = cast(object, json.loads(text))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("health_lease_claims_invalid") from exc
+    if not isinstance(decoded, dict) or set(decoded) != {"claims", "schemaVersion"}:
+        raise ValueError("health_lease_claims_invalid")
+    payload = cast(dict[str, object], decoded)
+    if payload.get("schemaVersion") != "protection-lease.v1":
+        raise ValueError("health_lease_claims_invalid")
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    if canonical != text:
+        raise ValueError("health_lease_claims_invalid")
+    from .health_lease_contract import ProtectionLeaseClaims
+
+    try:
+        ProtectionLeaseClaims.parse(payload.get("claims"))
+    except ValueError as exc:
+        raise ValueError("health_lease_claims_invalid") from exc
+    return text
+
+
+def _validated_canonical_health_key_registration(registration: bytes) -> str:
+    if not registration or len(registration) > _MAX_HEALTH_LEASE_CLAIMS_BYTES:
+        raise ValueError("health_key_registration_invalid")
+    try:
+        text = registration.decode("utf-8")
+        decoded = cast(object, json.loads(text))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("health_key_registration_invalid") from exc
+    if not isinstance(decoded, dict):
+        raise ValueError("health_key_registration_invalid")
+    payload = cast(dict[str, object], decoded)
+    if (
+        set(payload) != _HEALTH_KEY_REGISTRATION_KEYS
+        or payload.get("schemaVersion") != "hol-guard-health-key-registration.v1"
+        or payload.get("algorithm") != "ecdsa-p256-sha256"
+    ):
+        raise ValueError("health_key_registration_invalid")
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    if canonical != text:
+        raise ValueError("health_key_registration_invalid")
+    key_id = payload.get("keyId")
+    if not isinstance(key_id, str) or re.fullmatch(r"[A-Za-z0-9_-]{43}", key_id) is None:
+        raise ValueError("health_key_registration_invalid")
     return text
 
 
@@ -265,6 +328,82 @@ def sign_health_lease(
     return NativeHealthLeaseSignature(_validated_der_signature(payload.get("signature")))
 
 
+def sign_protection_lease(
+    paths: MachinePaths, generation: str, canonical_unsigned_lease: bytes, *, system_name: str
+) -> NativeHealthLeaseSignature:
+    if re.fullmatch(r"[0-9a-f]{32}", generation) is None:
+        raise ValueError("device_key_request_invalid")
+    lease_text = _validated_canonical_protection_lease(canonical_unsigned_lease)
+    command, environment, cwd = _helper_invocation(paths, "sign-protection-lease", generation, system_name)
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        cwd=cwd,
+        env=environment,
+        input=lease_text,
+        text=True,
+        timeout=_HELPER_TIMEOUT_SECONDS,
+    )
+    if (
+        len(result.stdout.encode("utf-8")) > _MAX_HELPER_OUTPUT_BYTES
+        or len(result.stderr.encode("utf-8")) > _MAX_HELPER_STDERR_BYTES
+    ):
+        raise OSError("device_key_probe_failed")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise OSError("device_key_probe_failed") from exc
+    if (
+        result.returncode != 0
+        or not isinstance(payload, dict)
+        or set(payload) != {"ok", "signature", "signatureAlgorithm", "signatureEncoding"}
+        or payload.get("ok") is not True
+        or payload.get("signatureAlgorithm") != "ecdsa-p256-sha256"
+        or payload.get("signatureEncoding") != "asn1-der"
+    ):
+        raise OSError("device_key_probe_failed")
+    return NativeHealthLeaseSignature(_validated_der_signature(payload.get("signature")))
+
+
+def sign_health_key_registration(
+    paths: MachinePaths, generation: str, canonical_registration: bytes, *, system_name: str
+) -> NativeHealthLeaseSignature:
+    if re.fullmatch(r"[0-9a-f]{32}", generation) is None:
+        raise ValueError("device_key_request_invalid")
+    registration_text = _validated_canonical_health_key_registration(canonical_registration)
+    command, environment, cwd = _helper_invocation(paths, "sign-health-key-registration", generation, system_name)
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        cwd=cwd,
+        env=environment,
+        input=registration_text,
+        text=True,
+        timeout=_HELPER_TIMEOUT_SECONDS,
+    )
+    if (
+        len(result.stdout.encode("utf-8")) > _MAX_HELPER_OUTPUT_BYTES
+        or len(result.stderr.encode("utf-8")) > _MAX_HELPER_STDERR_BYTES
+    ):
+        raise OSError("device_key_probe_failed")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise OSError("device_key_probe_failed") from exc
+    if (
+        result.returncode != 0
+        or not isinstance(payload, dict)
+        or set(payload) != {"ok", "signature", "signatureAlgorithm", "signatureEncoding"}
+        or payload.get("ok") is not True
+        or payload.get("signatureAlgorithm") != "ecdsa-p256-sha256"
+        or payload.get("signatureEncoding") != "asn1-der"
+    ):
+        raise OSError("device_key_probe_failed")
+    return NativeHealthLeaseSignature(_validated_der_signature(payload.get("signature")))
+
+
 def windows_current_user_sid() -> str:
     from ctypes import wintypes
 
@@ -308,6 +447,8 @@ __all__ = [
     "NativeKeyEvidence",
     "require_machine_context",
     "run_helper",
+    "sign_health_key_registration",
     "sign_health_lease",
+    "sign_protection_lease",
     "windows_current_user_sid",
 ]

--- a/src/codex_plugin_scanner/guard/mdm/health_key_registration.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_key_registration.py
@@ -21,6 +21,7 @@ def build_machine_health_key_registration(
     *,
     installation_generation: str,
     machine_installation_id: str,
+    key_id: str | None = None,
     now: datetime | None = None,
     system_name: str,
 ) -> bytes:
@@ -28,7 +29,7 @@ def build_machine_health_key_registration(
 
     from .device_key_native import sign_health_key_registration
 
-    generation = verified_machine_device_key_by_id(paths, system_name=system_name)
+    generation = verified_machine_device_key_by_id(paths, key_id, system_name=system_name)
     timestamp = canonical_timestamp((now or datetime.now(timezone.utc)).astimezone(timezone.utc))
     registration: dict[str, object] = {
         "algorithm": "ecdsa-p256-sha256",

--- a/src/codex_plugin_scanner/guard/mdm/health_key_registration.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_key_registration.py
@@ -1,0 +1,76 @@
+"""Proof-of-possession registration for machine health signing keys."""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
+
+from .contracts import MachinePaths
+from .device_key_access import verified_machine_device_key_by_id
+from .health_lease_contract import HealthLeaseBinding, canonical_json_bytes, canonical_timestamp
+
+_SCHEMA = "hol-guard-health-key-registration.v1"
+_P256_ORDER = int("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551", 16)
+
+
+def build_machine_health_key_registration(
+    paths: MachinePaths,
+    binding: HealthLeaseBinding,
+    *,
+    installation_generation: str,
+    machine_installation_id: str,
+    now: datetime | None = None,
+    system_name: str,
+) -> bytes:
+    """Build a fresh, canonical registration signed by the non-exportable machine key."""
+
+    from .device_key_native import sign_health_key_registration
+
+    generation = verified_machine_device_key_by_id(paths, system_name=system_name)
+    timestamp = canonical_timestamp((now or datetime.now(timezone.utc)).astimezone(timezone.utc))
+    registration: dict[str, object] = {
+        "algorithm": "ecdsa-p256-sha256",
+        "deviceId": binding.device_id,
+        "installationGeneration": installation_generation,
+        "keyId": generation.key_id,
+        "machineInstallationId": machine_installation_id,
+        "previousInstallationGeneration": None,
+        "publicKeySpki": generation.public_key_spki,
+        "registeredAt": timestamp,
+        "schemaVersion": _SCHEMA,
+        "workspaceId": binding.workspace_id,
+    }
+    canonical_registration = canonical_json_bytes(registration)
+    signature = _low_s_signature(
+        sign_health_key_registration(
+            paths,
+            generation.generation,
+            canonical_registration,
+            system_name=system_name,
+        ).signature
+    )
+    return canonical_json_bytes(
+        {
+            **registration,
+            "proof": {
+                "algorithm": "ecdsa-p256-sha256",
+                "encoding": "asn1-der",
+                "value": base64.b64encode(signature).decode("ascii"),
+            },
+        }
+    )
+
+
+def _low_s_signature(signature: bytes) -> bytes:
+    try:
+        r, s = decode_dss_signature(signature)
+    except ValueError as exc:
+        raise OSError("health_key_registration_signature_invalid") from exc
+    if not 1 <= r < _P256_ORDER or not 1 <= s < _P256_ORDER:
+        raise OSError("health_key_registration_signature_invalid")
+    return encode_dss_signature(r, min(s, _P256_ORDER - s))
+
+
+__all__ = ["build_machine_health_key_registration"]

--- a/src/codex_plugin_scanner/guard/mdm/health_lease.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_lease.py
@@ -14,6 +14,7 @@ from contextlib import suppress
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import cast
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
@@ -37,14 +38,16 @@ from .health_lease_contract import (
     HealthLeaseBinding,
     HealthLeaseClaims,
     HealthLeaseOutbox,
-    ProtectionLeaseChallenge,
-    ProtectionLeaseClaims,
     SignedHealthLease,
-    SignedProtectionLease,
     canonical_json_bytes,
     canonical_timestamp,
 )
 from .integrity import machine_integrity_snapshot
+from .protection_lease_contract import (
+    ProtectionLeaseChallenge,
+    ProtectionLeaseClaims,
+    SignedProtectionLease,
+)
 
 _OUTBOX_NAME = "health-lease-outbox.json"
 _ACK_NAME = "health-lease-ack.json"
@@ -371,12 +374,12 @@ def acknowledge_pending_health_lease(
             pending.lease.claims.signing_key_id,
             system_name=resolved_system,
         )
-        _verify_signature(generation, pending.lease.claims, pending.lease.signature)
+        _verify_signature(generation, cast(LeaseClaims, pending.lease.claims), pending.lease.signature)
         _validate_ack(ack, pending)
         if requires_recovery:
             recovered = _advanced_record(
                 record,
-                pending.lease,
+                cast(SignedHealthLease | SignedProtectionLease, pending.lease),
                 system_name=resolved_system,
                 now=ack.received_datetime,
             )
@@ -425,9 +428,14 @@ def issue_or_load_pending_health_lease(
                 pending.lease.claims.signing_key_id,
                 system_name=resolved_system,
             )
-            _verify_signature(generation, pending.lease.claims, pending.lease.signature)
+            _verify_signature(generation, cast(LeaseClaims, pending.lease.claims), pending.lease.signature)
             if requires_recovery:
-                recovered = _advanced_record(record, pending.lease, system_name=resolved_system, now=resolved_now)
+                recovered = _advanced_record(
+                    record,
+                    cast(SignedHealthLease | SignedProtectionLease, pending.lease),
+                    system_name=resolved_system,
+                    now=resolved_now,
+                )
                 _atomic_write(paths, recovered)
                 record = recovered
             if ack is not None and _ack_matches_pending(ack, pending):

--- a/src/codex_plugin_scanner/guard/mdm/health_lease.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_lease.py
@@ -245,9 +245,7 @@ def _default_signer(paths: MachinePaths, generation: KeyGeneration, claims: Leas
     from .device_key_native import sign_health_lease, sign_protection_lease
 
     if isinstance(claims, ProtectionLeaseClaims):
-        result = sign_protection_lease(
-            paths, generation.generation, claims.signing_payload(), system_name=system_name
-        )
+        result = sign_protection_lease(paths, generation.generation, claims.signing_payload(), system_name=system_name)
     else:
         result = sign_health_lease(
             paths, generation.generation, canonical_json_bytes(claims.to_dict()), system_name=system_name
@@ -274,12 +272,8 @@ def _validate_pending(
         return False
     if claims.sequence != record.last_issued_sequence + 1:
         raise OSError("health_lease_pending_conflict")
-    if (
-        claims.previous_lease_digest != record.last_lease_digest
-        or (
-            isinstance(claims, HealthLeaseClaims)
-            and claims.previous_lease_key_id != record.last_lease_key_id
-        )
+    if claims.previous_lease_digest != record.last_lease_digest or (
+        isinstance(claims, HealthLeaseClaims) and claims.previous_lease_key_id != record.last_lease_key_id
     ):
         raise OSError("health_lease_pending_conflict")
     return True

--- a/src/codex_plugin_scanner/guard/mdm/health_lease.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_lease.py
@@ -12,7 +12,7 @@ import stat
 from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import replace
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 
 from cryptography.exceptions import InvalidSignature
@@ -37,7 +37,10 @@ from .health_lease_contract import (
     HealthLeaseBinding,
     HealthLeaseClaims,
     HealthLeaseOutbox,
+    ProtectionLeaseChallenge,
+    ProtectionLeaseClaims,
     SignedHealthLease,
+    SignedProtectionLease,
     canonical_json_bytes,
     canonical_timestamp,
 )
@@ -46,7 +49,8 @@ from .integrity import machine_integrity_snapshot
 _OUTBOX_NAME = "health-lease-outbox.json"
 _ACK_NAME = "health-lease-ack.json"
 SnapshotFactory = Callable[[], LocalIntegritySnapshot]
-LeaseSigner = Callable[[MachinePaths, KeyGeneration, HealthLeaseClaims, str], bytes]
+LeaseClaims = HealthLeaseClaims | ProtectionLeaseClaims
+LeaseSigner = Callable[[MachinePaths, KeyGeneration, LeaseClaims, str], bytes]
 CrashHook = Callable[[str], None]
 
 
@@ -227,7 +231,7 @@ def _normalized_snapshot(
     return payload
 
 
-def _verify_signature(generation: KeyGeneration, claims: HealthLeaseClaims, signature: bytes) -> None:
+def _verify_signature(generation: KeyGeneration, claims: LeaseClaims, signature: bytes) -> None:
     try:
         public_key = serialization.load_der_public_key(base64.b64decode(generation.public_key_spki, validate=True))
         if not isinstance(public_key, ec.EllipticCurvePublicKey) or not isinstance(public_key.curve, ec.SECP256R1):
@@ -237,17 +241,17 @@ def _verify_signature(generation: KeyGeneration, claims: HealthLeaseClaims, sign
         raise OSError("health_lease_signature_invalid") from exc
 
 
-def _default_signer(
-    paths: MachinePaths, generation: KeyGeneration, claims: HealthLeaseClaims, system_name: str
-) -> bytes:
-    from .device_key_native import sign_health_lease
+def _default_signer(paths: MachinePaths, generation: KeyGeneration, claims: LeaseClaims, system_name: str) -> bytes:
+    from .device_key_native import sign_health_lease, sign_protection_lease
 
-    result = sign_health_lease(
-        paths,
-        generation.generation,
-        canonical_json_bytes(claims.to_dict()),
-        system_name=system_name,
-    )
+    if isinstance(claims, ProtectionLeaseClaims):
+        result = sign_protection_lease(
+            paths, generation.generation, claims.signing_payload(), system_name=system_name
+        )
+    else:
+        result = sign_health_lease(
+            paths, generation.generation, canonical_json_bytes(claims.to_dict()), system_name=system_name
+        )
     return result.signature
 
 
@@ -272,7 +276,10 @@ def _validate_pending(
         raise OSError("health_lease_pending_conflict")
     if (
         claims.previous_lease_digest != record.last_lease_digest
-        or claims.previous_lease_key_id != record.last_lease_key_id
+        or (
+            isinstance(claims, HealthLeaseClaims)
+            and claims.previous_lease_key_id != record.last_lease_key_id
+        )
     ):
         raise OSError("health_lease_pending_conflict")
     return True
@@ -325,7 +332,7 @@ def _retire_outbox(paths: MachinePaths) -> None:
 
 def _advanced_record(
     record: InstallationContinuityRecord,
-    lease: SignedHealthLease,
+    lease: SignedHealthLease | SignedProtectionLease,
     *,
     system_name: str,
     now: datetime,
@@ -400,6 +407,7 @@ def issue_or_load_pending_health_lease(
     snapshot_factory: SnapshotFactory = machine_integrity_snapshot,
     signer: LeaseSigner = _default_signer,
     crash_hook: CrashHook | None = None,
+    challenge: ProtectionLeaseChallenge | None = None,
 ) -> HealthLeaseOutbox:
     """Issue one lease or recover the exact pending artifact after a crash."""
 
@@ -449,25 +457,24 @@ def issue_or_load_pending_health_lease(
             raise OSError("health_lease_outbox_absent")
         generation = verified_machine_device_key_by_id(paths, system_name=resolved_system)
         snapshot_bytes = _normalized_snapshot(snapshot_factory(), binding, record)
-        claims = HealthLeaseClaims.parse(
+        claims = ProtectionLeaseClaims.parse(
             {
-                "schemaVersion": "hol-guard-health-lease.v1",
                 "workspaceId": binding.workspace_id,
                 "deviceId": binding.device_id,
                 "machineInstallationId": record.machine_installation_id,
                 "installationGeneration": record.installation_generation,
                 "sequence": record.last_issued_sequence + 1,
                 "issuedAt": canonical_timestamp(resolved_now),
-                "leaseExpiresAt": canonical_timestamp(resolved_now + timedelta(seconds=lease_seconds)),
+                "validForSeconds": lease_seconds,
                 "snapshotSchemaVersion": LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION,
                 "snapshotDigest": hashlib.sha256(snapshot_bytes).hexdigest(),
                 "previousLeaseDigest": record.last_lease_digest,
-                "previousLeaseKeyId": record.last_lease_key_id,
                 "signingKeyId": generation.key_id,
+                "challenge": challenge.to_dict() if challenge is not None else None,
             }
         )
         signature = signer(paths, generation, claims, resolved_system)
-        lease = SignedHealthLease.parse(SignedHealthLease(claims, signature).canonical_bytes())
+        lease = SignedProtectionLease.parse(SignedProtectionLease(claims, signature).canonical_bytes())
         _verify_signature(generation, claims, lease.signature)
         outbox = HealthLeaseOutbox(lease, snapshot_bytes)
         _atomic_outbox_write(paths, outbox)

--- a/src/codex_plugin_scanner/guard/mdm/health_lease_contract.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_lease_contract.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import importlib
 import json
 import math
 import re
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
-from typing import Final, get_args
+from datetime import datetime, timezone
+from typing import Final, Protocol, cast, get_args
 
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
 
@@ -24,8 +25,51 @@ from .contracts import (
     SupervisorState,
 )
 
+
+class LeaseClaims(Protocol):
+    @property
+    def workspace_id(self) -> str: ...
+    @property
+    def device_id(self) -> str: ...
+    @property
+    def machine_installation_id(self) -> str: ...
+    @property
+    def installation_generation(self) -> str: ...
+    @property
+    def sequence(self) -> int: ...
+    @property
+    def issued_at(self) -> str: ...
+    @property
+    def lease_expires_at(self) -> str: ...
+    @property
+    def snapshot_schema_version(self) -> str: ...
+    @property
+    def snapshot_digest(self) -> str: ...
+    @property
+    def previous_lease_digest(self) -> str | None: ...
+    @property
+    def signing_key_id(self) -> str: ...
+
+
+class ProtectionLease(Protocol):
+    @property
+    def claims(self) -> LeaseClaims: ...
+
+    @property
+    def signature(self) -> bytes: ...
+
+    @property
+    def digest(self) -> str: ...
+
+    def to_dict(self) -> dict[str, object]: ...
+
+    def canonical_bytes(self) -> bytes: ...
+
+    @classmethod
+    def parse(cls, payload: bytes) -> ProtectionLease: ...
+
+
 HEALTH_LEASE_SCHEMA: Final = "hol-guard-health-lease.v1"
-PROTECTION_LEASE_SCHEMA: Final = "protection-lease.v1"
 HEALTH_LEASE_OUTBOX_SCHEMA: Final = "hol-guard-health-lease-outbox.v1"
 HEALTH_LEASE_SIGNING_DOMAIN: Final = b"HOL-GUARD-HEALTH-LEASE-V1\x00"
 SIGNATURE_ALGORITHM: Final = "ecdsa-p256-sha256"
@@ -58,21 +102,6 @@ _CLAIM_KEYS = {
     "previousLeaseKeyId",
     "signingKeyId",
 }
-_PROTECTION_CLAIM_KEYS = {
-    "workspaceId",
-    "deviceId",
-    "machineInstallationId",
-    "installationGeneration",
-    "sequence",
-    "issuedAt",
-    "validForSeconds",
-    "snapshotSchemaVersion",
-    "snapshotDigest",
-    "previousLeaseDigest",
-    "signingKeyId",
-    "challenge",
-}
-_CHALLENGE_KEYS = {"challengeId", "issuedAt", "nonce", "validForSeconds"}
 _SNAPSHOT_KEYS = {
     "schemaVersion",
     "generatedAt",
@@ -280,139 +309,6 @@ class HealthLeaseClaims:
         return HEALTH_LEASE_SIGNING_DOMAIN + canonical_json_bytes(self.to_dict())
 
 
-@dataclass(frozen=True, slots=True)
-class ProtectionLeaseChallenge:
-    challenge_id: str
-    issued_at: str
-    nonce: str
-    valid_for_seconds: int
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "challengeId": self.challenge_id,
-            "issuedAt": self.issued_at,
-            "nonce": self.nonce,
-            "validForSeconds": self.valid_for_seconds,
-        }
-
-    @classmethod
-    def parse(cls, raw: object) -> ProtectionLeaseChallenge:
-        if not isinstance(raw, dict):
-            raise ValueError("health_lease_challenge_invalid")
-        _exact_keys(raw, _CHALLENGE_KEYS, "health_lease_challenge_invalid")
-        challenge_id = _safe_id(raw.get("challengeId"))
-        issued_at = raw.get("issuedAt")
-        nonce = raw.get("nonce")
-        valid_for_seconds = raw.get("validForSeconds")
-        if (
-            not isinstance(issued_at, str)
-            or _SNAPSHOT_TIMESTAMP.fullmatch(issued_at) is None
-            or not isinstance(nonce, str)
-            or re.fullmatch(r"[A-Za-z0-9_-]{32,128}", nonce) is None
-            or not isinstance(valid_for_seconds, int)
-            or isinstance(valid_for_seconds, bool)
-            or not 30 <= valid_for_seconds <= 300
-        ):
-            raise ValueError("health_lease_challenge_invalid")
-        try:
-            parsed = datetime.fromisoformat(f"{issued_at[:-1]}+00:00")
-        except ValueError as exc:
-            raise ValueError("health_lease_challenge_invalid") from exc
-        if parsed.tzinfo is None:
-            raise ValueError("health_lease_challenge_invalid")
-        return cls(challenge_id, issued_at, nonce, valid_for_seconds)
-
-
-@dataclass(frozen=True, slots=True)
-class ProtectionLeaseClaims:
-    workspace_id: str
-    device_id: str
-    machine_installation_id: str
-    installation_generation: str
-    sequence: int
-    issued_at: str
-    valid_for_seconds: int
-    snapshot_schema_version: str
-    snapshot_digest: str
-    previous_lease_digest: str | None
-    signing_key_id: str
-    challenge: ProtectionLeaseChallenge | None
-
-    @property
-    def lease_expires_at(self) -> str:
-        issued = _parse_timestamp(self.issued_at)
-        return canonical_timestamp(issued + timedelta(seconds=self.valid_for_seconds))
-
-    @property
-    def previous_lease_key_id(self) -> None:
-        return None
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "workspaceId": self.workspace_id,
-            "deviceId": self.device_id,
-            "machineInstallationId": self.machine_installation_id,
-            "installationGeneration": self.installation_generation,
-            "sequence": self.sequence,
-            "issuedAt": self.issued_at,
-            "validForSeconds": self.valid_for_seconds,
-            "snapshotSchemaVersion": self.snapshot_schema_version,
-            "snapshotDigest": self.snapshot_digest,
-            "previousLeaseDigest": self.previous_lease_digest,
-            "signingKeyId": self.signing_key_id,
-            "challenge": self.challenge.to_dict() if self.challenge is not None else None,
-        }
-
-    @classmethod
-    def parse(cls, raw: object) -> ProtectionLeaseClaims:
-        if not isinstance(raw, dict):
-            raise ValueError("health_lease_invalid")
-        _exact_keys(raw, _PROTECTION_CLAIM_KEYS)
-        sequence = raw.get("sequence")
-        valid_for_seconds = raw.get("validForSeconds")
-        if (
-            not isinstance(sequence, int)
-            or isinstance(sequence, bool)
-            or not 1 <= sequence <= MAX_UINT64
-            or not isinstance(valid_for_seconds, int)
-            or isinstance(valid_for_seconds, bool)
-            or not 180 <= valid_for_seconds <= 1800
-        ):
-            raise ValueError("health_lease_invalid")
-        previous_digest = raw.get("previousLeaseDigest")
-        if (sequence == 1 and previous_digest is not None) or (
-            sequence > 1 and (not isinstance(previous_digest, str) or _HEX_64.fullmatch(previous_digest) is None)
-        ):
-            raise ValueError("health_lease_invalid")
-        issued_at = canonical_timestamp(_parse_timestamp(raw.get("issuedAt")))
-        challenge_raw = raw.get("challenge")
-        challenge = None if challenge_raw is None else ProtectionLeaseChallenge.parse(challenge_raw)
-        if raw.get("snapshotSchemaVersion") != LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION:
-            raise ValueError("health_lease_invalid")
-        if challenge is not None:
-            challenge_issued = datetime.fromisoformat(f"{challenge.issued_at[:-1]}+00:00")
-            lease_issued = _parse_timestamp(issued_at)
-            if not challenge_issued <= lease_issued < challenge_issued + timedelta(seconds=challenge.valid_for_seconds):
-                raise ValueError("health_lease_challenge_invalid")
-        return cls(
-            _safe_id(raw.get("workspaceId")),
-            _safe_id(raw.get("deviceId")),
-            _match(raw.get("machineInstallationId"), _HEX_32),
-            _match(raw.get("installationGeneration"), _HEX_32),
-            sequence,
-            issued_at,
-            valid_for_seconds,
-            LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION,
-            _match(raw.get("snapshotDigest"), _HEX_64),
-            None if previous_digest is None else previous_digest,
-            _match(raw.get("signingKeyId"), _KEY_ID),
-            challenge,
-        )
-
-    def signing_payload(self) -> bytes:
-        return canonical_json_bytes({"claims": self.to_dict(), "schemaVersion": PROTECTION_LEASE_SCHEMA})
-
-
 def _canonical_ecdsa_signature(signature: bytes) -> bytes:
     try:
         r, s = decode_dss_signature(signature)
@@ -474,80 +370,9 @@ class SignedHealthLease:
         return cls(HealthLeaseClaims.parse(raw.get("claims")), signature)
 
 
-def _der_to_p1363(signature: bytes) -> bytes:
-    canonical = _canonical_ecdsa_signature(signature)
-    r, s = decode_dss_signature(canonical)
-    return r.to_bytes(32, "big") + s.to_bytes(32, "big")
-
-
-def _p1363_to_der(signature: bytes) -> bytes:
-    if len(signature) != 64:
-        raise ValueError("health_lease_invalid")
-    r = int.from_bytes(signature[:32], "big")
-    s = int.from_bytes(signature[32:], "big")
-    if not 1 <= r < P256_ORDER or not 1 <= s <= P256_ORDER // 2:
-        raise ValueError("health_lease_invalid")
-    return encode_dss_signature(r, s)
-
-
-@dataclass(frozen=True, slots=True)
-class SignedProtectionLease:
-    claims: ProtectionLeaseClaims
-    signature: bytes
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "schemaVersion": PROTECTION_LEASE_SCHEMA,
-            "claims": self.claims.to_dict(),
-            "signature": {
-                "algorithm": SIGNATURE_ALGORITHM,
-                "keyId": self.claims.signing_key_id,
-                "value": base64.b64encode(_der_to_p1363(self.signature)).decode("ascii"),
-            },
-        }
-
-    def canonical_bytes(self) -> bytes:
-        payload = canonical_json_bytes(self.to_dict())
-        if len(payload) > MAX_LEASE_BYTES:
-            raise ValueError("health_lease_invalid")
-        return payload
-
-    @property
-    def digest(self) -> str:
-        return hashlib.sha256(self.canonical_bytes()).hexdigest()
-
-    @classmethod
-    def parse(cls, payload: bytes) -> SignedProtectionLease:
-        raw = _strict_json(payload, maximum=MAX_LEASE_BYTES, reason="health_lease_invalid")
-        _exact_keys(raw, {"schemaVersion", "claims", "signature"})
-        if raw.get("schemaVersion") != PROTECTION_LEASE_SCHEMA:
-            raise ValueError("health_lease_invalid")
-        claims = ProtectionLeaseClaims.parse(raw.get("claims"))
-        signature_raw = raw.get("signature")
-        if not isinstance(signature_raw, dict):
-            raise ValueError("health_lease_invalid")
-        _exact_keys(signature_raw, {"algorithm", "keyId", "value"})
-        value = signature_raw.get("value")
-        if (
-            signature_raw.get("algorithm") != SIGNATURE_ALGORITHM
-            or signature_raw.get("keyId") != claims.signing_key_id
-            or not isinstance(value, str)
-            or len(value) > 128
-        ):
-            raise ValueError("health_lease_invalid")
-        try:
-            raw_signature = base64.b64decode(value, validate=True)
-            signature = _p1363_to_der(raw_signature)
-        except (ValueError, TypeError) as exc:
-            raise ValueError("health_lease_invalid") from exc
-        if base64.b64encode(raw_signature).decode("ascii") != value:
-            raise ValueError("health_lease_invalid")
-        return cls(claims, signature)
-
-
 @dataclass(frozen=True, slots=True)
 class HealthLeaseOutbox:
-    lease: SignedHealthLease | SignedProtectionLease
+    lease: SignedHealthLease | ProtectionLease
     snapshot_bytes: bytes
 
     def to_dict(self) -> dict[str, object]:
@@ -574,11 +399,12 @@ class HealthLeaseOutbox:
         lease_raw = raw.get("lease")
         if not isinstance(lease_raw, dict):
             raise ValueError("health_lease_outbox_invalid")
-        lease = (
-            SignedProtectionLease.parse(canonical_json_bytes(lease_raw))
-            if lease_raw.get("schemaVersion") == PROTECTION_LEASE_SCHEMA
-            else SignedHealthLease.parse(canonical_json_bytes(lease_raw))
-        )
+        if lease_raw.get("schemaVersion") == "protection-lease.v1":
+            module = importlib.import_module(".protection_lease_contract", __package__)
+            lease_type = cast(type[ProtectionLease], module.SignedProtectionLease)
+            lease: SignedHealthLease | ProtectionLease = lease_type.parse(canonical_json_bytes(lease_raw))
+        else:
+            lease = SignedHealthLease.parse(canonical_json_bytes(lease_raw))
         snapshot_raw = raw.get("snapshot")
         if not isinstance(snapshot_raw, str):
             raise ValueError("health_lease_outbox_invalid")
@@ -596,7 +422,7 @@ class HealthLeaseOutbox:
         return outbox
 
 
-def _validate_snapshot_binding(snapshot: bytes, claims: HealthLeaseClaims | ProtectionLeaseClaims) -> None:
+def _validate_snapshot_binding(snapshot: bytes, claims: LeaseClaims) -> None:
     raw = _strict_json(snapshot, maximum=MAX_SNAPSHOT_BYTES, reason="health_lease_outbox_invalid")
     _exact_keys(raw, _SNAPSHOT_KEYS, "health_lease_outbox_invalid")
     if raw.get("schemaVersion") != claims.snapshot_schema_version:
@@ -703,14 +529,10 @@ def _validate_snapshot_binding(snapshot: bytes, claims: HealthLeaseClaims | Prot
 
 __all__ = [
     "HEALTH_LEASE_SIGNING_DOMAIN",
-    "PROTECTION_LEASE_SCHEMA",
     "HealthLeaseBinding",
     "HealthLeaseClaims",
     "HealthLeaseOutbox",
-    "ProtectionLeaseChallenge",
-    "ProtectionLeaseClaims",
     "SignedHealthLease",
-    "SignedProtectionLease",
     "canonical_json_bytes",
     "canonical_timestamp",
 ]

--- a/src/codex_plugin_scanner/guard/mdm/health_lease_contract.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_lease_contract.py
@@ -8,7 +8,7 @@ import json
 import math
 import re
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Final, get_args
 
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
@@ -25,6 +25,7 @@ from .contracts import (
 )
 
 HEALTH_LEASE_SCHEMA: Final = "hol-guard-health-lease.v1"
+PROTECTION_LEASE_SCHEMA: Final = "protection-lease.v1"
 HEALTH_LEASE_OUTBOX_SCHEMA: Final = "hol-guard-health-lease-outbox.v1"
 HEALTH_LEASE_SIGNING_DOMAIN: Final = b"HOL-GUARD-HEALTH-LEASE-V1\x00"
 SIGNATURE_ALGORITHM: Final = "ecdsa-p256-sha256"
@@ -57,6 +58,21 @@ _CLAIM_KEYS = {
     "previousLeaseKeyId",
     "signingKeyId",
 }
+_PROTECTION_CLAIM_KEYS = {
+    "workspaceId",
+    "deviceId",
+    "machineInstallationId",
+    "installationGeneration",
+    "sequence",
+    "issuedAt",
+    "validForSeconds",
+    "snapshotSchemaVersion",
+    "snapshotDigest",
+    "previousLeaseDigest",
+    "signingKeyId",
+    "challenge",
+}
+_CHALLENGE_KEYS = {"challengeId", "issuedAt", "nonce", "validForSeconds"}
 _SNAPSHOT_KEYS = {
     "schemaVersion",
     "generatedAt",
@@ -264,6 +280,139 @@ class HealthLeaseClaims:
         return HEALTH_LEASE_SIGNING_DOMAIN + canonical_json_bytes(self.to_dict())
 
 
+@dataclass(frozen=True, slots=True)
+class ProtectionLeaseChallenge:
+    challenge_id: str
+    issued_at: str
+    nonce: str
+    valid_for_seconds: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "challengeId": self.challenge_id,
+            "issuedAt": self.issued_at,
+            "nonce": self.nonce,
+            "validForSeconds": self.valid_for_seconds,
+        }
+
+    @classmethod
+    def parse(cls, raw: object) -> ProtectionLeaseChallenge:
+        if not isinstance(raw, dict):
+            raise ValueError("health_lease_challenge_invalid")
+        _exact_keys(raw, _CHALLENGE_KEYS, "health_lease_challenge_invalid")
+        challenge_id = _safe_id(raw.get("challengeId"))
+        issued_at = raw.get("issuedAt")
+        nonce = raw.get("nonce")
+        valid_for_seconds = raw.get("validForSeconds")
+        if (
+            not isinstance(issued_at, str)
+            or _SNAPSHOT_TIMESTAMP.fullmatch(issued_at) is None
+            or not isinstance(nonce, str)
+            or re.fullmatch(r"[A-Za-z0-9_-]{32,128}", nonce) is None
+            or not isinstance(valid_for_seconds, int)
+            or isinstance(valid_for_seconds, bool)
+            or not 30 <= valid_for_seconds <= 300
+        ):
+            raise ValueError("health_lease_challenge_invalid")
+        try:
+            parsed = datetime.fromisoformat(f"{issued_at[:-1]}+00:00")
+        except ValueError as exc:
+            raise ValueError("health_lease_challenge_invalid") from exc
+        if parsed.tzinfo is None:
+            raise ValueError("health_lease_challenge_invalid")
+        return cls(challenge_id, issued_at, nonce, valid_for_seconds)
+
+
+@dataclass(frozen=True, slots=True)
+class ProtectionLeaseClaims:
+    workspace_id: str
+    device_id: str
+    machine_installation_id: str
+    installation_generation: str
+    sequence: int
+    issued_at: str
+    valid_for_seconds: int
+    snapshot_schema_version: str
+    snapshot_digest: str
+    previous_lease_digest: str | None
+    signing_key_id: str
+    challenge: ProtectionLeaseChallenge | None
+
+    @property
+    def lease_expires_at(self) -> str:
+        issued = _parse_timestamp(self.issued_at)
+        return canonical_timestamp(issued + timedelta(seconds=self.valid_for_seconds))
+
+    @property
+    def previous_lease_key_id(self) -> None:
+        return None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "workspaceId": self.workspace_id,
+            "deviceId": self.device_id,
+            "machineInstallationId": self.machine_installation_id,
+            "installationGeneration": self.installation_generation,
+            "sequence": self.sequence,
+            "issuedAt": self.issued_at,
+            "validForSeconds": self.valid_for_seconds,
+            "snapshotSchemaVersion": self.snapshot_schema_version,
+            "snapshotDigest": self.snapshot_digest,
+            "previousLeaseDigest": self.previous_lease_digest,
+            "signingKeyId": self.signing_key_id,
+            "challenge": self.challenge.to_dict() if self.challenge is not None else None,
+        }
+
+    @classmethod
+    def parse(cls, raw: object) -> ProtectionLeaseClaims:
+        if not isinstance(raw, dict):
+            raise ValueError("health_lease_invalid")
+        _exact_keys(raw, _PROTECTION_CLAIM_KEYS)
+        sequence = raw.get("sequence")
+        valid_for_seconds = raw.get("validForSeconds")
+        if (
+            not isinstance(sequence, int)
+            or isinstance(sequence, bool)
+            or not 1 <= sequence <= MAX_UINT64
+            or not isinstance(valid_for_seconds, int)
+            or isinstance(valid_for_seconds, bool)
+            or not 180 <= valid_for_seconds <= 1800
+        ):
+            raise ValueError("health_lease_invalid")
+        previous_digest = raw.get("previousLeaseDigest")
+        if (sequence == 1 and previous_digest is not None) or (
+            sequence > 1 and (not isinstance(previous_digest, str) or _HEX_64.fullmatch(previous_digest) is None)
+        ):
+            raise ValueError("health_lease_invalid")
+        issued_at = canonical_timestamp(_parse_timestamp(raw.get("issuedAt")))
+        challenge_raw = raw.get("challenge")
+        challenge = None if challenge_raw is None else ProtectionLeaseChallenge.parse(challenge_raw)
+        if raw.get("snapshotSchemaVersion") != LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION:
+            raise ValueError("health_lease_invalid")
+        if challenge is not None:
+            challenge_issued = datetime.fromisoformat(f"{challenge.issued_at[:-1]}+00:00")
+            lease_issued = _parse_timestamp(issued_at)
+            if not challenge_issued <= lease_issued < challenge_issued + timedelta(seconds=challenge.valid_for_seconds):
+                raise ValueError("health_lease_challenge_invalid")
+        return cls(
+            _safe_id(raw.get("workspaceId")),
+            _safe_id(raw.get("deviceId")),
+            _match(raw.get("machineInstallationId"), _HEX_32),
+            _match(raw.get("installationGeneration"), _HEX_32),
+            sequence,
+            issued_at,
+            valid_for_seconds,
+            LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION,
+            _match(raw.get("snapshotDigest"), _HEX_64),
+            None if previous_digest is None else previous_digest,
+            _match(raw.get("signingKeyId"), _KEY_ID),
+            challenge,
+        )
+
+    def signing_payload(self) -> bytes:
+        return canonical_json_bytes({"claims": self.to_dict(), "schemaVersion": PROTECTION_LEASE_SCHEMA})
+
+
 def _canonical_ecdsa_signature(signature: bytes) -> bytes:
     try:
         r, s = decode_dss_signature(signature)
@@ -325,9 +474,80 @@ class SignedHealthLease:
         return cls(HealthLeaseClaims.parse(raw.get("claims")), signature)
 
 
+def _der_to_p1363(signature: bytes) -> bytes:
+    canonical = _canonical_ecdsa_signature(signature)
+    r, s = decode_dss_signature(canonical)
+    return r.to_bytes(32, "big") + s.to_bytes(32, "big")
+
+
+def _p1363_to_der(signature: bytes) -> bytes:
+    if len(signature) != 64:
+        raise ValueError("health_lease_invalid")
+    r = int.from_bytes(signature[:32], "big")
+    s = int.from_bytes(signature[32:], "big")
+    if not 1 <= r < P256_ORDER or not 1 <= s <= P256_ORDER // 2:
+        raise ValueError("health_lease_invalid")
+    return encode_dss_signature(r, s)
+
+
+@dataclass(frozen=True, slots=True)
+class SignedProtectionLease:
+    claims: ProtectionLeaseClaims
+    signature: bytes
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schemaVersion": PROTECTION_LEASE_SCHEMA,
+            "claims": self.claims.to_dict(),
+            "signature": {
+                "algorithm": SIGNATURE_ALGORITHM,
+                "keyId": self.claims.signing_key_id,
+                "value": base64.b64encode(_der_to_p1363(self.signature)).decode("ascii"),
+            },
+        }
+
+    def canonical_bytes(self) -> bytes:
+        payload = canonical_json_bytes(self.to_dict())
+        if len(payload) > MAX_LEASE_BYTES:
+            raise ValueError("health_lease_invalid")
+        return payload
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.canonical_bytes()).hexdigest()
+
+    @classmethod
+    def parse(cls, payload: bytes) -> SignedProtectionLease:
+        raw = _strict_json(payload, maximum=MAX_LEASE_BYTES, reason="health_lease_invalid")
+        _exact_keys(raw, {"schemaVersion", "claims", "signature"})
+        if raw.get("schemaVersion") != PROTECTION_LEASE_SCHEMA:
+            raise ValueError("health_lease_invalid")
+        claims = ProtectionLeaseClaims.parse(raw.get("claims"))
+        signature_raw = raw.get("signature")
+        if not isinstance(signature_raw, dict):
+            raise ValueError("health_lease_invalid")
+        _exact_keys(signature_raw, {"algorithm", "keyId", "value"})
+        value = signature_raw.get("value")
+        if (
+            signature_raw.get("algorithm") != SIGNATURE_ALGORITHM
+            or signature_raw.get("keyId") != claims.signing_key_id
+            or not isinstance(value, str)
+            or len(value) > 128
+        ):
+            raise ValueError("health_lease_invalid")
+        try:
+            raw_signature = base64.b64decode(value, validate=True)
+            signature = _p1363_to_der(raw_signature)
+        except (ValueError, TypeError) as exc:
+            raise ValueError("health_lease_invalid") from exc
+        if base64.b64encode(raw_signature).decode("ascii") != value:
+            raise ValueError("health_lease_invalid")
+        return cls(claims, signature)
+
+
 @dataclass(frozen=True, slots=True)
 class HealthLeaseOutbox:
-    lease: SignedHealthLease
+    lease: SignedHealthLease | SignedProtectionLease
     snapshot_bytes: bytes
 
     def to_dict(self) -> dict[str, object]:
@@ -354,7 +574,11 @@ class HealthLeaseOutbox:
         lease_raw = raw.get("lease")
         if not isinstance(lease_raw, dict):
             raise ValueError("health_lease_outbox_invalid")
-        lease = SignedHealthLease.parse(canonical_json_bytes(lease_raw))
+        lease = (
+            SignedProtectionLease.parse(canonical_json_bytes(lease_raw))
+            if lease_raw.get("schemaVersion") == PROTECTION_LEASE_SCHEMA
+            else SignedHealthLease.parse(canonical_json_bytes(lease_raw))
+        )
         snapshot_raw = raw.get("snapshot")
         if not isinstance(snapshot_raw, str):
             raise ValueError("health_lease_outbox_invalid")
@@ -372,7 +596,7 @@ class HealthLeaseOutbox:
         return outbox
 
 
-def _validate_snapshot_binding(snapshot: bytes, claims: HealthLeaseClaims) -> None:
+def _validate_snapshot_binding(snapshot: bytes, claims: HealthLeaseClaims | ProtectionLeaseClaims) -> None:
     raw = _strict_json(snapshot, maximum=MAX_SNAPSHOT_BYTES, reason="health_lease_outbox_invalid")
     _exact_keys(raw, _SNAPSHOT_KEYS, "health_lease_outbox_invalid")
     if raw.get("schemaVersion") != claims.snapshot_schema_version:
@@ -479,10 +703,14 @@ def _validate_snapshot_binding(snapshot: bytes, claims: HealthLeaseClaims) -> No
 
 __all__ = [
     "HEALTH_LEASE_SIGNING_DOMAIN",
+    "PROTECTION_LEASE_SCHEMA",
     "HealthLeaseBinding",
     "HealthLeaseClaims",
     "HealthLeaseOutbox",
+    "ProtectionLeaseChallenge",
+    "ProtectionLeaseClaims",
     "SignedHealthLease",
+    "SignedProtectionLease",
     "canonical_json_bytes",
     "canonical_timestamp",
 ]

--- a/src/codex_plugin_scanner/guard/mdm/health_reporter.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_reporter.py
@@ -86,7 +86,12 @@ def run_machine_health_cadence(
                 )
             )
             ack = resolved_transport.deliver_lease(outbox)
-            lease_acknowledger(resolved_paths, binding, ack, system_name=resolved_system)
+            lease_acknowledger(
+                resolved_paths,
+                binding,
+                ack.canonical_bytes(),
+                system_name=resolved_system,
+            )
             queue_depth = 0
             challenge = resolved_transport.poll_challenge(
                 binding=binding,
@@ -102,7 +107,12 @@ def run_machine_health_cadence(
                     challenge=challenge,
                 )
                 challenge_ack = resolved_transport.deliver_lease(outbox)
-                lease_acknowledger(resolved_paths, binding, challenge_ack, system_name=resolved_system)
+                lease_acknowledger(
+                    resolved_paths,
+                    binding,
+                    challenge_ack.canonical_bytes(),
+                    system_name=resolved_system,
+                )
                 queue_depth = 0
                 challenge_responded = True
             state = "lease-delivered"

--- a/src/codex_plugin_scanner/guard/mdm/health_reporter.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_reporter.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import platform
+import time
 from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
 from typing import cast
 
 from .contracts import MachinePaths, ManagedPolicyState, default_machine_paths
-from .health_lease import issue_or_load_pending_health_lease
+from .health_key_registration import build_machine_health_key_registration
+from .health_lease import acknowledge_pending_health_lease, issue_or_load_pending_health_lease
+from .health_lease_ack import HealthLeaseAck
 from .health_lease_contract import HealthLeaseBinding, HealthLeaseOutbox
+from .health_transport import MachineHealthTransport, build_machine_health_transport
 from .policy import load_managed_policy
 
 _WORKSPACE_LOCK = "selfProtection.workspaceId"
@@ -16,6 +21,7 @@ _DEVICE_LOCK = "selfProtection.deviceId"
 
 PolicyLoader = Callable[..., ManagedPolicyState]
 LeaseIssuer = Callable[..., HealthLeaseOutbox]
+LeaseAcknowledger = Callable[..., HealthLeaseAck]
 
 
 def _machine_binding(policy_state: ManagedPolicyState) -> HealthLeaseBinding:
@@ -47,6 +53,8 @@ def run_machine_health_cadence(
     system_name: str | None = None,
     policy_loader: PolicyLoader = load_managed_policy,
     lease_issuer: LeaseIssuer = issue_or_load_pending_health_lease,
+    lease_acknowledger: LeaseAcknowledger = acknowledge_pending_health_lease,
+    transport: MachineHealthTransport | None = None,
 ) -> dict[str, object]:
     """Issue or recover the current signed lease from protected machine state."""
 
@@ -54,14 +62,72 @@ def run_machine_health_cadence(
     resolved_paths = paths or default_machine_paths(system_name=resolved_system)
     policy_state = policy_loader(system_name=resolved_system)
     binding = _machine_binding(policy_state)
+    started = time.monotonic()
     outbox = lease_issuer(resolved_paths, binding, system_name=resolved_system)
+    snapshot_duration_ms = max(0, round((time.monotonic() - started) * 1000))
+    delivery_latency_ms: int | None = None
+    rejection_reason: str | None = None
+    queue_depth = 1
+    challenge_responded = False
+    state = "lease-ready"
+    reason_codes = ["health_lease_ready"]
+    resolved_transport = transport or build_machine_health_transport(resolved_paths.state_root)
+    if resolved_transport is not None:
+        delivery_started = time.monotonic()
+        try:
+            resolved_transport.register_key(
+                build_machine_health_key_registration(
+                    resolved_paths,
+                    binding,
+                    installation_generation=outbox.lease.claims.installation_generation,
+                    machine_installation_id=outbox.lease.claims.machine_installation_id,
+                    system_name=resolved_system,
+                )
+            )
+            ack = resolved_transport.deliver_lease(outbox)
+            lease_acknowledger(resolved_paths, binding, ack, system_name=resolved_system)
+            queue_depth = 0
+            challenge = resolved_transport.poll_challenge(
+                binding=binding,
+                installation_generation=outbox.lease.claims.installation_generation,
+                machine_installation_id=outbox.lease.claims.machine_installation_id,
+            )
+            if challenge is not None:
+                queue_depth = 1
+                outbox = lease_issuer(
+                    resolved_paths,
+                    binding,
+                    system_name=resolved_system,
+                    challenge=challenge,
+                )
+                challenge_ack = resolved_transport.deliver_lease(outbox)
+                lease_acknowledger(resolved_paths, binding, challenge_ack, system_name=resolved_system)
+                queue_depth = 0
+                challenge_responded = True
+            state = "lease-delivered"
+            reason_codes = ["health_lease_delivered"]
+        except Exception as exc:
+            rejection_reason = _bounded_reason(exc)
+            state = "delivery-failed"
+            reason_codes = ["health_lease_delivery_failed"]
+        delivery_latency_ms = max(0, round((time.monotonic() - delivery_started) * 1000))
     claims = outbox.lease.claims
+    lease_age_seconds = max(
+        0,
+        round(
+            (
+                datetime.now(timezone.utc)
+                - datetime.strptime(claims.issued_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+            ).total_seconds()
+        ),
+    )
     return {
         "schemaVersion": "hol-guard-mdm-status.v1",
         "operation": "health-report",
-        "healthy": True,
-        "state": "lease-ready",
-        "reasonCodes": ["health_lease_ready"],
+        "healthy": _local_integrity_healthy(outbox),
+        "state": state,
+        "reasonCodes": reason_codes,
+        "localEnforcementHealthy": _local_integrity_healthy(outbox),
         "workspaceId": claims.workspace_id,
         "deviceId": claims.device_id,
         "machineInstallationId": claims.machine_installation_id,
@@ -70,7 +136,42 @@ def run_machine_health_cadence(
         "issuedAt": claims.issued_at,
         "leaseExpiresAt": claims.lease_expires_at,
         "leaseDigest": outbox.lease.digest,
+        "challengeResponded": challenge_responded,
+        "metrics": {
+            "snapshotDurationMs": snapshot_duration_ms,
+            "leaseAgeSeconds": lease_age_seconds,
+            "deliveryLatencyMs": delivery_latency_ms,
+            "rejectionReason": rejection_reason,
+            "queueDepth": queue_depth,
+            "keyStorageHealth": _key_storage_health(outbox),
+        },
     }
+
+
+def _bounded_reason(error: BaseException) -> str:
+    reason = str(error).strip().splitlines()[0] if str(error).strip() else type(error).__name__
+    return reason[:128]
+
+
+def _key_storage_health(outbox: HealthLeaseOutbox) -> str:
+    import json
+
+    try:
+        snapshot = json.loads(outbox.snapshot_bytes)
+        state = snapshot["components"]["deviceKey"]["state"]
+    except (KeyError, TypeError, json.JSONDecodeError):
+        return "unknown"
+    return state if isinstance(state, str) and len(state) <= 32 else "unknown"
+
+
+def _local_integrity_healthy(outbox: HealthLeaseOutbox) -> bool:
+    import json
+
+    try:
+        snapshot = json.loads(outbox.snapshot_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    return snapshot.get("healthy") is True if isinstance(snapshot, dict) else False
 
 
 __all__ = ["run_machine_health_cadence"]

--- a/src/codex_plugin_scanner/guard/mdm/health_reporter.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_reporter.py
@@ -81,6 +81,7 @@ def run_machine_health_cadence(
                     binding,
                     installation_generation=outbox.lease.claims.installation_generation,
                     machine_installation_id=outbox.lease.claims.machine_installation_id,
+                    key_id=outbox.lease.claims.signing_key_id,
                     system_name=resolved_system,
                 )
             )

--- a/src/codex_plugin_scanner/guard/mdm/health_transport.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_transport.py
@@ -9,7 +9,8 @@ from pathlib import Path
 from typing import Protocol, cast
 
 from .health_lease_ack import HealthLeaseAck
-from .health_lease_contract import HealthLeaseBinding, HealthLeaseOutbox, ProtectionLeaseChallenge
+from .health_lease_contract import HealthLeaseBinding, HealthLeaseOutbox
+from .protection_lease_contract import ProtectionLeaseChallenge
 
 _CHALLENGE_SCHEMA = "guard-protection-attestation-challenge.v1"
 _CHALLENGE_KEYS = {

--- a/src/codex_plugin_scanner/guard/mdm/health_transport.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_transport.py
@@ -1,0 +1,208 @@
+"""Purpose-bound transport contracts for machine health evidence."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+from pathlib import Path
+from typing import Protocol, cast
+
+from .health_lease_ack import HealthLeaseAck
+from .health_lease_contract import HealthLeaseBinding, HealthLeaseOutbox, ProtectionLeaseChallenge
+
+_CHALLENGE_SCHEMA = "guard-protection-attestation-challenge.v1"
+_CHALLENGE_KEYS = {
+    "challengeId",
+    "deviceId",
+    "installationGeneration",
+    "issuedAt",
+    "machineInstallationId",
+    "nonce",
+    "schemaVersion",
+    "validForSeconds",
+    "workspaceId",
+}
+
+
+class MachineHealthTransport(Protocol):
+    """Authenticated Cloud channel limited to challenge polling and lease delivery."""
+
+    def register_key(self, payload: bytes) -> None: ...
+
+    def poll_challenge(
+        self,
+        *,
+        binding: HealthLeaseBinding,
+        installation_generation: str,
+        machine_installation_id: str,
+    ) -> ProtectionLeaseChallenge | None: ...
+
+    def deliver_lease(self, outbox: HealthLeaseOutbox) -> HealthLeaseAck: ...
+
+
+class GuardCloudMachineHealthTransport:
+    """OAuth/DPoP transport backed by a machine-owned Guard connection store."""
+
+    def __init__(self, guard_home: Path) -> None:
+        from ..store import GuardStore
+
+        self._store = GuardStore(guard_home, prime_policy_integrity=False, source="machine-health")
+
+    def configured(self) -> bool:
+        return self._store.get_cloud_sync_profile() is not None
+
+    def _request(self, method: str, path: str, body: bytes | None = None) -> tuple[int, bytes]:
+        from ..runtime.runner import (
+            _guard_sync_request,
+            _resolve_guard_sync_auth_context,
+        )
+        from .network import managed_urlopen
+
+        auth_context = _resolve_guard_sync_auth_context(self._store)
+        sync_url = auth_context.get("sync_url")
+        if not isinstance(sync_url, str):
+            raise OSError("health_lease_delivery_auth_invalid")
+        parsed = urllib.parse.urlsplit(sync_url)
+        origin = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+        sync_suffix = "/api/guard/receipts/sync"
+        if not parsed.path.endswith(sync_suffix):
+            raise OSError("health_lease_delivery_auth_invalid")
+        api_prefix = parsed.path[: -len(sync_suffix)]
+        request_url = f"{origin}{api_prefix}{path}"
+        request = _guard_sync_request(
+            auth_context,
+            request_url=request_url,
+            method=method,
+            data=body,
+        )
+        try:
+            with managed_urlopen(request, timeout=15) as response:
+                status = int(getattr(response, "status", 200))
+                payload = response.read(4097)
+        except urllib.error.HTTPError as exc:
+            bounded = exc.read(1025)
+            raise OSError(f"health_lease_delivery_http_{exc.code}:{_cloud_error_code(bounded)}") from exc
+        if len(payload) > 4096:
+            raise OSError("health_lease_delivery_response_oversized")
+        return status, payload
+
+    def poll_challenge(
+        self,
+        *,
+        binding: HealthLeaseBinding,
+        installation_generation: str,
+        machine_installation_id: str,
+    ) -> ProtectionLeaseChallenge | None:
+        status, payload = self._request("GET", "/api/guard/runtime/machine-health/challenges/pending")
+        if status == 204:
+            if payload:
+                raise ValueError("health_lease_challenge_invalid")
+            return None
+        if status != 200:
+            raise OSError(f"health_lease_challenge_http_{status}")
+        return parse_pending_challenge(
+            payload,
+            binding=binding,
+            installation_generation=installation_generation,
+            machine_installation_id=machine_installation_id,
+        )
+
+    def register_key(self, payload: bytes) -> None:
+        status, response = self._request(
+            "POST",
+            "/api/guard/runtime/machine-health/keys",
+            payload,
+        )
+        if status != 200:
+            raise OSError(f"health_key_registration_http_{status}")
+        try:
+            decoded = json.loads(response.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise OSError("health_key_registration_ack_invalid") from exc
+        if (
+            not isinstance(decoded, dict)
+            or decoded.get("schemaVersion") != "hol-guard-health-key-registration-ack.v1"
+            or decoded.get("status") not in {"registered", "replayed"}
+        ):
+            raise OSError("health_key_registration_ack_invalid")
+
+    def deliver_lease(self, outbox: HealthLeaseOutbox) -> HealthLeaseAck:
+        status, payload = self._request(
+            "POST",
+            "/api/guard/runtime/machine-health/leases",
+            outbox.canonical_bytes(),
+        )
+        if status != 200:
+            raise OSError(f"health_lease_delivery_http_{status}")
+        return HealthLeaseAck.parse(payload)
+
+
+def build_machine_health_transport(state_root: Path) -> MachineHealthTransport | None:
+    """Use an explicitly machine-connected OAuth store; never borrow a logged-in user's credentials."""
+
+    guard_home = state_root / "cloud"
+    if not (guard_home / "guard.db").is_file():
+        return None
+    transport = GuardCloudMachineHealthTransport(guard_home)
+    if not transport.configured():
+        return None
+    return transport
+
+
+def _cloud_error_code(payload: bytes) -> str:
+    try:
+        decoded = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return "unknown"
+    if not isinstance(decoded, dict):
+        return "unknown"
+    for key in ("code", "error"):
+        value = decoded.get(key)
+        if isinstance(value, str) and value and len(value) <= 64:
+            return value
+    return "unknown"
+
+
+def parse_pending_challenge(
+    payload: bytes,
+    *,
+    binding: HealthLeaseBinding,
+    installation_generation: str,
+    machine_installation_id: str,
+) -> ProtectionLeaseChallenge:
+    """Parse only the frozen attestation challenge shape; reject command-like extensions."""
+
+    if not payload or len(payload) > 4096:
+        raise ValueError("health_lease_challenge_invalid")
+    try:
+        decoded = cast(object, json.loads(payload.decode("utf-8")))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("health_lease_challenge_invalid") from exc
+    if not isinstance(decoded, dict) or set(decoded) != _CHALLENGE_KEYS:
+        raise ValueError("health_lease_challenge_invalid")
+    raw = cast(dict[str, object], decoded)
+    if (
+        raw.get("schemaVersion") != _CHALLENGE_SCHEMA
+        or raw.get("workspaceId") != binding.workspace_id
+        or raw.get("deviceId") != binding.device_id
+        or raw.get("machineInstallationId") != machine_installation_id
+        or raw.get("installationGeneration") != installation_generation
+    ):
+        raise ValueError("health_lease_challenge_invalid")
+    return ProtectionLeaseChallenge.parse(
+        {
+            "challengeId": raw.get("challengeId"),
+            "issuedAt": raw.get("issuedAt"),
+            "nonce": raw.get("nonce"),
+            "validForSeconds": raw.get("validForSeconds"),
+        }
+    )
+
+
+__all__ = [
+    "GuardCloudMachineHealthTransport",
+    "MachineHealthTransport",
+    "build_machine_health_transport",
+    "parse_pending_challenge",
+]

--- a/src/codex_plugin_scanner/guard/mdm/protection_lease_contract.py
+++ b/src/codex_plugin_scanner/guard/mdm/protection_lease_contract.py
@@ -1,0 +1,256 @@
+"""Frozen ``protection-lease.v1`` challenge and signature contract."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
+
+from .contracts import LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION
+from .health_lease_contract import (
+    MAX_LEASE_BYTES,
+    MAX_UINT64,
+    P256_ORDER,
+    SIGNATURE_ALGORITHM,
+    _exact_keys,
+    _match,
+    _parse_timestamp,
+    _safe_id,
+    _strict_json,
+    canonical_json_bytes,
+    canonical_timestamp,
+)
+
+PROTECTION_LEASE_SCHEMA = "protection-lease.v1"
+_HEX_32 = __import__("re").compile(r"[0-9a-f]{32}\Z")
+_HEX_64 = __import__("re").compile(r"[0-9a-f]{64}\Z")
+_KEY_ID = __import__("re").compile(r"[A-Za-z0-9_-]{43}\Z")
+_SNAPSHOT_TIMESTAMP = __import__("re").compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\Z")
+_PROTECTION_CLAIM_KEYS = {
+    "workspaceId",
+    "deviceId",
+    "machineInstallationId",
+    "installationGeneration",
+    "sequence",
+    "issuedAt",
+    "validForSeconds",
+    "snapshotSchemaVersion",
+    "snapshotDigest",
+    "previousLeaseDigest",
+    "signingKeyId",
+    "challenge",
+}
+_CHALLENGE_KEYS = {"challengeId", "issuedAt", "nonce", "validForSeconds"}
+
+
+@dataclass(frozen=True, slots=True)
+class ProtectionLeaseChallenge:
+    challenge_id: str
+    issued_at: str
+    nonce: str
+    valid_for_seconds: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "challengeId": self.challenge_id,
+            "issuedAt": self.issued_at,
+            "nonce": self.nonce,
+            "validForSeconds": self.valid_for_seconds,
+        }
+
+    @classmethod
+    def parse(cls, raw: object) -> ProtectionLeaseChallenge:
+        import re
+
+        if not isinstance(raw, dict):
+            raise ValueError("health_lease_challenge_invalid")
+        _exact_keys(raw, _CHALLENGE_KEYS, "health_lease_challenge_invalid")
+        issued_at = raw.get("issuedAt")
+        nonce = raw.get("nonce")
+        valid_for_seconds = raw.get("validForSeconds")
+        if (
+            not isinstance(issued_at, str)
+            or _SNAPSHOT_TIMESTAMP.fullmatch(issued_at) is None
+            or not isinstance(nonce, str)
+            or re.fullmatch(r"[A-Za-z0-9_-]{32,128}", nonce) is None
+            or not isinstance(valid_for_seconds, int)
+            or isinstance(valid_for_seconds, bool)
+            or not 30 <= valid_for_seconds <= 300
+        ):
+            raise ValueError("health_lease_challenge_invalid")
+        try:
+            parsed = datetime.fromisoformat(f"{issued_at[:-1]}+00:00")
+        except ValueError as exc:
+            raise ValueError("health_lease_challenge_invalid") from exc
+        if parsed.tzinfo is None:
+            raise ValueError("health_lease_challenge_invalid")
+        return cls(_safe_id(raw.get("challengeId")), issued_at, nonce, valid_for_seconds)
+
+
+@dataclass(frozen=True, slots=True)
+class ProtectionLeaseClaims:
+    workspace_id: str
+    device_id: str
+    machine_installation_id: str
+    installation_generation: str
+    sequence: int
+    issued_at: str
+    valid_for_seconds: int
+    snapshot_schema_version: str
+    snapshot_digest: str
+    previous_lease_digest: str | None
+    signing_key_id: str
+    challenge: ProtectionLeaseChallenge | None
+
+    @property
+    def lease_expires_at(self) -> str:
+        return canonical_timestamp(_parse_timestamp(self.issued_at) + timedelta(seconds=self.valid_for_seconds))
+
+    @property
+    def previous_lease_key_id(self) -> None:
+        return None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "workspaceId": self.workspace_id,
+            "deviceId": self.device_id,
+            "machineInstallationId": self.machine_installation_id,
+            "installationGeneration": self.installation_generation,
+            "sequence": self.sequence,
+            "issuedAt": self.issued_at,
+            "validForSeconds": self.valid_for_seconds,
+            "snapshotSchemaVersion": self.snapshot_schema_version,
+            "snapshotDigest": self.snapshot_digest,
+            "previousLeaseDigest": self.previous_lease_digest,
+            "signingKeyId": self.signing_key_id,
+            "challenge": self.challenge.to_dict() if self.challenge is not None else None,
+        }
+
+    @classmethod
+    def parse(cls, raw: object) -> ProtectionLeaseClaims:
+        if not isinstance(raw, dict):
+            raise ValueError("health_lease_invalid")
+        _exact_keys(raw, _PROTECTION_CLAIM_KEYS)
+        sequence = raw.get("sequence")
+        duration = raw.get("validForSeconds")
+        if (
+            not isinstance(sequence, int)
+            or isinstance(sequence, bool)
+            or not 1 <= sequence <= MAX_UINT64
+            or not isinstance(duration, int)
+            or isinstance(duration, bool)
+            or not 180 <= duration <= 1800
+        ):
+            raise ValueError("health_lease_invalid")
+        previous = raw.get("previousLeaseDigest")
+        if (sequence == 1 and previous is not None) or (
+            sequence > 1 and (not isinstance(previous, str) or _HEX_64.fullmatch(previous) is None)
+        ):
+            raise ValueError("health_lease_invalid")
+        issued_at = canonical_timestamp(_parse_timestamp(raw.get("issuedAt")))
+        challenge_raw = raw.get("challenge")
+        challenge = None if challenge_raw is None else ProtectionLeaseChallenge.parse(challenge_raw)
+        if raw.get("snapshotSchemaVersion") != LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION:
+            raise ValueError("health_lease_invalid")
+        if challenge is not None:
+            challenge_issued = datetime.fromisoformat(f"{challenge.issued_at[:-1]}+00:00")
+            lease_issued = _parse_timestamp(issued_at)
+            if not challenge_issued <= lease_issued < challenge_issued + timedelta(seconds=challenge.valid_for_seconds):
+                raise ValueError("health_lease_challenge_invalid")
+        return cls(
+            _safe_id(raw.get("workspaceId")),
+            _safe_id(raw.get("deviceId")),
+            _match(raw.get("machineInstallationId"), _HEX_32),
+            _match(raw.get("installationGeneration"), _HEX_32),
+            sequence,
+            issued_at,
+            duration,
+            LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION,
+            _match(raw.get("snapshotDigest"), _HEX_64),
+            None if previous is None else previous,
+            _match(raw.get("signingKeyId"), _KEY_ID),
+            challenge,
+        )
+
+    def signing_payload(self) -> bytes:
+        return canonical_json_bytes({"claims": self.to_dict(), "schemaVersion": PROTECTION_LEASE_SCHEMA})
+
+
+def _canonical_signature(signature: bytes) -> bytes:
+    try:
+        r, s = decode_dss_signature(signature)
+    except ValueError as exc:
+        raise ValueError("health_lease_invalid") from exc
+    if not 1 <= r < P256_ORDER or not 1 <= s < P256_ORDER or encode_dss_signature(r, s) != signature:
+        raise ValueError("health_lease_invalid")
+    return encode_dss_signature(r, min(s, P256_ORDER - s))
+
+
+@dataclass(frozen=True, slots=True)
+class SignedProtectionLease:
+    claims: ProtectionLeaseClaims
+    signature: bytes
+
+    def to_dict(self) -> dict[str, object]:
+        canonical = _canonical_signature(self.signature)
+        r, s = decode_dss_signature(canonical)
+        value = base64.b64encode(r.to_bytes(32, "big") + s.to_bytes(32, "big")).decode("ascii")
+        return {
+            "schemaVersion": PROTECTION_LEASE_SCHEMA,
+            "claims": self.claims.to_dict(),
+            "signature": {
+                "algorithm": SIGNATURE_ALGORITHM,
+                "keyId": self.claims.signing_key_id,
+                "value": value,
+            },
+        }
+
+    def canonical_bytes(self) -> bytes:
+        payload = canonical_json_bytes(self.to_dict())
+        if len(payload) > MAX_LEASE_BYTES:
+            raise ValueError("health_lease_invalid")
+        return payload
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.canonical_bytes()).hexdigest()
+
+    @classmethod
+    def parse(cls, payload: bytes) -> SignedProtectionLease:
+        raw = _strict_json(payload, maximum=MAX_LEASE_BYTES, reason="health_lease_invalid")
+        _exact_keys(raw, {"schemaVersion", "claims", "signature"})
+        if raw.get("schemaVersion") != PROTECTION_LEASE_SCHEMA:
+            raise ValueError("health_lease_invalid")
+        claims = ProtectionLeaseClaims.parse(raw.get("claims"))
+        signature = raw.get("signature")
+        if not isinstance(signature, dict):
+            raise ValueError("health_lease_invalid")
+        _exact_keys(signature, {"algorithm", "keyId", "value"})
+        value = signature.get("value")
+        if (
+            signature.get("algorithm") != SIGNATURE_ALGORITHM
+            or signature.get("keyId") != claims.signing_key_id
+            or not isinstance(value, str)
+            or len(value) > 128
+        ):
+            raise ValueError("health_lease_invalid")
+        try:
+            raw_signature = base64.b64decode(value, validate=True)
+            if len(raw_signature) != 64:
+                raise ValueError
+            r = int.from_bytes(raw_signature[:32], "big")
+            s = int.from_bytes(raw_signature[32:], "big")
+            if not 1 <= r < P256_ORDER or not 1 <= s <= P256_ORDER // 2:
+                raise ValueError
+            parsed = encode_dss_signature(r, s)
+        except (ValueError, TypeError) as exc:
+            raise ValueError("health_lease_invalid") from exc
+        if base64.b64encode(raw_signature).decode("ascii") != value:
+            raise ValueError("health_lease_invalid")
+        return cls(claims, parsed)
+
+
+__all__ = ["PROTECTION_LEASE_SCHEMA", "ProtectionLeaseChallenge", "ProtectionLeaseClaims", "SignedProtectionLease"]

--- a/tests/test_guard_mdm_device_key_signing.py
+++ b/tests/test_guard_mdm_device_key_signing.py
@@ -60,6 +60,85 @@ def _successful_result(signature: bytes) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _canonical_protection_lease(**changes: object) -> bytes:
+    claims: dict[str, object] = {
+        "workspaceId": "workspace-1",
+        "deviceId": "device-1",
+        "machineInstallationId": "a" * 32,
+        "installationGeneration": "b" * 32,
+        "sequence": 1,
+        "issuedAt": "2026-07-18T12:00:00Z",
+        "validForSeconds": 900,
+        "snapshotSchemaVersion": "local-integrity-snapshot.v1",
+        "snapshotDigest": "c" * 64,
+        "previousLeaseDigest": None,
+        "signingKeyId": "A" * 43,
+        "challenge": None,
+    }
+    claims.update(changes)
+    return json.dumps(
+        {"claims": claims, "schemaVersion": "protection-lease.v1"},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+
+
+def test_protection_lease_signing_uses_distinct_purpose_bound_native_operation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    signature = utils.encode_dss_signature(1, 2)
+    run = Mock(return_value=_successful_result(signature))
+    monkeypatch.setattr(device_key_native.subprocess, "run", run)
+    lease = _canonical_protection_lease()
+
+    result = device_key_native.sign_protection_lease(
+        _paths(tmp_path), "d" * 32, lease, system_name="Darwin"
+    )
+
+    assert result.signature == signature
+    assert run.call_args.args[0] == [
+        str(tmp_path / "runtime" / "hol-guard-device-key"),
+        "sign-protection-lease",
+        "d" * 32,
+    ]
+    assert run.call_args.kwargs["input"] == lease.decode()
+
+
+def test_health_key_registration_signing_uses_distinct_purpose_bound_native_operation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    signature = utils.encode_dss_signature(1, 2)
+    run = Mock(return_value=_successful_result(signature))
+    monkeypatch.setattr(device_key_native.subprocess, "run", run)
+    registration = json.dumps(
+        {
+            "algorithm": "ecdsa-p256-sha256",
+            "deviceId": "device-1",
+            "installationGeneration": "b" * 32,
+            "keyId": "A" * 43,
+            "machineInstallationId": "a" * 32,
+            "previousInstallationGeneration": None,
+            "publicKeySpki": base64.b64encode(b"public-key").decode(),
+            "registeredAt": "2026-07-18T12:00:00Z",
+            "schemaVersion": "hol-guard-health-key-registration.v1",
+            "workspaceId": "workspace-1",
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+
+    result = device_key_native.sign_health_key_registration(
+        _paths(tmp_path), "d" * 32, registration, system_name="Darwin"
+    )
+
+    assert result.signature == signature
+    assert run.call_args.args[0] == [
+        str(tmp_path / "runtime" / "hol-guard-device-key"),
+        "sign-health-key-registration",
+        "d" * 32,
+    ]
+
+
 def test_health_lease_signing_uses_only_purpose_bound_native_operation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_guard_mdm_health_key_registration.py
+++ b/tests/test_guard_mdm_health_key_registration.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import utils
+
+from codex_plugin_scanner.guard.mdm.contracts import MachinePaths
+from codex_plugin_scanner.guard.mdm.health_key_registration import build_machine_health_key_registration
+from codex_plugin_scanner.guard.mdm.health_lease_contract import HealthLeaseBinding
+
+
+def _paths(root: Path) -> MachinePaths:
+    return MachinePaths(root / "runtime", root / "state", root / "policy", root / "logs", root / "manifest")
+
+
+def test_machine_health_key_registration_is_canonical_and_proves_possession(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    signature = utils.encode_dss_signature(1, 2)
+    generation = SimpleNamespace(
+        generation="3" * 32,
+        key_id="A" * 43,
+        public_key_spki=base64.b64encode(b"public-key").decode(),
+    )
+    signed_payloads: list[bytes] = []
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.mdm.health_key_registration.verified_machine_device_key_by_id",
+        lambda *_args, **_kwargs: generation,
+    )
+
+    def sign(_paths: object, _generation: str, payload: bytes, **_kwargs: object) -> SimpleNamespace:
+        signed_payloads.append(payload)
+        return SimpleNamespace(signature=signature)
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.mdm.device_key_native.sign_health_key_registration",
+        sign,
+    )
+
+    payload = build_machine_health_key_registration(
+        _paths(tmp_path),
+        HealthLeaseBinding("workspace-a", "device-a"),
+        machine_installation_id="1" * 32,
+        installation_generation="2" * 32,
+        system_name="Darwin",
+    )
+    decoded = json.loads(payload)
+    proof = decoded.pop("proof")
+
+    assert payload == json.dumps({**decoded, "proof": proof}, sort_keys=True, separators=(",", ":")).encode()
+    assert signed_payloads == [json.dumps(decoded, sort_keys=True, separators=(",", ":")).encode()]
+    assert proof == {
+        "algorithm": "ecdsa-p256-sha256",
+        "encoding": "asn1-der",
+        "value": base64.b64encode(signature).decode(),
+    }
+    assert decoded["workspaceId"] == "workspace-a"
+    assert decoded["deviceId"] == "device-a"
+    assert decoded["keyId"] == "A" * 43

--- a/tests/test_guard_mdm_health_lease_ack.py
+++ b/tests/test_guard_mdm_health_lease_ack.py
@@ -87,7 +87,8 @@ def test_authenticated_ack_retires_one_item_and_advances_exact_chain(
     )
     assert second.lease.claims.sequence == 2
     assert second.lease.claims.previous_lease_digest == first.lease.digest
-    assert second.lease.claims.previous_lease_key_id == first.lease.claims.signing_key_id
+    assert second.lease.claims.previous_lease_key_id is None
+    assert second.lease.claims.signing_key_id == first.lease.claims.signing_key_id
 
 
 def test_replayed_ack_is_idempotent_after_retirement(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_guard_mdm_health_lease_contract.py
+++ b/tests/test_guard_mdm_health_lease_contract.py
@@ -15,7 +15,10 @@ from codex_plugin_scanner.guard.mdm.health_lease_contract import (
     MAX_LEASE_BYTES,
     HealthLeaseClaims,
     HealthLeaseOutbox,
+    ProtectionLeaseChallenge,
+    ProtectionLeaseClaims,
     SignedHealthLease,
+    SignedProtectionLease,
     canonical_json_bytes,
 )
 
@@ -57,6 +60,71 @@ def _signed_lease(private: ec.EllipticCurvePrivateKey, key_id: str) -> SignedHea
         private.sign(claims.signing_payload(), ec.ECDSA(hashes.SHA256())),
     )
     return SignedHealthLease.parse(signed.canonical_bytes())
+
+
+def test_protection_lease_round_trips_frozen_p1363_contract_and_challenge() -> None:
+    private, key_id = _key()
+    claims = ProtectionLeaseClaims.parse(
+        {
+            "workspaceId": "workspace-a",
+            "deviceId": "device-a",
+            "machineInstallationId": "1" * 32,
+            "installationGeneration": "2" * 32,
+            "sequence": 1,
+            "issuedAt": "2026-07-18T14:00:00Z",
+            "validForSeconds": 900,
+            "snapshotSchemaVersion": "local-integrity-snapshot.v1",
+            "snapshotDigest": "4" * 64,
+            "previousLeaseDigest": None,
+            "signingKeyId": key_id,
+            "challenge": {
+                "challengeId": "challenge-a",
+                "issuedAt": "2026-07-18T13:59:30Z",
+                "nonce": "n" * 43,
+                "validForSeconds": 120,
+            },
+        }
+    )
+    lease = SignedProtectionLease(
+        claims,
+        private.sign(claims.signing_payload(), ec.ECDSA(hashes.SHA256())),
+    )
+    parsed = SignedProtectionLease.parse(lease.canonical_bytes())
+
+    assert parsed == SignedProtectionLease(claims, parsed.signature)
+    assert parsed.claims.challenge == ProtectionLeaseChallenge(
+        "challenge-a", "2026-07-18T13:59:30Z", "n" * 43, 120
+    )
+    assert parsed.claims.lease_expires_at == "2026-07-18T14:15:00Z"
+    signature = cast(dict[str, object], parsed.to_dict()["signature"])
+    assert signature["keyId"] == key_id
+    assert len(base64.b64decode(cast(str, signature["value"]), validate=True)) == 64
+
+
+def test_protection_lease_rejects_expired_challenge_at_issuance() -> None:
+    _, key_id = _key()
+    payload = {
+        "workspaceId": "workspace-a",
+        "deviceId": "device-a",
+        "machineInstallationId": "1" * 32,
+        "installationGeneration": "2" * 32,
+        "sequence": 1,
+        "issuedAt": "2026-07-18T14:02:00Z",
+        "validForSeconds": 900,
+        "snapshotSchemaVersion": "local-integrity-snapshot.v1",
+        "snapshotDigest": "4" * 64,
+        "previousLeaseDigest": None,
+        "signingKeyId": key_id,
+        "challenge": {
+            "challengeId": "challenge-a",
+            "issuedAt": "2026-07-18T13:59:30Z",
+            "nonce": "n" * 43,
+            "validForSeconds": 120,
+        },
+    }
+
+    with pytest.raises(ValueError, match="health_lease_challenge_invalid"):
+        ProtectionLeaseClaims.parse(payload)
 
 
 def _snapshot() -> dict[str, object]:

--- a/tests/test_guard_mdm_health_lease_contract.py
+++ b/tests/test_guard_mdm_health_lease_contract.py
@@ -15,11 +15,13 @@ from codex_plugin_scanner.guard.mdm.health_lease_contract import (
     MAX_LEASE_BYTES,
     HealthLeaseClaims,
     HealthLeaseOutbox,
+    SignedHealthLease,
+    canonical_json_bytes,
+)
+from codex_plugin_scanner.guard.mdm.protection_lease_contract import (
     ProtectionLeaseChallenge,
     ProtectionLeaseClaims,
-    SignedHealthLease,
     SignedProtectionLease,
-    canonical_json_bytes,
 )
 
 
@@ -92,9 +94,7 @@ def test_protection_lease_round_trips_frozen_p1363_contract_and_challenge() -> N
     parsed = SignedProtectionLease.parse(lease.canonical_bytes())
 
     assert parsed == SignedProtectionLease(claims, parsed.signature)
-    assert parsed.claims.challenge == ProtectionLeaseChallenge(
-        "challenge-a", "2026-07-18T13:59:30Z", "n" * 43, 120
-    )
+    assert parsed.claims.challenge == ProtectionLeaseChallenge("challenge-a", "2026-07-18T13:59:30Z", "n" * 43, 120)
     assert parsed.claims.lease_expires_at == "2026-07-18T14:15:00Z"
     signature = cast(dict[str, object], parsed.to_dict()["signature"])
     assert signature["keyId"] == key_id

--- a/tests/test_guard_mdm_health_reporter.py
+++ b/tests/test_guard_mdm_health_reporter.py
@@ -21,9 +21,9 @@ from codex_plugin_scanner.guard.mdm.health_lease_ack import HealthLeaseAck
 from codex_plugin_scanner.guard.mdm.health_lease_contract import (
     HealthLeaseBinding,
     HealthLeaseOutbox,
-    ProtectionLeaseChallenge,
 )
 from codex_plugin_scanner.guard.mdm.health_reporter import run_machine_health_cadence
+from codex_plugin_scanner.guard.mdm.protection_lease_contract import ProtectionLeaseChallenge
 
 
 def _paths(root: Path) -> MachinePaths:
@@ -57,6 +57,7 @@ def _outbox() -> HealthLeaseOutbox:
         device_id="device-a",
         machine_installation_id="1" * 32,
         installation_generation="2" * 32,
+        signing_key_id="A" * 43,
         sequence=7,
         issued_at="2026-07-18T18:00:00Z",
         lease_expires_at="2026-07-18T18:15:00Z",
@@ -114,9 +115,7 @@ def test_machine_cadence_delivers_then_answers_only_purpose_bound_challenge(
     delivered: list[HealthLeaseOutbox] = []
     issued_challenges: list[ProtectionLeaseChallenge | None] = []
     acknowledgements: list[HealthLeaseAck] = []
-    challenge = ProtectionLeaseChallenge(
-        "challenge-a", "2026-07-18T17:59:30Z", "n" * 43, 120
-    )
+    challenge = ProtectionLeaseChallenge("challenge-a", "2026-07-18T17:59:30Z", "n" * 43, 120)
 
     class Transport:
         def register_key(self, _payload: bytes) -> None:
@@ -167,6 +166,54 @@ def test_machine_cadence_delivers_then_answers_only_purpose_bound_challenge(
     assert result["state"] == "lease-delivered"
     assert result["challengeResponded"] is True
     assert cast(dict[str, object], result["metrics"])["queueDepth"] == 0
+
+
+def test_machine_cadence_registers_the_recovered_lease_signing_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recovered = _outbox()
+    recovered.lease.claims.signing_key_id = "p" * 43
+    registered_key_ids: list[str | None] = []
+
+    class Transport:
+        def register_key(self, _payload: bytes) -> None:
+            return None
+
+        def deliver_lease(self, outbox: HealthLeaseOutbox) -> HealthLeaseAck:
+            claims = outbox.lease.claims
+            return HealthLeaseAck(
+                "accepted",
+                claims.workspace_id,
+                claims.device_id,
+                claims.machine_installation_id,
+                claims.installation_generation,
+                claims.sequence,
+                outbox.lease.digest,
+                "2026-07-18T18:00:01.000Z",
+            )
+
+        def poll_challenge(self, **_kwargs: object) -> None:
+            return None
+
+    def registration(*_args: object, key_id: str | None = None, **_kwargs: object) -> bytes:
+        registered_key_ids.append(key_id)
+        return b"registration"
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.mdm.health_reporter.build_machine_health_key_registration",
+        registration,
+    )
+
+    run_machine_health_cadence(
+        paths=_paths(tmp_path),
+        system_name="Darwin",
+        policy_loader=lambda **_kwargs: _policy(),
+        lease_issuer=lambda *_args, **_kwargs: recovered,
+        lease_acknowledger=lambda _paths, _binding, ack, **_kwargs: ack,
+        transport=Transport(),
+    )
+
+    assert registered_key_ids == ["p" * 43]
 
 
 def test_delivery_failure_is_exposed_without_weakening_local_enforcement(

--- a/tests/test_guard_mdm_health_reporter.py
+++ b/tests/test_guard_mdm_health_reporter.py
@@ -17,7 +17,12 @@ from codex_plugin_scanner.guard.mdm.contracts import (
     ManagedPolicyState,
     ManagedUpdatePolicy,
 )
-from codex_plugin_scanner.guard.mdm.health_lease_contract import HealthLeaseBinding, HealthLeaseOutbox
+from codex_plugin_scanner.guard.mdm.health_lease_ack import HealthLeaseAck
+from codex_plugin_scanner.guard.mdm.health_lease_contract import (
+    HealthLeaseBinding,
+    HealthLeaseOutbox,
+    ProtectionLeaseChallenge,
+)
 from codex_plugin_scanner.guard.mdm.health_reporter import run_machine_health_cadence
 
 
@@ -57,7 +62,11 @@ def _outbox() -> HealthLeaseOutbox:
         lease_expires_at="2026-07-18T18:15:00Z",
     )
     lease = SimpleNamespace(claims=claims, digest="3" * 64)
-    return cast(HealthLeaseOutbox, SimpleNamespace(lease=lease))
+    snapshot = json.dumps(
+        {"healthy": True, "components": {"deviceKey": {"state": "healthy"}}},
+        separators=(",", ":"),
+    ).encode()
+    return cast(HealthLeaseOutbox, SimpleNamespace(lease=lease, snapshot_bytes=snapshot))
 
 
 def test_machine_cadence_uses_only_locked_machine_policy_binding(tmp_path: Path) -> None:
@@ -76,23 +85,121 @@ def test_machine_cadence_uses_only_locked_machine_policy_binding(tmp_path: Path)
     )
 
     assert calls == [(paths, HealthLeaseBinding("workspace-a", "device-a"), "Darwin")]
-    assert result == {
-        "schemaVersion": "hol-guard-mdm-status.v1",
-        "operation": "health-report",
-        "healthy": True,
-        "state": "lease-ready",
-        "reasonCodes": ["health_lease_ready"],
-        "workspaceId": "workspace-a",
-        "deviceId": "device-a",
-        "machineInstallationId": "1" * 32,
-        "installationGeneration": "2" * 32,
-        "sequence": 7,
-        "issuedAt": "2026-07-18T18:00:00Z",
-        "leaseExpiresAt": "2026-07-18T18:15:00Z",
-        "leaseDigest": "3" * 64,
+    assert result["state"] == "lease-ready"
+    assert result["reasonCodes"] == ["health_lease_ready"]
+    assert result["localEnforcementHealthy"] is True
+    assert result["workspaceId"] == "workspace-a"
+    assert result["deviceId"] == "device-a"
+    assert result["sequence"] == 7
+    assert result["leaseDigest"] == "3" * 64
+    metrics = cast(dict[str, object], result["metrics"])
+    assert metrics == {
+        "snapshotDurationMs": 0,
+        "leaseAgeSeconds": metrics["leaseAgeSeconds"],
+        "deliveryLatencyMs": None,
+        "rejectionReason": None,
+        "queueDepth": 1,
+        "keyStorageHealth": "healthy",
     }
     assert "signature" not in result
     assert "snapshot" not in result
+
+
+def test_machine_cadence_delivers_then_answers_only_purpose_bound_challenge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first = _outbox()
+    second = _outbox()
+    second.lease.claims.sequence = 8
+    delivered: list[HealthLeaseOutbox] = []
+    issued_challenges: list[ProtectionLeaseChallenge | None] = []
+    acknowledgements: list[HealthLeaseAck] = []
+    challenge = ProtectionLeaseChallenge(
+        "challenge-a", "2026-07-18T17:59:30Z", "n" * 43, 120
+    )
+
+    class Transport:
+        def register_key(self, _payload: bytes) -> None:
+            return None
+
+        def deliver_lease(self, outbox: HealthLeaseOutbox) -> HealthLeaseAck:
+            delivered.append(outbox)
+            claims = outbox.lease.claims
+            return HealthLeaseAck(
+                "accepted",
+                claims.workspace_id,
+                claims.device_id,
+                claims.machine_installation_id,
+                claims.installation_generation,
+                claims.sequence,
+                outbox.lease.digest,
+                "2026-07-18T18:00:01.000Z",
+            )
+
+        def poll_challenge(self, **_kwargs: object) -> ProtectionLeaseChallenge:
+            return challenge
+
+    def issue(
+        *_args: object,
+        challenge: ProtectionLeaseChallenge | None = None,
+        **_kwargs: object,
+    ) -> HealthLeaseOutbox:
+        issued_challenges.append(challenge)
+        return first if challenge is None else second
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.mdm.health_reporter.build_machine_health_key_registration",
+        lambda *_args, **_kwargs: b"registration",
+    )
+
+    result = run_machine_health_cadence(
+        paths=_paths(tmp_path),
+        system_name="Darwin",
+        policy_loader=lambda **_kwargs: _policy(),
+        lease_issuer=issue,
+        lease_acknowledger=lambda _paths, _binding, ack, **_kwargs: acknowledgements.append(ack) or ack,
+        transport=Transport(),
+    )
+
+    assert issued_challenges == [None, challenge]
+    assert delivered == [first, second]
+    assert len(acknowledgements) == 2
+    assert result["state"] == "lease-delivered"
+    assert result["challengeResponded"] is True
+    assert cast(dict[str, object], result["metrics"])["queueDepth"] == 0
+
+
+def test_delivery_failure_is_exposed_without_weakening_local_enforcement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class OfflineTransport:
+        def register_key(self, _payload: bytes) -> None:
+            return None
+
+        def deliver_lease(self, _outbox: HealthLeaseOutbox) -> HealthLeaseAck:
+            raise TimeoutError("cloud delivery timed out")
+
+        def poll_challenge(self, **_kwargs: object) -> None:
+            pytest.fail("challenge polling must not run after failed delivery")
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.mdm.health_reporter.build_machine_health_key_registration",
+        lambda *_args, **_kwargs: b"registration",
+    )
+
+    result = run_machine_health_cadence(
+        paths=_paths(tmp_path),
+        system_name="Darwin",
+        policy_loader=lambda **_kwargs: _policy(),
+        lease_issuer=lambda *_args, **_kwargs: _outbox(),
+        transport=OfflineTransport(),
+    )
+
+    assert result["healthy"] is True
+    assert result["localEnforcementHealthy"] is True
+    assert result["state"] == "delivery-failed"
+    assert result["reasonCodes"] == ["health_lease_delivery_failed"]
+    assert cast(dict[str, object], result["metrics"])["rejectionReason"] == "cloud delivery timed out"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_mdm_health_reporter.py
+++ b/tests/test_guard_mdm_health_reporter.py
@@ -156,7 +156,7 @@ def test_machine_cadence_delivers_then_answers_only_purpose_bound_challenge(
         system_name="Darwin",
         policy_loader=lambda **_kwargs: _policy(),
         lease_issuer=issue,
-        lease_acknowledger=lambda _paths, _binding, ack, **_kwargs: acknowledgements.append(ack) or ack,
+        lease_acknowledger=lambda _paths, _binding, ack, **_kwargs: acknowledgements.append(HealthLeaseAck.parse(ack)),
         transport=Transport(),
     )
 

--- a/tests/test_guard_mdm_health_transport.py
+++ b/tests/test_guard_mdm_health_transport.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from codex_plugin_scanner.guard.mdm.health_lease_contract import HealthLeaseBinding
+from codex_plugin_scanner.guard.mdm.health_transport import (
+    GuardCloudMachineHealthTransport,
+    parse_pending_challenge,
+)
+
+
+def _payload(**updates: object) -> bytes:
+    value: dict[str, object] = {
+        "schemaVersion": "guard-protection-attestation-challenge.v1",
+        "challengeId": "challenge-a",
+        "workspaceId": "workspace-a",
+        "deviceId": "device-a",
+        "machineInstallationId": "1" * 32,
+        "installationGeneration": "2" * 32,
+        "issuedAt": "2026-07-18T17:59:30Z",
+        "nonce": "n" * 43,
+        "validForSeconds": 120,
+    }
+    value.update(updates)
+    return json.dumps(value, separators=(",", ":")).encode()
+
+
+def test_pending_challenge_is_bound_to_exact_machine_identity() -> None:
+    challenge = parse_pending_challenge(
+        _payload(),
+        binding=HealthLeaseBinding("workspace-a", "device-a"),
+        machine_installation_id="1" * 32,
+        installation_generation="2" * 32,
+    )
+
+    assert challenge.challenge_id == "challenge-a"
+    assert challenge.nonce == "n" * 43
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        _payload(command="repair"),
+        _payload(workspaceId="workspace-b"),
+        _payload(deviceId="device-b"),
+        _payload(machineInstallationId="3" * 32),
+        _payload(installationGeneration="4" * 32),
+        b"[]",
+        b"x" * 4097,
+    ],
+)
+def test_pending_challenge_rejects_commands_cross_identity_and_unbounded_payloads(payload: bytes) -> None:
+    with pytest.raises(ValueError, match="health_lease_challenge_invalid"):
+        parse_pending_challenge(
+            payload,
+            binding=HealthLeaseBinding("workspace-a", "device-a"),
+            machine_installation_id="1" * 32,
+            installation_generation="2" * 32,
+        )
+
+
+def test_cloud_transport_accepts_empty_204_without_creating_a_command_channel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = object.__new__(GuardCloudMachineHealthTransport)
+    monkeypatch.setattr(transport, "_request", lambda *_args, **_kwargs: (204, b""))
+
+    result = transport.poll_challenge(
+        binding=HealthLeaseBinding("workspace-a", "device-a"),
+        machine_installation_id="1" * 32,
+        installation_generation="2" * 32,
+    )
+
+    assert result is None
+
+
+def test_cloud_transport_rejects_body_on_no_content_challenge_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = object.__new__(GuardCloudMachineHealthTransport)
+    monkeypatch.setattr(transport, "_request", lambda *_args, **_kwargs: (204, b"{}"))
+
+    with pytest.raises(ValueError, match="health_lease_challenge_invalid"):
+        transport.poll_challenge(
+            binding=HealthLeaseBinding("workspace-a", "device-a"),
+            machine_installation_id="1" * 32,
+            installation_generation="2" * 32,
+        )


### PR DESCRIPTION
## Summary
- emit the frozen protection-lease.v1 contract with canonical low-S P-256 signatures
- register machine health keys and deliver/ack leases through a dedicated machine-owned OAuth/DPoP profile
- answer only strict identity-bound attestation challenges and expose bounded delivery metrics without weakening local enforcement

## Verification
- `uv run pytest -q tests/test_guard_mdm*.py tests/test_guard_self_protection_schemas.py` (412 passed, 7 skipped)
- focused delivery/contract suite (102 passed, 3 skipped)
- `uv run ruff check ...`
- `basedpyright ...` (0 errors)
- `swiftc -typecheck scripts/mdm/macos/device-key-helper.swift` (passes; existing Security deprecation warnings)

## Release
Targets `release/3.1`; report-only alpha behavior. Stable channels are unchanged.