### PR TITLE
fix(policy): suppress rollout cohort hash false positive

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -134,6 +134,8 @@ def _canonical_policy_enforcement_enabled(
     if percentage in {0, 100}:
         return percentage == 100
     cohort_key = f"{workspace_id or 'local'}:{device_id}".encode()
+    # This is an in-memory rollout bucket for opaque installation IDs, not a password verifier.
+    # codeql[py/weak-sensitive-data-hashing]
     cohort = int.from_bytes(hashlib.sha256(cohort_key).digest()[:8], "big") % 100
     return cohort < percentage
 


### PR DESCRIPTION
## Summary

- Document that canonical-policy rollout bucketing hashes opaque installation identifiers, not passwords.
- Suppress the inapplicable CodeQL password-hashing rule without changing cohort assignment.

## Testing

- `uv run pytest -q tests/test_guard_cloud_local_sync.py --tb=short`
- `uv tool run ruff check src/codex_plugin_scanner/guard/runtime/runner.py tests/test_guard_cloud_local_sync.py`
- `uv run --no-sync basedpyright --level error`
