### PR TITLE
feat(guard): add central effect decision plane

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_decision_adapter.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_decision_adapter.py
@@ -1,0 +1,220 @@
+"""Compatibility adapters from command heuristics to the central decision plane."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from codex_plugin_scanner.guard.models import GuardAction
+
+from .command_extension_observations import CommandExtensionObservation
+from .command_extensions import CommandSafetyExtension
+from .command_matcher_contracts import MatcherEvidence
+from .command_model import CanonicalCommand
+from .command_rules import CommandRuleMode, CommandSafetyRule
+from .effect_contract import (
+    UNCERTAINTY_FLOOR,
+    EffectKind,
+    ProofRequirement,
+    UncertaintyKind,
+    maximum_action_floor,
+)
+from .effect_decision_plane import DecisionCandidate, DecisionSourceKind
+from .extension_evidence import (
+    EvidenceSeverity,
+    ExtensionEvidence,
+    ExtensionEvidenceBatch,
+    ExtensionMatchClass,
+    ExtensionRuleIdentity,
+    OwnedSafeVariant,
+    SafeVariantOutcome,
+)
+
+LegacyCommandFloor = Literal["allow", "monitor", "review", "block"]
+
+_MODE_FLOOR: dict[CommandRuleMode, LegacyCommandFloor] = {
+    "disabled": "allow",
+    "monitor": "monitor",
+    "review": "review",
+    "enforce": "block",
+    "required": "review",
+}
+_CANONICAL_FLOOR: dict[LegacyCommandFloor, GuardAction] = {
+    "allow": "allow",
+    "monitor": "warn",
+    "review": "review",
+    "block": "block",
+}
+_LEGACY_FLOOR: dict[GuardAction, LegacyCommandFloor] = {
+    "allow": "allow",
+    "warn": "monitor",
+    "review": "review",
+    "require-reapproval": "review",
+    "sandbox-required": "review",
+    "block": "block",
+}
+_SEVERITY: dict[str, EvidenceSeverity] = {
+    "low": EvidenceSeverity.LOW,
+    "medium": EvidenceSeverity.MEDIUM,
+    "high": EvidenceSeverity.HIGH,
+    "critical": EvidenceSeverity.CRITICAL,
+}
+
+
+def legacy_rule_floor(extension: CommandSafetyExtension, rule: CommandSafetyRule) -> LegacyCommandFloor:
+    if extension.required and rule.severity == "critical":
+        return "block"
+    if extension.required:
+        return "review"
+    return _MODE_FLOOR[rule.default_mode]
+
+
+def legacy_floor_for_action(action: GuardAction) -> LegacyCommandFloor:
+    return _LEGACY_FLOOR[action]
+
+
+def command_rule_candidates(
+    selected: tuple[tuple[CommandSafetyExtension, CommandSafetyRule, tuple[MatcherEvidence, ...]], ...],
+) -> tuple[DecisionCandidate, ...]:
+    """Adapt every effective legacy rule floor without granting interaction."""
+
+    candidates: list[DecisionCandidate] = []
+    for extension, rule, evidence in selected:
+        floor = _CANONICAL_FLOOR[legacy_rule_floor(extension, rule)]
+        segment_indexes: tuple[int | None, ...] = tuple(sorted({item.segment_index for item in evidence})) or (None,)
+        for segment_index in segment_indexes:
+            candidates.append(
+                DecisionCandidate(
+                    source_id=f"extension-rule:{rule.rule_id}",
+                    source_kind=DecisionSourceKind.EXTENSION,
+                    action_floor=floor,
+                    reason_code="reason:extension-rule-floor",
+                    segment_ref=None if segment_index is None else f"segment:{segment_index}",
+                )
+            )
+    return tuple(candidates)
+
+
+def extension_evidence_batch(
+    command: CanonicalCommand,
+    observations: tuple[CommandExtensionObservation[CommandSafetyExtension], ...],
+) -> ExtensionEvidenceBatch:
+    """Translate review-or-stronger effective matches to strict immutable evidence."""
+
+    evidence: list[ExtensionEvidence] = []
+    operation_ref = f"operation:{command.security_identity.rsplit(':', 1)[-1]}"
+    for observation in observations:
+        floor = _CANONICAL_FLOOR[legacy_rule_floor(observation.extension, observation.rule)]
+        if observation.uncertainty_reasons:
+            evidence.append(
+                ExtensionEvidence(
+                    identity=_rule_identity(observation),
+                    match_class=ExtensionMatchClass.UNCERTAINTY,
+                    severity=EvidenceSeverity.CRITICAL,
+                    declared_floor=maximum_action_floor(
+                        UNCERTAINTY_FLOOR[item] for item in observation.uncertainty_reasons
+                    ),
+                    base_fact="matcher-failure",
+                    segment_ref="segment:unknown",
+                    operation_ref=operation_ref,
+                    effect_claims=_effect_claims(observation.rule.risk_classes),
+                    proof_requirements=_extension_proof_requirements(),
+                    uncertainty_reasons=observation.uncertainty_reasons,
+                )
+            )
+        if floor in {"allow", "warn"}:
+            continue
+        identity = _rule_identity(observation)
+        for segment_index in sorted({match.segment_index for match in observation.matcher_evidence}):
+            safe_variant_ids = sorted(
+                {
+                    variant.variant_id
+                    for variant in observation.safe_variants
+                    if any(item.segment_index == segment_index for item in variant.matcher_evidence)
+                }
+            )
+            owned_safe_variants: tuple[OwnedSafeVariant | None, ...] = tuple(
+                OwnedSafeVariant(
+                    identity=identity,
+                    safe_variant_id=variant_id,
+                    outcome=SafeVariantOutcome.OWNED_RULE_NOT_RAISED,
+                )
+                for variant_id in safe_variant_ids
+            ) or (None,)
+            for safe_variant in owned_safe_variants:
+                evidence.append(
+                    ExtensionEvidence(
+                        identity=identity,
+                        match_class=ExtensionMatchClass.UNSAFE,
+                        severity=_SEVERITY[observation.rule.severity],
+                        declared_floor=floor,
+                        base_fact="rule-match",
+                        segment_ref=f"segment:{segment_index}",
+                        operation_ref=operation_ref,
+                        effect_claims=_effect_claims(observation.rule.risk_classes),
+                        proof_requirements=_extension_proof_requirements(),
+                        safe_variant=safe_variant,
+                    )
+                )
+    return ExtensionEvidenceBatch(tuple(evidence))
+
+
+def compatibility_candidate(action_class: str) -> DecisionCandidate:
+    identity = hashlib.sha256(action_class.strip().lower().encode("utf-8")).hexdigest()
+    return DecisionCandidate(
+        source_id=f"legacy-heuristic:{identity}",
+        source_kind=DecisionSourceKind.LEGACY_HEURISTIC,
+        action_floor="review",
+        reason_code="reason:compatibility-action",
+    )
+
+
+def command_uncertainties(command: CanonicalCommand, *, sensitive: bool) -> tuple[UncertaintyKind, ...]:
+    if not sensitive or command.confidence == "exact":
+        return ()
+    if command.confidence == "fallback":
+        return (UncertaintyKind.PARTIAL_PARSE,)
+    return (UncertaintyKind.DYNAMIC_INPUT,)
+
+
+def extension_uncertainties(
+    observations: tuple[CommandExtensionObservation[CommandSafetyExtension], ...],
+) -> tuple[UncertaintyKind, ...]:
+    return tuple(sorted({item for observation in observations for item in observation.uncertainty_reasons}, key=str))
+
+
+def _rule_identity(
+    observation: CommandExtensionObservation[CommandSafetyExtension],
+) -> ExtensionRuleIdentity:
+    return ExtensionRuleIdentity(
+        extension_id=observation.extension.extension_id,
+        extension_version=observation.extension.version,
+        rule_id=observation.rule.rule_id,
+        rule_version=observation.rule.rule_version,
+    )
+
+
+def _extension_proof_requirements() -> frozenset[ProofRequirement]:
+    return frozenset(
+        {
+            ProofRequirement.OPERATION_AND_TARGETS,
+            ProofRequirement.PARSER_CONFIDENCE,
+            ProofRequirement.EXPECTED_EFFECTS,
+        }
+    )
+
+
+def _effect_claims(risk_classes: tuple[str, ...]) -> frozenset[EffectKind]:
+    effects: set[EffectKind] = set()
+    for risk in risk_classes:
+        if "destructive" in risk:
+            effects.add(EffectKind.DESTRUCTIVE_OR_IRREVERSIBLE_OPERATION)
+        if "network" in risk or "exfiltration" in risk:
+            effects.add(EffectKind.NETWORK_WRITE)
+        if "secret" in risk or "credential" in risk:
+            effects.add(EffectKind.CREDENTIAL_OR_SECRET_OPERATION)
+        if "execution" in risk:
+            effects.add(EffectKind.PROCESS_EXECUTION)
+        if "policy" in risk:
+            effects.add(EffectKind.GUARD_CONTROL_OPERATION)
+    return frozenset(effects or {EffectKind.PROCESS_EXECUTION})

--- a/src/codex_plugin_scanner/guard/runtime/command_evaluation.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_evaluation.py
@@ -4,26 +4,36 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
 
+from .command_decision_adapter import (
+    LegacyCommandFloor,
+    command_rule_candidates,
+    command_uncertainties,
+    compatibility_candidate,
+    extension_evidence_batch,
+    extension_uncertainties,
+    legacy_floor_for_action,
+    legacy_rule_floor,
+)
+from .command_extension_observations import CommandExtensionObservation, observe_command_extensions
 from .command_extensions import (
     BUILT_IN_COMMAND_EXTENSION_REGISTRY,
     CommandSafetyExtension,
     CommandSafetyExtensionRegistry,
 )
 from .command_model import CanonicalCommand, parse_shell_command
-from .command_rules import CommandRuleMatch, CommandRuleMode
+from .command_rules import CommandRuleMatch
+from .effect_decision_plane import (
+    DecisionCandidate,
+    DecisionSourceKind,
+    EffectDecision,
+    EffectDecisionRequest,
+    evaluate_effect_decision,
+)
 
-CommandDecisionFloor = Literal["allow", "monitor", "review", "block"]
+CommandDecisionFloor = LegacyCommandFloor
 _FLOOR_RANK: dict[CommandDecisionFloor, int] = {"allow": 0, "monitor": 1, "review": 2, "block": 3}
 _SEVERITY_RANK = {"low": 0, "medium": 1, "high": 2, "critical": 3}
-_MODE_FLOOR: dict[CommandRuleMode, CommandDecisionFloor] = {
-    "disabled": "allow",
-    "monitor": "monitor",
-    "review": "review",
-    "enforce": "block",
-    "required": "review",
-}
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,6 +60,8 @@ class CompositeCommandEvaluation:
     controlling_reason: str | None
     controlling_rule_id: str | None
     minimum_action: CommandDecisionFloor
+    extension_observations: tuple[CommandExtensionObservation[CommandSafetyExtension], ...]
+    decision_plane: EffectDecision
 
     @property
     def risk_classes(self) -> tuple[str, ...]:
@@ -68,6 +80,8 @@ class CompositeCommandEvaluation:
             "minimum_action": self.minimum_action,
             "risk_classes": list(self.risk_classes),
             "matches": [owned.to_dict() for owned in self.matches],
+            "extension_observations": [item.to_dict() for item in self.extension_observations],
+            "decision_plane": self.decision_plane.to_dict(),
             "parse_confidence": self.command.confidence,
             "uncertainty_reason": self.command.uncertainty_reason,
         }
@@ -86,7 +100,10 @@ def evaluate_command(
     """Evaluate every built-in rule without executing or persisting the command."""
 
     command = canonical_command or parse_shell_command(command_text, cwd=cwd, home_dir=home_dir)
-    structured = registry.matching_rules(command)
+    observations = observe_command_extensions(command, registry.extensions, registry.candidate_rule_ids(command))
+    structured = tuple(
+        (item.extension, item.rule, item.effective_evidence) for item in observations if item.effective_evidence
+    )
     selected = list(structured)
     selected_rule_ids = {rule.rule_id for _extension, rule, _evidence in selected}
     if compatibility_action_class is not None:
@@ -120,34 +137,46 @@ def evaluate_command(
     if controlling_action_class is None and controlling_match is not None:
         controlling_action_class = controlling_match.match.action_class
         controlling_reason = controlling_match.match.reason
-    minimum_action: CommandDecisionFloor = "allow"
-    for owned in owned_matches:
-        minimum_action = _stronger_floor(minimum_action, _rule_floor(owned))
+    selected_tuple = tuple(selected)
+    candidates = list(command_rule_candidates(selected_tuple))
+    candidates.append(
+        DecisionCandidate("policy:legacy-baseline", DecisionSourceKind.POLICY, "allow", "reason:legacy-baseline")
+    )
     if compatibility_action_class is not None:
-        minimum_action = _stronger_floor(minimum_action, "review")
-    if command.confidence != "exact" and (compatibility_action_class is not None or owned_matches):
-        minimum_action = _stronger_floor(minimum_action, "review")
+        candidates.append(compatibility_candidate(compatibility_action_class))
+    decision = evaluate_effect_decision(
+        EffectDecisionRequest(
+            effects=(),
+            extension_evidence=extension_evidence_batch(command, observations),
+            candidates=tuple(candidates),
+            uncertainties=tuple(
+                sorted(
+                    {
+                        *command_uncertainties(
+                            command,
+                            sensitive=compatibility_action_class is not None or bool(owned_matches),
+                        ),
+                        *extension_uncertainties(observations),
+                    },
+                    key=str,
+                )
+            ),
+        )
+    )
     return CompositeCommandEvaluation(
         command=command,
         matches=tuple(owned_matches),
         controlling_action_class=controlling_action_class,
         controlling_reason=controlling_reason,
         controlling_rule_id=controlling_match.match.rule.rule_id if controlling_match is not None else None,
-        minimum_action=minimum_action,
+        minimum_action=legacy_floor_for_action(decision.action),
+        extension_observations=observations,
+        decision_plane=decision,
     )
 
 
 def _rule_floor(owned: OwnedCommandRuleMatch) -> CommandDecisionFloor:
-    rule = owned.match.rule
-    if owned.extension.required and rule.severity == "critical":
-        return "block"
-    if owned.extension.required:
-        return "review"
-    return _MODE_FLOOR[rule.default_mode]
-
-
-def _stronger_floor(left: CommandDecisionFloor, right: CommandDecisionFloor) -> CommandDecisionFloor:
-    return left if _FLOOR_RANK[left] >= _FLOOR_RANK[right] else right
+    return legacy_rule_floor(owned.extension, owned.match.rule)
 
 
 def _match_precedence_key(owned: OwnedCommandRuleMatch) -> tuple[int, int, int]:

--- a/src/codex_plugin_scanner/guard/runtime/command_extension_observations.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extension_observations.py
@@ -101,6 +101,8 @@ def observe_command_extensions(
                     )
                 )
                 continue
+            if not matcher_evidence:
+                continue
             safe_variants: list[SafeVariantObservation] = []
             uncertainty_reasons: tuple[UncertaintyKind, ...] = ()
             for variant in rule.safe_variants:

--- a/src/codex_plugin_scanner/guard/runtime/command_extension_observations.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extension_observations.py
@@ -1,0 +1,134 @@
+"""Lossless evidence observations for command safety extension matchers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, Protocol, TypeVar, cast
+
+from .command_matcher_contracts import CommandMatcher, MatcherEvidence
+from .command_model import CanonicalCommand
+from .command_rules import CommandSafetyRule
+from .effect_contract import UncertaintyKind
+
+
+class CommandSafetyExtensionView(Protocol):
+    @property
+    def extension_id(self) -> str: ...
+
+    @property
+    def version(self) -> str: ...
+
+    @property
+    def rules(self) -> tuple[CommandSafetyRule, ...]: ...
+
+
+_ExtensionT = TypeVar("_ExtensionT", bound=CommandSafetyExtensionView)
+
+
+@dataclass(frozen=True, slots=True)
+class SafeVariantObservation:
+    """Every segment-level match emitted by one owned safe variant."""
+
+    variant_id: str
+    matcher_evidence: tuple[MatcherEvidence, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "match_class": "safe-variant",
+            "variant_id": self.variant_id,
+            "matcher_evidence": [item.to_dict() for item in self.matcher_evidence],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CommandExtensionObservation(Generic[_ExtensionT]):
+    """Immutable base and safe-variant evidence from one extension rule."""
+
+    extension: _ExtensionT
+    rule: CommandSafetyRule
+    matcher_evidence: tuple[MatcherEvidence, ...]
+    safe_variants: tuple[SafeVariantObservation, ...]
+    uncertainty_reasons: tuple[UncertaintyKind, ...] = ()
+
+    @property
+    def safe_segment_indexes(self) -> frozenset[int]:
+        return frozenset(
+            item.segment_index for observation in self.safe_variants for item in observation.matcher_evidence
+        )
+
+    @property
+    def effective_evidence(self) -> tuple[MatcherEvidence, ...]:
+        safe_indexes = self.safe_segment_indexes
+        return tuple(item for item in self.matcher_evidence if item.segment_index not in safe_indexes)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "extension_id": self.extension.extension_id,
+            "extension_version": self.extension.version,
+            "rule_id": self.rule.rule_id,
+            "rule_version": self.rule.rule_version,
+            "match_class": "unsafe",
+            "matcher_evidence": [item.to_dict() for item in self.matcher_evidence],
+            "safe_variants": [item.to_dict() for item in self.safe_variants],
+            "uncertainty_reasons": [item.value for item in self.uncertainty_reasons],
+            "effective_segment_indexes": [item.segment_index for item in self.effective_evidence],
+        }
+
+
+def observe_command_extensions(
+    command: CanonicalCommand,
+    extensions: tuple[_ExtensionT, ...],
+    candidate_rule_ids: tuple[str, ...],
+) -> tuple[CommandExtensionObservation[_ExtensionT], ...]:
+    """Evaluate every candidate matcher without suppressing owned safe evidence."""
+
+    candidates = frozenset(candidate_rule_ids)
+    observations: list[CommandExtensionObservation[_ExtensionT]] = []
+    for extension in extensions:
+        for rule in extension.rules:
+            if rule.matcher is None or rule.rule_id not in candidates:
+                continue
+            try:
+                matcher_evidence = _validated_match(rule.matcher, command)
+            except Exception:
+                observations.append(
+                    CommandExtensionObservation(
+                        extension,
+                        rule,
+                        (),
+                        (),
+                        (UncertaintyKind.MATCHER_FAILURE,),
+                    )
+                )
+                continue
+            safe_variants: list[SafeVariantObservation] = []
+            uncertainty_reasons: tuple[UncertaintyKind, ...] = ()
+            for variant in rule.safe_variants:
+                try:
+                    evidence = _validated_match(variant.matcher, command)
+                except Exception:
+                    uncertainty_reasons = (UncertaintyKind.MATCHER_FAILURE,)
+                    continue
+                if evidence:
+                    safe_variants.append(SafeVariantObservation(variant.variant_id, evidence))
+            if matcher_evidence or safe_variants or uncertainty_reasons:
+                observations.append(
+                    CommandExtensionObservation(
+                        extension,
+                        rule,
+                        matcher_evidence,
+                        tuple(safe_variants),
+                        uncertainty_reasons,
+                    )
+                )
+    return tuple(observations)
+
+
+def _validated_match(matcher: CommandMatcher, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+    evidence_value = cast(object, matcher.match(command))
+    if not isinstance(evidence_value, tuple):
+        raise ValueError("matcher evidence must be a tuple of MatcherEvidence values")
+    evidence = cast(tuple[object, ...], evidence_value)
+    if any(not isinstance(item, MatcherEvidence) for item in evidence):
+        raise ValueError("matcher evidence must be a tuple of MatcherEvidence values")
+    return cast(tuple[MatcherEvidence, ...], evidence)

--- a/src/codex_plugin_scanner/guard/runtime/command_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extensions.py
@@ -9,9 +9,10 @@ from typing import Literal, final
 
 from .command_builtin_extension_catalog import DIRECT_COMMAND_EXTENSION_VALUES
 from .command_builtin_rules import COMMAND_ACTION_RISK_CLASSES, rules_for_extension
+from .command_matcher_contracts import MatcherEvidence
 from .command_model import CanonicalCommand
 from .command_package_extensions import PACKAGE_COMMAND_EXTENSION_SPECS, PackageCommandExtensionSpec
-from .command_rules import CommandSafetyRule, MatcherEvidence, matcher_index_hints
+from .command_rules import CommandSafetyRule, matcher_index_hints
 
 COMMAND_EXTENSION_SCHEMA_VERSION = 2
 _VERSION_PATTERN = re.compile(r"^[1-9][0-9]*\.[0-9]+\.[0-9]+$")

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Literal, final
 
@@ -298,6 +299,7 @@ class CommandSafetyRule:
     matcher: CommandMatcher | None = None
     safe_variants: tuple[CommandSafeVariant, ...] = ()
     compatibility_fallback: bool = False
+    rule_version: str = "1.0.0"
 
     def __post_init__(self) -> None:
         if not self.rule_id.startswith("command.") or self.rule_id != self.rule_id.lower():
@@ -308,6 +310,8 @@ class CommandSafetyRule:
             raise ValueError(f"Command safety rule {self.rule_id} has invalid severity")
         if self.default_mode not in _VALID_MODES:
             raise ValueError(f"Command safety rule {self.rule_id} has invalid default mode")
+        if re.fullmatch(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)", self.rule_version) is None:
+            raise ValueError(f"Command safety rule {self.rule_id} has invalid rule version")
         for field_name, values in (
             ("risk classes", self.risk_classes),
             ("safer alternatives", self.safer_alternatives),
@@ -325,6 +329,7 @@ class CommandSafetyRule:
     def to_dict(self) -> dict[str, object]:
         return {
             "rule_id": self.rule_id,
+            "rule_version": self.rule_version,
             "title": self.title,
             "description": self.description,
             "severity": self.severity,
@@ -439,11 +444,6 @@ def _segment_matches_executable(segment: CommandSegment, executables: frozenset[
         return False
     executable = segment.executable.replace("\\", "/").rsplit("/", 1)[-1].lower()
     return executable in executables
-
-
-def _normalize_option_token(value: str) -> str:
-    stripped = value.strip()
-    return stripped.lower() if stripped.startswith("--") else stripped
 
 
 def _after_leading_options(

--- a/src/codex_plugin_scanner/guard/runtime/effect_decision_plane.py
+++ b/src/codex_plugin_scanner/guard/runtime/effect_decision_plane.py
@@ -1,0 +1,396 @@
+"""Pure, monotonic effect-capability decision plane for Guard commands."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Final, TypeVar, cast
+
+from codex_plugin_scanner.guard.action_lattice import guard_action_severity, is_guard_action
+from codex_plugin_scanner.guard.models import GuardAction
+
+from .effect_contract import (
+    ContainmentRequirement,
+    EffectAssessment,
+    ProofRequirement,
+    ProofRoute,
+    UncertaintyKind,
+    apply_uncertainty_floor,
+    maximum_action_floor,
+)
+from .extension_evidence import ExtensionEvidenceBatch
+
+EFFECT_DECISION_PLANE_SCHEMA_VERSION: Final = "1.0.0"
+_STABLE_REFERENCE: Final[re.Pattern[str]] = re.compile(r"[a-z][a-z0-9_-]*:[a-z0-9][a-z0-9._:/-]*")
+_FRAMED_DIGEST: Final[re.Pattern[str]] = re.compile(r"[a-z][a-z0-9-]*-v[1-9][0-9]*:[0-9a-f]{64}")
+_T = TypeVar("_T")
+_LAUNCH_PROOF_REQUIREMENTS: Final = frozenset(
+    {
+        ProofRequirement.EXECUTABLE_IDENTITY,
+        ProofRequirement.LAUNCH_CHAIN,
+        ProofRequirement.DEPENDENCY_PROVENANCE,
+        ProofRequirement.CONFIGURATION_IDENTITY,
+        ProofRequirement.WORKING_DIRECTORY_IDENTITY,
+    }
+)
+
+
+class DecisionDisposition(str, Enum):
+    SILENT_VERIFIED = "silent-verified"
+    SILENT_CONTAINED = "silent-contained"
+    WORKFLOW_AUTHORIZED = "workflow-authorized"
+    REVIEW = "review"
+    REQUIRE_REAPPROVAL = "require-reapproval"
+    BLOCK = "block"
+
+
+class DecisionSourceKind(str, Enum):
+    EFFECT = "effect"
+    EXTENSION = "extension"
+    POLICY = "policy"
+    LEGACY_HEURISTIC = "legacy-heuristic"
+    UNCERTAINTY = "uncertainty"
+
+
+class LaunchComponentKind(str, Enum):
+    EXECUTABLE = "executable"
+    WRAPPER = "wrapper"
+    INTERPRETER = "interpreter"
+    PATH_ENTRY = "path-entry"
+    SYMLINK = "symlink"
+    PACKAGE_ALIAS = "package-alias"
+    PACKAGE_SOURCE = "package-source"
+    MANIFEST = "manifest"
+    LOCKFILE = "lockfile"
+    CONFIGURATION = "configuration"
+    REDIRECTION = "redirection"
+
+
+@dataclass(frozen=True, slots=True)
+class LaunchIdentityComponent:
+    kind: LaunchComponentKind
+    component_ref: str
+    input_identity: str
+    resolved_identity: str
+
+    def __post_init__(self) -> None:
+        _require_enum(self.kind, LaunchComponentKind, "kind")
+        _require_reference(self.component_ref, "component_ref")
+        _require_digest(self.input_identity, "input_identity")
+        _require_digest(self.resolved_identity, "resolved_identity")
+
+    @property
+    def semantic_key(self) -> tuple[str, str, str, str]:
+        return self.kind.value, self.component_ref, self.input_identity, self.resolved_identity
+
+
+@dataclass(frozen=True, slots=True)
+class LaunchIdentityBinding:
+    command_security_identity: str
+    working_directory_identity: str
+    components: tuple[LaunchIdentityComponent, ...]
+
+    def __post_init__(self) -> None:
+        if not re.fullmatch(r"command-security-v[1-9][0-9]*:[0-9a-f]{64}", self.command_security_identity):
+            raise ValueError("command_security_identity must be a framed command identity")
+        _require_digest(self.working_directory_identity, "working_directory_identity")
+        components_value = cast(object, self.components)
+        if not isinstance(components_value, tuple) or not components_value:
+            raise ValueError("components must be a non-empty tuple")
+        components = cast(tuple[object, ...], components_value)
+        if any(not isinstance(item, LaunchIdentityComponent) for item in components):
+            raise ValueError("components must contain LaunchIdentityComponent values")
+        typed_components = cast(tuple[LaunchIdentityComponent, ...], components)
+        ordered = tuple(sorted(typed_components, key=lambda item: item.semantic_key))
+        if len({item.semantic_key for item in ordered}) != len(ordered):
+            raise ValueError("components cannot contain duplicate launch identities")
+        if not any(item.kind is LaunchComponentKind.EXECUTABLE for item in ordered):
+            raise ValueError("launch identity requires an executable component")
+        object.__setattr__(self, "components", ordered)
+
+
+@dataclass(frozen=True, slots=True)
+class EffectProof:
+    route: ProofRoute
+    satisfied_requirements: frozenset[ProofRequirement]
+    launch_identity: LaunchIdentityBinding | None = None
+    containment_identity: str | None = None
+    capability_identity: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_enum(self.route, ProofRoute, "route")
+        requirements_value = cast(object, self.satisfied_requirements)
+        if not isinstance(requirements_value, frozenset):
+            raise ValueError("satisfied_requirements must be a frozenset")
+        requirements = requirements_value
+        if any(not isinstance(item, ProofRequirement) for item in requirements):
+            raise ValueError("satisfied_requirements must contain ProofRequirement values")
+        if self.satisfied_requirements.intersection(_LAUNCH_PROOF_REQUIREMENTS) and self.launch_identity is None:
+            raise ValueError("launch requirements require a LaunchIdentityBinding")
+        if ProofRequirement.CONTAINMENT_IDENTITY in self.satisfied_requirements:
+            _require_optional_digest(self.containment_identity, "containment_identity", required=True)
+        elif self.containment_identity is not None:
+            raise ValueError("containment identity cannot be supplied without its proof requirement")
+        if ProofRequirement.CAPABILITY_CONSTRAINTS in self.satisfied_requirements:
+            _require_optional_digest(self.capability_identity, "capability_identity", required=True)
+        elif self.capability_identity is not None:
+            raise ValueError("capability identity cannot be supplied without its proof requirement")
+        if self.route is ProofRoute.CONTAINED and self.containment_identity is None:
+            raise ValueError("contained proof requires containment identity")
+        if self.route is ProofRoute.WORKFLOW_AUTHORIZED and self.capability_identity is None:
+            raise ValueError("workflow proof requires capability identity")
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionCandidate:
+    source_id: str
+    source_kind: DecisionSourceKind
+    action_floor: GuardAction
+    reason_code: str
+    segment_ref: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_reference(self.source_id, "source_id")
+        _require_enum(self.source_kind, DecisionSourceKind, "source_kind")
+        _require_action(self.action_floor, "action_floor")
+        _require_reference(self.reason_code, "reason_code")
+        if self.segment_ref is not None:
+            _require_reference(self.segment_ref, "segment_ref")
+
+    @property
+    def semantic_key(self) -> tuple[str, str, str, str, str]:
+        return (
+            self.source_kind.value,
+            self.source_id,
+            self.segment_ref or "",
+            self.action_floor,
+            self.reason_code,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EffectObservation:
+    segment_ref: str
+    effect_ref: str
+    assessment: EffectAssessment
+    policy_floor: GuardAction
+    proof: EffectProof | None = None
+    workflow_authorization_eligible: bool = False
+    expected_launch_identity: LaunchIdentityBinding | None = None
+
+    def __post_init__(self) -> None:
+        _require_reference(self.segment_ref, "segment_ref")
+        _require_reference(self.effect_ref, "effect_ref")
+        if not isinstance(cast(object, self.assessment), EffectAssessment):
+            raise ValueError("assessment must be an EffectAssessment")
+        _require_action(self.policy_floor, "policy_floor")
+        if self.proof is not None and not isinstance(cast(object, self.proof), EffectProof):
+            raise ValueError("proof must be an EffectProof")
+        if type(self.workflow_authorization_eligible) is not bool:
+            raise ValueError("workflow_authorization_eligible must be a boolean")
+        launch_requirements = self.assessment.proof_requirements.intersection(_LAUNCH_PROOF_REQUIREMENTS)
+        if launch_requirements and self.expected_launch_identity is None:
+            raise ValueError("launch proof requirements require an expected launch identity")
+        if self.expected_launch_identity is not None:
+            if not isinstance(cast(object, self.expected_launch_identity), LaunchIdentityBinding):
+                raise ValueError("expected_launch_identity must be a LaunchIdentityBinding")
+            if not launch_requirements:
+                raise ValueError("expected launch identity requires a launch proof requirement")
+
+
+@dataclass(frozen=True, slots=True)
+class EffectDecisionRequest:
+    effects: tuple[EffectObservation, ...]
+    extension_evidence: ExtensionEvidenceBatch
+    candidates: tuple[DecisionCandidate, ...] = ()
+    uncertainties: tuple[UncertaintyKind, ...] = ()
+    schema_version: str = EFFECT_DECISION_PLANE_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != EFFECT_DECISION_PLANE_SCHEMA_VERSION:
+            raise ValueError("unsupported effect decision plane schema version")
+        _ = _require_tuple_members(self.effects, EffectObservation, "effects")
+        if not isinstance(cast(object, self.extension_evidence), ExtensionEvidenceBatch):
+            raise ValueError("extension_evidence must be an ExtensionEvidenceBatch")
+        _ = _require_tuple_members(self.candidates, DecisionCandidate, "candidates")
+        _ = _require_tuple_members(self.uncertainties, UncertaintyKind, "uncertainties")
+        effect_keys = {(item.segment_ref, item.effect_ref) for item in self.effects}
+        if len(effect_keys) != len(self.effects):
+            raise ValueError("effects cannot contain duplicate segment/effect references")
+        candidate_keys = {item.semantic_key for item in self.candidates}
+        if len(candidate_keys) != len(self.candidates):
+            raise ValueError("candidates cannot contain duplicates")
+
+
+@dataclass(frozen=True, slots=True)
+class EffectDecision:
+    action: GuardAction
+    disposition: DecisionDisposition
+    controlling_sources: tuple[str, ...]
+    reason_codes: tuple[str, ...]
+    segment_actions: tuple[tuple[str, GuardAction], ...]
+    proof_routes: tuple[ProofRoute, ...]
+    schema_version: str = EFFECT_DECISION_PLANE_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "action": self.action,
+            "disposition": self.disposition.value,
+            "controlling_sources": list(self.controlling_sources),
+            "reason_codes": list(self.reason_codes),
+            "segment_actions": [
+                {"segment_ref": segment_ref, "action": action} for segment_ref, action in self.segment_actions
+            ],
+            "proof_routes": [item.value for item in self.proof_routes],
+        }
+
+
+def evaluate_effect_decision(request: EffectDecisionRequest) -> EffectDecision:
+    """Return one deterministic maximum action across all effects and evidence."""
+
+    if not isinstance(cast(object, request), EffectDecisionRequest):
+        raise ValueError("request must be an EffectDecisionRequest")
+    candidates = list(request.candidates)
+    proof_routes: set[ProofRoute] = set()
+    segment_floors: dict[str, list[GuardAction]] = {}
+    for candidate in request.candidates:
+        if candidate.segment_ref is not None:
+            segment_floors.setdefault(candidate.segment_ref, []).append(candidate.action_floor)
+    for effect in request.effects:
+        floor, route, reason = _effect_floor(effect)
+        candidates.append(
+            DecisionCandidate(effect.effect_ref, DecisionSourceKind.EFFECT, floor, reason, effect.segment_ref)
+        )
+        segment_floors.setdefault(effect.segment_ref, []).append(floor)
+        if route is not None:
+            proof_routes.add(route)
+    for evidence in request.extension_evidence.evidence:
+        extension_floor = evidence.effective_floor
+        if extension_floor is None:
+            continue
+        candidates.append(
+            DecisionCandidate(
+                f"extension-evidence:{evidence.identity.rule_id}",
+                DecisionSourceKind.EXTENSION,
+                extension_floor,
+                "reason:extension-floor",
+                evidence.segment_ref,
+            )
+        )
+        segment_floors.setdefault(evidence.segment_ref, []).append(extension_floor)
+    if request.uncertainties:
+        uncertainty_floor = apply_uncertainty_floor("allow", request.uncertainties)
+        candidates.append(
+            DecisionCandidate(
+                "uncertainty:request",
+                DecisionSourceKind.UNCERTAINTY,
+                uncertainty_floor,
+                "reason:typed-uncertainty",
+            )
+        )
+    if not candidates:
+        candidates.append(
+            DecisionCandidate(
+                "uncertainty:empty",
+                DecisionSourceKind.UNCERTAINTY,
+                "review",
+                "reason:empty-decision-input",
+            )
+        )
+    ordered = tuple(sorted(candidates, key=lambda item: item.semantic_key))
+    action = maximum_action_floor(item.action_floor for item in ordered)
+    controlling = tuple(item for item in ordered if item.action_floor == action)
+    return EffectDecision(
+        action=action,
+        disposition=_disposition(action, proof_routes),
+        controlling_sources=tuple(item.source_id for item in controlling),
+        reason_codes=tuple(sorted({item.reason_code for item in ordered})),
+        segment_actions=tuple(
+            (segment_ref, maximum_action_floor(floors)) for segment_ref, floors in sorted(segment_floors.items())
+        ),
+        proof_routes=tuple(sorted(proof_routes, key=lambda item: item.value)),
+    )
+
+
+def _effect_floor(effect: EffectObservation) -> tuple[GuardAction, ProofRoute | None, str]:
+    proof = effect.proof
+    base_floor = effect.policy_floor
+    if effect.assessment.uncertainty_reasons:
+        base_floor = apply_uncertainty_floor(base_floor, effect.assessment.uncertainty_reasons)
+    if proof is None or not effect.assessment.proof_requirements <= proof.satisfied_requirements:
+        missing_floor: GuardAction = "review"
+        if effect.assessment.containment is ContainmentRequirement.REQUIRED:
+            missing_floor = "sandbox-required"
+        return maximum_action_floor((base_floor, missing_floor)), None, "reason:effect-proof-incomplete"
+    if effect.expected_launch_identity is not None and proof.launch_identity != effect.expected_launch_identity:
+        mismatch_floor: GuardAction = "require-reapproval"
+        if effect.assessment.containment is ContainmentRequirement.REQUIRED:
+            mismatch_floor = "sandbox-required"
+        return maximum_action_floor((base_floor, mismatch_floor)), None, "reason:launch-identity-mismatch"
+    if effect.assessment.uncertainty_reasons:
+        return base_floor, None, "reason:effect-uncertain"
+    if proof.route is ProofRoute.WORKFLOW_AUTHORIZED:
+        if not effect.workflow_authorization_eligible or base_floor == "block":
+            return base_floor, None, "reason:workflow-authorization-ineligible"
+        return "allow", proof.route, "reason:workflow-authorization-exact"
+    if proof.route is ProofRoute.CONTAINED:
+        if effect.assessment.containment not in {ContainmentRequirement.ELIGIBLE, ContainmentRequirement.REQUIRED}:
+            return maximum_action_floor((base_floor, "review")), None, "reason:containment-ineligible"
+        if base_floor == "block":
+            return "block", None, "reason:block-floor-retained"
+        return "allow", proof.route, "reason:containment-enforced"
+    if guard_action_severity(base_floor) >= guard_action_severity("review"):
+        return base_floor, None, "reason:policy-floor-retained"
+    return base_floor, proof.route, "reason:positive-proof-complete"
+
+
+def _disposition(action: GuardAction, proof_routes: set[ProofRoute]) -> DecisionDisposition:
+    if action == "block":
+        return DecisionDisposition.BLOCK
+    if action in {"require-reapproval", "sandbox-required"}:
+        return DecisionDisposition.REQUIRE_REAPPROVAL
+    if action in {"review", "warn"}:
+        return DecisionDisposition.REVIEW
+    if ProofRoute.WORKFLOW_AUTHORIZED in proof_routes:
+        return DecisionDisposition.WORKFLOW_AUTHORIZED
+    if ProofRoute.CONTAINED in proof_routes:
+        return DecisionDisposition.SILENT_CONTAINED
+    return DecisionDisposition.SILENT_VERIFIED
+
+
+def _require_action(value: object, label: str) -> None:
+    if not is_guard_action(value):
+        raise ValueError(f"{label} must be a canonical GuardAction")
+
+
+def _require_enum(value: object, expected: type[Enum], label: str) -> None:
+    if not isinstance(value, expected):
+        raise ValueError(f"{label} must be an exact {expected.__name__} value")
+
+
+def _require_reference(value: object, label: str) -> None:
+    if not isinstance(value, str) or len(value) > 256 or _STABLE_REFERENCE.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a canonical reference")
+
+
+def _require_digest(value: object, label: str) -> None:
+    if not isinstance(value, str) or _FRAMED_DIGEST.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a framed digest")
+
+
+def _require_optional_digest(value: object, label: str, *, required: bool) -> None:
+    if required and value is None:
+        raise ValueError(f"{label} is required")
+    if value is not None:
+        _require_digest(value, label)
+
+
+def _require_tuple_members(value: object, expected: type[_T], label: str) -> tuple[_T, ...]:
+    if not isinstance(value, tuple):
+        raise ValueError(f"{label} must be a tuple of {expected.__name__} values")
+    items = cast(tuple[object, ...], value)
+    if any(not isinstance(item, expected) for item in items):
+        raise ValueError(f"{label} must be a tuple of {expected.__name__} values")
+    return cast(tuple[_T, ...], items)

--- a/tests/test_guard_command_decision_plane.py
+++ b/tests/test_guard_command_decision_plane.py
@@ -20,6 +20,7 @@ from codex_plugin_scanner.guard.runtime.command_rules import (
     CommandRuleMode,
     CommandRuleSeverity,
     CommandSafetyRule,
+    CommandSafeVariant,
     ExecutableMatcher,
 )
 
@@ -34,6 +35,12 @@ class _MalformedMatcher:
     def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
         del command
         return cast(tuple[MatcherEvidence, ...], ("not-evidence",))
+
+
+class _EmptyMatcher:
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+        del command
+        return ()
 
 
 def _registry(
@@ -234,6 +241,68 @@ def test_malformed_matcher_evidence_becomes_typed_uncertainty() -> None:
     )
 
     evaluation = evaluate_command("test-tool target", registry=registry)
+
+    assert evaluation.minimum_action == "block"
+    assert evaluation.extension_observations[0].uncertainty_reasons[0].value == "matcher-failure"
+
+
+def test_safe_variant_failure_is_scoped_to_an_owning_base_match() -> None:
+    safe_variant = CommandSafeVariant("broken-safe", "Broken safe matcher", _FailingMatcher())
+    rule = CommandSafetyRule(
+        rule_id="command.test.scoped-safe",
+        title="Scoped safe rule",
+        description="Exercises owned safe-variant failure scoping.",
+        severity="high",
+        risk_classes=("test_risk",),
+        action_classes=(),
+        safer_alternatives=("Review the operation.",),
+        matcher=_EmptyMatcher(),
+        safe_variants=(safe_variant,),
+    )
+    extension = CommandSafetyExtension(
+        extension_id="command.test",
+        version="1.0.0",
+        name="Test extension",
+        description="Exercises owned safe-variant failure scoping.",
+        action_classes=(),
+        risk_classes=("test_risk",),
+        safer_alternatives=("Review the operation.",),
+        rules=(rule,),
+    )
+
+    evaluation = evaluate_command(
+        "unrelated-tool inspect",
+        registry=CommandSafetyExtensionRegistry((extension,)),
+    )
+
+    assert evaluation.minimum_action == "allow"
+    assert evaluation.extension_observations == ()
+
+
+def test_owned_safe_variant_failure_remains_blocking_uncertainty() -> None:
+    rule = CommandSafetyRule(
+        rule_id="command.test.owned-safe",
+        title="Owned safe rule",
+        description="Exercises matched safe-variant failure handling.",
+        severity="high",
+        risk_classes=("test_risk",),
+        action_classes=(),
+        safer_alternatives=("Review the operation.",),
+        matcher=ExecutableMatcher(executables=frozenset({"test-tool"})),
+        safe_variants=(CommandSafeVariant("broken-safe", "Broken safe matcher", _FailingMatcher()),),
+    )
+    extension = CommandSafetyExtension(
+        extension_id="command.test",
+        version="1.0.0",
+        name="Test extension",
+        description="Exercises matched safe-variant failure handling.",
+        action_classes=(),
+        risk_classes=("test_risk",),
+        safer_alternatives=("Review the operation.",),
+        rules=(rule,),
+    )
+
+    evaluation = evaluate_command("test-tool target", registry=CommandSafetyExtensionRegistry((extension,)))
 
     assert evaluation.minimum_action == "block"
     assert evaluation.extension_observations[0].uncertainty_reasons[0].value == "matcher-failure"

--- a/tests/test_guard_command_decision_plane.py
+++ b/tests/test_guard_command_decision_plane.py
@@ -1,0 +1,239 @@
+"""Compatibility and evidence tests for command decision-plane routing."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.command_decision_adapter import extension_evidence_batch
+from codex_plugin_scanner.guard.runtime.command_evaluation import CommandDecisionFloor, evaluate_command
+from codex_plugin_scanner.guard.runtime.command_extension_observations import observe_command_extensions
+from codex_plugin_scanner.guard.runtime.command_extensions import (
+    BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+    CommandSafetyExtension,
+    CommandSafetyExtensionRegistry,
+)
+from codex_plugin_scanner.guard.runtime.command_matcher_contracts import MatcherEvidence
+from codex_plugin_scanner.guard.runtime.command_model import CanonicalCommand, parse_shell_command
+from codex_plugin_scanner.guard.runtime.command_rules import (
+    CommandRuleMode,
+    CommandRuleSeverity,
+    CommandSafetyRule,
+    ExecutableMatcher,
+)
+
+
+class _FailingMatcher:
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+        del command
+        raise RuntimeError("private matcher detail")
+
+
+class _MalformedMatcher:
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+        del command
+        return cast(tuple[MatcherEvidence, ...], ("not-evidence",))
+
+
+def _registry(
+    mode: CommandRuleMode,
+    *,
+    required: bool = False,
+    severity: CommandRuleSeverity = "high",
+) -> CommandSafetyExtensionRegistry:
+    rule = CommandSafetyRule(
+        rule_id="command.test.rule",
+        title="Test rule",
+        description="Exercises decision-plane compatibility.",
+        severity=severity,
+        risk_classes=("destructive_shell",),
+        action_classes=(),
+        safer_alternatives=("Preview the operation.",),
+        default_mode=mode,
+        matcher=ExecutableMatcher(executables=frozenset({"test-tool"})),
+    )
+    extension = CommandSafetyExtension(
+        extension_id="command.test",
+        version="1.0.0",
+        name="Test extension",
+        description="Exercises decision-plane compatibility.",
+        action_classes=(),
+        risk_classes=("destructive_shell",),
+        safer_alternatives=("Preview the operation.",),
+        rules=(rule,),
+        required=required,
+    )
+    return CommandSafetyExtensionRegistry((extension,))
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_legacy", "expected_canonical"),
+    [
+        ("disabled", "allow", "allow"),
+        ("monitor", "monitor", "warn"),
+        ("review", "review", "review"),
+        ("enforce", "block", "block"),
+        ("required", "review", "review"),
+    ],
+)
+def test_legacy_mode_truth_table_is_owned_by_canonical_plane(
+    mode: CommandRuleMode,
+    expected_legacy: CommandDecisionFloor,
+    expected_canonical: str,
+) -> None:
+    evaluation = evaluate_command("test-tool target", registry=_registry(mode))
+
+    assert evaluation.minimum_action == expected_legacy
+    assert evaluation.decision_plane.action == expected_canonical
+    assert "extension-rule:command.test.rule" in evaluation.decision_plane.controlling_sources
+
+
+def test_required_extension_floors_remain_monotonic() -> None:
+    high = evaluate_command("test-tool target", registry=_registry("disabled", required=True))
+    critical = evaluate_command(
+        "test-tool target",
+        registry=_registry("disabled", required=True, severity="critical"),
+    )
+
+    assert (high.minimum_action, high.decision_plane.action) == ("review", "review")
+    assert (critical.minimum_action, critical.decision_plane.action) == ("block", "block")
+
+
+def test_safe_variant_remains_visible_without_suppressing_stronger_sibling() -> None:
+    evaluation = evaluate_command("git clean -nfdx && rm -rf ./build")
+    force_clean = next(
+        item for item in evaluation.extension_observations if item.rule.rule_id == "command.git.force-clean"
+    )
+
+    assert force_clean.matcher_evidence
+    assert [item.variant_id for item in force_clean.safe_variants] == ["dry-run"]
+    assert force_clean.effective_evidence == ()
+    assert evaluation.minimum_action == "review"
+    assert "extension-rule:command.filesystem.recursive-delete" in evaluation.decision_plane.controlling_sources
+    assert evaluation.decision_plane.segment_actions == (("segment:1", "review"),)
+
+
+def test_owned_safe_variant_is_preserved_in_strict_extension_evidence() -> None:
+    command = parse_shell_command("git clean -nfdx")
+    observations = observe_command_extensions(
+        command,
+        BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions,
+        BUILT_IN_COMMAND_EXTENSION_REGISTRY.candidate_rule_ids(command),
+    )
+    batch = extension_evidence_batch(command, observations)
+    force_clean = next(item for item in batch.evidence if item.identity.rule_id == "command.git.force-clean")
+
+    assert force_clean.safe_variant is not None
+    assert force_clean.safe_variant.safe_variant_id == "dry-run"
+    assert force_clean.effective_floor is None
+
+
+@pytest.mark.parametrize(
+    "action_class",
+    [
+        "destructive shell command",
+        "GitHub remote mutation command",
+        "package installation command",
+        "unresolved interpreter command",
+    ],
+)
+def test_parallel_legacy_heuristics_route_through_plane(action_class: str) -> None:
+    evaluation = evaluate_command(
+        "routine-tool inspect",
+        compatibility_action_class=action_class,
+        compatibility_reason="Existing heuristic requires review.",
+    )
+
+    assert evaluation.minimum_action == "review"
+    assert evaluation.decision_plane.action == "review"
+    assert any(source.startswith("legacy-heuristic:") for source in evaluation.decision_plane.controlling_sources)
+
+
+def test_segment_order_cannot_change_the_maximum_floor() -> None:
+    first = evaluate_command("git clean -nfdx && rm -rf ./build")
+    second = evaluate_command("rm -rf ./build && git clean -nfdx")
+
+    assert first.minimum_action == second.minimum_action == "review"
+    assert first.decision_plane.action == second.decision_plane.action == "review"
+    assert {item.rule.rule_id for item in first.extension_observations} == {
+        item.rule.rule_id for item in second.extension_observations
+    }
+
+
+def test_public_payload_contains_versions_and_no_raw_command() -> None:
+    payload = evaluate_command("rm -rf ./private-name").to_dict()
+    observations = cast(list[dict[str, object]], payload["extension_observations"])
+
+    assert observations
+    assert all(item["extension_version"] and item["rule_version"] for item in observations)
+    assert "./private-name" not in repr(payload)
+    assert cast(dict[str, object], payload["decision_plane"])["schema_version"] == "1.0.0"
+
+
+def test_matcher_failure_becomes_typed_blocking_uncertainty() -> None:
+    rule = CommandSafetyRule(
+        rule_id="command.test.failure",
+        title="Failing rule",
+        description="Exercises failure-closed matcher handling.",
+        severity="low",
+        risk_classes=("test_risk",),
+        action_classes=(),
+        safer_alternatives=("Review the operation.",),
+        default_mode="disabled",
+        matcher=_FailingMatcher(),
+    )
+    registry = CommandSafetyExtensionRegistry(
+        (
+            CommandSafetyExtension(
+                extension_id="command.test",
+                version="1.0.0",
+                name="Test extension",
+                description="Exercises matcher failure handling.",
+                action_classes=(),
+                risk_classes=("test_risk",),
+                safer_alternatives=("Review the operation.",),
+                rules=(rule,),
+            ),
+        )
+    )
+
+    evaluation = evaluate_command("test-tool target", registry=registry)
+
+    assert evaluation.minimum_action == "block"
+    assert evaluation.decision_plane.action == "block"
+    assert evaluation.extension_observations[0].to_dict()["uncertainty_reasons"] == ["matcher-failure"]
+    assert "private matcher detail" not in repr(evaluation.to_dict())
+
+
+def test_malformed_matcher_evidence_becomes_typed_uncertainty() -> None:
+    rule = CommandSafetyRule(
+        rule_id="command.test.malformed",
+        title="Malformed rule",
+        description="Exercises matcher boundary validation.",
+        severity="low",
+        risk_classes=("test_risk",),
+        action_classes=(),
+        safer_alternatives=("Review the operation.",),
+        default_mode="disabled",
+        matcher=_MalformedMatcher(),
+    )
+    registry = CommandSafetyExtensionRegistry(
+        (
+            CommandSafetyExtension(
+                extension_id="command.test",
+                version="1.0.0",
+                name="Test extension",
+                description="Exercises malformed matcher handling.",
+                action_classes=(),
+                risk_classes=("test_risk",),
+                safer_alternatives=("Review the operation.",),
+                rules=(rule,),
+            ),
+        )
+    )
+
+    evaluation = evaluate_command("test-tool target", registry=registry)
+
+    assert evaluation.minimum_action == "block"
+    assert evaluation.extension_observations[0].uncertainty_reasons[0].value == "matcher-failure"

--- a/tests/test_guard_effect_decision_plane.py
+++ b/tests/test_guard_effect_decision_plane.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import itertools
+from dataclasses import FrozenInstanceError, replace
+
+import pytest
+
+from codex_plugin_scanner.guard.models import GuardAction
+from codex_plugin_scanner.guard.runtime.effect_contract import (
+    ContainmentRequirement,
+    EffectAssessment,
+    EffectBlastRadius,
+    EffectConfidence,
+    EffectEvidenceSource,
+    EffectKind,
+    EffectReversibility,
+    EffectTargetScope,
+    ProofRequirement,
+    ProofRoute,
+    UncertaintyKind,
+)
+from codex_plugin_scanner.guard.runtime.effect_decision_plane import (
+    EFFECT_DECISION_PLANE_SCHEMA_VERSION,
+    DecisionCandidate,
+    DecisionDisposition,
+    DecisionSourceKind,
+    EffectDecisionRequest,
+    EffectObservation,
+    EffectProof,
+    LaunchComponentKind,
+    LaunchIdentityBinding,
+    LaunchIdentityComponent,
+    evaluate_effect_decision,
+)
+from codex_plugin_scanner.guard.runtime.extension_evidence import ExtensionEvidenceBatch
+
+_READ_REQUIREMENTS = frozenset({ProofRequirement.OPERATION_AND_TARGETS, ProofRequirement.PARSER_CONFIDENCE})
+
+
+def _digest(label: str, value: str = "a") -> str:
+    return f"{label}-v1:{value * 64}"
+
+
+def _assessment(
+    *,
+    kind: EffectKind = EffectKind.WORKSPACE_OR_PUBLIC_READ,
+    containment: ContainmentRequirement = ContainmentRequirement.NONE,
+    requirements: frozenset[ProofRequirement] = _READ_REQUIREMENTS,
+    uncertainty: tuple[UncertaintyKind, ...] = (),
+) -> EffectAssessment:
+    confidence = EffectConfidence.STRONG if uncertainty else EffectConfidence.EXACT
+    return EffectAssessment(
+        kind=kind,
+        target_scope=EffectTargetScope.WORKSPACE,
+        reversibility=EffectReversibility.TRIVIALLY_RECOVERABLE,
+        blast_radius=EffectBlastRadius.WORKSPACE,
+        evidence_source=EffectEvidenceSource.PARSER,
+        confidence=confidence,
+        containment=containment,
+        proof_requirements=requirements,
+        uncertainty_reasons=uncertainty,
+    )
+
+
+def _proof(
+    route: ProofRoute = ProofRoute.VERIFIED,
+    *,
+    requirements: frozenset[ProofRequirement] = _READ_REQUIREMENTS,
+    launch_identity: LaunchIdentityBinding | None = None,
+) -> EffectProof:
+    return EffectProof(
+        route=route,
+        satisfied_requirements=requirements,
+        launch_identity=launch_identity,
+        containment_identity=_digest("containment") if route is ProofRoute.CONTAINED else None,
+        capability_identity=_digest("capability") if route is ProofRoute.WORKFLOW_AUTHORIZED else None,
+    )
+
+
+def _observation(
+    segment: int,
+    *,
+    policy_floor: GuardAction = "allow",
+    assessment: EffectAssessment | None = None,
+    proof: EffectProof | None = None,
+    workflow_eligible: bool = False,
+    expected_launch_identity: LaunchIdentityBinding | None = None,
+) -> EffectObservation:
+    return EffectObservation(
+        segment_ref=f"segment:{segment}",
+        effect_ref=f"effect:{segment}",
+        assessment=assessment or _assessment(),
+        policy_floor=policy_floor,
+        proof=proof,
+        workflow_authorization_eligible=workflow_eligible,
+        expected_launch_identity=expected_launch_identity,
+    )
+
+
+def _request(
+    effects: tuple[EffectObservation, ...] = (),
+    *,
+    candidates: tuple[DecisionCandidate, ...] = (),
+    uncertainties: tuple[UncertaintyKind, ...] = (),
+) -> EffectDecisionRequest:
+    return EffectDecisionRequest(
+        effects=effects,
+        extension_evidence=ExtensionEvidenceBatch(()),
+        candidates=candidates,
+        uncertainties=uncertainties,
+    )
+
+
+def _launch_binding() -> LaunchIdentityBinding:
+    kinds = tuple(LaunchComponentKind)
+    return LaunchIdentityBinding(
+        command_security_identity=f"command-security-v2:{'c' * 64}",
+        working_directory_identity=_digest("cwd"),
+        components=tuple(
+            LaunchIdentityComponent(
+                kind=kind,
+                component_ref=f"component:{index}",
+                input_identity=_digest("input", format(index % 16, "x")),
+                resolved_identity=_digest("resolved", format((index + 1) % 16, "x")),
+            )
+            for index, kind in enumerate(kinds)
+        ),
+    )
+
+
+def test_empty_or_incomplete_input_fails_closed_to_review() -> None:
+    empty = evaluate_effect_decision(_request())
+    incomplete = evaluate_effect_decision(_request((_observation(0),)))
+
+    assert empty.action == "review"
+    assert empty.disposition is DecisionDisposition.REVIEW
+    assert empty.controlling_sources == ("uncertainty:empty",)
+    assert incomplete.action == "review"
+    assert incomplete.reason_codes == ("reason:effect-proof-incomplete",)
+
+
+def test_typed_effect_uncertainty_applies_before_incomplete_proof_floor() -> None:
+    assessment = _assessment(uncertainty=(UncertaintyKind.MATCHER_FAILURE,))
+
+    decision = evaluate_effect_decision(_request((_observation(0, assessment=assessment),)))
+
+    assert decision.action == "block"
+    assert decision.reason_codes == ("reason:effect-proof-incomplete",)
+
+
+def test_complete_positive_read_proof_is_silent_verified() -> None:
+    decision = evaluate_effect_decision(_request((_observation(0, proof=_proof()),)))
+
+    assert decision.action == "allow"
+    assert decision.disposition is DecisionDisposition.SILENT_VERIFIED
+    assert decision.segment_actions == (("segment:0", "allow"),)
+    assert decision.proof_routes == (ProofRoute.VERIFIED,)
+
+
+def test_required_containment_fails_closed_and_complete_containment_is_silent() -> None:
+    requirements = frozenset(
+        {
+            ProofRequirement.OPERATION_AND_TARGETS,
+            ProofRequirement.EXECUTABLE_IDENTITY,
+            ProofRequirement.CONTAINMENT_IDENTITY,
+        }
+    )
+    assessment = _assessment(
+        kind=EffectKind.PROCESS_EXECUTION,
+        containment=ContainmentRequirement.REQUIRED,
+        requirements=requirements,
+    )
+    launch_identity = _launch_binding()
+    missing = evaluate_effect_decision(
+        _request((_observation(0, assessment=assessment, expected_launch_identity=launch_identity),))
+    )
+    complete = evaluate_effect_decision(
+        _request(
+            (
+                _observation(
+                    0,
+                    policy_floor="sandbox-required",
+                    assessment=assessment,
+                    proof=_proof(ProofRoute.CONTAINED, requirements=requirements, launch_identity=launch_identity),
+                    expected_launch_identity=launch_identity,
+                ),
+            )
+        )
+    )
+
+    assert missing.action == "sandbox-required"
+    assert missing.disposition is DecisionDisposition.REQUIRE_REAPPROVAL
+    assert complete.action == "allow"
+    assert complete.disposition is DecisionDisposition.SILENT_CONTAINED
+
+
+def test_launch_identity_drift_invalidates_an_otherwise_complete_proof() -> None:
+    requirements = frozenset({ProofRequirement.OPERATION_AND_TARGETS, ProofRequirement.EXECUTABLE_IDENTITY})
+    assessment = _assessment(kind=EffectKind.PROCESS_EXECUTION, requirements=requirements)
+    expected = _launch_binding()
+    drifted = replace(expected, working_directory_identity=_digest("cwd", "e"))
+
+    decision = evaluate_effect_decision(
+        _request(
+            (
+                _observation(
+                    0,
+                    assessment=assessment,
+                    proof=_proof(requirements=requirements, launch_identity=drifted),
+                    expected_launch_identity=expected,
+                ),
+            )
+        )
+    )
+
+    assert decision.action == "require-reapproval"
+    assert "reason:launch-identity-mismatch" in decision.reason_codes
+
+
+def test_workflow_authorization_requires_explicit_eligibility_and_never_lowers_block() -> None:
+    requirements = frozenset({ProofRequirement.OPERATION_AND_TARGETS, ProofRequirement.CAPABILITY_CONSTRAINTS})
+    proof = _proof(ProofRoute.WORKFLOW_AUTHORIZED, requirements=requirements)
+    assessment = _assessment(kind=EffectKind.REMOTE_STATE_MUTATION, requirements=requirements)
+
+    eligible = evaluate_effect_decision(
+        _request(
+            (
+                _observation(
+                    0,
+                    policy_floor="review",
+                    assessment=assessment,
+                    proof=proof,
+                    workflow_eligible=True,
+                ),
+            )
+        )
+    )
+    ineligible = evaluate_effect_decision(
+        _request((_observation(0, policy_floor="review", assessment=assessment, proof=proof),))
+    )
+    blocked = evaluate_effect_decision(
+        _request(
+            (
+                _observation(
+                    0,
+                    policy_floor="block",
+                    assessment=assessment,
+                    proof=proof,
+                    workflow_eligible=True,
+                ),
+            )
+        )
+    )
+
+    assert eligible.disposition is DecisionDisposition.WORKFLOW_AUTHORIZED
+    assert eligible.action == "allow"
+    assert ineligible.action == "review"
+    assert blocked.action == "block"
+
+
+def test_stronger_sibling_suffix_and_legacy_candidates_always_dominate_safe_proof() -> None:
+    safe = _observation(0, proof=_proof())
+    destructive = _observation(1, policy_floor="block", proof=_proof())
+    legacy = DecisionCandidate(
+        source_id="heuristic:github",
+        source_kind=DecisionSourceKind.LEGACY_HEURISTIC,
+        action_floor="require-reapproval",
+        reason_code="reason:remote-mutation",
+        segment_ref="segment:2",
+    )
+
+    decision = evaluate_effect_decision(_request((safe, destructive), candidates=(legacy,)))
+
+    assert decision.action == "block"
+    assert decision.controlling_sources == ("effect:1",)
+    assert decision.segment_actions == (
+        ("segment:0", "allow"),
+        ("segment:1", "block"),
+        ("segment:2", "require-reapproval"),
+    )
+
+
+def test_typed_uncertainty_is_monotonic_across_every_candidate_permutation() -> None:
+    candidates = (
+        DecisionCandidate("policy:workspace", DecisionSourceKind.POLICY, "warn", "reason:policy"),
+        DecisionCandidate("heuristic:package", DecisionSourceKind.LEGACY_HEURISTIC, "review", "reason:package"),
+        DecisionCandidate("policy:critical", DecisionSourceKind.POLICY, "block", "reason:critical"),
+    )
+    results = {
+        evaluate_effect_decision(
+            _request(
+                (_observation(0, proof=_proof()),),
+                candidates=order,
+                uncertainties=(UncertaintyKind.UNRESOLVED_LAUNCH_IDENTITY,),
+            )
+        ).action
+        for order in itertools.permutations(candidates)
+    }
+
+    assert results == {"block"}
+
+
+def test_launch_identity_binds_every_launch_family_and_any_drift_changes_identity() -> None:
+    binding = _launch_binding()
+
+    assert {item.kind for item in binding.components} == set(LaunchComponentKind)
+    assert LaunchComponentKind.REDIRECTION in {item.kind for item in binding.components}
+    assert replace(binding, working_directory_identity=_digest("cwd", "e")) != binding
+    assert replace(binding, command_security_identity=f"command-security-v2:{'d' * 64}") != binding
+    for component in binding.components:
+        input_drifted = replace(component, input_identity=_digest("input", "e"))
+        input_components = tuple(item if item != component else input_drifted for item in binding.components)
+        assert replace(binding, components=input_components) != binding
+        drifted = replace(component, resolved_identity=_digest("resolved", "f"))
+        drifted_components = tuple(item if item != component else drifted for item in binding.components)
+        assert replace(binding, components=drifted_components) != binding
+    with pytest.raises(ValueError, match="executable component"):
+        _ = replace(
+            binding,
+            components=tuple(item for item in binding.components if item.kind is not LaunchComponentKind.EXECUTABLE),
+        )
+    with pytest.raises(ValueError, match="framed command identity"):
+        _ = replace(binding, command_security_identity="command-security-v2:not-a-digest")
+
+
+def test_contracts_are_immutable_and_reject_untyped_boundaries() -> None:
+    decision = evaluate_effect_decision(_request((_observation(0, proof=_proof()),)))
+
+    assert decision.schema_version == EFFECT_DECISION_PLANE_SCHEMA_VERSION
+    with pytest.raises(FrozenInstanceError):
+        decision.action = "block"  # pyright: ignore[reportAttributeAccessIssue]
+    with pytest.raises(ValueError, match="DecisionSourceKind"):
+        _ = DecisionCandidate(
+            "policy:test",
+            "policy",  # pyright: ignore[reportArgumentType]
+            "review",
+            "reason:test",
+        )
+    with pytest.raises(ValueError, match="schema version"):
+        _ = replace(_request(), schema_version="2.0.0")
+    with pytest.raises(ValueError, match="EffectDecisionRequest"):
+        _ = evaluate_effect_decision({})  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
## Summary
- add a pure monotonic effect decision evaluator over canonical Guard actions, typed proof requirements, policy floors, and uncertainty
- preserve immutable extension base, owned safe-variant, and matcher-failure evidence while retaining existing command decisions
- bind launch proofs across executables, wrappers, interpreters, paths, sources, configuration, and redirection, with drift rejection
- compose every effect and segment without allowing safe evidence to suppress a stronger sibling

## Verification
- 1,077 command and effect contract tests passed
- Ruff check and format validation passed
- basedpyright passed with 0 errors and 0 warnings
- wheel build and isolated CLI version smoke passed
- independent adversarial review: SHIP
