### PR TITLE
fix(guard): preserve Claude hook argv exactly

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -41,6 +41,7 @@ def _command_available(command: str) -> bool:
 
 def _shell_command(command: tuple[str, ...], *, windows: bool | None = None) -> str:
     """Return a shell-escaped command string appropriate for the target OS."""
+
     is_windows = os.name == "nt" if windows is None else windows
     if is_windows:
         return subprocess.list2cmdline(list(command))

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -5,16 +5,15 @@ from __future__ import annotations
 import hashlib
 import importlib
 import json
-import sys
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
-from urllib.parse import urlencode
 
 from ...path_support import iter_safe_matching_files, resolves_within_root
 from ..aibom_detection import enrich_mcp_server_metadata
 from ..models import GuardArtifact, HarnessDetection
-from ..runtime.harness_attribution import cursor_hook_query_extras
 from ..shims import install_guard_shim, remove_guard_shim
+from . import claude_hook_argv as _hook_argv
+from . import claude_hook_config as _hook_config
 from .base import (
     HarnessAdapter,
     HarnessContext,
@@ -24,16 +23,24 @@ from .base import (
     _shell_command,
 )
 
-CLAUDE_GUARD_TOOL_MATCHER = "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*"
-CLAUDE_GUARD_POST_TOOL_MATCHER = f"{CLAUDE_GUARD_TOOL_MATCHER}|AskUserQuestion"
-CLAUDE_GUARD_NOTIFICATION_MATCHER = "permission_prompt"
-CLAUDE_GUARD_SESSION_START_MATCHERS = ("startup", "resume", "clear", "compact")
-CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS = 30
-CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS = 10
-CLAUDE_GUARD_SESSION_START_TIMEOUT_SECONDS = 10
-CLAUDE_GUARD_STOP_TIMEOUT_SECONDS = 10
+CLAUDE_GUARD_DAEMON_HOOK_MARKER = _hook_config.CLAUDE_GUARD_DAEMON_HOOK_MARKER
+CLAUDE_GUARD_SESSION_START_HOOK_MARKER = _hook_config.CLAUDE_GUARD_SESSION_START_HOOK_MARKER
+CLAUDE_GUARD_SESSION_START_MATCHERS = _hook_config.CLAUDE_GUARD_SESSION_START_MATCHERS
+CLAUDE_GUARD_SESSION_START_TIMEOUT_SECONDS = _hook_config.CLAUDE_GUARD_SESSION_START_TIMEOUT_SECONDS
+CLAUDE_GUARD_TOOL_MATCHER = _hook_config.CLAUDE_GUARD_TOOL_MATCHER
+_claude_managed_settings_path = _hook_config.claude_managed_settings_path
+_command_handler_argv = _hook_config.command_handler_argv
+_guard_command_handler = _hook_config.guard_command_handler
+_handler_identity = _hook_config.handler_identity
+_is_guard_hook_command = _hook_config.is_guard_hook_command
+_is_guard_hook_url = _hook_config.is_guard_hook_url
+_manifest_notes = _hook_config.manifest_notes
+_merge_hook_group = _hook_config.merge_hook_group
+_prune_guard_hook_entries = _hook_config.prune_guard_hook_entries
+_remove_unsupported_guard_hook_groups = _hook_config.remove_unsupported_guard_hook_groups
+_sync_runtime_hook_groups = _hook_config.sync_runtime_hook_groups
+
 CLAUDE_SETTINGS_FILES = ("settings.json", "settings.local.json")
-CLAUDE_GUARD_DAEMON_HOOK_MARKER = "HOL_GUARD_CLAUDE_DAEMON_HOOK"
 
 
 def _aibom_detection_module():
@@ -52,200 +59,12 @@ def load_guard_daemon_url(guard_home: Path) -> str | None:
     return _daemon_module().load_guard_daemon_url(guard_home)
 
 
-def _guard_command_handler(
-    command: str,
-    *,
-    timeout: int,
-    status_message: str | None = None,
-) -> dict[str, object]:
-    handler: dict[str, object] = {"type": "command", "command": command, "timeout": timeout}
-    if status_message is not None:
-        handler["statusMessage"] = status_message
-    return handler
-
-
-def _manifest_notes(payload: dict[str, object]) -> list[str]:
-    notes = payload.get("notes")
-    if not isinstance(notes, list):
-        return []
-    return [str(note) for note in notes]
-
-
-def _claude_managed_settings_path(context: HarnessContext) -> Path:
-    return context.home_dir / ".claude" / "settings.json"
-
-
-def _sync_runtime_hook_groups(hooks: dict[str, object], hook_command: str) -> None:
-    for key, matcher, timeout, status_message in (
-        (
-            "PreToolUse",
-            CLAUDE_GUARD_TOOL_MATCHER,
-            CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS,
-            "HOL Guard is checking this tool use",
-        ),
-        (
-            "PermissionRequest",
-            CLAUDE_GUARD_TOOL_MATCHER,
-            CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS,
-            "HOL Guard is reviewing this approval prompt",
-        ),
-        ("PostToolUse", CLAUDE_GUARD_POST_TOOL_MATCHER, CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS, None),
-        ("Notification", CLAUDE_GUARD_NOTIFICATION_MATCHER, CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS, None),
-        ("Stop", None, CLAUDE_GUARD_STOP_TIMEOUT_SECONDS, None),
-    ):
-        existing_entries = hooks.get(key)
-        hooks[key] = _merge_hook_group(
-            _prune_guard_hook_entries(existing_entries if isinstance(existing_entries, list) else []),
-            matcher,
-            _guard_command_handler(hook_command, timeout=timeout, status_message=status_message),
-        )
-
-
-def _remove_unsupported_guard_hook_groups(hooks: dict[str, object]) -> None:
-    for key in ("PermissionDenied", "UserPromptSubmit"):
-        entries = hooks.get(key)
-        if not isinstance(entries, list):
-            continue
-        remaining = _prune_guard_hook_entries(entries)
-        if remaining:
-            hooks[key] = remaining
-        else:
-            hooks.pop(key, None)
-
-
-def _guard_hook_group(matcher: str | None, handler: dict[str, object]) -> dict[str, object]:
-    payload: dict[str, object] = {"hooks": [handler]}
-    if isinstance(matcher, str) and matcher.strip():
-        payload["matcher"] = matcher
-    return payload
-
-
-def _is_guard_hook_command(command: object) -> bool:
-    if not isinstance(command, str):
-        return False
-    if CLAUDE_GUARD_DAEMON_HOOK_MARKER in command:
-        return True
-    if "codex_plugin_scanner.cli" in command:
-        return "guard hook" in command or "'guard', 'hook'" in command or '"guard", "hook"' in command
-    return "ensure_guard_daemon(" in command and "HOL Guard protection is active for this workspace." in command
-
-
-def _handler_identity(handler: dict[str, object]) -> tuple[str, str]:
-    handler_type = str(handler.get("type", ""))
-    if handler_type == "http":
-        return (handler_type, str(handler.get("url", "")))
-    return (handler_type, str(handler.get("command", "")))
-
-
-def _is_guard_hook_url(url: object) -> bool:
-    if not isinstance(url, str):
-        return False
-    return url.startswith("http://127.0.0.1:") and "/v1/hooks/claude-code" in url
-
-
-def _is_guard_hook_handler(handler: object) -> bool:
-    if not isinstance(handler, dict):
-        return False
-    handler_type = handler.get("type")
-    if handler_type == "command":
-        return _is_guard_hook_command(handler.get("command"))
-    if handler_type == "http":
-        return _is_guard_hook_url(handler.get("url"))
-    return False
-
-
-def _merge_hook_group(
-    entries: list[object],
-    matcher: str | None,
-    handler: dict[str, object],
-) -> list[object]:
-    normalized: list[object] = []
-    for entry in entries:
-        if isinstance(entry, dict):
-            normalized.append(entry)
-    matcher_key = matcher.strip() if isinstance(matcher, str) and matcher.strip() else None
-    handler_identity = _handler_identity(handler)
-    for index, entry in enumerate(normalized):
-        if not isinstance(entry, dict):
-            continue
-        entry_matcher = entry.get("matcher")
-        entry_matcher_key = entry_matcher.strip() if isinstance(entry_matcher, str) and entry_matcher.strip() else None
-        if entry_matcher_key != matcher_key:
-            continue
-        hooks = entry.get("hooks")
-        if not isinstance(hooks, list):
-            hooks = []
-        if any(isinstance(item, dict) and _handler_identity(item) == handler_identity for item in hooks):
-            updated_entry = dict(entry)
-            updated_entry["hooks"] = [
-                handler if isinstance(item, dict) and _handler_identity(item) == handler_identity else item
-                for item in hooks
-            ]
-            normalized[index] = updated_entry
-            return normalized
-        hooks.append(handler)
-        updated_entry = dict(entry)
-        updated_entry["hooks"] = hooks
-        normalized[index] = updated_entry
-        return normalized
-    normalized.append(_guard_hook_group(matcher_key, handler))
-    return normalized
-
-
-def _group_has_handler(entry: object, handler: dict[str, object]) -> bool:
-    if not isinstance(entry, dict):
-        return False
-    hooks = entry.get("hooks")
-    if not isinstance(hooks, list):
-        return False
-    handler_identity = _handler_identity(handler)
-    return any(isinstance(hook, dict) and _handler_identity(hook) == handler_identity for hook in hooks)
-
-
-def _prune_guard_hook_entries(entries: list[object]) -> list[object]:
-    remaining: list[object] = []
-    for entry in entries:
-        if not isinstance(entry, dict):
-            remaining.append(entry)
-            continue
-        if _is_guard_hook_command(entry.get("command")):
-            continue
-        hooks = entry.get("hooks")
-        if not isinstance(hooks, list):
-            remaining.append(entry)
-            continue
-        filtered_hooks = [item for item in hooks if not _is_guard_hook_handler(item)]
-        if filtered_hooks:
-            updated_entry = dict(entry)
-            updated_entry["hooks"] = filtered_hooks
-            remaining.append(updated_entry)
-    return remaining
-
-
-def _remove_hook_entry(entries: list[object], handler: dict[str, object]) -> list[object]:
-    remaining: list[object] = []
-    for entry in entries:
-        if not isinstance(entry, dict):
-            remaining.append(entry)
-            continue
-        if _is_guard_hook_command(entry.get("command")):
-            continue
-        if _group_has_handler(entry, handler):
-            hooks = entry.get("hooks")
-            if not isinstance(hooks, list):
-                continue
-            filtered_hooks = [
-                item
-                for item in hooks
-                if not (isinstance(item, dict) and _handler_identity(item) == _handler_identity(handler))
-            ]
-            if filtered_hooks:
-                updated_entry = dict(entry)
-                updated_entry["hooks"] = filtered_hooks
-                remaining.append(updated_entry)
-            continue
-        remaining.append(entry)
-    return remaining
+def _run_session_start_from_argv(argv: Sequence[str]) -> int:
+    return _hook_argv.run_session_start_from_argv(
+        argv,
+        ensure_guard_daemon=_daemon_module().ensure_guard_daemon,
+        refresh_installed_hook_urls=ClaudeCodeHarnessAdapter.refresh_installed_hook_urls,
+    )
 
 
 def _claude_digest(path: Path) -> str:
@@ -446,6 +265,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                             continue
                         flat_command = entry.get("command")
                         if isinstance(flat_command, str):
+                            flat_argv = _command_handler_argv(entry)
                             artifacts.append(
                                 GuardArtifact(
                                     artifact_id=f"claude-code:{scope}:{normalized_event}:{group_index}",
@@ -455,6 +275,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                                     source_scope=scope,
                                     config_path=str(config_path),
                                     command=flat_command,
+                                    args=flat_argv[1:] if flat_argv is not None else (),
                                 )
                             )
                             continue
@@ -466,6 +287,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                             if not isinstance(handler, dict):
                                 continue
                             command = handler.get("command")
+                            handler_argv = _command_handler_argv(handler)
                             metadata: dict[str, object] = {}
                             if isinstance(matcher, str):
                                 metadata["matcher"] = matcher
@@ -490,6 +312,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                                     source_scope=scope,
                                     config_path=str(config_path),
                                     command=command if isinstance(command, str) else None,
+                                    args=handler_argv[1:] if handler_argv is not None else (),
                                     url=url if isinstance(url, str) else None,
                                     metadata=metadata,
                                 )
@@ -568,7 +391,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
     @staticmethod
     def _hook_command(context: HarnessContext) -> str:
         command = ClaudeCodeHarnessAdapter._hook_command_parts(context)
-        return _shell_command(command, windows=True)
+        return _shell_command(command)
 
     @staticmethod
     def _daemon_hook_command(context: HarnessContext) -> str:
@@ -578,88 +401,28 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
     @staticmethod
     def _session_start_command(context: HarnessContext) -> str:
         command = ClaudeCodeHarnessAdapter._session_start_command_parts(context)
-        return _shell_command(command, windows=True)
+        return _shell_command(command)
 
     @staticmethod
     def _hook_http_url(context: HarnessContext) -> str:
         daemon_url = load_guard_daemon_url(context.guard_home) or guard_daemon_url_for_home(context.guard_home)
-        query: dict[str, str] = {"guard-home": str(context.guard_home)}
-        if context.home_dir.resolve() != Path.home().resolve():
-            query["home"] = str(context.home_dir)
-        if context.workspace_dir is not None:
-            query["workspace"] = str(context.workspace_dir)
-        for key, value in cursor_hook_query_extras().items():
-            query[key] = value
-        return f"{daemon_url}/v1/hooks/claude-code?{urlencode(query)}"
+        return _hook_argv.hook_http_url(context, daemon_url=daemon_url)
 
     @staticmethod
     def _daemon_hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
         fallback_daemon_url = load_guard_daemon_url(context.guard_home) or guard_daemon_url_for_home(context.guard_home)
-        state_path = context.guard_home / "daemon-state.json"
-        fallback_command = ClaudeCodeHarnessAdapter._hook_command_parts(context)
-        query: dict[str, str] = {"guard-home": str(context.guard_home)}
-        if context.home_dir.resolve() != Path.home().resolve():
-            query["home"] = str(context.home_dir)
-        if context.workspace_dir is not None:
-            query["workspace"] = str(context.workspace_dir)
-        for key, value in cursor_hook_query_extras().items():
-            query[key] = value
-        package_root = Path(__file__).resolve().parents[3]
-        code = (
-            f"_HOL_GUARD_CLAUDE_DAEMON_HOOK_MARKER = {CLAUDE_GUARD_DAEMON_HOOK_MARKER!r};"
-            "import sys;"
-            f"sys.path.insert(0, {str(package_root)!r});"
-            "from codex_plugin_scanner.guard.adapters.claude_daemon_hook_bridge import main;"
-            f"raise SystemExit(main(state_path={str(state_path)!r}, "
-            f"fallback_daemon_url={fallback_daemon_url!r}, "
-            f"fallback_command={fallback_command!r}, query={urlencode(query)!r}))"
-        )
-        return (sys.executable, "-c", code)
+        return _hook_argv.daemon_hook_command_parts(context, fallback_daemon_url=fallback_daemon_url)
 
     @staticmethod
     def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
-        guard_args = [
-            "guard",
-            "hook",
-            "--guard-home",
-            str(context.guard_home),
-        ]
-        if context.home_dir.resolve() != Path.home().resolve():
-            guard_args.extend(["--home", str(context.home_dir)])
-        if context.workspace_dir is not None:
-            guard_args.extend(["--workspace", str(context.workspace_dir)])
-        package_root = Path(__file__).resolve().parents[3]
-        code = (
-            "import sys;"
-            f"sys.path.insert(0, {str(package_root)!r});"
-            "from codex_plugin_scanner.cli import main;"
-            f"raise SystemExit(main({guard_args!r}))"
-        )
-        return (sys.executable, "-c", code)
+        return _hook_argv.guard_hook_command_parts(context)
 
     @staticmethod
     def _session_start_command_parts(context: HarnessContext) -> tuple[str, ...]:
-        package_root = Path(__file__).resolve().parents[3]
-        workspace_dir_literal = f"Path({str(context.workspace_dir)!r})" if context.workspace_dir is not None else "None"
-        code = (
-            "import sys;"
-            f"sys.path.insert(0, {str(package_root)!r});"
-            "import json;"
-            "from pathlib import Path;"
-            "from codex_plugin_scanner.guard.daemon import ensure_guard_daemon;"
-            "from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter;"
-            f"ensure_guard_daemon(Path({str(context.guard_home)!r}));"
-            f"ClaudeCodeHarnessAdapter.refresh_installed_hook_urls(home_dir=Path({str(context.home_dir)!r}), "
-            f"workspace_dir={workspace_dir_literal}, "
-            f"guard_home=Path({str(context.guard_home)!r}));"
-            "print(json.dumps({'hookSpecificOutput': {'hookEventName': 'SessionStart', "
-            "'additionalContext': 'HOL Guard protection is active for this workspace.'}}, "
-            "separators=(',', ':')))"
-        )
-        return (sys.executable, "-c", code)
+        return _hook_argv.session_start_command_parts(context)
 
     @classmethod
-    def refresh_installed_hook_urls(cls, *, home_dir: Path, workspace_dir: Path, guard_home: Path) -> None:
+    def refresh_installed_hook_urls(cls, *, home_dir: Path, workspace_dir: Path | None, guard_home: Path) -> None:
         cls().refresh_runtime_hook_urls(
             HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=guard_home)
         )
@@ -670,7 +433,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
         hooks = payload.get("hooks")
         if not isinstance(hooks, dict):
             return
-        _sync_runtime_hook_groups(hooks, self._daemon_hook_command(context))
+        _sync_runtime_hook_groups(hooks, self._daemon_hook_command_parts(context))
         _remove_unsupported_guard_hook_groups(hooks)
         settings_path.parent.mkdir(parents=True, exist_ok=True)
         settings_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
@@ -691,8 +454,8 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
         settings_path = _claude_managed_settings_path(context)
         _ensure_path_within_root(context.home_dir, settings_path, label="Claude Code")
         payload = _json_payload(settings_path)
-        session_start_command = self._session_start_command(context)
-        hook_command = self._daemon_hook_command(context)
+        session_start_argv = self._session_start_command_parts(context)
+        hook_argv = self._daemon_hook_command_parts(context)
         hooks_payload = payload.get("hooks")
         if isinstance(hooks_payload, dict):
             hooks: dict[str, object] = {str(key): value for key, value in hooks_payload.items()}
@@ -704,13 +467,13 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             session_start_payload if isinstance(session_start_payload, list) else []
         )
         session_start_handler = _guard_command_handler(
-            session_start_command,
+            session_start_argv,
             timeout=CLAUDE_GUARD_SESSION_START_TIMEOUT_SECONDS,
         )
         for matcher in CLAUDE_GUARD_SESSION_START_MATCHERS:
             session_start_entries = _merge_hook_group(session_start_entries, matcher, session_start_handler)
         hooks["SessionStart"] = session_start_entries
-        _sync_runtime_hook_groups(hooks, hook_command)
+        _sync_runtime_hook_groups(hooks, hook_argv)
         _remove_unsupported_guard_hook_groups(hooks)
         settings_path.parent.mkdir(parents=True, exist_ok=True)
         settings_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/src/codex_plugin_scanner/guard/adapters/claude_hook_argv.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_hook_argv.py
@@ -1,0 +1,134 @@
+"""Shell-free Claude hook argv construction and SessionStart entry point."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from urllib.parse import urlencode
+
+from ..runtime.harness_attribution import cursor_hook_query_extras
+from .base import HarnessContext
+from .claude_hook_config import (
+    CLAUDE_GUARD_DAEMON_HOOK_MARKER,
+    CLAUDE_GUARD_SESSION_START_HOOK_MARKER,
+)
+
+_SESSION_START_ERROR = (
+    "claude_session_start_argv_invalid: reinstall the managed Claude hooks with `hol-guard install claude`"
+)
+
+
+def run_session_start_from_argv(
+    argv: Sequence[str],
+    *,
+    ensure_guard_daemon: Callable[[Path], object],
+    refresh_installed_hook_urls: Callable[..., object],
+) -> int:
+    """Refresh managed hook URLs from a validated, shell-free path vector."""
+
+    if len(argv) not in {2, 3} or any(not value or "\x00" in value for value in argv):
+        raise SystemExit(_SESSION_START_ERROR)
+
+    guard_home = Path(argv[0])
+    home_dir = Path(argv[1])
+    workspace_dir = Path(argv[2]) if len(argv) == 3 else None
+    ensure_guard_daemon(guard_home)
+    refresh_installed_hook_urls(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=guard_home,
+    )
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "SessionStart",
+                    "additionalContext": "HOL Guard protection is active for this workspace.",
+                }
+            },
+            separators=(",", ":"),
+        )
+    )
+    return 0
+
+
+def guard_hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
+    guard_args = [
+        "guard",
+        "hook",
+        f"--guard-home={context.guard_home}",
+    ]
+    if context.home_dir.resolve() != Path.home().resolve():
+        guard_args.append(f"--home={context.home_dir}")
+    if context.workspace_dir is not None:
+        guard_args.append(f"--workspace={context.workspace_dir}")
+    package_root = Path(__file__).resolve().parents[3]
+    code = (
+        "import sys;"
+        f"sys.path.insert(0, {str(package_root)!r});"
+        "from codex_plugin_scanner.cli import main;"
+        "raise SystemExit(main(sys.argv[1:]))"
+    )
+    return (sys.executable, "-c", code, *guard_args)
+
+
+def daemon_hook_command_parts(
+    context: HarnessContext,
+    *,
+    fallback_daemon_url: str,
+) -> tuple[str, ...]:
+    state_path = context.guard_home / "daemon-state.json"
+    fallback_command = guard_hook_command_parts(context)
+    package_root = Path(__file__).resolve().parents[3]
+    bridge_config = json.dumps(
+        {
+            "state_path": str(state_path),
+            "fallback_daemon_url": fallback_daemon_url,
+            "fallback_command": list(fallback_command),
+            "query": urlencode(_hook_query(context, cursor_hook_query_extras())),
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    code = (
+        f"_HOL_GUARD_CLAUDE_DAEMON_HOOK_MARKER = {CLAUDE_GUARD_DAEMON_HOOK_MARKER!r};"
+        "import sys;"
+        f"sys.path.insert(0, {str(package_root)!r});"
+        "from codex_plugin_scanner.guard.adapters.claude_daemon_hook_bridge import _bridge_config_from_argv,main;"
+        "_config=_bridge_config_from_argv(sys.argv);"
+        "raise SystemExit(main(state_path=_config['state_path'], "
+        "fallback_daemon_url=_config['fallback_daemon_url'], "
+        "fallback_command=_config['fallback_command'], query=_config['query']))"
+    )
+    return (sys.executable, "-c", code, bridge_config)
+
+
+def session_start_command_parts(context: HarnessContext) -> tuple[str, ...]:
+    package_root = Path(__file__).resolve().parents[3]
+    code = (
+        f"_HOL_GUARD_CLAUDE_SESSION_START_HOOK_MARKER = {CLAUDE_GUARD_SESSION_START_HOOK_MARKER!r};"
+        "import sys;"
+        f"sys.path.insert(0, {str(package_root)!r});"
+        "from codex_plugin_scanner.guard.adapters.claude_code import _run_session_start_from_argv;"
+        "raise SystemExit(_run_session_start_from_argv(sys.argv[1:]))"
+    )
+    path_argv = (str(context.guard_home), str(context.home_dir))
+    if context.workspace_dir is not None:
+        path_argv = (*path_argv, str(context.workspace_dir))
+    return (sys.executable, "-c", code, *path_argv)
+
+
+def hook_http_url(context: HarnessContext, *, daemon_url: str) -> str:
+    return f"{daemon_url}/v1/hooks/claude-code?{urlencode(_hook_query(context, cursor_hook_query_extras()))}"
+
+
+def _hook_query(context: HarnessContext, extras: Mapping[str, str]) -> dict[str, str]:
+    query = {"guard-home": str(context.guard_home)}
+    if context.home_dir.resolve() != Path.home().resolve():
+        query["home"] = str(context.home_dir)
+    if context.workspace_dir is not None:
+        query["workspace"] = str(context.workspace_dir)
+    query.update(extras)
+    return query

--- a/src/codex_plugin_scanner/guard/adapters/claude_hook_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_hook_config.py
@@ -1,0 +1,240 @@
+"""Claude hook configuration primitives and managed-handler identity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import HarnessContext
+
+CLAUDE_GUARD_TOOL_MATCHER = "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*"
+CLAUDE_GUARD_POST_TOOL_MATCHER = f"{CLAUDE_GUARD_TOOL_MATCHER}|AskUserQuestion"
+CLAUDE_GUARD_NOTIFICATION_MATCHER = "permission_prompt"
+CLAUDE_GUARD_SESSION_START_MATCHERS = ("startup", "resume", "clear", "compact")
+CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS = 30
+CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS = 10
+CLAUDE_GUARD_SESSION_START_TIMEOUT_SECONDS = 10
+CLAUDE_GUARD_STOP_TIMEOUT_SECONDS = 10
+CLAUDE_GUARD_DAEMON_HOOK_MARKER = "HOL_GUARD_CLAUDE_DAEMON_HOOK"
+CLAUDE_GUARD_SESSION_START_HOOK_MARKER = "HOL_GUARD_CLAUDE_SESSION_START_HOOK"
+
+
+def manifest_notes(payload: dict[str, object]) -> list[str]:
+    notes = payload.get("notes")
+    if not isinstance(notes, list):
+        return []
+    return [str(note) for note in notes]
+
+
+def claude_managed_settings_path(context: HarnessContext) -> Path:
+    return context.home_dir / ".claude" / "settings.json"
+
+
+def guard_command_handler(
+    argv: tuple[str, ...],
+    *,
+    timeout: int,
+    status_message: str | None = None,
+) -> dict[str, object]:
+    """Build Claude's shell-free exec form from one canonical argv."""
+
+    if not argv:
+        raise ValueError("claude_guard_hook_argv_empty: provide the Guard executable and its argument vector")
+    handler: dict[str, object] = {
+        "type": "command",
+        "command": argv[0],
+        "args": list(argv[1:]),
+        "timeout": timeout,
+    }
+    if status_message is not None:
+        handler["statusMessage"] = status_message
+    return handler
+
+
+def sync_runtime_hook_groups(hooks: dict[str, object], hook_argv: tuple[str, ...]) -> None:
+    for key, matcher, timeout, status_message in (
+        (
+            "PreToolUse",
+            CLAUDE_GUARD_TOOL_MATCHER,
+            CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS,
+            "HOL Guard is checking this tool use",
+        ),
+        (
+            "PermissionRequest",
+            CLAUDE_GUARD_TOOL_MATCHER,
+            CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS,
+            "HOL Guard is reviewing this approval prompt",
+        ),
+        ("PostToolUse", CLAUDE_GUARD_POST_TOOL_MATCHER, CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS, None),
+        ("Notification", CLAUDE_GUARD_NOTIFICATION_MATCHER, CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS, None),
+        ("Stop", None, CLAUDE_GUARD_STOP_TIMEOUT_SECONDS, None),
+    ):
+        existing_entries = hooks.get(key)
+        hooks[key] = merge_hook_group(
+            prune_guard_hook_entries(existing_entries if isinstance(existing_entries, list) else []),
+            matcher,
+            guard_command_handler(hook_argv, timeout=timeout, status_message=status_message),
+        )
+
+
+def remove_unsupported_guard_hook_groups(hooks: dict[str, object]) -> None:
+    for key in ("PermissionDenied", "UserPromptSubmit"):
+        entries = hooks.get(key)
+        if not isinstance(entries, list):
+            continue
+        remaining = prune_guard_hook_entries(entries)
+        if remaining:
+            hooks[key] = remaining
+        else:
+            hooks.pop(key, None)
+
+
+def guard_hook_group(matcher: str | None, handler: dict[str, object]) -> dict[str, object]:
+    payload: dict[str, object] = {"hooks": [handler]}
+    if isinstance(matcher, str) and matcher.strip():
+        payload["matcher"] = matcher
+    return payload
+
+
+def is_guard_hook_command(command: object) -> bool:
+    if not isinstance(command, str):
+        return False
+    if CLAUDE_GUARD_DAEMON_HOOK_MARKER in command:
+        return True
+    if CLAUDE_GUARD_SESSION_START_HOOK_MARKER in command:
+        return True
+    if "codex_plugin_scanner.cli" in command:
+        return "guard hook" in command or "'guard', 'hook'" in command or '"guard", "hook"' in command
+    return "ensure_guard_daemon(" in command and "HOL Guard protection is active for this workspace." in command
+
+
+def command_handler_argv(handler: dict[str, object]) -> tuple[str, ...] | None:
+    command = handler.get("command")
+    args = handler.get("args")
+    if not isinstance(command, str) or not isinstance(args, list) or not all(isinstance(arg, str) for arg in args):
+        return None
+    return (command, *args)
+
+
+def handler_identity(handler: dict[str, object]) -> tuple[str, ...]:
+    handler_type = str(handler.get("type", ""))
+    if handler_type == "http":
+        return (handler_type, str(handler.get("url", "")))
+    argv = command_handler_argv(handler)
+    if argv is not None:
+        return (handler_type, "exec", *argv)
+    shell = handler.get("shell")
+    shell_identity = shell if isinstance(shell, str) and shell else "default"
+    return (handler_type, f"shell:{shell_identity}", str(handler.get("command", "")))
+
+
+def is_guard_hook_url(url: object) -> bool:
+    if not isinstance(url, str):
+        return False
+    return url.startswith("http://127.0.0.1:") and "/v1/hooks/claude-code" in url
+
+
+def is_guard_hook_handler(handler: object) -> bool:
+    if not isinstance(handler, dict):
+        return False
+    handler_type = handler.get("type")
+    if handler_type in {None, "command"}:
+        argv = command_handler_argv(handler)
+        if argv is not None:
+            return any(is_guard_hook_command(argument) for argument in argv)
+        return is_guard_hook_command(handler.get("command"))
+    if handler_type == "http":
+        return is_guard_hook_url(handler.get("url"))
+    return False
+
+
+def merge_hook_group(
+    entries: list[object],
+    matcher: str | None,
+    handler: dict[str, object],
+) -> list[object]:
+    normalized: list[object] = []
+    for entry in entries:
+        if isinstance(entry, dict):
+            normalized.append(entry)
+    matcher_key = matcher.strip() if isinstance(matcher, str) and matcher.strip() else None
+    expected_identity = handler_identity(handler)
+    for index, entry in enumerate(normalized):
+        if not isinstance(entry, dict):
+            continue
+        entry_matcher = entry.get("matcher")
+        entry_matcher_key = entry_matcher.strip() if isinstance(entry_matcher, str) and entry_matcher.strip() else None
+        if entry_matcher_key != matcher_key:
+            continue
+        hooks = entry.get("hooks")
+        if not isinstance(hooks, list):
+            hooks = []
+        if any(isinstance(item, dict) and handler_identity(item) == expected_identity for item in hooks):
+            updated_entry = dict(entry)
+            updated_entry["hooks"] = [
+                handler if isinstance(item, dict) and handler_identity(item) == expected_identity else item
+                for item in hooks
+            ]
+            normalized[index] = updated_entry
+            return normalized
+        hooks.append(handler)
+        updated_entry = dict(entry)
+        updated_entry["hooks"] = hooks
+        normalized[index] = updated_entry
+        return normalized
+    normalized.append(guard_hook_group(matcher_key, handler))
+    return normalized
+
+
+def group_has_handler(entry: object, handler: dict[str, object]) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    hooks = entry.get("hooks")
+    if not isinstance(hooks, list):
+        return False
+    expected_identity = handler_identity(handler)
+    return any(isinstance(hook, dict) and handler_identity(hook) == expected_identity for hook in hooks)
+
+
+def prune_guard_hook_entries(entries: list[object]) -> list[object]:
+    remaining: list[object] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            remaining.append(entry)
+            continue
+        if is_guard_hook_handler(entry):
+            continue
+        hooks = entry.get("hooks")
+        if not isinstance(hooks, list):
+            remaining.append(entry)
+            continue
+        filtered_hooks = [item for item in hooks if not is_guard_hook_handler(item)]
+        if filtered_hooks:
+            updated_entry = dict(entry)
+            updated_entry["hooks"] = filtered_hooks
+            remaining.append(updated_entry)
+    return remaining
+
+
+def remove_hook_entry(entries: list[object], handler: dict[str, object]) -> list[object]:
+    remaining: list[object] = []
+    expected_identity = handler_identity(handler)
+    for entry in entries:
+        if not isinstance(entry, dict):
+            remaining.append(entry)
+            continue
+        if is_guard_hook_handler(entry):
+            continue
+        if group_has_handler(entry, handler):
+            hooks = entry.get("hooks")
+            if not isinstance(hooks, list):
+                continue
+            filtered_hooks = [
+                item for item in hooks if not (isinstance(item, dict) and handler_identity(item) == expected_identity)
+            ]
+            if filtered_hooks:
+                updated_entry = dict(entry)
+                updated_entry["hooks"] = filtered_hooks
+                remaining.append(updated_entry)
+            continue
+        remaining.append(entry)
+    return remaining

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -61,6 +61,15 @@ def _runtime_hook_handlers(payload: dict[str, object]) -> list[dict[str, object]
     return handlers
 
 
+def _handler_argv(handler: dict[str, object]) -> tuple[str, ...]:
+    command = handler.get("command")
+    args = handler.get("args")
+    assert isinstance(command, str)
+    assert isinstance(args, list)
+    assert all(isinstance(arg, str) for arg in args)
+    return (command, *args)
+
+
 def test_claude_detect_marks_local_cli_install_as_available_when_not_on_path(monkeypatch, tmp_path):
     context = _build_context(tmp_path)
     adapter = ClaudeCodeHarnessAdapter()
@@ -113,27 +122,6 @@ def test_claude_detect_ignores_non_executable_local_cli_candidate_when_not_on_pa
     assert detection.command_available is False
 
 
-def test_claude_install_bakes_current_source_root_into_session_start_command(tmp_path):
-    context = _build_context(tmp_path)
-    adapter = ClaudeCodeHarnessAdapter()
-
-    install_output = adapter.install(context)
-
-    settings_path = context.home_dir / ".claude" / "settings.json"
-    payload = json.loads(settings_path.read_text(encoding="utf-8"))
-    hook_command = str(payload["hooks"]["SessionStart"][0]["hooks"][0]["command"])
-    expected_source_root = str(Path(__file__).resolve().parents[1] / "src")
-
-    assert install_output["active"] is True
-    assert "ensure_guard_daemon" in hook_command
-    assert "refresh_installed_hook_urls" in hook_command
-    assert "hookEventName" in hook_command
-    assert "SessionStart" in hook_command
-    assert "HOL Guard protection is active for this workspace." in hook_command
-    assert expected_source_root in hook_command
-    assert '"guard", "hook"' not in hook_command
-
-
 def test_claude_install_writes_session_start_and_command_hook_schema_and_is_idempotent(tmp_path):
     context = _build_context(tmp_path)
     adapter = ClaudeCodeHarnessAdapter()
@@ -155,7 +143,7 @@ def test_claude_install_writes_session_start_and_command_hook_schema_and_is_idem
     assert len(pre_tool_use) == 1
     assert pre_tool_use[0]["matcher"] == "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*"
     assert pre_tool_use[0]["hooks"][0]["type"] == "command"
-    assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in pre_tool_use[0]["hooks"][0]["command"]
+    assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in "\0".join(_handler_argv(pre_tool_use[0]["hooks"][0]))
     assert "url" not in pre_tool_use[0]["hooks"][0]
     assert pre_tool_use[0]["hooks"][0]["timeout"] == 30
     assert pre_tool_use[0]["hooks"][0]["statusMessage"] == "HOL Guard is checking this tool use"
@@ -257,7 +245,7 @@ def test_claude_install_replaces_legacy_http_guard_hooks(tmp_path):
         "command",
     ]
     assert payload["hooks"].get("UserPromptSubmit", []) == []
-    assert all(CLAUDE_GUARD_DAEMON_HOOK_MARKER in str(handler.get("command", "")) for handler in installed_handlers)
+    assert all(CLAUDE_GUARD_DAEMON_HOOK_MARKER in "\0".join(_handler_argv(handler)) for handler in installed_handlers)
     assert all("url" not in handler for handler in installed_handlers)
 
 
@@ -303,8 +291,8 @@ def test_claude_refresh_runtime_hook_urls_rewrites_stale_daemon_port(tmp_path):
 
     assert all(handler["type"] == "command" for handler in installed_handlers)
     assert all("url" not in handler for handler in installed_handlers)
-    assert all("http://127.0.0.1:5999" in str(handler["command"]) for handler in installed_handlers)
-    assert all(CLAUDE_GUARD_DAEMON_HOOK_MARKER in str(handler["command"]) for handler in installed_handlers)
+    assert all("http://127.0.0.1:5999" in "\0".join(_handler_argv(handler)) for handler in installed_handlers)
+    assert all(CLAUDE_GUARD_DAEMON_HOOK_MARKER in "\0".join(_handler_argv(handler)) for handler in installed_handlers)
 
 
 def test_claude_install_rejects_symlinked_settings_file(tmp_path):
@@ -497,9 +485,9 @@ def test_claude_install_replaces_prior_session_start_guard_handlers_when_context
     settings_path = initial_context.home_dir / ".claude" / "settings.json"
     payload = json.loads(settings_path.read_text(encoding="utf-8"))
     session_start = payload["hooks"]["SessionStart"]
-    hook_commands = [entry["hooks"][0]["command"] for entry in session_start]
+    hook_commands = ["\0".join(_handler_argv(entry["hooks"][0])) for entry in session_start]
     operational_handlers = _runtime_hook_handlers(payload)
-    operational_commands = [str(handler["command"]) for handler in operational_handlers]
+    operational_commands = ["\0".join(_handler_argv(handler)) for handler in operational_handlers]
 
     assert len(session_start) == 4
     assert all(len(entry["hooks"]) == 1 for entry in session_start)
@@ -571,10 +559,10 @@ def test_claude_install_migrates_legacy_flat_guard_hook_entries(tmp_path):
 
     assert len(pre_tool_use) == 1
     assert pre_tool_use[0]["hooks"][0]["type"] == "command"
-    assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in pre_tool_use[0]["hooks"][0]["command"]
+    assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in "\0".join(_handler_argv(pre_tool_use[0]["hooks"][0]))
     assert len(post_tool_use) == 1
     assert post_tool_use[0]["hooks"][0]["type"] == "command"
-    assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in post_tool_use[0]["hooks"][0]["command"]
+    assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in "\0".join(_handler_argv(post_tool_use[0]["hooks"][0]))
 
 
 def test_claude_detect_discovers_nested_hooks_skills_commands_and_rules(tmp_path):
@@ -599,7 +587,14 @@ def test_claude_detect_discovers_nested_hooks_skills_commands_and_rules(tmp_path
                 "PreToolUse": [
                     {
                         "matcher": "Bash|Read",
-                        "hooks": [{"type": "command", "command": "python3 guard-pre.py", "timeout": 30}],
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "python3",
+                                "args": ["guard-pre.py", "workspace with 'quote $value"],
+                                "timeout": 30,
+                            }
+                        ],
                     }
                 ],
                 "UserPromptSubmit": [
@@ -640,6 +635,9 @@ def test_claude_detect_discovers_nested_hooks_skills_commands_and_rules(tmp_path
     assert "claude-code:project:mcp:workspace-tools" in artifacts
     assert artifacts["claude-code:project:mcp:workspace-tools"].metadata["headers_keys"] == ["Authorization"]
     assert "claude-code:project:pretooluse:0:0" in artifacts
+    pretool_artifact = artifacts["claude-code:project:pretooluse:0:0"]
+    assert pretool_artifact.command == "python3"
+    assert pretool_artifact.args == ("guard-pre.py", "workspace with 'quote $value")
     assert "claude-code:project:userpromptsubmit:0:0" in artifacts
     assert "claude-code:project:skill:review" in artifacts
     assert "claude-code:project:command:deploy" in artifacts

--- a/tests/test_guard_claude_hook_argv.py
+++ b/tests/test_guard_claude_hook_argv.py
@@ -1,0 +1,312 @@
+"""Focused regressions for shell-free Claude hook argument vectors."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import claude_code
+from codex_plugin_scanner.guard.adapters.base import HarnessContext, _shell_command
+from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
+from codex_plugin_scanner.guard.adapters.claude_hook_config import (
+    CLAUDE_GUARD_SESSION_START_HOOK_MARKER,
+    command_handler_argv,
+    handler_identity,
+)
+
+
+def _handler_argv(handler: dict[str, object]) -> tuple[str, ...]:
+    argv = command_handler_argv(handler)
+    assert argv is not None
+    return argv
+
+
+def _runtime_hook_handlers(payload: dict[str, object]) -> list[dict[str, object]]:
+    hooks = payload["hooks"]
+    assert isinstance(hooks, dict)
+    handlers: list[dict[str, object]] = []
+    for key in ("PreToolUse", "PermissionRequest", "PostToolUse", "Notification", "Stop"):
+        entries = hooks.get(key, [])
+        assert isinstance(entries, list)
+        for entry in entries:
+            assert isinstance(entry, dict)
+            entry_hooks = entry["hooks"]
+            assert isinstance(entry_hooks, list)
+            for hook in entry_hooks:
+                assert isinstance(hook, dict)
+                handlers.append(hook)
+    return handlers
+
+
+def _windows_crt_split(command_line: str) -> tuple[str, ...]:
+    """Parse list2cmdline output using the documented MS C runtime rules."""
+
+    arguments: list[str] = []
+    index = 0
+    while index < len(command_line):
+        while index < len(command_line) and command_line[index] in " \t":
+            index += 1
+        if index == len(command_line):
+            break
+        argument: list[str] = []
+        quoted = False
+        while index < len(command_line) and (quoted or command_line[index] not in " \t"):
+            if command_line[index] != "\\":
+                if command_line[index] == '"':
+                    quoted = not quoted
+                else:
+                    argument.append(command_line[index])
+                index += 1
+                continue
+            backslash_start = index
+            while index < len(command_line) and command_line[index] == "\\":
+                index += 1
+            backslash_count = index - backslash_start
+            if index >= len(command_line) or command_line[index] != '"':
+                argument.extend("\\" * backslash_count)
+                continue
+            argument.extend("\\" * (backslash_count // 2))
+            if backslash_count % 2:
+                argument.append('"')
+            else:
+                quoted = not quoted
+            index += 1
+        arguments.append("".join(argument))
+    return tuple(arguments)
+
+
+def test_install_bakes_source_root_into_structured_session_start_argv(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace_dir,
+        guard_home=tmp_path / "guard-home",
+    )
+
+    install_output = ClaudeCodeHarnessAdapter().install(context)
+
+    payload = json.loads((context.home_dir / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    hook_argv = _handler_argv(payload["hooks"]["SessionStart"][0]["hooks"][0])
+    hook_command = "\0".join(hook_argv)
+    expected_source_root = str(Path(__file__).resolve().parents[1] / "src")
+    assert install_output["active"] is True
+    assert "run_session_start_from_argv" in hook_command
+    assert CLAUDE_GUARD_SESSION_START_HOOK_MARKER in hook_command
+    assert expected_source_root in hook_command
+    assert '"guard", "hook"' not in hook_command
+    assert hook_argv[-3:] == (str(context.guard_home), str(context.home_dir), str(context.workspace_dir))
+
+
+def test_session_start_argv_preserves_exact_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = str(tmp_path / "guard home 'quote $dollar `backtick` & semicolon; 雪 ")
+    home_dir = str(tmp_path / 'home "double" (paren) \\backslash')
+    workspace_dir = str(tmp_path / "-workspace trailing ")
+    captured: dict[str, object] = {}
+
+    class FakeDaemonModule:
+        @staticmethod
+        def ensure_guard_daemon(path: Path) -> None:
+            captured["daemon_guard_home"] = path
+
+    def fake_refresh(*, home_dir: Path, workspace_dir: Path | None, guard_home: Path) -> None:
+        captured["refresh"] = (home_dir, workspace_dir, guard_home)
+
+    monkeypatch.setattr(claude_code, "_daemon_module", lambda: FakeDaemonModule())
+    monkeypatch.setattr(ClaudeCodeHarnessAdapter, "refresh_installed_hook_urls", fake_refresh)
+
+    result = claude_code._run_session_start_from_argv((guard_home, home_dir, workspace_dir))
+
+    assert result == 0
+    assert captured["daemon_guard_home"] == Path(guard_home)
+    assert captured["refresh"] == (Path(home_dir), Path(workspace_dir), Path(guard_home))
+    assert json.loads(capsys.readouterr().out) == {
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": "HOL Guard protection is active for this workspace.",
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ("guard-home-only",),
+        ("", "home"),
+        ("guard-home", ""),
+        ("guard-home", "home", ""),
+        ("guard\x00home", "home"),
+    ],
+)
+def test_session_start_rejects_malformed_argv(argv: tuple[str, ...]) -> None:
+    with pytest.raises(SystemExit, match="claude_session_start_argv_invalid"):
+        claude_code._run_session_start_from_argv(argv)
+
+
+def test_shell_command_round_trips_hostile_posix_arguments_without_running_marker(tmp_path: Path) -> None:
+    marker_path = tmp_path / "p43-shell-marker"
+    arguments = (
+        "path with spaces",
+        "single'quote",
+        'double"quote',
+        "$HOME",
+        f"`touch {marker_path}`",
+        f"$(touch {marker_path})",
+        "parentheses() & ampersand; semicolon",
+        "backslash\\tail",
+        "Unicode-雪-é",
+        "-leading-dash",
+        "trailing-space ",
+        "",
+    )
+    argv = (sys.executable, "-c", "import json,sys;print(json.dumps(sys.argv[1:]))", *arguments)
+
+    rendered = _shell_command(argv, windows=False)
+    result = subprocess.run(
+        ["/bin/sh", "-c", rendered],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert shlex.split(rendered) == list(argv)
+    assert result.returncode == 0
+    assert json.loads(result.stdout) == list(arguments)
+    assert result.stderr == ""
+    assert not marker_path.exists()
+
+
+def test_shell_command_round_trips_hostile_windows_arguments_with_crt_reference() -> None:
+    argv = (
+        r"C:\Program Files\HOL Guard\python.exe",
+        "-c",
+        'print("quoted")',
+        r"C:\workspace with spaces\project",
+        "single' and double\" quotes",
+        r"backslash\\tail",
+        "trailing-backslash\\",
+        "Unicode-雪-é",
+        "&|<>^;$`()",
+        "-leading-dash",
+        "trailing-space ",
+        "",
+    )
+
+    assert _windows_crt_split(_shell_command(argv, windows=True)) == argv
+
+
+def test_legacy_session_start_command_uses_posix_round_trip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace with 'quote $dollar `backtick` & semicolon; 雪 "
+    workspace_dir.mkdir(parents=True)
+    context = HarnessContext(
+        home_dir=tmp_path / "home with 'quote",
+        workspace_dir=workspace_dir,
+        guard_home=tmp_path / "guard home $value",
+    )
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.base.os.name", "posix")
+
+    rendered = ClaudeCodeHarnessAdapter._session_start_command(context)
+
+    assert shlex.split(rendered) == list(ClaudeCodeHarnessAdapter._session_start_command_parts(context))
+
+
+def test_install_uses_exec_argv_for_every_managed_hook_with_hostile_paths(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace with 'single' \"double\" $dollar `backtick` & semi; (paren) 雪 "
+    workspace_dir.mkdir(parents=True)
+    context = HarnessContext(
+        home_dir=tmp_path / "home with spaces & quotes'",
+        workspace_dir=workspace_dir,
+        guard_home=tmp_path / "guard home; $value ",
+    )
+    adapter = ClaudeCodeHarnessAdapter()
+
+    adapter.install(context)
+
+    payload = json.loads((context.home_dir / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    session_handlers = [entry["hooks"][0] for entry in payload["hooks"]["SessionStart"]]
+    runtime_handlers = _runtime_hook_handlers(payload)
+    expected_session_argv = adapter._session_start_command_parts(context)
+    expected_runtime_argv = adapter._daemon_hook_command_parts(context)
+    bridge_config = json.loads(expected_runtime_argv[-1])
+    assert all(_handler_argv(handler) == expected_session_argv for handler in session_handlers)
+    assert all(_handler_argv(handler) == expected_runtime_argv for handler in runtime_handlers)
+    assert all("shell" not in handler for handler in [*session_handlers, *runtime_handlers])
+    assert tuple(bridge_config["fallback_command"]) == adapter._hook_command_parts(context)
+    assert f"--workspace={context.workspace_dir}" in bridge_config["fallback_command"]
+    assert bridge_config["state_path"] == str(context.guard_home / "daemon-state.json")
+    assert handler_identity(session_handlers[0]) == ("command", "exec", *expected_session_argv)
+    assert handler_identity(runtime_handlers[0]) == ("command", "exec", *expected_runtime_argv)
+
+
+def test_global_install_uses_exec_argv_without_workspace(tmp_path: Path) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home global $value",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard global 'quote",
+    )
+    adapter = ClaudeCodeHarnessAdapter()
+
+    adapter.install(context)
+
+    payload = json.loads((context.home_dir / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    session_handler = payload["hooks"]["SessionStart"][0]["hooks"][0]
+    expected = adapter._session_start_command_parts(context)
+    assert _handler_argv(session_handler) == expected
+    assert expected[-2:] == (str(context.guard_home), str(context.home_dir))
+    assert "--workspace" not in adapter._hook_command_parts(context)
+
+
+def test_fallback_argv_preserves_leading_dash_paths_as_option_values() -> None:
+    context = HarnessContext(
+        home_dir=Path("-home trailing "),
+        workspace_dir=Path("-workspace trailing "),
+        guard_home=Path("-guard-home trailing "),
+    )
+
+    argv = ClaudeCodeHarnessAdapter._hook_command_parts(context)
+
+    assert "--guard-home=-guard-home trailing " in argv
+    assert "--home=-home trailing " in argv
+    assert "--workspace=-workspace trailing " in argv
+
+
+def test_exec_hook_does_not_run_marker_embedded_in_workspace_path(tmp_path: Path) -> None:
+    marker_path = tmp_path / "p43-claude-marker"
+    workspace_dir = tmp_path / "workspace; touch p43-claude-marker; # 'quote $value `backtick` 雪"
+    workspace_dir.mkdir(parents=True)
+    context = HarnessContext(
+        home_dir=tmp_path / "home with spaces",
+        workspace_dir=workspace_dir,
+        guard_home=tmp_path / "guard home & state",
+    )
+    ClaudeCodeHarnessAdapter().install(context)
+    payload = json.loads((context.home_dir / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    handler = payload["hooks"]["PreToolUse"][0]["hooks"][0]
+
+    result = subprocess.run(
+        list(_handler_argv(handler)),
+        cwd=tmp_path,
+        input=json.dumps({"hook_event_name": "UserPromptSubmit", "prompt": "hello"}),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=40,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert not marker_path.exists()

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -62,6 +62,15 @@ def _use_legacy_update_context(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+def _command_handler_argv(handler: dict[str, object]) -> tuple[str, ...]:
+    command = handler.get("command")
+    args = handler.get("args")
+    assert isinstance(command, str)
+    assert isinstance(args, list)
+    assert all(isinstance(arg, str) for arg in args)
+    return (command, *args)
+
+
 def _seed_guard_cloud(
     store, *, workspace_id="workspace-1", sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"
 ):
@@ -2887,34 +2896,28 @@ args = ["workspace-skill.js", "--changed"]
         assert pretool_entries[0] == {"command": "python guard-pre.py"}
         guard_pretool_entry = pretool_entries[1]
         assert install_output["managed_install"]["manifest"]["notes"][0]
-        expected_session_start_command = ClaudeCodeHarnessAdapter._session_start_command(
-            HarnessContext(
-                home_dir=home_dir,
-                workspace_dir=workspace_dir,
-                guard_home=home_dir,
-            )
+        context = HarnessContext(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            guard_home=home_dir,
         )
+        expected_session_start_argv = ClaudeCodeHarnessAdapter._session_start_command_parts(context)
         assert guard_pretool_entry["matcher"] == "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*"
         assert (
-            install_settings_payload["hooks"]["SessionStart"][0]["hooks"][0]["command"]
-            == expected_session_start_command
+            _command_handler_argv(install_settings_payload["hooks"]["SessionStart"][0]["hooks"][0])
+            == expected_session_start_argv
         )
-        expected_hook_command = ClaudeCodeHarnessAdapter._daemon_hook_command(
-            HarnessContext(
-                home_dir=home_dir,
-                workspace_dir=workspace_dir,
-                guard_home=home_dir,
-            )
-        )
+        expected_hook_argv = ClaudeCodeHarnessAdapter._daemon_hook_command_parts(context)
         assert guard_pretool_entry["hooks"][0]["type"] == "command"
-        assert guard_pretool_entry["hooks"][0]["command"] == expected_hook_command
+        assert _command_handler_argv(guard_pretool_entry["hooks"][0]) == expected_hook_argv
         assert "url" not in guard_pretool_entry["hooks"][0]
         assert install_settings_payload["hooks"].get("UserPromptSubmit", []) == []
         assert install_settings_payload["hooks"]["Notification"][0]["matcher"] == "permission_prompt"
-        assert install_settings_payload["hooks"]["Notification"][0]["hooks"][0]["type"] == "command"
-        assert install_settings_payload["hooks"]["Notification"][0]["hooks"][0]["command"] == expected_hook_command
-        assert "url" not in install_settings_payload["hooks"]["Notification"][0]["hooks"][0]
-        assert install_settings_payload["hooks"]["Stop"][0]["hooks"][0]["command"] == expected_hook_command
+        notification_handler = install_settings_payload["hooks"]["Notification"][0]["hooks"][0]
+        assert notification_handler["type"] == "command"
+        assert _command_handler_argv(notification_handler) == expected_hook_argv
+        assert "url" not in notification_handler
+        assert _command_handler_argv(install_settings_payload["hooks"]["Stop"][0]["hooks"][0]) == expected_hook_argv
         assert uninstall_rc == 0
         assert uninstall_output["managed_install"]["active"] is False
         assert settings_payload["hooks"]["SessionStart"] == []
@@ -3172,7 +3175,7 @@ args = ["workspace-skill.js", "--changed"]
         assert len(payload["hooks"]["Notification"]) == 1
         assert len(payload["hooks"]["Stop"]) == 1
         pretool_hook_commands = [
-            hook["command"]
+            "\0".join(_command_handler_argv(hook))
             for hook in payload["hooks"]["PreToolUse"][0]["hooks"]
             if isinstance(hook, dict) and isinstance(hook.get("command"), str)
         ]
@@ -3180,7 +3183,7 @@ args = ["workspace-skill.js", "--changed"]
         assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in pretool_hook_commands[0]
         assert "legacy-guard-home" not in pretool_hook_commands[0]
         notification_hook_commands = [
-            hook["command"]
+            "\0".join(_command_handler_argv(hook))
             for hook in payload["hooks"]["Notification"][0]["hooks"]
             if isinstance(hook, dict) and isinstance(hook.get("command"), str)
         ]

--- a/tests/test_guard_phase04_harness_contracts.py
+++ b/tests/test_guard_phase04_harness_contracts.py
@@ -145,7 +145,10 @@ def test_gr096_managed_hook_json_matches_each_harness_schema(tmp_path: Path) -> 
 
     assert {"PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse"}.issubset(codex_hooks)
     assert claude_hooks["PreToolUse"][0]["hooks"][0]["type"] == "command"
-    assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in claude_hooks["PreToolUse"][0]["hooks"][0]["command"]
+    assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in json.dumps(
+        claude_hooks["PreToolUse"][0]["hooks"][0],
+        ensure_ascii=False,
+    )
     assert opencode_runtime["permission"]
     assert {"preToolUse", "postToolUse", "permissionRequest", "userPromptSubmitted"}.issubset(copilot_hooks["hooks"])
 


### PR DESCRIPTION
## Summary

- Serialize managed Claude Code command hooks as structured `command` plus `args` argv entries.
- Pass SessionStart, runtime bridge, Guard home, user home, and workspace values through `sys.argv` instead of interpolating path-controlled text into generated Python source.
- Preserve exact hook argv during detection, refresh, migration, install, and uninstall while retaining legacy command-string recognition.
- Keep platform-correct shell rendering only for compatibility paths that still require a command string.
- Replay the fix directly on `release/2.1` with corrected GitHub author and committer attribution.

## Security boundary

Paths containing quotes, shell metacharacters, backticks, dollar expansion syntax, leading dashes, Unicode, backslashes, spaces, and trailing whitespace remain inert argument data. Claude's structured command-hook execution receives exact argv without shell tokenization, and generated Python snippets consume positional arguments only.

## Validation

- 47 focused Claude/CLI tests passed after the `release/2.1` replay (246 unrelated tests deselected).
- Earlier broader adapter/CLI regression passed 338 tests with 10 skips; one unrelated local credential-store availability test failed.
- Ruff, formatting, basedpyright, wheel, and source distribution checks passed.
