### PR TITLE
fix(guard): bind cleared launch environments

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/launch_identity_binding.py
+++ b/src/codex_plugin_scanner/guard/runtime/launch_identity_binding.py
@@ -1,10 +1,7 @@
-"""Observation-only launch binding until Guard owns an execution boundary."""
-
 from __future__ import annotations
 
 import hashlib
 import json
-import os
 import re
 import secrets
 from collections.abc import Mapping
@@ -21,8 +18,18 @@ from .approval_context import (
     runtime_launch_identity_is_reusable,
 )
 from .command_model import CanonicalCommand
-from .command_tokens import leading_environment
+from .command_tokens import shell_tokens
 from .effect_contract import ProofRequirement, UncertaintyKind, maximum_action_floor
+from .launch_identity_environment import (
+    LaunchEnvironmentPlan,
+    environment_observation_material,
+    inherited_launch_environment,
+    launch_environment_scope_is_ambiguous,
+    launch_search_path,
+    plan_command_segment_environment,
+    plan_launch_environment,
+    unresolved_launch_observation,
+)
 
 LAUNCH_IDENTITY_BINDING_VERSION: Final = "1.0.0"
 _SHA256 = re.compile(r"[0-9a-f]{64}")
@@ -210,31 +217,11 @@ def observe_launch_identity_binding(
     launch_env: Mapping[str, str] | None = None,
     package_contexts: tuple[PackageExecutionContext, ...] = (),
 ) -> LaunchIdentityBindingObservation:
-    """Build fresh drift evidence without claiming execution or effect authority."""
-
     if _VERSION.fullmatch(policy_version) is None or not rules:
         raise ValueError("policy and rule versions are required")
     if len({item.rule_id for item in rules}) != len(rules):
         raise ValueError("rule bindings must be unique")
     cwd = _resolved(working_directory)
-    runtime_identities = tuple(
-        build_runtime_launch_identity(
-            segment.executable,
-            args=segment.arguments,
-            structured_command=True,
-            cwd=cwd,
-            launch_env=_segment_launch_environment(segment.tokens, launch_env),
-        )
-        for segment in command.segments
-    )
-    executable_material = [
-        {
-            "segment_index": index,
-            "identity_digest": _framed_digest("hol-guard.runtime-launch", identity),
-            "reusable_observation": runtime_launch_identity_is_reusable(identity),
-        }
-        for index, identity in enumerate(runtime_identities)
-    ]
     segment_wrapper_order = tuple(
         dict.fromkeys(
             wrapper
@@ -245,19 +232,78 @@ def observe_launch_identity_binding(
     )
     normalization_wrapper_count = len(command.wrapper_chain) - len(segment_wrapper_order)
     normalization_wrappers = command.wrapper_chain[:normalization_wrapper_count]
-    if normalization_wrapper_count < 0 or command.wrapper_chain[normalization_wrapper_count:] != segment_wrapper_order:
-        executable_material.append(
-            {
-                "segment_index": "unresolved-wrapper-chain",
-                "identity_digest": secrets.token_hex(32),
-                "reusable_observation": False,
-            }
-        )
+    wrapper_chain_complete = (
+        normalization_wrapper_count >= 0
+        and command.wrapper_chain[normalization_wrapper_count:] == segment_wrapper_order
+    )
+    if not wrapper_chain_complete:
         normalization_wrappers = ()
+    inherited_plan = inherited_launch_environment(launch_env)
+    inherited_environment = inherited_plan.executable_environment
+    raw_tokens, _raw_tokens_exact = shell_tokens(command.raw_text)
+    raw_plan = (
+        plan_launch_environment(raw_tokens, inherited_environment, inherited_complete=inherited_plan.complete)
+        if command.raw_text != command.normalized_text
+        else inherited_plan
+    )
+    first_top_level_index = next(
+        (index for index, segment in enumerate(command.segments) if segment.execution_context.startswith("top:")),
+        None,
+    )
+    script_scope_ambiguous = launch_environment_scope_is_ambiguous(normalization_wrappers, len(command.segments))
+    planned_segments = tuple(
+        plan_command_segment_environment(
+            segment,
+            command.embedded_commands,
+            (
+                raw_plan.executable_environment
+                if command.raw_text != command.normalized_text and index == first_top_level_index
+                else inherited_environment
+            ),
+        )
+        for index, segment in enumerate(command.segments)
+    )
+    segment_plans = tuple(
+        LaunchEnvironmentPlan(
+            plan.executable_environment,
+            plan.wrapper_environments,
+            inherited_plan.complete and plan.complete and not script_scope_ambiguous,
+        )
+        for plan in planned_segments
+    )
+    runtime_identities = tuple(
+        build_runtime_launch_identity(
+            segment.executable,
+            args=segment.arguments,
+            structured_command=True,
+            cwd=cwd,
+            launch_env=plan.executable_environment,
+        )
+        for segment, plan in zip(command.segments, segment_plans, strict=True)
+    )
+    executable_material: list[dict[str, object]] = [
+        {
+            "segment_index": index,
+            "identity_digest": _framed_digest("hol-guard.runtime-launch", identity),
+            "reusable_observation": runtime_launch_identity_is_reusable(identity),
+        }
+        for index, identity in enumerate(runtime_identities)
+    ]
+    if not wrapper_chain_complete:
+        executable_material.append(unresolved_launch_observation("unresolved-wrapper-chain"))
+    if script_scope_ambiguous:
+        executable_material.append(unresolved_launch_observation("unresolved-script-environment-scope"))
+    raw_wrapper_environments = list(raw_plan.wrapper_environments)
     for index, wrapper in enumerate(normalization_wrappers):
+        wrapper_environment = raw_plan.executable_environment
+        for wrapper_environment_index, candidate in enumerate(raw_wrapper_environments):
+            if candidate.name == wrapper:
+                wrapper_environment = candidate.environment
+                del raw_wrapper_environments[wrapper_environment_index]
+                break
         wrapper_identity = build_runtime_executable_identity(
             wrapper,
-            search_path=_launch_search_path(launch_env),
+            search_path=launch_search_path(wrapper_environment),
             cwd=cwd,
         )
         executable_material.append(
@@ -267,12 +313,15 @@ def observe_launch_identity_binding(
                 "reusable_observation": runtime_launch_identity_is_reusable(wrapper_identity),
             }
         )
-    for segment_index, segment in enumerate(command.segments):
-        segment_environment = _segment_launch_environment(segment.tokens, launch_env)
+    for segment_index, (segment, plan) in enumerate(zip(command.segments, segment_plans, strict=True)):
         for wrapper_index, wrapper in enumerate(segment.wrapper_chain):
+            if wrapper_index >= len(plan.wrapper_environments):
+                executable_material.append(unresolved_launch_observation(f"segment:{segment_index}:wrapper-unresolved"))
+                continue
+            wrapper_environment = plan.wrapper_environments[wrapper_index].environment
             wrapper_identity = build_runtime_executable_identity(
                 wrapper,
-                search_path=_launch_search_path(segment_environment),
+                search_path=launch_search_path(wrapper_environment),
                 cwd=cwd,
             )
             executable_material.append(
@@ -283,6 +332,13 @@ def observe_launch_identity_binding(
                 }
             )
     package_material = [_validated_package_observation(context) for context in package_contexts]
+    environment_plans = [*segment_plans]
+    for plan in (raw_plan, *segment_plans):
+        environment_plans.extend(
+            LaunchEnvironmentPlan(wrapper.environment, (), plan.complete) for wrapper in plan.wrapper_environments
+        )
+    if not environment_plans:
+        environment_plans.append(raw_plan)
     dimensions = tuple(
         sorted(
             (
@@ -290,7 +346,7 @@ def observe_launch_identity_binding(
                 _dimension(LaunchBindingDimension.EXECUTABLE_OBSERVATION, executable_material),
                 _dimension(
                     LaunchBindingDimension.LAUNCH_ENVIRONMENT_OBSERVATION,
-                    _launch_environment_material(launch_env),
+                    environment_observation_material(tuple(environment_plans)),
                 ),
                 _dimension(
                     LaunchBindingDimension.REDIRECTION_TARGET_OBSERVATION,
@@ -370,41 +426,6 @@ def _command_requires_package_context(command: CanonicalCommand) -> bool:
         ):
             return True
     return False
-
-
-def _launch_environment_material(launch_env: Mapping[str, str] | None) -> dict[str, object]:
-    environment = os.environ if launch_env is None else launch_env
-    raw_environment = cast(Mapping[object, object], cast(object, environment))
-    items = [
-        (name, value) for name, value in raw_environment.items() if isinstance(name, str) and isinstance(value, str)
-    ]
-    if len(items) != len(environment):
-        return {"status": "invalid", "reuse_nonce": secrets.token_hex(16)}
-    return {
-        "status": "observed",
-        "entry_count": len(items),
-        "environment_digest": _framed_digest("hol-guard.launch-environment", sorted(items)),
-    }
-
-
-def _segment_launch_environment(
-    tokens: tuple[str, ...],
-    launch_env: Mapping[str, str] | None,
-) -> dict[str, str]:
-    environment = dict(os.environ if launch_env is None else launch_env)
-    names, executable_index, _wrappers = leading_environment(tokens)
-    assignment_names = frozenset(names)
-    for token in tokens[:executable_index]:
-        name, separator, value = token.partition("=")
-        if separator and name in assignment_names:
-            environment[name] = value
-    return environment
-
-
-def _launch_search_path(launch_env: Mapping[str, str] | None) -> str:
-    environment = os.environ if launch_env is None else launch_env
-    search_path = environment.get("PATH")
-    return search_path if isinstance(search_path, str) else os.defpath
 
 
 def _wrapper_identity_digest(identity: Mapping[str, object]) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/launch_identity_environment.py
+++ b/src/codex_plugin_scanner/guard/runtime/launch_identity_environment.py
@@ -1,0 +1,186 @@
+"""Side-effect-free effective environment plans for launch observations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import cast
+
+from .command_model import CommandSegment
+from .command_structure import EmbeddedCommand
+from .command_tokens import executable_name, leading_environment, shell_tokens
+
+_ENVIRONMENT_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_SCRIPT_SCOPE_WRAPPERS = frozenset({"ash", "bash", "bash.exe", "dash", "fish", "ksh", "sh", "sh.exe", "zsh"})
+
+
+@dataclass(frozen=True, slots=True)
+class WrapperLaunchEnvironment:
+    name: str
+    environment: dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class LaunchEnvironmentPlan:
+    executable_environment: dict[str, str]
+    wrapper_environments: tuple[WrapperLaunchEnvironment, ...]
+    complete: bool
+
+
+def inherited_launch_environment(launch_env: Mapping[str, str] | None) -> LaunchEnvironmentPlan:
+    environment = os.environ if launch_env is None else launch_env
+    raw_environment = cast(Mapping[object, object], cast(object, environment))
+    items = [
+        (name, value) for name, value in raw_environment.items() if isinstance(name, str) and isinstance(value, str)
+    ]
+    return LaunchEnvironmentPlan(dict(items), (), len(items) == len(environment))
+
+
+def plan_launch_environment(
+    tokens: tuple[str, ...],
+    inherited: Mapping[str, str],
+    *,
+    inherited_complete: bool = True,
+) -> LaunchEnvironmentPlan:
+    """Apply leading assignments and static ``env`` controls in shell order."""
+
+    environment = dict(inherited)
+    _names, executable_index, wrappers = leading_environment(tokens)
+    wrapper_environments: list[WrapperLaunchEnvironment] = []
+    wrapper_index = 0
+    env_options = False
+    complete = inherited_complete
+    index = 0
+    while index < executable_index:
+        token = tokens[index]
+        name, separator, value = token.partition("=")
+        if separator and _ENVIRONMENT_NAME.fullmatch(name) is not None:
+            environment[name] = value
+            index += 1
+            continue
+        command_name = executable_name(token)
+        if wrapper_index < len(wrappers) and command_name == wrappers[wrapper_index]:
+            wrapper_environments.append(WrapperLaunchEnvironment(wrappers[wrapper_index], dict(environment)))
+            wrapper_index += 1
+            env_options = command_name == "env"
+            index += 1
+            continue
+        if not env_options:
+            index += 1
+            continue
+        if token in {"-i", "--ignore-environment"}:
+            environment.clear()
+            index += 1
+            continue
+        if token in {"-u", "--unset"}:
+            if index + 1 >= executable_index:
+                complete = False
+                break
+            _ = environment.pop(tokens[index + 1], None)
+            index += 2
+            continue
+        if token.startswith("--unset="):
+            _ = environment.pop(token.split("=", 1)[1], None)
+            index += 1
+            continue
+        if token in {"-C", "--chdir"}:
+            if index + 1 >= executable_index:
+                complete = False
+                break
+            index += 2
+            continue
+        if token.startswith("--chdir="):
+            index += 1
+            continue
+        if token == "--":
+            env_options = False
+            index += 1
+            continue
+        if token.startswith("-"):
+            complete = False
+        index += 1
+    if env_options and executable_index < len(tokens) and tokens[executable_index].startswith("-"):
+        complete = False
+    if wrapper_index != len(wrappers):
+        complete = False
+        for wrapper in wrappers[wrapper_index:]:
+            wrapper_environments.append(WrapperLaunchEnvironment(wrapper, dict(environment)))
+    return LaunchEnvironmentPlan(environment, tuple(wrapper_environments), complete)
+
+
+def plan_command_segment_environment(
+    segment: CommandSegment,
+    embedded_commands: tuple[EmbeddedCommand, ...],
+    inherited: Mapping[str, str],
+) -> LaunchEnvironmentPlan:
+    embedded = next(
+        (item for item in embedded_commands if segment.execution_context.startswith(f"{item.execution_context}:")),
+        None,
+    )
+    if embedded is None:
+        return plan_launch_environment(segment.tokens, inherited)
+    embedded_tokens, _exact = shell_tokens(embedded.text)
+    outer = plan_launch_environment(embedded_tokens, inherited)
+    normalized = plan_launch_environment(segment.tokens, outer.executable_environment)
+    return LaunchEnvironmentPlan(
+        normalized.executable_environment,
+        (*outer.wrapper_environments, *normalized.wrapper_environments),
+        outer.complete and normalized.complete,
+    )
+
+
+def launch_search_path(environment: Mapping[str, str]) -> str:
+    search_path = environment.get("PATH")
+    return search_path if isinstance(search_path, str) else os.defpath
+
+
+def launch_environment_scope_is_ambiguous(wrappers: tuple[str, ...], segment_count: int) -> bool:
+    return segment_count > 1 and any(wrapper in _SCRIPT_SCOPE_WRAPPERS for wrapper in wrappers)
+
+
+def unresolved_launch_observation(segment_index: str) -> dict[str, object]:
+    return {
+        "segment_index": segment_index,
+        "identity_digest": secrets.token_hex(32),
+        "reusable_observation": False,
+    }
+
+
+def environment_observation_material(
+    plans: tuple[LaunchEnvironmentPlan, ...],
+) -> list[dict[str, object]]:
+    material: list[dict[str, object]] = []
+    for index, plan in enumerate(plans):
+        payload = json.dumps(
+            sorted(plan.executable_environment.items()),
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+        material.append(
+            {
+                "index": index,
+                "complete": plan.complete,
+                "entry_count": len(plan.executable_environment),
+                "environment_digest": hashlib.sha256(b"hol-guard.launch-environment\x00" + payload).hexdigest(),
+                **({"reuse_nonce": secrets.token_hex(16)} if not plan.complete else {}),
+            }
+        )
+    return material
+
+
+__all__ = [
+    "LaunchEnvironmentPlan",
+    "WrapperLaunchEnvironment",
+    "environment_observation_material",
+    "inherited_launch_environment",
+    "launch_environment_scope_is_ambiguous",
+    "launch_search_path",
+    "plan_command_segment_environment",
+    "plan_launch_environment",
+    "unresolved_launch_observation",
+]

--- a/src/codex_plugin_scanner/guard/runtime/launch_identity_environment.py
+++ b/src/codex_plugin_scanner/guard/runtime/launch_identity_environment.py
@@ -34,7 +34,7 @@ class LaunchEnvironmentPlan:
 
 def inherited_launch_environment(launch_env: Mapping[str, str] | None) -> LaunchEnvironmentPlan:
     environment = os.environ if launch_env is None else launch_env
-    raw_environment = cast(Mapping[object, object], cast(object, environment))
+    raw_environment = cast(Mapping[object, object], environment)
     items = [
         (name, value) for name, value in raw_environment.items() if isinstance(name, str) and isinstance(value, str)
     ]

--- a/tests/test_guard_launch_identity_environment.py
+++ b/tests/test_guard_launch_identity_environment.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from collections.abc import Mapping
+from dataclasses import replace
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.command_model import parse_shell_command
+from codex_plugin_scanner.guard.runtime.launch_identity_binding import (
+    LaunchBindingDimension,
+    RuleVersionBinding,
+    changed_launch_binding_dimensions,
+    observe_launch_identity_binding,
+)
+from codex_plugin_scanner.guard.runtime.launch_identity_environment import plan_launch_environment
+
+_ECHO = shutil.which("echo") or sys.executable
+_SH = shutil.which("sh")
+_RULES = (RuleVersionBinding("command.test.launch-environment", "1.0.0"),)
+
+
+def test_env_ignore_environment_clears_inherited_values() -> None:
+    inherited = {"PATH": "/inherited", "TOKEN": "private"}
+    plan = plan_launch_environment(("env", "-i", "tool"), inherited)
+
+    assert plan.complete
+    assert plan.executable_environment == {}
+    assert plan.wrapper_environments[0].environment == inherited
+
+
+def test_env_ignore_environment_applies_following_assignments() -> None:
+    plan = plan_launch_environment(
+        ("env", "--ignore-environment", "PATH=/reviewed", "MODE=safe", "tool"),
+        {"PATH": "/inherited", "TOKEN": "private"},
+    )
+
+    assert plan.complete
+    assert plan.executable_environment == {"PATH": "/reviewed", "MODE": "safe"}
+
+
+@pytest.mark.parametrize("unset_args", (("-u", "TOKEN"), ("--unset", "TOKEN"), ("--unset=TOKEN",)))
+def test_env_unset_removes_inherited_value(unset_args: tuple[str, ...]) -> None:
+    plan = plan_launch_environment(("env", *unset_args, "tool"), {"PATH": "/bin", "TOKEN": "private"})
+
+    assert plan.complete
+    assert plan.executable_environment == {"PATH": "/bin"}
+
+
+@pytest.mark.parametrize("option", ("--bad", "-Z", "-S", "--debug"))
+def test_unsupported_env_option_is_incomplete(option: str) -> None:
+    plan = plan_launch_environment(("env", option, "tool"), {"PATH": "/bin"})
+
+    assert not plan.complete
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the synthetic PATH launcher probe is POSIX-specific")
+def test_cleared_environment_assignment_binds_actual_executable(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    executable = bin_dir / "tool"
+    _ = executable.write_bytes(b"first")
+    executable.chmod(0o755)
+    command = parse_shell_command(
+        f"env --ignore-environment PATH={bin_dir} tool",
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    def observe():
+        return observe_launch_identity_binding(
+            command=command,
+            workspace=tmp_path,
+            repository=tmp_path,
+            working_directory=tmp_path,
+            policy_version="policy-v1",
+            rules=_RULES,
+            launch_env={"PATH": os.defpath, "TOKEN": "private"},
+        )
+
+    baseline = observe()
+    _ = executable.write_bytes(b"second")
+    changed = observe()
+    assert LaunchBindingDimension.EXECUTABLE_OBSERVATION in changed_launch_binding_dimensions(baseline, changed)
+    assert not changed.can_issue_positive_proof
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the synthetic PATH launcher probe is POSIX-specific")
+@pytest.mark.parametrize("prefix", ("env -i", "env PATH=/missing"))
+def test_leading_env_wrapper_does_not_leak_into_shell_sibling(tmp_path: Path, prefix: str) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    executable = bin_dir / "tool"
+    _ = executable.write_bytes(b"first")
+    executable.chmod(0o755)
+    command = parse_shell_command(
+        f"{prefix} {_ECHO} first && tool",
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    def observe():
+        return observe_launch_identity_binding(
+            command=command,
+            workspace=tmp_path,
+            repository=tmp_path,
+            working_directory=tmp_path,
+            policy_version="policy-v1",
+            rules=_RULES,
+            launch_env={"PATH": str(bin_dir)},
+        )
+
+    baseline = observe()
+    assert baseline == observe()
+    _ = executable.write_bytes(b"second")
+    changed = observe()
+    assert LaunchBindingDimension.EXECUTABLE_OBSERVATION in changed_launch_binding_dimensions(baseline, changed)
+
+
+@pytest.mark.skipif(_SH is None or os.name == "nt", reason="the shell-scope probe is POSIX-specific")
+@pytest.mark.parametrize(
+    "command_text",
+    (
+        "env -i {shell} -c '{echo} inside && tool'",
+        "env -i {shell} -c '{echo} inside' && tool",
+    ),
+)
+def test_normalized_multi_segment_shell_scope_is_nonreusable(tmp_path: Path, command_text: str) -> None:
+    assert _SH is not None
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    executable = bin_dir / "tool"
+    _ = executable.write_bytes(b"first")
+    executable.chmod(0o755)
+    command = parse_shell_command(
+        command_text.format(shell=_SH, echo=_ECHO),
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    def observe():
+        return observe_launch_identity_binding(
+            command=command,
+            workspace=tmp_path,
+            repository=tmp_path,
+            working_directory=tmp_path,
+            policy_version="policy-v1",
+            rules=_RULES,
+            launch_env={"PATH": str(bin_dir)},
+        )
+
+    baseline = observe()
+    repeated = observe()
+    assert LaunchBindingDimension.EXECUTABLE_OBSERVATION in changed_launch_binding_dimensions(baseline, repeated)
+    assert not baseline.can_issue_positive_proof
+    assert baseline.required_requirements == baseline.unresolved_requirements
+
+
+def test_env_clear_command_remains_unproven(tmp_path: Path) -> None:
+    command = parse_shell_command(f"env -i {_ECHO} baseline", cwd=tmp_path, home_dir=tmp_path)
+    observation = observe_launch_identity_binding(
+        command=command,
+        workspace=tmp_path,
+        repository=tmp_path,
+        working_directory=tmp_path,
+        policy_version="policy-v1",
+        rules=_RULES,
+        launch_env={"PATH": os.defpath, "TOKEN": "private"},
+    )
+    assert not observation.can_issue_positive_proof
+    assert observation.required_requirements == observation.unresolved_requirements
+
+
+def test_inconsistent_wrapper_evidence_is_nonreusable_instead_of_crashing(tmp_path: Path) -> None:
+    parsed = parse_shell_command(f"{_ECHO} baseline", cwd=tmp_path, home_dir=tmp_path)
+    forged_segment = replace(parsed.segments[0], wrapper_chain=("sudo",))
+    forged = replace(parsed, segments=(forged_segment,), wrapper_chain=())
+
+    def observe():
+        return observe_launch_identity_binding(
+            command=forged,
+            workspace=tmp_path,
+            repository=tmp_path,
+            working_directory=tmp_path,
+            policy_version="policy-v1",
+            rules=_RULES,
+        )
+
+    first = observe()
+    second = observe()
+    assert LaunchBindingDimension.EXECUTABLE_OBSERVATION in changed_launch_binding_dimensions(first, second)
+    assert not first.can_issue_positive_proof
+
+
+def test_malformed_inherited_environment_is_incomplete_and_nonreusable(tmp_path: Path) -> None:
+    malformed = cast(Mapping[str, str], cast(object, {"PATH": 7, 8: "invalid"}))
+    command = parse_shell_command("echo baseline", cwd=tmp_path, home_dir=tmp_path)
+
+    def observe():
+        return observe_launch_identity_binding(
+            command=command,
+            workspace=tmp_path,
+            repository=tmp_path,
+            working_directory=tmp_path,
+            policy_version="policy-v1",
+            rules=_RULES,
+            launch_env=malformed,
+        )
+
+    first = observe()
+    second = observe()
+    assert LaunchBindingDimension.LAUNCH_ENVIRONMENT_OBSERVATION in changed_launch_binding_dimensions(first, second)
+    assert not first.can_issue_positive_proof


### PR DESCRIPTION
## Summary
- bind wrappers and interpreters under their effective PATH, including inline assignments and cleared environments
- bind launch environments opaquely while treating ambiguous shell scope and malformed evidence as non-reusable
- capture redirection target, input, symlink, policy/rule, and package-context drift while retaining unresolved proof requirements and the reapproval floor

## Testing
- `uv run --no-sync pytest -q tests/test_guard_launch_identity_binding.py tests/test_guard_launch_identity_environment.py --tb=short` (60 passed)
- broader launch, approval-context, effect, package-context, and command-model suite (253 passed)
- Ruff check and format check
- BasedPyright: 0 errors, 0 warnings
- independent adversarial review: SHIP (106 targeted probes)
- exact TestPyPI canary `2.0.1116.dev24667736619082` installed and verified from site-packages
