### PR TITLE
feat(guard): route extension evidence centrally

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -695,13 +695,15 @@ def _runtime_artifact_policy_action(config: GuardConfig, artifact: GuardArtifact
         artifact.artifact_id,
         artifact.publisher,
     )
+    command_action_floor = _runtime_artifact_command_action_floor(artifact)
 
     def with_config_policy(action: GuardAction) -> GuardAction:
         # Artifact/publisher/harness settings are more-specific resolutions of
         # the global default, not additional inputs.  Scanner/risk results are
         # independent and therefore remain a floor even for an exact allow.
         current_config_action = configured_override if configured_override is not None else config.default_action
-        return most_restrictive_guard_action(action, current_config_action)
+        actions = (action, current_config_action, command_action_floor)
+        return most_restrictive_guard_action(*(item for item in actions if item is not None))
 
     risk_classes = _runtime_artifact_risk_classes(artifact)
     has_configured_risk_action = any(
@@ -743,6 +745,12 @@ def _resolve_configured_risk_action(config: GuardConfig, risk_class: str, *, har
 def _runtime_artifact_guard_default_action(artifact: GuardArtifact) -> GuardAction | None:
     value = artifact.metadata.get("guard_default_action")
     return normalize_guard_action(value, unknown_action="require-reapproval") if value is not None else None
+
+def _runtime_artifact_command_action_floor(artifact: GuardArtifact) -> GuardAction | None:
+    if artifact.artifact_type != "tool_action_request":
+        return None
+    value = artifact.metadata.get("command_action_floor")
+    return normalize_guard_action(value, unknown_action="block") if value is not None else None
 
 def _runtime_action_data_flow_signals(
     action_envelope: GuardActionEnvelope | None,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -749,8 +749,9 @@ def _runtime_artifact_guard_default_action(artifact: GuardArtifact) -> GuardActi
 def _runtime_artifact_command_action_floor(artifact: GuardArtifact) -> GuardAction | None:
     if artifact.artifact_type != "tool_action_request":
         return None
-    value = artifact.metadata.get("command_action_floor")
-    return normalize_guard_action(value, unknown_action="block") if value is not None else None
+    if "command_action_floor" not in artifact.metadata:
+        return None
+    return normalize_guard_action(artifact.metadata.get("command_action_floor"), unknown_action="block")
 
 def _runtime_action_data_flow_signals(
     action_envelope: GuardActionEnvelope | None,

--- a/src/codex_plugin_scanner/guard/runtime/command_activity_lifecycle.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_activity_lifecycle.py
@@ -26,8 +26,9 @@ from .command_activity_contract import (
     ReceiptLinkStatus,
 )
 from .command_evaluation import CompositeCommandEvaluation, OwnedCommandRuleMatch
+from .command_risk_effects import command_risk_effects
 from .command_rules import CommandRuleMode
-from .effect_contract import EffectKind, UncertaintyKind
+from .effect_contract import UncertaintyKind
 from .extension_evidence import EvidenceSeverity, ExtensionRuleIdentity
 
 
@@ -52,19 +53,6 @@ class CommandActivityDecisionFacts:
             raise ValueError("approval_reuse_status must be an ActivityApprovalReuseStatus")
 
 
-_RISK_EFFECTS: Final = MappingProxyType(
-    {
-        "credential_exfiltration": frozenset({EffectKind.CREDENTIAL_OR_SECRET_OPERATION}),
-        "data_flow_exfiltration": frozenset({EffectKind.NETWORK_WRITE}),
-        "destructive_shell": frozenset({EffectKind.DESTRUCTIVE_OR_IRREVERSIBLE_OPERATION}),
-        "encoded_execution": frozenset({EffectKind.PROCESS_EXECUTION}),
-        "execution": frozenset({EffectKind.PROCESS_EXECUTION}),
-        "local_secret_read": frozenset({EffectKind.SENSITIVE_READ}),
-        "network_egress": frozenset({EffectKind.NETWORK_WRITE}),
-        "policy_bypass": frozenset({EffectKind.GUARD_CONTROL_OPERATION}),
-        "supply_chain": frozenset({EffectKind.PACKAGE_OR_SOURCE_INSTALLATION}),
-    }
-)
 _RULE_MODE_FLOOR: Final[dict[CommandRuleMode, GuardAction]] = {
     "disabled": "allow",
     "monitor": "warn",
@@ -217,12 +205,7 @@ def build_unpaired_post_evidence(
 
 
 def _activity_match(activity_id: str, ordinal: int, owned: OwnedCommandRuleMatch) -> CommandActivityMatch:
-    effects: set[EffectKind] = set()
-    for risk_class in owned.match.rule.risk_classes:
-        mapped = _RISK_EFFECTS.get(risk_class)
-        if mapped is None:
-            raise ValueError(f"unsupported command risk class: {risk_class}")
-        effects.update(mapped)
+    effects = command_risk_effects(owned.match.rule.risk_classes)
     rule = owned.match.rule
     default_floor = _RULE_MODE_FLOOR[rule.default_mode]
     if owned.extension.required:

--- a/src/codex_plugin_scanner/guard/runtime/command_decision_adapter.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_decision_adapter.py
@@ -10,6 +10,7 @@ from codex_plugin_scanner.guard.models import GuardAction
 from .command_extension_observations import CommandExtensionObservation
 from .command_extensions import CommandSafetyExtension
 from .command_model import CanonicalCommand
+from .command_risk_effects import command_risk_effects
 from .command_rules import CommandRuleMode, CommandSafetyRule
 from .effect_contract import (
     UNCERTAINTY_FLOOR,
@@ -58,17 +59,6 @@ _SEVERITY: dict[str, EvidenceSeverity] = {
     "medium": EvidenceSeverity.MEDIUM,
     "high": EvidenceSeverity.HIGH,
     "critical": EvidenceSeverity.CRITICAL,
-}
-_RISK_EFFECTS: dict[str, frozenset[EffectKind]] = {
-    "credential_exfiltration": frozenset({EffectKind.CREDENTIAL_OR_SECRET_OPERATION, EffectKind.NETWORK_WRITE}),
-    "data_flow_exfiltration": frozenset({EffectKind.NETWORK_WRITE}),
-    "destructive_shell": frozenset({EffectKind.DESTRUCTIVE_OR_IRREVERSIBLE_OPERATION}),
-    "encoded_execution": frozenset({EffectKind.PROCESS_EXECUTION}),
-    "execution": frozenset({EffectKind.PROCESS_EXECUTION}),
-    "local_secret_read": frozenset({EffectKind.CREDENTIAL_OR_SECRET_OPERATION}),
-    "network_egress": frozenset({EffectKind.NETWORK_WRITE}),
-    "policy_bypass": frozenset({EffectKind.GUARD_CONTROL_OPERATION}),
-    "supply_chain": frozenset({EffectKind.PROCESS_EXECUTION}),
 }
 
 
@@ -272,7 +262,7 @@ def _extension_proof_requirements() -> frozenset[ProofRequirement]:
 
 
 def _effect_claims(risk_classes: tuple[str, ...]) -> frozenset[EffectKind]:
-    effects: set[EffectKind] = set()
-    for risk in risk_classes:
-        effects.update(_RISK_EFFECTS.get(risk, ()))
-    return frozenset(effects or {EffectKind.PROCESS_EXECUTION})
+    return command_risk_effects(
+        risk_classes,
+        unknown_fallback=frozenset({EffectKind.PROCESS_EXECUTION}),
+    ) or frozenset({EffectKind.PROCESS_EXECUTION})

--- a/src/codex_plugin_scanner/guard/runtime/command_decision_adapter.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_decision_adapter.py
@@ -133,16 +133,23 @@ def decision_factors(
     batch: ExtensionEvidenceBatch,
     *,
     compatibility_action_class: str | None,
+    compatibility_rule: tuple[CommandSafetyExtension, CommandSafetyRule] | None = None,
 ) -> tuple[DecisionFactor, ...]:
     factors = list(factors_from_extension_evidence(batch))
     if compatibility_action_class is not None:
         identity = hashlib.sha256(compatibility_action_class.strip().lower().encode("utf-8")).hexdigest()
+        compatibility_floor: GuardAction = "review"
+        producer_ref = f"legacy:{identity}"
+        if compatibility_rule is not None:
+            extension, rule = compatibility_rule
+            compatibility_floor = maximum_action_floor(("review", _CANONICAL_FLOOR[legacy_rule_floor(extension, rule)]))
+            producer_ref = f"rule:{rule.rule_id}"
         factors.append(
             DecisionFactor(
                 source=DecisionFactorSource.POLICY,
                 reason_code="compatibility-action",
-                basis=DecisionBasis("review", None),
-                producer_ref=f"legacy:{identity}",
+                basis=DecisionBasis(compatibility_floor, None),
+                producer_ref=producer_ref,
             )
         )
     return tuple(factors)

--- a/src/codex_plugin_scanner/guard/runtime/command_decision_adapter.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_decision_adapter.py
@@ -59,6 +59,17 @@ _SEVERITY: dict[str, EvidenceSeverity] = {
     "high": EvidenceSeverity.HIGH,
     "critical": EvidenceSeverity.CRITICAL,
 }
+_RISK_EFFECTS: dict[str, frozenset[EffectKind]] = {
+    "credential_exfiltration": frozenset({EffectKind.CREDENTIAL_OR_SECRET_OPERATION, EffectKind.NETWORK_WRITE}),
+    "data_flow_exfiltration": frozenset({EffectKind.NETWORK_WRITE}),
+    "destructive_shell": frozenset({EffectKind.DESTRUCTIVE_OR_IRREVERSIBLE_OPERATION}),
+    "encoded_execution": frozenset({EffectKind.PROCESS_EXECUTION}),
+    "execution": frozenset({EffectKind.PROCESS_EXECUTION}),
+    "local_secret_read": frozenset({EffectKind.CREDENTIAL_OR_SECRET_OPERATION}),
+    "network_egress": frozenset({EffectKind.NETWORK_WRITE}),
+    "policy_bypass": frozenset({EffectKind.GUARD_CONTROL_OPERATION}),
+    "supply_chain": frozenset({EffectKind.PROCESS_EXECUTION}),
+}
 
 
 def legacy_rule_floor(extension: CommandSafetyExtension, rule: CommandSafetyRule) -> LegacyCommandFloor:
@@ -263,14 +274,5 @@ def _extension_proof_requirements() -> frozenset[ProofRequirement]:
 def _effect_claims(risk_classes: tuple[str, ...]) -> frozenset[EffectKind]:
     effects: set[EffectKind] = set()
     for risk in risk_classes:
-        if "destructive" in risk:
-            effects.add(EffectKind.DESTRUCTIVE_OR_IRREVERSIBLE_OPERATION)
-        if "network" in risk or "exfiltration" in risk:
-            effects.add(EffectKind.NETWORK_WRITE)
-        if "secret" in risk or "credential" in risk:
-            effects.add(EffectKind.CREDENTIAL_OR_SECRET_OPERATION)
-        if "execution" in risk:
-            effects.add(EffectKind.PROCESS_EXECUTION)
-        if "policy" in risk:
-            effects.add(EffectKind.GUARD_CONTROL_OPERATION)
+        effects.update(_RISK_EFFECTS.get(risk, ()))
     return frozenset(effects or {EffectKind.PROCESS_EXECUTION})

--- a/src/codex_plugin_scanner/guard/runtime/command_decision_adapter.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_decision_adapter.py
@@ -1,0 +1,269 @@
+"""Compatibility adapters from command evidence to the central evaluator."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from codex_plugin_scanner.guard.models import GuardAction
+
+from .command_extension_observations import CommandExtensionObservation
+from .command_extensions import CommandSafetyExtension
+from .command_model import CanonicalCommand
+from .command_rules import CommandRuleMode, CommandSafetyRule
+from .effect_contract import (
+    UNCERTAINTY_FLOOR,
+    DecisionBasis,
+    EffectKind,
+    ProofRequirement,
+    UncertaintyKind,
+    maximum_action_floor,
+)
+from .effect_decision import (
+    DecisionFactor,
+    DecisionFactorSource,
+    DecisionReason,
+    EffectDecision,
+    EffectDecisionRequest,
+    evaluate_effect_decision,
+    factors_from_extension_evidence,
+)
+from .extension_evidence import (
+    EvidenceSeverity,
+    ExtensionEvidence,
+    ExtensionEvidenceBatch,
+    ExtensionMatchClass,
+    ExtensionRuleIdentity,
+    OwnedSafeVariant,
+    SafeVariantOutcome,
+)
+
+LegacyCommandFloor = Literal["allow", "monitor", "review", "block"]
+
+_MODE_FLOOR: dict[CommandRuleMode, LegacyCommandFloor] = {
+    "disabled": "allow",
+    "monitor": "monitor",
+    "review": "review",
+    "enforce": "block",
+    "required": "review",
+}
+_CANONICAL_FLOOR: dict[LegacyCommandFloor, GuardAction] = {
+    "allow": "allow",
+    "monitor": "warn",
+    "review": "review",
+    "block": "block",
+}
+_SEVERITY: dict[str, EvidenceSeverity] = {
+    "low": EvidenceSeverity.LOW,
+    "medium": EvidenceSeverity.MEDIUM,
+    "high": EvidenceSeverity.HIGH,
+    "critical": EvidenceSeverity.CRITICAL,
+}
+
+
+def legacy_rule_floor(extension: CommandSafetyExtension, rule: CommandSafetyRule) -> LegacyCommandFloor:
+    if extension.required and rule.severity == "critical":
+        return "block"
+    if extension.required:
+        return "review"
+    return _MODE_FLOOR[rule.default_mode]
+
+
+def extension_evidence_batch(
+    command: CanonicalCommand,
+    observations: tuple[CommandExtensionObservation[CommandSafetyExtension], ...],
+) -> ExtensionEvidenceBatch:
+    """Translate every review-or-stronger match and matcher uncertainty."""
+
+    evidence: list[ExtensionEvidence] = []
+    operation_ref = f"operation:{command.security_identity.rsplit(':', 1)[-1]}"
+    for observation in observations:
+        floor = _CANONICAL_FLOOR[legacy_rule_floor(observation.extension, observation.rule)]
+        if observation.uncertainty_reasons:
+            evidence.append(
+                ExtensionEvidence(
+                    identity=_rule_identity(observation),
+                    match_class=ExtensionMatchClass.UNCERTAINTY,
+                    severity=EvidenceSeverity.CRITICAL,
+                    declared_floor=maximum_action_floor(
+                        UNCERTAINTY_FLOOR[item] for item in observation.uncertainty_reasons
+                    ),
+                    base_fact="matcher-failure",
+                    segment_ref="segment:unknown",
+                    operation_ref=operation_ref,
+                    effect_claims=_effect_claims(observation.rule.risk_classes),
+                    proof_requirements=_extension_proof_requirements(),
+                    uncertainty_reasons=observation.uncertainty_reasons,
+                )
+            )
+        if floor in {"allow", "warn"}:
+            continue
+        identity = _rule_identity(observation)
+        for segment_index in sorted({match.segment_index for match in observation.matcher_evidence}):
+            safe_variant_ids = sorted(
+                {
+                    variant.variant_id
+                    for variant in observation.safe_variants
+                    if any(item.segment_index == segment_index for item in variant.matcher_evidence)
+                }
+            )
+            owned_safe_variants: tuple[OwnedSafeVariant | None, ...] = tuple(
+                OwnedSafeVariant(identity, variant_id, SafeVariantOutcome.OWNED_RULE_NOT_RAISED)
+                for variant_id in safe_variant_ids
+            ) or (None,)
+            for safe_variant in owned_safe_variants:
+                evidence.append(
+                    ExtensionEvidence(
+                        identity=identity,
+                        match_class=ExtensionMatchClass.UNSAFE,
+                        severity=_SEVERITY[observation.rule.severity],
+                        declared_floor=floor,
+                        base_fact="rule-match",
+                        segment_ref=f"segment:{segment_index}",
+                        operation_ref=operation_ref,
+                        effect_claims=_effect_claims(observation.rule.risk_classes),
+                        proof_requirements=_extension_proof_requirements(),
+                        safe_variant=safe_variant,
+                    )
+                )
+    return ExtensionEvidenceBatch(tuple(evidence))
+
+
+def decision_factors(
+    batch: ExtensionEvidenceBatch,
+    *,
+    compatibility_action_class: str | None,
+) -> tuple[DecisionFactor, ...]:
+    factors = list(factors_from_extension_evidence(batch))
+    if compatibility_action_class is not None:
+        identity = hashlib.sha256(compatibility_action_class.strip().lower().encode("utf-8")).hexdigest()
+        factors.append(
+            DecisionFactor(
+                source=DecisionFactorSource.POLICY,
+                reason_code="compatibility-action",
+                basis=DecisionBasis("review", None),
+                producer_ref=f"legacy:{identity}",
+            )
+        )
+    return tuple(factors)
+
+
+def interaction_policy_factors(
+    observations: tuple[CommandExtensionObservation[CommandSafetyExtension], ...],
+) -> tuple[DecisionFactor, ...]:
+    """Preserve the existing review floor outside extension-owned evidence."""
+
+    factors: list[DecisionFactor] = []
+    for observation in observations:
+        if not observation.effective_evidence or not observation.rule.action_classes:
+            continue
+        segment_indexes = sorted({item.segment_index for item in observation.effective_evidence})
+        for segment_index in segment_indexes:
+            factors.append(
+                DecisionFactor(
+                    source=DecisionFactorSource.POLICY,
+                    reason_code="extension-interaction-floor",
+                    basis=DecisionBasis("review", None),
+                    segment_ref=f"segment:{segment_index}",
+                    producer_ref=f"rule:{observation.rule.rule_id}",
+                )
+            )
+    return tuple(factors)
+
+
+def evaluate_extension_interaction(
+    command: CanonicalCommand,
+    observations: tuple[CommandExtensionObservation[CommandSafetyExtension], ...],
+) -> EffectDecision:
+    """Evaluate extension evidence plus the compatibility review policy."""
+
+    batch = extension_evidence_batch(command, observations)
+    factors = (
+        *decision_factors(batch, compatibility_action_class=None),
+        *interaction_policy_factors(observations),
+    )
+    return evaluate_effect_decision(
+        EffectDecisionRequest(
+            factors=factors,
+            uncertainties=extension_uncertainties(observations),
+        )
+    )
+
+
+def command_uncertainties(command: CanonicalCommand, *, sensitive: bool) -> tuple[UncertaintyKind, ...]:
+    if not sensitive or command.confidence == "exact":
+        return ()
+    if command.confidence == "fallback":
+        return (UncertaintyKind.PARTIAL_PARSE,)
+    return (UncertaintyKind.DYNAMIC_INPUT,)
+
+
+def extension_uncertainties(
+    observations: tuple[CommandExtensionObservation[CommandSafetyExtension], ...],
+) -> tuple[UncertaintyKind, ...]:
+    return tuple(
+        sorted(
+            {item for observation in observations for item in observation.uncertainty_reasons},
+            key=lambda item: item.value,
+        )
+    )
+
+
+def effect_decision_to_dict(decision: EffectDecision) -> dict[str, object]:
+    return {
+        "schema_version": decision.schema_version,
+        "action": decision.action,
+        "disposition": decision.disposition.value,
+        "proof_routes": sorted(item.value for item in decision.proof_routes),
+        "controlling_reasons": [_reason_to_dict(item) for item in decision.controlling_reasons],
+        "reasons": [_reason_to_dict(item) for item in decision.reasons],
+    }
+
+
+def _reason_to_dict(reason: object) -> dict[str, object]:
+    if not isinstance(reason, DecisionReason):
+        raise ValueError("reason must be a DecisionReason")
+    return {
+        "source": reason.source.value,
+        "reason_code": reason.reason_code,
+        "action_floor": reason.action_floor,
+        "segment_ref": reason.segment_ref,
+        "operation_ref": reason.operation_ref,
+    }
+
+
+def _rule_identity(
+    observation: CommandExtensionObservation[CommandSafetyExtension],
+) -> ExtensionRuleIdentity:
+    return ExtensionRuleIdentity(
+        extension_id=observation.extension.extension_id,
+        extension_version=observation.extension.version,
+        rule_id=observation.rule.rule_id,
+        rule_version=observation.rule.rule_version,
+    )
+
+
+def _extension_proof_requirements() -> frozenset[ProofRequirement]:
+    return frozenset(
+        {
+            ProofRequirement.OPERATION_AND_TARGETS,
+            ProofRequirement.PARSER_CONFIDENCE,
+            ProofRequirement.EXPECTED_EFFECTS,
+        }
+    )
+
+
+def _effect_claims(risk_classes: tuple[str, ...]) -> frozenset[EffectKind]:
+    effects: set[EffectKind] = set()
+    for risk in risk_classes:
+        if "destructive" in risk:
+            effects.add(EffectKind.DESTRUCTIVE_OR_IRREVERSIBLE_OPERATION)
+        if "network" in risk or "exfiltration" in risk:
+            effects.add(EffectKind.NETWORK_WRITE)
+        if "secret" in risk or "credential" in risk:
+            effects.add(EffectKind.CREDENTIAL_OR_SECRET_OPERATION)
+        if "execution" in risk:
+            effects.add(EffectKind.PROCESS_EXECUTION)
+        if "policy" in risk:
+            effects.add(EffectKind.GUARD_CONTROL_OPERATION)
+    return frozenset(effects or {EffectKind.PROCESS_EXECUTION})

--- a/src/codex_plugin_scanner/guard/runtime/command_evaluation.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_evaluation.py
@@ -6,6 +6,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from .command_decision_adapter import (
+    command_uncertainties,
+    decision_factors,
+    effect_decision_to_dict,
+    extension_evidence_batch,
+    extension_uncertainties,
+)
+from .command_extension_observations import CommandExtensionObservation
 from .command_extensions import (
     BUILT_IN_COMMAND_EXTENSION_REGISTRY,
     CommandSafetyExtension,
@@ -13,6 +21,7 @@ from .command_extensions import (
 )
 from .command_model import CanonicalCommand, parse_shell_command
 from .command_rules import CommandRuleMatch, CommandRuleMode
+from .effect_decision import EffectDecision, EffectDecisionRequest, evaluate_effect_decision
 
 CommandDecisionFloor = Literal["allow", "monitor", "review", "block"]
 _FLOOR_RANK: dict[CommandDecisionFloor, int] = {"allow": 0, "monitor": 1, "review": 2, "block": 3}
@@ -50,6 +59,8 @@ class CompositeCommandEvaluation:
     controlling_reason: str | None
     controlling_rule_id: str | None
     minimum_action: CommandDecisionFloor
+    extension_observations: tuple[CommandExtensionObservation[CommandSafetyExtension], ...]
+    decision_plane: EffectDecision
 
     @property
     def risk_classes(self) -> tuple[str, ...]:
@@ -68,6 +79,8 @@ class CompositeCommandEvaluation:
             "minimum_action": self.minimum_action,
             "risk_classes": list(self.risk_classes),
             "matches": [owned.to_dict() for owned in self.matches],
+            "extension_observations": [item.to_dict() for item in self.extension_observations],
+            "decision_plane": effect_decision_to_dict(self.decision_plane),
             "parse_confidence": self.command.confidence,
             "uncertainty_reason": self.command.uncertainty_reason,
         }
@@ -86,7 +99,10 @@ def evaluate_command(
     """Evaluate every built-in rule without executing or persisting the command."""
 
     command = canonical_command or parse_shell_command(command_text, cwd=cwd, home_dir=home_dir)
-    structured = registry.matching_rules(command)
+    observations = registry.observations(command)
+    structured = tuple(
+        (item.extension, item.rule, item.effective_evidence) for item in observations if item.effective_evidence
+    )
     selected = list(structured)
     selected_rule_ids = {rule.rule_id for _extension, rule, _evidence in selected}
     if compatibility_action_class is not None:
@@ -127,6 +143,29 @@ def evaluate_command(
         minimum_action = _stronger_floor(minimum_action, "review")
     if command.confidence != "exact" and (compatibility_action_class is not None or owned_matches):
         minimum_action = _stronger_floor(minimum_action, "review")
+    if extension_uncertainties(observations):
+        minimum_action = "block"
+    evidence_batch = extension_evidence_batch(command, observations)
+    decision_plane = evaluate_effect_decision(
+        EffectDecisionRequest(
+            factors=decision_factors(
+                evidence_batch,
+                compatibility_action_class=compatibility_action_class,
+            ),
+            uncertainties=tuple(
+                sorted(
+                    {
+                        *command_uncertainties(
+                            command,
+                            sensitive=compatibility_action_class is not None or bool(owned_matches),
+                        ),
+                        *extension_uncertainties(observations),
+                    },
+                    key=lambda item: item.value,
+                )
+            ),
+        )
+    )
     return CompositeCommandEvaluation(
         command=command,
         matches=tuple(owned_matches),
@@ -134,6 +173,8 @@ def evaluate_command(
         controlling_reason=controlling_reason,
         controlling_rule_id=controlling_match.match.rule.rule_id if controlling_match is not None else None,
         minimum_action=minimum_action,
+        extension_observations=observations,
+        decision_plane=decision_plane,
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/command_evaluation.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_evaluation.py
@@ -20,7 +20,7 @@ from .command_extensions import (
     CommandSafetyExtensionRegistry,
 )
 from .command_model import CanonicalCommand, parse_shell_command
-from .command_rules import CommandRuleMatch, CommandRuleMode
+from .command_rules import CommandRuleMatch, CommandRuleMode, CommandSafetyRule
 from .effect_decision import EffectDecision, EffectDecisionRequest, evaluate_effect_decision
 
 CommandDecisionFloor = Literal["allow", "monitor", "review", "block"]
@@ -105,11 +105,13 @@ def evaluate_command(
     )
     selected = list(structured)
     selected_rule_ids = {rule.rule_id for _extension, rule, _evidence in selected}
+    compatibility_rule: tuple[CommandSafetyExtension, CommandSafetyRule] | None = None
     if compatibility_action_class is not None:
         extension = registry.for_action_class(compatibility_action_class)
         rule = registry.rule_for_action_class(compatibility_action_class)
         if extension is not None and rule is not None and rule.rule_id not in selected_rule_ids:
             selected.append((extension, rule, ()))
+            compatibility_rule = (extension, rule)
 
     owned_matches: list[OwnedCommandRuleMatch] = []
     for extension, rule, evidence in selected:
@@ -151,6 +153,7 @@ def evaluate_command(
             factors=decision_factors(
                 evidence_batch,
                 compatibility_action_class=compatibility_action_class,
+                compatibility_rule=compatibility_rule,
             ),
             uncertainties=tuple(
                 sorted(

--- a/src/codex_plugin_scanner/guard/runtime/command_extension_interaction.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extension_interaction.py
@@ -1,0 +1,55 @@
+"""Project central extension decisions onto the legacy request classifier."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..action_lattice import guard_action_severity
+from .command_decision_adapter import evaluate_extension_interaction
+from .command_extensions import CommandSafetyExtensionRegistry
+from .command_model import CanonicalCommand
+
+
+@dataclass(frozen=True, slots=True)
+class CommandExtensionInteractionMatch:
+    action_class: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class CommandExtensionInteraction:
+    priority: CommandExtensionInteractionMatch | None
+    fallback: CommandExtensionInteractionMatch | None
+
+
+def classify_command_extension_interaction(
+    command: CanonicalCommand,
+    registry: CommandSafetyExtensionRegistry,
+) -> CommandExtensionInteraction:
+    """Return sanitized legacy interaction projections from the central plane."""
+
+    observations = registry.observations(command)
+    has_signal = any(item.effective_evidence or item.uncertainty_reasons for item in observations)
+    decision = evaluate_extension_interaction(command, observations)
+    requires_interaction = has_signal and guard_action_severity(decision.action) >= guard_action_severity("review")
+    if not requires_interaction:
+        return CommandExtensionInteraction(None, None)
+    if any(item.uncertainty_reasons for item in observations):
+        return CommandExtensionInteraction(
+            CommandExtensionInteractionMatch(
+                "command extension matcher failure",
+                "Guard blocked an extension matcher boundary failure without exposing matcher-provided data.",
+            ),
+            None,
+        )
+
+    matches = tuple(
+        CommandExtensionInteractionMatch(item.rule.action_classes[0], item.rule.description)
+        for item in observations
+        if item.effective_evidence and item.rule.action_classes
+    )
+    priority = next(
+        (item for item in matches if item.action_class == "GitHub Actions administrative command"),
+        None,
+    )
+    return CommandExtensionInteraction(priority, matches[0] if matches else None)

--- a/src/codex_plugin_scanner/guard/runtime/command_extension_interaction.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extension_interaction.py
@@ -34,7 +34,11 @@ def classify_command_extension_interaction(
     requires_interaction = has_signal and guard_action_severity(decision.action) >= guard_action_severity("review")
     if not requires_interaction:
         return CommandExtensionInteraction(None, None)
-    if any(item.uncertainty_reasons for item in observations):
+    matcher_failure_controls = any(
+        reason.reason_code in {"matcher-failure", "uncertainty.matcher-failure"}
+        for reason in decision.controlling_reasons
+    )
+    if matcher_failure_controls:
         return CommandExtensionInteraction(
             CommandExtensionInteractionMatch(
                 "command extension matcher failure",

--- a/src/codex_plugin_scanner/guard/runtime/command_extension_observations.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extension_observations.py
@@ -66,12 +66,16 @@ class CommandExtensionObservation(Generic[_ExtensionT]):
         return tuple(item for item in self.matcher_evidence if item.segment_index not in safe_indexes)
 
     def to_dict(self) -> dict[str, object]:
+        match_classes = ["unsafe"] if self.matcher_evidence else []
+        if self.uncertainty_reasons:
+            match_classes.append("uncertainty")
         return {
             "extension_id": self.extension.extension_id,
             "extension_version": self.extension.version,
             "rule_id": self.rule.rule_id,
             "rule_version": self.rule.rule_version,
-            "match_class": "uncertainty" if self.uncertainty_reasons else "unsafe",
+            "match_class": "unsafe" if self.matcher_evidence else "uncertainty",
+            "match_classes": match_classes,
             "matcher_evidence": [item.to_dict() for item in self.matcher_evidence],
             "safe_variants": [item.to_dict() for item in self.safe_variants],
             "uncertainty_reasons": [item.value for item in self.uncertainty_reasons],

--- a/src/codex_plugin_scanner/guard/runtime/command_extension_observations.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extension_observations.py
@@ -71,7 +71,7 @@ class CommandExtensionObservation(Generic[_ExtensionT]):
             "extension_version": self.extension.version,
             "rule_id": self.rule.rule_id,
             "rule_version": self.rule.rule_version,
-            "match_class": "unsafe",
+            "match_class": "uncertainty" if self.uncertainty_reasons else "unsafe",
             "matcher_evidence": [item.to_dict() for item in self.matcher_evidence],
             "safe_variants": [item.to_dict() for item in self.safe_variants],
             "uncertainty_reasons": [item.value for item in self.uncertainty_reasons],

--- a/src/codex_plugin_scanner/guard/runtime/command_extension_observations.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extension_observations.py
@@ -108,15 +108,22 @@ def observe_command_extensions(
             if not matcher_evidence:
                 continue
             safe_variants: list[SafeVariantObservation] = []
-            uncertainty_reasons: tuple[UncertaintyKind, ...] = ()
+            safe_matcher_failed = False
             for variant in rule.safe_variants:
                 try:
                     evidence = _validated_match(variant.matcher, command)
                 except Exception:
-                    uncertainty_reasons = (UncertaintyKind.MATCHER_FAILURE,)
+                    safe_matcher_failed = True
                     continue
                 if evidence:
                     safe_variants.append(SafeVariantObservation(variant.variant_id, evidence))
+            base_segments = {item.segment_index for item in matcher_evidence}
+            safe_segments = {
+                item.segment_index for observation in safe_variants for item in observation.matcher_evidence
+            }
+            uncertainty_reasons = (
+                (UncertaintyKind.MATCHER_FAILURE,) if safe_matcher_failed and not base_segments <= safe_segments else ()
+            )
             observations.append(
                 CommandExtensionObservation(
                     extension,

--- a/src/codex_plugin_scanner/guard/runtime/command_extension_observations.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extension_observations.py
@@ -74,7 +74,7 @@ class CommandExtensionObservation(Generic[_ExtensionT]):
             "extension_version": self.extension.version,
             "rule_id": self.rule.rule_id,
             "rule_version": self.rule.rule_version,
-            "match_class": "unsafe" if self.matcher_evidence else "uncertainty",
+            "match_class": "uncertainty" if self.uncertainty_reasons else "unsafe",
             "match_classes": match_classes,
             "matcher_evidence": [item.to_dict() for item in self.matcher_evidence],
             "safe_variants": [item.to_dict() for item in self.safe_variants],

--- a/src/codex_plugin_scanner/guard/runtime/command_extension_observations.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extension_observations.py
@@ -1,0 +1,149 @@
+"""Lossless evidence observations for command safety extension matchers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Generic, Protocol, TypeVar, cast
+
+from .command_matcher_contracts import CommandMatcher, MatcherEvidence
+from .command_model import CanonicalCommand
+from .command_rules import CommandSafetyRule
+from .effect_contract import UncertaintyKind
+
+_EXECUTABLE_BASENAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+-]{0,127}")
+_MATCH_DETAIL = "Matched bounded structured command constraints."
+
+
+class CommandSafetyExtensionView(Protocol):
+    @property
+    def extension_id(self) -> str: ...
+
+    @property
+    def version(self) -> str: ...
+
+    @property
+    def rules(self) -> tuple[CommandSafetyRule, ...]: ...
+
+
+_ExtensionT = TypeVar("_ExtensionT", bound=CommandSafetyExtensionView)
+
+
+@dataclass(frozen=True, slots=True)
+class SafeVariantObservation:
+    """Every segment-level match emitted by one owned safe variant."""
+
+    variant_id: str
+    matcher_evidence: tuple[MatcherEvidence, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "match_class": "safe-variant",
+            "variant_id": self.variant_id,
+            "matcher_evidence": [item.to_dict() for item in self.matcher_evidence],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CommandExtensionObservation(Generic[_ExtensionT]):
+    """Immutable base and safe-variant evidence from one extension rule."""
+
+    extension: _ExtensionT
+    rule: CommandSafetyRule
+    matcher_evidence: tuple[MatcherEvidence, ...]
+    safe_variants: tuple[SafeVariantObservation, ...]
+    uncertainty_reasons: tuple[UncertaintyKind, ...] = ()
+
+    @property
+    def safe_segment_indexes(self) -> frozenset[int]:
+        return frozenset(
+            item.segment_index for observation in self.safe_variants for item in observation.matcher_evidence
+        )
+
+    @property
+    def effective_evidence(self) -> tuple[MatcherEvidence, ...]:
+        safe_indexes = self.safe_segment_indexes
+        return tuple(item for item in self.matcher_evidence if item.segment_index not in safe_indexes)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "extension_id": self.extension.extension_id,
+            "extension_version": self.extension.version,
+            "rule_id": self.rule.rule_id,
+            "rule_version": self.rule.rule_version,
+            "match_class": "unsafe",
+            "matcher_evidence": [item.to_dict() for item in self.matcher_evidence],
+            "safe_variants": [item.to_dict() for item in self.safe_variants],
+            "uncertainty_reasons": [item.value for item in self.uncertainty_reasons],
+            "effective_segment_indexes": [item.segment_index for item in self.effective_evidence],
+        }
+
+
+def observe_command_extensions(
+    command: CanonicalCommand,
+    extensions: tuple[_ExtensionT, ...],
+    candidate_rule_ids: tuple[str, ...],
+) -> tuple[CommandExtensionObservation[_ExtensionT], ...]:
+    """Evaluate every candidate matcher without suppressing owned safe evidence."""
+
+    candidates = frozenset(candidate_rule_ids)
+    observations: list[CommandExtensionObservation[_ExtensionT]] = []
+    for extension in extensions:
+        for rule in extension.rules:
+            if rule.matcher is None or rule.rule_id not in candidates:
+                continue
+            try:
+                matcher_evidence = _validated_match(rule.matcher, command)
+            except Exception:
+                observations.append(
+                    CommandExtensionObservation(
+                        extension,
+                        rule,
+                        (),
+                        (),
+                        (UncertaintyKind.MATCHER_FAILURE,),
+                    )
+                )
+                continue
+            if not matcher_evidence:
+                continue
+            safe_variants: list[SafeVariantObservation] = []
+            uncertainty_reasons: tuple[UncertaintyKind, ...] = ()
+            for variant in rule.safe_variants:
+                try:
+                    evidence = _validated_match(variant.matcher, command)
+                except Exception:
+                    uncertainty_reasons = (UncertaintyKind.MATCHER_FAILURE,)
+                    continue
+                if evidence:
+                    safe_variants.append(SafeVariantObservation(variant.variant_id, evidence))
+            observations.append(
+                CommandExtensionObservation(
+                    extension,
+                    rule,
+                    matcher_evidence,
+                    tuple(safe_variants),
+                    uncertainty_reasons,
+                )
+            )
+    return tuple(observations)
+
+
+def _validated_match(matcher: CommandMatcher, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+    evidence_value = cast(object, matcher.match(command))
+    if not isinstance(evidence_value, tuple):
+        raise ValueError("matcher evidence must be a tuple of MatcherEvidence values")
+    evidence = cast(tuple[object, ...], evidence_value)
+    if any(not isinstance(item, MatcherEvidence) for item in evidence):
+        raise ValueError("matcher evidence must be a tuple of MatcherEvidence values")
+    typed_evidence = cast(tuple[MatcherEvidence, ...], evidence)
+    normalized: list[MatcherEvidence] = []
+    for item in typed_evidence:
+        if type(item.segment_index) is not int or not 0 <= item.segment_index < len(command.segments):
+            raise ValueError("matcher evidence segment index is outside the command")
+        executable = command.segments[item.segment_index].executable
+        executable_basename = executable.replace("\\", "/").rsplit("/", 1)[-1] if executable else None
+        if executable_basename is not None and _EXECUTABLE_BASENAME.fullmatch(executable_basename) is None:
+            executable_basename = None
+        normalized.append(MatcherEvidence(item.segment_index, executable_basename, _MATCH_DETAIL))
+    return tuple(normalized)

--- a/src/codex_plugin_scanner/guard/runtime/command_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extensions.py
@@ -9,9 +9,11 @@ from typing import Literal, final
 
 from .command_builtin_extension_catalog import DIRECT_COMMAND_EXTENSION_VALUES
 from .command_builtin_rules import COMMAND_ACTION_RISK_CLASSES, rules_for_extension
+from .command_extension_observations import CommandExtensionObservation, observe_command_extensions
+from .command_matcher_contracts import MatcherEvidence
 from .command_model import CanonicalCommand
 from .command_package_extensions import PACKAGE_COMMAND_EXTENSION_SPECS, PackageCommandExtensionSpec
-from .command_rules import CommandSafetyRule, MatcherEvidence, matcher_index_hints
+from .command_rules import CommandSafetyRule, matcher_index_hints
 
 COMMAND_EXTENSION_SCHEMA_VERSION = 2
 _VERSION_PATTERN = re.compile(r"^[1-9][0-9]*\.[0-9]+\.[0-9]+$")
@@ -210,26 +212,22 @@ class CommandSafetyExtensionRegistry:
         self,
         command: CanonicalCommand,
     ) -> tuple[tuple[CommandSafetyExtension, CommandSafetyRule, tuple[MatcherEvidence, ...]], ...]:
-        """Return every structured rule match in deterministic registry order."""
+        """Return the effective compatibility projection of lossless observations."""
 
-        matches: list[tuple[CommandSafetyExtension, CommandSafetyRule, tuple[MatcherEvidence, ...]]] = []
-        candidate_rule_ids = frozenset(self.candidate_rule_ids(command))
-        for extension, rule in self._rule_records:
-            if rule.matcher is None or rule.rule_id not in candidate_rule_ids:
-                continue
-            evidence = rule.matcher.match(command)
-            if not evidence:
-                continue
-            safe_segment_indexes = {
-                safe_evidence.segment_index
-                for variant in rule.safe_variants
-                for safe_evidence in variant.matcher.match(command)
-            }
-            effective_evidence = tuple(item for item in evidence if item.segment_index not in safe_segment_indexes)
-            if not effective_evidence:
-                continue
-            matches.append((extension, rule, effective_evidence))
-        return tuple(matches)
+        observations = self.observations(command)
+        if any(item.uncertainty_reasons for item in observations):
+            raise RuntimeError("command extension matcher boundary failure")
+        return tuple(
+            (item.extension, item.rule, item.effective_evidence) for item in observations if item.effective_evidence
+        )
+
+    def observations(
+        self,
+        command: CanonicalCommand,
+    ) -> tuple[CommandExtensionObservation[CommandSafetyExtension], ...]:
+        """Return lossless base, safe-variant, and uncertainty evidence."""
+
+        return observe_command_extensions(command, self.extensions, self.candidate_rule_ids(command))
 
 
 def _validate_extension(extension: CommandSafetyExtension) -> None:

--- a/src/codex_plugin_scanner/guard/runtime/command_risk_effects.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_risk_effects.py
@@ -1,0 +1,41 @@
+"""Canonical command risk-class to effect-kind mapping."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from types import MappingProxyType
+from typing import Final
+
+from .effect_contract import EffectKind
+
+COMMAND_RISK_EFFECTS: Final = MappingProxyType(
+    {
+        "credential_exfiltration": frozenset({EffectKind.CREDENTIAL_OR_SECRET_OPERATION}),
+        "data_flow_exfiltration": frozenset({EffectKind.NETWORK_WRITE}),
+        "destructive_shell": frozenset({EffectKind.DESTRUCTIVE_OR_IRREVERSIBLE_OPERATION}),
+        "encoded_execution": frozenset({EffectKind.PROCESS_EXECUTION}),
+        "execution": frozenset({EffectKind.PROCESS_EXECUTION}),
+        "local_secret_read": frozenset({EffectKind.SENSITIVE_READ}),
+        "network_egress": frozenset({EffectKind.NETWORK_WRITE}),
+        "policy_bypass": frozenset({EffectKind.GUARD_CONTROL_OPERATION}),
+        "supply_chain": frozenset({EffectKind.PACKAGE_OR_SOURCE_INSTALLATION}),
+    }
+)
+
+
+def command_risk_effects(
+    risk_classes: Iterable[str],
+    *,
+    unknown_fallback: frozenset[EffectKind] | None = None,
+) -> frozenset[EffectKind]:
+    """Resolve effect kinds, rejecting unknown classes unless policy supplies a fallback."""
+
+    effects: set[EffectKind] = set()
+    for risk_class in risk_classes:
+        mapped = COMMAND_RISK_EFFECTS.get(risk_class)
+        if mapped is None:
+            if unknown_fallback is None:
+                raise ValueError(f"unsupported command risk class: {risk_class}")
+            mapped = unknown_fallback
+        effects.update(mapped)
+    return frozenset(effects)

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Literal, final
 
@@ -298,6 +299,7 @@ class CommandSafetyRule:
     matcher: CommandMatcher | None = None
     safe_variants: tuple[CommandSafeVariant, ...] = ()
     compatibility_fallback: bool = False
+    rule_version: str = "1.0.0"
 
     def __post_init__(self) -> None:
         if not self.rule_id.startswith("command.") or self.rule_id != self.rule_id.lower():
@@ -308,6 +310,8 @@ class CommandSafetyRule:
             raise ValueError(f"Command safety rule {self.rule_id} has invalid severity")
         if self.default_mode not in _VALID_MODES:
             raise ValueError(f"Command safety rule {self.rule_id} has invalid default mode")
+        if re.fullmatch(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)", self.rule_version) is None:
+            raise ValueError(f"Command safety rule {self.rule_id} has invalid rule version")
         for field_name, values in (
             ("risk classes", self.risk_classes),
             ("safer alternatives", self.safer_alternatives),
@@ -325,6 +329,7 @@ class CommandSafetyRule:
     def to_dict(self) -> dict[str, object]:
         return {
             "rule_id": self.rule_id,
+            "rule_version": self.rule_version,
             "title": self.title,
             "description": self.description,
             "severity": self.severity,
@@ -439,11 +444,6 @@ def _segment_matches_executable(segment: CommandSegment, executables: frozenset[
         return False
     executable = segment.executable.replace("\\", "/").rsplit("/", 1)[-1].lower()
     return executable in executables
-
-
-def _normalize_option_token(value: str) -> str:
-    stripped = value.strip()
-    return stripped.lower() if stripped.startswith("--") else stripped
 
 
 def _after_leading_options(

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -15,11 +15,10 @@ import stat
 from dataclasses import dataclass, replace
 from pathlib import Path
 
-from ..action_lattice import guard_action_severity
 from ..models import GuardArtifact
 from .actions import GuardActionEnvelope, apply_patch_target_paths
-from .command_decision_adapter import evaluate_extension_interaction
 from .command_evaluation import evaluate_command
+from .command_extension_interaction import classify_command_extension_interaction
 from .command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from .command_model import CanonicalCommand, parse_shell_command
 from .data_flow import extract_heredocs
@@ -1188,37 +1187,17 @@ def _destructive_shell_tool_action_request(
             ),
             canonical_command=canonical_command,
         )
-    extension_observations = BUILT_IN_COMMAND_EXTENSION_REGISTRY.observations(canonical_command)
-    has_extension_signal = any(
-        observation.effective_evidence or observation.uncertainty_reasons for observation in extension_observations
+    extension_interaction = classify_command_extension_interaction(
+        canonical_command,
+        BUILT_IN_COMMAND_EXTENSION_REGISTRY,
     )
-    extension_decision = evaluate_extension_interaction(canonical_command, extension_observations)
-    extension_requires_interaction = has_extension_signal and guard_action_severity(extension_decision.action) >= (
-        guard_action_severity("review")
-    )
-    if extension_requires_interaction and any(
-        observation.uncertainty_reasons for observation in extension_observations
-    ):
+    if extension_interaction.priority is not None:
         return ToolActionRequestMatch(
             tool_name=tool_name,
             normalized_tool_name=normalized_tool_name,
             command_text=command_text,
-            action_class="command extension matcher failure",
-            reason="Guard blocked an extension matcher boundary failure without exposing matcher-provided data.",
-            canonical_command=canonical_command,
-        )
-    for observation in extension_observations:
-        rule = observation.rule
-        if not extension_requires_interaction or not observation.effective_evidence:
-            continue
-        if not rule.action_classes or rule.action_classes[0] != "GitHub Actions administrative command":
-            continue
-        return ToolActionRequestMatch(
-            tool_name=tool_name,
-            normalized_tool_name=normalized_tool_name,
-            command_text=command_text,
-            action_class=rule.action_classes[0],
-            reason=rule.description,
+            action_class=extension_interaction.priority.action_class,
+            reason=extension_interaction.priority.reason,
             canonical_command=canonical_command,
         )
     if _looks_destructive_shell_command(detection_command_text, cwd=cwd, home_dir=home_dir):
@@ -1257,18 +1236,13 @@ def _destructive_shell_tool_action_request(
             ),
             canonical_command=canonical_command,
         )
-    for observation in extension_observations:
-        rule = observation.rule
-        if not extension_requires_interaction or not observation.effective_evidence:
-            continue
-        if not rule.action_classes:
-            continue
+    if extension_interaction.fallback is not None:
         return ToolActionRequestMatch(
             tool_name=tool_name,
             normalized_tool_name=normalized_tool_name,
             command_text=command_text,
-            action_class=rule.action_classes[0],
-            reason=rule.description,
+            action_class=extension_interaction.fallback.action_class,
+            reason=extension_interaction.fallback.reason,
             canonical_command=canonical_command,
         )
     return None

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from ..models import GuardArtifact
 from .actions import GuardActionEnvelope, apply_patch_target_paths
+from .command_decision_adapter import effect_decision_to_dict
 from .command_evaluation import evaluate_command
 from .command_extension_interaction import classify_command_extension_interaction
 from .command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
@@ -3918,6 +3919,8 @@ def build_tool_action_request_artifact(
             "raw_command_text": request.raw_command_text,
             "wrapper_chain": list(wrapper_chain),
             "command_security_identity": evaluation.command.security_identity,
+            "command_action_floor": evaluation.decision_plane.action,
+            "command_decision_plane": effect_decision_to_dict(evaluation.decision_plane),
             "command_rule_matches": [owned.to_dict() for owned in evaluation.matches],
             "risk_classes": list(evaluation.risk_classes),
             "command_parse_confidence": evaluation.command.confidence,

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -15,8 +15,10 @@ import stat
 from dataclasses import dataclass, replace
 from pathlib import Path
 
+from ..action_lattice import guard_action_severity
 from ..models import GuardArtifact
 from .actions import GuardActionEnvelope, apply_patch_target_paths
+from .command_decision_adapter import evaluate_extension_interaction
 from .command_evaluation import evaluate_command
 from .command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from .command_model import CanonicalCommand, parse_shell_command
@@ -1186,7 +1188,29 @@ def _destructive_shell_tool_action_request(
             ),
             canonical_command=canonical_command,
         )
-    for _extension, rule, _evidence in BUILT_IN_COMMAND_EXTENSION_REGISTRY.matching_rules(canonical_command):
+    extension_observations = BUILT_IN_COMMAND_EXTENSION_REGISTRY.observations(canonical_command)
+    has_extension_signal = any(
+        observation.effective_evidence or observation.uncertainty_reasons for observation in extension_observations
+    )
+    extension_decision = evaluate_extension_interaction(canonical_command, extension_observations)
+    extension_requires_interaction = has_extension_signal and guard_action_severity(extension_decision.action) >= (
+        guard_action_severity("review")
+    )
+    if extension_requires_interaction and any(
+        observation.uncertainty_reasons for observation in extension_observations
+    ):
+        return ToolActionRequestMatch(
+            tool_name=tool_name,
+            normalized_tool_name=normalized_tool_name,
+            command_text=command_text,
+            action_class="command extension matcher failure",
+            reason="Guard blocked an extension matcher boundary failure without exposing matcher-provided data.",
+            canonical_command=canonical_command,
+        )
+    for observation in extension_observations:
+        rule = observation.rule
+        if not extension_requires_interaction or not observation.effective_evidence:
+            continue
         if not rule.action_classes or rule.action_classes[0] != "GitHub Actions administrative command":
             continue
         return ToolActionRequestMatch(
@@ -1233,7 +1257,10 @@ def _destructive_shell_tool_action_request(
             ),
             canonical_command=canonical_command,
         )
-    for _extension, rule, _evidence in BUILT_IN_COMMAND_EXTENSION_REGISTRY.matching_rules(canonical_command):
+    for observation in extension_observations:
+        rule = observation.rule
+        if not extension_requires_interaction or not observation.effective_evidence:
+            continue
         if not rule.action_classes:
             continue
         return ToolActionRequestMatch(

--- a/tests/test_guard_command_decision_routing.py
+++ b/tests/test_guard_command_decision_routing.py
@@ -69,6 +69,8 @@ class _SegmentMatcher:
 def _registry(
     mode: CommandRuleMode,
     *,
+    action_classes: tuple[str, ...] = (),
+    compatibility_fallback: bool = False,
     required: bool = False,
     severity: CommandRuleSeverity = "high",
     matcher: object | None = None,
@@ -80,20 +82,21 @@ def _registry(
         description="Exercises decision routing compatibility.",
         severity=severity,
         risk_classes=("destructive_shell",),
-        action_classes=(),
+        action_classes=action_classes,
         safer_alternatives=("Preview the operation.",),
         default_mode=mode,
         matcher=cast(ExecutableMatcher, matcher)
         if matcher is not None
         else ExecutableMatcher(executables=frozenset({"test-tool"})),
         safe_variants=safe_variants,
+        compatibility_fallback=compatibility_fallback,
     )
     extension = CommandSafetyExtension(
         extension_id="command.test",
         version="1.0.0",
         name="Test extension",
         description="Exercises decision routing compatibility.",
-        action_classes=(),
+        action_classes=action_classes,
         risk_classes=("destructive_shell",),
         safer_alternatives=("Preview the operation.",),
         rules=(rule,),
@@ -176,6 +179,38 @@ def test_parallel_legacy_heuristics_route_through_plane(action_class: str) -> No
     assert evaluation.minimum_action == "review"
     assert evaluation.decision_plane.action == "review"
     assert any(reason.reason_code == "compatibility-action" for reason in evaluation.decision_plane.reasons)
+
+
+@pytest.mark.parametrize(
+    ("mode", "required", "severity", "expected"),
+    [
+        ("disabled", False, "high", "review"),
+        ("monitor", False, "high", "review"),
+        ("enforce", False, "high", "block"),
+        ("disabled", True, "critical", "block"),
+    ],
+)
+def test_compatibility_fallback_preserves_its_block_floor_in_central_decision(
+    mode: CommandRuleMode,
+    required: bool,
+    severity: CommandRuleSeverity,
+    expected: CommandDecisionFloor,
+) -> None:
+    action_class = "compatibility fallback"
+    evaluation = evaluate_command(
+        "unmatched-tool target",
+        compatibility_action_class=action_class,
+        registry=_registry(
+            mode,
+            action_classes=(action_class,),
+            compatibility_fallback=True,
+            required=required,
+            severity=severity,
+            matcher=_EmptyMatcher(),
+        ),
+    )
+    assert evaluation.minimum_action == expected
+    assert evaluation.decision_plane.action == expected
 
 
 def test_public_payload_contains_versions_without_raw_command_or_failure_detail() -> None:

--- a/tests/test_guard_command_decision_routing.py
+++ b/tests/test_guard_command_decision_routing.py
@@ -387,7 +387,7 @@ def test_failed_safe_matcher_remains_uncertain_when_safe_evidence_is_partial() -
     assert evaluation.extension_observations[0].uncertainty_reasons == (UncertaintyKind.MATCHER_FAILURE,)
     assert evaluation.minimum_action == "block"
     payload = evaluation.extension_observations[0].to_dict()
-    assert payload["match_class"] == "unsafe"
+    assert payload["match_class"] == "uncertainty"
     assert payload["match_classes"] == ["unsafe", "uncertainty"]
 
 

--- a/tests/test_guard_command_decision_routing.py
+++ b/tests/test_guard_command_decision_routing.py
@@ -24,6 +24,7 @@ from codex_plugin_scanner.guard.runtime.command_rules import (
     CommandSafeVariant,
     ExecutableMatcher,
 )
+from codex_plugin_scanner.guard.runtime.effect_contract import UncertaintyKind
 
 
 class _FailingMatcher:
@@ -54,6 +55,15 @@ class _OutOfBoundsMatcher:
     def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
         del command
         return (MatcherEvidence(99, "test-tool", "invalid index"),)
+
+
+class _SegmentMatcher:
+    def __init__(self, *segment_indexes: int) -> None:
+        self._segment_indexes: tuple[int, ...] = segment_indexes
+
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+        del command
+        return tuple(MatcherEvidence(index, None, "test evidence") for index in self._segment_indexes)
 
 
 def _registry(
@@ -244,6 +254,32 @@ def test_owned_safe_variant_failure_remains_blocking_uncertainty() -> None:
     )
     assert evaluation.minimum_action == "block"
     assert evaluation.decision_plane.action == "block"
+
+
+def test_failed_optional_safe_matcher_does_not_override_complete_safe_evidence() -> None:
+    safe_variants = (
+        CommandSafeVariant("broken-safe", "Broken safe matcher", _FailingMatcher()),
+        CommandSafeVariant("proven-safe", "Proven safe matcher", _SegmentMatcher(0)),
+    )
+    evaluation = evaluate_command(
+        "test-tool target",
+        registry=_registry("review", safe_variants=safe_variants),
+    )
+    assert evaluation.extension_observations[0].uncertainty_reasons == ()
+    assert evaluation.extension_observations[0].effective_evidence == ()
+
+
+def test_failed_safe_matcher_remains_uncertain_when_safe_evidence_is_partial() -> None:
+    safe_variants = (
+        CommandSafeVariant("broken-safe", "Broken safe matcher", _FailingMatcher()),
+        CommandSafeVariant("partially-safe", "Partial safe matcher", _SegmentMatcher(0)),
+    )
+    evaluation = evaluate_command(
+        "test-tool target && other-tool target",
+        registry=_registry("review", matcher=_SegmentMatcher(0, 1), safe_variants=safe_variants),
+    )
+    assert evaluation.extension_observations[0].uncertainty_reasons == (UncertaintyKind.MATCHER_FAILURE,)
+    assert evaluation.minimum_action == "block"
 
 
 def test_rule_versions_are_stable_and_serialized() -> None:

--- a/tests/test_guard_command_decision_routing.py
+++ b/tests/test_guard_command_decision_routing.py
@@ -1,0 +1,263 @@
+"""Compatibility and evidence tests for command decision routing."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime import secret_file_requests
+from codex_plugin_scanner.guard.runtime.command_decision_adapter import extension_evidence_batch
+from codex_plugin_scanner.guard.runtime.command_evaluation import CommandDecisionFloor, evaluate_command
+from codex_plugin_scanner.guard.runtime.command_extension_observations import observe_command_extensions
+from codex_plugin_scanner.guard.runtime.command_extensions import (
+    BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+    CommandSafetyExtension,
+    CommandSafetyExtensionRegistry,
+)
+from codex_plugin_scanner.guard.runtime.command_matcher_contracts import MatcherEvidence
+from codex_plugin_scanner.guard.runtime.command_model import CanonicalCommand, parse_shell_command
+from codex_plugin_scanner.guard.runtime.command_rules import (
+    CommandRuleMode,
+    CommandRuleSeverity,
+    CommandSafetyRule,
+    CommandSafeVariant,
+    ExecutableMatcher,
+)
+
+
+class _FailingMatcher:
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+        del command
+        raise RuntimeError("private matcher detail")
+
+
+class _MalformedMatcher:
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+        del command
+        return cast(tuple[MatcherEvidence, ...], ("not-evidence",))
+
+
+class _EmptyMatcher:
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+        del command
+        return ()
+
+
+class _LeakingMatcher:
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+        del command
+        return (MatcherEvidence(0, "/private/path/test-tool", "private matcher-provided detail"),)
+
+
+class _OutOfBoundsMatcher:
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+        del command
+        return (MatcherEvidence(99, "test-tool", "invalid index"),)
+
+
+def _registry(
+    mode: CommandRuleMode,
+    *,
+    required: bool = False,
+    severity: CommandRuleSeverity = "high",
+    matcher: object | None = None,
+    safe_variants: tuple[CommandSafeVariant, ...] = (),
+) -> CommandSafetyExtensionRegistry:
+    rule = CommandSafetyRule(
+        rule_id="command.test.rule",
+        title="Test rule",
+        description="Exercises decision routing compatibility.",
+        severity=severity,
+        risk_classes=("destructive_shell",),
+        action_classes=(),
+        safer_alternatives=("Preview the operation.",),
+        default_mode=mode,
+        matcher=cast(ExecutableMatcher, matcher)
+        if matcher is not None
+        else ExecutableMatcher(executables=frozenset({"test-tool"})),
+        safe_variants=safe_variants,
+    )
+    extension = CommandSafetyExtension(
+        extension_id="command.test",
+        version="1.0.0",
+        name="Test extension",
+        description="Exercises decision routing compatibility.",
+        action_classes=(),
+        risk_classes=("destructive_shell",),
+        safer_alternatives=("Preview the operation.",),
+        rules=(rule,),
+        required=required,
+    )
+    return CommandSafetyExtensionRegistry((extension,))
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_legacy", "expected_plane"),
+    [
+        ("disabled", "allow", "review"),
+        ("monitor", "monitor", "review"),
+        ("review", "review", "review"),
+        ("enforce", "block", "block"),
+        ("required", "review", "review"),
+    ],
+)
+def test_legacy_floor_is_preserved_without_inventing_permissive_proof(
+    mode: CommandRuleMode,
+    expected_legacy: CommandDecisionFloor,
+    expected_plane: str,
+) -> None:
+    evaluation = evaluate_command("test-tool target", registry=_registry(mode))
+    assert evaluation.minimum_action == expected_legacy
+    assert evaluation.decision_plane.action == expected_plane
+
+
+def test_required_extension_floors_remain_monotonic() -> None:
+    high = evaluate_command("test-tool target", registry=_registry("disabled", required=True))
+    critical = evaluate_command(
+        "test-tool target",
+        registry=_registry("disabled", required=True, severity="critical"),
+    )
+    assert (high.minimum_action, high.decision_plane.action) == ("review", "review")
+    assert (critical.minimum_action, critical.decision_plane.action) == ("block", "block")
+
+
+def test_safe_variant_remains_visible_without_suppressing_stronger_sibling() -> None:
+    evaluation = evaluate_command("git clean -nfdx && rm -rf ./build")
+    force_clean = next(
+        item for item in evaluation.extension_observations if item.rule.rule_id == "command.git.force-clean"
+    )
+    assert force_clean.matcher_evidence
+    assert [item.variant_id for item in force_clean.safe_variants] == ["dry-run"]
+    assert force_clean.effective_evidence == ()
+    assert evaluation.minimum_action == "review"
+    assert evaluation.decision_plane.action == "review"
+
+
+def test_owned_safe_variant_is_preserved_in_strict_extension_evidence() -> None:
+    command = parse_shell_command("git clean -nfdx")
+    observations = observe_command_extensions(
+        command,
+        BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions,
+        BUILT_IN_COMMAND_EXTENSION_REGISTRY.candidate_rule_ids(command),
+    )
+    batch = extension_evidence_batch(command, observations)
+    force_clean = next(item for item in batch.evidence if item.identity.rule_id == "command.git.force-clean")
+    assert force_clean.safe_variant is not None
+    assert force_clean.safe_variant.safe_variant_id == "dry-run"
+    assert force_clean.effective_floor is None
+
+
+@pytest.mark.parametrize(
+    "action_class",
+    [
+        "destructive shell command",
+        "GitHub remote mutation command",
+        "package installation command",
+        "unresolved interpreter command",
+    ],
+)
+def test_parallel_legacy_heuristics_route_through_plane(action_class: str) -> None:
+    evaluation = evaluate_command(
+        "routine-tool inspect",
+        compatibility_action_class=action_class,
+        compatibility_reason="Existing heuristic requires review.",
+    )
+    assert evaluation.minimum_action == "review"
+    assert evaluation.decision_plane.action == "review"
+    assert any(reason.reason_code == "compatibility-action" for reason in evaluation.decision_plane.reasons)
+
+
+def test_public_payload_contains_versions_without_raw_command_or_failure_detail() -> None:
+    payload = evaluate_command("rm -rf ./private-name").to_dict()
+    observations = cast(list[dict[str, object]], payload["extension_observations"])
+    assert observations
+    assert all(item["extension_version"] and item["rule_version"] for item in observations)
+    assert "./private-name" not in repr(payload)
+    assert cast(dict[str, object], payload["decision_plane"])["schema_version"] == "1.0.0"
+
+
+@pytest.mark.parametrize("matcher", [_FailingMatcher(), _MalformedMatcher()])
+def test_matcher_failure_becomes_typed_blocking_uncertainty(matcher: object) -> None:
+    evaluation = evaluate_command(
+        "test-tool target",
+        registry=_registry("disabled", matcher=matcher),
+    )
+    assert evaluation.minimum_action == "block"
+    assert evaluation.decision_plane.action == "block"
+    assert evaluation.extension_observations[0].to_dict()["uncertainty_reasons"] == ["matcher-failure"]
+    assert "private matcher detail" not in repr(evaluation.to_dict())
+
+
+def test_typed_matcher_evidence_is_bounded_and_privacy_normalized() -> None:
+    command = parse_shell_command("test-tool target")
+    registry = _registry("review", matcher=_LeakingMatcher())
+    observations = observe_command_extensions(command, registry.extensions, registry.candidate_rule_ids(command))
+    payload = observations[0].to_dict()
+    assert payload["matcher_evidence"] == [
+        {
+            "segment_index": 0,
+            "executable": "test-tool",
+            "detail": "Matched bounded structured command constraints.",
+        }
+    ]
+    assert "private matcher-provided detail" not in repr(payload)
+    assert "/private/path" not in repr(payload)
+
+
+def test_live_request_classifier_routes_matcher_failure_through_plane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _registry("disabled", matcher=_OutOfBoundsMatcher())
+    monkeypatch.setattr(secret_file_requests, "BUILT_IN_COMMAND_EXTENSION_REGISTRY", registry)
+    match = secret_file_requests.extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": "test-tool target"},
+    )
+    assert match is not None
+    assert match.action_class == "command extension matcher failure"
+    assert "invalid index" not in match.reason
+
+
+def test_legacy_matching_projection_cannot_silence_matcher_failure() -> None:
+    registry = _registry("disabled", matcher=_FailingMatcher())
+    with pytest.raises(RuntimeError, match="matcher boundary failure") as captured:
+        _ = registry.matching_rules(parse_shell_command("test-tool target"))
+    assert "private matcher detail" not in str(captured.value)
+
+
+def test_safe_variant_failure_is_scoped_to_an_owning_base_match() -> None:
+    safe_variant = CommandSafeVariant("broken-safe", "Broken safe matcher", _FailingMatcher())
+    evaluation = evaluate_command(
+        "unrelated-tool inspect",
+        registry=_registry("review", matcher=_EmptyMatcher(), safe_variants=(safe_variant,)),
+    )
+    assert evaluation.minimum_action == "allow"
+    assert evaluation.extension_observations == ()
+
+
+def test_owned_safe_variant_failure_remains_blocking_uncertainty() -> None:
+    safe_variant = CommandSafeVariant("broken-safe", "Broken safe matcher", _FailingMatcher())
+    evaluation = evaluate_command(
+        "test-tool target",
+        registry=_registry("review", safe_variants=(safe_variant,)),
+    )
+    assert evaluation.minimum_action == "block"
+    assert evaluation.decision_plane.action == "block"
+
+
+def test_rule_versions_are_stable_and_serialized() -> None:
+    rule = _registry("review").extensions[0].rules[0]
+    assert rule.to_dict()["rule_version"] == "1.0.0"
+    with pytest.raises(ValueError, match="invalid rule version"):
+        _ = CommandSafetyRule(
+            rule_id="command.test.invalid",
+            title="Invalid version",
+            description="Exercises version validation.",
+            severity="high",
+            risk_classes=("test_risk",),
+            action_classes=(),
+            safer_alternatives=("Review the operation.",),
+            matcher=_EmptyMatcher(),
+            rule_version="01.0.0",
+        )

--- a/tests/test_guard_command_decision_routing.py
+++ b/tests/test_guard_command_decision_routing.py
@@ -6,10 +6,13 @@ from typing import cast
 
 import pytest
 
-from codex_plugin_scanner.guard.runtime import secret_file_requests
+from codex_plugin_scanner.guard.runtime import command_extension_interaction, secret_file_requests
 from codex_plugin_scanner.guard.runtime.command_decision_adapter import extension_evidence_batch
 from codex_plugin_scanner.guard.runtime.command_evaluation import CommandDecisionFloor, evaluate_command
-from codex_plugin_scanner.guard.runtime.command_extension_observations import observe_command_extensions
+from codex_plugin_scanner.guard.runtime.command_extension_observations import (
+    CommandExtensionObservation,
+    observe_command_extensions,
+)
 from codex_plugin_scanner.guard.runtime.command_extensions import (
     BUILT_IN_COMMAND_EXTENSION_REGISTRY,
     CommandSafetyExtension,
@@ -24,7 +27,14 @@ from codex_plugin_scanner.guard.runtime.command_rules import (
     CommandSafeVariant,
     ExecutableMatcher,
 )
-from codex_plugin_scanner.guard.runtime.effect_contract import UncertaintyKind
+from codex_plugin_scanner.guard.runtime.effect_contract import DecisionBasis, EffectKind, UncertaintyKind
+from codex_plugin_scanner.guard.runtime.effect_decision import (
+    DecisionFactor,
+    DecisionFactorSource,
+    EffectDecision,
+    EffectDecisionRequest,
+    evaluate_effect_decision,
+)
 
 
 class _FailingMatcher:
@@ -72,6 +82,7 @@ def _registry(
     action_classes: tuple[str, ...] = (),
     compatibility_fallback: bool = False,
     required: bool = False,
+    risk_classes: tuple[str, ...] = ("destructive_shell",),
     severity: CommandRuleSeverity = "high",
     matcher: object | None = None,
     safe_variants: tuple[CommandSafeVariant, ...] = (),
@@ -81,7 +92,7 @@ def _registry(
         title="Test rule",
         description="Exercises decision routing compatibility.",
         severity=severity,
-        risk_classes=("destructive_shell",),
+        risk_classes=risk_classes,
         action_classes=action_classes,
         safer_alternatives=("Preview the operation.",),
         default_mode=mode,
@@ -97,7 +108,7 @@ def _registry(
         name="Test extension",
         description="Exercises decision routing compatibility.",
         action_classes=action_classes,
-        risk_classes=("destructive_shell",),
+        risk_classes=risk_classes,
         safer_alternatives=("Preview the operation.",),
         rules=(rule,),
         required=required,
@@ -230,8 +241,21 @@ def test_matcher_failure_becomes_typed_blocking_uncertainty(matcher: object) -> 
     )
     assert evaluation.minimum_action == "block"
     assert evaluation.decision_plane.action == "block"
-    assert evaluation.extension_observations[0].to_dict()["uncertainty_reasons"] == ["matcher-failure"]
+    payload = evaluation.extension_observations[0].to_dict()
+    assert payload["match_class"] == "uncertainty"
+    assert payload["uncertainty_reasons"] == ["matcher-failure"]
     assert "private matcher detail" not in repr(evaluation.to_dict())
+
+
+def test_risk_effect_mapping_does_not_use_substring_classification() -> None:
+    evaluation = evaluate_command(
+        "test-tool target",
+        registry=_registry("review", risk_classes=("non-destructive",)),
+    )
+    batch = extension_evidence_batch(evaluation.command, evaluation.extension_observations)
+    effect_claims = frozenset(effect for item in batch.evidence for effect in item.effect_claims)
+    assert EffectKind.DESTRUCTIVE_OR_IRREVERSIBLE_OPERATION not in effect_claims
+    assert EffectKind.PROCESS_EXECUTION in effect_claims
 
 
 def test_typed_matcher_evidence_is_bounded_and_privacy_normalized() -> None:
@@ -262,6 +286,38 @@ def test_live_request_classifier_routes_matcher_failure_through_plane(
     assert match is not None
     assert match.action_class == "command extension matcher failure"
     assert "invalid index" not in match.reason
+
+
+def test_matcher_failure_projection_requires_a_controlling_uncertainty_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    decision = evaluate_effect_decision(
+        EffectDecisionRequest(
+            factors=(
+                DecisionFactor(
+                    source=DecisionFactorSource.POLICY,
+                    reason_code="rule-match",
+                    basis=DecisionBasis("block", None),
+                    producer_ref="test:controlling-rule",
+                ),
+            )
+        )
+    )
+
+    def fixed_decision(
+        command: CanonicalCommand,
+        observations: tuple[CommandExtensionObservation[CommandSafetyExtension], ...],
+    ) -> EffectDecision:
+        del command, observations
+        return decision
+
+    monkeypatch.setattr(command_extension_interaction, "evaluate_extension_interaction", fixed_decision)
+    interaction = command_extension_interaction.classify_command_extension_interaction(
+        parse_shell_command("test-tool target"),
+        _registry("disabled", matcher=_FailingMatcher()),
+    )
+    assert interaction.priority is None
+    assert interaction.fallback is None
 
 
 def test_legacy_matching_projection_cannot_silence_matcher_failure() -> None:

--- a/tests/test_guard_command_decision_routing.py
+++ b/tests/test_guard_command_decision_routing.py
@@ -20,6 +20,7 @@ from codex_plugin_scanner.guard.runtime.command_extensions import (
 )
 from codex_plugin_scanner.guard.runtime.command_matcher_contracts import MatcherEvidence
 from codex_plugin_scanner.guard.runtime.command_model import CanonicalCommand, parse_shell_command
+from codex_plugin_scanner.guard.runtime.command_risk_effects import COMMAND_RISK_EFFECTS
 from codex_plugin_scanner.guard.runtime.command_rules import (
     CommandRuleMode,
     CommandRuleSeverity,
@@ -243,6 +244,7 @@ def test_matcher_failure_becomes_typed_blocking_uncertainty(matcher: object) -> 
     assert evaluation.decision_plane.action == "block"
     payload = evaluation.extension_observations[0].to_dict()
     assert payload["match_class"] == "uncertainty"
+    assert payload["match_classes"] == ["uncertainty"]
     assert payload["uncertainty_reasons"] == ["matcher-failure"]
     assert "private matcher detail" not in repr(evaluation.to_dict())
 
@@ -256,6 +258,19 @@ def test_risk_effect_mapping_does_not_use_substring_classification() -> None:
     effect_claims = frozenset(effect for item in batch.evidence for effect in item.effect_claims)
     assert EffectKind.DESTRUCTIVE_OR_IRREVERSIBLE_OPERATION not in effect_claims
     assert EffectKind.PROCESS_EXECUTION in effect_claims
+
+
+@pytest.mark.parametrize(("risk_class", "expected"), tuple(COMMAND_RISK_EFFECTS.items()))
+def test_extension_evidence_uses_canonical_risk_effect_mapping(
+    risk_class: str,
+    expected: frozenset[EffectKind],
+) -> None:
+    evaluation = evaluate_command(
+        "test-tool target",
+        registry=_registry("review", risk_classes=(risk_class,)),
+    )
+    batch = extension_evidence_batch(evaluation.command, evaluation.extension_observations)
+    assert frozenset(effect for item in batch.evidence for effect in item.effect_claims) == expected
 
 
 def test_typed_matcher_evidence_is_bounded_and_privacy_normalized() -> None:
@@ -371,6 +386,9 @@ def test_failed_safe_matcher_remains_uncertain_when_safe_evidence_is_partial() -
     )
     assert evaluation.extension_observations[0].uncertainty_reasons == (UncertaintyKind.MATCHER_FAILURE,)
     assert evaluation.minimum_action == "block"
+    payload = evaluation.extension_observations[0].to_dict()
+    assert payload["match_class"] == "unsafe"
+    assert payload["match_classes"] == ["unsafe", "uncertainty"]
 
 
 def test_rule_versions_are_stable_and_serialized() -> None:

--- a/tests/test_guard_command_decision_runtime_policy.py
+++ b/tests/test_guard_command_decision_runtime_policy.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from functools import partial
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.cli.commands_support_runtime_policy import _runtime_artifact_policy_action
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.runtime import secret_file_requests
+from codex_plugin_scanner.guard.runtime.command_evaluation import evaluate_command
+from codex_plugin_scanner.guard.runtime.command_extensions import (
+    CommandSafetyExtension,
+    CommandSafetyExtensionRegistry,
+)
+from codex_plugin_scanner.guard.runtime.command_matcher_contracts import MatcherEvidence
+from codex_plugin_scanner.guard.runtime.command_model import CanonicalCommand
+from codex_plugin_scanner.guard.runtime.command_rules import CommandSafetyRule
+
+
+class _FailingMatcher:
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+        del command
+        raise RuntimeError("private matcher detail")
+
+
+def _failing_registry() -> CommandSafetyExtensionRegistry:
+    rule = CommandSafetyRule(
+        rule_id="command.test.failure",
+        title="Failing matcher",
+        description="Exercises the matcher failure boundary.",
+        severity="high",
+        risk_classes=("destructive_shell",),
+        action_classes=(),
+        safer_alternatives=("Review the operation.",),
+        matcher=_FailingMatcher(),
+    )
+    return CommandSafetyExtensionRegistry(
+        (
+            CommandSafetyExtension(
+                extension_id="command.test",
+                version="1.0.0",
+                name="Test extension",
+                description="Exercises runtime policy composition.",
+                action_classes=(),
+                risk_classes=("destructive_shell",),
+                safer_alternatives=("Review the operation.",),
+                rules=(rule,),
+            ),
+        )
+    )
+
+
+def test_matcher_failure_central_block_reaches_final_runtime_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _failing_registry()
+    monkeypatch.setattr(secret_file_requests, "BUILT_IN_COMMAND_EXTENSION_REGISTRY", registry)
+    monkeypatch.setattr(secret_file_requests, "evaluate_command", partial(evaluate_command, registry=registry))
+    request = secret_file_requests.extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": "test-tool target"},
+    )
+    assert request is not None
+    artifact = secret_file_requests.build_tool_action_request_artifact(
+        "codex",
+        request,
+        config_path="guard-config",
+        source_scope="project",
+    )
+
+    assert artifact.metadata["command_action_floor"] == "block"
+    decision = cast(dict[str, object], artifact.metadata["command_decision_plane"])
+    assert decision["action"] == "block"
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=tmp_path, default_action="allow")
+    assert _runtime_artifact_policy_action(config, artifact, "codex") == "block"
+    assert "private matcher detail" not in repr(artifact.metadata)

--- a/tests/test_guard_command_decision_runtime_policy.py
+++ b/tests/test_guard_command_decision_runtime_policy.py
@@ -77,3 +77,12 @@ def test_matcher_failure_central_block_reaches_final_runtime_policy(
     config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=tmp_path, default_action="allow")
     assert _runtime_artifact_policy_action(config, artifact, "codex") == "block"
     assert "private matcher detail" not in repr(artifact.metadata)
+
+    floor = artifact.metadata.pop("command_action_floor")
+    assert _runtime_artifact_policy_action(config, artifact, "codex") == "require-reapproval"
+    artifact.metadata["command_action_floor"] = None
+    assert _runtime_artifact_policy_action(config, artifact, "codex") == "block"
+    artifact.metadata["command_action_floor"] = "invalid"
+    assert _runtime_artifact_policy_action(config, artifact, "codex") == "block"
+    artifact.metadata["command_action_floor"] = floor
+    assert _runtime_artifact_policy_action(config, artifact, "codex") == "block"


### PR DESCRIPTION
## Summary
- emit immutable base, owned safe-variant, and typed matcher-failure observations before policy evaluation
- route command inspection and live extension interaction through the central evaluator while preserving every legacy command floor
- bound matcher evidence to canonical segment indexes and privacy-safe executable metadata

## Testing
- `uv run --no-sync pytest -q tests/test_guard_command_decision_routing.py tests/test_guard_command_model.py tests/test_guard_command_extension_registry.py tests/test_guard_command_*extensions.py tests/test_guard_command_safe_variants.py tests/test_guard_command_specialized_variants.py tests/test_guard_command_corpus.py tests/test_guard_command_activity_lifecycle.py tests/test_guard_command_activity_hook_integration.py tests/test_guard_effect_decision.py tests/test_guard_effect_contract.py tests/test_guard_extension_evidence_contract.py --tb=short`
- `uv run --no-sync ruff check <changed Python files>`
- `uv run --no-sync ruff format --check <changed Python files>`
- `uv run --no-sync basedpyright <bounded changed Python files>`
- `git diff --check`
