### PR TITLE
fix(mdm): align protection lease duration contract

### DIFF
--- a/src/codex_plugin_scanner/guard/mdm/health_lease.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_lease.py
@@ -32,7 +32,6 @@ from .device_key import KeyGeneration
 from .device_key_access import verified_machine_device_key_by_id
 from .health_lease_ack import MAX_ACK_BYTES, HealthLeaseAck
 from .health_lease_contract import (
-    MAX_LEASE_SECONDS,
     MAX_OUTBOX_BYTES,
     MAX_SNAPSHOT_BYTES,
     HealthLeaseBinding,
@@ -44,6 +43,8 @@ from .health_lease_contract import (
 )
 from .integrity import machine_integrity_snapshot
 from .protection_lease_contract import (
+    MAX_PROTECTION_LEASE_SECONDS,
+    MIN_PROTECTION_LEASE_SECONDS,
     ProtectionLeaseChallenge,
     ProtectionLeaseClaims,
     SignedProtectionLease,
@@ -413,7 +414,7 @@ def issue_or_load_pending_health_lease(
         raise ValueError("health_lease_time_invalid")
     resolved_now = requested_now.astimezone(timezone.utc).replace(microsecond=0)
     resolved_system = system_name or platform.system()
-    if not 1 <= lease_seconds <= MAX_LEASE_SECONDS:
+    if not MIN_PROTECTION_LEASE_SECONDS <= lease_seconds <= MAX_PROTECTION_LEASE_SECONDS:
         raise ValueError("health_lease_duration_invalid")
     with _continuity_lock(paths):
         record = _read_record(paths)

--- a/src/codex_plugin_scanner/guard/mdm/health_lease_contract.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_lease_contract.py
@@ -6,24 +6,14 @@ import base64
 import hashlib
 import importlib
 import json
-import math
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Final, Protocol, cast, get_args
+from typing import Final, Protocol, cast
 
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
 
-from .contracts import (
-    LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION,
-    AssuranceLevel,
-    InstallOwner,
-    IntegrityReasonCode,
-    IntegrityState,
-    KeyProtectionLevel,
-    RemediationClass,
-    SupervisorState,
-)
+from .contracts import LOCAL_INTEGRITY_SNAPSHOT_SCHEMA_VERSION
 
 
 class LeaseClaims(Protocol):
@@ -86,7 +76,6 @@ _HEX_32 = re.compile(r"[0-9a-f]{32}\Z")
 _HEX_64 = re.compile(r"[0-9a-f]{64}\Z")
 _KEY_ID = re.compile(r"[A-Za-z0-9_-]{43}\Z")
 _TIMESTAMP = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\Z")
-_SNAPSHOT_TIMESTAMP = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\Z")
 _CLAIM_KEYS = {
     "schemaVersion",
     "workspaceId",
@@ -102,46 +91,6 @@ _CLAIM_KEYS = {
     "previousLeaseKeyId",
     "signingKeyId",
 }
-_SNAPSHOT_KEYS = {
-    "schemaVersion",
-    "generatedAt",
-    "scope",
-    "healthy",
-    "assuranceLevel",
-    "installOwner",
-    "platform",
-    "architecture",
-    "identifiers",
-    "product",
-    "components",
-    "harnessCoverage",
-    "continuity",
-    "reasonCodes",
-    "remediationClass",
-}
-_IDENTIFIER_KEYS = {"workspaceId", "deviceId", "machineInstallationId", "installationGeneration"}
-_PRODUCT_KEYS = {"version", "buildId", "sourceCommit", "packageIdentity", "manifestHash", "policyHash"}
-_COMPONENT_KEYS = {
-    "manifest",
-    "nativePackage",
-    "managedPolicy",
-    "ownershipAndAcl",
-    "supervisor",
-    "deviceKey",
-    "harnessCoverage",
-    "installationIdentity",
-    "leaseContinuity",
-    "daemon",
-    "commandShadowing",
-    "update",
-}
-_HARNESS_KEYS = {"required", "protected", "degraded", "missing"}
-_CONTINUITY_KEYS = {"monotonicUptimeSeconds", "sequence", "previousLeaseDigest", "bootSessionId"}
-_BASIC_COMPONENT_KEYS = {"state", "healthy", "reasonCode"}
-_INTEGRITY_STATES = frozenset(get_args(IntegrityState))
-_SUPERVISOR_STATES = frozenset(get_args(SupervisorState))
-_KEY_LEVELS = frozenset(get_args(KeyProtectionLevel))
-_REASON_CODES = frozenset(get_args(IntegrityReasonCode))
 
 
 def canonical_json_bytes(payload: dict[str, object]) -> bytes:
@@ -423,108 +372,9 @@ class HealthLeaseOutbox:
 
 
 def _validate_snapshot_binding(snapshot: bytes, claims: LeaseClaims) -> None:
-    raw = _strict_json(snapshot, maximum=MAX_SNAPSHOT_BYTES, reason="health_lease_outbox_invalid")
-    _exact_keys(raw, _SNAPSHOT_KEYS, "health_lease_outbox_invalid")
-    if raw.get("schemaVersion") != claims.snapshot_schema_version:
-        raise ValueError("health_lease_outbox_invalid")
-    identifiers = raw.get("identifiers")
-    product = raw.get("product")
-    components = raw.get("components")
-    harness = raw.get("harnessCoverage")
-    continuity = raw.get("continuity")
-    if not all(isinstance(value, dict) for value in (identifiers, product, components, harness, continuity)):
-        raise ValueError("health_lease_outbox_invalid")
-    assert isinstance(identifiers, dict)
-    assert isinstance(product, dict)
-    assert isinstance(components, dict)
-    assert isinstance(harness, dict)
-    assert isinstance(continuity, dict)
-    for value, keys in (
-        (identifiers, _IDENTIFIER_KEYS),
-        (product, _PRODUCT_KEYS),
-        (components, _COMPONENT_KEYS),
-        (harness, _HARNESS_KEYS),
-        (continuity, _CONTINUITY_KEYS),
-    ):
-        _exact_keys(value, keys, "health_lease_outbox_invalid")
-    for name, component in components.items():
-        if not isinstance(component, dict):
-            raise ValueError("health_lease_outbox_invalid")
-        expected = _BASIC_COMPONENT_KEYS | ({"level"} if name == "deviceKey" else set())
-        _exact_keys(component, expected, "health_lease_outbox_invalid")
-        allowed_states = _SUPERVISOR_STATES if name == "supervisor" else _INTEGRITY_STATES
-        state = component.get("state")
-        reason_code = component.get("reasonCode")
-        level = component.get("level")
-        if (
-            not isinstance(state, str)
-            or state not in allowed_states
-            or not isinstance(component.get("healthy"), bool)
-            or not isinstance(reason_code, str)
-            or reason_code not in _REASON_CODES
-            or (name == "deviceKey" and (not isinstance(level, str) or level not in _KEY_LEVELS))
-        ):
-            raise ValueError("health_lease_outbox_invalid")
-    generated_at = raw.get("generatedAt")
-    if not isinstance(generated_at, str):
-        raise ValueError("health_lease_outbox_invalid")
-    if _SNAPSHOT_TIMESTAMP.fullmatch(generated_at) is None:
-        raise ValueError("health_lease_outbox_invalid")
-    try:
-        # Python 3.10 does not accept the RFC 3339 ``Z`` suffix directly.
-        generated = datetime.fromisoformat(f"{generated_at[:-1]}+00:00")
-    except ValueError as exc:
-        raise ValueError("health_lease_outbox_invalid") from exc
-    reason_codes = raw.get("reasonCodes")
-    if (
-        generated.tzinfo is None
-        or len(generated_at.encode("utf-8")) > 64
-        or raw.get("scope") != "machine"
-        or not isinstance(raw.get("healthy"), bool)
-        or raw.get("assuranceLevel") not in get_args(AssuranceLevel)
-        or raw.get("installOwner") not in get_args(InstallOwner)
-        or raw.get("remediationClass") not in get_args(RemediationClass)
-        or not isinstance(reason_codes, list)
-        or len(reason_codes) > 64
-        or any(not isinstance(reason, str) or reason not in _REASON_CODES for reason in reason_codes)
-        or reason_codes != sorted(set(reason_codes))
-    ):
-        raise ValueError("health_lease_outbox_invalid")
-    _bounded_string(raw.get("platform"), maximum=64)
-    _bounded_string(raw.get("architecture"), maximum=64)
-    _bounded_string(product.get("version"), maximum=128)
-    _bounded_string(product.get("buildId"), maximum=256, nullable=True)
-    _bounded_string(product.get("sourceCommit"), maximum=256, nullable=True)
-    _bounded_string(product.get("packageIdentity"), maximum=256)
-    for name in ("manifestHash", "policyHash"):
-        value = product.get(name)
-        if value is not None:
-            _match(value, _HEX_64)
-    for value in harness.values():
-        _optional_uint64(value)
-    uptime = continuity.get("monotonicUptimeSeconds")
-    if uptime is not None and (
-        not isinstance(uptime, (int, float)) or isinstance(uptime, bool) or not math.isfinite(uptime) or uptime < 0
-    ):
-        raise ValueError("health_lease_outbox_invalid")
-    _optional_uint64(continuity.get("sequence"))
-    previous = continuity.get("previousLeaseDigest")
-    if previous is not None:
-        _match(previous, _HEX_64)
-    _bounded_string(continuity.get("bootSessionId"), maximum=256, nullable=True)
-    expected_identifiers = {
-        "workspaceId": claims.workspace_id,
-        "deviceId": claims.device_id,
-        "machineInstallationId": claims.machine_installation_id,
-        "installationGeneration": claims.installation_generation,
-    }
-    if any(identifiers.get(key) != value for key, value in expected_identifiers.items()):
-        raise ValueError("health_lease_outbox_invalid")
-    if (
-        continuity.get("sequence") != claims.sequence - 1
-        or continuity.get("previousLeaseDigest") != claims.previous_lease_digest
-    ):
-        raise ValueError("health_lease_outbox_invalid")
+    from .health_snapshot_validation import validate_health_snapshot_binding
+
+    validate_health_snapshot_binding(snapshot, claims)
 
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/mdm/health_snapshot_validation.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_snapshot_validation.py
@@ -1,0 +1,232 @@
+"""Strict binding validation for machine health snapshots carried by lease outboxes."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from datetime import datetime
+from typing import Protocol, get_args
+
+from .contracts import (
+    AssuranceLevel,
+    InstallOwner,
+    IntegrityReasonCode,
+    IntegrityState,
+    KeyProtectionLevel,
+    RemediationClass,
+    SupervisorState,
+)
+
+_MAX_SNAPSHOT_BYTES = 256 * 1024
+_MAX_UINT64 = (1 << 64) - 1
+_HEX_64 = re.compile(r"[0-9a-f]{64}\Z")
+_SNAPSHOT_TIMESTAMP = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\Z")
+_SNAPSHOT_KEYS = {
+    "schemaVersion",
+    "generatedAt",
+    "scope",
+    "healthy",
+    "assuranceLevel",
+    "installOwner",
+    "platform",
+    "architecture",
+    "identifiers",
+    "product",
+    "components",
+    "harnessCoverage",
+    "continuity",
+    "reasonCodes",
+    "remediationClass",
+}
+_IDENTIFIER_KEYS = {"workspaceId", "deviceId", "machineInstallationId", "installationGeneration"}
+_PRODUCT_KEYS = {"version", "buildId", "sourceCommit", "packageIdentity", "manifestHash", "policyHash"}
+_COMPONENT_KEYS = {
+    "manifest",
+    "nativePackage",
+    "managedPolicy",
+    "ownershipAndAcl",
+    "supervisor",
+    "deviceKey",
+    "harnessCoverage",
+    "installationIdentity",
+    "leaseContinuity",
+    "daemon",
+    "commandShadowing",
+    "update",
+}
+_HARNESS_KEYS = {"required", "protected", "degraded", "missing"}
+_CONTINUITY_KEYS = {"monotonicUptimeSeconds", "sequence", "previousLeaseDigest", "bootSessionId"}
+_BASIC_COMPONENT_KEYS = {"state", "healthy", "reasonCode"}
+_INTEGRITY_STATES = frozenset(get_args(IntegrityState))
+_SUPERVISOR_STATES = frozenset(get_args(SupervisorState))
+_KEY_LEVELS = frozenset(get_args(KeyProtectionLevel))
+_REASON_CODES = frozenset(get_args(IntegrityReasonCode))
+
+
+class SnapshotLeaseClaims(Protocol):
+    @property
+    def workspace_id(self) -> str: ...
+    @property
+    def device_id(self) -> str: ...
+    @property
+    def machine_installation_id(self) -> str: ...
+    @property
+    def installation_generation(self) -> str: ...
+    @property
+    def sequence(self) -> int: ...
+    @property
+    def snapshot_schema_version(self) -> str: ...
+    @property
+    def previous_lease_digest(self) -> str | None: ...
+
+
+def _reject_json_constant(_value: str) -> None:
+    raise ValueError("health_lease_json_invalid")
+
+
+def _strict_json(payload: bytes) -> dict[str, object]:
+    if not payload or len(payload) > _MAX_SNAPSHOT_BYTES:
+        raise ValueError("health_lease_outbox_invalid")
+    try:
+        raw = json.loads(payload.decode("utf-8"), parse_constant=_reject_json_constant)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("health_lease_outbox_invalid") from exc
+    if not isinstance(raw, dict):
+        raise ValueError("health_lease_outbox_invalid")
+    canonical = json.dumps(raw, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False).encode()
+    if canonical != payload:
+        raise ValueError("health_lease_outbox_invalid")
+    return raw
+
+
+def _exact_keys(raw: dict[str, object], expected: set[str]) -> None:
+    if set(raw) != expected:
+        raise ValueError("health_lease_outbox_invalid")
+
+
+def _match(value: object, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str) or pattern.fullmatch(value) is None:
+        raise ValueError("health_lease_outbox_invalid")
+    return value
+
+
+def _bounded_string(value: object, *, maximum: int, nullable: bool = False) -> str | None:
+    if value is None and nullable:
+        return None
+    if not isinstance(value, str) or not value or len(value.encode()) > maximum:
+        raise ValueError("health_lease_outbox_invalid")
+    return value
+
+
+def _optional_uint64(value: object) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= _MAX_UINT64:
+        raise ValueError("health_lease_outbox_invalid")
+    return value
+
+
+def validate_health_snapshot_binding(snapshot: bytes, claims: SnapshotLeaseClaims) -> None:
+    raw = _strict_json(snapshot)
+    _exact_keys(raw, _SNAPSHOT_KEYS)
+    if raw.get("schemaVersion") != claims.snapshot_schema_version:
+        raise ValueError("health_lease_outbox_invalid")
+    identifiers = raw.get("identifiers")
+    product = raw.get("product")
+    components = raw.get("components")
+    harness = raw.get("harnessCoverage")
+    continuity = raw.get("continuity")
+    if not all(isinstance(value, dict) for value in (identifiers, product, components, harness, continuity)):
+        raise ValueError("health_lease_outbox_invalid")
+    assert isinstance(identifiers, dict)
+    assert isinstance(product, dict)
+    assert isinstance(components, dict)
+    assert isinstance(harness, dict)
+    assert isinstance(continuity, dict)
+    for value, keys in (
+        (identifiers, _IDENTIFIER_KEYS),
+        (product, _PRODUCT_KEYS),
+        (components, _COMPONENT_KEYS),
+        (harness, _HARNESS_KEYS),
+        (continuity, _CONTINUITY_KEYS),
+    ):
+        _exact_keys(value, keys)
+    for name, component in components.items():
+        if not isinstance(component, dict):
+            raise ValueError("health_lease_outbox_invalid")
+        expected = _BASIC_COMPONENT_KEYS | ({"level"} if name == "deviceKey" else set())
+        _exact_keys(component, expected)
+        allowed_states = _SUPERVISOR_STATES if name == "supervisor" else _INTEGRITY_STATES
+        state = component.get("state")
+        reason_code = component.get("reasonCode")
+        level = component.get("level")
+        if (
+            not isinstance(state, str)
+            or state not in allowed_states
+            or not isinstance(component.get("healthy"), bool)
+            or not isinstance(reason_code, str)
+            or reason_code not in _REASON_CODES
+            or (name == "deviceKey" and (not isinstance(level, str) or level not in _KEY_LEVELS))
+        ):
+            raise ValueError("health_lease_outbox_invalid")
+    generated_at = raw.get("generatedAt")
+    if not isinstance(generated_at, str) or _SNAPSHOT_TIMESTAMP.fullmatch(generated_at) is None:
+        raise ValueError("health_lease_outbox_invalid")
+    try:
+        generated = datetime.fromisoformat(f"{generated_at[:-1]}+00:00")
+    except ValueError as exc:
+        raise ValueError("health_lease_outbox_invalid") from exc
+    reason_codes = raw.get("reasonCodes")
+    if (
+        generated.tzinfo is None
+        or len(generated_at.encode("utf-8")) > 64
+        or raw.get("scope") != "machine"
+        or not isinstance(raw.get("healthy"), bool)
+        or raw.get("assuranceLevel") not in get_args(AssuranceLevel)
+        or raw.get("installOwner") not in get_args(InstallOwner)
+        or raw.get("remediationClass") not in get_args(RemediationClass)
+        or not isinstance(reason_codes, list)
+        or len(reason_codes) > 64
+        or any(not isinstance(reason, str) or reason not in _REASON_CODES for reason in reason_codes)
+        or reason_codes != sorted(set(reason_codes))
+    ):
+        raise ValueError("health_lease_outbox_invalid")
+    _bounded_string(raw.get("platform"), maximum=64)
+    _bounded_string(raw.get("architecture"), maximum=64)
+    _bounded_string(product.get("version"), maximum=128)
+    _bounded_string(product.get("buildId"), maximum=256, nullable=True)
+    _bounded_string(product.get("sourceCommit"), maximum=256, nullable=True)
+    _bounded_string(product.get("packageIdentity"), maximum=256)
+    for name in ("manifestHash", "policyHash"):
+        value = product.get(name)
+        if value is not None:
+            _match(value, _HEX_64)
+    for value in harness.values():
+        _optional_uint64(value)
+    uptime = continuity.get("monotonicUptimeSeconds")
+    if uptime is not None and (
+        not isinstance(uptime, (int, float)) or isinstance(uptime, bool) or not math.isfinite(uptime) or uptime < 0
+    ):
+        raise ValueError("health_lease_outbox_invalid")
+    _optional_uint64(continuity.get("sequence"))
+    previous = continuity.get("previousLeaseDigest")
+    if previous is not None:
+        _match(previous, _HEX_64)
+    _bounded_string(continuity.get("bootSessionId"), maximum=256, nullable=True)
+    expected_identifiers = {
+        "workspaceId": claims.workspace_id,
+        "deviceId": claims.device_id,
+        "machineInstallationId": claims.machine_installation_id,
+        "installationGeneration": claims.installation_generation,
+    }
+    if any(identifiers.get(key) != value for key, value in expected_identifiers.items()):
+        raise ValueError("health_lease_outbox_invalid")
+    if (
+        continuity.get("sequence") != claims.sequence - 1
+        or continuity.get("previousLeaseDigest") != claims.previous_lease_digest
+    ):
+        raise ValueError("health_lease_outbox_invalid")
+
+
+__all__ = ["validate_health_snapshot_binding"]

--- a/src/codex_plugin_scanner/guard/mdm/protection_lease_contract.py
+++ b/src/codex_plugin_scanner/guard/mdm/protection_lease_contract.py
@@ -25,6 +25,8 @@ from .health_lease_contract import (
 )
 
 PROTECTION_LEASE_SCHEMA = "protection-lease.v1"
+MIN_PROTECTION_LEASE_SECONDS = 180
+MAX_PROTECTION_LEASE_SECONDS = 1800
 _HEX_32 = __import__("re").compile(r"[0-9a-f]{32}\Z")
 _HEX_64 = __import__("re").compile(r"[0-9a-f]{64}\Z")
 _KEY_ID = __import__("re").compile(r"[A-Za-z0-9_-]{43}\Z")
@@ -142,7 +144,7 @@ class ProtectionLeaseClaims:
             or not 1 <= sequence <= MAX_UINT64
             or not isinstance(duration, int)
             or isinstance(duration, bool)
-            or not 180 <= duration <= 1800
+            or not MIN_PROTECTION_LEASE_SECONDS <= duration <= MAX_PROTECTION_LEASE_SECONDS
         ):
             raise ValueError("health_lease_invalid")
         previous = raw.get("previousLeaseDigest")
@@ -253,4 +255,11 @@ class SignedProtectionLease:
         return cls(claims, parsed)
 
 
-__all__ = ["PROTECTION_LEASE_SCHEMA", "ProtectionLeaseChallenge", "ProtectionLeaseClaims", "SignedProtectionLease"]
+__all__ = [
+    "MAX_PROTECTION_LEASE_SECONDS",
+    "MIN_PROTECTION_LEASE_SECONDS",
+    "PROTECTION_LEASE_SCHEMA",
+    "ProtectionLeaseChallenge",
+    "ProtectionLeaseClaims",
+    "SignedProtectionLease",
+]

--- a/tests/test_guard_mdm_health_lease.py
+++ b/tests/test_guard_mdm_health_lease.py
@@ -315,6 +315,47 @@ def test_issue_binds_exact_normalized_snapshot_digest_and_verifies_signature(
     assert outbox.lease.claims.signing_key_id == key.key_id
 
 
+@pytest.mark.parametrize("lease_seconds", [180, 1800])
+def test_issue_accepts_frozen_protection_lease_duration_boundaries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    lease_seconds: int,
+) -> None:
+    paths, private, _key_generation = _prepare(tmp_path, monkeypatch)
+
+    outbox = health_lease.issue_or_load_pending_health_lease(
+        paths,
+        HealthLeaseBinding("workspace-a", "device-a"),
+        lease_seconds=lease_seconds,
+        now=_NOW,
+        system_name="Darwin",
+        snapshot_factory=_snapshot,
+        signer=_signer(private),
+    )
+
+    assert outbox.lease.claims.valid_for_seconds == lease_seconds
+
+
+@pytest.mark.parametrize("lease_seconds", [179, 1801])
+def test_issue_rejects_durations_outside_frozen_protection_lease_bounds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    lease_seconds: int,
+) -> None:
+    paths, private, _key_generation = _prepare(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError, match="health_lease_duration_invalid"):
+        health_lease.issue_or_load_pending_health_lease(
+            paths,
+            HealthLeaseBinding("workspace-a", "device-a"),
+            lease_seconds=lease_seconds,
+            now=_NOW,
+            system_name="Darwin",
+            snapshot_factory=_snapshot,
+            signer=_signer(private),
+        )
+
+
 def test_issue_rejects_signature_from_an_unrelated_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     paths, _private, _key_generation = _prepare(tmp_path, monkeypatch)
     attacker = ec.generate_private_key(ec.SECP256R1())

--- a/tests/test_guard_mdm_health_reporter.py
+++ b/tests/test_guard_mdm_health_reporter.py
@@ -94,8 +94,10 @@ def test_machine_cadence_uses_only_locked_machine_policy_binding(tmp_path: Path)
     assert result["sequence"] == 7
     assert result["leaseDigest"] == "3" * 64
     metrics = cast(dict[str, object], result["metrics"])
+    snapshot_duration_ms = metrics.pop("snapshotDurationMs")
+    assert isinstance(snapshot_duration_ms, int)
+    assert snapshot_duration_ms >= 0
     assert metrics == {
-        "snapshotDurationMs": 0,
         "leaseAgeSeconds": metrics["leaseAgeSeconds"],
         "deliveryLatencyMs": None,
         "rejectionReason": None,


### PR DESCRIPTION
## Summary
- align issuer validation with the frozen 180–1800 second protection-lease contract
- add boundary regression coverage for accepted and rejected lease lifetimes
- extract snapshot binding validation so touched contract modules remain below 500 lines

## Verification
- `uv run --no-sync pytest -q tests/test_guard_mdm_health_lease.py tests/test_guard_mdm_health_lease_contract.py tests/test_guard_mdm_health_lease_ack.py tests/test_guard_mdm_health_reporter.py tests/test_guard_mdm_health_transport.py` (81 passed)
- `uv run --no-sync python -m ruff check src/`
- `uv run --no-sync python -m ruff format --check src/`
- `uv run --no-sync basedpyright --level error` (0 errors)