### PR TITLE
feat(mdm): add observer adapter conformance kit

### DIFF
--- a/docs/guard/observer-adapter-conformance.md
+++ b/docs/guard/observer-adapter-conformance.md
@@ -17,4 +17,6 @@ The adapter receives bounded dictionaries and must return one of three outcomes:
 
 The deterministic suite covers a current observation, positive clock skew, replay and duplicate idempotency, partial detection data, mapping collision, and provider outage. It verifies fixture identity binding, detection fidelity, the independent observer authority, Ed25519 signature validity, absence of fabricated remediation state, stable duplicate output, and a replay digest.
 
+Adapter code and returned objects are untrusted. The harness gives each invocation an isolated fixture copy, retains an independent expected fixture, snapshots every returned result before the next call, and compares duplicate outputs only after both individual assertions pass validation. Mutation, aliasing, recursive/invalid objects, and exceptions produce bounded failed results; they cannot rewrite expected evidence, satisfy duplicate idempotency, or crash the conformance run.
+
 The bundled key is test-only. Production adapters must use their own independently managed observer signing credential and register only its public key with Guard Cloud. Passing this kit proves protocol conformance; it does not replace real managed-device or vendor certification.

--- a/docs/guard/observer-adapter-conformance.md
+++ b/docs/guard/observer-adapter-conformance.md
@@ -1,0 +1,20 @@
+# Observer adapter conformance kit
+
+HOL Guard's observer boundary is vendor-neutral. MDM, EDR, RMM, and partner adapters can run the same in-process conformance kit before certification:
+
+```python
+from codex_plugin_scanner.guard.mdm import run_observer_adapter_conformance
+
+report = run_observer_adapter_conformance("vendor-adapter-v1", adapter.observe)
+assert report.passed, report.results
+```
+
+The adapter receives bounded dictionaries and must return one of three outcomes:
+
+- `observed` with a strict, signed `observer-assertion.v1` object;
+- `collision` with `mappingStatus=ambiguous` and no assertion;
+- `outage` with `errorCode=provider_unavailable` and no fabricated assertion.
+
+The deterministic suite covers a current observation, positive clock skew, replay and duplicate idempotency, partial detection data, mapping collision, and provider outage. It verifies fixture identity binding, detection fidelity, the independent observer authority, Ed25519 signature validity, absence of fabricated remediation state, stable duplicate output, and a replay digest.
+
+The bundled key is test-only. Production adapters must use their own independently managed observer signing credential and register only its public key with Guard Cloud. Passing this kit proves protocol conformance; it does not replace real managed-device or vendor certification.

--- a/src/codex_plugin_scanner/guard/mdm/__init__.py
+++ b/src/codex_plugin_scanner/guard/mdm/__init__.py
@@ -12,6 +12,12 @@ from .contracts import (
 )
 from .integrity import machine_integrity_snapshot
 from .manifest import verify_release_manifest
+from .observer_conformance import (
+    observer_conformance_cases,
+    observer_conformance_public_key_base64,
+    run_observer_adapter_conformance,
+    sign_observer_assertion,
+)
 from .policy import apply_managed_policy, load_managed_policy
 from .supervisor import install_machine_supervisor, remove_machine_supervisor, verify_machine_supervisor
 
@@ -28,7 +34,11 @@ __all__ = [
     "install_machine_supervisor",
     "load_managed_policy",
     "machine_integrity_snapshot",
+    "observer_conformance_cases",
+    "observer_conformance_public_key_base64",
     "remove_machine_supervisor",
+    "run_observer_adapter_conformance",
+    "sign_observer_assertion",
     "verify_machine_supervisor",
     "verify_release_manifest",
 ]

--- a/src/codex_plugin_scanner/guard/mdm/observer_conformance.py
+++ b/src/codex_plugin_scanner/guard/mdm/observer_conformance.py
@@ -246,9 +246,11 @@ def run_observer_adapter_conformance(adapter_id: str, adapter: ObserverAdapter) 
         result, output = _run_case(adapter, case)
         results.append(result)
         outputs[case.case_id] = copy.deepcopy(output)
-    duplicate_a = outputs["duplicate-a"].get("assertion")
-    duplicate_b = outputs["duplicate-b"].get("assertion")
-    duplicate_valid = duplicate_a == duplicate_b and isinstance(duplicate_a, dict)
+    case_passed = {result.case_id: result.passed for result in results}
+    duplicate_cases_valid = case_passed["duplicate-a"] and case_passed["duplicate-b"]
+    duplicate_a = outputs["duplicate-a"].get("assertion") if duplicate_cases_valid else None
+    duplicate_b = outputs["duplicate-b"].get("assertion") if duplicate_cases_valid else None
+    duplicate_valid = duplicate_cases_valid and isinstance(duplicate_a, dict) and duplicate_a == duplicate_b
     results.append(
         ObserverConformanceResult(
             "duplicate-idempotency",

--- a/src/codex_plugin_scanner/guard/mdm/observer_conformance.py
+++ b/src/codex_plugin_scanner/guard/mdm/observer_conformance.py
@@ -245,7 +245,7 @@ def run_observer_adapter_conformance(adapter_id: str, adapter: ObserverAdapter) 
     for case in observer_conformance_cases(adapter_id):
         result, output = _run_case(adapter, case)
         results.append(result)
-        outputs[case.case_id] = output
+        outputs[case.case_id] = copy.deepcopy(output)
     duplicate_a = outputs["duplicate-a"].get("assertion")
     duplicate_b = outputs["duplicate-b"].get("assertion")
     duplicate_valid = duplicate_a == duplicate_b and isinstance(duplicate_a, dict)

--- a/src/codex_plugin_scanner/guard/mdm/observer_conformance.py
+++ b/src/codex_plugin_scanner/guard/mdm/observer_conformance.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import copy
 import hashlib
 import json
 import re
@@ -200,8 +201,10 @@ def _run_case(
     adapter: ObserverAdapter,
     case: ObserverConformanceCase,
 ) -> tuple[ObserverConformanceResult, AdapterResult]:
+    expected_fixture = copy.deepcopy(case.fixture)
+    adapter_fixture = copy.deepcopy(expected_fixture)
     try:
-        raw_result = _invoke_untrusted_adapter(adapter, case.fixture)
+        raw_result = _invoke_untrusted_adapter(adapter, adapter_fixture)
         if not isinstance(raw_result, dict):
             return (
                 ObserverConformanceResult(
@@ -230,7 +233,7 @@ def _run_case(
         return ObserverConformanceResult(case.case_id, "ok" if valid else "collision_contract_invalid", valid), result
     if result.get("status") != "observed":
         return ObserverConformanceResult(case.case_id, "observation_status_invalid", False), result
-    error = _assertion_error(result, case.fixture)
+    error = _assertion_error(result, expected_fixture)
     return ObserverConformanceResult(case.case_id, error or "ok", error is None), result
 
 

--- a/src/codex_plugin_scanner/guard/mdm/observer_conformance.py
+++ b/src/codex_plugin_scanner/guard/mdm/observer_conformance.py
@@ -11,7 +11,8 @@ import base64
 import binascii
 import hashlib
 import json
-from collections.abc import Callable, Mapping
+import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Final, Literal, TypeAlias, cast
 
@@ -19,13 +20,14 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 JsonValue: TypeAlias = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
-AdapterResult: TypeAlias = Mapping[str, JsonValue]
-ObserverAdapter: TypeAlias = Callable[[Mapping[str, JsonValue]], AdapterResult]
+AdapterResult: TypeAlias = dict[str, JsonValue]
+ObserverAdapter: TypeAlias = Callable[[dict[str, JsonValue]], AdapterResult]
 
 _PRIVATE_KEY_BYTES: Final = bytes(range(32))
 _PRIVATE_KEY: Final = Ed25519PrivateKey.from_private_bytes(_PRIVATE_KEY_BYTES)
 _PUBLIC_KEY: Final = _PRIVATE_KEY.public_key()
 _SIGNATURE_KEYS: Final = frozenset({"algorithm", "keyId", "value"})
+_SAFE_ID: Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 _ASSERTION_KEYS: Final = frozenset(
     {
         "schemaVersion",
@@ -46,7 +48,7 @@ _ASSERTION_KEYS: Final = frozenset(
 @dataclass(frozen=True)
 class ObserverConformanceCase:
     case_id: str
-    fixture: Mapping[str, JsonValue]
+    fixture: dict[str, JsonValue]
     expected: Literal["assertion", "collision", "outage"]
 
 
@@ -68,11 +70,11 @@ class ObserverConformanceReport:
         return all(result.passed for result in self.results)
 
 
-def _canonical(value: Mapping[str, JsonValue]) -> bytes:
+def _canonical(value: dict[str, JsonValue]) -> bytes:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
 
 
-def sign_observer_assertion(assertion: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
+def sign_observer_assertion(assertion: dict[str, JsonValue]) -> dict[str, JsonValue]:
     """Return a deterministic Ed25519-signed copy for fixture authors."""
 
     unsigned = {key: value for key, value in assertion.items() if key != "signature"}
@@ -93,11 +95,13 @@ def observer_conformance_public_key_base64() -> str:
     return base64.b64encode(_PUBLIC_KEY.public_bytes_raw()).decode("ascii")
 
 
-def observer_conformance_cases() -> tuple[ObserverConformanceCase, ...]:
+def observer_conformance_cases(adapter_id: str = "adapter-under-test") -> tuple[ObserverConformanceCase, ...]:
+    if not _SAFE_ID.fullmatch(adapter_id):
+        raise ValueError("adapter_id must be a safe identifier")
     base: dict[str, JsonValue] = {
         "workspaceId": "workspace-conformance",
         "observerId": "observer-conformance",
-        "adapterId": "adapter-under-test",
+        "adapterId": adapter_id,
         "externalDeviceId": "vendor-device-1",
         "sourceEventId": "source-event-1",
         "observedAt": "2026-07-19T06:00:00Z",
@@ -153,7 +157,7 @@ def observer_conformance_cases() -> tuple[ObserverConformanceCase, ...]:
     )
 
 
-def _assertion_error(result: AdapterResult, fixture: Mapping[str, JsonValue]) -> str | None:
+def _assertion_error(result: AdapterResult, fixture: dict[str, JsonValue]) -> str | None:
     assertion_value = result.get("assertion")
     if not isinstance(assertion_value, dict) or set(assertion_value) != set(_ASSERTION_KEYS):
         return "assertion_shape_invalid"
@@ -166,6 +170,9 @@ def _assertion_error(result: AdapterResult, fixture: Mapping[str, JsonValue]) ->
         return "signature_authority_invalid"
     if assertion.get("schemaVersion") != "observer-assertion.v1":
         return "schema_version_invalid"
+    assertion_id = assertion.get("assertionId")
+    if not isinstance(assertion_id, str) or not _SAFE_ID.fullmatch(assertion_id):
+        return "assertion_id_invalid"
     for field in ("workspaceId", "observerId", "adapterId", "externalDeviceId", "observedAt", "expiresAt"):
         if assertion.get(field) != fixture.get(field):
             return f"{field}_binding_invalid"
@@ -185,12 +192,26 @@ def _assertion_error(result: AdapterResult, fixture: Mapping[str, JsonValue]) ->
     return None
 
 
+def _invoke_untrusted_adapter(adapter: ObserverAdapter, fixture: dict[str, JsonValue]) -> object:
+    return adapter(fixture)
+
+
 def _run_case(
     adapter: ObserverAdapter,
     case: ObserverConformanceCase,
 ) -> tuple[ObserverConformanceResult, AdapterResult]:
     try:
-        result = adapter(case.fixture)
+        raw_result = _invoke_untrusted_adapter(adapter, case.fixture)
+        if not isinstance(raw_result, dict):
+            return (
+                ObserverConformanceResult(
+                    case.case_id,
+                    f"adapter_invalid_return_type:{type(raw_result).__name__}",
+                    False,
+                ),
+                {},
+            )
+        result = cast(AdapterResult, raw_result)
     except Exception as exc:
         return ObserverConformanceResult(case.case_id, f"adapter_exception:{type(exc).__name__}", False), {}
     if case.expected == "outage":
@@ -218,7 +239,7 @@ def run_observer_adapter_conformance(adapter_id: str, adapter: ObserverAdapter) 
 
     results: list[ObserverConformanceResult] = []
     outputs: dict[str, AdapterResult] = {}
-    for case in observer_conformance_cases():
+    for case in observer_conformance_cases(adapter_id):
         result, output = _run_case(adapter, case)
         results.append(result)
         outputs[case.case_id] = output

--- a/src/codex_plugin_scanner/guard/mdm/observer_conformance.py
+++ b/src/codex_plugin_scanner/guard/mdm/observer_conformance.py
@@ -1,0 +1,245 @@
+"""Vendor-neutral observer adapter conformance kit.
+
+Adapters receive bounded fixtures and return contract-shaped observations. The
+kit never executes vendor commands and therefore remains safe to embed in an
+MDM, EDR, RMM, or partner test runner.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Final, Literal, TypeAlias, cast
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+JsonValue: TypeAlias = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+AdapterResult: TypeAlias = Mapping[str, JsonValue]
+ObserverAdapter: TypeAlias = Callable[[Mapping[str, JsonValue]], AdapterResult]
+
+_PRIVATE_KEY_BYTES: Final = bytes(range(32))
+_PRIVATE_KEY: Final = Ed25519PrivateKey.from_private_bytes(_PRIVATE_KEY_BYTES)
+_PUBLIC_KEY: Final = _PRIVATE_KEY.public_key()
+_SIGNATURE_KEYS: Final = frozenset({"algorithm", "keyId", "value"})
+_ASSERTION_KEYS: Final = frozenset(
+    {
+        "schemaVersion",
+        "assertionId",
+        "workspaceId",
+        "observerId",
+        "adapterId",
+        "externalDeviceId",
+        "observedAt",
+        "expiresAt",
+        "detection",
+        "remediation",
+        "signature",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ObserverConformanceCase:
+    case_id: str
+    fixture: Mapping[str, JsonValue]
+    expected: Literal["assertion", "collision", "outage"]
+
+
+@dataclass(frozen=True)
+class ObserverConformanceResult:
+    case_id: str
+    detail: str
+    passed: bool
+
+
+@dataclass(frozen=True)
+class ObserverConformanceReport:
+    adapter_id: str
+    results: tuple[ObserverConformanceResult, ...]
+    schema_version: Literal["guard-observer-adapter-conformance.v1"] = "guard-observer-adapter-conformance.v1"
+
+    @property
+    def passed(self) -> bool:
+        return all(result.passed for result in self.results)
+
+
+def _canonical(value: Mapping[str, JsonValue]) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def sign_observer_assertion(assertion: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
+    """Return a deterministic Ed25519-signed copy for fixture authors."""
+
+    unsigned = {key: value for key, value in assertion.items() if key != "signature"}
+    signature = base64.b64encode(_PRIVATE_KEY.sign(_canonical(unsigned))).decode("ascii")
+    return {
+        **unsigned,
+        "signature": {
+            "algorithm": "ed25519",
+            "keyId": "conformance-observer-key-v1",
+            "value": signature,
+        },
+    }
+
+
+def observer_conformance_public_key_base64() -> str:
+    """Return the raw deterministic fixture public key, never the private key."""
+
+    return base64.b64encode(_PUBLIC_KEY.public_bytes_raw()).decode("ascii")
+
+
+def observer_conformance_cases() -> tuple[ObserverConformanceCase, ...]:
+    base: dict[str, JsonValue] = {
+        "workspaceId": "workspace-conformance",
+        "observerId": "observer-conformance",
+        "adapterId": "adapter-under-test",
+        "externalDeviceId": "vendor-device-1",
+        "sourceEventId": "source-event-1",
+        "observedAt": "2026-07-19T06:00:00Z",
+        "expiresAt": "2026-07-19T06:10:00Z",
+        "detection": {
+            "state": "present",
+            "endpointOnline": True,
+            "version": "3.1.0a9",
+            "packageIdentity": "org.hol.guard",
+            "reasonCodes": ["observer_current_present"],
+        },
+    }
+    return (
+        ObserverConformanceCase("valid-current", {**base, "caseId": "valid-current"}, "assertion"),
+        ObserverConformanceCase(
+            "clock-skew",
+            {
+                **base,
+                "caseId": "clock-skew",
+                "sourceEventId": "source-event-skew",
+                "observedAt": "2026-07-19T06:04:00Z",
+            },
+            "assertion",
+        ),
+        ObserverConformanceCase("duplicate-a", {**base, "caseId": "duplicate-a"}, "assertion"),
+        ObserverConformanceCase("duplicate-b", {**base, "caseId": "duplicate-b"}, "assertion"),
+        ObserverConformanceCase(
+            "partial-data",
+            {
+                **base,
+                "caseId": "partial-data",
+                "sourceEventId": "source-event-partial",
+                "detection": {
+                    "state": "partial",
+                    "endpointOnline": True,
+                    "version": None,
+                    "packageIdentity": None,
+                    "reasonCodes": ["observer_current_partial"],
+                },
+            },
+            "assertion",
+        ),
+        ObserverConformanceCase(
+            "mapping-collision",
+            {**base, "caseId": "mapping-collision", "candidateDeviceIds": ["device-a", "device-b"]},
+            "collision",
+        ),
+        ObserverConformanceCase(
+            "provider-outage",
+            {**base, "caseId": "provider-outage", "providerAvailable": False},
+            "outage",
+        ),
+    )
+
+
+def _assertion_error(result: AdapterResult, fixture: Mapping[str, JsonValue]) -> str | None:
+    assertion_value = result.get("assertion")
+    if not isinstance(assertion_value, dict) or set(assertion_value) != set(_ASSERTION_KEYS):
+        return "assertion_shape_invalid"
+    assertion = cast(dict[str, JsonValue], assertion_value)
+    signature_value = assertion.get("signature")
+    if not isinstance(signature_value, dict) or set(signature_value) != set(_SIGNATURE_KEYS):
+        return "signature_shape_invalid"
+    signature = cast(dict[str, JsonValue], signature_value)
+    if signature.get("algorithm") != "ed25519" or signature.get("keyId") != "conformance-observer-key-v1":
+        return "signature_authority_invalid"
+    if assertion.get("schemaVersion") != "observer-assertion.v1":
+        return "schema_version_invalid"
+    for field in ("workspaceId", "observerId", "adapterId", "externalDeviceId", "observedAt", "expiresAt"):
+        if assertion.get(field) != fixture.get(field):
+            return f"{field}_binding_invalid"
+    if assertion.get("detection") != fixture.get("detection"):
+        return "detection_fidelity_invalid"
+    remediation = assertion.get("remediation")
+    if remediation != {"state": "none", "jobId": None}:
+        return "remediation_fabricated"
+    encoded_signature = signature.get("value")
+    if not isinstance(encoded_signature, str):
+        return "signature_value_invalid"
+    try:
+        unsigned = {key: value for key, value in assertion.items() if key != "signature"}
+        _PUBLIC_KEY.verify(base64.b64decode(encoded_signature, validate=True), _canonical(unsigned))
+    except (binascii.Error, InvalidSignature, ValueError, TypeError):
+        return "signature_invalid"
+    return None
+
+
+def _run_case(
+    adapter: ObserverAdapter,
+    case: ObserverConformanceCase,
+) -> tuple[ObserverConformanceResult, AdapterResult]:
+    try:
+        result = adapter(case.fixture)
+    except Exception as exc:
+        return ObserverConformanceResult(case.case_id, f"adapter_exception:{type(exc).__name__}", False), {}
+    if case.expected == "outage":
+        valid = (
+            result.get("status") == "outage"
+            and result.get("assertion") is None
+            and result.get("errorCode") == "provider_unavailable"
+        )
+        return ObserverConformanceResult(case.case_id, "ok" if valid else "outage_contract_invalid", valid), result
+    if case.expected == "collision":
+        valid = (
+            result.get("status") == "collision"
+            and result.get("mappingStatus") == "ambiguous"
+            and result.get("assertion") is None
+        )
+        return ObserverConformanceResult(case.case_id, "ok" if valid else "collision_contract_invalid", valid), result
+    if result.get("status") != "observed":
+        return ObserverConformanceResult(case.case_id, "observation_status_invalid", False), result
+    error = _assertion_error(result, case.fixture)
+    return ObserverConformanceResult(case.case_id, error or "ok", error is None), result
+
+
+def run_observer_adapter_conformance(adapter_id: str, adapter: ObserverAdapter) -> ObserverConformanceReport:
+    """Run replay, skew, partial-data, collision, and outage conformance cases."""
+
+    results: list[ObserverConformanceResult] = []
+    outputs: dict[str, AdapterResult] = {}
+    for case in observer_conformance_cases():
+        result, output = _run_case(adapter, case)
+        results.append(result)
+        outputs[case.case_id] = output
+    duplicate_a = outputs["duplicate-a"].get("assertion")
+    duplicate_b = outputs["duplicate-b"].get("assertion")
+    duplicate_valid = duplicate_a == duplicate_b and isinstance(duplicate_a, dict)
+    results.append(
+        ObserverConformanceResult(
+            "duplicate-idempotency",
+            "ok" if duplicate_valid else "duplicate_output_changed",
+            duplicate_valid,
+        )
+    )
+    replay_digest = (
+        hashlib.sha256(_canonical(cast(dict[str, JsonValue], duplicate_a))).hexdigest() if duplicate_valid else None
+    )
+    results.append(
+        ObserverConformanceResult(
+            "replay-digest",
+            f"sha256:{replay_digest}" if replay_digest else "replay_digest_unavailable",
+            replay_digest is not None,
+        )
+    )
+    return ObserverConformanceReport(adapter_id=adapter_id, results=tuple(results))

--- a/tests/test_guard_mdm_observer_conformance.py
+++ b/tests/test_guard_mdm_observer_conformance.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Mapping
+from typing import cast
 
 from codex_plugin_scanner.guard.mdm.observer_conformance import (
     JsonValue,
+    ObserverAdapter,
     run_observer_adapter_conformance,
     sign_observer_assertion,
 )
 
 
-def conforming_adapter(fixture: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
+def conforming_adapter(fixture: dict[str, JsonValue]) -> dict[str, JsonValue]:
     case_id = fixture["caseId"]
     if case_id == "provider-outage":
         return {"status": "outage", "assertion": None, "errorCode": "provider_unavailable"}
@@ -38,6 +39,7 @@ def test_conforming_adapter_passes_all_signed_cases() -> None:
     report = run_observer_adapter_conformance("reference-adapter", conforming_adapter)
 
     assert report.passed
+    assert report.adapter_id == "reference-adapter"
     assert {result.case_id for result in report.results} >= {
         "clock-skew",
         "duplicate-idempotency",
@@ -51,7 +53,7 @@ def test_conforming_adapter_passes_all_signed_cases() -> None:
 
 
 def test_harness_rejects_fabricated_outage_evidence() -> None:
-    def unsafe_adapter(fixture: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
+    def unsafe_adapter(fixture: dict[str, JsonValue]) -> dict[str, JsonValue]:
         result = dict(conforming_adapter(fixture))
         if fixture["caseId"] == "provider-outage":
             result["assertion"] = conforming_adapter({**fixture, "caseId": "valid-current"})["assertion"]
@@ -68,7 +70,7 @@ def test_harness_rejects_fabricated_outage_evidence() -> None:
 def test_harness_rejects_non_idempotent_duplicate_outputs() -> None:
     counter = 0
 
-    def unstable_adapter(fixture: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
+    def unstable_adapter(fixture: dict[str, JsonValue]) -> dict[str, JsonValue]:
         nonlocal counter
         counter += 1
         if fixture["caseId"] not in {"duplicate-a", "duplicate-b"}:
@@ -83,3 +85,13 @@ def test_harness_rejects_non_idempotent_duplicate_outputs() -> None:
     assert next(result for result in report.results if result.case_id == "duplicate-idempotency").detail == (
         "duplicate_output_changed"
     )
+
+
+def test_harness_reports_invalid_adapter_return_without_crashing() -> None:
+    def invalid_adapter(_fixture: dict[str, JsonValue]) -> object:
+        return None
+
+    report = run_observer_adapter_conformance("invalid-adapter", cast(ObserverAdapter, invalid_adapter))
+
+    assert not report.passed
+    assert report.results[0].detail == "adapter_invalid_return_type:NoneType"

--- a/tests/test_guard_mdm_observer_conformance.py
+++ b/tests/test_guard_mdm_observer_conformance.py
@@ -95,3 +95,22 @@ def test_harness_reports_invalid_adapter_return_without_crashing() -> None:
 
     assert not report.passed
     assert report.results[0].detail == "adapter_invalid_return_type:NoneType"
+
+
+def test_adapter_cannot_mutate_fixture_to_bypass_fidelity_validation() -> None:
+    def mutating_adapter(fixture: dict[str, JsonValue]) -> dict[str, JsonValue]:
+        if fixture["caseId"] == "valid-current":
+            fixture["detection"] = {
+                "state": "absent",
+                "endpointOnline": False,
+                "version": None,
+                "packageIdentity": None,
+                "reasonCodes": ["forged_absence"],
+            }
+        return conforming_adapter(fixture)
+
+    report = run_observer_adapter_conformance("mutating-adapter", mutating_adapter)
+
+    result = next(result for result in report.results if result.case_id == "valid-current")
+    assert not result.passed
+    assert result.detail == "detection_fidelity_invalid"

--- a/tests/test_guard_mdm_observer_conformance.py
+++ b/tests/test_guard_mdm_observer_conformance.py
@@ -136,3 +136,18 @@ def test_duplicate_comparison_snapshots_shared_mutable_outputs() -> None:
     result = next(result for result in report.results if result.case_id == "duplicate-idempotency")
     assert not result.passed
     assert result.detail == "duplicate_output_changed"
+
+
+def test_invalid_recursive_duplicate_assertions_are_bounded_failures() -> None:
+    def recursive_adapter(fixture: dict[str, JsonValue]) -> dict[str, JsonValue]:
+        if fixture["caseId"] not in {"duplicate-a", "duplicate-b"}:
+            return conforming_adapter(fixture)
+        recursive_assertion: dict[str, JsonValue] = {}
+        recursive_assertion["self"] = recursive_assertion
+        return {"status": "observed", "assertion": recursive_assertion}
+
+    report = run_observer_adapter_conformance("recursive-adapter", recursive_adapter)
+
+    result = next(result for result in report.results if result.case_id == "duplicate-idempotency")
+    assert not report.passed
+    assert result.detail == "duplicate_output_changed"

--- a/tests/test_guard_mdm_observer_conformance.py
+++ b/tests/test_guard_mdm_observer_conformance.py
@@ -114,3 +114,25 @@ def test_adapter_cannot_mutate_fixture_to_bypass_fidelity_validation() -> None:
     result = next(result for result in report.results if result.case_id == "valid-current")
     assert not result.passed
     assert result.detail == "detection_fidelity_invalid"
+
+
+def test_duplicate_comparison_snapshots_shared_mutable_outputs() -> None:
+    shared_result: dict[str, JsonValue] = {}
+
+    def shared_mutable_adapter(fixture: dict[str, JsonValue]) -> dict[str, JsonValue]:
+        result = conforming_adapter(fixture)
+        if fixture["caseId"] not in {"duplicate-a", "duplicate-b"}:
+            return result
+        if fixture["caseId"] == "duplicate-b":
+            assertion = dict(cast(dict[str, JsonValue], result["assertion"]))
+            assertion["assertionId"] = "assertion-mutated-on-second-call"
+            result["assertion"] = sign_observer_assertion(assertion)
+        shared_result.clear()
+        shared_result.update(result)
+        return shared_result
+
+    report = run_observer_adapter_conformance("shared-mutable-adapter", shared_mutable_adapter)
+
+    result = next(result for result in report.results if result.case_id == "duplicate-idempotency")
+    assert not result.passed
+    assert result.detail == "duplicate_output_changed"

--- a/tests/test_guard_mdm_observer_conformance.py
+++ b/tests/test_guard_mdm_observer_conformance.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+
+from codex_plugin_scanner.guard.mdm.observer_conformance import (
+    JsonValue,
+    run_observer_adapter_conformance,
+    sign_observer_assertion,
+)
+
+
+def conforming_adapter(fixture: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
+    case_id = fixture["caseId"]
+    if case_id == "provider-outage":
+        return {"status": "outage", "assertion": None, "errorCode": "provider_unavailable"}
+    if case_id == "mapping-collision":
+        return {"status": "collision", "assertion": None, "mappingStatus": "ambiguous"}
+    source_event_id = str(fixture["sourceEventId"])
+    assertion = sign_observer_assertion(
+        {
+            "schemaVersion": "observer-assertion.v1",
+            "assertionId": f"assertion-{hashlib.sha256(source_event_id.encode()).hexdigest()[:16]}",
+            "workspaceId": fixture["workspaceId"],
+            "observerId": fixture["observerId"],
+            "adapterId": fixture["adapterId"],
+            "externalDeviceId": fixture["externalDeviceId"],
+            "observedAt": fixture["observedAt"],
+            "expiresAt": fixture["expiresAt"],
+            "detection": fixture["detection"],
+            "remediation": {"state": "none", "jobId": None},
+        }
+    )
+    return {"status": "observed", "assertion": assertion}
+
+
+def test_conforming_adapter_passes_all_signed_cases() -> None:
+    report = run_observer_adapter_conformance("reference-adapter", conforming_adapter)
+
+    assert report.passed
+    assert {result.case_id for result in report.results} >= {
+        "clock-skew",
+        "duplicate-idempotency",
+        "mapping-collision",
+        "partial-data",
+        "provider-outage",
+        "replay-digest",
+        "valid-current",
+    }
+    assert next(result for result in report.results if result.case_id == "replay-digest").detail.startswith("sha256:")
+
+
+def test_harness_rejects_fabricated_outage_evidence() -> None:
+    def unsafe_adapter(fixture: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
+        result = dict(conforming_adapter(fixture))
+        if fixture["caseId"] == "provider-outage":
+            result["assertion"] = conforming_adapter({**fixture, "caseId": "valid-current"})["assertion"]
+        return result
+
+    report = run_observer_adapter_conformance("unsafe-adapter", unsafe_adapter)
+
+    assert not report.passed
+    assert next(result for result in report.results if result.case_id == "provider-outage").detail == (
+        "outage_contract_invalid"
+    )
+
+
+def test_harness_rejects_non_idempotent_duplicate_outputs() -> None:
+    counter = 0
+
+    def unstable_adapter(fixture: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
+        nonlocal counter
+        counter += 1
+        if fixture["caseId"] not in {"duplicate-a", "duplicate-b"}:
+            return conforming_adapter(fixture)
+        changed = dict(fixture)
+        changed["sourceEventId"] = f"unstable-{counter}"
+        return conforming_adapter(changed)
+
+    report = run_observer_adapter_conformance("unstable-adapter", unstable_adapter)
+
+    assert not report.passed
+    assert next(result for result in report.results if result.case_id == "duplicate-idempotency").detail == (
+        "duplicate_output_changed"
+    )


### PR DESCRIPTION
## Summary
- publish a vendor-neutral in-process observer adapter conformance API
- provide deterministic signed fixtures for clock skew, replay/duplicates, partial data, mapping collisions, and provider outages
- verify identity binding, evidence fidelity, independent signatures, no fabricated remediation, stable replay output, and bounded outage behavior

## Verification
- 22 focused schema/conformance tests passed
- Ruff passed
- basedpyright passed with 0 errors and 0 warnings
- git diff --check passed