### PR TITLE
fix(guard): contain pytest repository execution

### DIFF
--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -247,6 +247,7 @@ def _resolve_legacy_args(
         "run",
         "protect",
         "preflight",
+        "pytest-contained",
         "diff",
         "test-eval",
         "command",

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py
@@ -21,6 +21,29 @@ if TYPE_CHECKING:
 from ._commands_shared import *
 from .commands_parser_helpers import *
 
+def _run_guard_pytest_contained_command(
+    args: argparse.Namespace,
+    *,
+    input_text: str | None = None,
+    output_stream: TextIO | None = None,
+) -> int:
+    """Run pytest only after the versioned OS containment profile is active."""
+
+    del input_text, output_stream
+    from ..runtime.restricted_pytest import RestrictedPytestError, run_restricted_pytest
+
+    command = list(getattr(args, "pytest_command", []) or [])
+    try:
+        return run_restricted_pytest(
+            command,
+            workspace=Path(str(args.workspace)),
+            cwd=Path(str(args.cwd)) if getattr(args, "cwd", None) else Path.cwd(),
+            timeout_seconds=int(args.timeout_seconds),
+        )
+    except RestrictedPytestError as error:
+        print(f"{error.reason_code}: {error}", file=sys.stderr)
+        return error.exit_code
+
 def _run_guard_command_inspection_command(
     args: argparse.Namespace,
     *,
@@ -462,6 +485,7 @@ __all__ = [
     "_run_guard_mcp_command",
     "_run_guard_preflight_command",
     "_run_guard_protect_command",
+    "_run_guard_pytest_contained_command",
     "_run_guard_scan_command",
     "_run_guard_start_command",
     "_run_guard_status_command",

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_local.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_local.py
@@ -13,6 +13,12 @@ from .commands_parser_helpers import *
 def _configure_guard_local_parsers(
     guard_subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
+    pytest_contained_parser = guard_subparsers.add_parser("pytest-contained", help=argparse.SUPPRESS)
+    pytest_contained_parser.add_argument("--workspace", required=True)
+    pytest_contained_parser.add_argument("--cwd")
+    pytest_contained_parser.add_argument("--timeout-seconds", type=int, default=30 * 60)
+    pytest_contained_parser.add_argument("pytest_command", nargs=argparse.REMAINDER)
+
     start_parser = guard_subparsers.add_parser("start", help="Show the first Guard steps for a local harness")
     _add_guard_common_args(start_parser)
     start_parser.add_argument("--json", action="store_true")

--- a/src/codex_plugin_scanner/guard/cli/commands_router.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_router.py
@@ -18,6 +18,7 @@ from .commands_parser_helpers import *
 _EARLY_HANDLERS = {
     "mdm": "_run_guard_mdm_command",
     "command": "_run_guard_command_inspection_command",
+    "pytest-contained": "_run_guard_pytest_contained_command",
     "scan": "_run_guard_scan_command",
     "preflight": "_run_guard_preflight_command",
     "mcp": "_run_guard_mcp_command",

--- a/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
@@ -35,6 +35,7 @@ COMMAND_ACTION_RISK_CLASSES: dict[str, tuple[str, ...]] = {
     "shell file upload command": ("credential_exfiltration", "network_egress"),
     "sensitive local file write": ("destructive_shell", "local_secret_read"),
     "destructive shell command": ("destructive_shell",),
+    "pytest repository-code execution": ("execution",),
     "guard approval self-authorization command": ("policy_bypass",),
     "github pr body shell substitution": ("execution",),
     "github remote mutation command": ("destructive_shell", "network_egress"),

--- a/src/codex_plugin_scanner/guard/runtime/restricted_pytest.py
+++ b/src/codex_plugin_scanner/guard/runtime/restricted_pytest.py
@@ -1,0 +1,166 @@
+"""Fail-closed launcher for repository-controlled pytest execution.
+
+Pytest imports tests, conftest.py files, configured plugins, and application
+modules during collection. This module treats pytest as repository-code
+execution and intentionally has no unsandboxed fallback.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from .restricted_pytest_model import (
+    _DEFAULT_TIMEOUT_SECONDS,
+    PYTEST_EXTERNAL_PYTHONPATH_REASON_CODE,
+    PYTEST_INVALID_COMMAND_REASON_CODE,
+    PYTEST_INVALID_WORKSPACE_REASON_CODE,
+    PYTEST_RESTRICTED_PROFILE_VERSION,
+    PYTEST_RESTRICTED_REASON_CODE,
+    PYTEST_SANDBOX_UNAVAILABLE_REASON_CODE,
+    RestrictedPytestError,
+    RestrictedPytestPlan,
+)
+from .restricted_pytest_sandbox import (
+    _backend_argv as _build_backend_argv,
+)
+from .restricted_pytest_sandbox import (
+    _macos_profile as _build_macos_profile,
+)
+from .restricted_pytest_sandbox import (
+    _restricted_environment,
+    _run_backend_process,
+)
+from .restricted_pytest_validation import (
+    _allowed_executables,
+    _normalized_command,
+    _resolve_cwd,
+    _resolve_pytest_executable,
+    _resolve_workspace,
+    _select_backend,
+)
+
+
+def prepare_restricted_pytest(
+    command: Sequence[str],
+    *,
+    workspace: Path,
+    cwd: Path | None = None,
+    platform: str | None = None,
+    backend_executable: Path | None = None,
+) -> RestrictedPytestPlan:
+    """Validate and resolve a pytest argv without executing repository code."""
+
+    normalized_command = _normalized_command(command)
+    selected_backend, selected_backend_executable = _select_backend(
+        platform=platform or sys.platform,
+        backend_executable=backend_executable,
+    )
+    resolved_workspace = _resolve_workspace(workspace)
+    resolved_cwd = _resolve_cwd(cwd or Path.cwd(), workspace=resolved_workspace)
+    launch_executable, executable = _resolve_pytest_executable(
+        normalized_command,
+        cwd=resolved_cwd,
+        workspace=resolved_workspace,
+    )
+    allowed_executables = _allowed_executables(
+        executable,
+        launch_executable,
+        normalized_command,
+        cwd=resolved_cwd,
+        workspace=resolved_workspace,
+    )
+    return RestrictedPytestPlan(
+        profile_version=PYTEST_RESTRICTED_PROFILE_VERSION,
+        backend=selected_backend,
+        backend_executable=selected_backend_executable,
+        workspace=resolved_workspace,
+        cwd=resolved_cwd,
+        command=(str(launch_executable), *normalized_command[1:]),
+        executable=executable,
+        allowed_executables=allowed_executables,
+        denied_capabilities=(
+            "host-home-read",
+            "host-secret-environment",
+            "network",
+            "docker-socket",
+            "write-outside-workspace-and-private-temp",
+            "unapproved-process-exec",
+            "privileged-operation",
+        ),
+    )
+
+
+def run_restricted_pytest(
+    command: Sequence[str],
+    *,
+    workspace: Path,
+    cwd: Path | None = None,
+    env: Mapping[str, str] | None = None,
+    timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
+    platform: str | None = None,
+    backend_executable: Path | None = None,
+) -> int:
+    """Run pytest inside the default restricted profile, with no fallback."""
+
+    if timeout_seconds <= 0 or timeout_seconds > 24 * 60 * 60:
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            "Restricted pytest timeout must be between 1 second and 24 hours.",
+        )
+    plan = prepare_restricted_pytest(
+        command,
+        workspace=workspace,
+        cwd=cwd,
+        platform=platform,
+        backend_executable=backend_executable,
+    )
+    with tempfile.TemporaryDirectory(prefix="hol-guard-pytest-") as temporary_directory:
+        private_root = Path(temporary_directory).resolve()
+        private_home = private_root / "home"
+        private_tmp = private_root / "tmp"
+        private_home.mkdir(mode=0o700)
+        private_tmp.mkdir(mode=0o700)
+        launch_env = _restricted_environment(
+            env if env is not None else os.environ,
+            workspace=plan.workspace,
+            cwd=plan.cwd,
+            private_home=private_home,
+            private_tmp=private_tmp,
+            allowed_executables=plan.allowed_executables,
+        )
+        backend_argv = _backend_argv(plan, private_root=private_root)
+        return _run_backend_process(
+            backend_argv,
+            env=launch_env,
+            timeout_seconds=timeout_seconds,
+        )
+
+
+def _backend_argv(plan: RestrictedPytestPlan, *, private_root: Path) -> list[str]:
+    """Compatibility wrapper for focused profile tests."""
+
+    return _build_backend_argv(plan, private_root=private_root)
+
+
+def _macos_profile(plan: RestrictedPytestPlan, *, private_root: Path) -> str:
+    """Compatibility wrapper for focused profile tests."""
+
+    return _build_macos_profile(plan, private_root=private_root)
+
+
+__all__ = [
+    "PYTEST_EXTERNAL_PYTHONPATH_REASON_CODE",
+    "PYTEST_INVALID_COMMAND_REASON_CODE",
+    "PYTEST_INVALID_WORKSPACE_REASON_CODE",
+    "PYTEST_RESTRICTED_PROFILE_VERSION",
+    "PYTEST_RESTRICTED_REASON_CODE",
+    "PYTEST_SANDBOX_UNAVAILABLE_REASON_CODE",
+    "RestrictedPytestError",
+    "RestrictedPytestPlan",
+    "prepare_restricted_pytest",
+    "run_restricted_pytest",
+]

--- a/src/codex_plugin_scanner/guard/runtime/restricted_pytest_model.py
+++ b/src/codex_plugin_scanner/guard/runtime/restricted_pytest_model.py
@@ -1,0 +1,236 @@
+"""Shared constants and immutable data for restricted pytest execution."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+PYTEST_RESTRICTED_PROFILE_VERSION = "pytest-restricted-v1"
+PYTEST_RESTRICTED_REASON_CODE = "pytest_restricted_profile_required"
+PYTEST_SANDBOX_UNAVAILABLE_REASON_CODE = "pytest_restricted_sandbox_unavailable"
+PYTEST_INVALID_COMMAND_REASON_CODE = "pytest_restricted_invalid_command"
+PYTEST_INVALID_WORKSPACE_REASON_CODE = "pytest_restricted_invalid_workspace"
+PYTEST_EXTERNAL_PYTHONPATH_REASON_CODE = "pytest_restricted_external_pythonpath"
+
+RestrictedPytestBackend = Literal["macos-seatbelt", "linux-bubblewrap"]
+
+_MAX_ARG_COUNT = 4_096
+_MAX_ARG_BYTES = 1_048_576
+_DEFAULT_TIMEOUT_SECONDS = 30 * 60
+_DEFAULT_CPU_SECONDS = 20 * 60
+_DEFAULT_MEMORY_BYTES = 4 * 1024 * 1024 * 1024
+_DEFAULT_FILE_BYTES = 256 * 1024 * 1024
+_DEFAULT_OPEN_FILES = 256
+_DEFAULT_PROCESSES = 64
+
+_PYTEST_EXECUTABLE_NAMES = frozenset({"pytest", "py.test", "pytest.exe", "py.test.exe"})
+_PYTHON_EXECUTABLE_PATTERN = re.compile(r"^(?:python|pythonw)(?:\d+(?:\.\d+)*)?(?:\.exe)?$", re.IGNORECASE)
+_PROJECT_WORKSPACE_MARKERS = (
+    ".git",
+    "pyproject.toml",
+    "pytest.ini",
+    "setup.cfg",
+    "setup.py",
+    "tox.ini",
+)
+_SENSITIVE_HOME_ROOT_NAMES = frozenset(
+    {
+        ".aws",
+        ".azure",
+        ".config",
+        ".docker",
+        ".gnupg",
+        ".kube",
+        ".ssh",
+        "Library",
+    }
+)
+_SECRET_ENV_MARKERS = (
+    r"API_?KEY",
+    r"AUTH(?:ORIZATION)?",
+    "BEARER",
+    "COOKIE",
+    r"CREDENTIALS?",
+    "DSN",
+    r"KEY(?:_?ID)?",
+    "PASSWORD",
+    r"PRIVATE_?KEY",
+    "SECRET",
+    "SESSION",
+    "TOKEN",
+)
+_SECRET_ENV_PATTERN = re.compile(
+    rf"(?:^|_)(?:{'|'.join(_SECRET_ENV_MARKERS)})(?:_|$)",
+    re.IGNORECASE,
+)
+_DENIED_ENV_KEYS = frozenset(
+    {
+        "AWS_CONFIG_FILE",
+        "AWS_SHARED_CREDENTIALS_FILE",
+        "BASH_ENV",
+        "DATABASE_URL",
+        "DOCKER_CONFIG",
+        "DOCKER_HOST",
+        "DYLD_INSERT_LIBRARIES",
+        "DYLD_LIBRARY_PATH",
+        "ENV",
+        "GIT_ASKPASS",
+        "GNUPGHOME",
+        "KRB5CCNAME",
+        "KUBECONFIG",
+        "LD_LIBRARY_PATH",
+        "LD_PRELOAD",
+        "MONGODB_URI",
+        "MYSQL_PWD",
+        "NODE_AUTH_TOKEN",
+        "NPM_CONFIG_USERCONFIG",
+        "PGPASSWORD",
+        "PIP_CONFIG_FILE",
+        "PYTHONBREAKPOINT",
+        "PYTHONHOME",
+        "PYTHONINSPECT",
+        "PYTHONSTARTUP",
+        "PYTHONUSERBASE",
+        "PYTHONWARNINGS",
+        "REDIS_URL",
+        "SSH_ASKPASS",
+        "SSH_AUTH_SOCK",
+        "ZDOTDIR",
+    }
+)
+_PROXY_ENV_KEYS = frozenset(
+    {
+        "ALL_PROXY",
+        "HTTPS_PROXY",
+        "HTTP_PROXY",
+        "NO_PROXY",
+        "all_proxy",
+        "https_proxy",
+        "http_proxy",
+        "no_proxy",
+    }
+)
+_SAFE_ENV_KEYS = frozenset(
+    {
+        "CI",
+        "CLICOLOR",
+        "CLICOLOR_FORCE",
+        "COLORTERM",
+        "COLUMNS",
+        "FORCE_COLOR",
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "LANG",
+        "LANGUAGE",
+        "LINES",
+        "LOGNAME",
+        "NO_COLOR",
+        "PYTHONHASHSEED",
+        "PYTHONIOENCODING",
+        "PYTHONUNBUFFERED",
+        "PYTHONUTF8",
+        "PYTHONDONTWRITEBYTECODE",
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+        "SOURCE_DATE_EPOCH",
+        "TERM",
+        "TERM_PROGRAM",
+        "TERM_PROGRAM_VERSION",
+        "TF_BUILD",
+        "TZ",
+        "USER",
+        "VIRTUAL_ENV_PROMPT",
+    }
+)
+_TRUSTED_EXECUTABLE_ROOTS = (
+    Path("/bin"),
+    Path("/opt/homebrew"),
+    Path("/opt/hostedtoolcache/Python"),
+    Path("/System"),
+    Path("/usr/bin"),
+    Path("/usr/local"),
+)
+_SEALED_SYSTEM_EXECUTABLE_ROOTS = (
+    Path("/bin"),
+    Path("/System"),
+    Path("/usr/bin"),
+)
+_MACOS_READ_ROOTS = (
+    Path("/System"),
+    Path("/Library/Apple"),
+    Path("/Library/Frameworks"),
+    Path("/opt/homebrew/Cellar"),
+    Path("/opt/homebrew/opt"),
+    Path("/usr/lib"),
+    Path("/usr/local/Cellar"),
+    Path("/usr/local/opt"),
+    Path("/usr/share"),
+)
+_MACOS_READ_FILES = (
+    Path("/dev/null"),
+    Path("/dev/random"),
+    Path("/dev/urandom"),
+    Path("/private/etc/hosts"),
+    Path("/private/etc/protocols"),
+    Path("/private/etc/resolv.conf"),
+    Path("/private/etc/services"),
+)
+_LINUX_READ_ROOTS = (
+    Path("/lib"),
+    Path("/lib64"),
+    Path("/usr/lib"),
+    Path("/usr/lib64"),
+    Path("/usr/share"),
+    Path("/usr/local/lib"),
+)
+_LINUX_READ_FILES = (
+    Path("/etc/hosts"),
+    Path("/etc/ld.so.cache"),
+    Path("/etc/nsswitch.conf"),
+    Path("/etc/protocols"),
+    Path("/etc/resolv.conf"),
+    Path("/etc/services"),
+)
+
+
+class RestrictedPytestError(RuntimeError):
+    """A stable fail-closed error emitted before repository code executes."""
+
+    reason_code: str
+    exit_code: int
+
+    def __init__(self, reason_code: str, message: str, *, exit_code: int = 126) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.exit_code = exit_code
+
+
+@dataclass(frozen=True, slots=True)
+class RestrictedPytestPlan:
+    """Resolved, non-shell launch plan for one restricted pytest run."""
+
+    profile_version: str
+    backend: RestrictedPytestBackend
+    backend_executable: Path
+    workspace: Path
+    cwd: Path
+    command: tuple[str, ...]
+    executable: Path
+    allowed_executables: tuple[Path, ...]
+    denied_capabilities: tuple[str, ...]
+
+    def to_evidence(self) -> dict[str, object]:
+        return {
+            "profile_version": self.profile_version,
+            "backend": self.backend,
+            "workspace": str(self.workspace),
+            "cwd": str(self.cwd),
+            "command": list(self.command),
+            "executable": str(self.executable),
+            "allowed_executables": [str(path) for path in self.allowed_executables],
+            "denied_capabilities": list(self.denied_capabilities),
+            "network": "denied",
+            "host_home": "unmounted-or-denied",
+            "writes": ["workspace", "private-temporary-directory"],
+        }

--- a/src/codex_plugin_scanner/guard/runtime/restricted_pytest_sandbox.py
+++ b/src/codex_plugin_scanner/guard/runtime/restricted_pytest_sandbox.py
@@ -1,0 +1,301 @@
+"""Operating-system sandbox construction and execution for restricted pytest."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from types import FrameType
+
+from .restricted_pytest_model import (
+    _DEFAULT_CPU_SECONDS,
+    _DEFAULT_FILE_BYTES,
+    _DEFAULT_MEMORY_BYTES,
+    _DEFAULT_OPEN_FILES,
+    _DEFAULT_PROCESSES,
+    _DENIED_ENV_KEYS,
+    _LINUX_READ_FILES,
+    _LINUX_READ_ROOTS,
+    _MACOS_READ_FILES,
+    _MACOS_READ_ROOTS,
+    _PROXY_ENV_KEYS,
+    _SAFE_ENV_KEYS,
+    _SEALED_SYSTEM_EXECUTABLE_ROOTS,
+    _SECRET_ENV_PATTERN,
+    PYTEST_SANDBOX_UNAVAILABLE_REASON_CODE,
+    RestrictedPytestError,
+    RestrictedPytestPlan,
+)
+from .restricted_pytest_validation import (
+    _first_symlink_expansion,
+    _path_is_within,
+    _path_is_within_any,
+    _restricted_pythonpath,
+    _runtime_distribution_root,
+)
+
+_RESOURCE_AVAILABLE = os.name == "posix"
+if _RESOURCE_AVAILABLE:
+    import resource as _resource
+else:
+    _resource = None
+
+
+def _restricted_environment(
+    source: Mapping[str, str],
+    *,
+    workspace: Path,
+    cwd: Path,
+    private_home: Path,
+    private_tmp: Path,
+    allowed_executables: tuple[Path, ...],
+) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for key, value in source.items():
+        if (
+            key in _DENIED_ENV_KEYS
+            or key in _PROXY_ENV_KEYS
+            or _SECRET_ENV_PATTERN.search(key)
+            or "\x00" in key
+            or "\x00" in value
+        ):
+            continue
+        if key in {"HOME", "PATH", "TEMP", "TMP", "TMPDIR"}:
+            continue
+        if key == "PYTHONPATH":
+            result[key] = _restricted_pythonpath(value, workspace=workspace, cwd=cwd)
+            continue
+        if key == "VIRTUAL_ENV":
+            virtual_environment = Path(value).expanduser()
+            try:
+                resolved_virtual_environment = virtual_environment.resolve(strict=True)
+            except (OSError, RuntimeError):
+                continue
+            if _path_is_within(resolved_virtual_environment, workspace):
+                result[key] = str(resolved_virtual_environment)
+            continue
+        if key in _SAFE_ENV_KEYS or key.startswith("LC_"):
+            result[key] = value
+    executable_dirs = list(dict.fromkeys(str(path.parent) for path in allowed_executables))
+    result.update(
+        {
+            "HOME": str(private_home),
+            "PATH": os.pathsep.join(executable_dirs),
+            "PWD": str(cwd),
+            "PYTHONNOUSERSITE": "1",
+            "TEMP": str(private_tmp),
+            "TMP": str(private_tmp),
+            "TMPDIR": str(private_tmp),
+        }
+    )
+    return result
+
+
+def _backend_argv(plan: RestrictedPytestPlan, *, private_root: Path) -> list[str]:
+    if plan.backend == "macos-seatbelt":
+        profile = _macos_profile(plan, private_root=private_root)
+        return [str(plan.backend_executable), "-p", profile, "--", *plan.command]
+    return _bubblewrap_argv(plan, private_root=private_root)
+
+
+def _macos_profile(plan: RestrictedPytestPlan, *, private_root: Path) -> str:
+    read_roots = [plan.workspace, private_root]
+    read_roots.extend(path for path in _MACOS_READ_ROOTS if path.exists())
+    read_roots.extend(_runtime_read_roots(plan))
+    read_files = [path for path in _MACOS_READ_FILES if path.exists()]
+    read_filters = " ".join(f"(subpath {_seatbelt_string(path)})" for path in read_roots)
+    read_file_filters = " ".join(f"(literal {_seatbelt_string(path)})" for path in read_files)
+    metadata_paths = (Path("/"), *_ancestor_paths((*read_roots, *plan.allowed_executables)))
+    metadata_filters = " ".join(f"(literal {_seatbelt_string(path)})" for path in metadata_paths)
+    executable_filters = " ".join(f"(literal {_seatbelt_string(path)})" for path in plan.allowed_executables)
+    write_filters = " ".join(
+        (
+            f"(subpath {_seatbelt_string(plan.workspace)})",
+            f"(subpath {_seatbelt_string(private_root)})",
+            '(literal "/dev/null")',
+        )
+    )
+    return "\n".join(
+        (
+            "(version 1)",
+            "(deny default)",
+            "(allow process-fork)",
+            f"(allow process-exec {executable_filters})",
+            "(allow signal (target self))",
+            "(allow sysctl-read)",
+            '(allow file-read-data (literal "/"))',
+            f"(allow file-read-metadata {metadata_filters})",
+            f"(allow file-read* {read_filters} {read_file_filters})",
+            f"(allow file-write* {write_filters})",
+        )
+    )
+
+
+def _seatbelt_string(path: Path) -> str:
+    value = str(path)
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r")
+    return f'"{escaped}"'
+
+
+def _bubblewrap_argv(plan: RestrictedPytestPlan, *, private_root: Path) -> list[str]:
+    argv = [
+        str(plan.backend_executable),
+        "--die-with-parent",
+        "--new-session",
+        "--unshare-all",
+        "--unshare-net",
+        "--proc",
+        "/proc",
+        "--dev",
+        "/dev",
+        "--tmpfs",
+        "/tmp",
+    ]
+    readonly_paths = [path for path in (*_LINUX_READ_ROOTS, *_LINUX_READ_FILES) if path.exists()]
+    readonly_paths.extend(_runtime_read_roots(plan))
+    readonly_paths.extend(path for path in plan.allowed_executables if not _path_is_within(path, plan.workspace))
+    for path in _dedupe_parent_paths(readonly_paths):
+        argv.extend(("--ro-bind", str(path), str(path)))
+    argv.extend(("--bind", str(plan.workspace), str(plan.workspace)))
+    argv.extend(("--dir", str(private_root)))
+    argv.extend(("--bind", str(private_root), str(private_root)))
+    argv.extend(("--chdir", str(plan.cwd), "--", *plan.command))
+    return argv
+
+
+def _dedupe_parent_paths(paths: Sequence[Path]) -> tuple[Path, ...]:
+    resolved: list[Path] = []
+    for path in sorted({item.resolve(strict=False) for item in paths}, key=lambda item: (len(item.parts), str(item))):
+        if any(_path_is_within(path, parent) for parent in resolved):
+            continue
+        resolved.append(path)
+    return tuple(resolved)
+
+
+def _ancestor_paths(paths: Sequence[Path]) -> tuple[Path, ...]:
+    ancestors: list[Path] = []
+    for path in paths:
+        current = path
+        for parent in (current, *current.parents):
+            if parent == Path("/") or parent in ancestors:
+                continue
+            ancestors.append(parent)
+    return tuple(ancestors)
+
+
+def _runtime_read_roots(plan: RestrictedPytestPlan) -> tuple[Path, ...]:
+    roots: list[Path] = []
+    for executable in plan.allowed_executables:
+        symlink_runtime_roots = _symlink_runtime_roots(executable)
+        for symlink_runtime_root in symlink_runtime_roots:
+            if symlink_runtime_root not in roots:
+                roots.append(symlink_runtime_root)
+        if symlink_runtime_roots:
+            continue
+        if _path_is_within(executable, plan.workspace) or _path_is_within_any(
+            executable, _SEALED_SYSTEM_EXECUTABLE_ROOTS
+        ):
+            continue
+        root = executable.parent.parent if executable.parent.name == "bin" else executable.parent
+        if root not in roots:
+            roots.append(root)
+    return tuple(roots)
+
+
+def _symlink_runtime_roots(executable: Path) -> tuple[Path, ...]:
+    """Return lexical runtime roots named by an executable's symlink chain.
+
+    Managed Python installations commonly expose a stable version alias (for
+    example ``cpython-3.12-*``) that points at a patch-version directory.  The
+    macOS sandbox must be able to traverse that alias before it can reach the
+    already-approved resolved executable. Homebrew adds both a package alias
+    and a framework-entrypoint symlink, so walk every bounded expansion. Keep
+    each grant at its exact distribution root instead of widening it to a
+    user runtime cache or package-manager prefix.
+    """
+
+    roots: list[Path] = []
+    current = executable.absolute()
+    for _depth in range(16):
+        expansion = _first_symlink_expansion(current)
+        if expansion is None:
+            break
+        current = expansion
+        if _path_is_within_any(current, _SEALED_SYSTEM_EXECUTABLE_ROOTS):
+            continue
+        root = _runtime_distribution_root(current)
+        if root not in roots:
+            roots.append(root)
+    return tuple(roots)
+
+
+def _run_backend_process(argv: Sequence[str], *, env: Mapping[str, str], timeout_seconds: int) -> int:
+    def apply_limits() -> None:
+        resource_module = _resource
+        if resource_module is None:
+            return
+        _set_resource_limit(resource_module.RLIMIT_CPU, _DEFAULT_CPU_SECONDS)
+        _set_resource_limit(resource_module.RLIMIT_AS, _DEFAULT_MEMORY_BYTES)
+        _set_resource_limit(resource_module.RLIMIT_FSIZE, _DEFAULT_FILE_BYTES)
+        _set_resource_limit(resource_module.RLIMIT_NOFILE, _DEFAULT_OPEN_FILES)
+        if hasattr(resource_module, "RLIMIT_NPROC"):
+            _set_resource_limit(resource_module.RLIMIT_NPROC, _DEFAULT_PROCESSES)
+
+    try:
+        process = subprocess.Popen(
+            list(argv),
+            env=dict(env),
+            stdin=None,
+            stdout=None,
+            stderr=None,
+            close_fds=True,
+            start_new_session=True,
+            preexec_fn=apply_limits if _RESOURCE_AVAILABLE else None,
+        )
+    except OSError as error:
+        raise RestrictedPytestError(
+            PYTEST_SANDBOX_UNAVAILABLE_REASON_CODE,
+            f"Restricted pytest sandbox could not start; execution was not started: {error}",
+        ) from error
+
+    previous_handlers: dict[int, int | signal.Handlers | Callable[[int, FrameType | None], object] | None] = {}
+
+    def forward_signal(signum: int, _frame: object) -> None:
+        with contextlib.suppress(OSError):
+            os.killpg(process.pid, signum)
+
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        previous_handlers[signum] = signal.getsignal(signum)
+        _ = signal.signal(signum, forward_signal)
+    try:
+        try:
+            return_code = process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired as error:
+            with contextlib.suppress(OSError):
+                os.killpg(process.pid, signal.SIGKILL)
+            _ = process.wait()
+            raise RestrictedPytestError(
+                "pytest_restricted_timeout",
+                f"Restricted pytest exceeded its {timeout_seconds}-second execution deadline.",
+                exit_code=124,
+            ) from error
+    finally:
+        for signum, handler in previous_handlers.items():
+            _ = signal.signal(signum, handler)
+    return return_code if return_code >= 0 else 128 + abs(return_code)
+
+
+def _set_resource_limit(resource_name: int, requested: int) -> None:
+    resource_module = _resource
+    if resource_module is None:
+        return
+    try:
+        current_soft, current_hard = resource_module.getrlimit(resource_name)
+        hard = requested if current_hard < 0 else min(requested, current_hard)
+        soft = hard if current_soft < 0 else min(requested, current_soft, hard)
+        resource_module.setrlimit(resource_name, (soft, hard))
+    except (OSError, ValueError):
+        return

--- a/src/codex_plugin_scanner/guard/runtime/restricted_pytest_validation.py
+++ b/src/codex_plugin_scanner/guard/runtime/restricted_pytest_validation.py
@@ -1,0 +1,497 @@
+"""Validation helpers for fail-closed restricted pytest launches."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import stat
+from collections.abc import Sequence
+from pathlib import Path
+
+from .restricted_pytest_model import (
+    _MAX_ARG_BYTES,
+    _MAX_ARG_COUNT,
+    _PROJECT_WORKSPACE_MARKERS,
+    _PYTEST_EXECUTABLE_NAMES,
+    _PYTHON_EXECUTABLE_PATTERN,
+    _SENSITIVE_HOME_ROOT_NAMES,
+    _TRUSTED_EXECUTABLE_ROOTS,
+    PYTEST_EXTERNAL_PYTHONPATH_REASON_CODE,
+    PYTEST_INVALID_COMMAND_REASON_CODE,
+    PYTEST_INVALID_WORKSPACE_REASON_CODE,
+    PYTEST_SANDBOX_UNAVAILABLE_REASON_CODE,
+    RestrictedPytestBackend,
+    RestrictedPytestError,
+)
+
+if os.name == "posix":
+    import pwd as _pwd
+else:
+    _pwd = None
+
+
+def _normalized_command(command: Sequence[str]) -> tuple[str, ...]:
+    normalized = tuple(str(item) for item in command)
+    if normalized and normalized[0] == "--":
+        normalized = normalized[1:]
+    total_bytes = sum(len(item.encode("utf-8", errors="surrogatepass")) for item in normalized)
+    if not normalized or len(normalized) > _MAX_ARG_COUNT or total_bytes > _MAX_ARG_BYTES:
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            "Restricted pytest requires a bounded, non-empty argv after `--`.",
+        )
+    if any("\x00" in item for item in normalized):
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            "Restricted pytest argv cannot contain NUL bytes.",
+        )
+    return normalized
+
+
+def _resolve_workspace(workspace: Path) -> Path:
+    try:
+        resolved = workspace.expanduser().resolve(strict=True)
+    except (OSError, RuntimeError) as error:
+        raise RestrictedPytestError(
+            PYTEST_INVALID_WORKSPACE_REASON_CODE,
+            f"Restricted pytest workspace could not be resolved: {error}",
+        ) from error
+    if not resolved.is_dir():
+        raise RestrictedPytestError(
+            PYTEST_INVALID_WORKSPACE_REASON_CODE,
+            "Restricted pytest workspace must be an existing directory.",
+        )
+    if _workspace_is_broad_or_sensitive(resolved):
+        raise RestrictedPytestError(
+            PYTEST_INVALID_WORKSPACE_REASON_CODE,
+            "Restricted pytest workspace cannot be a filesystem, home, temporary, or credential-directory root.",
+        )
+    if not any((resolved / marker).exists() for marker in _PROJECT_WORKSPACE_MARKERS):
+        raise RestrictedPytestError(
+            PYTEST_INVALID_WORKSPACE_REASON_CODE,
+            "Restricted pytest workspace must be an explicit project root with a recognized project marker.",
+        )
+    return resolved
+
+
+def _workspace_is_broad_or_sensitive(workspace: Path) -> bool:
+    broad_roots = {
+        Path("/"),
+        Path("/Users"),
+        Path("/etc"),
+        Path("/home"),
+        Path("/private"),
+        Path("/private/tmp"),
+        Path("/private/var"),
+        Path("/tmp"),
+        Path("/var"),
+        Path("/var/tmp"),
+    }
+    if workspace in broad_roots:
+        return True
+    home = _host_home_directory()
+    if home is None:
+        return True
+    if workspace == home or workspace in home.parents:
+        return True
+    try:
+        relative_to_home = workspace.relative_to(home)
+    except ValueError:
+        return False
+    return bool(relative_to_home.parts and relative_to_home.parts[0] in _SENSITIVE_HOME_ROOT_NAMES)
+
+
+def _resolve_cwd(cwd: Path, *, workspace: Path) -> Path:
+    try:
+        resolved = cwd.expanduser().resolve(strict=True)
+        _ = resolved.relative_to(workspace)
+    except (OSError, RuntimeError, ValueError) as error:
+        raise RestrictedPytestError(
+            PYTEST_INVALID_WORKSPACE_REASON_CODE,
+            "Restricted pytest cwd must resolve to an existing directory inside the approved workspace.",
+        ) from error
+    if not resolved.is_dir():
+        raise RestrictedPytestError(
+            PYTEST_INVALID_WORKSPACE_REASON_CODE,
+            "Restricted pytest cwd must be a directory.",
+        )
+    return resolved
+
+
+def _resolve_pytest_executable(
+    command: tuple[str, ...],
+    *,
+    cwd: Path,
+    workspace: Path,
+) -> tuple[Path, Path]:
+    command_name = Path(command[0].replace("\\", "/")).name.lower()
+    if command_name in _PYTEST_EXECUTABLE_NAMES:
+        _validate_pytest_args(command[1:])
+    elif _PYTHON_EXECUTABLE_PATTERN.fullmatch(command_name):
+        if not _python_args_target_pytest(command[1:]):
+            raise RestrictedPytestError(
+                PYTEST_INVALID_COMMAND_REASON_CODE,
+                "Restricted pytest accepts only a pytest executable or a Python `-m pytest` invocation.",
+            )
+    else:
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            "Restricted pytest accepts only a pytest executable or a Python `-m pytest` invocation.",
+        )
+    launch_executable = _locate_executable(command[0], cwd=cwd)
+    executable = _resolve_executable(command[0], cwd=cwd)
+    launched_from_workspace = _path_is_within_lexically(launch_executable, workspace)
+    if not launched_from_workspace and not _path_is_within_any(executable, _TRUSTED_EXECUTABLE_ROOTS):
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            "Restricted pytest executable must be inside the workspace or a trusted system installation root.",
+        )
+    if command_name in _PYTEST_EXECUTABLE_NAMES and Path(executable).name.lower() not in _PYTEST_EXECUTABLE_NAMES:
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            "Restricted pytest executable symlink does not resolve to a pytest executable.",
+        )
+    if _PYTHON_EXECUTABLE_PATTERN.fullmatch(command_name) and not _PYTHON_EXECUTABLE_PATTERN.fullmatch(executable.name):
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            "Restricted Python symlink does not resolve to a Python executable.",
+        )
+    return launch_executable, executable
+
+
+def _validate_pytest_args(args: Sequence[str]) -> None:
+    if any(item in {";", "&&", "||", "|", "|&", "&"} for item in args):
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            "Restricted pytest receives argv directly and does not accept shell control operators.",
+        )
+
+
+def _python_args_target_pytest(args: Sequence[str]) -> bool:
+    index = 0
+    while index < len(args):
+        item = args[index]
+        if item == "--":
+            return False
+        if item in {"-c", "--command"} or item.startswith(("-c", "--command=")):
+            return False
+        if item == "-m":
+            return index + 1 < len(args) and args[index + 1].split(".", 1)[0] == "pytest"
+        if item.startswith("-m") and len(item) > 2:
+            return item[2:].split(".", 1)[0] == "pytest"
+        if item in {"-W", "-X", "--check-hash-based-pycs"}:
+            index += 2
+            continue
+        if item.startswith(("-W", "-X", "--check-hash-based-pycs=")):
+            index += 1
+            continue
+        if not item.startswith("-"):
+            return False
+        index += 1
+    return False
+
+
+def _resolve_executable(value: str, *, cwd: Path) -> Path:
+    candidate = _locate_executable(value, cwd=cwd)
+    try:
+        resolved = candidate.resolve(strict=True)
+    except (OSError, RuntimeError) as error:
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            f"Restricted pytest executable could not be resolved: {value}",
+        ) from error
+    try:
+        metadata = resolved.stat()
+    except OSError as error:
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            f"Restricted pytest executable could not be inspected: {value}",
+        ) from error
+    if not stat.S_ISREG(metadata.st_mode) or (os.name != "nt" and metadata.st_mode & 0o111 == 0):
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            f"Restricted pytest target is not an executable regular file: {value}",
+        )
+    return resolved
+
+
+def _locate_executable(value: str, *, cwd: Path) -> Path:
+    candidate = Path(value).expanduser()
+    if candidate.is_absolute() or "/" in value or "\\" in value:
+        if not candidate.is_absolute():
+            candidate = cwd / candidate
+        return candidate.absolute()
+    located = shutil.which(value)
+    if located is None:
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            f"Restricted pytest executable was not found on PATH: {value}",
+        )
+    return Path(located).expanduser().absolute()
+
+
+def _select_backend(
+    *,
+    platform: str,
+    backend_executable: Path | None,
+) -> tuple[RestrictedPytestBackend, Path]:
+    if platform == "darwin":
+        backend: RestrictedPytestBackend = "macos-seatbelt"
+        candidate = backend_executable or Path("/usr/bin/sandbox-exec")
+    elif platform.startswith("linux"):
+        backend = "linux-bubblewrap"
+        located = shutil.which("bwrap")
+        candidate = backend_executable or (Path(located) if located else Path("/usr/bin/bwrap"))
+    else:
+        raise RestrictedPytestError(
+            PYTEST_SANDBOX_UNAVAILABLE_REASON_CODE,
+            "No enforceable restricted pytest backend is available for this platform; execution was not started.",
+        )
+    trusted = _trusted_backend_executable(candidate)
+    if trusted is None:
+        raise RestrictedPytestError(
+            PYTEST_SANDBOX_UNAVAILABLE_REASON_CODE,
+            f"Required {backend} backend is missing or not a trusted system executable; execution was not started.",
+        )
+    return backend, trusted
+
+
+def _trusted_backend_executable(candidate: Path) -> Path | None:
+    try:
+        resolved = candidate.expanduser().resolve(strict=True)
+        metadata = resolved.stat()
+    except (OSError, RuntimeError):
+        return None
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_mode & 0o111 == 0:
+        return None
+    if metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        return None
+    if hasattr(os, "getuid") and metadata.st_uid != 0:
+        return None
+    if not _path_is_within_any(resolved, (Path("/bin"), Path("/usr/bin"), Path("/usr/local/bin"))):
+        return None
+    return resolved
+
+
+def _allowed_executables(
+    executable: Path,
+    launch_executable: Path,
+    command: tuple[str, ...],
+    *,
+    cwd: Path,
+    workspace: Path,
+) -> tuple[Path, ...]:
+    allowed = [launch_executable, executable]
+    if Path(command[0].replace("\\", "/")).name.lower() in _PYTEST_EXECUTABLE_NAMES:
+        interpreter = _script_interpreter(executable, cwd=cwd)
+        if interpreter is not None:
+            if _PYTHON_EXECUTABLE_PATTERN.fullmatch(interpreter[-1].name) is None:
+                raise RestrictedPytestError(
+                    PYTEST_INVALID_COMMAND_REASON_CODE,
+                    "Restricted pytest entry points must use a Python interpreter.",
+                )
+            allowed.extend(interpreter)
+    for allowed_executable in tuple(allowed):
+        allowed.extend(_framework_python_helpers(allowed_executable))
+    workspace_launcher = _path_is_within_lexically(launch_executable, workspace)
+    if any(
+        not _allowed_executable_path(path, workspace=workspace, workspace_launcher=workspace_launcher)
+        for path in allowed
+    ):
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            "Restricted pytest script resolves to an interpreter outside the workspace and trusted system roots.",
+        )
+    if any(not _executable_symlink_chain_is_approved(path, workspace=workspace) for path in allowed):
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            "Restricted pytest executable has an unapproved path in its interpreter symlink chain.",
+        )
+    return tuple(dict.fromkeys(allowed))
+
+
+def _framework_python_helpers(executable: Path) -> tuple[Path, ...]:
+    if executable.parent.name != "bin":
+        return ()
+    version_root = executable.parent.parent
+    if version_root.parent.name != "Versions" or version_root.parent.parent.name != "Python.framework":
+        return ()
+    helper = version_root / "Resources" / "Python.app" / "Contents" / "MacOS" / "Python"
+    if not helper.exists():
+        return ()
+    try:
+        resolved = _resolve_executable(str(helper), cwd=helper.parent)
+    except RestrictedPytestError:
+        return ()
+    return tuple(dict.fromkeys((helper.absolute(), resolved)))
+
+
+def _allowed_executable_path(path: Path, *, workspace: Path, workspace_launcher: bool) -> bool:
+    if _path_is_within_lexically(path, workspace) or _path_is_within_any(path, _TRUSTED_EXECUTABLE_ROOTS):
+        return True
+    basename = path.name.lower()
+    return (
+        workspace_launcher
+        and _PYTHON_EXECUTABLE_PATTERN.fullmatch(basename) is not None
+        and _approved_user_python_runtime(path)
+    )
+
+
+def _approved_user_python_runtime(path: Path) -> bool:
+    """Allow exact, recognized interpreter distributions without widening to home."""
+
+    home = _host_home_directory()
+    if home is None:
+        return False
+    try:
+        relative_parts = path.absolute().relative_to(home).parts
+    except (OSError, RuntimeError, ValueError):
+        return False
+    managed_prefixes = (
+        (".asdf", "installs", "python"),
+        (".local", "share", "mise", "installs", "python"),
+        (".local", "share", "uv", "python"),
+        (".pyenv", "versions"),
+        ("Library", "Application Support", "uv", "python"),
+        ("Library", "Caches", "uv", "python"),
+    )
+    if any(
+        len(relative_parts) > len(prefix) and relative_parts[: len(prefix)] == prefix for prefix in managed_prefixes
+    ):
+        return True
+    return bool(
+        relative_parts
+        and relative_parts[0] in {"anaconda3", "mambaforge", "miniconda3", "miniforge3"}
+        and len(relative_parts) > 2
+    )
+
+
+def _executable_symlink_chain_is_approved(path: Path, *, workspace: Path) -> bool:
+    current = path.absolute()
+    for _depth in range(16):
+        expansion = _first_symlink_expansion(current)
+        if expansion is None:
+            return True
+        current = expansion
+        if (
+            not _path_is_within_lexically(current, workspace)
+            and not _path_is_within_any_lexically(current, _TRUSTED_EXECUTABLE_ROOTS)
+            and not _approved_user_python_runtime(current)
+        ):
+            return False
+    return _first_symlink_expansion(current) is None
+
+
+def _script_interpreter(executable: Path, *, cwd: Path) -> tuple[Path, ...] | None:
+    try:
+        with executable.open("rb") as handle:
+            first_line = handle.readline(4_096)
+    except OSError:
+        return None
+    if not first_line.startswith(b"#!"):
+        return None
+    try:
+        shebang = first_line[2:].decode("utf-8", errors="strict").strip()
+        parts = shlex.split(shebang, posix=True)
+    except (UnicodeDecodeError, ValueError):
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            "Restricted pytest executable has an invalid interpreter declaration.",
+        ) from None
+    if not parts:
+        raise RestrictedPytestError(
+            PYTEST_INVALID_COMMAND_REASON_CODE,
+            "Restricted pytest executable has an empty interpreter declaration.",
+        )
+    interpreter_launch = _locate_executable(parts[0], cwd=cwd)
+    interpreter = _resolve_executable(parts[0], cwd=cwd)
+    interpreters = [interpreter_launch, interpreter]
+    if interpreter == Path("/usr/bin/env") and len(parts) >= 2:
+        target_launch = _locate_executable(parts[-1], cwd=cwd)
+        interpreters.extend((target_launch, _resolve_executable(parts[-1], cwd=cwd)))
+    return tuple(interpreters)
+
+
+def _restricted_pythonpath(value: str, *, workspace: Path, cwd: Path) -> str:
+    entries: list[str] = []
+    for raw_entry in value.split(os.pathsep):
+        if raw_entry == "":
+            resolved = cwd
+        else:
+            candidate = Path(raw_entry).expanduser()
+            try:
+                resolved = (candidate if candidate.is_absolute() else cwd / candidate).resolve(strict=False)
+                _ = resolved.relative_to(workspace)
+            except (OSError, RuntimeError, ValueError) as error:
+                raise RestrictedPytestError(
+                    PYTEST_EXTERNAL_PYTHONPATH_REASON_CODE,
+                    "Restricted pytest rejected PYTHONPATH because it references a path outside the workspace.",
+                ) from error
+        text = str(resolved)
+        if text not in entries:
+            entries.append(text)
+    return os.pathsep.join(entries)
+
+
+def _first_symlink_expansion(path: Path) -> Path | None:
+    parts = path.parts
+    if not parts:
+        return None
+    current = Path(parts[0])
+    for index, part in enumerate(parts[1:], start=1):
+        current /= part
+        try:
+            if not current.is_symlink():
+                continue
+            raw_target = Path(os.readlink(current))
+        except OSError:
+            return None
+        target = raw_target if raw_target.is_absolute() else current.parent / raw_target
+        expanded = target.joinpath(*parts[index + 1 :])
+        return Path(os.path.abspath(expanded))
+    return None
+
+
+def _runtime_distribution_root(executable: Path) -> Path:
+    bin_indexes = [index for index, part in enumerate(executable.parts) if part == "bin"]
+    if not bin_indexes:
+        return executable.parent
+    return Path(*executable.parts[: bin_indexes[-1]])
+
+
+def _host_home_directory() -> Path | None:
+    password_database = _pwd
+    if password_database is not None and hasattr(os, "getuid"):
+        try:
+            return Path(password_database.getpwuid(os.getuid()).pw_dir).resolve(strict=True)
+        except (KeyError, OSError, RuntimeError):
+            return None
+    try:
+        return Path.home().resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+
+
+def _path_is_within(path: Path, root: Path) -> bool:
+    try:
+        _ = path.resolve(strict=False).relative_to(root.resolve(strict=False))
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return True
+
+
+def _path_is_within_lexically(path: Path, root: Path) -> bool:
+    try:
+        _ = path.absolute().relative_to(root.resolve(strict=False))
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return True
+
+
+def _path_is_within_any(path: Path, roots: Sequence[Path]) -> bool:
+    return any(_path_is_within(path, root) for root in roots)
+
+
+def _path_is_within_any_lexically(path: Path, roots: Sequence[Path]) -> bool:
+    return any(_path_is_within_lexically(path, root) for root in roots)

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -36,6 +36,7 @@ from .false_positive_rules import (
 from .github_command_capabilities import GitHubCommandAssessment, classify_github_cli
 from .interpreter_options import shell_interpreter_command_payload as _shell_interpreter_command_payload
 from .kubernetes_commands import kubernetes_secret_read_source
+from .restricted_pytest import PYTEST_RESTRICTED_PROFILE_VERSION
 from .secret_sensitivity import SecretPathMatch as SensitivePathMatch
 from .secret_sensitivity import classify_secret_path
 from .sed_scripts import sed_script_is_bounded_print
@@ -396,7 +397,22 @@ _WGET_CREDENTIAL_EXFILTRATION_FLAGS_WITH_VALUE = frozenset(
     {"--body-data", "--header", "--method", "--password", "--post-data", "--user"}
 )
 _SHELL_COMMAND_SEPARATORS = frozenset({"&&", "||", ";", "|", "&", "|&"})
-_SHELL_COMMAND_WRAPPERS = frozenset({"command", "env", "nice", "nohup", "stdbuf", "sudo", "time"})
+_SHELL_COMMAND_WRAPPERS = frozenset({"builtin", "command", "env", "exec", "nice", "nohup", "stdbuf", "sudo", "time"})
+_PYTEST_COMMAND_NAMES = frozenset({"py.test", "py.test.exe", "pytest", "pytest.exe"})
+_PYTEST_COMMAND_RUNNER_SUBCOMMANDS = {
+    "conda": frozenset({"run"}),
+    "direnv": frozenset({"exec"}),
+    "hatch": frozenset({"run"}),
+    "mise": frozenset({"exec", "x"}),
+    "pdm": frozenset({"run"}),
+    "pipenv": frozenset({"run"}),
+    "pipx": frozenset({"run"}),
+    "pixi": frozenset({"run"}),
+    "poetry": frozenset({"run"}),
+    "rye": frozenset({"run"}),
+    "uv": frozenset({"run"}),
+}
+_PYTEST_EXECUTOR_COMMANDS = frozenset({"parallel", "watch", "xargs"})
 _BROAD_CREDENTIAL_EXFILTRATION_SKIP_COMMANDS = frozenset({"cat", "curl", "echo", "printf", "sed", "tr", "wget"})
 _SHELL_NETWORK_SINK_COMMANDS = frozenset({"curl", "wget", "nc", "ncat", "netcat", "scp", "rsync", "ssh"})
 _SHELL_LOCAL_READ_COMMANDS = frozenset({"cat", "grep", "egrep", "fgrep", "head", "rg", "sed", "tail"})
@@ -517,6 +533,7 @@ _GIT_GLOBAL_OPTIONS_WITH_VALUE = frozenset(
 )
 _WRAPPER_FLAGS_WITH_VALUES = {
     "env": frozenset({"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}),
+    "exec": frozenset({"-a"}),
     "nice": frozenset({"-n", "--adjustment"}),
     "stdbuf": frozenset({"-i", "--input", "-o", "--output", "-e", "--error"}),
     "sudo": frozenset(
@@ -659,6 +676,9 @@ class ToolActionRequestMatch:
     shell_execution_context_hash: str | None = None
     shell_execution_context_reason_code: str | None = None
     shell_execution_effective_cwds: tuple[str, ...] = ()
+    guard_default_action: str | None = None
+    reason_code: str | None = None
+    restricted_profile_version: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -1022,6 +1042,15 @@ def extract_sensitive_tool_action_request(
             cwd=cwd,
             workspace_root=cwd,
         )
+        raw_destructive_execution_context = (
+            model_shell_execution_context(
+                raw_command_text,
+                cwd=cwd,
+                workspace_root=cwd,
+            )
+            if raw_command_text != command_text
+            else destructive_execution_context
+        )
         destructive_shell_request = _destructive_shell_tool_action_request(
             tool_name=requested_tool_name,
             normalized_tool_name=effective_tool_name,
@@ -1035,6 +1064,7 @@ def extract_sensitive_tool_action_request(
             ),
             raw_command_text=raw_command_text,
             execution_context=destructive_execution_context,
+            raw_execution_context=raw_destructive_execution_context,
         )
         if destructive_shell_request is not None:
             destructive_shell_request = _request_with_shell_execution_context(
@@ -1051,11 +1081,6 @@ def extract_sensitive_tool_action_request(
                 )
             return destructive_shell_request
         if wrapper_chain:
-            raw_execution_context = model_shell_execution_context(
-                raw_command_text,
-                cwd=cwd,
-                workspace_root=cwd,
-            )
             destructive_shell_request = _destructive_shell_tool_action_request(
                 tool_name=requested_tool_name,
                 normalized_tool_name=effective_tool_name,
@@ -1064,7 +1089,8 @@ def extract_sensitive_tool_action_request(
                 home_dir=home_dir,
                 canonical_command=candidate_canonical,
                 raw_command_text=raw_command_text,
-                execution_context=raw_execution_context,
+                execution_context=raw_destructive_execution_context,
+                raw_execution_context=raw_destructive_execution_context,
             )
             if destructive_shell_request is not None:
                 destructive_shell_request = _request_with_shell_execution_context(
@@ -1171,6 +1197,7 @@ def _destructive_shell_tool_action_request(
     canonical_command: CanonicalCommand | None = None,
     raw_command_text: str | None = None,
     execution_context: ShellExecutionContext | None = None,
+    raw_execution_context: ShellExecutionContext | None = None,
 ) -> ToolActionRequestMatch | None:
     if normalized_tool_name not in _SHELL_TOOL_NAMES:
         return None
@@ -1181,6 +1208,7 @@ def _destructive_shell_tool_action_request(
         workspace_root=cwd,
     )
     detection_command_text = command_text
+    pytest_execution_requested = _shell_command_targets_pytest(detection_command_text)
     if is_guard_approval_mutation_command(detection_command_text):
         return ToolActionRequestMatch(
             tool_name=tool_name,
@@ -1270,13 +1298,29 @@ def _destructive_shell_tool_action_request(
             shell_execution_context_hash=execution_context.context_hash,
             shell_execution_context_reason_code=execution_context_reason,
             shell_execution_effective_cwds=tuple(str(path) for path in execution_context.effective_cwds),
+            guard_default_action="sandbox-required" if pytest_execution_requested else None,
+            reason_code="pytest_restricted_profile_required" if pytest_execution_requested else None,
+            restricted_profile_version=PYTEST_RESTRICTED_PROFILE_VERSION if pytest_execution_requested else None,
         )
-    if _looks_destructive_shell_command(
+    detection_command_is_destructive = _looks_destructive_shell_command(
         detection_command_text,
         cwd=cwd,
         home_dir=home_dir,
         execution_context=execution_context,
-    ):
+    )
+    raw_command_is_destructive = (
+        raw_command_text is not None
+        and raw_command_text != detection_command_text
+        and _looks_destructive_shell_command(
+            raw_command_text,
+            cwd=cwd,
+            home_dir=home_dir,
+            execution_context=raw_execution_context,
+        )
+    )
+    if detection_command_is_destructive or raw_command_is_destructive:
+        matched_execution_context = raw_execution_context if raw_command_is_destructive else execution_context
+        matched_execution_context = matched_execution_context or execution_context
         return ToolActionRequestMatch(
             tool_name=tool_name,
             normalized_tool_name=normalized_tool_name,
@@ -1288,14 +1332,34 @@ def _destructive_shell_tool_action_request(
             ),
             canonical_command=canonical_command,
             shell_execution_context_hash=(
-                execution_context.context_hash if execution_context.directory_change_present else None
+                matched_execution_context.context_hash if matched_execution_context.directory_change_present else None
             ),
-            shell_execution_context_reason_code=execution_context.reason_code,
+            shell_execution_context_reason_code=matched_execution_context.reason_code,
             shell_execution_effective_cwds=(
-                tuple(str(path) for path in execution_context.effective_cwds)
-                if execution_context.directory_change_present
+                tuple(str(path) for path in matched_execution_context.effective_cwds)
+                if matched_execution_context.directory_change_present
                 else ()
             ),
+            guard_default_action="sandbox-required" if pytest_execution_requested else None,
+            reason_code="pytest_restricted_profile_required" if pytest_execution_requested else None,
+            restricted_profile_version=PYTEST_RESTRICTED_PROFILE_VERSION if pytest_execution_requested else None,
+        )
+    if pytest_execution_requested:
+        return ToolActionRequestMatch(
+            tool_name=tool_name,
+            normalized_tool_name=normalized_tool_name,
+            command_text=command_text,
+            action_class="pytest repository-code execution",
+            reason=(
+                "pytest_restricted_profile_required: Pytest collection imports repository-controlled tests, "
+                "conftest.py files, and plugins. Run the exact pytest argv through "
+                "`hol-guard pytest-contained --workspace <workspace> -- ...`; Guard will not launch pytest when "
+                "the required operating-system sandbox is unavailable."
+            ),
+            canonical_command=canonical_command,
+            guard_default_action="sandbox-required",
+            reason_code="pytest_restricted_profile_required",
+            restricted_profile_version=PYTEST_RESTRICTED_PROFILE_VERSION,
         )
     github_assessment = _github_shell_capability_assessment(
         detection_command_text,
@@ -3972,18 +4036,16 @@ def build_tool_action_request_artifact(
         compatibility_reason=request.reason,
     )
     wrapper_chain = tuple(dict.fromkeys((*evaluation.command.wrapper_chain, *request.wrapper_chain)))
-    fingerprint = hashlib.sha256(
-        json.dumps(
-            {
-                "harness": harness,
-                "tool_name": request.normalized_tool_name,
-                "command_text": request.command_text,
-                "action_class": request.action_class,
-                "shell_execution_context_hash": request.shell_execution_context_hash,
-            },
-            sort_keys=True,
-        ).encode("utf-8")
-    ).hexdigest()
+    fingerprint_payload = {
+        "harness": harness,
+        "tool_name": request.normalized_tool_name,
+        "command_text": request.command_text,
+        "action_class": request.action_class,
+        "shell_execution_context_hash": request.shell_execution_context_hash,
+    }
+    if request.restricted_profile_version is not None:
+        fingerprint_payload["restricted_profile_version"] = request.restricted_profile_version
+    fingerprint = hashlib.sha256(json.dumps(fingerprint_payload, sort_keys=True).encode("utf-8")).hexdigest()
     request_summary = f"Requested `{request.tool_name}` action `{request.command_text}` ({request.action_class})."
     if wrapper_chain:
         request_summary = (
@@ -4031,6 +4093,28 @@ def build_tool_action_request_artifact(
             "command_parse_confidence": evaluation.command.confidence,
             "command_uncertainty_reason": evaluation.command.uncertainty_reason,
             **execution_context_metadata,
+            **(
+                {"guard_default_action": request.guard_default_action}
+                if request.guard_default_action is not None
+                else {}
+            ),
+            **({"reason_code": request.reason_code} if request.reason_code is not None else {}),
+            **(
+                {
+                    "restricted_profile_version": request.restricted_profile_version,
+                    "restricted_capabilities": {
+                        "workspace": "read-write",
+                        "private_temporary_directory": "read-write",
+                        "host_home": "denied",
+                        "host_secret_environment": "denied",
+                        "network": "denied",
+                        "outside_writes": "denied",
+                        "process_execution": "approved-interpreter-runtime-only",
+                    },
+                }
+                if request.restricted_profile_version is not None
+                else {}
+            ),
         },
     )
 
@@ -4053,6 +4137,9 @@ def _request_with_wrapper_context(
         shell_execution_context_hash=request.shell_execution_context_hash,
         shell_execution_context_reason_code=request.shell_execution_context_reason_code,
         shell_execution_effective_cwds=request.shell_execution_effective_cwds,
+        guard_default_action=request.guard_default_action,
+        reason_code=request.reason_code,
+        restricted_profile_version=request.restricted_profile_version,
     )
 
 
@@ -6775,6 +6862,30 @@ def _shell_script_targets_pytest(script_text: str) -> bool:
     return False
 
 
+def _shell_command_targets_pytest(command_text: str, *, depth: int = 0) -> bool:
+    """Return whether shell evaluation can reach pytest outside Guard containment."""
+
+    if depth > 8:
+        return any(
+            _normalized_shell_command_name(token) in _PYTEST_COMMAND_NAMES for token in _split_shell_parts(command_text)
+        )
+    parts = _split_shell_parts(command_text)
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name is None or command_index is None:
+            continue
+        if _segment_targets_pytest(segment, command_name, command_index, depth=depth):
+            return True
+        if command_name in _SHELL_COMMAND_STRING_INTERPRETERS:
+            flag_payload = _shell_interpreter_command_payload(segment, command_index)
+            if flag_payload is not None and _shell_command_targets_pytest(flag_payload.script_text, depth=depth + 1):
+                return True
+    return any(
+        _shell_command_targets_pytest(payload, depth=depth + 1)
+        for payload in _shell_command_substitution_payloads(command_text)
+    )
+
+
 def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:
     scripts: list[str] = []
     current_command: str | None = None
@@ -7012,12 +7123,279 @@ def _contains_prior_pytest_state_mutation(parts: list[str]) -> bool:
     return False
 
 
-def _segment_targets_pytest(segment: list[str], command_name: str, command_index: int) -> bool:
-    if command_name == "pytest":
+def _segment_targets_pytest(
+    segment: list[str],
+    command_name: str,
+    command_index: int,
+    *,
+    depth: int = 0,
+) -> bool:
+    if command_name in _PYTEST_COMMAND_NAMES:
         return True
-    return _is_python_interpreter_command(command_name) and _python_segment_targets_module(
-        segment[command_index + 1 :],
-        "pytest",
+    command_args = segment[command_index + 1 :]
+    if _is_pytest_python_interpreter_command(command_name):
+        return _python_segment_targets_module(command_args, "pytest") or _python_inline_script_runs_pytest(command_args)
+    if command_name == "uvx":
+        return _argument_sequence_targets_pytest(command_args)
+    runner_subcommands = _PYTEST_COMMAND_RUNNER_SUBCOMMANDS.get(command_name)
+    if runner_subcommands is not None:
+        return any(
+            token in runner_subcommands and _argument_sequence_targets_pytest(command_args[index + 1 :])
+            for index, token in enumerate(command_args)
+        )
+    if command_name in _PYTEST_EXECUTOR_COMMANDS:
+        return _argument_sequence_targets_pytest(command_args)
+    if command_name == "eval":
+        return _shell_command_targets_pytest(" ".join(command_args), depth=depth + 1)
+    if command_name == "find":
+        return any(
+            token in _FIND_EXEC_ACTION_FLAGS and _argument_sequence_targets_pytest(command_args[index + 1 :])
+            for index, token in enumerate(command_args)
+        )
+    if command_name == "fd":
+        return any(
+            fd_arg_requests_exec(token) and _argument_sequence_targets_pytest(command_args[index + 1 :])
+            for index, token in enumerate(command_args)
+        )
+    return False
+
+
+def _argument_sequence_targets_pytest(args: list[str]) -> bool:
+    for index, token in enumerate(args):
+        command_token = token.rsplit(":", 1)[-1]
+        command_name = _normalized_shell_command_name(command_token)
+        if command_name in _PYTEST_COMMAND_NAMES:
+            return True
+        if _is_pytest_python_interpreter_command(command_name) and (
+            _python_segment_targets_module(args[index + 1 :], "pytest")
+            or _python_inline_script_runs_pytest(args[index + 1 :])
+        ):
+            return True
+    return False
+
+
+def _python_inline_script_runs_pytest(args: list[str]) -> bool:
+    for index, token in enumerate(args):
+        if token in {"-c", "--command"} and index + 1 < len(args):
+            return _inline_python_payload_runs_pytest(args[index + 1])
+        if token.startswith("--command="):
+            return _inline_python_payload_runs_pytest(token.split("=", 1)[1])
+        if token.startswith("-c") and token != "-c":
+            return _inline_python_payload_runs_pytest(token[2:])
+        if not token.startswith("-"):
+            return False
+    return False
+
+
+def _inline_python_payload_runs_pytest(payload: str, *, depth: int = 0) -> bool:
+    if depth > 8:
+        return "pytest" in payload.casefold()
+    try:
+        tree = ast.parse(payload, mode="exec")
+    except (SyntaxError, ValueError):
+        return False
+
+    pytest_module_aliases = {"pytest"}
+    pytest_main_aliases: set[str] = set()
+    importlib_aliases = {"importlib"}
+    import_module_aliases: set[str] = set()
+    runpy_aliases = {"runpy"}
+    run_module_aliases: set[str] = set()
+    os_aliases = {"os"}
+    os_process_aliases: set[str] = set()
+    subprocess_aliases = {"subprocess"}
+    subprocess_process_aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "pytest":
+                    pytest_module_aliases.add(alias.asname or "pytest")
+                elif alias.name == "importlib":
+                    importlib_aliases.add(alias.asname or "importlib")
+                elif alias.name == "runpy":
+                    runpy_aliases.add(alias.asname or "runpy")
+                elif alias.name == "os":
+                    os_aliases.add(alias.asname or "os")
+                elif alias.name == "subprocess":
+                    subprocess_aliases.add(alias.asname or "subprocess")
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "pytest":
+                pytest_main_aliases.update(
+                    alias.asname or alias.name for alias in node.names if alias.name in {"console_main", "main"}
+                )
+            elif node.module == "importlib":
+                import_module_aliases.update(
+                    alias.asname or alias.name for alias in node.names if alias.name == "import_module"
+                )
+            elif node.module == "runpy":
+                run_module_aliases.update(
+                    alias.asname or alias.name for alias in node.names if alias.name == "run_module"
+                )
+            elif node.module == "os":
+                os_process_aliases.update(
+                    alias.asname or alias.name for alias in node.names if alias.name in {"popen", "system"}
+                )
+            elif node.module == "subprocess":
+                subprocess_process_aliases.update(
+                    alias.asname or alias.name
+                    for alias in node.names
+                    if alias.name in {"Popen", "call", "check_call", "check_output", "run"}
+                )
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        function = node.func
+        if isinstance(function, ast.Name) and function.id in pytest_main_aliases:
+            return True
+        if isinstance(function, ast.Call) and _python_call_resolves_pytest_main(
+            function,
+            pytest_module_aliases=pytest_module_aliases,
+            importlib_aliases=importlib_aliases,
+            import_module_aliases=import_module_aliases,
+        ):
+            return True
+        if isinstance(function, ast.Attribute) and function.attr in {"console_main", "main"}:
+            if isinstance(function.value, ast.Name) and function.value.id in pytest_module_aliases:
+                return True
+            if isinstance(function.value, ast.Call) and _python_call_imports_pytest(
+                function.value,
+                importlib_aliases=importlib_aliases,
+                import_module_aliases=import_module_aliases,
+            ):
+                return True
+        if _python_call_runs_pytest_module(
+            node,
+            runpy_aliases=runpy_aliases,
+            run_module_aliases=run_module_aliases,
+        ):
+            return True
+        if _python_process_call_targets_pytest(
+            node,
+            depth=depth,
+            os_aliases=os_aliases,
+            os_process_aliases=os_process_aliases,
+            subprocess_aliases=subprocess_aliases,
+            subprocess_process_aliases=subprocess_process_aliases,
+        ):
+            return True
+        if (
+            isinstance(function, ast.Name)
+            and function.id in {"eval", "exec"}
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+            and _inline_python_payload_runs_pytest(node.args[0].value, depth=depth + 1)
+        ):
+            return True
+    return False
+
+
+def _python_process_call_targets_pytest(
+    node: ast.Call,
+    *,
+    depth: int,
+    os_aliases: set[str],
+    os_process_aliases: set[str],
+    subprocess_aliases: set[str],
+    subprocess_process_aliases: set[str],
+) -> bool:
+    function = node.func
+    recognized = isinstance(function, ast.Name) and function.id in {
+        *os_process_aliases,
+        *subprocess_process_aliases,
+    }
+    if isinstance(function, ast.Attribute) and isinstance(function.value, ast.Name):
+        recognized = recognized or (function.value.id in os_aliases and function.attr in {"popen", "system"})
+        recognized = recognized or (
+            function.value.id in subprocess_aliases
+            and function.attr in {"Popen", "call", "check_call", "check_output", "run"}
+        )
+    if not recognized:
+        return False
+
+    command_node: ast.expr | None = node.args[0] if node.args else None
+    if command_node is None:
+        command_node = next((keyword.value for keyword in node.keywords if keyword.arg in {"args", "command"}), None)
+    if isinstance(command_node, ast.Constant) and isinstance(command_node.value, str):
+        return _shell_command_targets_pytest(command_node.value, depth=depth + 1)
+    literal_argv = _literal_python_argv(command_node)
+    return literal_argv is not None and _argument_sequence_targets_pytest(literal_argv)
+
+
+def _literal_python_argv(node: ast.expr | None) -> list[str] | None:
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return None
+    argv: list[str] = []
+    for element in node.elts:
+        if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+            return None
+        argv.append(element.value)
+    return argv
+
+
+def _python_call_resolves_pytest_main(
+    node: ast.Call,
+    *,
+    pytest_module_aliases: set[str],
+    importlib_aliases: set[str],
+    import_module_aliases: set[str],
+) -> bool:
+    if (
+        not isinstance(node.func, ast.Name)
+        or node.func.id != "getattr"
+        or len(node.args) < 2
+        or not isinstance(node.args[1], ast.Constant)
+        or node.args[1].value not in {"console_main", "main"}
+    ):
+        return False
+    target = node.args[0]
+    if isinstance(target, ast.Name):
+        return target.id in pytest_module_aliases
+    return isinstance(target, ast.Call) and _python_call_imports_pytest(
+        target,
+        importlib_aliases=importlib_aliases,
+        import_module_aliases=import_module_aliases,
+    )
+
+
+def _python_call_imports_pytest(
+    node: ast.Call,
+    *,
+    importlib_aliases: set[str],
+    import_module_aliases: set[str],
+) -> bool:
+    if not node.args or not isinstance(node.args[0], ast.Constant) or node.args[0].value != "pytest":
+        return False
+    if isinstance(node.func, ast.Name):
+        return node.func.id == "__import__" or node.func.id in import_module_aliases
+    return (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "import_module"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id in importlib_aliases
+    )
+
+
+def _python_call_runs_pytest_module(
+    node: ast.Call,
+    *,
+    runpy_aliases: set[str],
+    run_module_aliases: set[str],
+) -> bool:
+    if (
+        not node.args
+        or not isinstance(node.args[0], ast.Constant)
+        or node.args[0].value not in {"pytest", "pytest.__main__"}
+    ):
+        return False
+    if isinstance(node.func, ast.Name):
+        return node.func.id in run_module_aliases
+    return (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "run_module"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id in runpy_aliases
     )
 
 
@@ -7695,6 +8073,10 @@ def _is_unmodeled_inline_interpreter_command(command_name: str) -> bool:
 
 def _is_python_interpreter_command(command_name: str) -> bool:
     return re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", command_name) is not None
+
+
+def _is_pytest_python_interpreter_command(command_name: str) -> bool:
+    return re.fullmatch(r"pythonw?(?:\d+(?:\.\d+)*)?(?:\.exe)?", command_name) is not None
 
 
 def _script_is_benign_wait(script_text: str) -> bool:

--- a/tests/test_guard_restricted_pytest.py
+++ b/tests/test_guard_restricted_pytest.py
@@ -1,0 +1,499 @@
+"""P35 regressions for default-contained repository pytest execution."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.cli.commands_support_runtime_policy import _runtime_artifact_policy_action
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.runtime import restricted_pytest as restricted_pytest_module
+from codex_plugin_scanner.guard.runtime.restricted_pytest import (
+    PYTEST_EXTERNAL_PYTHONPATH_REASON_CODE,
+    PYTEST_INVALID_COMMAND_REASON_CODE,
+    PYTEST_INVALID_WORKSPACE_REASON_CODE,
+    PYTEST_RESTRICTED_PROFILE_VERSION,
+    PYTEST_SANDBOX_UNAVAILABLE_REASON_CODE,
+    RestrictedPytestError,
+    _backend_argv,
+    _macos_profile,
+    prepare_restricted_pytest,
+    run_restricted_pytest,
+)
+from codex_plugin_scanner.guard.runtime.secret_file_requests import (
+    build_tool_action_request_artifact,
+    extract_sensitive_tool_action_request,
+)
+
+
+def test_uncontained_pytest_is_repository_execution_requiring_sandbox(tmp_path: Path) -> None:
+    for command in (
+        "pytest -q",
+        "py.test -q",
+        "pytest.exe -q",
+        "python3 -m pytest --collect-only",
+        "pythonw -m pytest -q",
+        "python.exe -m pytest -q",
+        "./.venv/bin/python -m pytest tests/unit -q",
+        "bash -c 'pytest -q'",
+        "eval 'pytest -q'",
+        "exec pytest -q",
+        "builtin command pytest -q",
+        "uv run python -m pytest -q",
+        "uvx pytest -q",
+        "poetry run pytest -q",
+        "mise exec -- pytest -q",
+        "direnv exec . pytest -q",
+        "pipx run pytest -q",
+        "xargs pytest",
+        "find . -exec pytest -q {} +",
+        "python -c 'import pytest; pytest.main()'",
+        "python -c \"getattr(__import__('pytest'), 'main')()\"",
+        "python -c \"exec('import pytest; pytest.main()')\"",
+    ):
+        match = extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=tmp_path)
+
+        assert match is not None, command
+        assert match.guard_default_action == "sandbox-required", command
+        assert match.reason_code == "pytest_restricted_profile_required", command
+
+
+def test_pytest_text_in_nonexecuted_inline_literal_is_not_classified(tmp_path: Path) -> None:
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python -c 'print(\"pytest.main()\")'"},
+        cwd=tmp_path,
+    )
+
+    assert match is None
+
+
+def test_contained_launcher_is_not_recursively_classified_as_uncontained(tmp_path: Path) -> None:
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": (f"hol-guard pytest-contained --workspace {tmp_path} -- python3 -m pytest tests/unit -q")},
+        cwd=tmp_path,
+    )
+
+    assert match is None
+
+
+def test_pytest_artifact_carries_terminal_profile_and_reason(tmp_path: Path) -> None:
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest -q"},
+        cwd=tmp_path,
+    )
+    assert match is not None
+
+    artifact = build_tool_action_request_artifact(
+        "codex",
+        match,
+        config_path="/dev/null",
+        source_scope="project",
+    )
+
+    assert artifact.metadata["guard_default_action"] == "sandbox-required"
+    assert artifact.metadata["reason_code"] == "pytest_restricted_profile_required"
+    assert artifact.metadata["restricted_profile_version"] == PYTEST_RESTRICTED_PROFILE_VERSION
+    assert artifact.metadata["restricted_capabilities"] == {
+        "workspace": "read-write",
+        "private_temporary_directory": "read-write",
+        "host_home": "denied",
+        "host_secret_environment": "denied",
+        "network": "denied",
+        "outside_writes": "denied",
+        "process_execution": "approved-interpreter-runtime-only",
+    }
+
+
+def test_terminal_pytest_profile_cannot_be_downgraded_by_exact_allow(tmp_path: Path) -> None:
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest -q"},
+        cwd=tmp_path,
+    )
+    assert match is not None
+    artifact = build_tool_action_request_artifact(
+        "codex",
+        match,
+        config_path="/dev/null",
+        source_scope="project",
+    )
+    config = GuardConfig(
+        guard_home=tmp_path,
+        workspace=tmp_path,
+        default_action="allow",
+        harness_actions={"codex": "allow"},
+        artifact_actions={artifact.artifact_id: "allow"},
+    )
+
+    assert _runtime_artifact_policy_action(config, artifact, "codex") == "sandbox-required"
+
+
+def test_pytest_contained_cli_dispatches_exact_argv(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    observed: dict[str, object] = {}
+
+    def fake_run_restricted_pytest(command, **kwargs):
+        observed["command"] = command
+        observed.update(kwargs)
+        return 23
+
+    monkeypatch.setattr(restricted_pytest_module, "run_restricted_pytest", fake_run_restricted_pytest)
+
+    return_code = main(
+        [
+            "guard",
+            "pytest-contained",
+            "--workspace",
+            str(tmp_path),
+            "--cwd",
+            str(tmp_path),
+            "--timeout-seconds",
+            "45",
+            "--",
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+        ]
+    )
+
+    assert return_code == 23
+    assert observed == {
+        "command": ["--", sys.executable, "-m", "pytest", "-q"],
+        "workspace": tmp_path,
+        "cwd": tmp_path,
+        "timeout_seconds": 45,
+    }
+
+
+def test_prepare_restricted_pytest_binds_profile_workspace_and_capabilities(tmp_path: Path) -> None:
+    executable = Path(sys.executable)
+    workspace = Path.cwd().resolve()
+    backend = Path("/usr/bin/true")
+    plan = prepare_restricted_pytest(
+        [str(executable), "-m", "pytest", "-q"],
+        workspace=workspace,
+        cwd=tmp_path if tmp_path.is_relative_to(workspace) else workspace,
+        platform="darwin",
+        backend_executable=backend,
+    )
+
+    evidence = plan.to_evidence()
+    assert evidence["profile_version"] == PYTEST_RESTRICTED_PROFILE_VERSION
+    assert evidence["network"] == "denied"
+    assert evidence["host_home"] == "unmounted-or-denied"
+    assert "write-outside-workspace-and-private-temp" in evidence["denied_capabilities"]
+
+
+def test_prepare_restricted_pytest_does_not_trust_spoofed_home(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    workspace = Path.cwd().resolve()
+
+    plan = prepare_restricted_pytest(
+        [sys.executable, "-m", "pytest", "-q"],
+        workspace=workspace,
+        cwd=workspace,
+        platform="darwin",
+        backend_executable=Path("/usr/bin/true"),
+    )
+
+    assert plan.workspace == workspace
+
+
+def test_linux_profile_unshares_network_and_does_not_mount_shell_toolchain() -> None:
+    workspace = Path.cwd().resolve()
+    private_root = Path("/tmp/hol-guard-pytest-test")
+    plan = prepare_restricted_pytest(
+        [sys.executable, "-m", "pytest", "-q"],
+        workspace=workspace,
+        cwd=workspace,
+        platform="linux",
+        backend_executable=Path("/usr/bin/true"),
+    )
+
+    argv = _backend_argv(plan, private_root=private_root)
+
+    assert "--unshare-all" in argv
+    assert "--unshare-net" in argv
+    assert "--bind" in argv
+    assert str(workspace) in argv
+    assert "/bin" not in argv
+    private_dir_index = argv.index("--dir")
+    assert argv[private_dir_index : private_dir_index + 5] == [
+        "--dir",
+        str(private_root),
+        "--bind",
+        str(private_root),
+        str(private_root),
+    ]
+
+
+def test_macos_profile_grants_only_root_metadata_and_bounded_runtime_reads(tmp_path: Path) -> None:
+    workspace = Path.cwd().resolve()
+    plan = prepare_restricted_pytest(
+        [sys.executable, "-m", "pytest", "-q"],
+        workspace=workspace,
+        cwd=workspace,
+        platform="darwin",
+        backend_executable=Path("/usr/bin/true"),
+    )
+
+    profile = _macos_profile(plan, private_root=tmp_path)
+
+    assert '(allow file-read-metadata (literal "/")' in profile
+    assert "(allow file-read-metadata)" not in profile
+    assert "(allow file-read*)" not in profile
+    assert f'(subpath "{Path.home()}")' not in profile
+    process_exec_rule = next(line for line in profile.splitlines() if line.startswith("(allow process-exec "))
+    assert "(subpath " not in process_exec_rule
+
+
+def test_prepare_restricted_pytest_rejects_non_pytest_command() -> None:
+    with pytest.raises(RestrictedPytestError) as error:
+        prepare_restricted_pytest(
+            [sys.executable, "-c", "print('not pytest')"],
+            workspace=Path.cwd(),
+            platform="darwin",
+            backend_executable=Path("/usr/bin/true"),
+        )
+
+    assert error.value.reason_code == PYTEST_INVALID_COMMAND_REASON_CODE
+
+
+def test_prepare_restricted_pytest_rejects_cwd_outside_workspace(tmp_path: Path) -> None:
+    with pytest.raises(RestrictedPytestError) as error:
+        prepare_restricted_pytest(
+            [sys.executable, "-m", "pytest"],
+            workspace=tmp_path,
+            cwd=Path.cwd(),
+            platform="darwin",
+            backend_executable=Path("/usr/bin/true"),
+        )
+
+    assert error.value.reason_code == PYTEST_INVALID_WORKSPACE_REASON_CODE
+
+
+def test_prepare_restricted_pytest_rejects_broad_workspace_root() -> None:
+    with pytest.raises(RestrictedPytestError) as error:
+        prepare_restricted_pytest(
+            [sys.executable, "-m", "pytest"],
+            workspace=Path("/"),
+            cwd=Path.cwd(),
+            platform="darwin",
+            backend_executable=Path("/usr/bin/true"),
+        )
+
+    assert error.value.reason_code == PYTEST_INVALID_WORKSPACE_REASON_CODE
+
+
+def test_prepare_restricted_pytest_rejects_non_python_pytest_entrypoint() -> None:
+    workspace = Path.cwd().resolve()
+    with tempfile.TemporaryDirectory(prefix=".guard-p35-entrypoint-", dir=workspace) as project_text:
+        entrypoint = Path(project_text) / "pytest"
+        entrypoint.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        entrypoint.chmod(0o700)
+
+        with pytest.raises(RestrictedPytestError) as error:
+            prepare_restricted_pytest(
+                [str(entrypoint), "-q"],
+                workspace=workspace,
+                cwd=workspace,
+                platform="darwin",
+                backend_executable=Path("/usr/bin/true"),
+            )
+
+    assert error.value.reason_code == PYTEST_INVALID_COMMAND_REASON_CODE
+
+
+def test_prepare_restricted_pytest_rejects_unrecognized_external_python_runtime(tmp_path: Path) -> None:
+    workspace = Path.cwd().resolve()
+    external_python = tmp_path / "untrusted-runtime" / "bin" / "python"
+    external_python.parent.mkdir(parents=True)
+    external_python.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    external_python.chmod(0o700)
+    with tempfile.TemporaryDirectory(prefix=".guard-p35-launcher-", dir=workspace) as project_text:
+        workspace_python = Path(project_text) / "python"
+        workspace_python.symlink_to(external_python)
+
+        with pytest.raises(RestrictedPytestError) as error:
+            prepare_restricted_pytest(
+                [str(workspace_python), "-m", "pytest"],
+                workspace=workspace,
+                cwd=workspace,
+                platform="darwin",
+                backend_executable=Path("/usr/bin/true"),
+            )
+
+    assert error.value.reason_code == PYTEST_INVALID_COMMAND_REASON_CODE
+
+
+def test_prepare_restricted_pytest_rejects_unapproved_intermediate_symlink_root(tmp_path: Path) -> None:
+    workspace = Path.cwd().resolve()
+    intermediate_python = tmp_path / "host-content" / "bin" / "python"
+    intermediate_python.parent.mkdir(parents=True)
+    intermediate_python.symlink_to(Path(sys.executable).resolve())
+    with tempfile.TemporaryDirectory(prefix=".guard-p35-chain-", dir=workspace) as project_text:
+        workspace_python = Path(project_text) / "python"
+        workspace_python.symlink_to(intermediate_python)
+
+        with pytest.raises(RestrictedPytestError) as error:
+            prepare_restricted_pytest(
+                [str(workspace_python), "-m", "pytest"],
+                workspace=workspace,
+                cwd=workspace,
+                platform="darwin",
+                backend_executable=Path("/usr/bin/true"),
+            )
+
+    assert error.value.reason_code == PYTEST_INVALID_COMMAND_REASON_CODE
+
+
+def test_restricted_pytest_rejects_external_pythonpath_before_backend_runs(tmp_path: Path) -> None:
+    workspace = Path.cwd().resolve()
+    external = tmp_path.resolve()
+    if external.is_relative_to(workspace):
+        pytest.skip("pytest temporary directory unexpectedly lies inside the repository")
+    with pytest.raises(RestrictedPytestError) as error:
+        run_restricted_pytest(
+            [sys.executable, "-m", "pytest", "-q"],
+            workspace=workspace,
+            cwd=workspace,
+            env={"PATH": os.environ.get("PATH", ""), "PYTHONPATH": str(external)},
+            platform="darwin",
+            backend_executable=Path("/usr/bin/true"),
+        )
+
+    assert error.value.reason_code == PYTEST_EXTERNAL_PYTHONPATH_REASON_CODE
+
+
+def test_restricted_pytest_fails_closed_without_platform_backend() -> None:
+    with pytest.raises(RestrictedPytestError) as error:
+        prepare_restricted_pytest(
+            [sys.executable, "-m", "pytest", "-q"],
+            workspace=Path.cwd(),
+            platform="win32",
+        )
+
+    assert error.value.reason_code == PYTEST_SANDBOX_UNAVAILABLE_REASON_CODE
+
+
+def test_restricted_pytest_fails_closed_when_supported_backend_is_missing(tmp_path: Path) -> None:
+    with pytest.raises(RestrictedPytestError) as error:
+        prepare_restricted_pytest(
+            [sys.executable, "-m", "pytest", "-q"],
+            workspace=Path.cwd(),
+            platform="linux",
+            backend_executable=tmp_path / "missing-bwrap",
+        )
+
+    assert error.value.reason_code == PYTEST_SANDBOX_UNAVAILABLE_REASON_CODE
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires the macOS Seatbelt backend")
+@pytest.mark.parametrize("launch_style", ("module", "entrypoint"))
+def test_real_restricted_pytest_blocks_host_sinks_and_preserves_harmless_suite(
+    tmp_path: Path,
+    launch_style: str,
+) -> None:
+    workspace = Path.cwd().resolve()
+    outside_read_marker = tmp_path / "host-read-marker.txt"
+    outside_write = tmp_path / "outside-write.txt"
+    outside_read_marker.write_text("host-only-marker", encoding="utf-8")
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    port = listener.getsockname()[1]
+    try:
+        with tempfile.TemporaryDirectory(prefix=".guard-p35-", dir=workspace) as project_text:
+            project = Path(project_text)
+            result_path = project / "containment-result.json"
+            test_path = project / "test_containment_fixture.py"
+            test_path.write_text(
+                f"""
+import json
+import os
+import socket
+import subprocess
+from pathlib import Path
+
+OUTSIDE_READ_MARKER = Path({json.dumps(str(outside_read_marker))})
+OUTSIDE_WRITE = Path({json.dumps(str(outside_write))})
+LOOPBACK_PORT = {port}
+RESULT_PATH = Path({json.dumps(str(result_path))})
+
+
+def _blocked(operation):
+    try:
+        operation()
+    except (OSError, subprocess.SubprocessError):
+        return True
+    return False
+
+
+def test_repository_code_is_contained():
+    result = {{
+        "outside_read_blocked": _blocked(lambda: OUTSIDE_READ_MARKER.read_text()),
+        "outside_write_blocked": _blocked(lambda: OUTSIDE_WRITE.write_text("escaped", encoding="utf-8")),
+        "network_blocked": _blocked(
+            lambda: socket.create_connection(("127.0.0.1", LOOPBACK_PORT), timeout=1)
+        ),
+        "subprocess_blocked": _blocked(
+            lambda: subprocess.run(["/bin/sh", "-c", "true"], check=True)
+        ),
+        "host_credentials_absent": all(
+            key not in os.environ
+            for key in ("DEPLOY_ACCESS", "P35_HOST_CREDENTIAL", "AWS_ACCESS_KEY_ID", "DATABASE_URL", "LD_PRELOAD")
+        ),
+        "home_is_private": os.environ["HOME"].startswith(os.environ["TMPDIR"].rsplit("/tmp", 1)[0]),
+    }}
+    RESULT_PATH.write_text(json.dumps(result), encoding="utf-8")
+    assert all(result.values())
+""".lstrip(),
+                encoding="utf-8",
+            )
+            launch_env = {
+                **os.environ,
+                "DEPLOY_ACCESS": "opaque-secret-without-a-sensitive-name",
+                "P35_HOST_CREDENTIAL": "must-not-enter-sandbox",
+                "AWS_ACCESS_KEY_ID": "must-not-enter-sandbox",
+                "DATABASE_URL": "postgres://user:password@host/database",
+                "LD_PRELOAD": "/private/tmp/must-not-load.dylib",
+            }
+
+            command = (
+                [sys.executable, "-m", "pytest", str(test_path), "-q"]
+                if launch_style == "module"
+                else [str(Path(sys.executable).parent / "pytest"), str(test_path), "-q"]
+            )
+            return_code = run_restricted_pytest(
+                command,
+                workspace=workspace,
+                cwd=project,
+                env=launch_env,
+                timeout_seconds=60,
+            )
+
+            assert return_code == 0
+            assert json.loads(result_path.read_text(encoding="utf-8")) == {
+                "outside_read_blocked": True,
+                "outside_write_blocked": True,
+                "network_blocked": True,
+                "subprocess_blocked": True,
+                "host_credentials_absent": True,
+                "home_is_private": True,
+            }
+            assert not outside_write.exists()
+    finally:
+        listener.close()

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -15711,7 +15711,14 @@ def test_guard_hook_codex_user_prompt_submit_applies_destructive_prompt_policy(
     assert "HOL Guard" in payload["reason"]
 
 
-def test_guard_runtime_allows_simple_pytest_module_invocation(tmp_path):
+def _assert_pytest_requires_restricted_profile(match):
+    assert match is not None
+    assert match.action_class == "pytest repository-code execution"
+    assert match.guard_default_action == "sandbox-required"
+    assert match.reason_code == "pytest_restricted_profile_required"
+
+
+def test_guard_runtime_requires_restricted_profile_for_simple_pytest_module_invocation(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",
         {
@@ -15724,7 +15731,39 @@ def test_guard_runtime_allows_simple_pytest_module_invocation(tmp_path):
         cwd=tmp_path,
     )
 
-    assert match is None
+    _assert_pytest_requires_restricted_profile(match)
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "python -c \"import os; os.system('pytest -q')\"",
+        "python -c \"import os as ops; ops.popen('python -m pytest -q')\"",
+        "python -c \"from os import system as launch; launch('pytest -q')\"",
+        "python -c \"import subprocess; subprocess.run(['pytest', '-q'])\"",
+        "python -c \"import subprocess as sp; sp.call(('python3', '-m', 'pytest', '-q'))\"",
+        "python -c \"import subprocess as sp; sp.check_call(args=['pytest', '-q'])\"",
+        "python -c \"import subprocess as sp; sp.check_output(['py.test', '-q'])\"",
+        "python -c \"from subprocess import Popen as launch; launch(('pytest', '-q'))\"",
+        "python -c \"from subprocess import run as launch; launch('pytest -q')\"",
+    ),
+)
+def test_guard_runtime_requires_restricted_profile_for_inline_process_pytest(command, tmp_path):
+    assert secret_file_requests_module._shell_command_targets_pytest(command)
+
+    match = extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=tmp_path)
+
+    assert match is not None
+    assert match.guard_default_action == "sandbox-required"
+    assert match.reason_code == "pytest_restricted_profile_required"
+
+
+def test_guard_runtime_does_not_target_harmless_inline_process_command():
+    command = "python -c \"import subprocess as sp; sp.run(['echo', 'harmless'])\""
+
+    assert not secret_file_requests_module._shell_command_targets_pytest(
+        command,
+    )
 
 
 def test_guard_runtime_allows_apply_patch_to_non_sensitive_source_file(tmp_path):
@@ -15794,7 +15833,7 @@ def test_guard_runtime_ignores_patch_syntax_for_other_write_tools(tmp_path):
     assert match is None
 
 
-def test_guard_runtime_allows_cd_prefixed_pytest_module_invocation(tmp_path):
+def test_guard_runtime_requires_restricted_profile_for_cd_prefixed_pytest_module_invocation(tmp_path):
     (tmp_path / "tests").mkdir()
     match = extract_sensitive_tool_action_request(
         "Bash",
@@ -15808,7 +15847,7 @@ def test_guard_runtime_allows_cd_prefixed_pytest_module_invocation(tmp_path):
         cwd=tmp_path,
     )
 
-    assert match is None
+    _assert_pytest_requires_restricted_profile(match)
 
 
 def test_guard_runtime_allows_ruff_check_and_fix_module_invocations(tmp_path):
@@ -15969,14 +16008,14 @@ def test_guard_runtime_blocks_local_pytest_entry_point_metadata(tmp_path):
     assert match.action_class == "destructive shell command"
 
 
-def test_guard_runtime_allows_simple_pytest_binary_invocation(tmp_path):
+def test_guard_runtime_requires_restricted_profile_for_simple_pytest_binary_invocation(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",
         {"command": "pytest tests/test_guard_harness_smoke.py -q"},
         cwd=tmp_path,
     )
 
-    assert match is None
+    _assert_pytest_requires_restricted_profile(match)
 
 
 def test_guard_runtime_blocks_pytest_binary_addopts(tmp_path):
@@ -16147,7 +16186,7 @@ def test_guard_runtime_blocks_pytest_config_addopts(tmp_path):
     assert binary_match.action_class == "destructive shell command"
 
 
-def test_guard_runtime_allows_pytest_config_without_addopts(tmp_path):
+def test_guard_runtime_requires_restricted_profile_for_pytest_config_without_addopts(tmp_path):
     _write_text(tmp_path / "pyproject.toml", "[tool.pytest.ini_options]\ntestpaths = ['tests']\n")
 
     match = extract_sensitive_tool_action_request(
@@ -16156,7 +16195,7 @@ def test_guard_runtime_allows_pytest_config_without_addopts(tmp_path):
         cwd=tmp_path,
     )
 
-    assert match is None
+    _assert_pytest_requires_restricted_profile(match)
 
 
 def test_guard_runtime_blocks_selected_test_root_pytest_config_addopts(tmp_path):
@@ -16271,7 +16310,7 @@ def test_guard_runtime_blocks_pytest_config_addopts_log_file(tmp_path):
     assert binary_match.action_class == "destructive shell command"
 
 
-def test_guard_runtime_allows_pytest_config_addopts_log_formatting(tmp_path):
+def test_guard_runtime_requires_restricted_profile_for_pytest_config_addopts_log_formatting(tmp_path):
     _write_text(
         tmp_path / "pytest.ini",
         "[pytest]\naddopts = --log-file-level INFO --log-file-format %(message)s --log-file-date-format %H:%M:%S\n",
@@ -16283,7 +16322,7 @@ def test_guard_runtime_allows_pytest_config_addopts_log_formatting(tmp_path):
         cwd=tmp_path,
     )
 
-    assert match is None
+    _assert_pytest_requires_restricted_profile(match)
 
 
 def test_guard_runtime_checks_absolute_selected_test_root_pytest_config_addopts(tmp_path):
@@ -16313,7 +16352,7 @@ def test_guard_runtime_checks_selected_test_path_ancestor_pytest_config_addopts(
     assert match.action_class == "destructive shell command"
 
 
-def test_guard_runtime_allows_prior_cd_before_pytest(tmp_path):
+def test_guard_runtime_requires_restricted_profile_after_prior_cd(tmp_path):
     (tmp_path / "sub").mkdir()
     match = extract_sensitive_tool_action_request(
         "Bash",
@@ -16321,10 +16360,10 @@ def test_guard_runtime_allows_prior_cd_before_pytest(tmp_path):
         cwd=tmp_path,
     )
 
-    assert match is None
+    _assert_pytest_requires_restricted_profile(match)
 
 
-def test_guard_runtime_allows_prior_pushd_before_pytest(tmp_path):
+def test_guard_runtime_requires_restricted_profile_after_prior_pushd(tmp_path):
     (tmp_path / "sub").mkdir()
     match = extract_sensitive_tool_action_request(
         "Bash",
@@ -16332,7 +16371,7 @@ def test_guard_runtime_allows_prior_pushd_before_pytest(tmp_path):
         cwd=tmp_path,
     )
 
-    assert match is None
+    _assert_pytest_requires_restricted_profile(match)
 
 
 def test_guard_runtime_blocks_prior_exported_pytest_environment(tmp_path):
@@ -16437,7 +16476,7 @@ def test_guard_runtime_blocks_path_overridden_pytest_binary(tmp_path):
     assert match.action_class == "destructive shell command"
 
 
-def test_guard_hook_codex_does_not_block_simple_pytest_command(tmp_path, capsys, monkeypatch):
+def test_guard_hook_codex_requires_sandbox_for_simple_pytest_command(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
@@ -16464,13 +16503,15 @@ def test_guard_hook_codex_does_not_block_simple_pytest_command(tmp_path, capsys,
         as_json=True,
     )
 
-    assert rc == 0
+    assert rc == 1
     assert output["recorded"] is True
-    assert output["policy_action"] == "warn"
-    assert "approval_requests" not in output
+    assert output["policy_action"] == "sandbox-required"
+    assert output["terminal"] is True
+    assert output["terminal_action"] == "sandbox-required"
+    assert output["approval_requests"] == []
 
 
-def test_guard_runtime_allows_literal_exit_code_echo_after_safe_pytest(tmp_path):
+def test_guard_runtime_requires_restricted_profile_for_pytest_exit_code_echo(tmp_path):
     (tmp_path / "sub").mkdir()
     match = extract_sensitive_tool_action_request(
         "Bash",
@@ -16484,10 +16525,10 @@ def test_guard_runtime_allows_literal_exit_code_echo_after_safe_pytest(tmp_path)
         cwd=tmp_path,
     )
 
-    assert match is None
+    _assert_pytest_requires_restricted_profile(match)
 
 
-def test_guard_hook_codex_does_not_block_safe_pytest_exit_code_echo(tmp_path, capsys, monkeypatch):
+def test_guard_hook_codex_requires_sandbox_for_pytest_exit_code_echo(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
@@ -16515,10 +16556,12 @@ def test_guard_hook_codex_does_not_block_safe_pytest_exit_code_echo(tmp_path, ca
         as_json=True,
     )
 
-    assert rc == 0
+    assert rc == 1
     assert output["recorded"] is True
-    assert output["policy_action"] == "warn"
-    assert "approval_requests" not in output
+    assert output["policy_action"] == "sandbox-required"
+    assert output["terminal"] is True
+    assert output["terminal_action"] == "sandbox-required"
+    assert output["approval_requests"] == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_shell_execution_context.py
+++ b/tests/test_guard_shell_execution_context.py
@@ -395,8 +395,13 @@ def test_python_safety_checks_use_project_b_not_the_launch_project(tmp_path: Pat
         cwd=project_a,
     )
 
-    assert safe_request is None
+    assert safe_request is not None
+    assert safe_request.guard_default_action == "sandbox-required"
+    assert safe_request.reason_code == "pytest_restricted_profile_required"
+    assert safe_request.shell_execution_effective_cwds == (str(project_b.resolve()),)
     assert unsafe_request is not None
+    assert unsafe_request.guard_default_action == "sandbox-required"
+    assert unsafe_request.reason_code == "pytest_restricted_profile_required"
     assert unsafe_request.shell_execution_effective_cwds == (str(project_b.resolve()),)
 
 


### PR DESCRIPTION
## Summary
- Reclassify direct and wrapped pytest invocations as repository-code execution with a terminal, versioned containment requirement and stable reason metadata.
- Add a fail-closed `pytest-contained` launcher backed by macOS Seatbelt or Linux Bubblewrap, with bounded workspace/temp access, a strict child environment, no host network, no outside writes, constrained executables, and process/resource limits.
- Harden executable, shebang, runtime-symlink, sandbox-backend, and workspace validation; add real macOS containment regressions for harmless tests, host-secret reads, arbitrary-name secret environment values, loopback access, outside writes, and unapproved subprocesses.
- Integrate with `release/2.1`'s effective-working-directory model so the same modeled context drives destructive checks and artifact identity; wrapped/raw pytest commands retain their sandbox requirement and unsafe wrapper classification.

## Testing
- `uv run --no-sync python -m pytest tests/test_guard_restricted_pytest.py -q` (21 passed)
- `.venv/p35-py310/bin/python -m pytest tests/test_guard_restricted_pytest.py -q` (21 passed)
- `uv run --no-sync pytest -q tests/test_guard_runtime.py -k pytest` (153 passed on the rebased release head)
- `uv run --no-sync pytest -q tests/test_guard_runtime.py` (670 passed on the rebased release head)
- `uv run pytest tests/test_guard_shell_execution_context.py tests/test_guard_restricted_pytest.py -q` (71 passed after aligning the release-context integration expectation with mandatory pytest containment)
- `.venv/p35-py310/bin/python -m pytest tests/test_guard_runtime.py -k pytest -q` (160 passed)
- `uv run --no-sync pytest --tb=short` (9,217 passed, 23 skipped, 5 deselected; one pre-existing macOS credential-store availability failure)
- `uv run --no-sync python -m ruff check src/`
- `uv run --no-sync python -m ruff format --check src/`
- `uv run --no-sync basedpyright --level error`
- `uv build` (rebased release-head sdist and wheel built successfully)
- Installed CLI containment smoke passed on Python 3.10 and 3.12 for direct entrypoint and `python -m pytest` launch forms.
- Rebased-head Ruff lint and formatting checks passed; basedpyright reports 0 errors and 0 warnings across all changed production modules.

## Notes
- Target branch: `release/2.1` (single commit directly parented by the current release head).
- Commit author/committer: `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>`.
- Real OS containment was exercised on macOS. Linux Bubblewrap construction/fail-closed behavior is covered by unit tests but was not executed on this macOS host.
- Harness hooks currently stop uncontained pytest and provide the exact contained-launch remediation; they cannot transparently substitute the command across every supported harness. The explicit `hol-guard pytest-contained` launcher is the enforced execution path in this change.
- Capability escalation is intentionally not converted into unrestricted execution: the default profile strips non-allowlisted environment capabilities and fails closed when the platform sandbox is unavailable.
