### PR TITLE
fix(hooks): preserve strict policy without blocking safe observers

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -110,6 +110,7 @@ _GENERIC_HOOK_NON_CONTENT_FIELDS = frozenset(
 )
 
 _COPILOT_VERIFIED_BENIGN_PAYLOAD_HINT_REASON = "untrusted_hook_payload_hint_ignored_guard_verified_benign"
+_VERIFIED_BENIGN_DEFAULT_DISPOSITION_REASON = "configured_default_relaxed_guard_verified_benign"
 _UNTRUSTED_DAEMON_PERMISSIVE_REASON = (
     "HOL Guard received an unauthenticated hint that the daemon was unreachable in permissive mode; "
     "the current local policy action was preserved."
@@ -481,9 +482,25 @@ def _run_hook_generic_payload(
         artifact_id,
         publisher,
     )
-    current_config_normalization = normalize_guard_action_result(
+    configured_policy_normalization = normalize_guard_action_result(
         configured_override if configured_override is not None else config.default_action,
         unknown_action="require-reapproval",
+    )
+    verified_benign_default = (
+        configured_override is None
+        and configured_policy_normalization.action in {"review", "require-reapproval"}
+        and _hook_event_name(payload_map) == "PreToolUse"
+        and is_explicitly_benign_tool_action_request(
+            payload_map.get("tool_name"),
+            payload_map.get("tool_input", payload_map.get("arguments")),
+            cwd=runtime_workspace,
+            home_dir=home_dir,
+        )
+    )
+    current_config_normalization = (
+        normalize_guard_action_result("warn", unknown_action="require-reapproval")
+        if verified_benign_default
+        else configured_policy_normalization
     )
     cli_action = getattr(args, "policy_action", None)
     cli_action_normalization = (
@@ -673,6 +690,11 @@ def _run_hook_generic_payload(
         approval_reuse_source = "claimed_saved_policy_decision"
     policy_composition = {
         "current_config_action": current_config_normalization.action,
+        "configured_policy_action": configured_policy_normalization.action,
+        "configured_default_disposition": ("relaxed_verified_benign" if verified_benign_default else "applied"),
+        "configured_default_disposition_reason_code": (
+            _VERIFIED_BENIGN_DEFAULT_DISPOSITION_REASON if verified_benign_default else None
+        ),
         "trusted_cli_override": cli_action_normalization.action if cli_action_normalization is not None else None,
         "untrusted_hook_payload_hint": (
             payload_action_normalization.action if payload_action_normalization is not None else None
@@ -707,6 +729,16 @@ def _run_hook_generic_payload(
                 "input_source": "untrusted_hook_payload_hint",
                 "status": "ignored",
                 "reason_code": ignored_payload_action_reason,
+                "classifier": "is_explicitly_benign_tool_action_request",
+            }
+        )
+    if verified_benign_default:
+        scanner_evidence.append(
+            {
+                "source": "configured_default",
+                "input_source": "local_config",
+                "status": "relaxed_verified_benign",
+                "reason_code": _VERIFIED_BENIGN_DEFAULT_DISPOSITION_REASON,
                 "classifier": "is_explicitly_benign_tool_action_request",
             }
         )

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -11,7 +11,9 @@ import json
 import os
 import re
 import shlex
+import shutil
 import stat
+import subprocess
 from dataclasses import dataclass, replace
 from pathlib import Path
 
@@ -310,6 +312,37 @@ _READ_ONLY_LOOKUP_COMMANDS = frozenset(
     {"cat", "fd", "find", "grep", "egrep", "fgrep", "head", "ls", "rg", "sed", "tail"}
 )
 _READ_ONLY_LOOKUP_FILTERS = frozenset({"grep", "egrep", "fgrep", "head", "sed", "tail"})
+_READ_ONLY_SEARCH_EXECUTION_FLAGS = {
+    "rg": frozenset({"--hostname-bin", "--pre", "--pre-glob"}),
+}
+_READ_ONLY_GIT_STATUS_FLAGS = frozenset(
+    {
+        "--ahead-behind",
+        "--branch",
+        "--ignored",
+        "--long",
+        "--no-ahead-behind",
+        "--no-renames",
+        "--porcelain",
+        "--renames",
+        "--short",
+        "--show-stash",
+        "--untracked-files",
+        "-b",
+        "-s",
+        "-u",
+        "-z",
+    }
+)
+_READ_ONLY_GIT_STATUS_VALUE_FLAGS = frozenset(
+    {
+        "--column",
+        "--find-renames",
+        "--ignored",
+        "--porcelain",
+        "--untracked-files",
+    }
+)
 _FIND_EXEC_PLACEHOLDER_TARGET = "guard-find-placeholder.py"
 _FIND_EXEC_ACTION_FLAGS = frozenset({"-exec", "-execdir", "-ok", "-okdir"})
 _FIND_EXEC_TERMINATOR_TOKENS = frozenset({";", r"\;", "+"})
@@ -1062,8 +1095,146 @@ def is_explicitly_benign_tool_action_request(
         if _looks_like_read_only_interpreter_command(stripped_command, parts, parsed_command_names):
             found_benign_candidate = True
             continue
+        if _looks_like_safe_read_only_lookup_command(
+            stripped_command,
+            parts,
+            home_dir=home_dir,
+        ):
+            found_benign_candidate = True
+            continue
+        if _looks_like_safe_git_status_command(stripped_command, parts, cwd=cwd):
+            found_benign_candidate = True
+            continue
         return False
     return found_benign_candidate
+
+
+def _looks_like_safe_git_status_command(
+    command_text: str,
+    parts: list[str],
+    *,
+    cwd: Path | None,
+) -> bool:
+    if any(marker in command_text for marker in ("$(", "`", "<(", ">(")):
+        return False
+    segments = _iter_shell_command_segments(parts)
+    if not segments:
+        return False
+    saw_status = False
+    effective_cwd = (cwd or Path.cwd()).resolve()
+    for segment in segments:
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name is None or command_index != 0:
+            return False
+        executable = segment[command_index]
+        if "/" in executable or "\\" in executable:
+            return False
+        args = segment[command_index + 1 :]
+        next_cwd = _safe_git_status_cd_target(command_name, args, cwd=effective_cwd)
+        if next_cwd is not None:
+            effective_cwd = next_cwd
+            continue
+        if command_name != "git" or not _git_status_args_are_read_only(args):
+            return False
+        if not _git_status_has_execution_free_config(effective_cwd):
+            return False
+        saw_status = True
+    return saw_status
+
+
+def _safe_git_status_cd_target(command_name: str, args: list[str], *, cwd: Path) -> Path | None:
+    if command_name != "cd":
+        return None
+    path_args = _shell_args_without_trailing_redirections(args)
+    if path_args != args or len(path_args) != 1 or path_args[0] in {"-", "--"}:
+        return None
+    path_text = path_args[0]
+    if _shell_token_has_command_substitution(path_text):
+        return None
+    candidate = Path(path_text).expanduser()
+    if not candidate.is_absolute():
+        candidate = cwd / candidate
+    try:
+        resolved = candidate.resolve()
+    except OSError:
+        return None
+    return resolved if resolved.is_dir() else None
+
+
+def _git_status_has_execution_free_config(cwd: Path | None) -> bool:
+    git_path = shutil.which("git")
+    if git_path is None:
+        return False
+    resolved_git = Path(git_path).resolve()
+    execution_cwd = (cwd or Path.cwd()).resolve()
+    if not _git_binary_path_is_trusted(resolved_git, cwd=execution_cwd):
+        return False
+    try:
+        result = subprocess.run(
+            [str(resolved_git), "config", "--null", "--get-all", "core.fsmonitor"],
+            cwd=execution_cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if result.returncode == 1 and not result.stdout:
+        return True
+    if result.returncode != 0:
+        return False
+    values = [value.strip().lower() for value in result.stdout.split("\0") if value.strip()]
+    return bool(values) and all(value in {"0", "false", "no", "off"} for value in values)
+
+
+def _git_binary_path_is_trusted(git_path: Path, *, cwd: Path) -> bool:
+    for untrusted_root in (cwd, Path.home().resolve(), Path("/tmp"), Path("/private/tmp")):
+        try:
+            _ = git_path.relative_to(untrusted_root)
+        except ValueError:
+            continue
+        return False
+    current_uid = getattr(os, "getuid", lambda: -1)()
+    current_groups = set(getattr(os, "getgroups", lambda: [])())
+    try:
+        for candidate in (git_path, *git_path.parents):
+            metadata = candidate.stat()
+            if metadata.st_mode & stat.S_IWOTH:
+                return False
+            if metadata.st_mode & stat.S_IWGRP and metadata.st_gid not in current_groups:
+                return False
+            if candidate == git_path and current_uid >= 0 and metadata.st_uid not in {0, current_uid}:
+                return False
+    except OSError:
+        return False
+    return True
+
+
+def _git_status_args_are_read_only(args: list[str]) -> bool:
+    if not args or args[0].lower() != "status":
+        return False
+    after_option_terminator = False
+    for token in args[1:]:
+        if after_option_terminator:
+            continue
+        if token == "--":
+            after_option_terminator = True
+            continue
+        normalized = token.lower()
+        if normalized in _READ_ONLY_GIT_STATUS_FLAGS:
+            continue
+        if "=" in normalized and normalized.split("=", 1)[0] in _READ_ONLY_GIT_STATUS_VALUE_FLAGS:
+            continue
+        if (
+            normalized.startswith("-")
+            and len(normalized) > 2
+            and not normalized.startswith("--")
+            and all(f"-{flag}" in _READ_ONLY_GIT_STATUS_FLAGS for flag in normalized[1:])
+        ):
+            continue
+        return False
+    return True
 
 
 def _docker_sensitive_tool_action_request(
@@ -4869,7 +5040,7 @@ def _read_only_lookup_primary_segment_is_safe(command: str, args: list[str], *, 
     if command == "ls":
         return _read_only_lookup_ls_args_are_safe(args, home_dir=home_dir)
     if command in {"grep", "egrep", "fgrep", "rg"}:
-        return _read_only_lookup_search_args_are_safe(args, home_dir=home_dir)
+        return _read_only_lookup_search_args_are_safe(command, args, home_dir=home_dir)
     if command == "fd":
         return _read_only_lookup_fd_args_are_safe(args, home_dir=home_dir)
     if command == "find":
@@ -5018,7 +5189,15 @@ def _read_only_lookup_ls_args_are_safe(args: list[str], *, home_dir: Path | None
     return _read_only_lookup_plain_targets_are_safe(args, allow_dirs=True, home_dir=home_dir)
 
 
-def _read_only_lookup_search_args_are_safe(args: list[str], *, home_dir: Path | None = None) -> bool:
+def _read_only_lookup_search_args_are_safe(
+    command: str,
+    args: list[str],
+    *,
+    home_dir: Path | None = None,
+) -> bool:
+    execution_flags = _READ_ONLY_SEARCH_EXECUTION_FLAGS.get(command, frozenset())
+    if any(arg in execution_flags or any(arg.startswith(f"{flag}=") for flag in execution_flags) for arg in args):
+        return False
     targets = [arg for arg in args if arg and not arg.startswith("-")]
     return len(targets) < 2 or all(
         _read_only_lookup_target_is_safe(target, allow_dirs=True, home_dir=home_dir) for target in targets[1:]

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -313,7 +313,7 @@ _READ_ONLY_LOOKUP_COMMANDS = frozenset(
 )
 _READ_ONLY_LOOKUP_FILTERS = frozenset({"grep", "egrep", "fgrep", "head", "sed", "tail"})
 _READ_ONLY_SEARCH_EXECUTION_FLAGS = {
-    "rg": frozenset({"--hostname-bin", "--pre", "--pre-glob"}),
+    "rg": frozenset({"--config-path", "--hostname-bin", "--pre", "--pre-glob"}),
 }
 _READ_ONLY_GIT_STATUS_FLAGS = frozenset(
     {
@@ -1121,7 +1121,10 @@ def _looks_like_safe_git_status_command(
     if not segments:
         return False
     saw_status = False
-    effective_cwd = (cwd or Path.cwd()).resolve()
+    try:
+        effective_cwd = (cwd or Path.cwd()).resolve()
+    except OSError:
+        return False
     for segment in segments:
         command_name, command_index = _shell_segment_primary_command(segment)
         if command_name is None or command_index != 0:
@@ -1151,12 +1154,12 @@ def _safe_git_status_cd_target(command_name: str, args: list[str], *, cwd: Path)
     path_text = path_args[0]
     if _shell_token_has_command_substitution(path_text):
         return None
-    candidate = Path(path_text).expanduser()
-    if not candidate.is_absolute():
-        candidate = cwd / candidate
     try:
+        candidate = Path(path_text).expanduser()
+        if not candidate.is_absolute():
+            candidate = cwd / candidate
         resolved = candidate.resolve()
-    except OSError:
+    except (OSError, RuntimeError):
         return None
     return resolved if resolved.is_dir() else None
 
@@ -1165,8 +1168,11 @@ def _git_status_has_execution_free_config(cwd: Path | None) -> bool:
     git_path = shutil.which("git")
     if git_path is None:
         return False
-    resolved_git = Path(git_path).resolve()
-    execution_cwd = (cwd or Path.cwd()).resolve()
+    try:
+        resolved_git = Path(git_path).resolve()
+        execution_cwd = (cwd or Path.cwd()).resolve()
+    except OSError:
+        return False
     if not _git_binary_path_is_trusted(resolved_git, cwd=execution_cwd):
         return False
     try:
@@ -1189,7 +1195,16 @@ def _git_status_has_execution_free_config(cwd: Path | None) -> bool:
 
 
 def _git_binary_path_is_trusted(git_path: Path, *, cwd: Path) -> bool:
-    for untrusted_root in (cwd, Path.home().resolve(), Path("/tmp"), Path("/private/tmp")):
+    try:
+        untrusted_roots = (
+            cwd.resolve(),
+            Path.home().resolve(),
+            Path("/tmp").resolve(),
+            Path("/private/tmp").resolve(),
+        )
+    except (OSError, RuntimeError):
+        return False
+    for untrusted_root in untrusted_roots:
         try:
             _ = git_path.relative_to(untrusted_root)
         except ValueError:

--- a/tests/test_guard_copilot_benign_policy_hint.py
+++ b/tests/test_guard_copilot_benign_policy_hint.py
@@ -282,12 +282,13 @@ def test_copilot_payload_allow_cannot_lower_stronger_current_policy(tmp_path: Pa
 
 
 @pytest.mark.parametrize(
-    ("current_action", "expected_permission"),
-    (("review", "deny"), ("block", "deny")),
+    ("current_action", "expected_action", "expected_permission"),
+    (("review", "warn", "allow"), ("block", "block", "deny")),
 )
-def test_untrusted_permissive_daemon_hint_never_lowers_current_policy(
+def test_untrusted_permissive_daemon_hint_never_lowers_effective_policy(
     tmp_path: Path,
     current_action: GuardAction,
+    expected_action: GuardAction,
     expected_permission: str,
 ) -> None:
     workspace = tmp_path / "workspace"
@@ -308,13 +309,14 @@ def test_untrusted_permissive_daemon_hint_never_lowers_current_policy(
 
     assert rc == 0
     assert response["permissionDecision"] == expected_permission
-    assert receipt["policy_decision"] == current_action
+    assert receipt["policy_decision"] == expected_action
     composition = _receipt_evidence(receipt, "policy_composition")
     assert composition["daemon_hint_trust"] == "untrusted_hook_payload"
     assert composition["daemon_hint_disposition"] == "preserved_current_action"
     assert composition["daemon_hint_reason_code"] == ("untrusted_daemon_permissive_hint_preserved_current_action")
-    assert composition["current_composed_action"] == current_action
-    assert composition["authoritative_action"] == current_action
+    assert composition["configured_policy_action"] == current_action
+    assert composition["current_composed_action"] == expected_action
+    assert composition["authoritative_action"] == expected_action
     daemon_evidence = _receipt_evidence(receipt, "daemon_hint_trust")
     assert daemon_evidence == {
         "source": "daemon_hint_trust",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -3119,6 +3120,93 @@ def test_explicitly_benign_tool_action_request_requires_all_command_variants_to_
             "command": "python3 - <<'PY'\nprint('rows')\nPY",
             "argv": ["rm", "-rf", "dangerous-marker.json"],
         },
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "git status --short",
+        "git status --porcelain=v2 --branch",
+        "cd src && git status -sb",
+        "rg -n 'GuardStore' src tests | sed -n '1,40p'",
+        "grep -n 'default_action' README.md",
+    ),
+)
+def test_explicitly_benign_tool_action_request_allows_verified_observers(command: str):
+    assert is_explicitly_benign_tool_action_request("bash", {"command": command})
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "git -c core.fsmonitor='rm -rf ./build' status --short",
+        "PATH=/tmp/evil:$PATH git status --short",
+        ("GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.fsmonitor GIT_CONFIG_VALUE_0=/tmp/payload git status --short"),
+        "/tmp/evil/git status --short",
+        "cd src >marker && git status --short",
+        "git status --short && rm -rf ./build",
+        "git status --short $(rm -rf ./build)",
+        "git diff --output=/tmp/diff",
+        "rg GuardStore src | tee /tmp/results",
+        "rg --pre /tmp/payload GuardStore src",
+        "rg --pre=/tmp/payload GuardStore src",
+        "rg --hostname-bin=/tmp/payload GuardStore src",
+    ),
+)
+def test_explicitly_benign_tool_action_request_rejects_unverified_observers(command: str):
+    assert not is_explicitly_benign_tool_action_request("bash", {"command": command})
+
+
+def test_explicitly_benign_git_status_rejects_repository_fsmonitor(tmp_path: Path):
+    subprocess.run(
+        ["git", "init", "--quiet", str(tmp_path)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "core.fsmonitor", "/tmp/payload"],
+        check=True,
+        capture_output=True,
+    )
+
+    assert not is_explicitly_benign_tool_action_request(
+        "bash",
+        {"command": "git status --short"},
+        cwd=tmp_path,
+    )
+
+
+def test_explicitly_benign_git_status_checks_effective_cd_repository(tmp_path: Path):
+    nested = tmp_path / "nested"
+    subprocess.run(
+        ["git", "init", "--quiet", str(nested)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(nested), "config", "core.fsmonitor", "/tmp/payload"],
+        check=True,
+        capture_output=True,
+    )
+
+    assert not is_explicitly_benign_tool_action_request(
+        "bash",
+        {"command": "cd nested && git status --short"},
+        cwd=tmp_path,
+    )
+
+
+def test_explicitly_benign_git_status_rejects_global_fsmonitor(tmp_path: Path, monkeypatch):
+    global_config = tmp_path / "global.gitconfig"
+    global_config.write_text("[core]\n\tfsmonitor = /tmp/payload\n", encoding="utf-8")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+    assert not is_explicitly_benign_tool_action_request(
+        "bash",
+        {"command": "git status --short"},
+        cwd=tmp_path,
     )
 
 

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -3152,6 +3152,7 @@ def test_explicitly_benign_tool_action_request_allows_verified_observers(command
         "rg --pre /tmp/payload GuardStore src",
         "rg --pre=/tmp/payload GuardStore src",
         "rg --hostname-bin=/tmp/payload GuardStore src",
+        "rg --config-path=/tmp/rg.conf GuardStore src",
     ),
 )
 def test_explicitly_benign_tool_action_request_rejects_unverified_observers(command: str):

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14756,6 +14756,134 @@ def test_guard_hook_codex_emits_no_native_output_for_safe_requests(tmp_path, cap
     assert pending == []
 
 
+def test_guard_hook_codex_strict_default_allows_verified_benign_git_status(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", 'default_action = "require-reapproval"\n')
+    event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "git status --short"},
+        "source_scope": "project",
+        "cwd": str(workspace_dir),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+        ]
+    )
+    output = capsys.readouterr().out
+    store = GuardStore(home_dir)
+
+    assert rc == 0
+    assert output == ""
+    assert store.list_approval_requests(limit=10) == []
+    assert store.list_receipts(limit=1) == []
+
+
+@pytest.mark.parametrize("explicit_action", ("block", "require-reapproval"))
+def test_guard_hook_codex_verified_benign_does_not_override_explicit_policy(
+    explicit_action,
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        home_dir / "config.toml",
+        (
+            'default_action = "require-reapproval"\n'
+            "approval_wait_timeout_seconds = 0\n"
+            f'[artifacts."codex:project:Bash"]\naction = "{explicit_action}"\n'
+        ),
+    )
+    monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "git status --short"},
+        "source_scope": "project",
+        "cwd": str(workspace_dir),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_guard_hook_codex_strict_default_still_denies_destructive_shell_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        home_dir / "config.toml",
+        'default_action = "require-reapproval"\napproval_wait_timeout_seconds = 0\n',
+    )
+    monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "git status --short && rm -rf ./build"},
+        "source_scope": "project",
+        "cwd": str(workspace_dir),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "destructive shell command" in payload["hookSpecificOutput"]["permissionDecisionReason"]
+
+
 def test_guard_hook_codex_emits_no_native_output_for_safe_github_node_review_thread_command(
     tmp_path,
     capsys,


### PR DESCRIPTION
## Summary
- allow positively verified read-only shell observers to proceed under strict default policy
- preserve explicit decisions and risky-command review while hardening Git and search-command validation

## Testing
- `uv run --no-sync pytest -q tests/test_guard_risk.py tests/test_guard_approval_precedence_generic_stdio.py --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_runtime.py -k 'codex_strict_default or verified_benign_does_not_override_explicit_policy or codex_emits_native_deny_for_sensitive_bash_command or codex_emits_no_native_output_for_safe_requests or codex_current_block_is_terminal_before_native_deny_output or ripgrep_preprocessor' --tb=short`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/cli/commands_hook_generic.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_risk.py tests/test_guard_runtime.py`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/commands_hook_generic.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_risk.py tests/test_guard_runtime.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/cli/commands_hook_generic.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py`
- `uv build`
