### PR TITLE
fix(updater): preserve daemon refresh handoff

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -82,6 +82,7 @@ _DAEMON_REFRESH_TIMEOUT_SECONDS = 35.0
 _DAEMON_REFRESH_SCRIPT = """
 from __future__ import annotations
 
+import inspect
 import json
 import sys
 from pathlib import Path
@@ -95,6 +96,7 @@ from codex_plugin_scanner.guard.daemon.manager import (
 
 payload = json.loads(sys.stdin.read())
 guard_home = Path(payload["guard_home"]).expanduser().resolve()
+home_dir = Path(payload["home_dir"]).expanduser().resolve()
 state_path = guard_home / "daemon-state.json"
 if not state_path.is_file():
     print(json.dumps({"status": "not_running"}))
@@ -107,7 +109,13 @@ preferred_port = state.get("port") if isinstance(state.get("port"), int) else No
 retired = retire_all_guard_daemons_for_home(guard_home)
 clear_guard_daemon_state(guard_home)
 repair_approval_center_locator(guard_home)
-daemon_url = ensure_guard_daemon_after_update(guard_home, preferred_port=preferred_port)
+refresh_parameters = inspect.signature(ensure_guard_daemon_after_update).parameters
+refresh_kwargs = {"preferred_port": preferred_port}
+if "home_dir" in refresh_parameters:
+    refresh_kwargs["home_dir"] = home_dir
+if "allow_windows_job_breakaway" in refresh_parameters:
+    refresh_kwargs["allow_windows_job_breakaway"] = True
+daemon_url = ensure_guard_daemon_after_update(guard_home, **refresh_kwargs)
 print(json.dumps({"status": "restarted", "retired": retired, "daemon_url": daemon_url}))
 """.strip()
 
@@ -1268,7 +1276,7 @@ def refresh_guard_daemon_after_update(context: HarnessContext) -> tuple[dict[str
         refresh_env.pop("PYTHONPATH", None)
         result = subprocess.run(
             [sys.executable, *_trusted_python_flags(), "-c", _DAEMON_REFRESH_SCRIPT],
-            input=json.dumps({"guard_home": str(context.guard_home)}),
+            input=json.dumps({"guard_home": str(context.guard_home), "home_dir": str(context.home_dir)}),
             capture_output=True,
             check=False,
             cwd=str(_trusted_import_root()),

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -96,7 +96,12 @@ from codex_plugin_scanner.guard.daemon.manager import (
 
 payload = json.loads(sys.stdin.read())
 guard_home = Path(payload["guard_home"]).expanduser().resolve()
-home_dir = Path(payload["home_dir"]).expanduser().resolve()
+home_dir_value = payload.get("home_dir")
+home_dir = (
+    Path(home_dir_value).expanduser().resolve()
+    if isinstance(home_dir_value, str) and home_dir_value.strip()
+    else Path.home().resolve()
+)
 state_path = guard_home / "daemon-state.json"
 if not state_path.is_file():
     print(json.dumps({"status": "not_running"}))

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -34,7 +34,10 @@ def test_daemon_refresh_after_update_uses_fresh_interpreter(tmp_path: Path, monk
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         assert command[-2:] == ["-c", update_commands._DAEMON_REFRESH_SCRIPT]
-        assert json.loads(str(kwargs["input"])) == {"guard_home": str(context.guard_home)}
+        assert json.loads(str(kwargs["input"])) == {
+            "guard_home": str(context.guard_home),
+            "home_dir": str(context.home_dir),
+        }
         return subprocess.CompletedProcess(command, 0, '{"status":"restarted","retired":[123]}', "")
 
     monkeypatch.setattr(update_commands.subprocess, "run", fake_run)

--- a/tests/test_guard_update_daemon_handoff.py
+++ b/tests/test_guard_update_daemon_handoff.py
@@ -1,0 +1,115 @@
+"""Cross-version daemon refresh handoff contracts."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.cli import update_commands
+from codex_plugin_scanner.guard.daemon import manager
+
+
+def test_refresh_script_adapts_to_new_manager_signature(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    guard_home = home_dir / ".hol-guard"
+    _ = guard_home.mkdir(parents=True)
+    _ = (guard_home / "daemon-state.json").write_text('{"port":8123}', encoding="utf-8")
+    observed: dict[str, object] = {}
+
+    def retire(_guard_home: Path) -> list[int]:
+        return [17]
+
+    def no_op(_guard_home: Path) -> None:
+        return None
+
+    monkeypatch.setattr(manager, "retire_all_guard_daemons_for_home", retire)
+    monkeypatch.setattr(manager, "clear_guard_daemon_state", no_op)
+    monkeypatch.setattr(manager, "repair_approval_center_locator", no_op)
+
+    def require_new_parameters(
+        received_guard_home: Path,
+        *,
+        home_dir: Path,
+        preferred_port: int | None = None,
+        allow_windows_job_breakaway: bool = False,
+    ) -> str:
+        observed.update(
+            guard_home=received_guard_home,
+            home_dir=home_dir,
+            preferred_port=preferred_port,
+            allow_windows_job_breakaway=allow_windows_job_breakaway,
+        )
+        return "http://127.0.0.1:8123"
+
+    monkeypatch.setattr(manager, "ensure_guard_daemon_after_update", require_new_parameters)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"guard_home": str(guard_home), "home_dir": str(home_dir)})),
+    )
+
+    refresh_script = cast(str, update_commands.__dict__["_DAEMON_REFRESH_SCRIPT"])
+    exec(refresh_script, {})
+
+    assert observed == {
+        "guard_home": guard_home.resolve(),
+        "home_dir": home_dir.resolve(),
+        "preferred_port": 8123,
+        "allow_windows_job_breakaway": True,
+    }
+    assert json.loads(capsys.readouterr().out) == {
+        "status": "restarted",
+        "retired": [17],
+        "daemon_url": "http://127.0.0.1:8123",
+    }
+
+
+def test_refresh_script_preserves_legacy_manager_signature(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    guard_home = home_dir / ".hol-guard"
+    _ = guard_home.mkdir(parents=True)
+    _ = (guard_home / "daemon-state.json").write_text('{"port":8124}', encoding="utf-8")
+    observed: dict[str, object] = {}
+
+    def retire(_guard_home: Path) -> list[int]:
+        return [18]
+
+    def no_op(_guard_home: Path) -> None:
+        return None
+
+    def legacy_parameters(received_guard_home: Path, *, preferred_port: int | None = None) -> str:
+        observed.update(guard_home=received_guard_home, preferred_port=preferred_port)
+        return "http://127.0.0.1:8124"
+
+    monkeypatch.setattr(manager, "retire_all_guard_daemons_for_home", retire)
+    monkeypatch.setattr(manager, "clear_guard_daemon_state", no_op)
+    monkeypatch.setattr(manager, "repair_approval_center_locator", no_op)
+    monkeypatch.setattr(manager, "ensure_guard_daemon_after_update", legacy_parameters)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"guard_home": str(guard_home), "home_dir": str(home_dir)})),
+    )
+
+    refresh_script = cast(str, update_commands.__dict__["_DAEMON_REFRESH_SCRIPT"])
+    exec(refresh_script, {})
+
+    assert observed == {"guard_home": guard_home.resolve(), "preferred_port": 8124}
+    assert json.loads(capsys.readouterr().out) == {
+        "status": "restarted",
+        "retired": [18],
+        "daemon_url": "http://127.0.0.1:8124",
+    }

--- a/tests/test_guard_update_daemon_handoff.py
+++ b/tests/test_guard_update_daemon_handoff.py
@@ -50,11 +50,15 @@ def test_refresh_script_adapts_to_new_manager_signature(
         )
         return "http://127.0.0.1:8123"
 
+    def process_home(_path_type: type[Path]) -> Path:
+        return home_dir
+
     monkeypatch.setattr(manager, "ensure_guard_daemon_after_update", require_new_parameters)
+    monkeypatch.setattr(Path, "home", classmethod(process_home))
     monkeypatch.setattr(
         sys,
         "stdin",
-        io.StringIO(json.dumps({"guard_home": str(guard_home), "home_dir": str(home_dir)})),
+        io.StringIO(json.dumps({"guard_home": str(guard_home)})),
     )
 
     refresh_script = cast(str, update_commands.__dict__["_DAEMON_REFRESH_SCRIPT"])


### PR DESCRIPTION
## Summary
- pass the trusted home directory through the isolated daemon refresh after package updates
- adapt the retained refresh script to both legacy and newer daemon manager signatures
- preserve Windows process breakaway support when the installed manager exposes it

## Testing
- `uv run --no-sync pytest -q tests/test_guard_update_daemon_handoff.py tests/test_guard_phase03_local_install.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_update_daemon_handoff.py tests/test_guard_phase03_local_install.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_update_daemon_handoff.py tests/test_guard_phase03_local_install.py`
- `uv run --no-sync basedpyright tests/test_guard_update_daemon_handoff.py`
- `git diff --check origin/release/2.2...HEAD`

## Notes
- This fixes future cross-version update handoffs; a process that already executed an older embedded refresh script cannot be changed retroactively.
