### PR TITLE
fix(codex): enforce native shell hook boundary

### DIFF
--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -48,7 +48,7 @@ For security reviews, sales conversations, and GRC packets, see the
    hol-guard install codex
    ```
 
-   For Codex, install now enables Guard-owned `PreToolUse` Bash hooks in `.codex/hooks.json` and turns on the Codex hooks feature. That native hook path still runs when Codex itself is in YOLO mode, so Guard can pause sensitive Bash commands before execution instead of forcing a slower Codex approval mode.
+   For Codex, install enables Guard-owned `PreToolUse` and `PermissionRequest` hooks in `.codex/config.toml` and turns on the Codex hooks feature. `PreToolUse` receives the complete Bash tool command before a shell starts, so shell startup files, debug traps, and shell options are not part of the enforcement boundary. `hol-guard run codex` refuses to launch if those native hooks are missing or disabled.
 
    After upgrading later, run `hol-guard update` to update the installed `hol-guard` package in that environment.
 
@@ -415,7 +415,7 @@ For a real Codex canary, point `~/.codex/config.toml` or `<workspace>/.codex/con
 Guard now has three real runtime paths for Codex:
 
 1. native Codex Bash tool calls
-   Guard installs a Codex `PreToolUse` hook in `.codex/hooks.json`, so sensitive Bash commands are denied before they run and routed into HOL Guard approval
+   Guard installs a Codex `PreToolUse` hook in `.codex/config.toml`, so the complete outer command is evaluated and sensitive Bash commands are denied before any shell code runs; legacy Bash/zsh/fish trap and startup-profile controls are removed during install or repair
 2. interactive Codex CLI and Codex App MCP tool calls
    Guard sends an MCP `elicitation/create` approval request, so the user can approve or deny in the same Codex chat
 3. noninteractive Codex runs such as `codex exec`

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -8,9 +8,11 @@ Current Guard support in this repo:
 
 - `codex`
   - detects global and project `config.toml`
-  - detects Guard-managed `.codex/hooks.json` Bash hook entries
+  - detects Guard-managed native hook entries in `.codex/config.toml` and migrates legacy `.codex/hooks.json` entries
   - parses configured MCP servers
-  - installs Guard-owned Codex `PreToolUse` Bash hooks so native shell commands can be denied before execution even when Codex itself is running in YOLO mode
+  - installs Guard-owned Codex `PreToolUse` and `PermissionRequest` hooks as the authoritative complete-command boundary, so native shell commands can be denied before execution even when Codex itself is running in YOLO mode
+  - does not install Bash DEBUG traps, zsh debug traps, fish preexec handlers, `BASH_ENV`, or shell profile blocks; install and repair remove previously managed copies without changing unrelated profile bytes
+  - refuses wrapper-mode launch when the authoritative native hooks are missing or disabled
   - serializes package-manager shell intent, package metadata, and the final pre-execution Guard result into the shared runtime envelope before Guard queues or blocks the action
   - supports wrapper-mode `guard run codex`
   - wrapper prompt screening now suppresses copied debug and incident context while still escalating risky prompt intent

--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -25,6 +25,7 @@ class HarnessContext:
     workspace_dir: Path | None
     guard_home: Path
     executable_overrides: Mapping[str, str] = field(default_factory=dict[str, str])
+    home_override_explicit: bool = False
 
 
 def _json_payload(path: Path) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -316,7 +316,7 @@ def _hook_command_parts_for_home_mode(
 def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
     return _hook_command_parts_for_home_mode(
         context,
-        home_is_current=context.home_dir.resolve() == Path.home().resolve(),
+        home_is_current=(not context.home_override_explicit and context.home_dir.resolve() == Path.home().resolve()),
         python_executable=_guard_python_executable(),
     )
 
@@ -649,16 +649,13 @@ def _hook_command_matches_current_boundary(command: object, context: HarnessCont
             return False
     except OSError:
         return False
-    current_home_mode = context.home_dir.resolve() == Path.home().resolve()
-    for home_is_current in (current_home_mode, not current_home_mode):
-        expected_tokens = _hook_command_parts_for_home_mode(
-            context,
-            home_is_current=home_is_current,
-            python_executable=tokens[0],
-        )
-        if tuple(tokens) == expected_tokens:
-            return True
-    return False
+    home_is_current = not context.home_override_explicit and context.home_dir.resolve() == Path.home().resolve()
+    expected_tokens = _hook_command_parts_for_home_mode(
+        context,
+        home_is_current=home_is_current,
+        python_executable=tokens[0],
+    )
+    return tuple(tokens) == expected_tokens
 
 
 def _is_current_managed_hook_group(

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -266,6 +266,22 @@ def _guard_python_executable() -> str:
     return str(Path(sys.executable).expanduser().absolute())
 
 
+def _home_is_current(context: HarnessContext) -> bool:
+    return not context.home_override_explicit and context.home_dir.resolve() == Path.home().resolve()
+
+
+def _runtime_guard_home(context: HarnessContext) -> Path:
+    return resolve_guard_home() if _home_is_current(context) else context.guard_home
+
+
+def _local_hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
+    return _local_hook_command_parts_for_home_mode(
+        context,
+        home_is_current=_home_is_current(context),
+        python_executable=_guard_python_executable(),
+    )
+
+
 def _daemon_start_command(guard_home: Path, *, python_executable: str = sys.executable) -> tuple[str, ...]:
     package_root = Path(__file__).resolve().parents[3]
     code = (
@@ -316,7 +332,7 @@ def _hook_command_parts_for_home_mode(
 def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
     return _hook_command_parts_for_home_mode(
         context,
-        home_is_current=(not context.home_override_explicit and context.home_dir.resolve() == Path.home().resolve()),
+        home_is_current=_home_is_current(context),
         python_executable=_guard_python_executable(),
     )
 
@@ -447,7 +463,10 @@ def _hook_manifest_spec(context: HarnessContext) -> CodexHookManifestSpec:
         package_version=__version__,
         packaged_file_paths=_hook_packaged_file_paths(),
         fallback_argv=_local_hook_command_parts(context),
-        daemon_start_argv=_daemon_start_command(_runtime_guard_home(context)),
+        daemon_start_argv=_daemon_start_command(
+            _runtime_guard_home(context),
+            python_executable=_guard_python_executable(),
+        ),
         event_bindings=tuple(_manifest_event_bindings(context)),
     )
 
@@ -639,7 +658,7 @@ def _is_managed_hook_group(group: object) -> bool:
 
 
 def _hook_command_matches_current_boundary(command: object, context: HarnessContext) -> bool:
-    tokens = _split_hook_command(command)
+    tokens = split_hook_command(command)
     if tokens is None or len(tokens) != 3:
         return False
     try:
@@ -1600,7 +1619,9 @@ class CodexHarnessAdapter(HarnessAdapter):
             state = codex_native_hook_state(context)
             if not bool(state.get("protection_active")):
                 reason = str(state.get("integrity_reason") or "codex_hook_integrity_readback_failed")
-                raise RuntimeError(f"Codex hook authentication readback failed: {reason}")
+                raise RuntimeError(
+                    f"{_AUTHORITATIVE_HOOK_UNAVAILABLE_REASON}: Codex hook authentication readback failed: {reason}"
+                )
             return state
         except BaseException:
             rollback_error: BaseException | None = None
@@ -1620,7 +1641,6 @@ class CodexHarnessAdapter(HarnessAdapter):
                     "Codex hook transaction failed and rollback could not be completed."
                 ) from rollback_error
             raise
-
 
     @staticmethod
     def _uninstall_shell_guard(context: HarnessContext) -> None:

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -11,7 +11,7 @@ import sys
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlencode
 
 from ...version import __version__
@@ -201,6 +201,8 @@ _CODEX_GUARD_TOOL_MATCHER = "Bash|Read|Write|Edit|MultiEdit|^apply_patch$|mcp__.
 _CODEX_GUARD_PERMISSION_MATCHER = "Bash|Read|Write|Edit|MultiEdit|^apply_patch$|mcp__.*"
 _SHELL_GUARD_BEGIN = "# >>> HOL Guard Codex shell guard >>>"
 _SHELL_GUARD_END = "# <<< HOL Guard Codex shell guard <<<"
+_AUTHORITATIVE_ENFORCEMENT_BOUNDARY = "codex-native-hooks"
+_AUTHORITATIVE_HOOK_UNAVAILABLE_REASON = "codex_authoritative_hook_unavailable"
 _DAEMON_BRIDGE_PATH_SUFFIX = (
     "codex_plugin_scanner",
     "guard",
@@ -237,22 +239,25 @@ def _strict_json_object(path: Path, *, label: str) -> dict[str, object]:
     return payload
 
 
-def _local_hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
-    resolved_home = context.home_dir.resolve()
-    resolved_user_home = Path.home().resolve()
+def _local_hook_command_parts_for_home_mode(
+    context: HarnessContext,
+    *,
+    home_is_current: bool,
+    python_executable: str,
+) -> tuple[str, ...]:
     guard_args = [
         "guard",
         "hook",
         "--harness",
         "codex",
     ]
-    if resolved_home != resolved_user_home:
+    if not home_is_current:
         guard_args.extend(["--home", str(context.home_dir)])
-        if context.guard_home.resolve() != resolved_home:
+        if context.guard_home.resolve() != context.home_dir.resolve():
             guard_args.extend(["--guard-home", str(context.guard_home)])
     if context.workspace_dir is not None:
         guard_args.extend(["--workspace", str(context.workspace_dir)])
-    return (_guard_python_executable(), "-m", "codex_plugin_scanner.cli", *guard_args)
+    return (python_executable, "-m", "codex_plugin_scanner.cli", *guard_args)
 
 
 def _guard_python_executable() -> str:
@@ -261,13 +266,7 @@ def _guard_python_executable() -> str:
     return str(Path(sys.executable).expanduser().absolute())
 
 
-def _runtime_guard_home(context: HarnessContext) -> Path:
-    if context.home_dir.resolve() == Path.home().resolve():
-        return resolve_guard_home()
-    return context.guard_home
-
-
-def _daemon_start_command(guard_home: Path) -> tuple[str, ...]:
+def _daemon_start_command(guard_home: Path, *, python_executable: str = sys.executable) -> tuple[str, ...]:
     package_root = Path(__file__).resolve().parents[3]
     code = (
         "import sys;"
@@ -276,21 +275,32 @@ def _daemon_start_command(guard_home: Path) -> tuple[str, ...]:
         "from codex_plugin_scanner.guard.daemon import ensure_guard_daemon;"
         f"ensure_guard_daemon(Path({str(guard_home)!r}))"
     )
-    return (_guard_python_executable(), "-c", code)
+    return (python_executable, "-c", code)
 
 
-def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
-    guard_home = _runtime_guard_home(context)
+def _hook_command_parts_for_home_mode(
+    context: HarnessContext,
+    *,
+    home_is_current: bool,
+    python_executable: str,
+) -> tuple[str, ...]:
+    guard_home = resolve_guard_home() if home_is_current else context.guard_home
     query = {"guard-home": str(guard_home)}
-    if context.home_dir.resolve() != Path.home().resolve():
+    if not home_is_current:
         query["home"] = str(context.home_dir)
     if context.workspace_dir is not None:
         query["workspace"] = str(context.workspace_dir)
     long_timeout = _post_tool_hook_timeout_seconds(context)
     config = {
         "state_path": str(guard_home / "daemon-state.json"),
-        "fallback_command": list(_local_hook_command_parts(context)),
-        "start_command": list(_daemon_start_command(guard_home)),
+        "fallback_command": list(
+            _local_hook_command_parts_for_home_mode(
+                context,
+                home_is_current=home_is_current,
+                python_executable=python_executable,
+            )
+        ),
+        "start_command": list(_daemon_start_command(guard_home, python_executable=python_executable)),
         "query": urlencode(query),
         "hook_timeouts": {
             "PreToolUse": long_timeout,
@@ -300,7 +310,15 @@ def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
         },
     }
     bridge_path = Path(__file__).with_name("codex_daemon_hook_bridge.py").resolve()
-    return (_guard_python_executable(), str(bridge_path), json.dumps(config, separators=(",", ":")))
+    return (python_executable, str(bridge_path), json.dumps(config, separators=(",", ":")))
+
+
+def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
+    return _hook_command_parts_for_home_mode(
+        context,
+        home_is_current=context.home_dir.resolve() == Path.home().resolve(),
+        python_executable=_guard_python_executable(),
+    )
 
 
 def _hook_command(context: HarnessContext) -> str:
@@ -620,6 +638,63 @@ def _is_managed_hook_group(group: object) -> bool:
     return any(_is_managed_hook_entry(entry) for entry in hooks)
 
 
+def _hook_command_matches_current_boundary(command: object, context: HarnessContext) -> bool:
+    tokens = _split_hook_command(command)
+    if tokens is None or len(tokens) != 3:
+        return False
+    try:
+        if Path(tokens[0]).resolve() != Path(sys.executable).resolve():
+            return False
+        if Path(tokens[1]).resolve() != Path(__file__).with_name("codex_daemon_hook_bridge.py").resolve():
+            return False
+    except OSError:
+        return False
+    current_home_mode = context.home_dir.resolve() == Path.home().resolve()
+    for home_is_current in (current_home_mode, not current_home_mode):
+        expected_tokens = _hook_command_parts_for_home_mode(
+            context,
+            home_is_current=home_is_current,
+            python_executable=tokens[0],
+        )
+        if tuple(tokens) == expected_tokens:
+            return True
+    return False
+
+
+def _is_current_managed_hook_group(
+    group: object,
+    expected: Mapping[str, object],
+    context: HarnessContext,
+) -> bool:
+    """Require an intact Guard-owned group used by the launch security boundary."""
+
+    if not isinstance(group, dict):
+        return False
+    group_payload = cast(dict[str, object], group)
+    actual_hooks = group_payload.get("hooks")
+    expected_hooks = expected.get("hooks")
+    if not isinstance(actual_hooks, list):
+        return False
+    if not isinstance(expected_hooks, list):
+        return False
+    actual_hook_entries = cast(list[object], actual_hooks)
+    expected_hook_entries = cast(list[object], expected_hooks)
+    if len(actual_hook_entries) != 1 or len(expected_hook_entries) != 1:
+        return False
+    actual_entry_value = actual_hook_entries[0]
+    expected_entry_value = expected_hook_entries[0]
+    if not isinstance(actual_entry_value, dict) or not isinstance(expected_entry_value, dict):
+        return False
+    actual_entry = cast(dict[str, object], actual_entry_value)
+    expected_entry = cast(dict[str, object], expected_entry_value)
+    if not _hook_command_matches_current_boundary(actual_entry.get("command"), context):
+        return False
+    comparison_entry = dict(expected_entry)
+    comparison_entry["command"] = actual_entry.get("command")
+    comparison = {**expected, "hooks": [comparison_entry]}
+    return group_payload == comparison
+
+
 def _is_managed_hook_entry(entry: object) -> bool:
     if not isinstance(entry, dict):
         return False
@@ -748,79 +823,54 @@ def _payload_has_hooks_feature_enabled(config_payload: dict[str, object]) -> boo
     return features.get("hooks") is True or features.get("codex_hooks") is True
 
 
-def _remove_managed_shell_guard_block(text: str) -> str:
-    pattern = re.compile(
-        rf"\n?{re.escape(_SHELL_GUARD_BEGIN)}.*?{re.escape(_SHELL_GUARD_END)}\n?",
-        re.DOTALL,
-    )
-    return pattern.sub("\n", text).strip("\n")
+def _line_marker_at(content: bytes, index: int, marker: bytes) -> bool:
+    if index < 0 or content[index : index + len(marker)] != marker:
+        return False
+    before_is_boundary = index == 0 or content[index - 1 : index] == b"\n"
+    after_index = index + len(marker)
+    after_is_boundary = after_index == len(content) or content[after_index : after_index + 1] in {b"\r", b"\n"}
+    return before_is_boundary and after_is_boundary
 
 
-def _codex_zshenv_guard_script() -> str:
-    return """# Managed by HOL Guard. Loaded by zsh only for Codex-owned shell commands.
-if [[ -n "${CODEX_MANAGED_BY_BUN:-}" || -n "${CODEX_MANAGED_PACKAGE_ROOT:-}" ]]; then
-  function TRAPDEBUG() {
-    emulate -L zsh
-    local cmd="${ZSH_DEBUG_CMD:-}"
-    [[ -z "$cmd" ]] && return 0
-    [[ "$cmd" == "TRAPDEBUG () {"* ]] && return 0
-    [[ "$cmd" == *"codex-zshenv-guard.zsh"* ]] && return 0
-    local normalized_cmd="${cmd//\\\"/}"
-    normalized_cmd="${normalized_cmd//\\'/}"
-    case "$normalized_cmd" in
-      *".npmrc"*|*".pypirc"*|*".netrc"*|*"id_rsa"*|*"id_ed25519"*|*"npm_token"*|*"NPM_TOKEN"*|*"_authToken"*|*".env"* )
-        print -u2 "HOL Guard blocked Codex before it could read a secret-looking local file."
-        print -u2 "Blocked command: ${cmd}"
+def _find_line_marker(content: bytes, marker: bytes, start: int) -> int:
+    index = content.find(marker, start)
+    while index >= 0 and not _line_marker_at(content, index, marker):
+        index = content.find(marker, index + len(marker))
+    return index
+
+
+def _trailing_line_break_length(content: bytes) -> int:
+    if content.endswith(b"\r\n"):
+        return 2
+    if content.endswith(b"\n"):
         return 1
-        ;;
-    esac
     return 0
-  }
-fi
-"""
 
 
-def _codex_bashenv_guard_script() -> str:
-    return """# Managed by HOL Guard. Loaded by bash only for Codex-owned shell commands.
-if [[ -n "${CODEX_MANAGED_BY_BUN:-}" || -n "${CODEX_MANAGED_PACKAGE_ROOT:-}" ]]; then
-  shopt -s extdebug 2>/dev/null || true
-  __hol_guard_codex_bash_debug_trap() {
-    local cmd="${BASH_COMMAND:-}"
-    [[ -z "$cmd" ]] && return 0
-    [[ "$cmd" == "__hol_guard_codex_bash_debug_trap"* ]] && return 0
-    [[ "$cmd" == *"codex-bashenv-guard.bash"* ]] && return 0
-    local normalized_cmd="${cmd//\\\"/}"
-    normalized_cmd="${normalized_cmd//\\'/}"
-    case "$normalized_cmd" in
-      *".npmrc"*|*".pypirc"*|*".netrc"*|*"id_rsa"*|*"id_ed25519"*|*"npm_token"*|*"NPM_TOKEN"*|*"_authToken"*|*".env"* )
-        printf '%s\\n' "HOL Guard blocked Codex before it could read a secret-looking local file." >&2
-        printf '%s\\n' "Blocked command: ${cmd}" >&2
-        exit 126
-        ;;
-    esac
-    return 0
-  }
-  trap '__hol_guard_codex_bash_debug_trap' DEBUG
-fi
-"""
+def _remove_managed_shell_guard_blocks(content: bytes) -> bytes:
+    """Remove only legacy Guard marker blocks while preserving every other byte."""
 
-
-def _codex_fish_guard_script() -> str:
-    return """# Managed by HOL Guard. Loaded by fish only for Codex-owned shell commands.
-if set -q CODEX_MANAGED_BY_BUN; or set -q CODEX_MANAGED_PACKAGE_ROOT
-  function __hol_guard_codex_fish_preexec --on-event fish_preexec
-    set -l cmd "$argv"
-    set -l normalized_cmd (string replace -a '"' '' -- "$cmd")
-    set normalized_cmd (string replace -a "'" "" -- "$normalized_cmd")
-    switch "$normalized_cmd"
-      case "*.npmrc*" "*.pypirc*" "*.netrc*" "*id_rsa*" "*id_ed25519*" "*token*" "*TOKEN*" "*authToken*" "*.env*"
-        echo "HOL Guard blocked Codex before it could read a secret-looking local file." >&2
-        echo "Blocked command: $cmd" >&2
-        exit 126
-    end
-  end
-end
-"""
+    begin = _SHELL_GUARD_BEGIN.encode("utf-8")
+    end = _SHELL_GUARD_END.encode("utf-8")
+    search_from = 0
+    while (block_start := _find_line_marker(content, begin, search_from)) >= 0:
+        block_end_start = _find_line_marker(content, end, block_start + len(begin))
+        if block_end_start < 0:
+            break
+        removal_start = block_start
+        prefix = content[:block_start]
+        last_break_length = _trailing_line_break_length(prefix)
+        if last_break_length and _trailing_line_break_length(prefix[:-last_break_length]):
+            # Legacy installation inserted one blank separator before its block.
+            removal_start -= last_break_length
+        removal_end = block_end_start + len(end)
+        if content[removal_end : removal_end + 2] == b"\r\n":
+            removal_end += 2
+        elif content[removal_end : removal_end + 1] == b"\n":
+            removal_end += 1
+        content = content[:removal_start] + content[removal_end:]
+        search_from = removal_start
+    return content
 
 
 def _hooks_have_registered_entries(hooks: object) -> bool:
@@ -862,6 +912,8 @@ def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
     managed_hook_installed = all(
         (pre_tool_hook_installed, permission_hook_installed, prompt_hook_installed, post_tool_hook_installed)
     )
+    authoritative_shell_hook_installed = pre_tool_hook_installed and permission_hook_installed
+    integrity_valid = integrity.get("integrity_status") == "valid"
     features_is_table = isinstance(features, dict)
     hooks_feature_enabled = not features_is_table or features.get("hooks") is not False
     legacy_codex_hooks_enabled = features_is_table and features.get("codex_hooks") is True
@@ -885,11 +937,28 @@ def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
         "managed_prompt_hook_installed": prompt_hook_installed,
         "managed_post_tool_hook_installed": post_tool_hook_installed,
         "managed_hook_installed": managed_hook_installed,
-        "protection_active": hooks_feature_enabled
-        and managed_hook_installed
-        and integrity.get("integrity_status") == "valid",
+        "shell_enforcement_boundary": _AUTHORITATIVE_ENFORCEMENT_BOUNDARY,
+        "shell_hook_installed": authoritative_shell_hook_installed,
+        "shell_protection_active": hooks_feature_enabled and authoritative_shell_hook_installed and integrity_valid,
+        "shell_reason_code": (
+            None
+            if hooks_feature_enabled and authoritative_shell_hook_installed and integrity_valid
+            else _AUTHORITATIVE_HOOK_UNAVAILABLE_REASON
+        ),
+        "protection_active": hooks_feature_enabled and managed_hook_installed and integrity_valid,
         **{key: value for key, value in integrity.items() if key != "event_matches"},
     }
+
+
+def _require_codex_authoritative_shell_hook(context: HarnessContext) -> None:
+    hook_state = codex_native_hook_state(context)
+    if bool(hook_state["shell_protection_active"]):
+        return
+    raise RuntimeError(
+        f"{_AUTHORITATIVE_HOOK_UNAVAILABLE_REASON}: Guard refused to launch Codex because the managed "
+        "PreToolUse and PermissionRequest hooks are missing or disabled. Run `hol-guard install codex` "
+        "or `hol-guard update` to repair the native-hook enforcement boundary."
+    )
 
 
 class CodexHarnessAdapter(HarnessAdapter):
@@ -899,18 +968,20 @@ class CodexHarnessAdapter(HarnessAdapter):
     executable = "codex"
     approval_tier = "native-or-center"
     approval_summary = (
-        "Guard installs native Codex Bash hooks for shell interception, PermissionRequest hooks for Codex approval "
-        "prompts, prompt hooks for sensitive file-read requests, keeps same-chat approvals for managed MCP tool "
-        "calls, and falls back to the local approval center when Codex cannot answer."
+        "Guard uses native Codex PreToolUse hooks as the authoritative complete-command boundary, "
+        "PermissionRequest hooks for Codex approval prompts, prompt hooks for sensitive file-read requests, "
+        "keeps same-chat approvals for managed MCP tool calls, and falls back to the local approval center when "
+        "Codex cannot answer."
     )
     fallback_hint = (
-        "If Codex cannot render or return the inline approval request, or a native Bash hook blocks a "
-        "sensitive command, Guard will queue it in the local approval center."
+        "If Codex cannot render or return the inline approval request, or the native PreToolUse hook blocks a "
+        "sensitive complete command, Guard will queue it in the local approval center."
     )
     approval_prompt_channel = "native"
     approval_auto_open_browser = False
 
     def launch_command(self, context: HarnessContext, passthrough_args: list[str]) -> list[str]:
+        _require_codex_authoritative_shell_hook(context)
         return guarded_codex_launch_command(
             executable=self.resolved_executable(context) or self.executable,
             home_dir=context.home_dir,
@@ -922,6 +993,7 @@ class CodexHarnessAdapter(HarnessAdapter):
         context: HarnessContext,
         passthrough_args: list[str],
     ) -> tuple[list[str], ...]:
+        _require_codex_authoritative_shell_hook(context)
         return guarded_codex_launch_command_candidates(
             executable=self.resolved_executable(context) or self.executable,
             home_dir=context.home_dir,
@@ -936,6 +1008,7 @@ class CodexHarnessAdapter(HarnessAdapter):
         authorized_executable_prefixes: Sequence[Sequence[str]],
         launch_environment: Mapping[str, str],
     ) -> list[str]:
+        _require_codex_authoritative_shell_hook(context)
         prefixes = {tuple(prefix) for prefix in authorized_executable_prefixes if prefix}
         if len(prefixes) != 1:
             raise ValueError("Codex launch candidates do not share one authorized executable prefix.")
@@ -1198,7 +1271,8 @@ class CodexHarnessAdapter(HarnessAdapter):
             skip_config_path=target_config_path,
         )
         hooks_path = self._remove_json_hook_files(context, payloads=hook_payloads)
-        shell_guard_paths = self._install_shell_guards(context)
+        self._uninstall_shell_guard(context)
+        _require_codex_authoritative_shell_hook(context)
         shim_manifest = install_guard_shim(self.harness, context)
         return {
             "harness": self.harness,
@@ -1211,8 +1285,8 @@ class CodexHarnessAdapter(HarnessAdapter):
             "managed_hook_manifest_path": str(hook_state["manifest_path"]),
             "managed_hook_integrity": str(hook_state["integrity_status"]),
             "managed_hooks_path": str(hooks_path),
-            "managed_shell_guard_path": str(shell_guard_paths["zsh"]),
-            "managed_shell_guard_paths": {shell: str(path) for shell, path in shell_guard_paths.items()},
+            "enforcement_boundary": _AUTHORITATIVE_ENFORCEMENT_BOUNDARY,
+            "legacy_shell_guard_cleanup": "complete",
             "backup_path": str(backup_path),
             "managed_servers": [server.name for server in managed_servers],
             "skipped_servers": list(skipped_servers),
@@ -1550,82 +1624,6 @@ class CodexHarnessAdapter(HarnessAdapter):
                 ) from rollback_error
             raise
 
-    @staticmethod
-    def _install_shell_guards(context: HarnessContext) -> dict[str, Path]:
-        guard_root = context.guard_home / "managed" / "codex"
-        guard_root.mkdir(parents=True, exist_ok=True)
-        zsh_guard_path = guard_root / "codex-zshenv-guard.zsh"
-        bash_guard_path = guard_root / "codex-bashenv-guard.bash"
-        fish_guard_path = guard_root / "codex-fish-guard.fish"
-
-        zsh_guard_path.write_text(_codex_zshenv_guard_script(), encoding="utf-8")
-        bash_guard_path.write_text(_codex_bashenv_guard_script(), encoding="utf-8")
-        fish_guard_path.write_text(_codex_fish_guard_script(), encoding="utf-8")
-
-        CodexHarnessAdapter._install_shell_guard_block(
-            context.home_dir / ".zshenv",
-            [
-                _SHELL_GUARD_BEGIN,
-                f'if [ -r "{zsh_guard_path}" ]; then',
-                f'  source "{zsh_guard_path}"',
-                "fi",
-                _SHELL_GUARD_END,
-            ],
-        )
-        bash_block = [
-            _SHELL_GUARD_BEGIN,
-            f'if [ -r "{bash_guard_path}" ]; then',
-            f'  export BASH_ENV="{bash_guard_path}"',
-            '  if [ -n "${BASH_VERSION:-}" ]; then',
-            f'    . "{bash_guard_path}"',
-            "  fi",
-            "fi",
-            _SHELL_GUARD_END,
-        ]
-        bash_login_files = [
-            context.home_dir / ".bash_profile",
-            context.home_dir / ".bash_login",
-            context.home_dir / ".profile",
-        ]
-        bash_startup_paths = [path for path in bash_login_files if path.is_file()]
-        bashrc_path = context.home_dir / ".bashrc"
-        if bashrc_path.is_file():
-            bash_startup_paths.append(bashrc_path)
-        if not bash_startup_paths:
-            bash_startup_paths = [context.home_dir / ".bash_profile", bashrc_path]
-        for bash_startup_path in bash_startup_paths:
-            CodexHarnessAdapter._install_shell_guard_block(bash_startup_path, bash_block)
-        fish_conf_path = context.home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish"
-        fish_conf_path.parent.mkdir(parents=True, exist_ok=True)
-        fish_conf_path.write_text(
-            "\n".join(
-                [
-                    _SHELL_GUARD_BEGIN,
-                    f'if test -r "{fish_guard_path}"',
-                    f'  source "{fish_guard_path}"',
-                    "end",
-                    _SHELL_GUARD_END,
-                    "",
-                ]
-            ),
-            encoding="utf-8",
-        )
-        return {
-            "zsh": zsh_guard_path,
-            "bash": bash_guard_path,
-            "fish": fish_guard_path,
-            "fish_conf": fish_conf_path,
-        }
-
-    @staticmethod
-    def _install_shell_guard_block(path: Path, block_lines: list[str]) -> None:
-        original = path.read_text(encoding="utf-8") if path.is_file() else ""
-        source_block = "\n".join(block_lines)
-        cleaned = _remove_managed_shell_guard_block(original).rstrip()
-        updated = f"{cleaned}\n\n{source_block}\n" if cleaned else f"{source_block}\n"
-        if updated != original:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(updated, encoding="utf-8")
 
     @staticmethod
     def _uninstall_shell_guard(context: HarnessContext) -> None:
@@ -1652,10 +1650,12 @@ class CodexHarnessAdapter(HarnessAdapter):
     def _remove_shell_guard_block(path: Path) -> None:
         if not path.is_file():
             return
-        original = path.read_text(encoding="utf-8")
-        cleaned = _remove_managed_shell_guard_block(original).rstrip()
+        original = path.read_bytes()
+        cleaned = _remove_managed_shell_guard_blocks(original)
+        if cleaned == original:
+            return
         if cleaned:
-            path.write_text(f"{cleaned}\n", encoding="utf-8")
+            path.write_bytes(cleaned)
         else:
             path.unlink()
 

--- a/src/codex_plugin_scanner/guard/cli/commands_router.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_router.py
@@ -118,6 +118,7 @@ def run_guard_command(
         workspace_dir=workspace,
         guard_home=guard_home,
         executable_overrides=executable_overrides,
+        home_override_explicit=bool(home_override),
     )
 
     handler = _resolve_guard_handler(_PRESTORE_HANDLERS, args.guard_command)

--- a/src/codex_plugin_scanner/guard/cli/uninstall_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/uninstall_commands.py
@@ -243,10 +243,19 @@ def _managed_install_context(
                 home_dir=context.home_dir,
                 workspace_dir=workspace_path,
                 guard_home=context.guard_home,
+                home_override_explicit=context.home_override_explicit,
             ),
             str(workspace_path),
         )
-    return HarnessContext(home_dir=context.home_dir, workspace_dir=None, guard_home=context.guard_home), None
+    return (
+        HarnessContext(
+            home_dir=context.home_dir,
+            workspace_dir=None,
+            guard_home=context.guard_home,
+            home_override_explicit=context.home_override_explicit,
+        ),
+        None,
+    )
 
 
 def _planned_uninstall_message(*, managed_count: int, package_shim_count: int) -> str:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -208,7 +208,12 @@ home_dir = Path(payload["home_dir"]).resolve()
 guard_home = Path(payload["guard_home"]).resolve()
 workspace_value = payload.get("workspace_dir")
 workspace_dir = Path(workspace_value).resolve() if isinstance(workspace_value, str) else None
-context = HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=guard_home)
+context = HarnessContext(
+    home_dir=home_dir,
+    workspace_dir=workspace_dir,
+    guard_home=guard_home,
+    home_override_explicit=bool(payload.get("home_override_explicit")),
+)
 store = GuardStore(guard_home)
 managed_installs, notes = _repair_supported_harnesses_in_process(
     context=context,
@@ -1922,6 +1927,7 @@ def _repair_supported_harnesses(
         "home_dir": str(context.home_dir),
         "workspace_dir": str(context.workspace_dir) if context.workspace_dir is not None else workspace,
         "guard_home": str(context.guard_home),
+        "home_override_explicit": context.home_override_explicit,
         "now": now,
     }
     try:
@@ -2021,10 +2027,19 @@ def _repair_context_from_managed_install(
                 home_dir=context.home_dir,
                 workspace_dir=workspace_path,
                 guard_home=context.guard_home,
+                home_override_explicit=context.home_override_explicit,
             ),
             str(workspace_path),
         )
-    return HarnessContext(context.home_dir, None, context.guard_home), None
+    return (
+        HarnessContext(
+            home_dir=context.home_dir,
+            workspace_dir=None,
+            guard_home=context.guard_home,
+            home_override_explicit=context.home_override_explicit,
+        ),
+        None,
+    )
 
 
 def _repair_codex_install(

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -2057,7 +2057,11 @@ def _repair_codex_install(
         hook_state = codex_native_hook_state(repair_context)
     except (OSError, RuntimeError) as error:
         return None, f"Could not inspect Codex protection during update: {error}"
-    if bool(hook_state["protection_active"]) and hook_state.get("integrity_status") == "valid":
+    if (
+        bool(hook_state["protection_active"])
+        and hook_state.get("integrity_status") == "valid"
+        and bool(hook_state["shell_protection_active"])
+    ):
         return None, None
     try:
         payload = apply_managed_install(

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -222,7 +222,9 @@ def _build_windows_script(posix_path: Path) -> str:
 def _home_override_args(context: HarnessContextLike) -> list[str]:
     if not context.home_dir:
         return []
-    if context.home_dir.resolve() == Path.home().resolve():
+    if not bool(getattr(context, "home_override_explicit", False)) and (
+        context.home_dir.resolve() == Path.home().resolve()
+    ):
         return []
     return ["--home", str(context.home_dir)]
 

--- a/tests/test_codex_daemon_hook_bridge.py
+++ b/tests/test_codex_daemon_hook_bridge.py
@@ -229,7 +229,13 @@ def test_main_posts_to_authenticated_daemon(
     monkeypatch.setenv("http_proxy", f"http://127.0.0.1:{proxy.server_address[1]}")
     monkeypatch.delenv("NO_PROXY", raising=False)
     monkeypatch.delenv("no_proxy", raising=False)
-    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "PreToolUse"})))
+    complete_command = "trap - DEBUG; { cat .env; } > /dev/null\ncat <<'EOF'\nharmless\nEOF"
+    hook_payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": complete_command},
+    }
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(hook_payload)))
 
     try:
         exit_code = bridge.main(**_bridge_config(guard_home, port))
@@ -242,7 +248,8 @@ def test_main_posts_to_authenticated_daemon(
     assert exit_code == 0
     assert _DaemonHandler.captured_challenge_guard_token is None
     assert _DaemonHandler.captured_guard_token == "fixture-token"
-    assert json.loads(str(_DaemonHandler.captured_hook_body))["hook_event_name"] == "PreToolUse"
+    assert json.loads(str(_DaemonHandler.captured_hook_body)) == hook_payload
+    assert json.loads(str(_DaemonHandler.captured_hook_body))["tool_input"]["command"] == complete_command
     assert _ProxyHandler.captured_paths == []
     assert json.loads(capsys.readouterr().out)["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -35,6 +35,7 @@ from codex_plugin_scanner.guard.cli import product as guard_product_module
 from codex_plugin_scanner.guard.cli import prompt as guard_prompt_module
 from codex_plugin_scanner.guard.cli import update_commands as guard_update_commands_module
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
+from codex_plugin_scanner.guard.codex_config import dump_toml
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config, resolve_risk_action
 from codex_plugin_scanner.guard.desktop_notifications import DesktopNotificationSetupResult
 from codex_plugin_scanner.guard.policy_bundle_parser import (
@@ -4258,17 +4259,39 @@ args = ["workspace-skill.js", "--changed"]
 
     def test_guard_update_repairs_stale_codex_native_hooks(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
-        _write_text(
-            home_dir / ".codex" / "config.toml",
-            """
-approval_policy = "never"
-
-[mcp_servers.test-stdio]
-command = "/bin/sh"
-args = ["-lc", "echo hi"]
-""".strip()
-            + "\n",
+        context = HarnessContext(
+            home_dir=home_dir,
+            workspace_dir=None,
+            guard_home=home_dir,
+            home_override_explicit=True,
         )
+        config_payload: dict[str, object] = {
+            "approval_policy": "never",
+            "features": {"hooks": True},
+            "mcp_servers": {
+                "test-stdio": {
+                    "command": "/bin/sh",
+                    "args": ["-lc", "echo hi"],
+                }
+            },
+        }
+        guard_update_commands_module.CodexHarnessAdapter._install_config_hooks(config_payload, context)
+        hooks = config_payload["hooks"]
+        assert isinstance(hooks, dict)
+        pre_tool_groups = hooks["PreToolUse"]
+        assert isinstance(pre_tool_groups, list)
+        pre_tool_group = pre_tool_groups[-1]
+        assert isinstance(pre_tool_group, dict)
+        entries = pre_tool_group["hooks"]
+        assert isinstance(entries, list)
+        entry = entries[0]
+        assert isinstance(entry, dict)
+        entry["command"] = f"{entry['command']} --tampered"
+        config_path = home_dir / ".codex" / "config.toml"
+        _write_text(config_path, dump_toml(config_payload))
+        stale_state = guard_update_commands_module.codex_native_hook_state(context)
+        assert stale_state["protection_active"] is True
+        assert stale_state["shell_protection_active"] is False
         GuardStore(home_dir).set_managed_install(
             "codex",
             True,
@@ -4296,8 +4319,9 @@ args = ["-lc", "echo hi"]
 
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
-        config_text = (home_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
-        hooks_payload = _read_codex_hooks(home_dir / ".codex" / "config.toml")
+        config_text = config_path.read_text(encoding="utf-8")
+        hooks_payload = _read_codex_hooks(config_path)
+        repaired_state = guard_update_commands_module.codex_native_hook_state(context)
 
         assert rc == 0
         assert output["status"] == "current"
@@ -4306,6 +4330,7 @@ args = ["-lc", "echo hi"]
         assert "hooks = true" in config_text
         assert "codex_hooks" not in config_text
         assert hooks_payload["PreToolUse"]
+        assert repaired_state["shell_protection_active"] is True
 
     def test_guard_update_repairs_authenticated_codex_hook_tampering_despite_shape_match(
         self, tmp_path, monkeypatch, capsys

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4286,11 +4286,17 @@ args = ["workspace-skill.js", "--changed"]
         assert isinstance(entries, list)
         entry = entries[0]
         assert isinstance(entry, dict)
-        entry["command"] = f"{entry['command']} --tampered"
         config_path = home_dir / ".codex" / "config.toml"
+        guard_update_commands_module.CodexHarnessAdapter._write_authenticated_hook_config(
+            context,
+            config_path=config_path,
+            payload=config_payload,
+            previous_manifest=None,
+        )
+        entry["command"] = f"{entry['command']} --tampered"
         _write_text(config_path, dump_toml(config_payload))
         stale_state = guard_update_commands_module.codex_native_hook_state(context)
-        assert stale_state["protection_active"] is True
+        assert stale_state["protection_active"] is False
         assert stale_state["shell_protection_active"] is False
         GuardStore(home_dir).set_managed_install(
             "codex",

--- a/tests/test_guard_codex_authoritative_hook_boundary.py
+++ b/tests/test_guard_codex_authoritative_hook_boundary.py
@@ -219,7 +219,11 @@ def test_codex_install_fails_closed_if_native_hook_reconciliation_is_unavailable
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
-    monkeypatch.setattr(CodexHarnessAdapter, "_install_config_hooks", staticmethod(lambda _payload, _context: None))
+    monkeypatch.setattr(
+        CodexHarnessAdapter,
+        "_install_config_hooks",
+        staticmethod(lambda _payload, _context, **_kwargs: None),
+    )
 
     result = main(
         [

--- a/tests/test_guard_codex_authoritative_hook_boundary.py
+++ b/tests/test_guard_codex_authoritative_hook_boundary.py
@@ -128,7 +128,12 @@ def test_codex_launch_fails_closed_when_native_hooks_are_disabled_after_install(
     config_text = config_path.read_text(encoding="utf-8")
     assert "hooks = true" in config_text
     config_path.write_text(config_text.replace("hooks = true", "hooks = false", 1), encoding="utf-8")
-    context = HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir)
+    context = HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=home_dir,
+        home_override_explicit=True,
+    )
 
     with pytest.raises(RuntimeError, match="codex_authoritative_hook_unavailable"):
         CodexHarnessAdapter().launch_command(context, ["Fix it."])
@@ -161,6 +166,46 @@ def test_codex_launch_fails_closed_when_authoritative_hook_is_tampered(
         entry["command"] = f"{entry['command']} --tampered"
     config_path.write_text(dump_toml(payload), encoding="utf-8")
     context = HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir)
+
+    with pytest.raises(RuntimeError, match="codex_authoritative_hook_unavailable"):
+        CodexHarnessAdapter().preview_launch_commands(context, ["Fix it."])
+
+
+def test_codex_launch_rejects_hook_bound_to_opposite_home_mode(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _install_codex(home_dir, workspace_dir, capsys)
+    context = HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=home_dir,
+        home_override_explicit=True,
+    )
+    config_path = home_dir / ".codex" / "config.toml"
+    payload = codex_adapter._read_toml(config_path)
+    hooks = payload["hooks"]
+    assert isinstance(hooks, dict)
+    pre_tool_groups = hooks["PreToolUse"]
+    assert isinstance(pre_tool_groups, list)
+    pre_tool_group = pre_tool_groups[-1]
+    assert isinstance(pre_tool_group, dict)
+    entries = pre_tool_group["hooks"]
+    assert isinstance(entries, list)
+    entry = entries[0]
+    assert isinstance(entry, dict)
+    monkeypatch.setattr(codex_adapter.Path, "home", lambda: home_dir)
+    opposite_home_command = codex_adapter._hook_command_parts_for_home_mode(
+        context,
+        home_is_current=True,
+        python_executable=sys.executable,
+    )
+    entry["command"] = shlex.join(opposite_home_command)
+    assert codex_adapter._hook_command_matches_current_boundary(entry["command"], context) is False
+    config_path.write_text(dump_toml(payload), encoding="utf-8")
 
     with pytest.raises(RuntimeError, match="codex_authoritative_hook_unavailable"):
         CodexHarnessAdapter().preview_launch_commands(context, ["Fix it."])

--- a/tests/test_guard_codex_authoritative_hook_boundary.py
+++ b/tests/test_guard_codex_authoritative_hook_boundary.py
@@ -1,0 +1,326 @@
+"""Security regressions for the authoritative Codex shell-hook boundary."""
+
+from __future__ import annotations
+
+import io
+import json
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.adapters import codex as codex_adapter
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
+from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.codex_config import dump_toml
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _install_codex(home_dir: Path, workspace_dir: Path, capsys: pytest.CaptureFixture[str]) -> dict[str, object]:
+    _write_text(
+        home_dir / ".codex" / "config.toml",
+        '[mcp_servers.example]\ncommand = "python"\nargs = ["-m", "http.server"]\n',
+    )
+    _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
+    result = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+    assert result == 0
+    return output
+
+
+def _managed_shell_block(body: str) -> str:
+    return "\n".join(
+        (
+            codex_adapter._SHELL_GUARD_BEGIN,
+            body,
+            codex_adapter._SHELL_GUARD_END,
+        )
+    )
+
+
+def test_install_migrates_legacy_shell_controls_without_changing_user_bytes(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    guard_root = home_dir / "managed" / "codex"
+    user_prefix = "export KEEP_BEFORE=1\n"
+    user_suffix = "export KEEP_AFTER=2\n\n"
+    legacy_profile = f"{user_prefix}\n{_managed_shell_block('source /old/guard')}\n{user_suffix}"
+
+    for startup_name in (".zshenv", ".bashrc", ".bash_profile", ".bash_login", ".profile"):
+        _write_text(home_dir / startup_name, legacy_profile)
+    fish_conf = home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish"
+    _write_text(fish_conf, f"{user_prefix}\n{_managed_shell_block('source /old/fish-guard')}\n{user_suffix}")
+    for guard_name in (
+        "codex-zshenv-guard.zsh",
+        "codex-bashenv-guard.bash",
+        "codex-fish-guard.fish",
+    ):
+        _write_text(guard_root / guard_name, "legacy Guard-owned shell control\n")
+
+    output = _install_codex(home_dir, workspace_dir, capsys)
+    manifest = output["managed_install"]["manifest"]
+
+    assert manifest["enforcement_boundary"] == "codex-native-hooks"
+    assert "managed_shell_guard_path" not in manifest
+    assert "managed_shell_guard_paths" not in manifest
+    for startup_name in (".zshenv", ".bashrc", ".bash_profile", ".bash_login", ".profile"):
+        assert (home_dir / startup_name).read_text(encoding="utf-8") == f"{user_prefix}{user_suffix}"
+    assert fish_conf.read_text(encoding="utf-8") == f"{user_prefix}{user_suffix}"
+    assert not any(
+        (guard_root / guard_name).exists()
+        for guard_name in (
+            "codex-zshenv-guard.zsh",
+            "codex-bashenv-guard.bash",
+            "codex-fish-guard.fish",
+        )
+    )
+
+
+def test_legacy_shell_cleanup_preserves_crlf_non_utf8_and_unmatched_markers() -> None:
+    begin = codex_adapter._SHELL_GUARD_BEGIN.encode("ascii")
+    end = codex_adapter._SHELL_GUARD_END.encode("ascii")
+    original = b"\xffKEEP\r\n\r\n" + begin + b"\r\nlegacy\r\n" + end + b"\r\nAFTER\xfe\r\n"
+
+    assert codex_adapter._remove_managed_shell_guard_blocks(original) == b"\xffKEEP\r\nAFTER\xfe\r\n"
+    assert codex_adapter._remove_managed_shell_guard_blocks(b"KEEP\n" + begin + b"\nunterminated\n") == (
+        b"KEEP\n" + begin + b"\nunterminated\n"
+    )
+
+
+def test_codex_launch_fails_closed_without_authoritative_native_hooks(tmp_path):
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=tmp_path / "workspace",
+        guard_home=tmp_path / "guard-home",
+    )
+    context.workspace_dir.mkdir(parents=True)
+
+    with pytest.raises(RuntimeError, match="codex_authoritative_hook_unavailable"):
+        CodexHarnessAdapter().preview_launch_commands(context, ["Fix it."])
+
+
+def test_codex_launch_fails_closed_when_native_hooks_are_disabled_after_install(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _install_codex(home_dir, workspace_dir, capsys)
+    config_path = home_dir / ".codex" / "config.toml"
+    config_text = config_path.read_text(encoding="utf-8")
+    assert "hooks = true" in config_text
+    config_path.write_text(config_text.replace("hooks = true", "hooks = false", 1), encoding="utf-8")
+    context = HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir)
+
+    with pytest.raises(RuntimeError, match="codex_authoritative_hook_unavailable"):
+        CodexHarnessAdapter().launch_command(context, ["Fix it."])
+
+
+@pytest.mark.parametrize("tamper_target", ("matcher", "command"))
+def test_codex_launch_fails_closed_when_authoritative_hook_is_tampered(
+    tamper_target,
+    tmp_path,
+    capsys,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _install_codex(home_dir, workspace_dir, capsys)
+    config_path = home_dir / ".codex" / "config.toml"
+    payload = codex_adapter._read_toml(config_path)
+    hooks = payload["hooks"]
+    assert isinstance(hooks, dict)
+    pre_tool_groups = hooks["PreToolUse"]
+    assert isinstance(pre_tool_groups, list)
+    pre_tool_group = pre_tool_groups[-1]
+    assert isinstance(pre_tool_group, dict)
+    if tamper_target == "matcher":
+        pre_tool_group["matcher"] = "Read"
+    else:
+        entries = pre_tool_group["hooks"]
+        assert isinstance(entries, list)
+        entry = entries[0]
+        assert isinstance(entry, dict)
+        entry["command"] = f"{entry['command']} --tampered"
+    config_path.write_text(dump_toml(payload), encoding="utf-8")
+    context = HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir)
+
+    with pytest.raises(RuntimeError, match="codex_authoritative_hook_unavailable"):
+        CodexHarnessAdapter().preview_launch_commands(context, ["Fix it."])
+
+
+def test_codex_install_fails_closed_if_native_hook_reconciliation_is_unavailable(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
+    monkeypatch.setattr(CodexHarnessAdapter, "_install_config_hooks", staticmethod(lambda _payload, _context: None))
+
+    result = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "codex_authoritative_hook_unavailable" in captured.err
+    assert (home_dir / "bin" / "guard-codex").exists() is False
+
+
+@pytest.mark.parametrize(
+    "command_template",
+    (
+        "trap - DEBUG; cat .env > {marker}",
+        "trap ':' DEBUG; cat .env > {marker}",
+        "set +T; cat .env > {marker}",
+        "function __hol_guard_codex_bash_debug_trap() {{ :; }}; cat .env > {marker}",
+        "BASH_ENV=/dev/null bash -c 'cat .env' > {marker}",
+        ". /dev/null; cat .env > {marker}",
+        "{{ cat .env; }} > {marker}",
+        "(cat .env) > {marker}",
+        "bash -c 'cat .env' > {marker}",
+        "cat <(cat .env) > {marker}",
+        "cat .env | tee {marker}",
+        'printf %s "$(cat .env)" > {marker}',
+        "cat <<EOF > {marker}\n$(cat .env)\nEOF",
+    ),
+    ids=(
+        "remove-debug-trap",
+        "replace-debug-trap",
+        "disable-functrace",
+        "replace-guard-function",
+        "replace-bash-env",
+        "source-clean-startup",
+        "group-outer-redirection",
+        "subshell-outer-redirection",
+        "nested-bash-c-outer-redirection",
+        "process-substitution",
+        "pipeline",
+        "command-substitution",
+        "heredoc-command-substitution",
+    ),
+)
+def test_native_pretool_checks_complete_command_before_shell_mutation_can_run(
+    command_template,
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    bash_path = shutil.which("bash")
+    if bash_path is None:
+        pytest.skip("bash is required for the marker-file security reproduction")
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _install_codex(home_dir, workspace_dir, capsys)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
+    _write_text(workspace_dir / ".env", "P25_FAKE_SECRET=marker-only-test-value\n")
+    marker_path = workspace_dir / "guard-p25-bypass-marker"
+    command = command_template.format(marker=shlex.quote(str(marker_path)))
+    event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "source_scope": "project",
+        "cwd": str(workspace_dir),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(
+        guard_commands_module,
+        "ensure_guard_daemon",
+        lambda _guard_home: "http://127.0.0.1:4455",
+    )
+
+    result = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+        ]
+    )
+    captured = capsys.readouterr()
+    response = json.loads(captured.out) if captured.out else {}
+    denied = response.get("hookSpecificOutput", {}).get("permissionDecision") == "deny"
+    if not denied:
+        subprocess.run(
+            [bash_path, "-c", command],
+            cwd=workspace_dir,
+            env={"HOME": str(home_dir), "PATH": str(Path(bash_path).parent)},
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+    assert result == 0
+    assert denied is True
+    assert marker_path.exists() is False
+    assert len(GuardStore(home_dir).list_approval_requests(limit=10)) <= 1
+
+
+def test_native_pretool_keeps_ordinary_safe_command_prompt_free(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _install_codex(home_dir, workspace_dir, capsys)
+    command = "git status --short"
+    event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "source_scope": "project",
+        "cwd": str(workspace_dir),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    result = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+        ]
+    )
+
+    assert result == 0
+    assert capsys.readouterr().out == ""
+    assert GuardStore(home_dir).list_approval_requests(limit=10) == []

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -721,6 +721,7 @@ def test_guard_codex_launch_uses_remote_control_for_dashboard_continuation(tmp_p
         captured.update(kwargs)
         return ["/usr/bin/codex", "--remote", "unix:///guarded.sock", "Fix it."]
 
+    monkeypatch.setattr(codex_adapter, "_require_codex_authoritative_shell_hook", lambda _context: None)
     monkeypatch.setattr(codex_adapter, "guarded_codex_launch_command", fake_remote_launch)
     monkeypatch.setattr(CodexHarnessAdapter, "resolved_executable", lambda self, ctx: "/usr/bin/codex")
 
@@ -1038,7 +1039,12 @@ def test_guard_install_and_repair_codex_preserve_ambiguous_legacy_post_tool_hook
         tokens for tokens in command_tokens if len(tokens) > 1 and Path(tokens[1]).resolve() == current_bridge_path
     ]
     final_state = codex_adapter.codex_native_hook_state(
-        HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=guard_home)
+        HarnessContext(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            guard_home=guard_home,
+            home_override_explicit=True,
+        )
     )
 
     assert install_rc == 0
@@ -2387,8 +2393,7 @@ def test_guard_install_codex_disables_empty_alternate_hook_config(tmp_path: Path
             {
                 "features": {"experimental": True, "hooks": True},
                 "hooks": {
-                    event_name: [group]
-                    for event_name, group in codex_adapter._managed_hook_groups(context).items()
+                    event_name: [group] for event_name, group in codex_adapter._managed_hook_groups(context).items()
                 },
             }
         ),

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import os
 import shlex
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -713,6 +712,9 @@ def test_guard_codex_launch_uses_remote_control_for_dashboard_continuation(tmp_p
         workspace_dir=workspace_dir,
         guard_home=tmp_path / "guard-home",
     )
+    hook_config: dict[str, object] = {"features": {"hooks": True}}
+    CodexHarnessAdapter._install_config_hooks(hook_config, context)
+    _write_text(home_dir / ".codex" / "config.toml", dump_toml(hook_config))
     captured: dict[str, object] = {}
 
     def fake_remote_launch(**kwargs):
@@ -1084,13 +1086,8 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert manifest["managed_config_path"] == str(home_dir / ".codex" / "config.toml")
     assert manifest["managed_hook_config_path"] == str(home_dir / ".codex" / "config.toml")
     assert manifest["managed_hooks_path"] == str(hooks_path)
-    assert manifest["managed_shell_guard_path"] == str(home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh")
-    assert manifest["managed_shell_guard_paths"] == {
-        "zsh": str(home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh"),
-        "bash": str(home_dir / "managed" / "codex" / "codex-bashenv-guard.bash"),
-        "fish": str(home_dir / "managed" / "codex" / "codex-fish-guard.fish"),
-        "fish_conf": str(home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish"),
-    }
+    assert manifest["enforcement_boundary"] == "codex-native-hooks"
+    assert manifest["legacy_shell_guard_cleanup"] == "complete"
     assert set(manifest["managed_servers"]) == {"global_tools", "workspace_skill"}
     assert "--server-name" in config_text
     assert "guard" in config_text
@@ -1127,21 +1124,15 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert "hook" in permission_handler["command"]
     assert "codex" in permission_handler["command"]
     assert permission_handler["env"]["PYTHONPATH"] == source_root
-    zshenv_text = (home_dir / ".zshenv").read_text(encoding="utf-8")
-    shell_guard_text = (home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh").read_text(encoding="utf-8")
-    bash_guard_text = (home_dir / "managed" / "codex" / "codex-bashenv-guard.bash").read_text(encoding="utf-8")
-    fish_guard_text = (home_dir / "managed" / "codex" / "codex-fish-guard.fish").read_text(encoding="utf-8")
-    fish_conf_text = (home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish").read_text(encoding="utf-8")
-    assert "HOL Guard Codex shell guard" in zshenv_text
-    assert "TRAPDEBUG" in shell_guard_text
-    assert "BASH_ENV" in (home_dir / ".bash_profile").read_text(encoding="utf-8")
-    assert "BASH_ENV" in (home_dir / ".bashrc").read_text(encoding="utf-8")
+    assert (home_dir / ".zshenv").exists() is False
+    assert (home_dir / ".bash_profile").exists() is False
+    assert (home_dir / ".bashrc").exists() is False
     assert (home_dir / ".bash_login").exists() is False
     assert (home_dir / ".profile").exists() is False
-    assert "extdebug" in bash_guard_text
-    assert "fish_preexec" in fish_guard_text
-    assert "codex-fish-guard.fish" in fish_conf_text
-    assert ".npmrc" in shell_guard_text
+    assert (home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish").exists() is False
+    assert (home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh").exists() is False
+    assert (home_dir / "managed" / "codex" / "codex-bashenv-guard.bash").exists() is False
+    assert (home_dir / "managed" / "codex" / "codex-fish-guard.fish").exists() is False
 
 
 def test_guard_install_codex_detects_wrapped_servers_without_rewrapping(tmp_path, capsys):
@@ -1181,7 +1172,7 @@ def test_guard_install_codex_detects_wrapped_servers_without_rewrapping(tmp_path
     assert managed_stdio_servers(detection) == ()
 
 
-def test_guard_install_codex_replaces_existing_zshenv_guard_block(tmp_path, capsys):
+def test_guard_install_codex_removes_existing_zshenv_guard_block(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
@@ -1217,7 +1208,7 @@ def test_guard_install_codex_replaces_existing_zshenv_guard_block(tmp_path, caps
     assert rc == 0
     assert "export KEEP_ME=1" in zshenv_text
     assert "/tmp/old" not in zshenv_text
-    assert zshenv_text.count("HOL Guard Codex shell guard") == 2
+    assert "HOL Guard Codex shell guard" not in zshenv_text
 
 
 def test_guard_install_codex_does_not_shadow_existing_bash_profile_precedence(tmp_path, capsys):
@@ -1243,8 +1234,7 @@ def test_guard_install_codex_does_not_shadow_existing_bash_profile_precedence(tm
     assert rc == 0
     assert (home_dir / ".bash_profile").exists() is False
     assert (home_dir / ".bash_login").exists() is False
-    assert "export KEEP_PROFILE=1" in (home_dir / ".profile").read_text(encoding="utf-8")
-    assert "BASH_ENV" in (home_dir / ".profile").read_text(encoding="utf-8")
+    assert (home_dir / ".profile").read_text(encoding="utf-8") == "export KEEP_PROFILE=1\n"
 
 
 def test_guard_uninstall_codex_removes_shell_guard_blocks(tmp_path, capsys):
@@ -1376,7 +1366,7 @@ def test_guard_codex_uninstall_removes_authenticated_baseline_before_reinstall(t
     assert secret_path.is_file()
 
 
-def test_guard_codex_shell_guards_block_zsh_and_bash_secret_reads(tmp_path, capsys):
+def test_guard_codex_install_does_not_install_mutable_shell_guards(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
@@ -1394,32 +1384,19 @@ def test_guard_codex_shell_guards_block_zsh_and_bash_secret_reads(tmp_path, caps
         ]
     )
     json.loads(capsys.readouterr().out)
-    npmrc_path = home_dir / ".npmrc"
-    _write_text(npmrc_path, "FAKE_HOL_GUARD_SHOULD_NOT_PRINT\n")
-
     assert rc == 0
-    shell_commands = []
-    zsh_path = shutil.which("zsh")
-    if zsh_path:
-        shell_commands.append((zsh_path, [zsh_path, "-lc", "cat ~/.np''mrc"]))
-    bash_path = shutil.which("bash")
-    if bash_path:
-        shell_commands.append((bash_path, [bash_path, "-lc", "cat ~/.np''mrc"]))
-    if not shell_commands:
-        return
-
-    for shell_name, command in shell_commands:
-        result = subprocess.run(
-            command,
-            cwd=workspace_dir,
-            env={**os.environ, "HOME": str(home_dir), "CODEX_MANAGED_BY_BUN": "1"},
-            text=True,
-            capture_output=True,
-            check=False,
+    assert (home_dir / ".zshenv").exists() is False
+    assert (home_dir / ".bashrc").exists() is False
+    assert (home_dir / ".bash_profile").exists() is False
+    assert (home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish").exists() is False
+    assert not any(
+        (home_dir / "managed" / "codex" / name).exists()
+        for name in (
+            "codex-zshenv-guard.zsh",
+            "codex-bashenv-guard.bash",
+            "codex-fish-guard.fish",
         )
-        combined = f"{result.stdout}\n{result.stderr}"
-        assert "FAKE_HOL_GUARD_SHOULD_NOT_PRINT" not in combined, shell_name
-        assert "HOL Guard blocked Codex before it could read a secret-looking local file." in combined, shell_name
+    )
 
 
 def test_guard_apps_connect_codex_defaults_to_project_scope_when_local_codex_config_exists(

--- a/tests/test_guard_consumer_approval_precedence.py
+++ b/tests/test_guard_consumer_approval_precedence.py
@@ -22,7 +22,6 @@ from codex_plugin_scanner.guard.adapters.grok import GrokHarnessAdapter
 from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
 from codex_plugin_scanner.guard.adapters.opencode_artifacts import runtime_config_path
 from codex_plugin_scanner.guard.approvals import queue_blocked_approvals
-from codex_plugin_scanner.guard.codex_config import dump_toml
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config
 from codex_plugin_scanner.guard.consumer import evaluate_detection
 from codex_plugin_scanner.guard.consumer.service import _consumer_execution_identity
@@ -185,7 +184,12 @@ def _install_codex_native_hooks(context: HarnessContext) -> None:
     CodexHarnessAdapter._install_config_hooks(payload, context)
     config_path = CodexHarnessAdapter._hook_config_path(context)
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(dump_toml(payload), encoding="utf-8")
+    CodexHarnessAdapter._write_authenticated_hook_config(
+        context,
+        config_path=config_path,
+        payload=payload,
+        previous_manifest=None,
+    )
 
 
 def test_guard_run_launch_environment_hash_is_canonical_and_value_sensitive() -> None:

--- a/tests/test_guard_consumer_approval_precedence.py
+++ b/tests/test_guard_consumer_approval_precedence.py
@@ -22,6 +22,7 @@ from codex_plugin_scanner.guard.adapters.grok import GrokHarnessAdapter
 from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
 from codex_plugin_scanner.guard.adapters.opencode_artifacts import runtime_config_path
 from codex_plugin_scanner.guard.approvals import queue_blocked_approvals
+from codex_plugin_scanner.guard.codex_config import dump_toml
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config
 from codex_plugin_scanner.guard.consumer import evaluate_detection
 from codex_plugin_scanner.guard.consumer.service import _consumer_execution_identity
@@ -177,6 +178,14 @@ def _write_test_executable(path: Path, body: str = "#!/bin/sh\nexit 0\n") -> Pat
     path.write_text(body, encoding="utf-8")
     path.chmod(0o755)
     return path
+
+
+def _install_codex_native_hooks(context: HarnessContext) -> None:
+    payload: dict[str, object] = {"features": {"hooks": True}}
+    CodexHarnessAdapter._install_config_hooks(payload, context)
+    config_path = CodexHarnessAdapter._hook_config_path(context)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(dump_toml(payload), encoding="utf-8")
 
 
 def test_guard_run_launch_environment_hash_is_canonical_and_value_sensitive() -> None:
@@ -581,6 +590,12 @@ def test_codex_postclaim_setup_uses_authorized_canonical_prefix_after_symlink_sw
     executable_alias.parent.mkdir(parents=True)
     executable_alias.symlink_to(safe_codex)
     monkeypatch.setenv("PATH", f"{executable_alias.parent}{os.pathsep}{os.environ.get('PATH', '')}")
+    context = HarnessContext(
+        home_dir=tmp_path,
+        workspace_dir=tmp_path / "workspace",
+        guard_home=config.guard_home,
+    )
+    _install_codex_native_hooks(context)
 
     class SwapAtAuthorizedSetupAdapter(CodexHarnessAdapter):
         def launch_command_from_authorized_plan(self, *args, **kwargs) -> list[str]:
@@ -598,11 +613,7 @@ def test_codex_postclaim_setup_uses_authorized_canonical_prefix_after_symlink_sw
 
     result = guard_runner_module.guard_run(
         "codex",
-        HarnessContext(
-            home_dir=tmp_path,
-            workspace_dir=tmp_path / "workspace",
-            guard_home=config.guard_home,
-        ),
+        context,
         store,
         config,
         dry_run=False,
@@ -634,6 +645,12 @@ def test_no_saved_codex_setup_uses_previewed_canonical_prefix_after_symlink_swap
     executable_alias.parent.mkdir(parents=True)
     executable_alias.symlink_to(safe_codex)
     monkeypatch.setenv("PATH", f"{executable_alias.parent}{os.pathsep}{os.environ.get('PATH', '')}")
+    context = HarnessContext(
+        home_dir=tmp_path,
+        workspace_dir=tmp_path / "workspace",
+        guard_home=config.guard_home,
+    )
+    _install_codex_native_hooks(context)
 
     class SwapAtAuthorizedSetupAdapter(CodexHarnessAdapter):
         def launch_command_from_authorized_plan(self, *args, **kwargs) -> list[str]:
@@ -651,11 +668,7 @@ def test_no_saved_codex_setup_uses_previewed_canonical_prefix_after_symlink_swap
 
     result = guard_runner_module.guard_run(
         "codex",
-        HarnessContext(
-            home_dir=tmp_path,
-            workspace_dir=tmp_path / "workspace",
-            guard_home=config.guard_home,
-        ),
+        context,
         store,
         config,
         dry_run=False,

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -20,7 +20,7 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
-from codex_plugin_scanner.guard.codex_config import read_toml_payload, write_toml_payload
+from codex_plugin_scanner.guard.codex_config import read_toml_payload
 from codex_plugin_scanner.guard.consumer.service import diff_artifact
 from codex_plugin_scanner.guard.policy_integrity import PolicyIntegrityVerificationResult
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
@@ -82,7 +82,12 @@ def _install_codex_native_hooks(home_dir: Path, workspace_dir: Path) -> None:
     config_path = home_dir / ".codex" / "config.toml"
     payload = read_toml_payload(config_path)
     CodexHarnessAdapter._install_config_hooks(payload, context)
-    write_toml_payload(config_path, payload)
+    CodexHarnessAdapter._write_authenticated_hook_config(
+        context,
+        config_path=config_path,
+        payload=payload,
+        previous_manifest=None,
+    )
 
 
 class _CompletedProcess:

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -18,7 +18,9 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.codex_config import read_toml_payload, write_toml_payload
 from codex_plugin_scanner.guard.consumer.service import diff_artifact
 from codex_plugin_scanner.guard.policy_integrity import PolicyIntegrityVerificationResult
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
@@ -68,6 +70,19 @@ args = ["workspace-skill.js"]
 """.strip()
         + "\n",
     )
+
+
+def _install_codex_native_hooks(home_dir: Path, workspace_dir: Path) -> None:
+    context = HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=home_dir,
+        home_override_explicit=True,
+    )
+    config_path = home_dir / ".codex" / "config.toml"
+    payload = read_toml_payload(config_path)
+    CodexHarnessAdapter._install_config_hooks(payload, context)
+    write_toml_payload(config_path, payload)
 
 
 class _CompletedProcess:
@@ -151,6 +166,7 @@ def test_guard_run_launches_with_configured_home(monkeypatch, tmp_path, capsys):
     _build_guard_fixture(home_dir, workspace_dir)
     fake_codex = _make_pinnable_harness_executable(tmp_path, monkeypatch, "codex")
     _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
+    _install_codex_native_hooks(home_dir, workspace_dir)
     captured_env: dict[str, str] = {}
     captured_cwd: Path | None = None
     captured_command: list[str] = []
@@ -1194,6 +1210,7 @@ def test_guard_run_allows_debug_prompt_with_quoted_publish_error(monkeypatch, tm
     marker_path = tmp_path / "codex-args.txt"
     _build_guard_fixture(home_dir, workspace_dir)
     _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\nmode = "prompt"\n')
+    _install_codex_native_hooks(home_dir, workspace_dir)
     _make_fake_codex(fake_bin, marker_path)
     monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}")
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")

--- a/tests/test_guard_package_shims_cli.py
+++ b/tests/test_guard_package_shims_cli.py
@@ -92,12 +92,19 @@ def _seed_retry_required_connect_state(home_dir: Path) -> None:
     )
 
 
-def _install_local_package_shim(guard_home: Path, home_dir: Path, manager: str) -> None:
+def _install_local_package_shim(
+    guard_home: Path,
+    home_dir: Path,
+    manager: str,
+    *,
+    home_override_explicit: bool = False,
+) -> None:
     install_package_shims(
         HarnessContext(
             home_dir=home_dir,
             workspace_dir=None,
             guard_home=guard_home,
+            home_override_explicit=home_override_explicit,
         ),
         managers=(manager,),
     )
@@ -504,7 +511,12 @@ def test_guard_doctor_repair_regenerates_stale_package_shim(
     monkeypatch.setenv("HOME", str(home_dir))
     monkeypatch.setenv("SHELL", "/bin/zsh")
     guard_home = tmp_path / "guard-home"
-    _install_local_package_shim(guard_home, home_dir, "npm")
+    _install_local_package_shim(
+        guard_home,
+        home_dir,
+        "npm",
+        home_override_explicit=True,
+    )
     shim_path = guard_home / "package-shims" / "bin" / "npm"
     current_content = shim_path.read_text(encoding="utf-8")
     stale_content = '#!/bin/sh\nexec npm "$@"\n'
@@ -557,7 +569,12 @@ def test_top_level_guard_doctor_repair_regenerates_stale_package_shim(
     monkeypatch.setenv("HOME", str(home_dir))
     monkeypatch.setenv("SHELL", "/bin/zsh")
     guard_home = tmp_path / "guard-home"
-    _install_local_package_shim(guard_home, home_dir, "npm")
+    _install_local_package_shim(
+        guard_home,
+        home_dir,
+        "npm",
+        home_override_explicit=True,
+    )
     shim_path = guard_home / "package-shims" / "bin" / "npm"
     current_content = shim_path.read_text(encoding="utf-8")
     stale_content = '#!/bin/sh\nexec npm "$@"\n'

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -119,7 +119,8 @@ class TestGuardProductFlow:
         assert codex_summary["next_action"] == "install"
         assert codex_summary["approval_flow"]["prompt_channel"] == "native"
         assert codex_summary["approval_flow"]["auto_open_browser"] is False
-        assert "native Codex Bash hooks" in codex_summary["approval_flow"]["summary"]
+        assert "native Codex PreToolUse hooks" in codex_summary["approval_flow"]["summary"]
+        assert "authoritative complete-command boundary" in codex_summary["approval_flow"]["summary"]
         assert "same-chat approvals" in codex_summary["approval_flow"]["summary"]
         assert output["next_steps"][0]["command"] == "hol-guard install codex"
         assert output["next_steps"][1]["command"] == "hol-guard run codex --dry-run"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -30,6 +30,7 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard import synced_policy as synced_policy_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution, wait_for_approval_requests
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.cli import commands_support_interaction as interaction_module
@@ -43,6 +44,7 @@ from codex_plugin_scanner.guard.cli.commands_support_runtime_policy import (
 from codex_plugin_scanner.guard.cli.commands_support_runtime_resolution import _runtime_policy_path
 from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
+from codex_plugin_scanner.guard.codex_config import read_toml_payload, write_toml_payload
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config, overlay_synced_guard_policy
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
@@ -137,6 +139,19 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
 def _write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def _install_codex_native_hooks(home_dir: Path, workspace_dir: Path) -> None:
+    context = HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=home_dir,
+        home_override_explicit=True,
+    )
+    config_path = home_dir / ".codex" / "config.toml"
+    payload = read_toml_payload(config_path)
+    CodexHarnessAdapter._install_config_hooks(payload, context)
+    write_toml_payload(config_path, payload)
 
 
 def _make_pinnable_harness_executable(
@@ -11695,6 +11710,7 @@ def test_guard_run_prompt_allow_once_launches_and_records_override(tmp_path, cap
         f"command = {json.dumps(sys.executable)}\n"
         f"args = [{json.dumps(str(workspace_server))}]\n",
     )
+    _install_codex_native_hooks(home_dir, workspace_dir)
     answers = iter(["1", "1"])
     monkeypatch.setattr(guard_commands_module.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr("rich.console.Console.input", lambda self, prompt="": next(answers))
@@ -11745,6 +11761,7 @@ def test_guard_run_prompt_allow_artifact_persists_for_next_run(tmp_path, capsys,
         f"command = {json.dumps(sys.executable)}\n"
         f"args = [{json.dumps(str(workspace_server))}]\n",
     )
+    _install_codex_native_hooks(home_dir, workspace_dir)
     answers = iter(["2", "2"])
     monkeypatch.setattr(guard_commands_module.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr("rich.console.Console.input", lambda self, prompt="": next(answers))
@@ -12860,6 +12877,7 @@ def test_guard_run_headless_allow_persists_state_when_approval_center_is_availab
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
     _make_pinnable_harness_executable(tmp_path, monkeypatch, "codex")
+    _install_codex_native_hooks(home_dir, workspace_dir)
     safe_detection = HarnessDetection(
         harness="codex",
         installed=True,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -44,7 +44,7 @@ from codex_plugin_scanner.guard.cli.commands_support_runtime_policy import (
 from codex_plugin_scanner.guard.cli.commands_support_runtime_resolution import _runtime_policy_path
 from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
-from codex_plugin_scanner.guard.codex_config import read_toml_payload, write_toml_payload
+from codex_plugin_scanner.guard.codex_config import read_toml_payload
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config, overlay_synced_guard_policy
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
@@ -151,7 +151,12 @@ def _install_codex_native_hooks(home_dir: Path, workspace_dir: Path) -> None:
     config_path = home_dir / ".codex" / "config.toml"
     payload = read_toml_payload(config_path)
     CodexHarnessAdapter._install_config_hooks(payload, context)
-    write_toml_payload(config_path, payload)
+    CodexHarnessAdapter._write_authenticated_hook_config(
+        context,
+        config_path=config_path,
+        payload=payload,
+        previous_manifest=None,
+    )
 
 
 def _make_pinnable_harness_executable(


### PR DESCRIPTION
## Summary

- make native Codex `PreToolUse` and `PermissionRequest` hooks the authoritative complete-command enforcement boundary and fail closed when that boundary is missing, disabled, altered, or unauthenticated
- integrate that boundary with the authenticated hook manifest/key model already merged into `release/2.1`, including exact event identities and install readback verification
- remove mutable Bash/zsh/fish trap and startup-profile controls, with byte-preserving migration cleanup for legacy Guard-managed blocks and files
- make install, launch, update repair, package shims, and tests use the same explicit-home and authenticated-hook contract
- preserve foreign/ambiguous hook entries instead of heuristically deleting them

## Testing

- `uv run pytest -q tests/test_guard_codex_authoritative_hook_boundary.py tests/test_guard_codex_install.py tests/test_guard_consumer_approval_precedence.py tests/test_codex_daemon_hook_bridge.py` (171 passed after the final `release/2.1` rebase)
- broad CLI/launch/shim/product-flow batch (380 passed, 1 deselected)
- the single deselected test requires an available macOS OS credential store and reproduces independently of this change in the local environment
- prior focused boundary/update/uninstall coverage (273 passed, 7 skipped)
- command-wrapper redirect/heredoc/process-substitution/command-substitution/pipeline coverage (85 passed, 713 deselected)
- Python 3.10–3.13 package-shim and launch/runtime regressions
- Ruff format/lint passed for changed source and tests
- basedpyright reports 0 errors for the changed Codex adapter
- wheel and sdist builds passed

## Branch and attribution

- rebased onto `release/2.1` after the authenticated-hook prerequisite merged
- all six feature commits use `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>` for both author and committer
