### PR TITLE
feat(dashboard): add command activity client contracts

### DIFF
--- a/dashboard/src/commands/command-activity-api.ts
+++ b/dashboard/src/commands/command-activity-api.ts
@@ -102,17 +102,21 @@ function validHarness(value: string | null): boolean {
 }
 
 function validateFilters(filters: CommandActivityFilters): void {
-  const rangeDays = filters.occurredFrom !== null && filters.occurredThrough !== null
-    ? (Date.parse(`${filters.occurredThrough}T00:00:00Z`) - Date.parse(`${filters.occurredFrom}T00:00:00Z`)) /
-      86_400_000
-    : null;
   if (
     !Number.isInteger(filters.limit) || filters.limit < 1 || filters.limit > 100 ||
     !validStableId(filters.extensionId) || !validStableId(filters.ruleId) ||
-    !validDate(filters.occurredFrom) || !validDate(filters.occurredThrough) ||
-    (rangeDays !== null && (rangeDays < 0 || rangeDays >= 397))
+    !validDate(filters.occurredFrom) || !validDate(filters.occurredThrough)
   ) {
     throw new CommandActivityRequestError("invalid_filters");
+  }
+  if (filters.occurredFrom !== null && filters.occurredThrough !== null) {
+    const rangeDays = (
+      Date.parse(`${filters.occurredThrough}T00:00:00Z`) -
+      Date.parse(`${filters.occurredFrom}T00:00:00Z`)
+    ) / 86_400_000;
+    if (rangeDays < 0 || rangeDays >= 397) {
+      throw new CommandActivityRequestError("invalid_filters");
+    }
   }
 }
 
@@ -217,7 +221,9 @@ export function parseCommandActivityUrlState(params: URLSearchParams): CommandAc
     ? rawLimit
     : DEFAULT_COMMAND_ACTIVITY_FILTERS.limit;
   const promptedValue = params.get("commandPrompted");
-  const prompted = promptedValue === "true" ? true : promptedValue === "false" ? false : null;
+  let prompted: boolean | null = null;
+  if (promptedValue === "true") prompted = true;
+  if (promptedValue === "false") prompted = false;
   let occurredFrom = dateParam(params, "commandFrom");
   let occurredThrough = dateParam(params, "commandThrough");
   const rangeDays = occurredFrom !== null && occurredThrough !== null

--- a/dashboard/src/commands/command-activity-api.ts
+++ b/dashboard/src/commands/command-activity-api.ts
@@ -1,0 +1,289 @@
+import { requestGuardJson } from "../guard-api";
+import {
+  COMMAND_ACTIVITY_HARNESSES,
+  COMMAND_APPROVAL_REUSE_STATUSES,
+  COMMAND_EXECUTION_STATUSES,
+  COMMAND_FEEDBACK_LABELS,
+  COMMAND_PROOF_LEVELS,
+} from "./command-activity-types";
+import {
+  normalizeCommandActivityAnalytics,
+  normalizeCommandActivityFeedback,
+  normalizeCommandActivityPage,
+  normalizeCommandExtensionsPage,
+} from "./command-activity-normalizers";
+import type {
+  CommandActivityAnalytics,
+  CommandActivityFeedbackResult,
+  CommandActivityHarness,
+  CommandActivityPage,
+  CommandApprovalReuseStatus,
+  CommandExecutionStatus,
+  CommandExtensionsPage,
+  CommandFeedbackLabel,
+  CommandProofLevel,
+} from "./command-activity-types";
+
+const STABLE_ID = /^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$/;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+export interface CommandActivityFilters {
+  limit: number;
+  harness: CommandActivityHarness | null;
+  executionStatus: CommandExecutionStatus | null;
+  proofLevel: CommandProofLevel | null;
+  prompted: boolean | null;
+  approvalReuseStatus: CommandApprovalReuseStatus | null;
+  extensionId: string | null;
+  ruleId: string | null;
+  occurredFrom: string | null;
+  occurredThrough: string | null;
+}
+
+export interface CommandActivityQueryState {
+  filters: CommandActivityFilters;
+  cursor: string | null;
+}
+
+export interface CommandActivityAnalyticsQuery {
+  days: number;
+  topLimit: number;
+  dimension: "harness" | "extension" | "rule" | null;
+  dimensionValue: string | null;
+}
+
+export const DEFAULT_COMMAND_ACTIVITY_FILTERS: CommandActivityFilters = {
+  limit: 50,
+  harness: null,
+  executionStatus: null,
+  proofLevel: null,
+  prompted: null,
+  approvalReuseStatus: null,
+  extensionId: null,
+  ruleId: null,
+  occurredFrom: null,
+  occurredThrough: null,
+};
+export const DEFAULT_COMMAND_ACTIVITY_QUERY: CommandActivityQueryState = {
+  filters: DEFAULT_COMMAND_ACTIVITY_FILTERS,
+  cursor: null,
+};
+export const DEFAULT_COMMAND_ACTIVITY_ANALYTICS_QUERY: CommandActivityAnalyticsQuery = {
+  days: 90,
+  topLimit: 10,
+  dimension: null,
+  dimensionValue: null,
+};
+
+export class CommandActivityRequestError extends Error {
+  constructor(readonly code: "invalid_filters" | "invalid_cursor") {
+    super(code === "invalid_cursor" ? "Invalid command activity cursor" : "Invalid command activity filters");
+    this.name = "CommandActivityRequestError";
+  }
+}
+
+function append(params: URLSearchParams, name: string, value: string | number | boolean | null): void {
+  if (value !== null) params.set(name, String(value));
+}
+
+function validDate(value: string | null): boolean {
+  if (value === null) return true;
+  if (!ISO_DATE.test(value) || value.startsWith("0000-")) return false;
+  const timestamp = Date.parse(`${value}T00:00:00Z`);
+  return !Number.isNaN(timestamp) && new Date(timestamp).toISOString().slice(0, 10) === value;
+}
+
+function validStableId(value: string | null): boolean {
+  return value === null || (value.length <= 256 && STABLE_ID.test(value));
+}
+
+function validHarness(value: string | null): boolean {
+  return value !== null && COMMAND_ACTIVITY_HARNESSES.some((harness) => harness === value);
+}
+
+function validateFilters(filters: CommandActivityFilters): void {
+  const rangeDays = filters.occurredFrom !== null && filters.occurredThrough !== null
+    ? (Date.parse(`${filters.occurredThrough}T00:00:00Z`) - Date.parse(`${filters.occurredFrom}T00:00:00Z`)) /
+      86_400_000
+    : null;
+  if (
+    !Number.isInteger(filters.limit) || filters.limit < 1 || filters.limit > 100 ||
+    !validStableId(filters.extensionId) || !validStableId(filters.ruleId) ||
+    !validDate(filters.occurredFrom) || !validDate(filters.occurredThrough) ||
+    (rangeDays !== null && (rangeDays < 0 || rangeDays >= 397))
+  ) {
+    throw new CommandActivityRequestError("invalid_filters");
+  }
+}
+
+function validateCursor(cursor: string | null): void {
+  if (cursor !== null && (!cursor || cursor.length > 2_048)) throw new CommandActivityRequestError("invalid_cursor");
+}
+
+function enumParam<const T extends readonly string[]>(
+  params: URLSearchParams,
+  name: string,
+  values: T,
+): T[number] | null {
+  const value = params.get(name);
+  return value !== null && values.includes(value) ? value as T[number] : null;
+}
+
+function stableIdParam(params: URLSearchParams, name: string): string | null {
+  const value = params.get(name);
+  return validStableId(value) ? value : null;
+}
+
+function dateParam(params: URLSearchParams, name: string): string | null {
+  const value = params.get(name);
+  return validDate(value) ? value : null;
+}
+
+export function commandActivityListPath(query: CommandActivityQueryState): string {
+  validateFilters(query.filters);
+  validateCursor(query.cursor);
+  const params = new URLSearchParams();
+  append(params, "limit", query.filters.limit);
+  append(params, "harness", query.filters.harness);
+  append(params, "execution_status", query.filters.executionStatus);
+  append(params, "proof_level", query.filters.proofLevel);
+  append(params, "prompted", query.filters.prompted);
+  append(params, "approval_reuse_status", query.filters.approvalReuseStatus);
+  append(params, "extension_id", query.filters.extensionId);
+  append(params, "rule_id", query.filters.ruleId);
+  append(params, "occurred_from", query.filters.occurredFrom);
+  append(params, "occurred_through", query.filters.occurredThrough);
+  append(params, "cursor", query.cursor);
+  return `/v1/command-activity?${params.toString()}`;
+}
+
+export function commandActivityAnalyticsPath(query: CommandActivityAnalyticsQuery): string {
+  if (
+    !Number.isInteger(query.days) || query.days < 1 || query.days > 397 ||
+    !Number.isInteger(query.topLimit) || query.topLimit < 1 || query.topLimit > 50 ||
+    (query.dimension === null) !== (query.dimensionValue === null) || !validStableId(query.dimensionValue) ||
+    (query.dimension === "harness" && !validHarness(query.dimensionValue))
+  ) {
+    throw new CommandActivityRequestError("invalid_filters");
+  }
+  const params = new URLSearchParams();
+  append(params, "days", query.days);
+  append(params, "top_limit", query.topLimit);
+  append(params, "dimension", query.dimension);
+  append(params, "dimension_value", query.dimensionValue);
+  return `/v1/command-activity/analytics?${params.toString()}`;
+}
+
+export function updateCommandActivityFilters(
+  state: CommandActivityQueryState,
+  patch: Partial<CommandActivityFilters>,
+): CommandActivityQueryState {
+  const filters = { ...state.filters, ...patch };
+  validateFilters(filters);
+  return { filters, cursor: null };
+}
+
+export function advanceCommandActivityCursor(
+  state: CommandActivityQueryState,
+  cursor: string | null,
+): CommandActivityQueryState {
+  validateCursor(cursor);
+  return { filters: state.filters, cursor };
+}
+
+export function serializeCommandActivityUrlState(state: CommandActivityQueryState): URLSearchParams {
+  validateFilters(state.filters);
+  validateCursor(state.cursor);
+  const params = new URLSearchParams();
+  if (state.filters.limit !== DEFAULT_COMMAND_ACTIVITY_FILTERS.limit) {
+    append(params, "commandLimit", state.filters.limit);
+  }
+  append(params, "commandHarness", state.filters.harness);
+  append(params, "commandExecution", state.filters.executionStatus);
+  append(params, "commandProof", state.filters.proofLevel);
+  append(params, "commandPrompted", state.filters.prompted);
+  append(params, "commandReuse", state.filters.approvalReuseStatus);
+  append(params, "commandExtension", state.filters.extensionId);
+  append(params, "commandRule", state.filters.ruleId);
+  append(params, "commandFrom", state.filters.occurredFrom);
+  append(params, "commandThrough", state.filters.occurredThrough);
+  append(params, "commandCursor", state.cursor);
+  return params;
+}
+
+export function parseCommandActivityUrlState(params: URLSearchParams): CommandActivityQueryState {
+  const rawLimit = Number(params.get("commandLimit"));
+  const limit = Number.isInteger(rawLimit) && rawLimit >= 1 && rawLimit <= 100
+    ? rawLimit
+    : DEFAULT_COMMAND_ACTIVITY_FILTERS.limit;
+  const promptedValue = params.get("commandPrompted");
+  const prompted = promptedValue === "true" ? true : promptedValue === "false" ? false : null;
+  let occurredFrom = dateParam(params, "commandFrom");
+  let occurredThrough = dateParam(params, "commandThrough");
+  const rangeDays = occurredFrom !== null && occurredThrough !== null
+    ? (Date.parse(`${occurredThrough}T00:00:00Z`) - Date.parse(`${occurredFrom}T00:00:00Z`)) / 86_400_000
+    : null;
+  if (rangeDays !== null && (rangeDays < 0 || rangeDays >= 397)) {
+    occurredFrom = null;
+    occurredThrough = null;
+  }
+  const cursorValue = params.get("commandCursor");
+  const cursor = cursorValue !== null && cursorValue.length <= 2_048 && cursorValue.length > 0
+    ? cursorValue
+    : null;
+  return {
+    filters: {
+      limit,
+      harness: enumParam(params, "commandHarness", COMMAND_ACTIVITY_HARNESSES),
+      executionStatus: enumParam(params, "commandExecution", COMMAND_EXECUTION_STATUSES),
+      proofLevel: enumParam(params, "commandProof", COMMAND_PROOF_LEVELS),
+      prompted,
+      approvalReuseStatus: enumParam(params, "commandReuse", COMMAND_APPROVAL_REUSE_STATUSES),
+      extensionId: stableIdParam(params, "commandExtension"),
+      ruleId: stableIdParam(params, "commandRule"),
+      occurredFrom,
+      occurredThrough,
+    },
+    cursor,
+  };
+}
+
+export async function fetchCommandActivityPage(
+  query: CommandActivityQueryState = DEFAULT_COMMAND_ACTIVITY_QUERY,
+): Promise<CommandActivityPage> {
+  return normalizeCommandActivityPage(await requestGuardJson<unknown>(commandActivityListPath(query)));
+}
+
+export async function fetchCommandActivityAnalytics(
+  query: CommandActivityAnalyticsQuery = DEFAULT_COMMAND_ACTIVITY_ANALYTICS_QUERY,
+): Promise<CommandActivityAnalytics> {
+  return normalizeCommandActivityAnalytics(await requestGuardJson<unknown>(commandActivityAnalyticsPath(query)));
+}
+
+export async function fetchCommandExtensions(cursor: string | null = null, limit = 50): Promise<CommandExtensionsPage> {
+  validateCursor(cursor);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+    throw new CommandActivityRequestError("invalid_filters");
+  }
+  const params = new URLSearchParams({ limit: String(limit) });
+  append(params, "cursor", cursor);
+  return normalizeCommandExtensionsPage(
+    await requestGuardJson<unknown>(`/v1/command-extensions?${params.toString()}`),
+  );
+}
+
+export async function submitCommandActivityFeedback(
+  activityId: string,
+  label: CommandFeedbackLabel,
+): Promise<CommandActivityFeedbackResult> {
+  if (!activityId || activityId.length > 256 || !COMMAND_FEEDBACK_LABELS.includes(label)) {
+    throw new CommandActivityRequestError("invalid_filters");
+  }
+  return normalizeCommandActivityFeedback(
+    await requestGuardJson<unknown>("/v1/command-activity/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ activity_id: activityId, label }),
+    }),
+  );
+}

--- a/dashboard/src/commands/command-activity-client.test.ts
+++ b/dashboard/src/commands/command-activity-client.test.ts
@@ -1,0 +1,319 @@
+import {
+  DEFAULT_COMMAND_ACTIVITY_QUERY,
+  CommandActivityRequestError,
+  advanceCommandActivityCursor,
+  commandActivityAnalyticsPath,
+  commandActivityListPath,
+  parseCommandActivityUrlState,
+  serializeCommandActivityUrlState,
+  updateCommandActivityFilters,
+} from "./command-activity-api";
+import {
+  CommandActivityContractError,
+  normalizeCommandActivityAnalytics,
+  normalizeCommandActivityFeedback,
+  normalizeCommandActivityPage,
+  normalizeCommandExtensionsPage,
+} from "./command-activity-normalizers";
+import { beginCommandActivityLoad, failCommandActivityLoad, loadCommandActivity } from "./command-activity-state";
+import {
+  COMMAND_ACTIVITY_TRUTH_COPY,
+  COMMAND_DECISIONS_SIBLING,
+  COMMANDS_INFORMATION_ARCHITECTURE,
+  commandActivityPathForHarness,
+  commandsSurface,
+  shouldShowHomeCommands,
+} from "./commands-information-architecture";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function expectContractError(run: () => unknown, field: string): void {
+  try {
+    run();
+  } catch (error) {
+    assert(error instanceof CommandActivityContractError, `${field}: expected contract error`);
+    assert(error.field === field, `${field}: error identifies field`);
+    return;
+  }
+  throw new Error(`${field}: expected failure`);
+}
+
+function expectRequestError(run: () => unknown, message: string): void {
+  try {
+    run();
+  } catch (error) {
+    assert(error instanceof CommandActivityRequestError, `${message}: expected request error`);
+    return;
+  }
+  throw new Error(message);
+}
+
+function activity(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    activity_id: "activity-1",
+    occurred_at: "2026-07-19T10:00:00+00:00",
+    harness: "codex",
+    hook_phase: "pre",
+    execution_status: "allowed_unconfirmed",
+    proof_level: "pre_hook",
+    policy_action: "allow",
+    decision_reason_code: "extension_match",
+    controlling_rule_id: "command.git.status",
+    parse_confidence: "exact",
+    uncertainty_class: null,
+    match_count: 1,
+    prompted: false,
+    approval_reuse_status: "not-applicable",
+    receipt_link_status: "not_applicable",
+    receipt_id: null,
+    evaluation_latency_bucket: "le_2_ms",
+    persistence_latency_bucket: "le_5_ms",
+    feedback_label: null,
+    schema_version: "1.0.0",
+    matches: [{
+      ordinal: 0,
+      extension_id: "command.git",
+      extension_version: "1.0.0",
+      rule_id: "command.git.status",
+      rule_version: "1.0.0",
+      match_class: "safe_variant",
+      severity: "low",
+      default_floor: "review",
+      safe_variant_id: "status-read",
+      effect_classes: ["workspace-or-public-read"],
+      schema_version: "1.0.0",
+    }],
+    ...overrides,
+  };
+}
+
+function analytics(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schema_version: "guard.command-activity-api.v1",
+    window: { from: "2026-07-13", through: "2026-07-19", days: 7 },
+    scope: { dimension: null, dimension_value: null },
+    commands_checked: 3,
+    trend: [{ day: "2026-07-19", count: 3 }],
+    dimensions: {
+      harness: [{ value: "codex", count: 3 }],
+      extension: [{ value: "command.git", count: 3 }],
+      rule: [{ value: "command.git.status", count: 3 }],
+      disposition: [{ value: "allow", count: 3 }],
+      execution_status: [{ value: "allowed_unconfirmed", count: 3 }],
+      prompt_status: [{ value: "not_prompted", count: 3 }],
+      proof_level: [{ value: "pre_hook", count: 3 }],
+      latency: [{ value: "evaluation:le_2_ms", count: 3 }],
+    },
+    dimension_breakdowns_scope: "global",
+    feedback: [{ label: "should_not_have_interrupted", count: 1 }],
+    health: {
+      status: "healthy",
+      dropped_events: 0,
+      persistence_errors: 0,
+      last_error_class: null,
+      last_error_at: null,
+    },
+    ...overrides,
+  };
+}
+
+const normalizedPage = normalizeCommandActivityPage({
+  schema_version: "guard.command-activity-api.v1",
+  items: [activity({ raw_command: "secret", environment: { TOKEN: "secret" } })],
+  next_cursor: "gca1.payload.signature",
+  raw_command: "must-not-survive",
+});
+assert(normalizedPage.items.length === 1, "list normalizer preserves valid activity");
+assert(normalizedPage.next_cursor === "gca1.payload.signature", "list normalizer preserves opaque cursor");
+assert(!("raw_command" in normalizedPage.items[0]), "list normalizer allowlists privacy-safe fields");
+assert(!("environment" in normalizedPage.items[0]), "list normalizer drops environment data");
+assert(normalizedPage.items[0].execution_status === "allowed_unconfirmed", "execution status is literal");
+assert(normalizedPage.items[0].matches[0].effect_classes[0] === "workspace-or-public-read", "effect is retained");
+
+expectContractError(
+  () => normalizeCommandActivityPage({ schema_version: "future", items: [], next_cursor: null }),
+  "response.schema_version",
+);
+expectContractError(
+  () => normalizeCommandActivityPage({
+    schema_version: "guard.command-activity-api.v1",
+    items: [activity({ execution_status: "executed" })],
+    next_cursor: null,
+  }),
+  "response.items[0].execution_status",
+);
+expectContractError(
+  () => normalizeCommandActivityPage({
+    schema_version: "guard.command-activity-api.v1",
+    items: [activity({ match_count: 2 })],
+    next_cursor: null,
+  }),
+  "response.items[0].match_count",
+);
+
+const normalizedAnalytics = normalizeCommandActivityAnalytics(analytics());
+assert(normalizedAnalytics.commands_checked === 3, "analytics preserves total");
+assert(normalizedAnalytics.dimension_breakdowns_scope === "global", "global breakdown scope is explicit");
+assert(normalizedAnalytics.health.status === "healthy", "health is normalized");
+expectContractError(
+  () => normalizeCommandActivityAnalytics(analytics({ dimension_breakdowns_scope: "filtered" })),
+  "response.dimension_breakdowns_scope",
+);
+expectContractError(
+  () => normalizeCommandActivityAnalytics(analytics({ dimensions: { harness: [] } })),
+  "response.dimensions.extension",
+);
+expectContractError(
+  () => normalizeCommandActivityAnalytics(analytics({ scope: { dimension: "harness", dimension_value: null } })),
+  "response.scope",
+);
+expectContractError(
+  () => normalizeCommandActivityAnalytics(analytics({ window: { from: "2026-02-30", through: "2026-03-01", days: 1 } })),
+  "response.window.from",
+);
+expectContractError(
+  () => normalizeCommandActivityAnalytics(analytics({ window: { from: "0000-01-01", through: "2026-03-01", days: 1 } })),
+  "response.window.from",
+);
+
+const normalizedExtensions = normalizeCommandExtensionsPage({
+  schema_version: 2,
+  source: "built-in",
+  items: [{
+    extension_id: "command.git",
+    version: "1.0.0",
+    name: "Git",
+    description: "Git command checks",
+    enabled: true,
+    required: false,
+    source: "built-in",
+    dependencies: [],
+    conflicts: [],
+    delegated_protection: null,
+    action_classes: ["git-read"],
+    risk_classes: ["remote-state"],
+    rule_count: 1,
+    rules: [{
+      rule_id: "command.git.status",
+      title: "Git status",
+      description: "Checks repository status",
+      severity: "low",
+      risk_classes: ["remote-state"],
+      action_classes: ["git-read"],
+      default_mode: "review",
+      safe_variant_ids: ["status-read"],
+      compatibility_fallback: false,
+    }],
+  }],
+  next_cursor: null,
+});
+assert(normalizedExtensions.items[0].rules[0].default_mode === "review", "extension rule mode is normalized");
+expectContractError(
+  () => normalizeCommandExtensionsPage({
+    schema_version: 2,
+    source: "built-in",
+    items: [{ ...normalizedExtensions.items[0], rule_count: 2 }],
+    next_cursor: null,
+  }),
+  "response.items[0].rule_count",
+);
+
+const feedback = normalizeCommandActivityFeedback({
+  schema_version: "guard.command-activity-api.v1",
+  activity_id: "activity-1",
+  label: "expected_guard_to_stop_this",
+  created_at: "2026-07-19T10:00:00Z",
+  updated_at: "2026-07-19T10:01:00Z",
+  changed: true,
+});
+assert(feedback.changed && feedback.label === "expected_guard_to_stop_this", "feedback response is typed");
+
+const filtered = updateCommandActivityFilters(
+  advanceCommandActivityCursor(DEFAULT_COMMAND_ACTIVITY_QUERY, "gca1.cursor.signature"),
+  {
+    harness: "codex",
+    executionStatus: "confirmed_success",
+    proofLevel: "post_hook",
+    prompted: false,
+    extensionId: "command.git",
+    occurredFrom: "2026-07-01",
+    occurredThrough: "2026-07-19",
+  },
+);
+assert(filtered.cursor === null, "any filter update clears the filter-bound cursor");
+const withCursor = advanceCommandActivityCursor(filtered, "gca1.next.signature");
+const listPath = commandActivityListPath(withCursor);
+assert(listPath.startsWith("/v1/command-activity?"), "list path targets local command API");
+assert(listPath.includes("harness=codex"), "list path includes harness filter");
+assert(listPath.includes("prompted=false"), "list path preserves explicit false");
+assert(listPath.includes("cursor=gca1.next.signature"), "list path includes opaque cursor");
+assert(
+  commandActivityAnalyticsPath({ days: 7, topLimit: 8, dimension: "harness", dimensionValue: "codex" }) ===
+    "/v1/command-activity/analytics?days=7&top_limit=8&dimension=harness&dimension_value=codex",
+  "analytics query is deterministic",
+);
+expectRequestError(
+  () => commandActivityAnalyticsPath({ days: 7, topLimit: 8, dimension: "harness", dimensionValue: "not-a-harness" }),
+  "unknown analytics harness is rejected locally",
+);
+expectRequestError(
+  () => updateCommandActivityFilters(DEFAULT_COMMAND_ACTIVITY_QUERY, {
+    occurredFrom: "2026-02-30",
+  }),
+  "impossible list date is rejected locally",
+);
+expectRequestError(
+  () => updateCommandActivityFilters(DEFAULT_COMMAND_ACTIVITY_QUERY, {
+    occurredFrom: "0000-01-01",
+  }),
+  "year-zero list date is rejected locally",
+);
+expectRequestError(
+  () => updateCommandActivityFilters(DEFAULT_COMMAND_ACTIVITY_QUERY, {
+    occurredFrom: "2025-01-01",
+    occurredThrough: "2026-02-02",
+  }),
+  "397-day list span is rejected locally",
+);
+
+const serialized = serializeCommandActivityUrlState(withCursor);
+const roundTrip = parseCommandActivityUrlState(serialized);
+assert(JSON.stringify(roundTrip) === JSON.stringify(withCursor), "filter and cursor URL state round trips");
+const malformedUrl = parseCommandActivityUrlState(new URLSearchParams({
+  commandLimit: "1000",
+  commandHarness: "unknown",
+  commandFrom: "2026-08-01",
+  commandThrough: "2026-07-01",
+  commandCursor: "",
+}));
+assert(malformedUrl.filters.limit === 50, "malformed URL limit falls back safely");
+assert(malformedUrl.filters.harness === null, "unknown URL harness is ignored");
+assert(malformedUrl.filters.occurredFrom === null, "reversed URL range is cleared");
+assert(malformedUrl.cursor === null, "empty URL cursor is cleared");
+
+const readyState = { kind: "ready" as const, data: normalizedPage };
+const loadingState = beginCommandActivityLoad(readyState);
+assert(loadingState.kind === "loading" && loadingState.previous === normalizedPage, "refresh retains last good data");
+const failedState = failCommandActivityLoad(loadingState, new Error("daemon unavailable"));
+assert(failedState.kind === "error" && failedState.previous === normalizedPage, "refresh error retains last good data");
+const emptyState = await loadCommandActivity(
+  { kind: "idle" },
+  async () => ({ ...normalizedPage, items: [] }),
+  (page) => page.items.length === 0,
+);
+assert(emptyState.kind === "empty", "loader distinguishes an empty successful response");
+
+assert(COMMANDS_INFORMATION_ARCHITECTURE.length === 3, "Commands IA owns three surfaces");
+assert(COMMAND_DECISIONS_SIBLING.route === "/evidence?view=actions", "decision receipts remain a sibling surface");
+assert(commandsSurface("evidence").route === "/evidence?view=commands", "Evidence owns global Commands");
+assert(commandsSurface("app-activity").scope === "selected-app", "app Commands are harness scoped");
+assert(commandsSurface("home").visibility === "when-command-data-exists", "Home card is data conditional");
+assert(
+  commandActivityPathForHarness("claude-code") === "/apps/claude-code?tab=activity&activity=commands",
+  "app route is deterministic",
+);
+assert(!shouldShowHomeCommands(0) && shouldShowHomeCommands(1), "Home card appears only after data exists");
+assert(COMMAND_ACTIVITY_TRUTH_COPY.activityMeaning.includes("not a threat"), "activity is not a threat claim");
+assert(COMMAND_ACTIVITY_TRUTH_COPY.allowedUnconfirmed.includes("not confirmed"), "unconfirmed is truthful");

--- a/dashboard/src/commands/command-activity-client.test.ts
+++ b/dashboard/src/commands/command-activity-client.test.ts
@@ -152,6 +152,14 @@ expectContractError(
   }),
   "response.items[0].match_count",
 );
+expectContractError(
+  () => normalizeCommandActivityPage({
+    schema_version: "guard.command-activity-api.v1",
+    items: [activity({ receipt_id: undefined })],
+    next_cursor: null,
+  }),
+  "response.items[0].receipt_id",
+);
 
 const normalizedAnalytics = normalizeCommandActivityAnalytics(analytics());
 assert(normalizedAnalytics.commands_checked === 3, "analytics preserves total");
@@ -298,6 +306,11 @@ const loadingState = beginCommandActivityLoad(readyState);
 assert(loadingState.kind === "loading" && loadingState.previous === normalizedPage, "refresh retains last good data");
 const failedState = failCommandActivityLoad(loadingState, new Error("daemon unavailable"));
 assert(failedState.kind === "error" && failedState.previous === normalizedPage, "refresh error retains last good data");
+const opaqueFailure = failCommandActivityLoad(loadingState, "raw command detail must not render");
+assert(
+  opaqueFailure.kind === "error" && opaqueFailure.message === "Command activity is temporarily unavailable.",
+  "non-Error throws use privacy-safe fallback copy",
+);
 const emptyState = await loadCommandActivity(
   { kind: "idle" },
   async () => ({ ...normalizedPage, items: [] }),

--- a/dashboard/src/commands/command-activity-normalizers.ts
+++ b/dashboard/src/commands/command-activity-normalizers.ts
@@ -1,0 +1,360 @@
+import {
+  COMMAND_ACTIVITY_API_SCHEMA_VERSION,
+  COMMAND_ACTIVITY_HARNESSES,
+  COMMAND_ACTIVITY_RECORD_SCHEMA_VERSION,
+  COMMAND_APPROVAL_REUSE_STATUSES,
+  COMMAND_DECISION_REASONS,
+  COMMAND_EFFECT_CLASSES,
+  COMMAND_EVIDENCE_SEVERITIES,
+  COMMAND_EXECUTION_STATUSES,
+  COMMAND_EXTENSION_SCHEMA_VERSION,
+  COMMAND_FEEDBACK_LABELS,
+  COMMAND_HOOK_PHASES,
+  COMMAND_LATENCY_BUCKETS,
+  COMMAND_MATCH_CLASSES,
+  COMMAND_PARSE_CONFIDENCES,
+  COMMAND_POLICY_ACTIONS,
+  COMMAND_PROOF_LEVELS,
+  COMMAND_RULE_MODES,
+  COMMAND_UNCERTAINTY_CLASSES,
+} from "./command-activity-types";
+import type {
+  CommandActivityAnalytics,
+  CommandActivityDimension,
+  CommandActivityDimensionValue,
+  CommandActivityFeedbackResult,
+  CommandActivityHealth,
+  CommandActivityItem,
+  CommandActivityMatch,
+  CommandActivityPage,
+  CommandExtension,
+  CommandExtensionRule,
+  CommandExtensionsPage,
+} from "./command-activity-types";
+
+const DIMENSIONS = [
+  "harness", "extension", "rule", "disposition", "execution_status", "prompt_status", "proof_level", "latency",
+] as const satisfies readonly CommandActivityDimension[];
+
+export class CommandActivityContractError extends Error {
+  constructor(readonly field: string) {
+    super(`Invalid command activity response at ${field}`);
+    this.name = "CommandActivityContractError";
+  }
+}
+
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new CommandActivityContractError(field);
+  }
+  return value as Record<string, unknown>;
+}
+
+function string(value: unknown, field: string): string {
+  if (typeof value !== "string") throw new CommandActivityContractError(field);
+  return value;
+}
+
+function nonEmptyString(value: unknown, field: string): string {
+  const result = string(value, field);
+  if (!result || result.length > 2_048) throw new CommandActivityContractError(field);
+  return result;
+}
+
+function nullableString(value: unknown, field: string): string | null {
+  return value === null ? null : nonEmptyString(value, field);
+}
+
+function boolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") throw new CommandActivityContractError(field);
+  return value;
+}
+
+function count(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) throw new CommandActivityContractError(field);
+  return value as number;
+}
+
+function positiveInteger(value: unknown, field: string): number {
+  const result = count(value, field);
+  if (result === 0) throw new CommandActivityContractError(field);
+  return result;
+}
+
+function array(value: unknown, field: string): unknown[] {
+  if (!Array.isArray(value)) throw new CommandActivityContractError(field);
+  return value;
+}
+
+function stringArray(value: unknown, field: string): string[] {
+  return array(value, field).map((item, index) => nonEmptyString(item, `${field}[${index}]`));
+}
+
+function member<const T extends readonly string[]>(value: unknown, values: T, field: string): T[number] {
+  if (typeof value !== "string" || !values.includes(value)) throw new CommandActivityContractError(field);
+  return value as T[number];
+}
+
+function nullableMember<const T extends readonly string[]>(
+  value: unknown,
+  values: T,
+  field: string,
+): T[number] | null {
+  return value === null ? null : member(value, values, field);
+}
+
+function isoDate(value: unknown, field: string): string {
+  const result = string(value, field);
+  const timestamp = Date.parse(`${result}T00:00:00Z`);
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/.test(result) ||
+    result.startsWith("0000-") ||
+    Number.isNaN(timestamp) ||
+    new Date(timestamp).toISOString().slice(0, 10) !== result
+  ) {
+    throw new CommandActivityContractError(field);
+  }
+  return result;
+}
+
+function isoTimestamp(value: unknown, field: string): string {
+  const result = nonEmptyString(value, field);
+  if (Number.isNaN(Date.parse(result))) throw new CommandActivityContractError(field);
+  return result;
+}
+
+function nullableTimestamp(value: unknown, field: string): string | null {
+  return value === null ? null : isoTimestamp(value, field);
+}
+
+function normalizeMatch(value: unknown, field: string): CommandActivityMatch {
+  const item = record(value, field);
+  return {
+    ordinal: count(item.ordinal, `${field}.ordinal`),
+    extension_id: nonEmptyString(item.extension_id, `${field}.extension_id`),
+    extension_version: nonEmptyString(item.extension_version, `${field}.extension_version`),
+    rule_id: nonEmptyString(item.rule_id, `${field}.rule_id`),
+    rule_version: nonEmptyString(item.rule_version, `${field}.rule_version`),
+    match_class: member(item.match_class, COMMAND_MATCH_CLASSES, `${field}.match_class`),
+    severity: member(item.severity, COMMAND_EVIDENCE_SEVERITIES, `${field}.severity`),
+    default_floor: member(item.default_floor, COMMAND_POLICY_ACTIONS, `${field}.default_floor`),
+    safe_variant_id: nullableString(item.safe_variant_id, `${field}.safe_variant_id`),
+    effect_classes: array(item.effect_classes, `${field}.effect_classes`).map((effect, index) =>
+      member(effect, COMMAND_EFFECT_CLASSES, `${field}.effect_classes[${index}]`),
+    ),
+    schema_version: member(
+      item.schema_version,
+      [COMMAND_ACTIVITY_RECORD_SCHEMA_VERSION] as const,
+      `${field}.schema_version`,
+    ),
+  };
+}
+
+function normalizeActivity(value: unknown, field: string): CommandActivityItem {
+  const item = record(value, field);
+  const matches = array(item.matches, `${field}.matches`).map((match, index) =>
+    normalizeMatch(match, `${field}.matches[${index}]`),
+  );
+  const matchCount = count(item.match_count, `${field}.match_count`);
+  if (matchCount !== matches.length) throw new CommandActivityContractError(`${field}.match_count`);
+  return {
+    activity_id: nonEmptyString(item.activity_id, `${field}.activity_id`),
+    occurred_at: isoTimestamp(item.occurred_at, `${field}.occurred_at`),
+    harness: member(item.harness, COMMAND_ACTIVITY_HARNESSES, `${field}.harness`),
+    hook_phase: member(item.hook_phase, COMMAND_HOOK_PHASES, `${field}.hook_phase`),
+    execution_status: member(item.execution_status, COMMAND_EXECUTION_STATUSES, `${field}.execution_status`),
+    proof_level: member(item.proof_level, COMMAND_PROOF_LEVELS, `${field}.proof_level`),
+    policy_action: nullableMember(item.policy_action, COMMAND_POLICY_ACTIONS, `${field}.policy_action`),
+    decision_reason_code: nullableMember(
+      item.decision_reason_code, COMMAND_DECISION_REASONS, `${field}.decision_reason_code`,
+    ),
+    controlling_rule_id: nullableString(item.controlling_rule_id, `${field}.controlling_rule_id`),
+    parse_confidence: nullableMember(item.parse_confidence, COMMAND_PARSE_CONFIDENCES, `${field}.parse_confidence`),
+    uncertainty_class: nullableMember(
+      item.uncertainty_class, COMMAND_UNCERTAINTY_CLASSES, `${field}.uncertainty_class`,
+    ),
+    match_count: matchCount,
+    prompted: boolean(item.prompted, `${field}.prompted`),
+    approval_reuse_status: member(
+      item.approval_reuse_status, COMMAND_APPROVAL_REUSE_STATUSES, `${field}.approval_reuse_status`,
+    ),
+    receipt_link_status: member(
+      item.receipt_link_status, ["not_applicable", "linked"] as const, `${field}.receipt_link_status`,
+    ),
+    receipt_id: nullableString(item.receipt_id, `${field}.receipt_id`),
+    evaluation_latency_bucket: member(
+      item.evaluation_latency_bucket, COMMAND_LATENCY_BUCKETS, `${field}.evaluation_latency_bucket`,
+    ),
+    persistence_latency_bucket: member(
+      item.persistence_latency_bucket, COMMAND_LATENCY_BUCKETS, `${field}.persistence_latency_bucket`,
+    ),
+    feedback_label: nullableMember(item.feedback_label, COMMAND_FEEDBACK_LABELS, `${field}.feedback_label`),
+    schema_version: member(
+      item.schema_version, [COMMAND_ACTIVITY_RECORD_SCHEMA_VERSION] as const, `${field}.schema_version`,
+    ),
+    matches,
+  };
+}
+
+function normalizeDimensionValues(value: unknown, field: string): CommandActivityDimensionValue[] {
+  return array(value, field).map((entry, index) => {
+    const item = record(entry, `${field}[${index}]`);
+    return {
+      value: nonEmptyString(item.value, `${field}[${index}].value`),
+      count: count(item.count, `${field}[${index}].count`),
+    };
+  });
+}
+
+function normalizeHealth(value: unknown, field: string): CommandActivityHealth {
+  const item = record(value, field);
+  return {
+    status: member(item.status, ["healthy", "degraded"] as const, `${field}.status`),
+    dropped_events: count(item.dropped_events, `${field}.dropped_events`),
+    persistence_errors: count(item.persistence_errors, `${field}.persistence_errors`),
+    last_error_class: item.last_error_class === undefined
+      ? null
+      : nullableString(item.last_error_class, `${field}.last_error_class`),
+    last_error_at: item.last_error_at === undefined
+      ? null
+      : nullableTimestamp(item.last_error_at, `${field}.last_error_at`),
+  };
+}
+
+export function normalizeCommandActivityPage(value: unknown): CommandActivityPage {
+  const payload = record(value, "response");
+  return {
+    schema_version: member(
+      payload.schema_version, [COMMAND_ACTIVITY_API_SCHEMA_VERSION] as const, "response.schema_version",
+    ),
+    items: array(payload.items, "response.items").map((item, index) =>
+      normalizeActivity(item, `response.items[${index}]`),
+    ),
+    next_cursor: nullableString(payload.next_cursor, "response.next_cursor"),
+  };
+}
+
+export function normalizeCommandActivityAnalytics(value: unknown): CommandActivityAnalytics {
+  const payload = record(value, "response");
+  const window = record(payload.window, "response.window");
+  const scope = record(payload.scope, "response.scope");
+  const dimensions = record(payload.dimensions, "response.dimensions");
+  const scopeDimension = nullableMember(
+    scope.dimension, ["harness", "extension", "rule"] as const, "response.scope.dimension",
+  );
+  const scopeValue = nullableString(scope.dimension_value, "response.scope.dimension_value");
+  if ((scopeDimension === null) !== (scopeValue === null)) {
+    throw new CommandActivityContractError("response.scope");
+  }
+  const normalizedDimensions = Object.fromEntries(
+    DIMENSIONS.map((dimension) => [
+      dimension,
+      normalizeDimensionValues(dimensions[dimension], `response.dimensions.${dimension}`),
+    ]),
+  ) as Record<CommandActivityDimension, CommandActivityDimensionValue[]>;
+  return {
+    schema_version: member(
+      payload.schema_version, [COMMAND_ACTIVITY_API_SCHEMA_VERSION] as const, "response.schema_version",
+    ),
+    window: {
+      from: isoDate(window.from, "response.window.from"),
+      through: isoDate(window.through, "response.window.through"),
+      days: positiveInteger(window.days, "response.window.days"),
+    },
+    scope: {
+      dimension: scopeDimension,
+      dimension_value: scopeValue,
+    },
+    commands_checked: count(payload.commands_checked, "response.commands_checked"),
+    trend: array(payload.trend, "response.trend").map((entry, index) => {
+      const item = record(entry, `response.trend[${index}]`);
+      return {
+        day: isoDate(item.day, `response.trend[${index}].day`),
+        count: count(item.count, `response.trend[${index}].count`),
+      };
+    }),
+    dimensions: normalizedDimensions,
+    dimension_breakdowns_scope: member(
+      payload.dimension_breakdowns_scope, ["global"] as const, "response.dimension_breakdowns_scope",
+    ),
+    feedback: array(payload.feedback, "response.feedback").map((entry, index) => {
+      const item = record(entry, `response.feedback[${index}]`);
+      return {
+        label: member(item.label, COMMAND_FEEDBACK_LABELS, `response.feedback[${index}].label`),
+        count: count(item.count, `response.feedback[${index}].count`),
+      };
+    }),
+    health: normalizeHealth(payload.health, "response.health"),
+  };
+}
+
+function normalizeExtensionRule(value: unknown, field: string): CommandExtensionRule {
+  const item = record(value, field);
+  return {
+    rule_id: nonEmptyString(item.rule_id, `${field}.rule_id`),
+    title: nonEmptyString(item.title, `${field}.title`),
+    description: nonEmptyString(item.description, `${field}.description`),
+    severity: member(item.severity, COMMAND_EVIDENCE_SEVERITIES, `${field}.severity`),
+    risk_classes: stringArray(item.risk_classes, `${field}.risk_classes`),
+    action_classes: stringArray(item.action_classes, `${field}.action_classes`),
+    default_mode: member(item.default_mode, COMMAND_RULE_MODES, `${field}.default_mode`),
+    safe_variant_ids: stringArray(item.safe_variant_ids, `${field}.safe_variant_ids`),
+    compatibility_fallback: boolean(item.compatibility_fallback, `${field}.compatibility_fallback`),
+  };
+}
+
+function normalizeExtension(value: unknown, field: string): CommandExtension {
+  const item = record(value, field);
+  const rules = array(item.rules, `${field}.rules`).map((rule, index) =>
+    normalizeExtensionRule(rule, `${field}.rules[${index}]`),
+  );
+  const ruleCount = count(item.rule_count, `${field}.rule_count`);
+  if (ruleCount !== rules.length) throw new CommandActivityContractError(`${field}.rule_count`);
+  return {
+    extension_id: nonEmptyString(item.extension_id, `${field}.extension_id`),
+    version: nonEmptyString(item.version, `${field}.version`),
+    name: nonEmptyString(item.name, `${field}.name`),
+    description: nonEmptyString(item.description, `${field}.description`),
+    enabled: boolean(item.enabled, `${field}.enabled`),
+    required: boolean(item.required, `${field}.required`),
+    source: member(item.source, ["built-in", "local-admin", "signed-cloud"] as const, `${field}.source`),
+    dependencies: stringArray(item.dependencies, `${field}.dependencies`),
+    conflicts: stringArray(item.conflicts, `${field}.conflicts`),
+    delegated_protection: nullableMember(
+      item.delegated_protection, ["package-firewall"] as const, `${field}.delegated_protection`,
+    ),
+    action_classes: stringArray(item.action_classes, `${field}.action_classes`),
+    risk_classes: stringArray(item.risk_classes, `${field}.risk_classes`),
+    rule_count: ruleCount,
+    rules,
+  };
+}
+
+export function normalizeCommandExtensionsPage(value: unknown): CommandExtensionsPage {
+  const payload = record(value, "response");
+  if (payload.schema_version !== COMMAND_EXTENSION_SCHEMA_VERSION) {
+    throw new CommandActivityContractError("response.schema_version");
+  }
+  return {
+    schema_version: COMMAND_EXTENSION_SCHEMA_VERSION,
+    source: member(payload.source, ["built-in"] as const, "response.source"),
+    items: array(payload.items, "response.items").map((item, index) =>
+      normalizeExtension(item, `response.items[${index}]`),
+    ),
+    next_cursor: nullableString(payload.next_cursor, "response.next_cursor"),
+  };
+}
+
+export function normalizeCommandActivityFeedback(value: unknown): CommandActivityFeedbackResult {
+  const payload = record(value, "response");
+  return {
+    schema_version: member(
+      payload.schema_version, [COMMAND_ACTIVITY_API_SCHEMA_VERSION] as const, "response.schema_version",
+    ),
+    activity_id: nonEmptyString(payload.activity_id, "response.activity_id"),
+    label: member(payload.label, COMMAND_FEEDBACK_LABELS, "response.label"),
+    created_at: isoTimestamp(payload.created_at, "response.created_at"),
+    updated_at: isoTimestamp(payload.updated_at, "response.updated_at"),
+    changed: boolean(payload.changed, "response.changed"),
+  };
+}

--- a/dashboard/src/commands/command-activity-state.ts
+++ b/dashboard/src/commands/command-activity-state.ts
@@ -1,0 +1,44 @@
+export type CommandActivityLoadState<T> =
+  | { kind: "idle" }
+  | { kind: "loading"; previous: T | null }
+  | { kind: "ready"; data: T }
+  | { kind: "empty"; data: T }
+  | { kind: "error"; message: string; previous: T | null };
+
+export function previousCommandActivityData<T>(state: CommandActivityLoadState<T>): T | null {
+  if (state.kind === "ready" || state.kind === "empty") return state.data;
+  if (state.kind === "loading" || state.kind === "error") return state.previous;
+  return null;
+}
+
+export function beginCommandActivityLoad<T>(state: CommandActivityLoadState<T>): CommandActivityLoadState<T> {
+  return { kind: "loading", previous: previousCommandActivityData(state) };
+}
+
+export function completeCommandActivityLoad<T>(data: T, empty: boolean): CommandActivityLoadState<T> {
+  return empty ? { kind: "empty", data } : { kind: "ready", data };
+}
+
+export function failCommandActivityLoad<T>(
+  state: CommandActivityLoadState<T>,
+  error: unknown,
+): CommandActivityLoadState<T> {
+  const message = error instanceof Error && error.message.trim()
+    ? error.message
+    : "Command activity is temporarily unavailable.";
+  return { kind: "error", message, previous: previousCommandActivityData(state) };
+}
+
+export async function loadCommandActivity<T>(
+  state: CommandActivityLoadState<T>,
+  loader: () => Promise<T>,
+  isEmpty: (data: T) => boolean,
+): Promise<CommandActivityLoadState<T>> {
+  const loading = beginCommandActivityLoad(state);
+  try {
+    const data = await loader();
+    return completeCommandActivityLoad(data, isEmpty(data));
+  } catch (error) {
+    return failCommandActivityLoad(loading, error);
+  }
+}

--- a/dashboard/src/commands/command-activity-state.ts
+++ b/dashboard/src/commands/command-activity-state.ts
@@ -23,9 +23,10 @@ export function failCommandActivityLoad<T>(
   state: CommandActivityLoadState<T>,
   error: unknown,
 ): CommandActivityLoadState<T> {
-  const message = error instanceof Error && error.message.trim()
-    ? error.message
-    : "Command activity is temporarily unavailable.";
+  let message = "Command activity is temporarily unavailable.";
+  if (error instanceof Error && error.message.trim()) {
+    message = error.message;
+  }
   return { kind: "error", message, previous: previousCommandActivityData(state) };
 }
 

--- a/dashboard/src/commands/command-activity-types.ts
+++ b/dashboard/src/commands/command-activity-types.ts
@@ -1,0 +1,172 @@
+export const COMMAND_ACTIVITY_API_SCHEMA_VERSION = "guard.command-activity-api.v1" as const;
+export const COMMAND_ACTIVITY_RECORD_SCHEMA_VERSION = "1.0.0" as const;
+export const COMMAND_EXTENSION_SCHEMA_VERSION = 2 as const;
+
+export const COMMAND_ACTIVITY_HARNESSES = [
+  "antigravity", "claude-code", "codex", "copilot", "cursor", "gemini", "grok",
+  "hermes", "kimi", "openclaw", "opencode", "pi", "zcode",
+] as const;
+export const COMMAND_EXECUTION_STATUSES = [
+  "attempted", "prevented", "allowed_unconfirmed", "confirmed_success", "confirmed_failure", "unpaired_post",
+] as const;
+export const COMMAND_PROOF_LEVELS = ["pre_hook", "post_hook", "unpaired_post"] as const;
+export const COMMAND_APPROVAL_REUSE_STATUSES = ["accepted", "rejected", "not-applicable"] as const;
+export const COMMAND_POLICY_ACTIONS = [
+  "allow", "warn", "review", "require-reapproval", "sandbox-required", "block",
+] as const;
+export const COMMAND_HOOK_PHASES = ["pre", "post_success", "post_failure"] as const;
+export const COMMAND_PARSE_CONFIDENCES = ["exact", "fallback", "uncertain"] as const;
+export const COMMAND_DECISION_REASONS = [
+  "no_match", "extension_match", "uncertainty", "policy", "approval_reuse", "containment", "capability",
+] as const;
+export const COMMAND_UNCERTAINTY_CLASSES = [
+  "partial-parse", "dynamic-input", "unsupported-input", "malformed-input", "parser-budget-exhausted",
+  "matcher-failure", "parser-failure", "unresolved-launch-identity", "unknown-effect", "degraded-containment",
+  "protection-health-degraded", "policy-version-mismatch", "malformed-boundary-version",
+  "unknown-boundary-version", "rollback-boundary-version",
+] as const;
+export const COMMAND_MATCH_CLASSES = ["unsafe", "safe_variant", "uncertainty"] as const;
+export const COMMAND_EVIDENCE_SEVERITIES = ["info", "low", "medium", "high", "critical"] as const;
+export const COMMAND_LATENCY_BUCKETS = [
+  "not_measured", "le_1_ms", "le_2_ms", "le_5_ms", "le_10_ms", "le_20_ms", "le_50_ms", "le_100_ms", "gt_100_ms",
+] as const;
+export const COMMAND_FEEDBACK_LABELS = [
+  "should_not_have_interrupted", "expected_guard_to_stop_this",
+] as const;
+export const COMMAND_RULE_MODES = ["required", "enforce", "review", "monitor", "disabled"] as const;
+export const COMMAND_EFFECT_CLASSES = [
+  "workspace-or-public-read", "sensitive-read", "workspace-write", "external-filesystem-write",
+  "process-execution", "network-read", "network-write", "remote-state-read", "remote-state-mutation",
+  "permission-or-access-change", "credential-or-secret-operation", "system-or-privilege-operation",
+  "package-or-source-installation", "destructive-or-irreversible-operation", "guard-control-operation",
+] as const;
+
+export type CommandActivityHarness = (typeof COMMAND_ACTIVITY_HARNESSES)[number];
+export type CommandExecutionStatus = (typeof COMMAND_EXECUTION_STATUSES)[number];
+export type CommandProofLevel = (typeof COMMAND_PROOF_LEVELS)[number];
+export type CommandApprovalReuseStatus = (typeof COMMAND_APPROVAL_REUSE_STATUSES)[number];
+export type CommandPolicyAction = (typeof COMMAND_POLICY_ACTIONS)[number];
+export type CommandHookPhase = (typeof COMMAND_HOOK_PHASES)[number];
+export type CommandParseConfidence = (typeof COMMAND_PARSE_CONFIDENCES)[number];
+export type CommandDecisionReason = (typeof COMMAND_DECISION_REASONS)[number];
+export type CommandUncertaintyClass = (typeof COMMAND_UNCERTAINTY_CLASSES)[number];
+export type CommandMatchClass = (typeof COMMAND_MATCH_CLASSES)[number];
+export type CommandEvidenceSeverity = (typeof COMMAND_EVIDENCE_SEVERITIES)[number];
+export type CommandLatencyBucket = (typeof COMMAND_LATENCY_BUCKETS)[number];
+export type CommandFeedbackLabel = (typeof COMMAND_FEEDBACK_LABELS)[number];
+export type CommandRuleMode = (typeof COMMAND_RULE_MODES)[number];
+export type CommandEffectClass = (typeof COMMAND_EFFECT_CLASSES)[number];
+
+export interface CommandActivityMatch {
+  ordinal: number;
+  extension_id: string;
+  extension_version: string;
+  rule_id: string;
+  rule_version: string;
+  match_class: CommandMatchClass;
+  severity: CommandEvidenceSeverity;
+  default_floor: CommandPolicyAction;
+  safe_variant_id: string | null;
+  effect_classes: CommandEffectClass[];
+  schema_version: typeof COMMAND_ACTIVITY_RECORD_SCHEMA_VERSION;
+}
+
+export interface CommandActivityItem {
+  activity_id: string;
+  occurred_at: string;
+  harness: CommandActivityHarness;
+  hook_phase: CommandHookPhase;
+  execution_status: CommandExecutionStatus;
+  proof_level: CommandProofLevel;
+  policy_action: CommandPolicyAction | null;
+  decision_reason_code: CommandDecisionReason | null;
+  controlling_rule_id: string | null;
+  parse_confidence: CommandParseConfidence | null;
+  uncertainty_class: CommandUncertaintyClass | null;
+  match_count: number;
+  prompted: boolean;
+  approval_reuse_status: CommandApprovalReuseStatus;
+  receipt_link_status: "not_applicable" | "linked";
+  receipt_id: string | null;
+  evaluation_latency_bucket: CommandLatencyBucket;
+  persistence_latency_bucket: CommandLatencyBucket;
+  feedback_label: CommandFeedbackLabel | null;
+  schema_version: typeof COMMAND_ACTIVITY_RECORD_SCHEMA_VERSION;
+  matches: CommandActivityMatch[];
+}
+
+export interface CommandActivityPage {
+  schema_version: typeof COMMAND_ACTIVITY_API_SCHEMA_VERSION;
+  items: CommandActivityItem[];
+  next_cursor: string | null;
+}
+
+export interface CommandActivityDimensionValue { value: string; count: number }
+export type CommandActivityDimension =
+  | "harness" | "extension" | "rule" | "disposition" | "execution_status"
+  | "prompt_status" | "proof_level" | "latency";
+
+export interface CommandActivityHealth {
+  status: "healthy" | "degraded";
+  dropped_events: number;
+  persistence_errors: number;
+  last_error_class: string | null;
+  last_error_at: string | null;
+}
+
+export interface CommandActivityAnalytics {
+  schema_version: typeof COMMAND_ACTIVITY_API_SCHEMA_VERSION;
+  window: { from: string; through: string; days: number };
+  scope: { dimension: "harness" | "extension" | "rule" | null; dimension_value: string | null };
+  commands_checked: number;
+  trend: Array<{ day: string; count: number }>;
+  dimensions: Record<CommandActivityDimension, CommandActivityDimensionValue[]>;
+  dimension_breakdowns_scope: "global";
+  feedback: Array<{ label: CommandFeedbackLabel; count: number }>;
+  health: CommandActivityHealth;
+}
+
+export interface CommandExtensionRule {
+  rule_id: string;
+  title: string;
+  description: string;
+  severity: CommandEvidenceSeverity;
+  risk_classes: string[];
+  action_classes: string[];
+  default_mode: CommandRuleMode;
+  safe_variant_ids: string[];
+  compatibility_fallback: boolean;
+}
+
+export interface CommandExtension {
+  extension_id: string;
+  version: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  required: boolean;
+  source: "built-in" | "local-admin" | "signed-cloud";
+  dependencies: string[];
+  conflicts: string[];
+  delegated_protection: "package-firewall" | null;
+  action_classes: string[];
+  risk_classes: string[];
+  rule_count: number;
+  rules: CommandExtensionRule[];
+}
+
+export interface CommandExtensionsPage {
+  schema_version: typeof COMMAND_EXTENSION_SCHEMA_VERSION;
+  source: "built-in";
+  items: CommandExtension[];
+  next_cursor: string | null;
+}
+
+export interface CommandActivityFeedbackResult {
+  schema_version: typeof COMMAND_ACTIVITY_API_SCHEMA_VERSION;
+  activity_id: string;
+  label: CommandFeedbackLabel;
+  created_at: string;
+  updated_at: string;
+  changed: boolean;
+}

--- a/dashboard/src/commands/commands-information-architecture.ts
+++ b/dashboard/src/commands/commands-information-architecture.ts
@@ -1,0 +1,74 @@
+import type { CommandActivityHarness } from "./command-activity-types";
+
+export type CommandsSurfaceId = "evidence" | "app-activity" | "home";
+export type CommandsDataSource = "activity" | "analytics" | "extensions" | "invalidations";
+
+export interface CommandsSurfaceContract {
+  id: CommandsSurfaceId;
+  parentLabel: string;
+  label: string;
+  route: string;
+  data: readonly CommandsDataSource[];
+  visibility: "always" | "when-command-data-exists";
+  scope: "all-apps" | "selected-app";
+}
+
+export const COMMANDS_INFORMATION_ARCHITECTURE: readonly CommandsSurfaceContract[] = [
+  {
+    id: "evidence",
+    parentLabel: "Evidence",
+    label: "Commands",
+    route: "/evidence?view=commands",
+    data: ["activity", "analytics", "extensions", "invalidations"],
+    visibility: "always",
+    scope: "all-apps",
+  },
+  {
+    id: "app-activity",
+    parentLabel: "Activity",
+    label: "Command protection",
+    route: "/apps/:harness?tab=activity&activity=commands",
+    data: ["activity", "analytics", "extensions", "invalidations"],
+    visibility: "always",
+    scope: "selected-app",
+  },
+  {
+    id: "home",
+    parentLabel: "Home",
+    label: "Commands checked",
+    route: "/",
+    data: ["analytics", "invalidations"],
+    visibility: "when-command-data-exists",
+    scope: "all-apps",
+  },
+] as const;
+
+export const COMMAND_ACTIVITY_TRUTH_COPY = {
+  activityMeaning: "A command match is local activity evidence, not a threat classification.",
+  allowedUnconfirmed: "Allowed; execution not confirmed",
+  confirmedSuccess: "Execution confirmed",
+  confirmedFailure: "Execution failure confirmed",
+  evidenceGap: "Some command activity may be missing.",
+} as const;
+
+export const COMMAND_DECISIONS_SIBLING = {
+  label: "Decisions",
+  route: "/evidence?view=actions",
+  meaning: "Saved policy decisions and receipts remain separate from command checks.",
+} as const;
+
+export function commandsSurface(id: CommandsSurfaceId): CommandsSurfaceContract {
+  const surface = COMMANDS_INFORMATION_ARCHITECTURE.find((item) => item.id === id);
+  if (!surface) throw new Error(`Unknown Commands surface: ${id}`);
+  return surface;
+}
+
+export function commandActivityPathForHarness(
+  harness: CommandActivityHarness,
+): string {
+  return `/apps/${encodeURIComponent(harness)}?tab=activity&activity=commands`;
+}
+
+export function shouldShowHomeCommands(commandsChecked: number): boolean {
+  return Number.isSafeInteger(commandsChecked) && commandsChecked > 0;
+}

--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -1,3 +1,11 @@
+import "./commands/command-activity-client.test";
+import {
+  fetchCommandActivityAnalytics,
+  fetchCommandActivityPage,
+  fetchCommandExtensions,
+  submitCommandActivityFeedback,
+} from "./commands/command-activity-api";
+
 import {
   buildDemoRuntimeSnapshot,
   clearReviewQueue,
@@ -1433,6 +1441,85 @@ assert(
 assert(
   headerValue(retryResumeCalls[2].init, "X-Guard-Dashboard-Session") === "fresh-retry-resume-session",
   "L080: retryResume retry uses refreshed dashboard session"
+);
+
+installGuardWindow("?guard-token=token-command-activity&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
+const commandActivityCalls: RecordedFetch[] = [];
+globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const url = input instanceof Request ? input.url : String(input);
+  commandActivityCalls.push({ url, init });
+  const path = new URL(url, "http://127.0.0.1:4174").pathname;
+  if (path === "/v1/command-activity") {
+    return new Response(JSON.stringify({
+      schema_version: "guard.command-activity-api.v1",
+      items: [],
+      next_cursor: null,
+    }), { status: 200, headers: { "Content-Type": "application/json" } });
+  }
+  if (path === "/v1/command-activity/analytics") {
+    return new Response(JSON.stringify({
+      schema_version: "guard.command-activity-api.v1",
+      window: { from: "2026-07-19", through: "2026-07-19", days: 1 },
+      scope: { dimension: null, dimension_value: null },
+      commands_checked: 0,
+      trend: [],
+      dimensions: {
+        harness: [], extension: [], rule: [], disposition: [], execution_status: [],
+        prompt_status: [], proof_level: [], latency: [],
+      },
+      dimension_breakdowns_scope: "global",
+      feedback: [],
+      health: { status: "healthy", dropped_events: 0, persistence_errors: 0 },
+    }), { status: 200, headers: { "Content-Type": "application/json" } });
+  }
+  if (path === "/v1/command-extensions") {
+    return new Response(JSON.stringify({
+      schema_version: 2,
+      source: "built-in",
+      items: [],
+      next_cursor: null,
+    }), { status: 200, headers: { "Content-Type": "application/json" } });
+  }
+  if (path === "/v1/command-activity/feedback") {
+    return new Response(JSON.stringify({
+      schema_version: "guard.command-activity-api.v1",
+      activity_id: "activity-api-test",
+      label: "should_not_have_interrupted",
+      created_at: "2026-07-19T10:00:00Z",
+      updated_at: "2026-07-19T10:00:00Z",
+      changed: true,
+    }), { status: 200, headers: { "Content-Type": "application/json" } });
+  }
+  return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
+};
+
+const commandActivityPage = await fetchCommandActivityPage();
+const commandActivityAnalytics = await fetchCommandActivityAnalytics({
+  days: 1,
+  topLimit: 1,
+  dimension: null,
+  dimensionValue: null,
+});
+const commandExtensions = await fetchCommandExtensions();
+const commandFeedback = await submitCommandActivityFeedback(
+  "activity-api-test",
+  "should_not_have_interrupted",
+);
+assert(commandActivityPage.items.length === 0, "CDX-036: authenticated command list normalizes empty pages");
+assert(commandActivityAnalytics.commands_checked === 0, "CDX-036: authenticated analytics normalizes totals");
+assert(commandExtensions.items.length === 0, "CDX-036: authenticated extension catalog normalizes empty pages");
+assert(commandFeedback.changed, "CDX-036: authenticated command feedback normalizes its result");
+assert(
+  headerValue(commandActivityCalls[0].init, "X-Guard-Dashboard-Session") === "token-command-activity",
+  "CDX-036: command list uses dashboard session authentication",
+);
+assert(commandActivityCalls.slice(0, 3).every((call) =>
+  headerValue(call.init, "X-Guard-Dashboard-Session") === "token-command-activity"
+), "CDX-036: every command read uses dashboard session authentication");
+assert(commandActivityCalls[3].init?.method === "POST", "CDX-036: feedback uses POST");
+assert(
+  headerValue(commandActivityCalls[3].init, "X-Guard-Dashboard-Session") === "token-command-activity",
+  "CDX-036: feedback uses dashboard session authentication",
 );
 
 console.log("guard-api.test.ts: all tests passed");

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -135,6 +135,10 @@ async function readJson<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
   return (await response.json()) as T;
 }
 
+export async function requestGuardJson<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  return readJson<T>(input, init);
+}
+
 async function requestErrorMessage(response: Response, fallback: string): Promise<string> {
   try {
     const payload = await response.clone().json();


### PR DESCRIPTION
## Summary

- define the Commands information architecture across Evidence, per-app Activity, and Home while keeping command checks distinct from saved decisions
- add typed, authenticated clients and allowlist-based normalizers for command activity, analytics, extensions, and feedback
- add bounded filter and cursor URL state plus refresh states that preserve the last valid response on transient failures
- keep unconfirmed execution and globally scoped analytics explicit in the client contract

## Verification

- `bun run src/commands/command-activity-client.test.ts`
- `bun run src/guard-api.test.ts`
- `bun run test`
- `bun run build`
- changed-file TypeScript scan: 0 errors