### PR TITLE
fix(guard): enforce npm prerelease range admission

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/js_semver.py
+++ b/src/codex_plugin_scanner/guard/runtime/js_semver.py
@@ -1,4 +1,14 @@
-"""Minimal JavaScript semver helpers for Guard runtime decisions."""
+"""Minimal, fail-closed JavaScript semver helpers for Guard runtime decisions.
+
+The range evaluator implements the npm/node-semver prerelease admission rule:
+ordering a prerelease inside a comparator set is not enough to admit it.  One
+comparator in the *same* ``||`` clause must itself contain a prerelease with the
+candidate's exact major/minor/patch tuple.
+
+Supported range forms are exact versions, primitive comparators, caret and
+tilde ranges, partial/x ranges, and one hyphen range per clause.  Other syntax
+is rejected rather than approximated as a broader range.
+"""
 
 from __future__ import annotations
 
@@ -7,10 +17,25 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import total_ordering
 
+_MAX_SEMVER_LENGTH = 256
+_MAX_SELECTOR_LENGTH = 1024
+_MAX_SELECTOR_CLAUSES = 32
+_MAX_COMPARATORS_PER_CLAUSE = 64
+_MAX_SAFE_INTEGER = 9_007_199_254_740_991
+_NUMERIC_COMPONENT = r"(?:0|[1-9][0-9]*)"
+_IDENTIFIER = r"[0-9A-Za-z-]+"
 _JS_VERSION_RE = re.compile(
-    r"^v?(?P<major>\d+)(?:\.(?P<minor>\d+))?(?:\.(?P<patch>\d+))?"
-    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$"
+    "".join(
+        (
+            rf"^v?(?P<major>{_NUMERIC_COMPONENT})\.(?P<minor>{_NUMERIC_COMPONENT})\.(?P<patch>{_NUMERIC_COMPONENT})",
+            rf"(?:-(?P<prerelease>{_IDENTIFIER}(?:\.{_IDENTIFIER})*))?",
+            rf"(?:\+(?P<build>{_IDENTIFIER}(?:\.{_IDENTIFIER})*))?$",
+        )
+    )
 )
+_HYPHEN_RANGE_RE = re.compile(r"^(?P<lower>\S+)\s+-\s+(?P<upper>\S+)$")
+_COMPARATOR_RE = re.compile(r"^(?P<operator>>=|<=|>|<|=)?(?P<version>.+)$")
+_WILDCARDS = frozenset({"*", "x", "X"})
 
 
 @total_ordering
@@ -21,41 +46,111 @@ class JsSemverVersion:
     patch: int
     prerelease: tuple[str, ...] | None = None
 
+    @property
+    def base(self) -> tuple[int, int, int]:
+        return (self.major, self.minor, self.patch)
+
     def __lt__(self, other: object) -> bool:
         if not isinstance(other, JsSemverVersion):
             return NotImplemented
-        if (self.major, self.minor, self.patch) != (other.major, other.minor, other.patch):
-            return (self.major, self.minor, self.patch) < (other.major, other.minor, other.patch)
+        if self.base != other.base:
+            return self.base < other.base
         if self.prerelease is None:
-            return other.prerelease is not None
+            return False
         if other.prerelease is None:
             return True
         return _compare_prerelease(self.prerelease, other.prerelease) < 0
 
 
+@dataclass(frozen=True, slots=True)
+class _RangeVersion:
+    major: int | None
+    minor: int | None
+    patch: int | None
+    prerelease: tuple[str, ...] | None = None
+
+    @property
+    def complete(self) -> bool:
+        return self.major is not None and self.minor is not None and self.patch is not None
+
+    def lower_bound(self) -> JsSemverVersion | None:
+        if self.major is None:
+            return None
+        return JsSemverVersion(
+            self.major,
+            self.minor or 0,
+            self.patch or 0,
+            self.prerelease,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _Comparator:
+    operator: str
+    version: JsSemverVersion
+
+    def matches(self, candidate: JsSemverVersion) -> bool:
+        if self.operator == ">=":
+            return candidate >= self.version
+        if self.operator == "<=":
+            return candidate <= self.version
+        if self.operator == ">":
+            return candidate > self.version
+        if self.operator == "<":
+            return candidate < self.version
+        return candidate == self.version
+
+
 def parse_js_semver(value: str | None) -> JsSemverVersion | None:
+    """Parse one complete SemVer value, ignoring build metadata for precedence."""
+
     if not value:
         return None
     normalized = value.strip()
-    matched = _JS_VERSION_RE.match(normalized)
+    if not normalized or normalized != value or len(normalized) > _MAX_SEMVER_LENGTH:
+        return None
+    matched = _JS_VERSION_RE.fullmatch(normalized)
     if matched is None:
         return None
-    return JsSemverVersion(
-        major=int(matched.group("major")),
-        minor=int(matched.group("minor") or 0),
-        patch=int(matched.group("patch") or 0),
-        prerelease=tuple(matched.group("prerelease").split(".")) if matched.group("prerelease") else None,
+    prerelease_raw = matched.group("prerelease")
+    prerelease = (
+        _parse_identifiers(prerelease_raw, numeric_leading_zero_forbidden=True) if prerelease_raw is not None else None
     )
+    if prerelease_raw is not None and prerelease is None:
+        return None
+    build_raw = matched.group("build")
+    if build_raw is not None and _parse_identifiers(build_raw, numeric_leading_zero_forbidden=False) is None:
+        return None
+    components = tuple(int(matched.group(name)) for name in ("major", "minor", "patch"))
+    if any(component > _MAX_SAFE_INTEGER for component in components):
+        return None
+    return JsSemverVersion(*components, prerelease=prerelease)
 
 
 def version_matches_js_selector(version: str, selector: str) -> bool:
+    """Return whether ``version`` satisfies a supported npm-compatible range.
+
+    Invalid or unsupported syntax invalidates the entire selector.  This is
+    intentionally stricter than accepting the valid side of a malformed ``||``
+    expression, because this function protects package-resolution decisions.
+    """
+
     parsed_version = parse_js_semver(version)
-    if parsed_version is None:
+    if parsed_version is None or len(selector) > _MAX_SELECTOR_LENGTH:
         return False
     normalized_selector = selector.strip()
-    if not normalized_selector or normalized_selector in {"*", "latest"}:
-        return True
-    return any(_matches_selector_clause(parsed_version, clause.strip()) for clause in normalized_selector.split("||"))
+    if not normalized_selector or normalized_selector == "latest":
+        normalized_selector = "*"
+    raw_clauses = normalized_selector.split("||")
+    if not raw_clauses or len(raw_clauses) > _MAX_SELECTOR_CLAUSES:
+        return False
+    clauses: list[tuple[_Comparator, ...]] = []
+    for raw_clause in raw_clauses:
+        clause = _parse_selector_clause(raw_clause.strip())
+        if clause is None:
+            return False
+        clauses.append(clause)
+    return any(_comparator_set_matches(parsed_version, clause) for clause in clauses)
 
 
 def highest_js_version_for_selector(versions: Sequence[str], selector: str) -> str | None:
@@ -71,64 +166,194 @@ def highest_js_version_for_selector(versions: Sequence[str], selector: str) -> s
     return matching_versions[-1][1]
 
 
-def _matches_selector_clause(version: JsSemverVersion, clause: str) -> bool:
-    if not clause:
-        return False
-    tokens = clause.replace(",", " ").split()
-    if not tokens:
-        return False
-    if len(tokens) == 1 and not tokens[0].startswith(("^", "~", "<", ">", "=", "!")):
-        exact_version = parse_js_semver(tokens[0])
-        return exact_version == version if exact_version is not None else False
-    return all(_matches_selector_token(version, token) for token in tokens)
+def _parse_selector_clause(clause: str) -> tuple[_Comparator, ...] | None:
+    if not clause or "," in clause:
+        return None
+    hyphen_match = _HYPHEN_RANGE_RE.fullmatch(clause)
+    comparators: list[_Comparator]
+    if hyphen_match is not None:
+        expanded = _expand_hyphen_range(hyphen_match.group("lower"), hyphen_match.group("upper"))
+        if expanded is None:
+            return None
+        comparators = list(expanded)
+    else:
+        tokens = clause.split()
+        if not tokens or len(tokens) > _MAX_COMPARATORS_PER_CLAUSE:
+            return None
+        comparators = []
+        for token in tokens:
+            expanded = _expand_selector_token(token)
+            if expanded is None:
+                return None
+            comparators.extend(expanded)
+            if len(comparators) > _MAX_COMPARATORS_PER_CLAUSE:
+                return None
+    if any(component > _MAX_SAFE_INTEGER for comparator in comparators for component in comparator.version.base):
+        # A partial/caret/tilde range can synthesize a successor outside the
+        # numeric domain accepted by node-semver even when its input component
+        # is itself valid.  Treat that selector as invalid instead of retaining
+        # an unrepresentable upper bound.
+        return None
+    # node-semver removes ``>=0.0.0`` after expanding x/partial ranges.  The
+    # comparison is redundant for stable versions, but retaining it would
+    # incorrectly exclude 0.0.0 prereleases that another comparator in this
+    # same set explicitly admits.
+    return tuple(
+        comparator
+        for comparator in comparators
+        if not (comparator.operator == ">=" and comparator.version == JsSemverVersion(0, 0, 0))
+    )
 
 
-def _matches_selector_token(version: JsSemverVersion, token: str) -> bool:
+def _comparator_set_matches(version: JsSemverVersion, comparators: tuple[_Comparator, ...]) -> bool:
+    if not all(comparator.matches(version) for comparator in comparators):
+        return False
+    if version.prerelease is None:
+        return True
+    return any(
+        comparator.version.prerelease is not None and comparator.version.base == version.base
+        for comparator in comparators
+    )
+
+
+def _expand_selector_token(token: str) -> tuple[_Comparator, ...] | None:
     if token.startswith("^"):
-        return _matches_caret(version, token[1:])
+        parsed = _parse_range_version(token[1:])
+        return _expand_caret(parsed) if parsed is not None else None
     if token.startswith("~"):
-        return _matches_tilde(version, token[1:])
-    for operator in (">=", "<=", ">", "<", "==", "="):
-        if token.startswith(operator):
-            return _matches_comparator(version, operator, token[len(operator) :])
-    exact_version = parse_js_semver(token)
-    return exact_version == version if exact_version is not None else False
+        parsed = _parse_range_version(token[1:])
+        return _expand_tilde(parsed) if parsed is not None else None
+    matched = _COMPARATOR_RE.fullmatch(token)
+    if matched is None:
+        return None
+    operator = matched.group("operator") or ""
+    parsed = _parse_range_version(matched.group("version"))
+    if parsed is None:
+        return None
+    return _expand_primitive_comparator(operator, parsed)
 
 
-def _matches_caret(version: JsSemverVersion, lower_bound: str) -> bool:
-    parsed_lower = parse_js_semver(lower_bound)
-    if parsed_lower is None or version < parsed_lower:
-        return False
-    if parsed_lower.major > 0:
-        return version < JsSemverVersion(parsed_lower.major + 1, 0, 0)
-    if parsed_lower.minor > 0:
-        return version < JsSemverVersion(0, parsed_lower.minor + 1, 0)
-    return version < JsSemverVersion(0, 0, parsed_lower.patch + 1)
+def _expand_primitive_comparator(operator: str, parsed: _RangeVersion) -> tuple[_Comparator, ...]:
+    lower = parsed.lower_bound()
+    if lower is None:
+        if operator in {"", "=", ">=", "<="}:
+            return ()
+        return (_Comparator("<", JsSemverVersion(0, 0, 0, ("0",))),)
+    if parsed.complete:
+        return (_Comparator(operator or "=", lower),)
 
-
-def _matches_tilde(version: JsSemverVersion, lower_bound: str) -> bool:
-    parsed_lower = parse_js_semver(lower_bound)
-    if parsed_lower is None or version < parsed_lower:
-        return False
-    normalized_lower = lower_bound.strip()
-    if normalized_lower.count(".") == 0:
-        return version < JsSemverVersion(parsed_lower.major + 1, 0, 0)
-    return version < JsSemverVersion(parsed_lower.major, parsed_lower.minor + 1, 0)
-
-
-def _matches_comparator(version: JsSemverVersion, operator: str, raw_value: str) -> bool:
-    parsed_value = parse_js_semver(raw_value)
-    if parsed_value is None:
-        return False
+    upper = _partial_upper_bound(parsed)
+    if operator in {"", "="}:
+        return (_Comparator(">=", lower), _Comparator("<", upper))
     if operator == ">=":
-        return version >= parsed_value
-    if operator == "<=":
-        return version <= parsed_value
+        return (_Comparator(">=", lower),)
     if operator == ">":
-        return version > parsed_value
-    if operator == "<":
-        return version < parsed_value
-    return version == parsed_value
+        return (_Comparator(">=", JsSemverVersion(upper.major, upper.minor, upper.patch)),)
+    if operator == "<=":
+        return (_Comparator("<", upper),)
+    return (_Comparator("<", JsSemverVersion(lower.major, lower.minor, lower.patch, ("0",))),)
+
+
+def _expand_caret(parsed: _RangeVersion) -> tuple[_Comparator, ...]:
+    lower = parsed.lower_bound()
+    if lower is None:
+        return ()
+    if lower.major > 0 or parsed.minor is None:
+        upper = JsSemverVersion(lower.major + 1, 0, 0, ("0",))
+    elif lower.minor > 0 or parsed.patch is None:
+        upper = JsSemverVersion(0, lower.minor + 1, 0, ("0",))
+    else:
+        upper = JsSemverVersion(0, 0, lower.patch + 1, ("0",))
+    return (_Comparator(">=", lower), _Comparator("<", upper))
+
+
+def _expand_tilde(parsed: _RangeVersion) -> tuple[_Comparator, ...]:
+    lower = parsed.lower_bound()
+    if lower is None:
+        return ()
+    if parsed.minor is None:
+        upper = JsSemverVersion(lower.major + 1, 0, 0, ("0",))
+    else:
+        upper = JsSemverVersion(lower.major, lower.minor + 1, 0, ("0",))
+    return (_Comparator(">=", lower), _Comparator("<", upper))
+
+
+def _expand_hyphen_range(lower_raw: str, upper_raw: str) -> tuple[_Comparator, ...] | None:
+    lower = _parse_range_version(lower_raw)
+    upper = _parse_range_version(upper_raw)
+    if lower is None or upper is None:
+        return None
+    comparators: list[_Comparator] = []
+    lower_bound = lower.lower_bound()
+    if lower_bound is not None:
+        comparators.append(_Comparator(">=", lower_bound))
+    upper_bound = upper.lower_bound()
+    if upper_bound is not None:
+        if upper.complete:
+            comparators.append(_Comparator("<=", upper_bound))
+        else:
+            comparators.append(_Comparator("<", _partial_upper_bound(upper)))
+    return tuple(comparators)
+
+
+def _partial_upper_bound(parsed: _RangeVersion) -> JsSemverVersion:
+    if parsed.major is None:
+        return JsSemverVersion(0, 0, 0, ("0",))
+    if parsed.minor is None:
+        return JsSemverVersion(parsed.major + 1, 0, 0, ("0",))
+    return JsSemverVersion(parsed.major, parsed.minor + 1, 0, ("0",))
+
+
+def _parse_range_version(value: str) -> _RangeVersion | None:
+    if not value or len(value) > _MAX_SEMVER_LENGTH or value != value.strip():
+        return None
+    normalized = value[1:] if value.startswith("v") else value
+    if not normalized:
+        return None
+    core_and_prerelease, plus, build = normalized.partition("+")
+    if plus and (not build or "+" in build):
+        return None
+    core, dash, prerelease_raw = core_and_prerelease.partition("-")
+    if dash and not prerelease_raw:
+        return None
+    parts = core.split(".")
+    if not 1 <= len(parts) <= 3 or any(not part for part in parts):
+        return None
+    components: list[int | None] = []
+    wildcard_seen = False
+    for part in parts:
+        if part in _WILDCARDS:
+            wildcard_seen = True
+            components.append(None)
+            continue
+        if wildcard_seen or re.fullmatch(_NUMERIC_COMPONENT, part) is None:
+            return None
+        component = int(part)
+        if component > _MAX_SAFE_INTEGER:
+            return None
+        components.append(component)
+    components.extend([None] * (3 - len(components)))
+    complete = all(component is not None for component in components)
+    prerelease = _parse_identifiers(prerelease_raw, numeric_leading_zero_forbidden=True) if dash else None
+    if dash and (not complete or prerelease is None):
+        return None
+    parsed_build = _parse_identifiers(build, numeric_leading_zero_forbidden=False) if plus else None
+    if plus and (not complete or parsed_build is None):
+        return None
+    return _RangeVersion(components[0], components[1], components[2], prerelease)
+
+
+def _parse_identifiers(value: str | None, *, numeric_leading_zero_forbidden: bool) -> tuple[str, ...] | None:
+    if value is None:
+        return None
+    identifiers = tuple(value.split("."))
+    if not identifiers or any(re.fullmatch(_IDENTIFIER, identifier) is None for identifier in identifiers):
+        return None
+    if numeric_leading_zero_forbidden and any(
+        identifier.isdigit() and len(identifier) > 1 and identifier.startswith("0") for identifier in identifiers
+    ):
+        return None
+    return identifiers
 
 
 def _compare_prerelease(left: Sequence[str], right: Sequence[str]) -> int:

--- a/src/codex_plugin_scanner/guard/runtime/npm_policy_range.py
+++ b/src/codex_plugin_scanner/guard/runtime/npm_policy_range.py
@@ -1,0 +1,74 @@
+"""Bind npm policy-range evaluation to the package version that will run."""
+
+from __future__ import annotations
+
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+from .js_semver import version_matches_js_selector
+
+
+def policy_selector_matches_target(selector: str, target: dict[str, object]) -> bool:
+    """Match policy selectors using the target ecosystem's range grammar."""
+
+    version = _optional_string(target.get("version"))
+    requested_range = _optional_string(target.get("range"))
+    ecosystem = _optional_string(target.get("ecosystem")) or "npm"
+    if ecosystem == "npm":
+        if version is None:
+            return requested_range is not None and requested_range == selector
+        return version_matches_js_selector(version, selector)
+    if requested_range is not None and requested_range == selector:
+        return True
+    if version is None:
+        return False
+    if selector in {version, f"={version}", f"=={version}"}:
+        return True
+    try:
+        return Version(version) in SpecifierSet(selector)
+    except (InvalidSpecifier, InvalidVersion):
+        return False
+
+
+def target_for_resolved_npm_policy_match(
+    target: dict[str, object],
+    *,
+    resolved_version: str | None,
+) -> dict[str, object]:
+    """Return a policy-only target whose selector input is the resolved npm version.
+
+    Package intent retains the user-requested range for receipts and prompts.
+    Policy matching must instead evaluate the lockfile/registry version that is
+    actually selected; otherwise an allow rule can match the requested range's
+    text while npm resolves an inadmissible prerelease.
+    """
+
+    ecosystem_value = target.get("ecosystem")
+    ecosystem = ecosystem_value.strip() if isinstance(ecosystem_value, str) else "npm"
+    if resolved_version is None or (ecosystem or "npm") != "npm":
+        return target
+    policy_target = dict(target)
+    policy_target["version"] = resolved_version
+    policy_target["range"] = None
+    return policy_target
+
+
+def bind_resolved_npm_policy_result(
+    package: dict[str, object],
+    *,
+    resolved_version: str | None,
+) -> dict[str, object]:
+    """Record the exact npm version without replacing the requested range."""
+
+    if resolved_version is None:
+        return package
+    bound = dict(package)
+    bound["resolvedVersion"] = resolved_version
+    return bound
+
+
+def _optional_string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -37,6 +37,11 @@ from ..store_evidence import EvidenceRecord
 from ..text import ensure_terminal_punctuation as _ensure_terminal_punctuation
 from .js_semver import highest_js_version_for_selector, version_matches_js_selector
 from .manifest_dependency_targets import evaluation_targets as _manifest_evaluation_targets
+from .npm_policy_range import (
+    bind_resolved_npm_policy_result,
+    policy_selector_matches_target,
+    target_for_resolved_npm_policy_match,
+)
 from .package_intent_common import split_python_extras
 from .package_manifest_diff import (
     _DeadlineExceededError,
@@ -1274,15 +1279,22 @@ def _evaluate_with_bundle(
             if resolved_version is not None
             else None
         )
+        resolved_npm_version = (
+            resolved_version if (_optional_string(target.get("ecosystem")) or "npm") == "npm" else None
+        )
+        policy_target = target_for_resolved_npm_policy_match(target, resolved_version=resolved_npm_version)
         matched_rule = _matching_policy_rule(
             bundle_response.bundle.policy_rules,
-            target=target,
+            target=policy_target,
             harness=artifact.harness,
             package_severity=package_match.normalized_severity if package_match is not None else None,
         )
         if matched_rule is not None:
             decision = _normalize_bundle_action(matched_rule.action)
-            package = _policy_package_result(target, decision=decision, rule_id=matched_rule.rule_id)
+            package = bind_resolved_npm_policy_result(
+                _policy_package_result(target, decision=decision, rule_id=matched_rule.rule_id),
+                resolved_version=resolved_npm_version,
+            )
             packages.append(package)
             continue
         confusion_result = _dependency_confusion_policy_package_result(
@@ -3851,8 +3863,9 @@ def _matching_policy_rule(
             }
             if selector not in candidates:
                 continue
-        if rule.version_range_selector is not None and not _selector_matches_version(
-            rule.version_range_selector, target
+        if rule.version_range_selector is not None and not policy_selector_matches_target(
+            rule.version_range_selector,
+            target,
         ):
             continue
         if rule.severity_threshold is not None:
@@ -3862,24 +3875,6 @@ def _matching_policy_rule(
                 continue
         return rule
     return None
-
-
-def _selector_matches_version(selector: str, target: dict[str, object]) -> bool:
-    version = _optional_string(target.get("version"))
-    requested_range = _optional_string(target.get("range"))
-    if requested_range is not None and requested_range == selector:
-        return True
-    ecosystem = _optional_string(target.get("ecosystem")) or "npm"
-    if version is None:
-        return False
-    if selector in {version, f"={version}", f"=={version}"}:
-        return True
-    if ecosystem == "npm" and version_matches_js_selector(version, selector):
-        return True
-    try:
-        return Version(version) in SpecifierSet(selector)
-    except (InvalidSpecifier, InvalidVersion):
-        return False
 
 
 def _bundle_package(

--- a/tests/test_guard_js_semver_phase11.py
+++ b/tests/test_guard_js_semver_phase11.py
@@ -1,16 +1,255 @@
-"""Phase 11 JavaScript semver regression tests."""
+"""Phase 11 JavaScript semver regression tests.
+
+Representative truth cases were checked against npm ``semver@7.7.3``; the
+production matcher remains self-contained and does not require Node.
+"""
 
 from __future__ import annotations
 
-from codex_plugin_scanner.guard.runtime.js_semver import version_matches_js_selector
-from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import _exact_version
+import pytest
+
+from codex_plugin_scanner.guard.runtime import supply_chain_package_eval as supply_chain_package_eval_module
+from codex_plugin_scanner.guard.runtime.js_semver import (
+    highest_js_version_for_selector,
+    parse_js_semver,
+    version_matches_js_selector,
+)
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
+    _exact_version,  # pyright: ignore[reportPrivateUsage]
+)
 
 
-def test_version_matches_js_selector_preserves_prerelease_ordering() -> None:
-    assert version_matches_js_selector("1.2.3-beta.1", "1.2.3-beta.1")
-    assert not version_matches_js_selector("1.2.3-beta.1", "1.2.3")
-    assert not version_matches_js_selector("1.2.3-beta.1", ">=1.2.3")
-    assert version_matches_js_selector("1.2.3", ">=1.2.3")
+@pytest.mark.parametrize(
+    ("version", "selector", "expected"),
+    [
+        ("1.2.3-beta.1", "^1.2.0", False),
+        ("1.2.3-beta.1", "~1.2.0", False),
+        ("1.2.3-beta.1", ">=1.2.0 <2.0.0", False),
+        ("1.2.3-beta.1", "*", False),
+        ("1.3.0-beta.1", "^1.2.3", False),
+        ("1.2.3-beta.1", "", False),
+        ("1.2.3-beta.1", "latest", False),
+        ("1.2.3", "^1.2.0", True),
+        ("1.9.9", ">=1.2.0 <2.0.0", True),
+        ("2.0.0", "*", True),
+        ("2.0.0", "", True),
+        ("2.0.0+linux.x64", "latest", True),
+    ],
+)
+def test_ordinary_ranges_do_not_admit_prereleases(version: str, selector: str, expected: bool) -> None:
+    assert version_matches_js_selector(version, selector) is expected
+
+
+@pytest.mark.parametrize(
+    ("version", "selector", "expected"),
+    [
+        ("1.2.3-beta.1", "1.2.3-beta.1", True),
+        ("1.2.3-beta.1+build.9", "=1.2.3-beta.1+build.2", True),
+        ("1.2.3-beta.2", ">=1.2.3-beta.1 <2.0.0", True),
+        ("1.2.3-rc.1", "^1.2.3-beta.1", True),
+        ("1.2.3-beta.2", "~1.2.3-beta.1", True),
+        ("0.0.0-beta.2", ">=0.0.0-alpha.1 >=0.0.0", True),
+        ("0.0.0-beta.2", "0 >=0.0.0-alpha.1", True),
+        ("1.2.3", ">=1.2.3-beta.1 <2.0.0", True),
+        ("1.2.4-beta.1", ">=1.2.3-beta.1 <2.0.0", False),
+        ("1.3.0-beta.1", "~1.2.3-beta.1", False),
+        ("2.0.0-beta.1", "^1.2.3-beta.1", False),
+    ],
+)
+def test_explicit_prerelease_comparator_only_admits_the_same_base(
+    version: str,
+    selector: str,
+    expected: bool,
+) -> None:
+    assert version_matches_js_selector(version, selector) is expected
+
+
+@pytest.mark.parametrize(
+    ("version", "selector", "expected"),
+    [
+        ("1.2.3-beta.2", ">=1.2.3-beta.1 <1.2.3 || >=2.0.0 <3.0.0", True),
+        ("2.1.0-alpha.2", ">=1.2.3-beta.1 <1.2.3 || >=2.0.0 <3.0.0", False),
+        ("2.1.0-alpha.2", ">=1.2.3-beta.1 <1.2.3 || >=2.1.0-alpha.1 <3.0.0", True),
+        ("3.1.0-alpha.1", ">=1.2.3-beta.1 <2.0.0 || >=3.0.0 <4.0.0", False),
+    ],
+)
+def test_prerelease_admission_is_local_to_each_or_clause(version: str, selector: str, expected: bool) -> None:
+    assert version_matches_js_selector(version, selector) is expected
+
+
+@pytest.mark.parametrize(
+    ("version", "selector", "expected"),
+    [
+        ("0.2.9", "^0.2.3", True),
+        ("0.3.0", "^0.2.3", False),
+        ("0.2.3-beta.2", "^0.2.3-beta.1", True),
+        ("0.2.4-beta.1", "^0.2.3-beta.1", False),
+        ("0.2.4", "^0.2.3-beta.1", True),
+        ("0.0.3", "^0.0.3", True),
+        ("0.0.4", "^0.0.3", False),
+        ("0.0.8", "^0.0", True),
+        ("0.1.0", "^0.0", False),
+    ],
+)
+def test_zero_major_caret_ranges_match_npm_boundaries(version: str, selector: str, expected: bool) -> None:
+    assert version_matches_js_selector(version, selector) is expected
+
+
+@pytest.mark.parametrize(
+    ("version", "selector", "expected"),
+    [
+        ("1.2.9", "~1.2.3", True),
+        ("1.3.0", "~1.2.3", False),
+        ("1.8.0", "~1", True),
+        ("2.0.0", "~1", False),
+        ("1.2.9", "1.2.x", True),
+        ("1.2.9", "1.2", True),
+        ("1.9.0", "1.x", True),
+        ("2.0.0", "1.x", False),
+        ("1.2.9", ">1.2", False),
+        ("1.3.0", ">1.2", True),
+        ("1.2.9", "<=1.2", True),
+        ("1.3.0", "<=1.2", False),
+        ("1.2.3", "1.2.3 - 2.3.4", True),
+        ("2.3.4", "1.2.3 - 2.3.4", True),
+        ("2.3.5", "1.2.3 - 2.3.4", False),
+        ("2.3.9", "1.2 - 2.3", True),
+        ("2.4.0", "1.2 - 2.3", False),
+    ],
+)
+def test_supported_npm_range_forms_use_npm_boundaries(version: str, selector: str, expected: bool) -> None:
+    assert version_matches_js_selector(version, selector) is expected
+
+
+@pytest.mark.parametrize(
+    ("version", "selector", "expected"),
+    [
+        ("1.2.3+build.9", "1.2.3+build.1", True),
+        ("1.2.3+build.9", ">=1.2.3+build.1 <=1.2.3+build.2", True),
+        ("1.2.3-beta.2+sha.9", ">=1.2.3-beta.1+sha.1 <1.2.3", True),
+        ("1.2.3-alpha.10", ">1.2.3-alpha.2 <1.2.3", True),
+        ("1.2.3-alpha.2", ">1.2.3-alpha.10 <1.2.3", False),
+        ("1.2.3-1", ">1.2.3-alpha <1.2.3", False),
+    ],
+)
+def test_build_metadata_and_prerelease_precedence_match_semver(
+    version: str,
+    selector: str,
+    expected: bool,
+) -> None:
+    assert version_matches_js_selector(version, selector) is expected
+
+
+@pytest.mark.parametrize(
+    ("version", "selector"),
+    [
+        ("1.2.3", "workspace:*"),
+        ("1.2.3", ">=1.2.3 || not-a-range"),
+        ("1.2.3", "1.2.3 ||"),
+        ("1.2.3", "|| 1.2.3"),
+        ("1.2.3", ">=1.2.3 # comment"),
+        ("1.2.3", "1.2.x-beta.1"),
+        ("1.2.3", "1.2.3 - nope"),
+        ("1.2.3", "!=1.2.3"),
+        ("1.2.3", "==1.2.3"),
+        ("1.2.3", "V1.2.3"),
+        ("1.2.3", "1.2.3\u0661"),
+        ("1.2.3", ">= 1.2.3"),
+        ("1.2.3", ">=1.2.3, <2.0.0"),
+    ],
+)
+def test_invalid_or_unsupported_selector_syntax_fails_closed(version: str, selector: str) -> None:
+    assert not version_matches_js_selector(version, selector)
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "1.2",
+        "01.2.3",
+        "1.02.3",
+        "1.2.03",
+        "1.2.3-01",
+        "1.2.3-beta..1",
+        "1.2.3+build..1",
+        "1.2.3\u0661",
+        " 1.2.3",
+        "1.2.3 ",
+    ],
+)
+def test_invalid_candidate_versions_fail_closed(version: str) -> None:
+    assert parse_js_semver(version) is None
+    assert not version_matches_js_selector(version, "*")
+
+
+def test_semver_parser_resource_limits_fail_closed() -> None:
+    assert parse_js_semver(f"1.2.3+{'x' * 257}") is None
+    assert not version_matches_js_selector("1.2.3", ">=1.0.0 " * 65)
+    assert not version_matches_js_selector("1.2.3", " || ".join([">=1.0.0"] * 33))
+    assert not version_matches_js_selector("1.2.3", "x" * 1025)
+    maximum = "9007199254740991"
+    assert version_matches_js_selector(f"{maximum}.0.0", f">={maximum}")
+    assert not version_matches_js_selector(f"{maximum}.0.0", maximum)
+    assert not version_matches_js_selector(f"0.0.{maximum}", f"^0.0.{maximum}")
+    assert not version_matches_js_selector(f"{maximum}.0.0", f"0 - {maximum}")
+
+
+def test_highest_version_selection_never_prefers_an_inadmissible_prerelease() -> None:
+    versions = ["1.9.9", "2.0.0-alpha.1", "1.5.0", "invalid"]
+
+    assert highest_js_version_for_selector(versions, ">=1.0.0 <3.0.0") == "1.9.9"
+    assert highest_js_version_for_selector(versions, "*") == "1.9.9"
+
+
+def test_highest_version_selection_keeps_explicitly_admitted_prereleases() -> None:
+    versions = ["1.2.2", "1.2.3-beta.1", "1.2.3-beta.10", "1.2.3-beta.2", "1.2.4-alpha.1"]
+
+    assert highest_js_version_for_selector(versions, ">=1.2.3-beta.1 <1.2.3") == "1.2.3-beta.10"
+
+
+def test_release_has_higher_precedence_than_its_prereleases() -> None:
+    versions = ["1.2.3-beta.10", "1.2.3", "1.2.3-rc.1"]
+
+    assert highest_js_version_for_selector(versions, ">=1.2.3-beta.1 <2.0.0") == "1.2.3"
+
+
+@pytest.mark.parametrize(
+    ("selector", "expected"),
+    [
+        (">=1.0.0 <3.0.0", "1.9.9"),
+        ("latest", "1.9.9"),
+        (">=2.0.0-alpha.1 <2.0.0", "2.0.0-alpha.10"),
+        (">=1.0.0 || not-a-range", None),
+    ],
+)
+def test_npm_registry_resolution_applies_prerelease_admission_at_the_selection_sink(
+    monkeypatch: pytest.MonkeyPatch,
+    selector: str,
+    expected: str | None,
+) -> None:
+    def registry_response(**_kwargs: object) -> dict[str, object]:
+        return {
+            "versions": {
+                "1.5.0": {},
+                "1.9.9": {},
+                "2.0.0-alpha.1": {},
+                "2.0.0-alpha.10": {},
+            }
+        }
+
+    monkeypatch.setattr(
+        supply_chain_package_eval_module,
+        "_urlopen_json_with_timeout_retry",
+        registry_response,
+    )
+
+    assert (
+        supply_chain_package_eval_module._npm_registry_resolved_version(  # pyright: ignore[reportPrivateUsage]
+            package_name="example-package",
+            requested_range=selector,
+        )
+        == expected
+    )
 
 
 def test_exact_version_ignores_all_js_source_prefixes() -> None:

--- a/tests/test_guard_js_semver_policy_phase11.py
+++ b/tests/test_guard_js_semver_policy_phase11.py
@@ -1,0 +1,78 @@
+"""Resolved-version policy sinks for npm prerelease admission."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.models import GuardArtifact
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.store import GuardStore
+from tests import test_guard_js_supply_chain_phase11 as support
+
+
+@pytest.mark.parametrize(
+    ("resolved_version", "policy_selector", "expected_decision", "expected_rule_id"),
+    [
+        ("1.3.0-beta.1", "^1.2.3", "block", None),
+        ("1.3.0-beta.1", ">=1.2.0, <2.0.0", "block", None),
+        ("1.3.0-beta.1", ">=1.3.0-beta.1 <1.3.0", "allow", "allow-range"),
+        ("1.3.0", "^1.2.3", "allow", "allow-range"),
+        ("1.2.3", "==1.2.3", "block", None),
+    ],
+)
+def test_policy_range_matches_resolved_npm_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    resolved_version: str,
+    policy_selector: str,
+    expected_decision: str,
+    expected_rule_id: str | None,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    support._write_text(
+        workspace_dir / "package.json",
+        '{"name":"demo","dependencies":{"minimist":"^1.2.3"}}\n',
+    )
+    support._write_text(
+        workspace_dir / "package-lock.json",
+        (
+            '{"lockfileVersion":3,"packages":{"":{"dependencies":{"minimist":"^1.2.3"}},'
+            f'"node_modules/minimist":{{"version":"{resolved_version}"}}}}}}\n'
+        ),
+    )
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: support.WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        support.WORKSPACE_ID,
+        support._bundle_response(
+            packages=[support._package(name="minimist", version=resolved_version, default_action="block")],
+            policy_rules=[
+                {
+                    "action": "allow",
+                    "ruleId": "allow-range",
+                    "ecosystemSelector": "npm",
+                    "enabled": True,
+                    "expiresAt": None,
+                    "harnessSelector": "codex",
+                    "packageSelector": "minimist",
+                    "priority": 1,
+                    "severityThreshold": None,
+                    "versionRangeSelector": policy_selector,
+                }
+            ],
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = support._artifact_from_command("npm install minimist@^1.2.3", workspace=workspace_dir)
+    assert isinstance(artifact, GuardArtifact)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == expected_decision
+    assert result.matched_rule_id == expected_rule_id
+    assert result.packages[0]["requestedVersion"] == "^1.2.3"
+    assert result.packages[0]["resolvedVersion"] == resolved_version


### PR DESCRIPTION
## Security invariant

An npm prerelease is eligible only when every comparator in one clause matches and that same clause contains a prerelease comparator for the candidate's exact major/minor/patch tuple. Ordinary ranges, wildcards, and unrelated `||` clauses cannot admit prereleases.

## Implementation

- Implement bounded, fail-closed npm range parsing for exact, comparator, caret, tilde, partial/wildcard, hyphen, and OR forms.
- Preserve SemVer precedence and ignore build metadata for matching.
- Reject invalid and unsupported selector syntax instead of broadening it.
- Apply the matcher at registry highest-version selection and bundle policy evaluation against the resolved npm version.
- Replay the fix directly on `release/2.1` with corrected GitHub author and committer attribution.

## Validation

- 127 focused SemVer and JavaScript supply-chain tests passed after the `release/2.1` replay.
- Earlier broad validation passed 224 related tests and matched canonical Node `semver` across 156,288 supported version/range pairs with zero mismatches.
- Ruff and format checks, basedpyright, wheel, and source distribution builds passed.
