### PR TITLE
feat(mdm): publish vendor-neutral adapter conformance contract

### DIFF
--- a/docs/guard/mdm-adapter-contract.md
+++ b/docs/guard/mdm-adapter-contract.md
@@ -1,0 +1,81 @@
+# HOL Guard MDM/EDR adapter contract
+
+Status: report-only alpha for release 3.1. This contract is vendor-neutral. Vendor names, API
+objects, package queries, and deployment commands belong in adapter implementations, not Guard
+core.
+
+## Trust boundaries
+
+- Observer adapters use workspace-scoped observer credentials distinct from endpoint device keys.
+- Remediation adapters accept only Cloud-signed `remediation-job.v1` envelopes from the approved
+  workspace authority. An observer credential cannot authorize remediation.
+- Adapters never accept a shell command, script body, URL-selected executable, or arbitrary
+  package identifier from a job.
+- Every vendor device identity maps explicitly to exactly one Guard installation generation.
+  Zero or multiple candidates are quarantined and cannot trigger automatic remediation.
+- An adapter outage produces integration-health evidence only. It must not synthesize package
+  absence, endpoint presence, or successful remediation.
+
+## Observer output
+
+Each observation is canonical UTF-8 JSON matching
+[`observer-assertion.v1`](schemas/observer-assertion.v1.schema.json). The Ed25519 signature covers
+the complete envelope except `signature`, serialized with sorted keys and compact separators.
+Adapters must provide:
+
+- stable workspace, observer, adapter, and external-device identifiers;
+- observation and expiry timestamps in UTC;
+- endpoint online state when the vendor can establish it;
+- detected package identity and version, or explicit nulls when unknown;
+- `present`, `absent`, `partial`, `unknown`, or `unsupported` detection state;
+- at least one bounded reason code for partial evidence; and
+- remediation state tied to a job identifier whenever the state is not `none`.
+
+Guard Cloud accepts at most 60 seconds of future clock skew and a 15-minute assertion lifetime.
+An exact `(observerId, assertionId, digest)` replay is idempotent. Reusing the identifier with a
+different digest is rejected. Freshness is based on signed observation time, never HTTP receipt
+time.
+
+## Remediation input
+
+Adapters accept canonical signed
+[`remediation-job.v1`](schemas/remediation-job.v1.schema.json) only. Allowed actions are:
+
+- `install`
+- `repair`
+- `policy-refresh`
+- `service-register`
+- `version-converge`
+
+`install` and `version-converge` require an approved target version. The adapter resolves that
+version through its pinned signed release channel; it does not execute caller-provided content.
+Jobs bind workspace, device, installation generation, idempotency key, issue time, expiry, and
+attempt limit. Exact retries are idempotent. A key reused for a changed target, action, generation,
+or payload is a conflict. Adapters report only `accepted`, `running`, `succeeded`, `failed`,
+`unsupported`, or `timed-out`; bounded retries and escalation remain Cloud policy.
+
+## Conformance harness
+
+`codex_plugin_scanner.guard.mdm.adapter_conformance` is the executable reference boundary. Adapter
+certification must feed the adapter's real canonical envelopes and configured public keys through
+both harnesses. The matrix must pass:
+
+| Case | Required result |
+| --- | --- |
+| Valid signed observation | accepted |
+| Exact duplicate | duplicate, same digest |
+| Same assertion ID with changed payload | replay conflict |
+| Invalid signature | rejected |
+| Future clock beyond skew | rejected |
+| Expired or overlong evidence | rejected |
+| Partial data without reason | rejected |
+| Zero or multiple mapping candidates | quarantined |
+| Vendor timeout/outage | outage, no assertion digest |
+| Valid signed allowlisted remediation | accepted |
+| Exact remediation retry | duplicate |
+| Changed payload under one idempotency key | replay conflict |
+| Arbitrary action, expired job, or wrong generation shape | rejected |
+
+Passing the in-process harness proves contract compatibility, not production certification. Apple
+and Windows certification additionally requires real managed-device runs, least-privilege vendor
+credentials, vendor audit logs, signed installer verification, and retained redacted evidence.

--- a/docs/guard/mdm-deployment.md
+++ b/docs/guard/mdm-deployment.md
@@ -10,6 +10,8 @@ Builds require Python 3.12, the locked `uv` environment, and PyInstaller. macOS 
 
 All MDM products use the same signed package, machine-policy schema, lifecycle commands, JSON status schema, and exit-code contract. Organization-specific assignment, proxy, trust, enrollment, retention, and policy values remain external configuration. Vendor adapters may translate these contracts into native packaging and detection formats, but must not fork Guard behavior or require a custom binary.
 
+Observer and remediation integrations additionally follow the [vendor-neutral MDM/EDR adapter contract](mdm-adapter-contract.md) and its executable conformance matrix.
+
 ### Policy-bundle signing trust
 
 Organizations that enable signed Guard Cloud policy bundles must provision the initial workspace signing trust through the optional top-level `policyBundleKeyring` field in the machine policy. The value uses the `guard-policy-keyring.v1` contract and contains:

--- a/src/codex_plugin_scanner/guard/mdm/adapter_conformance.py
+++ b/src/codex_plugin_scanner/guard/mdm/adapter_conformance.py
@@ -1,0 +1,310 @@
+"""Vendor-neutral conformance checks for MDM/EDR observer adapters."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Literal
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+MAX_ASSERTION_BYTES = 16_384
+MAX_CLOCK_SKEW_SECONDS = 60
+MAX_ASSERTION_LIFETIME_SECONDS = 900
+ALLOWED_REMEDIATION_ACTIONS = frozenset(
+    {"install", "repair", "policy-refresh", "service-register", "version-converge"}
+)
+ALLOWED_OBSERVER_REASONS = frozenset(
+    {
+        "observer_current_present",
+        "observer_current_absent",
+        "observer_current_partial",
+        "observer_offline",
+        "observer_stale",
+        "observer_mapping_ambiguous",
+        "observer_credential_invalid",
+    }
+)
+_SAFE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}\Z")
+_TIMESTAMP = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\Z")
+_HEX_32 = re.compile(r"[0-9a-f]{32}\Z")
+
+
+class AdapterConformanceError(ValueError):
+    """Stable rejection reason raised by the conformance harness."""
+
+
+@dataclass(frozen=True, slots=True)
+class ObserverConformanceResult:
+    assertion_id: str | None
+    digest: str | None
+    outcome: Literal["accepted", "duplicate", "outage", "quarantined"]
+    reason: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class RemediationConformanceResult:
+    digest: str
+    job_id: str
+    outcome: Literal["accepted", "duplicate"]
+
+
+def _error(reason: str) -> AdapterConformanceError:
+    return AdapterConformanceError(reason)
+
+
+def _object(value: object, reason: str) -> dict[str, object]:
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        raise _error(reason)
+    return value
+
+
+def _exact_keys(value: Mapping[str, object], expected: set[str], reason: str) -> None:
+    if set(value) != expected:
+        raise _error(reason)
+
+
+def _safe_id(value: object, reason: str) -> str:
+    if not isinstance(value, str) or _SAFE_ID.fullmatch(value) is None:
+        raise _error(reason)
+    return value
+
+
+def _timestamp(value: object, reason: str) -> datetime:
+    if not isinstance(value, str) or _TIMESTAMP.fullmatch(value) is None:
+        raise _error(reason)
+    try:
+        parsed = datetime.fromisoformat(f"{value[:-1]}+00:00")
+    except ValueError as exc:
+        raise _error(reason) from exc
+    if parsed.tzinfo is None:
+        raise _error(reason)
+    return parsed.astimezone(timezone.utc)
+
+
+def _strict_json(payload: bytes, *, maximum: int, reason: str) -> dict[str, object]:
+    if not payload or len(payload) > maximum:
+        raise _error(reason)
+    try:
+        text = payload.decode("utf-8")
+        value = json.loads(text)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise _error(reason) from exc
+    if json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode() != payload:
+        raise _error(reason)
+    return _object(value, reason)
+
+
+def _verify_signature(
+    envelope: Mapping[str, object], public_key: Ed25519PublicKey, *, reason: str
+) -> None:
+    signature = _object(envelope.get("signature"), reason)
+    _exact_keys(signature, {"algorithm", "keyId", "value"}, reason)
+    _safe_id(signature.get("keyId"), reason)
+    encoded = signature.get("value")
+    if signature.get("algorithm") != "ed25519" or not isinstance(encoded, str):
+        raise _error(reason)
+    try:
+        raw = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise _error(reason) from exc
+    if len(raw) != 64:
+        raise _error(reason)
+    unsigned = dict(envelope)
+    unsigned.pop("signature")
+    canonical = json.dumps(unsigned, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+    try:
+        public_key.verify(raw, canonical)
+    except InvalidSignature as exc:
+        raise _error("adapter_signature_invalid") from exc
+
+
+@dataclass(slots=True)
+class ObserverAdapterConformanceHarness:
+    """Validate adapter assertions without embedding vendor-specific logic."""
+
+    accepted: dict[tuple[str, str], str] = field(default_factory=dict)
+
+    def evaluate(
+        self,
+        payload: bytes | None,
+        *,
+        mapping_candidates: int,
+        now: datetime,
+        public_key: Ed25519PublicKey,
+        transport_error: str | None = None,
+    ) -> ObserverConformanceResult:
+        if payload is None:
+            if not transport_error or len(transport_error) > 128:
+                raise _error("adapter_outage_invalid")
+            return ObserverConformanceResult(None, None, "outage", "observer_unavailable")
+        if transport_error is not None:
+            raise _error("adapter_outage_invalid")
+        if now.tzinfo is None:
+            raise _error("adapter_clock_invalid")
+        if not isinstance(mapping_candidates, int) or isinstance(mapping_candidates, bool) or mapping_candidates < 0:
+            raise _error("adapter_mapping_invalid")
+        envelope = _strict_json(payload, maximum=MAX_ASSERTION_BYTES, reason="adapter_assertion_invalid")
+        _exact_keys(
+            envelope,
+            {
+                "schemaVersion",
+                "assertionId",
+                "workspaceId",
+                "observerId",
+                "adapterId",
+                "externalDeviceId",
+                "observedAt",
+                "expiresAt",
+                "detection",
+                "remediation",
+                "signature",
+            },
+            "adapter_assertion_invalid",
+        )
+        if envelope.get("schemaVersion") != "observer-assertion.v1":
+            raise _error("adapter_assertion_invalid")
+        assertion_id = _safe_id(envelope.get("assertionId"), "adapter_assertion_invalid")
+        observer_id = _safe_id(envelope.get("observerId"), "adapter_assertion_invalid")
+        for key in ("workspaceId", "adapterId", "externalDeviceId"):
+            _safe_id(envelope.get(key), "adapter_assertion_invalid")
+        observed_at = _timestamp(envelope.get("observedAt"), "adapter_assertion_invalid")
+        expires_at = _timestamp(envelope.get("expiresAt"), "adapter_assertion_invalid")
+        current = now.astimezone(timezone.utc)
+        if observed_at > current + timedelta(seconds=MAX_CLOCK_SKEW_SECONDS):
+            raise _error("adapter_clock_skew")
+        if expires_at <= current or expires_at <= observed_at:
+            raise _error("adapter_assertion_expired")
+        if expires_at > observed_at + timedelta(seconds=MAX_ASSERTION_LIFETIME_SECONDS):
+            raise _error("adapter_assertion_lifetime")
+        detection = _object(envelope.get("detection"), "adapter_assertion_invalid")
+        _exact_keys(
+            detection,
+            {"state", "endpointOnline", "version", "packageIdentity", "reasonCodes"},
+            "adapter_assertion_invalid",
+        )
+        state = detection.get("state")
+        reasons = detection.get("reasonCodes")
+        if state not in {"present", "absent", "partial", "unknown", "unsupported"}:
+            raise _error("adapter_assertion_invalid")
+        if (
+            not isinstance(reasons, list)
+            or len(reasons) > 32
+            or not all(isinstance(item, str) and item in ALLOWED_OBSERVER_REASONS for item in reasons)
+            or len(set(reasons)) != len(reasons)
+        ):
+            raise _error("adapter_assertion_invalid")
+        if state == "partial" and not reasons:
+            raise _error("adapter_partial_without_reason")
+        remediation = _object(envelope.get("remediation"), "adapter_assertion_invalid")
+        _exact_keys(remediation, {"state", "jobId"}, "adapter_assertion_invalid")
+        remediation_state = remediation.get("state")
+        remediation_job_id = remediation.get("jobId")
+        if remediation_state not in {
+            "none",
+            "queued",
+            "accepted",
+            "running",
+            "succeeded",
+            "failed",
+            "paused",
+            "unknown",
+        }:
+            raise _error("adapter_assertion_invalid")
+        if remediation_state == "none":
+            if remediation_job_id is not None:
+                raise _error("adapter_assertion_invalid")
+        else:
+            _safe_id(remediation_job_id, "adapter_assertion_invalid")
+        _verify_signature(envelope, public_key, reason="adapter_assertion_invalid")
+        digest = hashlib.sha256(payload).hexdigest()
+        replay_key = (observer_id, assertion_id)
+        previous = self.accepted.get(replay_key)
+        if previous is not None:
+            if previous != digest:
+                raise _error("adapter_assertion_replay_conflict")
+            return ObserverConformanceResult(assertion_id, digest, "duplicate", None)
+        self.accepted[replay_key] = digest
+        if mapping_candidates != 1:
+            return ObserverConformanceResult(assertion_id, digest, "quarantined", "mapping_not_unique")
+        return ObserverConformanceResult(assertion_id, digest, "accepted", None)
+
+
+@dataclass(slots=True)
+class RemediationAdapterConformanceHarness:
+    """Validate signed, bounded, replay-safe remediation jobs."""
+
+    accepted: dict[tuple[str, str], str] = field(default_factory=dict)
+
+    def evaluate(
+        self, payload: bytes, *, now: datetime, public_key: Ed25519PublicKey
+    ) -> RemediationConformanceResult:
+        if now.tzinfo is None:
+            raise _error("adapter_clock_invalid")
+        envelope = _strict_json(payload, maximum=MAX_ASSERTION_BYTES, reason="adapter_remediation_invalid")
+        _exact_keys(
+            envelope,
+            {
+                "schemaVersion",
+                "jobId",
+                "workspaceId",
+                "deviceId",
+                "installationGeneration",
+                "action",
+                "targetVersion",
+                "idempotencyKey",
+                "issuedAt",
+                "validForSeconds",
+                "attemptLimit",
+                "signature",
+            },
+            "adapter_remediation_invalid",
+        )
+        if envelope.get("schemaVersion") != "remediation-job.v1":
+            raise _error("adapter_remediation_invalid")
+        job_id = _safe_id(envelope.get("jobId"), "adapter_remediation_invalid")
+        workspace_id = _safe_id(envelope.get("workspaceId"), "adapter_remediation_invalid")
+        _safe_id(envelope.get("deviceId"), "adapter_remediation_invalid")
+        idempotency_key = _safe_id(envelope.get("idempotencyKey"), "adapter_remediation_invalid")
+        generation = envelope.get("installationGeneration")
+        action = envelope.get("action")
+        duration = envelope.get("validForSeconds")
+        attempt_limit = envelope.get("attemptLimit")
+        if not isinstance(generation, str) or _HEX_32.fullmatch(generation) is None:
+            raise _error("adapter_remediation_invalid")
+        if action not in ALLOWED_REMEDIATION_ACTIONS:
+            raise _error("adapter_remediation_action_denied")
+        if not isinstance(duration, int) or isinstance(duration, bool) or not 60 <= duration <= 3600:
+            raise _error("adapter_remediation_invalid")
+        if not isinstance(attempt_limit, int) or isinstance(attempt_limit, bool) or not 1 <= attempt_limit <= 5:
+            raise _error("adapter_remediation_invalid")
+        issued_at = _timestamp(envelope.get("issuedAt"), "adapter_remediation_invalid")
+        current = now.astimezone(timezone.utc)
+        if issued_at > current + timedelta(seconds=MAX_CLOCK_SKEW_SECONDS):
+            raise _error("adapter_clock_skew")
+        if issued_at + timedelta(seconds=duration) <= current:
+            raise _error("adapter_remediation_expired")
+        target = envelope.get("targetVersion")
+        if action in {"install", "version-converge"} and (
+            not isinstance(target, str) or not 1 <= len(target) <= 128
+        ):
+            raise _error("adapter_remediation_invalid")
+        if target is not None and (not isinstance(target, str) or len(target) > 128):
+            raise _error("adapter_remediation_invalid")
+        _verify_signature(envelope, public_key, reason="adapter_remediation_invalid")
+        digest = hashlib.sha256(payload).hexdigest()
+        replay_key = (workspace_id, idempotency_key)
+        previous = self.accepted.get(replay_key)
+        if previous is not None:
+            if previous != digest:
+                raise _error("adapter_remediation_replay_conflict")
+            return RemediationConformanceResult(digest, job_id, "duplicate")
+        self.accepted[replay_key] = digest
+        return RemediationConformanceResult(digest, job_id, "accepted")

--- a/src/codex_plugin_scanner/guard/mdm/adapter_conformance.py
+++ b/src/codex_plugin_scanner/guard/mdm/adapter_conformance.py
@@ -79,7 +79,7 @@ def _timestamp(value: object, reason: str) -> datetime:
     if not isinstance(value, str) or _TIMESTAMP.fullmatch(value) is None:
         raise _error(reason)
     try:
-        parsed = datetime.fromisoformat(value)
+        parsed = datetime.fromisoformat(f"{value[:-1]}+00:00")
     except ValueError as exc:
         raise _error(reason) from exc
     return parsed.astimezone(timezone.utc)

--- a/src/codex_plugin_scanner/guard/mdm/adapter_conformance.py
+++ b/src/codex_plugin_scanner/guard/mdm/adapter_conformance.py
@@ -79,16 +79,14 @@ def _timestamp(value: object, reason: str) -> datetime:
     if not isinstance(value, str) or _TIMESTAMP.fullmatch(value) is None:
         raise _error(reason)
     try:
-        parsed = datetime.fromisoformat(f"{value[:-1]}+00:00")
+        parsed = datetime.fromisoformat(value)
     except ValueError as exc:
         raise _error(reason) from exc
-    if parsed.tzinfo is None:
-        raise _error(reason)
     return parsed.astimezone(timezone.utc)
 
 
 def _strict_json(payload: bytes, *, maximum: int, reason: str) -> dict[str, object]:
-    if not payload or len(payload) > maximum:
+    if not isinstance(payload, bytes) or not payload or len(payload) > maximum:
         raise _error(reason)
     try:
         text = payload.decode("utf-8")
@@ -187,8 +185,17 @@ class ObserverAdapterConformanceHarness:
             "adapter_assertion_invalid",
         )
         state = detection.get("state")
+        endpoint_online = detection.get("endpointOnline")
+        version = detection.get("version")
+        package_identity = detection.get("packageIdentity")
         reasons = detection.get("reasonCodes")
         if state not in {"present", "absent", "partial", "unknown", "unsupported"}:
+            raise _error("adapter_assertion_invalid")
+        if endpoint_online is not None and not isinstance(endpoint_online, bool):
+            raise _error("adapter_assertion_invalid")
+        if version is not None and (not isinstance(version, str) or len(version) > 128):
+            raise _error("adapter_assertion_invalid")
+        if package_identity is not None and (not isinstance(package_identity, str) or len(package_identity) > 256):
             raise _error("adapter_assertion_invalid")
         if (
             not isinstance(reasons, list)

--- a/src/codex_plugin_scanner/guard/mdm/adapter_conformance.py
+++ b/src/codex_plugin_scanner/guard/mdm/adapter_conformance.py
@@ -18,9 +18,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 MAX_ASSERTION_BYTES = 16_384
 MAX_CLOCK_SKEW_SECONDS = 60
 MAX_ASSERTION_LIFETIME_SECONDS = 900
-ALLOWED_REMEDIATION_ACTIONS = frozenset(
-    {"install", "repair", "policy-refresh", "service-register", "version-converge"}
-)
+ALLOWED_REMEDIATION_ACTIONS = frozenset({"install", "repair", "policy-refresh", "service-register", "version-converge"})
 ALLOWED_OBSERVER_REASONS = frozenset(
     {
         "observer_current_present",
@@ -102,9 +100,7 @@ def _strict_json(payload: bytes, *, maximum: int, reason: str) -> dict[str, obje
     return _object(value, reason)
 
 
-def _verify_signature(
-    envelope: Mapping[str, object], public_key: Ed25519PublicKey, *, reason: str
-) -> None:
+def _verify_signature(envelope: Mapping[str, object], public_key: Ed25519PublicKey, *, reason: str) -> None:
     signature = _object(envelope.get("signature"), reason)
     _exact_keys(signature, {"algorithm", "keyId", "value"}, reason)
     _safe_id(signature.get("keyId"), reason)
@@ -243,9 +239,7 @@ class RemediationAdapterConformanceHarness:
 
     accepted: dict[tuple[str, str], str] = field(default_factory=dict)
 
-    def evaluate(
-        self, payload: bytes, *, now: datetime, public_key: Ed25519PublicKey
-    ) -> RemediationConformanceResult:
+    def evaluate(self, payload: bytes, *, now: datetime, public_key: Ed25519PublicKey) -> RemediationConformanceResult:
         if now.tzinfo is None:
             raise _error("adapter_clock_invalid")
         envelope = _strict_json(payload, maximum=MAX_ASSERTION_BYTES, reason="adapter_remediation_invalid")
@@ -292,9 +286,7 @@ class RemediationAdapterConformanceHarness:
         if issued_at + timedelta(seconds=duration) <= current:
             raise _error("adapter_remediation_expired")
         target = envelope.get("targetVersion")
-        if action in {"install", "version-converge"} and (
-            not isinstance(target, str) or not 1 <= len(target) <= 128
-        ):
+        if action in {"install", "version-converge"} and (not isinstance(target, str) or not 1 <= len(target) <= 128):
             raise _error("adapter_remediation_invalid")
         if target is not None and (not isinstance(target, str) or len(target) > 128):
             raise _error("adapter_remediation_invalid")

--- a/tests/test_guard_mdm_adapter_conformance.py
+++ b/tests/test_guard_mdm_adapter_conformance.py
@@ -88,8 +88,15 @@ def test_rejects_replay_with_changed_payload_and_bad_signature() -> None:
     harness.evaluate(assertion(), mapping_candidates=1, now=NOW, public_key=PUBLIC_KEY)
     with pytest.raises(AdapterConformanceError) as replay:
         harness.evaluate(
-            assertion(detection={"state": "absent", "endpointOnline": True, "version": None,
-                                 "packageIdentity": None, "reasonCodes": ["observer_current_absent"]}),
+            assertion(
+                detection={
+                    "state": "absent",
+                    "endpointOnline": True,
+                    "version": None,
+                    "packageIdentity": None,
+                    "reasonCodes": ["observer_current_absent"],
+                }
+            ),
             mapping_candidates=1,
             now=NOW,
             public_key=PUBLIC_KEY,
@@ -125,8 +132,15 @@ def test_enforces_clock_skew_expiry_and_partial_evidence() -> None:
 
     with pytest.raises(AdapterConformanceError) as partial:
         ObserverAdapterConformanceHarness().evaluate(
-            assertion(detection={"state": "partial", "endpointOnline": True, "version": None,
-                                 "packageIdentity": None, "reasonCodes": []}),
+            assertion(
+                detection={
+                    "state": "partial",
+                    "endpointOnline": True,
+                    "version": None,
+                    "packageIdentity": None,
+                    "reasonCodes": [],
+                }
+            ),
             mapping_candidates=1,
             now=NOW,
             public_key=PUBLIC_KEY,
@@ -160,9 +174,7 @@ def test_remediation_is_signed_allowlisted_bounded_and_replay_safe() -> None:
     assert harness.evaluate(payload, now=NOW, public_key=PUBLIC_KEY).outcome == "duplicate"
 
     with pytest.raises(AdapterConformanceError) as action:
-        RemediationAdapterConformanceHarness().evaluate(
-            remediation(action="shell"), now=NOW, public_key=PUBLIC_KEY
-        )
+        RemediationAdapterConformanceHarness().evaluate(remediation(action="shell"), now=NOW, public_key=PUBLIC_KEY)
     assert reason(action) == "adapter_remediation_action_denied"
 
     with pytest.raises(AdapterConformanceError) as replay:

--- a/tests/test_guard_mdm_adapter_conformance.py
+++ b/tests/test_guard_mdm_adapter_conformance.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import json
 from datetime import datetime, timezone
+from typing import cast
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -83,6 +84,14 @@ def test_accepts_signed_assertion_and_treats_exact_duplicate_as_idempotent() -> 
     assert duplicate.digest == first.digest
 
 
+def test_rejects_non_bytes_payload_with_stable_error() -> None:
+    with pytest.raises(AdapterConformanceError) as invalid:
+        ObserverAdapterConformanceHarness().evaluate(
+            cast(bytes, "not-bytes"), mapping_candidates=1, now=NOW, public_key=PUBLIC_KEY
+        )
+    assert reason(invalid) == "adapter_assertion_invalid"
+
+
 def test_rejects_replay_with_changed_payload_and_bad_signature() -> None:
     harness = ObserverAdapterConformanceHarness()
     harness.evaluate(assertion(), mapping_candidates=1, now=NOW, public_key=PUBLIC_KEY)
@@ -146,6 +155,34 @@ def test_enforces_clock_skew_expiry_and_partial_evidence() -> None:
             public_key=PUBLIC_KEY,
         )
     assert reason(partial) == "adapter_partial_without_reason"
+
+
+@pytest.mark.parametrize(
+    "detection",
+    [
+        {
+            "state": "present",
+            "endpointOnline": "yes",
+            "version": "3.1.0a9",
+            "packageIdentity": "org.hiero.hol-guard",
+            "reasonCodes": [],
+        },
+        {
+            "state": "present",
+            "endpointOnline": True,
+            "version": 31,
+            "packageIdentity": "org.hiero.hol-guard",
+            "reasonCodes": [],
+        },
+        {"state": "present", "endpointOnline": True, "version": "3.1.0a9", "packageIdentity": {}, "reasonCodes": []},
+    ],
+)
+def test_rejects_signed_schema_invalid_detection_fields(detection: dict[str, object]) -> None:
+    with pytest.raises(AdapterConformanceError) as invalid:
+        ObserverAdapterConformanceHarness().evaluate(
+            assertion(detection=detection), mapping_candidates=1, now=NOW, public_key=PUBLIC_KEY
+        )
+    assert reason(invalid) == "adapter_assertion_invalid"
 
 
 def test_quarantines_mapping_collisions_and_represents_outage_without_evidence() -> None:

--- a/tests/test_guard_mdm_adapter_conformance.py
+++ b/tests/test_guard_mdm_adapter_conformance.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timezone
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from codex_plugin_scanner.guard.mdm.adapter_conformance import (
+    AdapterConformanceError,
+    ObserverAdapterConformanceHarness,
+    RemediationAdapterConformanceHarness,
+)
+
+NOW = datetime(2026, 7, 19, 12, 0, tzinfo=timezone.utc)
+PRIVATE_KEY = Ed25519PrivateKey.from_private_bytes(bytes(range(32)))
+PUBLIC_KEY = PRIVATE_KEY.public_key()
+
+
+def signed(payload: dict[str, object], key_id: str) -> bytes:
+    unsigned = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    value = base64.b64encode(PRIVATE_KEY.sign(unsigned)).decode()
+    envelope = {
+        **payload,
+        "signature": {"algorithm": "ed25519", "keyId": key_id, "value": value},
+    }
+    return json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode()
+
+
+def assertion(**updates: object) -> bytes:
+    payload: dict[str, object] = {
+        "schemaVersion": "observer-assertion.v1",
+        "assertionId": "assertion-a",
+        "workspaceId": "workspace-a",
+        "observerId": "observer-a",
+        "adapterId": "vendor-neutral-v1",
+        "externalDeviceId": "external-device-a",
+        "observedAt": "2026-07-19T11:59:30Z",
+        "expiresAt": "2026-07-19T12:09:30Z",
+        "detection": {
+            "state": "present",
+            "endpointOnline": True,
+            "version": "3.1.0a9",
+            "packageIdentity": "org.hiero.hol-guard",
+            "reasonCodes": ["observer_current_present"],
+        },
+        "remediation": {"state": "none", "jobId": None},
+    }
+    payload.update(updates)
+    return signed(payload, "observer-key-a")
+
+
+def remediation(**updates: object) -> bytes:
+    payload: dict[str, object] = {
+        "schemaVersion": "remediation-job.v1",
+        "jobId": "job-a",
+        "workspaceId": "workspace-a",
+        "deviceId": "device-a",
+        "installationGeneration": "a" * 32,
+        "action": "repair",
+        "targetVersion": None,
+        "idempotencyKey": "repair-device-a-generation-a",
+        "issuedAt": "2026-07-19T11:59:30Z",
+        "validForSeconds": 900,
+        "attemptLimit": 3,
+    }
+    payload.update(updates)
+    return signed(payload, "cloud-remediation-key-a")
+
+
+def reason(exc: pytest.ExceptionInfo[AdapterConformanceError]) -> str:
+    return str(exc.value)
+
+
+def test_accepts_signed_assertion_and_treats_exact_duplicate_as_idempotent() -> None:
+    harness = ObserverAdapterConformanceHarness()
+    payload = assertion()
+    first = harness.evaluate(payload, mapping_candidates=1, now=NOW, public_key=PUBLIC_KEY)
+    duplicate = harness.evaluate(payload, mapping_candidates=1, now=NOW, public_key=PUBLIC_KEY)
+    assert first.outcome == "accepted"
+    assert duplicate.outcome == "duplicate"
+    assert duplicate.digest == first.digest
+
+
+def test_rejects_replay_with_changed_payload_and_bad_signature() -> None:
+    harness = ObserverAdapterConformanceHarness()
+    harness.evaluate(assertion(), mapping_candidates=1, now=NOW, public_key=PUBLIC_KEY)
+    with pytest.raises(AdapterConformanceError) as replay:
+        harness.evaluate(
+            assertion(detection={"state": "absent", "endpointOnline": True, "version": None,
+                                 "packageIdentity": None, "reasonCodes": ["observer_current_absent"]}),
+            mapping_candidates=1,
+            now=NOW,
+            public_key=PUBLIC_KEY,
+        )
+    assert reason(replay) == "adapter_assertion_replay_conflict"
+
+    tampered = bytearray(assertion())
+    tampered[-10] = ord("B")
+    with pytest.raises(AdapterConformanceError):
+        ObserverAdapterConformanceHarness().evaluate(
+            bytes(tampered), mapping_candidates=1, now=NOW, public_key=PUBLIC_KEY
+        )
+
+
+def test_enforces_clock_skew_expiry_and_partial_evidence() -> None:
+    with pytest.raises(AdapterConformanceError) as skew:
+        ObserverAdapterConformanceHarness().evaluate(
+            assertion(observedAt="2026-07-19T12:01:01Z", expiresAt="2026-07-19T12:10:00Z"),
+            mapping_candidates=1,
+            now=NOW,
+            public_key=PUBLIC_KEY,
+        )
+    assert reason(skew) == "adapter_clock_skew"
+
+    with pytest.raises(AdapterConformanceError) as expired:
+        ObserverAdapterConformanceHarness().evaluate(
+            assertion(observedAt="2026-07-19T11:40:00Z", expiresAt="2026-07-19T11:50:00Z"),
+            mapping_candidates=1,
+            now=NOW,
+            public_key=PUBLIC_KEY,
+        )
+    assert reason(expired) == "adapter_assertion_expired"
+
+    with pytest.raises(AdapterConformanceError) as partial:
+        ObserverAdapterConformanceHarness().evaluate(
+            assertion(detection={"state": "partial", "endpointOnline": True, "version": None,
+                                 "packageIdentity": None, "reasonCodes": []}),
+            mapping_candidates=1,
+            now=NOW,
+            public_key=PUBLIC_KEY,
+        )
+    assert reason(partial) == "adapter_partial_without_reason"
+
+
+def test_quarantines_mapping_collisions_and_represents_outage_without_evidence() -> None:
+    collision = ObserverAdapterConformanceHarness().evaluate(
+        assertion(), mapping_candidates=2, now=NOW, public_key=PUBLIC_KEY
+    )
+    outage = ObserverAdapterConformanceHarness().evaluate(
+        None,
+        mapping_candidates=0,
+        now=NOW,
+        public_key=PUBLIC_KEY,
+        transport_error="vendor_timeout",
+    )
+    assert (collision.outcome, collision.reason) == ("quarantined", "mapping_not_unique")
+    assert (outage.outcome, outage.reason, outage.digest) == (
+        "outage",
+        "observer_unavailable",
+        None,
+    )
+
+
+def test_remediation_is_signed_allowlisted_bounded_and_replay_safe() -> None:
+    harness = RemediationAdapterConformanceHarness()
+    payload = remediation()
+    assert harness.evaluate(payload, now=NOW, public_key=PUBLIC_KEY).outcome == "accepted"
+    assert harness.evaluate(payload, now=NOW, public_key=PUBLIC_KEY).outcome == "duplicate"
+
+    with pytest.raises(AdapterConformanceError) as action:
+        RemediationAdapterConformanceHarness().evaluate(
+            remediation(action="shell"), now=NOW, public_key=PUBLIC_KEY
+        )
+    assert reason(action) == "adapter_remediation_action_denied"
+
+    with pytest.raises(AdapterConformanceError) as replay:
+        harness.evaluate(remediation(action="policy-refresh"), now=NOW, public_key=PUBLIC_KEY)
+    assert reason(replay) == "adapter_remediation_replay_conflict"
+
+
+def test_remediation_rejects_expired_and_generationless_jobs() -> None:
+    with pytest.raises(AdapterConformanceError) as expired:
+        RemediationAdapterConformanceHarness().evaluate(
+            remediation(issuedAt="2026-07-19T11:00:00Z", validForSeconds=60),
+            now=NOW,
+            public_key=PUBLIC_KEY,
+        )
+    assert reason(expired) == "adapter_remediation_expired"
+
+    with pytest.raises(AdapterConformanceError) as generation:
+        RemediationAdapterConformanceHarness().evaluate(
+            remediation(installationGeneration="old-generation"), now=NOW, public_key=PUBLIC_KEY
+        )
+    assert reason(generation) == "adapter_remediation_invalid"


### PR DESCRIPTION
## Summary
- publish a vendor-neutral observer and remediation adapter contract
- add reusable signed-envelope conformance harnesses with strict freshness, replay, mapping, outage, action, generation, and expiry checks
- add deterministic signed fixtures covering the certification matrix

## Verification
- `uv run pytest -q tests/test_guard_mdm_adapter_conformance.py tests/test_guard_self_protection_schemas.py` (25 passed)
- `uv run ruff check src/codex_plugin_scanner/guard/mdm/adapter_conformance.py tests/test_guard_mdm_adapter_conformance.py`
- `uv run basedpyright --level error src/codex_plugin_scanner/guard/mdm/adapter_conformance.py` (0 errors)