### PR TITLE
docs(guard): add protection operations runbooks

### DIFF
--- a/docs/guard/enterprise-packet.md
+++ b/docs/guard/enterprise-packet.md
@@ -119,5 +119,7 @@ delivery, retry, and tests ship for each provider.
 
 - Guard architecture: [architecture.md](./architecture.md)
 - Incident response: [incident-response.md](./incident-response.md)
+- Protection incident response: [protection-incident-response-runbook.md](./protection-incident-response-runbook.md)
+- Protection credential rotation: [protection-credential-rotation-runbook.md](./protection-credential-rotation-runbook.md)
 - Remediation patterns: [remediation.md](./remediation.md)
 - Cloud API inventory: `hol-points-portal/docs/guard-cloud-api-inventory.generated.md`

--- a/docs/guard/protection-credential-rotation-runbook.md
+++ b/docs/guard/protection-credential-rotation-runbook.md
@@ -1,0 +1,40 @@
+# Protection credential rotation and revocation runbook
+
+Use this runbook for Guard device signing keys and independent observer credentials. Keep both authorities separate: a device key signs local leases only; an observer credential signs normalized observations only.
+
+## Required evidence
+
+Record the workspace, installation or observer identifier, old and new key identifiers, actor, reason, start/end time, affected scope, verification result, rollback decision, and related incident. Never record private keys, client secrets, tokens, raw vendor payloads, usernames, home paths, or command content.
+
+## Planned rotation
+
+1. Confirm the target mapping is unique and the installation generation is current. Pause automatic remediation for the affected workspace; detection and evidence must remain active.
+2. Create the replacement credential with the same bounded scope. Prefer hardware-backed device storage and an independently managed observer signing key. Do not revoke the old credential yet.
+3. Register the new public key or observer JWKS entry. Verify its algorithm, key identifier, workspace/observer binding, expiry, and least-privilege OAuth scopes.
+4. Produce one new signed lease or observer assertion. Confirm Cloud accepts it, the evidence digest references the new key, freshness becomes current, and no identity/generation fork is created.
+5. Revoke the old credential. Confirm a newly signed payload using the old key is rejected with the bounded revoked/invalid-credential reason while the new key remains accepted.
+6. Resume the previous remediation mode only after current lease and observer evidence agree. Export the transition/audit evidence and close the change record.
+
+If device key state is lost, rolled back, cloned, or replaced without a trusted rotation chain, do not reuse the prior generation. Re-enroll as a new installation generation and retain the bounded old-generation tombstone.
+
+## Emergency revocation
+
+1. Pause automatic remediation for the affected scope and open a high-severity incident. Do not suppress detection.
+2. Revoke the suspected key, secret, token, or client immediately. Invalidate outstanding challenges or jobs bound to it where supported.
+3. Quarantine ambiguous mappings. Treat evidence signed after the compromise boundary as untrusted until independently reconciled.
+4. Issue a replacement credential through the planned-rotation steps. Require fresh evidence from both authorities before recovery.
+5. Search for replay, wrong-workspace, wrong-generation, clone, signature-rejection, and mapping-collision evidence. Preserve audit retention and legal hold requirements.
+
+## Exercise and acceptance record
+
+Run at least quarterly and after authentication changes. The exercise passes only when:
+
+- new credentials are accepted before old credentials are revoked;
+- revoked credentials fail immediately and cannot extend health;
+- device rotation preserves the generation only for a verified rotation chain;
+- loss or untrusted replacement creates a new generation;
+- observer rotation does not grant device-signing, removal, policy, or remediation authority;
+- detection/evidence continue throughout the pause;
+- exports contain actor, reason, key identifiers, digests, and timestamps with no secrets.
+
+Store the completed checklist with the release or customer change evidence. A failed assertion keeps the exercise open and automatic remediation paused for the affected scope.

--- a/docs/guard/protection-incident-response-runbook.md
+++ b/docs/guard/protection-incident-response-runbook.md
@@ -1,0 +1,38 @@
+# Protection incident response runbook
+
+Use the projected state, reason codes, evidence identifiers/digests, and independent observer freshness as the source of truth. Lease silence alone never confirms deletion. Suppression changes routing only; it never changes underlying state or evidence.
+
+## First response
+
+1. Confirm workspace/device/installation/generation identity and current policy revision.
+2. Capture the last healthy lease, observer assertion, mapping status, removal authorization, remediation job/attempts, and transition identifiers.
+3. Confirm each credential is current. Check ingestion and evaluator lag, maintenance windows, endpoint connectivity, and notification delivery.
+4. Pause automatic remediation when identity, mapping, authorization, or evidence is ambiguous. Preserve detection, append-only evidence, audit retention, and legal holds.
+
+## Scenario playbooks
+
+### Confirmed unexpected deletion
+
+Require managed lease absence plus a fresh, uniquely mapped observer assertion of complete absence and no valid removal authorization. Open one deduplicated critical episode, preserve the last healthy and confirming evidence, quarantine clone/mapping concerns, then request only an allowlisted signed remediation job. Resolve only after the configured consecutive healthy leases and required fresh observer evidence of presence.
+
+### False positive or expected offline
+
+Check endpoint sleep/offline status, Cloud/observer outage, proxy delay, cadence/grace bounds, and approved maintenance. Classify as `offline`, `late`, `suspected_absent`, or `unknown`; never rewrite it as healthy or confirmed deletion. Add a bounded maintenance window or suppression only with authorized actor, reason, and expiry. Close manually only with an audit event and linked evidence.
+
+### Authorized removal
+
+Verify a short-lived, single-use authorization bound to workspace, device, installation generation, actor, and reason. Keep the state `removal_pending` until a fresh independent observer confirms absence; then transition to `removed_authorized`. Reject expired, replayed, wrong-generation, or reused authorization and retain the bounded tombstone.
+
+### Device transfer
+
+Pause automatic remediation. Retire or remove the old workspace binding through an authorized workflow, revoke old credentials, and preserve its evidence/tombstone. Enroll the recipient as a new workspace/device relationship and installation generation. Never transfer signing keys, observer mappings, or prior health trust.
+
+### Retirement
+
+Require explicit retirement permission, actor, reason, and immutable audit evidence. Revoke device and observer access, stop future remediation, retain transitions according to policy, and verify new leases/assertions cannot reactivate the retired generation. Retirement must not delete evidence subject to retention or legal hold.
+
+## Closure evidence
+
+Record the incident/episode identifier, state transitions, actor and authorization decisions, lease/assertion/removal/remediation evidence identifiers and digests, notification delivery, root cause, corrective action, recovery threshold proof, and export checksum. Do not include raw commands, prompts, secrets, tokens, private keys, or unrestricted vendor payloads.
+
+The incident remains open when identity is ambiguous, observer evidence is stale, required recovery evidence is missing, notification delivery is unreconciled, or any remediation attempt exceeded its signed expiry or retry bound.

--- a/docs/guard/release-checklist.md
+++ b/docs/guard/release-checklist.md
@@ -17,6 +17,8 @@ Before each Guard harness release:
   workspace PATH collision, explicit custom registration, executable replacement, and sanitized-environment coverage.
 - Verify known read-only `gh` commands remain prompt-free and remote mutations still require approval when piped
   through output formatters; see [GitHub CLI Capability Boundary](github-command-capability-security.md).
+- Exercise device-key and observer-credential rotation/revocation using [the Protection Credential Rotation and Revocation Runbook](protection-credential-rotation-runbook.md), and attach the redacted acceptance record.
+- Walk the confirmed deletion, false-positive/expected-offline, authorized-removal, transfer, and retirement cases in [the Protection Incident Response Runbook](protection-incident-response-runbook.md).
 
 For GitHub Action pin updates, keep Dependabot updates as individual pull requests. Review the upstream changelog
 between the old and new commits, verify permission and runtime changes, retain the full commit SHA, and require the


### PR DESCRIPTION
## Summary

- add an auditable device-key and observer-credential rotation/revocation runbook
- add customer response playbooks for deletion, false positives, expected offline periods, authorized removal, transfer, and retirement
- wire both exercises into the enterprise packet and release checklist

## Verification

- `git diff --check`
- verified every new documentation link resolves to a tracked file
- scanned added lines and PR-facing text for workstation, internal-context, and infrastructure disclosure
