### PR TITLE
fix(guard): harden launch identity drift observations

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/launch_identity_binding.py
+++ b/src/codex_plugin_scanner/guard/runtime/launch_identity_binding.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
+import secrets
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
@@ -15,20 +17,54 @@ from ..models import GuardAction
 from ..package_execution_context import PackageExecutionContext, package_execution_context_from_evidence
 from .approval_context import build_runtime_launch_identity, runtime_launch_identity_is_reusable
 from .command_model import CanonicalCommand
+from .command_tokens import leading_environment
 from .effect_contract import ProofRequirement, UncertaintyKind, maximum_action_floor
 
 LAUNCH_IDENTITY_BINDING_VERSION: Final = "1.0.0"
 _SHA256 = re.compile(r"[0-9a-f]{64}")
-_REFERENCE = re.compile(r"[a-z][a-z0-9_-]*:[a-z0-9][a-z0-9._/-]*")
+_REFERENCE = re.compile(r"[a-z][a-z0-9_-]*(?:[.:/][a-z0-9][a-z0-9_-]*)+")
 _VERSION = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+-]{0,127}")
 _MANDATORY_UNCERTAINTIES: Final = frozenset(
     {UncertaintyKind.UNKNOWN_EFFECT, UncertaintyKind.UNRESOLVED_LAUNCH_IDENTITY}
 )
+_PACKAGE_LAUNCHERS: Final = frozenset(
+    {
+        "bun",
+        "bunx",
+        "corepack",
+        "npm",
+        "npx",
+        "pip",
+        "pip3",
+        "pipenv",
+        "pipx",
+        "pnpm",
+        "poetry",
+        "uv",
+        "uvx",
+        "yarn",
+    }
+)
+_PACKAGE_CONTEXT_COMPONENTS: Final = frozenset(
+    {
+        "repository_identity",
+        "workspace_identity",
+        "package_manager_executable",
+        "manifests_and_lockfiles",
+        "registry_and_proxy_configuration",
+        "workspace_configuration",
+        "lifecycle_hooks_overrides_and_patches",
+        "environment_policy",
+    }
+)
+_NON_PORTABLE_PACKAGE_CONTEXT_COMPONENTS: Final = _PACKAGE_CONTEXT_COMPONENTS | {"exact_workspace"}
 
 
 class LaunchBindingDimension(str, Enum):
     COMMAND_STRUCTURE = "command-structure"
     EXECUTABLE_OBSERVATION = "executable-observation"
+    LAUNCH_ENVIRONMENT_OBSERVATION = "launch-environment-observation"
+    REDIRECTION_TARGET_OBSERVATION = "redirection-target-observation"
     WORKSPACE_LOCATION = "workspace-location"
     REPOSITORY_LOCATION = "repository-location"
     WORKING_DIRECTORY_LOCATION = "working-directory-location"
@@ -112,6 +148,13 @@ class LaunchIdentityBindingObservation:
             raise ValueError("uncertainties must be unique and ordered")
         if not set(self.uncertainties) >= _MANDATORY_UNCERTAINTIES:
             raise ValueError("observation-only bindings require launch and effect uncertainty")
+        expected_binding_digest = _binding_digest(
+            dimensions=self.dimensions,
+            required_requirements=self.required_requirements,
+            uncertainties=self.uncertainties,
+        )
+        if self.binding_digest != expected_binding_digest:
+            raise ValueError("binding digest does not match launch binding material")
 
     @property
     def can_issue_positive_proof(self) -> bool:
@@ -144,6 +187,7 @@ _CORE_REQUIREMENTS: Final = frozenset(
         ProofRequirement.WORKING_DIRECTORY_IDENTITY,
         ProofRequirement.EXECUTABLE_IDENTITY,
         ProofRequirement.LAUNCH_CHAIN,
+        ProofRequirement.CONFIGURATION_IDENTITY,
         ProofRequirement.SHELL_DATA_FLOW,
         ProofRequirement.PARSER_CONFIDENCE,
         ProofRequirement.EXPECTED_EFFECTS,
@@ -175,7 +219,7 @@ def observe_launch_identity_binding(
             args=segment.arguments,
             structured_command=True,
             cwd=cwd,
-            launch_env=launch_env,
+            launch_env=_segment_launch_environment(segment.tokens, launch_env),
         )
         for segment in command.segments
     )
@@ -187,12 +231,64 @@ def observe_launch_identity_binding(
         }
         for index, identity in enumerate(runtime_identities)
     ]
+    segment_wrapper_order = tuple(
+        dict.fromkeys(wrapper for segment in command.segments for wrapper in segment.wrapper_chain)
+    )
+    normalization_wrapper_count = len(command.wrapper_chain) - len(segment_wrapper_order)
+    normalization_wrappers = command.wrapper_chain[:normalization_wrapper_count]
+    if normalization_wrapper_count < 0 or command.wrapper_chain[normalization_wrapper_count:] != segment_wrapper_order:
+        executable_material.append(
+            {
+                "segment_index": "unresolved-wrapper-chain",
+                "identity_digest": secrets.token_hex(32),
+                "reusable_observation": False,
+            }
+        )
+        normalization_wrappers = ()
+    for index, wrapper in enumerate(normalization_wrappers):
+        wrapper_identity = build_runtime_launch_identity(
+            wrapper,
+            structured_command=True,
+            cwd=cwd,
+            launch_env=launch_env,
+        )
+        executable_material.append(
+            {
+                "segment_index": f"wrapper:{index}",
+                "identity_digest": _framed_digest("hol-guard.runtime-launch", wrapper_identity),
+                "reusable_observation": runtime_launch_identity_is_reusable(wrapper_identity),
+            }
+        )
+    for segment_index, segment in enumerate(command.segments):
+        segment_environment = _segment_launch_environment(segment.tokens, launch_env)
+        for wrapper_index, wrapper in enumerate(segment.wrapper_chain):
+            wrapper_identity = build_runtime_launch_identity(
+                wrapper,
+                structured_command=True,
+                cwd=cwd,
+                launch_env=segment_environment,
+            )
+            executable_material.append(
+                {
+                    "segment_index": f"segment:{segment_index}:wrapper:{wrapper_index}",
+                    "identity_digest": _framed_digest("hol-guard.runtime-launch", wrapper_identity),
+                    "reusable_observation": runtime_launch_identity_is_reusable(wrapper_identity),
+                }
+            )
     package_material = [_validated_package_observation(context) for context in package_contexts]
     dimensions = tuple(
         sorted(
             (
                 _dimension(LaunchBindingDimension.COMMAND_STRUCTURE, command.security_identity),
                 _dimension(LaunchBindingDimension.EXECUTABLE_OBSERVATION, executable_material),
+                _dimension(
+                    LaunchBindingDimension.LAUNCH_ENVIRONMENT_OBSERVATION,
+                    _launch_environment_material(launch_env),
+                ),
+                _dimension(
+                    LaunchBindingDimension.REDIRECTION_TARGET_OBSERVATION,
+                    _redirection_target_material(command, cwd=cwd),
+                ),
                 _dimension(LaunchBindingDimension.WORKSPACE_LOCATION, str(_resolved(workspace))),
                 _dimension(LaunchBindingDimension.REPOSITORY_LOCATION, str(_resolved(repository))),
                 _dimension(LaunchBindingDimension.WORKING_DIRECTORY_LOCATION, str(cwd)),
@@ -206,23 +302,23 @@ def observe_launch_identity_binding(
         )
     )
     required = set(_CORE_REQUIREMENTS)
-    if package_contexts:
+    if package_contexts or _command_requires_package_context(command):
         required.update({ProofRequirement.DEPENDENCY_PROVENANCE, ProofRequirement.CONFIGURATION_IDENTITY})
     uncertainties = {UncertaintyKind.UNRESOLVED_LAUNCH_IDENTITY, UncertaintyKind.UNKNOWN_EFFECT}
     if command.confidence != "exact" or command.uncertainty_reason is not None:
         uncertainties.add(UncertaintyKind.PARTIAL_PARSE)
-    material = {
-        "schema_version": LAUNCH_IDENTITY_BINDING_VERSION,
-        "dimensions": [(item.dimension.value, item.digest) for item in dimensions],
-        "required_requirements": sorted(item.value for item in required),
-        "uncertainties": sorted(item.value for item in uncertainties),
-    }
+    typed_required = frozenset(required)
+    typed_uncertainties = tuple(sorted(uncertainties, key=lambda item: item.value))
     return LaunchIdentityBindingObservation(
-        binding_digest=_framed_digest("hol-guard.launch-binding-observation", material),
+        binding_digest=_binding_digest(
+            dimensions=dimensions,
+            required_requirements=typed_required,
+            uncertainties=typed_uncertainties,
+        ),
         dimensions=dimensions,
-        required_requirements=frozenset(required),
-        unresolved_requirements=frozenset(required),
-        uncertainties=tuple(sorted(uncertainties, key=lambda item: item.value)),
+        required_requirements=typed_required,
+        unresolved_requirements=typed_required,
+        uncertainties=typed_uncertainties,
     )
 
 
@@ -246,13 +342,107 @@ def changed_launch_binding_dimensions(
 
 def _validated_package_observation(context: PackageExecutionContext) -> dict[str, object]:
     validated = package_execution_context_from_evidence(context.to_evidence())
-    if validated != context:
+    component_names = frozenset(item.name for item in context.components)
+    expected_names = _PACKAGE_CONTEXT_COMPONENTS if context.portable else _NON_PORTABLE_PACKAGE_CONTEXT_COMPONENTS
+    if validated != context or component_names != expected_names:
         return {"status": "invalid"}
     return {
         "status": "portable-observation" if context.portable else "non-portable-observation",
         "context_digest": context.digest,
         "component_digests": sorted((item.name, item.digest) for item in context.components),
     }
+
+
+def _command_requires_package_context(command: CanonicalCommand) -> bool:
+    for segment in command.segments:
+        launch_tokens = (segment.executable, *segment.arguments)
+        if any(
+            token.replace("\\", "/").rsplit("/", 1)[-1].lower() in _PACKAGE_LAUNCHERS
+            for token in launch_tokens
+            if isinstance(token, str)
+        ):
+            return True
+    return False
+
+
+def _launch_environment_material(launch_env: Mapping[str, str] | None) -> dict[str, object]:
+    environment = os.environ if launch_env is None else launch_env
+    raw_environment = cast(Mapping[object, object], cast(object, environment))
+    items = [
+        (name, value) for name, value in raw_environment.items() if isinstance(name, str) and isinstance(value, str)
+    ]
+    if len(items) != len(environment):
+        return {"status": "invalid", "reuse_nonce": secrets.token_hex(16)}
+    return {
+        "status": "observed",
+        "entry_count": len(items),
+        "environment_digest": _framed_digest("hol-guard.launch-environment", sorted(items)),
+    }
+
+
+def _segment_launch_environment(
+    tokens: tuple[str, ...],
+    launch_env: Mapping[str, str] | None,
+) -> dict[str, str]:
+    environment = dict(os.environ if launch_env is None else launch_env)
+    names, executable_index, _wrappers = leading_environment(tokens)
+    assignment_names = frozenset(names)
+    for token in tokens[:executable_index]:
+        name, separator, value = token.partition("=")
+        if separator and name in assignment_names:
+            environment[name] = value
+    return environment
+
+
+def _redirection_target_material(command: CanonicalCommand, *, cwd: Path) -> list[dict[str, object]]:
+    material: list[dict[str, object]] = []
+    for index, redirect in enumerate(command.redirects):
+        target = redirect.target
+        base = {"index": index, "operator": redirect.operator}
+        operator = redirect.operator.lstrip("0123456789")
+        if operator in {"<<", "<<-", "<<<"}:
+            material.append({**base, "status": "inline-input-bound-by-command-structure"})
+            continue
+        if any(marker in target for marker in ("$", "`", "*", "?", "[", "]", "{", "}")):
+            material.append({**base, "status": "dynamic", "reuse_nonce": secrets.token_hex(16)})
+            continue
+        lexical = Path(target).expanduser()
+        if not lexical.is_absolute():
+            lexical = cwd / lexical
+        try:
+            canonical = lexical.resolve(strict=False)
+            observation: dict[str, object] = {
+                **base,
+                "canonical_path": str(canonical),
+                "exists": lexical.exists(),
+                "is_symlink": lexical.is_symlink(),
+                "status": "observed",
+            }
+            if operator == "<":
+                observation["input_identity"] = build_runtime_launch_identity(
+                    str(lexical),
+                    structured_command=True,
+                    cwd=cwd,
+                )["executable"]
+            material.append(observation)
+        except (OSError, RuntimeError, ValueError):
+            material.append({**base, "status": "unresolved", "reuse_nonce": secrets.token_hex(16)})
+    return material
+
+
+def _binding_digest(
+    *,
+    dimensions: tuple[LaunchBindingDimensionDigest, ...],
+    required_requirements: frozenset[ProofRequirement],
+    uncertainties: tuple[UncertaintyKind, ...],
+) -> str:
+    material = {
+        "schema_version": LAUNCH_IDENTITY_BINDING_VERSION,
+        "dimensions": [(item.dimension.value, item.digest) for item in dimensions],
+        "required_requirements": sorted(item.value for item in required_requirements),
+        "uncertainties": sorted(item.value for item in uncertainties),
+    }
+    return _framed_digest("hol-guard.launch-binding-observation", material)
 
 
 def _dimension(dimension: LaunchBindingDimension, material: object) -> LaunchBindingDimensionDigest:

--- a/src/codex_plugin_scanner/guard/runtime/launch_identity_binding.py
+++ b/src/codex_plugin_scanner/guard/runtime/launch_identity_binding.py
@@ -232,7 +232,12 @@ def observe_launch_identity_binding(
         for index, identity in enumerate(runtime_identities)
     ]
     segment_wrapper_order = tuple(
-        dict.fromkeys(wrapper for segment in command.segments for wrapper in segment.wrapper_chain)
+        dict.fromkeys(
+            wrapper
+            for segment in command.segments
+            if segment.execution_context.startswith("top:")
+            for wrapper in segment.wrapper_chain
+        )
     )
     normalization_wrapper_count = len(command.wrapper_chain) - len(segment_wrapper_order)
     normalization_wrappers = command.wrapper_chain[:normalization_wrapper_count]

--- a/src/codex_plugin_scanner/guard/runtime/launch_identity_binding.py
+++ b/src/codex_plugin_scanner/guard/runtime/launch_identity_binding.py
@@ -15,7 +15,11 @@ from typing import Final, cast
 
 from ..models import GuardAction
 from ..package_execution_context import PackageExecutionContext, package_execution_context_from_evidence
-from .approval_context import build_runtime_launch_identity, runtime_launch_identity_is_reusable
+from .approval_context import (
+    build_runtime_executable_identity,
+    build_runtime_launch_identity,
+    runtime_launch_identity_is_reusable,
+)
 from .command_model import CanonicalCommand
 from .command_tokens import leading_environment
 from .effect_contract import ProofRequirement, UncertaintyKind, maximum_action_floor
@@ -251,32 +255,30 @@ def observe_launch_identity_binding(
         )
         normalization_wrappers = ()
     for index, wrapper in enumerate(normalization_wrappers):
-        wrapper_identity = build_runtime_launch_identity(
+        wrapper_identity = build_runtime_executable_identity(
             wrapper,
-            structured_command=True,
+            search_path=_launch_search_path(launch_env),
             cwd=cwd,
-            launch_env=launch_env,
         )
         executable_material.append(
             {
                 "segment_index": f"wrapper:{index}",
-                "identity_digest": _framed_digest("hol-guard.runtime-launch", wrapper_identity),
+                "identity_digest": _wrapper_identity_digest(wrapper_identity),
                 "reusable_observation": runtime_launch_identity_is_reusable(wrapper_identity),
             }
         )
     for segment_index, segment in enumerate(command.segments):
         segment_environment = _segment_launch_environment(segment.tokens, launch_env)
         for wrapper_index, wrapper in enumerate(segment.wrapper_chain):
-            wrapper_identity = build_runtime_launch_identity(
+            wrapper_identity = build_runtime_executable_identity(
                 wrapper,
-                structured_command=True,
+                search_path=_launch_search_path(segment_environment),
                 cwd=cwd,
-                launch_env=segment_environment,
             )
             executable_material.append(
                 {
                     "segment_index": f"segment:{segment_index}:wrapper:{wrapper_index}",
-                    "identity_digest": _framed_digest("hol-guard.runtime-launch", wrapper_identity),
+                    "identity_digest": _wrapper_identity_digest(wrapper_identity),
                     "reusable_observation": runtime_launch_identity_is_reusable(wrapper_identity),
                 }
             )
@@ -397,6 +399,17 @@ def _segment_launch_environment(
         if separator and name in assignment_names:
             environment[name] = value
     return environment
+
+
+def _launch_search_path(launch_env: Mapping[str, str] | None) -> str:
+    environment = os.environ if launch_env is None else launch_env
+    search_path = environment.get("PATH")
+    return search_path if isinstance(search_path, str) else os.defpath
+
+
+def _wrapper_identity_digest(identity: Mapping[str, object]) -> str:
+    stable_material = {key: value for key, value in identity.items() if key != "reuse_nonce"}
+    return _framed_digest("hol-guard.runtime-wrapper-executable", stable_material)
 
 
 def _redirection_target_material(command: CanonicalCommand, *, cwd: Path) -> list[dict[str, object]]:

--- a/tests/test_guard_launch_identity_binding.py
+++ b/tests/test_guard_launch_identity_binding.py
@@ -121,6 +121,14 @@ def test_heredoc_observation_is_deterministic(tmp_path: Path) -> None:
     assert first == second
 
 
+@pytest.mark.skipif(shutil.which("env") is None, reason="env wrapper is unavailable")
+def test_embedded_wrapper_observation_is_deterministic(tmp_path: Path) -> None:
+    command = f"{_ECHO} $(env {_ECHO} nested)"
+    first = _observe(tmp_path, command)
+    second = _observe(tmp_path, command)
+    assert first == second
+
+
 def test_direct_construction_cannot_omit_mandatory_uncertainty_or_requirements(tmp_path: Path) -> None:
     observation = _observe(tmp_path, f"{_ECHO} baseline")
     with pytest.raises(ValueError, match="launch and effect uncertainty"):

--- a/tests/test_guard_launch_identity_binding.py
+++ b/tests/test_guard_launch_identity_binding.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shutil
+import sys
 from dataclasses import replace
 from pathlib import Path
 from typing import cast
@@ -23,8 +25,9 @@ from codex_plugin_scanner.guard.runtime.launch_identity_binding import (
 )
 
 _DIGEST = "a" * 64
-_ECHO = shutil.which("echo") or "/bin/echo"
-_RULES = (RuleVersionBinding("rule:command.test", "1.0.0"),)
+_ECHO = shutil.which("echo") or sys.executable
+_ALTERNATE_EXECUTABLE = shutil.which("true") or shutil.which("git") or sys.executable
+_RULES = (RuleVersionBinding("command.test.launch-identity", "1.0.0"),)
 _PACKAGE_COMPONENT_NAMES = (
     "repository_identity",
     "workspace_identity",
@@ -62,7 +65,8 @@ def _observe(
 
 
 def _package_context(*, component_digest: str = _DIGEST, portable: bool = True) -> PackageExecutionContext:
-    components = tuple(PackageExecutionContextComponent(name, component_digest) for name in _PACKAGE_COMPONENT_NAMES)
+    component_names = _PACKAGE_COMPONENT_NAMES if portable else (*_PACKAGE_COMPONENT_NAMES, "exact_workspace")
+    components = tuple(PackageExecutionContextComponent(name, component_digest) for name in component_names)
     digest = hashlib.sha256(
         json.dumps(
             {
@@ -82,6 +86,13 @@ def _package_context(*, component_digest: str = _DIGEST, portable: bool = True) 
     )
 
 
+def _symlink_or_skip(link: Path, target: str | Path) -> None:
+    try:
+        link.symlink_to(target)
+    except (NotImplementedError, OSError) as error:
+        pytest.skip(f"symlink creation is unavailable: {error}")
+
+
 def test_observation_exposes_no_positive_proof_and_retains_reapproval_floor(tmp_path: Path) -> None:
     observation = _observe(tmp_path, f"{_ECHO} baseline")
     assert not observation.can_issue_positive_proof
@@ -95,6 +106,19 @@ def test_observation_exposes_no_positive_proof_and_retains_reapproval_floor(tmp_
     payload = observation.to_dict()
     assert payload["can_issue_positive_proof"] is False
     assert payload["action_floor"] == "require-reapproval"
+
+
+def test_verified_launch_observation_is_deterministic(tmp_path: Path) -> None:
+    first = _observe(tmp_path, f"{_ECHO} baseline")
+    second = _observe(tmp_path, f"{_ECHO} baseline")
+    assert first == second
+
+
+def test_heredoc_observation_is_deterministic(tmp_path: Path) -> None:
+    command = "cat <<'EOF'\nvalue\nEOF"
+    first = _observe(tmp_path, command)
+    second = _observe(tmp_path, command)
+    assert first == second
 
 
 def test_direct_construction_cannot_omit_mandatory_uncertainty_or_requirements(tmp_path: Path) -> None:
@@ -129,6 +153,12 @@ def test_direct_construction_requires_every_dimension_exactly_once(tmp_path: Pat
         _ = replace(observation, dimensions=observation.dimensions + observation.dimensions[:1])
 
 
+def test_direct_construction_cannot_forge_aggregate_binding_digest(tmp_path: Path) -> None:
+    observation = _observe(tmp_path, f"{_ECHO} baseline")
+    with pytest.raises(ValueError, match="does not match launch binding material"):
+        _ = replace(observation, binding_digest="b" * 64)
+
+
 @pytest.mark.parametrize(
     "changed_command",
     [
@@ -154,14 +184,41 @@ def test_path_symlink_and_executable_drift_rekeys_observation(tmp_path: Path) ->
     first = tmp_path / "first"
     second = tmp_path / "second"
     launcher = tmp_path / "tool"
-    first.symlink_to(_ECHO)
-    second.symlink_to(shutil.which("true") or "/bin/true")
-    launcher.symlink_to(first)
+    _symlink_or_skip(first, _ECHO)
+    _symlink_or_skip(second, _ALTERNATE_EXECUTABLE)
+    _symlink_or_skip(launcher, first)
     command = f"{launcher} baseline"
     baseline = _observe(tmp_path, command)
     launcher.unlink()
-    launcher.symlink_to(second)
+    _symlink_or_skip(launcher, second)
     changed = _observe(tmp_path, command)
+    assert LaunchBindingDimension.EXECUTABLE_OBSERVATION in changed_launch_binding_dimensions(baseline, changed)
+    assert not changed.can_issue_positive_proof
+
+
+def test_redirection_symlink_retarget_rekeys_target_observation(tmp_path: Path) -> None:
+    first = tmp_path / "first-output"
+    second = tmp_path / "second-output"
+    target = tmp_path / "result"
+    _symlink_or_skip(target, first)
+    command = f"{_ECHO} baseline > {target}"
+    baseline = _observe(tmp_path, command)
+    target.unlink()
+    _symlink_or_skip(target, second)
+    changed = _observe(tmp_path, command)
+    assert LaunchBindingDimension.REDIRECTION_TARGET_OBSERVATION in changed_launch_binding_dimensions(baseline, changed)
+    assert not changed.can_issue_positive_proof
+
+
+def test_interpreter_entrypoint_bytes_rekey_executable_observation(tmp_path: Path) -> None:
+    python = shutil.which("python3") or shutil.which("python")
+    if python is None:
+        pytest.skip("Python interpreter is unavailable")
+    script = tmp_path / "task.py"
+    _ = script.write_text("print('first')\n", encoding="utf-8")
+    baseline = _observe(tmp_path, f"{python} {script}")
+    _ = script.write_text("print('second')\n", encoding="utf-8")
+    changed = _observe(tmp_path, f"{python} {script}")
     assert LaunchBindingDimension.EXECUTABLE_OBSERVATION in changed_launch_binding_dimensions(baseline, changed)
     assert not changed.can_issue_positive_proof
 
@@ -171,8 +228,8 @@ def test_inline_path_and_working_directory_drift_are_bound_but_unproven(tmp_path
     second_bin = tmp_path / "second-bin"
     first_bin.mkdir()
     second_bin.mkdir()
-    (first_bin / "tool").symlink_to(_ECHO)
-    (second_bin / "tool").symlink_to(shutil.which("true") or "/bin/true")
+    _symlink_or_skip(first_bin / "tool", _ECHO)
+    _symlink_or_skip(second_bin / "tool", _ALTERNATE_EXECUTABLE)
     baseline = _observe(tmp_path, "tool baseline", launch_env={"PATH": str(first_bin)})
     path_changed = _observe(tmp_path, "tool baseline", launch_env={"PATH": str(second_bin)})
     assert LaunchBindingDimension.EXECUTABLE_OBSERVATION in changed_launch_binding_dimensions(baseline, path_changed)
@@ -182,6 +239,97 @@ def test_inline_path_and_working_directory_drift_are_bound_but_unproven(tmp_path
     changes = changed_launch_binding_dimensions(baseline, cwd_changed)
     assert LaunchBindingDimension.WORKING_DIRECTORY_LOCATION in changes
     assert not cwd_changed.can_issue_positive_proof
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the synthetic PATH launcher probe is POSIX-specific")
+def test_inline_path_resolves_and_binds_actual_executable_bytes(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    executable = bin_dir / "tool"
+    _ = executable.write_bytes(b"first")
+    executable.chmod(0o755)
+    command = f"PATH={bin_dir} tool baseline"
+    baseline = _observe(tmp_path, command, launch_env={"PATH": os.defpath})
+    _ = executable.write_bytes(b"second")
+    changed = _observe(tmp_path, command, launch_env={"PATH": os.defpath})
+    assert LaunchBindingDimension.EXECUTABLE_OBSERVATION in changed_launch_binding_dimensions(baseline, changed)
+    assert not changed.can_issue_positive_proof
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the synthetic PATH launcher probe is POSIX-specific")
+def test_inline_path_resolves_and_binds_wrapper_bytes(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    wrapper = bin_dir / "env"
+    _ = wrapper.write_bytes(b"first")
+    wrapper.chmod(0o755)
+    command = f"PATH={bin_dir} env {_ECHO} baseline"
+    baseline = _observe(tmp_path, command, launch_env={"PATH": os.defpath})
+    repeated = _observe(tmp_path, command, launch_env={"PATH": os.defpath})
+    assert baseline == repeated
+    _ = wrapper.write_bytes(b"second")
+    changed = _observe(tmp_path, command, launch_env={"PATH": os.defpath})
+    assert LaunchBindingDimension.EXECUTABLE_OBSERVATION in changed_launch_binding_dimensions(baseline, changed)
+    assert not changed.can_issue_positive_proof
+
+
+@pytest.mark.parametrize(
+    "name",
+    ("LD_PRELOAD", "DYLD_INSERT_LIBRARIES", "NODE_OPTIONS", "PYTHONPATH", "GIT_SSH_COMMAND", "MAKEFLAGS"),
+)
+def test_launch_influence_environment_drift_rekeys_observation(tmp_path: Path, name: str) -> None:
+    baseline = _observe(tmp_path, f"{_ECHO} baseline", launch_env={"PATH": "", name: "first"})
+    changed = _observe(tmp_path, f"{_ECHO} baseline", launch_env={"PATH": "", name: "second"})
+    assert LaunchBindingDimension.LAUNCH_ENVIRONMENT_OBSERVATION in changed_launch_binding_dimensions(baseline, changed)
+    assert ProofRequirement.CONFIGURATION_IDENTITY in changed.unresolved_requirements
+    assert not changed.can_issue_positive_proof
+
+
+@pytest.mark.parametrize("wrapper", ("env", "sh -c"))
+def test_outer_wrapper_identity_is_bound(tmp_path: Path, wrapper: str) -> None:
+    command = f'{wrapper} "{_ECHO} baseline"' if wrapper == "sh -c" else f"{wrapper} {_ECHO} baseline"
+    observation = _observe(tmp_path, command)
+    executable_dimension = next(
+        item for item in observation.dimensions if item.dimension == LaunchBindingDimension.EXECUTABLE_OBSERVATION
+    )
+    baseline = _observe(tmp_path, f"{_ECHO} baseline")
+    assert executable_dimension.digest != next(
+        item.digest for item in baseline.dimensions if item.dimension == LaunchBindingDimension.EXECUTABLE_OBSERVATION
+    )
+    assert not observation.can_issue_positive_proof
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the synthetic PATH launcher probe is POSIX-specific")
+@pytest.mark.parametrize("wrapper", ("env", "sh"))
+def test_outer_wrapper_path_drift_rekeys_executable_observation(tmp_path: Path, wrapper: str) -> None:
+    first_bin = tmp_path / "first-bin"
+    second_bin = tmp_path / "second-bin"
+    first_bin.mkdir()
+    second_bin.mkdir()
+    for directory, content in ((first_bin, b"first"), (second_bin, b"second")):
+        launcher = directory / wrapper
+        _ = launcher.write_bytes(content)
+        launcher.chmod(0o755)
+    command = f'{wrapper} -c "{_ECHO} baseline"' if wrapper == "sh" else f"{wrapper} {_ECHO} baseline"
+    baseline = _observe(tmp_path, command, launch_env={"PATH": str(first_bin)})
+    changed = _observe(tmp_path, command, launch_env={"PATH": str(second_bin)})
+    assert LaunchBindingDimension.EXECUTABLE_OBSERVATION in changed_launch_binding_dimensions(baseline, changed)
+    assert not changed.can_issue_positive_proof
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the synthetic PATH launcher probe is POSIX-specific")
+def test_retained_wrapper_byte_drift_rekeys_executable_observation(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    wrapper = bin_dir / "sudo"
+    _ = wrapper.write_bytes(b"first")
+    wrapper.chmod(0o755)
+    command = f"sudo {_ECHO} baseline"
+    baseline = _observe(tmp_path, command, launch_env={"PATH": str(bin_dir)})
+    _ = wrapper.write_bytes(b"second")
+    changed = _observe(tmp_path, command, launch_env={"PATH": str(bin_dir)})
+    assert LaunchBindingDimension.EXECUTABLE_OBSERVATION in changed_launch_binding_dimensions(baseline, changed)
+    assert not changed.can_issue_positive_proof
 
 
 def test_partial_parse_adds_typed_uncertainty_without_issuing_proof(tmp_path: Path) -> None:
@@ -197,7 +345,7 @@ def test_policy_rule_and_package_context_drift_rekey_observation(tmp_path: Path)
     rule_changed = _observe(
         tmp_path,
         command,
-        rules=(RuleVersionBinding("rule:command.test", "1.0.1"),),
+        rules=(RuleVersionBinding("command.test.launch-identity", "1.0.1"),),
         package_contexts=(_package_context(),),
     )
     package_changed = _observe(
@@ -217,6 +365,33 @@ def test_policy_rule_and_package_context_drift_rekey_observation(tmp_path: Path)
     assert not baseline.can_issue_positive_proof
 
 
+@pytest.mark.parametrize(
+    "changed_command",
+    (
+        "npx --package tsc@file:./evil tsc --noEmit",
+        "bunx --package ./evil tsc --noEmit",
+        "uvx --from ./evil ruff check .",
+        "python -m pip install --index-url https://packages.invalid/simple demo",
+    ),
+)
+def test_package_aliases_and_explicit_sources_rekey_command_structure(
+    tmp_path: Path,
+    changed_command: str,
+) -> None:
+    baseline = _observe(tmp_path, "npx tsc --noEmit")
+    changed = _observe(tmp_path, changed_command)
+    assert LaunchBindingDimension.COMMAND_STRUCTURE in changed_launch_binding_dimensions(baseline, changed)
+    assert ProofRequirement.DEPENDENCY_PROVENANCE in changed.unresolved_requirements
+    assert ProofRequirement.CONFIGURATION_IDENTITY in changed.unresolved_requirements
+    assert not changed.can_issue_positive_proof
+
+
+def test_real_guard_rule_ids_are_accepted() -> None:
+    assert RuleVersionBinding("command.git.force-clean", "2.2.0").rule_id == "command.git.force-clean"
+    with pytest.raises(ValueError, match="canonical identifiers"):
+        _ = RuleVersionBinding("force-clean", "2.2.0")
+
+
 def test_fabricated_package_context_is_marked_invalid_and_never_proves_provenance(tmp_path: Path) -> None:
     invalid = PackageExecutionContext(
         digest="b" * 64,
@@ -229,11 +404,48 @@ def test_fabricated_package_context_is_marked_invalid_and_never_proves_provenanc
     assert "invalid" not in repr(observation)
 
 
+def test_self_consistent_incomplete_package_context_is_not_labeled_portable(tmp_path: Path) -> None:
+    def incomplete_context(component_digest: str) -> PackageExecutionContext:
+        components = (PackageExecutionContextComponent("foo", component_digest),)
+        digest = hashlib.sha256(
+            json.dumps(
+                {
+                    "components": [{"name": "foo", "digest": component_digest}],
+                    "portable": True,
+                    "version": 2,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        return PackageExecutionContext(digest=digest, portable=True, components=components)
+
+    first = _observe(tmp_path, f"{_ECHO} baseline", package_contexts=(incomplete_context("a" * 64),))
+    second = _observe(tmp_path, f"{_ECHO} baseline", package_contexts=(incomplete_context("b" * 64),))
+    first_package_digest = next(
+        item.digest for item in first.dimensions if item.dimension == LaunchBindingDimension.PACKAGE_CONTEXT_OBSERVATION
+    )
+    second_package_digest = next(
+        item.digest
+        for item in second.dimensions
+        if item.dimension == LaunchBindingDimension.PACKAGE_CONTEXT_OBSERVATION
+    )
+    assert first_package_digest == second_package_digest
+    assert not first.can_issue_positive_proof
+
+
 def test_serialized_observation_contains_no_commands_paths_or_package_values(tmp_path: Path) -> None:
     command = f"{_ECHO} private-value > private-output"
-    observation = _observe(tmp_path, command, package_contexts=(_package_context(),))
+    observation = _observe(
+        tmp_path,
+        command,
+        launch_env={"PATH": os.defpath, "GIT_SSH_COMMAND": "private-environment-value"},
+        package_contexts=(_package_context(),),
+    )
     payload = repr(observation.to_dict())
     assert str(tmp_path) not in payload
     assert command not in payload
     assert "private-value" not in payload
     assert "private-output" not in payload
+    assert "GIT_SSH_COMMAND" not in payload
+    assert "private-environment-value" not in payload

--- a/tests/test_guard_launch_identity_binding.py
+++ b/tests/test_guard_launch_identity_binding.py
@@ -129,6 +129,16 @@ def test_embedded_wrapper_observation_is_deterministic(tmp_path: Path) -> None:
     assert first == second
 
 
+@pytest.mark.skipif(shutil.which("sudo") is None, reason="sudo wrapper is unavailable")
+@pytest.mark.parametrize("embedded", (False, True))
+def test_unreadable_wrapper_observation_is_stable_but_unproven(tmp_path: Path, embedded: bool) -> None:
+    command = f"{_ECHO} $(sudo {_ECHO} nested)" if embedded else f"sudo {_ECHO} baseline"
+    first = _observe(tmp_path, command)
+    second = _observe(tmp_path, command)
+    assert first == second
+    assert not first.can_issue_positive_proof
+
+
 def test_direct_construction_cannot_omit_mandatory_uncertainty_or_requirements(tmp_path: Path) -> None:
     observation = _observe(tmp_path, f"{_ECHO} baseline")
     with pytest.raises(ValueError, match="launch and effect uncertainty"):


### PR DESCRIPTION
## Summary
- bind wrappers and interpreters under their effective PATH, including inline assignments and cleared environments
- bind launch environments opaquely while treating ambiguous shell scope and malformed evidence as non-reusable
- capture redirection target, input, symlink, policy/rule, and package-context drift while retaining unresolved proof requirements and the reapproval floor

## Testing
- `uv run --no-sync pytest -q tests/test_guard_launch_identity_binding.py tests/test_guard_launch_identity_environment.py --tb=short` (60 passed)
- broader launch, approval-context, effect, package-context, and command-model suite (253 passed)
- Ruff check and format check
- BasedPyright: 0 errors, 0 warnings
- independent adversarial review: SHIP (106 targeted probes)
