### PR TITLE
feat(guard): add central effect evaluator

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/effect_decision.py
+++ b/src/codex_plugin_scanner/guard/runtime/effect_decision.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from dataclasses import dataclass
 from enum import Enum
@@ -88,6 +90,7 @@ class DecisionFactor:
     segment_ref: str | None = None
     operation_ref: str | None = None
     producer_ref: str | None = None
+    evidence_digest: str | None = None
     assessment: EffectAssessment | None = None
     proof: PositiveProof | None = None
 
@@ -108,6 +111,8 @@ class DecisionFactor:
             raise ValueError("operation_ref must be a canonical reference")
         if self.producer_ref is not None and _REFERENCE.fullmatch(self.producer_ref) is None:
             raise ValueError("producer_ref must be a canonical reference")
+        if self.evidence_digest is not None and _SHA256.fullmatch(self.evidence_digest) is None:
+            raise ValueError("evidence_digest must be a lowercase SHA-256 digest")
         if assessment is not None and not isinstance(assessment, EffectAssessment):
             raise ValueError("assessment must be an EffectAssessment")
         if self.source is DecisionFactorSource.EFFECT and self.assessment is None:
@@ -142,6 +147,7 @@ class DecisionFactor:
             self.segment_ref or "",
             self.operation_ref or "",
             self.producer_ref or "",
+            self.evidence_digest or "",
             self.source.value,
             self.reason_code,
             self.basis.action_floor,
@@ -264,6 +270,7 @@ def factors_from_extension_evidence(batch: ExtensionEvidenceBatch) -> tuple[Deci
                     f"{evidence.identity.extension_id}/{evidence.identity.extension_version}/"
                     f"{evidence.identity.rule_id}/{evidence.identity.rule_version}"
                 ),
+                evidence_digest=_extension_evidence_digest(evidence.semantic_key),
             )
         )
     return tuple(sorted(factors, key=lambda item: item.semantic_key))
@@ -318,6 +325,16 @@ def _proof_key(proof: PositiveProof | None) -> tuple[str, ...]:
         ",".join(sorted(item.value for item in proof.satisfied_requirements)),
         "enforced" if proof.enforced else "not-enforced",
     )
+
+
+def _extension_evidence_digest(semantic_key: object) -> str:
+    payload = json.dumps(
+        {"schema": "guard-extension-evidence-factor-v1", "semantic_key": semantic_key},
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("ascii")
+    return hashlib.sha256(b"guard-extension-evidence-factor-v1\x00" + payload).hexdigest()
 
 
 def _require_factor_tuple(value: object) -> tuple[DecisionFactor, ...]:

--- a/src/codex_plugin_scanner/guard/runtime/effect_decision.py
+++ b/src/codex_plugin_scanner/guard/runtime/effect_decision.py
@@ -1,0 +1,338 @@
+"""Pure, monotonic composition for Guard effect decisions."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Final, cast
+
+from codex_plugin_scanner.guard.action_lattice import guard_action_severity, is_guard_action
+from codex_plugin_scanner.guard.models import GuardAction
+
+from .effect_contract import (
+    UNCERTAINTY_FLOOR,
+    ContainmentRequirement,
+    DecisionBasis,
+    EffectAssessment,
+    ProofRequirement,
+    ProofRoute,
+    UncertaintyKind,
+    maximum_action_floor,
+)
+from .extension_evidence import ExtensionEvidenceBatch
+
+EFFECT_DECISION_SCHEMA_VERSION: Final = "1.0.0"
+_REASON_CODE: Final = re.compile(r"[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*")
+_REFERENCE: Final = re.compile(r"[a-z][a-z0-9_-]*:[a-z0-9][a-z0-9._/-]*")
+_SHA256: Final = re.compile(r"[0-9a-f]{64}")
+
+
+class DecisionFactorSource(str, Enum):
+    EFFECT = "effect"
+    MATCH = "match"
+    POLICY = "policy"
+    CONTAINMENT = "containment"
+    AUTHORIZATION = "authorization"
+
+
+class FinalDisposition(str, Enum):
+    SILENT_VERIFIED = "silent-verified"
+    SILENT_CONTAINED = "silent-contained"
+    WORKFLOW_AUTHORIZED = "workflow-authorized"
+    WARN = "warn"
+    REVIEW = "review"
+    REQUIRE_REAPPROVAL = "require-reapproval"
+    SANDBOX_REQUIRED = "sandbox-required"
+    BLOCK = "block"
+
+
+@dataclass(frozen=True, slots=True)
+class PositiveProof:
+    """Proof of exact binding for one decision factor."""
+
+    route: ProofRoute
+    binding_digest: str
+    satisfied_requirements: frozenset[ProofRequirement]
+    enforced: bool = False
+
+    def __post_init__(self) -> None:
+        route = cast(object, self.route)
+        requirements = cast(object, self.satisfied_requirements)
+        if not isinstance(route, ProofRoute):
+            raise ValueError("route must be an exact ProofRoute value")
+        if _SHA256.fullmatch(self.binding_digest) is None:
+            raise ValueError("binding_digest must be a lowercase SHA-256 digest")
+        if not isinstance(requirements, frozenset) or any(
+            not isinstance(item, ProofRequirement) for item in requirements
+        ):
+            raise ValueError("satisfied_requirements must contain exact ProofRequirement values")
+        if type(self.enforced) is not bool:
+            raise ValueError("enforced must be a boolean")
+        if self.route is ProofRoute.CONTAINED:
+            if not self.enforced:
+                raise ValueError("contained proof must be enforced")
+            if ProofRequirement.CONTAINMENT_IDENTITY not in self.satisfied_requirements:
+                raise ValueError("contained proof must bind containment identity")
+        elif self.enforced:
+            raise ValueError("only contained proof may claim enforcement")
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionFactor:
+    """One independently auditable lower bound on the final action."""
+
+    source: DecisionFactorSource
+    reason_code: str
+    basis: DecisionBasis
+    segment_ref: str | None = None
+    operation_ref: str | None = None
+    producer_ref: str | None = None
+    assessment: EffectAssessment | None = None
+    proof: PositiveProof | None = None
+
+    def __post_init__(self) -> None:
+        source = cast(object, self.source)
+        basis = cast(object, self.basis)
+        assessment = cast(object, self.assessment)
+        proof = cast(object, self.proof)
+        if not isinstance(source, DecisionFactorSource):
+            raise ValueError("source must be an exact DecisionFactorSource value")
+        if _REASON_CODE.fullmatch(self.reason_code) is None:
+            raise ValueError("reason_code must be a stable lowercase identifier")
+        if not isinstance(basis, DecisionBasis):
+            raise ValueError("basis must be a DecisionBasis")
+        if self.segment_ref is not None and _REFERENCE.fullmatch(self.segment_ref) is None:
+            raise ValueError("segment_ref must be a canonical reference")
+        if self.operation_ref is not None and _REFERENCE.fullmatch(self.operation_ref) is None:
+            raise ValueError("operation_ref must be a canonical reference")
+        if self.producer_ref is not None and _REFERENCE.fullmatch(self.producer_ref) is None:
+            raise ValueError("producer_ref must be a canonical reference")
+        if assessment is not None and not isinstance(assessment, EffectAssessment):
+            raise ValueError("assessment must be an EffectAssessment")
+        if self.source is DecisionFactorSource.EFFECT and self.assessment is None:
+            raise ValueError("effect factors require an assessment")
+        if self.source is not DecisionFactorSource.EFFECT and self.assessment is not None:
+            raise ValueError("only effect factors may carry an assessment")
+        if proof is not None and not isinstance(proof, PositiveProof):
+            raise ValueError("proof must be a PositiveProof")
+        if self.basis.proof_route is None:
+            if self.proof is not None:
+                raise ValueError("proof requires a matching proof route")
+        elif self.proof is None or self.proof.route is not self.basis.proof_route:
+            raise ValueError("permissive basis requires proof on the exact route")
+        if self.proof is not None and self.assessment is not None:
+            missing = self.assessment.proof_requirements - self.proof.satisfied_requirements
+            if missing:
+                raise ValueError("proof does not satisfy every effect requirement")
+            if self.proof.route is ProofRoute.CONTAINED and self.assessment.containment not in {
+                ContainmentRequirement.ELIGIBLE,
+                ContainmentRequirement.REQUIRED,
+            }:
+                raise ValueError("contained proof is incompatible with the effect containment requirement")
+            if (
+                self.assessment.containment is ContainmentRequirement.REQUIRED
+                and self.proof.route is not ProofRoute.CONTAINED
+            ):
+                raise ValueError("containment-required effects require contained proof")
+
+    @property
+    def semantic_key(self) -> tuple[str, ...]:
+        return (
+            self.segment_ref or "",
+            self.operation_ref or "",
+            self.producer_ref or "",
+            self.source.value,
+            self.reason_code,
+            self.basis.action_floor,
+            self.basis.proof_route.value if self.basis.proof_route is not None else "",
+            *_assessment_key(self.assessment),
+            *_proof_key(self.proof),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionReason:
+    source: DecisionFactorSource
+    reason_code: str
+    action_floor: GuardAction
+    segment_ref: str | None
+    operation_ref: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class EffectDecisionRequest:
+    factors: tuple[DecisionFactor, ...]
+    uncertainties: tuple[UncertaintyKind, ...] = ()
+    schema_version: str = EFFECT_DECISION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != EFFECT_DECISION_SCHEMA_VERSION:
+            raise ValueError("unsupported effect decision schema version")
+        factors = _require_factor_tuple(cast(object, self.factors))
+        uncertainties = _require_uncertainty_tuple(cast(object, self.uncertainties))
+        ordered = tuple(sorted(factors, key=lambda item: item.semantic_key))
+        keys = tuple(item.semantic_key for item in ordered)
+        if len(keys) != len(set(keys)):
+            raise ValueError("duplicate decision factors are not allowed")
+        if len(uncertainties) != len(set(uncertainties)):
+            raise ValueError("uncertainties cannot contain duplicates")
+        object.__setattr__(self, "factors", ordered)
+        object.__setattr__(self, "uncertainties", tuple(sorted(uncertainties, key=lambda item: item.value)))
+
+
+@dataclass(frozen=True, slots=True)
+class EffectDecision:
+    action: GuardAction
+    disposition: FinalDisposition
+    controlling_reasons: tuple[DecisionReason, ...]
+    reasons: tuple[DecisionReason, ...]
+    proof_routes: frozenset[ProofRoute]
+    schema_version: str = EFFECT_DECISION_SCHEMA_VERSION
+
+
+def evaluate_effect_decision(request: EffectDecisionRequest) -> EffectDecision:
+    """Return the maximum floor from every factor and uncertainty."""
+
+    if not isinstance(cast(object, request), EffectDecisionRequest):
+        raise ValueError("request must be an EffectDecisionRequest")
+    reasons = [
+        DecisionReason(
+            item.source,
+            item.reason_code,
+            item.basis.action_floor,
+            item.segment_ref,
+            item.operation_ref,
+        )
+        for item in request.factors
+    ]
+    reasons.extend(
+        DecisionReason(
+            DecisionFactorSource.POLICY,
+            f"uncertainty.{uncertainty.value}",
+            UNCERTAINTY_FLOOR[uncertainty],
+            None,
+            None,
+        )
+        for uncertainty in request.uncertainties
+    )
+    for factor in request.factors:
+        if factor.assessment is None:
+            continue
+        reasons.extend(
+            DecisionReason(
+                DecisionFactorSource.EFFECT,
+                f"uncertainty.{uncertainty.value}",
+                UNCERTAINTY_FLOOR[uncertainty],
+                factor.segment_ref,
+                factor.operation_ref,
+            )
+            for uncertainty in factor.assessment.uncertainty_reasons
+        )
+    reasons.sort(key=_reason_key)
+    action = maximum_action_floor(reason.action_floor for reason in reasons)
+    controlling = tuple(reason for reason in reasons if reason.action_floor == action)
+    routes = frozenset(factor.proof.route for factor in request.factors if factor.proof is not None)
+    return EffectDecision(
+        action=action,
+        disposition=_disposition(action, routes),
+        controlling_reasons=controlling,
+        reasons=tuple(reasons),
+        proof_routes=routes,
+    )
+
+
+def factors_from_extension_evidence(batch: ExtensionEvidenceBatch) -> tuple[DecisionFactor, ...]:
+    """Translate immutable extension observations without granting interaction."""
+
+    if not isinstance(cast(object, batch), ExtensionEvidenceBatch):
+        raise ValueError("batch must be an ExtensionEvidenceBatch")
+    factors: list[DecisionFactor] = []
+    for evidence in batch.evidence:
+        floor = evidence.effective_floor
+        if floor is None:
+            continue
+        factors.append(
+            DecisionFactor(
+                source=DecisionFactorSource.MATCH,
+                reason_code=evidence.base_fact,
+                basis=DecisionBasis(floor, None),
+                segment_ref=evidence.segment_ref,
+                operation_ref=evidence.operation_ref,
+                producer_ref=(
+                    "extension:"
+                    f"{evidence.identity.extension_id}/{evidence.identity.extension_version}/"
+                    f"{evidence.identity.rule_id}/{evidence.identity.rule_version}"
+                ),
+            )
+        )
+    return tuple(sorted(factors, key=lambda item: item.semantic_key))
+
+
+def _reason_key(reason: DecisionReason) -> tuple[str, str, str, str, int]:
+    return (
+        reason.segment_ref or "",
+        reason.operation_ref or "",
+        reason.source.value,
+        reason.reason_code,
+        guard_action_severity(reason.action_floor),
+    )
+
+
+def _disposition(action: GuardAction, routes: frozenset[ProofRoute]) -> FinalDisposition:
+    if not is_guard_action(action):  # pragma: no cover - typed defensive boundary
+        raise ValueError("action must be a canonical GuardAction")
+    if action == "allow":
+        if ProofRoute.WORKFLOW_AUTHORIZED in routes:
+            return FinalDisposition.WORKFLOW_AUTHORIZED
+        if ProofRoute.CONTAINED in routes:
+            return FinalDisposition.SILENT_CONTAINED
+        return FinalDisposition.SILENT_VERIFIED
+    return FinalDisposition(action)
+
+
+def _assessment_key(assessment: EffectAssessment | None) -> tuple[str, ...]:
+    if assessment is None:
+        return ("",) * 11
+    return (
+        assessment.kind.value,
+        assessment.target_scope.value,
+        assessment.reversibility.value,
+        assessment.blast_radius.value,
+        assessment.evidence_source.value,
+        assessment.confidence.value,
+        assessment.containment.value,
+        ",".join(sorted(item.value for item in assessment.proof_requirements)),
+        ",".join(sorted(item.value for item in assessment.uncertainty_reasons)),
+        assessment.schema_version,
+        "assessment",
+    )
+
+
+def _proof_key(proof: PositiveProof | None) -> tuple[str, ...]:
+    if proof is None:
+        return ("", "", "", "")
+    return (
+        proof.route.value,
+        proof.binding_digest,
+        ",".join(sorted(item.value for item in proof.satisfied_requirements)),
+        "enforced" if proof.enforced else "not-enforced",
+    )
+
+
+def _require_factor_tuple(value: object) -> tuple[DecisionFactor, ...]:
+    if not isinstance(value, tuple):
+        raise ValueError("factors must contain DecisionFactor values")
+    items = cast(tuple[object, ...], value)
+    if any(not isinstance(item, DecisionFactor) for item in items):
+        raise ValueError("factors must contain DecisionFactor values")
+    return cast(tuple[DecisionFactor, ...], items)
+
+
+def _require_uncertainty_tuple(value: object) -> tuple[UncertaintyKind, ...]:
+    if not isinstance(value, tuple):
+        raise ValueError("uncertainties must contain exact UncertaintyKind values")
+    items = cast(tuple[object, ...], value)
+    if any(not isinstance(item, UncertaintyKind) for item in items):
+        raise ValueError("uncertainties must contain exact UncertaintyKind values")
+    return cast(tuple[UncertaintyKind, ...], items)

--- a/src/codex_plugin_scanner/guard/runtime/effect_decision.py
+++ b/src/codex_plugin_scanner/guard/runtime/effect_decision.py
@@ -265,11 +265,7 @@ def factors_from_extension_evidence(batch: ExtensionEvidenceBatch) -> tuple[Deci
                 basis=DecisionBasis(floor, None),
                 segment_ref=evidence.segment_ref,
                 operation_ref=evidence.operation_ref,
-                producer_ref=(
-                    "extension:"
-                    f"{evidence.identity.extension_id}/{evidence.identity.extension_version}/"
-                    f"{evidence.identity.rule_id}/{evidence.identity.rule_version}"
-                ),
+                producer_ref=(f"extension:{evidence.identity.extension_id}/{evidence.identity.rule_id}"),
                 evidence_digest=_extension_evidence_digest(evidence.semantic_key),
             )
         )

--- a/tests/test_guard_effect_decision.py
+++ b/tests/test_guard_effect_decision.py
@@ -253,3 +253,15 @@ def test_extension_factor_identity_binds_the_complete_evidence_record() -> None:
     factors = factors_from_extension_evidence(ExtensionEvidenceBatch((first, second)))
     assert len({factor.evidence_digest for factor in factors}) == 2
     assert evaluate_effect_decision(EffectDecisionRequest(factors)).action == "review"
+
+
+def test_extension_versions_with_build_metadata_remain_valid() -> None:
+    evidence = _evidence("metadata", "review")
+    identity = replace(
+        evidence.identity,
+        extension_version="1.0.0+build.1",
+        rule_version="1.0.0+rule.2",
+    )
+    factors = factors_from_extension_evidence(ExtensionEvidenceBatch((replace(evidence, identity=identity),)))
+    assert factors[0].producer_ref == "extension:command.test/command.test.metadata"
+    assert evaluate_effect_decision(EffectDecisionRequest(factors)).action == "review"

--- a/tests/test_guard_effect_decision.py
+++ b/tests/test_guard_effect_decision.py
@@ -245,3 +245,11 @@ def test_owned_safe_variant_never_suppresses_a_stronger_sibling() -> None:
     decision = evaluate_effect_decision(EffectDecisionRequest(factors))
     assert [factor.reason_code for factor in factors] == ["sibling.matched"]
     assert decision.action == "block"
+
+
+def test_extension_factor_identity_binds_the_complete_evidence_record() -> None:
+    first = _evidence("shared", "review")
+    second = replace(first, severity=EvidenceSeverity.CRITICAL)
+    factors = factors_from_extension_evidence(ExtensionEvidenceBatch((first, second)))
+    assert len({factor.evidence_digest for factor in factors}) == 2
+    assert evaluate_effect_decision(EffectDecisionRequest(factors)).action == "review"

--- a/tests/test_guard_effect_decision.py
+++ b/tests/test_guard_effect_decision.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import itertools
+from dataclasses import replace
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.action_lattice import GUARD_ACTION_LATTICE, GUARD_ACTION_SEVERITY
+from codex_plugin_scanner.guard.models import GuardAction
+from codex_plugin_scanner.guard.runtime.effect_contract import (
+    ContainmentRequirement,
+    DecisionBasis,
+    EffectAssessment,
+    EffectBlastRadius,
+    EffectConfidence,
+    EffectEvidenceSource,
+    EffectKind,
+    EffectReversibility,
+    EffectTargetScope,
+    ProofRequirement,
+    ProofRoute,
+    UncertaintyKind,
+)
+from codex_plugin_scanner.guard.runtime.effect_decision import (
+    DecisionFactor,
+    DecisionFactorSource,
+    EffectDecisionRequest,
+    FinalDisposition,
+    PositiveProof,
+    evaluate_effect_decision,
+    factors_from_extension_evidence,
+)
+from codex_plugin_scanner.guard.runtime.extension_evidence import (
+    EvidenceSeverity,
+    ExtensionEvidence,
+    ExtensionEvidenceBatch,
+    ExtensionMatchClass,
+    ExtensionRuleIdentity,
+    OwnedSafeVariant,
+    SafeVariantOutcome,
+)
+
+_DIGEST = "a" * 64
+
+
+def _assessment(*, uncertainty_reasons: tuple[UncertaintyKind, ...] = ()) -> EffectAssessment:
+    return EffectAssessment(
+        kind=EffectKind.PROCESS_EXECUTION,
+        target_scope=EffectTargetScope.WORKSPACE,
+        reversibility=EffectReversibility.TRIVIALLY_RECOVERABLE,
+        blast_radius=EffectBlastRadius.WORKSPACE,
+        evidence_source=EffectEvidenceSource.LAUNCH_IDENTITY,
+        confidence=EffectConfidence.EXACT if not uncertainty_reasons else EffectConfidence.PARTIAL,
+        containment=ContainmentRequirement.REQUIRED,
+        proof_requirements=frozenset({ProofRequirement.EXECUTABLE_IDENTITY, ProofRequirement.CONTAINMENT_IDENTITY}),
+        uncertainty_reasons=uncertainty_reasons,
+    )
+
+
+def _proof(route: ProofRoute = ProofRoute.CONTAINED) -> PositiveProof:
+    return PositiveProof(
+        route=route,
+        binding_digest=_DIGEST,
+        satisfied_requirements=frozenset({ProofRequirement.EXECUTABLE_IDENTITY, ProofRequirement.CONTAINMENT_IDENTITY}),
+        enforced=route is ProofRoute.CONTAINED,
+    )
+
+
+def _factor(
+    floor: GuardAction,
+    reason: str,
+    *,
+    segment: str,
+    route: ProofRoute | None = None,
+    assessment: EffectAssessment | None = None,
+) -> DecisionFactor:
+    return DecisionFactor(
+        source=DecisionFactorSource.EFFECT if assessment is not None else DecisionFactorSource.POLICY,
+        reason_code=reason,
+        basis=DecisionBasis(floor, route),
+        segment_ref=segment,
+        operation_ref=f"operation:{segment.removeprefix('segment:')}",
+        assessment=assessment,
+        proof=_proof(route) if route is not None else None,
+    )
+
+
+def test_truth_table_uses_the_canonical_maximum_for_every_pair() -> None:
+    for left, right in itertools.product(GUARD_ACTION_LATTICE, repeat=2):
+        left_route = ProofRoute.VERIFIED if GUARD_ACTION_SEVERITY[left] < GUARD_ACTION_SEVERITY["review"] else None
+        right_route = ProofRoute.VERIFIED if GUARD_ACTION_SEVERITY[right] < GUARD_ACTION_SEVERITY["review"] else None
+        decision = evaluate_effect_decision(
+            EffectDecisionRequest(
+                (
+                    _factor(left, "left", segment="segment:0", route=left_route),
+                    _factor(right, "right", segment="segment:1", route=right_route),
+                )
+            )
+        )
+        assert GUARD_ACTION_SEVERITY[decision.action] == max(GUARD_ACTION_SEVERITY[left], GUARD_ACTION_SEVERITY[right])
+
+
+def test_all_segment_all_effect_composition_is_permutation_independent() -> None:
+    factors = (
+        _factor("allow", "read.proven", segment="segment:0", route=ProofRoute.VERIFIED),
+        _factor("review", "remote.mutation", segment="segment:1"),
+        _factor("block", "guard.tamper", segment="segment:2"),
+    )
+    decisions = {evaluate_effect_decision(EffectDecisionRequest(order)) for order in itertools.permutations(factors)}
+    assert len(decisions) == 1
+    decision = decisions.pop()
+    assert decision.action == "block"
+    assert [reason.reason_code for reason in decision.controlling_reasons] == ["guard.tamper"]
+
+
+@pytest.mark.parametrize(
+    ("route", "disposition"),
+    [
+        (ProofRoute.VERIFIED, FinalDisposition.SILENT_VERIFIED),
+        (ProofRoute.CONTAINED, FinalDisposition.SILENT_CONTAINED),
+        (ProofRoute.WORKFLOW_AUTHORIZED, FinalDisposition.WORKFLOW_AUTHORIZED),
+    ],
+)
+def test_silent_dispositions_require_exact_positive_proof(route: ProofRoute, disposition: FinalDisposition) -> None:
+    factor = _factor("allow", "bounded.operation", segment="segment:0", route=route)
+    assert evaluate_effect_decision(EffectDecisionRequest((factor,))).disposition is disposition
+    with pytest.raises(ValueError, match="exact route"):
+        _ = replace(factor, proof=None)
+
+
+def test_containment_must_be_enforced_and_bind_every_effect_requirement() -> None:
+    with pytest.raises(ValueError, match="must be enforced"):
+        _ = replace(_proof(), enforced=False)
+    incomplete = PositiveProof(
+        ProofRoute.VERIFIED,
+        _DIGEST,
+        frozenset({ProofRequirement.EXECUTABLE_IDENTITY}),
+    )
+    with pytest.raises(ValueError, match="every effect requirement"):
+        _ = DecisionFactor(
+            source=DecisionFactorSource.EFFECT,
+            reason_code="process.proven",
+            basis=DecisionBasis("allow", ProofRoute.VERIFIED),
+            segment_ref="segment:0",
+            operation_ref="operation:0",
+            assessment=_assessment(),
+            proof=incomplete,
+        )
+
+
+def test_containment_route_must_match_effect_eligibility() -> None:
+    ineligible = replace(_assessment(), containment=ContainmentRequirement.NOT_ELIGIBLE)
+    with pytest.raises(ValueError, match="incompatible"):
+        _ = _factor(
+            "allow",
+            "process.contained",
+            segment="segment:0",
+            route=ProofRoute.CONTAINED,
+            assessment=ineligible,
+        )
+    with pytest.raises(ValueError, match="require contained proof"):
+        _ = _factor(
+            "allow",
+            "process.verified",
+            segment="segment:0",
+            route=ProofRoute.VERIFIED,
+            assessment=_assessment(),
+        )
+
+
+def test_distinct_same_kind_assessments_retain_lossless_identity() -> None:
+    workspace = _factor(
+        "allow",
+        "process.contained",
+        segment="segment:0",
+        route=ProofRoute.CONTAINED,
+        assessment=_assessment(),
+    )
+    external = replace(
+        workspace,
+        assessment=replace(_assessment(), target_scope=EffectTargetScope.EXTERNAL_LOCAL),
+    )
+    request = EffectDecisionRequest((workspace, external))
+    assert len(request.factors) == 2
+    assert evaluate_effect_decision(request).action == "allow"
+
+
+def test_effect_and_global_uncertainty_can_only_raise_the_result() -> None:
+    factor = _factor(
+        "allow",
+        "process.contained",
+        segment="segment:0",
+        route=ProofRoute.CONTAINED,
+        assessment=_assessment(uncertainty_reasons=(UncertaintyKind.PARTIAL_PARSE,)),
+    )
+    decision = evaluate_effect_decision(EffectDecisionRequest((factor,), (UncertaintyKind.PARSER_FAILURE,)))
+    assert decision.action == "block"
+    assert decision.disposition is FinalDisposition.BLOCK
+    assert {reason.reason_code for reason in decision.reasons} >= {
+        "uncertainty.partial-parse",
+        "uncertainty.parser-failure",
+    }
+
+
+def test_empty_or_malformed_input_fails_closed() -> None:
+    assert evaluate_effect_decision(EffectDecisionRequest(())).action == "review"
+    with pytest.raises(ValueError, match="DecisionFactor"):
+        _ = EffectDecisionRequest(cast(tuple[DecisionFactor, ...], (object(),)))
+    with pytest.raises(ValueError, match="schema version"):
+        _ = EffectDecisionRequest((), schema_version="2.0.0")
+    with pytest.raises(ValueError, match="lowercase SHA-256"):
+        _ = replace(_proof(), binding_digest="not-a-digest")
+
+
+def _evidence(
+    rule_suffix: str,
+    floor: GuardAction,
+    *,
+    safe: bool = False,
+) -> ExtensionEvidence:
+    identity = ExtensionRuleIdentity("command.test", "1.0.0", f"command.test.{rule_suffix}", "1.0.0")
+    return ExtensionEvidence(
+        identity=identity,
+        match_class=ExtensionMatchClass.UNSAFE,
+        severity=EvidenceSeverity.CRITICAL if floor == "block" else EvidenceSeverity.HIGH,
+        declared_floor=floor,
+        base_fact=f"{rule_suffix}.matched",
+        segment_ref=f"segment:{rule_suffix}",
+        operation_ref=f"operation:{rule_suffix}",
+        effect_claims=frozenset({EffectKind.DESTRUCTIVE_OR_IRREVERSIBLE_OPERATION}),
+        proof_requirements=frozenset({ProofRequirement.OPERATION_AND_TARGETS}),
+        safe_variant=(
+            OwnedSafeVariant(identity, f"{rule_suffix}.safe", SafeVariantOutcome.OWNED_RULE_NOT_RAISED)
+            if safe
+            else None
+        ),
+    )
+
+
+def test_owned_safe_variant_never_suppresses_a_stronger_sibling() -> None:
+    safe = _evidence("owned", "review", safe=True)
+    sibling = _evidence("sibling", "block")
+    factors = factors_from_extension_evidence(ExtensionEvidenceBatch((safe, sibling)))
+    decision = evaluate_effect_decision(EffectDecisionRequest(factors))
+    assert [factor.reason_code for factor in factors] == ["sibling.matched"]
+    assert decision.action == "block"


### PR DESCRIPTION
## Summary
- add a pure central evaluator that composes effect, match, policy, containment, authorization, and uncertainty floors monotonically
- require exact positive proof for permissive decisions and preserve lossless extension and multi-segment evidence identity

## Testing
- `uv run --no-sync pytest -q tests/test_guard_effect_decision.py tests/test_guard_effect_contract.py tests/test_guard_extension_evidence_contract.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/runtime/effect_decision.py tests/test_guard_effect_decision.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/runtime/effect_decision.py tests/test_guard_effect_decision.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/runtime/effect_decision.py tests/test_guard_effect_decision.py`
- `git diff --check`
