### PR TITLE
feat(guard): add execution-bound TypeScript containment

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -1145,6 +1145,7 @@ def build_runtime_snapshot(
     receipt_limit: int = 25,
     active_request_id: str | None = None,
     include_items: bool = True,
+    containment_health: object = None,
 ) -> dict[str, object]:
     queue_page = store.list_pending_approval_summaries(limit=1)
     queue_items = queue_page["items"] if isinstance(queue_page["items"], list) else []
@@ -1167,9 +1168,12 @@ def build_runtime_snapshot(
     trust_status = store.get_cached_policy_trust_status()
     managed_installs = store.list_managed_installs()
     runtime_state = store.get_runtime_state()
+    health_runtime_state = dict(runtime_state) if runtime_state is not None else None
+    if health_runtime_state is not None and containment_health is not None:
+        health_runtime_state["containment_health"] = containment_health
     protection_health = build_runtime_protection_health(
         store=store,
-        runtime_state=runtime_state,
+        runtime_state=health_runtime_state,
         managed_installs=managed_installs,
         trust_status=trust_status,
         now=datetime.fromisoformat(snapshot_now.replace("Z", "+00:00")),
@@ -1182,7 +1186,7 @@ def build_runtime_snapshot(
     return {
         "generated_at": snapshot_now,
         "approval_center_url": approval_center_url,
-        "runtime_state": runtime_state,
+        "runtime_state": health_runtime_state,
         "oauth_storage_health": oauth_storage_health,
         "device": _build_runtime_device_context(store),
         "latest_connect_state": latest_connect_state,

--- a/src/codex_plugin_scanner/guard/contained_typescript_execution.py
+++ b/src/codex_plugin_scanner/guard/contained_typescript_execution.py
@@ -1,0 +1,327 @@
+"""Execution-owned containment for exact local TypeScript checks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Final
+
+from .runtime.containment_contract import ContainmentInput, ContainmentPolicy, ContainmentRequest
+from .runtime.containment_executor import ContainmentExecutionResult, execute_contained, file_sha256
+from .runtime.containment_health import (
+    ContainmentHealthEvidence,
+    contained_positive_proof,
+)
+from .runtime.effect_contract import (
+    ContainmentRequirement,
+    DecisionBasis,
+    EffectAssessment,
+    EffectBlastRadius,
+    EffectConfidence,
+    EffectEvidenceSource,
+    EffectKind,
+    EffectReversibility,
+    EffectTargetScope,
+    ProofRequirement,
+    ProofRoute,
+)
+from .runtime.effect_decision import (
+    DecisionFactor,
+    DecisionFactorSource,
+    EffectDecision,
+    EffectDecisionRequest,
+    PositiveProof,
+    evaluate_effect_decision,
+)
+from .runtime.package_intent_parser import parse_package_intent
+
+_MAX_TREE_FILES: Final = 10_000
+_MAX_TREE_BYTES: Final = 128 * 1024 * 1024
+_MAX_SOURCE_BYTES: Final = 32 * 1024 * 1024
+_PROTECTED_NAMES: Final = frozenset(
+    {".git", ".ssh", ".aws", ".gnupg", ".guard", "credentials", "credentials.json", "secrets.json"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ContainedTypeScriptResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+    proof: PositiveProof
+    decision: EffectDecision
+    operation_id: str = "typecheck"
+
+
+def try_execute_contained_typescript(
+    manager: str,
+    argv: tuple[str, ...],
+    *,
+    workspace: Path,
+    guard_home: Path,
+    shim_directory: Path,
+    environment: dict[str, str],
+    timeout_seconds: float = 120.0,
+) -> ContainedTypeScriptResult | None:
+    """Run one exact compiler check under enforcement or return to Guard review."""
+
+    if manager.strip().lower() != "npx":
+        return None
+    canonical_workspace = _canonical_directory(workspace)
+    intent = parse_package_intent(
+        _shell_join(("npx", *argv)),
+        workspace=canonical_workspace,
+    )
+    if intent is None or len(intent.local_executions) != 1:
+        return None
+    local_execution = intent.local_executions[0]
+    evidence = local_execution.typescript_launch
+    if evidence is None or evidence.status != "complete" or evidence.direct_silent_verification:
+        return None
+    executable = local_execution.local_executable
+    if executable is None or executable.resolved_path is None or executable.content_hash is None:
+        return None
+    compiler = Path(executable.resolved_path)
+    package_root = compiler.parent.parent
+    if package_root.name != "typescript" or package_root.parent.name != "node_modules":
+        return None
+    compiler_args = _compiler_args(argv)
+    if compiler_args is None:
+        return None
+    try:
+        tree_digest, package_inputs = _tree_inputs(canonical_workspace, package_root)
+        source_digest, source_inputs = _source_inputs(canonical_workspace, evidence.source_files)
+        compiler_digest = file_sha256(str(compiler))
+        node_path = _resolve_node(environment.get("PATH", ""), shim_directory)
+        node_digest = file_sha256(node_path)
+    except (OSError, ValueError):
+        return None
+    launch_digest = _binding_digest(
+        {
+            "typescript_evidence": evidence.binding_digest,
+            "tree_digest": tree_digest,
+            "source_digest": source_digest,
+            "compiler_digest": compiler_digest,
+            "node_digest": node_digest,
+            "compiler_args": list(compiler_args),
+        }
+    )
+    request = ContainmentRequest(
+        argv=(node_path, "node_modules/typescript/bin/tsc", *compiler_args),
+        cwd=str(canonical_workspace),
+        environment=_clean_environment(environment),
+        policy=ContainmentPolicy(str(canonical_workspace), ()),
+        inputs=(*package_inputs, *source_inputs),
+        launch_digest=launch_digest,
+        executable_digest=node_digest,
+        operation_id="typecheck",
+    )
+    try:
+        health, runtime_fingerprint = _load_current_containment_health(guard_home)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+    result = execute_contained(request, timeout_seconds=timeout_seconds)
+    if not result.enforced or result.exit_code is None:
+        return None
+    try:
+        proof = _proof_from_result(result, request, health, runtime_fingerprint)
+    except ValueError:
+        return None
+    decision = _contained_decision(proof)
+    if decision.disposition.value != "silent-contained":
+        return None
+    return ContainedTypeScriptResult(result.exit_code, result.stdout, result.stderr, proof, decision)
+
+
+def _proof_from_result(
+    result: ContainmentExecutionResult,
+    request: ContainmentRequest,
+    health: ContainmentHealthEvidence,
+    runtime_fingerprint: str,
+) -> PositiveProof:
+    now = datetime.now(timezone.utc)
+    return contained_positive_proof(
+        result.attestation,
+        request,
+        health,
+        requirements=(
+            ProofRequirement.OPERATION_AND_TARGETS,
+            ProofRequirement.WORKSPACE_IDENTITY,
+            ProofRequirement.WORKING_DIRECTORY_IDENTITY,
+            ProofRequirement.EXECUTABLE_IDENTITY,
+            ProofRequirement.LAUNCH_CHAIN,
+            ProofRequirement.PARSER_CONFIDENCE,
+            ProofRequirement.EXPECTED_EFFECTS,
+        ),
+        now=now,
+        runtime_fingerprint=runtime_fingerprint,
+    )
+
+
+def _load_current_containment_health(guard_home: Path) -> tuple[ContainmentHealthEvidence, str]:
+    from .daemon.client import load_guard_surface_daemon_client
+    from .daemon.manager import current_guard_daemon_runtime_fingerprint
+
+    client = load_guard_surface_daemon_client(guard_home.resolve(strict=True))
+    evidence = ContainmentHealthEvidence.from_mapping(client.containment_health())
+    runtime_fingerprint = current_guard_daemon_runtime_fingerprint()
+    errors = evidence.compatibility_errors(now=datetime.now(timezone.utc), runtime_fingerprint=runtime_fingerprint)
+    if errors:
+        raise RuntimeError(f"containment health incompatible: {errors[0]}")
+    return evidence, runtime_fingerprint
+
+
+def _contained_decision(proof: PositiveProof) -> EffectDecision:
+    requirements = frozenset(
+        {
+            ProofRequirement.OPERATION_AND_TARGETS,
+            ProofRequirement.WORKSPACE_IDENTITY,
+            ProofRequirement.WORKING_DIRECTORY_IDENTITY,
+            ProofRequirement.EXECUTABLE_IDENTITY,
+            ProofRequirement.LAUNCH_CHAIN,
+            ProofRequirement.PARSER_CONFIDENCE,
+            ProofRequirement.EXPECTED_EFFECTS,
+            ProofRequirement.CONTAINMENT_IDENTITY,
+        }
+    )
+    assessment = EffectAssessment(
+        kind=EffectKind.PROCESS_EXECUTION,
+        target_scope=EffectTargetScope.WORKSPACE,
+        reversibility=EffectReversibility.TRIVIALLY_RECOVERABLE,
+        blast_radius=EffectBlastRadius.WORKSPACE,
+        evidence_source=EffectEvidenceSource.CONTAINMENT,
+        confidence=EffectConfidence.STRONG,
+        containment=ContainmentRequirement.REQUIRED,
+        proof_requirements=requirements,
+    )
+    return evaluate_effect_decision(
+        EffectDecisionRequest(
+            factors=(
+                DecisionFactor(
+                    source=DecisionFactorSource.EFFECT,
+                    reason_code="routine-typecheck-contained",
+                    basis=DecisionBasis("allow", ProofRoute.CONTAINED),
+                    operation_ref="operation:typecheck",
+                    producer_ref="containment:typescript-v1",
+                    evidence_digest=proof.binding_digest,
+                    assessment=assessment,
+                    proof=proof,
+                ),
+            )
+        )
+    )
+
+
+def _tree_inputs(workspace: Path, root: Path) -> tuple[str, tuple[ContainmentInput, ...]]:
+    canonical_root = _canonical_directory(root)
+    records: list[tuple[str, str]] = []
+    inputs: list[ContainmentInput] = []
+    total_bytes = 0
+    for path in sorted(canonical_root.rglob("*")):
+        relative = path.relative_to(canonical_root)
+        if any(part.lower() in _PROTECTED_NAMES or part.lower().startswith(".env") for part in relative.parts):
+            raise ValueError("protected package-tree path")
+        if path.is_symlink():
+            raise ValueError("package tree cannot contain symlinks")
+        if not path.is_file():
+            continue
+        total_bytes += path.stat().st_size
+        if len(records) >= _MAX_TREE_FILES or total_bytes > _MAX_TREE_BYTES:
+            raise ValueError("package tree exceeds containment identity budget")
+        digest = _file_digest(path)
+        records.append((relative.as_posix(), digest))
+        snapshot_path = path.relative_to(workspace).as_posix()
+        inputs.append(ContainmentInput(str(path), snapshot_path, digest))
+    if not records:
+        raise ValueError("package tree is empty")
+    return _binding_digest({"files": records}), tuple(inputs)
+
+
+def _source_inputs(workspace: Path, sources: tuple[str, ...]) -> tuple[str, tuple[ContainmentInput, ...]]:
+    records: list[tuple[str, str]] = []
+    inputs: list[ContainmentInput] = []
+    total_bytes = 0
+    for raw_source in sources:
+        candidate = workspace / raw_source
+        if candidate.is_symlink() or not candidate.is_file():
+            raise ValueError("source must be a regular non-symlinked file")
+        canonical = candidate.resolve(strict=True)
+        try:
+            relative = canonical.relative_to(workspace)
+        except ValueError as exc:
+            raise ValueError("source escaped workspace") from exc
+        if any(part.lower() in _PROTECTED_NAMES or part.lower().startswith(".env") for part in relative.parts):
+            raise ValueError("protected source path")
+        total_bytes += canonical.stat().st_size
+        if total_bytes > _MAX_SOURCE_BYTES:
+            raise ValueError("source closure exceeds containment identity budget")
+        digest = _file_digest(canonical)
+        records.append((relative.as_posix(), digest))
+        inputs.append(ContainmentInput(str(canonical), relative.as_posix(), digest))
+    if len(records) != len(set(path for path, _ in records)):
+        raise ValueError("source closure cannot contain aliases")
+    return _binding_digest({"sources": records}), tuple(inputs)
+
+
+def _compiler_args(argv: tuple[str, ...]) -> tuple[str, ...] | None:
+    try:
+        index = argv.index("tsc")
+    except ValueError:
+        return None
+    return argv[index + 1 :]
+
+
+def _resolve_node(path_value: str, shim_directory: Path) -> str:
+    shim = str(shim_directory.resolve(strict=True))
+    filtered = os.pathsep.join(
+        entry for entry in path_value.split(os.pathsep) if entry and str(Path(entry).resolve(strict=False)) != shim
+    )
+    candidate = shutil.which("node", path=filtered)
+    if candidate is None:
+        raise ValueError("node executable unavailable")
+    path = Path(candidate)
+    canonical = path.resolve(strict=True)
+    if not canonical.is_file() or not os.access(canonical, os.X_OK):
+        raise ValueError("node executable is not path-pinned")
+    return str(canonical)
+
+
+def _clean_environment(environment: dict[str, str]) -> tuple[tuple[str, str], ...]:
+    allowed: dict[str, str] = {}
+    for key in ("LANG", "LC_ALL", "LC_CTYPE", "NO_COLOR", "TERM"):
+        value = environment.get(key)
+        if value:
+            allowed[key] = value
+    return tuple(sorted(allowed.items()))
+
+
+def _canonical_directory(path: Path) -> Path:
+    if path.is_symlink() or not path.is_dir():
+        raise ValueError("workspace must be an existing canonical directory")
+    canonical = path.resolve(strict=True)
+    if canonical != Path(os.path.normpath(str(path))):
+        raise ValueError("workspace cannot contain aliases")
+    return canonical
+
+
+def _file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _binding_digest(payload: dict[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+    return hashlib.sha256(len(encoded).to_bytes(8, "big") + encoded).hexdigest()
+
+
+def _shell_join(tokens: tuple[str, ...]) -> str:
+    import shlex
+
+    return shlex.join(tokens)
+
+
+__all__ = ("ContainedTypeScriptResult", "try_execute_contained_typescript")

--- a/src/codex_plugin_scanner/guard/contained_typescript_execution.py
+++ b/src/codex_plugin_scanner/guard/contained_typescript_execution.py
@@ -9,9 +9,8 @@ import shutil
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Final
 
-from .runtime.containment_contract import ContainmentInput, ContainmentPolicy, ContainmentRequest
+from .runtime.containment_contract import ContainmentPolicy, ContainmentRequest
 from .runtime.containment_executor import ContainmentExecutionResult, execute_contained, file_sha256
 from .runtime.containment_health import (
     ContainmentHealthEvidence,
@@ -39,13 +38,7 @@ from .runtime.effect_decision import (
     evaluate_effect_decision,
 )
 from .runtime.package_intent_parser import parse_package_intent
-
-_MAX_TREE_FILES: Final = 10_000
-_MAX_TREE_BYTES: Final = 128 * 1024 * 1024
-_MAX_SOURCE_BYTES: Final = 32 * 1024 * 1024
-_PROTECTED_NAMES: Final = frozenset(
-    {".git", ".ssh", ".aws", ".gnupg", ".guard", "credentials", "credentials.json", "secrets.json"}
-)
+from .runtime.typescript_snapshot_inputs import typescript_snapshot_inputs
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,8 +87,11 @@ def try_execute_contained_typescript(
     if compiler_args is None:
         return None
     try:
-        tree_digest, package_inputs = _tree_inputs(canonical_workspace, package_root)
-        source_digest, source_inputs = _source_inputs(canonical_workspace, evidence.source_files)
+        tree_digest, package_inputs, closure_digest, closure_inputs = typescript_snapshot_inputs(
+            canonical_workspace,
+            package_root,
+            evidence.source_files,
+        )
         compiler_digest = file_sha256(str(compiler))
         node_path = _resolve_node(environment.get("PATH", ""), shim_directory)
         node_digest = file_sha256(node_path)
@@ -105,7 +101,7 @@ def try_execute_contained_typescript(
         {
             "typescript_evidence": evidence.binding_digest,
             "tree_digest": tree_digest,
-            "source_digest": source_digest,
+            "closure_digest": closure_digest,
             "compiler_digest": compiler_digest,
             "node_digest": node_digest,
             "compiler_args": list(compiler_args),
@@ -116,7 +112,7 @@ def try_execute_contained_typescript(
         cwd=str(canonical_workspace),
         environment=_clean_environment(environment),
         policy=ContainmentPolicy(str(canonical_workspace), ()),
-        inputs=(*package_inputs, *source_inputs),
+        inputs=(*package_inputs, *closure_inputs),
         launch_digest=launch_digest,
         executable_digest=node_digest,
         operation_id="typecheck",
@@ -126,7 +122,7 @@ def try_execute_contained_typescript(
     except (OSError, RuntimeError, TypeError, ValueError):
         return None
     result = execute_contained(request, timeout_seconds=timeout_seconds)
-    if not result.enforced or result.exit_code is None:
+    if not result.enforced or result.exit_code != 0:
         return None
     try:
         proof = _proof_from_result(result, request, health, runtime_fingerprint)
@@ -217,57 +213,6 @@ def _contained_decision(proof: PositiveProof) -> EffectDecision:
     )
 
 
-def _tree_inputs(workspace: Path, root: Path) -> tuple[str, tuple[ContainmentInput, ...]]:
-    canonical_root = _canonical_directory(root)
-    records: list[tuple[str, str]] = []
-    inputs: list[ContainmentInput] = []
-    total_bytes = 0
-    for path in sorted(canonical_root.rglob("*")):
-        relative = path.relative_to(canonical_root)
-        if any(part.lower() in _PROTECTED_NAMES or part.lower().startswith(".env") for part in relative.parts):
-            raise ValueError("protected package-tree path")
-        if path.is_symlink():
-            raise ValueError("package tree cannot contain symlinks")
-        if not path.is_file():
-            continue
-        total_bytes += path.stat().st_size
-        if len(records) >= _MAX_TREE_FILES or total_bytes > _MAX_TREE_BYTES:
-            raise ValueError("package tree exceeds containment identity budget")
-        digest = _file_digest(path)
-        records.append((relative.as_posix(), digest))
-        snapshot_path = path.relative_to(workspace).as_posix()
-        inputs.append(ContainmentInput(str(path), snapshot_path, digest))
-    if not records:
-        raise ValueError("package tree is empty")
-    return _binding_digest({"files": records}), tuple(inputs)
-
-
-def _source_inputs(workspace: Path, sources: tuple[str, ...]) -> tuple[str, tuple[ContainmentInput, ...]]:
-    records: list[tuple[str, str]] = []
-    inputs: list[ContainmentInput] = []
-    total_bytes = 0
-    for raw_source in sources:
-        candidate = workspace / raw_source
-        if candidate.is_symlink() or not candidate.is_file():
-            raise ValueError("source must be a regular non-symlinked file")
-        canonical = candidate.resolve(strict=True)
-        try:
-            relative = canonical.relative_to(workspace)
-        except ValueError as exc:
-            raise ValueError("source escaped workspace") from exc
-        if any(part.lower() in _PROTECTED_NAMES or part.lower().startswith(".env") for part in relative.parts):
-            raise ValueError("protected source path")
-        total_bytes += canonical.stat().st_size
-        if total_bytes > _MAX_SOURCE_BYTES:
-            raise ValueError("source closure exceeds containment identity budget")
-        digest = _file_digest(canonical)
-        records.append((relative.as_posix(), digest))
-        inputs.append(ContainmentInput(str(canonical), relative.as_posix(), digest))
-    if len(records) != len(set(path for path, _ in records)):
-        raise ValueError("source closure cannot contain aliases")
-    return _binding_digest({"sources": records}), tuple(inputs)
-
-
 def _compiler_args(argv: tuple[str, ...]) -> tuple[str, ...] | None:
     try:
         index = argv.index("tsc")
@@ -307,10 +252,6 @@ def _canonical_directory(path: Path) -> Path:
     if canonical != Path(os.path.normpath(str(path))):
         raise ValueError("workspace cannot contain aliases")
     return canonical
-
-
-def _file_digest(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def _binding_digest(payload: dict[str, object]) -> str:

--- a/src/codex_plugin_scanner/guard/daemon/client.py
+++ b/src/codex_plugin_scanner/guard/daemon/client.py
@@ -143,6 +143,34 @@ class GuardSurfaceDaemonClient:
         operation = response.get("operation")
         return dict(operation) if _is_string_object_dict(operation) else response
 
+    def containment_health(self) -> dict[str, object]:
+        response = self._get("/v1/runtime/containment-health", timeout=5.0)
+        value = response.get("containment_health")
+        if not _is_string_object_dict(value):
+            raise GuardDaemonRequestError("Guard daemon returned invalid containment health")
+        return value
+
+    def _get(self, path: str, *, timeout: float) -> dict[str, object]:
+        request = urllib.request.Request(
+            f"{self.daemon_url}{path}",
+            headers={"X-Guard-Token": self.auth_token},
+            method="GET",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return self._decode_json_response(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            try:
+                payload = self._decode_json_response(error.read().decode("utf-8"))
+                message = payload.get("error", str(error))
+            except (OSError, json.JSONDecodeError):
+                message = str(error)
+            raise GuardDaemonRequestError(f"Guard daemon request failed: {message}") from error
+        except GuardDaemonRequestError:
+            raise
+        except (OSError, urllib.error.URLError) as error:
+            raise GuardDaemonTransportError(f"Guard daemon request failed: {error}") from error
+
     def _post(
         self,
         path: str,

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -1106,6 +1106,12 @@ def _current_guard_daemon_runtime_fingerprint() -> str:
     return _runtime_fingerprint_cache
 
 
+def current_guard_daemon_runtime_fingerprint() -> str:
+    """Return the installed runtime identity used for daemon compatibility."""
+
+    return _current_guard_daemon_runtime_fingerprint()
+
+
 def _guard_daemon_start_in_progress(guard_home: Path) -> bool:
     payload = _load_state(guard_home)
     if not isinstance(payload, dict):

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -199,6 +199,7 @@ from .discovery import (
 from .manager import (
     GUARD_DAEMON_COMPATIBILITY_VERSION,
     clear_guard_daemon_state_if_current,
+    current_guard_daemon_runtime_fingerprint,
     load_guard_daemon_auth_token,
     repair_approval_center_locator,
     write_guard_daemon_state,
@@ -296,6 +297,9 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
     approval_attention: ApprovalAttentionCoordinator
     daemon_discovery_challenges: dict[str, dict[str, object]]
     daemon_discovery_challenges_lock: threading.Lock
+    containment_health_cache: dict[str, object] | None
+    containment_health_cache_monotonic: float
+    containment_health_cache_lock: threading.Lock
 
     def __init__(
         self,
@@ -333,6 +337,9 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
         self.package_firewall_session_nonces_lock = threading.Lock()
         self.daemon_discovery_challenges = {}
         self.daemon_discovery_challenges_lock = threading.Lock()
+        self.containment_health_cache = None
+        self.containment_health_cache_monotonic = 0.0
+        self.containment_health_cache_lock = threading.Lock()
         from .hook_worker import HookWorker
 
         self.hook_worker = HookWorker(store=store)
@@ -1396,6 +1403,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if parsed.path == "/v1/capabilities":
             self._handle_capabilities()
             return
+        if parsed.path == "/v1/runtime/containment-health":
+            self._write_json(
+                {"containment_health": self._containment_health_payload(force_refresh=True)},
+                extra_headers={"Cache-Control": "no-store"},
+            )
+            return
         if parsed.path == "/v1/sessions":
             self._write_json({"items": store.list_guard_sessions(limit=200)})
             return
@@ -1412,6 +1425,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 active_request_id=self._query_string(parsed.query, "active_request_id"),
                 include_items=self._query_bool(parsed.query, "include_items", default=True),
                 receipt_limit=25 if include_receipts else 0,
+                containment_health=self._containment_health_payload(),
             )
             self._write_json({**snapshot, "security_level": config.security_level})
             return
@@ -5209,6 +5223,26 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "ok": True,
             "compatibility_version": GUARD_DAEMON_COMPATIBILITY_VERSION,
         }
+
+    def _containment_health_payload(self, *, force_refresh: bool = False) -> dict[str, object] | None:
+        from ..runtime.containment_health import probe_containment_health
+
+        server = self._daemon_server()
+        with server.containment_health_cache_lock:
+            age = time.monotonic() - server.containment_health_cache_monotonic
+            if not force_refresh and server.containment_health_cache is not None and age <= 10.0:
+                return dict(server.containment_health_cache)
+            try:
+                payload = probe_containment_health(
+                    daemon_fingerprint=current_guard_daemon_runtime_fingerprint(),
+                ).to_dict()
+            except (OSError, RuntimeError, TypeError, ValueError):
+                server.containment_health_cache = None
+                server.containment_health_cache_monotonic = time.monotonic()
+                return None
+            server.containment_health_cache = payload
+            server.containment_health_cache_monotonic = time.monotonic()
+            return dict(payload)
 
     def _detailed_healthz_payload(self) -> dict[str, object]:
         uptime = round(time.monotonic() - self.server.start_monotonic, 1)  # type: ignore[attr-defined]

--- a/src/codex_plugin_scanner/guard/runtime/containment_contract.py
+++ b/src/codex_plugin_scanner/guard/runtime/containment_contract.py
@@ -1,0 +1,379 @@
+"""Typed contract for execution-enforced Guard containment."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path, PurePosixPath
+from typing import Final, cast
+
+from .effect_contract import ProofRequirement, ProofRoute
+from .effect_decision import PositiveProof
+
+CONTAINMENT_SCHEMA_VERSION: Final = "guard.containment.v1"
+CONTAINMENT_POLICY_VERSION: Final = "guard.containment-policy.v1"
+_SHA256: Final = re.compile(r"[0-9a-f]{64}")
+_STABLE_ID: Final = re.compile(r"[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*")
+_SECRET_ENV: Final = re.compile(
+    r"(?:^|_)(?:auth|credential|key|password|secret|token)(?:_|$)|^(?:aws|azure|gcp|github|gitlab|npm|pypi)_",
+    re.IGNORECASE,
+)
+_PROTECTED_PARTS: Final = frozenset(
+    {".git", ".ssh", ".aws", ".gnupg", ".guard", "guard-home", "credentials", "credentials.json", "secrets.json"}
+)
+
+
+class ContainmentBackend(str, Enum):
+    UNSUPPORTED = "unsupported"
+    MACOS_SANDBOX = "macos-sandbox"
+    LINUX_BWRAP = "linux-bwrap"
+
+
+class ContainmentFailure(str, Enum):
+    UNSUPPORTED_PLATFORM = "unsupported-platform"
+    BACKEND_UNAVAILABLE = "backend-unavailable"
+    BACKEND_IDENTITY_MISMATCH = "backend-identity-mismatch"
+    POLICY_MISMATCH = "policy-mismatch"
+    LAUNCH_MISMATCH = "launch-mismatch"
+    APPLY_FAILED = "apply-failed"
+    ATTESTATION_INVALID = "attestation-invalid"
+
+
+@dataclass(frozen=True, slots=True)
+class ContainmentInput:
+    """One exact workspace file copied into the isolated execution snapshot."""
+
+    source_path: str
+    snapshot_path: str
+    content_digest: str
+
+    def __post_init__(self) -> None:
+        source = _canonical_file(self.source_path, "containment input")
+        snapshot = PurePosixPath(self.snapshot_path)
+        if (
+            snapshot.is_absolute()
+            or not snapshot.parts
+            or any(part in {"", ".", ".."} for part in snapshot.parts)
+            or any(part.lower() in _PROTECTED_PARTS or part.lower().startswith(".env") for part in snapshot.parts)
+        ):
+            raise ValueError("snapshot_path must be a safe relative workspace path")
+        if _SHA256.fullmatch(self.content_digest) is None:
+            raise ValueError("content_digest must be a lowercase SHA-256 digest")
+        object.__setattr__(self, "source_path", source)
+        object.__setattr__(self, "snapshot_path", snapshot.as_posix())
+
+
+@dataclass(frozen=True, slots=True)
+class ContainmentPolicy:
+    """Exact deny-by-default policy for one contained launch."""
+
+    workspace: str
+    allowed_write_paths: tuple[str, ...]
+    network_allowed: bool = False
+    policy_version: str = CONTAINMENT_POLICY_VERSION
+
+    def __post_init__(self) -> None:
+        if self.policy_version != CONTAINMENT_POLICY_VERSION:
+            raise ValueError("unsupported containment policy version")
+        workspace = _canonical_directory(self.workspace, "workspace")
+        if self.network_allowed:
+            raise ValueError("routine containment cannot allow network access")
+        writes = _canonical_paths(self.allowed_write_paths, workspace=workspace)
+        if any(_is_protected(path, workspace=workspace) for path in writes):
+            raise ValueError("allowed write paths cannot include protected Guard, VCS, or secret paths")
+        object.__setattr__(self, "workspace", workspace)
+        object.__setattr__(self, "allowed_write_paths", writes)
+
+    @property
+    def digest(self) -> str:
+        return _framed_digest(
+            {
+                "schema_version": CONTAINMENT_SCHEMA_VERSION,
+                "policy_version": self.policy_version,
+                "workspace": _path_digest(self.workspace),
+                "allowed_write_paths": [_path_digest(path) for path in self.allowed_write_paths],
+                "network_allowed": self.network_allowed,
+                "secret_reads": "deny",
+                "external_writes": "deny",
+                "guard_controls": "deny",
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ContainmentRequest:
+    """Path-pinned execution request whose identity is checked immediately before spawn."""
+
+    argv: tuple[str, ...]
+    cwd: str
+    environment: tuple[tuple[str, str], ...]
+    policy: ContainmentPolicy
+    inputs: tuple[ContainmentInput, ...]
+    launch_digest: str
+    executable_digest: str
+    operation_id: str
+    schema_version: str = CONTAINMENT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != CONTAINMENT_SCHEMA_VERSION:
+            raise ValueError("unsupported containment schema version")
+        raw_argv = cast(object, self.argv)
+        if (
+            not isinstance(raw_argv, tuple)
+            or not raw_argv
+            or any(not isinstance(arg, str) or "\x00" in arg for arg in cast(tuple[object, ...], raw_argv))
+        ):
+            raise ValueError("argv must contain non-NUL strings")
+        executable = _canonical_executable(self.argv[0])
+        cwd = _canonical_directory(self.cwd, "cwd")
+        _require_within(cwd, self.policy.workspace, "cwd")
+        if _SHA256.fullmatch(self.launch_digest) is None:
+            raise ValueError("launch_digest must be a lowercase SHA-256 digest")
+        if _SHA256.fullmatch(self.executable_digest) is None:
+            raise ValueError("executable_digest must be a lowercase SHA-256 digest")
+        if _STABLE_ID.fullmatch(self.operation_id) is None:
+            raise ValueError("operation_id must be a stable identifier")
+        environment = _validated_environment(self.environment)
+        inputs = _validated_inputs(self.inputs, workspace=self.policy.workspace)
+        object.__setattr__(self, "argv", (executable, *self.argv[1:]))
+        object.__setattr__(self, "cwd", cwd)
+        object.__setattr__(self, "environment", environment)
+        object.__setattr__(self, "inputs", inputs)
+
+    @property
+    def binding_digest(self) -> str:
+        return _framed_digest(
+            {
+                "schema_version": self.schema_version,
+                "operation_id": self.operation_id,
+                "argv": list(self.argv),
+                "cwd": _path_digest(self.cwd),
+                "environment": [[key, _value_digest(value)] for key, value in self.environment],
+                "inputs": [
+                    {
+                        "source_path": _path_digest(item.source_path),
+                        "snapshot_path": item.snapshot_path,
+                        "content_digest": item.content_digest,
+                    }
+                    for item in self.inputs
+                ],
+                "policy_digest": self.policy.digest,
+                "launch_digest": self.launch_digest,
+                "executable_digest": self.executable_digest,
+            }
+        )
+
+    def environment_dict(self) -> dict[str, str]:
+        return dict(self.environment)
+
+
+@dataclass(frozen=True, slots=True)
+class ContainmentAttestation:
+    """Privacy-safe statement that an exact launch ran under an exact backend policy."""
+
+    backend: ContainmentBackend
+    backend_digest: str
+    request_digest: str
+    policy_digest: str
+    launch_digest: str
+    executable_digest: str
+    enforced: bool
+    failure: ContainmentFailure | None
+    schema_version: str = CONTAINMENT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != CONTAINMENT_SCHEMA_VERSION:
+            raise ValueError("unsupported containment attestation schema version")
+        if not isinstance(cast(object, self.backend), ContainmentBackend):
+            raise ValueError("backend must be an exact ContainmentBackend")
+        digests = (
+            ("backend_digest", self.backend_digest),
+            ("request_digest", self.request_digest),
+            ("policy_digest", self.policy_digest),
+            ("launch_digest", self.launch_digest),
+            ("executable_digest", self.executable_digest),
+        )
+        for name, value in digests:
+            if _SHA256.fullmatch(value) is None:
+                raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+        if type(self.enforced) is not bool:
+            raise ValueError("enforced must be a boolean")
+        if self.failure is not None and not isinstance(cast(object, self.failure), ContainmentFailure):
+            raise ValueError("failure must be an exact ContainmentFailure")
+        if self.enforced == (self.failure is not None):
+            raise ValueError("enforced attestations cannot fail and failed attestations cannot claim enforcement")
+
+    def execution_bound_proof(
+        self,
+        request: ContainmentRequest,
+        *,
+        requirements: Sequence[ProofRequirement],
+    ) -> PositiveProof:
+        """Build the execution-bound portion of proof; runtime health must gate its caller."""
+
+        if not self.enforced or self.failure is not None:
+            raise ValueError("failed containment cannot mint positive proof")
+        if self.request_digest != request.binding_digest:
+            raise ValueError("containment request binding changed")
+        if self.policy_digest != request.policy.digest:
+            raise ValueError("containment policy binding changed")
+        if self.launch_digest != request.launch_digest:
+            raise ValueError("contained launch identity changed")
+        if self.executable_digest != request.executable_digest:
+            raise ValueError("contained executable identity changed")
+        raw_requirements = cast(object, requirements)
+        if not isinstance(raw_requirements, Sequence) or any(
+            not isinstance(item, ProofRequirement) for item in raw_requirements
+        ):
+            raise ValueError("requirements must contain exact ProofRequirement values")
+        typed = frozenset(cast(Sequence[ProofRequirement], raw_requirements))
+        typed = typed | {ProofRequirement.CONTAINMENT_IDENTITY}
+        return PositiveProof(
+            route=ProofRoute.CONTAINED,
+            binding_digest=_framed_digest(
+                {
+                    "attestation": self.request_digest,
+                    "backend": self.backend.value,
+                    "backend_digest": self.backend_digest,
+                    "policy": self.policy_digest,
+                    "launch": self.launch_digest,
+                    "executable": self.executable_digest,
+                }
+            ),
+            satisfied_requirements=typed,
+            enforced=True,
+        )
+
+
+def _canonical_directory(value: object, name: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise ValueError(f"{name} must be a non-empty path")
+    path = Path(value)
+    if not path.is_absolute() or path.is_symlink() or not path.is_dir():
+        raise ValueError(f"{name} must be an existing canonical directory")
+    canonical = str(path.resolve(strict=True))
+    if canonical != os.path.normpath(value):
+        raise ValueError(f"{name} must not contain symlink or traversal aliases")
+    return canonical
+
+
+def _canonical_executable(value: object) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise ValueError("executable must be a non-empty path")
+    path = Path(value)
+    if not path.is_absolute() or path.is_symlink() or not path.is_file() or not os.access(path, os.X_OK):
+        raise ValueError("executable must be an existing path-pinned executable")
+    canonical = str(path.resolve(strict=True))
+    if canonical != os.path.normpath(value):
+        raise ValueError("executable must not contain symlink or traversal aliases")
+    return canonical
+
+
+def _canonical_file(value: object, name: str) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise ValueError(f"{name} must be a non-empty path")
+    path = Path(value)
+    if not path.is_absolute() or path.is_symlink() or not path.is_file():
+        raise ValueError(f"{name} must be an existing canonical file")
+    canonical = str(path.resolve(strict=True))
+    if canonical != os.path.normpath(value):
+        raise ValueError(f"{name} must not contain symlink or traversal aliases")
+    return canonical
+
+
+def _canonical_paths(values: object, *, workspace: str) -> tuple[str, ...]:
+    if not isinstance(values, tuple):
+        raise ValueError("allowed_write_paths must be an immutable tuple")
+    result: list[str] = []
+    for value in cast(tuple[object, ...], values):
+        if not isinstance(value, str) or not value or "\x00" in value:
+            raise ValueError("allowed write paths must be non-empty paths")
+        path = Path(value)
+        if not path.is_absolute() or path.is_symlink():
+            raise ValueError("allowed write paths must be absolute and non-symlinked")
+        canonical = str(path.resolve(strict=False))
+        if canonical != os.path.normpath(value):
+            raise ValueError("allowed write paths must not contain aliases")
+        _require_within(canonical, workspace, "allowed write path")
+        result.append(canonical)
+    if len(result) != len(set(result)):
+        raise ValueError("allowed write paths cannot contain duplicates")
+    return tuple(sorted(result))
+
+
+def _validated_environment(values: object) -> tuple[tuple[str, str], ...]:
+    if not isinstance(values, tuple):
+        raise ValueError("environment must be an immutable tuple")
+    result: list[tuple[str, str]] = []
+    for item in cast(tuple[object, ...], values):
+        if not isinstance(item, tuple):
+            raise ValueError("environment entries must be immutable key/value pairs")
+        raw_item = cast(tuple[object, ...], item)
+        if len(raw_item) != 2:
+            raise ValueError("environment entries must be immutable key/value pairs")
+        key, value = raw_item
+        if not isinstance(key, str) or not isinstance(value, str) or "\x00" in key or "\x00" in value:
+            raise ValueError("environment entries must be non-NUL strings")
+        if not key or "=" in key or _SECRET_ENV.search(key):
+            raise ValueError("contained environment cannot carry secret-bearing keys")
+        result.append((key, value))
+    if len(result) != len({key for key, _ in result}):
+        raise ValueError("contained environment keys cannot repeat")
+    return tuple(sorted(result))
+
+
+def _validated_inputs(values: object, *, workspace: str) -> tuple[ContainmentInput, ...]:
+    if not isinstance(values, tuple):
+        raise ValueError("inputs must be an immutable tuple")
+    typed: list[ContainmentInput] = []
+    for value in cast(tuple[object, ...], values):
+        if not isinstance(value, ContainmentInput):
+            raise ValueError("inputs must contain exact ContainmentInput values")
+        _require_within(value.source_path, workspace, "containment input")
+        typed.append(value)
+    destinations = [item.snapshot_path for item in typed]
+    if len(destinations) != len(set(destinations)):
+        raise ValueError("containment snapshot paths cannot repeat")
+    return tuple(sorted(typed, key=lambda item: item.snapshot_path))
+
+
+def _is_protected(path: str, *, workspace: str) -> bool:
+    relative = Path(path).relative_to(workspace)
+    return any(part.lower() in _PROTECTED_PARTS or part.lower().startswith(".env") for part in relative.parts)
+
+
+def _require_within(path: str, root: str, name: str) -> None:
+    try:
+        _ = Path(path).relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"{name} must remain inside the workspace") from exc
+
+
+def _path_digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _value_digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _framed_digest(payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return hashlib.sha256(len(encoded).to_bytes(8, "big") + encoded).hexdigest()
+
+
+__all__ = (
+    "CONTAINMENT_POLICY_VERSION",
+    "CONTAINMENT_SCHEMA_VERSION",
+    "ContainmentAttestation",
+    "ContainmentBackend",
+    "ContainmentFailure",
+    "ContainmentInput",
+    "ContainmentPolicy",
+    "ContainmentRequest",
+)

--- a/src/codex_plugin_scanner/guard/runtime/containment_executor.py
+++ b/src/codex_plugin_scanner/guard/runtime/containment_executor.py
@@ -1,0 +1,409 @@
+"""OS-enforced execution for Guard containment requests."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from .containment_contract import (
+    ContainmentAttestation,
+    ContainmentBackend,
+    ContainmentFailure,
+    ContainmentRequest,
+)
+
+_OUTPUT_LIMIT: Final = 64 * 1024
+_MAX_EXECUTABLE_BYTES: Final = 256 * 1024 * 1024
+_MAX_INPUT_BYTES: Final = 256 * 1024 * 1024
+_MAX_INPUT_FILES: Final = 20_000
+
+
+@dataclass(frozen=True, slots=True)
+class ContainmentExecutionResult:
+    exit_code: int | None
+    stdout: str
+    stderr: str
+    timed_out: bool
+    attestation: ContainmentAttestation
+
+    @property
+    def enforced(self) -> bool:
+        return self.attestation.enforced
+
+
+@dataclass(frozen=True, slots=True)
+class _BackendIdentity:
+    kind: ContainmentBackend
+    path: str
+    digest: str
+
+
+def file_sha256(path: str) -> str:
+    """Hash one non-symlinked regular file without following a replacement link."""
+
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > _MAX_EXECUTABLE_BYTES:
+            raise ValueError("executable must be a bounded regular file")
+        digest = hashlib.sha256()
+        while chunk := os.read(descriptor, 1024 * 1024):
+            digest.update(chunk)
+        return digest.hexdigest()
+    finally:
+        os.close(descriptor)
+
+
+def execute_contained(
+    request: ContainmentRequest,
+    *,
+    timeout_seconds: float = 60.0,
+    platform: str | None = None,
+) -> ContainmentExecutionResult:
+    """Execute exactly once under a verified platform backend or fail closed."""
+
+    if not 0.1 <= float(timeout_seconds) <= 600:
+        raise ValueError("timeout_seconds must be between 0.1 and 600")
+    selected_platform = platform or sys.platform
+    backend = _select_backend(selected_platform)
+    if backend is None:
+        return _failure_result(request, ContainmentFailure.UNSUPPORTED_PLATFORM)
+    try:
+        actual_backend_digest = file_sha256(backend.path)
+    except (OSError, ValueError):
+        return _failure_result(request, ContainmentFailure.BACKEND_UNAVAILABLE, backend=backend.kind)
+    if actual_backend_digest != backend.digest:
+        return _failure_result(
+            request,
+            ContainmentFailure.BACKEND_IDENTITY_MISMATCH,
+            backend=backend.kind,
+            backend_digest=actual_backend_digest,
+        )
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="guard-contained-") as temp_root:
+            root = Path(temp_root).resolve(strict=True)
+            snapshot = _snapshot_inputs(request, root)
+            if backend.kind is ContainmentBackend.MACOS_SANDBOX:
+                pinned_executable = _pin_executable(request, root, backend=backend.kind)
+                argv = _macos_argv(backend.path, request, pinned_executable, root)
+                cwd = str(snapshot)
+                home = str(root / "home")
+                temporary = str(root / "tmp")
+            else:
+                _ = _pin_executable(request, root, backend=backend.kind)
+                argv = _linux_argv(backend.path, request, root)
+                cwd = str(root)
+                home = "/guard/home"
+                temporary = "/guard/tmp"
+            exit_code, stdout, stderr, timed_out = _run_process(
+                argv,
+                cwd=cwd,
+                environment={
+                    **request.environment_dict(),
+                    "HOME": home,
+                    "TMPDIR": temporary,
+                },
+                timeout_seconds=float(timeout_seconds),
+                temp_root=root,
+            )
+    except (OSError, ValueError) as exc:
+        return ContainmentExecutionResult(
+            exit_code=None,
+            stdout="",
+            stderr=_bounded_text(str(exc)),
+            timed_out=False,
+            attestation=_failed_attestation(request, backend.kind, backend.digest, ContainmentFailure.APPLY_FAILED),
+        )
+    return ContainmentExecutionResult(
+        exit_code=exit_code,
+        stdout=stdout,
+        stderr=stderr,
+        timed_out=timed_out,
+        attestation=_success_attestation(request, backend),
+    )
+
+
+def _select_backend(platform: str) -> _BackendIdentity | None:
+    if platform == "darwin":
+        return _backend_at(ContainmentBackend.MACOS_SANDBOX, "/usr/bin/sandbox-exec")
+    if platform.startswith("linux"):
+        for path in ("/usr/bin/bwrap", "/bin/bwrap"):
+            backend = _backend_at(ContainmentBackend.LINUX_BWRAP, path)
+            if backend is not None:
+                return backend
+    return None
+
+
+def _backend_at(kind: ContainmentBackend, path: str) -> _BackendIdentity | None:
+    candidate = Path(path)
+    if candidate.is_symlink() or not candidate.is_file() or not os.access(candidate, os.X_OK):
+        return None
+    try:
+        digest = file_sha256(path)
+    except (OSError, ValueError):
+        return None
+    return _BackendIdentity(kind, path, digest)
+
+
+def _pin_executable(
+    request: ContainmentRequest,
+    temp_root: Path,
+    *,
+    backend: ContainmentBackend,
+) -> str:
+    source = request.argv[0]
+    if file_sha256(source) != request.executable_digest:
+        raise ValueError("executable identity changed before contained execution")
+    if backend is ContainmentBackend.MACOS_SANDBOX:
+        metadata = os.stat(source, follow_symlinks=False)
+        immutable_prefix = source.startswith(("/System/", "/usr/", "/bin/", "/sbin/"))
+        if not immutable_prefix or metadata.st_uid != 0 or metadata.st_mode & 0o022:
+            raise ValueError("macOS containment requires an immutable system executable")
+        return source
+    destination = temp_root / "guard-exec"
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(source, flags)
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > _MAX_EXECUTABLE_BYTES:
+            raise ValueError("executable must remain a bounded regular file")
+        with destination.open("xb") as target, os.fdopen(os.dup(descriptor), "rb") as source_file:
+            shutil.copyfileobj(source_file, target, length=1024 * 1024)
+    finally:
+        os.close(descriptor)
+    destination.chmod(0o500)
+    if file_sha256(str(destination)) != request.executable_digest:
+        raise ValueError("pinned executable copy failed identity verification")
+    return str(destination)
+
+
+def _snapshot_inputs(request: ContainmentRequest, temp_root: Path) -> Path:
+    snapshot = temp_root / "workspace"
+    snapshot.mkdir(mode=0o700)
+    (temp_root / "home").mkdir(mode=0o700)
+    (temp_root / "tmp").mkdir(mode=0o700)
+    if len(request.inputs) > _MAX_INPUT_FILES:
+        raise ValueError("containment input file budget exceeded")
+    total_bytes = 0
+    for item in request.inputs:
+        destination = snapshot.joinpath(*item.snapshot_path.split("/"))
+        destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        copied_bytes, copied_digest = _copy_verified_input(item.source_path, destination)
+        total_bytes += copied_bytes
+        if total_bytes > _MAX_INPUT_BYTES:
+            raise ValueError("containment input byte budget exceeded")
+        if copied_digest != item.content_digest:
+            raise ValueError("containment input identity changed before snapshot")
+    relative_cwd = Path(request.cwd).relative_to(request.policy.workspace)
+    snapshot_cwd = snapshot / relative_cwd
+    snapshot_cwd.mkdir(mode=0o700, parents=True, exist_ok=True)
+    for write_path in request.policy.allowed_write_paths:
+        relative = Path(write_path).relative_to(request.policy.workspace)
+        (snapshot / relative).mkdir(mode=0o700, parents=True, exist_ok=True)
+    return snapshot_cwd
+
+
+def _copy_verified_input(source: str, destination: Path) -> tuple[int, str]:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(source, flags)
+    digest = hashlib.sha256()
+    copied = 0
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > _MAX_INPUT_BYTES:
+            raise ValueError("containment input must remain a bounded regular file")
+        with destination.open("xb") as target:
+            while chunk := os.read(descriptor, 1024 * 1024):
+                copied += len(chunk)
+                if copied > _MAX_INPUT_BYTES:
+                    raise ValueError("containment input byte budget exceeded")
+                digest.update(chunk)
+                _ = target.write(chunk)
+    finally:
+        os.close(descriptor)
+    destination.chmod(0o400)
+    return copied, digest.hexdigest()
+
+
+def _run_process(
+    argv: list[str],
+    *,
+    cwd: str,
+    environment: dict[str, str],
+    timeout_seconds: float,
+    temp_root: Path,
+) -> tuple[int | None, str, str, bool]:
+    stdout_path = temp_root / "stdout"
+    stderr_path = temp_root / "stderr"
+    with stdout_path.open("xb") as stdout_file, stderr_path.open("xb") as stderr_file:
+        process = subprocess.Popen(
+            argv,
+            cwd=cwd,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout_file,
+            stderr=stderr_file,
+            start_new_session=True,
+        )
+        timed_out = False
+        try:
+            exit_code = process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            _kill_process_group(process.pid)
+            _ = process.wait(timeout=5)
+            exit_code = None
+        else:
+            _kill_process_group(process.pid)
+    return (
+        exit_code,
+        _read_bounded(stdout_path),
+        _read_bounded(stderr_path),
+        timed_out,
+    )
+
+
+def _macos_argv(
+    backend_path: str,
+    request: ContainmentRequest,
+    pinned_executable: str,
+    temp_root: Path,
+) -> list[str]:
+    profile = [
+        "(version 1)",
+        "(deny default)",
+        '(import "system.sb")',
+        "(allow process*)",
+        "(deny process-fork)",
+        "(allow sysctl-read)",
+        "(allow mach-lookup)",
+        "(allow ipc-posix*)",
+        "(allow file-read-metadata)",
+        f'(allow file-map-executable (literal "{_profile_escape(pinned_executable)}"))',
+    ]
+    for path in ("/System", "/usr", "/bin", "/sbin", str(temp_root)):
+        profile.append(f'(allow file-read* (subpath "{_profile_escape(path)}"))')
+    profile.append(f'(allow file-write* (subpath "{_profile_escape(str(temp_root))}"))')
+    profile.append("(deny network*)")
+    profile.append('(deny file-write* (subpath "/cores"))')
+    return [backend_path, "-p", "\n".join(profile), pinned_executable, *request.argv[1:]]
+
+
+def _linux_argv(
+    backend_path: str,
+    request: ContainmentRequest,
+    temp_root: Path,
+) -> list[str]:
+    argv = [
+        backend_path,
+        "--die-with-parent",
+        "--new-session",
+        "--unshare-all",
+        "--tmpfs",
+        "/",
+        "--proc",
+        "/proc",
+        "--dev",
+        "/dev",
+        "--bind",
+        str(temp_root),
+        "/guard",
+    ]
+    for path in ("/usr", "/bin", "/lib", "/lib64", "/sbin"):
+        if Path(path).exists():
+            argv.extend(("--ro-bind", path, path))
+    relative_cwd = Path(request.cwd).relative_to(request.policy.workspace)
+    sandbox_cwd = Path("/guard/workspace") / relative_cwd
+    argv.extend(("--chdir", str(sandbox_cwd), "--clearenv"))
+    for key, value in request.environment:
+        argv.extend(("--setenv", key, value))
+    argv.extend(("--setenv", "HOME", "/guard/home", "--setenv", "TMPDIR", "/guard/tmp"))
+    sandbox_executable = "/guard/guard-exec"
+    argv.extend(("--", sandbox_executable, *request.argv[1:]))
+    return argv
+
+
+def _kill_process_group(process_group_id: int) -> None:
+    try:
+        _ = os.killpg(process_group_id, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+
+
+def _success_attestation(request: ContainmentRequest, backend: _BackendIdentity) -> ContainmentAttestation:
+    return ContainmentAttestation(
+        backend=backend.kind,
+        backend_digest=backend.digest,
+        request_digest=request.binding_digest,
+        policy_digest=request.policy.digest,
+        launch_digest=request.launch_digest,
+        executable_digest=request.executable_digest,
+        enforced=True,
+        failure=None,
+    )
+
+
+def _failed_attestation(
+    request: ContainmentRequest,
+    backend: ContainmentBackend,
+    backend_digest: str,
+    failure: ContainmentFailure,
+) -> ContainmentAttestation:
+    return ContainmentAttestation(
+        backend=backend,
+        backend_digest=backend_digest,
+        request_digest=request.binding_digest,
+        policy_digest=request.policy.digest,
+        launch_digest=request.launch_digest,
+        executable_digest=request.executable_digest,
+        enforced=False,
+        failure=failure,
+    )
+
+
+def _failure_result(
+    request: ContainmentRequest,
+    failure: ContainmentFailure,
+    *,
+    backend: ContainmentBackend = ContainmentBackend.UNSUPPORTED,
+    backend_digest: str | None = None,
+) -> ContainmentExecutionResult:
+    digest = backend_digest or hashlib.sha256(f"unavailable:{backend.value}".encode()).hexdigest()
+    return ContainmentExecutionResult(
+        exit_code=None,
+        stdout="",
+        stderr=failure.value,
+        timed_out=False,
+        attestation=_failed_attestation(request, backend, digest, failure),
+    )
+
+
+def _profile_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _bounded_text(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")[:_OUTPUT_LIMIT]
+    return str(value)[:_OUTPUT_LIMIT]
+
+
+def _read_bounded(path: Path) -> str:
+    with path.open("rb") as stream:
+        return stream.read(_OUTPUT_LIMIT).decode("utf-8", errors="replace")
+
+
+__all__ = ("ContainmentExecutionResult", "execute_contained", "file_sha256")

--- a/src/codex_plugin_scanner/guard/runtime/containment_health.py
+++ b/src/codex_plugin_scanner/guard/runtime/containment_health.py
@@ -1,0 +1,318 @@
+"""Fail-closed health and proof gating for enforced containment."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Final, cast
+
+from .containment_contract import (
+    CONTAINMENT_POLICY_VERSION,
+    CONTAINMENT_SCHEMA_VERSION,
+    ContainmentAttestation,
+    ContainmentBackend,
+    ContainmentRequest,
+)
+from .effect_contract import (
+    EFFECT_CONTRACT_SCHEMA_VERSION,
+    ProofRequirement,
+    UncertaintyKind,
+)
+from .effect_decision import EFFECT_DECISION_SCHEMA_VERSION, PositiveProof
+from .protection_health import ProtectionCheckStatus, ProtectionSignal
+
+CONTAINMENT_HEALTH_SCHEMA_VERSION: Final = "guard.containment-health.v1"
+CONTAINMENT_POLICY_CONTRACT_DIGEST: Final = hashlib.sha256(
+    b"guard.containment-policy.v1\x00deny-network\x00deny-external-writes\x00deny-live-workspace-reads"
+).hexdigest()
+_SHA256: Final = re.compile(r"[0-9a-f]{64}")
+_PROBE_MAX_AGE: Final = timedelta(minutes=5)
+_FUTURE_TOLERANCE: Final = timedelta(seconds=5)
+
+
+@dataclass(frozen=True, slots=True)
+class ContainmentHealthEvidence:
+    """Privacy-safe compatibility and self-probe evidence from the active daemon."""
+
+    backend: ContainmentBackend
+    backend_digest: str
+    policy_contract_digest: str
+    daemon_fingerprint: str
+    runtime_fingerprint: str
+    probe_at: str
+    probe_enforced: bool
+    containment_schema_version: str = CONTAINMENT_SCHEMA_VERSION
+    policy_version: str = CONTAINMENT_POLICY_VERSION
+    effect_contract_schema_version: str = EFFECT_CONTRACT_SCHEMA_VERSION
+    effect_decision_schema_version: str = EFFECT_DECISION_SCHEMA_VERSION
+    schema_version: str = CONTAINMENT_HEALTH_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != CONTAINMENT_HEALTH_SCHEMA_VERSION:
+            raise ValueError("unsupported containment health schema version")
+        if not isinstance(cast(object, self.backend), ContainmentBackend):
+            raise ValueError("backend must be an exact ContainmentBackend")
+        digests = (
+            ("backend_digest", self.backend_digest),
+            ("policy_contract_digest", self.policy_contract_digest),
+            ("daemon_fingerprint", self.daemon_fingerprint),
+            ("runtime_fingerprint", self.runtime_fingerprint),
+        )
+        for name, value in digests:
+            if _SHA256.fullmatch(value) is None:
+                raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+        if type(self.probe_enforced) is not bool:
+            raise ValueError("probe_enforced must be a boolean")
+        _ = _parse_time(self.probe_at)
+
+    @classmethod
+    def from_mapping(cls, value: object) -> ContainmentHealthEvidence:
+        if not isinstance(value, Mapping):
+            raise ValueError("containment health evidence must be a mapping")
+        expected_keys = {
+            "backend",
+            "backend_digest",
+            "policy_contract_digest",
+            "daemon_fingerprint",
+            "runtime_fingerprint",
+            "probe_at",
+            "probe_enforced",
+            "containment_schema_version",
+            "policy_version",
+            "effect_contract_schema_version",
+            "effect_decision_schema_version",
+            "schema_version",
+        }
+        raw_mapping = cast(Mapping[object, object], value)
+        if set(raw_mapping) != expected_keys:
+            raise ValueError("containment health evidence fields are incomplete or unknown")
+        try:
+            backend = ContainmentBackend(raw_mapping["backend"])
+        except (TypeError, ValueError) as exc:
+            raise ValueError("unsupported containment backend") from exc
+        string_fields = {
+            key: _require_string(raw_mapping[key], key)
+            for key in expected_keys.difference({"backend", "probe_enforced"})
+        }
+        return cls(
+            backend=backend,
+            probe_enforced=_require_bool(raw_mapping["probe_enforced"], "probe_enforced"),
+            **string_fields,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "backend": self.backend.value,
+            "backend_digest": self.backend_digest,
+            "policy_contract_digest": self.policy_contract_digest,
+            "daemon_fingerprint": self.daemon_fingerprint,
+            "runtime_fingerprint": self.runtime_fingerprint,
+            "probe_at": self.probe_at,
+            "probe_enforced": self.probe_enforced,
+            "containment_schema_version": self.containment_schema_version,
+            "policy_version": self.policy_version,
+            "effect_contract_schema_version": self.effect_contract_schema_version,
+            "effect_decision_schema_version": self.effect_decision_schema_version,
+            "schema_version": self.schema_version,
+        }
+
+    def compatibility_errors(self, *, now: datetime, runtime_fingerprint: str | None = None) -> tuple[str, ...]:
+        errors: list[str] = []
+        if self.backend is ContainmentBackend.UNSUPPORTED:
+            errors.append("unsupported_platform")
+        if self.containment_schema_version != CONTAINMENT_SCHEMA_VERSION:
+            errors.append("containment_schema_mismatch")
+        if self.policy_version != CONTAINMENT_POLICY_VERSION:
+            errors.append("policy_version_mismatch")
+        if self.effect_contract_schema_version != EFFECT_CONTRACT_SCHEMA_VERSION:
+            errors.append("effect_contract_mismatch")
+        if self.effect_decision_schema_version != EFFECT_DECISION_SCHEMA_VERSION:
+            errors.append("decision_plane_mismatch")
+        if self.policy_contract_digest != CONTAINMENT_POLICY_CONTRACT_DIGEST:
+            errors.append("policy_digest_mismatch")
+        if self.daemon_fingerprint != self.runtime_fingerprint:
+            errors.append("daemon_runtime_drift")
+        if runtime_fingerprint is not None and self.daemon_fingerprint != runtime_fingerprint:
+            errors.append("daemon_runtime_drift")
+        if not self.probe_enforced:
+            errors.append("containment_probe_failed")
+        probe_time = _parse_time(self.probe_at)
+        normalized_now = _normalized_now(now)
+        age = normalized_now - probe_time
+        if age < -_FUTURE_TOLERANCE:
+            errors.append("containment_probe_future")
+        elif age > _PROBE_MAX_AGE:
+            errors.append("containment_probe_stale")
+        return tuple(sorted(errors))
+
+    def binding_digest(self) -> str:
+        encoded = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+        return hashlib.sha256(len(encoded).to_bytes(8, "big") + encoded).hexdigest()
+
+
+def contained_positive_proof(
+    attestation: ContainmentAttestation,
+    request: ContainmentRequest,
+    health: ContainmentHealthEvidence,
+    *,
+    requirements: Sequence[ProofRequirement],
+    now: datetime,
+    runtime_fingerprint: str,
+) -> PositiveProof:
+    """Construct contained proof only when execution and current runtime health agree."""
+
+    if _SHA256.fullmatch(runtime_fingerprint) is None:
+        raise ValueError("runtime fingerprint must be a lowercase SHA-256 digest")
+    errors = health.compatibility_errors(now=now, runtime_fingerprint=runtime_fingerprint)
+    if errors:
+        raise ValueError(f"containment health is incompatible: {errors[0]}")
+    if attestation.backend is not health.backend or attestation.backend_digest != health.backend_digest:
+        raise ValueError("containment backend identity drifted")
+    base = attestation.execution_bound_proof(request, requirements=requirements)
+    digest = hashlib.sha256(f"{base.binding_digest}:{health.binding_digest()}".encode()).hexdigest()
+    return PositiveProof(base.route, digest, base.satisfied_requirements, enforced=True)
+
+
+def probe_containment_health(*, daemon_fingerprint: str) -> ContainmentHealthEvidence:
+    """Run a fresh execution-owned backend probe in the daemon process."""
+
+    from .containment_contract import ContainmentPolicy, ContainmentRequest
+    from .containment_executor import execute_contained, file_sha256
+
+    if _SHA256.fullmatch(daemon_fingerprint) is None:
+        raise ValueError("daemon fingerprint must be a lowercase SHA-256 digest")
+    executable = next((path for path in ("/usr/bin/true", "/bin/true") if os.path.isfile(path)), None)
+    if executable is None:
+        raise RuntimeError("containment probe executable is unavailable")
+    with tempfile.TemporaryDirectory(prefix="guard-containment-probe-") as workspace_value:
+        workspace = os.path.realpath(workspace_value)
+        request = ContainmentRequest(
+            argv=(executable,),
+            cwd=workspace,
+            environment=(),
+            policy=ContainmentPolicy(workspace, ()),
+            inputs=(),
+            launch_digest=hashlib.sha256(b"guard-containment-health-probe-v1").hexdigest(),
+            executable_digest=file_sha256(executable),
+            operation_id="health-probe",
+        )
+        result = execute_contained(request, timeout_seconds=5.0)
+    return ContainmentHealthEvidence(
+        backend=result.attestation.backend,
+        backend_digest=result.attestation.backend_digest,
+        policy_contract_digest=CONTAINMENT_POLICY_CONTRACT_DIGEST,
+        daemon_fingerprint=daemon_fingerprint,
+        runtime_fingerprint=daemon_fingerprint,
+        probe_at=datetime.now(timezone.utc).isoformat(),
+        probe_enforced=result.enforced and result.exit_code == 0 and not result.timed_out,
+    )
+
+
+def containment_health_signals(
+    value: object,
+    *,
+    now: datetime,
+) -> dict[str, ProtectionSignal]:
+    """Map runtime evidence into existing protection-health check IDs."""
+
+    try:
+        evidence = ContainmentHealthEvidence.from_mapping(value)
+    except (TypeError, ValueError):
+        return _failed_signals("containment_health_invalid")
+    errors = evidence.compatibility_errors(now=now)
+    if not errors:
+        return {
+            "policy_engine": ProtectionSignal(ProtectionCheckStatus.PASS, "policy_engine_compatible"),
+            "decision_plane_compatibility": ProtectionSignal(
+                ProtectionCheckStatus.PASS,
+                "decision_plane_compatible",
+            ),
+            "containment_compatibility": ProtectionSignal(
+                ProtectionCheckStatus.PASS,
+                "containment_compatible",
+            ),
+            "sandbox": ProtectionSignal(ProtectionCheckStatus.PASS, "containment_backend_enforced"),
+        }
+    reason = errors[0]
+    policy_error = reason in {
+        "policy_version_mismatch",
+        "policy_digest_mismatch",
+        "effect_contract_mismatch",
+        "decision_plane_mismatch",
+        "containment_schema_mismatch",
+    }
+    return _failed_signals("policy_version_mismatch" if policy_error else reason)
+
+
+def containment_health_uncertainties(
+    value: object,
+    *,
+    now: datetime,
+) -> tuple[UncertaintyKind, ...]:
+    try:
+        evidence = ContainmentHealthEvidence.from_mapping(value)
+    except (TypeError, ValueError):
+        return (UncertaintyKind.DEGRADED_CONTAINMENT, UncertaintyKind.PROTECTION_HEALTH_DEGRADED)
+    errors = evidence.compatibility_errors(now=now)
+    result: set[UncertaintyKind] = set()
+    if errors:
+        result.add(UncertaintyKind.DEGRADED_CONTAINMENT)
+    if any("policy" in item or "schema" in item or "decision_plane" in item for item in errors):
+        result.add(UncertaintyKind.POLICY_VERSION_MISMATCH)
+    if "daemon_runtime_drift" in errors:
+        result.add(UncertaintyKind.PROTECTION_HEALTH_DEGRADED)
+    return tuple(sorted(result, key=lambda item: item.value))
+
+
+def _failed_signals(reason: str) -> dict[str, ProtectionSignal]:
+    return {
+        "policy_engine": ProtectionSignal(ProtectionCheckStatus.FAIL, reason),
+        "decision_plane_compatibility": ProtectionSignal(ProtectionCheckStatus.FAIL, reason),
+        "containment_compatibility": ProtectionSignal(ProtectionCheckStatus.FAIL, reason),
+        "sandbox": ProtectionSignal(ProtectionCheckStatus.FAIL, reason),
+    }
+
+
+def _parse_time(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("probe_at must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("probe_at must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _normalized_now(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        raise ValueError("now must include a timezone")
+    return value.astimezone(timezone.utc)
+
+
+def _require_string(value: object, name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string")
+    return value
+
+
+def _require_bool(value: object, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean")
+    return value
+
+
+__all__ = (
+    "CONTAINMENT_HEALTH_SCHEMA_VERSION",
+    "CONTAINMENT_POLICY_CONTRACT_DIGEST",
+    "ContainmentHealthEvidence",
+    "contained_positive_proof",
+    "containment_health_signals",
+    "containment_health_uncertainties",
+    "probe_containment_health",
+)

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
@@ -12,6 +12,7 @@ from typing import Literal
 
 from ..models import GuardArtifact
 from .mcp_protection import _split_package_token
+from .typescript_launch_evidence import TypeScriptLaunchEvidence
 from .workspace_path_guard import existing_paths_within_workspace
 
 IntentKind = Literal["install", "execute", "sync"]
@@ -70,6 +71,7 @@ class LocalPackageExecutionEvidence:
     local_executable: PackageExecutionFileEvidence | None
     manifests: tuple[PackageExecutionFileEvidence, ...] = ()
     lockfiles: tuple[PackageExecutionFileEvidence, ...] = ()
+    typescript_launch: TypeScriptLaunchEvidence | None = None
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -37,6 +37,7 @@ from .package_intent_common import (
 )
 from .package_manager_command import strip_package_manager_global_options
 from .secret_file_requests import _SHELL_TOOL_NAMES, _candidate_command_texts, _normalize_tool_name
+from .typescript_launch_evidence import TypeScriptLaunchInputs, build_typescript_launch_evidence
 
 _CONTROL_TOKENS = {"&&", "||", ";", "|", "|&", "&"}
 _ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
@@ -45,20 +46,6 @@ _LOCAL_EXECUTION_FLAGS_BY_COMMAND = {
     "bunx": frozenset({"--bun", "--no-install"}),
     "npx": frozenset({"--no", "--no-install"}),
 }
-_TSC_READ_ONLY_FLAGS = frozenset(
-    {
-        "--diagnostics",
-        "--extendedDiagnostics",
-        "--explainFiles",
-        "--listFiles",
-        "--listFilesOnly",
-        "--noEmit",
-        "--noErrorTruncation",
-        "--pretty",
-        "--skipLibCheck",
-        "--traceResolution",
-    }
-)
 _LOCAL_EXECUTABLE_PACKAGE_ALIASES = {"tsc": "typescript"}
 _JS_LOCKFILE_NAMES = ("bun.lock", "bun.lockb", "package-lock.json", "pnpm-lock.yaml", "yarn.lock")
 _PYTHON_EXECUTABLES = {"py", "python", "python3", "python3.11", "python3.12", "python3.13", "python3.14"}
@@ -300,8 +287,9 @@ def _parse_exec_intent(
         manifest_paths=intent.manifest_paths,
         lockfile_paths=intent.lockfile_paths,
     )
-    if _is_verified_read_only_typescript_check(tokens, local_execution):
-        return None
+    typescript_launch = build_typescript_launch_evidence(_typescript_launch_inputs(tokens, local_execution))
+    if typescript_launch is not None:
+        local_execution = replace(local_execution, typescript_launch=typescript_launch)
     return replace(
         intent,
         local_executions=(local_execution,),
@@ -309,62 +297,38 @@ def _parse_exec_intent(
     )
 
 
-def _is_verified_read_only_typescript_check(
+def _typescript_launch_inputs(
     tokens: tuple[str, ...],
     evidence: LocalPackageExecutionEvidence,
-) -> bool:
-    if any(token == "--package" or token.startswith("--package=") for token in tokens[1:]):
-        return False
-    if evidence.package_name not in {"tsc", "typescript"} or evidence.executable_name != "tsc":
-        return False
-    required_files = (evidence.manager, evidence.local_executable, *evidence.manifests, *evidence.lockfiles)
-    if (
-        evidence.declared_version is None
-        or not evidence.manifests
-        or not evidence.lockfiles
-        or any(file is None or file.status != "available" for file in required_files)
-        or not _lockfiles_record_typescript(evidence.lockfiles)
-    ):
-        return False
-    try:
-        executable_index = tokens.index("tsc", 1)
-    except ValueError:
-        return False
-    compiler_args = tokens[executable_index + 1 :]
-    if "--noEmit" not in compiler_args:
-        return False
-    if "2>" in compiler_args and compiler_args[-1] != "2>":
-        return False
-    return all(_is_read_only_typescript_argument(token) for token in compiler_args)
-
-
-def _lockfiles_record_typescript(lockfiles: tuple[PackageExecutionFileEvidence, ...]) -> bool:
-    for lockfile in lockfiles:
-        if (
-            lockfile.resolved_path is None
-            or lockfile.status != "available"
-            or Path(lockfile.path).name != "package-lock.json"
-        ):
-            continue
-        try:
-            payload = json.loads(Path(lockfile.resolved_path).read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError, ValueError):
-            continue
-        packages = payload.get("packages") if isinstance(payload, dict) else None
-        typescript_entry = packages.get("node_modules/typescript") if isinstance(packages, dict) else None
-        if isinstance(typescript_entry, dict) and isinstance(typescript_entry.get("version"), str):
-            return True
-    return False
-
-
-def _is_read_only_typescript_argument(token: str) -> bool:
-    if token in _TSC_READ_ONLY_FLAGS or token == "2>":
-        return True
-    if re.match(r"^\d*(?:>>?|<<?)", token):
-        return False
-    if token.startswith("-"):
-        return False
-    return token.endswith((".cts", ".mts", ".ts", ".tsx"))
+) -> TypeScriptLaunchInputs:
+    manager = evidence.manager
+    executable = evidence.local_executable
+    available_manifests = tuple(
+        item for item in evidence.manifests if item.status == "available" and item.resolved_path and item.content_hash
+    )
+    available_lockfiles = tuple(
+        item for item in evidence.lockfiles if item.status == "available" and item.resolved_path and item.content_hash
+    )
+    return TypeScriptLaunchInputs(
+        tokens=tokens,
+        manager_name=evidence.manager_name,
+        local_only_requested=evidence.local_only_requested,
+        package_name=evidence.package_name,
+        executable_name=evidence.executable_name,
+        declared_version=evidence.declared_version,
+        manager_path=manager.resolved_path if manager is not None and manager.status == "available" else None,
+        manager_hash=manager.content_hash if manager is not None and manager.status == "available" else None,
+        executable_path=(
+            executable.resolved_path if executable is not None and executable.status == "available" else None
+        ),
+        executable_hash=(
+            executable.content_hash if executable is not None and executable.status == "available" else None
+        ),
+        manifest_paths=tuple(str(item.resolved_path) for item in available_manifests),
+        manifest_hashes=tuple(str(item.content_hash) for item in available_manifests),
+        lockfile_paths=tuple(str(item.resolved_path) for item in available_lockfiles),
+        lockfile_hashes=tuple(str(item.content_hash) for item in available_lockfiles),
+    )
 
 
 def _local_execution_disables_install(tokens: tuple[str, ...]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/protection_health_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/protection_health_runtime.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from typing import Protocol
 
+from .containment_health import ContainmentHealthEvidence, containment_health_signals
 from .protection_health import (
     ProtectionCheckStatus,
     ProtectionSignal,
@@ -86,6 +87,14 @@ def _daemon_signal(runtime_state: Mapping[str, object] | None, *, now: datetime)
         return _signal(ProtectionCheckStatus.UNKNOWN, "daemon_heartbeat_future")
     if age > _DAEMON_HEARTBEAT_MAX_AGE:
         return _signal(ProtectionCheckStatus.FAIL, "daemon_heartbeat_stale")
+    containment_health = runtime_state.get("containment_health")
+    if containment_health is not None:
+        try:
+            evidence = ContainmentHealthEvidence.from_mapping(containment_health)
+        except (TypeError, ValueError):
+            return _signal(ProtectionCheckStatus.FAIL, "daemon_containment_health_invalid")
+        if evidence.daemon_fingerprint != evidence.runtime_fingerprint:
+            return _signal(ProtectionCheckStatus.FAIL, "daemon_runtime_drift")
     return _signal(ProtectionCheckStatus.PASS, "daemon_healthy")
 
 
@@ -124,14 +133,18 @@ def build_runtime_protection_health(
     """Build current health without treating configuration as runtime proof."""
 
     harness_signals = _hook_signals(managed_installs)
+    containment_signals = containment_health_signals(
+        runtime_state.get("containment_health") if runtime_state is not None else None,
+        now=now,
+    )
     signals = {
         "harness_hooks": _global_hook_signal(harness_signals),
         "daemon": _daemon_signal(runtime_state, now=now),
-        "policy_engine": _signal(ProtectionCheckStatus.UNKNOWN, "policy_engine_health_unavailable"),
+        "policy_engine": containment_signals["policy_engine"],
         "rule_packs": _rule_pack_signal(),
-        "decision_plane_compatibility": _signal(ProtectionCheckStatus.UNKNOWN, "decision_plane_proof_unavailable"),
-        "containment_compatibility": _signal(ProtectionCheckStatus.UNKNOWN, "containment_proof_unavailable"),
-        "sandbox": _signal(ProtectionCheckStatus.UNKNOWN, "sandbox_proof_unavailable"),
+        "decision_plane_compatibility": containment_signals["decision_plane_compatibility"],
+        "containment_compatibility": containment_signals["containment_compatibility"],
+        "sandbox": containment_signals["sandbox"],
         "decision_stream": _decision_stream_signal(store),
         "tamper_checks": _tamper_signal(trust_status),
     }

--- a/src/codex_plugin_scanner/guard/runtime/typescript_launch_evidence.py
+++ b/src/codex_plugin_scanner/guard/runtime/typescript_launch_evidence.py
@@ -1,0 +1,276 @@
+"""Typed evidence for reviewable local TypeScript compiler launches."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal, cast
+
+TypeScriptLaunchStatus = Literal["complete", "incomplete"]
+
+_SAFE_COMPILER_FLAGS = frozenset(
+    {
+        "--diagnostics",
+        "--extendedDiagnostics",
+        "--explainFiles",
+        "--listFiles",
+        "--listFilesOnly",
+        "--noEmit",
+        "--noErrorTruncation",
+        "--pretty",
+        "--skipLibCheck",
+        "--traceResolution",
+    }
+)
+_UNSAFE_SOURCE_PREFIXES = ("file:", "git+", "git://", "github:", "http://", "https://", "npm:", "workspace:")
+_VERSION_RE = re.compile(r"^(?:[~^])?(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?$")
+
+
+@dataclass(frozen=True, slots=True)
+class TypeScriptLaunchInputs:
+    """Normalized inputs captured by the package-runner parser."""
+
+    tokens: tuple[str, ...]
+    manager_name: str
+    local_only_requested: bool
+    package_name: str | None
+    executable_name: str | None
+    declared_version: str | None
+    manager_path: str | None
+    manager_hash: str | None
+    executable_path: str | None
+    executable_hash: str | None
+    manifest_paths: tuple[str, ...]
+    manifest_hashes: tuple[str, ...]
+    lockfile_paths: tuple[str, ...]
+    lockfile_hashes: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class TypeScriptLaunchEvidence:
+    """Complete launch identity evidence that never grants a silent allow."""
+
+    schema_version: int
+    status: TypeScriptLaunchStatus
+    reasons: tuple[str, ...]
+    binding_digest: str
+    manager_name: str
+    package_name: str | None
+    executable_name: str | None
+    declared_version: str | None
+    locked_version: str | None
+    installed_version: str | None
+    config_mode: str
+    source_files: tuple[str, ...]
+    evidence_scope: Literal["launch_identity"] = "launch_identity"
+    review_disposition: Literal["review_required"] = "review_required"
+    direct_silent_verification: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def build_typescript_launch_evidence(inputs: TypeScriptLaunchInputs) -> TypeScriptLaunchEvidence | None:
+    """Return immutable evidence for a TypeScript launch, without authorizing it."""
+
+    if inputs.package_name not in {"tsc", "typescript"} and inputs.executable_name != "tsc":
+        return None
+
+    reasons: list[str] = []
+    _require(inputs.manager_name == "npx", "manager_mismatch", reasons)
+    _require(inputs.local_only_requested, "remote_install_not_disabled", reasons)
+    _require(inputs.package_name in {"tsc", "typescript"}, "package_mismatch", reasons)
+    _require(inputs.executable_name == "tsc", "executable_mismatch", reasons)
+    _require(bool(inputs.manager_path and inputs.manager_hash), "manager_identity_incomplete", reasons)
+    _require(bool(inputs.executable_path and inputs.executable_hash), "executable_identity_incomplete", reasons)
+
+    compiler_args, explicit_package = _compiler_args(inputs.tokens)
+    if explicit_package:
+        reasons.append("explicit_package_source")
+    source_files, arguments_valid = _read_only_compiler_arguments(compiler_args)
+    _require(arguments_valid, "compiler_arguments_not_read_only", reasons)
+    _require(bool(source_files), "implicit_or_config_driven_launch", reasons)
+
+    manifest_version, manifest_source_ok, manifest_identity_ok = _manifest_typescript_version(
+        inputs.manifest_paths,
+        inputs.manifest_hashes,
+    )
+    locked_version, lock_source_ok, lock_identity_ok = _locked_typescript_version(
+        inputs.lockfile_paths,
+        inputs.lockfile_hashes,
+    )
+    installed_version, executable_matches, installed_manifest_hash = _installed_typescript_identity(
+        inputs.executable_path
+    )
+    _require(manifest_version is not None, "manifest_dependency_missing", reasons)
+    _require(manifest_source_ok, "manifest_source_drift", reasons)
+    _require(manifest_identity_ok, "manifest_identity_drift", reasons)
+    _require(locked_version is not None, "lock_dependency_missing", reasons)
+    _require(lock_source_ok, "lock_source_drift", reasons)
+    _require(lock_identity_ok, "lock_identity_drift", reasons)
+    _require(installed_version is not None, "installed_package_missing", reasons)
+    _require(executable_matches, "wrong_typescript_executable", reasons)
+    _require(inputs.declared_version == manifest_version, "declared_dependency_mismatch", reasons)
+    _require(_version_spec_matches(manifest_version, locked_version), "manifest_lock_version_drift", reasons)
+    _require(locked_version == installed_version, "lock_install_version_drift", reasons)
+    _require(len(inputs.manifest_paths) == len(inputs.manifest_hashes), "manifest_identity_incomplete", reasons)
+    _require(len(inputs.lockfile_paths) == len(inputs.lockfile_hashes), "lock_identity_incomplete", reasons)
+
+    normalized_reasons = tuple(dict.fromkeys(reasons))
+    binding_payload = {
+        "schema_version": 1,
+        "inputs": asdict(inputs),
+        "locked_version": locked_version,
+        "installed_version": installed_version,
+        "installed_manifest_hash": installed_manifest_hash,
+        "config_mode": "explicit_sources" if source_files else "implicit_or_config_driven",
+        "source_files": source_files,
+        "reasons": normalized_reasons,
+    }
+    binding_digest = hashlib.sha256(
+        b"hol-guard:typescript-launch-evidence:v1\0"
+        + json.dumps(binding_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return TypeScriptLaunchEvidence(
+        schema_version=1,
+        status="complete" if not normalized_reasons else "incomplete",
+        reasons=normalized_reasons,
+        binding_digest=f"sha256:{binding_digest}",
+        manager_name=inputs.manager_name,
+        package_name=inputs.package_name,
+        executable_name=inputs.executable_name,
+        declared_version=inputs.declared_version,
+        locked_version=locked_version,
+        installed_version=installed_version,
+        config_mode="explicit_sources" if source_files else "implicit_or_config_driven",
+        source_files=source_files,
+    )
+
+
+def _require(condition: bool, reason: str, reasons: list[str]) -> None:
+    if not condition:
+        reasons.append(reason)
+
+
+def _compiler_args(tokens: tuple[str, ...]) -> tuple[tuple[str, ...], bool]:
+    explicit_package = any(token == "--package" or token.startswith("--package=") for token in tokens[1:])
+    try:
+        executable_index = tokens.index("tsc", 1)
+    except ValueError:
+        return (), explicit_package
+    return tokens[executable_index + 1 :], explicit_package
+
+
+def _read_only_compiler_arguments(arguments: tuple[str, ...]) -> tuple[tuple[str, ...], bool]:
+    if "--noEmit" not in arguments:
+        return (), False
+    sources: list[str] = []
+    for argument in arguments:
+        if argument in _SAFE_COMPILER_FLAGS:
+            continue
+        if argument.endswith((".cts", ".mts", ".ts", ".tsx")) and not argument.startswith("-"):
+            sources.append(argument)
+            continue
+        return tuple(sources), False
+    return tuple(sources), True
+
+
+def _manifest_typescript_version(
+    paths: tuple[str, ...],
+    hashes: tuple[str, ...],
+) -> tuple[str | None, bool, bool]:
+    identity_ok = len(paths) == len(hashes)
+    for raw_path, expected_hash in zip(paths, hashes, strict=False):
+        if Path(raw_path).name != "package.json":
+            continue
+        payload, observed_hash = _read_json(Path(raw_path))
+        if payload is None:
+            continue
+        identity_ok = identity_ok and observed_hash == expected_hash
+        for group in ("dependencies", "devDependencies", "optionalDependencies", "peerDependencies"):
+            dependencies = _object_mapping(payload.get(group))
+            value = dependencies.get("typescript") if dependencies is not None else None
+            if isinstance(value, str) and value.strip():
+                normalized = value.strip()
+                return normalized, not normalized.lower().startswith(_UNSAFE_SOURCE_PREFIXES), identity_ok
+    return None, False, identity_ok
+
+
+def _locked_typescript_version(
+    paths: tuple[str, ...],
+    hashes: tuple[str, ...],
+) -> tuple[str | None, bool, bool]:
+    identity_ok = len(paths) == len(hashes)
+    for raw_path, expected_hash in zip(paths, hashes, strict=False):
+        if Path(raw_path).name != "package-lock.json":
+            continue
+        payload, observed_hash = _read_json(Path(raw_path))
+        identity_ok = identity_ok and observed_hash == expected_hash
+        packages = _object_mapping(payload.get("packages")) if payload is not None else None
+        entry = _object_mapping(packages.get("node_modules/typescript")) if packages is not None else None
+        if entry is None:
+            continue
+        version = entry.get("version")
+        if not isinstance(version, str) or not version.strip():
+            continue
+        resolved = entry.get("resolved")
+        source_ok = entry.get("link") is not True and (
+            resolved is None
+            or (isinstance(resolved, str) and not resolved.lower().startswith(("file:", "git+", "git://")))
+        )
+        return version.strip(), source_ok, identity_ok
+    return None, False, identity_ok
+
+
+def _installed_typescript_identity(executable_path: str | None) -> tuple[str | None, bool, str | None]:
+    if executable_path is None:
+        return None, False, None
+    executable = Path(executable_path)
+    if executable.name != "tsc" or executable.parent.name != "bin" or executable.parent.parent.name != "typescript":
+        return None, False, None
+    package_manifest = executable.parent.parent / "package.json"
+    payload, manifest_hash = _read_json(package_manifest)
+    if payload is None:
+        return None, False, manifest_hash
+    version = payload.get("version")
+    bin_value = _object_mapping(payload.get("bin"))
+    bin_target = bin_value.get("tsc") if bin_value is not None else None
+    target_ok = isinstance(bin_target, str) and (package_manifest.parent / bin_target).resolve() == executable.resolve()
+    return (version.strip() if isinstance(version, str) and version.strip() else None), target_ok, manifest_hash
+
+
+def _version_spec_matches(specifier: str | None, version: str | None) -> bool:
+    if specifier is None or version is None:
+        return False
+    spec_match = _VERSION_RE.fullmatch(specifier)
+    version_match = _VERSION_RE.fullmatch(version)
+    if spec_match is None or version_match is None:
+        return False
+    spec_parts = tuple(int(value) for value in spec_match.groups())
+    version_parts = tuple(int(value) for value in version_match.groups())
+    if specifier.startswith("^"):
+        return version_parts >= spec_parts and version_parts[0] == spec_parts[0]
+    if specifier.startswith("~"):
+        return version_parts >= spec_parts and version_parts[:2] == spec_parts[:2]
+    return version_parts == spec_parts
+
+
+def _read_json(path: Path) -> tuple[dict[str, object] | None, str | None]:
+    try:
+        content = path.read_bytes()
+        raw_payload = cast(object, json.loads(content.decode("utf-8")))
+    except (OSError, UnicodeDecodeError, ValueError):
+        return None, None
+    return _object_mapping(raw_payload), f"sha256:{hashlib.sha256(content).hexdigest()}"
+
+
+def _object_mapping(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    raw_mapping = cast(dict[object, object], value)
+    if not all(isinstance(key, str) for key in raw_mapping):
+        return None
+    return {str(key): item for key, item in raw_mapping.items()}

--- a/src/codex_plugin_scanner/guard/runtime/typescript_snapshot_inputs.py
+++ b/src/codex_plugin_scanner/guard/runtime/typescript_snapshot_inputs.py
@@ -1,0 +1,218 @@
+"""Bounded, hash-bound inputs for contained explicit-source TypeScript checks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Final
+
+from .containment_contract import ContainmentInput
+from .containment_executor import file_sha256
+
+_MAX_TREE_FILES: Final = 10_000
+_MAX_TREE_BYTES: Final = 128 * 1024 * 1024
+_MAX_SOURCE_BYTES: Final = 32 * 1024 * 1024
+_MAX_DISCOVERY_ENTRIES: Final = 50_000
+_DISCOVERY_TIMEOUT_SECONDS: Final = 5.0
+_PROTECTED_NAMES: Final = frozenset(
+    {".git", ".ssh", ".aws", ".gnupg", ".guard", "credentials", "credentials.json", "secrets.json"}
+)
+_TYPESCRIPT_INPUT_SUFFIXES: Final = frozenset({".cjs", ".cts", ".js", ".jsx", ".mjs", ".mts", ".ts", ".tsx"})
+
+
+def typescript_snapshot_inputs(
+    workspace: Path,
+    package_root: Path,
+    sources: tuple[str, ...],
+) -> tuple[str, tuple[ContainmentInput, ...], str, tuple[ContainmentInput, ...]]:
+    """Return exact compiler and workspace closures or reject uncertain discovery."""
+
+    tree_digest, package_inputs = _tree_inputs(workspace, package_root)
+    closure_digest, closure_inputs = _typescript_closure_inputs(workspace, package_root, sources)
+    return tree_digest, package_inputs, closure_digest, closure_inputs
+
+
+def _tree_inputs(workspace: Path, root: Path) -> tuple[str, tuple[ContainmentInput, ...]]:
+    canonical_root = _canonical_directory(root)
+    captured: list[tuple[str, str, ContainmentInput]] = []
+    total_bytes = 0
+    started_at = time.monotonic()
+    visited_entries = [0]
+    directories = [canonical_root]
+    while directories:
+        directory = directories.pop()
+        for entry in _bounded_entries(directory, started_at, visited_entries):
+            path = Path(entry.path)
+            relative = path.relative_to(canonical_root)
+            if _is_protected_path(relative):
+                raise ValueError("protected package-tree path")
+            if entry.is_symlink():
+                raise ValueError("package tree cannot contain symlinks")
+            if entry.is_dir(follow_symlinks=False):
+                directories.append(path)
+                continue
+            if not entry.is_file(follow_symlinks=False):
+                raise ValueError("package tree inputs must be regular files")
+            total_bytes += entry.stat(follow_symlinks=False).st_size
+            if len(captured) >= _MAX_TREE_FILES or total_bytes > _MAX_TREE_BYTES:
+                raise ValueError("package tree exceeds containment identity budget")
+            digest = _file_digest(path)
+            _check_discovery_budget(started_at, visited_entries[0])
+            snapshot_path = path.relative_to(workspace).as_posix()
+            captured.append(
+                (
+                    relative.as_posix(),
+                    digest,
+                    ContainmentInput(str(path), snapshot_path, digest),
+                )
+            )
+    if not captured:
+        raise ValueError("package tree is empty")
+    captured.sort(key=lambda item: item[0])
+    records = [(relative, digest) for relative, digest, _item in captured]
+    return _binding_digest({"files": records}), tuple(item for _relative, _digest, item in captured)
+
+
+def _typescript_closure_inputs(
+    workspace: Path,
+    package_root: Path,
+    sources: tuple[str, ...],
+) -> tuple[str, tuple[ContainmentInput, ...]]:
+    _reject_external_node_modules(workspace)
+    source_paths = _validated_source_paths(workspace, sources)
+    captured: list[tuple[str, str, ContainmentInput]] = []
+    total_bytes = 0
+    started_at = time.monotonic()
+    visited_entries = [0]
+    directories = [workspace]
+    while directories:
+        directory = directories.pop()
+        for entry in _bounded_entries(directory, started_at, visited_entries):
+            path = Path(entry.path)
+            relative = path.relative_to(workspace)
+            if path == package_root or (entry.is_dir(follow_symlinks=False) and entry.name == ".bin"):
+                continue
+            if _is_protected_path(relative):
+                if _protected_path_requires_review(relative):
+                    raise ValueError("protected TypeScript dependency cannot be omitted")
+                continue
+            if entry.is_symlink():
+                raise ValueError("TypeScript closure cannot contain symlinks")
+            if entry.is_dir(follow_symlinks=False):
+                directories.append(path)
+                continue
+            if not entry.is_file(follow_symlinks=False):
+                raise ValueError("TypeScript closure inputs must be regular files")
+            if not _is_typescript_input(relative):
+                continue
+            canonical = path.resolve(strict=True)
+            total_bytes += entry.stat(follow_symlinks=False).st_size
+            if len(captured) >= _MAX_TREE_FILES or total_bytes > _MAX_SOURCE_BYTES:
+                raise ValueError("TypeScript closure exceeds containment identity budget")
+            digest = _file_digest(canonical)
+            _check_discovery_budget(started_at, visited_entries[0])
+            snapshot_path = relative.as_posix()
+            captured.append(
+                (
+                    snapshot_path,
+                    digest,
+                    ContainmentInput(str(canonical), snapshot_path, digest),
+                )
+            )
+    captured.sort(key=lambda item: item[0])
+    captured_paths = {path for path, _digest, _item in captured}
+    if not all(path.relative_to(workspace).as_posix() in captured_paths for path in source_paths):
+        raise ValueError("TypeScript closure omitted an explicit source")
+    records = [(path, digest) for path, digest, _item in captured]
+    return _binding_digest({"files": records}), tuple(item for _path, _digest, item in captured)
+
+
+def _bounded_entries(
+    directory: Path,
+    started_at: float,
+    visited_entries: list[int],
+) -> Iterator[os.DirEntry[str]]:
+    try:
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                visited_entries[0] += 1
+                _check_discovery_budget(started_at, visited_entries[0])
+                yield entry
+    except OSError as exc:
+        raise ValueError("containment input discovery failed") from exc
+
+
+def _validated_source_paths(workspace: Path, sources: tuple[str, ...]) -> tuple[Path, ...]:
+    canonical_sources: list[Path] = []
+    for raw_source in sources:
+        candidate = workspace / raw_source
+        if candidate.is_symlink() or not candidate.is_file():
+            raise ValueError("source must be a regular non-symlinked file")
+        canonical = candidate.resolve(strict=True)
+        try:
+            relative = canonical.relative_to(workspace)
+        except ValueError as exc:
+            raise ValueError("source escaped workspace") from exc
+        if _is_protected_path(relative) or ".bin" in relative.parts:
+            raise ValueError("protected source path")
+        canonical_sources.append(canonical)
+    if len(canonical_sources) != len(set(canonical_sources)):
+        raise ValueError("source closure cannot contain aliases")
+    return tuple(canonical_sources)
+
+
+def _reject_external_node_modules(workspace: Path) -> None:
+    for ancestor in workspace.parents:
+        dependency_root = ancestor / "node_modules"
+        try:
+            _ = dependency_root.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise ValueError("external TypeScript dependency identity is unavailable") from exc
+        raise ValueError("external TypeScript dependencies require Guard review")
+
+
+def _is_protected_path(relative: Path) -> bool:
+    return any(part.lower() in _PROTECTED_NAMES or part.lower().startswith(".env") for part in relative.parts)
+
+
+def _protected_path_requires_review(relative: Path) -> bool:
+    lowered_parts = tuple(part.lower() for part in relative.parts)
+    return "node_modules" in lowered_parts or _is_typescript_input(relative)
+
+
+def _is_typescript_input(relative: Path) -> bool:
+    return relative.name == "package.json" or relative.suffix.lower() in _TYPESCRIPT_INPUT_SUFFIXES
+
+
+def _check_discovery_budget(started_at: float, visited_entries: int) -> None:
+    if visited_entries > _MAX_DISCOVERY_ENTRIES:
+        raise ValueError("containment discovery entry budget exceeded")
+    if time.monotonic() - started_at > _DISCOVERY_TIMEOUT_SECONDS:
+        raise ValueError("containment discovery time budget exceeded")
+
+
+def _canonical_directory(path: Path) -> Path:
+    if path.is_symlink() or not path.is_dir():
+        raise ValueError("package tree must be an existing canonical directory")
+    canonical = path.resolve(strict=True)
+    if canonical != Path(os.path.normpath(str(path))):
+        raise ValueError("package tree cannot contain aliases")
+    return canonical
+
+
+def _file_digest(path: Path) -> str:
+    return file_sha256(str(path))
+
+
+def _binding_digest(payload: dict[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+    return hashlib.sha256(len(encoded).to_bytes(8, "big") + encoded).hexdigest()
+
+
+__all__ = ("typescript_snapshot_inputs",)

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -249,6 +249,9 @@ def _normalized_package_shim_content(content: bytes) -> str:
         if line.startswith("guard_cwd = ") or line.startswith("guard_cli_cwd = "):
             normalized_lines.append("guard_cli_cwd = '<path>'")
             continue
+        if line.startswith("guard_home = "):
+            normalized_lines.append("guard_home = '<path>'")
+            continue
         if line.startswith("guard_workspace = "):
             normalized_lines.append("guard_workspace = <workspace-path>")
             continue
@@ -1015,6 +1018,7 @@ def _build_package_manager_python_shim(context: HarnessContext, command: str) ->
             f"command_name = {command!r}",
             f"guard_cli_cwd = {str(_trusted_import_root())!r}",
             f"guard_workspace = {str(context.workspace_dir) if context.workspace_dir is not None else None!r}",
+            f"guard_home = {str(context.guard_home)!r}",
             f"guard_has_explicit_workspace = {context.workspace_dir is not None!r}",
             f"shim_dir = {str(shim_dir.resolve())!r}",
             f"local_test_runners = {tuple(sorted(_LOCAL_TEST_RUNNER_COMMANDS))!r}",
@@ -1067,6 +1071,26 @@ def _build_package_manager_python_shim(context: HarnessContext, command: str) ->
             "    guard_required = True",
             "if not guard_required:",
             "    _exec_real_manager()",
+            "try:",
+            "    from codex_plugin_scanner.guard.contained_typescript_execution import (",
+            "        try_execute_contained_typescript,",
+            "    )",
+            "    contained_result = try_execute_contained_typescript(",
+            "        command_name,",
+            "        tuple(sys.argv[1:]),",
+            "        workspace=Path(guard_workspace) if guard_workspace is not None else Path.cwd(),",
+            "        guard_home=Path(guard_home),",
+            "        shim_directory=Path(shim_dir),",
+            "        environment=dict(os.environ),",
+            "    )",
+            "except Exception:",
+            "    contained_result = None",
+            "if contained_result is not None:",
+            "    if contained_result.stdout:",
+            "        sys.stdout.write(contained_result.stdout)",
+            "    if contained_result.stderr:",
+            "        sys.stderr.write(contained_result.stderr)",
+            "    raise SystemExit(contained_result.exit_code)",
             "guard_env = dict(os.environ)",
             "guard_env.pop('PYTHONPATH', None)",
             "guard_command = [*base_command, command_name]",

--- a/tests/test_guard_contained_typescript_execution.py
+++ b/tests/test_guard_contained_typescript_execution.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard import contained_typescript_execution as execution_module
+from codex_plugin_scanner.guard.contained_typescript_execution import try_execute_contained_typescript
+from codex_plugin_scanner.guard.runtime.containment_contract import (
+    ContainmentAttestation,
+    ContainmentBackend,
+    ContainmentFailure,
+    ContainmentRequest,
+)
+from codex_plugin_scanner.guard.runtime.containment_executor import ContainmentExecutionResult, file_sha256
+from codex_plugin_scanner.guard.runtime.containment_health import (
+    CONTAINMENT_POLICY_CONTRACT_DIGEST,
+    ContainmentHealthEvidence,
+)
+from codex_plugin_scanner.guard.runtime.effect_contract import ProofRoute
+from codex_plugin_scanner.guard.runtime.effect_decision import FinalDisposition
+
+
+def _write(path: Path, content: str, *, executable: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text(content, encoding="utf-8")
+    if executable:
+        _ = path.chmod(0o755)
+
+
+def _workspace(root: Path) -> Path:
+    workspace = root / "workspace"
+    _write(workspace / "package.json", '{"devDependencies":{"typescript":"^5.9.0"}}\n')
+    _write(
+        workspace / "package-lock.json",
+        '{"packages":{"node_modules/typescript":{"version":"5.9.0","integrity":"sha512-reviewed"}}}\n',
+    )
+    _write(workspace / "src" / "example.ts", "export const value: number = 1;\n")
+    compiler = workspace / "node_modules" / "typescript" / "bin" / "tsc"
+    _write(compiler, "#!/usr/bin/env node\nrequire('../lib/tsc.js')\n", executable=True)
+    _write(workspace / "node_modules" / "typescript" / "lib" / "tsc.js", "process.exit(0);\n")
+    _write(
+        workspace / "node_modules" / "typescript" / "package.json",
+        '{"name":"typescript","version":"5.9.0","bin":{"tsc":"./bin/tsc"}}\n',
+    )
+    runner = workspace / "node_modules" / ".bin" / "tsc"
+    runner.parent.mkdir(parents=True)
+    runner.symlink_to(Path("..") / "typescript" / "bin" / "tsc")
+    return workspace.resolve()
+
+
+def _manager(root: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    bin_directory = root / "bin"
+    manager = bin_directory / "npx"
+    _write(manager, "#!/bin/sh\nexit 99\n", executable=True)
+    node = bin_directory / "node"
+    _write(node, "synthetic-node", executable=True)
+    monkeypatch.setenv("PATH", str(bin_directory))
+    monkeypatch.setattr(execution_module, "_load_current_containment_health", _fake_health)
+    return bin_directory.resolve(), node.resolve()
+
+
+def _success(request: ContainmentRequest) -> ContainmentExecutionResult:
+    return ContainmentExecutionResult(
+        exit_code=0,
+        stdout="typecheck-ok\n",
+        stderr="",
+        timed_out=False,
+        attestation=ContainmentAttestation(
+            backend=ContainmentBackend.LINUX_BWRAP,
+            backend_digest=hashlib.sha256(b"backend").hexdigest(),
+            request_digest=request.binding_digest,
+            policy_digest=request.policy.digest,
+            launch_digest=request.launch_digest,
+            executable_digest=request.executable_digest,
+            enforced=True,
+            failure=None,
+        ),
+    )
+
+
+def _health() -> tuple[ContainmentHealthEvidence, str]:
+    fingerprint = hashlib.sha256(b"runtime").hexdigest()
+    return (
+        ContainmentHealthEvidence(
+            backend=ContainmentBackend.LINUX_BWRAP,
+            backend_digest=hashlib.sha256(b"backend").hexdigest(),
+            policy_contract_digest=CONTAINMENT_POLICY_CONTRACT_DIGEST,
+            daemon_fingerprint=fingerprint,
+            runtime_fingerprint=fingerprint,
+            probe_at=datetime.now(timezone.utc).isoformat(),
+            probe_enforced=True,
+        ),
+        fingerprint,
+    )
+
+
+def _fake_health(_guard_home: Path) -> tuple[ContainmentHealthEvidence, str]:
+    return _health()
+
+
+def _node_resolver(node: Path) -> Callable[[str, Path], str]:
+    def resolve(_path: str, _shim: Path) -> str:
+        return str(node)
+
+    return resolve
+
+
+def test_exact_local_typecheck_routes_through_central_contained_decision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = _workspace(tmp_path)
+    shim_directory, node = _manager(tmp_path, monkeypatch)
+    captured: list[ContainmentRequest] = []
+
+    def fake_execute(request: ContainmentRequest, *, timeout_seconds: float) -> ContainmentExecutionResult:
+        assert timeout_seconds == 120.0
+        captured.append(request)
+        return _success(request)
+
+    monkeypatch.setattr(execution_module, "execute_contained", fake_execute)
+    monkeypatch.setattr(execution_module, "_resolve_node", _node_resolver(node))
+
+    result = try_execute_contained_typescript(
+        "npx",
+        ("--no-install", "tsc", "--noEmit", "src/example.ts"),
+        workspace=workspace,
+        guard_home=tmp_path,
+        shim_directory=shim_directory,
+        environment={"PATH": str(shim_directory), "GITHUB_TOKEN": "must-not-cross"},
+    )
+
+    assert result is not None
+    assert result.exit_code == 0
+    assert result.stdout == "typecheck-ok\n"
+    assert result.proof.route is ProofRoute.CONTAINED
+    assert result.proof.enforced is True
+    assert result.decision.action == "allow"
+    assert result.decision.disposition is FinalDisposition.SILENT_CONTAINED
+    assert len(captured) == 1
+    request = captured[0]
+    assert request.argv[0] == str(node)
+    assert request.argv[1].endswith("node_modules/typescript/bin/tsc")
+    assert request.policy.allowed_write_paths == ()
+    assert "GITHUB_TOKEN" not in request.environment_dict()
+
+
+def test_backend_failure_falls_back_to_guard_without_executing_manager(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = _workspace(tmp_path)
+    shim_directory, node = _manager(tmp_path, monkeypatch)
+
+    def failed_execute(request: ContainmentRequest, *, timeout_seconds: float) -> ContainmentExecutionResult:
+        del timeout_seconds
+        return ContainmentExecutionResult(
+            exit_code=None,
+            stdout="",
+            stderr="unsupported-platform",
+            timed_out=False,
+            attestation=ContainmentAttestation(
+                backend=ContainmentBackend.UNSUPPORTED,
+                backend_digest=hashlib.sha256(b"unavailable").hexdigest(),
+                request_digest=request.binding_digest,
+                policy_digest=request.policy.digest,
+                launch_digest=request.launch_digest,
+                executable_digest=request.executable_digest,
+                enforced=False,
+                failure=ContainmentFailure.UNSUPPORTED_PLATFORM,
+            ),
+        )
+
+    monkeypatch.setattr(execution_module, "execute_contained", failed_execute)
+    monkeypatch.setattr(execution_module, "_resolve_node", _node_resolver(node))
+
+    assert (
+        try_execute_contained_typescript(
+            "npx",
+            ("--no-install", "tsc", "--noEmit", "src/example.ts"),
+            workspace=workspace,
+            guard_home=tmp_path,
+            shim_directory=shim_directory,
+            environment={"PATH": str(shim_directory)},
+        )
+        is None
+    )
+
+
+def test_missing_authenticated_health_never_reaches_executor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = _workspace(tmp_path)
+    shim_directory, node = _manager(tmp_path, monkeypatch)
+    monkeypatch.setattr(execution_module, "_resolve_node", _node_resolver(node))
+
+    def unavailable_health(_guard_home: Path) -> tuple[ContainmentHealthEvidence, str]:
+        raise RuntimeError("daemon unavailable")
+
+    def unexpected_execute(
+        request: ContainmentRequest,
+        *,
+        timeout_seconds: float,
+    ) -> ContainmentExecutionResult:
+        del request, timeout_seconds
+        pytest.fail("missing daemon health reached containment executor")
+
+    monkeypatch.setattr(execution_module, "_load_current_containment_health", unavailable_health)
+    monkeypatch.setattr(execution_module, "execute_contained", unexpected_execute)
+
+    result = try_execute_contained_typescript(
+        "npx",
+        ("--no-install", "tsc", "--noEmit", "src/example.ts"),
+        workspace=workspace,
+        guard_home=tmp_path,
+        shim_directory=shim_directory,
+        environment={"PATH": str(shim_directory)},
+    )
+
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "argv",
+    (
+        ("--no-install", "--package", "typescript", "tsc", "--noEmit", "src/example.ts"),
+        ("tsc", "--noEmit", "src/example.ts"),
+        ("--no-install", "tsc", "--project", "tsconfig.json", "--noEmit"),
+        ("--no-install", "tsc", "--noEmit=false", "src/example.ts"),
+    ),
+)
+def test_exploit_deltas_never_reach_containment_executor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    argv: tuple[str, ...],
+) -> None:
+    workspace = _workspace(tmp_path)
+    shim_directory, _node = _manager(tmp_path, monkeypatch)
+
+    def unexpected_execute(
+        request: ContainmentRequest,
+        *,
+        timeout_seconds: float,
+    ) -> ContainmentExecutionResult:
+        del request, timeout_seconds
+        pytest.fail("ineligible command reached containment executor")
+
+    monkeypatch.setattr(execution_module, "execute_contained", unexpected_execute)
+
+    assert (
+        try_execute_contained_typescript(
+            "npx",
+            argv,
+            workspace=workspace,
+            guard_home=tmp_path,
+            shim_directory=shim_directory,
+            environment={"PATH": str(shim_directory)},
+        )
+        is None
+    )
+
+
+def test_package_tree_symlink_never_reaches_executor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace = _workspace(tmp_path)
+    shim_directory, _node = _manager(tmp_path, monkeypatch)
+    link = workspace / "node_modules" / "typescript" / "lib" / "escape.js"
+    link.symlink_to("/usr/bin/true")
+
+    def unexpected_execute(
+        request: ContainmentRequest,
+        *,
+        timeout_seconds: float,
+    ) -> ContainmentExecutionResult:
+        del request, timeout_seconds
+        pytest.fail("symlinked package tree reached containment executor")
+
+    monkeypatch.setattr(execution_module, "execute_contained", unexpected_execute)
+
+    assert (
+        try_execute_contained_typescript(
+            "npx",
+            ("--no-install", "tsc", "--noEmit", "src/example.ts"),
+            workspace=workspace,
+            guard_home=tmp_path,
+            shim_directory=shim_directory,
+            environment={"PATH": str(shim_directory)},
+        )
+        is None
+    )
+
+
+def test_node_digest_is_bound_into_request(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace = _workspace(tmp_path)
+    shim_directory, node = _manager(tmp_path, monkeypatch)
+    observed: list[str] = []
+
+    def fake_execute(request: ContainmentRequest, *, timeout_seconds: float) -> ContainmentExecutionResult:
+        del timeout_seconds
+        observed.append(request.executable_digest)
+        return _success(request)
+
+    monkeypatch.setattr(execution_module, "execute_contained", fake_execute)
+    monkeypatch.setattr(execution_module, "_resolve_node", _node_resolver(node))
+    result = try_execute_contained_typescript(
+        "npx",
+        ("--no-install", "tsc", "--noEmit", "src/example.ts"),
+        workspace=workspace,
+        guard_home=tmp_path,
+        shim_directory=shim_directory,
+        environment={"PATH": str(shim_directory)},
+    )
+
+    assert result is not None
+    assert observed == [file_sha256(str(node))]

--- a/tests/test_guard_contained_typescript_execution.py
+++ b/tests/test_guard_contained_typescript_execution.py
@@ -149,6 +149,90 @@ def test_exact_local_typecheck_routes_through_central_contained_decision(
     assert "GITHUB_TOKEN" not in request.environment_dict()
 
 
+def test_typecheck_snapshot_includes_imports_and_ambient_declarations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = _workspace(tmp_path)
+    _write(workspace / "src" / "example.ts", "import { value } from './util';\nexport { value };\n")
+    _write(workspace / "src" / "util.ts", "export const value: number = 1;\n")
+    _write(workspace / "node_modules" / "@types" / "example" / "index.d.ts", "declare const ambient: string;\n")
+    _write(workspace / "node_modules" / "@types" / "example" / "package.json", '{"types":"index.d.ts"}\n')
+    shim_directory, node = _manager(tmp_path, monkeypatch)
+    captured: list[ContainmentRequest] = []
+
+    def fake_execute(request: ContainmentRequest, *, timeout_seconds: float) -> ContainmentExecutionResult:
+        del timeout_seconds
+        captured.append(request)
+        return _success(request)
+
+    monkeypatch.setattr(execution_module, "execute_contained", fake_execute)
+    monkeypatch.setattr(execution_module, "_resolve_node", _node_resolver(node))
+
+    result = try_execute_contained_typescript(
+        "npx",
+        ("--no-install", "tsc", "--noEmit", "src/example.ts"),
+        workspace=workspace,
+        guard_home=tmp_path,
+        shim_directory=shim_directory,
+        environment={"PATH": str(shim_directory)},
+    )
+
+    assert result is not None
+    snapshot_paths = {item.snapshot_path for item in captured[0].inputs}
+    assert "src/example.ts" in snapshot_paths
+    assert "src/util.ts" in snapshot_paths
+    assert "node_modules/@types/example/index.d.ts" in snapshot_paths
+    assert "node_modules/@types/example/package.json" in snapshot_paths
+
+
+def test_typecheck_dependency_drift_changes_launch_binding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = _workspace(tmp_path)
+    dependency = workspace / "src" / "util.ts"
+    _write(dependency, "export const value = 1;\n")
+    shim_directory, node = _manager(tmp_path, monkeypatch)
+    observed: list[str] = []
+
+    def fake_execute(request: ContainmentRequest, *, timeout_seconds: float) -> ContainmentExecutionResult:
+        del timeout_seconds
+        observed.append(request.launch_digest)
+        return _success(request)
+
+    monkeypatch.setattr(execution_module, "execute_contained", fake_execute)
+    monkeypatch.setattr(execution_module, "_resolve_node", _node_resolver(node))
+    arguments = ("--no-install", "tsc", "--noEmit", "src/example.ts")
+
+    assert (
+        try_execute_contained_typescript(
+            "npx",
+            arguments,
+            workspace=workspace,
+            guard_home=tmp_path,
+            shim_directory=shim_directory,
+            environment={"PATH": str(shim_directory)},
+        )
+        is not None
+    )
+    _write(dependency, "export const value = 2;\n")
+    assert (
+        try_execute_contained_typescript(
+            "npx",
+            arguments,
+            workspace=workspace,
+            guard_home=tmp_path,
+            shim_directory=shim_directory,
+            environment={"PATH": str(shim_directory)},
+        )
+        is not None
+    )
+
+    assert len(observed) == 2
+    assert observed[0] != observed[1]
+
+
 def test_backend_failure_falls_back_to_guard_without_executing_manager(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -176,6 +260,48 @@ def test_backend_failure_falls_back_to_guard_without_executing_manager(
         )
 
     monkeypatch.setattr(execution_module, "execute_contained", failed_execute)
+    monkeypatch.setattr(execution_module, "_resolve_node", _node_resolver(node))
+
+    assert (
+        try_execute_contained_typescript(
+            "npx",
+            ("--no-install", "tsc", "--noEmit", "src/example.ts"),
+            workspace=workspace,
+            guard_home=tmp_path,
+            shim_directory=shim_directory,
+            environment={"PATH": str(shim_directory)},
+        )
+        is None
+    )
+
+
+def test_contained_typecheck_failure_returns_to_guard_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = _workspace(tmp_path)
+    shim_directory, node = _manager(tmp_path, monkeypatch)
+
+    def failed_typecheck(request: ContainmentRequest, *, timeout_seconds: float) -> ContainmentExecutionResult:
+        del timeout_seconds
+        return ContainmentExecutionResult(
+            exit_code=2,
+            stdout="",
+            stderr="TS2307: dependency unavailable",
+            timed_out=False,
+            attestation=ContainmentAttestation(
+                backend=ContainmentBackend.LINUX_BWRAP,
+                backend_digest=hashlib.sha256(b"backend").hexdigest(),
+                request_digest=request.binding_digest,
+                policy_digest=request.policy.digest,
+                launch_digest=request.launch_digest,
+                executable_digest=request.executable_digest,
+                enforced=True,
+                failure=None,
+            ),
+        )
+
+    monkeypatch.setattr(execution_module, "execute_contained", failed_typecheck)
     monkeypatch.setattr(execution_module, "_resolve_node", _node_resolver(node))
 
     assert (

--- a/tests/test_guard_containment_contract.py
+++ b/tests/test_guard_containment_contract.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.containment_contract import (
+    ContainmentAttestation,
+    ContainmentBackend,
+    ContainmentFailure,
+    ContainmentPolicy,
+    ContainmentRequest,
+)
+from codex_plugin_scanner.guard.runtime.containment_executor import file_sha256
+from codex_plugin_scanner.guard.runtime.containment_health import (
+    CONTAINMENT_POLICY_CONTRACT_DIGEST,
+    ContainmentHealthEvidence,
+    contained_positive_proof,
+)
+from codex_plugin_scanner.guard.runtime.effect_contract import ProofRequirement, ProofRoute
+
+
+def _request(workspace: Path, *, executable: str = "/usr/bin/true") -> ContainmentRequest:
+    output = workspace / "output"
+    output.mkdir(exist_ok=True)
+    return ContainmentRequest(
+        argv=(executable,),
+        cwd=str(workspace),
+        environment=(("HOME", str(output)), ("PATH", "/usr/bin:/bin")),
+        policy=ContainmentPolicy(str(workspace), (str(output),)),
+        inputs=(),
+        launch_digest=hashlib.sha256(b"launch").hexdigest(),
+        executable_digest=file_sha256(executable),
+        operation_id="typecheck",
+    )
+
+
+def _attestation(request: ContainmentRequest, *, enforced: bool = True) -> ContainmentAttestation:
+    return ContainmentAttestation(
+        backend=ContainmentBackend.MACOS_SANDBOX,
+        backend_digest=hashlib.sha256(b"backend").hexdigest(),
+        request_digest=request.binding_digest,
+        policy_digest=request.policy.digest,
+        launch_digest=request.launch_digest,
+        executable_digest=request.executable_digest,
+        enforced=enforced,
+        failure=None if enforced else ContainmentFailure.APPLY_FAILED,
+    )
+
+
+def _health(attestation: ContainmentAttestation) -> ContainmentHealthEvidence:
+    fingerprint = hashlib.sha256(b"runtime").hexdigest()
+    return ContainmentHealthEvidence(
+        backend=attestation.backend,
+        backend_digest=attestation.backend_digest,
+        policy_contract_digest=CONTAINMENT_POLICY_CONTRACT_DIGEST,
+        daemon_fingerprint=fingerprint,
+        runtime_fingerprint=fingerprint,
+        probe_at="2026-07-19T15:00:00+00:00",
+        probe_enforced=True,
+    )
+
+
+def test_contract_binds_paths_environment_policy_and_executable(tmp_path: Path) -> None:
+    workspace = tmp_path.resolve()
+    request = _request(workspace)
+
+    assert len(request.binding_digest) == 64
+    assert len(request.policy.digest) == 64
+    assert request.environment_dict() == {"HOME": str(workspace / "output"), "PATH": "/usr/bin:/bin"}
+    assert request.argv[0] == "/usr/bin/true"
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    (("GITHUB_TOKEN", "sentinel"), ("AWS_PROFILE", "prod"), ("PASSWORD", "sentinel")),
+)
+def test_contract_rejects_secret_bearing_environment(tmp_path: Path, key: str, value: str) -> None:
+    workspace = tmp_path.resolve()
+    output = workspace / "output"
+    output.mkdir()
+    with pytest.raises(ValueError, match="secret-bearing"):
+        _ = ContainmentRequest(
+            argv=("/usr/bin/true",),
+            cwd=str(workspace),
+            environment=((key, value),),
+            policy=ContainmentPolicy(str(workspace), (str(output),)),
+            inputs=(),
+            launch_digest=hashlib.sha256(b"launch").hexdigest(),
+            executable_digest=file_sha256("/usr/bin/true"),
+            operation_id="test",
+        )
+
+
+@pytest.mark.parametrize("relative", (".git", ".guard", ".env.local", "nested/credentials"))
+def test_policy_rejects_protected_write_scope(tmp_path: Path, relative: str) -> None:
+    workspace = tmp_path.resolve()
+    target = workspace / relative
+    target.mkdir(parents=True)
+    with pytest.raises(ValueError, match="protected"):
+        _ = ContainmentPolicy(str(workspace), (str(target),))
+
+
+def test_contract_rejects_aliases_and_external_cwd(tmp_path: Path) -> None:
+    workspace = (tmp_path / "workspace").resolve()
+    workspace.mkdir()
+    output = workspace / "output"
+    output.mkdir()
+    executable_link = workspace / "true"
+    executable_link.symlink_to("/usr/bin/true")
+    policy = ContainmentPolicy(str(workspace), (str(output),))
+    with pytest.raises(ValueError, match="path-pinned"):
+        _ = ContainmentRequest(
+            argv=(str(executable_link),),
+            cwd=str(workspace),
+            environment=(),
+            policy=policy,
+            inputs=(),
+            launch_digest=hashlib.sha256(b"launch").hexdigest(),
+            executable_digest=file_sha256("/usr/bin/true"),
+            operation_id="test",
+        )
+    with pytest.raises(ValueError, match="inside the workspace"):
+        _ = ContainmentRequest(
+            argv=("/usr/bin/true",),
+            cwd=str(tmp_path),
+            environment=(),
+            policy=policy,
+            inputs=(),
+            launch_digest=hashlib.sha256(b"launch").hexdigest(),
+            executable_digest=file_sha256("/usr/bin/true"),
+            operation_id="test",
+        )
+
+
+def test_only_exact_successful_attestation_mints_contained_proof(tmp_path: Path) -> None:
+    request = _request(tmp_path.resolve())
+    attestation = _attestation(request)
+    proof = contained_positive_proof(
+        attestation,
+        request,
+        _health(attestation),
+        requirements=(ProofRequirement.EXECUTABLE_IDENTITY, ProofRequirement.LAUNCH_CHAIN),
+        now=datetime(2026, 7, 19, 15, 0, tzinfo=timezone.utc),
+        runtime_fingerprint=hashlib.sha256(b"runtime").hexdigest(),
+    )
+
+    assert proof.route is ProofRoute.CONTAINED
+    assert proof.enforced is True
+    assert ProofRequirement.CONTAINMENT_IDENTITY in proof.satisfied_requirements
+
+    failed = _attestation(request, enforced=False)
+    with pytest.raises(ValueError, match="failed containment"):
+        _ = contained_positive_proof(
+            failed,
+            request,
+            _health(failed),
+            requirements=(),
+            now=datetime(2026, 7, 19, 15, 0, tzinfo=timezone.utc),
+            runtime_fingerprint=hashlib.sha256(b"runtime").hexdigest(),
+        )
+
+    changed_output = request.policy.allowed_write_paths[0] + "-changed"
+    os.mkdir(changed_output)
+    changed = ContainmentRequest(
+        argv=request.argv,
+        cwd=request.cwd,
+        environment=request.environment,
+        policy=ContainmentPolicy(request.policy.workspace, (changed_output,)),
+        inputs=request.inputs,
+        launch_digest=request.launch_digest,
+        executable_digest=request.executable_digest,
+        operation_id=request.operation_id,
+    )
+    with pytest.raises(ValueError, match="request binding changed"):
+        _ = contained_positive_proof(
+            attestation,
+            changed,
+            _health(attestation),
+            requirements=(),
+            now=datetime(2026, 7, 19, 15, 0, tzinfo=timezone.utc),
+            runtime_fingerprint=hashlib.sha256(b"runtime").hexdigest(),
+        )
+
+
+def test_attestation_rejects_enforcement_failure_contradictions(tmp_path: Path) -> None:
+    request = _request(tmp_path.resolve())
+    with pytest.raises(ValueError, match="cannot fail"):
+        _ = ContainmentAttestation(
+            backend=ContainmentBackend.MACOS_SANDBOX,
+            backend_digest=hashlib.sha256(b"backend").hexdigest(),
+            request_digest=request.binding_digest,
+            policy_digest=request.policy.digest,
+            launch_digest=request.launch_digest,
+            executable_digest=request.executable_digest,
+            enforced=True,
+            failure=ContainmentFailure.APPLY_FAILED,
+        )
+    with pytest.raises(ValueError, match="cannot claim enforcement"):
+        _ = ContainmentAttestation(
+            backend=ContainmentBackend.MACOS_SANDBOX,
+            backend_digest=hashlib.sha256(b"backend").hexdigest(),
+            request_digest=request.binding_digest,
+            policy_digest=request.policy.digest,
+            launch_digest=request.launch_digest,
+            executable_digest=request.executable_digest,
+            enforced=False,
+            failure=None,
+        )

--- a/tests/test_guard_containment_executor.py
+++ b/tests/test_guard_containment_executor.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.containment_contract import (
+    ContainmentFailure,
+    ContainmentInput,
+    ContainmentPolicy,
+    ContainmentRequest,
+)
+from codex_plugin_scanner.guard.runtime.containment_executor import execute_contained, file_sha256
+
+
+def _request(workspace: Path, argv: tuple[str, ...]) -> ContainmentRequest:
+    output = workspace / "output"
+    output.mkdir(exist_ok=True)
+    return ContainmentRequest(
+        argv=argv,
+        cwd=str(workspace),
+        environment=(("HOME", str(output)), ("PATH", "/usr/bin:/bin")),
+        policy=ContainmentPolicy(str(workspace), (str(output),)),
+        inputs=(),
+        launch_digest=hashlib.sha256(b"exact-launch").hexdigest(),
+        executable_digest=file_sha256(argv[0]),
+        operation_id="test",
+    )
+
+
+def test_unsupported_platform_fails_closed(tmp_path: Path) -> None:
+    request = _request(tmp_path.resolve(), ("/usr/bin/true",))
+    result = execute_contained(request, platform="win32")
+
+    assert result.exit_code is None
+    assert result.enforced is False
+    assert result.attestation.failure is ContainmentFailure.UNSUPPORTED_PLATFORM
+
+
+def test_executable_drift_fails_before_spawn(tmp_path: Path) -> None:
+    workspace = tmp_path.resolve()
+    executable = workspace / "runner"
+    _ = executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    _ = executable.chmod(0o700)
+    request = _request(workspace, (str(executable),))
+    _ = executable.write_text("#!/bin/sh\nexit 9\n", encoding="utf-8")
+
+    result = execute_contained(request)
+
+    assert result.exit_code is None
+    assert result.enforced is False
+    assert result.attestation.failure is ContainmentFailure.APPLY_FAILED
+
+
+def test_input_drift_fails_before_spawn(tmp_path: Path) -> None:
+    workspace = tmp_path.resolve()
+    source = workspace / "input.txt"
+    _ = source.write_text("reviewed", encoding="utf-8")
+    request = ContainmentRequest(
+        argv=("/usr/bin/true",),
+        cwd=str(workspace),
+        environment=(),
+        policy=ContainmentPolicy(str(workspace), ()),
+        inputs=(ContainmentInput(str(source), "input.txt", hashlib.sha256(b"reviewed").hexdigest()),),
+        launch_digest=hashlib.sha256(b"exact-launch").hexdigest(),
+        executable_digest=file_sha256("/usr/bin/true"),
+        operation_id="test",
+    )
+    _ = source.write_text("changed", encoding="utf-8")
+
+    result = execute_contained(request)
+
+    assert result.exit_code is None
+    assert result.enforced is False
+    assert result.attestation.failure is ContainmentFailure.APPLY_FAILED
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires the macOS sandbox backend")
+def test_macos_backend_keeps_bounded_output_inside_ephemeral_snapshot(tmp_path: Path) -> None:
+    workspace = tmp_path.resolve()
+    output = workspace / "output"
+    request = _request(workspace, ("/bin/sh", "-c", "printf allowed > output/result.txt"))
+
+    result = execute_contained(request)
+
+    assert result.enforced is True
+    assert result.exit_code == 0, result.stderr
+    assert not (output / "result.txt").exists()
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires the macOS sandbox backend")
+def test_macos_backend_denies_external_and_protected_writes(tmp_path: Path) -> None:
+    workspace = (tmp_path / "workspace").resolve()
+    _ = workspace.mkdir()
+    protected = workspace / ".guard"
+    _ = protected.mkdir()
+    marker = protected / "state"
+    _ = marker.write_text("unchanged", encoding="utf-8")
+    external = tmp_path / "external"
+    _ = external.write_text("unchanged", encoding="utf-8")
+    command = f"printf changed > {external}; printf changed > .guard/state"
+    request = _request(workspace, ("/bin/sh", "-c", command))
+
+    result = execute_contained(request)
+
+    assert result.enforced is True
+    assert result.exit_code != 0
+    assert external.read_text(encoding="utf-8") == "unchanged"
+    assert marker.read_text(encoding="utf-8") == "unchanged"
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires the macOS sandbox backend")
+def test_macos_backend_denies_protected_reads(tmp_path: Path) -> None:
+    workspace = tmp_path.resolve()
+    protected = workspace / ".guard"
+    _ = protected.mkdir()
+    marker = protected / "credentials.json"
+    _ = marker.write_text("synthetic-secret-sentinel", encoding="utf-8")
+    request = _request(workspace, ("/bin/sh", "-c", "cat .guard/credentials.json"))
+
+    result = execute_contained(request)
+
+    assert result.enforced is True
+    assert result.exit_code != 0
+    assert "synthetic-secret-sentinel" not in result.stdout
+    assert "synthetic-secret-sentinel" not in result.stderr
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires the macOS sandbox backend")
+def test_macos_backend_cannot_read_undeclared_live_workspace_file(tmp_path: Path) -> None:
+    workspace = tmp_path.resolve()
+    secret = workspace / "ordinary-private-input.txt"
+    _ = secret.write_text("synthetic-secret-sentinel", encoding="utf-8")
+    request = _request(workspace, ("/bin/sh", "-c", f"cat {secret}"))
+
+    result = execute_contained(request)
+
+    assert result.enforced is True
+    assert result.exit_code != 0
+    assert "synthetic-secret-sentinel" not in result.stdout
+    assert "synthetic-secret-sentinel" not in result.stderr
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires the macOS sandbox backend")
+def test_macos_backend_denies_network_even_for_loopback(tmp_path: Path) -> None:
+    workspace = tmp_path.resolve()
+    code = "import socket; socket.socket().bind(('127.0.0.1', 0))"
+    request = _request(workspace, ("/usr/bin/python3", "-c", code))
+
+    result = execute_contained(request)
+
+    assert result.enforced is True
+    assert result.exit_code != 0
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires the macOS sandbox backend")
+def test_macos_backend_denies_sensitive_system_library_reads(tmp_path: Path) -> None:
+    sensitive = Path("/Library/Preferences/SystemConfiguration/preferences.plist")
+    if not sensitive.is_file():
+        pytest.skip("system preference fixture is unavailable")
+    request = _request(tmp_path.resolve(), ("/bin/sh", "-c", f"cat {sensitive}"))
+
+    result = execute_contained(request)
+
+    assert result.enforced is True
+    assert result.exit_code != 0
+    assert result.stdout == ""
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires the macOS sandbox backend")
+def test_macos_backend_leaves_no_background_descendant(tmp_path: Path) -> None:
+    request = _request(tmp_path.resolve(), ("/bin/sh", "-c", "sleep 30 & printf '%s' $!"))
+
+    result = execute_contained(request)
+
+    assert result.enforced is True
+    raw_pid = result.stdout.strip()
+    if raw_pid.isdigit():
+        child_pid = int(raw_pid)
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline and _pid_exists(child_pid):
+            time.sleep(0.02)
+        assert not _pid_exists(child_pid)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="requires the macOS sandbox backend")
+def test_timeout_retains_enforcement_attestation(tmp_path: Path) -> None:
+    request = _request(tmp_path.resolve(), ("/bin/sh", "-c", "sleep 5"))
+
+    result = execute_contained(request, timeout_seconds=0.1)
+
+    assert result.enforced is True
+    assert result.timed_out is True
+    assert result.exit_code is None
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True

--- a/tests/test_guard_containment_executor.py
+++ b/tests/test_guard_containment_executor.py
@@ -5,10 +5,12 @@ import os
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from codex_plugin_scanner.guard.runtime.containment_contract import (
+    ContainmentBackend,
     ContainmentFailure,
     ContainmentInput,
     ContainmentPolicy,
@@ -32,6 +34,22 @@ def _request(workspace: Path, argv: tuple[str, ...]) -> ContainmentRequest:
     )
 
 
+def _force_available_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = SimpleNamespace(
+        kind=ContainmentBackend.LINUX_BWRAP,
+        path="/usr/bin/true",
+        digest=file_sha256("/usr/bin/true"),
+    )
+
+    def select_backend(_platform: str) -> object:
+        return backend
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.runtime.containment_executor._select_backend",
+        select_backend,
+    )
+
+
 def test_unsupported_platform_fails_closed(tmp_path: Path) -> None:
     request = _request(tmp_path.resolve(), ("/usr/bin/true",))
     result = execute_contained(request, platform="win32")
@@ -41,7 +59,8 @@ def test_unsupported_platform_fails_closed(tmp_path: Path) -> None:
     assert result.attestation.failure is ContainmentFailure.UNSUPPORTED_PLATFORM
 
 
-def test_executable_drift_fails_before_spawn(tmp_path: Path) -> None:
+def test_executable_drift_fails_before_spawn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_available_backend(monkeypatch)
     workspace = tmp_path.resolve()
     executable = workspace / "runner"
     _ = executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
@@ -56,7 +75,8 @@ def test_executable_drift_fails_before_spawn(tmp_path: Path) -> None:
     assert result.attestation.failure is ContainmentFailure.APPLY_FAILED
 
 
-def test_input_drift_fails_before_spawn(tmp_path: Path) -> None:
+def test_input_drift_fails_before_spawn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_available_backend(monkeypatch)
     workspace = tmp_path.resolve()
     source = workspace / "input.txt"
     _ = source.write_text("reviewed", encoding="utf-8")

--- a/tests/test_guard_containment_health.py
+++ b/tests/test_guard_containment_health.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.containment_contract import (
+    ContainmentBackend,
+    ContainmentPolicy,
+    ContainmentRequest,
+)
+from codex_plugin_scanner.guard.runtime.containment_executor import file_sha256
+from codex_plugin_scanner.guard.runtime.containment_health import (
+    CONTAINMENT_POLICY_CONTRACT_DIGEST,
+    ContainmentHealthEvidence,
+    containment_health_signals,
+    containment_health_uncertainties,
+)
+from codex_plugin_scanner.guard.runtime.effect_contract import UncertaintyKind
+from codex_plugin_scanner.guard.runtime.protection_health_runtime import build_runtime_protection_health
+
+_NOW = datetime(2026, 7, 19, 15, 0, tzinfo=timezone.utc)
+
+
+class _Health:
+    dropped_event_count: int = 0
+    persistence_error_count: int = 0
+
+
+class _Store:
+    def count_command_activities(self) -> int:
+        return 1
+
+    def get_command_activity_persistence_health(self) -> _Health:
+        return _Health()
+
+
+def _evidence(**overrides: object) -> ContainmentHealthEvidence:
+    digest = hashlib.sha256(b"stable").hexdigest()
+    values: dict[str, object] = {
+        "backend": ContainmentBackend.MACOS_SANDBOX,
+        "backend_digest": hashlib.sha256(b"backend").hexdigest(),
+        "policy_contract_digest": CONTAINMENT_POLICY_CONTRACT_DIGEST,
+        "daemon_fingerprint": digest,
+        "runtime_fingerprint": digest,
+        "probe_at": _NOW.isoformat(),
+        "probe_enforced": True,
+    }
+    values.update(overrides)
+    return ContainmentHealthEvidence(
+        backend=cast(ContainmentBackend, values["backend"]),
+        backend_digest=cast(str, values["backend_digest"]),
+        policy_contract_digest=cast(str, values["policy_contract_digest"]),
+        daemon_fingerprint=cast(str, values["daemon_fingerprint"]),
+        runtime_fingerprint=cast(str, values["runtime_fingerprint"]),
+        probe_at=cast(str, values["probe_at"]),
+        probe_enforced=cast(bool, values["probe_enforced"]),
+    )
+
+
+def _runtime_payload(evidence: object) -> dict[str, object]:
+    return build_runtime_protection_health(
+        store=_Store(),
+        runtime_state={"last_heartbeat_at": _NOW.isoformat(), "containment_health": evidence},
+        managed_installs=[{"harness": "codex", "active": True}],
+        trust_status={},
+        now=_NOW,
+    )
+
+
+def test_compatible_health_proves_only_the_containment_owned_checks() -> None:
+    evidence = _evidence()
+    signals = containment_health_signals(evidence.to_dict(), now=_NOW)
+
+    assert set(signals) == {
+        "policy_engine",
+        "decision_plane_compatibility",
+        "containment_compatibility",
+        "sandbox",
+    }
+    assert all(signal.status.value == "pass" for signal in signals.values())
+    assert containment_health_uncertainties(evidence.to_dict(), now=_NOW) == ()
+
+    payload = _runtime_payload(evidence.to_dict())
+    checks = cast(list[dict[str, str]], payload["checks"])
+    by_id = {item["check_id"]: item for item in checks}
+    assert by_id["daemon"]["status"] == "pass"
+    assert by_id["containment_compatibility"]["status"] == "pass"
+    assert by_id["sandbox"]["reason_code"] == "containment_backend_enforced"
+    assert payload["state"] == "degraded"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "reason", "uncertainty"),
+    (
+        ({"backend": ContainmentBackend.UNSUPPORTED}, "unsupported_platform", UncertaintyKind.DEGRADED_CONTAINMENT),
+        ({"probe_enforced": False}, "containment_probe_failed", UncertaintyKind.DEGRADED_CONTAINMENT),
+        (
+            {"probe_at": (_NOW - timedelta(minutes=6)).isoformat()},
+            "containment_probe_stale",
+            UncertaintyKind.DEGRADED_CONTAINMENT,
+        ),
+        (
+            {"probe_at": (_NOW + timedelta(seconds=6)).isoformat()},
+            "containment_probe_future",
+            UncertaintyKind.DEGRADED_CONTAINMENT,
+        ),
+        (
+            {"policy_contract_digest": hashlib.sha256(b"other").hexdigest()},
+            "policy_version_mismatch",
+            UncertaintyKind.POLICY_VERSION_MISMATCH,
+        ),
+        (
+            {"runtime_fingerprint": hashlib.sha256(b"drift").hexdigest()},
+            "daemon_runtime_drift",
+            UncertaintyKind.PROTECTION_HEALTH_DEGRADED,
+        ),
+    ),
+)
+def test_faults_fail_closed_and_surface_degraded(
+    overrides: dict[str, object],
+    reason: str,
+    uncertainty: UncertaintyKind,
+) -> None:
+    evidence = _evidence(**overrides)
+    signals = containment_health_signals(evidence.to_dict(), now=_NOW)
+    uncertainties = containment_health_uncertainties(evidence.to_dict(), now=_NOW)
+    payload = _runtime_payload(evidence.to_dict())
+
+    assert all(signal.status.value == "fail" for signal in signals.values())
+    assert {signal.reason_code for signal in signals.values()} == {reason}
+    assert uncertainty in uncertainties
+    assert payload["state"] == "degraded"
+    assert payload["label"] == "Degraded"
+
+
+def test_daemon_drift_has_an_explicit_daemon_failure() -> None:
+    evidence = _evidence(runtime_fingerprint=hashlib.sha256(b"drift").hexdigest())
+    payload = _runtime_payload(evidence.to_dict())
+    checks = cast(list[dict[str, str]], payload["checks"])
+    daemon = next(item for item in checks if item["check_id"] == "daemon")
+
+    assert daemon == {
+        "check_id": "daemon",
+        "status": "fail",
+        "reason_code": "daemon_runtime_drift",
+    }
+
+
+def test_missing_or_malformed_health_is_blocking_not_unknown() -> None:
+    for value in (None, {}, {"schema_version": "future"}, ["not", "a", "mapping"]):
+        signals = containment_health_signals(value, now=_NOW)
+        assert all(signal.status.value == "fail" for signal in signals.values())
+        assert containment_health_uncertainties(value, now=_NOW) == (
+            UncertaintyKind.DEGRADED_CONTAINMENT,
+            UncertaintyKind.PROTECTION_HEALTH_DEGRADED,
+        )
+
+
+def test_health_mapping_is_strict_and_privacy_safe(tmp_path: Path) -> None:
+    evidence = _evidence()
+    serialized = repr(evidence.to_dict())
+    assert str(tmp_path) not in serialized
+    with pytest.raises(ValueError, match="fields"):
+        _ = ContainmentHealthEvidence.from_mapping({**evidence.to_dict(), "raw_command": "secret"})
+
+
+def test_request_fixture_remains_path_pinned(tmp_path: Path) -> None:
+    output = tmp_path / "output"
+    output.mkdir()
+    request = ContainmentRequest(
+        argv=("/usr/bin/true",),
+        cwd=str(tmp_path.resolve()),
+        environment=(),
+        policy=ContainmentPolicy(str(tmp_path.resolve()), (str(output.resolve()),)),
+        inputs=(),
+        launch_digest=hashlib.sha256(b"launch").hexdigest(),
+        executable_digest=file_sha256("/usr/bin/true"),
+        operation_id="test",
+    )
+    assert request.argv == ("/usr/bin/true",)

--- a/tests/test_guard_daemon_containment_health.py
+++ b/tests/test_guard_daemon_containment_health.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from http.client import HTTPResponse
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon.client import GuardSurfaceDaemonClient
+from codex_plugin_scanner.guard.daemon.manager import (
+    current_guard_daemon_runtime_fingerprint,
+    load_guard_daemon_auth_token,
+)
+from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.runtime.containment_health import ContainmentHealthEvidence
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def test_authenticated_daemon_returns_fresh_execution_owned_health(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        auth_token = load_guard_daemon_auth_token(guard_home)
+        assert auth_token is not None
+        client = GuardSurfaceDaemonClient(
+            f"http://127.0.0.1:{daemon.port}",
+            auth_token,
+        )
+        payload = client.containment_health()
+        runtime_request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/runtime?include_items=false&include_receipts=false",
+            headers={"X-Guard-Token": auth_token},
+            method="GET",
+        )
+        with cast(HTTPResponse, urllib.request.urlopen(runtime_request, timeout=5)) as response:
+            raw_runtime_payload = cast(object, json.loads(response.read().decode("utf-8")))
+    finally:
+        daemon.stop()
+
+    evidence = ContainmentHealthEvidence.from_mapping(payload)
+    assert (
+        evidence.compatibility_errors(
+            now=_parsed_probe_time(evidence),
+            runtime_fingerprint=current_guard_daemon_runtime_fingerprint(),
+        )
+        == ()
+    )
+    serialized = json.dumps(payload, sort_keys=True)
+    assert str(tmp_path) not in serialized
+    assert "command" not in serialized
+    assert "environment" not in serialized
+    assert isinstance(raw_runtime_payload, dict)
+    runtime_payload = cast(dict[str, object], raw_runtime_payload)
+    protection_health = runtime_payload.get("protection_health")
+    assert isinstance(protection_health, dict)
+    raw_checks = cast(dict[str, object], protection_health).get("checks")
+    assert isinstance(raw_checks, list)
+    checks: dict[str, dict[str, object]] = {}
+    for raw_item in cast(list[object], raw_checks):
+        assert isinstance(raw_item, dict)
+        item = cast(dict[str, object], raw_item)
+        check_id = item.get("check_id")
+        assert isinstance(check_id, str)
+        checks[check_id] = item
+    assert checks["containment_compatibility"]["status"] == "pass"
+    assert checks["sandbox"]["status"] == "pass"
+
+
+def test_containment_health_endpoint_rejects_missing_token(tmp_path: Path) -> None:
+    daemon = GuardDaemonServer(GuardStore(tmp_path / "guard-home"), host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/runtime/containment-health",
+            method="GET",
+        )
+        with pytest.raises(urllib.error.HTTPError) as error:
+            urllib.request.urlopen(request, timeout=5)
+    finally:
+        daemon.stop()
+
+    assert error.value.code == 401
+
+
+def _parsed_probe_time(evidence: ContainmentHealthEvidence):
+    from datetime import datetime
+
+    return datetime.fromisoformat(evidence.probe_at)

--- a/tests/test_guard_daemon_containment_health.py
+++ b/tests/test_guard_daemon_containment_health.py
@@ -42,12 +42,9 @@ def test_authenticated_daemon_returns_fresh_execution_owned_health(tmp_path: Pat
         daemon.stop()
 
     evidence = ContainmentHealthEvidence.from_mapping(payload)
-    assert (
-        evidence.compatibility_errors(
-            now=_parsed_probe_time(evidence),
-            runtime_fingerprint=current_guard_daemon_runtime_fingerprint(),
-        )
-        == ()
+    compatibility_errors = evidence.compatibility_errors(
+        now=_parsed_probe_time(evidence),
+        runtime_fingerprint=current_guard_daemon_runtime_fingerprint(),
     )
     serialized = json.dumps(payload, sort_keys=True)
     assert str(tmp_path) not in serialized
@@ -66,8 +63,11 @@ def test_authenticated_daemon_returns_fresh_execution_owned_health(tmp_path: Pat
         check_id = item.get("check_id")
         assert isinstance(check_id, str)
         checks[check_id] = item
-    assert checks["containment_compatibility"]["status"] == "pass"
-    assert checks["sandbox"]["status"] == "pass"
+    expected_status = "fail" if compatibility_errors else "pass"
+    assert checks["containment_compatibility"]["status"] == expected_status
+    assert checks["sandbox"]["status"] == expected_status
+    if not evidence.probe_enforced:
+        assert "containment_probe_failed" in compatibility_errors
 
 
 def test_containment_health_endpoint_rejects_missing_token(tmp_path: Path) -> None:

--- a/tests/test_guard_package_intent.py
+++ b/tests/test_guard_package_intent.py
@@ -20,6 +20,39 @@ def _write_text(path: Path, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
+def _write_typescript_workspace(
+    workspace: Path,
+    *,
+    dependency: str = "^5.9.0",
+    locked_version: str = "5.9.0",
+    installed_version: str = "5.9.0",
+    wrong_executable: bool = False,
+) -> None:
+    _write_text(workspace / "package.json", f'{{"devDependencies":{{"typescript":"{dependency}"}}}}\n')
+    _write_text(
+        workspace / "package-lock.json",
+        (
+            '{"packages":{"node_modules/typescript":'
+            f'{{"version":"{locked_version}","integrity":"sha512-reviewed"}}}}}}\n'
+        ),
+    )
+    _write_text(workspace / "src" / "example.ts", "export const value: number = 1;\n")
+    runner = workspace / "node_modules" / ".bin" / "tsc"
+    if wrong_executable:
+        _write_text(runner, "#!/bin/sh\nexit 0\n")
+        runner.chmod(0o755)
+        return
+    compiler = workspace / "node_modules" / "typescript" / "bin" / "tsc"
+    _write_text(compiler, "#!/usr/bin/env node\nrequire('../lib/tsc.js')\n")
+    compiler.chmod(0o755)
+    _write_text(
+        workspace / "node_modules" / "typescript" / "package.json",
+        f'{{"name":"typescript","version":"{installed_version}","bin":{{"tsc":"./bin/tsc"}}}}\n',
+    )
+    runner.parent.mkdir(parents=True, exist_ok=True)
+    runner.symlink_to(Path("..") / "typescript" / "bin" / "tsc")
+
+
 def test_parse_package_intent_empty_command_returns_none() -> None:
     assert parse_package_intent("") is None
     assert parse_package_intent("   \t\n") is None
@@ -296,28 +329,92 @@ def test_parse_package_intent_reviews_declared_local_executable(tmp_path: Path) 
     assert parse_package_intent("bunx --no-install eslint .", workspace=tmp_path) is not None
 
 
-def test_parse_package_intent_allows_verified_local_typescript_check(
+def test_parse_package_intent_records_complete_typescript_launch_without_silent_verification(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workspace = tmp_path / "workspace"
-    project = workspace / "crm-install-dropdowns"
-    project.mkdir(parents=True)
-    _write_text(project / "package.json", '{"devDependencies":{"typescript":"^5.9.0"}}\n')
-    _write_text(
-        project / "package-lock.json",
-        '{"packages":{"node_modules/typescript":{"version":"5.9.0"}}}\n',
-    )
-    runner = project / "node_modules" / ".bin" / "tsc"
-    _write_text(runner, "#!/bin/sh\n")
-    runner.chmod(0o755)
+    workspace.mkdir()
+    _write_typescript_workspace(workspace)
     manager = tmp_path / "bin" / "npx"
     _write_text(manager, "#!/bin/sh\n")
     manager.chmod(0o755)
     monkeypatch.setenv("PATH", str(manager.parent))
-    command = "cd crm-install-dropdowns && npx tsc --noEmit --pretty 2>&1 | head -40"
+    command = "npx --no-install tsc --noEmit --pretty src/example.ts"
 
-    assert parse_package_intent(command, workspace=workspace) is None
+    intent = parse_package_intent(command, workspace=workspace)
+
+    assert intent is not None
+    assert "local-execution-requires-review" in intent.notes
+    evidence = intent.local_executions[0].typescript_launch
+    assert evidence is not None
+    assert evidence.status == "complete"
+    assert evidence.reasons == ()
+    assert evidence.config_mode == "explicit_sources"
+    assert evidence.source_files == ("src/example.ts",)
+    assert evidence.evidence_scope == "launch_identity"
+    assert evidence.review_disposition == "review_required"
+    assert evidence.direct_silent_verification is False
+    assert evidence.binding_digest.startswith("sha256:")
+
+
+@pytest.mark.parametrize(
+    ("case", "command", "expected_reason"),
+    (
+        (
+            "explicit-package",
+            "npx --no-install --package typescript tsc --noEmit src/example.ts",
+            "explicit_package_source",
+        ),
+        ("source-drift", "npx --no-install tsc --noEmit src/example.ts", "manifest_source_drift"),
+        ("wrong-executable", "npx --no-install tsc --noEmit src/example.ts", "wrong_typescript_executable"),
+        ("config", "npx --no-install tsc --noEmit --project tsconfig.json", "compiler_arguments_not_read_only"),
+        ("launch-mismatch", "npx tsc --noEmit src/example.ts", "remote_install_not_disabled"),
+        ("lock-drift", "npx --no-install tsc --noEmit src/example.ts", "manifest_lock_version_drift"),
+    ),
+)
+def test_typescript_launch_evidence_rejects_minimal_exploit_deltas(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    command: str,
+    expected_reason: str,
+) -> None:
+    baseline_workspace = tmp_path / "baseline"
+    baseline_workspace.mkdir()
+    _write_typescript_workspace(baseline_workspace)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_typescript_workspace(
+        workspace,
+        dependency="file:./substituted" if case == "source-drift" else "^5.9.0",
+        locked_version="5.8.4" if case == "lock-drift" else "5.9.0",
+        wrong_executable=case == "wrong-executable",
+    )
+    manager = tmp_path / "bin" / "npx"
+    _write_text(manager, "#!/bin/sh\n")
+    manager.chmod(0o755)
+    monkeypatch.setenv("PATH", str(manager.parent))
+
+    baseline_intent = parse_package_intent(
+        "npx --no-install tsc --noEmit src/example.ts",
+        workspace=baseline_workspace,
+    )
+    assert baseline_intent is not None
+    baseline_evidence = baseline_intent.local_executions[0].typescript_launch
+    assert baseline_evidence is not None
+    assert baseline_evidence.status == "complete"
+
+    intent = parse_package_intent(command, workspace=workspace)
+
+    assert intent is not None
+    evidence = intent.local_executions[0].typescript_launch
+    assert evidence is not None
+    assert evidence.status == "incomplete"
+    assert expected_reason in evidence.reasons
+    assert evidence.binding_digest != baseline_evidence.binding_digest
+    assert evidence.review_disposition == "review_required"
+    assert evidence.direct_silent_verification is False
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_protection_health.py
+++ b/tests/test_guard_protection_health.py
@@ -98,8 +98,9 @@ def test_report_distinguishes_failed_and_unproven_facts() -> None:
     assert by_id["daemon"]["status"] == "pass"
     assert by_id["harness_hooks"]["status"] == "unknown"
     assert by_id["harness_hooks"]["reason_code"] == "hook_attestation_unavailable"
-    assert by_id["decision_plane_compatibility"]["status"] == "unknown"
-    assert by_id["sandbox"]["status"] == "unknown"
+    assert by_id["decision_plane_compatibility"]["status"] == "fail"
+    assert by_id["decision_plane_compatibility"]["reason_code"] == "containment_health_invalid"
+    assert by_id["sandbox"]["status"] == "fail"
 
     degraded = _payload(
         installs=[{"harness": "codex", "active": False}],

--- a/tests/test_guard_typescript_snapshot_inputs.py
+++ b/tests/test_guard_typescript_snapshot_inputs.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.typescript_snapshot_inputs import typescript_snapshot_inputs
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text(content, encoding="utf-8")
+
+
+def _workspace(root: Path) -> tuple[Path, Path]:
+    workspace = root / "workspace"
+    package_root = workspace / "node_modules" / "typescript"
+    _write(workspace / "src" / "example.ts", "export const value: number = 1;\n")
+    _write(package_root / "bin" / "tsc", "require('../lib/tsc.js');\n")
+    _write(package_root / "lib" / "tsc.js", "process.exit(0);\n")
+    _write(package_root / "package.json", '{"name":"typescript","version":"5.9.0"}\n')
+    return workspace.resolve(), package_root.resolve()
+
+
+@pytest.mark.parametrize("dependency", ("node_modules/@types/bad", "node_modules/parent-dep"))
+def test_visible_ancestor_dependencies_require_guard_review(tmp_path: Path, dependency: str) -> None:
+    workspace, package_root = _workspace(tmp_path / "project")
+    _write(tmp_path / "project" / dependency / "index.d.ts", "declare const broken: MissingType;\n")
+
+    with pytest.raises(ValueError, match="external TypeScript dependencies"):
+        _ = typescript_snapshot_inputs(workspace, package_root, ("src/example.ts",))
+
+
+@pytest.mark.parametrize("dependency", ("node_modules/@types/credentials", "node_modules/credentials"))
+def test_protected_workspace_dependencies_require_guard_review(tmp_path: Path, dependency: str) -> None:
+    workspace, package_root = _workspace(tmp_path)
+    _write(workspace / dependency / "index.d.ts", "declare const broken: MissingType;\n")
+
+    with pytest.raises(ValueError, match="protected TypeScript dependency"):
+        _ = typescript_snapshot_inputs(workspace, package_root, ("src/example.ts",))
+
+
+@pytest.mark.parametrize("budget", ("entries", "time"))
+def test_streaming_discovery_enforces_hard_budgets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    budget: str,
+) -> None:
+    workspace, package_root = _workspace(tmp_path)
+    _write(package_root / "lib" / "extra.js", "module.exports = {};\n")
+    if budget == "entries":
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.runtime.typescript_snapshot_inputs._MAX_DISCOVERY_ENTRIES",
+            1,
+        )
+    else:
+        observed_times = iter((0.0, 10.0))
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.runtime.typescript_snapshot_inputs.time.monotonic",
+            lambda: next(observed_times),
+        )
+
+    expected_message = "discovery entry budget" if budget == "entries" else "discovery time budget"
+    with pytest.raises(ValueError, match=expected_message):
+        _ = typescript_snapshot_inputs(workspace, package_root, ("src/example.ts",))
+
+
+def test_snapshot_input_order_and_digests_are_deterministic(tmp_path: Path) -> None:
+    workspace, package_root = _workspace(tmp_path)
+    _write(workspace / "src" / "util.ts", "export const util = true;\n")
+    _write(workspace / "node_modules" / "@types" / "example" / "index.d.ts", "declare const ambient: string;\n")
+
+    first = typescript_snapshot_inputs(workspace, package_root, ("src/example.ts",))
+    second = typescript_snapshot_inputs(workspace, package_root, ("src/example.ts",))
+
+    assert first == second
+    closure_paths = tuple(item.snapshot_path for item in first[3])
+    assert closure_paths == tuple(sorted(closure_paths))
+    assert "src/util.ts" in closure_paths
+    assert "node_modules/@types/example/index.d.ts" in closure_paths


### PR DESCRIPTION
## Summary
- replace the TypeScript package-runner bypass with exact launch, dependency, source, and executable evidence
- run eligible explicit-source TypeScript checks from hash-verified snapshots under an OS-enforced, network-denied boundary
- bind compiler-relevant imports and ambient declarations with bounded streaming discovery, returning uncertain dependency layouts to normal Guard review
- require fresh authenticated daemon health and fail closed on drift, unsupported platforms, or enforcement failure
- surface containment compatibility truthfully in the authenticated runtime health response

## Testing
- `uv run --no-sync pytest -q tests/test_guard_package_intent.py tests/test_guard_package_shims.py tests/test_guard_protection_health.py tests/test_guard_containment_contract.py tests/test_guard_containment_executor.py tests/test_guard_containment_health.py tests/test_guard_contained_typescript_execution.py tests/test_guard_typescript_snapshot_inputs.py tests/test_guard_daemon_containment_health.py tests/test_guard_surface_server.py --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_effect_contract.py tests/test_guard_effect_decision.py tests/test_guard_decision_propagation.py tests/test_guard_risk.py tests/test_guard_command_corpus.py tests/test_guard_package_execution_context.py tests/test_guard_package_execution_policy.py tests/test_guard_package_runner_identity.py --tb=short`
- `uv run --no-sync ruff check <changed-python-files>`
- `uv run --no-sync ruff format --check <changed-python-files>`
- `uv run --no-sync basedpyright <new-containment-modules-and-tests>`
- `git diff --check`

## Notes
- mutable, incomplete, or unsupported executable, dependency, and backend identities fall back to the existing Guard review flow
