### PR TITLE
fix(mdm): redact support diagnostics errors

### DIFF
--- a/src/codex_plugin_scanner/guard/mdm/health_reporter.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_reporter.py
@@ -25,6 +25,19 @@ PolicyLoader = Callable[..., ManagedPolicyState]
 LeaseIssuer = Callable[..., HealthLeaseOutbox]
 LeaseAcknowledger = Callable[..., HealthLeaseAck]
 
+_SAFE_TRANSPORT_REASON_CODES = frozenset(
+    {
+        "health_key_registration_ack_invalid",
+        "health_lease_challenge_invalid",
+        "health_lease_delivery_auth_invalid",
+        "health_lease_delivery_response_oversized",
+    }
+)
+_SAFE_HTTP_REASON = re.compile(
+    r"health_(?:key_registration|lease_challenge|lease_delivery)_http_[1-5][0-9]{2}"
+)
+_SAFE_STRUCTURED_HTTP_REASON = re.compile(r"(health_lease_delivery_http_[1-5][0-9]{2}):(.+)")
+
 
 def _machine_binding(policy_state: ManagedPolicyState) -> HealthLeaseBinding:
     policy = policy_state.policy
@@ -163,9 +176,9 @@ def run_machine_health_cadence(
 
 def _bounded_reason(error: BaseException) -> str:
     reason = str(error).strip()
-    if len(reason) <= 128 and re.fullmatch(r"health_[a-z0-9_]+", reason):
+    if reason in _SAFE_TRANSPORT_REASON_CODES or _SAFE_HTTP_REASON.fullmatch(reason):
         return reason
-    structured = re.fullmatch(r"(health_[a-z0-9_]+):(.+)", reason)
+    structured = _SAFE_STRUCTURED_HTTP_REASON.fullmatch(reason)
     if structured is not None:
         cloud_code_digest = hashlib.sha256(structured.group(2).encode("utf-8")).hexdigest()[:12]
         return f"{structured.group(1)}:cloud_error_{cloud_code_digest}"[:128]

--- a/src/codex_plugin_scanner/guard/mdm/health_reporter.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_reporter.py
@@ -33,9 +33,7 @@ _SAFE_TRANSPORT_REASON_CODES = frozenset(
         "health_lease_delivery_response_oversized",
     }
 )
-_SAFE_HTTP_REASON = re.compile(
-    r"health_(?:key_registration|lease_challenge|lease_delivery)_http_[1-5][0-9]{2}"
-)
+_SAFE_HTTP_REASON = re.compile(r"health_(?:key_registration|lease_challenge|lease_delivery)_http_[1-5][0-9]{2}")
 _SAFE_STRUCTURED_HTTP_REASON = re.compile(r"(health_lease_delivery_http_[1-5][0-9]{2}):(.+)")
 
 

--- a/src/codex_plugin_scanner/guard/mdm/health_reporter.py
+++ b/src/codex_plugin_scanner/guard/mdm/health_reporter.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
 import platform
+import re
 import time
 from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
@@ -160,8 +162,18 @@ def run_machine_health_cadence(
 
 
 def _bounded_reason(error: BaseException) -> str:
-    reason = str(error).strip().splitlines()[0] if str(error).strip() else type(error).__name__
-    return reason[:128]
+    reason = str(error).strip()
+    if len(reason) <= 128 and re.fullmatch(r"health_[a-z0-9_]+", reason):
+        return reason
+    structured = re.fullmatch(r"(health_[a-z0-9_]+):(.+)", reason)
+    if structured is not None:
+        cloud_code_digest = hashlib.sha256(structured.group(2).encode("utf-8")).hexdigest()[:12]
+        return f"{structured.group(1)}:cloud_error_{cloud_code_digest}"[:128]
+    if isinstance(error, TimeoutError):
+        return "health_transport_timeout"
+    if isinstance(error, ConnectionError):
+        return "health_transport_unavailable"
+    return "health_transport_failure"
 
 
 def _key_storage_health(outbox: HealthLeaseOutbox) -> str:

--- a/tests/test_guard_mdm_health_reporter.py
+++ b/tests/test_guard_mdm_health_reporter.py
@@ -321,6 +321,34 @@ def test_delivery_diagnostics_preserve_structured_http_context_without_echoing_c
     assert "customer_secret_value" not in reason
 
 
+def test_delivery_diagnostics_reject_arbitrary_health_prefixed_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class ArbitraryHealthErrorTransport:
+        def register_key(self, _payload: bytes) -> None:
+            return None
+
+        def deliver_lease(self, _outbox: HealthLeaseOutbox) -> HealthLeaseAck:
+            raise RuntimeError("health_secret_token_value")
+
+        def poll_challenge(self, **_kwargs: object) -> None:
+            pytest.fail("challenge polling must not run after failed delivery")
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.mdm.health_reporter.build_machine_health_key_registration",
+        lambda *_args, **_kwargs: b"registration",
+    )
+    result = run_machine_health_cadence(
+        paths=_paths(tmp_path),
+        system_name="Darwin",
+        policy_loader=lambda **_kwargs: _policy(),
+        lease_issuer=lambda *_args, **_kwargs: _outbox(),
+        transport=ArbitraryHealthErrorTransport(),
+    )
+
+    assert cast(dict[str, object], result["metrics"])["rejectionReason"] == "health_transport_failure"
+
+
 @pytest.mark.parametrize(
     ("state", "reason"),
     [

--- a/tests/test_guard_mdm_health_reporter.py
+++ b/tests/test_guard_mdm_health_reporter.py
@@ -248,7 +248,77 @@ def test_delivery_failure_is_exposed_without_weakening_local_enforcement(
     assert result["localEnforcementHealthy"] is True
     assert result["state"] == "delivery-failed"
     assert result["reasonCodes"] == ["health_lease_delivery_failed"]
-    assert cast(dict[str, object], result["metrics"])["rejectionReason"] == "cloud delivery timed out"
+    assert cast(dict[str, object], result["metrics"])["rejectionReason"] == "health_transport_timeout"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Authorization: Bearer secret-token-value",
+        "-----BEGIN PRIVATE KEY-----",
+        "host=/private/customer/path command=rm -rf /",
+        "https://user:password@example.test/health",
+    ],
+)
+def test_delivery_diagnostics_never_echo_transport_exception_data(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, message: str
+) -> None:
+    class UnsafeTransport:
+        def register_key(self, _payload: bytes) -> None:
+            return None
+
+        def deliver_lease(self, _outbox: HealthLeaseOutbox) -> HealthLeaseAck:
+            raise RuntimeError(message)
+
+        def poll_challenge(self, **_kwargs: object) -> None:
+            pytest.fail("challenge polling must not run after failed delivery")
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.mdm.health_reporter.build_machine_health_key_registration",
+        lambda *_args, **_kwargs: b"registration",
+    )
+    result = run_machine_health_cadence(
+        paths=_paths(tmp_path),
+        system_name="Darwin",
+        policy_loader=lambda **_kwargs: _policy(),
+        lease_issuer=lambda *_args, **_kwargs: _outbox(),
+        transport=UnsafeTransport(),
+    )
+
+    metrics = cast(dict[str, object], result["metrics"])
+    assert metrics["rejectionReason"] == "health_transport_failure"
+    assert message not in json.dumps(result, sort_keys=True)
+
+
+def test_delivery_diagnostics_preserve_structured_http_context_without_echoing_cloud_data(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class StructuredErrorTransport:
+        def register_key(self, _payload: bytes) -> None:
+            return None
+
+        def deliver_lease(self, _outbox: HealthLeaseOutbox) -> HealthLeaseAck:
+            raise OSError("health_lease_delivery_http_403:customer_secret_value")
+
+        def poll_challenge(self, **_kwargs: object) -> None:
+            pytest.fail("challenge polling must not run after failed delivery")
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.mdm.health_reporter.build_machine_health_key_registration",
+        lambda *_args, **_kwargs: b"registration",
+    )
+    result = run_machine_health_cadence(
+        paths=_paths(tmp_path),
+        system_name="Darwin",
+        policy_loader=lambda **_kwargs: _policy(),
+        lease_issuer=lambda *_args, **_kwargs: _outbox(),
+        transport=StructuredErrorTransport(),
+    )
+
+    reason = cast(dict[str, object], result["metrics"])["rejectionReason"]
+    assert isinstance(reason, str)
+    assert reason.startswith("health_lease_delivery_http_403:cloud_error_")
+    assert "customer_secret_value" not in reason
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- preserve bounded machine health state, reason codes, and lease evidence identifiers for support
- replace arbitrary transport exception text with stable diagnostic codes
- prove tokens, private keys, host paths, credentials, and raw commands cannot echo through JSON diagnostics

## Verification
- `uv run pytest -q tests/test_guard_mdm_health_reporter.py` (13 passed)
- Ruff on changed files
- basedpyright on changed source (0 errors)
- `git diff --check`