### PR TITLE
fix(hooks): align scoped default handling

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -482,12 +482,16 @@ def _run_hook_generic_payload(
         artifact_id,
         publisher,
     )
+    configured_narrow_override = config.resolve_artifact_or_publisher_action_override(
+        artifact_id,
+        publisher,
+    )
     configured_policy_normalization = normalize_guard_action_result(
         configured_override if configured_override is not None else config.default_action,
         unknown_action="require-reapproval",
     )
     verified_benign_default = (
-        configured_override is None
+        configured_narrow_override is None
         and configured_policy_normalization.action in {"review", "require-reapproval"}
         and _hook_event_name(payload_map) == "PreToolUse"
         and is_explicitly_benign_tool_action_request(

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -336,12 +336,25 @@ class GuardConfig:
         artifact_id: str | None,
         publisher: str | None,
     ) -> GuardAction | None:
+        narrow_override = self.resolve_artifact_or_publisher_action_override(
+            artifact_id,
+            publisher,
+        )
+        if narrow_override is not None:
+            return narrow_override
+        if self.harness_actions is not None and harness in self.harness_actions:
+            return self.harness_actions[harness]
+        return None
+
+    def resolve_artifact_or_publisher_action_override(
+        self,
+        artifact_id: str | None,
+        publisher: str | None,
+    ) -> GuardAction | None:
         if artifact_id is not None and self.artifact_actions is not None and artifact_id in self.artifact_actions:
             return self.artifact_actions[artifact_id]
         if publisher is not None and self.publisher_actions is not None and publisher in self.publisher_actions:
             return self.publisher_actions[publisher]
-        if self.harness_actions is not None and harness in self.harness_actions:
-            return self.harness_actions[harness]
         return None
 
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14756,7 +14756,16 @@ def test_guard_hook_codex_emits_no_native_output_for_safe_requests(tmp_path, cap
     assert pending == []
 
 
+@pytest.mark.parametrize(
+    "strict_config",
+    (
+        'default_action = "require-reapproval"\n',
+        '[harnesses.codex]\ndefault_action = "require-reapproval"\n',
+    ),
+    ids=("global", "harness"),
+)
 def test_guard_hook_codex_strict_default_allows_verified_benign_git_status(
+    strict_config,
     tmp_path,
     capsys,
     monkeypatch,
@@ -14764,7 +14773,7 @@ def test_guard_hook_codex_strict_default_allows_verified_benign_git_status(
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
-    _write_text(home_dir / "config.toml", 'default_action = "require-reapproval"\n')
+    _write_text(home_dir / "config.toml", strict_config)
     event = {
         "hook_event_name": "PreToolUse",
         "tool_name": "Bash",
@@ -14842,7 +14851,16 @@ def test_guard_hook_codex_verified_benign_does_not_override_explicit_policy(
     assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
+@pytest.mark.parametrize(
+    "strict_config",
+    (
+        'default_action = "require-reapproval"\napproval_wait_timeout_seconds = 0\n',
+        'approval_wait_timeout_seconds = 0\n[harnesses.codex]\ndefault_action = "require-reapproval"\n',
+    ),
+    ids=("global", "harness"),
+)
 def test_guard_hook_codex_strict_default_still_denies_destructive_shell_command(
+    strict_config,
     tmp_path,
     capsys,
     monkeypatch,
@@ -14850,10 +14868,7 @@ def test_guard_hook_codex_strict_default_still_denies_destructive_shell_command(
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
-    _write_text(
-        home_dir / "config.toml",
-        'default_action = "require-reapproval"\napproval_wait_timeout_seconds = 0\n',
-    )
+    _write_text(home_dir / "config.toml", strict_config)
     monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
     event = {


### PR DESCRIPTION
## Summary
- align verified read-only handling across default scopes
- preserve narrower artifact and publisher decisions
- cover safe and destructive behavior in focused regressions

## Verification
- focused hook runtime tests
- policy precedence tests
- risk classifier suite
- Ruff and basedpyright
- editable installed-package canary