### PR TITLE
fix(guard): bind approvals to complete skill identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,25 @@ jobs:
         with:
           enable-cache: true
       - run: uv sync --frozen --extra dev --python ${{ matrix.python-version }}
-      - run: uv run --no-sync pytest tests/test_cli.py tests/test_verification.py tests/test_action_runner.py --tb=short
+      - name: Run cross-platform Guard regressions
+        run: >-
+          uv run --no-sync pytest
+          tests/test_cli.py
+          tests/test_verification.py
+          tests/test_action_runner.py
+          tests/test_guard_skill_directory_identity.py
+          tests/test_guard_skill_directory_identity_discovery.py
+          tests/test_guard_skill_directory_identity_downstream.py
+          tests/test_guard_skill_directory_identity_links.py
+          tests/test_guard_consumer_skill_directory_identity.py
+          tests/test_guard_runner_skill_directory_identity.py
+          tests/test_gemini_adapter.py
+          tests/test_gemini_skill_directory_identity.py
+          tests/test_antigravity_adapter.py
+          tests/test_guard_aibom_detection.py
+          tests/test_guard_aibom_content_upload_batches.py
+          tests/test_guard_aibom_skill_directory_identity.py
+          --tb=short
 
   windows-updater:
     runs-on: windows-latest

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -104,6 +104,12 @@ Current Guard support in this repo:
   - blocks by returning exit code `2` and ZCode-native stdout JSON `hookSpecificOutput.permissionDecision: "deny"` with approval-center copy in stderr
   - fails open if a hook crashes or times out, so ZCode keeps working when Guard is unreachable
 
+Gemini, Antigravity, and shared Codex/AIBOM skill discovery bind approval and
+inventory identity to the complete accepted skill directory rather than only
+`SKILL.md`. See [Skill directory identity](./skill-directory-identity.md) for
+the canonical stream, symlink rules, resource ceilings, and incomplete-state
+behavior.
+
 Approval tiers:
 
 1. native harness approval when the harness already has strong permission controls

--- a/docs/guard/skill-directory-identity.md
+++ b/docs/guard/skill-directory-identity.md
@@ -1,0 +1,93 @@
+# Skill directory identity
+
+Guard treats a skill as a directory bundle, not as `SKILL.md` alone. Gemini,
+Antigravity, and shared Codex/AIBOM discovery use the same v1 identity contract.
+Hermes remains on its legacy primary-document identity until its separate
+complete-input migration.
+
+## Metadata contract
+
+A complete inspection emits these related values:
+
+- `content_hash`: SHA-256 of the exact primary `SKILL.md` body.
+- `directory_hash`: SHA-256 of the canonical full-directory identity stream.
+- `skillDirectoryIdentity`: an envelope with
+  `schemaVersion: guard.skill-directory-identity.v1`, `status: complete`, the
+  directory digest in `contentHash`, `entryCount`, `totalBytes`, and
+  `reusable: true`.
+- `versionInfo.contentHash`: the same complete directory digest.
+
+Inventory uses the validated directory digest as the skill item's
+`content_hash`, so a secondary-file or mode change changes the item and
+snapshot identity. Guard also records a locally recomputed
+`primaryContentHash`; it is distinct from the bundle identity and cannot be
+supplied authoritatively by an adapter.
+
+The three directory bindings (`directory_hash`,
+`skillDirectoryIdentity.contentHash`, and `versionInfo.contentHash`) must agree.
+Malformed or mismatched metadata is not promoted to a directory identity, and
+an unverified bare `directory_hash` is removed from inventory metadata.
+
+## Canonical stream
+
+Inspection starts at the directory containing the primary `SKILL.md` and
+accounts for every nested entry; there are no filename or cache-directory
+exclusions. Records are ordered by canonical `/`-separated relative path and
+bind:
+
+- the relative path and entry type;
+- security-relevant POSIX mode bits, including executable state;
+- the complete byte length and SHA-256 digest of each accepted regular file;
+- directory records, including empty directories; and
+- for an accepted non-primary, in-tree file symlink, the link spelling,
+  canonical target path, target type, mode, length, and complete target digest.
+
+The stream excludes mtime, inode, device number, and filesystem enumeration
+order. Therefore touching a file without changing its accepted identity is
+stable, while changing a path, type, bytes, executable mode, or symlink target
+changes the directory digest.
+
+A directory symlink is never recursively traversed during discovery. Skill-root
+and nested directory symlinks are reported as incomplete and non-reusable. The
+primary `SKILL.md` must be a regular file; contained regular-file symlinks are
+accepted only for secondary entries. Broken links,
+links outside the skill directory, loops, special files, reparse-point
+ambiguity, path/case collisions, unreadable entries, and observed read races
+make the inspection incomplete instead of silently omitting an entry.
+
+## Resource limits and incomplete results
+
+Both grouping-path discovery and the shared inspector accept at most 32 nested
+path components and 4,096 entries. Discovery stops at a primary document and
+hands its full subtree to the inspector, so the limits apply without first
+materializing an unbounded directory. The inspector accepts
+128 MiB per regular file, and 256 MiB of total bytes read. Symlink target reads
+also consume the total-byte budget, so aliases cannot amplify unbounded hashing
+work. These defaults are defined by `DEFAULT_SKILL_DIRECTORY_LIMITS` in
+`guard/skill_directory_identity.py` and are applied before a result can be
+marked complete. Operating-system path/symlink resolution errors and reaching a
+Guard resource bound produce a typed reason rather than a prefix hash.
+
+An incomplete inspection emits `status: incomplete`, `reusable: false`, a safe
+reason, observed counts, and a deterministic `incompleteStateHash`; it does not
+emit `directory_hash`. The state hash keeps repeated observation of the same
+incomplete state stable for inventory and the runner's approve-then-redetect
+flow, but it is never reusable approval authority. `versionInfo` binds this
+incomplete marker rather than claiming a complete bundle digest. The consumer
+applies a `require-reapproval` floor and will neither accept nor claim saved
+approval evidence for a marked incomplete, non-reusable, malformed, or
+mismatched identity. An exact fresh approval can still follow the normal
+explicit authority path.
+
+## Primary content and previews
+
+Directory identity reads and hashes all accepted bytes. Bounded document
+analysis and display previews remain separate and may report truncation without
+weakening the bundle identity.
+
+AIBOM primary-content upload remains intentionally narrower: it uploads only
+the exact `SKILL.md` body and labels it with the trusted primary digest. The
+inventory item's directory-wide hash is never used as the body hash, and
+scripts, references, templates, assets, and other supplementary files are never
+uploaded by this path. The upload path rereads the bounded body and verifies its
+digest immediately before serialization.

--- a/src/codex_plugin_scanner/guard/adapters/antigravity.py
+++ b/src/codex_plugin_scanner/guard/adapters/antigravity.py
@@ -6,6 +6,12 @@ import json
 from pathlib import Path
 
 from ..models import GuardArtifact, HarnessDetection
+from ..skill_directory_identity import (
+    discover_skill_documents,
+    incomplete_skill_directory_identity,
+    inspect_skill_directory,
+    skill_directory_identity_metadata,
+)
 from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload
 
 
@@ -79,6 +85,7 @@ class AntigravityHarnessAdapter(HarnessAdapter):
     def detect(self, context: HarnessContext) -> HarnessDetection:
         artifacts: list[GuardArtifact] = []
         found_paths: list[str] = []
+        warnings: list[str] = []
 
         extension_index = context.home_dir / ".antigravity" / "extensions" / "extensions.json"
         extension_payload = self._extension_index_payload(extension_index)
@@ -97,16 +104,26 @@ class AntigravityHarnessAdapter(HarnessAdapter):
             scope = self._scope_for(context, config_path)
             self._append_mcp_artifacts(artifacts, config_path, payload, scope)
 
-        skill_roots = [context.home_dir / ".gemini" / "antigravity" / "skills"]
+        skill_roots = [(context.home_dir / ".gemini" / "antigravity" / "skills", context.home_dir)]
         if context.workspace_dir is not None:
-            skill_roots.append(context.workspace_dir / ".gemini" / "antigravity" / "skills")
-        for skill_root in skill_roots:
-            if not skill_root.is_dir():
-                continue
+            skill_roots.append(
+                (
+                    context.workspace_dir / ".gemini" / "antigravity" / "skills",
+                    context.workspace_dir,
+                )
+            )
+        for skill_root, identity_scope_root in skill_roots:
             scope = self._scope_for(context, skill_root)
-            for skill_path in sorted(skill_root.rglob("SKILL.md")):
+            discovery = discover_skill_documents(skill_root)
+            for skill_path in discovery.documents:
                 self._append_found_path(found_paths, skill_path)
                 relative_id = f"skills/{skill_path.parent.relative_to(skill_root).as_posix()}"
+                identity = inspect_skill_directory(skill_path, scope_root=identity_scope_root)
+                metadata = skill_directory_identity_metadata(identity, version_label=relative_id)
+                if identity.status != "complete":
+                    warnings.append(
+                        f"Antigravity {scope} skill directory identity is incomplete; approval reuse is disabled."
+                    )
                 artifacts.append(
                     GuardArtifact(
                         artifact_id=f"antigravity:{scope}:skill:{relative_id}",
@@ -115,6 +132,24 @@ class AntigravityHarnessAdapter(HarnessAdapter):
                         artifact_type="skill",
                         source_scope=scope,
                         config_path=str(skill_path),
+                        metadata=metadata,
+                    )
+                )
+            for issue in discovery.issues:
+                self._append_found_path(found_paths, issue.path)
+                relative_id = f"skills/.guard-discovery/{issue.issue_id}"
+                identity = incomplete_skill_directory_identity(issue.failure_reason)
+                metadata = skill_directory_identity_metadata(identity, version_label=relative_id)
+                warnings.append(f"Antigravity {scope} skill discovery is incomplete; approval reuse is disabled.")
+                artifacts.append(
+                    GuardArtifact(
+                        artifact_id=f"antigravity:{scope}:skill-discovery:{issue.issue_id}",
+                        name="Incomplete Antigravity skill discovery",
+                        harness=self.harness,
+                        artifact_type="skill",
+                        source_scope=scope,
+                        config_path=str(issue.path),
+                        metadata=metadata,
                     )
                 )
 
@@ -147,7 +182,7 @@ class AntigravityHarnessAdapter(HarnessAdapter):
             command_available=_command_available(self.executable),
             config_paths=tuple(found_paths),
             artifacts=tuple(artifacts),
-            warnings=(),
+            warnings=tuple(dict.fromkeys(warnings)),
         )
 
     @staticmethod

--- a/src/codex_plugin_scanner/guard/adapters/gemini.py
+++ b/src/codex_plugin_scanner/guard/adapters/gemini.py
@@ -6,6 +6,12 @@ from pathlib import Path
 
 from ..aibom_detection import extend_detection_with_workspace_aibom
 from ..models import GuardArtifact, HarnessDetection
+from ..skill_directory_identity import (
+    discover_skill_documents,
+    incomplete_skill_directory_identity,
+    inspect_skill_directory,
+    skill_directory_identity_metadata,
+)
 from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload
 
 
@@ -48,11 +54,13 @@ class GeminiHarnessAdapter(HarnessAdapter):
     def detect(self, context: HarnessContext) -> HarnessDetection:
         artifacts: list[GuardArtifact] = []
         found_paths: list[str] = []
+        warnings: list[str] = []
         scope_specs = [
             (
                 context.home_dir / ".gemini" / "settings.json",
                 context.home_dir / ".gemini" / "extensions",
                 context.home_dir / ".gemini" / "skills",
+                context.home_dir,
             )
         ]
         if context.workspace_dir is not None:
@@ -61,23 +69,31 @@ class GeminiHarnessAdapter(HarnessAdapter):
                     context.workspace_dir / ".gemini" / "settings.json",
                     context.workspace_dir / ".gemini" / "extensions",
                     context.workspace_dir / ".gemini" / "skills",
+                    context.workspace_dir,
                 )
             )
-        for settings_path, extension_root, skill_root in scope_specs:
+        for settings_path, extension_root, skill_root, identity_scope_root in scope_specs:
             scope = self._scope_for(context, settings_path)
             self._append_extension_artifacts(artifacts, found_paths, extension_root, scope)
             payload = _json_payload(settings_path)
             if payload:
                 self._append_found_path(found_paths, settings_path)
                 self._append_settings_artifacts(artifacts, settings_path, payload, scope)
-            self._append_skill_artifacts(artifacts, found_paths, skill_root, scope)
+            self._append_skill_artifacts(
+                artifacts,
+                found_paths,
+                warnings,
+                skill_root,
+                identity_scope_root,
+                scope,
+            )
         detection = HarnessDetection(
             harness=self.harness,
             installed=bool(found_paths) or _command_available(self.executable),
             command_available=_command_available(self.executable),
             config_paths=tuple(found_paths),
             artifacts=tuple(artifacts),
-            warnings=(),
+            warnings=tuple(dict.fromkeys(warnings)),
         )
         return extend_detection_with_workspace_aibom(
             detection,
@@ -191,14 +207,19 @@ class GeminiHarnessAdapter(HarnessAdapter):
         self,
         artifacts: list[GuardArtifact],
         found_paths: list[str],
+        warnings: list[str],
         skill_root: Path,
+        identity_scope_root: Path,
         scope: str,
     ) -> None:
-        if not skill_root.is_dir():
-            return
-        for skill_path in sorted(skill_root.rglob("SKILL.md")):
+        discovery = discover_skill_documents(skill_root)
+        for skill_path in discovery.documents:
             self._append_found_path(found_paths, skill_path)
             relative_id = f"skills/{skill_path.parent.relative_to(skill_root).as_posix()}"
+            identity = inspect_skill_directory(skill_path, scope_root=identity_scope_root)
+            metadata = skill_directory_identity_metadata(identity, version_label=relative_id)
+            if identity.status != "complete":
+                warnings.append(f"Gemini {scope} skill directory identity is incomplete; approval reuse is disabled.")
             artifacts.append(
                 GuardArtifact(
                     artifact_id=f"gemini:{scope}:skill:{relative_id}",
@@ -207,6 +228,24 @@ class GeminiHarnessAdapter(HarnessAdapter):
                     artifact_type="skill",
                     source_scope=scope,
                     config_path=str(skill_path),
+                    metadata=metadata,
+                )
+            )
+        for issue in discovery.issues:
+            self._append_found_path(found_paths, issue.path)
+            relative_id = f"skills/.guard-discovery/{issue.issue_id}"
+            identity = incomplete_skill_directory_identity(issue.failure_reason)
+            metadata = skill_directory_identity_metadata(identity, version_label=relative_id)
+            warnings.append(f"Gemini {scope} skill discovery is incomplete; approval reuse is disabled.")
+            artifacts.append(
+                GuardArtifact(
+                    artifact_id=f"gemini:{scope}:skill-discovery:{issue.issue_id}",
+                    name="Incomplete Gemini skill discovery",
+                    harness=self.harness,
+                    artifact_type="skill",
+                    source_scope=scope,
+                    config_path=str(issue.path),
+                    metadata=metadata,
                 )
             )
 

--- a/src/codex_plugin_scanner/guard/aibom_content_upload.py
+++ b/src/codex_plugin_scanner/guard/aibom_content_upload.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, TypedDict
 
 from ..path_support import resolves_within_root
-from .inventory_contract import GuardAgentInventorySnapshot
+from .inventory_contract import GuardAgentInventoryItem, GuardAgentInventorySnapshot
 
 _CONTENT_HASH_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 _MAX_CONTENT_ITEMS_PER_BATCH = 100
@@ -95,7 +95,10 @@ def primary_content_sources_from_artifacts(
             continue
         item_id = str(getattr(artifact, "artifact_id", ""))
         item = items_by_id.get(item_id)
-        if item is None or not _CONTENT_HASH_PATTERN.fullmatch(item.content_hash):
+        if item is None:
+            continue
+        primary_content_hash = _primary_content_hash(item, artifact_type=artifact_type)
+        if primary_content_hash is None:
             continue
         path_value = getattr(artifact, "config_path", None)
         if not isinstance(path_value, str) or not path_value.strip():
@@ -112,7 +115,7 @@ def primary_content_sources_from_artifacts(
             GuardAibomPrimaryContentSource(
                 agent_id=snapshot.agent_id,
                 allowed_root=allowed_root,
-                content_hash=item.content_hash,
+                content_hash=primary_content_hash,
                 harness_id=snapshot.agent_type,
                 item_id=item.item_id,
                 item_kind=item.item_kind,
@@ -123,6 +126,18 @@ def primary_content_sources_from_artifacts(
             )
         )
     return tuple(sources)
+
+
+def _primary_content_hash(item: GuardAgentInventoryItem, *, artifact_type: str) -> str | None:
+    """Resolve the exact primary-body digest independently of bundle identity."""
+
+    if artifact_type == "instruction":
+        candidate: object = item.content_hash
+    else:
+        candidate = item.metadata.get("primaryContentHash")
+    if not isinstance(candidate, str) or _CONTENT_HASH_PATTERN.fullmatch(candidate) is None:
+        return None
+    return candidate
 
 
 def _primary_allowed_root(

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -10,9 +10,15 @@ from typing import Literal
 from ..marketplace_support import extract_marketplace_source, load_marketplace_context
 from ..path_support import is_safe_relative_path, iter_safe_matching_files, resolves_within_root
 from .codex_skill_config import load_codex_skill_config_rules, resolve_codex_skill_enabled
-from .inventory_contract import fingerprint_mapping, fingerprint_path_tree, fingerprint_text
+from .inventory_contract import fingerprint_mapping, fingerprint_text
 from .models import GuardArtifact, HarnessDetection
 from .runtime.approval_context import build_configured_environment_hash, build_configured_header_values_hash
+from .skill_directory_identity import (
+    discover_skill_documents,
+    incomplete_skill_directory_identity,
+    inspect_skill_directory,
+    skill_directory_identity_metadata,
+)
 
 InstructionRole = Literal[
     "agents_md",
@@ -113,10 +119,6 @@ def file_content_hash(path: Path, *, max_bytes: int | None = None) -> str | None
         return None
 
 
-def directory_content_hash(root: Path, *, home_dir: Path) -> str:
-    return fingerprint_path_tree(root, home_dir=home_dir)
-
-
 def mcp_server_content_hash(
     *,
     command: str | None,
@@ -192,6 +194,7 @@ def discover_shared_workspace_aibom_artifacts(
     home_dir: Path,
     workspace_dir: Path,
 ) -> tuple[GuardArtifact, ...]:
+    _ = home_dir  # Retained for API compatibility; skill containment is workspace-relative.
     if not workspace_dir.is_dir():
         return ()
     try:
@@ -207,7 +210,6 @@ def discover_shared_workspace_aibom_artifacts(
             _discover_codex_skills(
                 harness,
                 workspace_dir=workspace_dir,
-                home_dir=home_dir,
                 skill_roots=_CODEX_WORKSPACE_SKILL_ROOTS,
                 source_scope="project",
                 artifact_scope="project",
@@ -330,7 +332,6 @@ def discover_codex_skill_artifacts(
             _discover_codex_skills(
                 harness,
                 workspace_dir=workspace_dir,
-                home_dir=home_dir,
                 skill_roots=_CODEX_WORKSPACE_SKILL_ROOTS,
                 source_scope="project",
                 artifact_scope="project",
@@ -340,7 +341,6 @@ def discover_codex_skill_artifacts(
         _discover_codex_skills(
             harness,
             workspace_dir=home_dir,
-            home_dir=home_dir,
             skill_roots=_CODEX_HOME_SKILL_ROOTS,
             source_scope="global",
             artifact_scope="global",
@@ -383,7 +383,6 @@ def _discover_codex_skills(
     harness: str,
     *,
     workspace_dir: Path,
-    home_dir: Path,
     skill_roots: tuple[str, ...],
     source_scope: str,
     artifact_scope: str,
@@ -391,23 +390,15 @@ def _discover_codex_skills(
     artifacts: list[GuardArtifact] = []
     for relative_root in skill_roots:
         skill_root = workspace_dir / relative_root
-        if not skill_root.is_dir() or not resolves_within_root(workspace_dir, skill_root, require_exists=True):
-            continue
-        for skill_md in sorted(skill_root.rglob("SKILL.md")):
-            if skill_md.is_symlink() or not skill_md.is_file():
-                continue
-            if not resolves_within_root(workspace_dir, skill_md, require_exists=True):
-                continue
+        discovery = discover_skill_documents(skill_root)
+        for skill_md in discovery.documents:
             skill_dir = skill_md.parent
             relative_id = skill_dir.relative_to(skill_root).as_posix()
-            content_hash = directory_content_hash(skill_dir, home_dir=home_dir)
-            digest = file_content_hash(skill_md)
+            identity = inspect_skill_directory(skill_md, scope_root=workspace_dir)
             metadata: dict[str, object] = {
                 "enabled": True,
                 "skill_root": relative_root,
-                "content_hash": digest,
-                "directory_hash": content_hash,
-                **version_info_metadata(content_hash=content_hash, version_label=relative_id or skill_dir.name),
+                **skill_directory_identity_metadata(identity, version_label=relative_id or skill_dir.name),
             }
             artifacts.append(
                 GuardArtifact(
@@ -417,6 +408,25 @@ def _discover_codex_skills(
                     artifact_type="skill",
                     source_scope=source_scope,
                     config_path=str(skill_md),
+                    metadata=metadata,
+                )
+            )
+        for issue in discovery.issues:
+            relative_id = f".guard-discovery/{issue.issue_id}"
+            identity = incomplete_skill_directory_identity(issue.failure_reason)
+            metadata = {
+                "enabled": True,
+                "skill_root": relative_root,
+                **skill_directory_identity_metadata(identity, version_label=relative_id),
+            }
+            artifacts.append(
+                GuardArtifact(
+                    artifact_id=f"{harness}:{artifact_scope}:skill-discovery:{relative_root}:{issue.issue_id}",
+                    name="Incomplete skill discovery",
+                    harness=harness,
+                    artifact_type="skill",
+                    source_scope=source_scope,
+                    config_path=str(issue.path),
                     metadata=metadata,
                 )
             )

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -44,6 +44,7 @@ from ..runtime.approval_reuse import (
 from ..runtime.decisions import build_authoritative_decision, evaluation_authority_error
 from ..runtime.signals import RiskSignalV2
 from ..schemas import build_consumer_mode_contract
+from ..skill_directory_identity import validated_complete_skill_directory_hash
 from ..store import GuardStore
 from ..types import (
     CapabilityDelta,
@@ -81,6 +82,7 @@ _TRUSTED_REQUEST_OVERRIDE_REASON = "trusted_request_override_exact_context"
 _RUNTIME_DETECTOR_BLOCK_REASON = "runtime_detector_block"
 _RUNTIME_DETECTOR_REVIEW_REASON = "runtime_detector_review"
 _RUNTIME_DETECTOR_WARN_REASON = "runtime_detector_warn"
+_SKILL_DIRECTORY_IDENTITY_REASON = "skill_directory_identity_non_reusable"
 
 
 class ArtifactDiff(TypedDict):
@@ -499,6 +501,39 @@ def _consumer_context_metadata(artifact: GuardArtifact) -> dict[str, object]:
     return {
         key: value for key, value in artifact.metadata.items() if key not in _PROMPT_FILE_HASH_VOLATILE_METADATA_KEYS
     }
+
+
+def _skill_directory_identity_reusable(
+    *,
+    artifact_type: object,
+    metadata: object,
+) -> bool | None:
+    """Classify the optional migrated skill identity boundary.
+
+    ``None`` preserves legacy behavior for adapters that do not emit the
+    marker.  Once the marker key is present, only a complete, reusable v1
+    envelope whose digest agrees with ``directory_hash`` may reuse approval.
+    """
+
+    if artifact_type != "skill" or not isinstance(metadata, Mapping):
+        return None
+    if "skillDirectoryIdentity" not in metadata:
+        return None
+    return validated_complete_skill_directory_hash(metadata) is not None
+
+
+def _skill_directory_identity_evidence(reusable: bool | None) -> tuple[dict[str, object], ...]:
+    if reusable is not False:
+        return ()
+    return (
+        {
+            "source": "skill_directory_identity",
+            "status": "incomplete",
+            "reason_code": _SKILL_DIRECTORY_IDENTITY_REASON,
+            "reusable": False,
+            "action_floor": "require-reapproval",
+        },
+    )
 
 
 def _consumer_policy_context(
@@ -1007,6 +1042,15 @@ def evaluate_detection(
             current_policy_action,
             scanner_action,
         )
+        skill_directory_identity_reusable = _skill_directory_identity_reusable(
+            artifact_type=artifact.artifact_type,
+            metadata=artifact.metadata,
+        )
+        if skill_directory_identity_reusable is False:
+            current_policy_action = most_restrictive_guard_action(
+                current_policy_action,
+                "require-reapproval",
+            )
         approval_context_hash = _consumer_approval_context_token(
             detection=detection,
             artifact=artifact,
@@ -1086,6 +1130,7 @@ def evaluate_detection(
             has_saved_state=has_saved_state,
         )
         scanner_evidence = (
+            *_skill_directory_identity_evidence(skill_directory_identity_reusable),
             *approval_reuse_evidence,
             *_runtime_signal_scanner_evidence(runtime_risk_signals_v2),
             *(
@@ -1124,6 +1169,14 @@ def evaluate_detection(
             "raw_scoring_recommendation": verdict.action,
             "scoring_recommendation_non_authoritative": True,
             "trusted_request_override": trusted_request_override,
+            **(
+                {
+                    "skill_directory_identity_reusable": skill_directory_identity_reusable,
+                    "skill_directory_identity_floor": "require-reapproval",
+                }
+                if skill_directory_identity_reusable is False
+                else {}
+            ),
             **({"saved_approval_claim": approval_claim} if approval_claim is not None else {}),
             **(
                 {
@@ -1328,6 +1381,15 @@ def evaluate_detection(
             config=config,
             changed=True,
         )
+        skill_directory_identity_reusable = _skill_directory_identity_reusable(
+            artifact_type=previous.get("artifact_type"),
+            metadata=previous.get("metadata"),
+        )
+        if skill_directory_identity_reusable is False:
+            current_policy_action = most_restrictive_guard_action(
+                current_policy_action,
+                "require-reapproval",
+            )
         approval_context_hash = _removed_consumer_approval_context_token(
             harness=detection.harness,
             artifact_id=artifact_id,
@@ -1410,6 +1472,7 @@ def evaluate_detection(
             has_saved_state=has_saved_state,
         )
         scanner_evidence = (
+            *_skill_directory_identity_evidence(skill_directory_identity_reusable),
             *approval_reuse_evidence,
             *_runtime_signal_scanner_evidence(runtime_risk_signals_v2),
             *(
@@ -1451,6 +1514,14 @@ def evaluate_detection(
             "raw_scoring_recommendation": "warn",
             "scoring_recommendation_non_authoritative": True,
             "trusted_request_override": trusted_request_override,
+            **(
+                {
+                    "skill_directory_identity_reusable": skill_directory_identity_reusable,
+                    "skill_directory_identity_floor": "require-reapproval",
+                }
+                if skill_directory_identity_reusable is False
+                else {}
+            ),
             **({"saved_approval_claim": approval_claim} if approval_claim is not None else {}),
             **(
                 {

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -17,6 +17,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from ..path_support import resolves_within_root
 from ..version import __version__
+from .skill_directory_identity import validated_complete_skill_directory_hash
 
 InventoryItemKind = Literal[
     "agent",
@@ -177,6 +178,7 @@ _AIBOM_METADATA_KEYS = (
     "instructionRole",
     "localSecurity",
     "registryIdentity",
+    "skillDirectoryIdentity",
     "sourceLinks",
     "sourceOfTruth",
     "trustLayers",
@@ -733,6 +735,7 @@ def _item_from_artifact(
             safe_metadata,
             primary_content_hash=primary_content_hash,
         )
+        safe_metadata = _discard_unverified_skill_directory_hash(safe_metadata)
     semantic_text = fingerprint_mapping(
         {
             "artifact_id": artifact_id,
@@ -741,7 +744,9 @@ def _item_from_artifact(
             "metadata": _stable_snapshot_value(safe_metadata),
         }
     )
-    if artifact_type in {"skill", "instruction"}:
+    if artifact_type == "skill":
+        content_hash = validated_complete_skill_directory_hash(safe_metadata) or primary_content_hash or semantic_text
+    elif artifact_type == "instruction":
         content_hash = primary_content_hash or semantic_text
     else:
         content_hash = _resolve_item_content_hash(safe_metadata, semantic_text)
@@ -1396,6 +1401,14 @@ def _resolve_item_content_hash(metadata: dict[str, object], semantic_text: str) 
     return semantic_text
 
 
+def _discard_unverified_skill_directory_hash(metadata: dict[str, object]) -> dict[str, object]:
+    if "skillDirectoryIdentity" not in metadata or validated_complete_skill_directory_hash(metadata) is not None:
+        return metadata
+    sanitized = dict(metadata)
+    sanitized.pop("directory_hash", None)
+    return sanitized
+
+
 def _primary_artifact_content_hash(
     artifact: object,
     *,
@@ -1612,20 +1625,27 @@ def _bind_skill_document_evidence(
     *,
     primary_content_hash: str | None,
 ) -> dict[str, object]:
+    bound = dict(metadata)
+    # This value is derived from Guard's own full, safe read of SKILL.md.  It
+    # remains the authority for primary-body upload when the inventory item's
+    # public content hash is upgraded to the full directory identity.
+    if isinstance(primary_content_hash, str):
+        bound["primaryContentHash"] = primary_content_hash
+    else:
+        bound.pop("primaryContentHash", None)
+
     evidence = metadata.get("contentEvidence")
     if (
         isinstance(evidence, dict)
         and isinstance(primary_content_hash, str)
         and evidence.get("contentHash") == primary_content_hash
     ):
-        return metadata
+        return bound
 
     if isinstance(evidence, dict) and "contentHash" not in evidence:
-        bound = dict(metadata)
         bound.pop("documentedCapabilities", None)
         return bound
 
-    bound = dict(metadata)
     bound.pop("contentEvidence", None)
     bound.pop("documentedCapabilities", None)
     return bound

--- a/src/codex_plugin_scanner/guard/skill_directory_discovery.py
+++ b/src/codex_plugin_scanner/guard/skill_directory_discovery.py
@@ -1,0 +1,179 @@
+"""Bounded, fail-closed discovery of primary skill documents."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import stat
+from pathlib import Path
+
+from codex_plugin_scanner.guard.skill_directory_identity_contract import (
+    DEFAULT_SKILL_DIRECTORY_LIMITS,
+    SkillDirectoryIdentityFailure,
+    SkillDirectoryIdentityLimits,
+    SkillDocumentDiscovery,
+    SkillDocumentDiscoveryIssue,
+    _canonical_component,
+    _IncompleteIdentityError,
+    _validate_limits,
+)
+
+
+def discover_skill_documents(
+    skill_root: Path,
+    *,
+    limits: SkillDirectoryIdentityLimits = DEFAULT_SKILL_DIRECTORY_LIMITS,
+) -> SkillDocumentDiscovery:
+    """Discover primary documents without following links or exceeding limits.
+
+    Discovery stops descending once a directory contains ``SKILL.md``; the
+    identity inspector owns that complete subtree. Any unreadable, linked, or
+    over-budget grouping path becomes a typed issue so callers can emit one
+    non-reusable artifact instead of silently omitting unknown content.
+    """
+
+    _validate_limits(limits)
+    root = Path(skill_root)
+    try:
+        root_metadata = os.lstat(root)
+    except FileNotFoundError:
+        return SkillDocumentDiscovery(documents=(), issues=())
+    except OSError:
+        return SkillDocumentDiscovery(
+            documents=(),
+            issues=(_discovery_issue(root, root, "unreadable_entry"),),
+        )
+    if stat.S_ISLNK(root_metadata.st_mode):
+        return SkillDocumentDiscovery(
+            documents=(),
+            issues=(_discovery_issue(root, root, _linked_directory_failure(root)),),
+        )
+    if _is_unsupported_reparse(root_metadata):
+        return SkillDocumentDiscovery(
+            documents=(),
+            issues=(_discovery_issue(root, root, "unsupported_reparse_point"),),
+        )
+    if not stat.S_ISDIR(root_metadata.st_mode):
+        return SkillDocumentDiscovery(
+            documents=(),
+            issues=(_discovery_issue(root, root, "root_not_directory"),),
+        )
+
+    discovered: set[Path] = set()
+    issues: dict[tuple[str, SkillDirectoryIdentityFailure], SkillDocumentDiscoveryIssue] = {}
+    pending: list[tuple[Path, tuple[str, ...]]] = [(root, ())]
+    visited_entries = 0
+    budget_exhausted = False
+    while pending and not budget_exhausted:
+        directory, relative_parts = pending.pop()
+        primary = directory / "SKILL.md"
+        try:
+            _ = os.lstat(primary)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            issue = _discovery_issue(root, primary, "unreadable_entry")
+            issues[(issue.relative_path, issue.failure_reason)] = issue
+            continue
+        else:
+            discovered.add(primary)
+            continue
+
+        try:
+            iterator = os.scandir(directory)
+        except OSError:
+            issue = _discovery_issue(root, directory, "unreadable_entry")
+            issues[(issue.relative_path, issue.failure_reason)] = issue
+            continue
+        try:
+            for child in iterator:
+                if visited_entries >= limits.max_entries:
+                    issue = _discovery_issue(root, root, "max_entries_exceeded")
+                    issues[(issue.relative_path, issue.failure_reason)] = issue
+                    budget_exhausted = True
+                    break
+                visited_entries += 1
+                path = Path(child.path)
+                try:
+                    canonical_name = _canonical_component(child.name)
+                except _IncompleteIdentityError as exc:
+                    issue = _discovery_issue(root, path, exc.reason)
+                    issues[(issue.relative_path, issue.failure_reason)] = issue
+                    continue
+                child_parts = (*relative_parts, canonical_name)
+                try:
+                    metadata = os.lstat(path)
+                except OSError:
+                    issue = _discovery_issue(root, path, "unreadable_entry")
+                    issues[(issue.relative_path, issue.failure_reason)] = issue
+                    continue
+                if stat.S_ISLNK(metadata.st_mode):
+                    issue = _discovery_issue(root, path, _linked_directory_failure(path))
+                    issues[(issue.relative_path, issue.failure_reason)] = issue
+                    continue
+                if _is_unsupported_reparse(metadata):
+                    issue = _discovery_issue(root, path, "unsupported_reparse_point")
+                    issues[(issue.relative_path, issue.failure_reason)] = issue
+                    continue
+                if not stat.S_ISDIR(metadata.st_mode):
+                    continue
+                if len(child_parts) > limits.max_depth:
+                    issue = _discovery_issue(root, path, "max_depth_exceeded")
+                    issues[(issue.relative_path, issue.failure_reason)] = issue
+                    continue
+                pending.append((path, child_parts))
+        except OSError:
+            issue = _discovery_issue(root, directory, "unreadable_entry")
+            issues[(issue.relative_path, issue.failure_reason)] = issue
+        finally:
+            close = getattr(iterator, "close", None)
+            if close is not None:
+                try:
+                    close()
+                except OSError:
+                    issue = _discovery_issue(root, directory, "unreadable_entry")
+                    issues[(issue.relative_path, issue.failure_reason)] = issue
+
+    return SkillDocumentDiscovery(
+        documents=tuple(sorted(discovered, key=os.fspath)),
+        issues=tuple(sorted(issues.values(), key=lambda issue: (issue.relative_path, issue.failure_reason))),
+    )
+
+
+def _discovery_issue(
+    root: Path,
+    path: Path,
+    reason: SkillDirectoryIdentityFailure,
+) -> SkillDocumentDiscoveryIssue:
+    try:
+        relative_path = path.relative_to(root).as_posix() or "."
+    except ValueError:
+        relative_path = "."
+    issue_material = os.fsencode(relative_path) + b"\0" + reason.encode("ascii")
+    return SkillDocumentDiscoveryIssue(
+        path=path,
+        relative_path=relative_path,
+        failure_reason=reason,
+        issue_id=hashlib.sha256(issue_material).hexdigest()[:16],
+    )
+
+
+def _linked_directory_failure(path: Path) -> SkillDirectoryIdentityFailure:
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError:
+        return "symlink_broken"
+    except RuntimeError:
+        return "symlink_loop"
+    except OSError as exc:
+        if getattr(exc, "errno", None) == errno.ELOOP:
+            return "symlink_loop"
+        return "unreadable_entry"
+    return "symlink_directory_unsupported" if resolved.is_dir() else "root_not_directory"
+
+
+def _is_unsupported_reparse(metadata: os.stat_result) -> bool:
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    attributes = int(getattr(metadata, "st_file_attributes", 0))
+    return bool(attributes & reparse_flag) and not stat.S_ISLNK(metadata.st_mode)

--- a/src/codex_plugin_scanner/guard/skill_directory_identity.py
+++ b/src/codex_plugin_scanner/guard/skill_directory_identity.py
@@ -1,0 +1,475 @@
+"""Deterministic, fail-closed identity for an agent skill directory."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import stat
+from pathlib import Path
+from typing import Literal
+
+from codex_plugin_scanner.guard.skill_directory_discovery import discover_skill_documents
+from codex_plugin_scanner.guard.skill_directory_identity_contract import (
+    DEFAULT_SKILL_DIRECTORY_LIMITS,
+    SKILL_DIRECTORY_IDENTITY_SCHEMA,
+    SkillDirectoryIdentity,
+    SkillDirectoryIdentityFailure,
+    SkillDirectoryIdentityLimits,
+    SkillDocumentDiscovery,
+    SkillDocumentDiscoveryIssue,
+    _canonical_component,
+    _canonical_relative_path,
+    _incomplete_result,
+    _IncompleteIdentityError,
+    _InspectionState,
+    _TreeEntry,
+    _update_canonical_digest,
+    _validate_limits,
+    _validate_text_path,
+    incomplete_skill_directory_identity,
+    skill_directory_identity_metadata,
+    validated_complete_skill_directory_hash,
+)
+from codex_plugin_scanner.guard.windows_paths import open_windows_locked_regular_descriptor
+
+_HASH_CHUNK_BYTES = 64 * 1024
+
+
+def inspect_skill_directory(
+    skill_document: Path,
+    *,
+    scope_root: Path,
+    limits: SkillDirectoryIdentityLimits = DEFAULT_SKILL_DIRECTORY_LIMITS,
+) -> SkillDirectoryIdentity:
+    """Return a complete canonical tree identity or a typed non-reusable result.
+
+    The complete digest covers every filesystem entry below the skill root.  A
+    tree that cannot be inspected in full is never represented by a partial
+    digest: it receives a typed stable state hash that cannot be reused as a
+    complete identity.
+    """
+
+    _validate_limits(limits)
+    state = _InspectionState()
+    logical_primary = Path(skill_document)
+    logical_root = logical_primary.parent
+    try:
+        resolved_scope = _resolve_scope_root(scope_root)
+        _validate_lexical_parent_links(scope_root, logical_root)
+        root_lstat = _root_lstat(logical_root)
+        _validate_skill_root_type(root_lstat)
+        resolved_root = _resolve_existing_path(logical_root, broken_reason="root_missing")
+        if not resolved_root.is_dir():
+            raise _IncompleteIdentityError("root_not_directory")
+        if not _is_relative_to(resolved_root, resolved_scope):
+            raise _IncompleteIdentityError("symlink_escape")
+
+        primary_name = _canonical_component(logical_primary.name)
+        entries, initial_structure = _collect_entries(resolved_root, limits=limits)
+        state.entry_count = len(entries)
+        primary_entry = next(
+            (entry for entry in entries if entry.relative_path == primary_name),
+            None,
+        )
+        if primary_entry is None or primary_entry.entry_type == "directory":
+            raise _IncompleteIdentityError("primary_missing")
+        if primary_entry.entry_type == "symlink":
+            raise _IncompleteIdentityError("primary_symlink_unsupported")
+
+        records: list[dict[str, object]] = []
+        ordered_entries = [primary_entry, *(entry for entry in entries if entry is not primary_entry)]
+        for entry in ordered_entries:
+            record, content_hash = _entry_record(
+                entry,
+                root=resolved_root,
+                limits=limits,
+                state=state,
+            )
+            records.append(record)
+            if entry is primary_entry:
+                state.primary_content_hash = content_hash
+
+        current_root_lstat = _safe_lstat(logical_root)
+        if _stat_key(current_root_lstat) != _stat_key(root_lstat):
+            raise _IncompleteIdentityError("tree_changed_during_hash")
+        _, final_structure = _collect_entries(resolved_root, limits=limits)
+        if final_structure != initial_structure:
+            raise _IncompleteIdentityError("tree_changed_during_hash")
+        final_root_lstat = _safe_lstat(logical_root)
+        if _stat_key(final_root_lstat) != _stat_key(root_lstat):
+            raise _IncompleteIdentityError("tree_changed_during_hash")
+
+        header: dict[str, object] = {
+            "schema": SKILL_DIRECTORY_IDENTITY_SCHEMA,
+            "rootMode": _security_mode(final_root_lstat.st_mode),
+        }
+        digest = hashlib.sha256()
+        _update_canonical_digest(digest, header)
+        for record in sorted(records, key=lambda item: str(item["path"]).encode("utf-8")):
+            _update_canonical_digest(digest, record)
+        return SkillDirectoryIdentity(
+            schema_version=SKILL_DIRECTORY_IDENTITY_SCHEMA,
+            status="complete",
+            directory_hash=f"sha256:{digest.hexdigest()}",
+            primary_content_hash=state.primary_content_hash,
+            entry_count=state.entry_count,
+            total_bytes=state.total_bytes,
+            failure_reason=None,
+            incomplete_state_hash=None,
+        )
+    except _IncompleteIdentityError as exc:
+        return _incomplete_result(state, exc.reason)
+    except (OSError, RuntimeError, ValueError):
+        return _incomplete_result(state, "unreadable_entry")
+
+
+def _resolve_scope_root(scope_root: Path) -> Path:
+    try:
+        resolved = Path(scope_root).resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise _IncompleteIdentityError("root_missing") from exc
+    except RuntimeError as exc:
+        raise _IncompleteIdentityError("symlink_loop") from exc
+    except OSError as exc:
+        raise _IncompleteIdentityError("unreadable_entry") from exc
+    if not resolved.is_dir():
+        raise _IncompleteIdentityError("root_not_directory")
+    return resolved
+
+
+def _validate_lexical_parent_links(scope_root: Path, logical_root: Path) -> None:
+    scope = Path(os.path.abspath(scope_root))
+    root = Path(os.path.abspath(logical_root))
+    try:
+        relative = root.relative_to(scope)
+    except ValueError as exc:
+        raise _IncompleteIdentityError("symlink_escape") from exc
+    current = scope
+    for part in relative.parts[:-1]:
+        current = current / part
+        try:
+            metadata = os.lstat(current)
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise _IncompleteIdentityError("unreadable_entry") from exc
+        if stat.S_ISLNK(metadata.st_mode):
+            raise _IncompleteIdentityError("symlink_directory_unsupported")
+        if _is_unsupported_reparse(metadata):
+            raise _IncompleteIdentityError("unsupported_reparse_point")
+
+
+def _root_lstat(root: Path) -> os.stat_result:
+    try:
+        metadata = os.lstat(root)
+    except FileNotFoundError as exc:
+        raise _IncompleteIdentityError("root_missing") from exc
+    except OSError as exc:
+        raise _IncompleteIdentityError("unreadable_entry") from exc
+    if _is_unsupported_reparse(metadata):
+        raise _IncompleteIdentityError("unsupported_reparse_point")
+    if not (stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode)):
+        raise _IncompleteIdentityError("root_not_directory")
+    return metadata
+
+
+def _validate_skill_root_type(root_lstat: os.stat_result) -> None:
+    if stat.S_ISLNK(root_lstat.st_mode):
+        raise _IncompleteIdentityError("symlink_directory_unsupported")
+
+
+def _resolve_existing_path(
+    path: Path,
+    *,
+    broken_reason: SkillDirectoryIdentityFailure,
+) -> Path:
+    try:
+        return path.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise _IncompleteIdentityError(broken_reason) from exc
+    except RuntimeError as exc:
+        raise _IncompleteIdentityError("symlink_loop") from exc
+    except OSError as exc:
+        if getattr(exc, "errno", None) == errno.ELOOP:
+            raise _IncompleteIdentityError("symlink_loop") from exc
+        raise _IncompleteIdentityError("unreadable_entry") from exc
+
+
+def _collect_entries(
+    root: Path,
+    *,
+    limits: SkillDirectoryIdentityLimits,
+) -> tuple[list[_TreeEntry], tuple[tuple[object, ...], ...]]:
+    entries: list[_TreeEntry] = []
+    normalized_paths: set[str] = set()
+    folded_paths: dict[str, str] = {}
+
+    def walk(directory: Path, relative_parts: tuple[str, ...]) -> None:
+        try:
+            children = os.scandir(directory)
+        except PermissionError as exc:
+            raise _IncompleteIdentityError("unreadable_entry") from exc
+        except FileNotFoundError as exc:
+            raise _IncompleteIdentityError("tree_changed_during_hash") from exc
+        except OSError as exc:
+            raise _IncompleteIdentityError("unreadable_entry") from exc
+        try:
+            for child in children:
+                raw_name = child.name
+                canonical_name = _canonical_component(raw_name)
+                canonical_parts = (*relative_parts, canonical_name)
+                relative_path = "/".join(canonical_parts)
+                if relative_path in normalized_paths:
+                    raise _IncompleteIdentityError("duplicate_path")
+                folded = relative_path.casefold()
+                prior = folded_paths.get(folded)
+                if prior is not None and prior != relative_path:
+                    raise _IncompleteIdentityError("case_collision")
+                normalized_paths.add(relative_path)
+                folded_paths[folded] = relative_path
+                if len(canonical_parts) > limits.max_depth:
+                    raise _IncompleteIdentityError("max_depth_exceeded")
+                if len(entries) >= limits.max_entries:
+                    raise _IncompleteIdentityError("max_entries_exceeded")
+
+                path = Path(child.path)
+                metadata = _safe_lstat(path)
+                if _is_unsupported_reparse(metadata):
+                    raise _IncompleteIdentityError("unsupported_reparse_point")
+                if stat.S_ISLNK(metadata.st_mode):
+                    try:
+                        raw_target = os.readlink(path)
+                    except OSError as exc:
+                        raise _IncompleteIdentityError("tree_changed_during_hash") from exc
+                    _validate_text_path(raw_target)
+                    entry_type: Literal["directory", "file", "symlink"] = "symlink"
+                elif stat.S_ISDIR(metadata.st_mode):
+                    raw_target = None
+                    entry_type = "directory"
+                elif stat.S_ISREG(metadata.st_mode):
+                    raw_target = None
+                    entry_type = "file"
+                else:
+                    raise _IncompleteIdentityError("special_file")
+                entry = _TreeEntry(
+                    path=path,
+                    relative_path=relative_path,
+                    entry_type=entry_type,
+                    metadata_key=_stat_key(metadata),
+                    raw_link_target=raw_target,
+                )
+                entries.append(entry)
+                if entry_type == "directory":
+                    walk(path, canonical_parts)
+        finally:
+            close = getattr(children, "close", None)
+            if close is not None:
+                close()
+
+    walk(root, ())
+    structure = tuple(
+        sorted(
+            (
+                entry.relative_path,
+                entry.entry_type,
+                entry.metadata_key,
+                entry.raw_link_target,
+            )
+            for entry in entries
+        )
+    )
+    return entries, structure
+
+
+def _entry_record(
+    entry: _TreeEntry,
+    *,
+    root: Path,
+    limits: SkillDirectoryIdentityLimits,
+    state: _InspectionState,
+) -> tuple[dict[str, object], str | None]:
+    metadata = _safe_lstat(entry.path)
+    if _stat_key(metadata) != entry.metadata_key:
+        raise _IncompleteIdentityError("tree_changed_during_hash")
+    mode = _security_mode(metadata.st_mode)
+    if entry.entry_type == "directory":
+        return {"type": "directory", "path": entry.relative_path, "mode": mode}, None
+    if entry.entry_type == "file":
+        digest, size = _hash_regular_file(
+            entry.path,
+            expected_metadata=metadata,
+            limits=limits,
+            state=state,
+        )
+        return {
+            "type": "file",
+            "path": entry.relative_path,
+            "mode": mode,
+            "size": size,
+            "digest": digest,
+        }, digest
+
+    raw_target = entry.raw_link_target
+    if raw_target is None:
+        raise _IncompleteIdentityError("tree_changed_during_hash")
+    # Resolve the captured link payload directly.  On Windows, resolving the
+    # link entry itself can reject an otherwise valid ``./name`` spelling even
+    # though ``readlink`` returned it and the target exists.  The later lstat
+    # and readlink checks still bind this target snapshot to the original link.
+    resolved_target = _resolve_existing_path(
+        entry.path.parent / raw_target,
+        broken_reason="symlink_broken",
+    )
+    if not _is_relative_to(resolved_target, root):
+        raise _IncompleteIdentityError("symlink_escape")
+    target_lstat = _safe_lstat(resolved_target)
+    if _is_unsupported_reparse(target_lstat):
+        raise _IncompleteIdentityError("unsupported_reparse_point")
+    if stat.S_ISDIR(target_lstat.st_mode):
+        raise _IncompleteIdentityError("symlink_directory_unsupported")
+    if not stat.S_ISREG(target_lstat.st_mode):
+        raise _IncompleteIdentityError("special_file")
+    target_digest, target_size = _hash_regular_file(
+        resolved_target,
+        expected_metadata=target_lstat,
+        limits=limits,
+        state=state,
+    )
+    current_link = _safe_lstat(entry.path)
+    try:
+        current_raw_target = os.readlink(entry.path)
+    except OSError as exc:
+        raise _IncompleteIdentityError("tree_changed_during_hash") from exc
+    if _stat_key(current_link) != entry.metadata_key or current_raw_target != raw_target:
+        raise _IncompleteIdentityError("tree_changed_during_hash")
+    target_path = _canonical_relative_path(resolved_target.relative_to(root).parts)
+    return {
+        "type": "symlink",
+        "path": entry.relative_path,
+        "mode": mode,
+        "target": raw_target,
+        "targetPath": target_path,
+        "targetType": "file",
+        "targetMode": _security_mode(target_lstat.st_mode),
+        "targetSize": target_size,
+        "targetDigest": target_digest,
+    }, target_digest
+
+
+def _hash_regular_file(
+    path: Path,
+    *,
+    expected_metadata: os.stat_result,
+    limits: SkillDirectoryIdentityLimits,
+    state: _InspectionState,
+) -> tuple[str, int]:
+    if expected_metadata.st_size > limits.max_file_bytes:
+        raise _IncompleteIdentityError("max_file_bytes_exceeded")
+    if state.total_bytes + expected_metadata.st_size > limits.max_total_bytes:
+        raise _IncompleteIdentityError("max_total_bytes_exceeded")
+    try:
+        if os.name == "nt":
+            descriptor = open_windows_locked_regular_descriptor(path)
+        else:
+            flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(path, flags)
+    except FileNotFoundError as exc:
+        raise _IncompleteIdentityError("tree_changed_during_hash") from exc
+    except OSError as exc:
+        raise _IncompleteIdentityError("unreadable_entry") from exc
+    total = 0
+    digest = hashlib.sha256()
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            raise _IncompleteIdentityError("tree_changed_during_hash")
+        if os.name == "nt":
+            # The native handle denies write and delete sharing. Comparing two
+            # path stats while that lock is held detects a replacement between
+            # discovery and open without relying on incompatible stat APIs.
+            if _stat_key(_safe_lstat(path)) != _stat_key(expected_metadata):
+                raise _IncompleteIdentityError("tree_changed_during_hash")
+        elif _stat_key(opened) != _stat_key(expected_metadata):
+            raise _IncompleteIdentityError("tree_changed_during_hash")
+        while True:
+            try:
+                chunk = os.read(descriptor, _HASH_CHUNK_BYTES)
+            except OSError as exc:
+                raise _IncompleteIdentityError("unreadable_entry") from exc
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > limits.max_file_bytes:
+                raise _IncompleteIdentityError("max_file_bytes_exceeded")
+            if state.total_bytes + total > limits.max_total_bytes:
+                raise _IncompleteIdentityError("max_total_bytes_exceeded")
+            digest.update(chunk)
+        if total != opened.st_size or _stat_key(os.fstat(descriptor)) != _stat_key(opened):
+            raise _IncompleteIdentityError("tree_changed_during_hash")
+    finally:
+        os.close(descriptor)
+    if _stat_key(_safe_lstat(path)) != _stat_key(expected_metadata):
+        raise _IncompleteIdentityError("tree_changed_during_hash")
+    state.total_bytes += total
+    return f"sha256:{digest.hexdigest()}", total
+
+
+def _safe_lstat(path: Path) -> os.stat_result:
+    try:
+        return os.lstat(path)
+    except FileNotFoundError as exc:
+        raise _IncompleteIdentityError("tree_changed_during_hash") from exc
+    except PermissionError as exc:
+        raise _IncompleteIdentityError("unreadable_entry") from exc
+    except OSError as exc:
+        raise _IncompleteIdentityError("unreadable_entry") from exc
+
+
+def _stat_key(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        int(metadata.st_dev),
+        int(metadata.st_ino),
+        int(metadata.st_mode),
+        int(metadata.st_nlink),
+        int(metadata.st_size),
+        int(getattr(metadata, "st_mtime_ns", int(metadata.st_mtime * 1_000_000_000))),
+        int(getattr(metadata, "st_ctime_ns", int(metadata.st_ctime * 1_000_000_000))),
+        int(getattr(metadata, "st_file_attributes", 0)),
+    )
+
+
+def _security_mode(mode: int) -> str | None:
+    if os.name == "nt":
+        return None
+    return f"{stat.S_IMODE(mode) & 0o7777:04o}"
+
+
+def _is_unsupported_reparse(metadata: os.stat_result) -> bool:
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    attributes = int(getattr(metadata, "st_file_attributes", 0))
+    return bool(attributes & reparse_flag) and not stat.S_ISLNK(metadata.st_mode)
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        _ = path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+__all__ = [
+    "DEFAULT_SKILL_DIRECTORY_LIMITS",
+    "SKILL_DIRECTORY_IDENTITY_SCHEMA",
+    "SkillDirectoryIdentity",
+    "SkillDirectoryIdentityFailure",
+    "SkillDirectoryIdentityLimits",
+    "SkillDocumentDiscovery",
+    "SkillDocumentDiscoveryIssue",
+    "discover_skill_documents",
+    "incomplete_skill_directory_identity",
+    "inspect_skill_directory",
+    "skill_directory_identity_metadata",
+    "validated_complete_skill_directory_hash",
+]

--- a/src/codex_plugin_scanner/guard/skill_directory_identity_contract.py
+++ b/src/codex_plugin_scanner/guard/skill_directory_identity_contract.py
@@ -1,0 +1,294 @@
+"""Public data contract and metadata helpers for skill-directory identity."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Protocol
+
+SKILL_DIRECTORY_IDENTITY_SCHEMA = "guard.skill-directory-identity.v1"
+
+SkillDirectoryIdentityFailure = Literal[
+    "root_missing",
+    "root_not_directory",
+    "primary_missing",
+    "primary_symlink_unsupported",
+    "invalid_relative_path",
+    "invalid_path_encoding",
+    "duplicate_path",
+    "case_collision",
+    "unreadable_entry",
+    "special_file",
+    "symlink_broken",
+    "symlink_loop",
+    "symlink_escape",
+    "symlink_directory_unsupported",
+    "unsupported_reparse_point",
+    "max_depth_exceeded",
+    "max_entries_exceeded",
+    "max_file_bytes_exceeded",
+    "max_total_bytes_exceeded",
+    "tree_changed_during_hash",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class SkillDirectoryIdentityLimits:
+    """Resource ceilings for a complete skill identity inspection."""
+
+    max_depth: int = 32
+    max_entries: int = 4096
+    max_file_bytes: int = 128 * 1024 * 1024
+    max_total_bytes: int = 256 * 1024 * 1024
+
+
+DEFAULT_SKILL_DIRECTORY_LIMITS = SkillDirectoryIdentityLimits()
+
+
+@dataclass(frozen=True, slots=True)
+class SkillDirectoryIdentity:
+    """Result of inspecting one primary skill document and its directory."""
+
+    schema_version: str
+    status: Literal["complete", "incomplete"]
+    directory_hash: str | None
+    primary_content_hash: str | None
+    entry_count: int
+    total_bytes: int
+    failure_reason: SkillDirectoryIdentityFailure | None
+    incomplete_state_hash: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class SkillDocumentDiscoveryIssue:
+    """One fail-closed gap encountered before a primary document was found."""
+
+    path: Path
+    relative_path: str
+    failure_reason: SkillDirectoryIdentityFailure
+    issue_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class SkillDocumentDiscovery:
+    """Bounded skill-document discovery plus typed omitted-scope diagnostics."""
+
+    documents: tuple[Path, ...]
+    issues: tuple[SkillDocumentDiscoveryIssue, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _TreeEntry:
+    path: Path
+    relative_path: str
+    entry_type: Literal["directory", "file", "symlink"]
+    metadata_key: tuple[int, ...]
+    raw_link_target: str | None = None
+
+
+@dataclass(slots=True)
+class _InspectionState:
+    entry_count: int = 0
+    total_bytes: int = 0
+    primary_content_hash: str | None = None
+
+
+class _Digest(Protocol):
+    def update(self, data: bytes, /) -> None: ...
+
+
+class _IncompleteIdentityError(Exception):
+    def __init__(self, reason: SkillDirectoryIdentityFailure) -> None:
+        super().__init__(reason)
+        self.reason: SkillDirectoryIdentityFailure = reason
+
+
+def skill_directory_identity_metadata(
+    identity: SkillDirectoryIdentity,
+    *,
+    version_label: str,
+) -> dict[str, object]:
+    """Return artifact metadata that binds identity into inventory/approval flows."""
+
+    envelope: dict[str, object] = {
+        "schemaVersion": identity.schema_version,
+        "status": identity.status,
+        "entryCount": identity.entry_count,
+        "totalBytes": identity.total_bytes,
+        "reusable": identity.status == "complete",
+    }
+    metadata: dict[str, object] = {"skillDirectoryIdentity": envelope}
+    if identity.primary_content_hash is not None:
+        metadata["content_hash"] = identity.primary_content_hash
+
+    if identity.status == "complete" and identity.directory_hash is not None:
+        envelope["contentHash"] = identity.directory_hash
+        metadata["directory_hash"] = identity.directory_hash
+        version_hash = identity.directory_hash
+    else:
+        if identity.failure_reason is not None:
+            envelope["reason"] = identity.failure_reason
+        if identity.incomplete_state_hash is not None:
+            envelope["incompleteStateHash"] = identity.incomplete_state_hash
+        version_hash = identity.incomplete_state_hash or _incomplete_state_hash(identity)
+
+    metadata["versionInfo"] = {
+        "versionLabel": version_label,
+        "hashBasis": "skill-directory-v1",
+        "contentHash": version_hash,
+        "changedFields": [],
+    }
+    return metadata
+
+
+def validated_complete_skill_directory_hash(metadata: object) -> str | None:
+    """Return the v1 directory digest only for a strict reusable envelope."""
+
+    typed_metadata = _string_object_mapping(metadata)
+    if typed_metadata is None:
+        return None
+    identity = typed_metadata.get("skillDirectoryIdentity")
+    typed_identity = _string_object_mapping(identity)
+    if typed_identity is None:
+        return None
+    if (
+        typed_identity.get("schemaVersion") != SKILL_DIRECTORY_IDENTITY_SCHEMA
+        or typed_identity.get("status") != "complete"
+        or typed_identity.get("reusable") is not True
+        or "reason" in typed_identity
+        or "reuseNonce" in typed_identity
+        or "incompleteStateHash" in typed_identity
+    ):
+        return None
+    entry_count = typed_identity.get("entryCount")
+    total_bytes = typed_identity.get("totalBytes")
+    if (
+        not isinstance(entry_count, int)
+        or isinstance(entry_count, bool)
+        or entry_count < 1
+        or not isinstance(total_bytes, int)
+        or isinstance(total_bytes, bool)
+        or total_bytes < 0
+    ):
+        return None
+    identity_hash = _canonical_sha256(typed_identity.get("contentHash"))
+    directory_hash = _canonical_sha256(typed_metadata.get("directory_hash"))
+    version_info = typed_metadata.get("versionInfo")
+    typed_version_info = _string_object_mapping(version_info)
+    if typed_version_info is None:
+        return None
+    if typed_version_info.get("hashBasis") != "skill-directory-v1":
+        return None
+    version_hash = _canonical_sha256(typed_version_info.get("contentHash"))
+    if identity_hash is None or identity_hash != directory_hash or identity_hash != version_hash:
+        return None
+    return identity_hash
+
+
+def _string_object_mapping(value: object) -> dict[str, object] | None:
+    """Return a typed copy only when every runtime mapping key is a string."""
+
+    if not isinstance(value, Mapping):
+        return None
+    result: dict[str, object] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            return None
+        result[key] = item
+    return result
+
+
+def _validate_limits(limits: SkillDirectoryIdentityLimits) -> None:
+    values = (
+        limits.max_depth,
+        limits.max_entries,
+        limits.max_file_bytes,
+        limits.max_total_bytes,
+    )
+    if any(type(value) is not int or value < 0 for value in values):
+        raise ValueError("skill directory identity limits must be non-negative integers")
+
+
+def _canonical_sha256(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if normalized.startswith("sha256:"):
+        normalized = normalized.removeprefix("sha256:")
+    if len(normalized) != 64 or any(character not in "0123456789abcdef" for character in normalized):
+        return None
+    return f"sha256:{normalized}"
+
+
+def _canonical_component(value: str) -> str:
+    _validate_text_path(value)
+    normalized = unicodedata.normalize("NFC", value)
+    if normalized in {"", ".", ".."} or "/" in normalized or "\\" in normalized:
+        raise _IncompleteIdentityError("invalid_relative_path")
+    return normalized
+
+
+def _canonical_relative_path(parts: tuple[str, ...]) -> str:
+    return "/".join(_canonical_component(part) for part in parts)
+
+
+def _validate_text_path(value: str) -> None:
+    if any(0xD800 <= ord(character) <= 0xDFFF for character in value):
+        raise _IncompleteIdentityError("invalid_path_encoding")
+
+
+def _update_canonical_digest(digest: _Digest, record: dict[str, object]) -> None:
+    encoded = json.dumps(record, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("ascii")
+    digest.update(encoded)
+    digest.update(b"\n")
+
+
+def _incomplete_result(
+    state: _InspectionState,
+    reason: SkillDirectoryIdentityFailure,
+) -> SkillDirectoryIdentity:
+    provisional = SkillDirectoryIdentity(
+        schema_version=SKILL_DIRECTORY_IDENTITY_SCHEMA,
+        status="incomplete",
+        directory_hash=None,
+        primary_content_hash=state.primary_content_hash,
+        entry_count=state.entry_count,
+        total_bytes=state.total_bytes,
+        failure_reason=reason,
+        incomplete_state_hash=None,
+    )
+    return SkillDirectoryIdentity(
+        schema_version=provisional.schema_version,
+        status=provisional.status,
+        directory_hash=None,
+        primary_content_hash=provisional.primary_content_hash,
+        entry_count=provisional.entry_count,
+        total_bytes=provisional.total_bytes,
+        failure_reason=provisional.failure_reason,
+        incomplete_state_hash=_incomplete_state_hash(provisional),
+    )
+
+
+def incomplete_skill_directory_identity(
+    reason: SkillDirectoryIdentityFailure,
+) -> SkillDirectoryIdentity:
+    """Create a stable, explicitly non-reusable identity for discovery gaps."""
+
+    return _incomplete_result(_InspectionState(), reason)
+
+
+def _incomplete_state_hash(identity: SkillDirectoryIdentity) -> str:
+    material = {
+        "schema": identity.schema_version,
+        "status": "incomplete",
+        "reason": identity.failure_reason,
+        "primaryContentHash": identity.primary_content_hash,
+        "entryCount": identity.entry_count,
+        "totalBytes": identity.total_bytes,
+    }
+    digest = hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+    return f"sha256:{digest.hexdigest()}"

--- a/src/codex_plugin_scanner/guard/windows_paths.py
+++ b/src/codex_plugin_scanner/guard/windows_paths.py
@@ -3,17 +3,28 @@
 from __future__ import annotations
 
 import ctypes
+import importlib
 import ntpath
 import os
 import stat
+import time
 import uuid
 from contextlib import suppress
 from ctypes import wintypes
 from pathlib import Path
 
 _WINDOWS_PATH_BUFFER_SIZE = 32_768
+_WINDOWS_FILE_ATTRIBUTE_DIRECTORY = 0x00000010
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+_WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
+_WINDOWS_FILE_FLAG_SEQUENTIAL_SCAN = 0x08000000
+_WINDOWS_GENERIC_READ = 0x80000000
+_WINDOWS_FILE_SHARE_READ = 0x00000001
+_WINDOWS_OPEN_EXISTING = 3
 _WINDOWS_ERROR_INVALID_PARAMETER = 87
+_WINDOWS_ERROR_SHARING_VIOLATION = 32
+_WINDOWS_LOCK_OPEN_ATTEMPTS = 6
+_WINDOWS_LOCK_RETRY_SECONDS = 0.01
 _WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION = 0x00001000
 _WINDOWS_PROCESS_TERMINATE = 0x00000001
 _WINDOWS_SYNCHRONIZE = 0x00100000
@@ -26,6 +37,103 @@ _FOLDERID_ROAMING_APPDATA = uuid.UUID("3eb685db-65f9-4cf6-a03a-e3ef65729f3d").by
 
 class _Guid(ctypes.Structure):
     _fields_ = [("bytes", ctypes.c_ubyte * 16)]
+
+
+class _WindowsByHandleFileInformation(ctypes.Structure):
+    _fields_ = [
+        ("dwFileAttributes", wintypes.DWORD),
+        ("ftCreationTime", wintypes.FILETIME),
+        ("ftLastAccessTime", wintypes.FILETIME),
+        ("ftLastWriteTime", wintypes.FILETIME),
+        ("dwVolumeSerialNumber", wintypes.DWORD),
+        ("nFileSizeHigh", wintypes.DWORD),
+        ("nFileSizeLow", wintypes.DWORD),
+        ("nNumberOfLinks", wintypes.DWORD),
+        ("nFileIndexHigh", wintypes.DWORD),
+        ("nFileIndexLow", wintypes.DWORD),
+    ]
+
+
+def open_windows_locked_regular_descriptor(path: Path | str) -> int:
+    """Open one regular file while denying concurrent write/delete access.
+
+    The returned CRT descriptor owns the native handle.  ``FILE_SHARE_READ``
+    deliberately excludes write and delete sharing, so the pathname cannot be
+    replaced and an existing writer cannot coexist while trusted bytes are
+    hashed.
+    """
+
+    if os.name != "nt":
+        raise OSError("windows_locked_file_unavailable")
+    win_dll = getattr(ctypes, "WinDLL", None)
+    if win_dll is None:
+        raise OSError("windows_locked_file_unavailable")
+    handle: object | None = None
+    close_handle = None
+    try:
+        msvcrt = importlib.import_module("msvcrt")
+        kernel32 = win_dll("kernel32", use_last_error=True)
+        create_file = kernel32.CreateFileW
+        create_file.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            ctypes.c_void_p,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.HANDLE,
+        ]
+        create_file.restype = wintypes.HANDLE
+        get_information = kernel32.GetFileInformationByHandle
+        get_information.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(_WindowsByHandleFileInformation),
+        ]
+        get_information.restype = wintypes.BOOL
+        close_handle = kernel32.CloseHandle
+        close_handle.argtypes = [wintypes.HANDLE]
+        close_handle.restype = wintypes.BOOL
+        invalid_handle = ctypes.c_void_p(-1).value
+        for attempt in range(_WINDOWS_LOCK_OPEN_ATTEMPTS):
+            handle = create_file(
+                str(path),
+                _WINDOWS_GENERIC_READ,
+                _WINDOWS_FILE_SHARE_READ,
+                None,
+                _WINDOWS_OPEN_EXISTING,
+                _WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT | _WINDOWS_FILE_FLAG_SEQUENTIAL_SCAN,
+                None,
+            )
+            if handle not in {None, invalid_handle}:
+                break
+            sharing_violation = ctypes.get_last_error() == _WINDOWS_ERROR_SHARING_VIOLATION
+            handle = None
+            if not sharing_violation or attempt + 1 == _WINDOWS_LOCK_OPEN_ATTEMPTS:
+                raise OSError("windows_locked_file_open_failed")
+            time.sleep(_WINDOWS_LOCK_RETRY_SECONDS)
+        information = _WindowsByHandleFileInformation()
+        if not get_information(handle, ctypes.byref(information)):
+            raise OSError("windows_locked_file_inspection_failed")
+        attributes = int(information.dwFileAttributes)
+        if attributes & (_WINDOWS_FILE_ATTRIBUTE_DIRECTORY | _FILE_ATTRIBUTE_REPARSE_POINT):
+            raise OSError("windows_locked_file_not_regular")
+        handle_value = handle if isinstance(handle, int) else getattr(handle, "value", None)
+        if not isinstance(handle_value, int):
+            raise OSError("windows_locked_file_handle_invalid")
+        descriptor = int(
+            msvcrt.open_osfhandle(
+                handle_value,
+                os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOINHERIT", 0),
+            )
+        )
+        handle = None
+        return descriptor
+    except (AttributeError, ImportError, RuntimeError, TypeError, ValueError) as exc:
+        raise OSError("windows_locked_file_unavailable") from exc
+    finally:
+        if handle is not None and close_handle is not None:
+            with suppress(OSError, RuntimeError, TypeError, ValueError):
+                _ = close_handle(handle)
 
 
 def windows_command_line_to_argv(command: str) -> list[str] | None:
@@ -355,6 +463,7 @@ def _trusted_real_directory(path: Path) -> Path:
 
 
 __all__ = [
+    "open_windows_locked_regular_descriptor",
     "trusted_windows_roaming_appdata",
     "trusted_windows_system_directories",
     "trusted_windows_system_executable",

--- a/tests/skill_directory_identity_test_support.py
+++ b/tests/skill_directory_identity_test_support.py
@@ -1,0 +1,65 @@
+"""Shared helpers for focused skill-directory identity tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.skill_directory_identity import (
+    SkillDirectoryIdentity,
+    SkillDirectoryIdentityLimits,
+    inspect_skill_directory,
+)
+
+
+def make_skill(scope: Path, name: str = "example") -> Path:
+    skill = scope / name / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("# Example skill\n", encoding="utf-8")
+    return skill
+
+
+def complete_identity(
+    skill: Path,
+    scope: Path,
+    *,
+    limits: SkillDirectoryIdentityLimits | None = None,
+) -> SkillDirectoryIdentity:
+    identity = (
+        inspect_skill_directory(skill, scope_root=scope, limits=limits)
+        if limits is not None
+        else inspect_skill_directory(skill, scope_root=scope)
+    )
+    assert identity.status == "complete", identity
+    assert identity.directory_hash is not None
+    assert identity.primary_content_hash is not None
+    assert identity.failure_reason is None
+    assert identity.incomplete_state_hash is None
+    return identity
+
+
+def incomplete_identity(
+    skill: Path,
+    scope: Path,
+    reason: str,
+    *,
+    limits: SkillDirectoryIdentityLimits | None = None,
+) -> SkillDirectoryIdentity:
+    identity = (
+        inspect_skill_directory(skill, scope_root=scope, limits=limits)
+        if limits is not None
+        else inspect_skill_directory(skill, scope_root=scope)
+    )
+    assert identity.status == "incomplete", identity
+    assert identity.directory_hash is None
+    assert identity.failure_reason == reason
+    assert identity.incomplete_state_hash is not None
+    return identity
+
+
+def symlink_or_skip(link: Path, target: str | Path, *, directory: bool = False) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=directory)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")

--- a/tests/test_antigravity_adapter.py
+++ b/tests/test_antigravity_adapter.py
@@ -1,0 +1,101 @@
+"""Focused Antigravity adapter skill-identity tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.antigravity import AntigravityHarnessAdapter
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.consumer.service import artifact_hash
+
+
+def _context(tmp_path: Path, *, workspace: bool) -> HarnessContext:
+    workspace_dir = tmp_path / "workspace" if workspace else None
+    if workspace_dir is not None:
+        workspace_dir.mkdir(parents=True)
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace_dir,
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def _write_text(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value, encoding="utf-8")
+
+
+@pytest.mark.parametrize("workspace", [False, True], ids=["global", "workspace"])
+def test_antigravity_skill_identity_covers_primary_and_nested_files(tmp_path: Path, workspace: bool) -> None:
+    context = _context(tmp_path, workspace=workspace)
+    base_dir = context.workspace_dir if workspace else context.home_dir
+    assert base_dir is not None
+    skill_dir = base_dir / ".gemini" / "antigravity" / "skills" / "review"
+    skill_path = skill_dir / "SKILL.md"
+    script_path = skill_dir / "scripts" / "review.py"
+    resource_path = skill_dir / "templates" / "nested" / "review.txt"
+    _write_text(skill_path, "---\nname: review\n---\nVersion one.\n")
+    _write_text(script_path, "print('one')\n")
+    _write_text(resource_path, "Template one.\n")
+
+    adapter = AntigravityHarnessAdapter()
+
+    def detected_skill_hash() -> tuple[str, dict[str, object]]:
+        detection = adapter.detect(context)
+        artifact = next(
+            item
+            for item in detection.artifacts
+            if item.artifact_id == f"antigravity:{'project' if workspace else 'global'}:skill:skills/review"
+        )
+        return artifact_hash(artifact), artifact.metadata
+
+    original_hash, metadata = detected_skill_hash()
+    stable_hash, stable_metadata = detected_skill_hash()
+
+    assert original_hash == stable_hash
+    assert metadata == stable_metadata
+    assert isinstance(metadata.get("content_hash"), str)
+    assert isinstance(metadata.get("directory_hash"), str)
+    identity_metadata = metadata.get("skillDirectoryIdentity")
+    assert isinstance(identity_metadata, dict)
+    assert identity_metadata.get("schemaVersion") == "guard.skill-directory-identity.v1"
+    assert identity_metadata.get("reusable") is True
+    version_info = metadata.get("versionInfo")
+    assert isinstance(version_info, dict)
+    assert metadata["directory_hash"] == version_info["contentHash"]
+
+    _write_text(skill_path, "---\nname: review\n---\nVersion two.\n")
+    primary_hash, _ = detected_skill_hash()
+    assert primary_hash != original_hash
+
+    _write_text(script_path, "print('two')\n")
+    script_hash, _ = detected_skill_hash()
+    assert script_hash != primary_hash
+
+    _write_text(resource_path, "Template two.\n")
+    resource_hash, _ = detected_skill_hash()
+    assert resource_hash != script_hash
+
+
+def test_antigravity_incomplete_skill_identity_warns_without_external_path_disclosure(tmp_path: Path) -> None:
+    context = _context(tmp_path, workspace=False)
+    skill_dir = context.home_dir / ".gemini" / "antigravity" / "skills" / "review"
+    _write_text(skill_dir / "SKILL.md", "---\nname: review\n---\n")
+    outside = tmp_path / "private" / "external-reference.md"
+    _write_text(outside, "outside\n")
+    try:
+        (skill_dir / "references").symlink_to(outside)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    result = AntigravityHarnessAdapter().detect(context)
+    skill = next(item for item in result.artifacts if item.artifact_type == "skill")
+    identity_metadata = skill.metadata.get("skillDirectoryIdentity")
+
+    assert isinstance(identity_metadata, dict)
+    assert identity_metadata.get("reusable") is False
+    assert result.warnings
+    assert all(str(outside) not in warning for warning in result.warnings)
+    assert any("approval reuse is disabled" in warning for warning in result.warnings)

--- a/tests/test_gemini_skill_directory_identity.py
+++ b/tests/test_gemini_skill_directory_identity.py
@@ -1,0 +1,147 @@
+"""Gemini adapter integration tests for complete skill-directory identity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.gemini import GeminiHarnessAdapter
+from codex_plugin_scanner.guard.consumer.service import artifact_hash
+
+
+def _ctx(tmp_path: Path, *, workspace: bool = False) -> HarnessContext:
+    workspace_dir = tmp_path / "workspace" if workspace else None
+    if workspace_dir is not None:
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace_dir,
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.mark.parametrize("workspace", [False, True], ids=["global", "workspace"])
+def test_skill_identity_covers_primary_and_nested_files(tmp_path: Path, workspace: bool) -> None:
+    ctx = _ctx(tmp_path, workspace=workspace)
+    base_dir = ctx.workspace_dir if workspace else ctx.home_dir
+    assert base_dir is not None
+    skill_dir = base_dir / ".gemini" / "skills" / "review"
+    skill_path = skill_dir / "SKILL.md"
+    script_path = skill_dir / "scripts" / "review.py"
+    reference_path = skill_dir / "references" / "nested" / "policy.md"
+    _write_text(skill_path, "---\nname: review\n---\nVersion one.\n")
+    _write_text(script_path, "print('one')\n")
+    _write_text(reference_path, "Policy one.\n")
+
+    adapter = GeminiHarnessAdapter()
+
+    def detected_skill_hash() -> tuple[str, dict[str, object]]:
+        detection = adapter.detect(ctx)
+        artifact = next(
+            item
+            for item in detection.artifacts
+            if item.artifact_id == f"gemini:{'project' if workspace else 'global'}:skill:skills/review"
+        )
+        return artifact_hash(artifact), artifact.metadata
+
+    original_hash, metadata = detected_skill_hash()
+    stable_hash, stable_metadata = detected_skill_hash()
+
+    assert original_hash == stable_hash
+    assert metadata == stable_metadata
+    assert isinstance(metadata.get("content_hash"), str)
+    assert isinstance(metadata.get("directory_hash"), str)
+    identity_metadata = metadata.get("skillDirectoryIdentity")
+    assert isinstance(identity_metadata, dict)
+    assert identity_metadata.get("schemaVersion") == "guard.skill-directory-identity.v1"
+    assert identity_metadata.get("reusable") is True
+    version_info = metadata.get("versionInfo")
+    assert isinstance(version_info, dict)
+    assert metadata["directory_hash"] == version_info["contentHash"]
+
+    _write_text(skill_path, "---\nname: review\n---\nVersion two.\n")
+    primary_hash, _ = detected_skill_hash()
+    assert primary_hash != original_hash
+
+    _write_text(script_path, "print('two')\n")
+    script_hash, _ = detected_skill_hash()
+    assert script_hash != primary_hash
+
+    _write_text(reference_path, "Policy two.\n")
+    reference_hash, _ = detected_skill_hash()
+    assert reference_hash != script_hash
+
+
+def test_linked_skill_directory_is_reported_as_nonreusable_discovery(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    skill_root = ctx.home_dir / ".gemini" / "skills"
+    target = ctx.home_dir / "linked-skills" / "review"
+    _write_text(target / "SKILL.md", "---\nname: review\n---\n")
+    _write_text(target / "scripts" / "run.py", "print('linked')\n")
+    skill_root.mkdir(parents=True)
+    linked_root = skill_root / "review"
+    try:
+        linked_root.symlink_to(target, target_is_directory=True)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    result = GeminiHarnessAdapter().detect(ctx)
+    skill = next(item for item in result.artifacts if "skill-discovery" in item.artifact_id)
+    identity_metadata = skill.metadata.get("skillDirectoryIdentity")
+
+    assert skill.config_path == str(linked_root)
+    assert isinstance(identity_metadata, dict)
+    assert identity_metadata["status"] == "incomplete"
+    assert identity_metadata["reason"] == "symlink_directory_unsupported"
+    assert identity_metadata["reusable"] is False
+    assert result.warnings
+
+
+def test_broken_linked_skill_root_is_not_silently_omitted(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    skill_root = ctx.home_dir / ".gemini" / "skills"
+    skill_root.mkdir(parents=True)
+    broken = skill_root / "broken"
+    try:
+        broken.symlink_to("missing", target_is_directory=True)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    result = GeminiHarnessAdapter().detect(ctx)
+    artifact = next(item for item in result.artifacts if "skill-discovery" in item.artifact_id)
+    identity_metadata = artifact.metadata.get("skillDirectoryIdentity")
+
+    assert result.installed is True
+    assert isinstance(identity_metadata, dict)
+    assert identity_metadata["reason"] == "symlink_broken"
+    assert identity_metadata["reusable"] is False
+    assert result.warnings
+
+
+def test_incomplete_skill_identity_warns_without_external_path_disclosure(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    skill_dir = ctx.home_dir / ".gemini" / "skills" / "review"
+    _write_text(skill_dir / "SKILL.md", "---\nname: review\n---\n")
+    outside = tmp_path / "private" / "external-reference.md"
+    _write_text(outside, "outside\n")
+    try:
+        (skill_dir / "references").symlink_to(outside)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    result = GeminiHarnessAdapter().detect(ctx)
+    skill = next(item for item in result.artifacts if item.artifact_type == "skill")
+    identity_metadata = skill.metadata.get("skillDirectoryIdentity")
+
+    assert isinstance(identity_metadata, dict)
+    assert identity_metadata.get("reusable") is False
+    assert result.warnings
+    assert all(str(outside) not in warning for warning in result.warnings)
+    assert any("approval reuse is disabled" in warning for warning in result.warnings)

--- a/tests/test_guard_aibom_content_upload.py
+++ b/tests/test_guard_aibom_content_upload.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
-import urllib.error
-from dataclasses import replace
-from email.message import Message
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -104,7 +100,7 @@ def test_primary_content_sources_include_skill_bodies_for_every_harness(
     assert sources[0].path == skill_path
 
 
-def test_gemini_adapter_skill_without_metadata_hash_has_uploadable_primary_content(tmp_path: Path) -> None:
+def test_gemini_directory_identity_still_has_uploadable_primary_content(tmp_path: Path) -> None:
     context = HarnessContext(
         home_dir=tmp_path / "home",
         workspace_dir=None,
@@ -116,7 +112,8 @@ def test_gemini_adapter_skill_without_metadata_hash_has_uploadable_primary_conte
 
     detection = GeminiHarnessAdapter().detect(context)
     skill_artifact = next(artifact for artifact in detection.artifacts if artifact.artifact_type == "skill")
-    assert "content_hash" not in skill_artifact.metadata
+    assert isinstance(skill_artifact.metadata.get("content_hash"), str)
+    assert isinstance(skill_artifact.metadata.get("directory_hash"), str)
 
     snapshot = inventory_snapshot_from_detection(
         detection,
@@ -132,6 +129,7 @@ def test_gemini_adapter_skill_without_metadata_hash_has_uploadable_primary_conte
     assert len(sources) == 1
     assert sources[0].content_hash == f"sha256:{hashlib.sha256(skill_path.read_bytes()).hexdigest()}"
     assert sources[0].path == skill_path
+    assert snapshot.items[0].content_hash != sources[0].content_hash
 
     runner = SimpleNamespace(
         _guard_sync_request=lambda *_args, **kwargs: SimpleNamespace(data=kwargs["data"]),
@@ -394,163 +392,3 @@ def test_skill_outside_skills_root_does_not_advertise_uploadable_body_hash(tmp_p
 
     assert not snapshot.items[0].content_hash.startswith("sha256:")
     assert sources == ()
-
-
-def test_primary_content_upload_batches_exact_bodies_and_item_count(tmp_path: Path) -> None:
-    sources = tuple(_source(tmp_path / "skills", index) for index in range(101))
-    requests: list[SimpleNamespace] = []
-
-    def guard_sync_request(_auth_context, *, request_url, method, data, extra_headers):
-        request = SimpleNamespace(data=data, full_url=request_url, method=method)
-        requests.append(request)
-        assert extra_headers is None
-        return request
-
-    def respond(*, request, **_kwargs):
-        payload = json.loads(request.data)
-        return {
-            "storedCount": len(payload["items"]),
-            "hashOnlyCount": 0,
-            "failedCount": 0,
-        }
-
-    runner = SimpleNamespace(
-        _guard_sync_request=guard_sync_request,
-        _urlopen_json_with_timeout_retry=respond,
-    )
-
-    summary, _auth_context = upload_primary_content_sources(
-        object(),
-        runner,
-        {"sync_url": "https://hol.test/api/v1/guard/events"},
-        sources=sources,
-        workspace_id="workspace-1",
-    )
-
-    assert summary == {
-        "eligible": 101,
-        "attempted": 101,
-        "uploaded": 101,
-        "stored": 101,
-        "hash_only": 0,
-        "failed": 0,
-        "skipped": 0,
-        "batches": 2,
-    }
-    assert [len(json.loads(request.data)["items"]) for request in requests] == [100, 1]
-    assert all(
-        request.full_url.endswith("/api/guard/aibom/workspaces/workspace-1/content-upload") for request in requests
-    )
-    first_item = json.loads(requests[0].data)["items"][0]
-    assert first_item["bodyBase64"] == "IyBTa2lsbCAwCg=="
-    assert first_item["agentId"] == sources[0].agent_id
-    assert first_item["contentHash"] == sources[0].content_hash
-    assert first_item["snapshotId"] == sources[0].snapshot_id
-    assert first_item["versionId"] == sources[0].version_id
-
-
-def test_primary_content_upload_failure_is_nonfatal(tmp_path: Path) -> None:
-    source = _source(tmp_path / "skills", 1)
-
-    def fail(*_args, **_kwargs):
-        raise urllib.error.HTTPError(
-            url="https://hol.test/content-upload",
-            code=404,
-            msg="Not Found",
-            hdrs=Message(),
-            fp=None,
-        )
-
-    runner = SimpleNamespace(
-        _guard_sync_request=lambda *_args, **kwargs: SimpleNamespace(data=kwargs["data"]),
-        _urlopen_json_with_timeout_retry=fail,
-    )
-
-    summary, _auth_context = upload_primary_content_sources(
-        object(),
-        runner,
-        {"sync_url": "https://hol.test/api/v1/guard/events"},
-        sources=(source,),
-        workspace_id="workspace-1",
-    )
-
-    assert summary["attempted"] == 1
-    assert summary["uploaded"] == 0
-    assert summary["failed"] == 1
-    assert summary["reason"] == "endpoint_unavailable"
-
-
-def test_primary_content_upload_accounts_for_partial_batch_failure(tmp_path: Path) -> None:
-    sources = tuple(_source(tmp_path / "skills", index) for index in range(2))
-    runner = SimpleNamespace(
-        _guard_sync_request=lambda *_args, **kwargs: SimpleNamespace(data=kwargs["data"]),
-        _urlopen_json_with_timeout_retry=lambda **_kwargs: {
-            "storedCount": 1,
-            "hashOnlyCount": 0,
-            "failedCount": 1,
-        },
-    )
-
-    summary, _auth_context = upload_primary_content_sources(
-        object(),
-        runner,
-        {"sync_url": "https://hol.test/api/v1/guard/events"},
-        sources=sources,
-        workspace_id="workspace-1",
-    )
-
-    assert summary["attempted"] == 2
-    assert summary["uploaded"] == 1
-    assert summary["stored"] == 1
-    assert summary["hash_only"] == 0
-    assert summary["failed"] == 1
-
-
-def test_primary_content_upload_skips_changed_body(tmp_path: Path) -> None:
-    source = _source(tmp_path / "skills", 1)
-    source.path.write_text("changed after snapshot\n", encoding="utf-8")
-    runner = SimpleNamespace(
-        _guard_sync_request=lambda *_args, **_kwargs: None,
-        _urlopen_json_with_timeout_retry=lambda **_kwargs: {},
-    )
-
-    summary, _auth_context = upload_primary_content_sources(
-        object(),
-        runner,
-        {"sync_url": "https://hol.test/api/v1/guard/events"},
-        sources=(source,),
-        workspace_id="workspace-1",
-    )
-
-    assert summary["eligible"] == 1
-    assert summary["attempted"] == 0
-    assert summary["skipped"] == 1
-
-
-def test_primary_content_upload_accepts_an_empty_primary_file(tmp_path: Path) -> None:
-    source = _source(tmp_path / "skills", 1)
-    source.path.write_bytes(b"")
-    source = replace(
-        source,
-        content_hash=f"sha256:{hashlib.sha256(b'').hexdigest()}",
-    )
-    runner = SimpleNamespace(
-        _guard_sync_request=lambda *_args, **kwargs: SimpleNamespace(data=kwargs["data"]),
-        _urlopen_json_with_timeout_retry=lambda **_kwargs: {
-            "storedCount": 1,
-            "hashOnlyCount": 0,
-            "failedCount": 0,
-        },
-    )
-
-    summary, _auth_context = upload_primary_content_sources(
-        object(),
-        runner,
-        {"sync_url": "https://hol.test/api/v1/guard/events"},
-        sources=(source,),
-        workspace_id="workspace-1",
-    )
-
-    assert summary["attempted"] == 1
-    assert summary["stored"] == 1
-    assert summary["failed"] == 0

--- a/tests/test_guard_aibom_content_upload_batches.py
+++ b/tests/test_guard_aibom_content_upload_batches.py
@@ -1,0 +1,196 @@
+"""Batching and transport tests for AIBOM primary-content upload."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import urllib.error
+from dataclasses import replace
+from email.message import Message
+from pathlib import Path
+from types import SimpleNamespace
+
+from codex_plugin_scanner.guard.aibom_content_upload import (
+    GuardAibomPrimaryContentSource,
+    upload_primary_content_sources,
+)
+
+
+def _source(skills_root: Path, index: int) -> GuardAibomPrimaryContentSource:
+    path = skills_root / "category" / f"skill-{index}" / "SKILL.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = f"# Skill {index}\n".encode()
+    path.write_bytes(body)
+    content_hash = f"sha256:{hashlib.sha256(body).hexdigest()}"
+    return GuardAibomPrimaryContentSource(
+        agent_id="hermes:local",
+        allowed_root=skills_root,
+        content_hash=content_hash,
+        harness_id="hermes",
+        item_id=f"hermes:skill:category:skill-{index}",
+        item_kind="skill",
+        mime_type="text/markdown; charset=utf-8",
+        path=path,
+        snapshot_id="hermes:snapshot:1",
+        version_id=f"fingerprint-{index}",
+    )
+
+
+def test_primary_content_upload_batches_exact_bodies_and_item_count(tmp_path: Path) -> None:
+    sources = tuple(_source(tmp_path / "skills", index) for index in range(101))
+    requests: list[SimpleNamespace] = []
+
+    def guard_sync_request(_auth_context, *, request_url, method, data, extra_headers):
+        request = SimpleNamespace(data=data, full_url=request_url, method=method)
+        requests.append(request)
+        assert extra_headers is None
+        return request
+
+    def respond(*, request, **_kwargs):
+        payload = json.loads(request.data)
+        return {
+            "storedCount": len(payload["items"]),
+            "hashOnlyCount": 0,
+            "failedCount": 0,
+        }
+
+    runner = SimpleNamespace(
+        _guard_sync_request=guard_sync_request,
+        _urlopen_json_with_timeout_retry=respond,
+    )
+
+    summary, _auth_context = upload_primary_content_sources(
+        object(),
+        runner,
+        {"sync_url": "https://hol.test/api/v1/guard/events"},
+        sources=sources,
+        workspace_id="workspace-1",
+    )
+
+    assert summary == {
+        "eligible": 101,
+        "attempted": 101,
+        "uploaded": 101,
+        "stored": 101,
+        "hash_only": 0,
+        "failed": 0,
+        "skipped": 0,
+        "batches": 2,
+    }
+    assert [len(json.loads(request.data)["items"]) for request in requests] == [100, 1]
+    assert all(
+        request.full_url.endswith("/api/guard/aibom/workspaces/workspace-1/content-upload") for request in requests
+    )
+    first_item = json.loads(requests[0].data)["items"][0]
+    assert first_item["bodyBase64"] == "IyBTa2lsbCAwCg=="
+    assert first_item["agentId"] == sources[0].agent_id
+    assert first_item["contentHash"] == sources[0].content_hash
+    assert first_item["snapshotId"] == sources[0].snapshot_id
+    assert first_item["versionId"] == sources[0].version_id
+
+
+def test_primary_content_upload_failure_is_nonfatal(tmp_path: Path) -> None:
+    source = _source(tmp_path / "skills", 1)
+
+    def fail(*_args, **_kwargs):
+        raise urllib.error.HTTPError(
+            url="https://hol.test/content-upload",
+            code=404,
+            msg="Not Found",
+            hdrs=Message(),
+            fp=None,
+        )
+
+    runner = SimpleNamespace(
+        _guard_sync_request=lambda *_args, **kwargs: SimpleNamespace(data=kwargs["data"]),
+        _urlopen_json_with_timeout_retry=fail,
+    )
+
+    summary, _auth_context = upload_primary_content_sources(
+        object(),
+        runner,
+        {"sync_url": "https://hol.test/api/v1/guard/events"},
+        sources=(source,),
+        workspace_id="workspace-1",
+    )
+
+    assert summary["attempted"] == 1
+    assert summary["uploaded"] == 0
+    assert summary["failed"] == 1
+    assert summary["reason"] == "endpoint_unavailable"
+
+
+def test_primary_content_upload_accounts_for_partial_batch_failure(tmp_path: Path) -> None:
+    sources = tuple(_source(tmp_path / "skills", index) for index in range(2))
+    runner = SimpleNamespace(
+        _guard_sync_request=lambda *_args, **kwargs: SimpleNamespace(data=kwargs["data"]),
+        _urlopen_json_with_timeout_retry=lambda **_kwargs: {
+            "storedCount": 1,
+            "hashOnlyCount": 0,
+            "failedCount": 1,
+        },
+    )
+
+    summary, _auth_context = upload_primary_content_sources(
+        object(),
+        runner,
+        {"sync_url": "https://hol.test/api/v1/guard/events"},
+        sources=sources,
+        workspace_id="workspace-1",
+    )
+
+    assert summary["attempted"] == 2
+    assert summary["uploaded"] == 1
+    assert summary["stored"] == 1
+    assert summary["hash_only"] == 0
+    assert summary["failed"] == 1
+
+
+def test_primary_content_upload_skips_changed_body(tmp_path: Path) -> None:
+    source = _source(tmp_path / "skills", 1)
+    source.path.write_text("changed after snapshot\n", encoding="utf-8")
+    runner = SimpleNamespace(
+        _guard_sync_request=lambda *_args, **_kwargs: None,
+        _urlopen_json_with_timeout_retry=lambda **_kwargs: {},
+    )
+
+    summary, _auth_context = upload_primary_content_sources(
+        object(),
+        runner,
+        {"sync_url": "https://hol.test/api/v1/guard/events"},
+        sources=(source,),
+        workspace_id="workspace-1",
+    )
+
+    assert summary["eligible"] == 1
+    assert summary["attempted"] == 0
+    assert summary["skipped"] == 1
+
+
+def test_primary_content_upload_accepts_an_empty_primary_file(tmp_path: Path) -> None:
+    source = _source(tmp_path / "skills", 1)
+    source.path.write_bytes(b"")
+    source = replace(
+        source,
+        content_hash=f"sha256:{hashlib.sha256(b'').hexdigest()}",
+    )
+    runner = SimpleNamespace(
+        _guard_sync_request=lambda *_args, **kwargs: SimpleNamespace(data=kwargs["data"]),
+        _urlopen_json_with_timeout_retry=lambda **_kwargs: {
+            "storedCount": 1,
+            "hashOnlyCount": 0,
+            "failedCount": 0,
+        },
+    )
+
+    summary, _auth_context = upload_primary_content_sources(
+        object(),
+        runner,
+        {"sync_url": "https://hol.test/api/v1/guard/events"},
+        sources=(source,),
+        workspace_id="workspace-1",
+    )
+
+    assert summary["attempted"] == 1
+    assert summary["stored"] == 1
+    assert summary["failed"] == 0

--- a/tests/test_guard_aibom_skill_directory_identity.py
+++ b/tests/test_guard_aibom_skill_directory_identity.py
@@ -1,0 +1,154 @@
+"""Codex/AIBOM skill-directory identity integration tests."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.aibom_detection import (
+    discover_codex_skill_artifacts,
+    file_content_hash,
+)
+from codex_plugin_scanner.guard.consumer.service import artifact_hash
+from codex_plugin_scanner.guard.models import GuardArtifact
+
+
+def test_codex_skill_uses_complete_directory_identity_and_detects_secondary_tail_change(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    skill_dir = workspace / ".agents" / "skills" / "review"
+    skill_dir.mkdir(parents=True)
+    skill_path = skill_dir / "SKILL.md"
+    script_path = skill_dir / "scripts" / "review.py"
+    skill_path.write_text("---\nname: review\n---\nReview carefully.\n", encoding="utf-8")
+    script_path.parent.mkdir()
+    prefix = b"#" * (1024 * 1024)
+    script_path.write_bytes(prefix + b"tail-one\n")
+
+    def discovered_skill() -> GuardArtifact:
+        return next(
+            artifact
+            for artifact in discover_codex_skill_artifacts(
+                "codex",
+                home_dir=tmp_path / "home",
+                workspace_dir=workspace,
+            )
+            if artifact.source_scope == "project" and artifact.name == "review"
+        )
+
+    first = discovered_skill()
+    stable = discovered_skill()
+
+    assert artifact_hash(first) == artifact_hash(stable)
+    assert first.metadata == stable.metadata
+    assert first.metadata.get("content_hash") == f"sha256:{file_content_hash(skill_path)}"
+    assert isinstance(first.metadata.get("directory_hash"), str)
+    identity_metadata = first.metadata.get("skillDirectoryIdentity")
+    assert isinstance(identity_metadata, dict)
+    assert identity_metadata.get("schemaVersion") == "guard.skill-directory-identity.v1"
+    assert identity_metadata.get("reusable") is True
+    version_info = first.metadata.get("versionInfo")
+    assert isinstance(version_info, dict)
+    assert first.metadata["directory_hash"] == version_info["contentHash"]
+
+    script_path.write_bytes(prefix + b"tail-two\n")
+    changed = discovered_skill()
+
+    assert changed.metadata.get("content_hash") == first.metadata.get("content_hash")
+    assert changed.metadata.get("directory_hash") != first.metadata.get("directory_hash")
+    assert artifact_hash(changed) != artifact_hash(first)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX executable mode is not portable to Windows")
+def test_codex_skill_directory_identity_detects_secondary_executable_mode_change(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    skill_dir = workspace / ".agents" / "skills" / "review"
+    skill_dir.mkdir(parents=True)
+    skill_path = skill_dir / "SKILL.md"
+    script_path = skill_dir / "scripts" / "review.sh"
+    skill_path.write_text("---\nname: review\n---\nReview carefully.\n", encoding="utf-8")
+    script_path.parent.mkdir()
+    script_path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    script_path.chmod(0o644)
+
+    def discovered_skill() -> GuardArtifact:
+        return next(
+            artifact
+            for artifact in discover_codex_skill_artifacts(
+                "codex",
+                home_dir=tmp_path / "home",
+                workspace_dir=workspace,
+            )
+            if artifact.source_scope == "project" and artifact.name == "review"
+        )
+
+    not_executable = discovered_skill()
+    script_path.chmod(0o744)
+    executable = discovered_skill()
+
+    assert executable.metadata.get("content_hash") == not_executable.metadata.get("content_hash")
+    assert executable.metadata.get("directory_hash") != not_executable.metadata.get("directory_hash")
+    assert artifact_hash(executable) != artifact_hash(not_executable)
+
+
+def test_codex_skill_external_primary_link_is_reported_as_incomplete_metadata(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    skill_dir = workspace / ".agents" / "skills" / "escaped"
+    skill_dir.mkdir(parents=True)
+    outside = tmp_path / "private" / "SKILL.md"
+    outside.parent.mkdir()
+    outside.write_text("---\nname: escaped\n---\nOutside instructions.\n", encoding="utf-8")
+    skill_path = skill_dir / "SKILL.md"
+    try:
+        skill_path.symlink_to(outside)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    artifact = next(
+        item
+        for item in discover_codex_skill_artifacts(
+            "codex",
+            home_dir=tmp_path / "home",
+            workspace_dir=workspace,
+        )
+        if item.source_scope == "project" and item.name == "escaped"
+    )
+    identity_metadata = artifact.metadata.get("skillDirectoryIdentity")
+
+    assert artifact.config_path == str(skill_path)
+    assert isinstance(identity_metadata, dict)
+    assert identity_metadata.get("schemaVersion") == "guard.skill-directory-identity.v1"
+    assert identity_metadata.get("status") == "incomplete"
+    assert identity_metadata.get("reusable") is False
+    assert isinstance(identity_metadata.get("reason"), str)
+    assert isinstance(identity_metadata.get("incompleteStateHash"), str)
+    assert "directory_hash" not in artifact.metadata
+
+
+def test_codex_broken_linked_skill_root_emits_incomplete_artifact(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    skill_root = workspace / ".agents" / "skills"
+    skill_root.mkdir(parents=True)
+    broken = skill_root / "broken"
+    try:
+        broken.symlink_to("missing", target_is_directory=True)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    artifact = next(
+        item
+        for item in discover_codex_skill_artifacts(
+            "codex",
+            home_dir=tmp_path / "home",
+            workspace_dir=workspace,
+        )
+        if "skill-discovery" in item.artifact_id
+    )
+    identity_metadata = artifact.metadata.get("skillDirectoryIdentity")
+
+    assert artifact.config_path == str(broken)
+    assert isinstance(identity_metadata, dict)
+    assert identity_metadata["status"] == "incomplete"
+    assert identity_metadata["reason"] == "symlink_broken"
+    assert identity_metadata["reusable"] is False

--- a/tests/test_guard_consumer_skill_directory_identity.py
+++ b/tests/test_guard_consumer_skill_directory_identity.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _identity_metadata(directory_hash: str, *, status: str = "complete") -> dict[str, object]:
+    complete = status == "complete"
+    return {
+        "content_hash": _digest("primary SKILL.md"),
+        "directory_hash": directory_hash,
+        "skillDirectoryIdentity": {
+            "schemaVersion": "guard.skill-directory-identity.v1",
+            "status": status,
+            "contentHash": directory_hash if complete else None,
+            "entryCount": 4,
+            "totalBytes": 128,
+            "reusable": complete,
+            **({"reason": "entry_limit", "incompleteStateHash": _digest("scan failure")} if not complete else {}),
+        },
+        "versionInfo": {
+            "hashBasis": "skill-directory-v1",
+            "contentHash": directory_hash if complete else _digest("scan failure"),
+        },
+    }
+
+
+def _artifact(tmp_path: Path, metadata: dict[str, object]) -> GuardArtifact:
+    workspace = tmp_path / "workspace"
+    skill_path = workspace / ".gemini" / "skills" / "review" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True, exist_ok=True)
+    skill_path.write_text("# Review\n", encoding="utf-8")
+    return GuardArtifact(
+        artifact_id="gemini:skill:review",
+        name="review",
+        harness="gemini",
+        artifact_type="skill",
+        source_scope="project",
+        config_path=str(skill_path),
+        publisher="local",
+        metadata=metadata,
+    )
+
+
+def _detection(artifact: GuardArtifact) -> HarnessDetection:
+    return HarnessDetection(
+        harness=artifact.harness,
+        installed=True,
+        command_available=False,
+        config_paths=(artifact.config_path,),
+        artifacts=(artifact,),
+    )
+
+
+def _config(tmp_path: Path, artifact_id: str) -> GuardConfig:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    return GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        artifact_actions={artifact_id: "review"},
+    )
+
+
+def _save_allow(
+    store: GuardStore,
+    *,
+    artifact: GuardArtifact,
+    context_hash: str,
+    workspace: Path,
+    request_id: str,
+) -> None:
+    approval_id = store.record_local_once_approval(
+        request_id=request_id,
+        harness=artifact.harness,
+        artifact_id=artifact.artifact_id,
+        artifact_hash=context_hash,
+        workspace=str(workspace),
+        publisher=artifact.publisher,
+        action="allow",
+        created_at="2026-07-19T00:00:00Z",
+        expires_at="2099-07-19T00:00:00Z",
+    )
+    assert approval_id is not None
+
+
+def test_complete_unchanged_directory_identity_reuses_exact_saved_approval(tmp_path: Path) -> None:
+    artifact = _artifact(tmp_path, _identity_metadata(_digest("directory-v1")))
+    detection = _detection(artifact)
+    config = _config(tmp_path, artifact.artifact_id)
+    store = GuardStore(config.guard_home)
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _save_allow(
+        store,
+        artifact=artifact,
+        context_hash=context_hash,
+        workspace=config.workspace or tmp_path,
+        request_id="complete-skill",
+    )
+    pending_claims: list[tuple[Mapping[str, object], str, str]] = []
+
+    result = evaluate_detection(
+        detection,
+        store,
+        config,
+        persist=False,
+        pending_approval_claims=pending_claims,
+    )
+    item = result["artifacts"][0]
+
+    assert item["approval_context_hash"] == context_hash
+    assert item["policy_action"] == "allow"
+    assert item["approval_reuse_status"] == "accepted"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_accepted"
+    assert len(pending_claims) == 1
+
+
+def test_directory_identity_change_invalidates_prior_saved_approval(tmp_path: Path) -> None:
+    original = _artifact(tmp_path, _identity_metadata(_digest("directory-v1")))
+    config = _config(tmp_path, original.artifact_id)
+    store = GuardStore(config.guard_home)
+    initial = evaluate_detection(_detection(original), store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _save_allow(
+        store,
+        artifact=original,
+        context_hash=context_hash,
+        workspace=config.workspace or tmp_path,
+        request_id="changed-skill",
+    )
+    changed = _artifact(tmp_path, _identity_metadata(_digest("directory-v2")))
+    pending_claims: list[tuple[Mapping[str, object], str, str]] = []
+
+    result = evaluate_detection(
+        _detection(changed),
+        store,
+        config,
+        persist=False,
+        pending_approval_claims=pending_claims,
+    )
+    item = result["artifacts"][0]
+
+    assert item["approval_context_hash"] != context_hash
+    assert item["policy_action"] == "review"
+    assert item["approval_reuse_status"] == "rejected"
+    assert item["approval_reuse_reason_code"] in {
+        "approval_reuse_content_changed",
+        "approval_reuse_identity_changed",
+    }
+    assert pending_claims == []
+
+
+@pytest.mark.parametrize(
+    "marker",
+    (
+        _identity_metadata(_digest("partial"), status="incomplete")["skillDirectoryIdentity"],
+        "malformed",
+    ),
+)
+def test_incomplete_or_malformed_identity_blocks_saved_approval_reuse(
+    tmp_path: Path,
+    marker: object,
+) -> None:
+    metadata = _identity_metadata(_digest("partial"), status="incomplete")
+    metadata["skillDirectoryIdentity"] = marker
+    artifact = _artifact(tmp_path, metadata)
+    detection = _detection(artifact)
+    config = _config(tmp_path, artifact.artifact_id)
+    store = GuardStore(config.guard_home)
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _save_allow(
+        store,
+        artifact=artifact,
+        context_hash=context_hash,
+        workspace=config.workspace or tmp_path,
+        request_id=f"incomplete-skill-{type(marker).__name__}",
+    )
+    pending_claims: list[tuple[Mapping[str, object], str, str]] = []
+
+    result = evaluate_detection(
+        detection,
+        store,
+        config,
+        persist=False,
+        pending_approval_claims=pending_claims,
+        claimed_saved_approval_overrides={artifact.artifact_id: context_hash},
+    )
+    item = result["artifacts"][0]
+
+    assert item["policy_action"] == "require-reapproval"
+    assert item["approval_reuse_status"] == "rejected"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_reapproval_required"
+    assert item["policy_composition"]["skill_directory_identity_reusable"] is False
+    assert item["policy_composition"]["skill_directory_identity_floor"] == "require-reapproval"
+    assert item["scanner_evidence"][0]["reason_code"] == "skill_directory_identity_non_reusable"
+    assert "approval_claim" not in item
+    assert pending_claims == []
+    assert (
+        store.peek_local_once_approval(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(config.workspace),
+            publisher=artifact.publisher,
+            now="2026-07-19T00:01:00Z",
+        )
+        is not None
+    )
+
+
+def test_removed_incomplete_skill_also_uses_reapproval_floor(tmp_path: Path) -> None:
+    artifact = _artifact(
+        tmp_path,
+        _identity_metadata(_digest("removed-partial"), status="incomplete"),
+    )
+    config = _config(tmp_path, artifact.artifact_id)
+    store = GuardStore(config.guard_home)
+    snapshot = artifact.to_dict()
+    snapshot["env_keys"] = []
+    snapshot_hash = artifact_hash(artifact)
+    snapshot["artifact_hash"] = snapshot_hash
+    store.save_snapshot(
+        artifact.harness,
+        artifact.artifact_id,
+        snapshot,
+        snapshot_hash,
+        "2026-07-19T00:00:00Z",
+    )
+    removed_detection = HarnessDetection(
+        harness=artifact.harness,
+        installed=True,
+        command_available=False,
+        config_paths=(),
+        artifacts=(),
+    )
+    initial = evaluate_detection(removed_detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _save_allow(
+        store,
+        artifact=artifact,
+        context_hash=context_hash,
+        workspace=config.workspace or tmp_path,
+        request_id="removed-incomplete-skill",
+    )
+    pending_claims: list[tuple[Mapping[str, object], str, str]] = []
+
+    result = evaluate_detection(
+        removed_detection,
+        store,
+        config,
+        persist=False,
+        pending_approval_claims=pending_claims,
+    )
+    item = result["artifacts"][0]
+
+    assert item["policy_action"] == "require-reapproval"
+    assert item["approval_reuse_status"] == "rejected"
+    assert item["policy_composition"]["skill_directory_identity_reusable"] is False
+    assert pending_claims == []

--- a/tests/test_guard_runner_skill_directory_identity.py
+++ b/tests/test_guard_runner_skill_directory_identity.py
@@ -1,0 +1,75 @@
+"""Runner regressions for incomplete skill-directory identity approvals."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.gemini import GeminiHarnessAdapter
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def test_fresh_approval_survives_unchanged_incomplete_skill_redetection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True)
+    skill_dir = home_dir / ".gemini" / "skills" / "review"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Review\n", encoding="utf-8")
+    try:
+        (skill_dir / "broken-reference").symlink_to("missing-reference.md")
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    context = HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir)
+    detect_count = 0
+
+    def detect(_harness: str, _context: HarnessContext):
+        nonlocal detect_count
+        detect_count += 1
+        return GeminiHarnessAdapter().detect(context)
+
+    def allow_once(_detection, evaluation: dict[str, object]) -> dict[str, object]:
+        items = evaluation.get("artifacts")
+        assert isinstance(items, list)
+        item = items[0]
+        assert isinstance(item, dict)
+        assert item["policy_action"] == "require-reapproval"
+        item["policy_action"] = "allow"
+        item["user_override"] = "allow-once"
+        evaluation["blocked"] = False
+        return evaluation
+
+    launch_calls: list[object] = []
+    monkeypatch.setattr(guard_runner_module, "detect_harness", detect)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *args, **kwargs: (
+            launch_calls.append((args, kwargs))
+            or subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        ),
+    )
+
+    result = guard_runner_module.guard_run(
+        "gemini",
+        context,
+        GuardStore(home_dir),
+        GuardConfig(guard_home=home_dir, workspace=workspace_dir),
+        dry_run=False,
+        passthrough_args=[],
+        interactive_resolver=allow_once,
+    )
+
+    assert detect_count >= 2
+    assert result["blocked"] is False
+    assert result["artifacts"][0]["policy_action"] == "allow"
+    assert result["artifacts"][0]["trusted_request_override"]["applied"] is True

--- a/tests/test_guard_skill_directory_identity.py
+++ b/tests/test_guard_skill_directory_identity.py
@@ -1,0 +1,434 @@
+"""Contract tests for complete, bounded skill-directory identities."""
+
+from __future__ import annotations
+
+import os
+import stat
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard import skill_directory_identity as identity_module
+from codex_plugin_scanner.guard.skill_directory_identity import (
+    SKILL_DIRECTORY_IDENTITY_SCHEMA,
+    SkillDirectoryIdentity,
+    SkillDirectoryIdentityLimits,
+    discover_skill_documents,
+    inspect_skill_directory,
+    skill_directory_identity_metadata,
+    validated_complete_skill_directory_hash,
+)
+
+
+def _make_skill(scope: Path, name: str = "example") -> Path:
+    skill = scope / name / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("# Example skill\n", encoding="utf-8")
+    return skill
+
+
+def _complete(
+    skill: Path,
+    scope: Path,
+    *,
+    limits: SkillDirectoryIdentityLimits | None = None,
+) -> SkillDirectoryIdentity:
+    identity = (
+        inspect_skill_directory(skill, scope_root=scope, limits=limits)
+        if limits is not None
+        else inspect_skill_directory(skill, scope_root=scope)
+    )
+    assert identity.status == "complete", identity
+    assert identity.directory_hash is not None
+    assert identity.primary_content_hash is not None
+    assert identity.failure_reason is None
+    assert identity.incomplete_state_hash is None
+    return identity
+
+
+def _incomplete(
+    skill: Path,
+    scope: Path,
+    reason: str,
+    *,
+    limits: SkillDirectoryIdentityLimits | None = None,
+) -> SkillDirectoryIdentity:
+    identity = (
+        inspect_skill_directory(skill, scope_root=scope, limits=limits)
+        if limits is not None
+        else inspect_skill_directory(skill, scope_root=scope)
+    )
+    assert identity.status == "incomplete", identity
+    assert identity.directory_hash is None
+    assert identity.failure_reason == reason
+    assert identity.incomplete_state_hash is not None
+    return identity
+
+
+def _symlink_or_skip(link: Path, target: str | Path, *, directory: bool = False) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=directory)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows suffix-derived execute bits are required")
+def test_windows_command_suffix_has_complete_identity(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    (skill.parent / "run.cmd").write_text("@echo off\r\n", encoding="utf-8")
+
+    _complete(skill, scope)
+
+
+def test_discovery_reports_a_linked_skill_root_without_following_it(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill_root = scope / "skills"
+    skill_root.mkdir(parents=True)
+    target = _make_skill(scope / "linked-targets", "review")
+    _make_skill(target.parent, "nested")
+    linked_root = skill_root / "review"
+    _symlink_or_skip(linked_root, target.parent, directory=True)
+
+    discovery = discover_skill_documents(skill_root)
+
+    assert discovery.documents == ()
+    assert len(discovery.issues) == 1
+    assert discovery.issues[0].path == linked_root
+    assert discovery.issues[0].failure_reason == "symlink_directory_unsupported"
+
+
+def test_complete_identity_reports_schema_counts_bytes_and_metadata(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    script = skill.parent / "scripts" / "run.py"
+    script.parent.mkdir()
+    script.write_bytes(b"print('safe')\n")
+
+    identity = _complete(skill, scope)
+
+    assert identity.schema_version == SKILL_DIRECTORY_IDENTITY_SCHEMA
+    assert identity.entry_count == 3
+    assert identity.total_bytes == len(skill.read_bytes()) + len(script.read_bytes())
+    metadata = skill_directory_identity_metadata(identity, version_label="Gemini skill")
+    assert metadata["content_hash"] == identity.primary_content_hash
+    assert metadata["directory_hash"] == identity.directory_hash
+    assert metadata["versionInfo"] == {
+        "versionLabel": "Gemini skill",
+        "hashBasis": "skill-directory-v1",
+        "contentHash": identity.directory_hash,
+        "changedFields": [],
+    }
+    assert metadata["skillDirectoryIdentity"] == {
+        "schemaVersion": SKILL_DIRECTORY_IDENTITY_SCHEMA,
+        "status": "complete",
+        "entryCount": 3,
+        "totalBytes": identity.total_bytes,
+        "reusable": True,
+        "contentHash": identity.directory_hash,
+    }
+    assert validated_complete_skill_directory_hash(metadata) == identity.directory_hash
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        "schema",
+        "status",
+        "reusable",
+        "reason",
+        "state",
+        "legacy-nonce",
+        "directory",
+        "version",
+        "basis",
+        "count",
+    ),
+)
+def test_complete_metadata_validator_rejects_malformed_or_mismatched_envelopes(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    scope = tmp_path / "scope"
+    identity = _complete(_make_skill(scope), scope)
+    metadata = skill_directory_identity_metadata(identity, version_label="skill")
+    altered = deepcopy(metadata)
+    envelope = altered["skillDirectoryIdentity"]
+    version_info = altered["versionInfo"]
+    assert isinstance(envelope, dict)
+    assert isinstance(version_info, dict)
+    if mutation == "schema":
+        envelope["schemaVersion"] = "guard.skill-directory-identity.v0"
+    elif mutation == "status":
+        envelope["status"] = "incomplete"
+    elif mutation == "reusable":
+        envelope["reusable"] = False
+    elif mutation == "reason":
+        envelope["reason"] = "unreadable_entry"
+    elif mutation == "state":
+        envelope["incompleteStateHash"] = "sha256:" + ("2" * 64)
+    elif mutation == "legacy-nonce":
+        envelope["reuseNonce"] = "legacy"
+    elif mutation == "directory":
+        altered["directory_hash"] = "sha256:" + ("0" * 64)
+    elif mutation == "version":
+        version_info["contentHash"] = "sha256:" + ("1" * 64)
+    elif mutation == "basis":
+        version_info["hashBasis"] = "legacy"
+    else:
+        envelope["entryCount"] = True
+
+    assert validated_complete_skill_directory_hash(altered) is None
+
+
+def test_complete_metadata_validator_rejects_non_string_mapping_keys(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    identity = _complete(_make_skill(scope), scope)
+    metadata: dict[object, object] = {}
+    metadata.update(skill_directory_identity_metadata(identity, version_label="skill"))
+    metadata[1] = "ambiguous"
+
+    assert validated_complete_skill_directory_hash(metadata) is None
+
+
+def test_primary_document_content_changes_both_hashes(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    before = _complete(skill, scope)
+
+    skill.write_text("# Changed skill\n", encoding="utf-8")
+    after = _complete(skill, scope)
+
+    assert after.primary_content_hash != before.primary_content_hash
+    assert after.directory_hash != before.directory_hash
+
+
+def test_nested_file_content_changes_only_directory_hash(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    nested = skill.parent / "scripts" / "run.py"
+    nested.parent.mkdir()
+    nested.write_text("print(1)\n", encoding="utf-8")
+    before = _complete(skill, scope)
+
+    nested.write_text("print(2)\n", encoding="utf-8")
+    after = _complete(skill, scope)
+
+    assert after.primary_content_hash == before.primary_content_hash
+    assert after.directory_hash != before.directory_hash
+
+
+def test_regular_file_tail_beyond_one_mebibyte_is_fully_hashed(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    payload = skill.parent / "payload.bin"
+    payload.write_bytes((b"a" * (1024 * 1024 + 17)) + b"first-tail")
+    before = _complete(skill, scope)
+
+    payload.write_bytes((b"a" * (1024 * 1024 + 17)) + b"other-tail")
+    after = _complete(skill, scope)
+
+    assert payload.stat().st_size > 1024 * 1024
+    assert after.directory_hash != before.directory_hash
+    assert after.primary_content_hash == before.primary_content_hash
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX executable mode is not portable to Windows")
+def test_executable_mode_change_changes_directory_hash(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    executable = skill.parent / "run.sh"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o644)
+    before = _complete(skill, scope)
+
+    executable.chmod(0o755)
+    after = _complete(skill, scope)
+
+    assert after.directory_hash != before.directory_hash
+    assert after.primary_content_hash == before.primary_content_hash
+
+
+def test_add_remove_and_rename_bind_every_relative_path(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    baseline = _complete(skill, scope)
+
+    added = skill.parent / "added.txt"
+    added.write_text("same bytes", encoding="utf-8")
+    with_file = _complete(skill, scope)
+    assert with_file.directory_hash != baseline.directory_hash
+
+    renamed = skill.parent / "renamed.txt"
+    added.rename(renamed)
+    after_rename = _complete(skill, scope)
+    assert after_rename.directory_hash != with_file.directory_hash
+
+    renamed.unlink()
+    after_remove = _complete(skill, scope)
+    assert after_remove.directory_hash == baseline.directory_hash
+
+
+def test_empty_files_and_directories_are_identity_entries(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    baseline = _complete(skill, scope)
+
+    empty_file = skill.parent / "empty"
+    empty_file.touch()
+    with_empty_file = _complete(skill, scope)
+    assert with_empty_file.directory_hash != baseline.directory_hash
+    assert with_empty_file.entry_count == baseline.entry_count + 1
+    assert with_empty_file.total_bytes == baseline.total_bytes
+
+    empty_directory = skill.parent / "empty-directory"
+    empty_directory.mkdir()
+    with_both = _complete(skill, scope)
+    assert with_both.directory_hash != with_empty_file.directory_hash
+    assert with_both.entry_count == with_empty_file.entry_count + 1
+    assert with_both.total_bytes == with_empty_file.total_bytes
+
+    empty_file.unlink()
+    without_file = _complete(skill, scope)
+    assert without_file.directory_hash != with_both.directory_hash
+    empty_directory.rmdir()
+    assert _complete(skill, scope).directory_hash == baseline.directory_hash
+
+
+def test_changing_regular_file_to_directory_changes_entry_type_identity(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    node = skill.parent / "node"
+    node.touch()
+    as_file = _complete(skill, scope)
+
+    node.unlink()
+    node.mkdir()
+    as_directory = _complete(skill, scope)
+
+    assert as_directory.entry_count == as_file.entry_count
+    assert as_directory.total_bytes == as_file.total_bytes
+    assert as_directory.directory_hash != as_file.directory_hash
+
+
+def test_mtime_changes_do_not_change_content_identity(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    nested = skill.parent / "script.py"
+    nested.write_text("print('stable')\n", encoding="utf-8")
+    before = _complete(skill, scope)
+
+    metadata = nested.stat()
+    os.utime(
+        nested,
+        ns=(metadata.st_atime_ns + 1_000_000_000, metadata.st_mtime_ns + 2_000_000_000),
+    )
+    after = _complete(skill, scope)
+
+    assert after.directory_hash == before.directory_hash
+    assert after.primary_content_hash == before.primary_content_hash
+
+
+def test_directory_enumeration_order_does_not_change_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    for relative_path in ("z.txt", "a.txt", "nested/y.txt", "nested/b.txt"):
+        path = skill.parent / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(relative_path, encoding="utf-8")
+    baseline = _complete(skill, scope)
+    original_scandir = os.scandir
+
+    def reversed_scandir(path: os.PathLike[str] | str) -> object:
+        with original_scandir(path) as iterator:
+            return iter(reversed(list(iterator)))
+
+    monkeypatch.setattr(identity_module.os, "scandir", reversed_scandir)
+    reversed_identity = _complete(skill, scope)
+
+    assert reversed_identity.directory_hash == baseline.directory_hash
+    assert reversed_identity.primary_content_hash == baseline.primary_content_hash
+
+
+def test_unicode_names_are_normalized_to_nfc(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    decomposed_skill = _make_skill(scope, "decomposed")
+    composed_skill = _make_skill(scope, "composed")
+    (decomposed_skill.parent / "cafe\N{COMBINING ACUTE ACCENT}.txt").write_text(
+        "same",
+        encoding="utf-8",
+    )
+    (composed_skill.parent / "caf\N{LATIN SMALL LETTER E WITH ACUTE}.txt").write_text(
+        "same",
+        encoding="utf-8",
+    )
+
+    decomposed = _complete(decomposed_skill, scope)
+    composed = _complete(composed_skill, scope)
+
+    assert decomposed.directory_hash == composed.directory_hash
+
+
+def test_unicode_nfc_aliases_are_rejected_as_duplicate_paths(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    decomposed = skill.parent / "cafe\N{COMBINING ACUTE ACCENT}.txt"
+    composed = skill.parent / "caf\N{LATIN SMALL LETTER E WITH ACUTE}.txt"
+    decomposed.write_text("first", encoding="utf-8")
+    composed.write_text("second", encoding="utf-8")
+    names = {entry.name for entry in os.scandir(skill.parent)}
+    if decomposed.name not in names or composed.name not in names:
+        pytest.skip("filesystem aliases canonically equivalent Unicode names")
+
+    _incomplete(skill, scope, "duplicate_path")
+
+
+def test_casefold_colliding_paths_are_rejected(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    upper = skill.parent / "Runner.py"
+    lower = skill.parent / "runner.py"
+    upper.write_text("first", encoding="utf-8")
+    lower.write_text("second", encoding="utf-8")
+    names = {entry.name for entry in os.scandir(skill.parent)}
+    if upper.name not in names or lower.name not in names:
+        pytest.skip("filesystem aliases casefold-equivalent names")
+
+    _incomplete(skill, scope, "case_collision")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission semantics are required")
+def test_unreadable_regular_file_fails_closed(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    unreadable = skill.parent / "secret.txt"
+    unreadable.write_text("secret", encoding="utf-8")
+    unreadable.chmod(0)
+    try:
+        try:
+            descriptor = os.open(unreadable, os.O_RDONLY)
+        except PermissionError:
+            pass
+        else:
+            os.close(descriptor)
+            pytest.skip("current user can read mode-000 files")
+        _incomplete(skill, scope, "unreadable_entry")
+    finally:
+        unreadable.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO creation is unavailable")
+def test_special_file_fails_closed(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    fifo = skill.parent / "events.fifo"
+    try:
+        os.mkfifo(fifo)
+    except OSError as exc:
+        pytest.skip(f"FIFO creation unavailable: {exc}")
+
+    _incomplete(skill, scope, "special_file")

--- a/tests/test_guard_skill_directory_identity_discovery.py
+++ b/tests/test_guard_skill_directory_identity_discovery.py
@@ -1,0 +1,237 @@
+"""Discovery and deterministic race tests for skill-directory identity."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard import skill_directory_discovery as discovery_module
+from codex_plugin_scanner.guard import skill_directory_identity as identity_module
+from codex_plugin_scanner.guard.skill_directory_identity import (
+    SkillDirectoryIdentityLimits,
+    discover_skill_documents,
+)
+from tests.skill_directory_identity_test_support import (
+    incomplete_identity as _incomplete,
+)
+from tests.skill_directory_identity_test_support import (
+    make_skill as _make_skill,
+)
+from tests.skill_directory_identity_test_support import (
+    symlink_or_skip as _symlink_or_skip,
+)
+
+
+def test_discovery_reports_broken_and_looped_skill_roots(tmp_path: Path) -> None:
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    broken = skill_root / "broken"
+    loop = skill_root / "loop"
+    _symlink_or_skip(broken, "missing", directory=True)
+    _symlink_or_skip(loop, loop.name, directory=True)
+
+    discovery = discover_skill_documents(skill_root)
+
+    assert discovery.documents == ()
+    assert {issue.path: issue.failure_reason for issue in discovery.issues} == {
+        broken: "symlink_broken",
+        loop: "symlink_loop",
+    }
+
+
+def test_discovery_entry_and_depth_budgets_emit_typed_issues(tmp_path: Path) -> None:
+    skill_root = tmp_path / "skills"
+    (skill_root / "one").mkdir(parents=True)
+    (skill_root / "two").mkdir()
+
+    entry_limited = discover_skill_documents(
+        skill_root,
+        limits=SkillDirectoryIdentityLimits(max_entries=1),
+    )
+    depth_limited = discover_skill_documents(
+        skill_root,
+        limits=SkillDirectoryIdentityLimits(max_depth=0),
+    )
+
+    assert any(issue.failure_reason == "max_entries_exceeded" for issue in entry_limited.issues)
+    assert depth_limited.documents == ()
+    assert {issue.failure_reason for issue in depth_limited.issues} == {"max_depth_exceeded"}
+
+
+def test_discovery_unreadable_grouping_directory_emits_typed_issue(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill_root = tmp_path / "skills"
+    unreadable = skill_root / "unreadable"
+    unreadable.mkdir(parents=True)
+    original_scandir = discovery_module.os.scandir
+
+    def selective_scandir(path: Path):
+        if Path(path) == unreadable:
+            raise PermissionError("simulated unreadable grouping directory")
+        return original_scandir(path)
+
+    monkeypatch.setattr(discovery_module.os, "scandir", selective_scandir)
+
+    discovery = discover_skill_documents(skill_root)
+
+    assert discovery.documents == ()
+    assert len(discovery.issues) == 1
+    assert discovery.issues[0].path == unreadable
+    assert discovery.issues[0].failure_reason == "unreadable_entry"
+
+
+def test_discovery_iterator_failure_emits_typed_issue(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill_root = tmp_path / "skills"
+    skill_root.mkdir()
+    original_scandir = discovery_module.os.scandir
+
+    class FailingIterator:
+        def __iter__(self) -> FailingIterator:
+            return self
+
+        def __next__(self) -> object:
+            raise OSError("simulated late directory read failure")
+
+        def close(self) -> None:
+            return None
+
+    def failing_scandir(path: Path):
+        if path == skill_root:
+            return FailingIterator()
+        return original_scandir(path)
+
+    monkeypatch.setattr(discovery_module.os, "scandir", failing_scandir)
+
+    discovery = discover_skill_documents(skill_root)
+
+    assert discovery.documents == ()
+    assert len(discovery.issues) == 1
+    assert discovery.issues[0].path == skill_root
+    assert discovery.issues[0].failure_reason == "unreadable_entry"
+
+
+@pytest.mark.parametrize(
+    ("setup", "reason"),
+    [
+        ("missing-root", "root_missing"),
+        ("root-file", "root_not_directory"),
+        ("outside-scope", "symlink_escape"),
+    ],
+)
+def test_invalid_roots_fail_closed(tmp_path: Path, setup: str, reason: str) -> None:
+    scope = tmp_path / "scope"
+    scope.mkdir()
+    if setup == "missing-root":
+        skill = scope / "missing" / "SKILL.md"
+    elif setup == "root-file":
+        root_file = scope / "not-a-directory"
+        root_file.write_text("file", encoding="utf-8")
+        skill = root_file / "SKILL.md"
+    else:
+        skill = tmp_path / "outside" / "SKILL.md"
+
+    _incomplete(skill, scope, reason)
+
+
+def test_structure_added_between_collection_passes_is_detected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    original_collect = identity_module._collect_entries
+    calls = 0
+
+    def mutating_collect(
+        root: Path,
+        *,
+        limits: SkillDirectoryIdentityLimits,
+    ) -> tuple[list[identity_module._TreeEntry], tuple[tuple[object, ...], ...]]:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            (root / "late-addition.txt").write_text("late", encoding="utf-8")
+        return original_collect(root, limits=limits)
+
+    monkeypatch.setattr(identity_module, "_collect_entries", mutating_collect)
+
+    _incomplete(skill, scope, "tree_changed_during_hash")
+    assert calls == 2
+
+
+def test_root_replaced_after_final_collection_is_detected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    original_collect = identity_module._collect_entries
+    calls = 0
+
+    def replacing_collect(
+        root: Path,
+        *,
+        limits: SkillDirectoryIdentityLimits,
+    ) -> tuple[list[identity_module._TreeEntry], tuple[tuple[object, ...], ...]]:
+        nonlocal calls
+        calls += 1
+        result = original_collect(root, limits=limits)
+        if calls == 2:
+            original_root = root.with_name(f"{root.name}-original")
+            root.rename(original_root)
+            root.mkdir()
+            (root / "SKILL.md").write_text("replacement\n", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(identity_module, "_collect_entries", replacing_collect)
+
+    _incomplete(skill, scope, "tree_changed_during_hash")
+    assert calls == 2
+
+
+def test_symlink_retargeted_while_target_is_hashed_is_detected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    first = skill.parent / "first.txt"
+    second = skill.parent / "second.txt"
+    first.write_text("first", encoding="utf-8")
+    second.write_text("second", encoding="utf-8")
+    alias = skill.parent / "alias.txt"
+    _symlink_or_skip(alias, first.name)
+    original_hash = identity_module._hash_regular_file
+    retargeted = False
+
+    def retargeting_hash(
+        path: Path,
+        *,
+        expected_metadata: os.stat_result,
+        limits: SkillDirectoryIdentityLimits,
+        state: identity_module._InspectionState,
+    ) -> tuple[str, int]:
+        nonlocal retargeted
+        result = original_hash(
+            path,
+            expected_metadata=expected_metadata,
+            limits=limits,
+            state=state,
+        )
+        if path == first and not retargeted:
+            alias.unlink()
+            alias.symlink_to(second.name)
+            retargeted = True
+        return result
+
+    monkeypatch.setattr(identity_module, "_hash_regular_file", retargeting_hash)
+
+    _incomplete(skill, scope, "tree_changed_during_hash")
+    assert retargeted is True

--- a/tests/test_guard_skill_directory_identity_downstream.py
+++ b/tests/test_guard_skill_directory_identity_downstream.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.gemini import GeminiHarnessAdapter
+from codex_plugin_scanner.guard.aibom_content_upload import (
+    primary_content_sources_from_artifacts,
+    upload_primary_content_sources,
+)
+from codex_plugin_scanner.guard.inventory_contract import (
+    extract_aibom_metadata_extensions,
+    inventory_snapshot_from_detection,
+)
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+
+
+def _sha256(body: bytes) -> str:
+    return hashlib.sha256(body).hexdigest()
+
+
+def _complete_metadata(*, primary_hash: str, directory_hash: str) -> dict[str, object]:
+    return {
+        "content_hash": primary_hash,
+        "directory_hash": directory_hash,
+        "skillDirectoryIdentity": {
+            "schemaVersion": "guard.skill-directory-identity.v1",
+            "status": "complete",
+            "contentHash": directory_hash,
+            "entryCount": 3,
+            "totalBytes": 41,
+            "reusable": True,
+        },
+        "versionInfo": {
+            "hashBasis": "skill-directory-v1",
+            "contentHash": directory_hash,
+        },
+    }
+
+
+def _skill_detection(
+    skill_path: Path,
+    *,
+    metadata: dict[str, object],
+    harness: str = "gemini",
+) -> HarnessDetection:
+    artifact = GuardArtifact(
+        artifact_id=f"{harness}:skill:review",
+        name="review",
+        harness=harness,
+        artifact_type="skill",
+        source_scope="global",
+        config_path=str(skill_path),
+        metadata=metadata,
+    )
+    return HarnessDetection(
+        harness=harness,
+        installed=True,
+        command_available=False,
+        config_paths=(str(skill_path),),
+        artifacts=(artifact,),
+    )
+
+
+def test_inventory_uses_complete_directory_hash_but_keeps_primary_evidence(tmp_path: Path) -> None:
+    skill_path = tmp_path / ".gemini" / "skills" / "review" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    body = b"# Review\nUse the complete bundle.\n"
+    skill_path.write_bytes(body)
+    primary_hash = _sha256(body)
+    directory_hash = _sha256(b"canonical full directory stream")
+    detection = _skill_detection(
+        skill_path,
+        metadata=_complete_metadata(
+            primary_hash=primary_hash,
+            directory_hash=directory_hash,
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-07-19T00:00:00Z",
+        home_dir=tmp_path,
+    )
+    item = snapshot.items[0]
+    evidence = item.metadata["contentEvidence"]
+
+    assert item.content_hash == f"sha256:{directory_hash}"
+    assert item.metadata["primaryContentHash"] == f"sha256:{primary_hash}"
+    assert isinstance(evidence, dict)
+    assert evidence["contentHash"] == f"sha256:{primary_hash}"
+    assert (
+        extract_aibom_metadata_extensions(item.metadata)["skillDirectoryIdentity"]
+        == (item.metadata["skillDirectoryIdentity"])
+    )
+
+
+def test_inventory_snapshot_tracks_secondary_identity_and_is_time_stable(tmp_path: Path) -> None:
+    skill_path = tmp_path / ".gemini" / "skills" / "review" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    body = b"# Review\n"
+    skill_path.write_bytes(body)
+    primary_hash = _sha256(body)
+    first_directory_hash = _sha256(b"scripts/check.py:first")
+    first_detection = _skill_detection(
+        skill_path,
+        metadata=_complete_metadata(
+            primary_hash=primary_hash,
+            directory_hash=first_directory_hash,
+        ),
+    )
+
+    first = inventory_snapshot_from_detection(
+        first_detection,
+        generated_at="2026-07-19T00:00:00Z",
+        home_dir=tmp_path,
+    )
+    replayed = inventory_snapshot_from_detection(
+        first_detection,
+        generated_at="2026-07-19T01:00:00Z",
+        home_dir=tmp_path,
+    )
+    second_directory_hash = _sha256(b"scripts/check.py:second")
+    changed = inventory_snapshot_from_detection(
+        _skill_detection(
+            skill_path,
+            metadata=_complete_metadata(
+                primary_hash=primary_hash,
+                directory_hash=second_directory_hash,
+            ),
+        ),
+        generated_at="2026-07-19T02:00:00Z",
+        home_dir=tmp_path,
+    )
+
+    assert replayed.snapshot_id == first.snapshot_id
+    assert replayed.items[0].content_hash == first.items[0].content_hash
+    assert changed.snapshot_id != first.snapshot_id
+    assert changed.items[0].content_hash == f"sha256:{second_directory_hash}"
+    assert changed.items[0].metadata["primaryContentHash"] == first.items[0].metadata["primaryContentHash"]
+
+
+def test_unchanged_incomplete_skill_has_stable_snapshot_identity(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    skill_dir = home_dir / ".gemini" / "skills" / "review"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Review\n", encoding="utf-8")
+    try:
+        (skill_dir / "broken-reference").symlink_to("missing.md")
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+    context = HarnessContext(home_dir=home_dir, workspace_dir=None, guard_home=tmp_path / "guard")
+
+    first_detection = GeminiHarnessAdapter().detect(context)
+    second_detection = GeminiHarnessAdapter().detect(context)
+    first = inventory_snapshot_from_detection(
+        first_detection,
+        generated_at="2026-07-19T00:00:00Z",
+        home_dir=home_dir,
+    )
+    second = inventory_snapshot_from_detection(
+        second_detection,
+        generated_at="2026-07-19T00:00:00Z",
+        home_dir=home_dir,
+    )
+
+    assert first.snapshot_id == second.snapshot_id
+    assert first.items[0].content_hash == second.items[0].content_hash
+    assert first.items[0].metadata["skillDirectoryIdentity"] == second.items[0].metadata["skillDirectoryIdentity"]
+
+
+def test_symlinked_primary_is_nonreusable_and_not_uploadable(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    skill_dir = home_dir / ".gemini" / "skills" / "review"
+    skill_dir.mkdir(parents=True)
+    body = skill_dir / "BODY.md"
+    body.write_text("# Review\n", encoding="utf-8")
+    primary = skill_dir / "SKILL.md"
+    try:
+        primary.symlink_to(body.name)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+    context = HarnessContext(home_dir=home_dir, workspace_dir=None, guard_home=tmp_path / "guard")
+
+    detection = GeminiHarnessAdapter().detect(context)
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-07-19T00:00:00Z",
+        home_dir=home_dir,
+    )
+    sources = primary_content_sources_from_artifacts(
+        detection.artifacts,
+        snapshot,
+        workspace_dir=None,
+    )
+    identity = detection.artifacts[0].metadata["skillDirectoryIdentity"]
+
+    assert isinstance(identity, dict)
+    assert identity["status"] == "incomplete"
+    assert identity["reason"] == "primary_symlink_unsupported"
+    assert "primaryContentHash" not in snapshot.items[0].metadata
+    assert sources == ()
+
+
+def test_inventory_does_not_promote_incomplete_or_malformed_directory_claim(tmp_path: Path) -> None:
+    skill_path = tmp_path / ".gemini" / "skills" / "review" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    body = b"# Review\n"
+    skill_path.write_bytes(body)
+    primary_hash = _sha256(body)
+    directory_hash = _sha256(b"partial walk")
+    metadata = _complete_metadata(primary_hash=primary_hash, directory_hash=directory_hash)
+    identity = metadata["skillDirectoryIdentity"]
+    assert isinstance(identity, dict)
+    identity.update({"status": "incomplete", "reusable": False, "reason": "entry_limit"})
+
+    incomplete = inventory_snapshot_from_detection(
+        _skill_detection(skill_path, metadata=metadata),
+        generated_at="2026-07-19T00:00:00Z",
+        home_dir=tmp_path,
+    )
+    mismatched_metadata = _complete_metadata(
+        primary_hash=primary_hash,
+        directory_hash=directory_hash,
+    )
+    mismatched_identity = mismatched_metadata["skillDirectoryIdentity"]
+    assert isinstance(mismatched_identity, dict)
+    mismatched_identity["contentHash"] = _sha256(b"different claim")
+    mismatched = inventory_snapshot_from_detection(
+        _skill_detection(skill_path, metadata=mismatched_metadata),
+        generated_at="2026-07-19T00:00:00Z",
+        home_dir=tmp_path,
+    )
+
+    assert incomplete.items[0].content_hash == f"sha256:{primary_hash}"
+    assert mismatched.items[0].content_hash == f"sha256:{primary_hash}"
+    assert incomplete.items[0].content_hash != f"sha256:{directory_hash}"
+    assert "directory_hash" not in incomplete.items[0].metadata
+    assert "directory_hash" not in mismatched.items[0].metadata
+
+
+def test_unmigrated_hermes_skill_keeps_primary_only_inventory_identity(tmp_path: Path) -> None:
+    skill_path = tmp_path / ".hermes" / "skills" / "ops" / "review" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    body = b"# Hermes review\n"
+    skill_path.write_bytes(body)
+    detection = _skill_detection(
+        skill_path,
+        harness="hermes",
+        metadata={"content_hash": _sha256(body)},
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-07-19T00:00:00Z",
+        home_dir=tmp_path,
+    )
+
+    assert snapshot.items[0].content_hash == f"sha256:{_sha256(body)}"
+    assert "skillDirectoryIdentity" not in snapshot.items[0].metadata
+
+
+def test_primary_upload_uses_exact_skill_document_not_directory_identity(tmp_path: Path) -> None:
+    skill_path = tmp_path / ".gemini" / "skills" / "review" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    # Deliberately exceeds the 256 KiB analysis preview while remaining below
+    # the primary-content uploader's 1 MiB body limit.
+    body = b"# Review\n" + (b"A" * (300 * 1024))
+    skill_path.write_bytes(body)
+    primary_hash = _sha256(body)
+    directory_hash = _sha256(b"directory stream including scripts and mode bits")
+    detection = _skill_detection(
+        skill_path,
+        metadata=_complete_metadata(
+            primary_hash=primary_hash,
+            directory_hash=directory_hash,
+        ),
+    )
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-07-19T00:00:00Z",
+        home_dir=tmp_path,
+    )
+    sources = primary_content_sources_from_artifacts(
+        detection.artifacts,
+        snapshot,
+        workspace_dir=None,
+    )
+    requests: list[bytes] = []
+
+    def guard_sync_request(_auth_context, *, data, **_kwargs):
+        requests.append(data)
+        return SimpleNamespace(data=data)
+
+    runner = SimpleNamespace(
+        _guard_sync_request=guard_sync_request,
+        _urlopen_json_with_timeout_retry=lambda **_kwargs: {
+            "storedCount": 1,
+            "hashOnlyCount": 0,
+            "failedCount": 0,
+        },
+    )
+
+    summary, _auth = upload_primary_content_sources(
+        object(),
+        runner,
+        {"sync_url": "https://hol.test/api/v1/guard/events"},
+        sources=sources,
+        workspace_id="workspace-1",
+    )
+    payload = json.loads(requests[0])
+    uploaded = payload["items"][0]
+
+    assert snapshot.items[0].content_hash == f"sha256:{directory_hash}"
+    assert sources[0].content_hash == f"sha256:{primary_hash}"
+    assert uploaded["contentHash"] == f"sha256:{primary_hash}"
+    assert base64.b64decode(uploaded["bodyBase64"]) == body
+    assert summary["stored"] == 1

--- a/tests/test_guard_skill_directory_identity_links.py
+++ b/tests/test_guard_skill_directory_identity_links.py
@@ -1,0 +1,246 @@
+"""Link-policy and resource-limit tests for skill-directory identities."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.skill_directory_identity import (
+    SKILL_DIRECTORY_IDENTITY_SCHEMA,
+    SkillDirectoryIdentityLimits,
+    inspect_skill_directory,
+    skill_directory_identity_metadata,
+)
+from tests.skill_directory_identity_test_support import (
+    complete_identity as _complete,
+)
+from tests.skill_directory_identity_test_support import (
+    incomplete_identity as _incomplete,
+)
+from tests.skill_directory_identity_test_support import (
+    make_skill as _make_skill,
+)
+from tests.skill_directory_identity_test_support import (
+    symlink_or_skip as _symlink_or_skip,
+)
+
+
+def test_in_tree_regular_file_symlink_binds_target_and_raw_spelling(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    first = skill.parent / "first.py"
+    second = skill.parent / "second.py"
+    first.write_text("same target bytes", encoding="utf-8")
+    second.write_text("same target bytes", encoding="utf-8")
+    alias = skill.parent / "alias.py"
+    _symlink_or_skip(alias, first.name)
+    first_identity = _complete(skill, scope)
+
+    alias.unlink()
+    _symlink_or_skip(alias, second.name)
+    retargeted = _complete(skill, scope)
+    assert retargeted.directory_hash != first_identity.directory_hash
+    assert retargeted.primary_content_hash == first_identity.primary_content_hash
+
+    alias.unlink()
+    _symlink_or_skip(alias, f"./{second.name}")
+    respelled = _complete(skill, scope)
+    assert respelled.directory_hash != retargeted.directory_hash
+
+    second.write_text("changed target bytes", encoding="utf-8")
+    changed_target = _complete(skill, scope)
+    assert changed_target.directory_hash != respelled.directory_hash
+
+
+def test_primary_document_symlink_is_rejected_even_when_target_is_in_tree(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill_dir = scope / "review"
+    skill_dir.mkdir(parents=True)
+    body = skill_dir / "BODY.md"
+    body.write_text("# Review\n", encoding="utf-8")
+    primary = skill_dir / "SKILL.md"
+    _symlink_or_skip(primary, body.name)
+
+    _incomplete(primary, scope, "primary_symlink_unsupported")
+
+
+def test_broken_nested_symlink_fails_closed(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    _symlink_or_skip(skill.parent / "broken", "missing-target")
+
+    _incomplete(skill, scope, "symlink_broken")
+
+
+def test_nested_symlink_loop_fails_closed(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    first = skill.parent / "first"
+    second = skill.parent / "second"
+    _symlink_or_skip(first, second.name)
+    _symlink_or_skip(second, first.name)
+
+    _incomplete(skill, scope, "symlink_loop")
+
+
+def test_nested_symlink_cannot_escape_skill_even_within_scope(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    outside_skill = scope / "shared.py"
+    outside_skill.write_text("outside", encoding="utf-8")
+    _symlink_or_skip(skill.parent / "escape.py", Path("..") / outside_skill.name)
+
+    _incomplete(skill, scope, "symlink_escape")
+
+
+def test_nested_directory_symlink_is_rejected(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    real_directory = skill.parent / "real-directory"
+    real_directory.mkdir()
+    (real_directory / "nested.txt").write_text("nested", encoding="utf-8")
+    _symlink_or_skip(skill.parent / "directory-link", real_directory.name, directory=True)
+
+    _incomplete(skill, scope, "symlink_directory_unsupported")
+
+
+def test_root_symlink_within_scope_is_rejected_consistently(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    first_skill = _make_skill(scope, "first-real")
+    link = scope / "linked-skill"
+    _symlink_or_skip(link, first_skill.parent.name, directory=True)
+    linked_primary = link / "SKILL.md"
+
+    _incomplete(linked_primary, scope, "symlink_directory_unsupported")
+
+
+def test_root_symlink_outside_scope_fails_closed(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    scope.mkdir()
+    outside_skill = _make_skill(tmp_path / "outside-scope")
+    link = scope / "linked-skill"
+    _symlink_or_skip(link, outside_skill.parent, directory=True)
+
+    _incomplete(link / "SKILL.md", scope, "symlink_directory_unsupported")
+
+
+def test_symlinked_parent_directory_is_rejected(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    real_parent = scope / "real-parent"
+    skill = _make_skill(real_parent)
+    parent_link = scope / "parent-link"
+    _symlink_or_skip(parent_link, real_parent.name, directory=True)
+
+    _incomplete(parent_link / skill.parent.name / "SKILL.md", scope, "symlink_directory_unsupported")
+
+
+def test_limits_allow_exact_boundaries(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    nested = skill.parent / "nested" / "payload.bin"
+    nested.parent.mkdir()
+    nested.write_bytes(b"12345")
+    total_bytes = len(skill.read_bytes()) + len(nested.read_bytes())
+    limits = SkillDirectoryIdentityLimits(
+        max_depth=2,
+        max_entries=3,
+        max_file_bytes=max(len(skill.read_bytes()), len(nested.read_bytes())),
+        max_total_bytes=total_bytes,
+    )
+
+    identity = _complete(skill, scope, limits=limits)
+
+    assert identity.entry_count == 3
+    assert identity.total_bytes == total_bytes
+
+
+def test_max_depth_limit_fails_closed(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    nested = skill.parent / "level-one" / "level-two.txt"
+    nested.parent.mkdir()
+    nested.write_text("nested", encoding="utf-8")
+    limits = SkillDirectoryIdentityLimits(max_depth=1)
+
+    _incomplete(skill, scope, "max_depth_exceeded", limits=limits)
+
+
+def test_max_entry_count_limit_fails_closed(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    (skill.parent / "extra.txt").write_text("extra", encoding="utf-8")
+    limits = SkillDirectoryIdentityLimits(max_entries=1)
+
+    _incomplete(skill, scope, "max_entries_exceeded", limits=limits)
+
+
+def test_max_per_file_byte_limit_fails_closed(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    primary_bytes = skill.read_bytes()
+    limits = SkillDirectoryIdentityLimits(max_file_bytes=len(primary_bytes) - 1)
+
+    _incomplete(skill, scope, "max_file_bytes_exceeded", limits=limits)
+
+
+def test_max_total_byte_limit_fails_closed(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+    extra = skill.parent / "extra.txt"
+    extra.write_bytes(b"extra bytes")
+    limits = SkillDirectoryIdentityLimits(
+        max_file_bytes=1024,
+        max_total_bytes=len(skill.read_bytes()) + len(extra.read_bytes()) - 1,
+    )
+
+    identity = _incomplete(skill, scope, "max_total_bytes_exceeded", limits=limits)
+    assert identity.primary_content_hash is not None
+
+
+@pytest.mark.parametrize(
+    "limits",
+    [
+        SkillDirectoryIdentityLimits(max_depth=-1),
+        SkillDirectoryIdentityLimits(max_entries=-1),
+        SkillDirectoryIdentityLimits(max_file_bytes=-1),
+        SkillDirectoryIdentityLimits(max_total_bytes=-1),
+        SkillDirectoryIdentityLimits(max_depth=True),
+    ],
+)
+def test_invalid_limits_are_rejected(limits: SkillDirectoryIdentityLimits, tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    skill = _make_skill(scope)
+
+    with pytest.raises(ValueError, match="non-negative integers"):
+        inspect_skill_directory(skill, scope_root=scope, limits=limits)
+
+
+def test_incomplete_identity_has_stable_state_hash_and_nonreusable_metadata(tmp_path: Path) -> None:
+    scope = tmp_path / "scope"
+    root = scope / "missing-primary"
+    root.mkdir(parents=True)
+    (root / "README.md").write_text("not a skill", encoding="utf-8")
+    skill = root / "SKILL.md"
+
+    first = _incomplete(skill, scope, "primary_missing")
+    second = _incomplete(skill, scope, "primary_missing")
+
+    assert first.incomplete_state_hash == second.incomplete_state_hash
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", first.incomplete_state_hash or "")
+    first_metadata = skill_directory_identity_metadata(first, version_label="Codex skill")
+    second_metadata = skill_directory_identity_metadata(second, version_label="Codex skill")
+    first_envelope = first_metadata["skillDirectoryIdentity"]
+    assert isinstance(first_envelope, dict)
+    assert first_envelope == {
+        "schemaVersion": SKILL_DIRECTORY_IDENTITY_SCHEMA,
+        "status": "incomplete",
+        "entryCount": 1,
+        "totalBytes": 0,
+        "reusable": False,
+        "reason": "primary_missing",
+        "incompleteStateHash": first.incomplete_state_hash,
+    }
+    assert "directory_hash" not in first_metadata
+    assert first_metadata["versionInfo"] == second_metadata["versionInfo"]

--- a/tests/test_guard_skill_document_evidence.py
+++ b/tests/test_guard_skill_document_evidence.py
@@ -315,7 +315,7 @@ def test_skill_types_do_not_claim_observed_file_reading() -> None:
 def test_rejected_document_evidence_is_preserved_without_capabilities(
     readability_status: str,
 ) -> None:
-    metadata = {
+    metadata: dict[str, object] = {
         "contentEvidence": {"readabilityStatus": readability_status},
         "documentedCapabilities": [{"capability": "network_egress"}],
     }
@@ -326,22 +326,16 @@ def test_rejected_document_evidence_is_preserved_without_capabilities(
 
 
 def test_unbound_document_evidence_is_removed_before_inventory_serialization() -> None:
-    metadata = {
+    metadata: dict[str, object] = {
         "contentEvidence": {"contentHash": "sha256:first"},
         "documentedCapabilities": [{"capability": "network_egress"}],
     }
 
-    assert (
-        _bind_skill_document_evidence(
-            metadata,
-            primary_content_hash="sha256:second",
-        )
-        == {}
-    )
-    assert (
-        _bind_skill_document_evidence(
-            metadata,
-            primary_content_hash="sha256:first",
-        )
-        == metadata
-    )
+    assert _bind_skill_document_evidence(
+        metadata,
+        primary_content_hash="sha256:second",
+    ) == {"primaryContentHash": "sha256:second"}
+    assert _bind_skill_document_evidence(
+        metadata,
+        primary_content_hash="sha256:first",
+    ) == {**metadata, "primaryContentHash": "sha256:first"}

--- a/tests/test_guard_windows_locked_file.py
+++ b/tests/test_guard_windows_locked_file.py
@@ -1,0 +1,188 @@
+"""Native Windows handle tests for immutable skill-file hashing."""
+
+from __future__ import annotations
+
+import ctypes
+import types
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard import windows_paths as windows_paths_module
+
+
+class _FakeWindowsFunction:
+    def __init__(self, implementation: object) -> None:
+        self._implementation = implementation
+
+    def __call__(self, *arguments: object) -> object:
+        assert callable(self._implementation)
+        return self._implementation(*arguments)
+
+
+def _fake_kernel32(
+    *,
+    attributes: int,
+    create_arguments: list[tuple[object, ...]],
+    closed_handles: list[object],
+    create_handles: list[int] | None = None,
+) -> object:
+    def create_file(*arguments: object) -> int:
+        create_arguments.append(arguments)
+        return create_handles.pop(0) if create_handles else 71
+
+    def get_information(_handle: object, information_pointer: ctypes.c_void_p) -> int:
+        information = ctypes.cast(
+            information_pointer,
+            ctypes.POINTER(windows_paths_module._WindowsByHandleFileInformation),
+        ).contents
+        information.dwFileAttributes = attributes
+        return 1
+
+    def close_handle(handle: object) -> int:
+        closed_handles.append(handle)
+        return 1
+
+    return types.SimpleNamespace(
+        CreateFileW=_FakeWindowsFunction(create_file),
+        GetFileInformationByHandle=_FakeWindowsFunction(get_information),
+        CloseHandle=_FakeWindowsFunction(close_handle),
+    )
+
+
+def _configure_windows_api(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    attributes: int,
+    open_osfhandle: object,
+    create_arguments: list[tuple[object, ...]],
+    closed_handles: list[object],
+    create_handles: list[int] | None = None,
+) -> None:
+    kernel32 = _fake_kernel32(
+        attributes=attributes,
+        create_arguments=create_arguments,
+        closed_handles=closed_handles,
+        create_handles=create_handles,
+    )
+    fake_msvcrt = types.SimpleNamespace(open_osfhandle=open_osfhandle)
+    monkeypatch.setattr(windows_paths_module.os, "name", "nt")
+    monkeypatch.setattr(
+        windows_paths_module.ctypes,
+        "WinDLL",
+        lambda *_args, **_kwargs: kernel32,
+        raising=False,
+    )
+    monkeypatch.setattr(windows_paths_module.importlib, "import_module", lambda _name: fake_msvcrt)
+
+
+def test_windows_locked_descriptor_excludes_write_and_delete_sharing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = Path("C:/Guard/SKILL.md")
+    create_arguments: list[tuple[object, ...]] = []
+    closed_handles: list[object] = []
+    converted_handles: list[int] = []
+
+    def open_osfhandle(handle: int, _flags: int) -> int:
+        converted_handles.append(handle)
+        return 83
+
+    _configure_windows_api(
+        monkeypatch,
+        attributes=0x20,
+        open_osfhandle=open_osfhandle,
+        create_arguments=create_arguments,
+        closed_handles=closed_handles,
+    )
+
+    descriptor = windows_paths_module.open_windows_locked_regular_descriptor(path)
+
+    assert descriptor == 83
+    assert converted_handles == [71]
+    assert closed_handles == []
+    desired_access = create_arguments[0][1]
+    share_mode = create_arguments[0][2]
+    flags = create_arguments[0][5]
+    assert isinstance(desired_access, int)
+    assert isinstance(share_mode, int)
+    assert isinstance(flags, int)
+    assert desired_access == windows_paths_module._WINDOWS_GENERIC_READ
+    assert share_mode == windows_paths_module._WINDOWS_FILE_SHARE_READ
+    assert not share_mode & 0x2
+    assert not share_mode & 0x4
+    assert flags & windows_paths_module._WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT
+
+
+def test_windows_locked_descriptor_rejects_reparse_and_closes_handle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = Path("C:/Guard/SKILL.md")
+    create_arguments: list[tuple[object, ...]] = []
+    closed_handles: list[object] = []
+
+    def forbidden_conversion(_handle: int, _flags: int) -> int:
+        raise AssertionError("a reparse point must not become a CRT descriptor")
+
+    _configure_windows_api(
+        monkeypatch,
+        attributes=windows_paths_module._FILE_ATTRIBUTE_REPARSE_POINT,
+        open_osfhandle=forbidden_conversion,
+        create_arguments=create_arguments,
+        closed_handles=closed_handles,
+    )
+
+    with pytest.raises(OSError, match="windows_locked_file_not_regular"):
+        windows_paths_module.open_windows_locked_regular_descriptor(path)
+
+    assert closed_handles == [71]
+
+
+def test_windows_locked_descriptor_closes_handle_when_conversion_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = Path("C:/Guard/SKILL.md")
+    create_arguments: list[tuple[object, ...]] = []
+    closed_handles: list[object] = []
+
+    def failed_conversion(_handle: int, _flags: int) -> int:
+        raise OSError("conversion failed")
+
+    _configure_windows_api(
+        monkeypatch,
+        attributes=0x20,
+        open_osfhandle=failed_conversion,
+        create_arguments=create_arguments,
+        closed_handles=closed_handles,
+    )
+
+    with pytest.raises(OSError, match="conversion failed"):
+        windows_paths_module.open_windows_locked_regular_descriptor(path)
+
+    assert closed_handles == [71]
+
+
+def test_windows_locked_descriptor_retries_transient_sharing_violation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = Path("C:/Guard/SKILL.md")
+    create_arguments: list[tuple[object, ...]] = []
+    closed_handles: list[object] = []
+    retry_delays: list[float] = []
+    invalid_handle = ctypes.c_void_p(-1).value
+    assert isinstance(invalid_handle, int)
+    _configure_windows_api(
+        monkeypatch,
+        attributes=0x20,
+        open_osfhandle=lambda _handle, _flags: 83,
+        create_arguments=create_arguments,
+        closed_handles=closed_handles,
+        create_handles=[invalid_handle, 71],
+    )
+    monkeypatch.setattr(windows_paths_module.ctypes, "get_last_error", lambda: 32, raising=False)
+    monkeypatch.setattr(windows_paths_module.time, "sleep", retry_delays.append)
+
+    assert windows_paths_module.open_windows_locked_regular_descriptor(path) == 83
+    assert len(create_arguments) == 2
+    assert retry_delays == [windows_paths_module._WINDOWS_LOCK_RETRY_SECONDS]
+    assert closed_handles == []


### PR DESCRIPTION
## Summary

- Replace primary-document-only skill identity with the shared `guard.skill-directory-identity.v1` contract for Gemini, Antigravity, and shared Codex/AIBOM discovery.
- Bind approvals, inventory, snapshots, and version metadata to every accepted path, entry type, digest, security-relevant mode, empty entry, and accepted secondary-file symlink target.
- Make incomplete discovery explicit and non-reusable while keeping a stable incomplete-state hash.
- Keep the primary `SKILL.md` upload identity separate from the directory-wide item hash.
- Replay the fix directly on `release/2.1` with corrected GitHub author and committer attribution.

## Canonical identity and limits

The SHA-256 stream is canonical JSON Lines ordered by NFC-normalized UTF-8 relative path. It excludes mtime, inode, device number, and enumeration order. Complete envelopes require the same digest in `skillDirectoryIdentity.contentHash`, `directory_hash`, and `versionInfo.contentHash`.

Default ceilings are 32 path components, 4,096 entries, 128 MiB per regular file, and 256 MiB total bytes. Directory/root links and a symlinked primary `SKILL.md` are non-reusable. Broken links, loops, escapes, special files, reparse ambiguity, collisions, unreadable entries, limit failures, and observed tree changes fail closed.

## Validation

- Complete changed-test matrix after the `release/2.1` replay: 148 passed, 3 expected filesystem skips.
- Earlier focused Python 3.12 and 3.10 matrices each passed 187 tests with 2 expected filesystem skips.
- Ruff, formatting, basedpyright, CI YAML/diff checks, wheel, and source distribution checks passed.
