### PR TITLE
feat(guard): add opt-in user-managed health leases

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -31,6 +31,11 @@ if TYPE_CHECKING:
 
 
 from ..local_supply_chain import _resolve_guard_sync_auth_context as _local_resolve_guard_sync_auth_context
+from ..mdm.user_health import (
+    configure_user_health_leases,
+    run_user_health_cadence,
+    user_health_status,
+)
 from ..runtime.command_capability import (
     READ_ONLY_COMMAND_OPERATIONS,
     CommandCapabilityError,
@@ -319,6 +324,9 @@ def _run_guard_sync_command(
                         workspace_dir=context.workspace_dir,
                     )
                 )
+            with suppress(OSError, PermissionError, RuntimeError, ValueError):
+                if user_health_status(context.guard_home)["enabled"] is True:
+                    payload["health_lease"] = run_user_health_cadence(context.guard_home)
             bar.done("Sync complete")
     except (GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError) as error:
         message = _guard_sync_failure_message(error)
@@ -334,6 +342,36 @@ def _run_guard_sync_command(
             print(str(error), file=sys.stderr)
         return 1
     _emit("sync", payload, getattr(args, "json", False))
+    return 0
+
+
+def _run_guard_health_leases_command(
+    args: argparse.Namespace,
+    *,
+    guard_home: Path | None = None,
+    **_kwargs: object,
+) -> int:
+    resolved_guard_home = guard_home or resolve_guard_home(getattr(args, "guard_home", None))
+    command = str(args.health_leases_command)
+    try:
+        if command == "enable":
+            payload = configure_user_health_leases(resolved_guard_home, enabled=True)
+        elif command == "disable":
+            payload = configure_user_health_leases(resolved_guard_home, enabled=False)
+        elif command == "report":
+            payload = run_user_health_cadence(resolved_guard_home)
+        else:
+            payload = user_health_status(resolved_guard_home)
+    except (OSError, PermissionError, RuntimeError, ValueError):
+        payload = {
+            "schemaVersion": "hol-guard-user-health-status.v1",
+            "ok": False,
+            "error": "user_health_operation_failed",
+            "assuranceLevel": "user-managed",
+        }
+        _emit("health-leases", payload, bool(getattr(args, "json", False)))
+        return 1
+    _emit("health-leases", payload, bool(getattr(args, "json", False)))
     return 0
 
 
@@ -689,6 +727,7 @@ __all__ = [
     "_run_guard_daemon_command",
     "_run_guard_device_command",
     "_run_guard_disconnect_command",
+    "_run_guard_health_leases_command",
     "_run_guard_login_command",
     "_run_guard_remote_pair_command",
     "_run_guard_service_command",

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -363,7 +363,7 @@ def _run_guard_health_leases_command(
         else:
             payload = user_health_status(resolved_guard_home)
     except (OSError, PermissionError, RuntimeError, ValueError):
-        payload = {
+        payload: dict[str, object] = {
             "schemaVersion": "hol-guard-user-health-status.v1",
             "ok": False,
             "error": "user_health_operation_failed",

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -34,6 +34,7 @@ from ..local_supply_chain import _resolve_guard_sync_auth_context as _local_reso
 from ..mdm.user_health import (
     configure_user_health_leases,
     run_user_health_cadence,
+    user_health_report_due,
     user_health_status,
 )
 from ..runtime.command_capability import (
@@ -325,7 +326,9 @@ def _run_guard_sync_command(
                     )
                 )
             with suppress(OSError, PermissionError, RuntimeError, ValueError):
-                if user_health_status(context.guard_home)["enabled"] is True:
+                if user_health_status(context.guard_home)["enabled"] is True and user_health_report_due(
+                    context.guard_home
+                ):
                     payload["health_lease"] = run_user_health_cadence(context.guard_home)
             bar.done("Sync complete")
     except (GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError) as error:

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_cloud.py
@@ -147,6 +147,17 @@ def _configure_guard_cloud_parsers(
         help="Also refresh AIBOM inventory during this foreground sync.",
     )
 
+    health_leases_parser = guard_subparsers.add_parser(
+        "health-leases",
+        help="Manage opt-in lower-assurance health reporting for this user installation",
+    )
+    _add_guard_common_args(health_leases_parser)
+    health_leases_parser.add_argument(
+        "health_leases_command",
+        choices=("enable", "disable", "status", "report"),
+    )
+    health_leases_parser.add_argument("--json", action="store_true")
+
     commands_parser = guard_subparsers.add_parser(
         "commands",
         help="Inspect Guard Cloud command queue state",

--- a/src/codex_plugin_scanner/guard/cli/commands_router.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_router.py
@@ -71,6 +71,7 @@ _COMMON_HANDLERS = {
     "disconnect": "_run_guard_disconnect_command",
     "bridge": "_run_guard_bridge_command",
     "sync": "_run_guard_sync_command",
+    "health-leases": "_run_guard_health_leases_command",
     "cloud": "_run_guard_cloud_command",
     "supply-chain": "_run_guard_supply_chain_command",
     "service": "_run_guard_service_command",

--- a/src/codex_plugin_scanner/guard/mdm/user_health.py
+++ b/src/codex_plugin_scanner/guard/mdm/user_health.py
@@ -1,0 +1,414 @@
+"""Opt-in lower-assurance health leases for user-managed Guard installations."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import stat
+from contextlib import suppress
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
+
+from ..review_contracts import guard_review_oauth_metadata
+from ..store import GuardStore
+from .health_lease_contract import HealthLeaseOutbox, canonical_json_bytes, canonical_timestamp
+from .health_transport import GuardCloudMachineHealthTransport, MachineHealthTransport
+from .integrity import machine_integrity_snapshot
+from .protection_lease_contract import ProtectionLeaseClaims, SignedProtectionLease
+
+_SCHEMA = "hol-guard-user-health-state.v1"
+_STATE_NAME = "user-health-state.json"
+_MAX_STATE_BYTES = 512 * 1024
+_MAX_UINT64 = (1 << 64) - 1
+_P256_ORDER = int("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551", 16)
+
+
+@dataclass(frozen=True, slots=True)
+class UserHealthState:
+    enabled: bool
+    workspace_id: str
+    device_id: str
+    machine_installation_id: str
+    installation_generation: str
+    sequence: int
+    last_lease_digest: str | None
+    key_id: str
+    public_key_spki: str
+    private_key_pem: str
+    pending_outbox: str | None
+    updated_at: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schemaVersion": _SCHEMA,
+            "enabled": self.enabled,
+            "workspaceId": self.workspace_id,
+            "deviceId": self.device_id,
+            "machineInstallationId": self.machine_installation_id,
+            "installationGeneration": self.installation_generation,
+            "sequence": self.sequence,
+            "lastLeaseDigest": self.last_lease_digest,
+            "keyId": self.key_id,
+            "publicKeySpki": self.public_key_spki,
+            "privateKeyPem": self.private_key_pem,
+            "pendingOutbox": self.pending_outbox,
+            "updatedAt": self.updated_at,
+        }
+
+
+def _state_path(guard_home: Path) -> Path:
+    return guard_home / _STATE_NAME
+
+
+def _low_s_signature(signature: bytes) -> bytes:
+    try:
+        r, s = decode_dss_signature(signature)
+    except ValueError as exc:
+        raise OSError("user_health_signature_invalid") from exc
+    if not 1 <= r < _P256_ORDER or not 1 <= s < _P256_ORDER:
+        raise OSError("user_health_signature_invalid")
+    return encode_dss_signature(r, min(s, _P256_ORDER - s))
+
+
+def _private_directory(guard_home: Path) -> None:
+    metadata = guard_home.lstat()
+    if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+        raise PermissionError("user_health_state_acl_invalid")
+    if os.name != "nt" and (metadata.st_uid != os.geteuid() or stat.S_IMODE(metadata.st_mode) & 0o077):
+        raise PermissionError("user_health_state_acl_invalid")
+
+
+def _read_state(guard_home: Path) -> UserHealthState | None:
+    _private_directory(guard_home)
+    try:
+        descriptor = os.open(
+            _state_path(guard_home),
+            os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+    except FileNotFoundError:
+        return None
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_size > _MAX_STATE_BYTES
+            or (os.name != "nt" and (metadata.st_uid != os.geteuid() or stat.S_IMODE(metadata.st_mode) & 0o077))
+        ):
+            raise PermissionError("user_health_state_acl_invalid")
+        payload = os.read(descriptor, _MAX_STATE_BYTES + 1)
+    finally:
+        os.close(descriptor)
+    try:
+        raw = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("user_health_state_invalid") from exc
+    expected = {
+        "schemaVersion",
+        "enabled",
+        "workspaceId",
+        "deviceId",
+        "machineInstallationId",
+        "installationGeneration",
+        "sequence",
+        "lastLeaseDigest",
+        "keyId",
+        "publicKeySpki",
+        "privateKeyPem",
+        "pendingOutbox",
+        "updatedAt",
+    }
+    if not isinstance(raw, dict) or set(raw) != expected or raw.get("schemaVersion") != _SCHEMA:
+        raise ValueError("user_health_state_invalid")
+    state = UserHealthState(
+        cast(bool, raw["enabled"]),
+        cast(str, raw["workspaceId"]),
+        cast(str, raw["deviceId"]),
+        cast(str, raw["machineInstallationId"]),
+        cast(str, raw["installationGeneration"]),
+        cast(int, raw["sequence"]),
+        cast(str | None, raw["lastLeaseDigest"]),
+        cast(str, raw["keyId"]),
+        cast(str, raw["publicKeySpki"]),
+        cast(str, raw["privateKeyPem"]),
+        cast(str | None, raw["pendingOutbox"]),
+        cast(str, raw["updatedAt"]),
+    )
+    _validate_state(state)
+    return state
+
+
+def _validate_state(state: UserHealthState) -> None:
+    if (
+        not isinstance(state.enabled, bool)
+        or not all(isinstance(value, str) and value for value in (state.workspace_id, state.device_id))
+        or any(
+            len(value) != 32 or any(char not in "0123456789abcdef" for char in value)
+            for value in (state.machine_installation_id, state.installation_generation)
+        )
+        or not isinstance(state.sequence, int)
+        or isinstance(state.sequence, bool)
+        or not 0 <= state.sequence <= _MAX_UINT64
+        or (state.sequence == 0) != (state.last_lease_digest is None)
+        or (
+            state.last_lease_digest is not None
+            and (
+                len(state.last_lease_digest) != 64
+                or any(char not in "0123456789abcdef" for char in state.last_lease_digest)
+            )
+        )
+        or len(state.key_id) != 43
+        or len(state.public_key_spki) > 1024
+        or len(state.private_key_pem) > 4096
+        or (state.pending_outbox is not None and len(state.pending_outbox) > 400_000)
+    ):
+        raise ValueError("user_health_state_invalid")
+    try:
+        private_key = serialization.load_pem_private_key(state.private_key_pem.encode(), password=None)
+        public_der = base64.b64decode(state.public_key_spki, validate=True)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("user_health_state_invalid") from exc
+    if not isinstance(private_key, ec.EllipticCurvePrivateKey) or not isinstance(private_key.curve, ec.SECP256R1):
+        raise ValueError("user_health_state_invalid")
+    expected_der = private_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    if expected_der != public_der or hashlib.sha256(public_der).digest() != base64.urlsafe_b64decode(
+        f"{state.key_id}="
+    ):
+        raise ValueError("user_health_state_invalid")
+
+
+def _write_state(guard_home: Path, state: UserHealthState) -> None:
+    _validate_state(state)
+    _private_directory(guard_home)
+    payload = canonical_json_bytes(state.to_dict())
+    temporary = guard_home / f".{_STATE_NAME}.{secrets.token_hex(16)}.tmp"
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb", closefd=True) as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, _state_path(guard_home))
+        os.chmod(_state_path(guard_home), 0o600)
+    finally:
+        with suppress(FileNotFoundError):
+            temporary.unlink()
+
+
+def _new_state(workspace_id: str, device_id: str, now: datetime) -> UserHealthState:
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    private_pem = private_key.private_bytes(
+        serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8, serialization.NoEncryption()
+    ).decode("ascii")
+    public_der = private_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    return UserHealthState(
+        True,
+        workspace_id,
+        device_id,
+        secrets.token_hex(16),
+        secrets.token_hex(16),
+        0,
+        None,
+        base64.urlsafe_b64encode(hashlib.sha256(public_der).digest()).rstrip(b"=").decode("ascii"),
+        base64.b64encode(public_der).decode("ascii"),
+        private_pem,
+        None,
+        now.isoformat(),
+    )
+
+
+def configure_user_health_leases(guard_home: Path, *, enabled: bool, now: datetime | None = None) -> dict[str, object]:
+    """Explicitly opt a connected user installation in or out without deleting continuity."""
+
+    resolved_now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    store = GuardStore(guard_home, prime_policy_integrity=False, source="user-health")
+    identity = guard_review_oauth_metadata(store)
+    state = _read_state(guard_home)
+    if state is None or (state.workspace_id, state.device_id) != (identity.workspace_id, identity.device_id):
+        state = _new_state(identity.workspace_id, identity.device_id, resolved_now)
+    state = replace(state, enabled=enabled, updated_at=resolved_now.isoformat())
+    _write_state(guard_home, state)
+    return user_health_status(guard_home)
+
+
+def user_health_status(guard_home: Path) -> dict[str, object]:
+    state = _read_state(guard_home)
+    return {
+        "schemaVersion": "hol-guard-user-health-status.v1",
+        "configured": state is not None,
+        "enabled": state.enabled if state is not None else False,
+        "assuranceLevel": "user-managed",
+        "sequence": state.sequence if state is not None else 0,
+        "pending": state.pending_outbox is not None if state is not None else False,
+    }
+
+
+def user_health_report_due(
+    guard_home: Path,
+    *,
+    now: datetime | None = None,
+    cadence_seconds: int = 300,
+) -> bool:
+    """Return whether the opted-in cadence should issue or retry a lease."""
+
+    if not 60 <= cadence_seconds <= 3_600:
+        raise ValueError("user_health_cadence_invalid")
+    state = _read_state(guard_home)
+    if state is None or not state.enabled:
+        return False
+    if state.pending_outbox is not None:
+        return True
+    resolved_now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    try:
+        updated_at = datetime.fromisoformat(state.updated_at).astimezone(timezone.utc)
+    except ValueError as exc:
+        raise ValueError("user_health_state_invalid") from exc
+    return (resolved_now - updated_at).total_seconds() >= cadence_seconds
+
+
+def _registration(state: UserHealthState, now: datetime) -> bytes:
+    registration: dict[str, object] = {
+        "algorithm": "ecdsa-p256-sha256",
+        "deviceId": state.device_id,
+        "installationGeneration": state.installation_generation,
+        "keyId": state.key_id,
+        "machineInstallationId": state.machine_installation_id,
+        "previousInstallationGeneration": None,
+        "publicKeySpki": state.public_key_spki,
+        "registeredAt": canonical_timestamp(now),
+        "schemaVersion": "hol-guard-health-key-registration.v1",
+        "workspaceId": state.workspace_id,
+    }
+    private_key = serialization.load_pem_private_key(state.private_key_pem.encode(), password=None)
+    assert isinstance(private_key, ec.EllipticCurvePrivateKey)
+    signature = _low_s_signature(private_key.sign(canonical_json_bytes(registration), ec.ECDSA(hashes.SHA256())))
+    return canonical_json_bytes(
+        {
+            **registration,
+            "proof": {
+                "algorithm": "ecdsa-p256-sha256",
+                "encoding": "asn1-der",
+                "value": base64.b64encode(signature).decode("ascii"),
+            },
+        }
+    )
+
+
+def _outbox(state: UserHealthState, now: datetime) -> HealthLeaseOutbox:
+    if state.pending_outbox is not None:
+        return HealthLeaseOutbox.parse(base64.b64decode(state.pending_outbox, validate=True))
+    snapshot = dict(machine_integrity_snapshot())
+    snapshot["assuranceLevel"] = "user-managed"
+    snapshot["installOwner"] = "user"
+    snapshot["identifiers"] = {
+        "workspaceId": state.workspace_id,
+        "deviceId": state.device_id,
+        "machineInstallationId": state.machine_installation_id,
+        "installationGeneration": state.installation_generation,
+    }
+    continuity = cast(dict[str, object], snapshot["continuity"])
+    snapshot["continuity"] = {**continuity, "sequence": state.sequence, "previousLeaseDigest": state.last_lease_digest}
+    snapshot_bytes = canonical_json_bytes(snapshot)
+    claims = ProtectionLeaseClaims.parse(
+        {
+            "workspaceId": state.workspace_id,
+            "deviceId": state.device_id,
+            "machineInstallationId": state.machine_installation_id,
+            "installationGeneration": state.installation_generation,
+            "sequence": state.sequence + 1,
+            "issuedAt": canonical_timestamp(now),
+            "validForSeconds": 900,
+            "snapshotSchemaVersion": "local-integrity-snapshot.v1",
+            "snapshotDigest": hashlib.sha256(snapshot_bytes).hexdigest(),
+            "previousLeaseDigest": state.last_lease_digest,
+            "signingKeyId": state.key_id,
+            "challenge": None,
+        }
+    )
+    private_key = serialization.load_pem_private_key(state.private_key_pem.encode(), password=None)
+    assert isinstance(private_key, ec.EllipticCurvePrivateKey)
+    signature = _low_s_signature(private_key.sign(claims.signing_payload(), ec.ECDSA(hashes.SHA256())))
+    return HealthLeaseOutbox(
+        SignedProtectionLease.parse(SignedProtectionLease(claims, signature).canonical_bytes()), snapshot_bytes
+    )
+
+
+def run_user_health_cadence(
+    guard_home: Path, *, now: datetime | None = None, transport: MachineHealthTransport | None = None
+) -> dict[str, object]:
+    """Register and deliver the exact durable pending user-managed lease."""
+
+    resolved_now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc).replace(microsecond=0)
+    state = _read_state(guard_home)
+    if state is None or not state.enabled:
+        raise PermissionError("user_health_opt_in_required")
+    outbox = _outbox(state, resolved_now)
+    if state.pending_outbox is None:
+        state = replace(
+            state,
+            pending_outbox=base64.b64encode(outbox.canonical_bytes()).decode("ascii"),
+            updated_at=resolved_now.isoformat(),
+        )
+        _write_state(guard_home, state)
+    resolved_transport = transport or GuardCloudMachineHealthTransport(guard_home)
+    resolved_transport.register_key(_registration(state, resolved_now))
+    ack = resolved_transport.deliver_lease(outbox)
+    claims = outbox.lease.claims
+    expected = (
+        state.workspace_id,
+        state.device_id,
+        state.machine_installation_id,
+        state.installation_generation,
+        claims.sequence,
+        outbox.lease.digest,
+    )
+    actual = (
+        ack.workspace_id,
+        ack.device_id,
+        ack.machine_installation_id,
+        ack.installation_generation,
+        ack.sequence,
+        ack.lease_digest,
+    )
+    if actual != expected:
+        raise OSError("health_lease_ack_conflict")
+    _write_state(
+        guard_home,
+        replace(
+            state,
+            sequence=claims.sequence,
+            last_lease_digest=outbox.lease.digest,
+            pending_outbox=None,
+            updated_at=ack.received_datetime.isoformat(),
+        ),
+    )
+    return {
+        "schemaVersion": "hol-guard-user-health-report.v1",
+        "delivered": True,
+        "assuranceLevel": "user-managed",
+        "workspaceId": state.workspace_id,
+        "deviceId": state.device_id,
+        "sequence": claims.sequence,
+        "leaseDigest": outbox.lease.digest,
+        "receivedAt": ack.received_at,
+    }
+
+
+__all__ = [
+    "configure_user_health_leases",
+    "run_user_health_cadence",
+    "user_health_report_due",
+    "user_health_status",
+]

--- a/src/codex_plugin_scanner/guard/mdm/user_health.py
+++ b/src/codex_plugin_scanner/guard/mdm/user_health.py
@@ -364,7 +364,10 @@ def _registration(state: UserHealthState, now: datetime) -> bytes:
 
 def _outbox(state: UserHealthState, now: datetime) -> HealthLeaseOutbox:
     if state.pending_outbox is not None:
-        return HealthLeaseOutbox.parse(base64.b64decode(state.pending_outbox, validate=True))
+        pending = HealthLeaseOutbox.parse(base64.b64decode(state.pending_outbox, validate=True))
+        expires_at = datetime.fromisoformat(pending.lease.claims.lease_expires_at.replace("Z", "+00:00"))
+        if now < expires_at:
+            return pending
     snapshot = dict(machine_integrity_snapshot())
     snapshot["assuranceLevel"] = "user-managed"
     snapshot["installOwner"] = "user"
@@ -412,10 +415,11 @@ def run_user_health_cadence(
         if state is None or not state.enabled:
             raise PermissionError("user_health_opt_in_required")
         outbox = _outbox(state, resolved_now)
-        if state.pending_outbox is None:
+        encoded_outbox = base64.b64encode(outbox.canonical_bytes()).decode("ascii")
+        if state.pending_outbox != encoded_outbox:
             state = replace(
                 state,
-                pending_outbox=base64.b64encode(outbox.canonical_bytes()).decode("ascii"),
+                pending_outbox=encoded_outbox,
                 updated_at=resolved_now.isoformat(),
             )
             _write_state(guard_home, state)

--- a/src/codex_plugin_scanner/guard/mdm/user_health.py
+++ b/src/codex_plugin_scanner/guard/mdm/user_health.py
@@ -8,12 +8,14 @@ import json
 import os
 import secrets
 import stat
-from contextlib import suppress
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import cast
 
+from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
@@ -27,6 +29,7 @@ from .protection_lease_contract import ProtectionLeaseClaims, SignedProtectionLe
 
 _SCHEMA = "hol-guard-user-health-state.v1"
 _STATE_NAME = "user-health-state.json"
+_LOCK_NAME = "user-health-state.lock"
 _MAX_STATE_BYTES = 512 * 1024
 _MAX_UINT64 = (1 << 64) - 1
 _P256_ORDER = int("FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551", 16)
@@ -88,7 +91,10 @@ def _private_directory(guard_home: Path) -> None:
 
 
 def _read_state(guard_home: Path) -> UserHealthState | None:
-    _private_directory(guard_home)
+    try:
+        _private_directory(guard_home)
+    except FileNotFoundError:
+        return None
     try:
         descriptor = os.open(
             _state_path(guard_home),
@@ -172,9 +178,15 @@ def _validate_state(state: UserHealthState) -> None:
     ):
         raise ValueError("user_health_state_invalid")
     try:
+        updated_at = datetime.fromisoformat(state.updated_at)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("user_health_state_invalid") from exc
+    if updated_at.tzinfo is None:
+        raise ValueError("user_health_state_invalid")
+    try:
         private_key = serialization.load_pem_private_key(state.private_key_pem.encode(), password=None)
         public_der = base64.b64decode(state.public_key_spki, validate=True)
-    except (TypeError, ValueError) as exc:
+    except (TypeError, UnsupportedAlgorithm, ValueError) as exc:
         raise ValueError("user_health_state_invalid") from exc
     if not isinstance(private_key, ec.EllipticCurvePrivateKey) or not isinstance(private_key.curve, ec.SECP256R1):
         raise ValueError("user_health_state_invalid")
@@ -185,6 +197,49 @@ def _validate_state(state: UserHealthState) -> None:
         f"{state.key_id}="
     ):
         raise ValueError("user_health_state_invalid")
+
+
+@contextmanager
+def _state_lock(guard_home: Path) -> Iterator[None]:
+    """Serialize state mutation across foreground and background processes."""
+
+    _private_directory(guard_home)
+    descriptor = os.open(
+        guard_home / _LOCK_NAME,
+        os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+    )
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or (
+            os.name != "nt" and (metadata.st_uid != os.geteuid() or stat.S_IMODE(metadata.st_mode) & 0o077)
+        ):
+            raise PermissionError("user_health_state_acl_invalid")
+        if os.name == "nt":
+            import msvcrt
+
+            if metadata.st_size == 0:
+                os.write(descriptor, b"0")
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if os.name == "nt":
+                import msvcrt
+
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
 
 
 def _write_state(guard_home: Path, state: UserHealthState) -> None:
@@ -235,11 +290,12 @@ def configure_user_health_leases(guard_home: Path, *, enabled: bool, now: dateti
     resolved_now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
     store = GuardStore(guard_home, prime_policy_integrity=False, source="user-health")
     identity = guard_review_oauth_metadata(store)
-    state = _read_state(guard_home)
-    if state is None or (state.workspace_id, state.device_id) != (identity.workspace_id, identity.device_id):
-        state = _new_state(identity.workspace_id, identity.device_id, resolved_now)
-    state = replace(state, enabled=enabled, updated_at=resolved_now.isoformat())
-    _write_state(guard_home, state)
+    with _state_lock(guard_home):
+        state = _read_state(guard_home)
+        if state is None or (state.workspace_id, state.device_id) != (identity.workspace_id, identity.device_id):
+            state = _new_state(identity.workspace_id, identity.device_id, resolved_now)
+        state = replace(state, enabled=enabled, updated_at=resolved_now.isoformat())
+        _write_state(guard_home, state)
     return user_health_status(guard_home)
 
 
@@ -351,49 +407,51 @@ def run_user_health_cadence(
     """Register and deliver the exact durable pending user-managed lease."""
 
     resolved_now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc).replace(microsecond=0)
-    state = _read_state(guard_home)
-    if state is None or not state.enabled:
-        raise PermissionError("user_health_opt_in_required")
-    outbox = _outbox(state, resolved_now)
-    if state.pending_outbox is None:
-        state = replace(
-            state,
-            pending_outbox=base64.b64encode(outbox.canonical_bytes()).decode("ascii"),
-            updated_at=resolved_now.isoformat(),
+    with _state_lock(guard_home):
+        state = _read_state(guard_home)
+        if state is None or not state.enabled:
+            raise PermissionError("user_health_opt_in_required")
+        outbox = _outbox(state, resolved_now)
+        if state.pending_outbox is None:
+            state = replace(
+                state,
+                pending_outbox=base64.b64encode(outbox.canonical_bytes()).decode("ascii"),
+                updated_at=resolved_now.isoformat(),
+            )
+            _write_state(guard_home, state)
+        resolved_transport = transport or GuardCloudMachineHealthTransport(guard_home)
+        if state.sequence == 0:
+            resolved_transport.register_key(_registration(state, resolved_now))
+        ack = resolved_transport.deliver_lease(outbox)
+        claims = outbox.lease.claims
+        expected = (
+            state.workspace_id,
+            state.device_id,
+            state.machine_installation_id,
+            state.installation_generation,
+            claims.sequence,
+            outbox.lease.digest,
         )
-        _write_state(guard_home, state)
-    resolved_transport = transport or GuardCloudMachineHealthTransport(guard_home)
-    resolved_transport.register_key(_registration(state, resolved_now))
-    ack = resolved_transport.deliver_lease(outbox)
-    claims = outbox.lease.claims
-    expected = (
-        state.workspace_id,
-        state.device_id,
-        state.machine_installation_id,
-        state.installation_generation,
-        claims.sequence,
-        outbox.lease.digest,
-    )
-    actual = (
-        ack.workspace_id,
-        ack.device_id,
-        ack.machine_installation_id,
-        ack.installation_generation,
-        ack.sequence,
-        ack.lease_digest,
-    )
-    if actual != expected:
-        raise OSError("health_lease_ack_conflict")
-    _write_state(
-        guard_home,
-        replace(
-            state,
-            sequence=claims.sequence,
-            last_lease_digest=outbox.lease.digest,
-            pending_outbox=None,
-            updated_at=ack.received_datetime.isoformat(),
-        ),
-    )
+        actual = (
+            ack.workspace_id,
+            ack.device_id,
+            ack.machine_installation_id,
+            ack.installation_generation,
+            ack.sequence,
+            ack.lease_digest,
+        )
+        if actual != expected:
+            raise OSError("health_lease_ack_conflict")
+        _write_state(
+            guard_home,
+            replace(
+                state,
+                sequence=claims.sequence,
+                last_lease_digest=outbox.lease.digest,
+                pending_outbox=None,
+                updated_at=ack.received_datetime.isoformat(),
+            ),
+        )
     return {
         "schemaVersion": "hol-guard-user-health-report.v1",
         "delivered": True,

--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -7,6 +7,7 @@ import os
 import threading
 import urllib.error
 import urllib.parse
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
@@ -705,6 +706,11 @@ def _cloud_sync_sync_loop(
         try:
             auth_context = _resolve_live_request_sync_auth_context(store)
             result = sync_live_requests_once(store, auth_context)
+            from ..mdm.user_health import run_user_health_cadence, user_health_report_due
+
+            with suppress(OSError, PermissionError, RuntimeError, ValueError):
+                if user_health_report_due(store.guard_home):
+                    run_user_health_cadence(store.guard_home)
             synced = result.get("synced", 0)
             if isinstance(synced, int) and synced > 0:
                 error_streak = 0

--- a/tests/test_guard_mdm_user_health.py
+++ b/tests/test_guard_mdm_user_health.py
@@ -159,6 +159,24 @@ def test_user_health_retries_exact_pending_lease_after_transport_failure(guard_h
     assert user_health.user_health_status(guard_home)["pending"] is False
 
 
+def test_user_health_refreshes_expired_unaccepted_lease(guard_home: Path) -> None:
+    user_health.configure_user_health_leases(guard_home, enabled=True, now=NOW)
+    failed = FailingTransport()
+    with pytest.raises(ConnectionError, match="offline"):
+        user_health.run_user_health_cadence(guard_home, now=NOW, transport=failed)
+
+    recovered = Transport()
+    result = user_health.run_user_health_cadence(
+        guard_home,
+        now=NOW.replace(minute=16),
+        transport=recovered,
+    )
+
+    assert result["sequence"] == 1
+    assert recovered.outboxes[0].lease.digest != failed.outboxes[0].lease.digest
+    assert recovered.outboxes[0].lease.claims.previous_lease_digest is None
+
+
 def test_user_health_due_gate_is_bounded_and_cadenced(guard_home: Path) -> None:
     user_health.configure_user_health_leases(guard_home, enabled=True, now=NOW)
     assert user_health.user_health_report_due(guard_home, now=NOW.replace(minute=4)) is False

--- a/tests/test_guard_mdm_user_health.py
+++ b/tests/test_guard_mdm_user_health.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -97,7 +98,7 @@ def test_user_health_registers_and_delivers_signed_monotonic_leases(guard_home: 
     assert first["sequence"] == 1
     assert second["sequence"] == 2
     assert first["assuranceLevel"] == "user-managed"
-    assert len(transport.registrations) == 2
+    assert len(transport.registrations) == 1
     registration = json.loads(transport.registrations[0])
     assert registration["deviceId"] == "device-a"
     assert registration["workspaceId"] == "workspace-a"
@@ -105,6 +106,27 @@ def test_user_health_registers_and_delivers_signed_monotonic_leases(guard_home: 
     assert first_snapshot["assuranceLevel"] == "user-managed"
     assert first_snapshot["installOwner"] == "user"
     assert transport.outboxes[1].lease.claims.previous_lease_digest == transport.outboxes[0].lease.digest
+
+
+def test_user_health_serializes_concurrent_cadence_runs(guard_home: Path) -> None:
+    user_health.configure_user_health_leases(guard_home, enabled=True, now=NOW)
+    transport = Transport()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        reports = list(
+            executor.map(
+                lambda minute: user_health.run_user_health_cadence(
+                    guard_home,
+                    now=NOW.replace(minute=minute),
+                    transport=transport,
+                ),
+                (0, 1),
+            )
+        )
+
+    assert {report["sequence"] for report in reports} == {1, 2}
+    ordered = sorted(transport.outboxes, key=lambda outbox: outbox.lease.claims.sequence)
+    assert ordered[1].lease.claims.previous_lease_digest == ordered[0].lease.digest
 
 
 def test_user_health_disable_preserves_continuity_but_stops_delivery(guard_home: Path) -> None:

--- a/tests/test_guard_mdm_user_health.py
+++ b/tests/test_guard_mdm_user_health.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.mdm import user_health
+from codex_plugin_scanner.guard.mdm.contracts import LocalIntegritySnapshot
+from codex_plugin_scanner.guard.mdm.health_lease_ack import HealthLeaseAck
+from codex_plugin_scanner.guard.mdm.health_lease_contract import HealthLeaseOutbox
+from tests.guard_mdm_health_lease_support import snapshot
+
+NOW = user_health.datetime(2026, 7, 19, 14, 0, tzinfo=user_health.timezone.utc)
+
+
+class Transport:
+    def __init__(self) -> None:
+        self.registrations: list[bytes] = []
+        self.outboxes: list[HealthLeaseOutbox] = []
+
+    def register_key(self, payload: bytes) -> None:
+        self.registrations.append(payload)
+
+    def poll_challenge(self, **_kwargs: object) -> None:
+        return None
+
+    def deliver_lease(self, outbox: HealthLeaseOutbox) -> HealthLeaseAck:
+        self.outboxes.append(outbox)
+        claims = outbox.lease.claims
+        return HealthLeaseAck(
+            "accepted",
+            claims.workspace_id,
+            claims.device_id,
+            claims.machine_installation_id,
+            claims.installation_generation,
+            claims.sequence,
+            outbox.lease.digest,
+            "2026-07-19T14:00:01.000Z",
+        )
+
+
+class FailingTransport(Transport):
+    def deliver_lease(self, outbox: HealthLeaseOutbox) -> HealthLeaseAck:
+        self.outboxes.append(outbox)
+        raise ConnectionError("offline")
+
+
+@pytest.fixture
+def guard_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hol-guard"
+    home.mkdir(mode=0o700)
+    monkeypatch.setattr(user_health, "GuardStore", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(
+        user_health,
+        "guard_review_oauth_metadata",
+        lambda _store: SimpleNamespace(workspace_id="workspace-a", device_id="device-a"),
+    )
+    monkeypatch.setattr(
+        user_health,
+        "machine_integrity_snapshot",
+        lambda: cast(LocalIntegritySnapshot, snapshot()),
+    )
+    return home
+
+
+def test_user_health_requires_explicit_opt_in_and_reports_lower_assurance(guard_home: Path) -> None:
+    assert user_health.user_health_status(guard_home) == {
+        "schemaVersion": "hol-guard-user-health-status.v1",
+        "configured": False,
+        "enabled": False,
+        "assuranceLevel": "user-managed",
+        "sequence": 0,
+        "pending": False,
+    }
+    with pytest.raises(PermissionError, match="user_health_opt_in_required"):
+        user_health.run_user_health_cadence(guard_home, now=NOW, transport=Transport())
+
+    configured = user_health.configure_user_health_leases(guard_home, enabled=True, now=NOW)
+    assert configured["enabled"] is True
+    assert configured["assuranceLevel"] == "user-managed"
+
+
+def test_user_health_registers_and_delivers_signed_monotonic_leases(guard_home: Path) -> None:
+    user_health.configure_user_health_leases(guard_home, enabled=True, now=NOW)
+    transport = Transport()
+    first = user_health.run_user_health_cadence(guard_home, now=NOW, transport=transport)
+    second = user_health.run_user_health_cadence(
+        guard_home,
+        now=NOW.replace(minute=15),
+        transport=transport,
+    )
+
+    assert first["sequence"] == 1
+    assert second["sequence"] == 2
+    assert first["assuranceLevel"] == "user-managed"
+    assert len(transport.registrations) == 2
+    registration = json.loads(transport.registrations[0])
+    assert registration["deviceId"] == "device-a"
+    assert registration["workspaceId"] == "workspace-a"
+    first_snapshot = json.loads(transport.outboxes[0].snapshot_bytes)
+    assert first_snapshot["assuranceLevel"] == "user-managed"
+    assert first_snapshot["installOwner"] == "user"
+    assert transport.outboxes[1].lease.claims.previous_lease_digest == transport.outboxes[0].lease.digest
+
+
+def test_user_health_disable_preserves_continuity_but_stops_delivery(guard_home: Path) -> None:
+    user_health.configure_user_health_leases(guard_home, enabled=True, now=NOW)
+    user_health.run_user_health_cadence(guard_home, now=NOW, transport=Transport())
+    status = user_health.configure_user_health_leases(guard_home, enabled=False, now=NOW)
+
+    assert status["sequence"] == 1
+    assert status["enabled"] is False
+    with pytest.raises(PermissionError, match="user_health_opt_in_required"):
+        user_health.run_user_health_cadence(guard_home, now=NOW, transport=Transport())
+
+
+def test_user_health_retries_exact_pending_lease_after_transport_failure(guard_home: Path) -> None:
+    user_health.configure_user_health_leases(guard_home, enabled=True, now=NOW)
+    failed = FailingTransport()
+    with pytest.raises(ConnectionError, match="offline"):
+        user_health.run_user_health_cadence(guard_home, now=NOW, transport=failed)
+    assert user_health.user_health_status(guard_home)["pending"] is True
+    assert user_health.user_health_report_due(guard_home, now=NOW) is True
+
+    recovered = Transport()
+    result = user_health.run_user_health_cadence(
+        guard_home,
+        now=NOW.replace(minute=1),
+        transport=recovered,
+    )
+    assert result["leaseDigest"] == failed.outboxes[0].lease.digest
+    assert recovered.outboxes[0].canonical_bytes() == failed.outboxes[0].canonical_bytes()
+    assert user_health.user_health_status(guard_home)["pending"] is False
+
+
+def test_user_health_due_gate_is_bounded_and_cadenced(guard_home: Path) -> None:
+    user_health.configure_user_health_leases(guard_home, enabled=True, now=NOW)
+    assert user_health.user_health_report_due(guard_home, now=NOW.replace(minute=4)) is False
+    assert user_health.user_health_report_due(guard_home, now=NOW.replace(minute=5)) is True
+    with pytest.raises(ValueError, match="user_health_cadence_invalid"):
+        user_health.user_health_report_due(guard_home, cadence_seconds=1)
+
+
+def test_user_health_rejects_group_readable_or_symlinked_state(guard_home: Path) -> None:
+    user_health.configure_user_health_leases(guard_home, enabled=True, now=NOW)
+    state_path = guard_home / "user-health-state.json"
+    state_path.chmod(0o644)
+    with pytest.raises(PermissionError, match="user_health_state_acl_invalid"):
+        user_health.user_health_status(guard_home)
+
+
+def test_user_health_cli_exposes_explicit_status_surface(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["guard", "health-leases", "status", "--home", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schemaVersion"] == "hol-guard-user-health-status.v1"
+    assert payload["enabled"] is False
+    assert payload["assuranceLevel"] == "user-managed"


### PR DESCRIPTION
## Summary
- add explicit `health-leases enable|disable|status|report` controls for connected user installations
- generate user-scoped P-256 signing and continuity state with private 0600/symlink-safe storage
- deliver replay-safe pending leases through the existing purpose-bound Cloud health endpoints with `assuranceLevel=user-managed`
- run the bounded five-minute cadence through the independent live-sync worker without coupling receipt delivery failures

## Security model
This is intentionally lower assurance than MDM. The user controls the key and local state, silence never proves deletion, and Cloud receives the existing explicit `user-managed` snapshot label. Machine root/SYSTEM key paths are unchanged.

## Verification
- `pytest tests/test_guard_mdm_user_health.py tests/test_guard_live_request_sync.py -q` (35 passed)
- `ruff check` on all changed Python files
- `ruff format --check` on all changed Python files
- `basedpyright` on user-health/live-sync sources (0 errors)
- `git diff --check`

Implements the Guard-side portion of SP-T057.