### PR TITLE
fix(guard): backport approval precedence to 2.1

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -7,7 +7,7 @@ import os
 import shlex
 import shutil
 import subprocess
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
@@ -184,6 +184,41 @@ class HarnessAdapter:
         if context.workspace_dir is not None and self.harness in {"opencode", "claude-code"}:
             command.append(str(context.workspace_dir))
         return [*command, *passthrough_args]
+
+    def preview_launch_commands(
+        self,
+        context: HarnessContext,
+        passthrough_args: list[str],
+    ) -> tuple[list[str], ...]:
+        """Return every command the next launch preparation may select.
+
+        Implementations must be side-effect free. Adapters whose
+        ``launch_command`` is a pure argv constructor can inherit this default;
+        adapters that perform setup while selecting an argv must override it.
+        """
+
+        return (self.launch_command(context, passthrough_args),)
+
+    def launch_command_from_authorized_plan(
+        self,
+        context: HarnessContext,
+        passthrough_args: list[str],
+        *,
+        authorized_executable_prefixes: Sequence[Sequence[str]],
+        launch_environment: Mapping[str, str],
+    ) -> list[str]:
+        """Finalize a command only after its preview plans were authorized.
+
+        The default is suitable for adapters whose launch selection has no
+        setup-time subprocess side effects. Adapters that execute their
+        harness while preparing a launch must use the supplied canonical,
+        content-bound executable prefix instead of resolving the executable
+        again. ``launch_environment`` is the exact prepared environment whose
+        digest participated in the authority comparison.
+        """
+
+        del authorized_executable_prefixes, launch_environment
+        return self.launch_command(context, passthrough_args)
 
     def policy_path(self, context: HarnessContext) -> Path:
         if context.workspace_dir is not None:

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from urllib.parse import urlencode
 
 from ...path_support import iter_safe_matching_files, resolves_within_root
+from ..aibom_detection import enrich_mcp_server_metadata
 from ..models import GuardArtifact, HarnessDetection
 from ..runtime.harness_attribution import cursor_hook_query_extras
 from ..shims import install_guard_shim, remove_guard_shim
@@ -381,6 +382,44 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                         continue
                     command = server_config.get("command")
                     url = server_config.get("url")
+                    args = tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str))
+                    raw_env = server_config.get("env")
+                    environment = (
+                        {
+                            key.strip(): value
+                            for key, value in raw_env.items()
+                            if isinstance(key, str) and key.strip() and isinstance(value, str)
+                        }
+                        if isinstance(raw_env, dict)
+                        else {}
+                    )
+                    headers = server_config.get("headers")
+                    configured_headers = (
+                        {
+                            key.strip(): value
+                            for key, value in headers.items()
+                            if isinstance(key, str) and key.strip() and isinstance(value, str)
+                        }
+                        if isinstance(headers, dict)
+                        else {}
+                    )
+                    metadata = enrich_mcp_server_metadata(
+                        {
+                            "name": name,
+                            "env": environment,
+                            "env_keys": sorted(environment),
+                            "headers_keys": (
+                                sorted(key for key in headers if isinstance(key, str))
+                                if isinstance(headers, dict)
+                                else []
+                            ),
+                        },
+                        command=command if isinstance(command, str) else None,
+                        args=args,
+                        url=url if isinstance(url, str) else None,
+                        transport="http" if isinstance(url, str) else "stdio",
+                        configured_headers=configured_headers,
+                    )
                     artifacts.append(
                         GuardArtifact(
                             artifact_id=_claude_mcp_artifact_id(scope, name),
@@ -390,17 +429,10 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                             source_scope=scope,
                             config_path=str(config_path),
                             command=command if isinstance(command, str) else None,
-                            args=tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str)),
+                            args=args,
                             url=url if isinstance(url, str) else None,
                             transport="http" if isinstance(server_config.get("url"), str) else "stdio",
-                            metadata={
-                                "env_keys": sorted(key for key in server_config.get("env", {}))
-                                if isinstance(server_config.get("env"), dict)
-                                else [],
-                                "headers_keys": sorted(key for key in server_config.get("headers", {}))
-                                if isinstance(server_config.get("headers"), dict)
-                                else [],
-                            },
+                            metadata=metadata,
                         )
                     )
             hooks = payload.get("hooks")

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -8,6 +8,7 @@ import json
 import re
 import shlex
 import sys
+from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -24,7 +25,12 @@ from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _command_available, _warnings_include_setup_failure
-from .codex_remote_control import codex_remote_launch_environment, guarded_codex_launch_command
+from .codex_remote_control import (
+    codex_remote_launch_environment,
+    guarded_codex_launch_command,
+    guarded_codex_launch_command_candidates,
+    guarded_codex_launch_command_from_prefix,
+)
 from .mcp_servers import (
     ManagedMcpServer,
     is_guard_proxy_command,
@@ -36,7 +42,7 @@ from .mcp_servers import (
 
 tomllib: Any
 try:  # pragma: no cover - Python 3.11+
-    import tomllib as tomllib  # type: ignore[attr-defined]
+    import tomllib as tomllib  # pyright: ignore[reportMissingImports]
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10
     tomllib = importlib.import_module("tomli")
 
@@ -59,6 +65,7 @@ def _artifact_from_guard_proxy_args(
     fallback_scope: str,
     fallback_config_path: Path,
     harness: str,
+    environment: object = None,
 ) -> GuardArtifact | None:
     """Expose the wrapped server for status/review without re-wrapping it."""
 
@@ -80,6 +87,20 @@ def _artifact_from_guard_proxy_args(
     server_args = server_args_value if isinstance(server_args_value, tuple) else ()
     env_keys_value = parsed.get("server-env-key")
     env_keys = tuple(sorted(env_keys_value)) if isinstance(env_keys_value, tuple) else ()
+    raw_environment = environment if isinstance(environment, dict) else {}
+    configured_environment = {key: value for key in env_keys if isinstance((value := raw_environment.get(key)), str)}
+    metadata = enrich_mcp_server_metadata(
+        {
+            "env": configured_environment,
+            "env_keys": list(env_keys),
+            "guard_managed_proxy": True,
+            "name": name,
+        },
+        command=command,
+        args=server_args,
+        url=None,
+        transport=transport,
+    )
     return GuardArtifact(
         artifact_id=f"codex:{source_scope}:{name}",
         name=name,
@@ -90,11 +111,7 @@ def _artifact_from_guard_proxy_args(
         command=command,
         args=server_args,
         transport=transport,
-        metadata={
-            "env": {},
-            "env_keys": list(env_keys),
-            "guard_managed_proxy": True,
-        },
+        metadata=metadata,
     )
 
 
@@ -784,6 +801,35 @@ class CodexHarnessAdapter(HarnessAdapter):
             passthrough_args=passthrough_args,
         )
 
+    def preview_launch_commands(
+        self,
+        context: HarnessContext,
+        passthrough_args: list[str],
+    ) -> tuple[list[str], ...]:
+        return guarded_codex_launch_command_candidates(
+            executable=self.resolved_executable(context) or self.executable,
+            home_dir=context.home_dir,
+            passthrough_args=passthrough_args,
+        )
+
+    def launch_command_from_authorized_plan(
+        self,
+        context: HarnessContext,
+        passthrough_args: list[str],
+        *,
+        authorized_executable_prefixes: Sequence[Sequence[str]],
+        launch_environment: Mapping[str, str],
+    ) -> list[str]:
+        prefixes = {tuple(prefix) for prefix in authorized_executable_prefixes if prefix}
+        if len(prefixes) != 1:
+            raise ValueError("Codex launch candidates do not share one authorized executable prefix.")
+        return guarded_codex_launch_command_from_prefix(
+            executable_prefix=prefixes.pop(),
+            home_dir=context.home_dir,
+            passthrough_args=passthrough_args,
+            environ=launch_environment,
+        )
+
     def launch_environment(self, context: HarnessContext) -> dict[str, str]:
         return codex_remote_launch_environment(context.home_dir)
 
@@ -842,25 +888,29 @@ class CodexHarnessAdapter(HarnessAdapter):
                             fallback_scope=scope,
                             fallback_config_path=config_path,
                             harness=self.harness,
+                            environment=server_config.get("env"),
                         )
                         if proxy_artifact is not None:
                             artifacts.append(proxy_artifact)
                         continue
                     url = server_config.get("url")
                     env = server_config.get("env")
+                    environment = (
+                        {
+                            key.strip(): value
+                            for key, value in env.items()
+                            if isinstance(key, str) and key.strip() and isinstance(value, str)
+                        }
+                        if isinstance(env, dict)
+                        else {}
+                    )
                     enabled = server_config.get("enabled", True) is not False
                     mcp_metadata = enrich_mcp_server_metadata(
                         {
                             "name": name,
                             "enabled": enabled,
-                            "env": {
-                                str(key): str(value)
-                                for key, value in env.items()
-                                if isinstance(key, str) and isinstance(value, str)
-                            }
-                            if isinstance(env, dict)
-                            else {},
-                            "env_keys": sorted(env.keys()) if isinstance(env, dict) else [],
+                            "env": environment,
+                            "env_keys": sorted(environment),
                         },
                         command=command if isinstance(command, str) else None,
                         args=args,

--- a/src/codex_plugin_scanner/guard/adapters/codex_remote_control.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_remote_control.py
@@ -7,7 +7,7 @@ import signal
 import socket
 import subprocess
 import time
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 _REMOTE_CONTROL_START_TIMEOUT_SECONDS = 10
@@ -55,10 +55,35 @@ def guarded_codex_launch_command(
 ) -> list[str]:
     """Return a remote TUI command when Codex app-server control is available."""
 
-    plain_command = [executable, *passthrough_args]
+    return guarded_codex_launch_command_from_prefix(
+        executable_prefix=(executable,),
+        home_dir=home_dir,
+        passthrough_args=passthrough_args,
+        environ=environ,
+    )
+
+
+def guarded_codex_launch_command_from_prefix(
+    *,
+    executable_prefix: Sequence[str],
+    home_dir: Path,
+    passthrough_args: list[str],
+    environ: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Prepare Codex using an already authorized canonical launch prefix.
+
+    Script-backed Codex launchers may require a verified interpreter and
+    launcher path. Keeping the complete prefix prevents remote-control or
+    app-server setup from resolving an attacker-swapped PATH entry or symlink.
+    """
+
+    prefix = list(executable_prefix)
+    if not prefix or any(not isinstance(part, str) or not part for part in prefix):
+        raise ValueError("Codex launch preparation requires a canonical executable prefix.")
+    plain_command = [*prefix, *passthrough_args]
     if not _supports_remote_tui(passthrough_args):
         return plain_command
-    environment = dict(environ or os.environ)
+    environment = dict(os.environ if environ is None else environ)
     codex_home = codex_home_for_user(home_dir)
     try:
         codex_home.mkdir(parents=True, exist_ok=True)
@@ -68,7 +93,7 @@ def guarded_codex_launch_command(
     environment["CODEX_HOME"] = str(codex_home)
     try:
         result = subprocess.run(
-            [executable, "remote-control", "start", "--json"],
+            [*prefix, "remote-control", "start", "--json"],
             capture_output=True,
             text=True,
             timeout=_REMOTE_CONTROL_START_TIMEOUT_SECONDS,
@@ -80,12 +105,38 @@ def guarded_codex_launch_command(
     socket_path = default_codex_control_socket(home_dir)
     managed_daemon_ready = result is not None and result.returncode == 0 and _wait_for_socket(socket_path)
     if not managed_daemon_ready and not _start_direct_app_server(
-        executable=executable,
+        executable_prefix=prefix,
         socket_path=socket_path,
         environment=environment,
     ):
         return plain_command
-    return [executable, "--remote", f"unix://{socket_path}", *passthrough_args]
+    return [*prefix, "--remote", f"unix://{socket_path}", *passthrough_args]
+
+
+def guarded_codex_launch_command_candidates(
+    *,
+    executable: str,
+    home_dir: Path,
+    passthrough_args: list[str],
+) -> tuple[list[str], ...]:
+    """Preview every argv the remote-control launch preparation may select.
+
+    This function intentionally performs no filesystem, socket, or subprocess
+    setup. Compatible TUI launches may select the remote argv when setup
+    succeeds or the ordinary argv when it does not; incompatible subcommands
+    have only the ordinary form.
+    """
+
+    plain_command = [executable, *passthrough_args]
+    if not _supports_remote_tui(passthrough_args):
+        return (plain_command,)
+    remote_command = [
+        executable,
+        "--remote",
+        f"unix://{default_codex_control_socket(home_dir)}",
+        *passthrough_args,
+    ]
+    return (remote_command, plain_command)
 
 
 def codex_remote_launch_environment(home_dir: Path) -> dict[str, str]:
@@ -141,7 +192,7 @@ def _socket_is_live(socket_path: Path) -> bool:
 
 def _start_direct_app_server(
     *,
-    executable: str,
+    executable_prefix: Sequence[str],
     socket_path: Path,
     environment: Mapping[str, str],
 ) -> bool:
@@ -165,7 +216,7 @@ def _start_direct_app_server(
                 if not _stop_tracked_process(tracked_pid):
                     return False
         process = subprocess.Popen(
-            [executable, "app-server", "--listen", f"unix://{socket_path}"],
+            [*executable_prefix, "app-server", "--listen", f"unix://{socket_path}"],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/src/codex_plugin_scanner/guard/adapters/cursor.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor.py
@@ -7,7 +7,7 @@ import sys
 from hashlib import sha256
 from pathlib import Path
 
-from ..aibom_detection import extend_detection_with_workspace_aibom
+from ..aibom_detection import enrich_mcp_server_metadata, extend_detection_with_workspace_aibom
 from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
 from ..runtime.mcp_skill_firewall import enrich_artifact_with_mcp_skill_firewall
@@ -89,6 +89,43 @@ class CursorHarnessAdapter(HarnessAdapter):
                 env_payload = server_config.get("env")
                 environment_payload = server_config.get("environment")
                 environment = env_payload if isinstance(env_payload, dict) else environment_payload
+                normalized_environment = (
+                    {
+                        key.strip(): value
+                        for key, value in environment.items()
+                        if isinstance(key, str) and key.strip() and isinstance(value, str)
+                    }
+                    if isinstance(environment, dict)
+                    else {}
+                )
+                url = server_config.get("url")
+                raw_headers = server_config.get("headers")
+                configured_headers = (
+                    {
+                        key.strip(): value
+                        for key, value in raw_headers.items()
+                        if isinstance(key, str) and key.strip() and isinstance(value, str)
+                    }
+                    if isinstance(raw_headers, dict)
+                    else {}
+                )
+                metadata = enrich_mcp_server_metadata(
+                    {
+                        "name": name,
+                        "env": normalized_environment,
+                        "env_keys": sorted(normalized_environment),
+                        "headers_keys": sorted(configured_headers),
+                        "guard_managed_proxy": is_guard_proxy_command(
+                            command if isinstance(command, str) else None,
+                            args,
+                        ),
+                    },
+                    command=command if isinstance(command, str) else None,
+                    args=args,
+                    url=url if isinstance(url, str) else None,
+                    transport="http" if isinstance(url, str) else "stdio",
+                    configured_headers=configured_headers,
+                )
                 artifacts.append(
                     enrich_artifact_with_mcp_skill_firewall(
                         GuardArtifact(
@@ -100,21 +137,9 @@ class CursorHarnessAdapter(HarnessAdapter):
                             config_path=str(config_path),
                             command=command if isinstance(command, str) else None,
                             args=args,
-                            url=server_config.get("url") if isinstance(server_config.get("url"), str) else None,
-                            transport="http" if isinstance(server_config.get("url"), str) else "stdio",
-                            metadata={
-                                "env": {
-                                    str(key): str(value)
-                                    for key, value in environment.items()
-                                    if isinstance(key, str) and isinstance(value, str)
-                                }
-                                if isinstance(environment, dict)
-                                else {},
-                                "guard_managed_proxy": is_guard_proxy_command(
-                                    command if isinstance(command, str) else None,
-                                    args,
-                                ),
-                            },
+                            url=url if isinstance(url, str) else None,
+                            transport="http" if isinstance(url, str) else "stdio",
+                            metadata=metadata,
                         )
                     )
                 )

--- a/src/codex_plugin_scanner/guard/adapters/grok.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok.py
@@ -51,7 +51,7 @@ from .grok_executable import (
 
 tomllib: Any
 try:
-    import tomllib as tomllib  # type: ignore[attr-defined]
+    import tomllib as tomllib  # pyright: ignore[reportMissingImports]
 except ModuleNotFoundError:
     tomllib = importlib.import_module("tomli")
 
@@ -171,6 +171,19 @@ class GrokHarnessAdapter(HarnessAdapter):
         if executable.source == "explicit":
             executable = register_trusted_grok_executable(context, executable)
         return [str(executable.path), *passthrough_args]
+
+    def preview_launch_commands(
+        self,
+        context: HarnessContext,
+        passthrough_args: list[str],
+    ) -> tuple[list[str], ...]:
+        """Resolve Grok without persisting an explicit-path registration."""
+
+        resolution = resolve_trusted_grok_executable(context)
+        executable = resolution.executable
+        if executable is None:
+            raise FileNotFoundError(resolution.error or "Trusted Grok executable not found.")
+        return ([str(executable.path), *passthrough_args],)
 
     def prepare_launch_environment(
         self,

--- a/src/codex_plugin_scanner/guard/adapters/grok_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok_config.py
@@ -171,19 +171,37 @@ def append_permission_artifacts(
 
 
 def _mcp_env_keys(server_config: dict[str, object]) -> list[str]:
-    keys: set[str] = set()
-    for field in ("env", "environment"):
+    return sorted(_mcp_environment(server_config))
+
+
+def _mcp_environment(server_config: dict[str, object]) -> dict[str, str]:
+    environment: dict[str, str] = {}
+    for field in ("environment", "env"):
         value = server_config.get(field)
         if isinstance(value, dict):
-            keys.update(key for key in value if isinstance(key, str))
-    return sorted(keys)
+            environment.update(
+                {
+                    key.strip(): item
+                    for key, item in value.items()
+                    if isinstance(key, str) and key.strip() and isinstance(item, str)
+                }
+            )
+    return environment
+
+
+def _mcp_headers(server_config: dict[str, object]) -> dict[str, str]:
+    headers = server_config.get("headers")
+    if not isinstance(headers, dict):
+        return {}
+    return {
+        key.strip(): item
+        for key, item in headers.items()
+        if isinstance(key, str) and key.strip() and isinstance(item, str)
+    }
 
 
 def _mcp_headers_keys(server_config: dict[str, object]) -> list[str]:
-    headers = server_config.get("headers")
-    if not isinstance(headers, dict):
-        return []
-    return sorted(key for key in headers if isinstance(key, str))
+    return sorted(_mcp_headers(server_config))
 
 
 def append_mcp_artifacts(
@@ -213,6 +231,8 @@ def append_mcp_artifacts(
         raw_args = server_config.get("args")
         args = tuple(str(item) for item in raw_args) if isinstance(raw_args, list) else ()
         transport = "http" if isinstance(url, str) else "stdio"
+        environment = _mcp_environment(server_config)
+        headers = _mcp_headers(server_config)
         metadata = enrich_mcp_server_metadata(
             {
                 "name": server_name,
@@ -223,6 +243,8 @@ def append_mcp_artifacts(
             args=args,
             url=url if isinstance(url, str) else None,
             transport=transport,
+            configured_environment=environment,
+            configured_headers=headers,
         )
         artifacts.append(
             GuardArtifact(

--- a/src/codex_plugin_scanner/guard/adapters/grok_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok_hooks.py
@@ -81,7 +81,7 @@ def prepare_grok_hook_payload(payload: Mapping[str, object]) -> dict[str, object
 def grok_hook_response_from_guard(*, policy_action: str, reason: str) -> dict[str, object]:
     """Translate Guard policy action into Grok PreToolUse stdout JSON."""
 
-    if policy_action in {"block", "sandbox-required", "require-reapproval"}:
+    if policy_action in {"review", "require-reapproval", "sandbox-required", "block"}:
         cleaned_reason = _dedupe_grok_block_reason(reason.strip() if isinstance(reason, str) else "")
         return {
             "decision": "deny",
@@ -116,7 +116,7 @@ def emit_grok_hook_response(
 
 
 def grok_hook_should_block(*, policy_action: str) -> bool:
-    return policy_action in {"block", "sandbox-required", "require-reapproval"}
+    return policy_action in {"review", "require-reapproval", "sandbox-required", "block"}
 
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from ..aibom_detection import enrich_mcp_server_metadata
 from ..inventory_cisco import run_cisco_inventory_scans
 from ..inventory_contract import GuardAgentInventorySnapshot, inventory_snapshot_from_detection
 from ..models import GuardArtifact, HarnessDetection
@@ -707,11 +708,22 @@ class HermesHarnessAdapter(HarnessAdapter):
 
             # Filter env keys to strings before sorting.
             env_str_keys = sorted(k for k in env if isinstance(k, str))
+            configured_environment = {
+                key.strip(): value
+                for key, value in env.items()
+                if isinstance(key, str) and key.strip() and isinstance(value, str)
+            }
+            configured_headers = {
+                key.strip(): value
+                for key, value in headers.items()
+                if isinstance(key, str) and key.strip() and isinstance(value, str)
+            }
 
             metadata: dict[str, object] = {
                 "source": source,
                 "env_keys": env_str_keys,
                 "header_keys": sorted(header_keys),
+                "headers_keys": sorted(header_keys),
                 "auth_header_keys": sorted(auth_header_keys),
                 "sampling_enabled": sampling_enabled,
                 "sampling_model": sampling_model,
@@ -730,6 +742,16 @@ class HermesHarnessAdapter(HarnessAdapter):
             ]
             if header_value_hints:
                 metadata["header_value_secret_keys"] = sorted(header_value_hints)
+
+            metadata = enrich_mcp_server_metadata(
+                metadata,
+                command=command if isinstance(command, str) else None,
+                args=args_tuple,
+                url=url if isinstance(url, str) else None,
+                transport=transport,
+                configured_environment=configured_environment,
+                configured_headers=configured_headers,
+            )
 
             # Include source in artifact_id to prevent collisions when the
             # same server name appears in both config.yaml and mcp_servers.json.

--- a/src/codex_plugin_scanner/guard/adapters/pi_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_hooks.py
@@ -16,7 +16,7 @@ def pi_hook_response_from_guard(
 ) -> dict[str, object]:
     """Translate a Guard policy action into the Pi extension bridge response."""
 
-    if policy_action in {"block", "sandbox-required", "require-reapproval"}:
+    if policy_action in {"review", "require-reapproval", "sandbox-required", "block"}:
         cleaned_reason = reason.strip() if isinstance(reason, str) else ""
         response: dict[str, object] = {
             "decision": "deny",

--- a/src/codex_plugin_scanner/guard/adapters/zcode_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode_config.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ..aibom_detection import enrich_mcp_server_metadata
 from ..models import GuardArtifact
 from .base import _json_payload
 
@@ -96,11 +97,58 @@ def _string_args(server_config: dict[str, object]) -> tuple[str, ...]:
 
 
 def _mcp_env_keys(server_config: dict[str, object]) -> list[str]:
+    return sorted(_mcp_environment(server_config))
+
+
+def _mcp_environment(server_config: dict[str, object]) -> dict[str, str]:
     for field in ("env", "environment"):
         value = server_config.get(field)
         if isinstance(value, dict):
-            return sorted(key for key in value if isinstance(key, str))
-    return []
+            return {
+                key.strip(): item
+                for key, item in value.items()
+                if isinstance(key, str) and key.strip() and isinstance(item, str)
+            }
+    return {}
+
+
+def _mcp_headers(server_config: dict[str, object]) -> dict[str, str]:
+    value = server_config.get("headers")
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key.strip(): item
+        for key, item in value.items()
+        if isinstance(key, str) and key.strip() and isinstance(item, str)
+    }
+
+
+def _mcp_metadata(
+    *,
+    server_name: str,
+    server_config: dict[str, object],
+    command: str | None,
+    args: tuple[str, ...],
+    url: str | None,
+    transport: str,
+    additional: dict[str, object] | None = None,
+) -> dict[str, object]:
+    environment = _mcp_environment(server_config)
+    headers = _mcp_headers(server_config)
+    return enrich_mcp_server_metadata(
+        {
+            "name": server_name,
+            "env_keys": sorted(environment),
+            "headers_keys": sorted(headers),
+            **(additional or {}),
+        },
+        command=command,
+        args=args,
+        url=url,
+        transport=transport,
+        configured_environment=environment,
+        configured_headers=headers,
+    )
 
 
 def _mcp_transport(server_config: dict[str, object]) -> str:
@@ -144,6 +192,8 @@ def append_cli_config_artifacts(
                 command, url = _mcp_endpoint(server_config)
                 if command is None and url is None:
                     continue
+                args = _string_args(server_config)
+                transport = _mcp_transport(server_config)
                 artifacts.append(
                     GuardArtifact(
                         artifact_id=f"{harness}:{scope}:mcp:{server_name}",
@@ -153,10 +203,17 @@ def append_cli_config_artifacts(
                         source_scope=scope,
                         config_path=str(config_path),
                         command=command,
-                        args=_string_args(server_config),
+                        args=args,
                         url=url,
-                        transport=_mcp_transport(server_config),
-                        metadata={"env_keys": _mcp_env_keys(server_config)},
+                        transport=transport,
+                        metadata=_mcp_metadata(
+                            server_name=server_name,
+                            server_config=server_config,
+                            command=command,
+                            args=args,
+                            url=url,
+                            transport=transport,
+                        ),
                     )
                 )
 
@@ -342,6 +399,8 @@ def append_plugin_manifest_artifacts(
                 command, url = _mcp_endpoint(server_config)
                 if command is None and url is None:
                     continue
+                args = _string_args(server_config)
+                transport = _mcp_transport(server_config)
                 artifacts.append(
                     GuardArtifact(
                         artifact_id=f"{harness}:{scope}:plugin:{plugin_name}:mcp:{server_name}",
@@ -351,13 +410,18 @@ def append_plugin_manifest_artifacts(
                         source_scope=scope,
                         config_path=str(plugin_mcp_path),
                         command=command,
-                        args=_string_args(server_config),
+                        args=args,
                         url=url,
-                        transport=_mcp_transport(server_config),
-                        metadata={
-                            "env_keys": _mcp_env_keys(server_config),
-                            "plugin": plugin_name,
-                        },
+                        transport=transport,
+                        metadata=_mcp_metadata(
+                            server_name=server_name,
+                            server_config=server_config,
+                            command=command,
+                            args=args,
+                            url=url,
+                            transport=transport,
+                            additional={"plugin": plugin_name},
+                        ),
                     )
                 )
 

--- a/src/codex_plugin_scanner/guard/adapters/zcode_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode_hooks.py
@@ -119,7 +119,7 @@ def zcode_hook_response_from_guard(
     """
 
     resolved_event = event_name or "PreToolUse"
-    if policy_action in {"block", "sandbox-required", "require-reapproval"}:
+    if policy_action in {"review", "require-reapproval", "sandbox-required", "block"}:
         cleaned_reason = (reason.strip() if isinstance(reason, str) else "") or "Blocked by HOL Guard."
         if resolved_event == "UserPromptSubmit":
             return {
@@ -164,7 +164,7 @@ def emit_zcode_hook_response(
 
 
 def zcode_hook_should_block(*, policy_action: str) -> bool:
-    return policy_action in {"block", "sandbox-required", "require-reapproval"}
+    return policy_action in {"review", "require-reapproval", "sandbox-required", "block"}
 
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Literal
 
@@ -11,6 +12,7 @@ from ..path_support import is_safe_relative_path, iter_safe_matching_files, reso
 from .codex_skill_config import load_codex_skill_config_rules, resolve_codex_skill_enabled
 from .inventory_contract import fingerprint_mapping, fingerprint_path_tree, fingerprint_text
 from .models import GuardArtifact, HarnessDetection
+from .runtime.approval_context import build_configured_environment_hash, build_configured_header_values_hash
 
 InstructionRole = Literal[
     "agents_md",
@@ -122,7 +124,9 @@ def mcp_server_content_hash(
     url: str | None,
     transport: str | None,
     env_keys: tuple[str, ...] = (),
+    env_values_hash: str | None = None,
     headers_keys: tuple[str, ...] = (),
+    header_values_hash: str | None = None,
 ) -> str:
     return fingerprint_mapping(
         {
@@ -131,7 +135,9 @@ def mcp_server_content_hash(
             "url": url,
             "transport": transport,
             "env_keys": sorted(env_keys),
+            "env_values_hash": env_values_hash,
             "headers_keys": sorted(headers_keys),
+            "header_values_hash": header_values_hash,
         }
     )
 
@@ -645,24 +651,77 @@ def enrich_mcp_server_metadata(
     args: tuple[str, ...],
     url: str | None,
     transport: str | None,
+    configured_environment: Mapping[str, object] | None = None,
+    configured_headers: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
-    env_keys = metadata.get("env_keys")
-    normalized_env_keys: tuple[str, ...] = ()
-    if isinstance(env_keys, list):
-        normalized_env_keys = tuple(str(key) for key in env_keys if isinstance(key, str))
-    headers_keys = metadata.get("headers_keys")
-    normalized_headers_keys: tuple[str, ...] = ()
-    if isinstance(headers_keys, list):
-        normalized_headers_keys = tuple(str(key) for key in headers_keys if isinstance(key, str))
+    normalized_env_keys = _canonical_mcp_configured_keys(metadata.get("env_keys"))
+    raw_env = configured_environment if configured_environment is not None else metadata.get("env")
+    normalized_env = _canonical_mcp_configured_values(raw_env)
+    if not normalized_env_keys and normalized_env:
+        normalized_env_keys = tuple(sorted(normalized_env))
+    raw_env_values_hash = metadata.get("env_values_hash")
+    env_values_hash = (
+        raw_env_values_hash.strip()
+        if isinstance(raw_env_values_hash, str) and raw_env_values_hash.strip()
+        else build_configured_environment_hash(
+            normalized_env,
+            configured_keys=normalized_env_keys,
+        )
+    )
+    normalized_headers_keys = _canonical_mcp_configured_keys(metadata.get("headers_keys"))
+    raw_headers = configured_headers if configured_headers is not None else metadata.get("headers")
+    normalized_headers = _canonical_mcp_configured_values(raw_headers)
+    if not normalized_headers_keys and normalized_headers:
+        normalized_headers_keys = tuple(sorted(normalized_headers))
+    raw_header_values_hash = metadata.get("header_values_hash")
+    header_values_hash = (
+        raw_header_values_hash.strip()
+        if isinstance(raw_header_values_hash, str) and raw_header_values_hash.strip()
+        else build_configured_header_values_hash(
+            normalized_headers,
+            configured_keys=normalized_headers_keys,
+        )
+    )
     content_hash = mcp_server_content_hash(
         command=command,
         args=args,
         url=url,
         transport=transport,
         env_keys=normalized_env_keys,
+        env_values_hash=env_values_hash,
         headers_keys=normalized_headers_keys,
+        header_values_hash=header_values_hash,
     )
     enriched = dict(metadata)
+    enriched["env_keys"] = list(normalized_env_keys)
+    enriched["headers_keys"] = list(normalized_headers_keys)
+    enriched["env_values_hash"] = env_values_hash
+    enriched["header_values_hash"] = header_values_hash
     enriched["content_hash"] = content_hash
     enriched.update(version_info_metadata(content_hash=content_hash, version_label=str(metadata.get("name", "mcp"))))
     return enriched
+
+
+def _canonical_mcp_configured_key(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _canonical_mcp_configured_keys(value: object) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    normalized = {key for item in value if (key := _canonical_mcp_configured_key(item)) is not None}
+    return tuple(sorted(normalized))
+
+
+def _canonical_mcp_configured_values(value: object) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        return {}
+    normalized: dict[str, str] = {}
+    for raw_key, raw_value in value.items():
+        key = _canonical_mcp_configured_key(raw_key)
+        if key is not None and isinstance(raw_value, str):
+            normalized[key] = raw_value
+    return normalized

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -47,6 +47,7 @@ from .models import (
 from .package_execution_context import package_execution_context_from_scanner_evidence
 from .redaction import redact_text
 from .risk import artifact_risk_signals, artifact_risk_summary
+from .runtime.approval_context import parse_approval_context_token
 from .runtime.command_capability import command_capability_status
 from .store import (
     GuardStore,
@@ -408,11 +409,7 @@ def queue_blocked_approvals(
             unknown_action="require-reapproval",
         )
         policy_action = normalization.action
-        if policy_action not in {
-            "block",
-            "sandbox-required",
-            "require-reapproval",
-        }:
+        if policy_action not in {"require-reapproval", "review"}:
             continue
         scanner_evidence = _item_scanner_evidence(item)
         if not normalization.recognized:
@@ -429,6 +426,13 @@ def queue_blocked_approvals(
         artifact_id = str(item.get("artifact_id") or "")
         if not artifact_id:
             continue
+        approval_context_hash = item.get("approval_context_hash")
+        request_artifact_hash = (
+            approval_context_hash
+            if isinstance(approval_context_hash, str)
+            and parse_approval_context_token(approval_context_hash) is not None
+            else str(item.get("artifact_hash") or "unknown")
+        )
         artifact = artifacts_by_id.get(artifact_id)
         request_id = uuid.uuid4().hex
         risk_summary = _item_risk_summary(item, artifact)
@@ -458,7 +462,7 @@ def queue_blocked_approvals(
             artifact_id=artifact_id,
             artifact_name=_artifact_name(item, artifact_id),
             artifact_type=artifact.artifact_type if artifact is not None else "artifact",
-            artifact_hash=str(item.get("artifact_hash") or "unknown"),
+            artifact_hash=request_artifact_hash,
             policy_action=policy_action,
             recommended_scope="publisher" if artifact is not None and artifact.publisher else "artifact",
             changed_fields=tuple(_string_list(item.get("changed_fields"))),
@@ -501,6 +505,24 @@ def queue_blocked_approvals(
     return queued
 
 
+def evaluation_has_terminal_policy_action(evaluation: Mapping[str, object]) -> bool:
+    """Return whether an evaluation contains a non-overridable policy action."""
+
+    artifacts = evaluation.get("artifacts")
+    if not isinstance(artifacts, list):
+        return False
+    for item in artifacts:
+        if not isinstance(item, Mapping):
+            continue
+        action = normalize_guard_action_result(
+            item.get("policy_action"),
+            unknown_action="require-reapproval",
+        ).action
+        if action in {"block", "sandbox-required"}:
+            return True
+    return False
+
+
 def apply_approval_resolution(
     *,
     store: GuardStore,
@@ -529,6 +551,10 @@ def apply_approval_resolution(
     workspace_artifact_id, workspace_artifact_hash = _workspace_policy_artifact_keys(request, scope)
     request_artifact_id = _string_or_none(request.get("artifact_id"))
     request_artifact_hash = _string_or_none(request.get("artifact_hash"))
+    approval_context_token = (
+        request_artifact_hash if parse_approval_context_token(request_artifact_hash) is not None else None
+    )
+    exact_context_allow = action == "allow" and approval_context_token is not None
     request_publisher = _string_or_none(request.get("publisher"))
     resolved_workspace = resolve_request_workspace_scope(request, workspace) if scope == "workspace" else None
     portable_package_workspace = package_request_portable_workspace_scope(
@@ -541,15 +567,23 @@ def apply_approval_resolution(
         resolved_workspace = portable_package_workspace
     scoped_artifact_id = request_artifact_id if scope in {"artifact", "harness", "global"} else workspace_artifact_id
     scoped_artifact_hash = request_artifact_hash if scope == "artifact" else workspace_artifact_hash
-    artifact_runtime_exact_match_key = _artifact_scope_runtime_exact_match_key(request, scope)
-    if artifact_runtime_exact_match_key is not None:
-        scoped_artifact_hash = artifact_runtime_exact_match_key
-    broad_runtime_exact_match_key = _broad_runtime_exact_match_key(request, scope)
-    if broad_runtime_exact_match_key is not None:
-        scoped_artifact_hash = broad_runtime_exact_match_key
-    browser_mcp_exact_key = _browser_mcp_exact_match_key(request, scope)
-    if browser_mcp_exact_key is not None:
-        scoped_artifact_hash = browser_mcp_exact_key
+    if exact_context_allow:
+        # The token already binds the exact request across every security
+        # dimension. Broad scopes remain match selectors; they do not discard
+        # this exact approval identity or turn it into a broad permission.
+        scoped_artifact_hash = approval_context_token
+        if scope in {"artifact", "workspace", "harness", "global"}:
+            scoped_artifact_id = request_artifact_id
+    else:
+        artifact_runtime_exact_match_key = _artifact_scope_runtime_exact_match_key(request, scope)
+        if artifact_runtime_exact_match_key is not None:
+            scoped_artifact_hash = artifact_runtime_exact_match_key
+        broad_runtime_exact_match_key = _broad_runtime_exact_match_key(request, scope)
+        if broad_runtime_exact_match_key is not None:
+            scoped_artifact_hash = broad_runtime_exact_match_key
+        browser_mcp_exact_key = _browser_mcp_exact_match_key(request, scope)
+        if browser_mcp_exact_key is not None:
+            scoped_artifact_hash = browser_mcp_exact_key
     decision = PolicyDecision(
         harness="*" if scope == "global" else str(request["harness"]),
         scope=scope,
@@ -628,7 +662,7 @@ def apply_approval_resolution(
                 raise ApprovalRequestAlreadyResolvedError(f"Approval request already resolved: {request_id}")
             if error == "not_found":
                 raise ApprovalRequestNotFoundError(f"Unknown approval request: {request_id}")
-        if resolve_scope_matches:
+        if resolve_scope_matches and not exact_context_allow:
             resolved_scope_ids = store.resolve_matching_approval_requests(
                 harness=resolution_harness,
                 scope=scope,
@@ -658,7 +692,7 @@ def apply_approval_resolution(
         )
         return result
     resolved_ids: list[str] = []
-    if resolve_scope_matches:
+    if resolve_scope_matches and not exact_context_allow:
         resolved_ids = store.resolve_matching_approval_requests(
             harness=resolution_harness,
             scope=scope,
@@ -1199,6 +1233,13 @@ def wait_for_approval_requests(
     timeout_seconds: int,
     poll_interval: float = 0.01,
 ) -> dict[str, object]:
+    if not request_ids:
+        return {
+            "resolved": False,
+            "pending_request_ids": [],
+            "items": [],
+            "reason": "no_approval_requests",
+        }
     deadline = time.monotonic() + max(timeout_seconds, 0)
     while True:
         items = [store.get_approval_request(request_id) for request_id in request_ids]
@@ -1259,6 +1300,9 @@ def _artifact_type(item: dict[str, object]) -> str:
 
 
 def _workspace_scope_target(item: dict[str, object], artifact) -> str | None:
+    effective_workspace = item.get("effective_workspace")
+    if isinstance(effective_workspace, str) and effective_workspace.strip():
+        return effective_workspace.strip()
     config_path = _config_path(item, artifact)
     if not config_path:
         return None

--- a/src/codex_plugin_scanner/guard/cli/_commands_shared.py
+++ b/src/codex_plugin_scanner/guard/cli/_commands_shared.py
@@ -61,6 +61,7 @@ from ..approvals import (
     attach_primary_approval_link,
     build_approval_browser_url,
     canonical_local_approval_url,
+    evaluation_has_terminal_policy_action,
     first_approval_url,
     queue_blocked_approvals,
     wait_for_approval_requests,

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ._commands_shared import _now, _require_guard_config, _require_guard_context, _require_guard_store
-    from .commands_support_connect import _refresh_cloud_policy_bundle
+    from .commands_support_connect import _refresh_cloud_policy_bundle, _synced_policy_payload
     from .commands_support_hook_payload import _open_approval_center
     from .commands_support_interaction import _emit, _run_apps_command, _run_consumer_scan_with_mode
     from .commands_support_runtime_policy import _approval_delivery_payload, _localize_pending_approval_copy
@@ -203,13 +203,20 @@ def _run_guard_protect_command(
         payload = build_supply_chain_status_payload(store=store, config=config, now=_now())
         _emit("protect", payload, getattr(args, "json", False))
         return 0
+    protect_workspace = workspace or Path.cwd()
+
+    def current_protect_config() -> GuardConfig:
+        local_config = load_guard_config(guard_home, workspace=protect_workspace)
+        return overlay_synced_guard_policy(local_config, _synced_policy_payload(store))
+
     payload, exit_code = build_protect_payload(
         command=protect_command,
         store=store,
-        workspace_dir=workspace or Path.cwd(),
+        workspace_dir=protect_workspace,
         dry_run=bool(getattr(args, "dry_run", False)),
         now=_now(),
         config=config,
+        current_config_provider=current_protect_config,
         unsafe_raw_output=bool(getattr(args, "unsafe_raw_output", False)),
     )
     _queue_local_protect_approvals(

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_proxy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_proxy.py
@@ -20,6 +20,11 @@ from ._commands_shared import *
 from .commands_parser_helpers import *
 
 
+def _current_proxy_config(context: HarnessContext, store: GuardStore) -> GuardConfig:
+    local_config = load_guard_config(context.guard_home, workspace=context.workspace_dir)
+    return overlay_synced_guard_policy(local_config, _synced_policy_payload(store))
+
+
 def _run_guard_codex_mcp_proxy_command(
     args: argparse.Namespace,
     *,
@@ -45,6 +50,7 @@ def _run_guard_codex_mcp_proxy_command(
         transport=args.transport,
         server_id=args.server_id,
         server_env_keys=tuple(args.server_env_keys),
+        current_config_provider=lambda: _current_proxy_config(context, store),
     )
     return proxy.serve()
 
@@ -74,6 +80,7 @@ def _run_guard_cursor_mcp_proxy_command(
         transport=args.transport,
         server_id=args.server_id,
         server_env_keys=tuple(args.server_env_keys),
+        current_config_provider=lambda: _current_proxy_config(context, store),
     )
     return proxy.serve()
 
@@ -103,6 +110,7 @@ def _run_guard_opencode_mcp_proxy_command(
         transport=args.transport,
         server_id=args.server_id,
         server_env_keys=tuple(args.server_env_keys),
+        current_config_provider=lambda: _current_proxy_config(context, store),
     )
     return proxy.serve()
 
@@ -132,6 +140,7 @@ def _run_guard_copilot_mcp_proxy_command(
         transport=args.transport,
         server_id=args.server_id,
         server_env_keys=tuple(args.server_env_keys),
+        current_config_provider=lambda: _current_proxy_config(context, store),
     )
     return proxy.serve()
 
@@ -331,6 +340,10 @@ def _run_guard_run_command(
     elif not bool(args.dry_run) and config.mode == "prompt":
         blocked_resolver_fn = _headless_approval_resolver(args=args, context=context, store=store, config=config)
 
+    def current_run_config() -> GuardConfig:
+        local_config = load_guard_config(context.guard_home, workspace=context.workspace_dir)
+        return overlay_synced_guard_policy(local_config, _synced_policy_payload(store))
+
     payload = guard_run(
         args.harness,
         context=context,
@@ -341,6 +354,7 @@ def _run_guard_run_command(
         default_action=args.default_action,
         interactive_resolver=interactive_resolver_fn,
         blocked_resolver=blocked_resolver_fn,
+        current_config_provider=current_run_config,
     )
     payload["dry_run"] = bool(args.dry_run)
     payload["rerun_command"] = _guard_rerun_command(args)

--- a/src/codex_plugin_scanner/guard/cli/commands_hook.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from ..runtime.hook_review_types import HookOutputSummary, HookSourceFileRef
     from ._commands_shared import _now, _require_guard_config, _require_guard_context, _require_guard_store
     from .commands_support_claude_approval import _persist_claude_guard_question_decision
+    from .commands_support_connect import _synced_policy_payload
     from .commands_support_hook_payload import _hook_action_envelope, _load_hook_payload, _normalize_hook_payload
     from .commands_support_interaction import _emit
     from .commands_support_permission_store import (
@@ -144,11 +145,30 @@ def _run_guard_hook_command(
             payload=payload,
             home_dir=context.home_dir,
             workspace=runtime_workspace,
+            config=config,
             preferred_workspace_config="ide" if workspace_was_explicit else "cli",
         )
         if args.harness == "copilot"
         else None
     )
+
+    def fresh_copilot_tool_call_authority():
+        fresh_config = overlay_synced_guard_policy(
+            load_guard_config(guard_home, workspace=runtime_workspace),
+            _synced_policy_payload(store),
+        )
+        fresh_tool_call = _copilot_runtime_tool_call(
+            payload=payload,
+            home_dir=context.home_dir,
+            workspace=runtime_workspace,
+            config=fresh_config,
+            preferred_workspace_config="ide" if workspace_was_explicit else "cli",
+        )
+        if fresh_tool_call is None:
+            return None
+        fresh_artifact, fresh_artifact_hash, fresh_arguments = fresh_tool_call
+        return fresh_config, fresh_artifact, fresh_artifact_hash, fresh_arguments
+
     result = _run_hook_copilot_pretool(
         args,
         action_envelope=action_envelope,
@@ -160,6 +180,7 @@ def _run_guard_hook_command(
         payload=payload,
         runtime_workspace=runtime_workspace,
         store=store,
+        fresh_tool_call_authority_provider=fresh_copilot_tool_call_authority,
     )
     if result is not None:
         return result
@@ -168,6 +189,7 @@ def _run_guard_hook_command(
             payload=payload,
             home_dir=context.home_dir,
             workspace=runtime_workspace,
+            config=config,
             preferred_workspace_config="ide" if workspace_was_explicit else "cli",
         )
         if args.harness == "copilot" and _is_copilot_permission_request(payload)
@@ -185,6 +207,7 @@ def _run_guard_hook_command(
         payload=payload,
         runtime_workspace=runtime_workspace,
         store=store,
+        fresh_tool_call_authority_provider=fresh_copilot_tool_call_authority,
     )
     if result is not None:
         return result
@@ -233,6 +256,65 @@ def _run_guard_hook_command(
     ):
         return 0
     if runtime_artifact is not None:
+
+        def evaluate_fresh_runtime_artifact(
+            *,
+            claimed_saved_allow_hash: str | None = None,
+            claimed_trusted_request_override: bool = False,
+            trusted_request_override_hash: str | None = None,
+        ):
+            fresh_config = overlay_synced_guard_policy(
+                load_guard_config(guard_home, workspace=runtime_workspace),
+                _synced_policy_payload(store),
+            )
+            fresh_action_envelope = _hook_action_envelope(
+                harness=args.harness,
+                payload=payload,
+                home_dir=context.home_dir,
+                workspace=runtime_workspace,
+            )
+            fresh_data_flow_signals = _runtime_action_data_flow_signals(
+                fresh_action_envelope,
+                workspace=runtime_workspace,
+            )
+            fresh_runtime_artifact = _hook_runtime_artifact(
+                harness=args.harness,
+                payload=payload,
+                action_envelope=fresh_action_envelope,
+                data_flow_signals=fresh_data_flow_signals,
+                home_dir=context.home_dir,
+                guard_home=context.guard_home,
+                workspace=runtime_workspace,
+            )
+            if fresh_runtime_artifact is None:
+                return None
+            return _evaluate_runtime_artifact_hook(
+                args,
+                action_envelope=fresh_action_envelope,
+                config=fresh_config,
+                context=context,
+                data_flow_signals=fresh_data_flow_signals,
+                guard_home=guard_home,
+                payload=payload,
+                runtime_artifact=fresh_runtime_artifact,
+                runtime_workspace=runtime_workspace,
+                store=store,
+                trusted_request_override_hash=trusted_request_override_hash,
+                post_claim_revalidator=(revalidate_runtime_after_claim if claimed_saved_allow_hash is None else None),
+                _claimed_saved_allow_hash=claimed_saved_allow_hash,
+                _claimed_trusted_request_override=claimed_trusted_request_override,
+                _claim_saved_approval=claimed_saved_allow_hash is None,
+            )
+
+        def revalidate_runtime_after_claim(
+            claimed_artifact_hash: str,
+            trusted_request_override: bool,
+        ):
+            return evaluate_fresh_runtime_artifact(
+                claimed_saved_allow_hash=claimed_artifact_hash,
+                claimed_trusted_request_override=trusted_request_override,
+            )
+
         evaluated = _evaluate_runtime_artifact_hook(
             args,
             action_envelope=action_envelope,
@@ -244,6 +326,7 @@ def _run_guard_hook_command(
             runtime_artifact=runtime_artifact,
             runtime_workspace=runtime_workspace,
             store=store,
+            post_claim_revalidator=revalidate_runtime_after_claim,
         )
         if isinstance(evaluated, int):
             return evaluated
@@ -261,6 +344,13 @@ def _run_guard_hook_command(
         )
         if result is not None:
             return result
+
+        def revalidate_after_browser_wait():
+            fresh_evaluation = evaluate_fresh_runtime_artifact(
+                trusted_request_override_hash=evaluated.runtime_artifact_hash,
+            )
+            return fresh_evaluation if not isinstance(fresh_evaluation, int) else None
+
         return _finalize_runtime_artifact_hook(
             evaluated,
             args,
@@ -268,7 +358,33 @@ def _run_guard_hook_command(
             output_stream=output_stream,
             payload=payload,
             store=store,
+            post_wait_revalidator=revalidate_after_browser_wait,
         )
+
+    def revalidate_generic_after_claim(claimed_artifact_hash: str) -> int:
+        fresh_config = overlay_synced_guard_policy(
+            load_guard_config(guard_home, workspace=runtime_workspace),
+            _synced_policy_payload(store),
+        )
+        fresh_action_envelope = _hook_action_envelope(
+            harness=args.harness,
+            payload=payload,
+            home_dir=context.home_dir,
+            workspace=runtime_workspace,
+        )
+        return _run_hook_generic_payload(
+            args,
+            action_envelope=fresh_action_envelope,
+            config=fresh_config,
+            home_dir=context.home_dir,
+            output_stream=output_stream,
+            payload=payload,
+            runtime_workspace=runtime_workspace,
+            store=store,
+            _claimed_saved_allow_hash=claimed_artifact_hash,
+            _claim_saved_approval=False,
+        )
+
     return _run_hook_generic_payload(
         args,
         action_envelope=action_envelope,
@@ -278,6 +394,7 @@ def _run_guard_hook_command(
         payload=payload,
         runtime_workspace=runtime_workspace,
         store=store,
+        post_claim_revalidator=revalidate_generic_after_claim,
     )
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_claude.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_claude.py
@@ -50,8 +50,9 @@ def _run_hook_claude_permission_request(
     if not _is_claude_permission_request(args, payload_map):
         return None
     notice = _peek_claude_permission_notice(store, payload_map)
-    if notice is not None and _claude_permission_notice_prefers_ask_user_question(notice):
+    if notice is not None:
         _mark_claude_pending_permission_prompt_seen(store=store, payload=payload_map, notice=notice)
+    if notice is not None and _claude_permission_notice_prefers_ask_user_question(notice):
         _emit_native_hook_response(
             harness=args.harness,
             policy_action="block",
@@ -75,7 +76,7 @@ def _run_hook_claude_permission_request(
             runtime_artifact=runtime_artifact,
             runtime_workspace=runtime_workspace,
         )
-        if policy_action not in {"block", "sandbox-required", "require-reapproval"}:
+        if policy_action not in {"review", "require-reapproval", "sandbox-required", "block"}:
             _emit_claude_permission_request_passthrough(output_stream=output_stream)
             return 0
         native_reason = _runtime_artifact_native_reason(runtime_artifact, reason_stub)

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from ..mcp_tool_calls import ToolCallDecision
@@ -28,8 +28,51 @@ if TYPE_CHECKING:
     from .commands_support_runtime_resolution import _canonical_harness_name, _runtime_detection
 
 
+from ..models import GuardAction
 from ._commands_shared import *
 from .commands_parser_helpers import *
+
+
+def _copilot_tool_decision_scanner_evidence(
+    decision: ToolCallDecision,
+) -> tuple[dict[str, object], ...]:
+    evidence: list[dict[str, object]] = []
+    if decision.normalization_reason_code is not None:
+        evidence.append(
+            {
+                "source": "guard_action_normalizer",
+                "input_source": "stored_tool_policy",
+                "reason_code": decision.normalization_reason_code,
+                "original_action": decision.original_action,
+                "normalized_action": decision.action,
+            }
+        )
+    if decision.approval_reuse_reason_code is not None:
+        evidence.append(
+            {
+                "source": "approval_reuse",
+                "status": decision.approval_reuse_status,
+                "reason_code": decision.approval_reuse_reason_code,
+                "current_action": decision.current_action,
+                "saved_action": decision.saved_action,
+                "effective_action": decision.action,
+            }
+        )
+    return tuple(evidence)
+
+
+def _copilot_approval_reuse_evidence(
+    decision: ToolCallDecision,
+) -> dict[str, object] | None:
+    if decision.approval_reuse_reason_code is None:
+        return None
+    return {
+        "status": decision.approval_reuse_status,
+        "reason_code": decision.approval_reuse_reason_code,
+        "current_action": decision.current_action,
+        "saved_action": decision.saved_action,
+        "effective_action": decision.action,
+    }
 
 
 def _queue_observed_copilot_approval(
@@ -66,6 +109,7 @@ def _queue_observed_copilot_approval(
                 if runtime_arguments is not None
                 else artifact.command,
                 "action_envelope_json": _action_envelope_json(action_envelope),
+                "scanner_evidence": list(_copilot_tool_decision_scanner_evidence(decision)),
             }
         ]
     }
@@ -137,6 +181,9 @@ def _run_hook_copilot_pretool(
     payload: Mapping[str, object],
     runtime_workspace: Path | None,
     store: GuardStore,
+    fresh_tool_call_authority_provider: (
+        Callable[[], tuple[GuardConfig, GuardArtifact, str, object] | None] | None
+    ) = None,
 ) -> int | None:
     if copilot_runtime_tool_call is None or copilot_hook_stage != "pretooluse":
         return None
@@ -147,33 +194,48 @@ def _run_hook_copilot_pretool(
         artifact=runtime_artifact,
         artifact_hash=runtime_artifact_hash,
         arguments=runtime_arguments,
+        fresh_authority_provider=fresh_tool_call_authority_provider,
     )
-    policy_action = {
-        "allow": "allow",
-        "warn": "allow",
-        "review": "require-reapproval",
-        "block": "block",
-        "sandbox-required": "sandbox-required",
-        "require-reapproval": "require-reapproval",
-    }.get(decision.action, "require-reapproval")
+    if decision.post_claim_authority is not None:
+        config = decision.post_claim_authority.config
+        runtime_artifact = decision.post_claim_authority.artifact
+        runtime_artifact_hash = decision.post_claim_authority.artifact_hash
+        runtime_arguments = decision.post_claim_authority.arguments
+    policy_action = cast(
+        GuardAction,
+        {
+            "allow": "allow",
+            "warn": "allow",
+            "review": "require-reapproval",
+            "block": "block",
+            "sandbox-required": "sandbox-required",
+            "require-reapproval": "require-reapproval",
+        }.get(decision.action, "require-reapproval"),
+    )
+    approval_reuse = _copilot_approval_reuse_evidence(decision)
+    decision_scanner_evidence = _copilot_tool_decision_scanner_evidence(decision)
+    saved_policy_blocks = decision.saved_action == "block"
+    post_claim_failure = decision.post_claim_revalidated and policy_action != "allow"
+    terminal_action = policy_action in {"block", "sandbox-required"}
     now = _now()
-    if config.mode == "observe" and policy_action != "allow":
-        _queue_observed_copilot_approval(
-            artifact=runtime_artifact,
-            artifact_hash=runtime_artifact_hash,
-            artifact_name=runtime_artifact.name,
-            args=args,
-            action_envelope=action_envelope,
-            config=config,
-            context=context,
-            decision=decision,
-            guard_home=context.guard_home,
-            managed_install=None,
-            payload=payload,
-            runtime_arguments=runtime_arguments,
-            runtime_workspace=runtime_workspace,
-            store=store,
-        )
+    if config.mode == "observe" and policy_action != "allow" and not saved_policy_blocks and not post_claim_failure:
+        if not terminal_action:
+            _queue_observed_copilot_approval(
+                artifact=runtime_artifact,
+                artifact_hash=runtime_artifact_hash,
+                artifact_name=runtime_artifact.name,
+                args=args,
+                action_envelope=action_envelope,
+                config=config,
+                context=context,
+                decision=decision,
+                guard_home=context.guard_home,
+                managed_install=None,
+                payload=payload,
+                runtime_arguments=runtime_arguments,
+                runtime_workspace=runtime_workspace,
+                store=store,
+            )
         policy_action = "allow"
     if policy_action == "allow":
         allow_tool_call(
@@ -186,6 +248,7 @@ def _run_hook_copilot_pretool(
             risk_categories=decision.risk_categories,
             remember=False,
             arguments=runtime_arguments,
+            additional_scanner_evidence=decision_scanner_evidence,
         )
         if _should_emit_copilot_hook_response(args):
             _record_harness_usage_for_hook(
@@ -194,7 +257,13 @@ def _run_hook_copilot_pretool(
                 payload=payload,
                 policy_action=policy_action,
             )
-            _emit_copilot_hook_response(policy_action="allow", reason="", output_stream=output_stream)
+            _emit_copilot_hook_response(
+                policy_action="allow",
+                reason="",
+                approval_reuse=approval_reuse,
+                scanner_evidence=decision_scanner_evidence,
+                output_stream=output_stream,
+            )
             return 0
     else:
         if policy_action in {"block", "sandbox-required"}:
@@ -207,6 +276,8 @@ def _run_hook_copilot_pretool(
                 signals=decision.signals,
                 risk_categories=decision.risk_categories,
                 arguments=runtime_arguments,
+                additional_scanner_evidence=decision_scanner_evidence,
+                policy_action=policy_action,
             )
         if _should_emit_copilot_hook_response(args):
             _record_harness_usage_for_hook(
@@ -217,7 +288,13 @@ def _run_hook_copilot_pretool(
             )
             _emit_copilot_hook_response(
                 policy_action=policy_action,
-                reason=_copilot_hook_reason(decision.summary, runtime_artifact.name),
+                reason=(
+                    f"HOL Guard blocked {runtime_artifact.name}. {decision.summary}"
+                    if saved_policy_blocks
+                    else _copilot_hook_reason(decision.summary, runtime_artifact.name)
+                ),
+                approval_reuse=approval_reuse,
+                scanner_evidence=decision_scanner_evidence,
                 output_stream=output_stream,
             )
             return 0
@@ -236,27 +313,44 @@ def _run_hook_copilot_permission_request(
     payload: Mapping[str, object],
     runtime_workspace: Path | None,
     store: GuardStore,
+    fresh_tool_call_authority_provider: (
+        Callable[[], tuple[GuardConfig, GuardArtifact, str, object] | None] | None
+    ) = None,
 ) -> int | None:
     if copilot_permission_request is None:
         return None
     runtime_artifact, runtime_artifact_hash, runtime_arguments = copilot_permission_request
-    artifact_id = runtime_artifact.artifact_id
-    artifact_name = runtime_artifact.name
     decision = evaluate_tool_call(
         store=store,
         config=config,
         artifact=runtime_artifact,
         artifact_hash=runtime_artifact_hash,
         arguments=runtime_arguments,
+        fresh_authority_provider=fresh_tool_call_authority_provider,
     )
-    policy_action = {
-        "allow": "allow",
-        "warn": "allow",
-        "review": "require-reapproval",
-        "block": "block",
-        "sandbox-required": "sandbox-required",
-        "require-reapproval": "require-reapproval",
-    }.get(decision.action, "require-reapproval")
+    if decision.post_claim_authority is not None:
+        config = decision.post_claim_authority.config
+        runtime_artifact = decision.post_claim_authority.artifact
+        runtime_artifact_hash = decision.post_claim_authority.artifact_hash
+        runtime_arguments = decision.post_claim_authority.arguments
+    artifact_id = runtime_artifact.artifact_id
+    artifact_name = runtime_artifact.name
+    policy_action = cast(
+        GuardAction,
+        {
+            "allow": "allow",
+            "warn": "allow",
+            "review": "require-reapproval",
+            "block": "block",
+            "sandbox-required": "sandbox-required",
+            "require-reapproval": "require-reapproval",
+        }.get(decision.action, "require-reapproval"),
+    )
+    approval_reuse = _copilot_approval_reuse_evidence(decision)
+    decision_scanner_evidence = _copilot_tool_decision_scanner_evidence(decision)
+    saved_policy_blocks = decision.saved_action == "block"
+    post_claim_failure = decision.post_claim_revalidated and policy_action != "allow"
+    terminal_action = policy_action in {"block", "sandbox-required"}
     runtime_detection = _runtime_detection(args.harness, runtime_artifact)
     evaluation_payload: dict[str, object] = {
         "artifacts": [
@@ -273,6 +367,7 @@ def _run_hook_copilot_permission_request(
                 if runtime_arguments is not None
                 else runtime_artifact.command,
                 "action_envelope_json": _action_envelope_json(action_envelope),
+                "scanner_evidence": list(decision_scanner_evidence),
             }
         ]
     }
@@ -290,24 +385,34 @@ def _run_hook_copilot_permission_request(
         if runtime_arguments is not None
         else runtime_artifact.command,
     }
-    if config.mode == "observe" and policy_action != "allow":
-        queued = _queue_observed_copilot_approval(
-            artifact=runtime_artifact,
-            artifact_hash=runtime_artifact_hash,
-            artifact_name=artifact_name,
-            args=args,
-            action_envelope=action_envelope,
-            config=config,
-            context=context,
-            decision=decision,
-            guard_home=guard_home,
-            managed_install=managed_install,
-            payload=payload,
-            runtime_arguments=runtime_arguments,
-            runtime_workspace=runtime_workspace,
-            store=store,
+    if approval_reuse is not None:
+        response_payload["approval_reuse"] = approval_reuse
+    if decision_scanner_evidence:
+        response_payload["scanner_evidence"] = list(decision_scanner_evidence)
+    if config.mode == "observe" and policy_action != "allow" and not saved_policy_blocks and not post_claim_failure:
+        queued = (
+            []
+            if terminal_action
+            else _queue_observed_copilot_approval(
+                artifact=runtime_artifact,
+                artifact_hash=runtime_artifact_hash,
+                artifact_name=artifact_name,
+                args=args,
+                action_envelope=action_envelope,
+                config=config,
+                context=context,
+                decision=decision,
+                guard_home=guard_home,
+                managed_install=managed_install,
+                payload=payload,
+                runtime_arguments=runtime_arguments,
+                runtime_workspace=runtime_workspace,
+                store=store,
+            )
         )
         response_payload["approval_requests"] = queued
+        if terminal_action:
+            response_payload["observed_terminal_action"] = policy_action
         policy_action = "allow"
         response_payload["policy_action"] = "allow"
     if policy_action == "allow":
@@ -321,6 +426,7 @@ def _run_hook_copilot_permission_request(
             risk_categories=decision.risk_categories,
             remember=False,
             arguments=runtime_arguments,
+            additional_scanner_evidence=decision_scanner_evidence,
         )
         if _should_emit_copilot_hook_response(args):
             _record_harness_usage_for_hook(
@@ -329,7 +435,12 @@ def _run_hook_copilot_permission_request(
                 payload=payload,
                 policy_action=policy_action,
             )
-            _emit_copilot_permission_request_response(behavior="allow", output_stream=output_stream)
+            _emit_copilot_permission_request_response(
+                behavior="allow",
+                approval_reuse=approval_reuse,
+                scanner_evidence=decision_scanner_evidence,
+                output_stream=output_stream,
+            )
             return 0
         _record_harness_usage_for_hook(
             store=store,
@@ -348,7 +459,31 @@ def _run_hook_copilot_permission_request(
         signals=decision.signals,
         risk_categories=decision.risk_categories,
         arguments=runtime_arguments,
+        additional_scanner_evidence=decision_scanner_evidence,
+        policy_action=policy_action,
     )
+    if terminal_action:
+        response_payload["approval_requests"] = []
+        response_payload["terminal"] = True
+        response_payload["terminal_action"] = policy_action
+        _record_harness_usage_for_hook(
+            store=store,
+            action_envelope=action_envelope,
+            payload=payload,
+            policy_action=policy_action,
+        )
+        if _should_emit_copilot_hook_response(args):
+            _emit_copilot_permission_request_response(
+                behavior="deny",
+                message=f"HOL Guard blocked {artifact_name}. {decision.summary}",
+                interrupt=True,
+                approval_reuse=approval_reuse,
+                scanner_evidence=decision_scanner_evidence,
+                output_stream=output_stream,
+            )
+            return 0
+        _emit("hook", response_payload, getattr(args, "json", False))
+        return 1
     approval_center_url = ensure_guard_daemon(guard_home)
     approval_flow = get_adapter(args.harness).approval_flow(managed_install=managed_install)
     try:
@@ -446,6 +581,8 @@ def _run_hook_copilot_permission_request(
                 review_context,
             ),
             interrupt=True,
+            approval_reuse=approval_reuse,
+            scanner_evidence=decision_scanner_evidence,
             output_stream=output_stream,
         )
         return 0

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -4,13 +4,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from ._commands_shared import (
         _HOOK_DAEMON_FAIL_MODES,
         _HOOK_DAEMON_FAILURE_STATUSES,
-        _HOOK_DAEMON_PERMISSIVE_REASON,
         _HOOK_DAEMON_PRESERVED_DENY_REASON,
         _HOOK_DAEMON_STRICT_REASON,
     )
@@ -52,8 +51,401 @@ if TYPE_CHECKING:
     from .commands_support_runtime_resolution import _canonical_harness_name, _copilot_hook_stage
 
 
+from ..action_lattice import (
+    guard_action_severity,
+    most_restrictive_guard_action,
+    normalize_guard_action_result,
+)
+from ..models import GuardAction
+from ..runtime.approval_context import (
+    approval_context_tokens_validation_reason,
+    build_approval_context_token,
+    build_runtime_launch_identity,
+)
+from ..runtime.approval_reuse import (
+    APPROVAL_REUSE_CLAIM_FAILED,
+    APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
+    ApprovalReuseDecision,
+    ApprovalReuseValidationFailure,
+    evaluate_approval_reuse,
+)
 from ._commands_shared import *
 from .commands_parser_helpers import *
+from .commands_support_runtime_policy import _runtime_hook_effective_policy_config
+
+# Bump when generic-hook classification or action-composition semantics change.
+_GENERIC_HOOK_EVALUATOR_POLICY_VERSION = "generic-hook-evaluation-v1"
+
+_GENERIC_HOOK_EXPLICIT_POSIX_SHELL_TOOLS = frozenset({"ash", "bash", "dash", "sh", "zsh"})
+
+_GENERIC_HOOK_NON_CONTENT_FIELDS = frozenset(
+    {
+        "action_id",
+        "approval_center_url",
+        "approval_delivery",
+        "approval_request_id",
+        "approval_requests",
+        "call_id",
+        "daemon_status",
+        "event_id",
+        "event_time",
+        "fail_mode",
+        "hook_id",
+        "invocation_id",
+        "message_id",
+        "permission_decision_reason",
+        "policy_action",
+        "received_at",
+        "request_id",
+        "review_hint",
+        "session_id",
+        "thread_id",
+        "timestamp",
+        "tool_call_id",
+        "tool_use_id",
+        "trace_id",
+        "turn_id",
+        "user_override",
+    }
+)
+
+_COPILOT_VERIFIED_BENIGN_PAYLOAD_HINT_REASON = "untrusted_hook_payload_hint_ignored_guard_verified_benign"
+_UNTRUSTED_DAEMON_PERMISSIVE_REASON = (
+    "HOL Guard received an unauthenticated hint that the daemon was unreachable in permissive mode; "
+    "the current local policy action was preserved."
+)
+_UNTRUSTED_DAEMON_PERMISSIVE_REASON_CODE = "untrusted_daemon_permissive_hint_preserved_current_action"
+_UNTRUSTED_DAEMON_STRICT_REASON_CODE = "untrusted_daemon_strict_hint_tightened_to_block"
+
+
+def _generic_hook_ignored_payload_action_reason(
+    *,
+    args: argparse.Namespace,
+    home_dir: Path | None,
+    payload: dict[str, object],
+    payload_action_recognized: bool,
+    runtime_workspace: Path | None,
+) -> str | None:
+    """Explain why a legacy Copilot policy hint is not an authority input.
+
+    ``policyAction`` is not part of Copilot's native pre-tool input contract,
+    and generic hook stdin has no authenticated provenance.  Retain it as a
+    conservative hint for opaque actions, but omit it from policy composition
+    when Guard's own command classifier has positively established that the
+    generic fallback action is read-only.
+
+    Unknown action spellings remain fail-closed through the normalizer.  The
+    caller reaches this generic path only after modeled runtime artifacts,
+    package requests, and data-flow signals have been evaluated.
+    """
+
+    if (
+        not payload_action_recognized
+        or _canonical_harness_name(args.harness) != "copilot"
+        or _copilot_hook_stage(payload) != "pretooluse"
+    ):
+        return None
+    if not is_explicitly_benign_tool_action_request(
+        payload.get("tool_name"),
+        payload.get("tool_input", payload.get("arguments")),
+        cwd=runtime_workspace,
+        home_dir=home_dir,
+    ):
+        return None
+    return _COPILOT_VERIFIED_BENIGN_PAYLOAD_HINT_REASON
+
+
+def _generic_hook_payload_digest(payload: Mapping[str, object]) -> str:
+    """Return a stable action digest without delivery metadata or policy hints.
+
+    Hook transports assign fresh request, session, tool-use, and timestamp fields
+    when an otherwise identical action is retried.  Those top-level delivery
+    fields are not part of the action the user reviewed.  Nested fields remain
+    intact because, for an opaque tool, a value such as
+    ``tool_input.request_id`` can be a real action argument.
+    """
+
+    content_payload = {
+        key: value
+        for key, value in payload.items()
+        if _generic_hook_content_key(key) not in _GENERIC_HOOK_NON_CONTENT_FIELDS
+        and _generic_hook_content_key(key) != "artifact_hash"
+    }
+    encoded = json.dumps(
+        content_payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _generic_hook_content_key(key: str) -> str:
+    """Canonicalize top-level hook keys across snake/camel/kebab transports."""
+
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", key).replace("-", "_").lower()
+
+
+def _generic_hook_workspace_identity(runtime_workspace: Path | None) -> str:
+    workspace = runtime_workspace or Path.cwd()
+    try:
+        return str(workspace.expanduser().resolve(strict=False))
+    except (OSError, RuntimeError):
+        return str(workspace.expanduser().absolute())
+
+
+def _generic_hook_action_capabilities(
+    action_envelope: GuardActionEnvelope | None,
+) -> dict[str, object] | None:
+    if action_envelope is None:
+        return None
+    return {
+        "action_type": action_envelope.action_type,
+        "event_name": action_envelope.event_name,
+        "mcp_server": action_envelope.mcp_server,
+        "mcp_tool": action_envelope.mcp_tool,
+        "network_hosts": list(action_envelope.network_hosts),
+        "package_intent_kind": action_envelope.package_intent_kind,
+        "package_manager": action_envelope.package_manager,
+        "package_targets": list(action_envelope.package_targets),
+        "target_paths": list(action_envelope.target_paths),
+        "tool_name": action_envelope.tool_name,
+    }
+
+
+def _generic_hook_runtime_launch_identity(
+    action_envelope: GuardActionEnvelope | None,
+    payload: Mapping[str, object],
+    *,
+    launch_cwd: Path,
+) -> dict[str, object]:
+    """Content-bind the complete launch represented by a generic hook action.
+
+    The normalized action envelope is preferred because it has already
+    removed transparent shell wrappers.  Payload fallbacks cover harnesses
+    that do not produce an action envelope.  The shared launch identity binds
+    the executable, argv, launch cwd, and any supported local interpreted
+    entrypoint.  Malformed or unresolved launch vectors receive a nonce so
+    saved approval reuse fails closed.
+    """
+
+    command_source: str | None = None
+    command: str | None = None
+    tool_command = command_text_from_tool_payload(
+        payload.get("tool_name"),
+        payload.get("tool_input", payload.get("arguments")),
+    )
+    if action_envelope is not None and isinstance(action_envelope.command, str) and action_envelope.command.strip():
+        command_source = "action_envelope"
+        command = action_envelope.command.strip()
+    else:
+        payload_command = payload.get("command")
+        if isinstance(payload_command, str) and payload_command.strip():
+            command_source = "payload"
+            command = payload_command.strip()
+        else:
+            if isinstance(tool_command, str) and tool_command.strip():
+                command_source = "payload_tool_input"
+                command = tool_command.strip()
+
+    tool_name = payload.get("tool_name")
+    normalized_tool_name = tool_name.strip().lower() if isinstance(tool_name, str) else None
+    if (
+        normalized_tool_name in _GENERIC_HOOK_EXPLICIT_POSIX_SHELL_TOOLS
+        and isinstance(tool_command, str)
+        and tool_command.strip()
+    ):
+        command_source = "payload_tool_input_shell"
+        command = tool_command.strip()
+        resolved_launch = build_runtime_launch_identity(
+            normalized_tool_name,
+            args=("-c", command),
+            structured_command=True,
+            cwd=launch_cwd,
+            launch_env=os.environ,
+        )
+    else:
+        resolved_launch = build_runtime_launch_identity(
+            command,
+            cwd=launch_cwd,
+            launch_env=os.environ,
+        )
+
+    return {
+        "command": command,
+        "command_source": command_source,
+        "resolved_launch": resolved_launch,
+    }
+
+
+def _generic_hook_approval_context_token(
+    *,
+    action_envelope: GuardActionEnvelope | None,
+    artifact_id: str,
+    artifact_name: str,
+    config: GuardConfig,
+    current_action: GuardAction,
+    current_config_action: GuardAction,
+    daemon_hint_disposition: str | None,
+    daemon_hint_reason_code: str | None,
+    daemon_status: str | None,
+    fail_mode: str | None,
+    harness: str,
+    payload: Mapping[str, object],
+    publisher: str | None,
+    runtime_workspace: Path | None,
+    trusted_cli_action: GuardAction | None,
+    untrusted_payload_action: GuardAction | None,
+    untrusted_payload_action_disposition: str | None,
+    untrusted_payload_action_reason: str | None,
+) -> str:
+    """Bind a generic fallback approval to its exact recomputed context."""
+
+    launch_cwd = runtime_workspace or Path.cwd()
+    return build_approval_context_token(
+        identity={
+            "artifact_id": artifact_id,
+            "artifact_name": artifact_name,
+            "canonical_harness": _canonical_harness_name(harness),
+            "harness": harness,
+            "publisher": publisher,
+            "runtime_launch": _generic_hook_runtime_launch_identity(
+                action_envelope,
+                payload,
+                launch_cwd=launch_cwd,
+            ),
+            "source_scope": _coalesce_string(payload.get("source_scope"), "project"),
+            "workspace": _generic_hook_workspace_identity(runtime_workspace),
+        },
+        content={
+            "payload_digest": _generic_hook_payload_digest(payload),
+            "provided_artifact_hash": _optional_string(payload.get("artifact_hash")),
+        },
+        capabilities={
+            "action_envelope": _generic_hook_action_capabilities(action_envelope),
+            "changed_capabilities": _string_list(payload.get("changed_capabilities")),
+            "event_name": _hook_event_name(dict(payload)) or "PreToolUse",
+            "tool_name": _optional_string(payload.get("tool_name")),
+        },
+        policy={
+            "config": _runtime_hook_effective_policy_config(config),
+            "evaluator_policy_version": _GENERIC_HOOK_EVALUATOR_POLICY_VERSION,
+            "composition": {
+                "current_action": current_action,
+                "current_config_action": current_config_action,
+                "daemon_hint_disposition": daemon_hint_disposition,
+                "daemon_hint_reason_code": daemon_hint_reason_code,
+                "daemon_status": daemon_status,
+                "fail_mode": fail_mode,
+                "trusted_cli_action": trusted_cli_action,
+                "untrusted_payload_action": untrusted_payload_action,
+                "untrusted_payload_action_disposition": untrusted_payload_action_disposition,
+                "untrusted_payload_action_reason": untrusted_payload_action_reason,
+            },
+        },
+        sandbox={
+            "analysis": config.sandbox_analysis,
+            "required": current_action == "sandbox-required",
+        },
+    )
+
+
+def _generic_hook_saved_decision(
+    *,
+    artifact_hash: str,
+    artifact_id: str,
+    artifact_name: str,
+    harness: str,
+    legacy_artifact_hash: str | None,
+    payload: Mapping[str, object],
+    publisher: str | None,
+    runtime_workspace: Path | None,
+    store: GuardStore,
+) -> tuple[dict[str, object] | None, dict[str, object] | None]:
+    """Peek saved evidence, retaining legacy blocks without trusting legacy allows."""
+
+    workspace = str(runtime_workspace) if runtime_workspace is not None else None
+    lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
+        harness,
+        artifact_id,
+        artifact_hash=artifact_hash,
+        workspace=workspace,
+        publisher=publisher,
+        memory_command=_coalesce_string(payload.get("command"), payload.get("tool_name")),
+        memory_artifact_type=_coalesce_string(payload.get("artifact_type"), payload.get("tool_type")),
+        memory_artifact_name=artifact_name,
+        consume_one_shot=False,
+    )
+    selected_decision = lookup["decision"]
+    ignored_integrity = lookup.get("ignored_local_integrity")
+    if legacy_artifact_hash is not None and legacy_artifact_hash != artifact_hash:
+        legacy_lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
+            harness,
+            artifact_id,
+            artifact_hash=legacy_artifact_hash,
+            workspace=workspace,
+            publisher=publisher,
+            memory_command=_coalesce_string(payload.get("command"), payload.get("tool_name")),
+            memory_artifact_type=_coalesce_string(payload.get("artifact_type"), payload.get("tool_type")),
+            memory_artifact_name=artifact_name,
+            consume_one_shot=False,
+        )
+        legacy_decision = legacy_lookup["decision"]
+        if ignored_integrity is None:
+            ignored_integrity = legacy_lookup.get("ignored_local_integrity")
+        if legacy_decision is not None and (
+            selected_decision is None
+            or guard_action_severity(legacy_decision.get("action"), unknown_action="block")
+            > guard_action_severity(selected_decision.get("action"), unknown_action="block")
+        ):
+            selected_decision = legacy_decision
+    return selected_decision, ignored_integrity
+
+
+def _generic_hook_approval_reuse(
+    *,
+    artifact_hash: str,
+    artifact_id: str,
+    current_action: GuardAction,
+    decision: dict[str, object] | None,
+    harness: str,
+    ignored_integrity: dict[str, object] | None,
+    publisher: str | None,
+    runtime_workspace: Path | None,
+    store: GuardStore,
+) -> tuple[ApprovalReuseDecision, bool]:
+    saved_action: object | None = decision.get("action") if decision is not None else None
+    saved_present = decision is not None or ignored_integrity is not None
+    validation_reason: ApprovalReuseValidationFailure | None = None
+    if ignored_integrity is not None:
+        if decision is None:
+            saved_action = "require-reapproval"
+        validation_reason = "approval_reuse_integrity_failure"
+    elif decision is not None and decision.get("action") == "allow":
+        validation_reason = cast(
+            ApprovalReuseValidationFailure | None,
+            approval_context_tokens_validation_reason(decision.get("artifact_hash"), artifact_hash),
+        )
+    if not saved_present:
+        diagnosed_reason = store.approval_reuse_validation_reason(
+            harness,
+            artifact_id,
+            artifact_hash,
+            str(runtime_workspace) if runtime_workspace is not None else None,
+            publisher,
+        )
+        if diagnosed_reason is not None:
+            saved_action = "allow"
+            saved_present = True
+            validation_reason = cast(ApprovalReuseValidationFailure, diagnosed_reason)
+    reuse = evaluate_approval_reuse(
+        current_action,
+        saved_action,
+        saved_decision_present=saved_present,
+        validation_reason=validation_reason,
+    )
+    return reuse, saved_present
 
 
 def _run_hook_generic_payload(
@@ -66,9 +458,12 @@ def _run_hook_generic_payload(
     payload: Mapping[str, object],
     runtime_workspace: Path | None,
     store: GuardStore,
+    post_claim_revalidator: Callable[[str], int | None] | None = None,
+    _claimed_saved_allow_hash: str | None = None,
+    _claim_saved_approval: bool = True,
+    _post_claim_refresh_failed: bool = False,
 ) -> int:
     payload_map = dict(payload)
-    runtime_artifact = None
     artifact_id = _coalesce_string(
         getattr(args, "artifact_id", None),
         payload_map.get("artifact_id"),
@@ -80,72 +475,267 @@ def _run_hook_generic_payload(
         payload_map.get("tool_name"),
         artifact_id,
     )
-    stored_policy_action = store.resolve_policy(
+    publisher = _optional_string(payload_map.get("publisher"))
+    configured_override = config.resolve_action_override(
         args.harness,
         artifact_id,
-        str(payload_map.get("artifact_hash")) if isinstance(payload_map.get("artifact_hash"), str) else None,
-        str(runtime_workspace) if runtime_workspace else None,
-        memory_command=_coalesce_string(
-            payload_map.get("command"),
-            payload_map.get("tool_name"),
-        ),
-        memory_artifact_type=_coalesce_string(
-            payload_map.get("artifact_type"),
-            payload_map.get("tool_type"),
-        ),
-        memory_artifact_name=artifact_name,
+        publisher,
     )
-    incoming_policy_action = _optional_string(payload_map.get("policy_action"))
-    policy_action = _coalesce_string(
-        getattr(args, "policy_action", None),
-        stored_policy_action,
-        incoming_policy_action,
-        config.default_action,
+    current_config_normalization = normalize_guard_action_result(
+        configured_override if configured_override is not None else config.default_action,
+        unknown_action="require-reapproval",
     )
-    if (
-        _canonical_harness_name(args.harness) == "copilot"
-        and _copilot_hook_stage(payload_map) == "pretooluse"
-        and runtime_artifact is None
-        and stored_policy_action is None
-        and not isinstance(getattr(args, "policy_action", None), str)
-        and incoming_policy_action in VALID_GUARD_ACTIONS
-        and is_explicitly_benign_tool_action_request(
-            payload_map.get("tool_name"),
-            payload_map.get("tool_input", payload_map.get("arguments")),
-            cwd=runtime_workspace,
-            home_dir=home_dir,
-        )
-    ):
-        policy_action = "allow"
-    if (
-        stored_policy_action is None
-        and not isinstance(getattr(args, "policy_action", None), str)
-        and not isinstance(payload_map.get("policy_action"), str)
-        and runtime_artifact is not None
-        and runtime_artifact.artifact_type == "tool_action_request"
-    ):
-        policy_action = SAFE_CHANGED_HASH_ACTION
-    if policy_action not in VALID_GUARD_ACTIONS:
-        policy_action = SAFE_CHANGED_HASH_ACTION
+    cli_action = getattr(args, "policy_action", None)
+    cli_action_normalization = (
+        normalize_guard_action_result(cli_action, unknown_action="require-reapproval")
+        if cli_action is not None
+        else None
+    )
+    payload_action_normalization = (
+        normalize_guard_action_result(payload_map.get("policy_action"), unknown_action="require-reapproval")
+        if "policy_action" in payload_map
+        else None
+    )
+    ignored_payload_action_reason = _generic_hook_ignored_payload_action_reason(
+        args=args,
+        home_dir=home_dir,
+        payload=payload_map,
+        payload_action_recognized=(
+            payload_action_normalization.recognized if payload_action_normalization is not None else False
+        ),
+        runtime_workspace=runtime_workspace,
+    )
+    payload_action_disposition = (
+        "ignored"
+        if ignored_payload_action_reason is not None
+        else "applied"
+        if payload_action_normalization is not None
+        else None
+    )
+    current_action_inputs: list[GuardAction] = [current_config_normalization.action]
+    if cli_action_normalization is not None:
+        current_action_inputs.append(cli_action_normalization.action)
+    if payload_action_normalization is not None and ignored_payload_action_reason is None:
+        # Hook payloads are untrusted hints. They may make local policy stricter
+        # but can never lower the current configured action.
+        current_action_inputs.append(payload_action_normalization.action)
+    policy_action = most_restrictive_guard_action(*current_action_inputs)
     daemon_status = _optional_string(payload_map.get("daemon_status"))
     fail_mode = _optional_string(payload_map.get("fail_mode"))
     daemon_failure_reason: str | None = None
+    daemon_hint_disposition: str | None = None
+    daemon_hint_reason_code: str | None = None
     if daemon_status in _HOOK_DAEMON_FAILURE_STATUSES and fail_mode in _HOOK_DAEMON_FAIL_MODES:
         if fail_mode == "strict":
-            policy_action = "block"
+            previous_action = policy_action
+            policy_action = most_restrictive_guard_action(policy_action, "block")
+            daemon_hint_disposition = "preserved_current_block" if previous_action == "block" else "tightened_to_block"
+            daemon_hint_reason_code = _UNTRUSTED_DAEMON_STRICT_REASON_CODE
             daemon_failure_reason = _HOOK_DAEMON_STRICT_REASON
             payload_map["permission_decision_reason"] = daemon_failure_reason
         else:
-            if policy_action in {"block", "sandbox-required", "require-reapproval"}:
+            daemon_hint_disposition = "preserved_current_action"
+            daemon_hint_reason_code = _UNTRUSTED_DAEMON_PERMISSIVE_REASON_CODE
+            if policy_action in {"review", "require-reapproval", "sandbox-required", "block"}:
                 daemon_failure_reason = _coalesce_string(
                     payload_map.get("permission_decision_reason"),
                     _HOOK_DAEMON_PRESERVED_DENY_REASON,
                 )
                 payload_map["permission_decision_reason"] = daemon_failure_reason
             else:
-                policy_action = "allow"
-                daemon_failure_reason = _HOOK_DAEMON_PERMISSIVE_REASON
+                daemon_failure_reason = _UNTRUSTED_DAEMON_PERMISSIVE_REASON
                 payload_map["permission_decision_reason"] = daemon_failure_reason
+    current_policy_action = policy_action
+    runtime_artifact_hash = _generic_hook_approval_context_token(
+        action_envelope=action_envelope,
+        artifact_id=artifact_id,
+        artifact_name=artifact_name,
+        config=config,
+        current_action=current_policy_action,
+        current_config_action=current_config_normalization.action,
+        daemon_hint_disposition=daemon_hint_disposition,
+        daemon_hint_reason_code=daemon_hint_reason_code,
+        daemon_status=daemon_status,
+        fail_mode=fail_mode,
+        harness=args.harness,
+        payload=payload_map,
+        publisher=publisher,
+        runtime_workspace=runtime_workspace,
+        trusted_cli_action=(cli_action_normalization.action if cli_action_normalization is not None else None),
+        untrusted_payload_action=(
+            payload_action_normalization.action if payload_action_normalization is not None else None
+        ),
+        untrusted_payload_action_disposition=payload_action_disposition,
+        untrusted_payload_action_reason=ignored_payload_action_reason,
+    )
+    legacy_artifact_hash = _optional_string(payload_map.get("artifact_hash"))
+    stored_policy_decision, ignored_integrity = _generic_hook_saved_decision(
+        artifact_hash=runtime_artifact_hash,
+        artifact_id=artifact_id,
+        artifact_name=artifact_name,
+        harness=args.harness,
+        legacy_artifact_hash=legacy_artifact_hash,
+        payload=payload_map,
+        publisher=publisher,
+        runtime_workspace=runtime_workspace,
+        store=store,
+    )
+    approval_reuse, saved_decision_present = _generic_hook_approval_reuse(
+        artifact_hash=runtime_artifact_hash,
+        artifact_id=artifact_id,
+        current_action=current_policy_action,
+        decision=stored_policy_decision,
+        harness=args.harness,
+        ignored_integrity=ignored_integrity,
+        publisher=publisher,
+        runtime_workspace=runtime_workspace,
+        store=store,
+    )
+    if approval_reuse.should_claim and stored_policy_decision is not None and _claim_saved_approval:
+        if not store.claim_approval_reuse_decision(stored_policy_decision):
+            approval_reuse = evaluate_approval_reuse(
+                current_policy_action,
+                stored_policy_decision.get("action"),
+                saved_decision_present=True,
+                validation_reason=APPROVAL_REUSE_CLAIM_FAILED,
+            )
+        else:
+            # A successful one-shot claim is not itself the launch authority.
+            # Rebuild the complete current context after the atomic write so a
+            # policy/configuration mutation performed by the claiming store (or
+            # racing with it) cannot inherit the stale pre-claim allow.
+            if post_claim_revalidator is not None:
+                try:
+                    refreshed_result = post_claim_revalidator(runtime_artifact_hash)
+                except Exception:
+                    refreshed_result = None
+                if refreshed_result is not None:
+                    return refreshed_result
+                _post_claim_refresh_failed = True
+            return _run_hook_generic_payload(
+                args,
+                action_envelope=action_envelope,
+                config=config,
+                home_dir=home_dir,
+                output_stream=output_stream,
+                payload=payload,
+                runtime_workspace=runtime_workspace,
+                store=store,
+                post_claim_revalidator=None,
+                _claimed_saved_allow_hash=runtime_artifact_hash,
+                _claim_saved_approval=False,
+                _post_claim_refresh_failed=_post_claim_refresh_failed,
+            )
+    policy_action = approval_reuse.action
+    stored_policy_action = (
+        _optional_string(stored_policy_decision.get("action")) if stored_policy_decision is not None else None
+    )
+    approval_reuse_source = (
+        "saved_policy_decision"
+        if stored_policy_decision is not None
+        else "saved_policy_integrity"
+        if ignored_integrity is not None
+        else "invalidated_saved_policy"
+        if saved_decision_present
+        else None
+    )
+    if _claimed_saved_allow_hash is not None:
+        context_changed = approval_context_tokens_validation_reason(
+            _claimed_saved_allow_hash,
+            runtime_artifact_hash,
+        )
+        claimed_validation_reason: ApprovalReuseValidationFailure | None = (
+            APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM
+            if _post_claim_refresh_failed or context_changed is not None
+            else None
+        )
+        if ignored_integrity is not None:
+            claimed_validation_reason = "approval_reuse_integrity_failure"
+
+        # An unclaimed allow found by the fresh lookup is evidence only. The
+        # already-claimed exact row may satisfy a freshly recomputed review;
+        # fresh blocks and terminal current actions remain authoritative.
+        post_claim_current_action = policy_action
+        if approval_reuse.saved_action == "allow" and approval_reuse.action == "allow":
+            post_claim_current_action = current_policy_action
+        if claimed_validation_reason is not None:
+            post_claim_current_action = most_restrictive_guard_action(
+                post_claim_current_action,
+                "require-reapproval",
+            )
+        approval_reuse = evaluate_approval_reuse(
+            post_claim_current_action,
+            "allow",
+            saved_decision_present=True,
+            validation_reason=claimed_validation_reason,
+        )
+        policy_action = approval_reuse.action
+        approval_reuse_source = "claimed_saved_policy_decision"
+    policy_composition = {
+        "current_config_action": current_config_normalization.action,
+        "trusted_cli_override": cli_action_normalization.action if cli_action_normalization is not None else None,
+        "untrusted_hook_payload_hint": (
+            payload_action_normalization.action if payload_action_normalization is not None else None
+        ),
+        "untrusted_hook_payload_hint_disposition": payload_action_disposition,
+        "untrusted_hook_payload_hint_reason_code": ignored_payload_action_reason,
+        "daemon_hint_disposition": daemon_hint_disposition,
+        "daemon_hint_reason_code": daemon_hint_reason_code,
+        "daemon_hint_trust": ("untrusted_hook_payload" if daemon_hint_disposition is not None else None),
+        "daemon_status": daemon_status,
+        "fail_mode": fail_mode,
+        "current_composed_action": current_policy_action,
+        "saved_policy_action": stored_policy_action,
+        "approval_reuse_source": approval_reuse_source,
+        "authoritative_action": policy_action,
+    }
+    scanner_evidence: list[dict[str, object]] = [
+        {
+            "source": "approval_reuse",
+            "input_source": approval_reuse_source,
+            **approval_reuse.to_evidence(),
+        },
+        {
+            "source": "policy_composition",
+            **policy_composition,
+        },
+    ]
+    if ignored_payload_action_reason is not None:
+        scanner_evidence.append(
+            {
+                "source": "hook_payload_trust",
+                "input_source": "untrusted_hook_payload_hint",
+                "status": "ignored",
+                "reason_code": ignored_payload_action_reason,
+                "classifier": "is_explicitly_benign_tool_action_request",
+            }
+        )
+    if daemon_hint_disposition is not None:
+        scanner_evidence.append(
+            {
+                "source": "daemon_hint_trust",
+                "input_source": "untrusted_hook_payload",
+                "status": "monotonic-only",
+                "disposition": daemon_hint_disposition,
+                "reason_code": daemon_hint_reason_code,
+            }
+        )
+    for input_source, normalization in (
+        ("current_config_action", current_config_normalization),
+        ("trusted_cli_override", cli_action_normalization),
+        ("untrusted_hook_payload_hint", payload_action_normalization),
+    ):
+        if normalization is not None and not normalization.recognized:
+            scanner_evidence.append(
+                {
+                    "source": "guard_action_normalizer",
+                    "input_source": input_source,
+                    "reason_code": normalization.reason_code,
+                    "original_action": normalization.original_action,
+                    "original_type": normalization.original_type,
+                    "normalized_action": normalization.action,
+                }
+            )
     hook_event_name = _hook_event_name(payload_map) or "PreToolUse"
     changed_capabilities = _string_list(payload_map.get("changed_capabilities"))
     if not changed_capabilities and isinstance(payload_map.get("event"), str):
@@ -153,13 +743,16 @@ def _run_hook_generic_payload(
     should_record_generic_hook_receipt = not (
         args.harness == "codex"
         and hook_event_name == "PreToolUse"
-        and policy_action not in {"block", "sandbox-required", "require-reapproval"}
+        and policy_action not in {"review", "require-reapproval", "sandbox-required", "block"}
+    )
+    effective_action_envelope = (
+        action_envelope.with_pre_execution_result(policy_action) if action_envelope is not None else None
     )
     if should_record_generic_hook_receipt:
         receipt = build_receipt(
             harness=args.harness,
             artifact_id=artifact_id,
-            artifact_hash=str(payload_map.get("artifact_hash", f"hook:{artifact_id}")),
+            artifact_hash=runtime_artifact_hash,
             policy_decision=policy_action,
             capabilities_summary=_coalesce_string(
                 payload_map.get("capabilities_summary"),
@@ -173,12 +766,13 @@ def _run_hook_generic_payload(
             artifact_name=artifact_name,
             source_scope=_coalesce_string(payload_map.get("source_scope"), "project"),
             user_override=_optional_string(payload_map.get("user_override")),
+            scanner_evidence=scanner_evidence,
             approval_source=("inline" if _optional_string(payload_map.get("user_override")) is not None else "policy"),
         )
-        store.add_receipt(receipt, action_envelope=action_envelope)
+        store.add_receipt(receipt, action_envelope=effective_action_envelope)
     _record_harness_usage_for_hook(
         store=store,
-        action_envelope=action_envelope,
+        action_envelope=effective_action_envelope,
         payload=payload_map,
         policy_action=policy_action,
     )
@@ -274,7 +868,7 @@ def _run_hook_generic_payload(
                 reason=reason,
                 output_stream=output_stream,
             )
-            return 0 if policy_action not in {"block", "sandbox-required", "require-reapproval"} else 2
+            return 0 if policy_action not in {"review", "require-reapproval", "sandbox-required", "block"} else 2
         if _canonical_harness_name(args.harness) == "pi":
             from ..adapters.pi_hooks import emit_pi_hook_response
 
@@ -284,7 +878,7 @@ def _run_hook_generic_payload(
                 approval_payload=payload_map,
                 output_stream=output_stream,
             )
-            return 0 if policy_action not in {"block", "sandbox-required", "require-reapproval"} else 2
+            return 0 if policy_action not in {"review", "require-reapproval", "sandbox-required", "block"} else 2
         if _canonical_harness_name(args.harness) == "zcode":
             from ..adapters.zcode_hooks import emit_zcode_hook_response
 
@@ -295,13 +889,13 @@ def _run_hook_generic_payload(
                 payload=payload_map,
                 output_stream=output_stream,
             )
-            return 0 if policy_action not in {"block", "sandbox-required", "require-reapproval"} else 2
+            return 0 if policy_action not in {"review", "require-reapproval", "sandbox-required", "block"} else 2
         system_message = None
         canonical_harness = _canonical_harness_name(args.harness)
         if (
             canonical_harness == "claude-code"
             and hook_event_name in {"UserPromptSubmit", "PreToolUse"}
-            and policy_action in {"block", "sandbox-required", "require-reapproval"}
+            and policy_action in {"review", "require-reapproval", "sandbox-required", "block"}
         ):
             system_message = _ensure_terminal_punctuation(reason)
         elif canonical_harness == "codex" and hook_event_name == "UserPromptSubmit":
@@ -325,10 +919,13 @@ def _run_hook_generic_payload(
             "artifact_id": artifact_id,
             "artifact_name": artifact_name,
             "policy_action": policy_action,
+            "approval_reuse": approval_reuse.to_evidence(),
+            "policy_composition": policy_composition,
+            "scanner_evidence": scanner_evidence,
         },
         getattr(args, "json", False),
     )
-    return 1 if policy_action in {"block", "require-reapproval"} else 0
+    return 1 if policy_action in {"review", "require-reapproval", "sandbox-required", "block"} else 0
 
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -4,12 +4,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from ._commands_shared import _now
-    from .commands_support_hook_state import _cursor_native_shell_is_approved
-    from .commands_support_interaction import _emit, _record_harness_usage_for_hook
     from .commands_support_permission_store import (
         _persist_claude_native_permission_for_runtime_artifact,
         _record_cursor_pending_shell_permission,
@@ -19,12 +17,12 @@ if TYPE_CHECKING:
     from .commands_support_runtime_policy import (
         _runtime_artifact_policy_action,
         _runtime_data_flow_summary,
-        _runtime_stored_policy_action,
+        _runtime_saved_allow_validation_reason,
+        _runtime_stored_policy_decision,
     )
     from .commands_support_runtime_resolution import (
         _canonical_harness_name,
         _legacy_claude_alias_runtime_artifact,
-        _queue_claude_native_approval_gate_fallback,
         _runtime_capabilities_summary,
         _runtime_request_summary,
         _runtime_requested_path,
@@ -34,16 +32,33 @@ if TYPE_CHECKING:
 from ..action_lattice import (
     GuardActionNormalization,
     coerce_guard_action,
+    guard_action_severity,
+    most_restrictive_guard_action,
     normalize_guard_action,
     normalize_guard_action_result,
 )
 from ..approval_scope_support import package_request_runtime_workspace_scope
 from ..models import GuardAction
 from ..package_execution_context import PackageExecutionContext, build_package_execution_context
+from ..runtime.approval_context import approval_context_tokens_validation_reason
+from ..runtime.approval_reuse import (
+    APPROVAL_REUSE_CLAIM_FAILED,
+    APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
+    ApprovalReuseDecision,
+    ApprovalReuseValidationFailure,
+    evaluate_approval_reuse,
+)
 from ._commands_shared import *
 from .commands_hook_runtime_state import RuntimeArtifactHookState
 from .commands_parser_helpers import *
-from .commands_support_runtime_policy import _remembered_rule_rejection_reason, _runtime_artifact_exact_match_context
+from .commands_support_hook_state import _load_cursor_native_shell_allowance
+from .commands_support_runtime_policy import (
+    _remembered_rule_rejection_reason,
+    _runtime_artifact_exact_match_context,
+    _runtime_hook_approval_context_token,
+    _runtime_saved_allow_validation_reason,
+    _runtime_stored_policy_decision,
+)
 
 
 def _resolved_guard_action(value: object, fallback: GuardAction) -> GuardAction:
@@ -64,6 +79,18 @@ def _requested_policy_action_normalization(
     return None
 
 
+def _cursor_native_saved_approval_hash(
+    store: GuardStore,
+    payload: Mapping[str, object],
+) -> str | None:
+    """Return the context token carried by a fresh Cursor native allowance."""
+
+    approved = _load_cursor_native_shell_allowance(store, payload)
+    if approved is None:
+        return None
+    return _optional_string(approved.get("artifact_hash"))
+
+
 def _evaluate_runtime_artifact_hook(
     args: argparse.Namespace,
     *,
@@ -76,8 +103,47 @@ def _evaluate_runtime_artifact_hook(
     runtime_artifact: GuardArtifact,
     runtime_workspace: Path | None,
     store: GuardStore,
+    trusted_request_override_hash: str | None = None,
+    post_claim_revalidator: (Callable[[str, bool], int | RuntimeArtifactHookState | None] | None) = None,
+    _claimed_saved_allow_hash: str | None = None,
+    _claimed_trusted_request_override: bool = False,
+    _claim_saved_approval: bool = True,
+    _post_claim_refresh_failed: bool = False,
 ) -> int | RuntimeArtifactHookState:
     payload_map = dict(payload)
+
+    def revalidate_claimed_allow(
+        claimed_hash: str,
+        *,
+        trusted_request_override: bool,
+    ) -> int | RuntimeArtifactHookState:
+        refresh_failed = False
+        if post_claim_revalidator is not None:
+            try:
+                refreshed_result = post_claim_revalidator(claimed_hash, trusted_request_override)
+            except Exception:
+                refreshed_result = None
+            if refreshed_result is not None:
+                return refreshed_result
+            refresh_failed = True
+        return _evaluate_runtime_artifact_hook(
+            args,
+            action_envelope=action_envelope,
+            config=config,
+            context=context,
+            data_flow_signals=data_flow_signals,
+            guard_home=guard_home,
+            payload=payload,
+            runtime_artifact=runtime_artifact,
+            runtime_workspace=runtime_workspace,
+            store=store,
+            post_claim_revalidator=None,
+            _claimed_saved_allow_hash=claimed_hash,
+            _claimed_trusted_request_override=trusted_request_override,
+            _claim_saved_approval=False,
+            _post_claim_refresh_failed=refresh_failed,
+        )
+
     event_name = _hook_event_name(payload_map) or "PreToolUse"
     package_evaluation = None
     package_execution_context: PackageExecutionContext | None = None
@@ -87,163 +153,56 @@ def _evaluate_runtime_artifact_hook(
             store=store,
             workspace_dir=runtime_workspace,
         )
-        if runtime_workspace is not None:
-            runtime_artifact_hash = package_request_policy_hash(
-                artifact=runtime_artifact,
-                store=store,
-                workspace_dir=runtime_workspace,
-                evaluation=package_evaluation,
-            )
-        else:
-            runtime_artifact_hash = artifact_hash(runtime_artifact)
-        if runtime_workspace is not None:
-            package_execution_context = build_package_execution_context(
-                workspace_dir=runtime_workspace,
-                artifact=runtime_artifact,
-            )
+        effective_package_workspace = runtime_workspace or Path.cwd()
+        package_execution_context = build_package_execution_context(
+            workspace_dir=effective_package_workspace,
+            artifact=runtime_artifact,
+        )
+        artifact_content_hash = package_request_policy_hash(
+            artifact=runtime_artifact,
+            store=store,
+            workspace_dir=effective_package_workspace,
+            evaluation=package_evaluation,
+            execution_context=package_execution_context,
+            config=config,
+        )
     else:
-        runtime_artifact_hash = artifact_hash(runtime_artifact)
+        artifact_content_hash = artifact_hash(runtime_artifact)
     artifact_id = runtime_artifact.artifact_id
     artifact_name = runtime_artifact.name
     policy_harness = _canonical_harness_name(args.harness)
-    policy_workspace = str(runtime_workspace) if runtime_workspace else None
-    if package_execution_context is not None:
-        policy_workspace = package_request_runtime_workspace_scope(
-            artifact_id=runtime_artifact.artifact_id,
-            artifact_hash=runtime_artifact_hash,
-            artifact_type=runtime_artifact.artifact_type,
-            execution_context=package_execution_context,
-        )
-    if (
-        policy_harness == "cursor"
-        and event_name == "PreToolUse"
-        and runtime_artifact.artifact_type == "tool_action_request"
-        and _cursor_native_shell_is_approved(store, payload)
-    ):
-        response_payload: dict[str, object] = {
-            "recorded": True,
-            "harness": policy_harness,
-            "artifact_id": artifact_id,
-            "artifact_name": artifact_name,
-            "artifact_type": runtime_artifact.artifact_type,
-            "policy_action": "allow",
-        }
-        _emit("hook", response_payload, getattr(args, "json", False))
-        _record_harness_usage_for_hook(
-            store=store,
-            action_envelope=action_envelope,
-            payload=payload_map,
-            policy_action="allow",
-        )
-        return 0
-    runtime_exact_match_context = _runtime_artifact_exact_match_context(runtime_artifact)
-    policy_lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
-        policy_harness,
-        artifact_id,
-        artifact_hash=runtime_artifact_hash,
-        workspace=policy_workspace,
-        publisher=runtime_artifact.publisher,
-        runtime_exact_match_context=runtime_exact_match_context,
-        memory_command=runtime_artifact.command,
-        memory_artifact_type=runtime_artifact.artifact_type,
-        memory_artifact_name=runtime_artifact.name,
+    cli_action = getattr(args, "policy_action", None)
+    cli_action_normalization = (
+        normalize_guard_action_result(cli_action, unknown_action="require-reapproval")
+        if cli_action is not None
+        else None
     )
-    stored_policy_action = _runtime_stored_policy_action(
-        store=store,
-        harness=policy_harness,
-        artifact=runtime_artifact,
-        artifact_id=artifact_id,
-        artifact_hash=runtime_artifact_hash,
-        workspace=policy_workspace,
-        decision_lookup=policy_lookup,
+    payload_action_normalization = (
+        normalize_guard_action_result(payload_map.get("policy_action"), unknown_action="require-reapproval")
+        if "policy_action" in payload_map
+        else None
     )
-    remembered_rule_rejection = policy_lookup["ignored_local_integrity"]
-    trust_status = policy_lookup["trust_status"]
-    if stored_policy_action is None and runtime_artifact.artifact_type != "package_request":
-        legacy_artifact = _legacy_claude_alias_runtime_artifact(
-            artifact=runtime_artifact,
-            requested_harness=args.harness,
-            home_dir=context.home_dir,
-            workspace=runtime_workspace,
-        )
-        if legacy_artifact is not None:
-            stored_policy_action = _runtime_stored_policy_action(
-                store=store,
-                harness=args.harness,
-                artifact=legacy_artifact,
-                artifact_id=legacy_artifact.artifact_id,
-                artifact_hash=artifact_hash(legacy_artifact),
-                workspace=str(runtime_workspace) if runtime_workspace else None,
-            )
-    requested_action_normalization = _requested_policy_action_normalization(
-        getattr(args, "policy_action", None),
-        stored_policy_action,
-        payload_map,
-    )
+    requested_action_normalization = cli_action_normalization or payload_action_normalization
     requested_policy_action = (
         requested_action_normalization.original_action if requested_action_normalization is not None else None
     )
-    if requested_action_normalization is not None:
-        policy_action = requested_action_normalization.action
-    else:
-        policy_action = _resolved_guard_action(
-            _runtime_artifact_policy_action(config, runtime_artifact, args.harness),
-            "warn",
-        )
-    if _canonical_harness_name(args.harness) == "claude-code" and event_name in {
-        "PostToolUse",
-        "PostToolUseFailure",
-    }:
-        saved = _persist_claude_native_permission_for_runtime_artifact(
-            store=store,
-            payload=payload_map,
-            artifact=runtime_artifact,
-            artifact_hash=runtime_artifact_hash,
-            action="allow",
-            reason="Approved in Claude native approval prompt.",
-        )
-        if saved:
-            receipt = build_receipt(
-                harness=policy_harness,
-                artifact_id=artifact_id,
-                artifact_hash=runtime_artifact_hash,
-                policy_decision="allow",
-                capabilities_summary=_runtime_capabilities_summary(runtime_artifact),
-                changed_capabilities=[runtime_artifact.artifact_type, "claude-native-approved"],
-                provenance_summary=f"runtime tool request approved from {runtime_artifact.config_path}",
-                artifact_name=artifact_name,
-                source_scope=runtime_artifact.source_scope,
-                user_override="claude-native-approve",
-                approval_source="inline",
-            )
-            store.add_receipt(receipt)
-        else:
-            _queue_claude_native_approval_gate_fallback(
-                store=store,
-                harness=policy_harness,
-                artifact=runtime_artifact,
-                artifact_digest=runtime_artifact_hash,
-                approval_center_url=load_guard_daemon_url(guard_home) or "http://127.0.0.1:5474",
-                action_envelope=action_envelope,
-                redaction_level=config.receipt_redaction_level,
-            )
-        _record_harness_usage_for_hook(
-            store=store,
-            action_envelope=action_envelope,
-            payload=payload_map,
-            policy_action="allow" if saved else "require-reapproval",
-        )
-        return 0
-    if package_evaluation is not None and runtime_workspace is not None:
-        package_evaluation = apply_stored_package_policy_override(
-            package_evaluation,
-            store=store,
-            artifact=runtime_artifact,
-            artifact_hash=runtime_artifact_hash,
-            workspace_dir=runtime_workspace,
-            now=_now(),
-            execution_context=package_execution_context,
-        )
+    current_config_action = _resolved_guard_action(
+        _runtime_artifact_policy_action(config, runtime_artifact, args.harness),
+        "warn",
+    )
+    current_action_override = config.resolve_action_override(
+        policy_harness,
+        runtime_artifact.artifact_id,
+        runtime_artifact.publisher,
+    )
+    current_action_inputs: list[GuardAction] = [current_config_action]
+    if cli_action_normalization is not None:
+        current_action_inputs.append(cli_action_normalization.action)
+    if payload_action_normalization is not None:
+        # Hook payloads are untrusted hints.  They may make a decision stricter,
+        # but can never lower current local policy or suppress later scanners.
+        current_action_inputs.append(payload_action_normalization.action)
+    policy_action = most_restrictive_guard_action(*current_action_inputs)
     changed_capabilities = [runtime_artifact.artifact_type]
     scanner_evidence = (
         scan_action_for_cisco_evidence(action_envelope, workspace=runtime_workspace)
@@ -251,26 +210,29 @@ def _evaluate_runtime_artifact_hook(
         else ()
     )
     scanner_evidence_payload = [signal.to_dict() for signal in scanner_evidence]
-    if requested_action_normalization is not None and not requested_action_normalization.recognized:
-        scanner_evidence_payload.append(
-            {
-                "source": "guard_action_normalizer",
-                "input_source": "runtime_hook_requested_policy",
-                "reason_code": requested_action_normalization.reason_code,
-                "original_action": requested_action_normalization.original_action,
-                "original_type": requested_action_normalization.original_type,
-                "normalized_action": requested_action_normalization.action,
-            }
-        )
+    for input_source, normalization in (
+        ("trusted_cli_override", cli_action_normalization),
+        ("untrusted_hook_payload_hint", payload_action_normalization),
+    ):
+        if normalization is not None and not normalization.recognized:
+            scanner_evidence_payload.append(
+                {
+                    "source": "guard_action_normalizer",
+                    "input_source": input_source,
+                    "reason_code": normalization.reason_code,
+                    "original_action": normalization.original_action,
+                    "original_type": normalization.original_type,
+                    "normalized_action": normalization.action,
+                }
+            )
     if package_execution_context is not None:
         scanner_evidence_payload.append(package_execution_context.to_evidence())
     package_policy_action: GuardAction | None = (
         normalize_guard_action(package_evaluation.policy_action) if package_evaluation is not None else None
     )
-    if package_policy_action is not None and guard_action_severity(package_policy_action) > guard_action_severity(
-        policy_action
-    ):
-        policy_action = package_policy_action
+    if package_policy_action is not None:
+        policy_action = most_restrictive_guard_action(policy_action, package_policy_action)
+    data_flow_action: GuardAction | None = None
     if data_flow_signals:
         data_flow_action = _resolved_guard_action(
             resolve_risk_action(
@@ -280,22 +242,21 @@ def _evaluate_runtime_artifact_hook(
             ),
             policy_action,
         )
-        if guard_action_severity(data_flow_action) > guard_action_severity(policy_action):
-            policy_action = data_flow_action
+        policy_action = most_restrictive_guard_action(policy_action, data_flow_action)
     _pre_scanner_policy_action = policy_action
     package_controls_pre_scanner_summary = (
         package_evaluation is not None
         and package_policy_action is not None
         and guard_action_severity(package_policy_action) >= guard_action_severity(_pre_scanner_policy_action)
     )
-    if scanner_evidence and requested_policy_action not in VALID_GUARD_ACTIONS:
+    scanner_action: GuardAction | None = None
+    if scanner_evidence:
         scanner_action = policy_action_for_cisco_signals(
             scanner_evidence,
             config=config,
             harness=policy_harness,
         )
-        if guard_action_severity(scanner_action) > guard_action_severity(policy_action):
-            policy_action = scanner_action
+        policy_action = most_restrictive_guard_action(policy_action, scanner_action)
     scanner_raised_to_block = (
         policy_action == "block" and _pre_scanner_policy_action != "block" and bool(scanner_evidence)
     )
@@ -329,11 +290,451 @@ def _evaluate_runtime_artifact_hook(
         risk_signals.extend(scanner_risk_signals)
         if scanner_raised_to_block:
             risk_summary = scanner_risk_signals[0]
+    current_policy_action = policy_action
+    runtime_artifact_hash = _runtime_hook_approval_context_token(
+        artifact=runtime_artifact,
+        content_hash=artifact_content_hash,
+        runtime_workspace=runtime_workspace,
+        action_envelope=action_envelope,
+        config=config,
+        current_config_action=current_config_action,
+        trusted_cli_action=cli_action_normalization.action if cli_action_normalization is not None else None,
+        untrusted_payload_action=(
+            payload_action_normalization.action if payload_action_normalization is not None else None
+        ),
+        package_action=package_policy_action,
+        data_flow_action=data_flow_action,
+        scanner_action=scanner_action,
+        current_action=current_policy_action,
+        data_flow_signals=data_flow_signals,
+        scanner_evidence=scanner_evidence,
+    )
+    policy_workspace = str(runtime_workspace) if runtime_workspace else None
+    if package_execution_context is not None:
+        policy_workspace = package_request_runtime_workspace_scope(
+            artifact_id=runtime_artifact.artifact_id,
+            artifact_hash=runtime_artifact_hash,
+            artifact_type=runtime_artifact.artifact_type,
+            execution_context=package_execution_context,
+        )
+    claude_native_approval_observed = False
+    claude_native_approval_saved = False
+    if _canonical_harness_name(args.harness) == "claude-code" and event_name in {
+        "PostToolUse",
+        "PostToolUseFailure",
+    }:
+        native_reuse = evaluate_approval_reuse(
+            current_policy_action,
+            "allow",
+            saved_decision_present=True,
+        )
+        claude_native_approval_observed, claude_native_approval_saved = (
+            _persist_claude_native_permission_for_runtime_artifact(
+                store=store,
+                payload=payload_map,
+                artifact=runtime_artifact,
+                artifact_hash=runtime_artifact_hash,
+                action="allow",
+                authoritative_action=native_reuse.action,
+                reason="Approved in Claude native approval prompt.",
+            )
+        )
+        scanner_evidence_payload.append(
+            {
+                "source": "claude_native_approval",
+                "native_action": "allow",
+                "observed": claude_native_approval_observed,
+                "reusable_policy_saved": claude_native_approval_saved,
+                "current_action": current_policy_action,
+                "authoritative_action": native_reuse.action,
+                "approval_reuse": native_reuse.to_evidence(),
+            }
+        )
+
+    # Resolve saved evidence only after all current policy, package, data-flow,
+    # scanner, configuration, workspace, and sandbox inputs are frozen above.
+    runtime_exact_match_context = _runtime_artifact_exact_match_context(runtime_artifact)
+    policy_lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
+        policy_harness,
+        artifact_id,
+        artifact_hash=runtime_artifact_hash,
+        workspace=policy_workspace,
+        publisher=runtime_artifact.publisher,
+        runtime_exact_match_context=runtime_exact_match_context,
+        memory_command=runtime_artifact.command,
+        memory_artifact_type=runtime_artifact.artifact_type,
+        memory_artifact_name=runtime_artifact.name,
+        consume_one_shot=False,
+    )
+    stored_policy_decision = _runtime_stored_policy_decision(
+        store=store,
+        harness=policy_harness,
+        artifact=runtime_artifact,
+        artifact_id=artifact_id,
+        artifact_hash=runtime_artifact_hash,
+        workspace=policy_workspace,
+        decision_lookup=policy_lookup,
+        consume_one_shot=False,
+    )
+    # Legacy exact hashes cannot authorize an allow, but they must still be
+    # inspected even when a v1 decision exists: a new exact allow must never
+    # hide an intentionally retained pre-v1 block during migration.
+    legacy_policy_workspace = str(runtime_workspace) if runtime_workspace else None
+    if package_execution_context is not None:
+        legacy_policy_workspace = package_request_runtime_workspace_scope(
+            artifact_id=runtime_artifact.artifact_id,
+            artifact_hash=artifact_content_hash,
+            artifact_type=runtime_artifact.artifact_type,
+            execution_context=package_execution_context,
+        )
+    legacy_lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
+        policy_harness,
+        artifact_id,
+        artifact_hash=artifact_content_hash,
+        workspace=legacy_policy_workspace,
+        publisher=runtime_artifact.publisher,
+        runtime_exact_match_context=runtime_exact_match_context,
+        memory_command=runtime_artifact.command,
+        memory_artifact_type=runtime_artifact.artifact_type,
+        memory_artifact_name=runtime_artifact.name,
+        consume_one_shot=False,
+    )
+    legacy_decision = _runtime_stored_policy_decision(
+        store=store,
+        harness=policy_harness,
+        artifact=runtime_artifact,
+        artifact_id=artifact_id,
+        artifact_hash=artifact_content_hash,
+        workspace=legacy_policy_workspace,
+        decision_lookup=legacy_lookup,
+        consume_one_shot=False,
+    )
+    if legacy_lookup.get("ignored_local_integrity") is not None:
+        policy_lookup = {
+            **policy_lookup,
+            "ignored_local_integrity": legacy_lookup["ignored_local_integrity"],
+        }
+    if legacy_decision is not None and (
+        stored_policy_decision is None
+        or guard_action_severity(legacy_decision.get("action"), unknown_action="block")
+        > guard_action_severity(stored_policy_decision.get("action"), unknown_action="block")
+    ):
+        merged_integrity = policy_lookup.get("ignored_local_integrity")
+        policy_lookup = dict(legacy_lookup)
+        if merged_integrity is not None:
+            policy_lookup["ignored_local_integrity"] = merged_integrity
+        stored_policy_decision = legacy_decision
+    if stored_policy_decision is None and runtime_artifact.artifact_type != "package_request":
+        legacy_artifact = _legacy_claude_alias_runtime_artifact(
+            artifact=runtime_artifact,
+            requested_harness=args.harness,
+            home_dir=context.home_dir,
+            workspace=runtime_workspace,
+        )
+        if legacy_artifact is not None:
+            stored_policy_decision = _runtime_stored_policy_decision(
+                store=store,
+                harness=args.harness,
+                artifact=legacy_artifact,
+                artifact_id=legacy_artifact.artifact_id,
+                artifact_hash=artifact_hash(legacy_artifact),
+                workspace=str(runtime_workspace) if runtime_workspace else None,
+                consume_one_shot=False,
+            )
+    stored_policy_action = (
+        _optional_string(stored_policy_decision.get("action")) if stored_policy_decision is not None else None
+    )
+    remembered_rule_rejection = policy_lookup.get("ignored_local_integrity")
+    trust_status = policy_lookup["trust_status"]
+    cursor_native_approval_hash = (
+        _cursor_native_saved_approval_hash(store, payload)
+        if policy_harness == "cursor"
+        and event_name == "PreToolUse"
+        and runtime_artifact.artifact_type == "tool_action_request"
+        else None
+    )
+    approval_reuse: ApprovalReuseDecision | None = None
+    package_approval_reuse_evidence: dict[str, object] | None = None
+    approval_reuse_source: str | None = None
+    if package_evaluation is not None:
+        # Package approval lookup/claim is deferred until every current policy,
+        # data-flow, and scanner input has been composed.
+        package_evaluation = apply_stored_package_policy_override(
+            package_evaluation,
+            store=store,
+            artifact=runtime_artifact,
+            artifact_hash=runtime_artifact_hash,
+            workspace_dir=runtime_workspace or Path.cwd(),
+            now=_now(),
+            execution_context=package_execution_context,
+            current_action=current_policy_action,
+            claim_saved_approval=_claim_saved_approval,
+        )
+        package_reuse_applied = False
+        package_saved_allow_applied = False
+        for reason in package_evaluation.reasons:
+            if reason.get("code") in {"saved_package_approval", "saved_package_block"}:
+                package_reuse_applied = True
+                approval_reuse_source = "saved_package_policy"
+            if reason.get("code") == "saved_package_approval":
+                package_saved_allow_applied = True
+            raw_reuse = reason.get("approval_reuse")
+            if isinstance(raw_reuse, Mapping):
+                package_reuse_applied = True
+                package_approval_reuse_evidence = dict(raw_reuse)
+                scanner_evidence_payload.append(
+                    {
+                        "source": "approval_reuse",
+                        "input_source": "saved_package_policy",
+                        **dict(raw_reuse),
+                    }
+                )
+                approval_reuse_source = "saved_package_policy"
+                break
+        if package_saved_allow_applied and _claim_saved_approval:
+            return revalidate_claimed_allow(
+                runtime_artifact_hash,
+                trusted_request_override=False,
+            )
+        policy_action = (
+            _resolved_guard_action(package_evaluation.policy_action, current_policy_action)
+            if package_reuse_applied
+            else current_policy_action
+        )
+        if stored_policy_action == "block":
+            approval_reuse = evaluate_approval_reuse(
+                current_policy_action,
+                "block",
+                saved_decision_present=True,
+            )
+            policy_action = most_restrictive_guard_action(policy_action, approval_reuse.action)
+            approval_reuse_source = approval_reuse_source or "saved_policy_decision"
+            if not package_reuse_applied:
+                scanner_evidence_payload.append(
+                    {
+                        "source": "approval_reuse",
+                        "input_source": approval_reuse_source,
+                        **approval_reuse.to_evidence(),
+                    }
+                )
+        if policy_action != current_policy_action:
+            risk_signals = [str(item.get("message") or item.get("code") or "") for item in package_evaluation.reasons]
+            risk_summary = package_evaluation.risk_summary
+    else:
+        saved_action: object | None = stored_policy_action
+        saved_present = stored_policy_decision is not None
+        validation_reason: ApprovalReuseValidationFailure | None = None
+        if policy_lookup.get("ignored_local_integrity") is not None:
+            # A matching integrity-invalid local rule is security-relevant even
+            # when a different, valid saved allow also matched.  Letting the
+            # valid row win would make a tampered broader block invisible.
+            validation_reason = "approval_reuse_integrity_failure"
+        elif stored_policy_decision is not None:
+            stored_validation_reason = _runtime_saved_allow_validation_reason(
+                stored_policy_decision,
+                artifact=runtime_artifact,
+                artifact_hash=runtime_artifact_hash,
+            )
+            if stored_validation_reason is not None:
+                validation_reason = cast(ApprovalReuseValidationFailure, stored_validation_reason)
+        if not saved_present and cursor_native_approval_hash is not None:
+            saved_action = "allow"
+            saved_present = True
+            approval_reuse_source = "cursor_native_approval"
+            cursor_validation_reason = approval_context_tokens_validation_reason(
+                cursor_native_approval_hash,
+                runtime_artifact_hash,
+            )
+            if cursor_validation_reason is not None:
+                validation_reason = cast(ApprovalReuseValidationFailure, cursor_validation_reason)
+        elif not saved_present and validation_reason is None:
+            diagnosed_reason = store.approval_reuse_validation_reason(
+                policy_harness,
+                artifact_id,
+                runtime_artifact_hash,
+                policy_workspace,
+                runtime_artifact.publisher,
+                _now(),
+            )
+            if diagnosed_reason is not None:
+                validation_reason = cast(ApprovalReuseValidationFailure, diagnosed_reason)
+                saved_action = "allow"
+        if saved_present:
+            approval_reuse_source = approval_reuse_source or "saved_policy_decision"
+        elif validation_reason is not None:
+            saved_present = True
+            approval_reuse_source = (
+                "saved_policy_integrity"
+                if validation_reason == "approval_reuse_integrity_failure"
+                else "invalidated_saved_policy"
+            )
+        approval_reuse = evaluate_approval_reuse(
+            current_policy_action,
+            saved_action,
+            saved_decision_present=saved_present,
+            validation_reason=validation_reason,
+        )
+        if approval_reuse.should_claim and stored_policy_decision is not None and _claim_saved_approval:
+            if not store.claim_approval_reuse_decision(stored_policy_decision, now=_now()):
+                approval_reuse = evaluate_approval_reuse(
+                    current_policy_action,
+                    saved_action,
+                    saved_decision_present=True,
+                    validation_reason=APPROVAL_REUSE_CLAIM_FAILED,
+                )
+            else:
+                return revalidate_claimed_allow(
+                    runtime_artifact_hash,
+                    trusted_request_override=False,
+                )
+        policy_action = approval_reuse.action
+        if approval_reuse_source is not None:
+            scanner_evidence_payload.append(
+                {
+                    "source": "approval_reuse",
+                    "input_source": approval_reuse_source,
+                    **approval_reuse.to_evidence(),
+                }
+            )
+    trusted_request_override_applied = False
+    trusted_request_override_reason: str | None = None
+    if trusted_request_override_hash is not None:
+        trusted_request_override_reason = approval_context_tokens_validation_reason(
+            trusted_request_override_hash,
+            runtime_artifact_hash,
+        )
+        if trusted_request_override_reason is None and policy_action in {
+            "review",
+            "require-reapproval",
+        }:
+            if remembered_rule_rejection is not None or (
+                approval_reuse is not None and approval_reuse.reason_code == "approval_reuse_integrity_failure"
+            ):
+                trusted_request_override_reason = "trusted_request_override_integrity_failure"
+            elif (
+                stored_policy_decision is not None
+                and stored_policy_decision.get("action") == "allow"
+                and stored_policy_decision.get("source")
+                in {
+                    "approval-gate",
+                    "approval-gate-once",
+                }
+                and _runtime_saved_allow_validation_reason(
+                    stored_policy_decision,
+                    artifact=runtime_artifact,
+                    artifact_hash=runtime_artifact_hash,
+                )
+                is None
+            ):
+                if store.claim_approval_reuse_decision(
+                    stored_policy_decision,
+                    now=_now(),
+                ):
+                    return revalidate_claimed_allow(
+                        runtime_artifact_hash,
+                        trusted_request_override=True,
+                    )
+                else:
+                    trusted_request_override_reason = "trusted_request_override_claim_failed"
+            else:
+                trusted_request_override_reason = "trusted_request_override_allow_missing"
+        scanner_evidence_payload.append(
+            {
+                "source": "trusted_request_override",
+                "applied": trusted_request_override_applied,
+                "reason_code": trusted_request_override_reason,
+                "authoritative_action": policy_action,
+            }
+        )
+    if _claimed_saved_allow_hash is not None:
+        context_changed = approval_context_tokens_validation_reason(
+            _claimed_saved_allow_hash,
+            runtime_artifact_hash,
+        )
+        claimed_validation_reason: ApprovalReuseValidationFailure | None = (
+            APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM
+            if _post_claim_refresh_failed or context_changed is not None
+            else None
+        )
+        if remembered_rule_rejection is not None or (
+            approval_reuse is not None and approval_reuse.reason_code == "approval_reuse_integrity_failure"
+        ):
+            claimed_validation_reason = "approval_reuse_integrity_failure"
+
+        post_claim_current_action = policy_action
+        if (
+            approval_reuse is not None and approval_reuse.saved_action == "allow" and approval_reuse.action == "allow"
+        ) or (
+            package_approval_reuse_evidence is not None
+            and package_approval_reuse_evidence.get("saved_action") == "allow"
+            and policy_action == "allow"
+        ):
+            post_claim_current_action = current_policy_action
+        if claimed_validation_reason is not None:
+            post_claim_current_action = most_restrictive_guard_action(
+                post_claim_current_action,
+                "require-reapproval",
+            )
+        elif _claimed_trusted_request_override and post_claim_current_action in {
+            "review",
+            "require-reapproval",
+        }:
+            # A just-resolved exact browser request is stronger than ordinary
+            # remembered approval evidence. It may satisfy the current request
+            # only after its one-shot row has been claimed and the complete
+            # runtime authority has been rebuilt.
+            post_claim_current_action = "review"
+        approval_reuse = evaluate_approval_reuse(
+            post_claim_current_action,
+            "allow",
+            saved_decision_present=True,
+            validation_reason=claimed_validation_reason,
+        )
+        policy_action = approval_reuse.action
+        approval_reuse_source = (
+            "claimed_trusted_request_override" if _claimed_trusted_request_override else "claimed_saved_policy_decision"
+        )
+        trusted_request_override_applied = (
+            _claimed_trusted_request_override and approval_reuse.accepted and approval_reuse.action == "allow"
+        )
+        trusted_request_override_reason = (
+            "trusted_request_override_exact_context" if trusted_request_override_applied else claimed_validation_reason
+        )
+        scanner_evidence_payload.append(
+            {
+                "source": "approval_reuse",
+                "input_source": approval_reuse_source,
+                **approval_reuse.to_evidence(),
+            }
+        )
+    policy_composition = {
+        "current_config_action": current_config_action,
+        "current_action_override": current_action_override,
+        "trusted_cli_override": cli_action_normalization.action if cli_action_normalization is not None else None,
+        "untrusted_hook_payload_hint": (
+            payload_action_normalization.action if payload_action_normalization is not None else None
+        ),
+        "package_action": package_policy_action,
+        "data_flow_action": data_flow_action,
+        "scanner_action": scanner_action,
+        "current_composed_action": current_policy_action,
+        "saved_policy_action": stored_policy_action,
+        "approval_reuse_source": approval_reuse_source,
+        "trusted_request_override": trusted_request_override_applied,
+        "trusted_request_override_reason": trusted_request_override_reason,
+        "authoritative_action": policy_action,
+    }
+    scanner_evidence_payload.append(
+        {
+            "source": "policy_composition",
+            **policy_composition,
+        }
+    )
     if action_envelope is not None:
         action_envelope = action_envelope.with_pre_execution_result(policy_action)
     decision_v2 = build_decision_v2(policy_action, reason=policy_action, signals=decision_signals)
     decision_v2_payload = decision_v2.to_dict()
-    if package_evaluation is not None and package_evaluation.policy_action == policy_action:
+    if package_evaluation is not None and package_policy_action == policy_action:
         decision_v2_payload["user_title"] = package_evaluation.user_copy.title
         decision_v2_payload["user_body"] = package_evaluation.user_copy.summary
         decision_v2_payload["harness_message"] = package_evaluation.user_copy.harness_message
@@ -361,21 +762,27 @@ def _evaluate_runtime_artifact_hook(
         provenance_summary=f"runtime tool request evaluated from {runtime_artifact.config_path}",
         artifact_name=artifact_name,
         source_scope=runtime_artifact.source_scope,
-        user_override=_optional_string(payload_map.get("user_override")),
+        user_override=(
+            "claude-native-approve"
+            if claude_native_approval_observed
+            else _optional_string(payload_map.get("user_override"))
+        ),
         scanner_evidence=scanner_evidence_payload,
         approval_source=(
             "inline"
-            if _optional_string(payload_map.get("user_override")) is not None
+            if claude_native_approval_observed or _optional_string(payload_map.get("user_override")) is not None
             else "approval_center"
             if policy_action == "require-reapproval"
             else "policy"
         ),
     )
-    store.add_receipt(receipt, action_envelope=action_envelope)
     response_payload: dict[str, object] = {
-        "recorded": True,
+        # Receipt persistence is intentionally delayed until the browser wait,
+        # when present, has produced the authoritative final action.
+        "recorded": False,
         "harness": _canonical_harness_name(args.harness),
         "artifact_id": artifact_id,
+        "artifact_hash": runtime_artifact_hash,
         "artifact_name": artifact_name,
         "artifact_type": runtime_artifact.artifact_type,
         "policy_action": policy_action,
@@ -391,7 +798,12 @@ def _evaluate_runtime_artifact_hook(
         "risk_headline": incident["risk_headline"],
         "path_summary": _runtime_requested_path(runtime_artifact),
         "trust_status": trust_status,
+        "policy_composition": policy_composition,
     }
+    if approval_reuse is not None:
+        response_payload["approval_reuse"] = approval_reuse.to_evidence()
+    elif package_approval_reuse_evidence is not None:
+        response_payload["approval_reuse"] = package_approval_reuse_evidence
     if remembered_rule_rejection is not None:
         response_payload["remembered_rule_rejection"] = remembered_rule_rejection
         if policy_action in {"review", "require-reapproval"}:
@@ -433,10 +845,13 @@ def _evaluate_runtime_artifact_hook(
         artifact_name=artifact_name,
         browser_approval_daemon_client=None,
         changed_capabilities=changed_capabilities,
+        decision_signals=tuple(decision_signals),
         decision_v2_payload=decision_v2_payload,
         event_name=event_name,
+        initial_policy_action=policy_action,
         package_evaluation=package_evaluation,
         policy_action=policy_action,
+        receipt=receipt,
         requested_policy_action=requested_policy_action,
         response_payload=response_payload,
         risk_summary=risk_summary,

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_finish.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_finish.py
@@ -42,7 +42,11 @@ if TYPE_CHECKING:
 from ._commands_shared import *
 from .commands_parser_helpers import *
 
-from .commands_hook_runtime_state import RuntimeArtifactHookState
+from .commands_hook_runtime_state import (
+    RuntimeArtifactHookState,
+    record_runtime_artifact_hook_receipt,
+    set_runtime_artifact_hook_final_action,
+)
 
 def _finalize_runtime_artifact_hook(
     state: RuntimeArtifactHookState,
@@ -52,6 +56,7 @@ def _finalize_runtime_artifact_hook(
     output_stream: TextIO | None = None,
     payload: Mapping[str, object],
     store: GuardStore,
+    post_wait_revalidator: Callable[[], RuntimeArtifactHookState | None] | None = None,
 ) -> int:
     action_envelope = state.action_envelope
     event_name = state.event_name
@@ -59,6 +64,7 @@ def _finalize_runtime_artifact_hook(
     response_payload = state.response_payload
     runtime_artifact = state.runtime_artifact
     if _should_emit_copilot_hook_response(args):
+        record_runtime_artifact_hook_receipt(state, store)
         _record_harness_usage_for_hook(
             store=store,
             action_envelope=action_envelope,
@@ -75,6 +81,28 @@ def _finalize_runtime_artifact_hook(
             output_stream=output_stream,
         )
         return 0
+    fresh_state: RuntimeArtifactHookState | None = None
+
+    def fresh_browser_context() -> Mapping[str, object] | None:
+        nonlocal fresh_state
+        if post_wait_revalidator is None:
+            return None
+        fresh_state = post_wait_revalidator()
+        if fresh_state is None:
+            return None
+        composition = fresh_state.response_payload.get("policy_composition")
+        current_action = (
+            composition.get("current_composed_action")
+            if isinstance(composition, Mapping)
+            else None
+        )
+        return {
+            "artifact_id": fresh_state.artifact_id,
+            "artifact_hash": fresh_state.runtime_artifact_hash,
+            "current_action": current_action,
+            "authoritative_action": fresh_state.policy_action,
+        }
+
     codex_browser_decision = _codex_browser_approval_decision(
         args=args,
         event_name=event_name,
@@ -83,8 +111,58 @@ def _finalize_runtime_artifact_hook(
         store=store,
         config=config,
         daemon_client=state.browser_approval_daemon_client,
+        expected_artifact_hash=state.runtime_artifact_hash,
+        fresh_context_provider=fresh_browser_context,
     )
+
+    def adopt_fresh_browser_state() -> None:
+        nonlocal action_envelope, event_name, policy_action, response_payload, runtime_artifact, state
+        if fresh_state is None or fresh_state is state:
+            return
+        previous_response = response_payload
+        previous_initial_action = state.initial_policy_action
+        previous_daemon_client = state.browser_approval_daemon_client
+        state = fresh_state
+        state.initial_policy_action = previous_initial_action
+        state.browser_approval_daemon_client = previous_daemon_client
+        for key in (
+            "approval_request_ids",
+            "approval_requests",
+            "approval_url",
+            "approval_url_terminal",
+            "approval_wait",
+            "browser_resolution_request_id",
+            "browser_resolution_validation",
+            "codex_resume",
+            "continuation",
+            "operation",
+            "operation_id",
+            "operation_status",
+            "review_hint",
+            "session_id",
+        ):
+            if key in previous_response:
+                state.response_payload[key] = previous_response[key]
+        action_envelope = state.action_envelope
+        event_name = state.event_name
+        policy_action = state.policy_action
+        response_payload = state.response_payload
+        runtime_artifact = state.runtime_artifact
+
     if codex_browser_decision == "allow":
+        adopt_fresh_browser_state()
+        approval_request_id = response_payload.get("browser_resolution_request_id")
+        set_runtime_artifact_hook_final_action(
+            state,
+            "allow",
+            approval_request_id=(
+                approval_request_id if isinstance(approval_request_id, str) else None
+            ),
+            approval_source="browser",
+        )
+        action_envelope = state.action_envelope
+        policy_action = state.policy_action
+        response_payload = state.response_payload
         if event_name != "PreToolUse":
             _emit_native_hook_response(
                 harness=args.harness,
@@ -93,6 +171,7 @@ def _finalize_runtime_artifact_hook(
                 reason="",
                 output_stream=output_stream,
             )
+        record_runtime_artifact_hook_receipt(state, store)
         _record_harness_usage_for_hook(
             store=store,
             action_envelope=action_envelope,
@@ -100,8 +179,27 @@ def _finalize_runtime_artifact_hook(
             policy_action="allow",
         )
         return 0
-    if codex_browser_decision == "block":
-        policy_action = "block"
+    if codex_browser_decision in {"block", "sandbox-required"}:
+        adopt_fresh_browser_state()
+        approval_request_id = response_payload.get("browser_resolution_request_id")
+        if not isinstance(approval_request_id, str):
+            approval_requests = response_payload.get("approval_requests")
+            if isinstance(approval_requests, list) and approval_requests:
+                first_request = approval_requests[0]
+                if isinstance(first_request, dict) and isinstance(first_request.get("request_id"), str):
+                    approval_request_id = first_request["request_id"]
+        set_runtime_artifact_hook_final_action(
+            state,
+            codex_browser_decision,
+            approval_request_id=(
+                approval_request_id if isinstance(approval_request_id, str) else None
+            ),
+            approval_source="browser",
+        )
+        action_envelope = state.action_envelope
+        policy_action = state.policy_action
+        response_payload = state.response_payload
+    record_runtime_artifact_hook_receipt(state, store)
     approval_context = _native_approval_center_context(response_payload, harness=args.harness)
     raw_runtime_reason = _runtime_artifact_native_reason(runtime_artifact, response_payload)
     if _should_emit_native_hook_exit_block(args, event_name=event_name, policy_action=policy_action):
@@ -158,11 +256,13 @@ def _finalize_runtime_artifact_hook(
         )
         return 2
     if _canonical_harness_name(args.harness) == "codex" and (
-        event_name == "UserPromptSubmit" or approval_context is not None
+        event_name == "UserPromptSubmit"
+        or approval_context is not None
+        or policy_action in {"block", "sandbox-required"}
     ):
         runtime_reason = _native_hook_reason(
             raw_runtime_reason,
-            approval_context,
+            approval_context or response_payload.get("review_hint"),
         )
     else:
         runtime_reason = _native_hook_reason_for_harness(
@@ -211,7 +311,7 @@ def _finalize_runtime_artifact_hook(
                 payload=payload,
                 policy_action=policy_action,
             )
-            return 0 if policy_action not in {"block", "sandbox-required", "require-reapproval"} else 2
+            return 0 if policy_action not in {"review", "require-reapproval", "sandbox-required", "block"} else 2
         if canonical_harness == "pi":
             from ..adapters.pi_hooks import emit_pi_hook_response
 
@@ -227,7 +327,7 @@ def _finalize_runtime_artifact_hook(
                 payload=payload,
                 policy_action=policy_action,
             )
-            return 0 if policy_action not in {"block", "sandbox-required", "require-reapproval"} else 2
+            return 0 if policy_action not in {"review", "require-reapproval", "sandbox-required", "block"} else 2
         if canonical_harness == "zcode":
             from ..adapters.zcode_hooks import emit_zcode_hook_response
 
@@ -244,7 +344,7 @@ def _finalize_runtime_artifact_hook(
                 payload=payload,
                 policy_action=policy_action,
             )
-            return 0 if policy_action not in {"block", "sandbox-required", "require-reapproval"} else 2
+            return 0 if policy_action not in {"review", "require-reapproval", "sandbox-required", "block"} else 2
         _emit_native_hook_response(
             harness=args.harness,
             policy_action=policy_action,
@@ -267,7 +367,7 @@ def _finalize_runtime_artifact_hook(
         payload=payload,
         policy_action=policy_action,
     )
-    return 1 if policy_action in {"block", "require-reapproval"} else 0
+    return 1 if policy_action in {"review", "require-reapproval", "sandbox-required", "block"} else 0
 
 __all__ = [
     "_finalize_runtime_artifact_hook",

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_review.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_review.py
@@ -37,7 +37,11 @@ if TYPE_CHECKING:
         _runtime_artifact_native_reason,
     )
     from .commands_support_runtime_artifacts import _optional_string
-    from .commands_support_runtime_policy import _approval_delivery_payload, _localize_pending_approval_copy
+    from .commands_support_runtime_policy import (
+        _approval_delivery_payload,
+        _localize_pending_approval_copy,
+        _terminalize_runtime_action_copy,
+    )
     from .commands_support_runtime_resolution import (
         _canonical_harness_name,
         _runtime_detection,
@@ -46,7 +50,10 @@ if TYPE_CHECKING:
 
 
 from ._commands_shared import *
-from .commands_hook_runtime_state import RuntimeArtifactHookState
+from .commands_hook_runtime_state import (
+    RuntimeArtifactHookState,
+    record_runtime_artifact_hook_receipt,
+)
 from .commands_parser_helpers import *
 
 
@@ -87,9 +94,35 @@ def _review_runtime_artifact_hook(
         guard_payload=response_payload,
     )
     observe_mode = config.mode == "observe"
-    if policy_action in {"block", "sandbox-required", "require-reapproval"} or cursor_native_queue:
+    terminal_action = policy_action in {
+        "block",
+        "sandbox-required",
+    }
+    policy_composition = response_payload.get("policy_composition")
+    post_claim_revalidated = (
+        isinstance(policy_composition, Mapping)
+        and isinstance(policy_composition.get("approval_reuse_source"), str)
+        and str(policy_composition["approval_reuse_source"]).startswith("claimed_")
+    )
+    post_claim_failure = post_claim_revalidated and policy_action not in {"allow", "warn"}
+    if terminal_action:
+        response_payload["approval_requests"] = []
+        response_payload["terminal_action"] = policy_action
+        _terminalize_runtime_action_copy(response_payload)
         if observe_mode:
-            should_queue_approval_center = not (policy_action == "block" and stored_policy_action == "block")
+            response_payload["observed_terminal_action"] = policy_action
+        else:
+            response_payload["operation_status"] = "blocked"
+            response_payload["terminal"] = True
+            response_payload["review_hint"] = (
+                "HOL Guard blocked this action with a terminal policy decision. Browser approval cannot override it."
+            )
+    if policy_action in {"review", "require-reapproval", "sandbox-required", "block"} or cursor_native_queue:
+        saved_policy_blocks = policy_action == "block" and stored_policy_action == "block"
+        if observe_mode and not saved_policy_blocks and not post_claim_failure:
+            should_queue_approval_center = not terminal_action and not (
+                policy_action == "block" and stored_policy_action == "block"
+            )
             if should_queue_approval_center:
                 approval_flow = get_adapter(args.harness).approval_flow(managed_install=managed_install)
                 approval_center_url = ensure_guard_daemon(guard_home)
@@ -231,7 +264,7 @@ def _review_runtime_artifact_hook(
         if (
             _canonical_harness_name(args.harness) == "claude-code"
             and event_name == "PreToolUse"
-            and policy_action == "require-reapproval"
+            and policy_action in {"review", "require-reapproval"}
         ):
             _record_claude_permission_notice(
                 store=store,
@@ -241,6 +274,7 @@ def _review_runtime_artifact_hook(
                 artifact_hash=runtime_artifact_hash,
             )
         if _should_emit_copilot_hook_response(args):
+            record_runtime_artifact_hook_receipt(state, store)
             _record_harness_usage_for_hook(
                 store=store,
                 action_envelope=action_envelope,
@@ -283,6 +317,7 @@ def _review_runtime_artifact_hook(
                 additional_context=additional_context,
                 output_stream=output_stream,
             )
+            record_runtime_artifact_hook_receipt(state, store)
             _record_harness_usage_for_hook(
                 store=store,
                 action_envelope=action_envelope,
@@ -290,7 +325,9 @@ def _review_runtime_artifact_hook(
                 policy_action=policy_action,
             )
             return 0
-        should_queue_approval_center = not (policy_action == "block" and stored_policy_action == "block")
+        should_queue_approval_center = not terminal_action and not (
+            policy_action == "block" and stored_policy_action == "block"
+        )
         if not _prompt_requires_hard_block(runtime_artifact) and should_queue_approval_center:
             approval_flow = get_adapter(args.harness).approval_flow(managed_install=managed_install)
             approval_center_url = ensure_guard_daemon(guard_home)

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_state.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_state.py
@@ -7,7 +7,11 @@ from __future__ import annotations
 
 from ._commands_shared import *
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+
+from ..action_lattice import normalize_guard_action
+from ..models import GuardReceipt
+from ..runtime.signals import RiskSignalV2
 
 
 @dataclass
@@ -17,10 +21,13 @@ class RuntimeArtifactHookState:
     artifact_name: str
     browser_approval_daemon_client: object | None
     changed_capabilities: list[str]
+    decision_signals: tuple[RiskSignalV2, ...]
     decision_v2_payload: dict[str, object]
     event_name: str
+    initial_policy_action: str
     package_evaluation: object | None
     policy_action: str
+    receipt: GuardReceipt
     requested_policy_action: str | None
     response_payload: dict[str, object]
     risk_summary: str
@@ -28,7 +35,92 @@ class RuntimeArtifactHookState:
     runtime_artifact_hash: str
     scanner_evidence_payload: list[dict[str, object]]
     stored_policy_action: str | None
+    receipt_recorded: bool = False
+
+
+def set_runtime_artifact_hook_final_action(
+    state: RuntimeArtifactHookState,
+    policy_action: str,
+    *,
+    approval_request_id: str | None = None,
+    approval_source: str | None = None,
+) -> None:
+    """Make one post-review action authoritative across every hook surface."""
+
+    normalized_action = normalize_guard_action(policy_action, unknown_action="block")
+    state.policy_action = normalized_action
+    state.response_payload["policy_action"] = normalized_action
+    state.response_payload["resolved_policy_action"] = normalized_action
+    if state.action_envelope is not None:
+        state.action_envelope = state.action_envelope.with_pre_execution_result(normalized_action)
+
+    decision_v2_payload = build_decision_v2(
+        normalized_action,
+        reason=(
+            "browser-approval"
+            if approval_source == "browser"
+            else normalized_action
+        ),
+        signals=state.decision_signals,
+    ).to_dict()
+    state.decision_v2_payload = decision_v2_payload
+    state.response_payload["decision_v2_json"] = decision_v2_payload
+
+    policy_composition = state.response_payload.get("policy_composition")
+    if isinstance(policy_composition, dict):
+        policy_composition["authoritative_action"] = normalized_action
+    for evidence in state.scanner_evidence_payload:
+        if evidence.get("source") == "policy_composition":
+            evidence["authoritative_action"] = normalized_action
+
+    receipt_evidence = tuple(
+        {
+            **evidence,
+            "authoritative_action": normalized_action,
+        }
+        if evidence.get("source") == "policy_composition"
+        else evidence
+        for evidence in state.receipt.scanner_evidence
+    )
+    if approval_source == "browser":
+        receipt_evidence = (
+            *receipt_evidence,
+            {
+                "source": "browser_approval_resolution",
+                "initial_action": state.initial_policy_action,
+                "authoritative_action": normalized_action,
+                "approval_request_id": approval_request_id,
+            },
+        )
+    state.receipt = replace(
+        state.receipt,
+        policy_decision=normalized_action,
+        approval_source=approval_source or state.receipt.approval_source,
+        approval_request_id=approval_request_id or state.receipt.approval_request_id,
+        user_override=(
+            "browser-approval"
+            if approval_source == "browser"
+            else state.receipt.user_override
+        ),
+        scanner_evidence=receipt_evidence,
+    )
+
+
+def record_runtime_artifact_hook_receipt(
+    state: RuntimeArtifactHookState,
+    store: GuardStore,
+) -> None:
+    """Persist the final hook receipt once, after any browser resolution."""
+
+    if state.receipt_recorded:
+        return
+    store.add_receipt(state.receipt, action_envelope=state.action_envelope)
+    state.receipt_recorded = True
+    state.response_payload["recorded"] = True
+    state.response_payload["receipt_id"] = state.receipt.receipt_id
 
 __all__ = [
     "RuntimeArtifactHookState",
+    "record_runtime_artifact_hook_receipt",
+    "set_runtime_artifact_hook_final_action",
 ]

--- a/src/codex_plugin_scanner/guard/cli/commands_support_claude_approval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_claude_approval.py
@@ -10,10 +10,10 @@ if TYPE_CHECKING:
     from ._commands_shared import _CLAUDE_GUARD_APPROVAL_HEADER, _CLAUDE_GUARD_APPROVAL_OPTIONS, _now
     from .commands_support_hook_state import (
         _claude_guard_approval_question_text,
-        _claude_pending_permission_index_key,
+        _load_claude_pending_permission_index,
         _load_single_claude_pending_permission,
+        _load_verified_claude_pending_permission,
         _remove_claude_pending_permission,
-        _sync_payload_list_from_row,
     )
     from .commands_support_permission_store import _persist_claude_native_permission_policy
     from .commands_support_runtime_artifacts import _hook_event_name, _optional_string
@@ -35,22 +35,16 @@ def _persist_claude_pending_permission_denials(store: GuardStore, payload: dict[
     session_id = _optional_string(payload.get("session_id"))
     if session_id is None:
         return 0
-    index_key = _claude_pending_permission_index_key(session_id)
-    try:
-        index_payload = store.get_sync_payload(index_key)
-    except (OSError, sqlite3.Error):
-        return 0
-    if not isinstance(index_payload, list):
-        return 0
-    pending_keys = [str(item) for item in index_payload]
+    pending_keys = _load_claude_pending_permission_index(store, session_id=session_id)
     processed_keys: list[str] = []
     denied = 0
     for pending_key in pending_keys:
-        try:
-            pending = store.get_sync_payload(pending_key)
-        except (OSError, sqlite3.Error):
-            continue
-        if not isinstance(pending, dict):
+        pending = _load_verified_claude_pending_permission(
+            store,
+            session_id=session_id,
+            pending_key=pending_key,
+        )
+        if pending is None:
             continue
         if pending.get("permission_prompt_seen") is not True:
             continue
@@ -82,34 +76,8 @@ def _persist_claude_pending_permission_denials(store: GuardStore, payload: dict[
             continue
         processed_keys.append(pending_key)
         denied += 1
-    if processed_keys:
-        processed_set = set(processed_keys)
-        try:
-            with store._connect() as connection:
-                connection.execute("begin immediate")
-                for pending_key in processed_keys:
-                    connection.execute("delete from sync_state where state_key = ?", (pending_key,))
-                row = connection.execute(
-                    "select payload_json from sync_state where state_key = ?",
-                    (index_key,),
-                ).fetchone()
-                current_keys = _sync_payload_list_from_row(row)
-                remaining_keys = [pending_key for pending_key in current_keys if pending_key not in processed_set]
-                if remaining_keys:
-                    connection.execute(
-                        """
-                        insert into sync_state (state_key, payload_json, updated_at)
-                        values (?, ?, ?)
-                        on conflict(state_key) do update set
-                          payload_json = excluded.payload_json,
-                          updated_at = excluded.updated_at
-                        """,
-                        (index_key, json.dumps(remaining_keys), _now()),
-                    )
-                else:
-                    connection.execute("delete from sync_state where state_key = ?", (index_key,))
-        except (OSError, sqlite3.Error):
-            return denied
+    for pending_key in processed_keys:
+        _remove_claude_pending_permission(store, session_id=session_id, pending_key=pending_key)
     return denied
 
 
@@ -312,8 +280,19 @@ def _persist_claude_guard_question_decision(store: GuardStore, payload: dict[str
     if pending_pair is None:
         return False
     pending_key, pending = pending_pair
-    approval_code = _optional_string(pending.get("approval_code"))
-    if approval_code is None and pending.get("permission_prompt_seen") is not True:
+    if pending.get("permission_prompt_seen") is not True:
+        with suppress(OSError, sqlite3.Error):
+            store.add_event(
+                "approval.pending_prompt_unseen",
+                {
+                    "harness": "claude-code",
+                    "source": "claude-pending-permission",
+                    "session_id": payload.get("session_id"),
+                    "artifact_id": pending.get("artifact_id"),
+                    "artifact_hash": pending.get("artifact_hash"),
+                },
+                _now(),
+            )
         return False
     if not _is_claude_guard_approval_question(payload, pending):
         return False

--- a/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 from ._commands_shared import *
 from .commands_parser_helpers import *
 from ..local_supply_chain import _resolve_guard_sync_auth_context as _local_resolve_guard_sync_auth_context
+from ..synced_policy import synced_policy_payload as _synced_policy_payload
 
 
 def _connect_guard_sync_auth_context(store: GuardStore) -> dict[str, object]:
@@ -102,26 +103,6 @@ def _guard_doctor_latest_connect_state_payload(latest_state: dict[str, object]) 
     if isinstance(poll_after_ms, int):
         payload["poll_after_ms"] = poll_after_ms
     return payload
-
-def _synced_policy_payload(store: GuardStore) -> dict[str, object] | None:
-    policy_bundle = store.get_sync_payload("policy_bundle")
-    if isinstance(policy_bundle, dict):
-        policy_defaults = policy_bundle.get("policyDefaults")
-        if isinstance(policy_defaults, dict):
-            payload = dict(policy_defaults)
-            issued_at = _optional_string(policy_bundle.get("issuedAt"))
-            bundle_hash = _optional_string(policy_bundle.get("bundleHash"))
-            bundle_version = _optional_string(policy_bundle.get("bundleVersion"))
-            if issued_at is not None:
-                payload["updatedAt"] = issued_at
-            if bundle_hash is not None:
-                payload["bundleHash"] = bundle_hash
-            if bundle_version is not None:
-                payload["bundleVersion"] = bundle_version
-            return payload
-    payload = store.get_sync_payload("policy")
-    return payload if isinstance(payload, dict) else None
-
 
 _PERSISTED_POLICY_BUNDLE_REJECTION_REASONS = frozenset(
     {

--- a/src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py
@@ -37,7 +37,7 @@ def _emit_native_hook_response(
     if isinstance(system_message, str) and system_message.strip():
         payload["systemMessage"] = system_message.strip()
     if event_name == "UserPromptSubmit":
-        if policy_action in {"block", "sandbox-required", "require-reapproval"} and not additional_context:
+        if policy_action in {"review", "require-reapproval", "sandbox-required", "block"} and not additional_context:
             payload["decision"] = "block"
             payload["reason"] = reason
             if _canonical_harness_name(harness) == "codex":
@@ -72,7 +72,7 @@ def _emit_native_hook_response(
             _write_json_line(payload, output_stream=output_stream)
             return
         if event_name == "PermissionRequest" and _canonical_harness_name(harness) == "codex":
-            if policy_action == "require-reapproval":
+            if policy_action in {"review", "require-reapproval"}:
                 payload["systemMessage"] = (
                     "HOL Guard is reviewing this Codex approval request. Codex will show its normal approval prompt; "
                     "choose allow only if you trust the exact tool action."
@@ -102,7 +102,12 @@ def _emit_native_hook_response(
         if payload:
             _write_json_line(payload, output_stream=output_stream)
         return
-    if event_name == "PostToolUse" and policy_action in {"block", "sandbox-required", "require-reapproval"}:
+    if event_name == "PostToolUse" and policy_action in {
+        "review",
+        "require-reapproval",
+        "sandbox-required",
+        "block",
+    }:
         payload["decision"] = "block"
         payload["reason"] = reason
         payload["continue"] = False
@@ -130,7 +135,7 @@ def _native_hook_permission_decision(policy_action: str, *, harness: str) -> str
     canonical = _canonical_harness_name(harness)
     if policy_action in {"block", "sandbox-required"}:
         return "deny"
-    if policy_action == "require-reapproval":
+    if policy_action in {"review", "require-reapproval"}:
         if canonical in {"codex", "kimi", "grok", "zcode"}:
             return "deny"
         return "ask"
@@ -139,7 +144,7 @@ def _native_hook_permission_decision(policy_action: str, *, harness: str) -> str
     return "allow"
 
 def _copilot_hook_permission_decision(policy_action: str) -> str:
-    if policy_action in {"block", "sandbox-required", "require-reapproval"}:
+    if policy_action in {"review", "require-reapproval", "sandbox-required", "block"}:
         return "deny"
     return "allow"
 
@@ -165,6 +170,8 @@ def _headless_approval_resolver(
     should_wait_for_approvals = not bool(getattr(args, "json", False))
 
     def resolve(detection, payload):
+        if evaluation_has_terminal_policy_action(payload):
+            return payload
         managed_install = _managed_install_for(store, args.harness)
         approval_flow = approval_prompt_flow(args.harness, managed_install=managed_install)
         approval_center_url = ensure_guard_daemon(context.guard_home)

--- a/src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py
@@ -5,7 +5,10 @@
 from __future__ import annotations
 
 import importlib
-from typing import TYPE_CHECKING
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, cast
+
+from ..local_authority_integrity import sign_local_authority_payload, verify_local_authority_payload
 
 if TYPE_CHECKING:
     from ._commands_shared import (
@@ -95,14 +98,229 @@ def _claude_pending_permission_state_key(session_id: str, artifact_id: str) -> s
     return f"claude_pending_permission:{session_id}:{fingerprint}"
 
 
-def _sync_payload_list_from_row(row: sqlite3.Row | None) -> list[str]:
-    if row is None:
-        return []
+_CLAUDE_PENDING_PERMISSION_MAX_AGE_SECONDS = 30 * 60
+_CLAUDE_NOTICE_INTEGRITY_PURPOSE = "claude-permission-notice"
+_CLAUDE_PENDING_INTEGRITY_PURPOSE = "claude-pending-permission"
+_CLAUDE_PENDING_INDEX_INTEGRITY_PURPOSE = "claude-pending-permission-index"
+_CURSOR_PENDING_INTEGRITY_PURPOSE = "cursor-pending-shell"
+_CURSOR_PENDING_INDEX_INTEGRITY_PURPOSE = "cursor-pending-shell-index"
+
+
+def _hook_authority_state_is_fresh(
+    payload: Mapping[str, object],
+    *,
+    now: str,
+    max_age_seconds: int,
+) -> bool:
+    saved_at = _optional_string(payload.get("saved_at"))
+    if saved_at is None:
+        return False
     try:
-        payload = json.loads(str(row["payload_json"]))
-    except json.JSONDecodeError:
-        return []
-    return [str(item) for item in payload] if isinstance(payload, list) else []
+        saved_time = datetime.fromisoformat(saved_at.replace("Z", "+00:00"))
+        current_time = datetime.fromisoformat(now.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if saved_time.tzinfo is None:
+        saved_time = saved_time.replace(tzinfo=timezone.utc)
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+    age_seconds = (current_time - saved_time).total_seconds()
+    return 0 <= age_seconds <= max_age_seconds
+
+
+def _record_hook_authority_integrity_failure(
+    store: GuardStore,
+    *,
+    harness: str,
+    source: str,
+    state_key: str,
+    artifact_id: object,
+    integrity_status: str,
+    message: str | None,
+    now: str,
+) -> None:
+    with suppress(OSError, sqlite3.Error):
+        store.add_event(
+            "rule.ignored.local_integrity",
+            {
+                "decision_id": None,
+                "harness": harness,
+                "artifact_id": artifact_id,
+                "scope": "session",
+                "source": source,
+                "integrity_status": integrity_status,
+                "message": message,
+                "state_key_fingerprint": hashlib.sha256(state_key.encode("utf-8")).hexdigest()[:16],
+            },
+            now,
+        )
+
+
+def _delete_hook_authority_state(store: GuardStore, state_key: str) -> None:
+    with suppress(OSError, sqlite3.Error):
+        store.delete_sync_payload(state_key)
+
+
+def _signed_hook_authority_payload(
+    store: GuardStore,
+    *,
+    state_key: str,
+    payload: Mapping[str, object],
+    purpose: str,
+    now: str,
+) -> dict[str, object] | None:
+    key, key_id = store._policy_integrity_secret_material(create=True)
+    if key is None or key_id is None:
+        return None
+    signed_payload = {name: value for name, value in payload.items() if name != "integrity"}
+    signed_payload["state_key"] = state_key
+    signed_payload["integrity"] = sign_local_authority_payload(
+        signed_payload,
+        key=key,
+        key_id=key_id,
+        purpose=purpose,
+        signed_at=now,
+    )
+    return signed_payload
+
+
+def _store_signed_hook_authority_payload(
+    store: GuardStore,
+    *,
+    state_key: str,
+    payload: Mapping[str, object],
+    purpose: str,
+    now: str,
+) -> bool:
+    signed_payload = _signed_hook_authority_payload(
+        store,
+        state_key=state_key,
+        payload=payload,
+        purpose=purpose,
+        now=now,
+    )
+    if signed_payload is None:
+        return False
+    try:
+        store.set_sync_payload(state_key, signed_payload, now)
+    except (OSError, sqlite3.Error):
+        return False
+    return True
+
+
+def _load_verified_hook_authority_payload(
+    store: GuardStore,
+    *,
+    state_key: str,
+    purpose: str,
+    harness: str,
+    source: str,
+    now: str,
+    max_age_seconds: int,
+) -> dict[str, object] | None:
+    try:
+        persisted = store.get_sync_payload(state_key)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        _record_hook_authority_integrity_failure(
+            store,
+            harness=harness,
+            source=source,
+            state_key=state_key,
+            artifact_id=None,
+            integrity_status="tampered",
+            message="local_authority_integrity_payload_invalid_json",
+            now=now,
+        )
+        _delete_hook_authority_state(store, state_key)
+        return None
+    except (OSError, sqlite3.Error):
+        return None
+    if persisted is None:
+        return None
+    if not isinstance(persisted, dict):
+        _record_hook_authority_integrity_failure(
+            store,
+            harness=harness,
+            source=source,
+            state_key=state_key,
+            artifact_id=None,
+            integrity_status="missing_integrity",
+            message="local_authority_integrity_metadata_missing",
+            now=now,
+        )
+        _delete_hook_authority_state(store, state_key)
+        return None
+    raw_integrity = persisted.get("integrity")
+    integrity: Mapping[str, object] = (
+        cast(Mapping[str, object], raw_integrity) if isinstance(raw_integrity, Mapping) else {}
+    )
+    signed_payload = {name: value for name, value in persisted.items() if name != "integrity"}
+    key, key_id = store._policy_integrity_secret_material(create=False)
+    integrity_result = verify_local_authority_payload(
+        signed_payload,
+        integrity,
+        key=key,
+        key_id=key_id,
+        purpose=purpose,
+    )
+    context_matches = persisted.get("state_key") == state_key
+    if integrity_result.status != "valid" or not context_matches:
+        integrity_status = integrity_result.status if integrity_result.status != "valid" else "tampered"
+        message = (
+            integrity_result.message
+            if integrity_result.status != "valid"
+            else "local_authority_integrity_state_key_mismatch"
+        )
+        _record_hook_authority_integrity_failure(
+            store,
+            harness=harness,
+            source=source,
+            state_key=state_key,
+            artifact_id=persisted.get("artifact_id"),
+            integrity_status=integrity_status,
+            message=message,
+            now=now,
+        )
+        _delete_hook_authority_state(store, state_key)
+        return None
+    if not _hook_authority_state_is_fresh(persisted, now=now, max_age_seconds=max_age_seconds):
+        with suppress(OSError, sqlite3.Error):
+            store.add_event(
+                "approval.pending_state_expired",
+                {
+                    "harness": harness,
+                    "source": source,
+                    "artifact_id": persisted.get("artifact_id"),
+                    "state_key_fingerprint": hashlib.sha256(state_key.encode("utf-8")).hexdigest()[:16],
+                },
+                now,
+            )
+        _delete_hook_authority_state(store, state_key)
+        return None
+    return persisted
+
+
+def _invalidate_hook_authority_context(
+    store: GuardStore,
+    *,
+    state_key: str,
+    payload: Mapping[str, object],
+    harness: str,
+    source: str,
+    message: str,
+    now: str,
+) -> None:
+    _record_hook_authority_integrity_failure(
+        store,
+        harness=harness,
+        source=source,
+        state_key=state_key,
+        artifact_id=payload.get("artifact_id"),
+        integrity_status="tampered",
+        message=message,
+        now=now,
+    )
+    _delete_hook_authority_state(store, state_key)
 
 
 def _append_claude_pending_permission_key(
@@ -111,32 +329,144 @@ def _append_claude_pending_permission_key(
     session_id: str,
     pending_key: str,
     now: str,
-) -> None:
+) -> bool:
+    pending_keys = _load_claude_pending_permission_index(store, session_id=session_id, now=now)
+    if pending_key in pending_keys:
+        return True
+    pending_keys.append(pending_key)
+    return _store_claude_pending_permission_index(
+        store,
+        session_id=session_id,
+        pending_keys=pending_keys,
+        now=now,
+    )
+
+
+def _load_claude_pending_permission_index(
+    store: GuardStore,
+    *,
+    session_id: str,
+    now: str | None = None,
+) -> list[str]:
+    current_time = now or _now()
     index_key = _claude_pending_permission_index_key(session_id)
-    with store._connect() as connection:
-        connection.execute("begin immediate")
-        row = connection.execute(
-            "select payload_json from sync_state where state_key = ?",
-            (index_key,),
-        ).fetchone()
-        pending_keys = _sync_payload_list_from_row(row)
-        if pending_key in pending_keys:
-            return
-        pending_keys.append(pending_key)
-        connection.execute(
-            """
-            insert into sync_state (state_key, payload_json, updated_at)
-            values (?, ?, ?)
-            on conflict(state_key) do update set
-              payload_json = excluded.payload_json,
-              updated_at = excluded.updated_at
-            """,
-            (index_key, json.dumps(pending_keys), now),
+    persisted = _load_verified_hook_authority_payload(
+        store,
+        state_key=index_key,
+        purpose=_CLAUDE_PENDING_INDEX_INTEGRITY_PURPOSE,
+        harness="claude-code",
+        source="claude-pending-permission-index",
+        now=current_time,
+        max_age_seconds=_CLAUDE_PENDING_PERMISSION_MAX_AGE_SECONDS,
+    )
+    if persisted is None:
+        return []
+    pending_keys_value = persisted.get("pending_keys")
+    expected_prefix = f"claude_pending_permission:{session_id}:"
+    context_matches = (
+        persisted.get("session_id") == session_id
+        and isinstance(pending_keys_value, list)
+        and all(isinstance(item, str) and item.startswith(expected_prefix) for item in pending_keys_value)
+    )
+    if not context_matches:
+        _invalidate_hook_authority_context(
+            store,
+            state_key=index_key,
+            payload=persisted,
+            harness="claude-code",
+            source="claude-pending-permission-index",
+            message="local_authority_integrity_pending_index_context_mismatch",
+            now=current_time,
         )
+        return []
+    return list(dict.fromkeys(cast(list[str], pending_keys_value)))
+
+
+def _store_claude_pending_permission_index(
+    store: GuardStore,
+    *,
+    session_id: str,
+    pending_keys: Sequence[str],
+    now: str,
+) -> bool:
+    index_key = _claude_pending_permission_index_key(session_id)
+    if not pending_keys:
+        _delete_hook_authority_state(store, index_key)
+        return True
+    return _store_signed_hook_authority_payload(
+        store,
+        state_key=index_key,
+        payload={
+            "session_id": session_id,
+            "pending_keys": list(dict.fromkeys(pending_keys)),
+            "saved_at": now,
+        },
+        purpose=_CLAUDE_PENDING_INDEX_INTEGRITY_PURPOSE,
+        now=now,
+    )
 
 
 def _claude_guard_approval_question_text(approval_code: str) -> str:
     return f"HOL Guard intercepted this sensitive action (approval code: {approval_code}). What should Claude do?"
+
+
+def _claude_artifact_command_binding(artifact: GuardArtifact) -> str:
+    raw_command_text = artifact.metadata.get("raw_command_text")
+    if isinstance(raw_command_text, str) and raw_command_text:
+        return raw_command_text
+    if isinstance(artifact.command, str) and artifact.command:
+        return artifact.command
+    return f"artifact:{artifact.artifact_id}"
+
+
+def _load_verified_claude_pending_permission(
+    store: GuardStore,
+    *,
+    session_id: str,
+    pending_key: str,
+    expected_artifact_id: str | None = None,
+    expected_artifact_hash: str | None = None,
+    expected_command: str | None = None,
+    now: str | None = None,
+) -> dict[str, object] | None:
+    current_time = now or _now()
+    persisted = _load_verified_hook_authority_payload(
+        store,
+        state_key=pending_key,
+        purpose=_CLAUDE_PENDING_INTEGRITY_PURPOSE,
+        harness="claude-code",
+        source="claude-pending-permission",
+        now=current_time,
+        max_age_seconds=_CLAUDE_PENDING_PERMISSION_MAX_AGE_SECONDS,
+    )
+    if persisted is None:
+        return None
+    artifact_id = _optional_string(persisted.get("artifact_id"))
+    artifact_hash = _optional_string(persisted.get("artifact_hash"))
+    command = _optional_string(persisted.get("command"))
+    expected_key = _claude_pending_permission_state_key(session_id, artifact_id) if artifact_id is not None else None
+    context_matches = (
+        persisted.get("session_id") == session_id
+        and artifact_id is not None
+        and artifact_hash is not None
+        and command is not None
+        and pending_key == expected_key
+        and (expected_artifact_id is None or artifact_id == expected_artifact_id)
+        and (expected_artifact_hash is None or artifact_hash == expected_artifact_hash)
+        and (expected_command is None or command == expected_command)
+    )
+    if context_matches:
+        return persisted
+    _invalidate_hook_authority_context(
+        store,
+        state_key=pending_key,
+        payload=persisted,
+        harness="claude-code",
+        source="claude-pending-permission",
+        message="local_authority_integrity_pending_context_mismatch",
+        now=current_time,
+    )
+    return None
 
 
 def _record_claude_permission_notice(
@@ -155,6 +485,7 @@ def _record_claude_permission_notice(
     approval_code = secrets.token_hex(6)
     approval_question = _claude_guard_approval_question_text(approval_code)
     notice_payload: dict[str, object] = {
+        "session_id": session_id,
         "saved_at": saved_at,
         "reason": reason,
         "artifact_id": artifact.artifact_id,
@@ -167,6 +498,7 @@ def _record_claude_permission_notice(
         "approval_question": approval_question,
         "approval_options": list(_CLAUDE_GUARD_APPROVAL_OPTIONS),
         "approval_code": approval_code,
+        "command": _claude_artifact_command_binding(artifact),
     }
     raw_command_text = artifact.metadata.get("raw_command_text")
     if isinstance(raw_command_text, str) and raw_command_text:
@@ -176,56 +508,115 @@ def _record_claude_permission_notice(
         notice_payload["wrapper_chain"] = [item for item in wrapper_chain if isinstance(item, str) and item]
     if tool_name is not None:
         notice_payload["tool_name"] = tool_name
-    try:
-        store.set_sync_payload(_claude_permission_notice_state_key(session_id, tool_name), notice_payload, saved_at)
-        pending_key = _claude_pending_permission_state_key(session_id, artifact.artifact_id)
-        store.set_sync_payload(pending_key, notice_payload, saved_at)
-        _append_claude_pending_permission_key(store, session_id=session_id, pending_key=pending_key, now=saved_at)
-    except (OSError, sqlite3.Error):
+    notice_key = _claude_permission_notice_state_key(session_id, tool_name)
+    pending_key = _claude_pending_permission_state_key(session_id, artifact.artifact_id)
+    if not _store_signed_hook_authority_payload(
+        store,
+        state_key=pending_key,
+        payload=notice_payload,
+        purpose=_CLAUDE_PENDING_INTEGRITY_PURPOSE,
+        now=saved_at,
+    ):
         return
+    if not _append_claude_pending_permission_key(
+        store,
+        session_id=session_id,
+        pending_key=pending_key,
+        now=saved_at,
+    ):
+        _delete_hook_authority_state(store, pending_key)
+        return
+    if not _store_signed_hook_authority_payload(
+        store,
+        state_key=notice_key,
+        payload=notice_payload,
+        purpose=_CLAUDE_NOTICE_INTEGRITY_PURPOSE,
+        now=saved_at,
+    ):
+        _remove_claude_pending_permission(store, session_id=session_id, pending_key=pending_key)
+
+
+def _load_verified_claude_permission_notice(
+    store: GuardStore,
+    payload: dict[str, object],
+) -> dict[str, object] | None:
+    session_id = _optional_string(payload.get("session_id"))
+    if session_id is None:
+        return None
+    tool_name = _claude_notification_tool_name(payload)
+    now = _now()
+    selected_tool_name = tool_name
+    selected_key = _claude_permission_notice_state_key(session_id, selected_tool_name)
+    persisted = _load_verified_hook_authority_payload(
+        store,
+        state_key=selected_key,
+        purpose=_CLAUDE_NOTICE_INTEGRITY_PURPOSE,
+        harness="claude-code",
+        source="claude-permission-notice",
+        now=now,
+        max_age_seconds=_CLAUDE_PENDING_PERMISSION_MAX_AGE_SECONDS,
+    )
+    if persisted is None and tool_name is not None:
+        selected_tool_name = None
+        selected_key = _claude_permission_notice_state_key(session_id)
+        persisted = _load_verified_hook_authority_payload(
+            store,
+            state_key=selected_key,
+            purpose=_CLAUDE_NOTICE_INTEGRITY_PURPOSE,
+            harness="claude-code",
+            source="claude-permission-notice",
+            now=now,
+            max_age_seconds=_CLAUDE_PENDING_PERMISSION_MAX_AGE_SECONDS,
+        )
+    if persisted is None:
+        return None
+    artifact_id = _optional_string(persisted.get("artifact_id"))
+    artifact_hash = _optional_string(persisted.get("artifact_hash"))
+    command = _optional_string(persisted.get("command"))
+    stored_tool_name = _optional_string(persisted.get("tool_name"))
+    context_matches = (
+        persisted.get("session_id") == session_id
+        and artifact_id is not None
+        and artifact_hash is not None
+        and command is not None
+        and stored_tool_name == selected_tool_name
+    )
+    if not context_matches:
+        _invalidate_hook_authority_context(
+            store,
+            state_key=selected_key,
+            payload=persisted,
+            harness="claude-code",
+            source="claude-permission-notice",
+            message="local_authority_integrity_notice_context_mismatch",
+            now=now,
+        )
+        return None
+    assert artifact_id is not None
+    assert artifact_hash is not None
+    assert command is not None
+    pending_key = _claude_pending_permission_state_key(session_id, artifact_id)
+    pending = _load_verified_claude_pending_permission(
+        store,
+        session_id=session_id,
+        pending_key=pending_key,
+        expected_artifact_id=artifact_id,
+        expected_artifact_hash=artifact_hash,
+        expected_command=command,
+        now=now,
+    )
+    if pending is None:
+        _delete_hook_authority_state(store, selected_key)
+        return None
+    return persisted
 
 
 def _load_claude_permission_notice(store: GuardStore, payload: dict[str, object]) -> dict[str, object] | None:
-    session_id = _optional_string(payload.get("session_id"))
-    if session_id is None:
-        return None
-    tool_name = _claude_notification_tool_name(payload)
-    try:
-        selected_key = _claude_permission_notice_state_key(session_id, tool_name)
-        persisted = store.get_sync_payload(selected_key)
-        if persisted is None and tool_name is not None:
-            selected_key = _claude_permission_notice_state_key(session_id)
-            persisted = store.get_sync_payload(selected_key)
-        if isinstance(persisted, dict):
-            artifact_id = _optional_string(persisted.get("artifact_id"))
-            if artifact_id is not None:
-                pending_key = _claude_pending_permission_state_key(session_id, artifact_id)
-                pending = store.get_sync_payload(pending_key)
-                if not isinstance(pending, dict):
-                    store.delete_sync_payload(selected_key)
-                    persisted = None
-            else:
-                store.delete_sync_payload(selected_key)
-                persisted = None
-    except (OSError, sqlite3.Error):
-        return None
-    if isinstance(persisted, dict):
-        return persisted
-    return None
+    return _load_verified_claude_permission_notice(store, payload)
 
 
 def _peek_claude_permission_notice(store: GuardStore, payload: dict[str, object]) -> dict[str, object] | None:
-    session_id = _optional_string(payload.get("session_id"))
-    if session_id is None:
-        return None
-    tool_name = _claude_notification_tool_name(payload)
-    try:
-        persisted = store.get_sync_payload(_claude_permission_notice_state_key(session_id, tool_name))
-        if persisted is None and tool_name is not None:
-            persisted = store.get_sync_payload(_claude_permission_notice_state_key(session_id))
-    except (OSError, sqlite3.Error):
-        return None
-    return persisted if isinstance(persisted, dict) else None
+    return _load_verified_claude_permission_notice(store, payload)
 
 
 def _mark_claude_pending_permission_prompt_seen(
@@ -239,19 +630,32 @@ def _mark_claude_pending_permission_prompt_seen(
     if session_id is None or artifact_id is None:
         return
     pending_key = _claude_pending_permission_state_key(session_id, artifact_id)
-    try:
-        pending = store.get_sync_payload(pending_key)
-    except (OSError, sqlite3.Error):
+    artifact_hash = _optional_string((notice or {}).get("artifact_hash"))
+    command = _optional_string((notice or {}).get("command"))
+    if artifact_hash is None or command is None:
         return
-    if not isinstance(pending, dict):
+    now = _now()
+    pending = _load_verified_claude_pending_permission(
+        store,
+        session_id=session_id,
+        pending_key=pending_key,
+        expected_artifact_id=artifact_id,
+        expected_artifact_hash=artifact_hash,
+        expected_command=command,
+        now=now,
+    )
+    if pending is None:
         return
     updated = dict(pending)
     updated["permission_prompt_seen"] = True
-    updated["permission_prompt_seen_at"] = _now()
-    try:
-        store.set_sync_payload(pending_key, updated, _now())
-    except (OSError, sqlite3.Error):
-        return
+    updated["permission_prompt_seen_at"] = now
+    _store_signed_hook_authority_payload(
+        store,
+        state_key=pending_key,
+        payload=updated,
+        purpose=_CLAUDE_PENDING_INTEGRITY_PURPOSE,
+        now=now,
+    )
 
 
 def _load_single_claude_pending_permission(
@@ -261,49 +665,44 @@ def _load_single_claude_pending_permission(
     session_id = _optional_string(payload.get("session_id"))
     if session_id is None:
         return None
-    try:
-        index_payload = store.get_sync_payload(_claude_pending_permission_index_key(session_id))
-    except (OSError, sqlite3.Error):
-        return None
-    if not isinstance(index_payload, list):
-        return None
-    pending_keys = [str(item) for item in index_payload]
+    now = _now()
+    pending_keys = _load_claude_pending_permission_index(store, session_id=session_id, now=now)
     pending_items: list[tuple[str, dict[str, object]]] = []
     for pending_key in pending_keys:
-        try:
-            pending = store.get_sync_payload(pending_key)
-        except (OSError, sqlite3.Error):
-            continue
-        if isinstance(pending, dict):
+        pending = _load_verified_claude_pending_permission(
+            store,
+            session_id=session_id,
+            pending_key=pending_key,
+            now=now,
+        )
+        if pending is not None:
             pending_items.append((pending_key, pending))
     prompt_seen_items = [item for item in pending_items if item[1].get("permission_prompt_seen") is True]
     if len(prompt_seen_items) == 1:
         return prompt_seen_items[0]
     if len(pending_items) != 1:
         return None
-    try:
-        pending = store.get_sync_payload(pending_items[0][0])
-    except (OSError, sqlite3.Error):
-        return None
-    if not isinstance(pending, dict):
-        return None
-    return pending_items[0][0], pending
+    return pending_items[0]
 
 
 def _load_claude_pending_permission(
     store: GuardStore,
     payload: dict[str, object],
     artifact: GuardArtifact,
+    artifact_hash: str,
 ) -> dict[str, object] | None:
     session_id = _optional_string(payload.get("session_id"))
     if session_id is None:
         return None
     pending_key = _claude_pending_permission_state_key(session_id, artifact.artifact_id)
-    try:
-        persisted = store.get_sync_payload(pending_key)
-    except (OSError, sqlite3.Error):
-        return None
-    return persisted if isinstance(persisted, dict) else None
+    return _load_verified_claude_pending_permission(
+        store,
+        session_id=session_id,
+        pending_key=pending_key,
+        expected_artifact_id=artifact.artifact_id,
+        expected_artifact_hash=artifact_hash,
+        expected_command=_claude_artifact_command_binding(artifact),
+    )
 
 
 def _remove_claude_pending_permission(
@@ -312,31 +711,19 @@ def _remove_claude_pending_permission(
     session_id: str,
     pending_key: str,
 ) -> None:
-    try:
-        index_key = _claude_pending_permission_index_key(session_id)
-        with store._connect() as connection:
-            connection.execute("begin immediate")
-            connection.execute("delete from sync_state where state_key = ?", (pending_key,))
-            row = connection.execute(
-                "select payload_json from sync_state where state_key = ?",
-                (index_key,),
-            ).fetchone()
-            remaining = [key for key in _sync_payload_list_from_row(row) if key != pending_key]
-            if remaining:
-                connection.execute(
-                    """
-                    insert into sync_state (state_key, payload_json, updated_at)
-                    values (?, ?, ?)
-                    on conflict(state_key) do update set
-                      payload_json = excluded.payload_json,
-                      updated_at = excluded.updated_at
-                    """,
-                    (index_key, json.dumps(remaining), _now()),
-                )
-            else:
-                connection.execute("delete from sync_state where state_key = ?", (index_key,))
-    except (OSError, sqlite3.Error):
-        return
+    now = _now()
+    _delete_hook_authority_state(store, pending_key)
+    remaining = [
+        key
+        for key in _load_claude_pending_permission_index(store, session_id=session_id, now=now)
+        if key != pending_key
+    ]
+    _store_claude_pending_permission_index(
+        store,
+        session_id=session_id,
+        pending_keys=remaining,
+        now=now,
+    )
 
 
 def _cursor_conversation_id(payload: dict[str, object]) -> str | None:
@@ -393,31 +780,148 @@ def _append_cursor_pending_shell_key(
     conversation_id: str,
     pending_key: str,
     now: str,
-) -> None:
+) -> bool:
+    pending_keys = _load_cursor_pending_shell_index(store, conversation_id=conversation_id, now=now)
+    if pending_key in pending_keys:
+        return True
+    pending_keys.append(pending_key)
+    return _store_cursor_pending_shell_index(
+        store,
+        conversation_id=conversation_id,
+        pending_keys=pending_keys,
+        now=now,
+    )
+
+
+def _load_cursor_pending_shell_index(
+    store: GuardStore,
+    *,
+    conversation_id: str,
+    now: str | None = None,
+) -> list[str]:
+    current_time = now or _now()
     index_key = _cursor_pending_shell_index_key(conversation_id)
-    try:
-        with store._connect() as connection:
-            connection.execute("begin immediate")
-            row = connection.execute(
-                "select payload_json from sync_state where state_key = ?",
-                (index_key,),
-            ).fetchone()
-            pending_keys = _sync_payload_list_from_row(row)
-            if pending_key in pending_keys:
-                return
-            pending_keys.append(pending_key)
-            connection.execute(
-                """
-                insert into sync_state (state_key, payload_json, updated_at)
-                values (?, ?, ?)
-                on conflict(state_key) do update set
-                  payload_json = excluded.payload_json,
-                  updated_at = excluded.updated_at
-                """,
-                (index_key, json.dumps(pending_keys), now),
-            )
-    except (OSError, sqlite3.Error):
-        return
+    persisted = _load_verified_hook_authority_payload(
+        store,
+        state_key=index_key,
+        purpose=_CURSOR_PENDING_INDEX_INTEGRITY_PURPOSE,
+        harness="cursor",
+        source="cursor-pending-shell-index",
+        now=current_time,
+        max_age_seconds=_CURSOR_PENDING_SHELL_MAX_AGE_SECONDS,
+    )
+    if persisted is None:
+        return []
+    pending_keys_value = persisted.get("pending_keys")
+    expected_prefix = f"cursor_pending_shell:{conversation_id}:"
+    context_matches = (
+        persisted.get("conversation_id") == conversation_id
+        and isinstance(pending_keys_value, list)
+        and all(isinstance(item, str) and item.startswith(expected_prefix) for item in pending_keys_value)
+    )
+    if not context_matches:
+        _invalidate_hook_authority_context(
+            store,
+            state_key=index_key,
+            payload=persisted,
+            harness="cursor",
+            source="cursor-pending-shell-index",
+            message="local_authority_integrity_pending_index_context_mismatch",
+            now=current_time,
+        )
+        return []
+    return list(dict.fromkeys(cast(list[str], pending_keys_value)))
+
+
+def _store_cursor_pending_shell_index(
+    store: GuardStore,
+    *,
+    conversation_id: str,
+    pending_keys: Sequence[str],
+    now: str,
+) -> bool:
+    index_key = _cursor_pending_shell_index_key(conversation_id)
+    if not pending_keys:
+        _delete_hook_authority_state(store, index_key)
+        return True
+    return _store_signed_hook_authority_payload(
+        store,
+        state_key=index_key,
+        payload={
+            "conversation_id": conversation_id,
+            "pending_keys": list(dict.fromkeys(pending_keys)),
+            "saved_at": now,
+        },
+        purpose=_CURSOR_PENDING_INDEX_INTEGRITY_PURPOSE,
+        now=now,
+    )
+
+
+def _store_cursor_pending_shell_state(
+    store: GuardStore,
+    *,
+    conversation_id: str,
+    command: str,
+    payload: Mapping[str, object],
+    now: str,
+) -> bool:
+    state_key = _cursor_pending_shell_state_key(conversation_id, command)
+    return _store_signed_hook_authority_payload(
+        store,
+        state_key=state_key,
+        payload=payload,
+        purpose=_CURSOR_PENDING_INTEGRITY_PURPOSE,
+        now=now,
+    )
+
+
+def _load_verified_cursor_pending_shell_state(
+    store: GuardStore,
+    *,
+    conversation_id: str,
+    command: str,
+    state_key: str | None = None,
+    now: str | None = None,
+) -> dict[str, object] | None:
+    from ..adapters.cursor_native_approval import normalize_cursor_shell_command
+
+    current_time = now or _now()
+    normalized_command = normalize_cursor_shell_command(command)
+    expected_key = _cursor_pending_shell_state_key(conversation_id, normalized_command)
+    selected_key = state_key or expected_key
+    persisted = _load_verified_hook_authority_payload(
+        store,
+        state_key=selected_key,
+        purpose=_CURSOR_PENDING_INTEGRITY_PURPOSE,
+        harness="cursor",
+        source="cursor-pending-shell",
+        now=current_time,
+        max_age_seconds=_CURSOR_PENDING_SHELL_MAX_AGE_SECONDS,
+    )
+    if persisted is None:
+        return None
+    artifact_id = _optional_string(persisted.get("artifact_id"))
+    artifact_hash = _optional_string(persisted.get("artifact_hash"))
+    stored_command = _optional_string(persisted.get("command"))
+    context_matches = (
+        selected_key == expected_key
+        and persisted.get("conversation_id") == conversation_id
+        and artifact_id is not None
+        and artifact_hash is not None
+        and stored_command == normalized_command
+    )
+    if context_matches:
+        return persisted
+    _invalidate_hook_authority_context(
+        store,
+        state_key=selected_key,
+        payload=persisted,
+        harness="cursor",
+        source="cursor-pending-shell",
+        message="local_authority_integrity_pending_context_mismatch",
+        now=current_time,
+    )
+    return None
 
 
 def _cursor_native_shell_allow_state_key(conversation_id: str, command: str) -> str:
@@ -425,23 +929,15 @@ def _cursor_native_shell_allow_state_key(conversation_id: str, command: str) -> 
 
 
 _CURSOR_PENDING_SHELL_MAX_AGE_SECONDS = 30 * 60
+_CURSOR_NATIVE_ALLOW_INTEGRITY_PURPOSE = "cursor-native-shell-allow"
 
 
 def _cursor_pending_shell_is_fresh(pending: Mapping[str, object], *, now: str) -> bool:
-    saved_at = _optional_string(pending.get("saved_at"))
-    if saved_at is None:
-        return False
-    try:
-        saved_time = datetime.fromisoformat(saved_at.replace("Z", "+00:00"))
-        current_time = datetime.fromisoformat(now.replace("Z", "+00:00"))
-    except ValueError:
-        return False
-    if saved_time.tzinfo is None:
-        saved_time = saved_time.replace(tzinfo=timezone.utc)
-    if current_time.tzinfo is None:
-        current_time = current_time.replace(tzinfo=timezone.utc)
-    age_seconds = (current_time - saved_time).total_seconds()
-    return 0 <= age_seconds <= _CURSOR_PENDING_SHELL_MAX_AGE_SECONDS
+    return _hook_authority_state_is_fresh(
+        pending,
+        now=now,
+        max_age_seconds=_CURSOR_PENDING_SHELL_MAX_AGE_SECONDS,
+    )
 
 
 def _cursor_after_shell_observed(payload: Mapping[str, object]) -> bool:
@@ -465,18 +961,34 @@ def _record_cursor_native_shell_allow_state(
     artifact_hash: str,
     now: str,
 ) -> bool:
+    from ..adapters.cursor_native_approval import normalize_cursor_shell_command
+
+    normalized_command = normalize_cursor_shell_command(command)
+    state_key = _cursor_native_shell_allow_state_key(conversation_id, normalized_command)
     allow_payload: dict[str, object] = {
+        "state_key": state_key,
+        "conversation_id": conversation_id,
         "saved_at": now,
         "action": "allow",
         "artifact_id": artifact.artifact_id,
         "artifact_hash": artifact_hash,
         "artifact_name": artifact.name,
-        "command": command,
+        "command": normalized_command,
         "native_source": "cursor-native",
     }
+    key, key_id = store._policy_integrity_secret_material(create=True)
+    if key is None or key_id is None:
+        return False
+    allow_payload["integrity"] = sign_local_authority_payload(
+        allow_payload,
+        key=key,
+        key_id=key_id,
+        purpose=_CURSOR_NATIVE_ALLOW_INTEGRITY_PURPOSE,
+        signed_at=now,
+    )
     try:
         store.set_sync_payload(
-            _cursor_native_shell_allow_state_key(conversation_id, command),
+            state_key,
             allow_payload,
             now,
         )
@@ -491,28 +1003,114 @@ def _cursor_native_shell_allowance_is_fresh(approved: Mapping[str, object], *, n
     return _cursor_pending_shell_is_fresh(approved, now=now)
 
 
+def _record_cursor_native_allow_integrity_failure(
+    store: GuardStore,
+    *,
+    state_key: str,
+    artifact_id: object,
+    integrity_status: str,
+    message: str | None,
+    now: str,
+) -> None:
+    with suppress(OSError, sqlite3.Error):
+        store.add_event(
+            "rule.ignored.local_integrity",
+            {
+                "decision_id": None,
+                "harness": "cursor",
+                "artifact_id": artifact_id,
+                "scope": "session",
+                "source": "cursor-native-session",
+                "integrity_status": integrity_status,
+                "message": message,
+                "state_key_fingerprint": hashlib.sha256(state_key.encode("utf-8")).hexdigest()[:16],
+            },
+            now,
+        )
+
+
+def _load_cursor_native_shell_allowance(
+    store: GuardStore,
+    payload: Mapping[str, object],
+) -> dict[str, object] | None:
+    conversation_id = _cursor_conversation_id(dict(payload))
+    command = _cursor_shell_command_from_payload(payload)
+    if conversation_id is None or command is None:
+        return None
+    state_key = _cursor_native_shell_allow_state_key(conversation_id, command)
+    now = _now()
+    try:
+        approved = store.get_sync_payload(state_key)
+    except json.JSONDecodeError:
+        _record_cursor_native_allow_integrity_failure(
+            store,
+            state_key=state_key,
+            artifact_id=None,
+            integrity_status="tampered",
+            message="local_authority_integrity_payload_invalid_json",
+            now=now,
+        )
+        with suppress(OSError, sqlite3.Error):
+            store.delete_sync_payload(state_key)
+        return None
+    except (OSError, sqlite3.Error):
+        approved = None
+    if not isinstance(approved, dict):
+        return None
+    raw_integrity = approved.get("integrity")
+    integrity: Mapping[str, object] = (
+        cast(Mapping[str, object], raw_integrity) if isinstance(raw_integrity, Mapping) else {}
+    )
+    signed_payload = {key: value for key, value in approved.items() if key != "integrity"}
+    integrity_key: bytes | None = None
+    integrity_key_id: str | None = None
+    if integrity:
+        integrity_key, integrity_key_id = store._policy_integrity_secret_material(create=False)
+    integrity_result = verify_local_authority_payload(
+        signed_payload,
+        integrity,
+        key=integrity_key,
+        key_id=integrity_key_id,
+        purpose=_CURSOR_NATIVE_ALLOW_INTEGRITY_PURPOSE,
+    )
+    context_matches = (
+        approved.get("state_key") == state_key
+        and approved.get("conversation_id") == conversation_id
+        and approved.get("command") == command
+    )
+    allowance_is_fresh = _cursor_native_shell_allowance_is_fresh(approved, now=now)
+    if integrity_result.status == "valid" and context_matches and allowance_is_fresh:
+        return approved
+    if integrity_result.status == "valid" and context_matches:
+        with suppress(OSError, sqlite3.Error):
+            store.delete_sync_payload(state_key)
+        return None
+    integrity_status = integrity_result.status if integrity_result.status != "valid" else "tampered"
+    integrity_message = (
+        integrity_result.message if integrity_result.status != "valid" else "local_authority_integrity_context_mismatch"
+    )
+    _record_cursor_native_allow_integrity_failure(
+        store,
+        state_key=state_key,
+        artifact_id=approved.get("artifact_id"),
+        integrity_status=integrity_status,
+        message=integrity_message,
+        now=now,
+    )
+    with suppress(OSError, sqlite3.Error):
+        store.delete_sync_payload(state_key)
+    return None
+
+
 def _cursor_native_shell_is_approved(
     store: GuardStore,
     payload: Mapping[str, object],
 ) -> bool:
-    conversation_id = _cursor_conversation_id(dict(payload))
-    command = _cursor_shell_command_from_payload(payload)
-    if conversation_id is None or command is None:
-        return False
-    now = _now()
-    try:
-        approved = store.get_sync_payload(_cursor_native_shell_allow_state_key(conversation_id, command))
-    except (OSError, sqlite3.Error):
-        approved = None
-    if isinstance(approved, dict) and _cursor_native_shell_allowance_is_fresh(approved, now=now):
-        return True
-    if isinstance(approved, dict):
-        with suppress(OSError, sqlite3.Error):
-            store.delete_sync_payload(_cursor_native_shell_allow_state_key(conversation_id, command))
-    return False
+    return _load_cursor_native_shell_allowance(store, payload) is not None
 
 
 __all__ = [
+    "_CLAUDE_PENDING_PERMISSION_MAX_AGE_SECONDS",
     "_CURSOR_PENDING_SHELL_MAX_AGE_SECONDS",
     "_append_claude_pending_permission_key",
     "_append_cursor_pending_shell_key",
@@ -532,14 +1130,20 @@ __all__ = [
     "_cursor_shell_command_from_payload",
     "_emit_claude_permission_request_passthrough",
     "_load_claude_pending_permission",
+    "_load_claude_pending_permission_index",
     "_load_claude_permission_notice",
+    "_load_cursor_native_shell_allowance",
+    "_load_cursor_pending_shell_index",
     "_load_single_claude_pending_permission",
+    "_load_verified_claude_pending_permission",
+    "_load_verified_cursor_pending_shell_state",
     "_mark_claude_pending_permission_prompt_seen",
     "_peek_claude_permission_notice",
     "_record_claude_permission_notice",
     "_record_cursor_native_shell_allow_state",
     "_remove_claude_pending_permission",
     "_should_emit_prequeue_native_hook_response",
-    "_sync_payload_list_from_row",
+    "_store_cursor_pending_shell_index",
+    "_store_cursor_pending_shell_state",
     "_update_codex_browser_operation_status",
 ]

--- a/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import importlib
 from typing import TYPE_CHECKING
 
+from ..runtime.approval_context import approval_context_tokens_validation_reason
+
 if TYPE_CHECKING:
     from ._commands_shared import _CODEX_BROWSER_APPROVAL_WAIT_MAX_SECONDS, _hook_command_text, _now
     from .commands_support_hook_payload import _browser_url_with_guard_params
@@ -33,11 +35,15 @@ def _optional_string(value: object | None) -> str | None:
     return _runtime_artifacts_module()._optional_string(value)
 
 
-def _update_codex_browser_operation_status(
+def _set_codex_browser_operation_status(
     response_payload: dict[str, object],
     daemon_client: object | None,
     status: str,
 ) -> None:
+    operation = response_payload.get("operation")
+    if isinstance(operation, dict):
+        operation["status"] = status
+    response_payload["operation_status"] = status
     _hook_state_module()._update_codex_browser_operation_status(response_payload, daemon_client, status)
 
 
@@ -298,7 +304,7 @@ def _should_emit_claude_native_pretooluse_notice(
         _canonical_harness_name(args.harness) == "claude-code"
         and not getattr(args, "json", False)
         and event_name == "PreToolUse"
-        and policy_action == "require-reapproval"
+        and policy_action in {"review", "require-reapproval"}
     )
 
 def _should_emit_native_hook_json_response(
@@ -325,7 +331,7 @@ def _should_emit_native_hook_exit_block(args: argparse.Namespace, *, event_name:
     # the tool. Blocking must be communicated through the JSON hook response.
     canonical = _canonical_harness_name(args.harness)
     if canonical in {"kimi", "grok", "pi", "zcode"} and event_name in {"PreToolUse", "UserPromptSubmit"}:
-        return policy_action in {"block", "sandbox-required", "require-reapproval"}
+        return policy_action in {"review", "require-reapproval", "sandbox-required", "block"}
     return False
 
 def _codex_browser_approval_decision(
@@ -337,6 +343,8 @@ def _codex_browser_approval_decision(
     store: GuardStore,
     config: GuardConfig,
     daemon_client: object | None = None,
+    expected_artifact_hash: str | None = None,
+    fresh_context_provider: Callable[[], Mapping[str, object] | None] | None = None,
 ) -> str | None:
     if not _codex_can_use_browser_approval(args=args, event_name=event_name, policy_action=policy_action):
         return None
@@ -367,7 +375,7 @@ def _codex_browser_approval_decision(
     )
     response_payload["approval_wait"] = wait_result
     if not bool(wait_result.get("resolved")):
-        _update_codex_browser_operation_status(response_payload, daemon_client, "approval_wait_timeout")
+        _set_codex_browser_operation_status(response_payload, daemon_client, "approval_wait_timeout")
         response_payload["review_hint"] = (
             "Approval is still pending in HOL Guard. Approve it in the browser, then retry the same Codex action."
         )
@@ -375,19 +383,210 @@ def _codex_browser_approval_decision(
     wait_items = wait_result.get("items")
     resolved_items = [item for item in (wait_items if isinstance(wait_items, list) else []) if isinstance(item, dict)]
     if any(str(item.get("resolution_action")) == "block" for item in resolved_items):
-        _update_codex_browser_operation_status(response_payload, daemon_client, "blocked")
+        _set_codex_browser_operation_status(response_payload, daemon_client, "blocked")
+        _record_codex_live_hook_continuation(
+            response_payload=response_payload,
+            store=store,
+            request_ids=request_ids,
+            action="block",
+        )
         response_payload["review_hint"] = "Browser decision saved. HOL Guard kept this Codex action blocked."
         return "block"
-    _update_codex_browser_operation_status(response_payload, daemon_client, "completed")
+    fresh_artifact_id: str | None = None
+    fresh_artifact_hash = expected_artifact_hash
+    fresh_current_action: str | None = None
+    fresh_authoritative_action: str | None = None
+    fresh_terminal_action: str | None = None
+    exact_validation_failure: str | None = None
+    if fresh_context_provider is None:
+        exact_validation_failure = "fresh_context_unavailable"
+    else:
+        try:
+            fresh_context = fresh_context_provider()
+        except Exception:
+            fresh_context = None
+        if not isinstance(fresh_context, Mapping):
+            exact_validation_failure = "fresh_context_unavailable"
+        else:
+            fresh_artifact_id = _optional_string(fresh_context.get("artifact_id"))
+            fresh_artifact_hash = _optional_string(fresh_context.get("artifact_hash"))
+            fresh_current_action = _optional_string(fresh_context.get("current_action"))
+            fresh_authoritative_action = _optional_string(
+                fresh_context.get("authoritative_action")
+            )
+            if fresh_authoritative_action in {"block", "sandbox-required"}:
+                fresh_terminal_action = fresh_authoritative_action
+            elif fresh_current_action in {"block", "sandbox-required"}:
+                fresh_terminal_action = fresh_current_action
+            if fresh_artifact_id is None or fresh_artifact_hash is None:
+                exact_validation_failure = "fresh_context_incomplete"
+            elif fresh_current_action in {"block", "sandbox-required"}:
+                exact_validation_failure = "current_policy_became_terminal"
+            elif fresh_current_action not in {"allow", "warn", "review", "require-reapproval"}:
+                exact_validation_failure = "fresh_current_action_unrecognized"
+    if exact_validation_failure is None:
+        exact_validation_failure = _codex_browser_exact_resolution_failure(
+            response_payload=response_payload,
+            store=store,
+            request_ids=request_ids,
+            resolved_items=resolved_items,
+            expected_artifact_hash=fresh_artifact_hash,
+            expected_artifact_id=fresh_artifact_id,
+        )
+    if (
+        exact_validation_failure is None
+        and fresh_context_provider is not None
+        and fresh_authoritative_action != "allow"
+    ):
+        # The exact browser decision is evidence, not the launch authority.
+        # Re-evaluation must have successfully applied (and, for one-shot
+        # rows, atomically claimed) that evidence.  A renewed review or a
+        # concurrent saved block must never be overwritten by this waiter.
+        exact_validation_failure = "fresh_authoritative_action_not_allowed"
+    if exact_validation_failure is not None:
+        terminal_action = fresh_terminal_action or "block"
+        response_payload["approval_requests"] = resolved_items
+        _set_codex_browser_operation_status(response_payload, daemon_client, "blocked")
+        _record_codex_live_hook_continuation(
+            response_payload=response_payload,
+            store=store,
+            request_ids=request_ids,
+            action=terminal_action,
+        )
+        response_payload["browser_resolution_validation"] = exact_validation_failure
+        if terminal_action == "sandbox-required":
+            response_payload["review_hint"] = (
+                "HOL Guard rejected the browser approval because current policy now requires a sandbox. "
+                "This Codex action was not resumed."
+            )
+        else:
+            response_payload["review_hint"] = (
+                "HOL Guard rejected the browser approval because it did not match the exact current request. "
+                "This Codex action remains blocked."
+            )
+        return terminal_action
+    response_payload["approval_requests"] = resolved_items
+    _set_codex_browser_operation_status(response_payload, daemon_client, "completed")
+    _record_codex_live_hook_continuation(
+        response_payload=response_payload,
+        store=store,
+        request_ids=request_ids,
+        action="allow",
+    )
+    response_payload["browser_resolution_request_id"] = request_ids[0]
     response_payload["review_hint"] = "Approval received in HOL Guard. Codex is resuming this action."
     return "allow"
+
+
+def _codex_browser_exact_resolution_failure(
+    *,
+    response_payload: Mapping[str, object],
+    store: GuardStore,
+    request_ids: list[str],
+    resolved_items: list[dict[str, object]],
+    expected_artifact_hash: str | None,
+    expected_artifact_id: str | None = None,
+) -> str | None:
+    resolved_by_id = {
+        str(item.get("request_id")): item
+        for item in resolved_items
+        if isinstance(item.get("request_id"), str)
+    }
+    current_artifact_hash = expected_artifact_hash
+    if current_artifact_hash is None:
+        current_artifact_hash = _optional_string(response_payload.get("artifact_hash"))
+    current_artifact_id = expected_artifact_id or _optional_string(response_payload.get("artifact_id"))
+    if current_artifact_hash is None:
+        return "missing_current_approval_context"
+    for request_id in request_ids:
+        resolved_item = resolved_by_id.get(request_id)
+        stored_item = store.get_approval_request(request_id)
+        item = dict(stored_item) if isinstance(stored_item, Mapping) else None
+        if resolved_item is not None:
+            item = {**(item or {}), **resolved_item}
+        if item is None:
+            return "missing_resolved_request"
+        if str(item.get("resolution_action")) != "allow":
+            return "non_allow_resolution"
+        if str(item.get("policy_action")) not in {"review", "require-reapproval"}:
+            return "terminal_request_is_not_approvable"
+        if current_artifact_id is not None and str(item.get("artifact_id")) != current_artifact_id:
+            return "approval_artifact_changed"
+        if approval_context_tokens_validation_reason(
+            item.get("artifact_hash"),
+            current_artifact_hash,
+        ) is not None:
+            return "approval_context_changed"
+    return None
+
+
+def _record_codex_live_hook_continuation(
+    *,
+    response_payload: dict[str, object],
+    store: GuardStore,
+    request_ids: list[str],
+    action: str,
+) -> None:
+    status = "resumed" if action == "allow" else "blocked"
+    sandbox_required = action == "sandbox-required"
+    continuation: dict[str, object] = {
+        "status": status,
+        "resolution_action": action,
+        "strategy": "live-hook",
+    }
+    response_payload["continuation"] = continuation
+    response_payload["codex_resume"] = dict(continuation)
+    now = _now()
+    for request_id in request_ids:
+        resume = store.get_request_resume(request_id)
+        if not isinstance(resume, Mapping):
+            continue
+        attempt_count = resume.get("attempt_count")
+        store.update_request_resume(
+            request_id=request_id,
+            resolution_action=action,
+            strategy=(
+                str(resume.get("strategy"))
+                if isinstance(resume.get("strategy"), str)
+                else "live-hook"
+            ),
+            supported=(
+                bool(resume.get("supported"))
+                if resume.get("supported") is not None
+                else action == "allow"
+            ),
+            status=status,
+            reason=(
+                "live_hook_completed"
+                if action == "allow"
+                else "sandbox_required_not_resumed"
+                if sandbox_required
+                else "blocked_not_resumed"
+            ),
+            message=(
+                "The original Codex hook consumed the exact browser approval and resumed the action."
+                if action == "allow"
+                else "Current HOL Guard policy requires a sandbox; the original Codex action was not resumed."
+                if sandbox_required
+                else "HOL Guard kept the original Codex action blocked."
+            ),
+            last_error=None,
+            attempt_count=int(attempt_count) if isinstance(attempt_count, int) else 0,
+            last_attempt_at=now,
+            sent_at=(
+                str(resume.get("sent_at"))
+                if isinstance(resume.get("sent_at"), str)
+                else None
+            ),
+            now=now,
+        )
 
 def _codex_can_use_browser_approval(args: argparse.Namespace, *, event_name: str, policy_action: str) -> bool:
     return (
         _canonical_harness_name(args.harness) == "codex"
         and not getattr(args, "json", False)
         and event_name in {"PreToolUse", "PostToolUse", "UserPromptSubmit"}
-        and policy_action in {"block", "sandbox-required", "require-reapproval"}
+        and policy_action in {"review", "require-reapproval"}
     )
 
 def _codex_hook_waits_for_browser_approval(

--- a/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
@@ -16,20 +16,25 @@ if TYPE_CHECKING:
         _claude_pending_permission_state_key,
         _cursor_after_shell_observed,
         _cursor_conversation_id,
-        _cursor_pending_shell_index_key,
         _cursor_pending_shell_is_fresh,
         _cursor_pending_shell_state_key,
         _cursor_shell_command_fingerprint,
         _cursor_shell_command_from_payload,
         _load_claude_pending_permission,
+        _load_claude_pending_permission_index,
+        _load_cursor_pending_shell_index,
+        _load_verified_cursor_pending_shell_state,
         _record_cursor_native_shell_allow_state,
         _remove_claude_pending_permission,
-        _sync_payload_list_from_row,
+        _store_cursor_pending_shell_index,
+        _store_cursor_pending_shell_state,
     )
     from .commands_support_runtime_artifacts import _hook_runtime_artifact, _optional_string, _string_list
     from .commands_support_runtime_resolution import _runtime_capabilities_summary
 
 
+from ..models import GuardAction
+from ..runtime.approval_context import parse_approval_context_token
 from ..store import _runtime_scoped_exact_match_key, runtime_tool_action_exact_match_context
 from ._commands_shared import *
 from .commands_parser_helpers import *
@@ -110,13 +115,22 @@ def _record_cursor_pending_shell_permission(
     }
     pending_key = _cursor_pending_shell_state_key(conversation_id, command)
     try:
-        store.set_sync_payload(pending_key, notice_payload, saved_at)
-        _append_cursor_pending_shell_key(
+        pending_saved = _store_cursor_pending_shell_state(
+            store,
+            conversation_id=conversation_id,
+            command=command,
+            payload=notice_payload,
+            now=saved_at,
+        )
+        indexed = pending_saved and _append_cursor_pending_shell_key(
             store,
             conversation_id=conversation_id,
             pending_key=pending_key,
             now=saved_at,
         )
+        if not indexed:
+            store.delete_sync_payload(pending_key)
+            return
         write_cursor_shell_binding_file(
             guard_home,
             conversation_id=conversation_id,
@@ -143,11 +157,13 @@ def _attach_cursor_pending_approval_request_ids(
     if conversation_id is None or command is None:
         return
     pending_key = _cursor_pending_shell_state_key(conversation_id, command)
-    try:
-        pending = store.get_sync_payload(pending_key)
-    except (OSError, sqlite3.Error):
-        return
-    if not isinstance(pending, dict):
+    pending = _load_verified_cursor_pending_shell_state(
+        store,
+        conversation_id=conversation_id,
+        command=command,
+        state_key=pending_key,
+    )
+    if pending is None:
         return
     request_ids: list[str] = []
     approval_requests = response_payload.get("approval_requests")
@@ -164,10 +180,13 @@ def _attach_cursor_pending_approval_request_ids(
         return
     updated = dict(pending)
     updated["approval_request_ids"] = request_ids
-    try:
-        store.set_sync_payload(pending_key, updated, _now())
-    except (OSError, sqlite3.Error):
-        return
+    _store_cursor_pending_shell_state(
+        store,
+        conversation_id=conversation_id,
+        command=command,
+        payload=updated,
+        now=_now(),
+    )
 
 
 def _load_cursor_pending_shell_permission(
@@ -177,27 +196,26 @@ def _load_cursor_pending_shell_permission(
     command: str,
 ) -> dict[str, object] | None:
     pending_key = _cursor_pending_shell_state_key(conversation_id, command)
-    try:
-        pending = store.get_sync_payload(pending_key)
-    except (OSError, sqlite3.Error):
-        pending = None
-    if isinstance(pending, dict):
+    now = _now()
+    pending = _load_verified_cursor_pending_shell_state(
+        store,
+        conversation_id=conversation_id,
+        command=command,
+        state_key=pending_key,
+        now=now,
+    )
+    if pending is not None:
         return pending
     target_fingerprint = _cursor_shell_command_fingerprint(command)
-    try:
-        index_payload = store.get_sync_payload(_cursor_pending_shell_index_key(conversation_id))
-    except (OSError, sqlite3.Error):
-        return None
-    if not isinstance(index_payload, list):
-        return None
-    for indexed_key in index_payload:
-        if not isinstance(indexed_key, str):
-            continue
-        try:
-            candidate = store.get_sync_payload(indexed_key)
-        except (OSError, sqlite3.Error):
-            continue
-        if not isinstance(candidate, dict):
+    for indexed_key in _load_cursor_pending_shell_index(store, conversation_id=conversation_id, now=now):
+        candidate = _load_verified_cursor_pending_shell_state(
+            store,
+            conversation_id=conversation_id,
+            command=command,
+            state_key=indexed_key,
+            now=now,
+        )
+        if candidate is None:
             continue
         stored_command = _optional_string(candidate.get("command"))
         if stored_command is None:
@@ -213,31 +231,20 @@ def _remove_cursor_pending_shell_permission(
     conversation_id: str,
     pending_key: str,
 ) -> None:
-    try:
-        index_key = _cursor_pending_shell_index_key(conversation_id)
-        with store._connect() as connection:
-            connection.execute("begin immediate")
-            connection.execute("delete from sync_state where state_key = ?", (pending_key,))
-            row = connection.execute(
-                "select payload_json from sync_state where state_key = ?",
-                (index_key,),
-            ).fetchone()
-            remaining = [key for key in _sync_payload_list_from_row(row) if key != pending_key]
-            if remaining:
-                connection.execute(
-                    """
-                    insert into sync_state (state_key, payload_json, updated_at)
-                    values (?, ?, ?)
-                    on conflict(state_key) do update set
-                      payload_json = excluded.payload_json,
-                      updated_at = excluded.updated_at
-                    """,
-                    (index_key, json.dumps(remaining), _now()),
-                )
-            else:
-                connection.execute("delete from sync_state where state_key = ?", (index_key,))
-    except (OSError, sqlite3.Error):
-        return
+    now = _now()
+    with suppress(OSError, sqlite3.Error):
+        store.delete_sync_payload(pending_key)
+    remaining = [
+        key
+        for key in _load_cursor_pending_shell_index(store, conversation_id=conversation_id, now=now)
+        if key != pending_key
+    ]
+    _store_cursor_pending_shell_index(
+        store,
+        conversation_id=conversation_id,
+        pending_keys=remaining,
+        now=now,
+    )
 
 
 def _persist_cursor_native_permission_policy(
@@ -441,7 +448,14 @@ def _persist_claude_native_permission_policy(
         if artifact_type == "tool_action_request"
         else None
     )
-    stored_artifact_hash = exact_artifact_hash or artifact_hash
+    # V1 approval-context tokens already bind the full tool identity and are
+    # the only values that may authorize P44 approval reuse.  Keep the legacy
+    # exact-command key only for legacy callers/blocks.
+    stored_artifact_hash = (
+        artifact_hash
+        if parse_approval_context_token(artifact_hash) is not None
+        else exact_artifact_hash or artifact_hash
+    )
     try:
         if artifact_type == "tool_action_request" and exact_artifact_hash is None:
             store.add_event(
@@ -487,12 +501,35 @@ def _persist_claude_native_permission_for_runtime_artifact(
     artifact: GuardArtifact,
     artifact_hash: str,
     action: str,
+    authoritative_action: GuardAction,
     reason: str,
-) -> bool:
-    pending = _load_claude_pending_permission(store, payload, artifact)
+) -> tuple[bool, bool]:
+    """Record a Claude-native answer without overriding current authority.
+
+    The first result reports whether a matching pending native prompt was
+    observed; the second reports whether a reusable allow policy was saved.
+    Stronger recomputed actions remain authoritative and are recorded only as
+    evidence/inventory, never as a contradictory effective allow.
+    """
+
+    pending = _load_claude_pending_permission(store, payload, artifact, artifact_hash)
     if pending is None:
-        return False
+        return False, False
     now = _now()
+    if pending.get("permission_prompt_seen") is not True:
+        with suppress(OSError, sqlite3.Error):
+            store.add_event(
+                "approval.pending_prompt_unseen",
+                {
+                    "harness": "claude-code",
+                    "source": "claude-pending-permission",
+                    "session_id": payload.get("session_id"),
+                    "artifact_id": artifact.artifact_id,
+                    "artifact_hash": artifact_hash,
+                },
+                now,
+            )
+        return False, False
     raw_command_text_value = artifact.metadata.get("raw_command_text")
     raw_command_text = raw_command_text_value if isinstance(raw_command_text_value, str) else None
     wrapper_chain_value = artifact.metadata.get("wrapper_chain")
@@ -501,32 +538,46 @@ def _persist_claude_native_permission_for_runtime_artifact(
         if isinstance(wrapper_chain_value, Sequence) and not isinstance(wrapper_chain_value, str)
         else None
     )
-    saved_policy = _persist_claude_native_permission_policy(
-        store=store,
-        artifact_id=artifact.artifact_id,
-        artifact_hash=artifact_hash,
-        artifact_type=artifact.artifact_type,
-        config_path=artifact.config_path,
-        source_scope=artifact.source_scope,
-        raw_command_text=raw_command_text,
-        wrapper_chain=wrapper_chain,
-        action=action,
-        reason=reason,
-        now=now,
-    )
-    if not saved_policy:
-        return False
+    saved_policy = False
+    if authoritative_action == "allow":
+        saved_policy = _persist_claude_native_permission_policy(
+            store=store,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=artifact_hash,
+            artifact_type=artifact.artifact_type,
+            config_path=artifact.config_path,
+            source_scope=artifact.source_scope,
+            raw_command_text=raw_command_text,
+            wrapper_chain=wrapper_chain,
+            action=action,
+            reason=reason,
+            now=now,
+        )
+        if not saved_policy:
+            return True, False
+    else:
+        with suppress(OSError, sqlite3.Error):
+            store.add_event(
+                "claude/native_permission_current_policy_retained",
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "artifact_hash": artifact_hash,
+                    "native_action": action,
+                    "authoritative_action": authoritative_action,
+                },
+                now,
+            )
     try:
         store.record_inventory_artifact(
             artifact=artifact,
             artifact_hash=artifact_hash,
-            policy_action="allow" if action == "allow" else "block",
+            policy_action=authoritative_action,
             changed=False,
             now=now,
-            approved=action == "allow",
+            approved=authoritative_action == "allow",
         )
     except (OSError, sqlite3.Error):
-        return False
+        return True, saved_policy
     session_id = _optional_string(payload.get("session_id"))
     if session_id is not None:
         _remove_claude_pending_permission(
@@ -534,7 +585,7 @@ def _persist_claude_native_permission_for_runtime_artifact(
             session_id=session_id,
             pending_key=_claude_pending_permission_state_key(session_id, artifact.artifact_id),
         )
-    return True
+    return True, saved_policy
 
 
 def _discard_claude_pending_permissions(store: GuardStore, payload: dict[str, object]) -> int:
@@ -542,13 +593,7 @@ def _discard_claude_pending_permissions(store: GuardStore, payload: dict[str, ob
     if session_id is None:
         return 0
     index_key = _claude_pending_permission_index_key(session_id)
-    try:
-        index_payload = store.get_sync_payload(index_key)
-    except (OSError, sqlite3.Error):
-        return 0
-    if not isinstance(index_payload, list):
-        return 0
-    pending_keys = [str(item) for item in index_payload]
+    pending_keys = _load_claude_pending_permission_index(store, session_id=session_id)
     if not pending_keys:
         return 0
     try:

--- a/src/codex_plugin_scanner/guard/cli/commands_support_prompts.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_prompts.py
@@ -408,7 +408,7 @@ def _claude_prompt_system_message(
     return None
 
 def _codex_prompt_block_system_message(*, policy_action: str, native_reason: str) -> str | None:
-    if policy_action not in {"block", "sandbox-required", "require-reapproval"}:
+    if policy_action not in {"review", "require-reapproval", "sandbox-required", "block"}:
         return None
     if "open hol guard" not in native_reason.lower():
         return None
@@ -469,11 +469,17 @@ def _emit_copilot_hook_response(
     *,
     policy_action: str,
     reason: str,
+    approval_reuse: dict[str, object] | None = None,
+    scanner_evidence: tuple[dict[str, object], ...] = (),
     output_stream: TextIO | None = None,
 ) -> None:
     payload: dict[str, object] = {"permissionDecision": _copilot_hook_permission_decision(policy_action)}
     if payload["permissionDecision"] != "allow":
         payload["permissionDecisionReason"] = reason
+    if approval_reuse is not None:
+        payload["approval_reuse"] = approval_reuse
+    if scanner_evidence:
+        payload["scanner_evidence"] = list(scanner_evidence)
     _write_json_line(payload, output_stream=output_stream)
 
 def _emit_copilot_permission_request_response(
@@ -481,6 +487,8 @@ def _emit_copilot_permission_request_response(
     behavior: str,
     message: str | None = None,
     interrupt: bool | None = None,
+    approval_reuse: dict[str, object] | None = None,
+    scanner_evidence: tuple[dict[str, object], ...] = (),
     output_stream: TextIO | None = None,
 ) -> None:
     payload: dict[str, object] = {"behavior": behavior}
@@ -488,6 +496,10 @@ def _emit_copilot_permission_request_response(
         payload["message"] = message.strip()
     if isinstance(interrupt, bool):
         payload["interrupt"] = interrupt
+    if approval_reuse is not None:
+        payload["approval_reuse"] = approval_reuse
+    if scanner_evidence:
+        payload["scanner_evidence"] = list(scanner_evidence)
     _write_json_line(payload, output_stream=output_stream)
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import importlib
+import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -16,11 +17,27 @@ if TYPE_CHECKING:
 
 from ..action_lattice import coerce_guard_action, most_restrictive_guard_action, normalize_guard_action
 from ..models import GuardAction
+from ..proxy._env import _build_scrubbed_env
+from ..runtime.approval_context import (
+    approval_context_tokens_validation_reason,
+    build_approval_context_token,
+    build_configured_environment_hash,
+    build_runtime_launch_identity,
+)
 from ..runtime.command_extensions import risk_classes_for_command_action
 from ..store import _runtime_scoped_exact_match_key, runtime_tool_action_exact_match_context
 from ..text import ensure_terminal_punctuation as _ensure_terminal_punctuation
 from ._commands_shared import *
 from .commands_parser_helpers import *
+
+# Bump when runtime scanner or action-composition semantics change. Product and
+# approval-surface versions deliberately do not participate in this identity.
+_RUNTIME_HOOK_EVALUATOR_POLICY_VERSION = "runtime-hook-evaluation-v1"
+_LOCAL_REVIEW_INSTRUCTION_RE = re.compile(
+    re.escape("Review this request in HOL Guard, then retry."),
+    re.IGNORECASE,
+)
+_LOCAL_APPROVAL_REQUEST_URL_RE = re.compile(r"https?://[^\s]+/requests(?:/[^\s]*)?", re.IGNORECASE)
 
 
 def _runtime_artifacts_module():
@@ -188,6 +205,30 @@ def _approval_center_routed_message(message: str, review_context: str) -> str:
         return review_context
     return f"{_ensure_terminal_punctuation(normalized)} {review_context}"
 
+def _terminal_action_message(message: str) -> str:
+    normalized = _strip_cloud_inbox_urls(message)
+    normalized = _strip_legacy_approval_center_sentence(normalized)
+    normalized = _LOCAL_REVIEW_INSTRUCTION_RE.sub("", normalized)
+    normalized = _LOCAL_APPROVAL_REQUEST_URL_RE.sub("", normalized)
+    normalized = " ".join(normalized.split())
+    return _strip_review_evidence_tail(normalized)
+
+def _terminalize_runtime_action_copy(response_payload: dict[str, object]) -> None:
+    decision_v2 = response_payload.get("decision_v2_json")
+    if isinstance(decision_v2, dict):
+        harness_message = _optional_string(decision_v2.get("harness_message"))
+        if harness_message is not None:
+            decision_v2["harness_message"] = _terminal_action_message(harness_message)
+        decision_v2.pop("retry_instruction", None)
+    supply_chain_evaluation = response_payload.get("supply_chain_evaluation")
+    if isinstance(supply_chain_evaluation, dict):
+        user_copy = supply_chain_evaluation.get("user_copy")
+        if isinstance(user_copy, dict):
+            harness_message = _optional_string(user_copy.get("harness_message"))
+            if harness_message is not None:
+                user_copy["harness_message"] = _terminal_action_message(harness_message)
+            user_copy["dashboard_url"] = None
+
 def _strip_review_evidence_tail(message: str) -> str:
     stripped = message.strip()
     lower_stripped = stripped.lower()
@@ -224,7 +265,7 @@ def _is_cloud_inbox_url(value: str) -> bool:
     parsed = urllib.parse.urlparse(value)
     return parsed.scheme in {"http", "https"} and parsed.path.rstrip("/") == "/guard/inbox"
 
-def _runtime_stored_policy_action(
+def _runtime_stored_policy_decision(
     *,
     store: GuardStore,
     harness: str,
@@ -233,7 +274,16 @@ def _runtime_stored_policy_action(
     artifact_hash: str,
     workspace: str | None,
     decision_lookup: Mapping[str, object] | None = None,
-) -> str | None:
+    consume_one_shot: bool = True,
+) -> Mapping[str, object] | None:
+    """Return a matching saved decision without conflating it with current policy.
+
+    Runtime launch paths pass ``consume_one_shot=False`` and claim an accepted
+    approval only after recomputing all current policy and scanner inputs.  The
+    consuming default preserves the compatibility contract for older direct
+    callers that use this helper outside the authoritative runtime path.
+    """
+
     runtime_exact_match_context = _runtime_artifact_exact_match_context(artifact)
     ignored_local_integrity: Mapping[str, object] | None = None
     if isinstance(decision_lookup, Mapping):
@@ -244,22 +294,43 @@ def _runtime_stored_policy_action(
             raw_ignored_local_integrity if isinstance(raw_ignored_local_integrity, Mapping) else None
         )
     else:
-        decision = store.resolve_policy_decision(
-            harness,
-            artifact_id,
-            artifact_hash=artifact_hash,
-            workspace=workspace,
-            publisher=artifact.publisher,
-            runtime_exact_match_context=runtime_exact_match_context,
-        )
+        if consume_one_shot:
+            decision = store.resolve_policy_decision(
+                harness,
+                artifact_id,
+                artifact_hash=artifact_hash,
+                workspace=workspace,
+                publisher=artifact.publisher,
+                runtime_exact_match_context=runtime_exact_match_context,
+            )
+        else:
+            decision = store.resolve_policy_decision(
+                harness,
+                artifact_id,
+                artifact_hash=artifact_hash,
+                workspace=workspace,
+                publisher=artifact.publisher,
+                runtime_exact_match_context=runtime_exact_match_context,
+                consume_one_shot=False,
+            )
     if decision is None and runtime_exact_match_context is not None and ignored_local_integrity is None:
-        legacy_decision = store.resolve_policy_decision(
-            harness,
-            artifact_id,
-            artifact_hash=artifact_hash,
-            workspace=workspace,
-            publisher=artifact.publisher,
-        )
+        if consume_one_shot:
+            legacy_decision = store.resolve_policy_decision(
+                harness,
+                artifact_id,
+                artifact_hash=artifact_hash,
+                workspace=workspace,
+                publisher=artifact.publisher,
+            )
+        else:
+            legacy_decision = store.resolve_policy_decision(
+                harness,
+                artifact_id,
+                artifact_hash=artifact_hash,
+                workspace=workspace,
+                publisher=artifact.publisher,
+                consume_one_shot=False,
+            )
         if _optional_string((legacy_decision or {}).get("scope")) in {"harness", "global"}:
             decision = legacy_decision
     if decision is None:
@@ -268,6 +339,13 @@ def _runtime_stored_policy_action(
     if action is None:
         return None
     scope = _optional_string(decision.get("scope"))
+    if action == "allow" and approval_context_tokens_validation_reason(
+        decision.get("artifact_hash"),
+        artifact_hash,
+    ) is None:
+        # A valid v1 token already binds the exact request context. Broad
+        # scopes are selectors only; they must not discard that exact token.
+        return decision
     if (
         action in {"allow", "warn", "review"}
         and scope in {"workspace", "publisher", "harness", "global"}
@@ -279,7 +357,7 @@ def _runtime_stored_policy_action(
             if decision_artifact_id == artifact_id and (
                 decision_artifact_hash is None or decision_artifact_hash == artifact_hash
             ):
-                return action
+                return decision
             return None
         if scope in {"harness", "global"}:
             decision_artifact_hash = _optional_string(decision.get("artifact_hash"))
@@ -292,10 +370,278 @@ def _runtime_stored_policy_action(
                 if key is not None
             }
             if not exact_match_keys:
-                return action if decision_artifact_id is not None else None
-            return action if decision_artifact_hash in exact_match_keys else None
+                return decision if decision_artifact_id is not None else None
+            return decision if decision_artifact_hash in exact_match_keys else None
         return None
-    return action
+    return decision
+
+
+def _runtime_stored_policy_action(
+    *,
+    store: GuardStore,
+    harness: str,
+    artifact: GuardArtifact,
+    artifact_id: str,
+    artifact_hash: str,
+    workspace: str | None,
+    decision_lookup: Mapping[str, object] | None = None,
+    consume_one_shot: bool = True,
+) -> str | None:
+    """Compatibility projection for callers that only need the saved action."""
+
+    decision = _runtime_stored_policy_decision(
+        store=store,
+        harness=harness,
+        artifact=artifact,
+        artifact_id=artifact_id,
+        artifact_hash=artifact_hash,
+        workspace=workspace,
+        decision_lookup=decision_lookup,
+        consume_one_shot=consume_one_shot,
+    )
+    return _optional_string(decision.get("action")) if decision is not None else None
+
+
+def _runtime_saved_allow_validation_reason(
+    decision: Mapping[str, object],
+    *,
+    artifact: GuardArtifact,
+    artifact_hash: str,
+) -> str | None:
+    """Require saved runtime allows to carry the complete current v1 context."""
+
+    if _optional_string(decision.get("action")) != "allow":
+        return None
+    stored_hash = _optional_string(decision.get("artifact_hash"))
+    return approval_context_tokens_validation_reason(stored_hash, artifact_hash)
+
+
+def _runtime_hook_approval_context_token(
+    *,
+    artifact: GuardArtifact,
+    content_hash: str,
+    runtime_workspace: Path | None,
+    action_envelope: GuardActionEnvelope | None,
+    config: GuardConfig,
+    current_config_action: GuardAction,
+    trusted_cli_action: GuardAction | None,
+    untrusted_payload_action: GuardAction | None,
+    package_action: GuardAction | None,
+    data_flow_action: GuardAction | None,
+    scanner_action: GuardAction | None,
+    current_action: GuardAction,
+    data_flow_signals: Sequence[object],
+    scanner_evidence: Sequence[object],
+) -> str:
+    """Bind a saved hook approval to the exact reviewed runtime context.
+
+    The returned token intentionally partitions context into independently
+    comparable dimensions.  Values are hashed by ``approval_context`` and are
+    never serialized into the stored token itself.
+    """
+
+    effective_cwd = _normalized_runtime_context_path(runtime_workspace or Path.cwd())
+    configured_workspace = (
+        _normalized_runtime_context_path(config.workspace) if config.workspace is not None else None
+    )
+    envelope_workspace = (
+        _normalized_runtime_context_path(Path(action_envelope.workspace))
+        if action_envelope is not None and action_envelope.workspace is not None
+        else None
+    )
+    metadata = artifact.metadata if isinstance(artifact.metadata, dict) else {}
+    return build_approval_context_token(
+        identity={
+            "artifact_id": artifact.artifact_id,
+            "artifact_name": artifact.name,
+            "artifact_type": artifact.artifact_type,
+            "config_path": artifact.config_path,
+            "configured_workspace": configured_workspace,
+            "cwd": effective_cwd,
+            "envelope_workspace": envelope_workspace,
+            "envelope_workspace_hash": action_envelope.workspace_hash if action_envelope is not None else None,
+            "executable": _runtime_hook_executable_identity(
+                artifact,
+                launch_cwd=runtime_workspace or Path.cwd(),
+            ),
+            "guard_home": _normalized_runtime_context_path(config.guard_home),
+            "harness": artifact.harness,
+            "publisher": artifact.publisher,
+            "source_scope": artifact.source_scope,
+        },
+        content={
+            "artifact_content_hash": content_hash,
+            "command_security_identity": metadata.get("command_security_identity"),
+        },
+        capabilities={
+            "action_envelope": _runtime_hook_action_capabilities(action_envelope),
+            "artifact_type": artifact.artifact_type,
+            "data_flow_signals": [_runtime_hook_evidence_payload(item) for item in data_flow_signals],
+            "risk_classes": _runtime_artifact_risk_classes(artifact),
+            "scanner_evidence": [_runtime_hook_evidence_payload(item) for item in scanner_evidence],
+            "transport": artifact.transport,
+        },
+        policy={
+            "config": _runtime_hook_effective_policy_config(config),
+            "evaluator_policy_version": _RUNTIME_HOOK_EVALUATOR_POLICY_VERSION,
+            "composition": {
+                "current_action": current_action,
+                "current_config_action": current_config_action,
+                "data_flow_action": data_flow_action,
+                "package_action": package_action,
+                "scanner_action": scanner_action,
+                "trusted_cli_action": trusted_cli_action,
+                "untrusted_payload_action": untrusted_payload_action,
+            },
+        },
+        sandbox={
+            "analysis": config.sandbox_analysis,
+            "required": current_action == "sandbox-required",
+        },
+    )
+
+
+def _runtime_hook_effective_policy_config(config: GuardConfig) -> dict[str, object]:
+    """Return effective settings that can change enforcement or risk evidence."""
+
+    return {
+        "artifact_actions": dict(config.artifact_actions or {}),
+        "changed_hash_action": config.changed_hash_action,
+        "default_action": config.default_action,
+        "harness_actions": dict(config.harness_actions or {}),
+        "harness_risk_actions": {
+            harness: dict(actions) for harness, actions in (config.harness_risk_actions or {}).items()
+        },
+        "install_owner": config.install_owner,
+        "managed_locked_settings": list(config.managed_locked_settings),
+        "managed_policy_hash": config.managed_policy_hash,
+        "managed_policy_status": config.managed_policy_status,
+        "mode": config.mode,
+        "new_network_domain_action": config.new_network_domain_action,
+        "publisher_actions": dict(config.publisher_actions or {}),
+        "risk_actions": dict(config.risk_actions or {}),
+        "runtime_detector_disabled_ids": list(config.runtime_detector_disabled_ids),
+        "runtime_detector_registry": config.runtime_detector_registry,
+        "runtime_detector_timeout_ms": config.runtime_detector_timeout_ms,
+        "security_level": config.security_level,
+        "subprocess_action": config.subprocess_action,
+        "unknown_publisher_action": config.unknown_publisher_action,
+    }
+
+
+def _runtime_hook_action_capabilities(action_envelope: GuardActionEnvelope | None) -> dict[str, object] | None:
+    if action_envelope is None:
+        return None
+    return {
+        "action_type": action_envelope.action_type,
+        "mcp_server": action_envelope.mcp_server,
+        "mcp_tool": action_envelope.mcp_tool,
+        "network_hosts": list(action_envelope.network_hosts),
+        "package_intent_kind": action_envelope.package_intent_kind,
+        "package_manager": action_envelope.package_manager,
+        "package_name": action_envelope.package_name,
+        "package_targets": list(action_envelope.package_targets),
+        "script_name": action_envelope.script_name,
+        "target_paths": list(action_envelope.target_paths),
+        "tool_name": action_envelope.tool_name,
+    }
+
+
+def _runtime_hook_evidence_payload(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in value.items()}
+    to_dict = getattr(value, "to_dict", None)
+    return to_dict() if callable(to_dict) else str(value)
+
+
+def _runtime_hook_executable_identity(
+    artifact: GuardArtifact,
+    *,
+    launch_cwd: Path,
+) -> dict[str, object]:
+    metadata = artifact.metadata if isinstance(artifact.metadata, dict) else {}
+    raw_environment = metadata.get("env")
+    configured_environment = (
+        {
+            str(key): str(value)
+            for key, value in raw_environment.items()
+            if isinstance(key, str) and isinstance(value, str)
+        }
+        if isinstance(raw_environment, Mapping)
+        else {}
+    )
+    raw_env_keys = metadata.get("env_keys")
+    configured_env_keys = tuple(
+        sorted(
+            {
+                *configured_environment,
+                *(
+                    (item for item in raw_env_keys if isinstance(item, str) and item)
+                    if isinstance(raw_env_keys, Sequence) and not isinstance(raw_env_keys, str)
+                    else ()
+                ),
+            }
+        )
+    )
+    provided_env_values_hash = _optional_string(
+        metadata.get("env_values_hash") or metadata.get("envValuesHash")
+    )
+    computed_env_values_hash = (
+        build_configured_environment_hash(
+            configured_environment,
+            configured_keys=configured_env_keys,
+        )
+        if configured_environment or not configured_env_keys
+        else None
+    )
+    launch_env = _build_scrubbed_env(configured_environment)
+    launch_identity = build_runtime_launch_identity(
+        artifact.command,
+        args=artifact.args,
+        structured_command=artifact.artifact_type != "tool_action_request",
+        search_path=launch_env.get("PATH"),
+        cwd=launch_cwd,
+        launch_env=launch_env,
+    )
+    missing_value_keys = tuple(key for key in configured_env_keys if key not in configured_environment)
+    unavailable_values = bool(missing_value_keys) and provided_env_values_hash is None
+    code_loading_keys = {"BASH_ENV", "ENV", "NODE_OPTIONS", "PYTHONINSPECT", "PYTHONPATH", "ZDOTDIR"}
+    unresolved_code_loading_environment = bool(code_loading_keys.intersection(missing_value_keys))
+    configured_environment_identity: dict[str, object] = {
+        "computed_values_hash": computed_env_values_hash,
+        "keys": list(configured_env_keys),
+        "provided_values_hash": provided_env_values_hash,
+        "values_hash": provided_env_values_hash if missing_value_keys else computed_env_values_hash,
+        "provided_values_hash_matches": (
+            provided_env_values_hash == computed_env_values_hash
+            if provided_env_values_hash is not None and computed_env_values_hash is not None
+            else None
+        ),
+        "status": (
+            "unproven"
+            if unavailable_values or unresolved_code_loading_environment
+            else "verified"
+        ),
+    }
+    if unavailable_values or unresolved_code_loading_environment:
+        configured_environment_identity["reuse_nonce"] = secrets.token_hex(16)
+    return {
+        "artifact_command": artifact.command,
+        "artifact_tool": metadata.get("tool_name"),
+        "configured_environment": configured_environment_identity,
+        "launch_argv_sha256": launch_identity["argv_sha256"],
+        "launch_cwd": launch_identity["launch_cwd"],
+        "resolved_artifact_command": launch_identity["executable"],
+        "resolved_entrypoint": launch_identity["entrypoint"],
+        "transport": artifact.transport,
+    }
+
+
+def _normalized_runtime_context_path(path: Path) -> str:
+    try:
+        return str(path.expanduser().resolve(strict=False))
+    except (OSError, RuntimeError):
+        return str(path.expanduser().absolute())
 
 
 def _remembered_rule_rejection_reason(
@@ -344,6 +690,19 @@ def _runtime_artifact_policy_action(config: GuardConfig, artifact: GuardArtifact
     if _prompt_requires_hard_block(artifact):
         return "block"
     canonical_harness = _canonical_harness_name(harness)
+    configured_override = config.resolve_action_override(
+        canonical_harness,
+        artifact.artifact_id,
+        artifact.publisher,
+    )
+
+    def with_config_policy(action: GuardAction) -> GuardAction:
+        # Artifact/publisher/harness settings are more-specific resolutions of
+        # the global default, not additional inputs.  Scanner/risk results are
+        # independent and therefore remain a floor even for an exact allow.
+        current_config_action = configured_override if configured_override is not None else config.default_action
+        return most_restrictive_guard_action(action, current_config_action)
+
     risk_classes = _runtime_artifact_risk_classes(artifact)
     has_configured_risk_action = any(
         _resolve_configured_risk_action(config, risk_class, harness=canonical_harness) for risk_class in risk_classes
@@ -356,20 +715,21 @@ def _runtime_artifact_policy_action(config: GuardConfig, artifact: GuardArtifact
         ]
         resolved_actions = [action for action in risk_actions if coerce_guard_action(action) is not None]
         if resolved_actions:
-            return most_restrictive_guard_action(*resolved_actions)
+            return with_config_policy(most_restrictive_guard_action(*resolved_actions))
     guard_default_action = _runtime_artifact_guard_default_action(artifact)
     risk_actions = [resolve_risk_action(config, risk_class, harness=canonical_harness) for risk_class in risk_classes]
     resolved_actions = [action for action in risk_actions if coerce_guard_action(action) is not None]
     if resolved_actions:
         resolved = most_restrictive_guard_action(*resolved_actions)
-        return (
+        resolved_with_default = (
             most_restrictive_guard_action(resolved, guard_default_action)
             if guard_default_action is not None
             else resolved
         )
+        return with_config_policy(resolved_with_default)
     if guard_default_action is not None:
-        return guard_default_action
-    return SAFE_CHANGED_HASH_ACTION
+        return with_config_policy(guard_default_action)
+    return with_config_policy(SAFE_CHANGED_HASH_ACTION)
 
 def _resolve_configured_risk_action(config: GuardConfig, risk_class: str, *, harness: str) -> str | None:
     if config.harness_risk_actions is not None:
@@ -594,5 +954,6 @@ __all__ = [
     "_runtime_artifact_guard_default_action", "_runtime_artifact_policy_action", "_runtime_artifact_risk_classes",
     "_runtime_data_flow_sink_type", "_runtime_data_flow_summary", "_runtime_detector_perf_payload",
     "_runtime_detector_registry_payload", "_runtime_stored_policy_action", "_strip_cloud_inbox_urls",
-    "_strip_legacy_approval_center_sentence", "_strip_review_evidence_tail",
+    "_strip_legacy_approval_center_sentence", "_strip_review_evidence_tail", "_terminal_action_message",
+    "_terminalize_runtime_action_copy",
 ]

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_resolution.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_resolution.py
@@ -5,7 +5,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import os
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from ._commands_shared import _now
@@ -15,6 +16,9 @@ if TYPE_CHECKING:
 
 from ._commands_shared import *
 from .commands_parser_helpers import *
+from ..runtime.approval_context import build_runtime_launch_identity
+from ..runtime.mcp_protection import McpServerIdentity, build_mcp_server_identity
+from ..synced_policy import synced_policy_payload as _synced_policy_payload
 
 def _redact_codex_prompt_secret_assignments(value: str) -> str:
     output: list[str] = []
@@ -113,49 +117,92 @@ def _copilot_hook_stage(payload: dict[str, object]) -> str | None:
             return value.strip().lower()
     return None
 
+@dataclass(frozen=True, slots=True)
+class _CopilotMcpRuntimeServer:
+    server_name: str
+    source_scope: str
+    config_path: str
+    server_config: object
+
+@dataclass(frozen=True, slots=True)
+class _CopilotMcpRuntimeTool:
+    server: _CopilotMcpRuntimeServer
+    tool_name: str
+
 def _copilot_runtime_tool_call(
     *,
     payload: dict[str, object],
     home_dir: Path,
     workspace: Path | None,
+    config: GuardConfig | None = None,
     preferred_workspace_config: str | None = None,
 ) -> tuple[GuardArtifact, str, object] | None:
     tool_name = payload.get("tool_name")
     if not isinstance(tool_name, str) or not tool_name.strip():
         return None
-    server_name: str | None = None
-    runtime_tool_name: str | None = None
-    source_scope = _coalesce_string(payload.get("source_scope"), "project" if workspace is not None else "global")
-    config_path = str(_runtime_policy_path("copilot", home_dir, workspace))
+    resolution: _CopilotMcpRuntimeTool | None = None
     if "/" in tool_name:
         server_name, runtime_tool_name = tool_name.split("/", 1)
+        if server_name.strip() and runtime_tool_name.strip():
+            runtime_server = _resolve_copilot_mcp_runtime_server(
+                server_name=server_name.strip(),
+                home_dir=home_dir,
+                workspace=workspace,
+                preferred_workspace_config=preferred_workspace_config,
+            )
+            if runtime_server is None:
+                runtime_server = _CopilotMcpRuntimeServer(
+                    server_name=server_name.strip(),
+                    source_scope=_coalesce_string(
+                        payload.get("source_scope"),
+                        "project" if workspace is not None else "global",
+                    ),
+                    config_path=str(_runtime_policy_path("copilot", home_dir, workspace)),
+                    server_config=None,
+                )
+            resolution = _CopilotMcpRuntimeTool(
+                server=runtime_server,
+                tool_name=runtime_tool_name.strip(),
+            )
     elif tool_name.startswith("mcp_"):
-        resolved = _resolve_copilot_mcp_runtime_tool(
+        resolution = _resolve_copilot_mcp_runtime_tool(
             tool_name=tool_name,
             home_dir=home_dir,
             workspace=workspace,
             preferred_workspace_config=preferred_workspace_config,
         )
-        if resolved is None:
-            return None
-        server_name, runtime_tool_name, source_scope, config_path = resolved
-    if (
-        not isinstance(server_name, str)
-        or not server_name.strip()
-        or not isinstance(runtime_tool_name, str)
-        or not runtime_tool_name.strip()
-    ):
+    if resolution is None:
         return None
+    launch_cwd = workspace or Path.cwd()
+    server_identity, server_fingerprint, transport = _copilot_runtime_server_identity(
+        resolution.server,
+        launch_cwd=launch_cwd,
+    )
+    tool_schema, tool_description = _copilot_runtime_tool_metadata(
+        payload,
+        server_config=resolution.server.server_config,
+        requested_tool_name=tool_name,
+        runtime_tool_name=resolution.tool_name,
+    )
     artifact = build_tool_call_artifact(
         harness="copilot",
-        server_name=server_name.strip(),
-        tool_name=runtime_tool_name.strip(),
-        source_scope=source_scope,
-        config_path=config_path,
-        transport="stdio",
+        server_name=resolution.server.server_name,
+        tool_name=resolution.tool_name,
+        source_scope=resolution.server.source_scope,
+        config_path=resolution.server.config_path,
+        transport=transport,
+        server_fingerprint=server_fingerprint,
+        server_identity=server_identity,
+        tool_schema=tool_schema,
+        tool_description=tool_description,
     )
     arguments = payload.get("tool_input", payload.get("arguments"))
-    artifact_hash = build_tool_call_hash(artifact, arguments)
+    artifact_hash = build_tool_call_hash(
+        artifact,
+        arguments,
+        workspace=workspace or Path.cwd(),
+        config=config,
+    )
     return artifact, artifact_hash, arguments
 
 def _resolve_copilot_mcp_runtime_tool(
@@ -164,15 +211,15 @@ def _resolve_copilot_mcp_runtime_tool(
     home_dir: Path,
     workspace: Path | None,
     preferred_workspace_config: str | None = None,
-) -> tuple[str, str, str, str] | None:
+) -> _CopilotMcpRuntimeTool | None:
     if not tool_name.startswith("mcp_"):
         return None
     suffix = tool_name[len("mcp_") :]
     if not suffix:
         return None
-    matches: list[tuple[int, int, str, str, str, str]] = []
-    for server_name, source_scope, config_path in _copilot_runtime_server_entries(home_dir, workspace):
-        server_token = _copilot_mcp_tool_token(server_name)
+    matches: list[tuple[int, int, _CopilotMcpRuntimeServer, str]] = []
+    for server in _copilot_runtime_server_entries(home_dir, workspace):
+        server_token = _copilot_mcp_tool_token(server.server_name)
         if suffix.startswith(f"{server_token}_"):
             runtime_tool_name = suffix[len(server_token) + 1 :]
             if runtime_tool_name:
@@ -180,25 +227,48 @@ def _resolve_copilot_mcp_runtime_tool(
                     (
                         len(server_token),
                         _copilot_runtime_match_priority(
-                            config_path=config_path,
+                            config_path=server.config_path,
                             preferred_workspace_config=preferred_workspace_config,
                         ),
-                        server_name,
+                        server,
                         runtime_tool_name,
-                        source_scope,
-                        config_path,
                     )
                 )
     if matches:
-        _length, _priority, server_name, runtime_tool_name, source_scope, config_path = max(
+        _length, _priority, server, runtime_tool_name = max(
             matches,
-            key=lambda item: (item[0], item[1], item[5]),
+            key=lambda item: (item[0], item[1], item[2].config_path),
         )
-        return server_name, runtime_tool_name, source_scope, config_path
+        return _CopilotMcpRuntimeTool(server=server, tool_name=runtime_tool_name)
     return None
 
-def _copilot_runtime_server_entries(home_dir: Path, workspace: Path | None) -> list[tuple[str, str, str]]:
-    entries: list[tuple[str, str, str]] = []
+def _resolve_copilot_mcp_runtime_server(
+    *,
+    server_name: str,
+    home_dir: Path,
+    workspace: Path | None,
+    preferred_workspace_config: str | None,
+) -> _CopilotMcpRuntimeServer | None:
+    matches = [
+        entry
+        for entry in _copilot_runtime_server_entries(home_dir, workspace)
+        if entry.server_name == server_name
+    ]
+    if not matches:
+        return None
+    return max(
+        matches,
+        key=lambda entry: (
+            _copilot_runtime_match_priority(
+                config_path=entry.config_path,
+                preferred_workspace_config=preferred_workspace_config,
+            ),
+            entry.config_path,
+        ),
+    )
+
+def _copilot_runtime_server_entries(home_dir: Path, workspace: Path | None) -> list[_CopilotMcpRuntimeServer]:
+    entries: list[_CopilotMcpRuntimeServer] = []
     if workspace is not None:
         for path in (workspace / ".vscode" / "mcp.json", workspace / ".mcp.json"):
             entries.extend(_mcp_server_entries_from_path(path, source_scope="project"))
@@ -232,7 +302,7 @@ def _resolve_copilot_workspace_root(workspace: Path | None) -> Path | None:
             return candidate
     return workspace
 
-def _mcp_server_entries_from_path(path: Path, *, source_scope: str) -> list[tuple[str, str, str]]:
+def _mcp_server_entries_from_path(path: Path, *, source_scope: str) -> list[_CopilotMcpRuntimeServer]:
     if not path.exists():
         return []
     try:
@@ -245,8 +315,13 @@ def _mcp_server_entries_from_path(path: Path, *, source_scope: str) -> list[tupl
     if not isinstance(servers, dict):
         return []
     return [
-        (str(server_name), source_scope, str(path))
-        for server_name in servers
+        _CopilotMcpRuntimeServer(
+            server_name=server_name.strip(),
+            source_scope=source_scope,
+            config_path=str(path),
+            server_config=server_config,
+        )
+        for server_name, server_config in servers.items()
         if isinstance(server_name, str) and server_name.strip()
     ]
 
@@ -257,6 +332,195 @@ def _mcp_servers_payload(payload: dict[str, object]) -> dict[str, object] | None
     mcp_servers = payload.get("mcpServers")
     if isinstance(mcp_servers, dict):
         return mcp_servers
+    return None
+
+def _copilot_runtime_server_identity(
+    server: _CopilotMcpRuntimeServer,
+    *,
+    launch_cwd: Path,
+) -> tuple[McpServerIdentity, dict[str, object], str]:
+    """Build a non-secret, content-bound identity for a Copilot MCP server."""
+
+    server_config = (
+        cast(Mapping[str, object], server.server_config)
+        if isinstance(server.server_config, Mapping)
+        else None
+    )
+    command, launch_args = _copilot_runtime_server_command(server_config)
+    transport = _copilot_runtime_server_transport(server_config)
+    config_sha256 = _copilot_runtime_server_config_digest(server.server_config)
+    configured_env, env_keys = _copilot_runtime_server_environment(server_config)
+    launch_env = dict(os.environ)
+    launch_env.update(configured_env)
+    launch_identity = build_runtime_launch_identity(
+        command,
+        args=launch_args,
+        structured_command=True,
+        search_path=launch_env.get("PATH"),
+        cwd=launch_cwd,
+        launch_env=launch_env,
+    )
+    launch_identity["launch_args_sha256"] = hashlib.sha256(
+        json.dumps(list(launch_args), sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    launch_identity["server_config_sha256"] = config_sha256
+    launch_identity["transport"] = transport
+    remote_url = server_config.get("url") if server_config is not None else None
+    has_remote_url = isinstance(remote_url, str) and bool(remote_url.strip())
+    if server_config is None or (command is None and not has_remote_url) or config_sha256 is None:
+        launch_identity["reuse_nonce"] = secrets.token_hex(16)
+        launch_identity["status"] = (
+            "server_config_unresolved"
+            if server_config is None
+            else "server_command_unresolved"
+            if command is None and not has_remote_url
+            else "server_config_unhashable"
+        )
+    elif command is None:
+        launch_identity["status"] = "remote_transport"
+
+    server_identity = build_mcp_server_identity(
+        config_path=server.config_path,
+        command=command or ("<remote>" if has_remote_url else "<unresolved>"),
+        args=launch_args,
+        transport=transport,
+        env=configured_env,
+        env_keys=env_keys,
+    )
+    server_fingerprint: dict[str, object] = {
+        "config_sha256": config_sha256,
+        "launch_args_sha256": launch_identity["launch_args_sha256"],
+        # ``build_tool_call_hash`` carries this full mapping into the v1
+        # approval identity.  It therefore binds the selected server config
+        # as well as executable and interpreted-entrypoint bytes without
+        # persisting config secrets.
+        "resolved_executable": launch_identity,
+        "transport": transport,
+    }
+    return server_identity, server_fingerprint, transport
+
+def _copilot_runtime_server_environment(
+    server_config: Mapping[str, object] | None,
+) -> tuple[dict[str, str], tuple[str, ...]]:
+    if server_config is None:
+        return {}, ()
+    env_config = server_config.get("env")
+    if not isinstance(env_config, Mapping):
+        return {}, ()
+    env_keys = tuple(sorted(str(key) for key in env_config if str(key).strip()))
+    configured_env = {
+        str(key): value
+        for key, value in env_config.items()
+        if str(key).strip() and isinstance(value, str)
+    }
+    return configured_env, env_keys
+
+def _copilot_runtime_server_command(
+    server_config: Mapping[str, object] | None,
+) -> tuple[str | None, tuple[str, ...]]:
+    if server_config is None:
+        return None, ()
+    command_value = server_config.get("command")
+    command: str | None = None
+    launch_args: list[str] = []
+    if isinstance(command_value, str) and command_value.strip():
+        command = command_value.strip()
+    elif isinstance(command_value, list):
+        command_parts = [item for item in command_value if isinstance(item, str) and item]
+        if command_parts:
+            command = command_parts[0]
+            launch_args.extend(command_parts[1:])
+    args_value = server_config.get("args")
+    if isinstance(args_value, list):
+        launch_args.extend(item for item in args_value if isinstance(item, str))
+    return command, tuple(launch_args)
+
+def _copilot_runtime_server_transport(server_config: Mapping[str, object] | None) -> str:
+    if server_config is None:
+        return "stdio"
+    raw_transport = server_config.get("transport", server_config.get("type"))
+    if isinstance(raw_transport, str) and raw_transport.strip():
+        normalized = raw_transport.strip().lower().replace("_", "-")
+        if normalized in {"local", "stdio"}:
+            return "stdio"
+        if normalized in {"http", "https", "remote", "streamable-http"}:
+            return "http"
+        return normalized
+    if isinstance(server_config.get("url"), str) and str(server_config["url"]).strip():
+        return "http"
+    return "stdio"
+
+def _copilot_runtime_server_config_digest(server_config: object) -> str | None:
+    try:
+        encoded = json.dumps(
+            server_config,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        return None
+    return hashlib.sha256(encoded).hexdigest()
+
+_COPILOT_TOOL_METADATA_MISSING = object()
+
+def _copilot_runtime_tool_metadata(
+    payload: Mapping[str, object],
+    *,
+    server_config: object,
+    requested_tool_name: str,
+    runtime_tool_name: str,
+) -> tuple[object | None, str | None]:
+    schema: object = _COPILOT_TOOL_METADATA_MISSING
+    description: str | None = None
+    candidates: list[Mapping[str, object]] = [payload]
+    for key in ("tool", "tool_definition", "toolDefinition"):
+        value = payload.get(key)
+        if isinstance(value, Mapping):
+            candidates.append(value)
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        for item in tool_calls:
+            if not isinstance(item, Mapping):
+                continue
+            candidate_name = item.get("name")
+            if candidate_name in {requested_tool_name, runtime_tool_name}:
+                candidates.append(item)
+    config_tool = _copilot_runtime_config_tool_definition(server_config, runtime_tool_name)
+    if config_tool is not None:
+        candidates.append(config_tool)
+
+    for candidate in candidates:
+        if schema is _COPILOT_TOOL_METADATA_MISSING:
+            for key in ("tool_schema", "toolSchema", "input_schema", "inputSchema", "schema"):
+                if key in candidate:
+                    schema = candidate[key]
+                    break
+        if description is None:
+            for key in ("tool_description", "toolDescription", "description"):
+                value = candidate.get(key)
+                if isinstance(value, str) and value.strip():
+                    description = value.strip()
+                    break
+        if schema is not _COPILOT_TOOL_METADATA_MISSING and description is not None:
+            break
+    return (None if schema is _COPILOT_TOOL_METADATA_MISSING else schema), description
+
+def _copilot_runtime_config_tool_definition(
+    server_config: object,
+    runtime_tool_name: str,
+) -> Mapping[str, object] | None:
+    if not isinstance(server_config, Mapping):
+        return None
+    tools = server_config.get("tools")
+    if isinstance(tools, Mapping):
+        definition = tools.get(runtime_tool_name)
+        return definition if isinstance(definition, Mapping) else None
+    if isinstance(tools, list):
+        for item in tools:
+            if isinstance(item, Mapping) and item.get("name") == runtime_tool_name:
+                return item
     return None
 
 def _copilot_mcp_tool_token(value: str) -> str:
@@ -495,6 +759,11 @@ def _run_hermes_mcp_proxy(
     if len(command) == 0:
         print(f"Hermes MCP server {args.server} is missing a launch command.", file=sys.stderr)
         return 2
+
+    def current_stdio_config() -> GuardConfig:
+        local_config = load_guard_config(context.guard_home, workspace=context.workspace_dir)
+        return overlay_synced_guard_policy(local_config, _synced_policy_payload(store))
+
     proxy = StdioGuardProxy(
         command=command,
         cwd=context.workspace_dir,
@@ -503,6 +772,7 @@ def _run_hermes_mcp_proxy(
         approval_center_url=approval_center_url,
         harness="hermes",
         env=_server_env(server),
+        current_config_provider=current_stdio_config,
     )
     return proxy.run_stream(
         input_stream=sys.stdin,

--- a/src/codex_plugin_scanner/guard/cli/prompt.py
+++ b/src/codex_plugin_scanner/guard/cli/prompt.py
@@ -13,7 +13,6 @@ from rich.text import Text
 from ..approval_gate import ApprovalGateError, ApprovalGateGrant, public_config, require_approval_decision
 from ..consumer import artifact_hash
 from ..models import GuardArtifact, PolicyDecision
-from ..receipts import build_receipt
 from ..store import GuardStore
 from .approval_gate_prompt import prompt_for_approval_gate
 
@@ -41,6 +40,7 @@ class PromptArtifact:
     metadata: dict[str, object]
     current_snapshot: dict[str, object] | None
     removed: bool = False
+    snapshot_hash: str | None = None
 
 
 def resolve_interactive_decisions(
@@ -52,7 +52,12 @@ def resolve_interactive_decisions(
     console: Console | None = None,
     input_func: Callable[[str], str] | None = None,
 ) -> dict[str, object]:
-    """Prompt for changed artifacts and apply the chosen Guard override."""
+    """Prompt for changed artifacts and return exact, unpersisted launch intents.
+
+    Persistent policy choices are stored against the reviewed context token,
+    but receipts and snapshots are left to ``guard_run`` after it redetects
+    the launch state and recomputes the authoritative action.
+    """
 
     review_items = [
         artifact
@@ -95,7 +100,6 @@ def resolve_interactive_decisions(
                 )
                 evaluation["blocked"] = True
                 return evaluation
-            _record_override_receipt(store, artifact, "allow", "allow-once", now)
             _set_decision_payload(decisions_by_artifact, artifact.artifact_id, "allow", "allow-once")
             continue
         if choice == "allow_artifact":
@@ -110,14 +114,13 @@ def resolve_interactive_decisions(
                     harness=artifact.harness,
                     scope="artifact",
                     artifact_id=artifact.artifact_id,
+                    artifact_hash=artifact.artifact_hash,
                     action="allow",
                     reason="interactive-allow-artifact",
                 ),
                 now,
                 approval_gate_grant=approval_gate_grant,
             )
-            _persist_allowed_artifact(store, artifact, now)
-            _record_override_receipt(store, artifact, "allow", "allow-artifact", now)
             _set_decision_payload(decisions_by_artifact, artifact.artifact_id, "allow", "allow-artifact")
             continue
         if choice == "allow_publisher":
@@ -132,6 +135,8 @@ def resolve_interactive_decisions(
                     PolicyDecision(
                         harness=artifact.harness,
                         scope="harness",
+                        artifact_id=artifact.artifact_id,
+                        artifact_hash=artifact.artifact_hash,
                         action="allow",
                         reason="interactive-allow-harness",
                     ),
@@ -150,6 +155,8 @@ def resolve_interactive_decisions(
                     PolicyDecision(
                         harness=artifact.harness,
                         scope="publisher",
+                        artifact_id=artifact.artifact_id,
+                        artifact_hash=artifact.artifact_hash,
                         publisher=artifact.publisher,
                         action="allow",
                         reason="interactive-allow-publisher",
@@ -158,8 +165,6 @@ def resolve_interactive_decisions(
                     approval_gate_grant=approval_gate_grant,
                 )
                 decision_scope = "allow-publisher"
-            _persist_allowed_artifact(store, artifact, now)
-            _record_override_receipt(store, artifact, "allow", decision_scope, now)
             _set_decision_payload(decisions_by_artifact, artifact.artifact_id, "allow", decision_scope)
             continue
 
@@ -180,7 +185,6 @@ def resolve_interactive_decisions(
             now,
             approval_gate_grant=approval_gate_grant,
         )
-        _record_override_receipt(store, artifact, "block", "block", now)
         _set_decision_payload(decisions_by_artifact, artifact.artifact_id, "block", "block")
         blocked = True
 
@@ -299,44 +303,6 @@ def _safe_prompt_value(value: str) -> str:
     return "".join(character if character.isprintable() else "?" for character in value)
 
 
-def _persist_allowed_artifact(store: GuardStore, artifact: PromptArtifact, now: str) -> None:
-    if artifact.removed:
-        store.delete_snapshot(artifact.harness, artifact.artifact_id)
-        return
-    if artifact.current_snapshot is None:
-        return
-    store.save_snapshot(
-        artifact.harness,
-        artifact.artifact_id,
-        {**artifact.current_snapshot, "artifact_hash": artifact.artifact_hash},
-        artifact.artifact_hash,
-        now,
-    )
-
-
-def _record_override_receipt(
-    store: GuardStore,
-    artifact: PromptArtifact,
-    policy_decision: str,
-    user_override: str,
-    now: str,
-) -> None:
-    receipt = build_receipt(
-        harness=artifact.harness,
-        artifact_id=artifact.artifact_id,
-        artifact_hash=artifact.artifact_hash,
-        policy_decision=policy_decision,
-        capabilities_summary=_capabilities_summary(artifact),
-        changed_capabilities=list(artifact.changed_fields),
-        provenance_summary=artifact.provenance_summary,
-        artifact_name=artifact.artifact_name,
-        source_scope=artifact.source_scope,
-        user_override=user_override,
-        approval_source="inline",
-    )
-    store.add_receipt(receipt)
-
-
 def _set_decision_payload(
     decision_map: dict[str, dict[str, object]],
     artifact_id: str,
@@ -362,6 +328,12 @@ def build_prompt_artifacts(
     for item in evaluation_artifacts:
         artifact_id = str(item.get("artifact_id"))
         artifact = artifacts_by_id.get(artifact_id)
+        approval_context_hash = item.get("approval_context_hash")
+        exact_approval_hash = (
+            approval_context_hash if isinstance(approval_context_hash, str) and approval_context_hash.strip() else None
+        )
+        raw_content_hash = item.get("artifact_hash")
+        content_hash = raw_content_hash if isinstance(raw_content_hash, str) and raw_content_hash else None
         raw_changed_fields = item.get("changed_fields")
         changed_fields = (
             tuple(str(field) for field in raw_changed_fields if isinstance(field, str))
@@ -374,7 +346,7 @@ def build_prompt_artifacts(
                     harness=harness,
                     artifact_id=artifact_id,
                     artifact_name=str(item.get("artifact_name") or artifact_id),
-                    artifact_hash=str(item.get("artifact_hash") or "removed"),
+                    artifact_hash=exact_approval_hash or str(item.get("artifact_hash") or "removed"),
                     policy_action=str(item.get("policy_action") or "review"),
                     changed_fields=changed_fields,
                     provenance_summary=f"artifact removed from {harness}",
@@ -388,6 +360,7 @@ def build_prompt_artifacts(
                     metadata={},
                     current_snapshot=None,
                     removed=bool(item.get("removed")),
+                    snapshot_hash=content_hash,
                 )
             )
             continue
@@ -396,7 +369,7 @@ def build_prompt_artifacts(
                 harness=harness,
                 artifact_id=artifact.artifact_id,
                 artifact_name=artifact.name,
-                artifact_hash=artifact_hash(artifact),
+                artifact_hash=exact_approval_hash or artifact_hash(artifact),
                 policy_action=str(item.get("policy_action") or "review"),
                 changed_fields=changed_fields,
                 provenance_summary=f"{artifact.source_scope} artifact defined at {artifact.config_path}",
@@ -408,11 +381,21 @@ def build_prompt_artifacts(
                 command=artifact.command,
                 transport=artifact.transport,
                 metadata=dict(artifact.metadata),
-                current_snapshot=artifact.to_dict(),
+                current_snapshot=_prompt_artifact_snapshot(artifact),
                 removed=False,
+                snapshot_hash=content_hash or artifact_hash(artifact),
             )
         )
     return prompt_artifacts
+
+
+def _prompt_artifact_snapshot(artifact: GuardArtifact) -> dict[str, object]:
+    """Mirror the consumer snapshot shape without persisting raw env values."""
+
+    snapshot = artifact.to_dict()
+    metadata = snapshot.get("metadata")
+    snapshot["env_keys"] = metadata.get("env_keys", []) if isinstance(metadata, dict) else []
+    return snapshot
 
 
 def _coerce_artifact_results(value: object) -> list[dict[str, object]]:

--- a/src/codex_plugin_scanner/guard/cli/protect_approvals.py
+++ b/src/codex_plugin_scanner/guard/cli/protect_approvals.py
@@ -90,6 +90,8 @@ def _queue_local_protect_approvals(
 def _should_queue_local_protect_approval(response_payload: dict[str, object]) -> bool:
     if os.environ.get(SHIM_PROBE_ENV_VAR) == SHIM_PROBE_ENV_VALUE:
         return False
+    if _protect_policy_action(response_payload) not in {"review", "require-reapproval"}:
+        return False
     if _protect_has_reason_code(response_payload, "saved_package_block"):
         return False
     return not (

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -2596,11 +2596,21 @@ def _artifact_risk_text(*artifacts: dict[str, object]) -> str:
 def _run_artifact_should_be_visible(artifact: dict[str, object]) -> bool:
     if bool(artifact.get("changed")):
         return True
-    return str(artifact.get("policy_action") or "allow") in {"block", "sandbox-required", "require-reapproval"}
+    return str(artifact.get("policy_action") or "allow") in {
+        "review",
+        "require-reapproval",
+        "sandbox-required",
+        "block",
+    }
 
 
 def _artifact_needs_review(artifact: dict[str, object]) -> bool:
-    return str(artifact.get("policy_action") or "allow") in {"block", "sandbox-required", "require-reapproval"}
+    return str(artifact.get("policy_action") or "allow") in {
+        "review",
+        "require-reapproval",
+        "sandbox-required",
+        "block",
+    }
 
 
 def _build_approval_table(items: list[dict[str, object]], *, title: str | None) -> Table:

--- a/src/codex_plugin_scanner/guard/consumer/__init__.py
+++ b/src/codex_plugin_scanner/guard/consumer/__init__.py
@@ -26,7 +26,17 @@ def detect_harness(harness: str, context: Any):
 
 
 def evaluate_detection(
-    detection: Any, store: Any, config: Any, default_action: str | None = None, persist: bool = True
+    detection: Any,
+    store: Any,
+    config: Any,
+    default_action: str | None = None,
+    persist: bool = True,
+    trusted_request_overrides: Any = None,
+    trusted_request_override_labels: Any = None,
+    pending_approval_claims: Any = None,
+    claimed_saved_approval_overrides: Any = None,
+    retained_saved_approval_overrides: Any = None,
+    runtime_detector_context: Any = None,
 ):
     return _service_module().evaluate_detection(
         detection,
@@ -34,6 +44,12 @@ def evaluate_detection(
         config,
         default_action=default_action,
         persist=persist,
+        trusted_request_overrides=trusted_request_overrides,
+        trusted_request_override_labels=trusted_request_override_labels,
+        pending_approval_claims=pending_approval_claims,
+        claimed_saved_approval_overrides=claimed_saved_approval_overrides,
+        retained_saved_approval_overrides=retained_saved_approval_overrides,
+        runtime_detector_context=runtime_detector_context,
     )
 
 

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Iterable, Mapping
+import os
+from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, TypedDict, TypeGuard
+from typing import Any, TypedDict, TypeGuard, cast
 
 from ...models import ScanOptions
 from ..action_lattice import is_guard_action as _is_guard_action
+from ..action_lattice import most_restrictive_guard_action
 from ..adapters.base import HarnessContext
 from ..approval_gate import ApprovalGateGrant
 from ..capabilities import compute_capability_delta, normalize_artifact_capabilities, severity_from_deltas
@@ -27,6 +29,18 @@ from ..models import (
 from ..policy import build_decision_v2, decide_action
 from ..receipts import build_receipt
 from ..risk import artifact_risk_signals_typed, artifact_risk_summary, summarize_signals
+from ..runtime.approval_context import (
+    approval_context_tokens_validation_reason,
+    build_approval_context_token,
+    build_runtime_launch_identity,
+)
+from ..runtime.approval_reuse import (
+    APPROVAL_REUSE_ACCEPTED,
+    APPROVAL_REUSE_NO_SAVED_DECISION,
+    ApprovalReuseDecision,
+    ApprovalReuseValidationFailure,
+    evaluate_approval_reuse,
+)
 from ..runtime.signals import RiskSignalV2
 from ..schemas import build_consumer_mode_contract
 from ..store import GuardStore
@@ -61,6 +75,9 @@ _PROMPT_FILE_HASH_VOLATILE_METADATA_KEYS = frozenset(
         "runtime_request_summary",
     }
 )
+_CONSUMER_APPROVAL_POLICY_VERSION = "consumer-evaluation-v1"
+_TRUSTED_REQUEST_OVERRIDE_REASON = "trusted_request_override_exact_context"
+_RUNTIME_DETECTOR_BLOCK_REASON = "runtime_detector_block"
 
 
 class ArtifactDiff(TypedDict):
@@ -176,7 +193,7 @@ def diff_removed_artifact(previous: dict[str, object]) -> ArtifactDiff:
 
 
 def _is_blocking_action(policy_action: GuardAction) -> bool:
-    return policy_action in {"block", "sandbox-required", "require-reapproval"}
+    return policy_action in {"review", "require-reapproval", "sandbox-required", "block"}
 
 
 def _guard_default_action(artifact: GuardArtifact) -> GuardAction | None:
@@ -237,9 +254,9 @@ def build_history_context(
 
     inventory_item = store.find_inventory_item(artifact_id)
     decision_counts = store.receipt_decision_counts(harness, artifact_id)
-    prior_approvals = sum(decision_counts.get(decision, 0) for decision in {"allow", "warn", "review"})
+    prior_approvals = sum(decision_counts.get(decision, 0) for decision in {"allow", "warn"})
     prior_blocks = sum(
-        decision_counts.get(decision, 0) for decision in {"block", "sandbox-required", "require-reapproval"}
+        decision_counts.get(decision, 0) for decision in {"review", "require-reapproval", "sandbox-required", "block"}
     )
     prior_incidents = 0
     for event in store.list_events(limit=1000):
@@ -431,6 +448,386 @@ def _default_action_from_verdict(verdict: GuardVerdict) -> GuardAction:
     return mapping[verdict.action]
 
 
+def _normalized_consumer_path(path: Path) -> str:
+    try:
+        return str(path.expanduser().resolve(strict=False))
+    except (OSError, RuntimeError):
+        return str(path.expanduser().absolute())
+
+
+def _consumer_effective_cwd(config: GuardConfig) -> Path:
+    return config.workspace if config.workspace is not None else Path.cwd()
+
+
+def _consumer_policy_workspace(config: GuardConfig) -> str:
+    return _normalized_consumer_path(_consumer_effective_cwd(config))
+
+
+def _consumer_execution_identity(
+    command: str | None,
+    *,
+    args: Sequence[object] = (),
+    cwd: Path,
+    structured_command: bool = False,
+) -> dict[str, object]:
+    requested = command.strip() if isinstance(command, str) else command
+    launch_identity = build_runtime_launch_identity(
+        command,
+        args=args,
+        structured_command=structured_command,
+        cwd=cwd,
+        launch_env=os.environ,
+    )
+    return {
+        "requested": requested,
+        "argv_sha256": launch_identity["argv_sha256"],
+        "entrypoint": launch_identity["entrypoint"],
+        "launch_cwd": launch_identity["launch_cwd"],
+        "resolved": launch_identity["executable"],
+    }
+
+
+def _consumer_context_metadata(artifact: GuardArtifact) -> dict[str, object]:
+    if artifact.artifact_type != "prompt_request":
+        return dict(artifact.metadata)
+    return {
+        key: value for key, value in artifact.metadata.items() if key not in _PROMPT_FILE_HASH_VOLATILE_METADATA_KEYS
+    }
+
+
+def _consumer_policy_context(
+    config: GuardConfig,
+    *,
+    harness: str,
+    artifact_id: str | None,
+    publisher: str | None,
+    configured_action: GuardAction | None,
+    effective_default_action: GuardAction | None,
+    current_action: GuardAction,
+) -> dict[str, object]:
+    return {
+        "artifact_override": configured_action,
+        "changed_hash_action": config.changed_hash_action,
+        "current_action": current_action,
+        "default_action": config.default_action,
+        "effective_default_action": effective_default_action,
+        "harness": harness,
+        "harness_risk_actions": config.harness_risk_actions or {},
+        "managed_locked_settings": list(config.managed_locked_settings),
+        "managed_policy_hash": config.managed_policy_hash,
+        "managed_policy_status": config.managed_policy_status,
+        "mode": config.mode,
+        "new_network_domain_action": config.new_network_domain_action,
+        "policy_version": _CONSUMER_APPROVAL_POLICY_VERSION,
+        "resolved_override": config.resolve_action_override(harness, artifact_id, publisher),
+        "risk_actions": config.risk_actions or {},
+        "security_level": config.security_level,
+        "subprocess_action": config.subprocess_action,
+        "unknown_publisher_action": config.unknown_publisher_action,
+    }
+
+
+def _consumer_approval_context_token(
+    *,
+    detection: HarnessDetection,
+    artifact: GuardArtifact,
+    content_hash: str,
+    capability_snapshot: Mapping[str, object],
+    structured_signals: tuple[GuardSignal, ...],
+    provenance: ProvenanceBundle,
+    config: GuardConfig,
+    configured_action: GuardAction | None,
+    effective_default_action: GuardAction | None,
+    current_action: GuardAction,
+    runtime_detector_context: Mapping[str, object] | None,
+) -> str:
+    effective_cwd = _consumer_effective_cwd(config)
+    normalized_cwd = _normalized_consumer_path(effective_cwd)
+    normalized_workspace = _normalized_consumer_path(config.workspace) if config.workspace is not None else None
+    return build_approval_context_token(
+        identity={
+            "artifact_id": artifact.artifact_id,
+            "artifact_name": artifact.name,
+            "artifact_type": artifact.artifact_type,
+            "config_path": artifact.config_path,
+            "cwd": normalized_cwd,
+            "detection_harness": detection.harness,
+            "executable": _consumer_execution_identity(
+                artifact.command,
+                args=artifact.args,
+                cwd=effective_cwd,
+                structured_command=artifact.artifact_type == "mcp_server",
+            ),
+            "harness": artifact.harness,
+            "publisher": artifact.publisher,
+            "source_scope": artifact.source_scope,
+            "workspace": normalized_workspace,
+        },
+        content={
+            "args": list(artifact.args),
+            "artifact_hash": content_hash,
+            "command": artifact.command,
+            "metadata": _consumer_context_metadata(artifact),
+            "url": artifact.url,
+        },
+        capabilities={
+            "artifact_capabilities": dict(capability_snapshot),
+            "command_available": detection.command_available,
+            "installed": detection.installed,
+            "provenance": provenance.to_dict(),
+            "runtime_detector": dict(runtime_detector_context or {}),
+            "scanner_policy_version": _CONSUMER_APPROVAL_POLICY_VERSION,
+            "signals": [signal.to_dict() for signal in structured_signals],
+            "transport": artifact.transport,
+        },
+        policy=_consumer_policy_context(
+            config,
+            harness=detection.harness,
+            artifact_id=artifact.artifact_id,
+            publisher=artifact.publisher,
+            configured_action=configured_action,
+            effective_default_action=effective_default_action,
+            current_action=current_action,
+        ),
+        sandbox={
+            "analysis": config.sandbox_analysis,
+            "required": current_action == "sandbox-required",
+        },
+    )
+
+
+def _removed_consumer_approval_context_token(
+    *,
+    harness: str,
+    artifact_id: str,
+    previous: Mapping[str, object],
+    previous_hash: str,
+    config: GuardConfig,
+    configured_action: GuardAction | None,
+    effective_default_action: GuardAction | None,
+    current_action: GuardAction,
+    runtime_detector_context: Mapping[str, object] | None,
+) -> str:
+    effective_cwd = _consumer_effective_cwd(config)
+    command = previous.get("command")
+    publisher = previous.get("publisher")
+    raw_args = previous.get("args")
+    previous_args = tuple(str(argument) for argument in raw_args) if isinstance(raw_args, (list, tuple)) else ()
+    return build_approval_context_token(
+        identity={
+            "artifact_id": artifact_id,
+            "artifact_name": previous.get("name"),
+            "artifact_type": previous.get("artifact_type"),
+            "config_path": previous.get("config_path"),
+            "cwd": _normalized_consumer_path(effective_cwd),
+            "executable": _consumer_execution_identity(
+                command if isinstance(command, str) else None,
+                args=previous_args,
+                cwd=effective_cwd,
+                structured_command=previous.get("artifact_type") == "mcp_server",
+            ),
+            "harness": harness,
+            "publisher": publisher if isinstance(publisher, str) else None,
+            "source_scope": previous.get("source_scope"),
+            "workspace": (_normalized_consumer_path(config.workspace) if config.workspace is not None else None),
+        },
+        content={"artifact_hash": previous_hash, "removed": True, "snapshot": dict(previous)},
+        capabilities={
+            "removed": True,
+            "runtime_detector": dict(runtime_detector_context or {}),
+            "snapshot": dict(previous),
+        },
+        policy=_consumer_policy_context(
+            config,
+            harness=harness,
+            artifact_id=artifact_id,
+            publisher=publisher if isinstance(publisher, str) else None,
+            configured_action=configured_action,
+            effective_default_action=effective_default_action,
+            current_action=current_action,
+        ),
+        sandbox={
+            "analysis": config.sandbox_analysis,
+            "required": current_action == "sandbox-required",
+        },
+    )
+
+
+def _consumer_saved_allow_validation_reason(
+    decision: Mapping[str, object],
+    *,
+    approval_context_hash: str,
+) -> ApprovalReuseValidationFailure | None:
+    if decision.get("action") != "allow":
+        return None
+    return cast(
+        ApprovalReuseValidationFailure,
+        approval_context_tokens_validation_reason(
+            decision.get("artifact_hash"),
+            approval_context_hash,
+        ),
+    )
+
+
+def _compose_consumer_saved_policy(
+    *,
+    store: GuardStore,
+    harness: str,
+    artifact_id: str,
+    artifact_hash: str,
+    workspace: str | None,
+    publisher: str | None,
+    current_action: GuardAction,
+    now: str,
+    memory_command: str | None = None,
+    memory_artifact_type: str | None = None,
+    memory_artifact_name: str | None = None,
+    pending_approval_claims: list[tuple[Mapping[str, object], str, str]] | None = None,
+) -> tuple[ApprovalReuseDecision, bool]:
+    lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
+        harness,
+        artifact_id,
+        artifact_hash=artifact_hash,
+        workspace=workspace,
+        publisher=publisher,
+        now=now,
+        memory_command=memory_command,
+        memory_artifact_type=memory_artifact_type,
+        memory_artifact_name=memory_artifact_name,
+        consume_one_shot=False,
+    )
+    saved_decision = lookup["decision"]
+    ignored_integrity = lookup["ignored_local_integrity"]
+    has_saved_state = saved_decision is not None or ignored_integrity is not None
+    validation_reason: ApprovalReuseValidationFailure | None = None
+    saved_action: object | None = None
+    if saved_decision is not None:
+        saved_action = saved_decision.get("action")
+        validation_reason = (
+            "approval_reuse_integrity_failure"
+            if ignored_integrity is not None
+            else _consumer_saved_allow_validation_reason(
+                saved_decision,
+                approval_context_hash=artifact_hash,
+            )
+        )
+    elif ignored_integrity is not None:
+        saved_action = "require-reapproval"
+        validation_reason = "approval_reuse_integrity_failure"
+    else:
+        diagnosed_reason = store.approval_reuse_validation_reason(
+            harness,
+            artifact_id,
+            artifact_hash,
+            workspace,
+            publisher,
+            now,
+        )
+        if diagnosed_reason is not None:
+            has_saved_state = True
+            saved_action = "allow"
+            validation_reason = cast(ApprovalReuseValidationFailure, diagnosed_reason)
+
+    if not has_saved_state:
+        return evaluate_approval_reuse(current_action), False
+
+    reuse = evaluate_approval_reuse(
+        current_action,
+        saved_action,
+        saved_decision_present=True,
+        validation_reason=validation_reason,
+    )
+    if reuse.should_claim and saved_decision is not None and pending_approval_claims is not None:
+        pending_approval_claims.append((saved_decision, artifact_id, artifact_hash))
+    return reuse, True
+
+
+def _approval_reuse_scanner_evidence(
+    reuse: ApprovalReuseDecision,
+    *,
+    has_saved_state: bool,
+) -> tuple[dict[str, object], ...]:
+    if not has_saved_state and reuse.reason_code == APPROVAL_REUSE_NO_SAVED_DECISION:
+        return ()
+    return ({"source": "approval_reuse", **reuse.to_evidence()},)
+
+
+def _runtime_detector_scanner_evidence(block_reason: str | None) -> tuple[dict[str, object], ...]:
+    if not block_reason:
+        return ()
+    return (
+        {
+            "source": "runtime_detector_registry",
+            "status": "blocked",
+            "reason_code": _RUNTIME_DETECTOR_BLOCK_REASON,
+            "reason": block_reason,
+        },
+    )
+
+
+def _trusted_request_override_applies(
+    trusted_request_overrides: Mapping[str, str] | None,
+    *,
+    artifact_id: str,
+    approval_context_hash: str,
+    approval_reuse: ApprovalReuseDecision,
+) -> bool:
+    """Accept a freshly resolved request only for the exact re-evaluated context.
+
+    This is a trusted, current-request authority input, not saved approval
+    reuse.  It may satisfy a review/reapproval prompt after the launch state is
+    re-detected, but can never lower a terminal block, sandbox requirement, or
+    local-integrity failure.
+    """
+
+    expected_hash = (trusted_request_overrides or {}).get(artifact_id)
+    return bool(
+        expected_hash == approval_context_hash
+        and approval_reuse.action in {"review", "require-reapproval"}
+        and approval_reuse.reason_code != "approval_reuse_integrity_failure"
+    )
+
+
+def _claimed_saved_approval_applies(
+    claimed_saved_approval_overrides: Mapping[str, str] | None,
+    retained_saved_approval_overrides: Mapping[str, str] | None,
+    *,
+    artifact_id: str,
+    approval_context_hash: str,
+    current_action: GuardAction,
+    has_saved_state: bool,
+    approval_reuse: ApprovalReuseDecision,
+) -> bool:
+    """Carry an atomically claimed saved allow into final persistence.
+
+    The claim may consume a one-shot or validate a persistent/reusable row.
+    Unlike a fresh request override, preclaimed saved evidence can satisfy only
+    an exact current ``review``. It cannot satisfy reapproval or lower a
+    sandbox/block result.
+    """
+
+    consumed_claim_matches = (claimed_saved_approval_overrides or {}).get(artifact_id) == approval_context_hash
+    retained_claim_matches = (retained_saved_approval_overrides or {}).get(artifact_id) == approval_context_hash
+    if current_action != "review" or not (consumed_claim_matches or retained_claim_matches):
+        return False
+    if consumed_claim_matches and not has_saved_state:
+        # A consuming one-shot disappears after the atomic claim. The exact
+        # claim override is therefore the only remaining proof carried into
+        # this persistence-phase evaluation.
+        return True
+    # Persistent policies and explicitly reusable local approvals remain in
+    # the store after a successful claim. Finalize them only while the fresh
+    # lookup still resolves the same context to an accepted saved allow. This
+    # prevents a stale claim proof from bypassing a changed, expired, corrupt,
+    # blocking, or otherwise non-exact row.
+    return bool(
+        approval_reuse.accepted
+        and approval_reuse.saved_action == "allow"
+        and approval_reuse.reason_code == APPROVAL_REUSE_ACCEPTED
+        and approval_reuse.should_claim
+    )
+
+
 def detect_all(context: HarnessContext) -> list[HarnessDetection]:
     """Run detection across all adapters."""
 
@@ -453,10 +850,17 @@ def evaluate_detection(
     config: GuardConfig,
     default_action: str | None = None,
     persist: bool = True,
+    trusted_request_overrides: Mapping[str, str] | None = None,
+    trusted_request_override_labels: Mapping[str, str] | None = None,
+    pending_approval_claims: list[tuple[Mapping[str, object], str, str]] | None = None,
+    claimed_saved_approval_overrides: Mapping[str, str] | None = None,
+    retained_saved_approval_overrides: Mapping[str, str] | None = None,
+    runtime_detector_block_reason: str | None = None,
+    runtime_detector_context: Mapping[str, object] | None = None,
 ) -> dict[str, Any]:
     """Apply policy, generate diffs, and persist receipts for a harness."""
 
-    workspace = str(config.workspace) if config.workspace is not None else None
+    workspace = _consumer_policy_workspace(config)
     results: list[dict[str, object]] = []
     blocked = False
     receipts_recorded = 0
@@ -470,22 +874,11 @@ def evaluate_detection(
         previous = previous_snapshots.get(artifact.artifact_id)
         diff = diff_artifact(previous, artifact)
         is_first_seen = diff["changed_fields"] == ["first_seen"]
-        configured_action = store.resolve_policy(
+        configured_action = config.resolve_action_override(
             detection.harness,
             artifact.artifact_id,
-            str(diff["current_hash"]),
-            workspace,
             artifact.publisher,
-            memory_command=artifact.command,
-            memory_artifact_type=artifact.artifact_type,
-            memory_artifact_name=artifact.name,
         )
-        if configured_action is None:
-            configured_action = config.resolve_action_override(
-                detection.harness,
-                artifact.artifact_id,
-                artifact.publisher,
-            )
         previous_capabilities = store.get_artifact_capability(detection.harness, artifact.artifact_id)
         current_capabilities = normalize_artifact_capabilities(artifact)
         capability_delta = compute_capability_delta(previous_capabilities, current_capabilities)
@@ -499,19 +892,108 @@ def evaluate_detection(
             "file_read_request",
             "tool_action_request",
         }:
-            policy_action = _guard_default_action(artifact) or "require-reapproval"
+            current_policy_action = _guard_default_action(artifact) or "require-reapproval"
         elif is_first_seen and configured_action is None and effective_default_action is not None:
-            policy_action = effective_default_action
+            current_policy_action = effective_default_action
         else:
-            policy_action = decide_action(
+            current_policy_action = decide_action(
                 configured_action=configured_action,
                 default_action=effective_default_action,
                 config=config,
                 changed=bool(diff["changed"]),
             )
+        scanner_action = _default_action_from_verdict(verdict)
+        current_policy_action = most_restrictive_guard_action(
+            current_policy_action,
+            scanner_action,
+        )
+        approval_context_hash = _consumer_approval_context_token(
+            detection=detection,
+            artifact=artifact,
+            content_hash=str(diff["current_hash"]),
+            capability_snapshot=current_capabilities.to_dict(),
+            structured_signals=structured_signals,
+            provenance=provenance_bundle,
+            config=config,
+            configured_action=configured_action,
+            effective_default_action=effective_default_action,
+            current_action=current_policy_action,
+            runtime_detector_context=runtime_detector_context,
+        )
+        approval_reuse, has_saved_state = _compose_consumer_saved_policy(
+            store=store,
+            harness=detection.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=approval_context_hash,
+            workspace=workspace,
+            publisher=artifact.publisher,
+            current_action=current_policy_action,
+            now=now,
+            memory_command=artifact.command,
+            memory_artifact_type=artifact.artifact_type,
+            memory_artifact_name=artifact.name,
+            pending_approval_claims=pending_approval_claims,
+        )
+        claimed_saved_approval = _claimed_saved_approval_applies(
+            claimed_saved_approval_overrides,
+            retained_saved_approval_overrides,
+            artifact_id=artifact.artifact_id,
+            approval_context_hash=approval_context_hash,
+            current_action=current_policy_action,
+            has_saved_state=has_saved_state,
+            approval_reuse=approval_reuse,
+        )
+        if claimed_saved_approval:
+            approval_reuse = evaluate_approval_reuse(
+                current_policy_action,
+                "allow",
+                saved_decision_present=True,
+            )
+            has_saved_state = True
+        trusted_request_override = _trusted_request_override_applies(
+            trusted_request_overrides,
+            artifact_id=artifact.artifact_id,
+            approval_context_hash=approval_context_hash,
+            approval_reuse=approval_reuse,
+        )
+        policy_action: GuardAction = "allow" if trusted_request_override else approval_reuse.action
+        if runtime_detector_block_reason:
+            policy_action = "block"
+        approval_authority_finalized = (
+            not approval_reuse.should_claim or claimed_saved_approval or trusted_request_override
+        )
+        approval_reuse_evidence = _approval_reuse_scanner_evidence(
+            approval_reuse,
+            has_saved_state=has_saved_state,
+        )
+        scanner_evidence = (
+            *approval_reuse_evidence,
+            *(
+                (
+                    {
+                        "source": "trusted_request_override",
+                        "status": "accepted",
+                        "reason_code": _TRUSTED_REQUEST_OVERRIDE_REASON,
+                        "artifact_hash": approval_context_hash,
+                    },
+                )
+                if trusted_request_override
+                else ()
+            ),
+            *_runtime_detector_scanner_evidence(runtime_detector_block_reason),
+        )
         if _is_blocking_action(policy_action):
             blocked = True
-        decision_v2 = build_decision_v2(policy_action, reason=policy_action, signals=risk_signals_v2)
+        decision_reason = (
+            _RUNTIME_DETECTOR_BLOCK_REASON
+            if runtime_detector_block_reason
+            else _TRUSTED_REQUEST_OVERRIDE_REASON
+            if trusted_request_override
+            else approval_reuse.reason_code
+            if has_saved_state
+            else policy_action
+        )
+        decision_v2 = build_decision_v2(policy_action, reason=decision_reason, signals=risk_signals_v2)
         risk_signals = tuple(signal.explanation for signal in structured_signals)
         risk_summary = artifact_risk_summary(artifact) if structured_signals else summarize_signals(())
         changed_capabilities = [delta.delta_type for delta in capability_delta] or list(diff["changed_fields"])
@@ -542,8 +1024,24 @@ def evaluate_detection(
             ),
             artifact_name=artifact.name,
             source_scope=artifact.source_scope,
+            user_override=(
+                (trusted_request_override_labels or {}).get(artifact.artifact_id)
+                if trusted_request_override and not runtime_detector_block_reason
+                else None
+            ),
             diff_summary=_build_diff_summary(diff),
-            approval_source="policy",
+            approval_source=(
+                "runtime-detector"
+                if runtime_detector_block_reason
+                else "fresh-approval"
+                if trusted_request_override
+                else "saved-approval"
+                if approval_reuse.accepted and approval_reuse.saved_action == "allow"
+                else "saved-policy"
+                if approval_reuse.saved_action == "block"
+                else "policy"
+            ),
+            scanner_evidence=scanner_evidence,
         )
         if persist:
             store.record_inventory_artifact(
@@ -552,7 +1050,7 @@ def evaluate_detection(
                 policy_action=policy_action,
                 changed=bool(diff["changed"]),
                 now=now,
-                approved=not _is_blocking_action(policy_action),
+                approved=not _is_blocking_action(policy_action) and approval_authority_finalized,
             )
             store.save_artifact_capability(
                 harness=detection.harness,
@@ -575,7 +1073,7 @@ def evaluate_detection(
                     str(diff["current_hash"]),
                     now,
                 )
-            if not _is_blocking_action(policy_action):
+            if not _is_blocking_action(policy_action) and approval_authority_finalized:
                 store.save_snapshot(
                     detection.harness,
                     artifact.artifact_id,
@@ -593,6 +1091,8 @@ def evaluate_detection(
                         "artifact_name": artifact.name,
                         "policy_action": policy_action,
                         "changed_fields": list(diff["changed_fields"]),
+                        "approval_reuse_status": approval_reuse.status,
+                        "approval_reuse_reason_code": approval_reuse.reason_code,
                     },
                     now,
                 )
@@ -606,6 +1106,34 @@ def evaluate_detection(
                 "policy_action": policy_action,
                 "decision_v2_json": decision_v2.to_dict(),
                 "artifact_hash": diff["current_hash"],
+                "approval_context_hash": approval_context_hash,
+                "effective_workspace": workspace,
+                "approval_reuse_status": approval_reuse.status,
+                "approval_reuse_reason_code": approval_reuse.reason_code,
+                "approval_reuse": approval_reuse.to_evidence(),
+                "scanner_evidence": list(scanner_evidence),
+                "trusted_request_override": {
+                    "applied": trusted_request_override,
+                    "reason_code": _TRUSTED_REQUEST_OVERRIDE_REASON if trusted_request_override else None,
+                },
+                "policy_composition": {
+                    "configured_action": configured_action,
+                    "current_action": current_policy_action,
+                    "saved_action": approval_reuse.saved_action,
+                    "saved_state_present": has_saved_state,
+                    "scanner_action": scanner_action,
+                    "scoring_recommendation": verdict.action,
+                    "trusted_request_override": trusted_request_override,
+                    **(
+                        {
+                            "runtime_detector_action": "block",
+                            "runtime_detector_reason": runtime_detector_block_reason,
+                        }
+                        if runtime_detector_block_reason
+                        else {}
+                    ),
+                    "final_action": policy_action,
+                },
                 "risk_signals": list(risk_signals),
                 "risk_summary": risk_summary,
                 "signals": [signal.to_dict() for signal in structured_signals],
@@ -638,15 +1166,111 @@ def evaluate_detection(
         previous = previous_snapshots[artifact_id]
         diff = diff_removed_artifact(previous)
         previous_hash = diff["previous_hash"] if isinstance(diff["previous_hash"], str) else "removed"
-        policy_action = decide_action(
-            configured_action=store.resolve_policy(detection.harness, artifact_id, previous_hash, workspace),
+        previous_publisher_value = previous.get("publisher")
+        previous_publisher = previous_publisher_value if isinstance(previous_publisher_value, str) else None
+        configured_action = config.resolve_action_override(
+            detection.harness,
+            artifact_id,
+            previous_publisher,
+        )
+        current_policy_action = decide_action(
+            configured_action=configured_action,
             default_action=effective_default_action,
             config=config,
             changed=True,
         )
+        approval_context_hash = _removed_consumer_approval_context_token(
+            harness=detection.harness,
+            artifact_id=artifact_id,
+            previous=previous,
+            previous_hash=previous_hash,
+            config=config,
+            configured_action=configured_action,
+            effective_default_action=effective_default_action,
+            current_action=current_policy_action,
+            runtime_detector_context=runtime_detector_context,
+        )
+        previous_command_value = previous.get("command")
+        previous_artifact_type_value = previous.get("artifact_type")
+        previous_name_value = previous.get("name")
+        approval_reuse, has_saved_state = _compose_consumer_saved_policy(
+            store=store,
+            harness=detection.harness,
+            artifact_id=artifact_id,
+            artifact_hash=approval_context_hash,
+            workspace=workspace,
+            publisher=previous_publisher,
+            current_action=current_policy_action,
+            now=now,
+            memory_command=previous_command_value if isinstance(previous_command_value, str) else None,
+            memory_artifact_type=(
+                previous_artifact_type_value if isinstance(previous_artifact_type_value, str) else None
+            ),
+            memory_artifact_name=previous_name_value if isinstance(previous_name_value, str) else None,
+            pending_approval_claims=pending_approval_claims,
+        )
+        claimed_saved_approval = _claimed_saved_approval_applies(
+            claimed_saved_approval_overrides,
+            retained_saved_approval_overrides,
+            artifact_id=artifact_id,
+            approval_context_hash=approval_context_hash,
+            current_action=current_policy_action,
+            has_saved_state=has_saved_state,
+            approval_reuse=approval_reuse,
+        )
+        if claimed_saved_approval:
+            approval_reuse = evaluate_approval_reuse(
+                current_policy_action,
+                "allow",
+                saved_decision_present=True,
+            )
+            has_saved_state = True
+        trusted_request_override = _trusted_request_override_applies(
+            trusted_request_overrides,
+            artifact_id=artifact_id,
+            approval_context_hash=approval_context_hash,
+            approval_reuse=approval_reuse,
+        )
+        policy_action = "allow" if trusted_request_override else approval_reuse.action
+        if runtime_detector_block_reason:
+            policy_action = "block"
+        approval_authority_finalized = (
+            not approval_reuse.should_claim or claimed_saved_approval or trusted_request_override
+        )
+        approval_reuse_evidence = _approval_reuse_scanner_evidence(
+            approval_reuse,
+            has_saved_state=has_saved_state,
+        )
+        scanner_evidence = (
+            *approval_reuse_evidence,
+            *(
+                (
+                    {
+                        "source": "trusted_request_override",
+                        "status": "accepted",
+                        "reason_code": _TRUSTED_REQUEST_OVERRIDE_REASON,
+                        "artifact_hash": approval_context_hash,
+                    },
+                )
+                if trusted_request_override
+                else ()
+            ),
+            *_runtime_detector_scanner_evidence(runtime_detector_block_reason),
+        )
         if _is_blocking_action(policy_action):
             blocked = True
-        decision_v2 = build_decision_v2(policy_action, reason=policy_action)
+        decision_v2 = build_decision_v2(
+            policy_action,
+            reason=(
+                _RUNTIME_DETECTOR_BLOCK_REASON
+                if runtime_detector_block_reason
+                else _TRUSTED_REQUEST_OVERRIDE_REASON
+                if trusted_request_override
+                else approval_reuse.reason_code
+                if has_saved_state
+                else policy_action
+            ),
+        )
         artifact_name = previous.get("name")
         source_scope = previous.get("source_scope")
         config_path = previous.get("config_path")
@@ -677,8 +1301,24 @@ def evaluate_detection(
             provenance_summary=_build_removed_provenance(previous),
             artifact_name=str(artifact_name) if isinstance(artifact_name, str) else artifact_id,
             source_scope=str(source_scope) if isinstance(source_scope, str) else None,
+            user_override=(
+                (trusted_request_override_labels or {}).get(artifact_id)
+                if trusted_request_override and not runtime_detector_block_reason
+                else None
+            ),
             diff_summary="artifact removed",
-            approval_source="policy",
+            approval_source=(
+                "runtime-detector"
+                if runtime_detector_block_reason
+                else "fresh-approval"
+                if trusted_request_override
+                else "saved-approval"
+                if approval_reuse.accepted and approval_reuse.saved_action == "allow"
+                else "saved-policy"
+                if approval_reuse.saved_action == "block"
+                else "policy"
+            ),
+            scanner_evidence=scanner_evidence,
         )
         if persist:
             store.mark_inventory_removed(
@@ -696,7 +1336,7 @@ def evaluate_detection(
                 "removed",
                 now,
             )
-            if not _is_blocking_action(policy_action):
+            if not _is_blocking_action(policy_action) and approval_authority_finalized:
                 store.delete_snapshot(detection.harness, artifact_id)
             store.add_receipt(receipt)
             store.add_event(
@@ -707,6 +1347,8 @@ def evaluate_detection(
                     "artifact_name": str(artifact_name) if isinstance(artifact_name, str) else artifact_id,
                     "policy_action": policy_action,
                     "changed_fields": ["removed"],
+                    "approval_reuse_status": approval_reuse.status,
+                    "approval_reuse_reason_code": approval_reuse.reason_code,
                 },
                 now,
             )
@@ -720,6 +1362,33 @@ def evaluate_detection(
                 "policy_action": policy_action,
                 "decision_v2_json": decision_v2.to_dict(),
                 "artifact_hash": previous_hash,
+                "approval_context_hash": approval_context_hash,
+                "effective_workspace": workspace,
+                "approval_reuse_status": approval_reuse.status,
+                "approval_reuse_reason_code": approval_reuse.reason_code,
+                "approval_reuse": approval_reuse.to_evidence(),
+                "scanner_evidence": list(scanner_evidence),
+                "trusted_request_override": {
+                    "applied": trusted_request_override,
+                    "reason_code": _TRUSTED_REQUEST_OVERRIDE_REASON if trusted_request_override else None,
+                },
+                "policy_composition": {
+                    "configured_action": configured_action,
+                    "current_action": current_policy_action,
+                    "saved_action": approval_reuse.saved_action,
+                    "saved_state_present": has_saved_state,
+                    "scoring_recommendation": "warn",
+                    "trusted_request_override": trusted_request_override,
+                    **(
+                        {
+                            "runtime_detector_action": "block",
+                            "runtime_detector_reason": runtime_detector_block_reason,
+                        }
+                        if runtime_detector_block_reason
+                        else {}
+                    ),
+                    "final_action": policy_action,
+                },
                 "removed": True,
                 "risk_signals": ["artifact removed from local harness configuration"],
                 "risk_summary": "Artifact was removed from the harness configuration.",

--- a/src/codex_plugin_scanner/guard/local_authority_integrity.py
+++ b/src/codex_plugin_scanner/guard/local_authority_integrity.py
@@ -1,0 +1,172 @@
+"""Domain-separated integrity for local approval authority outside policy rows."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from collections.abc import Mapping
+
+from .policy_integrity import PolicyIntegrityVerificationResult
+
+LOCAL_AUTHORITY_INTEGRITY_VERSION = 1
+LOCAL_AUTHORITY_INTEGRITY_MAC_ALGORITHM = "hmac-sha256"
+_LOCAL_AUTHORITY_INTEGRITY_DOMAIN = b"hol-guard.local-authority-integrity.v1"
+
+
+def sign_local_authority_payload(
+    payload: Mapping[str, object],
+    *,
+    key: bytes,
+    key_id: str,
+    purpose: str,
+    signed_at: str,
+) -> dict[str, object]:
+    """Sign a local authority payload with a purpose-specific derived key."""
+
+    canonical_payload = _canonical_local_authority_payload(
+        payload,
+        purpose=purpose,
+        signed_at=signed_at,
+        integrity_version=LOCAL_AUTHORITY_INTEGRITY_VERSION,
+    )
+    return {
+        "integrity_version": LOCAL_AUTHORITY_INTEGRITY_VERSION,
+        "payload_hash": hashlib.sha256(canonical_payload).hexdigest(),
+        "payload_mac": hmac.new(
+            _purpose_key(key, purpose=purpose),
+            canonical_payload,
+            hashlib.sha256,
+        ).hexdigest(),
+        "integrity_key_id": key_id,
+        "signed_at": signed_at,
+    }
+
+
+def verify_local_authority_payload(
+    payload: Mapping[str, object],
+    integrity: Mapping[str, object],
+    *,
+    key: bytes | None,
+    key_id: str | None,
+    purpose: str,
+) -> PolicyIntegrityVerificationResult:
+    """Verify purpose-bound local authority without creating key material."""
+
+    version = _int_or_none(_mapping_value(integrity, "integrity_version"))
+    stored_payload_hash = _string_or_none(_mapping_value(integrity, "payload_hash"))
+    stored_payload_mac = _string_or_none(_mapping_value(integrity, "payload_mac"))
+    stored_key_id = _string_or_none(_mapping_value(integrity, "integrity_key_id"))
+    signed_at = _string_or_none(_mapping_value(integrity, "signed_at"))
+    if (
+        version is None
+        or stored_payload_hash is None
+        or stored_payload_mac is None
+        or stored_key_id is None
+        or signed_at is None
+    ):
+        return PolicyIntegrityVerificationResult(
+            status="missing_integrity",
+            payload_hash=stored_payload_hash,
+            key_id=stored_key_id,
+            message="local_authority_integrity_metadata_missing",
+        )
+    if version != LOCAL_AUTHORITY_INTEGRITY_VERSION:
+        return PolicyIntegrityVerificationResult(
+            status="tampered",
+            payload_hash=stored_payload_hash,
+            key_id=stored_key_id,
+            message="local_authority_integrity_version_unsupported",
+        )
+    if key is None or key_id is None or not _constant_time_text_equal(stored_key_id, key_id):
+        return PolicyIntegrityVerificationResult(
+            status="unknown_key",
+            payload_hash=stored_payload_hash,
+            key_id=stored_key_id,
+            message="local_authority_integrity_key_unavailable",
+        )
+
+    try:
+        canonical_payload = _canonical_local_authority_payload(
+            payload,
+            purpose=purpose,
+            signed_at=signed_at,
+            integrity_version=version,
+        )
+    except (TypeError, UnicodeError, ValueError):
+        return PolicyIntegrityVerificationResult(
+            status="tampered",
+            payload_hash=stored_payload_hash,
+            key_id=stored_key_id,
+            message="local_authority_integrity_payload_invalid",
+        )
+    computed_payload_hash = hashlib.sha256(canonical_payload).hexdigest()
+    if not _constant_time_text_equal(stored_payload_hash, computed_payload_hash):
+        return PolicyIntegrityVerificationResult(
+            status="tampered",
+            payload_hash=computed_payload_hash,
+            key_id=stored_key_id,
+            message="local_authority_integrity_payload_hash_mismatch",
+        )
+    computed_payload_mac = hmac.new(
+        _purpose_key(key, purpose=purpose),
+        canonical_payload,
+        hashlib.sha256,
+    ).hexdigest()
+    if not _constant_time_text_equal(stored_payload_mac, computed_payload_mac):
+        return PolicyIntegrityVerificationResult(
+            status="tampered",
+            payload_hash=computed_payload_hash,
+            key_id=stored_key_id,
+            message="local_authority_integrity_mac_mismatch",
+        )
+    return PolicyIntegrityVerificationResult(
+        status="valid",
+        payload_hash=computed_payload_hash,
+        key_id=stored_key_id,
+        message=LOCAL_AUTHORITY_INTEGRITY_MAC_ALGORITHM,
+    )
+
+
+def _canonical_local_authority_payload(
+    payload: Mapping[str, object],
+    *,
+    purpose: str,
+    signed_at: str,
+    integrity_version: int,
+) -> bytes:
+    envelope = {
+        "domain": _LOCAL_AUTHORITY_INTEGRITY_DOMAIN.decode("ascii"),
+        "integrity_version": integrity_version,
+        "payload": dict(payload),
+        "purpose": purpose,
+        "signed_at": signed_at,
+    }
+    return json.dumps(envelope, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def _purpose_key(key: bytes, *, purpose: str) -> bytes:
+    return hmac.new(
+        key,
+        _LOCAL_AUTHORITY_INTEGRITY_DOMAIN + b"\0" + purpose.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+
+
+def _string_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _int_or_none(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _mapping_value(mapping: Mapping[str, object], key: str) -> object:
+    try:
+        return mapping[key]
+    except KeyError:
+        return None
+
+
+def _constant_time_text_equal(left: str, right: str) -> bool:
+    return hmac.compare_digest(left.encode("utf-8"), right.encode("utf-8"))

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -14,16 +14,17 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Sequence
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import suppress
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, TypeGuard
+from typing import Any, Literal, TypeGuard, cast
 from uuid import uuid4
 
 from codex_plugin_scanner.path_support import resolve_path_within_allowed_roots, resolves_within_root
 
+from .action_lattice import most_restrictive_guard_action, normalize_guard_action
 from .adapters.base import HarnessContext
 from .advisory_model import ProtectTargetIdentity, advisory_matches_target, build_package_url
 from .approval_scope_support import package_request_runtime_workspace_scope
@@ -31,8 +32,21 @@ from .config import GuardConfig, resolve_risk_action
 from .mdm.network import managed_urlopen
 from .models import GuardAction, GuardArtifact, GuardReceipt
 from .package_execution_context import PackageExecutionContext, build_package_execution_context
-from .policy_integrity import is_remote_policy_source
 from .redaction import redact_local_path, redact_text
+from .runtime.approval_context import (
+    approval_context_tokens_validation_reason,
+    build_approval_context_token,
+    build_runtime_launch_identity,
+    resolved_runtime_launch_argv,
+    runtime_launch_identity_is_reusable,
+)
+from .runtime.approval_reuse import (
+    APPROVAL_REUSE_CLAIM_FAILED,
+    APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
+    ApprovalReuseDecision,
+    ApprovalReuseValidationFailure,
+    evaluate_approval_reuse,
+)
 from .runtime.package_execution_policy import is_execution_permitted
 from .runtime.package_intent_common import (
     PackageIntent,
@@ -262,6 +276,7 @@ def _build_guard_receipt(
     provenance_summary: str,
     artifact_name: str | None,
     source_scope: str | None,
+    scanner_evidence: tuple[dict[str, object], ...] = (),
 ) -> GuardReceipt:
     sample = ", ".join(changed_capabilities[:3])
     suffix = " ..." if len(changed_capabilities) > 3 else ""
@@ -279,6 +294,7 @@ def _build_guard_receipt(
         artifact_name=artifact_name,
         source_scope=source_scope,
         diff_summary=diff_summary,
+        scanner_evidence=scanner_evidence,
     )
 
 
@@ -1198,19 +1214,57 @@ def build_supply_chain_explain_payload(
     return (payload, _evaluation_exit_code(evaluation.decision))
 
 
-def build_package_protect_payload(
+@dataclass(frozen=True, slots=True)
+class _PackageProtectAuthority:
+    intent: PackageIntent
+    artifact: GuardArtifact
+    evaluation: Any
+    current_action: GuardAction
+    execution_context: PackageExecutionContext
+    artifact_hash: str
+    launch_identity: dict[str, object]
+    launch_cwd: Path
+    launch_environment: Mapping[str, str]
+    additional_current_action: object | None
+    additional_policy_context: dict[str, object] | None
+
+
+_PackageApprovalClaimDisposition = Literal["consumed", "retained"]
+
+
+@dataclass(frozen=True, slots=True)
+class _StoredPackagePolicyResolution:
+    evaluation: Any
+    approval_reuse_decision: Mapping[str, object] | None = None
+    claim_disposition: _PackageApprovalClaimDisposition | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _PackageProtectProjection:
+    receipt: GuardReceipt
+    receipt_policy_metadata: dict[str, object]
+    verdict_action: GuardAction
+    risk_signals: tuple[str, ...]
+
+
+def _build_package_protect_authority(
     *,
     command: Sequence[str],
     store: Any,
     workspace_dir: Path,
-    dry_run: bool,
-    allow_saved_approval_execution: bool = False,
     now: str,
     config: GuardConfig | None,
-    unsafe_raw_output: bool,
-    timeout_seconds: int,
-) -> tuple[dict[str, object], int] | None:
-    intent = _package_intent_parser_module().parse_package_intent(shlex.join(command), workspace=workspace_dir)
+    additional_current_action: object | None,
+    additional_policy_context: dict[str, object] | None,
+) -> _PackageProtectAuthority | None:
+    try:
+        launch_cwd = workspace_dir.expanduser().resolve(strict=True)
+    except (OSError, RuntimeError):
+        raise ValueError("package workspace must resolve to an existing directory") from None
+    if not launch_cwd.is_dir():
+        raise ValueError("package workspace must resolve to an existing directory")
+    launch_environment = dict(os.environ)
+    intent = _package_intent_parser_module().parse_package_intent(shlex.join(command), workspace=launch_cwd)
     if intent is None:
         return None
     sanitized_intent = replace(intent, redacted_command=shlex.join(redacted_command_tokens(command)))
@@ -1223,26 +1277,392 @@ def build_package_protect_payload(
     evaluation = evaluate_package_request_artifact(
         artifact=artifact,
         store=store,
-        workspace_dir=workspace_dir,
+        workspace_dir=launch_cwd,
         now=now,
     )
-    package_execution_context = build_package_execution_context(
-        workspace_dir=workspace_dir,
+    current_action = compose_current_package_policy_action(
         artifact=artifact,
-        executable=(
-            sanitized_intent.command_tokens[0]
-            if sanitized_intent.command_tokens and ";" not in sanitized_intent.command_tokens
-            else None
-        ),
+        evaluation=evaluation,
+        config=config,
+        additional_current_action=additional_current_action,
     )
+    executable = sanitized_intent.command_tokens[0] if sanitized_intent.command_tokens else None
+    executable_args = sanitized_intent.command_tokens[1:] if executable is not None else ()
+    if sanitized_intent.command_tokens and ";" in sanitized_intent.command_tokens:
+        executable = None
+        executable_args = ()
+    execution_context = build_package_execution_context(
+        workspace_dir=launch_cwd,
+        artifact=artifact,
+        executable=executable,
+        executable_args=executable_args,
+        environment=launch_environment,
+    )
+    launch_identity = build_runtime_launch_identity(
+        str(command[0]) if command else None,
+        args=tuple(str(item) for item in command[1:]),
+        structured_command=True,
+        direct_executable=True,
+        cwd=launch_cwd,
+        launch_env=launch_environment,
+    )
+    if command and executable is not None and str(command[0]) != executable:
+        launch_identity["wrapper_resolution"] = {
+            "reason": "package_command_wrapper_unresolved",
+            "reuse_nonce": uuid4().hex,
+            "status": "unproven",
+        }
     artifact_hash = _package_request_artifact_hash(
         artifact,
-        workspace_dir=workspace_dir,
+        workspace_dir=launch_cwd,
         store=store,
         evaluation=evaluation,
-        execution_context=package_execution_context,
+        execution_context=execution_context,
+        launch_identity=launch_identity,
+        config=config,
+        additional_current_action=additional_current_action,
+        additional_policy_context=additional_policy_context,
     )
-    evaluation = _apply_stored_package_policy_override(
+    return _PackageProtectAuthority(
+        intent=sanitized_intent,
+        artifact=artifact,
+        evaluation=evaluation,
+        current_action=current_action,
+        execution_context=execution_context,
+        artifact_hash=artifact_hash,
+        launch_identity=launch_identity,
+        launch_cwd=launch_cwd,
+        launch_environment=launch_environment,
+        additional_current_action=additional_current_action,
+        additional_policy_context=additional_policy_context,
+    )
+
+
+def _final_package_protect_authority(
+    *,
+    initial: _PackageProtectAuthority,
+    saved_approval_claimed: bool,
+    saved_approval_claim_disposition: _PackageApprovalClaimDisposition | None,
+    command: Sequence[str],
+    store: Any,
+    workspace_dir: Path,
+    now: str,
+    config: GuardConfig | None,
+    current_config_provider: Callable[[], GuardConfig] | None,
+    additional_authority_provider: Callable[[], tuple[object | None, dict[str, object] | None]] | None,
+) -> tuple[_PackageProtectAuthority, Any]:
+    """Rebuild all current authority after a claim and immediately before spawn."""
+
+    additional_action: object | None = initial.additional_current_action
+    additional_context: dict[str, object] | None = initial.additional_policy_context
+    current_config = config
+    config_refresh_failed = False
+    if current_config_provider is not None:
+        try:
+            current_config = current_config_provider()
+            if not isinstance(current_config, GuardConfig):
+                raise TypeError("current config provider returned an invalid value")
+        except Exception:
+            config_refresh_failed = True
+    if additional_authority_provider is not None:
+        try:
+            additional_action, additional_context = additional_authority_provider()
+        except Exception as error:
+            additional_action = "block"
+            additional_context = {
+                "available": False,
+                "error": type(error).__name__,
+                "status": "authority_refresh_failed",
+                "version": 1,
+            }
+    if config_refresh_failed:
+        additional_action = most_restrictive_guard_action(
+            additional_action,
+            "block",
+            unknown_action="block",
+        )
+        additional_context = {
+            "additional": additional_context,
+            "available": False,
+            "reason_code": "package_config_refresh_failed",
+            "status": "authority_refresh_failed",
+            "version": 1,
+        }
+    current = _build_package_protect_authority(
+        command=command,
+        store=store,
+        workspace_dir=workspace_dir,
+        now=now,
+        config=current_config,
+        additional_current_action=additional_action,
+        additional_policy_context=additional_context,
+    )
+    if current is None:
+        reuse = evaluate_approval_reuse(
+            "review",
+            "allow",
+            saved_decision_present=True,
+            validation_reason="approval_reuse_identity_changed",
+        )
+        return initial, _package_evaluation_with_rejected_reuse(initial.evaluation, reuse)
+    validation_reason: ApprovalReuseValidationFailure | None
+    if current.artifact.artifact_id != initial.artifact.artifact_id:
+        validation_reason = "approval_reuse_identity_changed"
+    else:
+        validation_reason = cast(
+            ApprovalReuseValidationFailure | None,
+            approval_context_tokens_validation_reason(initial.artifact_hash, current.artifact_hash),
+        )
+    current_evaluation = _package_evaluation_with_current_policy_action(
+        current.evaluation,
+        current_action=current.current_action,
+    )
+    if saved_approval_claimed:
+        if validation_reason is not None:
+            reuse = evaluate_approval_reuse(
+                current.current_action,
+                "allow",
+                saved_decision_present=True,
+                validation_reason=validation_reason,
+            )
+            return current, _package_evaluation_with_rejected_reuse(current_evaluation, reuse)
+        refreshed_saved_policy = _apply_stored_package_policy_override(
+            current_evaluation,
+            store=store,
+            artifact=current.artifact,
+            artifact_hash=current.artifact_hash,
+            workspace_dir=workspace_dir,
+            now=now,
+            execution_context=current.execution_context,
+            current_action=current.current_action,
+            claim_saved_approval=False,
+        )
+        if _evaluation_uses_saved_package_approval(refreshed_saved_policy):
+            # Persistent and explicitly reusable approvals must still exist
+            # and match at the final boundary. The fresh resolver has already
+            # composed any newly inserted block or integrity failure.
+            return current, refreshed_saved_policy
+        if _package_approval_reuse_evidence(refreshed_saved_policy):
+            # A fresh saved-policy result exists but is no longer an accepted
+            # exact allow (for example, a new block or tampered authority).
+            return current, refreshed_saved_policy
+        if saved_approval_claim_disposition != "consumed":
+            # Retained package local-once and persistent policy grants remain
+            # authoritative after a successful claim. Their disappearance is
+            # a post-claim revocation, never evidence of one-shot consumption.
+            reuse = evaluate_approval_reuse(
+                current.current_action,
+                "allow",
+                saved_decision_present=True,
+                validation_reason=APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
+            )
+            return current, _package_evaluation_with_rejected_reuse(current_evaluation, reuse)
+        # Only a consuming one-shot is expected to disappear at claim time.
+        # Carry its atomic proof after the fresh lookup establishes that no
+        # newer saved authority applies and every current context still matches.
+        reuse = evaluate_approval_reuse(
+            current.current_action,
+            "allow",
+            saved_decision_present=True,
+        )
+        if reuse.accepted and reuse.saved_action == "allow":
+            return current, _package_policy_override_evaluation(
+                current_evaluation,
+                decision="allow",
+                policy_action="allow",
+                title="Allowed by saved approval",
+                summary="HOL Guard reused your saved approval for this package request.",
+                harness_message=(
+                    "HOL Guard revalidated the repository, package manager, dependency files, settings, "
+                    "registry environment, and current advisory authority after atomically claiming approval."
+                ),
+                reason_code="saved_package_approval",
+                reason_message="HOL Guard reused your saved approval for this package request.",
+                approval_reuse=reuse,
+            )
+        return current, _package_evaluation_with_rejected_reuse(current_evaluation, reuse)
+    if validation_reason is not None:
+        reuse = evaluate_approval_reuse(
+            current.current_action,
+            "require-reapproval",
+            saved_decision_present=True,
+            validation_reason=validation_reason,
+        )
+        return current, _package_evaluation_with_rejected_reuse(current_evaluation, reuse)
+    resolved = _apply_stored_package_policy_override(
+        current_evaluation,
+        store=store,
+        artifact=current.artifact,
+        artifact_hash=current.artifact_hash,
+        workspace_dir=workspace_dir,
+        now=now,
+        execution_context=current.execution_context,
+        current_action=current.current_action,
+        claim_saved_approval=False,
+    )
+    if _evaluation_uses_saved_package_approval(resolved):
+        reuse = evaluate_approval_reuse(
+            current.current_action,
+            "allow",
+            saved_decision_present=True,
+            validation_reason=APPROVAL_REUSE_CLAIM_FAILED,
+        )
+        resolved = _package_evaluation_with_rejected_reuse(current_evaluation, reuse)
+    return current, resolved
+
+
+def _apply_package_protect_projection(
+    *,
+    payload: dict[str, object],
+    authority: _PackageProtectAuthority,
+    evaluation: Any,
+    command: Sequence[str],
+    blocking: bool,
+    executed: bool,
+) -> _PackageProtectProjection:
+    """Project one authority/evaluation pair into every user and audit surface."""
+
+    intent = authority.intent
+    artifact = authority.artifact
+    artifact_hash = authority.artifact_hash
+    verdict_action = _protect_action_for_policy_action(evaluation.policy_action)
+    risk_signals = tuple(_evaluation_risk_signals(evaluation))
+    approval_reuse_evidence = _package_approval_reuse_evidence(evaluation)
+    receipt_policy_metadata: dict[str, object] = {
+        "matched_rule_id": evaluation.matched_rule_id,
+        "package_execution_context": authority.execution_context.to_evidence(),
+        "package_manager": intent.package_manager,
+        "package_targets": [target.raw_spec for target in intent.targets],
+        "policy_action": verdict_action,
+        "policy_version": evaluation.policy_version,
+        "redacted_command": intent.redacted_command,
+    }
+    if evaluation.bundle_version is not None:
+        receipt_policy_metadata["bundle_version"] = evaluation.bundle_version
+    if authority.additional_policy_context is not None:
+        receipt_policy_metadata["additional_policy_context"] = authority.additional_policy_context
+    if approval_reuse_evidence:
+        receipt_policy_metadata["approval_reuse"] = list(approval_reuse_evidence)
+    receipt = _build_guard_receipt(
+        harness=_LOCAL_SUPPLY_CHAIN_HARNESS,
+        artifact_id=artifact.artifact_id,
+        artifact_hash=artifact_hash,
+        policy_decision=verdict_action,
+        capabilities_summary=evaluation.user_copy.summary,
+        changed_capabilities=[target.package_name or target.raw_spec for target in intent.targets],
+        provenance_summary=evaluation.user_copy.harness_message,
+        artifact_name=artifact.name,
+        source_scope=artifact.source_scope,
+        scanner_evidence=approval_reuse_evidence,
+    )
+    matched_advisories = _matched_advisories(evaluation)
+    payload["request"] = {
+        "command": list(redacted_command_tokens(command)),
+        "redacted_command": intent.redacted_command,
+        "install_kind": intent.intent_kind,
+        "executor": str(command[0]) if command else _LOCAL_SUPPLY_CHAIN_HARNESS,
+        "package_manager": intent.package_manager,
+        "harness": _LOCAL_SUPPLY_CHAIN_HARNESS,
+        "targets": [target.to_dict() for target in intent.targets],
+        "manifest_paths": list(intent.manifest_paths),
+        "lockfile_paths": list(intent.lockfile_paths),
+        "package_execution_context": authority.execution_context.to_evidence(),
+    }
+    payload["targets"] = [_protect_target_payload(target) for target in intent.targets]
+    payload["verdict"] = {
+        "action": verdict_action,
+        "reason": evaluation.user_copy.summary,
+        "risk_signals": list(risk_signals),
+        "matched_advisories": matched_advisories,
+        "blocking": blocking,
+    }
+    payload["receipt"] = {
+        **receipt.to_dict(),
+        "action_envelope_json": receipt_policy_metadata,
+    }
+    payload["matched_advisories"] = matched_advisories
+    payload["supply_chain_evaluation"] = evaluation.to_dict()
+    payload["executed"] = executed
+    return _PackageProtectProjection(
+        receipt=receipt,
+        receipt_policy_metadata=receipt_policy_metadata,
+        verdict_action=verdict_action,
+        risk_signals=risk_signals,
+    )
+
+
+def _package_protect_denied_after_final_boundary(
+    *,
+    payload: dict[str, object],
+    authority: _PackageProtectAuthority,
+    evaluation: Any,
+    command: Sequence[str],
+    store: Any,
+    now: str,
+) -> tuple[dict[str, object], int]:
+    projection = _apply_package_protect_projection(
+        payload=payload,
+        authority=authority,
+        evaluation=evaluation,
+        command=command,
+        blocking=True,
+        executed=False,
+    )
+    store.add_receipt(projection.receipt)
+    store.set_receipt_action_envelope(
+        projection.receipt.receipt_id,
+        projection.receipt_policy_metadata,
+    )
+    store.add_event(
+        f"install_time_{projection.verdict_action}",
+        {
+            "artifact_id": authority.artifact.artifact_id,
+            "artifact_name": authority.artifact.name,
+            "executor": str(command[0]) if command else _LOCAL_SUPPLY_CHAIN_HARNESS,
+            "install_kind": authority.intent.intent_kind,
+            "action": projection.verdict_action,
+            "risk_signals": list(projection.risk_signals),
+        },
+        now,
+    )
+    return payload, _package_execution_exit_code(evaluation.policy_action)
+
+
+def build_package_protect_payload(
+    *,
+    command: Sequence[str],
+    store: Any,
+    workspace_dir: Path,
+    dry_run: bool,
+    allow_saved_approval_execution: bool = False,
+    now: str,
+    config: GuardConfig | None,
+    unsafe_raw_output: bool,
+    timeout_seconds: int,
+    additional_current_action: object | None = None,
+    additional_policy_context: dict[str, object] | None = None,
+    current_config_provider: Callable[[], GuardConfig] | None = None,
+    additional_authority_provider: Callable[[], tuple[object | None, dict[str, object] | None]] | None = None,
+) -> tuple[dict[str, object], int] | None:
+    authority = _build_package_protect_authority(
+        command=command,
+        store=store,
+        workspace_dir=workspace_dir,
+        now=now,
+        config=config,
+        additional_current_action=additional_current_action,
+        additional_policy_context=additional_policy_context,
+    )
+    if authority is None:
+        return None
+    sanitized_intent = authority.intent
+    artifact = authority.artifact
+    evaluation = authority.evaluation
+    current_evaluation = evaluation
+    current_action = authority.current_action
+    package_execution_context = authority.execution_context
+    artifact_hash = authority.artifact_hash
+    initial_policy_resolution = _resolve_stored_package_policy_override(
         evaluation,
         store=store,
         artifact=artifact,
@@ -1250,89 +1670,136 @@ def build_package_protect_payload(
         workspace_dir=workspace_dir,
         now=now,
         execution_context=package_execution_context,
+        current_action=current_action,
+        claim_saved_approval=False,
     )
-    verdict_action = _protect_action_for_policy_action(evaluation.policy_action)
-    execution_permitted = is_execution_permitted(evaluation.policy_action)
-    risk_signals = tuple(_evaluation_risk_signals(evaluation))
-    receipt_policy_metadata: dict[str, object] = {
-        "matched_rule_id": evaluation.matched_rule_id,
-        "package_manager": sanitized_intent.package_manager,
-        "package_targets": [target.raw_spec for target in sanitized_intent.targets],
-        "policy_version": evaluation.policy_version,
-        "redacted_command": sanitized_intent.redacted_command,
-        "package_execution_context": package_execution_context.to_evidence(),
-    }
-    if evaluation.bundle_version is not None:
-        receipt_policy_metadata["bundle_version"] = evaluation.bundle_version
-    receipt = _build_guard_receipt(
-        harness=_LOCAL_SUPPLY_CHAIN_HARNESS,
-        artifact_id=artifact.artifact_id,
-        artifact_hash=artifact_hash,
-        policy_decision=verdict_action,
-        capabilities_summary=evaluation.user_copy.summary,
-        changed_capabilities=[target.package_name or target.raw_spec for target in sanitized_intent.targets],
-        provenance_summary=evaluation.user_copy.harness_message,
-        artifact_name=artifact.name,
-        source_scope=artifact.source_scope,
-    )
-    receipt_payload = {
-        **receipt.to_dict(),
-        "action_envelope_json": receipt_policy_metadata,
-    }
-    payload: dict[str, object] = {
-        "generated_at": now,
-        "request": {
-            "command": list(redacted_command_tokens(command)),
-            "redacted_command": sanitized_intent.redacted_command,
-            "install_kind": sanitized_intent.intent_kind,
-            "executor": str(command[0]) if command else _LOCAL_SUPPLY_CHAIN_HARNESS,
-            "package_manager": sanitized_intent.package_manager,
-            "harness": _LOCAL_SUPPLY_CHAIN_HARNESS,
-            "targets": [target.to_dict() for target in sanitized_intent.targets],
-            "manifest_paths": list(sanitized_intent.manifest_paths),
-            "lockfile_paths": list(sanitized_intent.lockfile_paths),
-            "package_execution_context": package_execution_context.to_evidence(),
-        },
-        "targets": [_protect_target_payload(target) for target in sanitized_intent.targets],
-        "verdict": {
-            "action": verdict_action,
-            "reason": evaluation.user_copy.summary,
-            "risk_signals": list(risk_signals),
-            "matched_advisories": _matched_advisories(evaluation),
-            "blocking": not execution_permitted,
-        },
-        "executed": False,
-        "dry_run": dry_run,
-        "receipt": receipt_payload,
-        "matched_advisories": _matched_advisories(evaluation),
-        "supply_chain_evaluation": evaluation.to_dict(),
-    }
-    if config is not None:
-        payload["supply_chain"] = build_local_supply_chain_posture(store, config, now=now)
+    evaluation = initial_policy_resolution.evaluation
     effective_dry_run = dry_run and not (
         allow_saved_approval_execution and _evaluation_uses_saved_package_approval(evaluation)
     )
+    execution_permitted = is_execution_permitted(evaluation.policy_action)
+    payload: dict[str, object] = {
+        "generated_at": now,
+        "executed": False,
+        "dry_run": dry_run,
+    }
+    projection = _apply_package_protect_projection(
+        payload=payload,
+        authority=authority,
+        evaluation=evaluation,
+        command=command,
+        blocking=not execution_permitted,
+        executed=False,
+    )
+    if config is not None:
+        payload["supply_chain"] = build_local_supply_chain_posture(store, config, now=now)
     if not execution_permitted or effective_dry_run:
-        store.add_receipt(receipt)
-        store.set_receipt_action_envelope(receipt.receipt_id, receipt_policy_metadata)
+        store.add_receipt(projection.receipt)
+        store.set_receipt_action_envelope(
+            projection.receipt.receipt_id,
+            projection.receipt_policy_metadata,
+        )
         store.add_event(
-            f"install_time_{verdict_action}",
+            f"install_time_{projection.verdict_action}",
             {
                 "artifact_id": artifact.artifact_id,
                 "artifact_name": artifact.name,
                 "executor": str(command[0]) if command else _LOCAL_SUPPLY_CHAIN_HARNESS,
                 "install_kind": sanitized_intent.intent_kind,
-                "action": verdict_action,
-                "risk_signals": list(risk_signals),
+                "action": projection.verdict_action,
+                "risk_signals": list(projection.risk_signals),
             },
             now,
         )
         return (payload, _package_execution_exit_code(evaluation.policy_action))
-    payload["executed"] = True
+    saved_approval_claimed = _evaluation_uses_saved_package_approval(evaluation)
+    saved_approval_claim_disposition: _PackageApprovalClaimDisposition | None = None
+    if saved_approval_claimed:
+        # Claim the one-shot first, then rebuild every current input. Mutations
+        # performed while the store claim is in flight cannot inherit the old
+        # authorization at the subsequent launch boundary.
+        claimed_resolution = _resolve_stored_package_policy_override(
+            current_evaluation,
+            store=store,
+            artifact=artifact,
+            artifact_hash=artifact_hash,
+            workspace_dir=workspace_dir,
+            now=now,
+            execution_context=package_execution_context,
+            current_action=current_action,
+            claim_saved_approval=True,
+        )
+        claimed_evaluation = claimed_resolution.evaluation
+        if not is_execution_permitted(claimed_evaluation.policy_action):
+            return _package_protect_denied_after_final_boundary(
+                payload=payload,
+                authority=authority,
+                evaluation=claimed_evaluation,
+                command=command,
+                store=store,
+                now=now,
+            )
+        saved_approval_claim_disposition = claimed_resolution.claim_disposition
+    final_authority, final_evaluation = _final_package_protect_authority(
+        initial=authority,
+        saved_approval_claimed=saved_approval_claimed,
+        saved_approval_claim_disposition=saved_approval_claim_disposition,
+        command=command,
+        store=store,
+        workspace_dir=workspace_dir,
+        now=now,
+        config=config,
+        current_config_provider=current_config_provider,
+        additional_authority_provider=additional_authority_provider,
+    )
+    if not is_execution_permitted(final_evaluation.policy_action):
+        return _package_protect_denied_after_final_boundary(
+            payload=payload,
+            authority=final_authority,
+            evaluation=final_evaluation,
+            command=command,
+            store=store,
+            now=now,
+        )
+    launch_command = resolved_runtime_launch_argv(
+        final_authority.launch_identity,
+        args=tuple(str(item) for item in command[1:]),
+    )
+    if launch_command is None or not runtime_launch_identity_is_reusable(final_authority.launch_identity):
+        reuse = evaluate_approval_reuse(
+            final_authority.current_action,
+            "require-reapproval",
+            saved_decision_present=True,
+            validation_reason="approval_reuse_identity_changed",
+        )
+        denied_evaluation = _package_evaluation_with_rejected_reuse(final_authority.evaluation, reuse)
+        return _package_protect_denied_after_final_boundary(
+            payload=payload,
+            authority=final_authority,
+            evaluation=denied_evaluation,
+            command=command,
+            store=store,
+            now=now,
+        )
+    authority = final_authority
+    sanitized_intent = authority.intent
+    artifact = authority.artifact
+    evaluation = final_evaluation
+    final_projection = _apply_package_protect_projection(
+        payload=payload,
+        authority=authority,
+        evaluation=evaluation,
+        command=command,
+        blocking=False,
+        executed=True,
+    )
+    verdict_action = final_projection.verdict_action
+    risk_signals = final_projection.risk_signals
     try:
         execution = subprocess.run(
-            list(command),
-            cwd=workspace_dir,
+            list(launch_command),
+            cwd=authority.launch_cwd,
+            env=authority.launch_environment,
             capture_output=True,
             check=False,
             text=True,
@@ -1366,10 +1833,13 @@ def build_package_protect_payload(
         unsafe_raw_output=unsafe_raw_output,
     )
     if execution.returncode == 0:
-        store.add_receipt(receipt)
-        store.set_receipt_action_envelope(receipt.receipt_id, receipt_policy_metadata)
+        store.add_receipt(final_projection.receipt)
+        store.set_receipt_action_envelope(
+            final_projection.receipt.receipt_id,
+            final_projection.receipt_policy_metadata,
+        )
         store.add_event(
-            "install_time_allow",
+            f"install_time_{verdict_action}",
             {
                 "artifact_id": artifact.artifact_id,
                 "artifact_name": artifact.name,
@@ -1406,6 +1876,8 @@ def apply_stored_package_policy_override(
     workspace_dir: Path,
     now: str,
     execution_context: PackageExecutionContext | None = None,
+    current_action: object | None = None,
+    claim_saved_approval: bool = True,
 ) -> Any:
     """Apply a saved package approval when the content hash still matches."""
 
@@ -1417,6 +1889,8 @@ def apply_stored_package_policy_override(
         workspace_dir=workspace_dir,
         now=now,
         execution_context=execution_context,
+        current_action=current_action,
+        claim_saved_approval=claim_saved_approval,
     )
 
 
@@ -1429,75 +1903,355 @@ def _apply_stored_package_policy_override(
     workspace_dir: Path,
     now: str,
     execution_context: PackageExecutionContext | None = None,
+    current_action: object | None = None,
+    claim_saved_approval: bool = True,
 ) -> Any:
+    return _resolve_stored_package_policy_override(
+        evaluation,
+        store=store,
+        artifact=artifact,
+        artifact_hash=artifact_hash,
+        workspace_dir=workspace_dir,
+        now=now,
+        execution_context=execution_context,
+        current_action=current_action,
+        claim_saved_approval=claim_saved_approval,
+    ).evaluation
+
+
+def _resolve_stored_package_policy_override(
+    evaluation: Any,
+    *,
+    store: Any,
+    artifact: GuardArtifact,
+    artifact_hash: str,
+    workspace_dir: Path,
+    now: str,
+    execution_context: PackageExecutionContext | None = None,
+    current_action: object | None = None,
+    claim_saved_approval: bool = True,
+) -> _StoredPackagePolicyResolution:
+    effective_current_action = (
+        evaluation.policy_action
+        if current_action is None
+        else most_restrictive_guard_action(evaluation.policy_action, current_action, unknown_action="block")
+    )
+    current_evaluation = _package_evaluation_with_current_policy_action(
+        evaluation,
+        current_action=effective_current_action,
+    )
     resolved_execution_context = execution_context or build_package_execution_context(
         workspace_dir=workspace_dir,
         artifact=artifact,
     )
     decision = None
-    for policy_workspace in _package_policy_workspace_candidates(
+    ignored_integrity = None
+    policy_workspaces = _package_policy_workspace_candidates(
         artifact=artifact,
         artifact_hash=artifact_hash,
         workspace_dir=workspace_dir,
         execution_context=resolved_execution_context,
-    ):
-        decision = store.resolve_policy_decision(
+    )
+    for policy_workspace in policy_workspaces:
+        lookup = store.resolve_policy_decision_lookup(
             artifact.harness,
             artifact.artifact_id,
             artifact_hash,
             policy_workspace,
             artifact.publisher,
             now,
+            consume_one_shot=False,
         )
+        decision = lookup["decision"]
+        ignored_integrity = lookup["ignored_local_integrity"]
         if isinstance(decision, dict):
             break
-    if not isinstance(decision, dict):
-        return evaluation
-    if (
-        decision.get("action") == "allow"
-        and decision.get("scope") not in {"artifact", "workspace"}
-        and not is_remote_policy_source(_string_value(decision.get("source")))
-    ):
-        return evaluation
-    if _stored_package_policy_is_stale_policy_bundle_family(decision, store=store):
-        return evaluation
-    action = decision.get("action")
-    if action == "allow":
-        return _package_policy_override_evaluation(
-            evaluation,
-            decision="allow",
-            policy_action="allow",
-            title="Allowed by saved approval",
-            summary="HOL Guard reused your saved approval for this package request.",
-            harness_message=(
-                "HOL Guard verified the same repository, package manager, dependency files, settings, and "
-                "registry environment before reusing your saved approval."
-            ),
-            reason_code="saved_package_approval",
-            reason_message="HOL Guard reused your saved approval for this package request.",
+        if ignored_integrity is not None:
+            break
+    diagnosed_reason: ApprovalReuseValidationFailure | None = None
+    if not isinstance(decision, dict) and ignored_integrity is None:
+        for policy_workspace in policy_workspaces:
+            raw_diagnosed_reason = store.approval_reuse_validation_reason(
+                artifact.harness,
+                artifact.artifact_id,
+                artifact_hash,
+                policy_workspace,
+                artifact.publisher,
+                now,
+            )
+            if raw_diagnosed_reason is not None:
+                diagnosed_reason = cast(ApprovalReuseValidationFailure, raw_diagnosed_reason)
+                break
+        if diagnosed_reason is None:
+            return _StoredPackagePolicyResolution(current_evaluation)
+    if isinstance(decision, dict) and _stored_package_policy_is_stale_policy_bundle_family(decision, store=store):
+        return _StoredPackagePolicyResolution(current_evaluation)
+    action = (
+        decision.get("action")
+        if isinstance(decision, dict)
+        else ("require-reapproval" if ignored_integrity is not None else "allow")
+    )
+    validation_reason: ApprovalReuseValidationFailure | None = (
+        "approval_reuse_integrity_failure"
+        if ignored_integrity is not None
+        else (
+            cast(
+                ApprovalReuseValidationFailure,
+                package_saved_allow_validation_reason(decision, artifact_hash=artifact_hash),
+            )
+            if isinstance(decision, dict)
+            else diagnosed_reason
         )
-    if action == "block":
+    )
+    reuse = evaluate_approval_reuse(
+        effective_current_action,
+        action,
+        saved_decision_present=True,
+        validation_reason=validation_reason,
+    )
+    claim_disposition: _PackageApprovalClaimDisposition | None = None
+    disposition_resolver = getattr(store, "approval_reuse_claim_disposition", None)
+    if isinstance(decision, dict) and callable(disposition_resolver):
+        raw_disposition = disposition_resolver(decision)
+        if raw_disposition in {"consumed", "retained"}:
+            claim_disposition = cast(_PackageApprovalClaimDisposition, raw_disposition)
+    if (
+        claim_saved_approval
+        and reuse.should_claim
+        and isinstance(decision, dict)
+        and not store.claim_approval_reuse_decision(decision, now=now)
+    ):
+        reuse = evaluate_approval_reuse(
+            effective_current_action,
+            action,
+            saved_decision_present=True,
+            validation_reason=APPROVAL_REUSE_CLAIM_FAILED,
+        )
+    if reuse.accepted and reuse.saved_action == "allow":
+        if not isinstance(decision, dict) or decision.get("action") != "allow":
+            failed_reuse = evaluate_approval_reuse(
+                most_restrictive_guard_action(
+                    effective_current_action,
+                    "require-reapproval",
+                    unknown_action="block",
+                ),
+                "allow",
+                saved_decision_present=True,
+                validation_reason=APPROVAL_REUSE_CLAIM_FAILED,
+            )
+            return _StoredPackagePolicyResolution(
+                _package_evaluation_with_rejected_reuse(current_evaluation, failed_reuse)
+            )
+        return _StoredPackagePolicyResolution(
+            _package_policy_override_evaluation(
+                current_evaluation,
+                decision="allow",
+                policy_action="allow",
+                title="Allowed by saved approval",
+                summary="HOL Guard reused your saved approval for this package request.",
+                harness_message=(
+                    "HOL Guard verified the same repository, package manager, dependency files, settings, and "
+                    "registry environment before reusing your saved approval."
+                ),
+                reason_code="saved_package_approval",
+                reason_message="HOL Guard reused your saved approval for this package request.",
+                approval_reuse=reuse,
+            ),
+            approval_reuse_decision=decision,
+            claim_disposition=claim_disposition,
+        )
+    if reuse.saved_action == "block":
+        assert isinstance(decision, dict)
         clear_command = _saved_package_policy_clear_command(
             artifact=artifact,
             artifact_hash=artifact_hash,
             matched_policy=decision,
             workspace_dir=workspace_dir,
         )
-        return _package_policy_override_evaluation(
-            evaluation,
-            decision="block",
-            policy_action="block",
-            title="Blocked by saved policy",
-            summary="HOL Guard kept this package blocked because a saved package policy already exists.",
-            harness_message=(
-                "HOL Guard kept this package blocked because a saved package policy already exists. "
-                f"To reconsider, run `{clear_command}`, then retry the install."
-            ),
-            next_step=clear_command,
-            reason_code="saved_package_block",
-            reason_message="HOL Guard kept this package blocked because a saved package policy already exists.",
+        return _StoredPackagePolicyResolution(
+            _package_policy_override_evaluation(
+                current_evaluation,
+                decision="block",
+                policy_action="block",
+                title="Blocked by saved policy",
+                summary="HOL Guard kept this package blocked because a saved package policy already exists.",
+                harness_message=(
+                    "HOL Guard kept this package blocked because a saved package policy already exists. "
+                    f"To reconsider, run `{clear_command}`, then retry the install."
+                ),
+                next_step=clear_command,
+                reason_code="saved_package_block",
+                reason_message="HOL Guard kept this package blocked because a saved package policy already exists.",
+                approval_reuse=reuse,
+            )
         )
-    return evaluation
+    return _StoredPackagePolicyResolution(_package_evaluation_with_rejected_reuse(current_evaluation, reuse))
+
+
+def package_saved_allow_validation_reason(
+    decision: dict[str, object],
+    *,
+    artifact_hash: str,
+) -> str | None:
+    """Validate that local saved package ``allow`` evidence is exact.
+
+    Broad policy scopes are matches for lookup only, not proof that this exact
+    package request was previously reviewed. Every stored ``allow``—regardless
+    of scope or source—must bind the current package/context digest before it
+    can satisfy review.
+    """
+
+    if decision.get("action") != "allow":
+        return None
+    # A matching legacy digest is still missing workspace, executable,
+    # capability, policy, and sandbox bindings. Require two valid v1 tokens.
+    return approval_context_tokens_validation_reason(decision.get("artifact_hash"), artifact_hash)
+
+
+def _package_evaluation_with_current_policy_action(
+    evaluation: Any,
+    *,
+    current_action: GuardAction,
+) -> Any:
+    """Apply current package policy before consulting remembered user state."""
+
+    if current_action == evaluation.policy_action:
+        return evaluation
+    decision = _package_decision_for_action(current_action)
+    rewritten_packages = tuple({**package, "decision": decision} for package in evaluation.packages)
+    action_label = {
+        "block": "blocks",
+        "sandbox-required": "requires sandbox enforcement for",
+        "require-reapproval": "requires fresh approval for",
+        "review": "requires review for",
+        "warn": "warns about",
+        "allow": "allows",
+    }[current_action]
+    package_label = "this package request"
+    package_label_entries = getattr(evaluation, "packages", ())
+    if (
+        isinstance(package_label_entries, tuple)
+        and package_label_entries
+        and isinstance(package_label_entries[0], dict)
+    ):
+        primary_package = package_label_entries[0]
+        package_name = primary_package.get("name")
+        package_version = primary_package.get("requestedVersion") or primary_package.get("resolvedVersion")
+        if isinstance(package_name, str) and package_name:
+            package_ref = (
+                f"{package_name}@{package_version}"
+                if isinstance(package_version, str) and package_version
+                else package_name
+            )
+            package_label = f"`{package_ref}`"
+    summary = f"HOL Guard's current package policy {action_label} {package_label}."
+    reason = {
+        "code": "current_package_policy",
+        "message": summary,
+        "severity": "high" if current_action in {"block", "sandbox-required"} else "medium",
+        "source": "guard-local",
+        "policy_action": current_action,
+    }
+    needs_review = current_action in {"review", "require-reapproval", "sandbox-required", "block"}
+    return replace(
+        evaluation,
+        decision=decision,
+        policy_action=current_action,
+        reasons=(reason, *tuple(item for item in evaluation.reasons if item.get("code") != reason["code"])),
+        packages=rewritten_packages,
+        risk_summary=summary,
+        user_copy=_supply_chain_package_eval_module().SupplyChainUserCopy(
+            title="Current package policy",
+            summary=summary,
+            next_step="Review the current package request in HOL Guard, then retry." if needs_review else None,
+            dashboard_url=None,
+            harness_message=summary,
+        ),
+        record_monitor_evidence=False,
+    )
+
+
+def _package_evaluation_with_rejected_reuse(
+    evaluation: Any,
+    reuse: ApprovalReuseDecision,
+) -> Any:
+    """Retain current package evidence while recording rejected saved state."""
+
+    reason = {
+        "code": reuse.reason_code,
+        "message": _approval_reuse_reason_message(reuse),
+        "severity": "high" if reuse.status == "rejected" else "low",
+        "source": "guard-local",
+        "approval_reuse": reuse.to_evidence(),
+    }
+    reasons = (reason, *tuple(item for item in evaluation.reasons if item.get("code") != reuse.reason_code))
+    if reuse.action == evaluation.policy_action:
+        return replace(evaluation, reasons=reasons)
+    decision = _package_decision_for_action(reuse.action)
+    packages = tuple({**package, "decision": decision} for package in evaluation.packages)
+    summary = _approval_reuse_reason_message(reuse)
+    return replace(
+        evaluation,
+        decision=decision,
+        policy_action=reuse.action,
+        reasons=reasons,
+        packages=packages,
+        risk_summary=summary,
+        user_copy=_supply_chain_package_eval_module().SupplyChainUserCopy(
+            title="Saved approval not reusable",
+            summary=summary,
+            next_step="Review the current package request in HOL Guard, then retry.",
+            dashboard_url=None,
+            harness_message=summary,
+        ),
+        record_monitor_evidence=False,
+    )
+
+
+def _approval_reuse_reason_message(reuse: ApprovalReuseDecision) -> str:
+    messages = {
+        "approval_reuse_current_block": (
+            "Saved approval was rejected because current package policy blocks this request."
+        ),
+        "approval_reuse_sandbox_required": (
+            "Saved approval was rejected because current package policy requires sandbox enforcement."
+        ),
+        "approval_reuse_reapproval_required": (
+            "Saved approval was rejected because current package policy requires fresh approval."
+        ),
+        "approval_reuse_integrity_failure": (
+            "Saved approval was rejected because its integrity could not be verified."
+        ),
+        "approval_reuse_identity_changed": (
+            "Saved approval was rejected because the current package identity or scope changed."
+        ),
+        "approval_reuse_content_changed": (
+            "Saved approval was rejected because the current package content or execution context changed."
+        ),
+        "approval_reuse_claim_failed": (
+            "Saved approval was rejected because it changed, expired, or was already consumed."
+        ),
+        "approval_reuse_context_changed_after_claim": (
+            "Saved approval was rejected because retained authority changed after it was claimed."
+        ),
+        "approval_reuse_saved_action_unknown": (
+            "Saved approval was rejected because its action is unknown or malformed."
+        ),
+    }
+    return messages.get(
+        reuse.reason_code,
+        f"Saved package policy was not reused ({reuse.reason_code}).",
+    )
+
+
+def _package_decision_for_action(action: GuardAction) -> str:
+    if action == "block":
+        return "block"
+    if action in {"review", "require-reapproval", "sandbox-required"}:
+        return "ask"
+    if action == "warn":
+        return "warn"
+    return "allow"
 
 
 def _package_policy_workspace_candidates(
@@ -1622,30 +2376,19 @@ def recompute_package_protect_artifact_hash(
     store: Any,
     workspace_dir: Path,
     now: str | None = None,
+    config: GuardConfig | None = None,
 ) -> str | None:
-    intent = _package_intent_parser_module().parse_package_intent(shlex.join(command), workspace=workspace_dir)
-    if intent is None:
-        return None
-    sanitized_intent = replace(intent, redacted_command=shlex.join(redacted_command_tokens(command)))
-    artifact = build_package_request_artifact(
-        _LOCAL_SUPPLY_CHAIN_HARNESS,
-        sanitized_intent,
-        config_path="hol-guard.toml",
-        source_scope="project",
-    )
     evaluation_timestamp = now or datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
-    evaluation = evaluate_package_request_artifact(
-        artifact=artifact,
+    authority = _build_package_protect_authority(
+        command=command,
         store=store,
         workspace_dir=workspace_dir,
         now=evaluation_timestamp,
+        config=config,
+        additional_current_action=None,
+        additional_policy_context=None,
     )
-    return _package_request_artifact_hash(
-        artifact,
-        workspace_dir=workspace_dir,
-        store=store,
-        evaluation=evaluation,
-    )
+    return authority.artifact_hash if authority is not None else None
 
 
 def _package_target_identities(artifact: GuardArtifact) -> tuple[ProtectTargetIdentity, ...]:
@@ -1713,11 +2456,104 @@ def _package_policy_gate_context(
     return {
         "bundle_version": evaluation.bundle_version,
         "decision": evaluation.decision,
+        "enforcement": evaluation.enforcement,
+        "entitlement_state": evaluation.entitlement_state,
+        "exception_id": evaluation.exception_id,
         "feed_snapshot_hash": _package_feed_snapshot_hash(store),
         "matched_advisory_ids": list(_package_matched_cached_advisory_ids(store, artifact)),
         "matched_rule_id": evaluation.matched_rule_id,
+        "packages": list(evaluation.packages),
         "policy_action": evaluation.policy_action,
         "policy_version": evaluation.policy_version,
+        "reasons": list(evaluation.reasons),
+    }
+
+
+def _package_config_policy_context(
+    *,
+    artifact: GuardArtifact,
+    config: GuardConfig | None,
+) -> dict[str, object]:
+    if config is None:
+        return {"available": False}
+    harness_package_script_action = (config.harness_risk_actions or {}).get(artifact.harness, {}).get("package_script")
+    artifact_override = (config.artifact_actions or {}).get(artifact.artifact_id)
+    publisher_override = (
+        (config.publisher_actions or {}).get(artifact.publisher) if artifact.publisher is not None else None
+    )
+    harness_override = (config.harness_actions or {}).get(artifact.harness)
+    return {
+        "artifact_override": artifact_override,
+        "available": True,
+        "effective_package_script_action": resolve_risk_action(
+            config,
+            "package_script",
+            harness=artifact.harness,
+        ),
+        "global_package_script_action": resolve_risk_action(config, "package_script", harness=None),
+        "harness": artifact.harness,
+        "harness_override": harness_override,
+        "harness_package_script_action": harness_package_script_action,
+        "managed_locked_settings": list(config.managed_locked_settings),
+        "managed_policy_hash": config.managed_policy_hash,
+        "managed_policy_status": config.managed_policy_status,
+        "mode": config.mode,
+        "publisher_override": publisher_override,
+        "resolved_override": config.resolve_action_override(
+            artifact.harness,
+            artifact.artifact_id,
+            artifact.publisher,
+        ),
+        "security_level": config.security_level,
+    }
+
+
+def compose_current_package_policy_action(
+    *,
+    artifact: GuardArtifact,
+    evaluation: Any,
+    config: GuardConfig | None,
+    additional_current_action: object | None = None,
+) -> GuardAction:
+    """Compose feed and effective Guard configuration before approval reuse."""
+
+    actions: list[object] = [evaluation.policy_action]
+    if additional_current_action is not None:
+        actions.append(additional_current_action)
+    if config is not None:
+        config_policy = _package_config_policy_context(artifact=artifact, config=config)
+        # Resolve specificity inside each configuration family first.  A
+        # harness risk action replaces its global risk action, and an exact
+        # artifact/publisher/harness action is one precedence chain.  The
+        # resulting configuration actions remain independent of the package
+        # feed/evaluator action and therefore cannot erase a feed block.
+        for key in ("effective_package_script_action", "resolved_override"):
+            action = config_policy.get(key)
+            if action is not None:
+                actions.append(action)
+    return most_restrictive_guard_action(*actions, unknown_action="block")
+
+
+def _package_current_policy_context(
+    *,
+    artifact: GuardArtifact,
+    store: Any,
+    evaluation: Any,
+    config: GuardConfig | None,
+    additional_current_action: object | None = None,
+    additional_policy_context: dict[str, object] | None = None,
+) -> dict[str, object]:
+    return {
+        "configuration": _package_config_policy_context(artifact=artifact, config=config),
+        "current_action": compose_current_package_policy_action(
+            artifact=artifact,
+            evaluation=evaluation,
+            config=config,
+            additional_current_action=additional_current_action,
+        ),
+        "additional": additional_policy_context if additional_policy_context is not None else {"available": False},
+        "feed": _package_policy_gate_context(store, artifact, evaluation),
+        "version": 1,
     }
 
 
@@ -1728,8 +2564,19 @@ def _package_request_artifact_hash(
     store: Any,
     evaluation: Any,
     execution_context: PackageExecutionContext | None = None,
+    launch_identity: Mapping[str, object] | None = None,
+    config: GuardConfig | None = None,
+    additional_current_action: object | None = None,
+    additional_policy_context: dict[str, object] | None = None,
 ) -> str:
-    policy_gate = _package_policy_gate_context(store, artifact, evaluation)
+    policy_context = _package_current_policy_context(
+        artifact=artifact,
+        store=store,
+        evaluation=evaluation,
+        config=config,
+        additional_current_action=additional_current_action,
+        additional_policy_context=additional_policy_context,
+    )
     metadata = artifact.metadata if isinstance(artifact.metadata, dict) else {}
     resolved_execution_context = execution_context or build_package_execution_context(
         workspace_dir=workspace_dir,
@@ -1742,13 +2589,9 @@ def _package_request_artifact_hash(
     )
     manifest_paths = _string_items(metadata.get("manifest_paths"))
     lockfile_paths = _string_items(metadata.get("lockfile_paths"))
-    hash_material: dict[str, object] = {
-        "approval_identity": approval_identity,
-        "artifact_id": artifact.artifact_id,
-        "policy_gate": policy_gate,
-    }
+    content_material: dict[str, object] = {}
     if manifest_paths or lockfile_paths:
-        hash_material.update(
+        content_material.update(
             {
                 "manifest_paths": list(manifest_paths),
                 "lockfile_paths": list(lockfile_paths),
@@ -1756,7 +2599,54 @@ def _package_request_artifact_hash(
                 "lockfile_hashes": _hash_existing_paths(workspace_dir, lockfile_paths),
             }
         )
-    return stable_digest_hex(json.dumps(hash_material, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+    component_digests = {component.name: component.digest for component in resolved_execution_context.components}
+    return build_approval_context_token(
+        identity={
+            "approval_identity": approval_identity,
+            "artifact_id": artifact.artifact_id,
+            "config_path": artifact.config_path,
+            "exact_workspace": component_digests.get("exact_workspace"),
+            "package_manager_executable": component_digests.get("package_manager_executable"),
+            "package_launch_identity": _package_launch_approval_identity(launch_identity),
+            "publisher": artifact.publisher,
+            "repository_identity": component_digests.get("repository_identity"),
+            "source_scope": artifact.source_scope,
+            "workspace_identity": component_digests.get("workspace_identity"),
+        },
+        content={
+            **content_material,
+            "manifests_and_lockfiles": component_digests.get("manifests_and_lockfiles"),
+            "workspace_configuration": component_digests.get("workspace_configuration"),
+        },
+        capabilities={
+            "environment_policy": component_digests.get("environment_policy"),
+            "lifecycle_hooks_overrides_and_patches": component_digests.get("lifecycle_hooks_overrides_and_patches"),
+            "registry_and_proxy_configuration": component_digests.get("registry_and_proxy_configuration"),
+        },
+        policy=policy_context,
+        sandbox={
+            "analysis": config.sandbox_analysis if config is not None else "unknown",
+            "required": policy_context["current_action"] == "sandbox-required",
+        },
+    )
+
+
+def _package_launch_approval_identity(launch_identity: Mapping[str, object] | None) -> dict[str, object]:
+    """Bind the raw launch vector without duplicating non-portable paths.
+
+    The package execution context already contains the normalized manager,
+    shebang interpreter, code-loading, and cwd identity. This additional
+    material binds the exact argv shape and forces wrapper launches to remain
+    one-attempt-only without breaking linked-worktree portability.
+    """
+
+    if launch_identity is None:
+        return {"available": False}
+    wrapper_resolution = launch_identity.get("wrapper_resolution")
+    return {
+        "argv_sha256": launch_identity.get("argv_sha256"),
+        "wrapper_resolution": (wrapper_resolution if isinstance(wrapper_resolution, Mapping) else {"status": "direct"}),
+    }
 
 
 def _package_approval_identity(
@@ -1824,6 +2714,7 @@ def package_request_policy_hash(
     workspace_dir: Path,
     evaluation: Any,
     execution_context: PackageExecutionContext | None = None,
+    config: GuardConfig | None = None,
 ) -> str:
     """Hash a package request using manifest and lockfile contents."""
 
@@ -1833,11 +2724,24 @@ def package_request_policy_hash(
         store=store,
         evaluation=evaluation,
         execution_context=execution_context,
+        config=config,
     )
 
 
 def _evaluation_uses_saved_package_approval(evaluation: Any) -> bool:
     return any(reason.get("code") == "saved_package_approval" for reason in evaluation.reasons)
+
+
+def _package_approval_reuse_evidence(evaluation: Any) -> tuple[dict[str, object], ...]:
+    evidence_items: list[dict[str, object]] = []
+    for reason in evaluation.reasons:
+        reuse_evidence = reason.get("approval_reuse")
+        if not isinstance(reuse_evidence, dict):
+            continue
+        evidence: dict[str, object] = {"source": "approval_reuse"}
+        evidence.update({str(key): value for key, value in reuse_evidence.items()})
+        evidence_items.append(evidence)
+    return tuple(evidence_items)
 
 
 def _package_policy_override_evaluation(
@@ -1851,13 +2755,16 @@ def _package_policy_override_evaluation(
     next_step: str | None = None,
     reason_code: str,
     reason_message: str,
+    approval_reuse: ApprovalReuseDecision | None = None,
 ) -> Any:
-    reason = {
+    reason: dict[str, object] = {
         "code": reason_code,
         "message": reason_message,
         "severity": "low",
         "source": "guard-local",
     }
+    if approval_reuse is not None:
+        reason["approval_reuse"] = approval_reuse.to_evidence()
     packages = tuple({**package, "decision": decision} for package in evaluation.packages)
     return replace(
         evaluation,
@@ -3114,13 +4021,7 @@ def _package_execution_exit_code(policy_action: object) -> int:
 
 
 def _protect_action_for_policy_action(policy_action: object) -> GuardAction:
-    if policy_action == "block":
-        return "block"
-    if policy_action == "warn":
-        return "warn"
-    if policy_action == "allow":
-        return "allow"
-    return "review"
+    return normalize_guard_action(policy_action, unknown_action="block")
 
 
 def _evaluation_risk_signals(evaluation: object) -> list[str]:

--- a/src/codex_plugin_scanner/guard/mcp_tool_calls.py
+++ b/src/codex_plugin_scanner/guard/mcp_tool_calls.py
@@ -4,16 +4,30 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Mapping
-from dataclasses import dataclass
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
 from hashlib import sha256
-from pathlib import PurePath
+from pathlib import Path, PurePath
+from typing import Literal, cast
 
-from .action_lattice import normalize_guard_action_result
+from .action_lattice import most_restrictive_guard_action
 from .approval_gate import ApprovalGateGrant
 from .config import DEFAULT_SECURITY_LEVEL, GuardConfig, resolve_risk_action
 from .models import GuardAction, GuardArtifact, GuardReceipt, PolicyDecision
 from .receipts import build_receipt
+from .runtime.approval_context import approval_context_tokens_validation_reason, build_approval_context_token
+from .runtime.approval_reuse import (
+    APPROVAL_REUSE_ACCEPTED,
+    APPROVAL_REUSE_CLAIM_FAILED,
+    APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
+    APPROVAL_REUSE_CURRENT_ACTION_UNKNOWN,
+    APPROVAL_REUSE_NO_SAVED_DECISION,
+    APPROVAL_REUSE_SAVED_ACTION_UNKNOWN,
+    ApprovalReuseDecision,
+    ApprovalReuseStatus,
+    ApprovalReuseValidationFailure,
+    evaluate_approval_reuse,
+)
 from .runtime.browser_mcp_intent import normalize_browser_mcp_intent
 from .runtime.mcp_protection import (
     McpServerIdentity,
@@ -22,7 +36,89 @@ from .runtime.mcp_protection import (
     mcp_tool_identity_metadata,
 )
 from .runtime.mcp_skill_firewall import enrich_artifact_with_mcp_skill_firewall, scanner_evidence_for_mcp_skill_firewall
-from .store import GuardStore
+from .store import GuardStore, browser_mcp_exact_match_context
+
+# Bump when MCP risk classification or action-composition semantics change.
+_MCP_TOOL_CALL_EVALUATOR_POLICY_VERSION = "mcp-tool-call-evaluation-v2"
+
+ApprovalReuseClaimDisposition = Literal["consumed", "retained"]
+
+_APPROVAL_REUSE_DECISION_IDENTITY_KEYS = (
+    "action",
+    "approval_id",
+    "artifact_hash",
+    "artifact_id",
+    "decision_id",
+    "expires_at",
+    "harness",
+    "integrity_enforcement",
+    "integrity_generation",
+    "integrity_key_id",
+    "integrity_mode",
+    "integrity_status",
+    "integrity_version",
+    "owner",
+    "publisher",
+    "reason",
+    "request_id",
+    "scope",
+    "signed_at",
+    "source",
+    "updated_at",
+    "workspace",
+)
+
+
+def approval_reuse_decisions_match(
+    expected: Mapping[str, object] | None,
+    current: Mapping[str, object] | None,
+) -> bool:
+    """Return whether two lookups selected the same saved authority row."""
+
+    if expected is None or current is None:
+        return False
+    expected_approval_id = expected.get("approval_id")
+    current_approval_id = current.get("approval_id")
+    expected_decision_id = expected.get("decision_id")
+    current_decision_id = current.get("decision_id")
+    same_identifier = (
+        isinstance(expected_approval_id, str)
+        and bool(expected_approval_id)
+        and current_approval_id == expected_approval_id
+    ) or (
+        isinstance(expected_decision_id, int)
+        and not isinstance(expected_decision_id, bool)
+        and current_decision_id == expected_decision_id
+    )
+    return same_identifier and all(
+        expected.get(key) == current.get(key) for key in _APPROVAL_REUSE_DECISION_IDENTITY_KEYS
+    )
+
+
+def claimed_approval_authorizes_postclaim_review(
+    *,
+    claim_disposition: ApprovalReuseClaimDisposition | None,
+    claimed_decision: Mapping[str, object] | None,
+    current_decision: Mapping[str, object] | None,
+) -> bool:
+    """Validate the saved proof used to lower a fresh review after claiming."""
+
+    if claim_disposition == "consumed":
+        return True
+    return claim_disposition == "retained" and approval_reuse_decisions_match(
+        claimed_decision,
+        current_decision,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCallAuthority:
+    """Fresh execution identity selected at the post-claim boundary."""
+
+    config: GuardConfig
+    artifact: GuardArtifact
+    artifact_hash: str
+    arguments: object
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,6 +132,14 @@ class ToolCallDecision:
     risk_categories: tuple[str, ...] = ()
     normalization_reason_code: str | None = None
     original_action: str | None = None
+    approval_reuse_status: ApprovalReuseStatus | None = None
+    approval_reuse_reason_code: str | None = None
+    current_action: GuardAction | None = None
+    saved_action: GuardAction | None = None
+    pending_approval_reuse_decision: Mapping[str, object] | None = None
+    approval_reuse_claim_disposition: ApprovalReuseClaimDisposition | None = None
+    post_claim_revalidated: bool = False
+    post_claim_authority: ToolCallAuthority | None = None
 
 
 _MCP_COMMAND_ARGUMENT_KEYS: tuple[str, ...] = (
@@ -144,19 +248,144 @@ def build_tool_call_artifact(
     )
 
 
-def build_tool_call_hash(artifact: GuardArtifact, arguments: object) -> str:
-    payload = json.dumps(
-        {
+def build_tool_call_hash(
+    artifact: GuardArtifact,
+    arguments: object,
+    *,
+    workspace: Path | str | None = None,
+    config: GuardConfig | None = None,
+) -> str:
+    browser_intent = normalize_browser_mcp_intent(artifact, arguments)
+    content_arguments: object = arguments
+    if browser_intent is not None:
+        content_arguments = {
+            "intent": browser_intent.intent,
+            "operation": browser_intent.operation,
+            "target_origin": browser_intent.target_origin,
+            "target_path_prefix": browser_intent.target_path_prefix,
+            "method": browser_intent.method,
+            "profile_mode": browser_intent.profile_mode,
+            "mcp_server_identity_hash": browser_intent.mcp_server_identity_hash,
+            "mcp_tool_identity_hash": browser_intent.mcp_tool_identity_hash,
+            "mcp_schema_hash": browser_intent.mcp_schema_hash,
+            "sensitive_surface_flags": list(browser_intent.sensitive_surface_flags),
+        }
+    legacy_material: dict[str, object] = {
+        "artifact_id": artifact.artifact_id,
+        "config_path": artifact.config_path,
+        "transport": artifact.transport,
+        "server_fingerprint": artifact.metadata.get("server_fingerprint"),
+        "server_identity": artifact.metadata.get("mcp_server_identity"),
+        "tool_identity": artifact.metadata.get("mcp_tool_identity"),
+        "arguments": content_arguments,
+    }
+    # Keep the legacy digest for callers that genuinely have no workspace,
+    # while binding every workspace-aware runtime call to its effective cwd.
+    # Artifact-scope policy rows intentionally discard their workspace column,
+    # so the digest itself must carry this part of the security identity.
+    if workspace is not None:
+        legacy_material["workspace"] = _normalized_tool_call_workspace(workspace)
+    legacy_payload = json.dumps(legacy_material, sort_keys=True)
+    legacy_hash = sha256(legacy_payload.encode()).hexdigest()
+    if config is None:
+        return legacy_hash
+    normalized_workspace = _normalized_tool_call_workspace(workspace) if workspace is not None else None
+    server_fingerprint = artifact.metadata.get("server_fingerprint")
+    resolved_executable = (
+        server_fingerprint.get("resolved_executable") if isinstance(server_fingerprint, Mapping) else None
+    )
+    tool_catalog_fingerprint = (
+        server_fingerprint.get("tool_catalog_fingerprint") if isinstance(server_fingerprint, Mapping) else None
+    )
+    content_hash = sha256(
+        json.dumps(
+            {
+                "arguments": content_arguments,
+                "artifact_id": artifact.artifact_id,
+                "config_path": artifact.config_path,
+            },
+            sort_keys=True,
+        ).encode()
+    ).hexdigest()
+    return build_approval_context_token(
+        identity={
             "artifact_id": artifact.artifact_id,
             "config_path": artifact.config_path,
-            "transport": artifact.transport,
-            "server_fingerprint": artifact.metadata.get("server_fingerprint"),
-            "tool_identity": artifact.metadata.get("mcp_tool_identity"),
-            "arguments": arguments,
+            "harness": artifact.harness,
+            "publisher": artifact.publisher,
+            "source_scope": artifact.source_scope,
+            "workspace": normalized_workspace,
+            "resolved_executable": resolved_executable,
         },
-        sort_keys=True,
+        content=content_hash,
+        capabilities={
+            "risk_categories": list(tool_call_risk_categories(artifact, arguments)),
+            "server_identity": artifact.metadata.get("mcp_server_identity"),
+            "tool_catalog_fingerprint": tool_catalog_fingerprint,
+            "tool_identity": artifact.metadata.get("mcp_tool_identity"),
+            "transport": artifact.transport,
+        },
+        policy=_tool_call_policy_context(config, artifact),
+        sandbox={"analysis": config.sandbox_analysis},
     )
-    return sha256(payload.encode()).hexdigest()
+
+
+def _tool_call_policy_context(config: GuardConfig, artifact: GuardArtifact) -> dict[str, object]:
+    explicit_risk_action = _configured_risk_action(config, "mcp_dangerous_tool", harness=artifact.harness)
+    return {
+        "artifact_override": config.resolve_action_override(
+            artifact.harness,
+            artifact.artifact_id,
+            artifact.publisher,
+        ),
+        "default_action": config.default_action,
+        "effective_risk_action": explicit_risk_action
+        or resolve_risk_action(config, "mcp_dangerous_tool", harness=artifact.harness),
+        "evaluator_policy_version": _MCP_TOOL_CALL_EVALUATOR_POLICY_VERSION,
+        "managed_locked_settings": list(config.managed_locked_settings),
+        "managed_policy_hash": config.managed_policy_hash,
+        "managed_policy_status": config.managed_policy_status,
+        "mode": config.mode,
+        "security_level": config.security_level,
+    }
+
+
+def _normalized_tool_call_workspace(workspace: Path | str) -> str:
+    candidate = Path(workspace).expanduser()
+    try:
+        return str(candidate.resolve(strict=False))
+    except (OSError, RuntimeError):
+        return str(candidate.absolute())
+
+
+def _browser_runtime_exact_match_context(artifact: GuardArtifact, arguments: object) -> str | None:
+    browser_intent = normalize_browser_mcp_intent(artifact, arguments)
+    if browser_intent is None:
+        return None
+    return browser_mcp_exact_match_context(
+        intent=browser_intent.intent,
+        operation=browser_intent.operation,
+        target_origin=browser_intent.target_origin,
+        target_path_prefix=browser_intent.target_path_prefix,
+        profile_mode=browser_intent.profile_mode,
+        mcp_server_identity_hash=browser_intent.mcp_server_identity_hash,
+        mcp_tool_identity_hash=browser_intent.mcp_tool_identity_hash,
+        mcp_schema_hash=browser_intent.mcp_schema_hash,
+        sensitive_surface_flags=browser_intent.sensitive_surface_flags,
+    )
+
+
+def _tool_call_saved_allow_validation_reason(
+    decision: Mapping[str, object],
+    *,
+    artifact_hash: str,
+) -> str | None:
+    if decision.get("action") != "allow":
+        return None
+    # Equality of a legacy digest cannot prove that workspace, executable,
+    # capabilities, policy, and sandbox are unchanged. Only a valid v1 token
+    # can authorize reuse; malformed and legacy values fail closed.
+    return approval_context_tokens_validation_reason(decision.get("artifact_hash"), artifact_hash)
 
 
 def evaluate_tool_call(
@@ -166,46 +395,310 @@ def evaluate_tool_call(
     artifact: GuardArtifact,
     artifact_hash: str,
     arguments: object,
+    claim_saved_approval: bool = True,
+    fresh_authority_provider: (Callable[[], tuple[GuardConfig, GuardArtifact, str, object] | None] | None) = None,
 ) -> ToolCallDecision:
-    override = store.resolve_policy(
+    current = _evaluate_current_tool_call(
+        config=config,
+        artifact=artifact,
+        arguments=arguments,
+    )
+    runtime_exact_match_context = _browser_runtime_exact_match_context(artifact, arguments)
+    policy_lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
         artifact.harness,
         artifact.artifact_id,
         artifact_hash=artifact_hash,
         workspace=str(config.workspace) if config.workspace is not None else None,
+        publisher=artifact.publisher,
+        runtime_exact_match_context=runtime_exact_match_context,
         memory_command=artifact.command,
         memory_artifact_type=artifact.artifact_type,
         memory_artifact_name=artifact.name,
+        consume_one_shot=False,
     )
-    if override is None:
-        override = config.resolve_action_override(artifact.harness, artifact.artifact_id, artifact.publisher)
-    normalized_override = (
-        normalize_guard_action_result(override, unknown_action="require-reapproval") if override is not None else None
+    saved_decision = policy_lookup["decision"]
+    ignored_integrity = policy_lookup["ignored_local_integrity"]
+    if saved_decision is None and ignored_integrity is None:
+        diagnosed_reason = store.approval_reuse_validation_reason(
+            artifact.harness,
+            artifact.artifact_id,
+            artifact_hash,
+            str(config.workspace) if config.workspace is not None else None,
+            artifact.publisher,
+        )
+        if diagnosed_reason is None:
+            return current
+        saved_action: object | None = "allow"
+        validation_reason: ApprovalReuseValidationFailure | None = cast(
+            ApprovalReuseValidationFailure,
+            diagnosed_reason,
+        )
+    else:
+        saved_action = (
+            saved_decision.get("action")
+            if saved_decision is not None
+            else ("require-reapproval" if ignored_integrity is not None else None)
+        )
+        validation_reason = (
+            "approval_reuse_integrity_failure"
+            if ignored_integrity is not None
+            else (
+                cast(
+                    ApprovalReuseValidationFailure,
+                    _tool_call_saved_allow_validation_reason(
+                        saved_decision,
+                        artifact_hash=artifact_hash,
+                    ),
+                )
+                if saved_decision is not None
+                else None
+            )
+        )
+
+    reuse = evaluate_approval_reuse(
+        current.action,
+        saved_action,
+        saved_decision_present=True,
+        validation_reason=validation_reason,
     )
-    if normalized_override is not None:
-        risk_categories = tool_call_risk_categories(artifact, arguments)
-        return ToolCallDecision(
-            action=normalized_override.action,
-            source="policy" if normalized_override.recognized else "policy-invalid",
-            signals=tool_call_risk_signals(artifact, arguments),
-            summary=(
-                "Local Guard policy matched this exact tool call."
-                if normalized_override.recognized
-                else "Local Guard found an unknown policy action and requires reapproval."
-            ),
-            risk_categories=risk_categories,
-            normalization_reason_code=normalized_override.reason_code,
-            original_action=normalized_override.original_action,
+    pending_decision: Mapping[str, object] | None = None
+    claim_disposition: ApprovalReuseClaimDisposition | None = None
+    if reuse.should_claim and saved_decision is not None:
+        raw_claim_disposition = store.approval_reuse_claim_disposition(saved_decision)
+        if raw_claim_disposition in {"consumed", "retained"}:
+            claim_disposition = raw_claim_disposition
+        if claim_saved_approval:
+            if not store.claim_approval_reuse_decision(saved_decision):
+                reuse = evaluate_approval_reuse(
+                    current.action,
+                    saved_action,
+                    saved_decision_present=True,
+                    validation_reason=APPROVAL_REUSE_CLAIM_FAILED,
+                )
+            else:
+                return _revalidate_claimed_tool_call_approval(
+                    store=store,
+                    initial_artifact=artifact,
+                    initial_artifact_hash=artifact_hash,
+                    initial_arguments=arguments,
+                    initial_config=config,
+                    claimed_decision=saved_decision,
+                    claim_disposition=claim_disposition,
+                    fresh_authority_provider=fresh_authority_provider,
+                )
+        else:
+            pending_decision = saved_decision
+    return _tool_call_decision_with_reuse(
+        current,
+        reuse,
+        pending_decision=pending_decision,
+        claim_disposition=claim_disposition,
+    )
+
+
+def _revalidate_claimed_tool_call_approval(
+    *,
+    store: GuardStore,
+    initial_artifact: GuardArtifact,
+    initial_artifact_hash: str,
+    initial_arguments: object,
+    initial_config: GuardConfig,
+    claimed_decision: Mapping[str, object],
+    claim_disposition: ApprovalReuseClaimDisposition | None,
+    fresh_authority_provider: (Callable[[], tuple[GuardConfig, GuardArtifact, str, object] | None] | None),
+) -> ToolCallDecision:
+    """Rebuild MCP authority after claiming an exact saved allow.
+
+    The claim closes the one-shot race, but it does not freeze configuration,
+    tool identity, arguments, or a concurrently inserted saved block.  Re-read
+    all of those inputs before returning an executable allow.
+    """
+
+    refresh_failed = False
+    if fresh_authority_provider is None:
+        fresh_config = initial_config
+        fresh_artifact = initial_artifact
+        fresh_arguments = initial_arguments
+        fresh_artifact_hash = build_tool_call_hash(
+            fresh_artifact,
+            fresh_arguments,
+            workspace=fresh_config.workspace or Path.cwd(),
+            config=fresh_config,
+        )
+    else:
+        try:
+            provided = fresh_authority_provider()
+        except Exception:
+            provided = None
+        if provided is None:
+            refresh_failed = True
+            fresh_config = initial_config
+            fresh_artifact = initial_artifact
+            fresh_arguments = initial_arguments
+            fresh_artifact_hash = initial_artifact_hash
+        else:
+            fresh_config, fresh_artifact, fresh_artifact_hash, fresh_arguments = provided
+
+    fresh_current = _evaluate_current_tool_call(
+        config=fresh_config,
+        artifact=fresh_artifact,
+        arguments=fresh_arguments,
+    )
+    fresh_decision = evaluate_tool_call(
+        store=store,
+        config=fresh_config,
+        artifact=fresh_artifact,
+        artifact_hash=fresh_artifact_hash,
+        arguments=fresh_arguments,
+        claim_saved_approval=False,
+    )
+    validation_reason: ApprovalReuseValidationFailure | None
+    if refresh_failed or fresh_artifact.artifact_id != initial_artifact.artifact_id:
+        validation_reason = APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM
+    else:
+        context_changed = approval_context_tokens_validation_reason(
+            initial_artifact_hash,
+            fresh_artifact_hash,
+        )
+        validation_reason = APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM if context_changed is not None else None
+    if fresh_decision.approval_reuse_reason_code == "approval_reuse_integrity_failure":
+        validation_reason = "approval_reuse_integrity_failure"
+
+    # A fresh unclaimed allow is not launch authority. Reuse the freshly
+    # computed current action, while preserving a newly observed saved block or
+    # another terminal result from the second lookup.
+    post_claim_current_action = fresh_decision.action
+    if fresh_decision.saved_action == "allow" and fresh_decision.approval_reuse_reason_code == APPROVAL_REUSE_ACCEPTED:
+        post_claim_current_action = fresh_current.action
+    if post_claim_current_action == "review" and not claimed_approval_authorizes_postclaim_review(
+        claim_disposition=claim_disposition,
+        claimed_decision=claimed_decision,
+        current_decision=fresh_decision.pending_approval_reuse_decision,
+    ):
+        validation_reason = APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM
+    if validation_reason is not None:
+        post_claim_current_action = most_restrictive_guard_action(
+            post_claim_current_action,
+            "require-reapproval",
+        )
+    post_claim_current = replace(
+        fresh_current,
+        action=post_claim_current_action,
+        summary=(
+            "Current tool-call authority changed after the saved approval was claimed."
+            if validation_reason is not None
+            else fresh_current.summary
+        ),
+    )
+    reuse = evaluate_approval_reuse(
+        post_claim_current.action,
+        "allow",
+        saved_decision_present=True,
+        validation_reason=validation_reason,
+    )
+    return replace(
+        _tool_call_decision_with_reuse(post_claim_current, reuse),
+        approval_reuse_claim_disposition=claim_disposition,
+        post_claim_revalidated=True,
+        post_claim_authority=ToolCallAuthority(
+            config=fresh_config,
+            artifact=fresh_artifact,
+            artifact_hash=fresh_artifact_hash,
+            arguments=fresh_arguments,
+        ),
+    )
+
+
+def claim_deferred_tool_call_approval(
+    *,
+    store: GuardStore,
+    decision: ToolCallDecision,
+) -> ToolCallDecision:
+    """Atomically claim a provisionally accepted approval at the launch gate."""
+
+    pending = decision.pending_approval_reuse_decision
+    if pending is None:
+        return decision
+    if store.claim_approval_reuse_decision(pending):
+        # This helper has no fresh artifact/config provider. A successful claim
+        # is atomic evidence, but it is not sufficient launch authority until
+        # retained-row presence and every current input are revalidated.
+        failed_action = most_restrictive_guard_action(
+            decision.current_action or "block",
+            "require-reapproval",
+        )
+        current = ToolCallDecision(
+            action=failed_action,
+            source="risk-policy",
+            signals=decision.signals,
+            summary="Current tool call requires reapproval because post-claim authority was unavailable.",
+            risk_categories=decision.risk_categories,
+        )
+        reuse = evaluate_approval_reuse(
+            current.action,
+            decision.saved_action,
+            saved_decision_present=True,
+            validation_reason=APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
+        )
+        return replace(
+            _tool_call_decision_with_reuse(current, reuse),
+            approval_reuse_claim_disposition=decision.approval_reuse_claim_disposition,
+            post_claim_revalidated=True,
+        )
+    current = ToolCallDecision(
+        action=decision.current_action or "block",
+        source="risk-policy",
+        signals=decision.signals,
+        summary="Current tool call still requires review because its saved approval could not be claimed.",
+        risk_categories=decision.risk_categories,
+    )
+    reuse = evaluate_approval_reuse(
+        current.action,
+        decision.saved_action,
+        saved_decision_present=True,
+        validation_reason=APPROVAL_REUSE_CLAIM_FAILED,
+    )
+    return _tool_call_decision_with_reuse(current, reuse)
+
+
+def _evaluate_current_tool_call(
+    *,
+    config: GuardConfig,
+    artifact: GuardArtifact,
+    arguments: object,
+) -> ToolCallDecision:
+    """Evaluate current configuration and call shape without saved state."""
+
+    configured_override = config.resolve_action_override(
+        artifact.harness,
+        artifact.artifact_id,
+        artifact.publisher,
+    )
+    current_config_action = configured_override if configured_override is not None else config.default_action
+
+    def with_current_config(decision: ToolCallDecision) -> ToolCallDecision:
+        effective_action = most_restrictive_guard_action(decision.action, current_config_action)
+        if effective_action == decision.action:
+            return decision
+        return replace(
+            decision,
+            action=effective_action,
+            source="policy",
+            summary=("Local Guard's current configuration is stricter than the tool-call-specific recommendation."),
         )
 
     signals = tool_call_risk_signals(artifact, arguments)
     risk_categories = tool_call_risk_categories(artifact, arguments)
+
     if len(signals) == 0:
-        return ToolCallDecision(
-            action="allow",
-            source="heuristic",
-            signals=(),
-            summary="Guard did not detect a high-risk signal in this tool call.",
-            risk_categories=(),
+        return with_current_config(
+            ToolCallDecision(
+                action="allow",
+                source="heuristic",
+                signals=(),
+                summary="Guard did not detect a high-risk signal in this tool call.",
+                risk_categories=(),
+            )
         )
     explicit_risk_action = _configured_risk_action(config, "mcp_dangerous_tool", harness=artifact.harness)
     configured_risk_action = explicit_risk_action or resolve_risk_action(
@@ -218,19 +711,67 @@ def evaluate_tool_call(
         if explicit_risk_action is None and config.mode == "prompt" and config.security_level == DEFAULT_SECURITY_LEVEL:
             configured_risk_action = "review"
             source = "risk-policy"
-        return ToolCallDecision(
-            action=configured_risk_action,
-            source=source,
+        return with_current_config(
+            ToolCallDecision(
+                action=configured_risk_action,
+                source=source,
+                signals=signals,
+                summary=tool_call_risk_summary(artifact, arguments),
+                risk_categories=risk_categories,
+            )
+        )
+    return with_current_config(
+        ToolCallDecision(
+            action="review" if config.mode == "prompt" else "block",
+            source="heuristic",
             signals=signals,
             summary=tool_call_risk_summary(artifact, arguments),
             risk_categories=risk_categories,
         )
+    )
+
+
+def _tool_call_decision_with_reuse(
+    current: ToolCallDecision,
+    reuse: ApprovalReuseDecision,
+    *,
+    pending_decision: Mapping[str, object] | None = None,
+    claim_disposition: ApprovalReuseClaimDisposition | None = None,
+) -> ToolCallDecision:
+    normalization_reason_code = reuse.saved_normalization_reason_code or reuse.current_normalization_reason_code
+    original_action = reuse.original_saved_action or reuse.original_current_action
+    if reuse.reason_code == APPROVAL_REUSE_SAVED_ACTION_UNKNOWN:
+        source = "policy-invalid"
+        summary = "Local Guard found an unknown policy action in saved state and requires reapproval."
+    elif reuse.reason_code == APPROVAL_REUSE_CURRENT_ACTION_UNKNOWN:
+        source = "policy-invalid"
+        summary = "Local Guard found an unknown current policy action and blocked the tool call."
+    elif reuse.reason_code == APPROVAL_REUSE_ACCEPTED:
+        source = "policy"
+        summary = "Local Guard reused an exact saved approval for the current reviewable tool call."
+    elif reuse.reason_code == APPROVAL_REUSE_NO_SAVED_DECISION:
+        source = current.source
+        summary = current.summary
+    elif reuse.saved_action == "block":
+        source = "policy"
+        summary = "Local Guard kept this tool call blocked by saved policy."
+    else:
+        source = current.source
+        summary = f"{current.summary} Saved approval was not reused ({reuse.reason_code})."
     return ToolCallDecision(
-        action="review" if config.mode == "prompt" else "block",
-        source="heuristic",
-        signals=signals,
-        summary=tool_call_risk_summary(artifact, arguments),
-        risk_categories=risk_categories,
+        action=reuse.action,
+        source=source,
+        signals=current.signals,
+        summary=summary,
+        risk_categories=current.risk_categories,
+        normalization_reason_code=normalization_reason_code,
+        original_action=original_action,
+        approval_reuse_status=reuse.status,
+        approval_reuse_reason_code=reuse.reason_code,
+        current_action=reuse.current_action,
+        saved_action=reuse.saved_action,
+        pending_approval_reuse_decision=pending_decision,
+        approval_reuse_claim_disposition=claim_disposition,
     )
 
 
@@ -736,6 +1277,9 @@ def allow_tool_call(
     approval_gate_grant: ApprovalGateGrant | None = None,
     arguments: object = None,
     policy_workspace: str | None = None,
+    additional_scanner_evidence: tuple[dict[str, object], ...] = (),
+    policy_action: GuardAction = "allow",
+    emit_runtime_evidence: bool = True,
 ) -> GuardReceipt:
     if remember:
         store.upsert_policy(
@@ -752,20 +1296,21 @@ def allow_tool_call(
             now,
             approval_gate_grant=approval_gate_grant,
         )
-    store.record_inventory_artifact(
-        artifact=artifact,
-        artifact_hash=artifact_hash,
-        policy_action="allow",
-        changed=False,
-        now=now,
-        approved=True,
-    )
+    if emit_runtime_evidence:
+        store.record_inventory_artifact(
+            artifact=artifact,
+            artifact_hash=artifact_hash,
+            policy_action=policy_action,
+            changed=False,
+            now=now,
+            approved=policy_action in {"allow", "warn"},
+        )
     raw_command_text = extract_mcp_command_text(artifact, arguments)
     receipt = build_receipt(
         harness=artifact.harness,
         artifact_id=artifact.artifact_id,
         artifact_hash=artifact_hash,
-        policy_decision="allow",
+        policy_decision=policy_action,
         capabilities_summary=f"mcp tool call • {artifact.name}",
         changed_capabilities=["runtime_tool_call", decision_source, *signals],
         provenance_summary=f"runtime tool call allowed from {artifact.config_path}",
@@ -778,21 +1323,24 @@ def allow_tool_call(
                 artifact,
                 risk_categories=risk_categories,
             ),
+            *additional_scanner_evidence,
         ),
         raw_command_text=raw_command_text,
     )
-    store.add_receipt(receipt)
-    store.add_event(
-        "runtime_tool_call_allowed",
-        {
-            "artifact_id": artifact.artifact_id,
-            "artifact_hash": artifact_hash,
-            "decision_source": decision_source,
-            "risk_categories": list(risk_categories),
-            "signals": list(signals),
-        },
-        now,
-    )
+    if emit_runtime_evidence:
+        store.add_receipt(receipt)
+        store.add_event(
+            "runtime_tool_call_allowed",
+            {
+                "artifact_id": artifact.artifact_id,
+                "artifact_hash": artifact_hash,
+                "decision_source": decision_source,
+                "policy_action": policy_action,
+                "risk_categories": list(risk_categories),
+                "signals": list(signals),
+            },
+            now,
+        )
     return receipt
 
 
@@ -806,11 +1354,13 @@ def block_tool_call(
     signals: tuple[str, ...],
     risk_categories: tuple[str, ...] = (),
     arguments: object = None,
+    additional_scanner_evidence: tuple[dict[str, object], ...] = (),
+    policy_action: GuardAction = "block",
 ) -> GuardReceipt:
     store.record_inventory_artifact(
         artifact=artifact,
         artifact_hash=artifact_hash,
-        policy_action="block",
+        policy_action=policy_action,
         changed=False,
         now=now,
         approved=False,
@@ -820,7 +1370,7 @@ def block_tool_call(
         harness=artifact.harness,
         artifact_id=artifact.artifact_id,
         artifact_hash=artifact_hash,
-        policy_decision="block",
+        policy_decision=policy_action,
         capabilities_summary=f"mcp tool call • {artifact.name}",
         changed_capabilities=["runtime_tool_call", decision_source, *signals],
         provenance_summary=f"runtime tool call blocked from {artifact.config_path}",
@@ -833,6 +1383,7 @@ def block_tool_call(
                 artifact,
                 risk_categories=risk_categories,
             ),
+            *additional_scanner_evidence,
         ),
         raw_command_text=raw_command_text,
     )
@@ -843,6 +1394,7 @@ def block_tool_call(
             "artifact_id": artifact.artifact_id,
             "artifact_hash": artifact_hash,
             "decision_source": decision_source,
+            "policy_action": policy_action,
             "risk_categories": list(risk_categories),
             "signals": list(signals),
         },

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -52,6 +52,8 @@ def _redact_arg(value: str) -> str:
 
 
 def _redact_metadata(value: object, key: str | None = None) -> object:
+    if key is not None and key.lower() in {"env", "environment"} and isinstance(value, dict):
+        return {item_key: "*****" for item_key in value}
     if key is not None and any(
         token in key.lower() for token in ("key", "token", "auth", "secret", "password", "credential")
     ):

--- a/src/codex_plugin_scanner/guard/package_execution_context.py
+++ b/src/codex_plugin_scanner/guard/package_execution_context.py
@@ -104,6 +104,7 @@ def build_package_execution_context(
     workspace_dir: Path,
     artifact: GuardArtifact,
     executable: str | None = None,
+    executable_args: Sequence[str] = (),
     environment: Mapping[str, str] | None = None,
 ) -> PackageExecutionContext:
     """Build a fail-closed package execution context for an approval request."""
@@ -133,6 +134,7 @@ def build_package_execution_context(
         repository_root=repository_root,
         manager=manager,
         executable=executable or _string_value(metadata.get("package_executable")),
+        arguments=executable_args,
         environment=env,
         files=files,
     )

--- a/src/codex_plugin_scanner/guard/package_execution_context_inputs.py
+++ b/src/codex_plugin_scanner/guard/package_execution_context_inputs.py
@@ -6,10 +6,12 @@ import hashlib
 import os
 import shutil
 import stat
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
+from .runtime.approval_context import build_runtime_launch_identity, runtime_launch_identity_is_reusable
 from .runtime.workspace_path_guard import resolve_path_within_workspace
 
 _MAX_CONFIG_FILE_BYTES = 2 * 1024 * 1024
@@ -189,6 +191,7 @@ def executable_material(
     repository_root: Path | None,
     manager: str,
     executable: str | None,
+    arguments: Sequence[str] = (),
     environment: Mapping[str, str],
     files: ContextFiles,
 ) -> tuple[dict[str, object], str | None]:
@@ -215,12 +218,43 @@ def executable_material(
     except ContextUnavailableError as error:
         return {"manager": manager, "requested": Path(requested).name, "status": error.reason}, error.reason
     location = _canonical_executable_location(candidate, workspace=workspace, repository_root=repository_root)
-    return {
+    launch_identity = build_runtime_launch_identity(
+        requested,
+        args=arguments,
+        structured_command=True,
+        direct_executable=True,
+        search_path=environment.get("PATH"),
+        cwd=workspace,
+        launch_env=environment,
+    )
+    executable_identity = launch_identity.get("executable")
+    if (
+        not isinstance(executable_identity, Mapping)
+        or executable_identity.get("status") != "verified"
+        or executable_identity.get("sha256") != hashlib.sha256(payload).hexdigest()
+    ):
+        return {
+            "manager": manager,
+            "requested": Path(requested).name,
+            "status": "package_manager_launch_identity_unavailable",
+        }, "package_manager_launch_identity_unavailable"
+    material: dict[str, object] = {
         "content_digest": hashlib.sha256(payload).hexdigest(),
+        "launch_identity": _portable_launch_identity(
+            launch_identity,
+            workspace=workspace,
+            repository_root=repository_root,
+        ),
         "location": location,
         "manager": manager,
         "requested": Path(requested).name,
-    }, None
+    }
+    if not ("/" in requested or "\\" in requested):
+        material["search_path_digest"] = hashlib.sha256((environment.get("PATH") or "").encode("utf-8")).hexdigest()
+    if not runtime_launch_identity_is_reusable(launch_identity):
+        material["status"] = "package_manager_launch_identity_unavailable"
+        return material, "package_manager_launch_identity_unavailable"
+    return material, None
 
 
 def _canonical_executable_location(candidate: Path, *, workspace: Path, repository_root: Path | None) -> str:
@@ -234,6 +268,42 @@ def _canonical_executable_location(candidate: Path, *, workspace: Path, reposito
     return f"external:{candidate}"
 
 
+def _portable_launch_identity(
+    value: object,
+    *,
+    workspace: Path,
+    repository_root: Path | None,
+) -> object:
+    """Normalize local absolute paths while retaining only hashed argv data."""
+
+    if isinstance(value, Mapping):
+        typed_value = cast(Mapping[object, object], value)
+        normalized: dict[str, object] = {}
+        for raw_key, item in typed_value.items():
+            key = str(raw_key)
+            if key in {"path", "launch_cwd", "command"} and isinstance(item, str):
+                candidate = Path(item)
+                normalized[key] = (
+                    _canonical_executable_location(
+                        candidate,
+                        workspace=workspace,
+                        repository_root=repository_root,
+                    )
+                    if candidate.is_absolute()
+                    else item
+                )
+                continue
+            normalized[key] = _portable_launch_identity(
+                item,
+                workspace=workspace,
+                repository_root=repository_root,
+            )
+        return normalized
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_portable_launch_identity(item, workspace=workspace, repository_root=repository_root) for item in value]
+    return value
+
+
 def dependency_material(
     *,
     workspace: Path,
@@ -242,8 +312,15 @@ def dependency_material(
 ) -> tuple[dict[str, object], str | None]:
     entries: list[dict[str, str]] = []
     failure: str | None = None
+    manager = _string_value(metadata.get("package_manager")) or ""
     for kind, key in (("manifest", "manifest_paths"), ("lockfile", "lockfile_paths")):
-        for relative_path in _string_items(metadata.get(key)):
+        configured_paths = _string_items(metadata.get(key))
+        inferred_paths = (
+            tuple(path for path in _default_dependency_paths(manager, kind=kind) if (workspace / path).is_file())
+            if not configured_paths
+            else ()
+        )
+        for relative_path in configured_paths or inferred_paths:
             resolved = resolve_path_within_workspace(workspace, relative_path)
             if resolved is None or not resolved.exists():
                 entries.append({"kind": kind, "path": relative_path, "status": "missing"})
@@ -269,6 +346,39 @@ def _string_items(value: object) -> tuple[str, ...]:
     if not isinstance(value, list | tuple):
         return ()
     return tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
+
+
+def _default_dependency_paths(manager: str, *, kind: str) -> tuple[str, ...]:
+    normalized = manager.strip().lower()
+    manifests: dict[str, tuple[str, ...]] = {
+        "bun": ("package.json",),
+        "bunx": ("package.json",),
+        "npm": ("package.json",),
+        "npx": ("package.json",),
+        "pnpm": ("package.json", "pnpm-workspace.yaml"),
+        "yarn": ("package.json",),
+        "pip": ("pyproject.toml", "requirements.txt", "setup.py", "setup.cfg"),
+        "pip3": ("pyproject.toml", "requirements.txt", "setup.py", "setup.cfg"),
+        "poetry": ("pyproject.toml",),
+        "uv": ("pyproject.toml", "requirements.txt"),
+    }
+    lockfiles: dict[str, tuple[str, ...]] = {
+        "bun": ("bun.lock", "bun.lockb"),
+        "bunx": ("bun.lock", "bun.lockb"),
+        "npm": ("package-lock.json", "npm-shrinkwrap.json"),
+        "npx": ("package-lock.json", "npm-shrinkwrap.json"),
+        "pnpm": ("pnpm-lock.yaml",),
+        "yarn": ("yarn.lock",),
+        "pip": ("uv.lock", "poetry.lock", "Pipfile.lock"),
+        "pip3": ("uv.lock", "poetry.lock", "Pipfile.lock"),
+        "poetry": ("poetry.lock",),
+        "uv": ("uv.lock",),
+    }
+    return (manifests if kind == "manifest" else lockfiles).get(normalized, ())
+
+
+def _string_value(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
 
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -7,6 +7,7 @@ import json
 import os
 import shlex
 import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -116,6 +117,7 @@ def build_protect_payload(
     dry_run: bool,
     now: str,
     config: GuardConfig | None = None,
+    current_config_provider: Callable[[], GuardConfig] | None = None,
     unsafe_raw_output: bool = False,
 ) -> tuple[dict[str, object], int]:
     """Evaluate and optionally execute an install command."""
@@ -126,7 +128,12 @@ def build_protect_payload(
     advisories = store.list_cached_advisories(limit=None)
     cached_verdict = evaluate_protect_request(request, advisories)
     cached_gate = cached_verdict.blocking
+    cached_policy_context = _cached_advisory_policy_context(cached_verdict)
     from .local_supply_chain import build_package_protect_payload
+
+    def current_cached_advisory_authority() -> tuple[object | None, dict[str, object] | None]:
+        current_verdict = evaluate_protect_request(request, store.list_cached_advisories(limit=None))
+        return current_verdict.action, _cached_advisory_policy_context(current_verdict)
 
     package_payload = build_package_protect_payload(
         command=command,
@@ -138,18 +145,21 @@ def build_protect_payload(
         config=config,
         unsafe_raw_output=unsafe_raw_output,
         timeout_seconds=_protect_command_timeout_seconds(),
+        additional_current_action=cached_verdict.action,
+        additional_policy_context=cached_policy_context,
+        current_config_provider=current_config_provider,
+        additional_authority_provider=current_cached_advisory_authority,
     )
     if package_payload is not None:
-        if cached_gate and not _package_saved_approval_covers_current_gate(
-            package_payload[0],
-            store=store,
-            workspace_dir=workspace_dir,
-            command=command,
-            now=now,
+        current_cached_verdict = evaluate_protect_request(request, store.list_cached_advisories(limit=None))
+        if (
+            current_cached_verdict.blocking
+            and package_payload[0].get("executed") is False
+            and not _package_payload_uses_saved_approval(package_payload[0])
         ):
             return _merge_cached_advisory_into_package_payload(
                 package_payload,
-                cached_verdict=cached_verdict,
+                cached_verdict=current_cached_verdict,
                 requested_dry_run=dry_run,
                 store=store,
                 now=now,
@@ -232,31 +242,16 @@ def build_protect_payload(
     return (payload, int(execution.returncode))
 
 
-def _package_saved_approval_covers_current_gate(
-    payload: dict[str, object],
-    *,
-    store: Any,
-    workspace_dir: Path,
-    command: list[str],
-    now: str,
-) -> bool:
-    if not _package_payload_uses_saved_approval(payload):
-        return False
-    receipt = payload.get("receipt")
-    if not isinstance(receipt, dict):
-        return False
-    stored_hash = receipt.get("artifact_hash")
-    if not isinstance(stored_hash, str) or not stored_hash:
-        return False
-    from .local_supply_chain import recompute_package_protect_artifact_hash
+def _cached_advisory_policy_context(verdict: ProtectVerdict) -> dict[str, object]:
+    """Return the complete cached-advisory authority bound to package approval reuse."""
 
-    current_hash = recompute_package_protect_artifact_hash(
-        command,
-        store=store,
-        workspace_dir=workspace_dir,
-        now=now,
-    )
-    return current_hash == stored_hash
+    return {
+        "action": verdict.action,
+        "matched_advisories": [dict(advisory) for advisory in verdict.matched_advisories],
+        "reason": verdict.reason,
+        "risk_signals": list(verdict.risk_signals),
+        "version": 1,
+    }
 
 
 def _package_payload_uses_saved_approval(payload: dict[str, object]) -> bool:
@@ -340,6 +335,7 @@ def _merge_cached_advisory_into_package_payload(
             receipt_id = updated_receipt.get("receipt_id")
             if isinstance(receipt_id, str) and receipt_id:
                 store.update_receipt_policy_decision(receipt_id, merged_action)
+        if action_changed:
             request = payload.get("request")
             executor = request.get("executor") if isinstance(request, dict) else None
             install_kind = request.get("install_kind") if isinstance(request, dict) else None

--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -2,41 +2,61 @@
 
 from __future__ import annotations
 
+import io
 import json
+import queue
 import subprocess
 import sys
+import threading
 import webbrowser
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
-from typing import IO, Any, TextIO
+from hashlib import sha256
+from pathlib import Path
+from typing import IO, Any, Literal, TextIO, cast
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from ..action_lattice import (
     GuardActionNormalization,
     most_restrictive_guard_action,
     normalize_guard_action,
-    normalize_guard_action_result,
 )
 from ..adapters.base import HarnessContext
 from ..approval_gate import ApprovalGateError
 from ..approval_scope_support import package_request_runtime_workspace_scope
 from ..approvals import approval_prompt_flow, build_approval_browser_url, first_approval_url, queue_blocked_approvals
 from ..config import GuardConfig
-from ..consumer.service import artifact_hash as compute_artifact_hash
 from ..daemon import ensure_guard_daemon
 from ..daemon.manager import load_guard_daemon_auth_token
-from ..local_supply_chain import package_request_policy_hash
+from ..local_supply_chain import (
+    _resolve_stored_package_policy_override,
+    compose_current_package_policy_action,
+    package_request_policy_hash,
+)
 from ..mcp_tool_calls import (
+    ApprovalReuseClaimDisposition,
+    ToolCallDecision,
     allow_tool_call,
     block_tool_call,
     build_tool_call_artifact,
     build_tool_call_hash,
+    claimed_approval_authorizes_postclaim_review,
     evaluate_tool_call,
     tool_call_risk_categories,
     tool_call_risk_summary,
 )
-from ..models import GuardAction, HarnessDetection
+from ..models import GuardAction, GuardArtifact, HarnessDetection
 from ..package_execution_context import build_package_execution_context
 from ..policy.engine import build_decision_v2
+from ..runtime.approval_context import (
+    build_configured_environment_hash,
+    build_runtime_launch_identity,
+    resolved_runtime_launch_executable,
+    runtime_launch_identity_matches,
+)
+from ..runtime.approval_reuse import APPROVAL_REUSE_CLAIM_FAILED
 from ..runtime.browser_mcp_intent import normalize_browser_mcp_intent
 from ..runtime.mcp_protection import McpServerIdentity, build_mcp_server_identity
 from ..runtime.package_execution_policy import is_execution_permitted
@@ -94,6 +114,289 @@ def _guard_action_normalization_evidence(
     }
 
 
+def _tool_decision_scanner_evidence(decision: Any) -> tuple[dict[str, object], ...]:
+    evidence: list[dict[str, object]] = []
+    if decision.normalization_reason_code is not None:
+        evidence.append(
+            {
+                "source": "guard_action_normalizer",
+                "input_source": "stored_tool_policy",
+                "reason_code": decision.normalization_reason_code,
+                "original_action": decision.original_action,
+                "normalized_action": decision.action,
+            }
+        )
+    if decision.approval_reuse_reason_code is not None:
+        evidence.append(
+            {
+                "source": "approval_reuse",
+                "status": decision.approval_reuse_status,
+                "reason_code": decision.approval_reuse_reason_code,
+                "current_action": decision.current_action,
+                "saved_action": decision.saved_action,
+                "effective_action": decision.action,
+            }
+        )
+    return tuple(evidence)
+
+
+def _tool_decision_after_runtime_allow(decision: ToolCallDecision, *, source: str) -> ToolCallDecision:
+    return replace(
+        decision,
+        action="allow",
+        source=source,
+        pending_approval_reuse_decision=None,
+        approval_reuse_claim_disposition=None,
+    )
+
+
+_APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM = "approval_reuse_context_changed_after_claim"
+_APPROVAL_REUSE_CONFIG_REFRESH_FAILED = "approval_reuse_current_config_refresh_failed"
+
+
+def _postclaim_authority_evidence(
+    scanner_evidence: tuple[dict[str, object], ...],
+    *,
+    context_matches: bool,
+    current_action: GuardAction,
+) -> tuple[dict[str, object], ...]:
+    if context_matches:
+        return scanner_evidence
+    return (
+        *scanner_evidence,
+        {
+            "source": "approval_reuse",
+            "status": "rejected",
+            "reason_code": _APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
+            "context_matches": context_matches,
+            "current_action": current_action,
+            "effective_action": current_action,
+        },
+    )
+
+
+def _postclaim_claim_evidence(
+    scanner_evidence: tuple[dict[str, object], ...],
+    *,
+    current_action: GuardAction,
+    claim_authorizes_review: bool,
+) -> tuple[dict[str, object], ...]:
+    """Record a retained-row revocation at an otherwise unchanged boundary."""
+
+    if current_action != "review" or claim_authorizes_review:
+        return scanner_evidence
+    return (
+        *scanner_evidence,
+        {
+            "source": "approval_reuse",
+            "status": "rejected",
+            "reason_code": _APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
+            "context_matches": True,
+            "claimed_authority_matches": False,
+            "current_action": current_action,
+            "effective_action": "require-reapproval",
+        },
+    )
+
+
+def _config_refresh_failure_evidence(
+    scanner_evidence: tuple[dict[str, object], ...],
+) -> tuple[dict[str, object], ...]:
+    return (
+        *scanner_evidence,
+        {
+            "source": "approval_reuse",
+            "status": "rejected",
+            "reason_code": _APPROVAL_REUSE_CONFIG_REFRESH_FAILED,
+            "effective_action": "require-reapproval",
+        },
+    )
+
+
+def _postclaim_tool_action(decision: ToolCallDecision) -> GuardAction:
+    current_action = normalize_guard_action(
+        decision.current_action if decision.current_action is not None else decision.action,
+        unknown_action="block",
+    )
+    if decision.saved_action is None or decision.saved_action == "allow":
+        return current_action
+    return most_restrictive_guard_action(
+        current_action,
+        decision.action,
+        unknown_action="block",
+    )
+
+
+_SECRET_ARGUMENT_KEY_FRAGMENTS = (
+    "apikey",
+    "authorization",
+    "cookie",
+    "credential",
+    "password",
+    "secret",
+    "token",
+)
+
+
+def _secret_shaped_argument_key(key: object) -> bool:
+    normalized = "".join(character for character in str(key).casefold() if character.isalnum())
+    return any(fragment in normalized for fragment in _SECRET_ARGUMENT_KEY_FRAGMENTS)
+
+
+def _redact_mcp_scalar(value: str) -> str:
+    parsed = urlsplit(value)
+    if parsed.scheme and parsed.netloc and parsed.query:
+        query = [
+            (key, "*****" if _secret_shaped_argument_key(key) else item)
+            for key, item in parse_qsl(parsed.query, keep_blank_values=True)
+        ]
+        value = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, urlencode(query), parsed.fragment))
+    redacted = _redact_json(value)
+    return redacted if isinstance(redacted, str) else "*****"
+
+
+def _safe_mcp_arguments(value: object) -> object:
+    """Project MCP arguments into a display/persistence-safe representation."""
+
+    if isinstance(value, Mapping):
+        return {
+            str(key): "*****" if _secret_shaped_argument_key(key) else _safe_mcp_arguments(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list | tuple):
+        return [_safe_mcp_arguments(item) for item in value]
+    if isinstance(value, str):
+        return _redact_mcp_scalar(value)
+    return value
+
+
+def _safe_mcp_params(params: Mapping[str, object]) -> dict[str, object]:
+    return cast(dict[str, object], _safe_mcp_arguments(params))
+
+
+def _mcp_arguments_digest(arguments: object) -> str:
+    try:
+        serialized = json.dumps(arguments, sort_keys=True, separators=(",", ":"), default=str)
+    except (TypeError, ValueError):
+        serialized = repr(arguments)
+    return sha256(serialized.encode("utf-8")).hexdigest()
+
+
+_ToolCatalogState = Literal["unobserved", "pending", "complete", "invalidated", "error"]
+_APPROVAL_REUSE_TOOL_CATALOG_INCOMPLETE = "approval_reuse_tool_catalog_incomplete"
+_TOOL_CATALOG_EXECUTION_BOUNDARY_CHANGED = "tool_catalog_changed_at_execution_boundary"
+_TOOLS_CALL_PREWRITE_QUIET_SECONDS = 0.005
+
+
+class _ToolCatalogBoundaryChangedError(RuntimeError):
+    """The catalog authority changed before a guarded tool call was written."""
+
+
+@dataclass(frozen=True, slots=True)
+class _ChildOutputFrame:
+    line: str | None = None
+    error: BaseException | None = None
+
+
+def _canonical_tool_catalog_entry(name: str, definition: Mapping[str, object]) -> dict[str, object]:
+    """Normalize internal aliases while retaining every advertised field."""
+
+    canonical = {str(key): deepcopy(value) for key, value in definition.items() if str(key) != "name"}
+    if "input_schema" in canonical:
+        canonical.setdefault("inputSchema", canonical["input_schema"])
+        canonical.pop("input_schema", None)
+    if "output_schema" in canonical:
+        canonical.setdefault("outputSchema", canonical["output_schema"])
+        canonical.pop("output_schema", None)
+    return {"name": name, **canonical}
+
+
+def _tool_catalog_fingerprint(
+    catalog: Mapping[str, Mapping[str, object]],
+    *,
+    state: _ToolCatalogState = "complete",
+) -> str:
+    """Hash catalog lifecycle state plus the complete canonical tool surface."""
+
+    canonical_tools = [_canonical_tool_catalog_entry(name, catalog[name]) for name in sorted(catalog)]
+    serialized = json.dumps(
+        {
+            "state": state,
+            "tools": canonical_tools,
+            "version": "mcp-advertised-tool-catalog-v2",
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _enforcement_action(action: object) -> GuardAction:
+    normalized = normalize_guard_action(action)
+    return "require-reapproval" if normalized == "review" else normalized
+
+
+def _resolved_executable_identity(
+    command: str,
+    *,
+    launch_cwd: Path | None,
+    launch_env: Mapping[str, str] | None = None,
+    launch_args: Sequence[str] = (),
+) -> dict[str, object]:
+    """Bind the executable Popen will resolve after applying its ``cwd``."""
+
+    effective_launch_env = launch_env if launch_env is not None else _build_scrubbed_env()
+    launch_identity = build_runtime_launch_identity(
+        command,
+        args=launch_args,
+        structured_command=True,
+        search_path=effective_launch_env.get("PATH"),
+        cwd=launch_cwd or Path.cwd(),
+        launch_env=effective_launch_env,
+    )
+    executable = launch_identity["executable"]
+    identity = dict(executable) if isinstance(executable, Mapping) else {}
+    identity["command"] = command
+    identity["launch_cwd"] = launch_identity["launch_cwd"]
+    identity["entrypoint"] = launch_identity["entrypoint"]
+    return identity
+
+
+def _configured_server_environment(
+    launch_env: Mapping[str, str],
+    configured_keys: Sequence[str],
+) -> dict[str, str]:
+    """Select only configured server values from the actual child environment."""
+
+    return {key: launch_env[key] for key in configured_keys if key in launch_env}
+
+
+@dataclass(frozen=True, slots=True)
+class _PackagePolicyResolution:
+    base_evaluation: Any
+    evaluation: Any
+    current_action: GuardAction
+    workspace: Path
+    execution_context: Any
+    artifact_digest: str
+    policy_workspace: str | None
+    saved_policy_blocks: bool
+    pending_approval_reuse_decision: Mapping[str, object] | None
+    approval_reuse_claim_disposition: ApprovalReuseClaimDisposition | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _ToolCallAuthority:
+    artifact: GuardArtifact
+    artifact_hash: str
+    decision: ToolCallDecision
+    catalog_generation: int
+    catalog_state: _ToolCatalogState
+    catalog_fingerprint: str
+
+
 class RuntimeMcpGuardProxy:
     """Guard-managed MCP proxy for harnesses that talk stdio MCP to local servers."""
 
@@ -112,6 +415,7 @@ class RuntimeMcpGuardProxy:
         server_id: str | None = None,
         server_env_keys: tuple[str, ...] = (),
         server_identity: McpServerIdentity | None = None,
+        current_config_provider: Callable[[], GuardConfig] | None = None,
     ) -> None:
         self.harness = harness
         self.server_name = server_name
@@ -123,22 +427,36 @@ class RuntimeMcpGuardProxy:
         self.config_path = config_path
         self.transport = transport
         self.server_id = server_id
+        self._current_config_provider = current_config_provider
         self.server_env_keys = tuple(dict.fromkeys(key.strip() for key in server_env_keys if key.strip()))
+        initial_launch_env = _build_scrubbed_env()
         self.server_identity = server_identity or build_mcp_server_identity(
             config_path=self.config_path,
             command=self.command[0] if self.command else "",
             args=tuple(self.command[1:]),
             transport=self.transport,
+            env=_configured_server_environment(initial_launch_env, self.server_env_keys),
             env_keys=self.server_env_keys,
         )
         self._inline_prompt_available = False
         self._inline_prompt_counter = 0
         self._buffered_child_responses: dict[str, list[dict[str, Any]]] = {}
         self._buffered_client_responses: dict[str, list[dict[str, Any]]] = {}
+        self._child_output_queue: queue.Queue[_ChildOutputFrame] | None = None
+        self._active_child_stdout: IO[str] | None = None
+        self._tools_call_boundary_lock = threading.RLock()
+        self._tool_catalog_state: _ToolCatalogState = "unobserved"
         self._tool_catalog: dict[str, dict[str, object]] = {}
         self._tool_catalog_pending: dict[str, dict[str, object]] | None = None
+        self._tool_catalog_expected_cursor: str | None = None
+        self._tool_catalog_inflight = False
+        self._tool_catalog_inflight_cursor: str | None = None
         self._tool_catalog_generation = 0
         self._active_process: subprocess.Popen[str] | None = None
+        self._active_runtime_launch_identity: dict[str, object] | None = None
+        self._active_executable_identity: dict[str, object] | None = None
+        self._active_server_env_values_hash: str | None = None
+        self._active_server_identity: McpServerIdentity | None = None
 
     def _child_response_timeout_seconds(self) -> float:
         configured = getattr(self.config, "approval_wait_timeout_seconds", None)
@@ -214,6 +532,11 @@ class RuntimeMcpGuardProxy:
             if process.poll() is None:
                 process.terminate()
                 process.wait(timeout=5)
+            self._active_executable_identity = None
+            self._active_runtime_launch_identity = None
+            self._active_server_env_values_hash = None
+            self._active_server_identity = None
+            self._deactivate_child_process_io()
         return {
             "command": self.command,
             "events": events,
@@ -263,16 +586,321 @@ class RuntimeMcpGuardProxy:
             if process.poll() is None:
                 process.terminate()
                 process.wait(timeout=5)
+            self._active_executable_identity = None
+            self._active_runtime_launch_identity = None
+            self._active_server_env_values_hash = None
+            self._active_server_identity = None
+            self._deactivate_child_process_io()
+
+    def _reset_child_process_state(self) -> None:
+        self._buffered_child_responses.clear()
+        self._buffered_client_responses.clear()
+        self._child_output_queue = None
+        self._active_child_stdout = None
+        self._reset_tools_catalog_unobserved()
+
+    def _deactivate_child_process_io(self) -> None:
+        self._buffered_child_responses.clear()
+        self._buffered_client_responses.clear()
+        self._child_output_queue = None
+        self._active_child_stdout = None
+
+    def _activate_child_output_pump(self, child_stdout: IO[str]) -> None:
+        output_queue: queue.Queue[_ChildOutputFrame] = queue.Queue()
+        self._child_output_queue = output_queue
+        self._active_child_stdout = child_stdout
+
+        def pump() -> None:
+            try:
+                while True:
+                    line = child_stdout.readline()
+                    if not line:
+                        output_queue.put(_ChildOutputFrame())
+                        return
+                    output_queue.put(_ChildOutputFrame(line=line))
+            except BaseException as exc:  # pragma: no cover - surfaced by the synchronous consumer
+                output_queue.put(_ChildOutputFrame(error=exc))
+
+        threading.Thread(
+            target=pump,
+            name=f"guard-mcp-child-output-{self.harness}-{self.server_name}",
+            daemon=True,
+        ).start()
 
     def _start_process(self) -> subprocess.Popen[str]:
-        return subprocess.Popen(
-            self.command,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=None,
-            text=True,
-            cwd=self.context.workspace_dir,
-            env=_build_scrubbed_env(),
+        # A catalog belongs to one concrete server process. A replacement
+        # process must explicitly advertise a complete root-to-terminal list
+        # before any saved allow can be reused against it.
+        self._reset_child_process_state()
+        launch_env = _build_scrubbed_env()
+        configured_env = _configured_server_environment(launch_env, self.server_env_keys)
+        self._active_runtime_launch_identity = build_runtime_launch_identity(
+            self.command[0] if self.command else "",
+            args=self.command[1:],
+            structured_command=True,
+            search_path=launch_env.get("PATH"),
+            cwd=self.context.workspace_dir or Path.cwd(),
+            launch_env=launch_env,
+        )
+        self._active_executable_identity = _resolved_executable_identity(
+            self.command[0] if self.command else "",
+            launch_cwd=self.context.workspace_dir,
+            launch_env=launch_env,
+            launch_args=self.command[1:],
+        )
+        self._active_server_env_values_hash = build_configured_environment_hash(
+            launch_env,
+            configured_keys=self.server_env_keys,
+        )
+        self._active_server_identity = build_mcp_server_identity(
+            config_path=self.config_path,
+            command=self.command[0] if self.command else "",
+            args=tuple(self.command[1:]),
+            transport=self.transport,
+            env=configured_env,
+            env_keys=self.server_env_keys,
+        )
+        process: subprocess.Popen[str] | None = None
+        try:
+            process = subprocess.Popen(
+                self.command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=None,
+                text=True,
+                cwd=self.context.workspace_dir,
+                env=launch_env,
+                executable=resolved_runtime_launch_executable(self._active_runtime_launch_identity),
+            )
+            if not self._verify_post_spawn_launch_identity(launch_env=launch_env):
+                raise RuntimeError(
+                    "Guard runtime MCP server launch identity changed while the child process was starting."
+                )
+            if process.stdout is not None:
+                self._activate_child_output_pump(process.stdout)
+            return process
+        except BaseException:
+            if process is not None:
+                _quarantine_process(process)
+            self._active_executable_identity = None
+            self._active_runtime_launch_identity = None
+            self._active_server_env_values_hash = None
+            self._active_server_identity = None
+            raise
+
+    def _verify_post_spawn_launch_identity(self, *, launch_env: Mapping[str, str]) -> bool:
+        """Re-hash launch inputs after ``Popen`` and reject a spawn-time swap."""
+
+        expected = self._active_runtime_launch_identity
+        if expected is None:
+            return False
+        return runtime_launch_identity_matches(
+            expected,
+            self.command[0] if self.command else "",
+            args=self.command[1:],
+            structured_command=True,
+            search_path=launch_env.get("PATH"),
+            cwd=self.context.workspace_dir or Path.cwd(),
+            launch_env=launch_env,
+        )
+
+    def _session_executable_identity(self) -> dict[str, object]:
+        identity = self._active_executable_identity
+        if identity is None:
+            identity = _resolved_executable_identity(
+                self.command[0] if self.command else "",
+                launch_cwd=self.context.workspace_dir,
+                launch_args=self.command[1:],
+            )
+        return dict(identity)
+
+    def _session_server_env_values_hash(self) -> str:
+        active_hash = self._active_server_env_values_hash
+        if active_hash is not None:
+            return active_hash
+        launch_env = _build_scrubbed_env()
+        return build_configured_environment_hash(
+            launch_env,
+            configured_keys=self.server_env_keys,
+        )
+
+    def _session_server_identity(self) -> McpServerIdentity:
+        identity = self._active_server_identity
+        if identity is not None:
+            return identity
+        launch_env = _build_scrubbed_env()
+        return build_mcp_server_identity(
+            config_path=self.config_path,
+            command=self.command[0] if self.command else "",
+            args=tuple(self.command[1:]),
+            transport=self.transport,
+            env=_configured_server_environment(launch_env, self.server_env_keys),
+            env_keys=self.server_env_keys,
+        )
+
+    def _claim_boundary_config(self) -> GuardConfig:
+        provider = self._current_config_provider
+        if provider is None:
+            raise RuntimeError("runtime_mcp_current_config_provider_unavailable")
+        config = provider()
+        if not isinstance(config, GuardConfig):
+            raise RuntimeError("runtime_mcp_current_config_provider_invalid")
+        return config
+
+    @staticmethod
+    def _catalog_boundary_failure_evidence(
+        scanner_evidence: tuple[dict[str, object], ...],
+        *,
+        phase: str,
+    ) -> tuple[dict[str, object], ...]:
+        return (
+            *scanner_evidence,
+            {
+                "source": "tool_catalog",
+                "status": "rejected",
+                "reason_code": _TOOL_CATALOG_EXECUTION_BOUNDARY_CHANGED,
+                "phase": phase,
+                "effective_action": "require-reapproval",
+            },
+        )
+
+    def _catalog_boundary_failure_response(
+        self,
+        *,
+        message_id: object,
+        tool_name: str,
+        params: dict[str, Any],
+        scanner_evidence: tuple[dict[str, object], ...],
+        phase: str,
+        package_request: bool,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        fresh_authority = self._resolve_tool_call_authority(
+            tool_name=tool_name,
+            arguments=params.get("arguments"),
+        )
+        fresh_decision = fresh_authority.decision
+        evidence = self._catalog_boundary_failure_evidence(
+            (*scanner_evidence, *_tool_decision_scanner_evidence(fresh_decision)),
+            phase=phase,
+        )
+        fresh_action = _enforcement_action(fresh_decision.action)
+        if fresh_decision.saved_action == "block":
+            return self._stored_tool_block_response(
+                message_id=message_id,
+                artifact=fresh_authority.artifact,
+                artifact_hash=fresh_authority.artifact_hash,
+                tool_name=tool_name,
+                params=params,
+                signals=fresh_decision.signals,
+                risk_categories=fresh_decision.risk_categories,
+                scanner_evidence=evidence,
+                package_request=package_request,
+            )
+        if fresh_action in {"block", "sandbox-required"}:
+            return self._terminal_tool_response(
+                message_id=message_id,
+                artifact=fresh_authority.artifact,
+                artifact_hash=fresh_authority.artifact_hash,
+                tool_name=tool_name,
+                params=params,
+                policy_action=fresh_action,
+                signals=fresh_decision.signals,
+                risk_categories=fresh_decision.risk_categories,
+                scanner_evidence=evidence,
+            )
+        return self._queue_approval_center_response(
+            message_id=message_id,
+            artifact=fresh_authority.artifact,
+            artifact_hash=fresh_authority.artifact_hash,
+            tool_name=tool_name,
+            signals=fresh_decision.signals,
+            params=params,
+            scanner_evidence=evidence,
+            policy_action="require-reapproval",
+        )
+
+    def _disable_saved_allow_without_complete_catalog(self, decision: ToolCallDecision) -> ToolCallDecision:
+        """Reject saved-allow authority until this process has a complete catalog."""
+
+        if self._tool_catalog_state == "complete" or decision.pending_approval_reuse_decision is None:
+            return decision
+        current_action = _guard_action(decision.current_action or decision.action)
+        return replace(
+            decision,
+            action=current_action,
+            source="tool-catalog-state",
+            summary=(
+                "Guard cannot reuse a saved MCP approval until the current server process "
+                "has advertised a complete tool catalog."
+            ),
+            approval_reuse_status="rejected",
+            approval_reuse_reason_code=_APPROVAL_REUSE_TOOL_CATALOG_INCOMPLETE,
+            pending_approval_reuse_decision=None,
+            approval_reuse_claim_disposition=None,
+        )
+
+    def _resolve_tool_call_authority(
+        self,
+        *,
+        tool_name: str,
+        arguments: object,
+        config: GuardConfig | None = None,
+    ) -> _ToolCallAuthority:
+        """Rebuild the complete current tool-call identity and policy result."""
+
+        authority_config = config or self.config
+        tool_definition = self._tool_catalog.get(tool_name, {})
+        tool_description_value = tool_definition.get("description")
+        tool_schema = tool_definition.get("inputSchema", tool_definition.get("input_schema"))
+        catalog_generation = self._tool_catalog_generation
+        catalog_state = self._tool_catalog_state
+        catalog_fingerprint = _tool_catalog_fingerprint(
+            self._tool_catalog,
+            state=catalog_state,
+        )
+        artifact = build_tool_call_artifact(
+            harness=self.harness,
+            server_name=self.server_name,
+            tool_name=tool_name,
+            source_scope=self.source_scope,
+            config_path=self.config_path,
+            transport=self.transport,
+            server_id=self.server_id,
+            server_fingerprint={
+                "command": self.command,
+                "configured_env_values_hash": self._session_server_env_values_hash(),
+                "transport": self.transport,
+                "resolved_executable": self._session_executable_identity(),
+                "tool_catalog_state": catalog_state,
+                "tool_catalog_fingerprint": catalog_fingerprint,
+            },
+            server_identity=self._session_server_identity(),
+            tool_schema=tool_schema,
+            tool_description=tool_description_value if isinstance(tool_description_value, str) else None,
+        )
+        artifact_hash = build_tool_call_hash(
+            artifact,
+            arguments,
+            workspace=self.context.workspace_dir or Path.cwd(),
+            config=authority_config,
+        )
+        decision = self._disable_saved_allow_without_complete_catalog(
+            evaluate_tool_call(
+                store=self.store,
+                config=authority_config,
+                artifact=artifact,
+                artifact_hash=artifact_hash,
+                arguments=arguments,
+                claim_saved_approval=False,
+            )
+        )
+        return _ToolCallAuthority(
+            artifact=artifact,
+            artifact_hash=artifact_hash,
+            decision=decision,
+            catalog_generation=catalog_generation,
+            catalog_state=catalog_state,
+            catalog_fingerprint=catalog_fingerprint,
         )
 
     def _handle_message(
@@ -285,14 +913,43 @@ class RuntimeMcpGuardProxy:
         server_output: TextIO | None,
         approval_callback: Any | None,
     ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+        if str(message.get("method", "")) == "tools/call":
+            with self._tools_call_boundary_lock:
+                return self._handle_message_serialized(
+                    message=message,
+                    child_stdin=child_stdin,
+                    child_stdout=child_stdout,
+                    client_input=client_input,
+                    server_output=server_output,
+                    approval_callback=approval_callback,
+                )
+        return self._handle_message_serialized(
+            message=message,
+            child_stdin=child_stdin,
+            child_stdout=child_stdout,
+            client_input=client_input,
+            server_output=server_output,
+            approval_callback=approval_callback,
+        )
+
+    def _handle_message_serialized(
+        self,
+        *,
+        message: dict[str, Any],
+        child_stdin: IO[str],
+        child_stdout: IO[str],
+        client_input: TextIO | None,
+        server_output: TextIO | None,
+        approval_callback: Any | None,
+    ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
         method = str(message.get("method", "unknown"))
         params = message.get("params", {})
         self._record_client_capabilities(method, params)
-        event = {
+        event: dict[str, Any] = {
             "method": method,
             "tool_name": params.get("name") if isinstance(params, dict) else None,
             "decision": "forward",
-            "redacted_params": _redact_json(params),
+            "redacted_params": _safe_mcp_params(params) if isinstance(params, Mapping) else {},
         }
         if method in {"notifications/tools/list_changed", "tools/list_changed"}:
             self._invalidate_tools_catalog()
@@ -305,16 +962,25 @@ class RuntimeMcpGuardProxy:
             event["decision"] = "forward-response"
             return None, event
         if method != "tools/call" or not isinstance(params, dict):
-            list_generation = self._tool_catalog_generation if method == "tools/list" else None
-            response = self._forward_message(
-                message,
-                child_stdin,
-                child_stdout,
-                client_input=client_input,
-                server_output=server_output,
-            )
+            list_cursor: object | None = None
+            list_generation: int | None = None
             if method == "tools/list":
-                list_cursor = params.get("cursor") if isinstance(params, dict) else None
+                list_cursor = params.get("cursor") if isinstance(params, dict) else object()
+                list_generation = self._begin_tools_catalog_request(list_cursor)
+            try:
+                response = self._forward_message(
+                    message,
+                    child_stdin,
+                    child_stdout,
+                    client_input=client_input,
+                    server_output=server_output,
+                )
+            except BaseException:
+                if list_generation is not None:
+                    self._fail_tools_catalog_request(list_generation)
+                raise
+            if method == "tools/list":
+                assert list_generation is not None
                 self._capture_tools_catalog(
                     response,
                     request_cursor=list_cursor,
@@ -324,47 +990,95 @@ class RuntimeMcpGuardProxy:
                 event["decision"] = "timeout"
             return response, event
 
+        try:
+            self._drain_child_messages(
+                child_stdin=child_stdin,
+                child_stdout=child_stdout,
+                client_input=client_input,
+                server_output=server_output,
+            )
+        except Exception:
+            self._poison_tools_catalog()
+            tool_name = str(params.get("name") or "unknown")
+            return _blocked_tool_response(
+                message.get("id"),
+                tool_name,
+                "HOL Guard could not synchronize the MCP server notification stream before this tool call.",
+                {"approvalRequests": [], "guardPolicyAction": "require-reapproval"},
+            ), {
+                **event,
+                "decision": "catalog-sync-failed",
+                "policy_action": "require-reapproval",
+                "approval_requests": [],
+            }
+
         tool_name = str(params.get("name") or "unknown")
         arguments = params.get("arguments")
-        tool_definition = self._tool_catalog.get(tool_name, {})
-        tool_description_value = tool_definition.get("description")
-        artifact = build_tool_call_artifact(
-            harness=self.harness,
-            server_name=self.server_name,
-            tool_name=tool_name,
-            source_scope=self.source_scope,
-            config_path=self.config_path,
-            transport=self.transport,
-            server_id=self.server_id,
-            server_fingerprint={
-                "command": self.command,
-                "transport": self.transport,
-            },
-            server_identity=self.server_identity,
-            tool_schema=tool_definition.get("input_schema"),
-            tool_description=tool_description_value if isinstance(tool_description_value, str) else None,
-        )
-        tool_artifact_hash = build_tool_call_hash(artifact, arguments)
-        decision = evaluate_tool_call(
-            store=self.store,
-            config=self.config,
-            artifact=artifact,
-            artifact_hash=tool_artifact_hash,
-            arguments=arguments,
-        )
-        decision_normalization_evidence: tuple[dict[str, object], ...] = ()
-        if decision.normalization_reason_code is not None:
-            decision_normalization_evidence = (
-                {
-                    "source": "guard_action_normalizer",
-                    "input_source": "stored_tool_policy",
-                    "reason_code": decision.normalization_reason_code,
-                    "original_action": decision.original_action,
-                    "normalized_action": decision.action,
-                },
-            )
+        authority = self._resolve_tool_call_authority(tool_name=tool_name, arguments=arguments)
+        artifact = authority.artifact
+        tool_artifact_hash = authority.artifact_hash
         package_artifact = self._package_request_artifact(tool_name=tool_name, arguments=arguments)
+        decision = authority.decision
+        if (
+            package_artifact is None
+            and self.config.mode == "observe"
+            and decision.pending_approval_reuse_decision is not None
+            and decision.current_action is not None
+        ):
+            decision = replace(
+                decision,
+                action=decision.current_action,
+                source="observe-current-policy",
+                pending_approval_reuse_decision=None,
+                approval_reuse_claim_disposition=None,
+            )
+        decision_scanner_evidence = _tool_decision_scanner_evidence(decision)
+        if decision.saved_action == "block":
+            return self._stored_tool_block_response(
+                message_id=message.get("id"),
+                artifact=artifact,
+                artifact_hash=tool_artifact_hash,
+                tool_name=tool_name,
+                params=params,
+                signals=decision.signals,
+                risk_categories=decision.risk_categories,
+                scanner_evidence=decision_scanner_evidence,
+                package_request=package_artifact is not None,
+            )
+        tool_policy_action = _enforcement_action(decision.action)
+        if tool_policy_action in {"block", "sandbox-required"}:
+            return self._terminal_tool_response(
+                message_id=message.get("id"),
+                artifact=artifact,
+                artifact_hash=tool_artifact_hash,
+                tool_name=tool_name,
+                params=params,
+                policy_action=tool_policy_action,
+                signals=decision.signals,
+                risk_categories=decision.risk_categories,
+                scanner_evidence=decision_scanner_evidence,
+            )
         if package_artifact is not None:
+            package_resolution = self._resolve_package_policy(artifact=package_artifact)
+            if package_resolution.saved_policy_blocks:
+                return self._handle_package_request(
+                    message=message,
+                    child_stdin=child_stdin,
+                    child_stdout=child_stdout,
+                    client_input=client_input,
+                    server_output=server_output,
+                    tool_name=tool_name,
+                    params=params,
+                    artifact=package_artifact,
+                    tool_artifact=artifact,
+                    tool_artifact_hash=tool_artifact_hash,
+                    tool_decision=decision,
+                    tool_scanner_evidence=decision_scanner_evidence,
+                    package_resolution=package_resolution,
+                    expected_catalog_generation=authority.catalog_generation,
+                    expected_catalog_state=authority.catalog_state,
+                    expected_catalog_fingerprint=authority.catalog_fingerprint,
+                )
             if decision.action in {"allow", "warn"}:
                 response, package_event = self._handle_package_request(
                     message=message,
@@ -375,6 +1089,14 @@ class RuntimeMcpGuardProxy:
                     tool_name=tool_name,
                     params=params,
                     artifact=package_artifact,
+                    tool_artifact=artifact,
+                    tool_artifact_hash=tool_artifact_hash,
+                    tool_decision=decision,
+                    tool_scanner_evidence=decision_scanner_evidence,
+                    package_resolution=package_resolution,
+                    expected_catalog_generation=authority.catalog_generation,
+                    expected_catalog_state=authority.catalog_state,
+                    expected_catalog_fingerprint=authority.catalog_fingerprint,
                 )
                 return response, package_event
             if self._allow_after_native_prompt(decision):
@@ -387,6 +1109,14 @@ class RuntimeMcpGuardProxy:
                     tool_name=tool_name,
                     params=params,
                     artifact=package_artifact,
+                    tool_artifact=artifact,
+                    tool_artifact_hash=tool_artifact_hash,
+                    tool_decision=_tool_decision_after_runtime_allow(decision, source="native-approved"),
+                    tool_scanner_evidence=decision_scanner_evidence,
+                    package_resolution=package_resolution,
+                    expected_catalog_generation=authority.catalog_generation,
+                    expected_catalog_state=authority.catalog_state,
+                    expected_catalog_fingerprint=authority.catalog_fingerprint,
                 )
                 return response, package_event
             if self._inline_prompt_available and approval_callback is not None:
@@ -402,7 +1132,9 @@ class RuntimeMcpGuardProxy:
                             signals=decision.signals,
                             risk_categories=decision.risk_categories,
                             remember=True,
-                            arguments=arguments,
+                            arguments=_safe_mcp_arguments(arguments),
+                            additional_scanner_evidence=decision_scanner_evidence,
+                            emit_runtime_evidence=False,
                         )
                     except ApprovalGateError:
                         return self._queue_approval_center_response(
@@ -412,7 +1144,8 @@ class RuntimeMcpGuardProxy:
                             tool_name=tool_name,
                             signals=decision.signals,
                             params=params,
-                            scanner_evidence=decision_normalization_evidence,
+                            scanner_evidence=decision_scanner_evidence,
+                            policy_action=tool_policy_action,
                         )
                     response, package_event = self._handle_package_request(
                         message=message,
@@ -423,6 +1156,14 @@ class RuntimeMcpGuardProxy:
                         tool_name=tool_name,
                         params=params,
                         artifact=package_artifact,
+                        tool_artifact=artifact,
+                        tool_artifact_hash=tool_artifact_hash,
+                        tool_decision=_tool_decision_after_runtime_allow(decision, source="inline-approved"),
+                        tool_scanner_evidence=decision_scanner_evidence,
+                        package_resolution=package_resolution,
+                        expected_catalog_generation=authority.catalog_generation,
+                        expected_catalog_state=authority.catalog_state,
+                        expected_catalog_fingerprint=authority.catalog_fingerprint,
                         remember_allow=True,
                         remember_decision_source="inline-approved",
                         remember_signals=decision.signals,
@@ -438,15 +1179,20 @@ class RuntimeMcpGuardProxy:
                         now=_now(),
                         signals=decision.signals,
                         risk_categories=decision.risk_categories,
-                        arguments=arguments,
+                        arguments=_safe_mcp_arguments(arguments),
+                        additional_scanner_evidence=decision_scanner_evidence,
+                        policy_action="block",
                     )
                     return _blocked_tool_response(
                         message.get("id"),
                         tool_name,
                         f"HOL Guard blocked tool call {tool_name} from {self.server_name}.",
+                        {"approvalRequests": [], "guardPolicyAction": "block"},
                     ), {
                         **event,
                         "decision": "deny-inline",
+                        "policy_action": "block",
+                        "approval_requests": [],
                     }
                 if _approval_invalid(approval_result):
                     block_tool_call(
@@ -457,7 +1203,9 @@ class RuntimeMcpGuardProxy:
                         now=_now(),
                         signals=decision.signals,
                         risk_categories=decision.risk_categories,
-                        arguments=arguments,
+                        arguments=_safe_mcp_arguments(arguments),
+                        additional_scanner_evidence=decision_scanner_evidence,
+                        policy_action="block",
                     )
                     return _blocked_tool_response(
                         message.get("id"),
@@ -466,9 +1214,12 @@ class RuntimeMcpGuardProxy:
                             f"HOL Guard blocked tool call {tool_name} from {self.server_name} because inline "
                             "approval returned an invalid response."
                         ),
+                        {"approvalRequests": [], "guardPolicyAction": "block"},
                     ), {
                         **event,
                         "decision": "deny-inline-invalid",
+                        "policy_action": "block",
+                        "approval_requests": [],
                     }
             if self.config.mode == "observe":
                 self._queue_observed_approval_requests(
@@ -476,10 +1227,10 @@ class RuntimeMcpGuardProxy:
                     artifact_hash=tool_artifact_hash,
                     tool_name=tool_name,
                     params=params,
-                    policy_action="require-reapproval",
+                    policy_action=tool_policy_action,
                     risk_summary=decision.summary,
                     risk_signals=list(decision.signals),
-                    extra_fields={"scanner_evidence": list(decision_normalization_evidence)},
+                    extra_fields={"scanner_evidence": list(decision_scanner_evidence)},
                 )
                 response, package_event = self._handle_package_request(
                     message=message,
@@ -490,10 +1241,14 @@ class RuntimeMcpGuardProxy:
                     tool_name=tool_name,
                     params=params,
                     artifact=package_artifact,
-                    remember_allow=True,
-                    remember_decision_source="policy-allow",
-                    remember_signals=decision.signals,
-                    remember_risk_categories=decision.risk_categories,
+                    tool_artifact=artifact,
+                    tool_artifact_hash=tool_artifact_hash,
+                    tool_decision=_tool_decision_after_runtime_allow(decision, source="policy-allow"),
+                    tool_scanner_evidence=decision_scanner_evidence,
+                    package_resolution=package_resolution,
+                    expected_catalog_generation=authority.catalog_generation,
+                    expected_catalog_state=authority.catalog_state,
+                    expected_catalog_fingerprint=authority.catalog_fingerprint,
                 )
                 return response, {
                     **package_event,
@@ -506,10 +1261,11 @@ class RuntimeMcpGuardProxy:
                 tool_name=tool_name,
                 signals=decision.signals,
                 params=params,
-                scanner_evidence=decision_normalization_evidence,
+                scanner_evidence=decision_scanner_evidence,
+                policy_action=tool_policy_action,
             )
             return response, queued_event
-        if decision.action == "allow" or (decision.source == "policy" and decision.action in {"warn", "review"}):
+        if decision.action in {"allow", "warn"}:
             return self._allow_and_forward(
                 message=message,
                 child_stdin=child_stdin,
@@ -522,6 +1278,12 @@ class RuntimeMcpGuardProxy:
                 signals=decision.signals,
                 risk_categories=decision.risk_categories,
                 params=params,
+                scanner_evidence=decision_scanner_evidence,
+                policy_action=_enforcement_action(decision.action),
+                approval_decision=decision,
+                expected_catalog_generation=authority.catalog_generation,
+                expected_catalog_state=authority.catalog_state,
+                expected_catalog_fingerprint=authority.catalog_fingerprint,
             )
         if self._allow_after_native_prompt(decision):
             return self._allow_and_forward(
@@ -536,6 +1298,11 @@ class RuntimeMcpGuardProxy:
                 signals=decision.signals,
                 risk_categories=decision.risk_categories,
                 params=params,
+                scanner_evidence=decision_scanner_evidence,
+                policy_action="allow",
+                expected_catalog_generation=authority.catalog_generation,
+                expected_catalog_state=authority.catalog_state,
+                expected_catalog_fingerprint=authority.catalog_fingerprint,
             )
         if self._inline_prompt_available and approval_callback is not None:
             approval_result = approval_callback(self._inline_approval_request(tool_name, decision.summary))
@@ -553,6 +1320,11 @@ class RuntimeMcpGuardProxy:
                     risk_categories=decision.risk_categories,
                     params=params,
                     remember=True,
+                    scanner_evidence=decision_scanner_evidence,
+                    policy_action="allow",
+                    expected_catalog_generation=authority.catalog_generation,
+                    expected_catalog_state=authority.catalog_state,
+                    expected_catalog_fingerprint=authority.catalog_fingerprint,
                 )
             if _approval_denies(approval_result):
                 block_tool_call(
@@ -563,15 +1335,20 @@ class RuntimeMcpGuardProxy:
                     now=_now(),
                     signals=decision.signals,
                     risk_categories=decision.risk_categories,
-                    arguments=arguments,
+                    arguments=_safe_mcp_arguments(arguments),
+                    additional_scanner_evidence=decision_scanner_evidence,
+                    policy_action="block",
                 )
                 return _blocked_tool_response(
                     message.get("id"),
                     tool_name,
                     f"HOL Guard blocked tool call {tool_name} from {self.server_name}.",
+                    {"approvalRequests": [], "guardPolicyAction": "block"},
                 ), {
                     **event,
                     "decision": "deny-inline",
+                    "policy_action": "block",
+                    "approval_requests": [],
                 }
             if _approval_invalid(approval_result):
                 block_tool_call(
@@ -582,7 +1359,9 @@ class RuntimeMcpGuardProxy:
                     now=_now(),
                     signals=decision.signals,
                     risk_categories=decision.risk_categories,
-                    arguments=arguments,
+                    arguments=_safe_mcp_arguments(arguments),
+                    additional_scanner_evidence=decision_scanner_evidence,
+                    policy_action="block",
                 )
                 return _blocked_tool_response(
                     message.get("id"),
@@ -591,21 +1370,81 @@ class RuntimeMcpGuardProxy:
                         f"HOL Guard blocked tool call {tool_name} from {self.server_name} because inline "
                         "approval returned an invalid response."
                     ),
+                    {"approvalRequests": [], "guardPolicyAction": "block"},
                 ), {
                     **event,
                     "decision": "deny-inline-invalid",
+                    "policy_action": "block",
+                    "approval_requests": [],
                 }
         if self.config.mode == "observe":
-            self._queue_observed_approval_requests(
-                artifact=artifact,
-                artifact_hash=tool_artifact_hash,
+            try:
+                catalog_current = self._drain_and_validate_catalog_authority(
+                    child_stdin=child_stdin,
+                    child_stdout=child_stdout,
+                    client_input=client_input,
+                    server_output=server_output,
+                    generation=authority.catalog_generation,
+                    state=authority.catalog_state,
+                    fingerprint=authority.catalog_fingerprint,
+                )
+            except Exception:
+                self._poison_tools_catalog()
+                catalog_current = False
+            if not catalog_current:
+                return self._catalog_boundary_failure_response(
+                    message_id=message.get("id"),
+                    tool_name=tool_name,
+                    params=params,
+                    scanner_evidence=decision_scanner_evidence,
+                    phase="before_observe_revalidation",
+                    package_request=False,
+                )
+            fresh_authority = self._resolve_tool_call_authority(
                 tool_name=tool_name,
-                params=params,
-                policy_action="require-reapproval",
-                risk_summary=decision.summary,
-                risk_signals=list(decision.signals),
-                extra_fields={"scanner_evidence": list(decision_normalization_evidence)},
+                arguments=arguments,
             )
+            artifact = fresh_authority.artifact
+            tool_artifact_hash = fresh_authority.artifact_hash
+            authority = fresh_authority
+            fresh_decision = fresh_authority.decision
+            fresh_scanner_evidence = _tool_decision_scanner_evidence(fresh_decision)
+            if fresh_decision.saved_action == "block":
+                return self._stored_tool_block_response(
+                    message_id=message.get("id"),
+                    artifact=artifact,
+                    artifact_hash=tool_artifact_hash,
+                    tool_name=tool_name,
+                    params=params,
+                    signals=fresh_decision.signals,
+                    risk_categories=fresh_decision.risk_categories,
+                    scanner_evidence=fresh_scanner_evidence,
+                    package_request=False,
+                )
+            fresh_policy_action = _enforcement_action(fresh_decision.current_action or fresh_decision.action)
+            if fresh_policy_action in {"block", "sandbox-required"}:
+                return self._terminal_tool_response(
+                    message_id=message.get("id"),
+                    artifact=artifact,
+                    artifact_hash=tool_artifact_hash,
+                    tool_name=tool_name,
+                    params=params,
+                    policy_action=fresh_policy_action,
+                    signals=fresh_decision.signals,
+                    risk_categories=fresh_decision.risk_categories,
+                    scanner_evidence=fresh_scanner_evidence,
+                )
+            if not is_execution_permitted(fresh_policy_action):
+                self._queue_observed_approval_requests(
+                    artifact=artifact,
+                    artifact_hash=tool_artifact_hash,
+                    tool_name=tool_name,
+                    params=params,
+                    policy_action=fresh_policy_action,
+                    risk_summary=fresh_decision.summary,
+                    risk_signals=list(fresh_decision.signals),
+                    extra_fields={"scanner_evidence": list(fresh_scanner_evidence)},
+                )
             response, observe_event = self._allow_and_forward(
                 message=message,
                 child_stdin=child_stdin,
@@ -614,10 +1453,15 @@ class RuntimeMcpGuardProxy:
                 server_output=server_output,
                 artifact=artifact,
                 artifact_hash=tool_artifact_hash,
-                decision_source="policy-allow",
-                signals=decision.signals,
-                risk_categories=decision.risk_categories,
+                decision_source="policy-observe",
+                signals=fresh_decision.signals,
+                risk_categories=fresh_decision.risk_categories,
                 params=params,
+                scanner_evidence=fresh_scanner_evidence,
+                policy_action=fresh_policy_action,
+                expected_catalog_generation=authority.catalog_generation,
+                expected_catalog_state=authority.catalog_state,
+                expected_catalog_fingerprint=authority.catalog_fingerprint,
             )
             return response, {
                 **observe_event,
@@ -630,7 +1474,8 @@ class RuntimeMcpGuardProxy:
             tool_name=tool_name,
             signals=decision.signals,
             params=params,
-            scanner_evidence=decision_normalization_evidence,
+            scanner_evidence=decision_scanner_evidence,
+            policy_action=tool_policy_action,
         )
         return response, queued_event
 
@@ -650,6 +1495,63 @@ class RuntimeMcpGuardProxy:
             source_scope=self.source_scope,
         )
 
+    def _resolve_package_policy(self, *, artifact: Any) -> _PackagePolicyResolution:
+        package_evaluation = evaluate_package_request_artifact(
+            artifact=artifact,
+            store=self.store,
+            workspace_dir=self.context.workspace_dir,
+        )
+        package_current_action = compose_current_package_policy_action(
+            artifact=artifact,
+            evaluation=package_evaluation,
+            config=self.config,
+        )
+        package_workspace = self.context.workspace_dir or Path.cwd()
+        package_context = build_package_execution_context(
+            workspace_dir=package_workspace,
+            artifact=artifact,
+        )
+        artifact_digest = package_request_policy_hash(
+            artifact=artifact,
+            store=self.store,
+            workspace_dir=package_workspace,
+            evaluation=package_evaluation,
+            execution_context=package_context,
+            config=self.config,
+        )
+        policy_workspace = package_request_runtime_workspace_scope(
+            artifact_id=artifact.artifact_id,
+            artifact_hash=artifact_digest,
+            artifact_type=artifact.artifact_type,
+            execution_context=package_context,
+        )
+        stored_package_resolution = _resolve_stored_package_policy_override(
+            package_evaluation,
+            store=self.store,
+            artifact=artifact,
+            artifact_hash=artifact_digest,
+            workspace_dir=package_workspace,
+            now=_now(),
+            execution_context=package_context,
+            current_action=package_current_action,
+            claim_saved_approval=False,
+        )
+        resolved_package_evaluation = stored_package_resolution.evaluation
+        return _PackagePolicyResolution(
+            base_evaluation=package_evaluation,
+            evaluation=resolved_package_evaluation,
+            current_action=package_current_action,
+            workspace=package_workspace,
+            execution_context=package_context,
+            artifact_digest=artifact_digest,
+            policy_workspace=policy_workspace,
+            saved_policy_blocks=any(
+                reason.get("code") == "saved_package_block" for reason in resolved_package_evaluation.reasons
+            ),
+            pending_approval_reuse_decision=stored_package_resolution.approval_reuse_decision,
+            approval_reuse_claim_disposition=stored_package_resolution.claim_disposition,
+        )
+
     def _handle_package_request(
         self,
         *,
@@ -661,225 +1563,667 @@ class RuntimeMcpGuardProxy:
         tool_name: str,
         params: dict[str, Any],
         artifact: Any,
+        tool_artifact: Any,
+        tool_artifact_hash: str,
+        tool_decision: ToolCallDecision,
+        tool_scanner_evidence: tuple[dict[str, object], ...],
+        package_resolution: _PackagePolicyResolution,
+        expected_catalog_generation: int,
+        expected_catalog_state: _ToolCatalogState,
+        expected_catalog_fingerprint: str,
         remember_allow: bool = False,
         remember_decision_source: str | None = None,
         remember_signals: tuple[str, ...] = (),
         remember_risk_categories: tuple[str, ...] = (),
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        package_evaluation = evaluate_package_request_artifact(
-            artifact=artifact,
-            store=self.store,
-            workspace_dir=self.context.workspace_dir,
+        package_evaluation = package_resolution.evaluation
+        scanner_evidence = self._package_scanner_evidence(
+            resolution=package_resolution,
+            tool_evidence=tool_scanner_evidence,
         )
-        package_context = None
-        policy_workspace = str(self.context.workspace_dir) if self.context.workspace_dir is not None else None
-        if self.context.workspace_dir is not None:
-            package_context = build_package_execution_context(
-                workspace_dir=self.context.workspace_dir,
-                artifact=artifact,
-            )
-            artifact_digest = package_request_policy_hash(
-                artifact=artifact,
-                store=self.store,
-                workspace_dir=self.context.workspace_dir,
-                evaluation=package_evaluation,
-                execution_context=package_context,
-            )
-            policy_workspace = package_request_runtime_workspace_scope(
-                artifact_id=artifact.artifact_id,
-                artifact_hash=artifact_digest,
-                artifact_type=artifact.artifact_type,
-                execution_context=package_context,
-            )
-        else:
-            artifact_digest = compute_artifact_hash(artifact)
-        stored_policy_action = self.store.resolve_policy(
-            artifact.harness,
-            artifact.artifact_id,
-            artifact_hash=artifact_digest,
-            workspace=policy_workspace,
-        )
-        current_action_normalization = normalize_guard_action_result(package_evaluation.policy_action)
-        stored_action_normalization = (
-            normalize_guard_action_result(stored_policy_action) if stored_policy_action is not None else None
-        )
-        policy_action = _most_restrictive_package_policy_action(stored_policy_action, package_evaluation.policy_action)
-        action_normalization_evidence = tuple(
-            evidence
-            for evidence in (
-                _guard_action_normalization_evidence("package_evaluation", current_action_normalization),
-                (
-                    _guard_action_normalization_evidence("stored_policy", stored_action_normalization)
-                    if stored_action_normalization is not None
-                    else None
-                ),
-            )
-            if evidence is not None
-        )
-        effective_package_reasons = (
-            *package_evaluation.reasons,
-            *(
-                {
-                    "code": evidence["reason_code"],
-                    "message": "Guard found an unknown action and conservatively requires review.",
-                    "original_action": evidence["original_action"],
-                    "normalized_action": evidence["normalized_action"],
-                }
-                for evidence in action_normalization_evidence
-            ),
-        )
-        package_scanner_evidence = [
-            *([package_context.to_evidence()] if package_context is not None else []),
-            *action_normalization_evidence,
-        ]
-        queue_policy_action = "require-reapproval" if policy_action == "review" else policy_action
-        if is_execution_permitted(queue_policy_action):
-            if remember_allow and remember_decision_source is not None:
-                try:
-                    allow_tool_call(
-                        store=self.store,
-                        artifact=artifact,
-                        artifact_hash=artifact_digest,
-                        decision_source=remember_decision_source,
-                        now=_now(),
-                        signals=remember_signals,
-                        risk_categories=remember_risk_categories,
-                        remember=True,
-                        arguments=params.get("arguments"),
-                        policy_workspace=policy_workspace,
-                    )
-                except ApprovalGateError:
-                    return self._queue_approval_center_response(
-                        message_id=message.get("id"),
-                        artifact=artifact,
-                        artifact_hash=artifact_digest,
-                        tool_name=tool_name,
-                        signals=remember_signals,
-                        params=params,
-                    )
-            response = self._forward_message(
-                message,
-                child_stdin,
-                child_stdout,
+        try:
+            catalog_current = self._drain_and_validate_catalog_authority(
+                child_stdin=child_stdin,
+                child_stdout=child_stdout,
                 client_input=client_input,
                 server_output=server_output,
+                generation=expected_catalog_generation,
+                state=expected_catalog_state,
+                fingerprint=expected_catalog_fingerprint,
             )
-            return response, {
-                "method": "tools/call",
-                "tool_name": tool_name,
-                "decision": "timeout" if _is_timeout_response(response) else f"package-{queue_policy_action}",
-                "redacted_params": _redact_json(params),
-            }
-        if self.config.mode == "observe":
-            decision_v2_payload = build_decision_v2(
-                _guard_action(queue_policy_action),
-                reason=queue_policy_action,
-                signals=_package_reason_signals(effective_package_reasons),
-            ).to_dict()
-            decision_v2_payload["user_title"] = package_evaluation.user_copy.title
-            decision_v2_payload["user_body"] = package_evaluation.user_copy.summary
-            decision_v2_payload["harness_message"] = package_evaluation.user_copy.harness_message
-            decision_v2_payload["dashboard_primary_detail"] = package_evaluation.user_copy.summary
-            self._queue_observed_approval_requests(
-                artifact=artifact,
-                artifact_hash=artifact_digest,
+        except Exception:
+            self._poison_tools_catalog()
+            catalog_current = False
+        if not catalog_current:
+            return self._catalog_boundary_failure_response(
+                message_id=message.get("id"),
                 tool_name=tool_name,
                 params=params,
-                policy_action=queue_policy_action,
-                risk_summary=package_evaluation.risk_summary,
-                risk_signals=[str(item.get("message") or item.get("code") or "") for item in effective_package_reasons],
-                decision_v2_payload=decision_v2_payload,
-                extra_fields={
-                    "changed_fields": ["runtime_tool_call", "package_request"],
-                    "scanner_evidence": package_scanner_evidence,
-                    "supply_chain_evaluation": package_evaluation.to_dict(),
-                },
+                scanner_evidence=scanner_evidence,
+                phase="before_package_revalidation",
+                package_request=True,
             )
-            if remember_allow and remember_decision_source is not None:
-                try:
-                    allow_tool_call(
-                        store=self.store,
-                        artifact=artifact,
-                        artifact_hash=artifact_digest,
-                        decision_source=remember_decision_source,
-                        now=_now(),
-                        signals=remember_signals,
-                        risk_categories=remember_risk_categories,
-                        remember=True,
-                        arguments=params.get("arguments"),
-                        policy_workspace=policy_workspace,
-                    )
-                except ApprovalGateError:
-                    return self._queue_approval_center_response(
-                        message_id=message.get("id"),
-                        artifact=artifact,
-                        artifact_hash=artifact_digest,
-                        tool_name=tool_name,
-                        signals=remember_signals,
-                        params=params,
-                    )
+        if package_resolution.saved_policy_blocks:
+            return self._stored_package_block_response(
+                message_id=message.get("id"),
+                artifact=artifact,
+                artifact_hash=package_resolution.artifact_digest,
+                tool_name=tool_name,
+                params=params,
+                package_evaluation=package_evaluation,
+                scanner_evidence=scanner_evidence,
+            )
+
+        package_action = _enforcement_action(package_evaluation.policy_action)
+        if package_action in {"block", "sandbox-required"}:
+            return self._terminal_package_response(
+                message_id=message.get("id"),
+                artifact=artifact,
+                artifact_hash=package_resolution.artifact_digest,
+                tool_name=tool_name,
+                params=params,
+                package_evaluation=package_evaluation,
+                policy_action=package_action,
+                scanner_evidence=scanner_evidence,
+            )
+        if not is_execution_permitted(package_action) and self.config.mode != "observe":
+            return self._queue_package_approval_response(
+                message_id=message.get("id"),
+                artifact=artifact,
+                artifact_hash=package_resolution.artifact_digest,
+                tool_name=tool_name,
+                params=params,
+                package_evaluation=package_evaluation,
+                policy_action=package_action,
+                scanner_evidence=scanner_evidence,
+            )
+
+        fresh_tool_authority = self._resolve_tool_call_authority(
+            tool_name=tool_name,
+            arguments=params.get("arguments"),
+        )
+        tool_artifact = fresh_tool_authority.artifact
+        tool_artifact_hash = fresh_tool_authority.artifact_hash
+        fresh_tool_decision = fresh_tool_authority.decision
+        expected_catalog_generation = fresh_tool_authority.catalog_generation
+        expected_catalog_state = fresh_tool_authority.catalog_state
+        expected_catalog_fingerprint = fresh_tool_authority.catalog_fingerprint
+        fresh_package_resolution = self._resolve_package_policy(artifact=artifact)
+        fresh_tool_evidence = _tool_decision_scanner_evidence(fresh_tool_decision)
+        fresh_scanner_evidence = self._package_scanner_evidence(
+            resolution=fresh_package_resolution,
+            tool_evidence=fresh_tool_evidence,
+        )
+        if fresh_tool_decision.saved_action == "block":
+            return self._stored_tool_block_response(
+                message_id=message.get("id"),
+                artifact=tool_artifact,
+                artifact_hash=tool_artifact_hash,
+                tool_name=tool_name,
+                params=params,
+                signals=fresh_tool_decision.signals,
+                risk_categories=fresh_tool_decision.risk_categories,
+                scanner_evidence=fresh_tool_evidence,
+                package_request=True,
+            )
+        if fresh_package_resolution.saved_policy_blocks:
+            return self._stored_package_block_response(
+                message_id=message.get("id"),
+                artifact=artifact,
+                artifact_hash=fresh_package_resolution.artifact_digest,
+                tool_name=tool_name,
+                params=params,
+                package_evaluation=fresh_package_resolution.evaluation,
+                scanner_evidence=fresh_scanner_evidence,
+            )
+
+        if self.config.mode == "observe":
+            tool_current_action = _enforcement_action(fresh_tool_decision.current_action or fresh_tool_decision.action)
+            package_current_action = _enforcement_action(fresh_package_resolution.current_action)
+            authoritative_action = most_restrictive_guard_action(tool_current_action, package_current_action)
+            if authoritative_action in {"block", "sandbox-required"}:
+                return self._terminal_package_response(
+                    message_id=message.get("id"),
+                    artifact=artifact,
+                    artifact_hash=fresh_package_resolution.artifact_digest,
+                    tool_name=tool_name,
+                    params=params,
+                    package_evaluation=fresh_package_resolution.evaluation,
+                    policy_action=authoritative_action,
+                    scanner_evidence=fresh_scanner_evidence,
+                )
+            if not is_execution_permitted(authoritative_action):
+                self._queue_observed_package_request(
+                    artifact=artifact,
+                    artifact_hash=fresh_package_resolution.artifact_digest,
+                    tool_name=tool_name,
+                    params=params,
+                    package_evaluation=fresh_package_resolution.evaluation,
+                    policy_action=authoritative_action,
+                    scanner_evidence=fresh_scanner_evidence,
+                )
+            return self._record_package_forward(
+                message=message,
+                child_stdin=child_stdin,
+                child_stdout=child_stdout,
+                client_input=client_input,
+                server_output=server_output,
+                artifact=artifact,
+                artifact_hash=fresh_package_resolution.artifact_digest,
+                tool_name=tool_name,
+                params=params,
+                policy_action=authoritative_action,
+                package_evaluation=fresh_package_resolution.evaluation,
+                scanner_evidence=fresh_scanner_evidence,
+                event_decision="observe-package",
+                remember=False,
+                policy_workspace=fresh_package_resolution.policy_workspace,
+                decision_source="policy-observe",
+                expected_catalog_generation=expected_catalog_generation,
+                expected_catalog_state=expected_catalog_state,
+                expected_catalog_fingerprint=expected_catalog_fingerprint,
+            )
+
+        authoritative_action = most_restrictive_guard_action(
+            fresh_tool_decision.action,
+            fresh_package_resolution.evaluation.policy_action,
+        )
+        authoritative_action = _enforcement_action(authoritative_action)
+        if authoritative_action in {"block", "sandbox-required"}:
+            return self._terminal_package_response(
+                message_id=message.get("id"),
+                artifact=artifact,
+                artifact_hash=fresh_package_resolution.artifact_digest,
+                tool_name=tool_name,
+                params=params,
+                package_evaluation=fresh_package_resolution.evaluation,
+                policy_action=authoritative_action,
+                scanner_evidence=fresh_scanner_evidence,
+            )
+        if not is_execution_permitted(authoritative_action):
+            if not is_execution_permitted(_enforcement_action(fresh_tool_decision.action)):
+                return self._queue_approval_center_response(
+                    message_id=message.get("id"),
+                    artifact=tool_artifact,
+                    artifact_hash=tool_artifact_hash,
+                    tool_name=tool_name,
+                    signals=fresh_tool_decision.signals,
+                    params=params,
+                    scanner_evidence=fresh_tool_evidence,
+                    policy_action=_enforcement_action(fresh_tool_decision.action),
+                )
+            return self._queue_package_approval_response(
+                message_id=message.get("id"),
+                artifact=artifact,
+                artifact_hash=fresh_package_resolution.artifact_digest,
+                tool_name=tool_name,
+                params=params,
+                package_evaluation=fresh_package_resolution.evaluation,
+                policy_action=_enforcement_action(fresh_package_resolution.evaluation.policy_action),
+                scanner_evidence=fresh_scanner_evidence,
+            )
+
+        pending_claims = tuple(
+            decision
+            for decision in (
+                fresh_tool_decision.pending_approval_reuse_decision,
+                fresh_package_resolution.pending_approval_reuse_decision,
+            )
+            if decision is not None
+        )
+        if pending_claims:
+            try:
+                catalog_current = self._drain_and_validate_catalog_authority(
+                    child_stdin=child_stdin,
+                    child_stdout=child_stdout,
+                    client_input=client_input,
+                    server_output=server_output,
+                    generation=expected_catalog_generation,
+                    state=expected_catalog_state,
+                    fingerprint=expected_catalog_fingerprint,
+                )
+            except Exception:
+                self._poison_tools_catalog()
+                catalog_current = False
+            if not catalog_current:
+                return self._catalog_boundary_failure_response(
+                    message_id=message.get("id"),
+                    tool_name=tool_name,
+                    params=params,
+                    scanner_evidence=fresh_scanner_evidence,
+                    phase="before_saved_approval_claim",
+                    package_request=True,
+                )
+        if pending_claims and not self.store.claim_approval_reuse_decisions(pending_claims, now=_now()):
+            claim_failure_item: dict[str, object] = {
+                "source": "approval_reuse",
+                "status": "rejected",
+                "reason_code": APPROVAL_REUSE_CLAIM_FAILED,
+                "effective_action": "require-reapproval",
+            }
+            claim_failure_evidence = (
+                *fresh_scanner_evidence,
+                claim_failure_item,
+            )
+            return self._queue_package_approval_response(
+                message_id=message.get("id"),
+                artifact=artifact,
+                artifact_hash=fresh_package_resolution.artifact_digest,
+                tool_name=tool_name,
+                params=params,
+                package_evaluation=fresh_package_resolution.evaluation,
+                policy_action="require-reapproval",
+                scanner_evidence=claim_failure_evidence,
+            )
+        if pending_claims:
+            try:
+                fresh_config = self._claim_boundary_config()
+            except Exception:
+                return self._queue_package_approval_response(
+                    message_id=message.get("id"),
+                    artifact=artifact,
+                    artifact_hash=fresh_package_resolution.artifact_digest,
+                    tool_name=tool_name,
+                    params=params,
+                    package_evaluation=fresh_package_resolution.evaluation,
+                    policy_action="require-reapproval",
+                    scanner_evidence=_config_refresh_failure_evidence(fresh_scanner_evidence),
+                )
+            self.config = fresh_config
+            claimed_tool_decision = fresh_tool_decision.pending_approval_reuse_decision
+            claimed_tool_disposition = fresh_tool_decision.approval_reuse_claim_disposition
+            claimed_package_decision = fresh_package_resolution.pending_approval_reuse_decision
+            claimed_package_disposition = fresh_package_resolution.approval_reuse_claim_disposition
+            postclaim_tool_authority = self._resolve_tool_call_authority(
+                tool_name=tool_name,
+                arguments=params.get("arguments"),
+            )
+            expected_catalog_generation = postclaim_tool_authority.catalog_generation
+            expected_catalog_state = postclaim_tool_authority.catalog_state
+            expected_catalog_fingerprint = postclaim_tool_authority.catalog_fingerprint
+            postclaim_package_artifact = self._package_request_artifact(
+                tool_name=tool_name,
+                arguments=params.get("arguments"),
+            )
+            postclaim_tool_decision = postclaim_tool_authority.decision
+            postclaim_tool_action = _postclaim_tool_action(postclaim_tool_decision)
+            tool_context_matches = (
+                postclaim_tool_authority.artifact.artifact_id == tool_artifact.artifact_id
+                and postclaim_tool_authority.artifact_hash == tool_artifact_hash
+            )
+            postclaim_tool_evidence = _postclaim_authority_evidence(
+                _tool_decision_scanner_evidence(postclaim_tool_decision),
+                context_matches=tool_context_matches,
+                current_action=postclaim_tool_action,
+            )
+            if postclaim_tool_decision.saved_action == "block":
+                return self._stored_tool_block_response(
+                    message_id=message.get("id"),
+                    artifact=postclaim_tool_authority.artifact,
+                    artifact_hash=postclaim_tool_authority.artifact_hash,
+                    tool_name=tool_name,
+                    params=params,
+                    signals=postclaim_tool_decision.signals,
+                    risk_categories=postclaim_tool_decision.risk_categories,
+                    scanner_evidence=postclaim_tool_evidence,
+                    package_request=True,
+                )
+            if postclaim_tool_action in {"block", "sandbox-required"}:
+                return self._terminal_tool_response(
+                    message_id=message.get("id"),
+                    artifact=postclaim_tool_authority.artifact,
+                    artifact_hash=postclaim_tool_authority.artifact_hash,
+                    tool_name=tool_name,
+                    params=params,
+                    policy_action=postclaim_tool_action,
+                    signals=postclaim_tool_decision.signals,
+                    risk_categories=postclaim_tool_decision.risk_categories,
+                    scanner_evidence=postclaim_tool_evidence,
+                )
+            if postclaim_package_artifact is None:
+                return self._queue_approval_center_response(
+                    message_id=message.get("id"),
+                    artifact=postclaim_tool_authority.artifact,
+                    artifact_hash=postclaim_tool_authority.artifact_hash,
+                    tool_name=tool_name,
+                    signals=postclaim_tool_decision.signals,
+                    params=params,
+                    scanner_evidence=postclaim_tool_evidence,
+                    policy_action="require-reapproval",
+                )
+
+            postclaim_package_resolution = self._resolve_package_policy(
+                artifact=postclaim_package_artifact,
+            )
+            postclaim_package_action = most_restrictive_guard_action(
+                postclaim_package_resolution.current_action,
+                postclaim_package_resolution.evaluation.policy_action,
+                unknown_action="block",
+            )
+            package_context_matches = (
+                postclaim_package_artifact.artifact_id == artifact.artifact_id
+                and postclaim_package_resolution.artifact_digest == fresh_package_resolution.artifact_digest
+            )
+            postclaim_package_evidence = _postclaim_authority_evidence(
+                self._package_scanner_evidence(
+                    resolution=postclaim_package_resolution,
+                    tool_evidence=_tool_decision_scanner_evidence(postclaim_tool_decision),
+                ),
+                context_matches=package_context_matches,
+                current_action=postclaim_package_action,
+            )
+            tool_claim_authorizes_review = claimed_approval_authorizes_postclaim_review(
+                claim_disposition=claimed_tool_disposition,
+                claimed_decision=claimed_tool_decision,
+                current_decision=postclaim_tool_decision.pending_approval_reuse_decision,
+            )
+            package_claim_authorizes_review = claimed_approval_authorizes_postclaim_review(
+                claim_disposition=claimed_package_disposition,
+                claimed_decision=claimed_package_decision,
+                current_decision=postclaim_package_resolution.pending_approval_reuse_decision,
+            )
+            postclaim_tool_evidence = _postclaim_claim_evidence(
+                postclaim_tool_evidence,
+                current_action=postclaim_tool_action,
+                claim_authorizes_review=tool_claim_authorizes_review,
+            )
+            postclaim_package_evidence = _postclaim_claim_evidence(
+                postclaim_package_evidence,
+                current_action=postclaim_package_action,
+                claim_authorizes_review=package_claim_authorizes_review,
+            )
+            if postclaim_package_resolution.saved_policy_blocks:
+                return self._stored_package_block_response(
+                    message_id=message.get("id"),
+                    artifact=postclaim_package_artifact,
+                    artifact_hash=postclaim_package_resolution.artifact_digest,
+                    tool_name=tool_name,
+                    params=params,
+                    package_evaluation=postclaim_package_resolution.evaluation,
+                    scanner_evidence=postclaim_package_evidence,
+                )
+            if postclaim_package_action in {"block", "sandbox-required"}:
+                return self._terminal_package_response(
+                    message_id=message.get("id"),
+                    artifact=postclaim_package_artifact,
+                    artifact_hash=postclaim_package_resolution.artifact_digest,
+                    tool_name=tool_name,
+                    params=params,
+                    package_evaluation=postclaim_package_resolution.evaluation,
+                    policy_action=postclaim_package_action,
+                    scanner_evidence=postclaim_package_evidence,
+                )
+            if (
+                not tool_context_matches
+                or postclaim_tool_action == "require-reapproval"
+                or (postclaim_tool_action == "review" and not tool_claim_authorizes_review)
+            ):
+                return self._queue_approval_center_response(
+                    message_id=message.get("id"),
+                    artifact=postclaim_tool_authority.artifact,
+                    artifact_hash=postclaim_tool_authority.artifact_hash,
+                    tool_name=tool_name,
+                    signals=postclaim_tool_decision.signals,
+                    params=params,
+                    scanner_evidence=postclaim_tool_evidence,
+                    policy_action="require-reapproval",
+                )
+            if (
+                not package_context_matches
+                or postclaim_package_action == "require-reapproval"
+                or (postclaim_package_action == "review" and not package_claim_authorizes_review)
+            ):
+                return self._queue_package_approval_response(
+                    message_id=message.get("id"),
+                    artifact=postclaim_package_artifact,
+                    artifact_hash=postclaim_package_resolution.artifact_digest,
+                    tool_name=tool_name,
+                    params=params,
+                    package_evaluation=postclaim_package_resolution.evaluation,
+                    policy_action="require-reapproval",
+                    scanner_evidence=postclaim_package_evidence,
+                )
+            effective_tool_action: GuardAction = "allow" if postclaim_tool_action == "review" else postclaim_tool_action
+            effective_package_action: GuardAction = (
+                "allow" if postclaim_package_action == "review" else postclaim_package_action
+            )
+            authoritative_action = most_restrictive_guard_action(
+                effective_tool_action,
+                effective_package_action,
+                unknown_action="block",
+            )
+            artifact = postclaim_package_artifact
+            fresh_package_resolution = postclaim_package_resolution
+            fresh_scanner_evidence = postclaim_package_evidence
+        return self._record_package_forward(
+            message=message,
+            child_stdin=child_stdin,
+            child_stdout=child_stdout,
+            client_input=client_input,
+            server_output=server_output,
+            artifact=artifact,
+            artifact_hash=fresh_package_resolution.artifact_digest,
+            tool_name=tool_name,
+            params=params,
+            policy_action=authoritative_action,
+            package_evaluation=fresh_package_resolution.evaluation,
+            scanner_evidence=fresh_scanner_evidence,
+            event_decision=f"package-{authoritative_action}",
+            remember=remember_allow and remember_decision_source is not None,
+            policy_workspace=fresh_package_resolution.policy_workspace,
+            decision_source=remember_decision_source or f"policy-{authoritative_action}",
+            expected_catalog_generation=expected_catalog_generation,
+            expected_catalog_state=expected_catalog_state,
+            expected_catalog_fingerprint=expected_catalog_fingerprint,
+            receipt_signals=remember_signals,
+            receipt_risk_categories=remember_risk_categories,
+        )
+
+    @staticmethod
+    def _package_scanner_evidence(
+        *,
+        resolution: _PackagePolicyResolution,
+        tool_evidence: tuple[dict[str, object], ...],
+    ) -> tuple[dict[str, object], ...]:
+        package_context = resolution.execution_context
+        context_evidence = (
+            (cast(dict[str, object], package_context.to_evidence()),) if package_context is not None else ()
+        )
+        reuse_evidence = tuple(
+            {"source": "approval_reuse", **cast(dict[str, object], raw)}
+            for reason in resolution.evaluation.reasons
+            if isinstance((raw := reason.get("approval_reuse")), dict)
+        )
+        return (*tool_evidence, *context_evidence, *reuse_evidence)
+
+    def _record_package_forward(
+        self,
+        *,
+        message: dict[str, Any],
+        child_stdin: IO[str],
+        child_stdout: IO[str],
+        client_input: TextIO | None,
+        server_output: TextIO | None,
+        artifact: Any,
+        artifact_hash: str,
+        tool_name: str,
+        params: dict[str, Any],
+        policy_action: GuardAction,
+        package_evaluation: Any,
+        scanner_evidence: tuple[dict[str, object], ...],
+        event_decision: str,
+        remember: bool,
+        policy_workspace: str | None,
+        decision_source: str,
+        expected_catalog_generation: int,
+        expected_catalog_state: _ToolCatalogState,
+        expected_catalog_fingerprint: str,
+        receipt_signals: tuple[str, ...] = (),
+        receipt_risk_categories: tuple[str, ...] = (),
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        reason_signals = tuple(
+            str(item.get("message") or item.get("code") or "") for item in package_evaluation.reasons
+        )
+        if remember:
+            allow_tool_call(
+                store=self.store,
+                artifact=artifact,
+                artifact_hash=artifact_hash,
+                decision_source=decision_source,
+                now=_now(),
+                signals=receipt_signals or reason_signals,
+                risk_categories=receipt_risk_categories,
+                remember=True,
+                arguments=_safe_mcp_arguments(params.get("arguments")),
+                policy_workspace=policy_workspace,
+                additional_scanner_evidence=scanner_evidence,
+                policy_action=policy_action,
+                emit_runtime_evidence=False,
+            )
+        try:
             response = self._forward_message(
                 message,
                 child_stdin,
                 child_stdout,
                 client_input=client_input,
                 server_output=server_output,
+                expected_catalog_generation=expected_catalog_generation,
+                expected_catalog_state=expected_catalog_state,
+                expected_catalog_fingerprint=expected_catalog_fingerprint,
             )
-            return response, {
-                "method": "tools/call",
-                "tool_name": tool_name,
-                "decision": "timeout" if _is_timeout_response(response) else "observe-package",
-                "redacted_params": _redact_json(params),
-            }
-        approval_center_url = ensure_guard_daemon(self.context.guard_home)
-        decision_v2_payload = build_decision_v2(
-            _guard_action(queue_policy_action),
-            reason=queue_policy_action,
-            signals=_package_reason_signals(effective_package_reasons),
+        except _ToolCatalogBoundaryChangedError:
+            return self._catalog_boundary_failure_response(
+                message_id=message.get("id"),
+                tool_name=tool_name,
+                params=params,
+                scanner_evidence=scanner_evidence,
+                phase="immediately_before_forward",
+                package_request=True,
+            )
+        allow_tool_call(
+            store=self.store,
+            artifact=artifact,
+            artifact_hash=artifact_hash,
+            decision_source=decision_source,
+            now=_now(),
+            signals=receipt_signals or reason_signals,
+            risk_categories=receipt_risk_categories,
+            remember=False,
+            arguments=_safe_mcp_arguments(params.get("arguments")),
+            policy_workspace=policy_workspace,
+            additional_scanner_evidence=scanner_evidence,
+            policy_action=policy_action,
+        )
+        return response, {
+            "method": "tools/call",
+            "tool_name": tool_name,
+            "decision": "timeout" if _is_timeout_response(response) else event_decision,
+            "policy_action": policy_action,
+            "redacted_params": _safe_mcp_params(params),
+            "scanner_evidence": list(scanner_evidence),
+        }
+
+    def _queue_observed_package_request(
+        self,
+        *,
+        artifact: Any,
+        artifact_hash: str,
+        tool_name: str,
+        params: dict[str, Any],
+        package_evaluation: Any,
+        policy_action: GuardAction,
+        scanner_evidence: tuple[dict[str, object], ...],
+    ) -> None:
+        decision_v2_payload = self._package_decision_v2(package_evaluation, policy_action)
+        self._queue_observed_approval_requests(
+            artifact=artifact,
+            artifact_hash=artifact_hash,
+            tool_name=tool_name,
+            params=params,
+            policy_action=policy_action,
+            risk_summary=package_evaluation.risk_summary,
+            risk_signals=[str(item.get("message") or item.get("code") or "") for item in package_evaluation.reasons],
+            decision_v2_payload=decision_v2_payload,
+            extra_fields={
+                "changed_fields": ["runtime_tool_call", "package_request"],
+                "scanner_evidence": list(scanner_evidence),
+                "supply_chain_evaluation": package_evaluation.to_dict(),
+            },
+        )
+
+    @staticmethod
+    def _package_decision_v2(package_evaluation: Any, policy_action: GuardAction) -> dict[str, Any]:
+        payload = build_decision_v2(
+            policy_action,
+            reason=policy_action,
+            signals=_package_reason_signals(package_evaluation.reasons),
         ).to_dict()
-        decision_v2_payload["user_title"] = package_evaluation.user_copy.title
-        decision_v2_payload["user_body"] = package_evaluation.user_copy.summary
-        decision_v2_payload["harness_message"] = package_evaluation.user_copy.harness_message
-        decision_v2_payload["dashboard_primary_detail"] = package_evaluation.user_copy.summary
-        should_queue_approval_center = not (queue_policy_action == "block" and stored_policy_action == "block")
-        queued: list[dict[str, Any]] = []
-        if should_queue_approval_center:
-            queued = queue_blocked_approvals(
-                redaction_level=self.config.receipt_redaction_level,
-                detection=HarnessDetection(
-                    harness=self.harness,
-                    installed=True,
-                    command_available=True,
-                    config_paths=(self.config_path,),
-                    artifacts=(artifact,),
-                ),
-                evaluation={
-                    "artifacts": [
-                        {
-                            "artifact_id": artifact.artifact_id,
-                            "artifact_name": artifact.name,
-                            "artifact_hash": artifact_digest,
-                            "artifact_type": artifact.artifact_type,
-                            "source_scope": artifact.source_scope,
-                            "config_path": artifact.config_path,
-                            "changed_fields": ["runtime_tool_call", "package_request"],
-                            "policy_action": queue_policy_action,
-                            "launch_target": self._launch_target(tool_name, params.get("arguments")),
-                            "risk_summary": package_evaluation.risk_summary,
-                            "risk_signals": [
-                                str(item.get("message") or item.get("code") or "") for item in effective_package_reasons
-                            ],
-                            "decision_v2_json": decision_v2_payload,
-                            "scanner_evidence": package_scanner_evidence,
-                            "supply_chain_evaluation": package_evaluation.to_dict(),
-                        }
-                    ]
-                },
-                store=self.store,
-                approval_center_url=approval_center_url,
-                now=_now(),
-            )
-        request_id = str(queued[0]["request_id"]) if queued else "stored-block"
+        payload["user_title"] = package_evaluation.user_copy.title
+        payload["user_body"] = package_evaluation.user_copy.summary
+        payload["harness_message"] = package_evaluation.user_copy.harness_message
+        payload["dashboard_primary_detail"] = package_evaluation.user_copy.summary
+        return payload
+
+    def _queue_package_approval_response(
+        self,
+        *,
+        message_id: Any,
+        artifact: Any,
+        artifact_hash: str,
+        tool_name: str,
+        params: dict[str, Any],
+        package_evaluation: Any,
+        policy_action: GuardAction,
+        scanner_evidence: tuple[dict[str, object], ...],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        approval_center_url = ensure_guard_daemon(self.context.guard_home)
+        decision_v2_payload = self._package_decision_v2(package_evaluation, policy_action)
+        risk_signals = tuple(str(item.get("message") or item.get("code") or "") for item in package_evaluation.reasons)
+        queued = queue_blocked_approvals(
+            redaction_level=self.config.receipt_redaction_level,
+            detection=HarnessDetection(
+                harness=self.harness,
+                installed=True,
+                command_available=True,
+                config_paths=(self.config_path,),
+                artifacts=(artifact,),
+            ),
+            evaluation={
+                "artifacts": [
+                    {
+                        "artifact_id": artifact.artifact_id,
+                        "artifact_name": artifact.name,
+                        "artifact_hash": artifact_hash,
+                        "artifact_type": artifact.artifact_type,
+                        "source_scope": artifact.source_scope,
+                        "config_path": artifact.config_path,
+                        "changed_fields": ["runtime_tool_call", "package_request"],
+                        "policy_action": policy_action,
+                        "launch_target": self._launch_target(tool_name, params.get("arguments")),
+                        "risk_summary": package_evaluation.risk_summary,
+                        "risk_signals": list(risk_signals),
+                        "decision_v2_json": decision_v2_payload,
+                        "scanner_evidence": list(scanner_evidence),
+                        "supply_chain_evaluation": package_evaluation.to_dict(),
+                    }
+                ]
+            },
+            store=self.store,
+            approval_center_url=approval_center_url,
+            now=_now(),
+        )
+        block_tool_call(
+            store=self.store,
+            artifact=artifact,
+            artifact_hash=artifact_hash,
+            decision_source="approval-center-pending",
+            now=_now(),
+            signals=risk_signals,
+            arguments=_safe_mcp_arguments(params.get("arguments")),
+            additional_scanner_evidence=scanner_evidence,
+            policy_action=policy_action,
+        )
+        request_id = str(queued[0]["request_id"]) if queued else "unknown"
         review_url = first_approval_url(queued, approval_center_url=approval_center_url) or approval_center_url
         self._maybe_open_approval_center(
             approval_center_url=approval_center_url,
@@ -889,34 +2233,231 @@ class RuntimeMcpGuardProxy:
         response_data = {
             "approvalCenterUrl": approval_center_url,
             "approvalRequests": queued,
+            "guardPolicyAction": policy_action,
             "reviewUrl": review_url,
             "supplyChainEvaluation": package_evaluation.to_dict(),
         }
-        blocked_message = (
-            f"HOL Guard stopped package install request {tool_name} from {self.server_name}. "
-            f"Approve request {request_id} at {review_url}, then retry the same action."
-        )
-        event_decision = "queue-package-approval"
-        if not should_queue_approval_center:
-            blocked_message = (
-                f"HOL Guard blocked package install request {tool_name} from {self.server_name}. "
-                f"This same request is already blocked by stored policy. Review policy settings at {review_url} "
-                f"before retrying."
-            )
-            event_decision = "package-block-stored"
         return _blocked_tool_response(
-            message.get("id"),
+            message_id,
             tool_name,
-            blocked_message,
+            (
+                f"HOL Guard stopped package install request {tool_name} from {self.server_name}. "
+                f"Approve request {request_id} at {review_url}, then retry the same action."
+            ),
             response_data,
         ), {
             "method": "tools/call",
             "tool_name": tool_name,
-            "decision": event_decision,
-            "redacted_params": _redact_json(params),
+            "decision": "queue-package-approval",
+            "policy_action": policy_action,
+            "redacted_params": _safe_mcp_params(params),
             "approval_center_url": approval_center_url,
             "approval_requests": queued,
             "review_url": review_url,
+            "scanner_evidence": list(scanner_evidence),
+        }
+
+    def _terminal_tool_response(
+        self,
+        *,
+        message_id: Any,
+        artifact: Any,
+        artifact_hash: str,
+        tool_name: str,
+        params: dict[str, Any],
+        policy_action: GuardAction,
+        signals: tuple[str, ...],
+        risk_categories: tuple[str, ...],
+        scanner_evidence: tuple[dict[str, object], ...],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        block_tool_call(
+            store=self.store,
+            artifact=artifact,
+            artifact_hash=artifact_hash,
+            decision_source="policy-block",
+            now=_now(),
+            signals=signals,
+            risk_categories=risk_categories,
+            arguments=_safe_mcp_arguments(params.get("arguments")),
+            additional_scanner_evidence=scanner_evidence,
+            policy_action=policy_action,
+        )
+        reason = (
+            f"HOL Guard blocked tool call {tool_name} from {self.server_name}."
+            if policy_action == "block"
+            else (
+                f"HOL Guard requires an enforceable sandbox for tool call {tool_name} from "
+                f"{self.server_name}; this runtime cannot provide one."
+            )
+        )
+        response = _blocked_tool_response(
+            message_id,
+            tool_name,
+            reason,
+            {"approvalRequests": [], "guardPolicyAction": policy_action},
+        )
+        event: dict[str, Any] = {
+            "method": "tools/call",
+            "tool_name": tool_name,
+            "decision": f"terminal-{policy_action}",
+            "policy_action": policy_action,
+            "redacted_params": _safe_mcp_params(params),
+            "approval_requests": [],
+        }
+        if scanner_evidence:
+            event["scanner_evidence"] = list(scanner_evidence)
+        return response, event
+
+    def _terminal_package_response(
+        self,
+        *,
+        message_id: Any,
+        artifact: Any,
+        artifact_hash: str,
+        tool_name: str,
+        params: dict[str, Any],
+        package_evaluation: Any,
+        policy_action: GuardAction,
+        scanner_evidence: tuple[dict[str, object], ...],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        reason_signals = tuple(
+            str(item.get("message") or item.get("code") or "") for item in package_evaluation.reasons
+        )
+        block_tool_call(
+            store=self.store,
+            artifact=artifact,
+            artifact_hash=artifact_hash,
+            decision_source="policy-block",
+            now=_now(),
+            signals=reason_signals,
+            arguments=_safe_mcp_arguments(params.get("arguments")),
+            additional_scanner_evidence=scanner_evidence,
+            policy_action=policy_action,
+        )
+        reason = (
+            f"HOL Guard blocked package install request {tool_name} from {self.server_name}."
+            if policy_action == "block"
+            else (
+                f"HOL Guard requires an enforceable sandbox for package install request {tool_name} from "
+                f"{self.server_name}; this runtime cannot provide one."
+            )
+        )
+        response = _blocked_tool_response(
+            message_id,
+            tool_name,
+            reason,
+            {
+                "approvalRequests": [],
+                "guardPolicyAction": policy_action,
+                "supplyChainEvaluation": package_evaluation.to_dict(),
+            },
+        )
+        return response, {
+            "method": "tools/call",
+            "tool_name": tool_name,
+            "decision": f"terminal-package-{policy_action}",
+            "policy_action": policy_action,
+            "redacted_params": _safe_mcp_params(params),
+            "approval_requests": [],
+            "scanner_evidence": list(scanner_evidence),
+        }
+
+    def _stored_tool_block_response(
+        self,
+        *,
+        message_id: Any,
+        artifact: Any,
+        artifact_hash: str,
+        tool_name: str,
+        params: dict[str, Any],
+        signals: tuple[str, ...],
+        risk_categories: tuple[str, ...],
+        scanner_evidence: tuple[dict[str, object], ...],
+        package_request: bool,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        block_tool_call(
+            store=self.store,
+            artifact=artifact,
+            artifact_hash=artifact_hash,
+            decision_source="policy-block",
+            now=_now(),
+            signals=signals,
+            risk_categories=risk_categories,
+            arguments=_safe_mcp_arguments(params.get("arguments")),
+            additional_scanner_evidence=scanner_evidence,
+            policy_action="block",
+        )
+        request_kind = "package tool call" if package_request else "tool call"
+        response = _blocked_tool_response(
+            message_id,
+            tool_name,
+            (
+                f"HOL Guard blocked {request_kind} {tool_name} from {self.server_name}. "
+                "This exact request is already blocked by authenticated saved policy."
+            ),
+            {
+                "approvalRequests": [],
+                "guardPolicyAction": "block",
+            },
+        )
+        event: dict[str, Any] = {
+            "method": "tools/call",
+            "tool_name": tool_name,
+            "decision": "block-stored-policy",
+            "policy_action": "block",
+            "redacted_params": _safe_mcp_params(params),
+            "approval_requests": [],
+        }
+        if scanner_evidence:
+            event["scanner_evidence"] = list(scanner_evidence)
+        return response, event
+
+    def _stored_package_block_response(
+        self,
+        *,
+        message_id: Any,
+        artifact: Any,
+        artifact_hash: str,
+        tool_name: str,
+        params: dict[str, Any],
+        package_evaluation: Any,
+        scanner_evidence: tuple[dict[str, object], ...],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        reason_signals = tuple(
+            str(item.get("message") or item.get("code") or "") for item in package_evaluation.reasons
+        )
+        block_tool_call(
+            store=self.store,
+            artifact=artifact,
+            artifact_hash=artifact_hash,
+            decision_source="policy-block",
+            now=_now(),
+            signals=reason_signals,
+            arguments=_safe_mcp_arguments(params.get("arguments")),
+            additional_scanner_evidence=scanner_evidence,
+            policy_action="block",
+        )
+        response = _blocked_tool_response(
+            message_id,
+            tool_name,
+            (
+                f"HOL Guard blocked package install request {tool_name} from {self.server_name}. "
+                "This exact request is already blocked by stored policy with authenticated local integrity."
+            ),
+            {
+                "approvalRequests": [],
+                "guardPolicyAction": "block",
+                "supplyChainEvaluation": package_evaluation.to_dict(),
+            },
+        )
+        return response, {
+            "method": "tools/call",
+            "tool_name": tool_name,
+            "decision": "package-block-stored",
+            "policy_action": "block",
+            "redacted_params": _safe_mcp_params(params),
+            "approval_requests": [],
+            "scanner_evidence": list(scanner_evidence),
         }
 
     def _record_client_capabilities(self, method: str, params: object) -> None:
@@ -943,22 +2484,65 @@ class RuntimeMcpGuardProxy:
         signals: tuple[str, ...],
         risk_categories: tuple[str, ...],
         params: dict[str, Any],
+        expected_catalog_generation: int | None = None,
+        expected_catalog_state: _ToolCatalogState | None = None,
+        expected_catalog_fingerprint: str | None = None,
         remember: bool = False,
+        scanner_evidence: tuple[dict[str, object], ...] = (),
+        policy_action: GuardAction = "allow",
+        approval_decision: ToolCallDecision | None = None,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        try:
-            allow_tool_call(
-                store=self.store,
-                artifact=artifact,
-                artifact_hash=artifact_hash,
-                decision_source=decision_source,
-                now=_now(),
-                signals=signals,
-                risk_categories=risk_categories,
-                remember=remember,
-                arguments=params.get("arguments"),
-            )
-        except ApprovalGateError:
-            if remember:
+        pending = approval_decision.pending_approval_reuse_decision if approval_decision is not None else None
+        claim_disposition = (
+            approval_decision.approval_reuse_claim_disposition if approval_decision is not None else None
+        )
+        if pending is not None:
+            if (
+                expected_catalog_generation is None
+                or expected_catalog_state is None
+                or expected_catalog_fingerprint is None
+            ):
+                return self._catalog_boundary_failure_response(
+                    message_id=message.get("id"),
+                    tool_name=str(params.get("name") or artifact.name),
+                    params=params,
+                    scanner_evidence=scanner_evidence,
+                    phase="missing_saved_approval_boundary",
+                    package_request=False,
+                )
+            try:
+                catalog_current = self._drain_and_validate_catalog_authority(
+                    child_stdin=child_stdin,
+                    child_stdout=child_stdout,
+                    client_input=client_input,
+                    server_output=server_output,
+                    generation=expected_catalog_generation,
+                    state=expected_catalog_state,
+                    fingerprint=expected_catalog_fingerprint,
+                )
+            except Exception:
+                self._poison_tools_catalog()
+                catalog_current = False
+            if not catalog_current:
+                return self._catalog_boundary_failure_response(
+                    message_id=message.get("id"),
+                    tool_name=str(params.get("name") or artifact.name),
+                    params=params,
+                    scanner_evidence=scanner_evidence,
+                    phase="before_saved_approval_claim",
+                    package_request=False,
+                )
+            if not self.store.claim_approval_reuse_decisions((pending,), now=_now()):
+                claim_failure_item: dict[str, object] = {
+                    "source": "approval_reuse",
+                    "status": "rejected",
+                    "reason_code": APPROVAL_REUSE_CLAIM_FAILED,
+                    "effective_action": "require-reapproval",
+                }
+                failed_evidence = (
+                    *scanner_evidence,
+                    claim_failure_item,
+                )
                 return self._queue_approval_center_response(
                     message_id=message.get("id"),
                     artifact=artifact,
@@ -966,26 +2550,332 @@ class RuntimeMcpGuardProxy:
                     tool_name=str(params.get("name") or artifact.name),
                     signals=signals,
                     params=params,
+                    scanner_evidence=failed_evidence,
+                    policy_action="require-reapproval",
                 )
-            raise
-        response = self._forward_message(
-            message,
-            child_stdin,
-            child_stdout,
-            client_input=client_input,
-            server_output=server_output,
+
+            tool_name = str(params.get("name") or artifact.name)
+            try:
+                fresh_config = self._claim_boundary_config()
+            except Exception:
+                return self._queue_approval_center_response(
+                    message_id=message.get("id"),
+                    artifact=artifact,
+                    artifact_hash=artifact_hash,
+                    tool_name=tool_name,
+                    signals=signals,
+                    params=params,
+                    scanner_evidence=_config_refresh_failure_evidence(scanner_evidence),
+                    policy_action="require-reapproval",
+                )
+            self.config = fresh_config
+            arguments = params.get("arguments")
+            fresh_authority = self._resolve_tool_call_authority(
+                tool_name=tool_name,
+                arguments=arguments,
+                config=fresh_config,
+            )
+            expected_catalog_generation = fresh_authority.catalog_generation
+            expected_catalog_state = fresh_authority.catalog_state
+            expected_catalog_fingerprint = fresh_authority.catalog_fingerprint
+            fresh_decision = fresh_authority.decision
+            fresh_evidence = _tool_decision_scanner_evidence(fresh_decision)
+            fresh_action = _postclaim_tool_action(fresh_decision)
+            context_matches = (
+                fresh_authority.artifact.artifact_id == artifact.artifact_id
+                and fresh_authority.artifact_hash == artifact_hash
+            )
+            postclaim_evidence = _postclaim_authority_evidence(
+                fresh_evidence,
+                context_matches=context_matches,
+                current_action=fresh_action,
+            )
+            claim_authorizes_review = claimed_approval_authorizes_postclaim_review(
+                claim_disposition=claim_disposition,
+                claimed_decision=pending,
+                current_decision=fresh_decision.pending_approval_reuse_decision,
+            )
+            postclaim_evidence = _postclaim_claim_evidence(
+                postclaim_evidence,
+                current_action=fresh_action,
+                claim_authorizes_review=claim_authorizes_review,
+            )
+            if fresh_decision.saved_action == "block":
+                return self._stored_tool_block_response(
+                    message_id=message.get("id"),
+                    artifact=fresh_authority.artifact,
+                    artifact_hash=fresh_authority.artifact_hash,
+                    tool_name=tool_name,
+                    params=params,
+                    signals=fresh_decision.signals,
+                    risk_categories=fresh_decision.risk_categories,
+                    scanner_evidence=postclaim_evidence,
+                    package_request=False,
+                )
+            if fresh_action in {"block", "sandbox-required"}:
+                return self._terminal_tool_response(
+                    message_id=message.get("id"),
+                    artifact=fresh_authority.artifact,
+                    artifact_hash=fresh_authority.artifact_hash,
+                    tool_name=tool_name,
+                    params=params,
+                    policy_action=fresh_action,
+                    signals=fresh_decision.signals,
+                    risk_categories=fresh_decision.risk_categories,
+                    scanner_evidence=postclaim_evidence,
+                )
+            if (
+                not context_matches
+                or fresh_action == "require-reapproval"
+                or (fresh_action == "review" and not claim_authorizes_review)
+            ):
+                return self._queue_approval_center_response(
+                    message_id=message.get("id"),
+                    artifact=fresh_authority.artifact,
+                    artifact_hash=fresh_authority.artifact_hash,
+                    tool_name=tool_name,
+                    signals=fresh_decision.signals,
+                    params=params,
+                    scanner_evidence=postclaim_evidence,
+                    policy_action="require-reapproval",
+                )
+            # An unchanged current review is satisfied by the exact claim. A
+            # current allow/warn is independently executable. Carry the fresh
+            # identity and risk material into the final receipt and forward.
+            artifact = fresh_authority.artifact
+            artifact_hash = fresh_authority.artifact_hash
+            signals = fresh_decision.signals
+            risk_categories = fresh_decision.risk_categories
+            scanner_evidence = postclaim_evidence
+        if remember:
+            try:
+                allow_tool_call(
+                    store=self.store,
+                    artifact=artifact,
+                    artifact_hash=artifact_hash,
+                    decision_source=decision_source,
+                    now=_now(),
+                    signals=signals,
+                    risk_categories=risk_categories,
+                    remember=True,
+                    arguments=_safe_mcp_arguments(params.get("arguments")),
+                    additional_scanner_evidence=scanner_evidence,
+                    policy_action=policy_action,
+                    emit_runtime_evidence=False,
+                )
+            except ApprovalGateError:
+                return self._queue_approval_center_response(
+                    message_id=message.get("id"),
+                    artifact=artifact,
+                    artifact_hash=artifact_hash,
+                    tool_name=str(params.get("name") or artifact.name),
+                    signals=signals,
+                    params=params,
+                    scanner_evidence=scanner_evidence,
+                    policy_action="require-reapproval",
+                )
+        try:
+            response = self._forward_message(
+                message,
+                child_stdin,
+                child_stdout,
+                client_input=client_input,
+                server_output=server_output,
+                expected_catalog_generation=expected_catalog_generation,
+                expected_catalog_state=expected_catalog_state,
+                expected_catalog_fingerprint=expected_catalog_fingerprint,
+            )
+        except _ToolCatalogBoundaryChangedError:
+            return self._catalog_boundary_failure_response(
+                message_id=message.get("id"),
+                tool_name=str(params.get("name") or artifact.name),
+                params=params,
+                scanner_evidence=scanner_evidence,
+                phase="immediately_before_forward",
+                package_request=False,
+            )
+        allow_tool_call(
+            store=self.store,
+            artifact=artifact,
+            artifact_hash=artifact_hash,
+            decision_source=decision_source,
+            now=_now(),
+            signals=signals,
+            risk_categories=risk_categories,
+            remember=False,
+            arguments=_safe_mcp_arguments(params.get("arguments")),
+            additional_scanner_evidence=scanner_evidence,
+            policy_action=policy_action,
         )
-        return response, {
+        event: dict[str, Any] = {
             "method": "tools/call",
             "tool_name": params.get("name"),
             "decision": "timeout" if _is_timeout_response(response) else decision_source,
-            "redacted_params": _redact_json(params),
+            "policy_action": policy_action,
+            "redacted_params": _safe_mcp_params(params),
         }
+        if scanner_evidence:
+            event["scanner_evidence"] = list(scanner_evidence)
+        return response, event
 
     @staticmethod
     def _forward_notification(message: dict[str, Any], child_stdin: IO[str]) -> None:
         child_stdin.write(json.dumps(message) + "\n")
         child_stdin.flush()
+
+    def _next_child_output_frame(
+        self,
+        child_stdout: IO[str],
+        *,
+        timeout_seconds: float,
+        required: bool,
+    ) -> _ChildOutputFrame | None:
+        output_queue = self._child_output_queue if child_stdout is self._active_child_stdout else None
+        if output_queue is not None:
+            try:
+                if required:
+                    return output_queue.get(timeout=timeout_seconds)
+                if timeout_seconds > 0:
+                    return output_queue.get(timeout=timeout_seconds)
+                return output_queue.get_nowait()
+            except queue.Empty as exc:
+                if required:
+                    raise ProxyIoTimeoutError(
+                        source="child_response",
+                        timeout_seconds=timeout_seconds,
+                    ) from exc
+                return None
+
+        if not required and isinstance(child_stdout, io.StringIO):
+            if child_stdout.tell() >= len(child_stdout.getvalue()):
+                return None
+            return _ChildOutputFrame(line=child_stdout.readline())
+        try:
+            line = _readline_with_timeout(
+                child_stdout,
+                timeout_seconds,
+                source="child_response",
+                allow_background_wait=required,
+            )
+        except ProxyIoTimeoutError:
+            if required:
+                raise
+            return None
+        return _ChildOutputFrame(line=line)
+
+    @staticmethod
+    def _child_output_line(frame: _ChildOutputFrame) -> str:
+        if frame.error is not None:
+            raise frame.error
+        if frame.line is None or not frame.line:
+            raise RuntimeError("Guard stdio proxy did not receive a response from the MCP server.")
+        return frame.line
+
+    def _multiplex_child_payload(
+        self,
+        payload: dict[str, Any],
+        *,
+        child_stdin: IO[str],
+        child_stdout: IO[str],
+        client_input: TextIO | None,
+        server_output: TextIO | None,
+    ) -> None:
+        method = str(payload.get("method", ""))
+        if method in {"notifications/tools/list_changed", "tools/list_changed"}:
+            self._invalidate_tools_catalog()
+        if _is_request(payload):
+            self._proxy_child_request(
+                payload=payload,
+                child_stdin=child_stdin,
+                child_stdout=child_stdout,
+                client_input=client_input,
+                server_output=server_output,
+            )
+            return
+        if "id" in payload:
+            self._buffer_child_response(payload)
+            return
+        if server_output is not None:
+            server_output.write(json.dumps(payload) + "\n")
+            server_output.flush()
+
+    def _drain_child_messages(
+        self,
+        *,
+        child_stdin: IO[str],
+        child_stdout: IO[str],
+        client_input: TextIO | None,
+        server_output: TextIO | None,
+        quiet_seconds: float = 0.0,
+    ) -> None:
+        """Multiplex every queued child frame and wait for an optional quiet edge."""
+
+        while True:
+            frame = self._next_child_output_frame(
+                child_stdout,
+                timeout_seconds=quiet_seconds,
+                required=False,
+            )
+            if frame is None:
+                return
+            line = self._child_output_line(frame)
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                self._poison_tools_catalog()
+                raise
+            if not isinstance(payload, dict):
+                self._poison_tools_catalog()
+                raise RuntimeError("Guard runtime MCP proxy received a non-object child payload.")
+            self._multiplex_child_payload(
+                payload,
+                child_stdin=child_stdin,
+                child_stdout=child_stdout,
+                client_input=client_input,
+                server_output=server_output,
+            )
+
+    def _catalog_authority_matches(
+        self,
+        *,
+        generation: int,
+        state: _ToolCatalogState,
+        fingerprint: str,
+    ) -> bool:
+        return (
+            generation == self._tool_catalog_generation
+            and state == self._tool_catalog_state
+            and fingerprint
+            == _tool_catalog_fingerprint(
+                self._tool_catalog,
+                state=self._tool_catalog_state,
+            )
+        )
+
+    def _drain_and_validate_catalog_authority(
+        self,
+        *,
+        child_stdin: IO[str],
+        child_stdout: IO[str],
+        client_input: TextIO | None,
+        server_output: TextIO | None,
+        generation: int,
+        state: _ToolCatalogState,
+        fingerprint: str,
+        quiet_seconds: float = 0.0,
+    ) -> bool:
+        self._drain_child_messages(
+            child_stdin=child_stdin,
+            child_stdout=child_stdout,
+            client_input=client_input,
+            server_output=server_output,
+            quiet_seconds=quiet_seconds,
+        )
+        return self._catalog_authority_matches(
+            generation=generation,
+            state=state,
+            fingerprint=fingerprint,
+        )
 
     def _forward_message(
         self,
@@ -995,8 +2885,28 @@ class RuntimeMcpGuardProxy:
         *,
         client_input: TextIO | None,
         server_output: TextIO | None,
+        expected_catalog_generation: int | None = None,
+        expected_catalog_state: _ToolCatalogState | None = None,
+        expected_catalog_fingerprint: str | None = None,
     ) -> dict[str, Any]:
         request_id = message.get("id")
+        if (
+            str(message.get("method", "")) == "tools/call"
+            and expected_catalog_generation is not None
+            and expected_catalog_state is not None
+            and expected_catalog_fingerprint is not None
+            and not self._drain_and_validate_catalog_authority(
+                child_stdin=child_stdin,
+                child_stdout=child_stdout,
+                client_input=client_input,
+                server_output=server_output,
+                generation=expected_catalog_generation,
+                state=expected_catalog_state,
+                fingerprint=expected_catalog_fingerprint,
+                quiet_seconds=_TOOLS_CALL_PREWRITE_QUIET_SECONDS,
+            )
+        ):
+            raise _ToolCatalogBoundaryChangedError(_TOOL_CATALOG_EXECUTION_BOUNDARY_CHANGED)
         child_stdin.write(json.dumps(message) + "\n")
         child_stdin.flush()
         while True:
@@ -1005,7 +2915,11 @@ class RuntimeMcpGuardProxy:
                 return buffered_response
             timeout_seconds = self._child_response_timeout_seconds()
             try:
-                line = _readline_with_timeout(child_stdout, timeout_seconds, source="child_response")
+                frame = self._next_child_output_frame(
+                    child_stdout,
+                    timeout_seconds=timeout_seconds,
+                    required=True,
+                )
             except ProxyIoTimeoutError:
                 active_process = self._active_process
                 if active_process is not None:
@@ -1016,28 +2930,20 @@ class RuntimeMcpGuardProxy:
                     timeout_seconds=timeout_seconds,
                     message="Guard runtime MCP proxy timed out waiting for the MCP server.",
                 )
-            if not line:
-                raise RuntimeError("Guard stdio proxy did not receive a response from the MCP server.")
+            assert frame is not None
+            line = self._child_output_line(frame)
             payload = json.loads(line)
+            if not isinstance(payload, dict):
+                raise RuntimeError("Guard runtime MCP proxy received a non-object child payload.")
             if payload.get("id") == request_id and not _is_request(payload):
                 return payload
-            if _is_request(payload):
-                self._proxy_child_request(
-                    payload=payload,
-                    child_stdin=child_stdin,
-                    child_stdout=child_stdout,
-                    client_input=client_input,
-                    server_output=server_output,
-                )
-                continue
-            if "id" in payload:
-                self._buffer_child_response(payload)
-                continue
-            if str(payload.get("method", "")) in {"notifications/tools/list_changed", "tools/list_changed"}:
-                self._invalidate_tools_catalog()
-            if server_output is not None:
-                server_output.write(json.dumps(payload) + "\n")
-                server_output.flush()
+            self._multiplex_child_payload(
+                payload,
+                child_stdin=child_stdin,
+                child_stdout=child_stdout,
+                client_input=client_input,
+                server_output=server_output,
+            )
 
     def _buffer_child_response(self, payload: dict[str, Any]) -> None:
         response_key = _response_key(payload.get("id"))
@@ -1224,24 +3130,29 @@ class RuntimeMcpGuardProxy:
             # Build a safer browser-specific launch target label
             target = browser_intent.target_domain or browser_intent.target_origin or "unknown"
             launch_target = f"{browser_intent.mcp_server_name} {browser_intent.operation} {target}"
-            browser_intent_dict = {
-                "version": browser_intent.version,
-                "intent": browser_intent.intent,
-                "operation": browser_intent.operation,
-                "target_url": browser_intent.target_url,
-                "target_origin": browser_intent.target_origin,
-                "target_domain": browser_intent.target_domain,
-                "target_path_prefix": browser_intent.target_path_prefix,
-                "method": browser_intent.method,
-                "profile_mode": browser_intent.profile_mode,
-                "mcp_server_name": browser_intent.mcp_server_name,
-                "mcp_server_identity_hash": browser_intent.mcp_server_identity_hash,
-                "mcp_tool_name": browser_intent.mcp_tool_name,
-                "mcp_tool_identity_hash": browser_intent.mcp_tool_identity_hash,
-                "mcp_schema_hash": browser_intent.mcp_schema_hash,
-                "sensitive_surface_flags": list(browser_intent.sensitive_surface_flags),
-                "volatile_fields_dropped": list(browser_intent.volatile_fields_dropped),
-            }
+            browser_intent_dict = cast(
+                dict[str, object],
+                _safe_mcp_arguments(
+                    {
+                        "version": browser_intent.version,
+                        "intent": browser_intent.intent,
+                        "operation": browser_intent.operation,
+                        "target_url": browser_intent.target_url,
+                        "target_origin": browser_intent.target_origin,
+                        "target_domain": browser_intent.target_domain,
+                        "target_path_prefix": browser_intent.target_path_prefix,
+                        "method": browser_intent.method,
+                        "profile_mode": browser_intent.profile_mode,
+                        "mcp_server_name": browser_intent.mcp_server_name,
+                        "mcp_server_identity_hash": browser_intent.mcp_server_identity_hash,
+                        "mcp_tool_name": browser_intent.mcp_tool_name,
+                        "mcp_tool_identity_hash": browser_intent.mcp_tool_identity_hash,
+                        "mcp_schema_hash": browser_intent.mcp_schema_hash,
+                        "sensitive_surface_flags": list(browser_intent.sensitive_surface_flags),
+                        "volatile_fields_dropped": list(browser_intent.volatile_fields_dropped),
+                    }
+                ),
+            )
         else:
             browser_intent_dict = None
 
@@ -1274,6 +3185,7 @@ class RuntimeMcpGuardProxy:
         signals: tuple[str, ...],
         params: dict[str, Any],
         scanner_evidence: tuple[dict[str, object], ...] = (),
+        policy_action: GuardAction = "require-reapproval",
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         approval_center_url = ensure_guard_daemon(self.context.guard_home)
         queued = queue_blocked_approvals(
@@ -1293,6 +3205,7 @@ class RuntimeMcpGuardProxy:
                         tool_name,
                         params,
                         signals,
+                        policy_action=policy_action,
                         scanner_evidence=scanner_evidence,
                     ),
                 ]
@@ -1309,7 +3222,9 @@ class RuntimeMcpGuardProxy:
             now=_now(),
             signals=signals,
             risk_categories=tool_call_risk_categories(artifact, params.get("arguments")),
-            arguments=params.get("arguments"),
+            arguments=_safe_mcp_arguments(params.get("arguments")),
+            additional_scanner_evidence=scanner_evidence,
+            policy_action=policy_action,
         )
         request_id = str(queued[0]["request_id"]) if queued else "unknown"
         review_url = first_approval_url(queued, approval_center_url=approval_center_url) or approval_center_url
@@ -1321,9 +3236,10 @@ class RuntimeMcpGuardProxy:
         response_data = {
             "approvalCenterUrl": approval_center_url,
             "approvalRequests": queued,
+            "guardPolicyAction": policy_action,
             "reviewUrl": review_url,
         }
-        return _blocked_tool_response(
+        response = _blocked_tool_response(
             message_id,
             tool_name,
             (
@@ -1331,15 +3247,20 @@ class RuntimeMcpGuardProxy:
                 f"Approve request {request_id} at {review_url}, then retry the same action."
             ),
             response_data,
-        ), {
+        )
+        queued_event: dict[str, Any] = {
             "method": "tools/call",
             "tool_name": tool_name,
             "decision": "queue-approval",
-            "redacted_params": _redact_json(params),
+            "policy_action": policy_action,
+            "redacted_params": _safe_mcp_params(params),
             "approval_center_url": approval_center_url,
             "approval_requests": queued,
             "review_url": review_url,
         }
+        if scanner_evidence:
+            queued_event["scanner_evidence"] = list(scanner_evidence)
+        return response, queued_event
 
     def _queue_observed_approval_requests(
         self,
@@ -1376,24 +3297,26 @@ class RuntimeMcpGuardProxy:
             artifact_payload["changed_fields"].append("runtime_browser_tool_call")
             target = browser_intent.target_domain or browser_intent.target_origin or "unknown"
             artifact_payload["launch_target"] = f"{browser_intent.mcp_server_name} {browser_intent.operation} {target}"
-            artifact_payload["browser_intent"] = {
-                "version": browser_intent.version,
-                "intent": browser_intent.intent,
-                "operation": browser_intent.operation,
-                "target_url": browser_intent.target_url,
-                "target_origin": browser_intent.target_origin,
-                "target_domain": browser_intent.target_domain,
-                "target_path_prefix": browser_intent.target_path_prefix,
-                "method": browser_intent.method,
-                "profile_mode": browser_intent.profile_mode,
-                "mcp_server_name": browser_intent.mcp_server_name,
-                "mcp_server_identity_hash": browser_intent.mcp_server_identity_hash,
-                "mcp_tool_name": browser_intent.mcp_tool_name,
-                "mcp_tool_identity_hash": browser_intent.mcp_tool_identity_hash,
-                "mcp_schema_hash": browser_intent.mcp_schema_hash,
-                "sensitive_surface_flags": list(browser_intent.sensitive_surface_flags),
-                "volatile_fields_dropped": list(browser_intent.volatile_fields_dropped),
-            }
+            artifact_payload["browser_intent"] = _safe_mcp_arguments(
+                {
+                    "version": browser_intent.version,
+                    "intent": browser_intent.intent,
+                    "operation": browser_intent.operation,
+                    "target_url": browser_intent.target_url,
+                    "target_origin": browser_intent.target_origin,
+                    "target_domain": browser_intent.target_domain,
+                    "target_path_prefix": browser_intent.target_path_prefix,
+                    "method": browser_intent.method,
+                    "profile_mode": browser_intent.profile_mode,
+                    "mcp_server_name": browser_intent.mcp_server_name,
+                    "mcp_server_identity_hash": browser_intent.mcp_server_identity_hash,
+                    "mcp_tool_name": browser_intent.mcp_tool_name,
+                    "mcp_tool_identity_hash": browser_intent.mcp_tool_identity_hash,
+                    "mcp_schema_hash": browser_intent.mcp_schema_hash,
+                    "sensitive_surface_flags": list(browser_intent.sensitive_surface_flags),
+                    "volatile_fields_dropped": list(browser_intent.volatile_fields_dropped),
+                }
+            )
         if decision_v2_payload is not None:
             artifact_payload["decision_v2_json"] = decision_v2_payload
         if extra_fields:
@@ -1413,6 +3336,92 @@ class RuntimeMcpGuardProxy:
             now=_now(),
         )
 
+    def _clear_tools_catalog(
+        self,
+        state: _ToolCatalogState,
+        *,
+        advance_generation: bool,
+    ) -> None:
+        self._tool_catalog_state = state
+        self._tool_catalog = {}
+        self._tool_catalog_pending = None
+        self._tool_catalog_expected_cursor = None
+        self._tool_catalog_inflight = False
+        self._tool_catalog_inflight_cursor = None
+        if advance_generation:
+            self._tool_catalog_generation += 1
+
+    def _reset_tools_catalog_unobserved(self) -> None:
+        self._clear_tools_catalog("unobserved", advance_generation=True)
+
+    def _poison_tools_catalog(self) -> None:
+        self._clear_tools_catalog("error", advance_generation=True)
+
+    def _begin_tools_catalog_request(
+        self,
+        request_cursor: object | None,
+        *,
+        advance_root_generation: bool = True,
+    ) -> int:
+        """Start one validated root or continuation request and return its generation."""
+
+        if request_cursor is None:
+            if advance_root_generation:
+                self._tool_catalog_generation += 1
+            self._tool_catalog_state = "pending"
+            self._tool_catalog = {}
+            self._tool_catalog_pending = {}
+            self._tool_catalog_expected_cursor = None
+            self._tool_catalog_inflight = True
+            self._tool_catalog_inflight_cursor = None
+            return self._tool_catalog_generation
+
+        request_generation = self._tool_catalog_generation
+        if (
+            not isinstance(request_cursor, str)
+            or self._tool_catalog_state != "pending"
+            or self._tool_catalog_pending is None
+            or self._tool_catalog_inflight
+            or self._tool_catalog_expected_cursor is None
+            or request_cursor != self._tool_catalog_expected_cursor
+        ):
+            self._poison_tools_catalog()
+            return request_generation
+        self._tool_catalog_inflight = True
+        self._tool_catalog_inflight_cursor = request_cursor
+        return request_generation
+
+    def _fail_tools_catalog_request(self, request_generation: int) -> None:
+        if request_generation == self._tool_catalog_generation:
+            self._poison_tools_catalog()
+
+    @staticmethod
+    def _normalized_tools_catalog_page(tools: object) -> dict[str, dict[str, object]] | None:
+        if not isinstance(tools, list):
+            return None
+        page: dict[str, dict[str, object]] = {}
+        for item in tools:
+            if not isinstance(item, dict) or any(not isinstance(key, str) for key in item):
+                return None
+            raw_name = item.get("name")
+            if not isinstance(raw_name, str) or not raw_name or raw_name != raw_name.strip():
+                return None
+            if raw_name in page:
+                return None
+            entry = {key: deepcopy(value) for key, value in item.items() if key != "name"}
+            try:
+                json.dumps(
+                    _canonical_tool_catalog_entry(raw_name, entry),
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                    allow_nan=False,
+                )
+            except (TypeError, ValueError):
+                return None
+            page[raw_name] = entry
+        return page
+
     def _capture_tools_catalog(
         self,
         response: dict[str, Any],
@@ -1420,56 +3429,67 @@ class RuntimeMcpGuardProxy:
         request_cursor: object | None = None,
         request_generation: int | None = None,
     ) -> None:
-        if request_generation is not None and request_generation != self._tool_catalog_generation:
+        # Keep direct unit callers safe while production always calls the
+        # explicit begin method before forwarding the list request.
+        if request_generation is None:
+            request_generation = self._begin_tools_catalog_request(request_cursor)
+        elif request_generation != self._tool_catalog_generation:
+            return
+        elif not self._tool_catalog_inflight:
+            request_generation = self._begin_tools_catalog_request(
+                request_cursor,
+                advance_root_generation=False,
+            )
+
+        if request_generation != self._tool_catalog_generation:
+            return
+        if not self._tool_catalog_inflight or request_cursor != self._tool_catalog_inflight_cursor:
+            self._poison_tools_catalog()
+            return
+        if _is_timeout_response(response) or "error" in response:
+            self._poison_tools_catalog()
             return
         result = response.get("result")
         if not isinstance(result, dict):
+            self._poison_tools_catalog()
             return
-        tools = result.get("tools")
-        if not isinstance(tools, list):
+        page = self._normalized_tools_catalog_page(result.get("tools"))
+        if page is None:
+            self._poison_tools_catalog()
             return
-        if request_cursor is None:
-            self._tool_catalog_pending = None
         next_cursor = result.get("nextCursor")
-        has_more_pages = next_cursor is not None
-        catalog: dict[str, dict[str, object]] = {}
-        for item in tools:
-            if not isinstance(item, dict):
-                continue
-            name = item.get("name")
-            if not isinstance(name, str) or not name.strip():
-                continue
-            entry: dict[str, object] = {}
-            description = item.get("description")
-            if isinstance(description, str) and description.strip():
-                entry["description"] = description.strip()
-            input_schema = item.get("inputSchema")
-            if input_schema is not None:
-                entry["input_schema"] = input_schema
-            catalog[name.strip()] = entry
-        if has_more_pages:
-            pending_snapshot = {} if self._tool_catalog_pending is None else dict(self._tool_catalog_pending)
-            pending_snapshot.update(catalog)
-            self._tool_catalog_pending = pending_snapshot
-            self._tool_catalog = dict(self._tool_catalog_pending)
+        if next_cursor is not None and not isinstance(next_cursor, str):
+            self._poison_tools_catalog()
             return
-        if self._tool_catalog_pending is not None:
-            merged_snapshot = dict(self._tool_catalog_pending)
-            merged_snapshot.update(catalog)
-            self._tool_catalog = merged_snapshot
-            self._tool_catalog_pending = None
+        pending = self._tool_catalog_pending
+        if pending is None or any(name in pending for name in page):
+            self._poison_tools_catalog()
             return
-        self._tool_catalog = catalog
+        merged = {**pending, **page}
+        self._tool_catalog_inflight = False
+        self._tool_catalog_inflight_cursor = None
+        if next_cursor is not None:
+            self._tool_catalog_state = "pending"
+            self._tool_catalog = {}
+            self._tool_catalog_pending = merged
+            self._tool_catalog_expected_cursor = next_cursor
+            return
+        self._tool_catalog_state = "complete"
+        self._tool_catalog = merged
+        self._tool_catalog_pending = None
+        self._tool_catalog_expected_cursor = None
 
     def _invalidate_tools_catalog(self) -> None:
-        self._tool_catalog = {}
-        self._tool_catalog_pending = None
-        self._tool_catalog_generation += 1
+        self._clear_tools_catalog("invalidated", advance_generation=True)
 
     @staticmethod
     def _launch_target(tool_name: str, arguments: object) -> str:
-        serialized_arguments = json.dumps(arguments) if arguments is not None else ""
-        return f"{tool_name} {serialized_arguments}".strip()
+        safe_arguments = _safe_mcp_arguments(arguments)
+        serialized_arguments = (
+            json.dumps(safe_arguments, sort_keys=True, separators=(",", ":")) if arguments is not None else ""
+        )
+        digest = _mcp_arguments_digest(arguments)
+        return f"{tool_name} {serialized_arguments} [arguments-sha256:{digest}]".strip()
 
 
 class ElicitationMcpGuardProxy(RuntimeMcpGuardProxy):

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -9,12 +9,14 @@ import select
 import subprocess
 import threading
 import webbrowser
+from collections.abc import Callable, Mapping
 from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
+from ..action_lattice import most_restrictive_guard_action
 from ..approvals import (
     approval_delivery_payload,
     approval_prompt_flow,
@@ -22,10 +24,26 @@ from ..approvals import (
     first_approval_url,
     queue_blocked_approvals,
 )
+from ..config import GuardConfig, resolve_risk_action
 from ..consumer import artifact_hash
 from ..daemon.manager import load_guard_daemon_auth_token
-from ..models import HarnessDetection
+from ..models import GuardAction, GuardArtifact, HarnessDetection
 from ..receipts import build_receipt
+from ..runtime.approval_context import (
+    approval_context_tokens_validation_reason,
+    build_approval_context_token,
+    build_configured_environment_hash,
+    build_runtime_launch_identity,
+    resolved_runtime_launch_executable,
+    runtime_launch_identity_matches,
+)
+from ..runtime.approval_reuse import (
+    APPROVAL_REUSE_CLAIM_FAILED,
+    APPROVAL_REUSE_NO_SAVED_DECISION,
+    ApprovalReuseDecision,
+    ApprovalReuseValidationFailure,
+    evaluate_approval_reuse,
+)
 from ..runtime.secret_file_requests import build_file_read_request_artifact, extract_sensitive_file_read_request
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
@@ -34,6 +52,106 @@ from ._env import _build_scrubbed_env
 _DEFAULT_PROXY_RESPONSE_TIMEOUT_SECONDS = 30.0
 _PROXY_TERMINATION_TIMEOUT_SECONDS = 1.0
 _GUARD_PROXY_TIMEOUT_ERROR_CODE = -32800
+# Bump when sensitive-read classification or action-composition semantics change.
+_STDIO_SENSITIVE_READ_EVALUATOR_POLICY_VERSION = "stdio-sensitive-read-evaluation-v1"
+_APPROVAL_REUSE_CONFIG_REFRESH_FAILED = "approval_reuse_current_config_refresh_failed"
+
+
+def _sensitive_read_current_action(
+    config: object,
+    *,
+    artifact: GuardArtifact,
+    harness: str,
+) -> GuardAction:
+    if not isinstance(config, GuardConfig):
+        return "require-reapproval"
+    configured_override = config.resolve_action_override(
+        harness,
+        artifact.artifact_id,
+        artifact.publisher,
+    )
+    current_config_action = configured_override if configured_override is not None else config.default_action
+    risk_action = resolve_risk_action(config, "local_secret_read", harness=harness) or "require-reapproval"
+    return most_restrictive_guard_action(risk_action, current_config_action)
+
+
+def build_sensitive_read_approval_hash(
+    artifact: GuardArtifact,
+    *,
+    config: object,
+    cwd: Path | None,
+    current_action: GuardAction,
+    server_launch_identity: Mapping[str, object] | None = None,
+    configured_env_values_hash: str | None = None,
+) -> str:
+    """Bind a file-read approval to exact runtime, policy, and sandbox context."""
+
+    effective_cwd = cwd or Path.cwd()
+    try:
+        normalized_cwd = str(effective_cwd.expanduser().resolve(strict=False))
+    except (OSError, RuntimeError):
+        normalized_cwd = str(effective_cwd.expanduser().absolute())
+    if isinstance(config, GuardConfig):
+        configured_override = config.resolve_action_override(
+            artifact.harness,
+            artifact.artifact_id,
+            artifact.publisher,
+        )
+        policy_context: dict[str, object] = {
+            "artifact_override": configured_override,
+            "default_action": config.default_action,
+            "effective_action": current_action,
+            "evaluator_policy_version": _STDIO_SENSITIVE_READ_EVALUATOR_POLICY_VERSION,
+            "managed_locked_settings": list(config.managed_locked_settings),
+            "managed_policy_hash": config.managed_policy_hash,
+            "managed_policy_status": config.managed_policy_status,
+            "mode": config.mode,
+            "security_level": config.security_level,
+        }
+        sandbox_context: dict[str, object] = {"analysis": config.sandbox_analysis}
+    else:
+        policy_context = {
+            "config_valid": False,
+            "effective_action": current_action,
+            "evaluator_policy_version": _STDIO_SENSITIVE_READ_EVALUATOR_POLICY_VERSION,
+        }
+        sandbox_context = {"analysis": "unknown"}
+    return build_approval_context_token(
+        identity={
+            "artifact_id": artifact.artifact_id,
+            "config_path": artifact.config_path,
+            "harness": artifact.harness,
+            "publisher": artifact.publisher,
+            "source_scope": artifact.source_scope,
+            "server_launch_identity": dict(server_launch_identity or {}),
+            "configured_env_values_hash": configured_env_values_hash,
+            "workspace": normalized_cwd,
+        },
+        content=artifact_hash(artifact),
+        capabilities={
+            "artifact_type": artifact.artifact_type,
+            "path_class": artifact.metadata.get("path_class"),
+            "tool_name": artifact.metadata.get("tool_name"),
+        },
+        policy=policy_context,
+        sandbox=sandbox_context,
+    )
+
+
+def _approval_reuse_evidence(reuse: ApprovalReuseDecision) -> tuple[dict[str, object], ...]:
+    if reuse.reason_code == APPROVAL_REUSE_NO_SAVED_DECISION:
+        return ()
+    return ({"source": "approval_reuse", **reuse.to_evidence()},)
+
+
+def _sensitive_read_saved_allow_validation_reason(
+    decision: dict[str, object],
+    *,
+    artifact_hash: str,
+) -> str | None:
+    if decision.get("action") != "allow":
+        return None
+    return approval_context_tokens_validation_reason(decision.get("artifact_hash"), artifact_hash)
 
 
 def _approval_surface_policy_for_browser(configured_policy: object, approval_flow: dict[str, object]) -> str:
@@ -52,6 +170,10 @@ class ProxyIoTimeoutError(TimeoutError):
         super().__init__(f"timeout waiting for {source}")
         self.source = source
         self.timeout_seconds = timeout_seconds
+
+
+class ProxyLaunchIdentityChangedError(RuntimeError):
+    """Raised when launch identity changes across subprocess creation."""
 
 
 def _redact_scalar(value: str) -> str:
@@ -218,6 +340,7 @@ class StdioGuardProxy:
         approval_center_url: str | None = None,
         harness: str = "guard-proxy",
         env: dict[str, str] | None = None,
+        current_config_provider: Callable[[], GuardConfig] | None = None,
     ) -> None:
         self.command = command
         self.blocked_tools = blocked_tools or set()
@@ -227,6 +350,9 @@ class StdioGuardProxy:
         self.approval_center_url = approval_center_url
         self.harness = harness
         self.env = env or {}
+        self._current_config_provider = current_config_provider
+        self._active_launch_identity: dict[str, object] | None = None
+        self._active_env_values_hash: str | None = None
 
     def _response_timeout_seconds(self) -> float:
         configured = getattr(self.guard_config, "approval_wait_timeout_seconds", None)
@@ -302,6 +428,8 @@ class StdioGuardProxy:
             if process.poll() is None:
                 process.terminate()
                 process.wait(timeout=5)
+            self._active_launch_identity = None
+            self._active_env_values_hash = None
         return process.returncode if isinstance(process.returncode, int) else 0
 
     def _run_messages(
@@ -329,17 +457,76 @@ class StdioGuardProxy:
             if process.poll() is None:
                 process.terminate()
                 process.wait(timeout=5)
+            self._active_launch_identity = None
+            self._active_env_values_hash = None
         return responses, events, process.returncode
 
     def _start_process(self) -> subprocess.Popen[str]:
-        return subprocess.Popen(
-            self.command,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=None,
-            text=True,
-            cwd=self.cwd,
-            env=_build_scrubbed_env(self.env),
+        launch_env = _build_scrubbed_env(self.env)
+        self._active_launch_identity = self._build_launch_identity(launch_env)
+        self._active_env_values_hash = build_configured_environment_hash(
+            launch_env,
+            configured_keys=tuple(self.env),
+        )
+        process: subprocess.Popen[str] | None = None
+        try:
+            process = subprocess.Popen(
+                self.command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=None,
+                text=True,
+                cwd=self.cwd,
+                env=launch_env,
+                executable=resolved_runtime_launch_executable(self._active_launch_identity),
+            )
+            if not self._active_launch_identity_matches(launch_env):
+                raise ProxyLaunchIdentityChangedError(
+                    "Guard stdio proxy launch identity changed while starting the MCP server."
+                )
+            return process
+        except BaseException:
+            if process is not None:
+                _quarantine_process(process)
+            self._active_launch_identity = None
+            self._active_env_values_hash = None
+            raise
+
+    def _build_launch_identity(self, launch_env: Mapping[str, str]) -> dict[str, object]:
+        command = self.command[0] if self.command else ""
+        return build_runtime_launch_identity(
+            command,
+            args=self.command[1:],
+            structured_command=True,
+            search_path=launch_env.get("PATH"),
+            cwd=self.cwd or Path.cwd(),
+            launch_env=launch_env,
+        )
+
+    def _active_launch_identity_matches(self, launch_env: Mapping[str, str]) -> bool:
+        identity = self._active_launch_identity
+        command = self.command[0] if self.command else ""
+        return identity is not None and runtime_launch_identity_matches(
+            identity,
+            command,
+            args=self.command[1:],
+            structured_command=True,
+            search_path=launch_env.get("PATH"),
+            cwd=self.cwd or Path.cwd(),
+            launch_env=launch_env,
+        )
+
+    def _session_launch_identity(self) -> dict[str, object]:
+        if self._active_launch_identity is not None:
+            return dict(self._active_launch_identity)
+        return self._build_launch_identity(_build_scrubbed_env(self.env))
+
+    def _session_env_values_hash(self) -> str:
+        if self._active_env_values_hash is not None:
+            return self._active_env_values_hash
+        return build_configured_environment_hash(
+            _build_scrubbed_env(self.env),
+            configured_keys=tuple(self.env),
         )
 
     def _forward_message(
@@ -387,23 +574,191 @@ class StdioGuardProxy:
                     config_path=str(self._policy_path()),
                     source_scope="project" if self.cwd is not None else "global",
                 )
-                runtime_artifact_hash = artifact_hash(runtime_artifact)
-                policy_action = (
-                    self.guard_store.resolve_policy(
+                current_action = _sensitive_read_current_action(
+                    self.guard_config,
+                    artifact=runtime_artifact,
+                    harness=self.harness,
+                )
+                runtime_artifact_hash = build_sensitive_read_approval_hash(
+                    runtime_artifact,
+                    config=self.guard_config,
+                    cwd=self.cwd,
+                    current_action=current_action,
+                    server_launch_identity=self._session_launch_identity(),
+                    configured_env_values_hash=self._session_env_values_hash(),
+                )
+                policy_lookup = (
+                    self.guard_store.resolve_policy_decision_lookup(
                         self.harness,
                         runtime_artifact.artifact_id,
-                        runtime_artifact_hash,
-                        str(self.cwd) if self.cwd is not None else None,
+                        artifact_hash=runtime_artifact_hash,
+                        workspace=str(self.cwd) if self.cwd is not None else None,
+                        publisher=runtime_artifact.publisher,
+                        consume_one_shot=False,
                     )
                     if self.guard_store is not None
                     else None
                 )
-                if not isinstance(policy_action, str):
-                    policy_action = "require-reapproval"
+                saved_decision = policy_lookup["decision"] if policy_lookup is not None else None
+                ignored_integrity = policy_lookup["ignored_local_integrity"] if policy_lookup is not None else None
+                diagnosed_reason: ApprovalReuseValidationFailure | None = None
+                if saved_decision is None and ignored_integrity is None and self.guard_store is not None:
+                    raw_diagnosed_reason = self.guard_store.approval_reuse_validation_reason(
+                        self.harness,
+                        runtime_artifact.artifact_id,
+                        runtime_artifact_hash,
+                        str(self.cwd) if self.cwd is not None else None,
+                        runtime_artifact.publisher,
+                    )
+                    if raw_diagnosed_reason is not None:
+                        diagnosed_reason = cast(ApprovalReuseValidationFailure, raw_diagnosed_reason)
+                saved_action = (
+                    saved_decision.get("action")
+                    if saved_decision is not None
+                    else (
+                        "require-reapproval"
+                        if ignored_integrity is not None
+                        else ("allow" if diagnosed_reason is not None else None)
+                    )
+                )
+                validation_reason: ApprovalReuseValidationFailure | None = (
+                    "approval_reuse_integrity_failure"
+                    if ignored_integrity is not None
+                    else (
+                        cast(
+                            ApprovalReuseValidationFailure,
+                            _sensitive_read_saved_allow_validation_reason(
+                                saved_decision,
+                                artifact_hash=runtime_artifact_hash,
+                            ),
+                        )
+                        if saved_decision is not None
+                        else diagnosed_reason
+                    )
+                )
+                reuse = evaluate_approval_reuse(
+                    current_action,
+                    saved_action,
+                    saved_decision_present=(
+                        saved_decision is not None or ignored_integrity is not None or diagnosed_reason is not None
+                    ),
+                    validation_reason=validation_reason,
+                )
+                claimed_allow_hash: str | None = None
+                config_refresh_failed = False
+                if reuse.should_claim and saved_decision is not None and self.guard_store is not None:
+                    if not self.guard_store.claim_approval_reuse_decision(saved_decision):
+                        reuse = evaluate_approval_reuse(
+                            current_action,
+                            saved_action,
+                            saved_decision_present=True,
+                            validation_reason=APPROVAL_REUSE_CLAIM_FAILED,
+                        )
+                    else:
+                        claimed_allow_hash = runtime_artifact_hash
+                if claimed_allow_hash is not None:
+                    # The atomic claim is authority only for the exact context it
+                    # consumed. Rebuild every policy and launch-bound input after
+                    # the claim so a concurrent policy/identity change cannot use
+                    # the stale pre-claim allow to reach the child process.
+                    assert self.guard_store is not None
+                    provider = self._current_config_provider
+                    try:
+                        fresh_config = provider() if provider is not None else None
+                    except Exception:
+                        fresh_config = None
+                    if not isinstance(fresh_config, GuardConfig):
+                        config_refresh_failed = True
+                        reuse = evaluate_approval_reuse(
+                            "require-reapproval",
+                            "allow",
+                            saved_decision_present=True,
+                        )
+                    else:
+                        self.guard_config = fresh_config
+                        fresh_artifact = build_file_read_request_artifact(
+                            harness=self.harness,
+                            request=sensitive_request,
+                            config_path=str(self._policy_path()),
+                            source_scope="project" if self.cwd is not None else "global",
+                        )
+                        fresh_current_action = _sensitive_read_current_action(
+                            fresh_config,
+                            artifact=fresh_artifact,
+                            harness=self.harness,
+                        )
+                        fresh_artifact_hash = build_sensitive_read_approval_hash(
+                            fresh_artifact,
+                            config=fresh_config,
+                            cwd=self.cwd,
+                            current_action=fresh_current_action,
+                            server_launch_identity=self._session_launch_identity(),
+                            configured_env_values_hash=self._session_env_values_hash(),
+                        )
+                        fresh_lookup = self.guard_store.resolve_policy_decision_lookup(
+                            self.harness,
+                            fresh_artifact.artifact_id,
+                            artifact_hash=fresh_artifact_hash,
+                            workspace=str(self.cwd) if self.cwd is not None else None,
+                            publisher=fresh_artifact.publisher,
+                            consume_one_shot=False,
+                        )
+                        fresh_saved_decision = fresh_lookup["decision"]
+                        fresh_ignored_integrity = fresh_lookup["ignored_local_integrity"]
+                        if fresh_ignored_integrity is not None:
+                            postclaim_saved_action = (
+                                fresh_saved_decision.get("action")
+                                if fresh_saved_decision is not None
+                                else "require-reapproval"
+                            )
+                            postclaim_validation_reason: ApprovalReuseValidationFailure | None = (
+                                "approval_reuse_integrity_failure"
+                            )
+                        elif fresh_saved_decision is not None and fresh_saved_decision.get("action") != "allow":
+                            postclaim_saved_action = fresh_saved_decision.get("action")
+                            postclaim_validation_reason = None
+                        else:
+                            postclaim_saved_action = "allow"
+                            postclaim_validation_reason = cast(
+                                ApprovalReuseValidationFailure,
+                                approval_context_tokens_validation_reason(
+                                    claimed_allow_hash,
+                                    fresh_artifact_hash,
+                                ),
+                            )
+                        reuse = evaluate_approval_reuse(
+                            fresh_current_action,
+                            postclaim_saved_action,
+                            saved_decision_present=True,
+                            validation_reason=postclaim_validation_reason,
+                        )
+                        runtime_artifact = fresh_artifact
+                        runtime_artifact_hash = fresh_artifact_hash
+                        current_action = fresh_current_action
+                policy_action = "require-reapproval" if reuse.action == "review" else reuse.action
+                reuse_evidence = _approval_reuse_evidence(reuse)
+                if config_refresh_failed:
+                    reuse_evidence = (
+                        *reuse_evidence,
+                        {
+                            "source": "approval_reuse",
+                            "status": "rejected",
+                            "reason_code": _APPROVAL_REUSE_CONFIG_REFRESH_FAILED,
+                            "effective_action": "require-reapproval",
+                        },
+                    )
+                terminal_saved_block = reuse.action == "block" and reuse.saved_action == "block"
+                terminal_policy_action = policy_action in {"block", "sandbox-required"}
                 event["artifact_id"] = runtime_artifact.artifact_id
                 event["artifact_type"] = runtime_artifact.artifact_type
                 event["path_summary"] = sensitive_request.path_match.normalized_path
                 event["risk_summary"] = runtime_artifact.metadata.get("runtime_request_summary")
+                event["approval_reuse_status"] = reuse.status
+                event["approval_reuse_reason_code"] = (
+                    _APPROVAL_REUSE_CONFIG_REFRESH_FAILED if config_refresh_failed else reuse.reason_code
+                )
+                if terminal_saved_block:
+                    event["terminal_saved_block"] = True
                 if self.guard_store is not None:
                     self.guard_store.add_receipt(
                         build_receipt(
@@ -421,16 +776,21 @@ class StdioGuardProxy:
                                 if policy_action == "require-reapproval" and self.approval_center_url is not None
                                 else "policy"
                             ),
+                            scanner_evidence=reuse_evidence,
                         )
                     )
-                if policy_action in {"block", "sandbox-required", "require-reapproval"}:
+                if policy_action in {"block", "review", "sandbox-required", "require-reapproval"}:
                     event["decision"] = "block"
                     blocked_message = (
                         f"Guard blocked sensitive local file access for {tool_name}: "
                         f"{sensitive_request.path_match.path_class}."
                     )
                     response_data = None
-                    if self.guard_store is not None and self.approval_center_url is not None:
+                    if (
+                        self.guard_store is not None
+                        and self.approval_center_url is not None
+                        and not terminal_policy_action
+                    ):
                         event["approval_requests"] = queue_blocked_approvals(
                             redaction_level=getattr(self.guard_config, "receipt_redaction_level", "full"),
                             detection=HarnessDetection(
@@ -452,6 +812,7 @@ class StdioGuardProxy:
                                         "source_scope": runtime_artifact.source_scope,
                                         "config_path": runtime_artifact.config_path,
                                         "launch_target": runtime_artifact.metadata.get("request_summary"),
+                                        "scanner_evidence": list(reuse_evidence),
                                     }
                                 ]
                             },

--- a/src/codex_plugin_scanner/guard/runtime/approval_context.py
+++ b/src/codex_plugin_scanner/guard/runtime/approval_context.py
@@ -1,0 +1,1586 @@
+"""Opaque context binding for saved runtime approvals.
+
+Approval evidence is valid only for the context that was reviewed.  These
+tokens bind the five context dimensions that can invalidate a saved approval
+without persisting their potentially sensitive source values.  The token is
+not an authority or a signature; consumers must still resolve and claim saved
+approval evidence through the policy store.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import shlex
+import shutil
+import stat
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Literal, TypeGuard, cast
+
+APPROVAL_CONTEXT_TOKEN_PREFIX = "guard-approval-context:v1:"
+
+ApprovalContextValidationFailure = Literal[
+    "approval_reuse_identity_changed",
+    "approval_reuse_content_changed",
+    "approval_reuse_capability_changed",
+    "approval_reuse_policy_changed",
+    "approval_reuse_sandbox_changed",
+]
+
+_TOKEN_VERSION = 1
+_TOKEN_DOMAIN = "hol.guard.approval-context"
+_CONFIGURED_ENV_HASH_DOMAIN = b"hol.guard.configured-environment:v1\x00"
+_CONFIGURED_HEADER_HASH_DOMAIN = b"hol.guard.configured-headers:v1\x00"
+_TOKEN_FIELDS = frozenset({"version", "identity", "content", "capabilities", "policy", "sandbox"})
+_ENCODED_PAYLOAD_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+_SHA256_HEX_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_MAX_TOKEN_LENGTH = 2048
+_MAX_EXECUTABLE_HASH_BYTES = 256 * 1024 * 1024
+_EXECUTABLE_HASH_CHUNK_BYTES = 1024 * 1024
+_MAX_SHEBANG_BYTES = 4096
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalContextToken:
+    """Parsed, non-secret approval-context component digests."""
+
+    identity_hash: str
+    content_hash: str
+    capabilities_hash: str
+    policy_hash: str
+    sandbox_hash: str
+
+    def _payload(self) -> dict[str, object]:
+        return {
+            "version": _TOKEN_VERSION,
+            "identity": self.identity_hash,
+            "content": self.content_hash,
+            "capabilities": self.capabilities_hash,
+            "policy": self.policy_hash,
+            "sandbox": self.sandbox_hash,
+        }
+
+
+def build_approval_context_token(
+    *,
+    identity: object,
+    content: object,
+    capabilities: object,
+    policy: object,
+    sandbox: object,
+) -> str:
+    """Build a deterministic token from JSON-compatible context components.
+
+    Mapping keys are canonicalized, so their insertion order does not affect
+    the result.  Each component is hashed independently with a domain label;
+    only those digests are serialized into the returned token.  In particular,
+    ``content`` may be any artifact-hash text and is never parsed or embedded.
+    """
+
+    parsed = ApprovalContextToken(
+        identity_hash=_component_hash("identity", identity),
+        content_hash=_component_hash("content", content),
+        capabilities_hash=_component_hash("capabilities", capabilities),
+        policy_hash=_component_hash("policy", policy),
+        sandbox_hash=_component_hash("sandbox", sandbox),
+    )
+    payload = json.dumps(
+        parsed._payload(),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    return f"{APPROVAL_CONTEXT_TOKEN_PREFIX}{encoded}"
+
+
+def parse_approval_context_token(token: object) -> ApprovalContextToken | None:
+    """Parse a well-formed v1 token, returning ``None`` for legacy/malformed input."""
+
+    if not isinstance(token, str) or not token.startswith(APPROVAL_CONTEXT_TOKEN_PREFIX):
+        return None
+    if len(token) > _MAX_TOKEN_LENGTH:
+        return None
+    encoded = token[len(APPROVAL_CONTEXT_TOKEN_PREFIX) :]
+    if not encoded or _ENCODED_PAYLOAD_PATTERN.fullmatch(encoded) is None:
+        return None
+    padding = "=" * (-len(encoded) % 4)
+    try:
+        raw_payload = base64.b64decode(
+            f"{encoded}{padding}".encode("ascii"),
+            altchars=b"-_",
+            validate=True,
+        )
+        payload = json.loads(raw_payload.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, Mapping) or set(payload) != _TOKEN_FIELDS:
+        return None
+    if payload.get("version") != _TOKEN_VERSION:
+        return None
+    identity_hash = payload.get("identity")
+    content_hash = payload.get("content")
+    capabilities_hash = payload.get("capabilities")
+    policy_hash = payload.get("policy")
+    sandbox_hash = payload.get("sandbox")
+    if not (
+        _is_sha256_hex(identity_hash)
+        and _is_sha256_hex(content_hash)
+        and _is_sha256_hex(capabilities_hash)
+        and _is_sha256_hex(policy_hash)
+        and _is_sha256_hex(sandbox_hash)
+    ):
+        return None
+    return ApprovalContextToken(
+        identity_hash=identity_hash,
+        content_hash=content_hash,
+        capabilities_hash=capabilities_hash,
+        policy_hash=policy_hash,
+        sandbox_hash=sandbox_hash,
+    )
+
+
+def approval_context_validation_reason(
+    saved_token: object,
+    *,
+    identity: object,
+    content: object,
+    capabilities: object,
+    policy: object,
+    sandbox: object,
+) -> ApprovalContextValidationFailure | None:
+    """Return the first changed context dimension for saved approval evidence."""
+
+    current_token = build_approval_context_token(
+        identity=identity,
+        content=content,
+        capabilities=capabilities,
+        policy=policy,
+        sandbox=sandbox,
+    )
+    return approval_context_tokens_validation_reason(saved_token, current_token)
+
+
+def approval_context_tokens_validation_reason(
+    saved_token: object,
+    current_token: object,
+) -> ApprovalContextValidationFailure | None:
+    """Compare opaque saved/current tokens without requiring their raw context.
+
+    Legacy artifact hashes and malformed tokens cannot prove that all context
+    dimensions are unchanged, so they fail closed as changed content.
+    """
+
+    saved = parse_approval_context_token(saved_token)
+    current = parse_approval_context_token(current_token)
+    if saved is None or current is None:
+        return "approval_reuse_content_changed"
+    comparisons: tuple[tuple[str, str, ApprovalContextValidationFailure], ...] = (
+        (saved.identity_hash, current.identity_hash, "approval_reuse_identity_changed"),
+        (saved.content_hash, current.content_hash, "approval_reuse_content_changed"),
+        (saved.capabilities_hash, current.capabilities_hash, "approval_reuse_capability_changed"),
+        (saved.policy_hash, current.policy_hash, "approval_reuse_policy_changed"),
+        (saved.sandbox_hash, current.sandbox_hash, "approval_reuse_sandbox_changed"),
+    )
+    for saved_hash, current_hash, reason in comparisons:
+        if not hmac.compare_digest(saved_hash, current_hash):
+            return reason
+    return None
+
+
+def build_runtime_executable_identity(
+    command: object,
+    *,
+    search_path: str | None = None,
+    cwd: Path | None = None,
+) -> dict[str, object]:
+    """Resolve and content-bind an executable without launching it.
+
+    Files that cannot be safely and completely hashed receive a per-evaluation
+    nonce. That deliberately disables approval reuse instead of treating an
+    incomplete executable identity as stable.
+    """
+
+    effective_cwd: Path | None = None
+    if cwd is not None:
+        try:
+            effective_cwd = cwd.expanduser().resolve(strict=False)
+        except (OSError, RuntimeError):
+            effective_cwd = cwd.expanduser().absolute()
+
+    def with_launch_cwd(identity: dict[str, object]) -> dict[str, object]:
+        if effective_cwd is not None:
+            identity["launch_cwd"] = str(effective_cwd)
+        return identity
+
+    if command is None or command == "":
+        return with_launch_cwd({"command": None, "path": None, "status": "not_applicable"})
+    if not isinstance(command, str) or not command.strip():
+        return with_launch_cwd(_unreusable_executable_identity(command, status="invalid_command"))
+    candidate = Path(command).expanduser()
+    has_explicit_path = os.sep in command or (os.altsep is not None and os.altsep in command)
+    if candidate.is_absolute():
+        resolved = candidate
+    elif has_explicit_path:
+        resolved = effective_cwd / candidate if effective_cwd is not None else candidate
+    else:
+        effective_search_path = search_path
+        if effective_cwd is not None:
+            inherited_search_path = search_path if search_path is not None else os.environ.get("PATH")
+            if inherited_search_path is not None:
+                normalized_entries: list[str] = []
+                for entry in inherited_search_path.split(os.pathsep):
+                    path_entry = Path(entry or ".").expanduser()
+                    if not path_entry.is_absolute():
+                        path_entry = effective_cwd / path_entry
+                    normalized_entries.append(str(path_entry))
+                effective_search_path = os.pathsep.join(normalized_entries)
+        located = shutil.which(command, path=effective_search_path)
+        if located is None:
+            return with_launch_cwd(_unreusable_executable_identity(command, status="unresolved"))
+        resolved = Path(located)
+    try:
+        canonical = resolved.resolve(strict=True)
+        metadata = canonical.stat()
+    except (OSError, RuntimeError):
+        return with_launch_cwd(_unreusable_executable_identity(command, status="unreadable", path=resolved))
+    if not stat.S_ISREG(metadata.st_mode):
+        return with_launch_cwd(_unreusable_executable_identity(command, status="not_regular", path=canonical))
+    stat_key = _executable_stat_key(metadata)
+    digest, hash_status, shebang, shebang_status = _cached_executable_hash(str(canonical), stat_key)
+    if shebang_status == "verified":
+        file_format = "script"
+    elif shebang_status == "not_script":
+        file_format = "native"
+    else:
+        file_format = "unverified"
+    identity: dict[str, object] = {
+        "command": command,
+        "file_format": file_format,
+        "path": str(canonical),
+        "shebang_status": shebang_status,
+        "size": metadata.st_size,
+        "mode": stat.S_IMODE(metadata.st_mode),
+        "status": hash_status,
+    }
+    if digest is None:
+        identity["reuse_nonce"] = secrets.token_hex(16)
+    else:
+        identity["sha256"] = digest
+    if shebang is not None:
+        identity["shebang_sha256"] = hashlib.sha256(shebang.encode("utf-8")).hexdigest()
+    return with_launch_cwd(identity)
+
+
+_PYTHON_LAUNCHER_PATTERN = re.compile(
+    r"(?:python|pypy)(?:\d+(?:\.\d+)*)?(?:\.exe)?",
+    re.IGNORECASE,
+)
+_NODE_LAUNCHER_NAMES = frozenset({"node", "node.exe", "nodejs", "nodejs.exe"})
+_SHELL_LAUNCHER_NAMES = frozenset(
+    {
+        "bash",
+        "bash.exe",
+        "dash",
+        "dash.exe",
+        "fish",
+        "fish.exe",
+        "ksh",
+        "ksh.exe",
+        "sh",
+        "sh.exe",
+        "zsh",
+        "zsh.exe",
+    }
+)
+_SIMPLE_SCRIPT_LAUNCHER_NAMES = frozenset(
+    {
+        "lua",
+        "lua.exe",
+        "perl",
+        "perl.exe",
+        "php",
+        "php.exe",
+        "rscript",
+        "rscript.exe",
+        "ruby",
+        "ruby.exe",
+        "ts-node",
+        "ts-node.cmd",
+        "tsx",
+        "tsx.cmd",
+    }
+)
+_UNRESOLVED_CODE_LAUNCHER_NAMES = frozenset(
+    {
+        "bunx",
+        "bunx.exe",
+        "docker",
+        "docker.exe",
+        "go",
+        "go.exe",
+        "npm",
+        "npm.cmd",
+        "npx",
+        "npx.cmd",
+        "pipx",
+        "pipx.exe",
+        "pnpm",
+        "pnpm.cmd",
+        "podman",
+        "podman.exe",
+        "uv",
+        "uv.exe",
+        "uvx",
+        "uvx.exe",
+        "yarn",
+        "yarn.cmd",
+    }
+)
+
+
+def build_runtime_launch_identity(
+    command: object,
+    *,
+    args: Sequence[object] = (),
+    structured_command: bool = False,
+    direct_executable: bool = False,
+    search_path: str | None = None,
+    cwd: Path | None = None,
+    launch_env: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    """Content-bind an executable and any local code-bearing entrypoint.
+
+    Hashing only an interpreter such as ``python`` or ``node`` does not bind
+    the code that will actually run.  This helper parses the launch vector,
+    resolves supported script/module entrypoints from the real launch cwd,
+    and hashes those bytes with the same race-resistant primitive used for
+    executables.  Ambiguous, unsupported, stdin-backed, or unreadable code
+    entrypoints receive a fresh nonce so saved approvals fail closed.
+    """
+
+    effective_cwd = _normalized_launch_cwd(cwd)
+    if command is None or command == "":
+        return {
+            "argv_sha256": _launch_argv_digest(()),
+            "entrypoint": {"kind": "not-applicable", "status": "not_applicable"},
+            "executable": build_runtime_executable_identity(command, search_path=search_path, cwd=effective_cwd),
+            "launch_cwd": str(effective_cwd),
+        }
+    if not isinstance(command, str) or not command.strip():
+        return {
+            "argv_sha256": _launch_argv_digest(()),
+            "entrypoint": _unproven_runtime_entrypoint(
+                kind="unknown-launch",
+                reason="invalid_launch_command",
+            ),
+            "executable": build_runtime_executable_identity(command, search_path=search_path, cwd=effective_cwd),
+            "launch_cwd": str(effective_cwd),
+        }
+    if structured_command:
+        command_tokens = [command]
+    else:
+        try:
+            command_tokens = shlex.split(command, posix=os.name != "nt")
+        except ValueError:
+            command_tokens = []
+    if not command_tokens or any(not isinstance(argument, str) for argument in args):
+        return {
+            "argv_sha256": _launch_argv_digest(()),
+            "entrypoint": _unproven_runtime_entrypoint(
+                kind="unknown-launch",
+                reason="unparseable_launch_vector",
+            ),
+            "executable": build_runtime_executable_identity(
+                command_tokens[0] if command_tokens else command,
+                search_path=search_path,
+                cwd=effective_cwd,
+            ),
+            "launch_cwd": str(effective_cwd),
+        }
+
+    executable = command_tokens[0]
+    launch_args = tuple(command_tokens[1:]) + tuple(str(argument) for argument in args)
+    environment = launch_env if launch_env is not None else os.environ
+    effective_search_path = search_path if search_path is not None else environment.get("PATH")
+    executable_identity = build_runtime_executable_identity(
+        executable,
+        search_path=effective_search_path,
+        cwd=effective_cwd,
+    )
+    executable_shebang, executable_shebang_status = _raw_shebang_for_identity(executable_identity)
+    return {
+        "argv_sha256": _launch_argv_digest((executable, *launch_args)),
+        "entrypoint": _runtime_entrypoint_identity(
+            executable_identity=executable_identity,
+            executable_shebang=executable_shebang,
+            executable_shebang_status=executable_shebang_status,
+            direct_executable=direct_executable,
+            launch_args=launch_args,
+            launch_cwd=effective_cwd,
+            launch_env=environment,
+        ),
+        "executable": executable_identity,
+        "launch_cwd": str(effective_cwd),
+    }
+
+
+def resolved_runtime_launch_executable(identity: Mapping[str, object]) -> str | None:
+    """Return the verified canonical executable path pinned by a launch identity.
+
+    Callers that spawn a process should prefer this absolute path over asking
+    the operating system to resolve the original command a second time.  This
+    closes the ordinary PATH/symlink resolution gap between identity creation
+    and ``exec``.  Unverified identities intentionally return ``None``.
+    """
+
+    executable = identity.get("executable")
+    if not isinstance(executable, Mapping):
+        return None
+    typed_executable = cast(Mapping[str, object], executable)
+    path = typed_executable.get("path")
+    digest = typed_executable.get("sha256")
+    if typed_executable.get("status") != "verified" or not isinstance(path, str) or not _is_sha256_hex(digest):
+        return None
+    candidate = Path(path)
+    return path if candidate.is_absolute() else None
+
+
+def runtime_launch_identity_is_reusable(identity: Mapping[str, object]) -> bool:
+    """Return whether every launch-identity dimension was proven stable."""
+
+    return not _runtime_identity_contains_reuse_nonce(identity)
+
+
+def resolved_runtime_launch_argv(
+    identity: Mapping[str, object],
+    *,
+    args: Sequence[str] = (),
+) -> tuple[str, ...] | None:
+    """Return a path-pinned argv for a verified direct executable launch.
+
+    Native executables use their canonical path. Script-backed executables
+    invoke the already verified shebang interpreter directly, avoiding a
+    second PATH lookup by the kernel or ``env``. Raw shebang arguments are
+    recovered from the descriptor-verified hash cache and are never persisted
+    in the identity.
+    """
+
+    if not runtime_launch_identity_is_reusable(identity):
+        return None
+    executable = identity.get("executable")
+    entrypoint = identity.get("entrypoint")
+    if not isinstance(executable, Mapping) or not isinstance(entrypoint, Mapping):
+        return None
+    executable_path = resolved_runtime_launch_executable(identity)
+    if executable_path is None:
+        return None
+    if entrypoint.get("kind") == "direct-executable" and entrypoint.get("status") == "bound-by-executable":
+        return (executable_path, *args)
+    if entrypoint.get("status") != "verified" or entrypoint.get("kind") not in {
+        "direct-script",
+        "direct-env-script",
+    }:
+        return None
+    shebang, shebang_status = _raw_shebang_for_identity(cast(Mapping[str, object], executable))
+    if shebang_status != "verified" or shebang is None:
+        return None
+    try:
+        shebang_tokens = tuple(shlex.split(shebang, posix=True))
+    except ValueError:
+        return None
+    if not shebang_tokens:
+        return None
+    launcher_name = Path(shebang_tokens[0]).name.lower()
+    shebang_args = shebang_tokens[1:]
+    if _launch_argv_digest(shebang_args) != entrypoint.get("shebang_args_sha256"):
+        return None
+    if launcher_name not in {"env", "env.exe"}:
+        # Kernels disagree about multiple non-env shebang arguments. Refuse to
+        # rewrite an invocation whose semantics cannot be preserved exactly.
+        if len(shebang_args) > 1:
+            return None
+        launcher_path = _verified_identity_path(entrypoint.get("launcher"))
+        if launcher_path is None:
+            return None
+        return (launcher_path, *shebang_args, executable_path, *args)
+    env_command = _env_shebang_command(shebang_args)
+    if env_command is None:
+        return None
+    _interpreter, interpreter_args = env_command
+    if _launch_argv_digest(interpreter_args) != entrypoint.get("interpreter_args_sha256"):
+        return None
+    interpreter_path = _verified_identity_path(entrypoint.get("interpreter"))
+    if interpreter_path is None:
+        return None
+    return (interpreter_path, *interpreter_args, executable_path, *args)
+
+
+def runtime_launch_identity_matches(
+    expected_identity: Mapping[str, object],
+    command: object,
+    *,
+    args: Sequence[object] = (),
+    structured_command: bool = False,
+    direct_executable: bool = False,
+    search_path: str | None = None,
+    cwd: Path | None = None,
+    launch_env: Mapping[str, str] | None = None,
+) -> bool:
+    """Rebuild and compare all provable launch identity at a spawn boundary.
+
+    Fresh ``reuse_nonce`` values are excluded from this comparison because
+    they describe deliberately unprovable launch portions rather than file
+    identity.  Every resolved executable, interpreter, package initializer,
+    and entrypoint path/hash remains in the comparison.  Callers must retain
+    the original nonce-bearing identity for approval decisions so unprovable
+    launches remain non-reusable.
+
+    This is a post-spawn containment check, not an atomic execution primitive:
+    platforms do not expose a portable descriptor-based process spawn, and an
+    interpreter can open its script after the parent returns from spawn.  A
+    caller should therefore also launch the canonical executable returned by
+    :func:`resolved_runtime_launch_executable`, validate immediately, and
+    terminate the child before forwarding traffic on mismatch.
+    """
+
+    current_identity = build_runtime_launch_identity(
+        command,
+        args=args,
+        structured_command=structured_command,
+        direct_executable=direct_executable,
+        search_path=search_path,
+        cwd=cwd,
+        launch_env=launch_env,
+    )
+    expected_digest = _runtime_launch_verification_digest(expected_identity)
+    current_digest = _runtime_launch_verification_digest(current_identity)
+    return (
+        expected_digest is not None
+        and current_digest is not None
+        and hmac.compare_digest(
+            expected_digest,
+            current_digest,
+        )
+    )
+
+
+def build_configured_environment_hash(
+    environment: Mapping[str, str] | None,
+    *,
+    configured_keys: Sequence[str] | None = None,
+) -> str:
+    """Hash configured environment values without exposing or binding ambient values."""
+
+    return _build_configured_values_hash(
+        environment,
+        configured_keys=configured_keys,
+        domain=_CONFIGURED_ENV_HASH_DOMAIN,
+    )
+
+
+def build_configured_header_values_hash(
+    headers: Mapping[str, str] | None,
+    *,
+    configured_keys: Sequence[str] | None = None,
+) -> str:
+    """Hash configured header values without retaining or exposing them."""
+
+    return _build_configured_values_hash(
+        headers,
+        configured_keys=configured_keys,
+        domain=_CONFIGURED_HEADER_HASH_DOMAIN,
+    )
+
+
+def _build_configured_values_hash(
+    values: Mapping[str, str] | None,
+    *,
+    configured_keys: Sequence[str] | None,
+    domain: bytes,
+) -> str:
+    """Hash one configured key/value namespace with stable framing."""
+
+    normalized_values = {str(key).strip(): value for key, value in (values or {}).items() if str(key).strip()}
+    keys = normalized_values.keys() if configured_keys is None else (str(key).strip() for key in configured_keys)
+    normalized_keys = sorted({key for key in keys if key})
+    digest = hashlib.sha256(domain)
+    for key in normalized_keys:
+        key_bytes = key.encode("utf-8")
+        digest.update(len(key_bytes).to_bytes(8, "big"))
+        digest.update(key_bytes)
+        if key not in normalized_values:
+            digest.update(b"\x00")
+            continue
+        value_bytes = normalized_values[key].encode("utf-8")
+        digest.update(b"\x01")
+        digest.update(len(value_bytes).to_bytes(8, "big"))
+        digest.update(value_bytes)
+    return digest.hexdigest()
+
+
+def _normalized_launch_cwd(cwd: Path | None) -> Path:
+    candidate = cwd if cwd is not None else Path.cwd()
+    try:
+        return candidate.expanduser().resolve(strict=False)
+    except (OSError, RuntimeError):
+        return candidate.expanduser().absolute()
+
+
+def _launch_argv_digest(argv: Sequence[str]) -> str:
+    material = json.dumps(list(argv), ensure_ascii=True, separators=(",", ":"))
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _runtime_entrypoint_identity(
+    *,
+    executable_identity: Mapping[str, object],
+    executable_shebang: str | None,
+    executable_shebang_status: str,
+    direct_executable: bool,
+    launch_args: tuple[str, ...],
+    launch_cwd: Path,
+    launch_env: Mapping[str, str],
+) -> dict[str, object]:
+    command_name = Path(str(executable_identity.get("command") or "")).name.lower()
+    resolved_path = executable_identity.get("path")
+    executable_name = Path(str(resolved_path or command_name)).name.lower()
+    if direct_executable:
+        return _direct_executable_runtime_entrypoint_identity(
+            executable_identity=executable_identity,
+            executable_shebang=executable_shebang,
+            executable_shebang_status=executable_shebang_status,
+            launch_args=launch_args,
+            launch_cwd=launch_cwd,
+            launch_env=launch_env,
+        )
+    if executable_name.endswith((".bat", ".cmd")):
+        return _unproven_runtime_entrypoint(
+            kind="command-script-launcher",
+            reason="command_interpreter_unresolved",
+            selector=launch_args,
+        )
+    if command_name in _UNRESOLVED_CODE_LAUNCHER_NAMES or executable_name in _UNRESOLVED_CODE_LAUNCHER_NAMES:
+        return _unproven_runtime_entrypoint(
+            kind="code-launcher",
+            reason="launcher_entrypoint_unresolved",
+            selector=launch_args,
+        )
+    if _known_runtime_launcher_name(executable_name) and _identity_shebang_status(executable_identity) != "native":
+        return _unproven_runtime_entrypoint(
+            kind="code-launcher",
+            reason="script_backed_launcher_unresolved",
+            selector=launch_args,
+        )
+    if _PYTHON_LAUNCHER_PATTERN.fullmatch(executable_name):
+        return _python_runtime_entrypoint_identity(
+            args=launch_args,
+            launch_cwd=launch_cwd,
+            launch_env=launch_env,
+        )
+    if executable_name in _NODE_LAUNCHER_NAMES:
+        return _node_runtime_entrypoint_identity(
+            args=launch_args,
+            launch_cwd=launch_cwd,
+            launch_env=launch_env,
+        )
+    if executable_name in _SHELL_LAUNCHER_NAMES:
+        return _shell_runtime_entrypoint_identity(
+            shell=executable_name,
+            args=launch_args,
+            launch_cwd=launch_cwd,
+            launch_env=launch_env,
+        )
+    if executable_name in _SIMPLE_SCRIPT_LAUNCHER_NAMES:
+        return _simple_runtime_entrypoint_identity(
+            launcher=executable_name,
+            args=launch_args,
+            launch_cwd=launch_cwd,
+        )
+    if executable_name in {"bun", "bun.exe", "deno", "deno.exe"}:
+        return _javascript_runtime_entrypoint_identity(
+            launcher=executable_name,
+            args=launch_args,
+            launch_cwd=launch_cwd,
+        )
+    if executable_name in {"java", "java.exe"}:
+        return _java_runtime_entrypoint_identity(args=launch_args, launch_cwd=launch_cwd)
+    if executable_name in {"dotnet", "dotnet.exe"}:
+        return _dotnet_runtime_entrypoint_identity(args=launch_args, launch_cwd=launch_cwd)
+    if executable_name in {"powershell", "powershell.exe", "pwsh", "pwsh.exe"}:
+        return _powershell_runtime_entrypoint_identity(args=launch_args, launch_cwd=launch_cwd)
+    return _direct_executable_runtime_entrypoint_identity(
+        executable_identity=executable_identity,
+        executable_shebang=executable_shebang,
+        executable_shebang_status=executable_shebang_status,
+        launch_args=launch_args,
+        launch_cwd=launch_cwd,
+        launch_env=launch_env,
+    )
+
+
+def _known_runtime_launcher_name(executable_name: str) -> bool:
+    return bool(
+        _PYTHON_LAUNCHER_PATTERN.fullmatch(executable_name)
+        or executable_name in _NODE_LAUNCHER_NAMES
+        or executable_name in _SHELL_LAUNCHER_NAMES
+        or executable_name in _SIMPLE_SCRIPT_LAUNCHER_NAMES
+        or executable_name
+        in {
+            "bun",
+            "bun.exe",
+            "deno",
+            "deno.exe",
+            "dotnet",
+            "dotnet.exe",
+            "java",
+            "java.exe",
+            "powershell",
+            "powershell.exe",
+            "pwsh",
+            "pwsh.exe",
+        }
+    )
+
+
+def _direct_executable_runtime_entrypoint_identity(
+    *,
+    executable_identity: Mapping[str, object],
+    executable_shebang: str | None,
+    executable_shebang_status: str,
+    launch_args: tuple[str, ...],
+    launch_cwd: Path,
+    launch_env: Mapping[str, str],
+) -> dict[str, object]:
+    """Bind the interpreter selected by a direct executable script shebang."""
+
+    if not isinstance(executable_identity.get("sha256"), str):
+        return {"kind": "direct-executable", "status": "bound-by-executable"}
+    if executable_shebang_status == "not_script":
+        return {"kind": "direct-executable", "status": "bound-by-executable"}
+    if executable_shebang is None:
+        return _unproven_runtime_entrypoint(
+            kind="direct-script",
+            reason=f"shebang_{executable_shebang_status}",
+        )
+    try:
+        shebang_tokens = shlex.split(executable_shebang, posix=True)
+    except ValueError:
+        shebang_tokens = []
+    if not shebang_tokens:
+        return _unproven_runtime_entrypoint(
+            kind="direct-script",
+            reason="shebang_interpreter_unparseable",
+        )
+
+    shebang_launcher = shebang_tokens[0]
+    shebang_args = tuple(shebang_tokens[1:])
+    launcher_identity = build_runtime_executable_identity(
+        shebang_launcher,
+        search_path=None,
+        cwd=launch_cwd,
+    )
+    launcher_name = Path(shebang_launcher).name.lower()
+    result: dict[str, object] = {
+        "kind": "direct-script",
+        "launcher": launcher_identity,
+        "script_args_sha256": _launch_argv_digest(launch_args),
+        "shebang_args_sha256": _launch_argv_digest(shebang_args),
+        "shebang_sha256": hashlib.sha256(executable_shebang.encode("utf-8")).hexdigest(),
+        "status": "verified",
+    }
+    if launcher_name not in {"env", "env.exe"}:
+        if len(shebang_args) > 1:
+            result.update(
+                _unproven_runtime_entrypoint(
+                    kind="direct-script",
+                    reason="nonportable_shebang_arguments",
+                    selector=shebang_args,
+                )
+            )
+            result["launcher"] = launcher_identity
+            return result
+        if launcher_name in _UNRESOLVED_CODE_LAUNCHER_NAMES or launcher_identity.get("status") != "verified":
+            result.update(
+                _unproven_runtime_entrypoint(
+                    kind="direct-script",
+                    reason="shebang_interpreter_unresolved",
+                )
+            )
+            result["launcher"] = launcher_identity
+            return result
+        if _identity_shebang_status(launcher_identity) != "native":
+            result.update(
+                _unproven_runtime_entrypoint(
+                    kind="direct-script",
+                    reason="nested_shebang_interpreter_unresolved",
+                )
+            )
+            result["launcher"] = launcher_identity
+            return result
+        nested_identity = _nested_shebang_interpreter_identity(
+            interpreter_name=launcher_name,
+            interpreter_args=shebang_args,
+            script_path=str(executable_identity.get("path") or ""),
+            launch_cwd=launch_cwd,
+            launch_env=launch_env,
+        )
+        result["interpreter_launch"] = nested_identity
+        if _runtime_identity_contains_reuse_nonce(nested_identity):
+            result.update(
+                _unproven_runtime_entrypoint(
+                    kind="direct-script",
+                    reason="shebang_interpreter_options_unresolved",
+                    selector=shebang_args,
+                )
+            )
+            result["launcher"] = launcher_identity
+        return result
+
+    env_command = _env_shebang_command(shebang_args)
+    search_path = launch_env.get("PATH")
+    result["search_path_sha256"] = hashlib.sha256((search_path or "").encode("utf-8")).hexdigest()
+    if env_command is None:
+        result.update(
+            _unproven_runtime_entrypoint(
+                kind="direct-env-script",
+                reason="env_shebang_command_unresolved",
+                selector=shebang_args,
+            )
+        )
+        result["launcher"] = launcher_identity
+        return result
+    interpreter, interpreter_args = env_command
+    interpreter_identity = build_runtime_executable_identity(
+        interpreter,
+        search_path=search_path,
+        cwd=launch_cwd,
+    )
+    result["interpreter"] = interpreter_identity
+    result["interpreter_args_sha256"] = _launch_argv_digest(interpreter_args)
+    interpreter_name = Path(interpreter).name.lower()
+    if (
+        interpreter_name in _UNRESOLVED_CODE_LAUNCHER_NAMES
+        or interpreter_identity.get("status") != "verified"
+        or _identity_shebang_status(interpreter_identity) != "native"
+    ):
+        result.update(
+            _unproven_runtime_entrypoint(
+                kind="direct-env-script",
+                reason="env_interpreter_unresolved",
+                selector=(interpreter, *interpreter_args),
+            )
+        )
+        result["interpreter"] = interpreter_identity
+        result["launcher"] = launcher_identity
+        return result
+    nested_identity = _nested_shebang_interpreter_identity(
+        interpreter_name=interpreter_name,
+        interpreter_args=interpreter_args,
+        script_path=str(executable_identity.get("path") or ""),
+        launch_cwd=launch_cwd,
+        launch_env=launch_env,
+    )
+    result["interpreter_launch"] = nested_identity
+    if _runtime_identity_contains_reuse_nonce(nested_identity):
+        result.update(
+            _unproven_runtime_entrypoint(
+                kind="direct-env-script",
+                reason="env_interpreter_options_unresolved",
+                selector=(interpreter, *interpreter_args),
+            )
+        )
+        result["interpreter"] = interpreter_identity
+        result["launcher"] = launcher_identity
+    return result
+
+
+def _nested_shebang_interpreter_identity(
+    *,
+    interpreter_name: str,
+    interpreter_args: tuple[str, ...],
+    script_path: str,
+    launch_cwd: Path,
+    launch_env: Mapping[str, str],
+) -> dict[str, object]:
+    """Bind code loaded by shebang interpreter options, or disable reuse."""
+
+    launch_args = (*interpreter_args, script_path)
+    if _PYTHON_LAUNCHER_PATTERN.fullmatch(interpreter_name):
+        return _python_runtime_entrypoint_identity(
+            args=launch_args,
+            launch_cwd=launch_cwd,
+            launch_env=launch_env,
+        )
+    if interpreter_name in _NODE_LAUNCHER_NAMES:
+        return _node_runtime_entrypoint_identity(
+            args=launch_args,
+            launch_cwd=launch_cwd,
+            launch_env=launch_env,
+        )
+    if interpreter_name in _SHELL_LAUNCHER_NAMES:
+        return _shell_runtime_entrypoint_identity(
+            shell=interpreter_name,
+            args=launch_args,
+            launch_cwd=launch_cwd,
+            launch_env=launch_env,
+        )
+    if interpreter_name in _SIMPLE_SCRIPT_LAUNCHER_NAMES:
+        return _simple_runtime_entrypoint_identity(
+            launcher=interpreter_name,
+            args=launch_args,
+            launch_cwd=launch_cwd,
+        )
+    if interpreter_args:
+        return _unproven_runtime_entrypoint(
+            kind="shebang-interpreter-options",
+            reason="unsupported_interpreter_options",
+            selector=interpreter_args,
+        )
+    return {"kind": "shebang-interpreter", "status": "verified"}
+
+
+def _env_shebang_command(args: tuple[str, ...]) -> tuple[str, tuple[str, ...]] | None:
+    if not args:
+        return None
+    if args[0] in {"-S", "--split-string"}:
+        if len(args) < 2:
+            return None
+        return args[1], args[2:]
+    if args[0].startswith("-") or "=" in args[0]:
+        return None
+    return args[0], args[1:]
+
+
+def _identity_shebang_status(identity: Mapping[str, object]) -> Literal["native", "script", "unverified"]:
+    if not isinstance(identity.get("sha256"), str):
+        return "unverified"
+    status = identity.get("shebang_status")
+    if isinstance(identity.get("shebang_sha256"), str) and status == "verified":
+        return "script"
+    return "native" if status == "not_script" else "unverified"
+
+
+def _raw_shebang_for_identity(identity: Mapping[str, object]) -> tuple[str | None, str]:
+    """Recover a verified shebang from the private hash cache without exposing it."""
+
+    initial_status = identity.get("shebang_status")
+    if initial_status != "verified":
+        return None, str(initial_status or "unverified")
+    path = identity.get("path")
+    expected_digest = identity.get("sha256")
+    if not isinstance(path, str) or not isinstance(expected_digest, str):
+        return None, "unverified"
+    try:
+        metadata = Path(path).stat()
+    except OSError:
+        return None, "identity_changed"
+    digest, hash_status, shebang, shebang_status = _cached_executable_hash(
+        path,
+        _executable_stat_key(metadata),
+    )
+    if (
+        hash_status != "verified"
+        or digest is None
+        or not hmac.compare_digest(digest, expected_digest)
+        or shebang_status != "verified"
+        or shebang is None
+    ):
+        return None, "identity_changed"
+    return shebang, "verified"
+
+
+def _python_runtime_entrypoint_identity(
+    *,
+    args: tuple[str, ...],
+    launch_cwd: Path,
+    launch_env: Mapping[str, str],
+) -> dict[str, object]:
+    index = 0
+    ignore_environment = False
+    isolated = False
+    no_value_flags = frozenset({"-b", "-B", "-d", "-O", "-OO", "-q", "-s", "-S", "-u", "-v", "-x"})
+    while index < len(args):
+        argument = args[index]
+        if argument == "--":
+            index += 1
+            break
+        if argument == "-E":
+            ignore_environment = True
+            index += 1
+            continue
+        if argument == "-I":
+            ignore_environment = True
+            isolated = True
+            index += 1
+            continue
+        if argument == "-c":
+            interactive = _python_interactive_environment_identity(
+                launch_env=launch_env,
+                ignore_environment=ignore_environment,
+            )
+            if interactive is not None:
+                return interactive
+            if index + 1 >= len(args):
+                return _unproven_runtime_entrypoint(kind="python-inline", reason="missing_inline_code")
+            return _inline_runtime_entrypoint(kind="python-inline", source=args[index + 1])
+        if argument.startswith("-c") and argument != "-c":
+            interactive = _python_interactive_environment_identity(
+                launch_env=launch_env,
+                ignore_environment=ignore_environment,
+            )
+            if interactive is not None:
+                return interactive
+            return _inline_runtime_entrypoint(kind="python-inline", source=argument[2:])
+        if argument == "-m":
+            interactive = _python_interactive_environment_identity(
+                launch_env=launch_env,
+                ignore_environment=ignore_environment,
+            )
+            if interactive is not None:
+                return interactive
+            if index + 1 >= len(args):
+                return _unproven_runtime_entrypoint(kind="python-module", reason="missing_module_name")
+            return _python_module_runtime_entrypoint_identity(
+                module=args[index + 1],
+                launch_cwd=launch_cwd,
+                launch_env=launch_env,
+                include_launch_cwd=not isolated,
+                include_python_path=not ignore_environment,
+            )
+        if argument.startswith("-m") and argument != "-m":
+            interactive = _python_interactive_environment_identity(
+                launch_env=launch_env,
+                ignore_environment=ignore_environment,
+            )
+            if interactive is not None:
+                return interactive
+            return _python_module_runtime_entrypoint_identity(
+                module=argument[2:],
+                launch_cwd=launch_cwd,
+                launch_env=launch_env,
+                include_launch_cwd=not isolated,
+                include_python_path=not ignore_environment,
+            )
+        if argument in no_value_flags:
+            index += 1
+            continue
+        if argument in {"-W", "-X"} or argument.startswith(("-W", "-X")):
+            return _unproven_runtime_entrypoint(
+                kind="python-script",
+                reason="code_loading_option_unresolved",
+                selector=(argument,),
+            )
+        if argument.startswith("-"):
+            return _unproven_runtime_entrypoint(
+                kind="python-script",
+                reason="unsupported_interpreter_option",
+                selector=(argument,),
+            )
+        break
+    interactive = _python_interactive_environment_identity(
+        launch_env=launch_env,
+        ignore_environment=ignore_environment,
+    )
+    if interactive is not None:
+        return interactive
+    if index >= len(args):
+        return _unproven_runtime_entrypoint(kind="python-script", reason="entrypoint_missing")
+    if args[index] == "-":
+        return _unproven_runtime_entrypoint(kind="python-stdin", reason="stdin_code_unprovable")
+    return _file_runtime_entrypoint(kind="python-script", argument=args[index], launch_cwd=launch_cwd)
+
+
+def _python_module_runtime_entrypoint_identity(
+    *,
+    module: str,
+    launch_cwd: Path,
+    launch_env: Mapping[str, str],
+    include_launch_cwd: bool,
+    include_python_path: bool,
+) -> dict[str, object]:
+    if re.fullmatch(r"[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*", module) is None:
+        return _unproven_runtime_entrypoint(
+            kind="python-module",
+            reason="invalid_module_name",
+            selector=(module,),
+        )
+    roots = [launch_cwd] if include_launch_cwd else []
+    raw_python_path = launch_env.get("PYTHONPATH") if include_python_path else None
+    if raw_python_path is not None:
+        for raw_root in raw_python_path.split(os.pathsep):
+            root = Path(raw_root or ".").expanduser()
+            roots.append(root if root.is_absolute() else launch_cwd / root)
+    relative_module = Path(*module.split("."))
+    for root in _unique_normalized_paths(roots):
+        candidates = (
+            ("python-module", root / relative_module.with_suffix(".py")),
+            ("python-module-bytecode", root / relative_module.with_suffix(".pyc")),
+            ("python-package-main", root / relative_module / "__main__.py"),
+            ("python-package-main-bytecode", root / relative_module / "__main__.pyc"),
+        )
+        existing = [(kind, path) for kind, path in candidates if path.is_file()]
+        if not existing:
+            continue
+        if len(existing) != 1:
+            return _unproven_runtime_entrypoint(
+                kind="python-module",
+                reason="module_entrypoint_ambiguous",
+                selector=(module,),
+            )
+        kind, entrypoint_path = existing[0]
+        identity = _file_runtime_entrypoint(
+            kind=kind,
+            argument=str(entrypoint_path),
+            launch_cwd=launch_cwd,
+        )
+        identity["module_sha256"] = hashlib.sha256(module.encode("utf-8")).hexdigest()
+        identity["package_initializers"] = _python_package_initializer_identities(
+            root=root,
+            relative_module=relative_module,
+            entrypoint_kind=kind,
+        )
+        return identity
+    return _unproven_runtime_entrypoint(
+        kind="python-module",
+        reason=("module_entrypoint_unresolved" if roots else "isolated_module_resolution_unproven"),
+        selector=(module,),
+    )
+
+
+def _python_interactive_environment_identity(
+    *,
+    launch_env: Mapping[str, str],
+    ignore_environment: bool,
+) -> dict[str, object] | None:
+    if ignore_environment or not launch_env.get("PYTHONINSPECT"):
+        return None
+    return _unproven_runtime_entrypoint(
+        kind="python-launch",
+        reason="interactive_environment_unresolved",
+    )
+
+
+def _unique_normalized_paths(paths: Sequence[Path]) -> tuple[Path, ...]:
+    unique: list[Path] = []
+    observed: set[str] = set()
+    for path in paths:
+        normalized = _normalized_launch_cwd(path)
+        key = os.path.normcase(str(normalized))
+        if key not in observed:
+            observed.add(key)
+            unique.append(normalized)
+    return tuple(unique)
+
+
+def _python_package_initializer_identities(
+    *,
+    root: Path,
+    relative_module: Path,
+    entrypoint_kind: str,
+) -> list[dict[str, object]]:
+    parts = relative_module.parts if entrypoint_kind.startswith("python-package-main") else relative_module.parts[:-1]
+    identities: list[dict[str, object]] = []
+    current = root
+    for part in parts:
+        current /= part
+        initializer = current / "__init__.py"
+        if initializer.is_file():
+            identities.append(
+                _file_runtime_entrypoint(
+                    kind="python-package-initializer",
+                    argument=str(initializer),
+                    launch_cwd=root,
+                )
+            )
+    return identities
+
+
+def _node_runtime_entrypoint_identity(
+    *,
+    args: tuple[str, ...],
+    launch_cwd: Path,
+    launch_env: Mapping[str, str],
+) -> dict[str, object]:
+    if launch_env.get("NODE_OPTIONS"):
+        return _unproven_runtime_entrypoint(
+            kind="node-launch",
+            reason="environment_options_unresolved",
+        )
+    index = 0
+    harmless_flags = frozenset(
+        {
+            "--abort-on-uncaught-exception",
+            "--enable-source-maps",
+            "--no-addons",
+            "--no-deprecation",
+            "--no-warnings",
+            "--trace-deprecation",
+            "--trace-uncaught",
+            "--trace-warnings",
+            "--use-bundled-ca",
+            "--use-openssl-ca",
+        }
+    )
+    while index < len(args):
+        argument = args[index]
+        if argument == "--":
+            index += 1
+            break
+        if argument in {"-e", "--eval", "-p", "--print"}:
+            if index + 1 >= len(args):
+                return _unproven_runtime_entrypoint(kind="node-inline", reason="missing_inline_code")
+            return _inline_runtime_entrypoint(kind="node-inline", source=args[index + 1])
+        if argument.startswith(("--eval=", "--print=")):
+            return _inline_runtime_entrypoint(kind="node-inline", source=argument.split("=", 1)[1])
+        if argument in harmless_flags:
+            index += 1
+            continue
+        if argument.startswith("-"):
+            return _unproven_runtime_entrypoint(
+                kind="node-script",
+                reason="unsupported_interpreter_option",
+                selector=(argument,),
+            )
+        break
+    if index >= len(args):
+        return _unproven_runtime_entrypoint(kind="node-script", reason="entrypoint_missing")
+    if args[index] == "-":
+        return _unproven_runtime_entrypoint(kind="node-stdin", reason="stdin_code_unprovable")
+    return _file_runtime_entrypoint(kind="node-script", argument=args[index], launch_cwd=launch_cwd)
+
+
+def _shell_runtime_entrypoint_identity(
+    *,
+    shell: str,
+    args: tuple[str, ...],
+    launch_cwd: Path,
+    launch_env: Mapping[str, str],
+) -> dict[str, object]:
+    if shell.startswith("fish"):
+        return _unproven_runtime_entrypoint(
+            kind="fish-launch",
+            reason="shell_startup_unresolved",
+        )
+    if launch_env.get("BASH_ENV") or launch_env.get("ENV") or launch_env.get("ZDOTDIR"):
+        return _unproven_runtime_entrypoint(
+            kind=f"{shell}-launch",
+            reason="shell_startup_environment_unresolved",
+        )
+    index = 0
+    harmless_long_flags = frozenset({"--noprofile", "--norc", "--posix", "--restricted", "--verbose"})
+    harmless_short_options = frozenset("abefhkmnptuvxBCEHPT") - {"i"}
+    while index < len(args):
+        argument = args[index]
+        if argument == "--":
+            index += 1
+            break
+        if argument in {"-c", "--command"} or (
+            argument.startswith("-") and not argument.startswith("--") and "c" in argument[1:]
+        ):
+            if index + 1 >= len(args):
+                return _unproven_runtime_entrypoint(kind=f"{shell}-inline", reason="missing_inline_code")
+            return _inline_runtime_entrypoint(kind=f"{shell}-inline", source=args[index + 1])
+        if argument in harmless_long_flags:
+            index += 1
+            continue
+        if argument.startswith("-") and not argument.startswith("--") and set(argument[1:]) <= harmless_short_options:
+            index += 1
+            continue
+        if argument.startswith("-"):
+            return _unproven_runtime_entrypoint(
+                kind=f"{shell}-script",
+                reason="unsupported_interpreter_option",
+                selector=(argument,),
+            )
+        break
+    if index >= len(args):
+        return _unproven_runtime_entrypoint(kind=f"{shell}-stdin", reason="stdin_code_unprovable")
+    return _file_runtime_entrypoint(kind=f"{shell}-script", argument=args[index], launch_cwd=launch_cwd)
+
+
+def _simple_runtime_entrypoint_identity(
+    *,
+    launcher: str,
+    args: tuple[str, ...],
+    launch_cwd: Path,
+) -> dict[str, object]:
+    if not args or args[0].startswith("-"):
+        return _unproven_runtime_entrypoint(
+            kind=f"{launcher}-script",
+            reason="entrypoint_unresolved",
+            selector=args[:1],
+        )
+    return _file_runtime_entrypoint(kind=f"{launcher}-script", argument=args[0], launch_cwd=launch_cwd)
+
+
+def _javascript_runtime_entrypoint_identity(
+    *,
+    launcher: str,
+    args: tuple[str, ...],
+    launch_cwd: Path,
+) -> dict[str, object]:
+    if launcher.startswith("deno"):
+        if not args or args[0] != "run":
+            return _unproven_runtime_entrypoint(
+                kind="deno-launch",
+                reason="launcher_entrypoint_unresolved",
+                selector=args,
+            )
+        args = args[1:]
+    elif args and args[0] == "run":
+        return _unproven_runtime_entrypoint(
+            kind="bun-package-script",
+            reason="package_script_entrypoint_unresolved",
+            selector=args,
+        )
+    if not args or args[0].startswith("-"):
+        return _unproven_runtime_entrypoint(
+            kind=f"{launcher}-script",
+            reason="entrypoint_unresolved",
+            selector=args[:1],
+        )
+    return _file_runtime_entrypoint(kind=f"{launcher}-script", argument=args[0], launch_cwd=launch_cwd)
+
+
+def _java_runtime_entrypoint_identity(*, args: tuple[str, ...], launch_cwd: Path) -> dict[str, object]:
+    try:
+        jar_index = args.index("-jar")
+    except ValueError:
+        return _unproven_runtime_entrypoint(
+            kind="java-class",
+            reason="class_entrypoint_unresolved",
+            selector=args,
+        )
+    if jar_index + 1 >= len(args):
+        return _unproven_runtime_entrypoint(kind="java-jar", reason="jar_entrypoint_missing")
+    return _file_runtime_entrypoint(kind="java-jar", argument=args[jar_index + 1], launch_cwd=launch_cwd)
+
+
+def _dotnet_runtime_entrypoint_identity(*, args: tuple[str, ...], launch_cwd: Path) -> dict[str, object]:
+    if not args or args[0].startswith("-") or not args[0].lower().endswith((".dll", ".exe")):
+        return _unproven_runtime_entrypoint(
+            kind="dotnet-launch",
+            reason="managed_entrypoint_unresolved",
+            selector=args[:1],
+        )
+    return _file_runtime_entrypoint(kind="dotnet-assembly", argument=args[0], launch_cwd=launch_cwd)
+
+
+def _powershell_runtime_entrypoint_identity(*, args: tuple[str, ...], launch_cwd: Path) -> dict[str, object]:
+    lowered = tuple(argument.lower() for argument in args)
+    for option in ("-command", "-c", "-encodedcommand", "-e"):
+        if option in lowered:
+            index = lowered.index(option)
+            if index + 1 >= len(args):
+                return _unproven_runtime_entrypoint(kind="powershell-inline", reason="missing_inline_code")
+            return _inline_runtime_entrypoint(kind="powershell-inline", source=args[index + 1])
+    for option in ("-file", "-f"):
+        if option in lowered:
+            index = lowered.index(option)
+            if index + 1 >= len(args):
+                return _unproven_runtime_entrypoint(kind="powershell-script", reason="entrypoint_missing")
+            return _file_runtime_entrypoint(
+                kind="powershell-script",
+                argument=args[index + 1],
+                launch_cwd=launch_cwd,
+            )
+    return _unproven_runtime_entrypoint(
+        kind="powershell-launch",
+        reason="entrypoint_unresolved",
+        selector=args,
+    )
+
+
+def _file_runtime_entrypoint(*, kind: str, argument: str, launch_cwd: Path) -> dict[str, object]:
+    candidate = Path(argument).expanduser()
+    if not candidate.is_absolute():
+        candidate = launch_cwd / candidate
+    identity = build_runtime_executable_identity(str(candidate), search_path=None, cwd=launch_cwd)
+    identity["argument_sha256"] = hashlib.sha256(argument.encode("utf-8")).hexdigest()
+    identity["kind"] = kind
+    return identity
+
+
+def _inline_runtime_entrypoint(*, kind: str, source: str) -> dict[str, object]:
+    return {
+        "kind": kind,
+        "sha256": hashlib.sha256(source.encode("utf-8")).hexdigest(),
+        "status": "verified",
+    }
+
+
+def _unproven_runtime_entrypoint(
+    *,
+    kind: str,
+    reason: str,
+    selector: Sequence[str] = (),
+) -> dict[str, object]:
+    return {
+        "kind": kind,
+        "reason": reason,
+        "reuse_nonce": secrets.token_hex(16),
+        "selector_sha256": _launch_argv_digest(selector),
+        "status": "unproven",
+    }
+
+
+def _runtime_launch_verification_digest(identity: object) -> str | None:
+    """Hash launch identity while ignoring only deliberate instability nonces."""
+
+    try:
+        material = json.dumps(
+            _without_runtime_reuse_nonces(identity),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        return None
+    return hashlib.sha256(material).hexdigest()
+
+
+def _runtime_identity_contains_reuse_nonce(value: object) -> bool:
+    if isinstance(value, Mapping):
+        typed_value = cast(Mapping[object, object], value)
+        return "reuse_nonce" in typed_value or any(
+            _runtime_identity_contains_reuse_nonce(item) for item in typed_value.values()
+        )
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return any(_runtime_identity_contains_reuse_nonce(item) for item in value)
+    return False
+
+
+def _verified_identity_path(value: object) -> str | None:
+    if not isinstance(value, Mapping):
+        return None
+    path = value.get("path")
+    digest = value.get("sha256")
+    if value.get("status") != "verified" or not isinstance(path, str) or not _is_sha256_hex(digest):
+        return None
+    return path if Path(path).is_absolute() else None
+
+
+def _without_runtime_reuse_nonces(value: object) -> object:
+    if isinstance(value, Mapping):
+        typed_value = cast(Mapping[object, object], value)
+        return {
+            str(key): _without_runtime_reuse_nonces(item) for key, item in typed_value.items() if key != "reuse_nonce"
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_without_runtime_reuse_nonces(item) for item in value]
+    return value
+
+
+@lru_cache(maxsize=128)
+def _cached_executable_hash(
+    path: str,
+    expected_stat: tuple[int, int, int, int, int, int],
+) -> tuple[str | None, str, str | None, str]:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        return None, "open_failed", None, "unverified"
+    try:
+        opened_stat = os.fstat(descriptor)
+        observed_stat = _executable_stat_key(opened_stat)
+        if observed_stat != expected_stat or not stat.S_ISREG(opened_stat.st_mode):
+            return None, "identity_raced", None, "unverified"
+        if opened_stat.st_size > _MAX_EXECUTABLE_HASH_BYTES:
+            return None, "too_large", None, "unverified"
+        digest = hashlib.sha256()
+        prefix = bytearray()
+        total = 0
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            while True:
+                chunk = stream.read(_EXECUTABLE_HASH_CHUNK_BYTES)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > _MAX_EXECUTABLE_HASH_BYTES:
+                    return None, "too_large", None, "unverified"
+                digest.update(chunk)
+                if len(prefix) <= _MAX_SHEBANG_BYTES:
+                    prefix.extend(chunk[: _MAX_SHEBANG_BYTES + 1 - len(prefix)])
+        if total != opened_stat.st_size:
+            return None, "size_changed", None, "unverified"
+        if _executable_stat_key(os.fstat(descriptor)) != observed_stat:
+            return None, "identity_raced", None, "unverified"
+        shebang, shebang_status = _parse_executable_shebang(bytes(prefix))
+        return digest.hexdigest(), "verified", shebang, shebang_status
+    except OSError:
+        return None, "read_failed", None, "unverified"
+    finally:
+        os.close(descriptor)
+
+
+def _parse_executable_shebang(prefix: bytes) -> tuple[str | None, str]:
+    if not prefix.startswith(b"#!"):
+        return None, "not_script"
+    first_line = prefix.splitlines()[0]
+    if len(first_line) > _MAX_SHEBANG_BYTES:
+        return None, "too_long"
+    try:
+        decoded = first_line[2:].decode("utf-8").strip()
+    except UnicodeDecodeError:
+        return None, "invalid_encoding"
+    return (decoded, "verified") if decoded else (None, "interpreter_missing")
+
+
+def _executable_stat_key(metadata: os.stat_result) -> tuple[int, int, int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_mode,
+    )
+
+
+def _unreusable_executable_identity(
+    command: object,
+    *,
+    status: str,
+    path: Path | None = None,
+) -> dict[str, object]:
+    return {
+        "command": command if isinstance(command, str) else None,
+        "path": str(path) if path is not None else None,
+        "status": status,
+        "reuse_nonce": secrets.token_hex(16),
+    }
+
+
+def _component_hash(component: str, value: object) -> str:
+    material = {
+        "component": component,
+        "domain": _TOKEN_DOMAIN,
+        "value": value,
+        "version": _TOKEN_VERSION,
+    }
+    try:
+        canonical = json.dumps(
+            material,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"approval context component {component!r} must be JSON-compatible") from exc
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _is_sha256_hex(value: object) -> TypeGuard[str]:
+    return isinstance(value, str) and _SHA256_HEX_PATTERN.fullmatch(value) is not None

--- a/src/codex_plugin_scanner/guard/runtime/approval_reuse.py
+++ b/src/codex_plugin_scanner/guard/runtime/approval_reuse.py
@@ -1,0 +1,239 @@
+"""Authoritative composition of current policy with saved approval evidence.
+
+A saved approval is evidence that an exact, previously reviewed request may
+proceed.  It is not a policy input and therefore cannot lower a newly computed
+``require-reapproval``, ``sandbox-required``, or ``block`` action.  This module
+keeps that exception to the normal action lattice explicit and independently
+testable: an exact, valid saved ``allow`` may satisfy only a current ``review``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ..action_lattice import (
+    UNKNOWN_GUARD_ACTION_REASON,
+    GuardActionNormalization,
+    most_restrictive_guard_action,
+    normalize_guard_action_result,
+)
+from ..models import GuardAction
+
+ApprovalReuseStatus = Literal["accepted", "rejected", "not-applicable"]
+ApprovalReuseValidationFailure = Literal[
+    "approval_reuse_identity_changed",
+    "approval_reuse_content_changed",
+    "approval_reuse_capability_changed",
+    "approval_reuse_policy_changed",
+    "approval_reuse_sandbox_changed",
+    "approval_reuse_expired",
+    "approval_reuse_integrity_failure",
+    "approval_reuse_claim_failed",
+    "approval_reuse_launch_identity_unverified",
+    "approval_reuse_context_changed_after_claim",
+]
+
+APPROVAL_REUSE_ACCEPTED = "approval_reuse_accepted"
+APPROVAL_REUSE_NO_SAVED_DECISION = "approval_reuse_no_saved_decision"
+APPROVAL_REUSE_CURRENT_ACTION_UNKNOWN = "approval_reuse_current_action_unknown"
+APPROVAL_REUSE_SAVED_ACTION_UNKNOWN = "approval_reuse_saved_action_unknown"
+APPROVAL_REUSE_CURRENT_BLOCK = "approval_reuse_current_block"
+APPROVAL_REUSE_SANDBOX_REQUIRED = "approval_reuse_sandbox_required"
+APPROVAL_REUSE_REAPPROVAL_REQUIRED = "approval_reuse_reapproval_required"
+APPROVAL_REUSE_CURRENT_ACTION_NOT_REVIEW = "approval_reuse_current_action_not_review"
+APPROVAL_REUSE_SAVED_ACTION_NOT_ALLOW = "approval_reuse_saved_action_not_allow"
+APPROVAL_REUSE_SAVED_BLOCK = "approval_reuse_saved_block"
+APPROVAL_REUSE_CLAIM_FAILED = "approval_reuse_claim_failed"
+APPROVAL_REUSE_LAUNCH_IDENTITY_UNVERIFIED = "approval_reuse_launch_identity_unverified"
+APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM = "approval_reuse_context_changed_after_claim"
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalReuseDecision:
+    """Result of composing current authority with optional saved evidence."""
+
+    action: GuardAction
+    status: ApprovalReuseStatus
+    reason_code: str
+    current_action: GuardAction
+    saved_action: GuardAction | None
+    should_claim: bool
+    current_normalization_reason_code: str | None = None
+    saved_normalization_reason_code: str | None = None
+    original_current_action: str | None = None
+    original_saved_action: str | None = None
+    original_current_type: str = "str"
+    original_saved_type: str | None = None
+
+    @property
+    def accepted(self) -> bool:
+        return self.status == "accepted"
+
+    def to_evidence(self) -> dict[str, object]:
+        """Return stable, non-secret diagnostics for receipts and UI evidence."""
+
+        return {
+            "action": self.action,
+            "status": self.status,
+            "reason_code": self.reason_code,
+            "current_action": self.current_action,
+            "saved_action": self.saved_action,
+            "should_claim": self.should_claim,
+            "current_normalization_reason_code": self.current_normalization_reason_code,
+            "saved_normalization_reason_code": self.saved_normalization_reason_code,
+            "original_current_action": self.original_current_action,
+            "original_saved_action": self.original_saved_action,
+            "original_current_type": self.original_current_type,
+            "original_saved_type": self.original_saved_type,
+        }
+
+
+def evaluate_approval_reuse(
+    current_action: object,
+    saved_action: object | None = None,
+    *,
+    saved_decision_present: bool | None = None,
+    validation_reason: ApprovalReuseValidationFailure | None = None,
+) -> ApprovalReuseDecision:
+    """Compose a recomputed action with saved approval evidence.
+
+    ``None`` means no saved decision unless ``saved_decision_present`` is set
+    explicitly.  The explicit flag lets untyped persistence callers distinguish
+    absence from a malformed stored row whose ``action`` value is null.
+    """
+
+    current = normalize_guard_action_result(current_action, unknown_action="block")
+    present = saved_action is not None if saved_decision_present is None else saved_decision_present
+    if not present:
+        reason_code = (
+            APPROVAL_REUSE_CURRENT_ACTION_UNKNOWN
+            if current.reason_code == UNKNOWN_GUARD_ACTION_REASON
+            else APPROVAL_REUSE_NO_SAVED_DECISION
+        )
+        return _decision(
+            action=current.action,
+            status="rejected" if current.reason_code is not None else "not-applicable",
+            reason_code=reason_code,
+            current=current,
+        )
+
+    saved = normalize_guard_action_result(saved_action, unknown_action="require-reapproval")
+    conservative_action = most_restrictive_guard_action(current.action, saved.action, unknown_action="block")
+    if current.reason_code is not None:
+        return _decision(
+            action=conservative_action,
+            status="rejected",
+            reason_code=APPROVAL_REUSE_CURRENT_ACTION_UNKNOWN,
+            current=current,
+            saved=saved,
+        )
+    if validation_reason is not None:
+        if validation_reason == "approval_reuse_integrity_failure":
+            # A matching integrity-invalid local authority may have contained
+            # a stronger action than the other valid row selected by lookup.
+            # Ordinary stale approval evidence is unnecessary when current
+            # policy independently allows a request, but a tampered authority
+            # cannot be ignored on that basis.  Require a fresh decision while
+            # preserving an already stronger sandbox/block result.
+            conservative_action = most_restrictive_guard_action(
+                conservative_action,
+                "require-reapproval",
+                unknown_action="block",
+            )
+        return _decision(
+            action=conservative_action,
+            status="rejected",
+            reason_code=validation_reason,
+            current=current,
+            saved=saved,
+        )
+    if saved.reason_code is not None:
+        return _decision(
+            action=conservative_action,
+            status="rejected",
+            reason_code=APPROVAL_REUSE_SAVED_ACTION_UNKNOWN,
+            current=current,
+            saved=saved,
+        )
+    if saved.action == "block":
+        return _decision(
+            action="block",
+            status="accepted",
+            reason_code=APPROVAL_REUSE_SAVED_BLOCK,
+            current=current,
+            saved=saved,
+        )
+    if current.action == "block":
+        return _decision(
+            action="block",
+            status="rejected",
+            reason_code=APPROVAL_REUSE_CURRENT_BLOCK,
+            current=current,
+            saved=saved,
+        )
+    if current.action == "sandbox-required":
+        return _decision(
+            action="sandbox-required",
+            status="rejected",
+            reason_code=APPROVAL_REUSE_SANDBOX_REQUIRED,
+            current=current,
+            saved=saved,
+        )
+    if current.action == "require-reapproval":
+        return _decision(
+            action=conservative_action,
+            status="rejected",
+            reason_code=APPROVAL_REUSE_REAPPROVAL_REQUIRED,
+            current=current,
+            saved=saved,
+        )
+    if current.action == "review" and saved.action == "allow":
+        return _decision(
+            action="allow",
+            status="accepted",
+            reason_code=APPROVAL_REUSE_ACCEPTED,
+            current=current,
+            saved=saved,
+            should_claim=True,
+        )
+    if saved.action == "allow":
+        return _decision(
+            action=current.action,
+            status="not-applicable",
+            reason_code=APPROVAL_REUSE_CURRENT_ACTION_NOT_REVIEW,
+            current=current,
+            saved=saved,
+        )
+    return _decision(
+        action=conservative_action,
+        status="rejected",
+        reason_code=APPROVAL_REUSE_SAVED_ACTION_NOT_ALLOW,
+        current=current,
+        saved=saved,
+    )
+
+
+def _decision(
+    *,
+    action: GuardAction,
+    status: ApprovalReuseStatus,
+    reason_code: str,
+    current: GuardActionNormalization,
+    saved: GuardActionNormalization | None = None,
+    should_claim: bool = False,
+) -> ApprovalReuseDecision:
+    return ApprovalReuseDecision(
+        action=action,
+        status=status,
+        reason_code=reason_code,
+        current_action=current.action,
+        saved_action=saved.action if saved is not None else None,
+        should_claim=should_claim,
+        current_normalization_reason_code=current.reason_code,
+        saved_normalization_reason_code=saved.reason_code if saved is not None else None,
+        original_current_action=current.original_action,
+        original_saved_action=saved.original_action if saved is not None else None,
+        original_current_type=current.original_type,
+        original_saved_type=saved.original_type if saved is not None else None,
+    )

--- a/src/codex_plugin_scanner/guard/runtime/mcp_protection.py
+++ b/src/codex_plugin_scanner/guard/runtime/mcp_protection.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import PurePath
 
+from .approval_context import build_configured_environment_hash
+
 
 @dataclass(frozen=True, slots=True)
 class McpServerIdentity:
@@ -19,6 +21,7 @@ class McpServerIdentity:
     package_version: str | None
     transport: str
     env_keys: tuple[str, ...]
+    env_values_hash: str
     identity_hash: str
 
 
@@ -42,21 +45,28 @@ def build_mcp_server_identity(
     env: dict[str, str] | None = None,
     env_keys: tuple[str, ...] = (),
 ) -> McpServerIdentity:
-    """Build a stable server identity using env key names only."""
+    """Build a stable server identity with secret-safe configured env binding."""
 
     package_name, package_version = _package_identity(command, args)
     env_key_set = {key.strip() for key in env_keys if key.strip()}
     if env is not None:
         env_key_set.update(key.strip() for key in env if key.strip())
     env_keys = tuple(sorted(env_key_set))
+    env_values_hash = build_configured_environment_hash(env, configured_keys=env_keys)
     args_hash = _stable_digest(list(args))
     payload = {
         "command": _command_name(command),
+        # The display-oriented command name is intentionally lossy (for a URL
+        # it is only the final path segment).  Bind the complete configured
+        # command separately so host, scheme, path, and executable-path drift
+        # cannot inherit a saved server/tool approval.
+        "command_hash": _stable_digest(command),
         "args_hash": args_hash,
         "package_name": package_name,
         "package_version": package_version,
         "transport": transport,
         "env_keys": list(env_keys),
+        "env_values_hash": env_values_hash,
     }
     return McpServerIdentity(
         config_path=config_path,
@@ -66,6 +76,7 @@ def build_mcp_server_identity(
         package_version=package_version,
         transport=transport,
         env_keys=env_keys,
+        env_values_hash=env_values_hash,
         identity_hash=_stable_digest(payload),
     )
 
@@ -107,6 +118,7 @@ def mcp_server_identity_metadata(identity: McpServerIdentity) -> dict[str, objec
         "package_version": identity.package_version,
         "transport": identity.transport,
         "env_keys": list(identity.env_keys),
+        "env_values_hash": identity.env_values_hash,
         "identity_hash": identity.identity_hash,
     }
 

--- a/src/codex_plugin_scanner/guard/runtime/mcp_skill_firewall.py
+++ b/src/codex_plugin_scanner/guard/runtime/mcp_skill_firewall.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ..models import GuardArtifact
+from .approval_context import build_configured_environment_hash
 from .mcp_protection import (
     McpServerIdentity,
     McpToolIdentity,
@@ -79,6 +80,7 @@ def portal_mcp_server_identity(
         "configPath": config_path,
         "dependencyHash": _dependency_hash(identity.package_name, identity.package_version),
         "envKeys": list(identity.env_keys),
+        "envValuesHash": identity.env_values_hash,
         "identityHash": identity.identity_hash,
         "packageName": identity.package_name,
         "packageVersion": identity.package_version,
@@ -376,6 +378,7 @@ def _portal_server_from_legacy(record: dict[str, object], artifact: GuardArtifac
     transport = str(record.get("transport") or artifact.transport or "unknown")
     raw_env_keys = record.get("env_keys") or record.get("envKeys")
     env_keys = [item for item in raw_env_keys if isinstance(item, str)] if isinstance(raw_env_keys, list) else []
+    env_values_hash = _legacy_environment_values_hash(record, env_keys=env_keys)
     return {
         "argsHash": args_hash,
         "command": command,
@@ -383,6 +386,7 @@ def _portal_server_from_legacy(record: dict[str, object], artifact: GuardArtifac
         "configPath": str(record.get("config_path") or record.get("configPath") or artifact.config_path),
         "dependencyHash": record.get("dependency_hash") or record.get("dependencyHash"),
         "envKeys": env_keys,
+        "envValuesHash": env_values_hash,
         "identityHash": identity_hash,
         "packageName": record.get("package_name") or record.get("packageName"),
         "packageVersion": record.get("package_version") or record.get("packageVersion"),
@@ -410,13 +414,16 @@ def _portal_tool_from_legacy(record: dict[str, object], metadata: dict[str, obje
 
 
 def _legacy_server_identity(server: dict[str, object]) -> dict[str, object]:
+    raw_env_keys = server.get("envKeys")
+    env_keys = [item for item in raw_env_keys if isinstance(item, str)] if isinstance(raw_env_keys, list) else []
     return {
         "args_hash": server.get("argsHash"),
         "command": server.get("command"),
         "command_hash": server.get("commandHash"),
         "config_path": server.get("configPath"),
         "dependency_hash": server.get("dependencyHash"),
-        "env_keys": server.get("envKeys"),
+        "env_keys": env_keys,
+        "env_values_hash": _legacy_environment_values_hash(server, env_keys=env_keys),
         "identity_hash": server.get("identityHash"),
         "package_name": server.get("packageName"),
         "package_version": server.get("packageVersion"),
@@ -424,6 +431,13 @@ def _legacy_server_identity(server: dict[str, object]) -> dict[str, object]:
         "transport": server.get("transport"),
         "transport_hash": server.get("transportHash"),
     }
+
+
+def _legacy_environment_values_hash(record: dict[str, object], *, env_keys: list[str]) -> str:
+    raw_hash = record.get("env_values_hash") or record.get("envValuesHash")
+    if isinstance(raw_hash, str) and raw_hash.strip():
+        return raw_hash.strip()
+    return build_configured_environment_hash(None, configured_keys=env_keys)
 
 
 def _legacy_tool_identity(tool: dict[str, object]) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -18,9 +18,10 @@ import urllib.request
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from contextlib import contextmanager, suppress
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from uuid import uuid4
 
 from cryptography.hazmat.primitives import hashes, serialization
@@ -28,7 +29,8 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 
 from ...version import __version__
-from ..adapters.base import HarnessContext
+from ..action_lattice import is_guard_action, most_restrictive_guard_action
+from ..adapters.base import HarnessAdapter, HarnessContext
 from ..approval_gate import ApprovalGateError
 from ..cli.oauth_client import (
     GuardDpopKeyMaterial,
@@ -47,7 +49,7 @@ from ..config import VALID_RECEIPT_REDACTION_LEVELS, GuardConfig, load_guard_con
 from ..edge_events import build_runtime_session_event
 from ..mdm.network import managed_urlopen
 from ..memory_pattern_fingerprint import build_exact_command_memory_artifact_id
-from ..models import GuardArtifact, HarnessDetection, PolicyDecision
+from ..models import GuardAction, GuardArtifact, HarnessDetection, PolicyDecision
 from ..package_firewall_defaults import extract_cloud_user_profile
 from ..package_firewall_entitlement import (
     build_oauth_package_firewall_entitlement,
@@ -70,6 +72,16 @@ from ..shims import package_shim_cloud_coverage
 from ..store import GuardStore
 from ..types import PromptRequest, RemediationAction
 from .actions import GuardActionEnvelope, redacted_workspace_label
+from .approval_context import (
+    build_runtime_launch_identity,
+    parse_approval_context_token,
+    resolved_runtime_launch_argv,
+    runtime_launch_identity_is_reusable,
+)
+from .approval_reuse import (
+    APPROVAL_REUSE_CLAIM_FAILED,
+    APPROVAL_REUSE_LAUNCH_IDENTITY_UNVERIFIED,
+)
 from .composition_rules import compose_action_from_signals
 from .detectors import DetectorContext, DetectorRegistry, DetectorRunResult, register_default_detectors
 from .prompt_injection import detect_prompt_injection_requests
@@ -96,13 +108,33 @@ def evaluate_detection(
     *,
     default_action: str | None = None,
     persist: bool = True,
+    trusted_request_overrides: Mapping[str, str] | None = None,
+    trusted_request_override_labels: Mapping[str, str] | None = None,
+    pending_approval_claims: list[tuple[Mapping[str, object], str, str]] | None = None,
+    claimed_saved_approval_overrides: Mapping[str, str] | None = None,
+    retained_saved_approval_overrides: Mapping[str, str] | None = None,
+    runtime_detector_context: Mapping[str, object] | None = None,
+    runtime_detector_block_reason: str | None = None,
 ):
-    from ..consumer import evaluate_detection as _evaluate_detection
+    from ..consumer.service import evaluate_detection as _evaluate_detection
 
-    return _evaluate_detection(detection, store, config, default_action=default_action, persist=persist)
+    return _evaluate_detection(
+        detection,
+        store,
+        config,
+        default_action=default_action,
+        persist=persist,
+        trusted_request_overrides=trusted_request_overrides,
+        trusted_request_override_labels=trusted_request_override_labels,
+        pending_approval_claims=pending_approval_claims,
+        claimed_saved_approval_overrides=claimed_saved_approval_overrides,
+        retained_saved_approval_overrides=retained_saved_approval_overrides,
+        runtime_detector_context=runtime_detector_context,
+        runtime_detector_block_reason=runtime_detector_block_reason,
+    )
 
 
-def get_adapter(harness: str):
+def get_adapter(harness: str) -> HarnessAdapter:
     from ..adapters import get_adapter as _get_adapter
 
     return _get_adapter(harness)
@@ -119,6 +151,485 @@ _APPROVAL_METADATA_KEYS = (
     "approval_wait",
     "review_hint",
 )
+
+_RUNTIME_DETECTOR_REVIEW_REASON = "runtime_detector_review"
+_RUNTIME_DETECTOR_WARN_REASON = "runtime_detector_warn"
+_APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM = "approval_reuse_context_changed_after_claim"
+# Every prepared launch-environment entry is authority-hashed except this
+# explicit execution-boundary credential. Inherited values are removed before
+# hashing; only Guard's freshly resolved Hermes credential may be added later.
+_HERMES_GUARD_TOKEN_ENV_KEY = "HERMES_GUARD_TOKEN"
+_GUARD_RUN_LATE_CREDENTIAL_ENV_KEYS = frozenset({_HERMES_GUARD_TOKEN_ENV_KEY})
+
+
+def _resolved_exact_request_overrides(evaluation: Mapping[str, object]) -> dict[str, str]:
+    """Extract trusted allow results bound to the exact queued context token."""
+
+    wait_result = evaluation.get("approval_wait")
+    if not isinstance(wait_result, Mapping) or wait_result.get("resolved") is not True:
+        return {}
+    raw_items = wait_result.get("items")
+    if not isinstance(raw_items, list) or not raw_items:
+        return {}
+    items = [item for item in raw_items if isinstance(item, Mapping)]
+    if len(items) != len(raw_items) or any(
+        item.get("status") != "resolved" or item.get("resolution_action") != "allow" for item in items
+    ):
+        return {}
+    overrides: dict[str, str] = {}
+    for item in items:
+        artifact_id = item.get("artifact_id")
+        artifact_hash = item.get("artifact_hash")
+        if (
+            not isinstance(artifact_id, str)
+            or not artifact_id
+            or not isinstance(artifact_hash, str)
+            or parse_approval_context_token(artifact_hash) is None
+        ):
+            return {}
+        overrides[artifact_id] = artifact_hash
+    return overrides
+
+
+_INTERACTIVE_ALLOW_OVERRIDE_LABELS = frozenset({"allow-once", "allow-artifact", "allow-publisher", "allow-harness"})
+
+
+def _resolved_interactive_request_overrides(
+    evaluation: Mapping[str, object],
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Extract exact allow intents returned by the trusted terminal resolver."""
+
+    raw_items = evaluation.get("artifacts")
+    if not isinstance(raw_items, list):
+        return {}, {}
+    overrides: dict[str, str] = {}
+    labels: dict[str, str] = {}
+    for item in raw_items:
+        if not isinstance(item, Mapping) or item.get("policy_action") != "allow":
+            continue
+        user_override = item.get("user_override")
+        artifact_id = item.get("artifact_id")
+        artifact_hash = item.get("approval_context_hash")
+        if (
+            not isinstance(user_override, str)
+            or user_override not in _INTERACTIVE_ALLOW_OVERRIDE_LABELS
+            or not isinstance(artifact_id, str)
+            or not artifact_id
+            or not isinstance(artifact_hash, str)
+            or parse_approval_context_token(artifact_hash) is None
+        ):
+            continue
+        overrides[artifact_id] = artifact_hash
+        labels[artifact_id] = user_override
+    return overrides, labels
+
+
+def _runtime_detector_authority(evaluation: Mapping[str, object]) -> tuple[GuardAction | None, str | None]:
+    composition = evaluation.get("runtime_detector_composition")
+    if not isinstance(composition, Mapping):
+        return None, None
+    action = composition.get("action")
+    reason = composition.get("reason")
+    if not is_guard_action(action) or action not in {"warn", "review", "block"}:
+        return None, None
+    return action, reason if isinstance(reason, str) and reason else None
+
+
+def _runtime_detector_context(evaluation: Mapping[str, object]) -> dict[str, object] | None:
+    """Return timing-free detector authority suitable for exact context hashing."""
+
+    raw_composition = evaluation.get("runtime_detector_composition")
+    composition = (
+        {
+            "action": raw_composition.get("action"),
+            "reason": raw_composition.get("reason"),
+            "downgraded": raw_composition.get("downgraded") is True,
+            "upgraded": raw_composition.get("upgraded") is True,
+        }
+        if isinstance(raw_composition, Mapping)
+        else {}
+    )
+    raw_signals = evaluation.get("runtime_detector_signals_v2")
+    signals = (
+        [dict(signal) for signal in raw_signals if isinstance(signal, Mapping)] if isinstance(raw_signals, list) else []
+    )
+    telemetry = _normalized_runtime_detector_telemetry(evaluation)
+    if not composition and not signals and not telemetry:
+        return None
+    return {"composition": composition, "signals_v2": signals, "telemetry": telemetry}
+
+
+def _normalized_runtime_detector_telemetry(evaluation: Mapping[str, object]) -> list[dict[str, object]]:
+    """Bind semantic detector outcomes while excluding nondeterministic duration."""
+
+    raw_telemetry = evaluation.get("runtime_detector_telemetry")
+    if not isinstance(raw_telemetry, list):
+        return []
+    telemetry: list[dict[str, object]] = []
+    for raw_item in raw_telemetry:
+        if not isinstance(raw_item, Mapping):
+            continue
+        item = {str(key): value for key, value in raw_item.items() if isinstance(key, str) and key != "elapsed_ms"}
+        categories = item.get("categories")
+        if isinstance(categories, (list, tuple)):
+            item["categories"] = sorted({category for category in categories if isinstance(category, str)})
+        telemetry.append(item)
+    return sorted(
+        telemetry,
+        key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":"), ensure_ascii=True),
+    )
+
+
+def _runtime_detector_nonterminal_evidence(
+    action: GuardAction | None,
+    reason: str | None,
+) -> dict[str, object] | None:
+    if action == "warn":
+        return {
+            "source": "runtime_detector_registry",
+            "status": "warning",
+            "reason_code": _RUNTIME_DETECTOR_WARN_REASON,
+            "reason": reason or "runtime detector signals require a warning",
+        }
+    if action == "review":
+        return {
+            "source": "runtime_detector_registry",
+            "status": "review-required",
+            "reason_code": _RUNTIME_DETECTOR_REVIEW_REASON,
+            "reason": reason or "runtime detector signals require review",
+        }
+    return None
+
+
+def _config_with_current_authority(
+    config: GuardConfig,
+    evaluation: Mapping[str, object],
+    authority_action: GuardAction,
+    *,
+    artifact_ids: set[str] | None = None,
+) -> GuardConfig:
+    """Bind runner-only authority into each artifact's current policy context.
+
+    Runtime detector composition happens outside the consumer service.  A
+    synthetic per-artifact override makes that current authority participate
+    in approval-context hashing and saved-decision composition before any
+    one-shot claim. Existing stronger current actions remain authoritative.
+    """
+
+    raw_artifacts = evaluation.get("artifacts")
+    if not isinstance(raw_artifacts, list) or not raw_artifacts:
+        return config
+    artifact_actions = dict(config.artifact_actions or {})
+    changed = False
+    for item in raw_artifacts:
+        if not isinstance(item, Mapping):
+            continue
+        artifact_id = item.get("artifact_id")
+        if not isinstance(artifact_id, str) or not artifact_id:
+            continue
+        if artifact_ids is not None and artifact_id not in artifact_ids:
+            continue
+        composition = item.get("policy_composition")
+        current_action = composition.get("current_action") if isinstance(composition, Mapping) else None
+        if not is_guard_action(current_action):
+            current_action = item.get("policy_action")
+        composed = most_restrictive_guard_action(current_action, authority_action, unknown_action="block")
+        if artifact_actions.get(artifact_id) != composed:
+            artifact_actions[artifact_id] = composed
+            changed = True
+    return replace(config, artifact_actions=artifact_actions) if changed else config
+
+
+@dataclass(frozen=True, slots=True)
+class _GuardRunLaunchPlan:
+    """The exact adapter launch vector resolved at an authority boundary."""
+
+    adapter_command: tuple[str, ...]
+    execution_command: tuple[str, ...]
+    environment: Mapping[str, str]
+    environment_sha256: str
+    identity: Mapping[str, object]
+    launch_cwd: Path
+    reusable: bool
+
+
+def _guard_run_launch_environment(
+    adapter: HarnessAdapter,
+    context: HarnessContext,
+) -> tuple[dict[str, str], Path]:
+    environment = os.environ.copy()
+    environment["HOME"] = str(context.home_dir)
+    if os.name == "nt":
+        environment["USERPROFILE"] = str(context.home_dir)
+    environment = adapter.prepare_launch_environment(context, environment)
+    for credential_key in _GUARD_RUN_LATE_CREDENTIAL_ENV_KEYS:
+        environment.pop(credential_key, None)
+    if any(not isinstance(key, str) or not isinstance(value, str) for key, value in environment.items()):
+        raise ValueError("Harness launch environment must contain only string keys and values.")
+    launch_cwd = (context.workspace_dir or Path.cwd()).expanduser().resolve(strict=True)
+    if not launch_cwd.is_dir():
+        raise NotADirectoryError(f"Harness launch cwd is not a directory: {launch_cwd}")
+    return dict(environment), launch_cwd
+
+
+def _guard_run_launch_environment_hash(environment: Mapping[str, str]) -> str:
+    """Return a canonical, non-reversible digest of the full prepared environment."""
+
+    material = json.dumps(
+        sorted(environment.items()),
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(b"hol.guard.guard-run-launch-environment:v1\x00" + material).hexdigest()
+
+
+def _guard_run_plan_for_command(
+    adapter_command: Sequence[str],
+    *,
+    environment: Mapping[str, str],
+    launch_cwd: Path,
+) -> _GuardRunLaunchPlan | None:
+    normalized_command = tuple(adapter_command)
+    if not normalized_command or any(not isinstance(part, str) or not part for part in normalized_command):
+        return None
+    identity = build_runtime_launch_identity(
+        normalized_command[0],
+        args=normalized_command[1:],
+        structured_command=True,
+        direct_executable=True,
+        search_path=environment.get("PATH"),
+        cwd=launch_cwd,
+        launch_env=environment,
+    )
+    pinned_command = resolved_runtime_launch_argv(identity, args=normalized_command[1:])
+    reusable = pinned_command is not None and runtime_launch_identity_is_reusable(identity)
+    return _GuardRunLaunchPlan(
+        adapter_command=normalized_command,
+        execution_command=pinned_command if reusable and pinned_command is not None else normalized_command,
+        environment=dict(environment),
+        environment_sha256=_guard_run_launch_environment_hash(environment),
+        identity=identity,
+        launch_cwd=launch_cwd,
+        reusable=reusable,
+    )
+
+
+def _guard_run_launch_previews(
+    harness: str,
+    context: HarnessContext,
+    passthrough_args: list[str],
+) -> tuple[_GuardRunLaunchPlan, ...]:
+    """Content-bind every launch argv without performing adapter setup."""
+
+    adapter = get_adapter(harness)
+    raw_commands: Sequence[Sequence[str]] = adapter.preview_launch_commands(context, passthrough_args)
+    environment, launch_cwd = _guard_run_launch_environment(adapter, context)
+    plans: list[_GuardRunLaunchPlan] = []
+    seen_commands: set[tuple[str, ...]] = set()
+    for raw_command in raw_commands:
+        plan = _guard_run_plan_for_command(
+            raw_command,
+            environment=environment,
+            launch_cwd=launch_cwd,
+        )
+        if plan is None or plan.adapter_command in seen_commands:
+            continue
+        seen_commands.add(plan.adapter_command)
+        plans.append(plan)
+    return tuple(plans)
+
+
+def _guard_run_executable_prefix(launch_plan: _GuardRunLaunchPlan) -> tuple[str, ...] | None:
+    """Recover the canonical prefix prepended while pinning a preview argv."""
+
+    adapter_arguments = launch_plan.adapter_command[1:]
+    prefix_length = len(launch_plan.execution_command) - len(adapter_arguments)
+    if prefix_length < 1:
+        return None
+    if adapter_arguments and launch_plan.execution_command[prefix_length:] != adapter_arguments:
+        return None
+    return launch_plan.execution_command[:prefix_length]
+
+
+def _guard_run_finalize_authorized_launch_plan(
+    harness: str,
+    context: HarnessContext,
+    passthrough_args: list[str],
+    authorized_plans: Sequence[_GuardRunLaunchPlan],
+) -> _GuardRunLaunchPlan | None:
+    """Run authorized setup without re-resolving previewed launch identity."""
+
+    if not authorized_plans or not all(plan.reusable for plan in authorized_plans):
+        return None
+    environment = authorized_plans[0].environment
+    environment_sha256 = authorized_plans[0].environment_sha256
+    if any(
+        plan.environment_sha256 != environment_sha256 or dict(plan.environment) != dict(environment)
+        for plan in authorized_plans[1:]
+    ):
+        return None
+    resolved_prefixes = [_guard_run_executable_prefix(plan) for plan in authorized_plans]
+    if any(prefix is None for prefix in resolved_prefixes):
+        return None
+    prefixes = tuple(dict.fromkeys(cast(tuple[str, ...], prefix) for prefix in resolved_prefixes))
+    adapter = get_adapter(harness)
+    actual_command = adapter.launch_command_from_authorized_plan(
+        context,
+        passthrough_args,
+        authorized_executable_prefixes=prefixes,
+        launch_environment=dict(environment),
+    )
+    normalized_actual = tuple(actual_command)
+    for plan in authorized_plans:
+        if normalized_actual in {plan.adapter_command, plan.execution_command}:
+            return plan
+    return None
+
+
+def _guard_run_launch_plan_signature(launch_plan: _GuardRunLaunchPlan) -> str | None:
+    if not launch_plan.reusable:
+        return None
+    return json.dumps(
+        {
+            "adapter_command": list(launch_plan.adapter_command),
+            "environment_sha256": launch_plan.environment_sha256,
+            "identity": launch_plan.identity,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+
+
+def _guard_run_authority_signature(
+    detection: HarnessDetection,
+    evaluation: Mapping[str, object],
+    launch_previews: Sequence[_GuardRunLaunchPlan] = (),
+) -> tuple[object, ...] | None:
+    """Return the exact launch authority checked on both sides of a claim."""
+
+    raw_artifacts = evaluation.get("artifacts")
+    if not isinstance(raw_artifacts, list):
+        return None
+    contexts: dict[str, tuple[str, str]] = {}
+    for item in raw_artifacts:
+        if not isinstance(item, Mapping):
+            return None
+        artifact_id = item.get("artifact_id")
+        approval_context_hash = item.get("approval_context_hash")
+        policy_action = item.get("policy_action")
+        if (
+            not isinstance(artifact_id, str)
+            or not artifact_id
+            or artifact_id in contexts
+            or not isinstance(approval_context_hash, str)
+            or parse_approval_context_token(approval_context_hash) is None
+            or not is_guard_action(policy_action)
+        ):
+            return None
+        contexts[artifact_id] = (approval_context_hash, policy_action)
+    detector_payload = _runtime_detector_context(evaluation)
+    return (
+        detection.harness,
+        detection.installed,
+        detection.command_available,
+        tuple(detection.config_paths),
+        tuple(sorted(contexts.items())),
+        json.dumps(detector_payload, sort_keys=True, separators=(",", ":"), default=str),
+        tuple(_guard_run_launch_plan_signature(plan) for plan in launch_previews),
+    )
+
+
+def _receipt_rowid_cursor(store: GuardStore) -> int:
+    with store._connect() as connection:
+        row = connection.execute("select coalesce(max(rowid), 0) as cursor from runtime_receipts").fetchone()
+    return int(row["cursor"]) if row is not None else 0
+
+
+def _saved_decision_is_retained(decision: Mapping[str, object]) -> bool:
+    """Return whether a successful claim leaves the authority row in place."""
+
+    approval_id = decision.get("approval_id")
+    if isinstance(approval_id, str) and approval_id:
+        artifact_id = decision.get("artifact_id")
+        return isinstance(artifact_id, str) and ":package-request:" in artifact_id
+    decision_id = decision.get("decision_id")
+    if isinstance(decision_id, int) and not isinstance(decision_id, bool):
+        return not (decision.get("source") == "approval-gate" and decision.get("expires_at") is not None)
+    # The store rejects unknown claim identities. Classifying them as retained
+    # is the conservative fallback if an alternate store implementation ever
+    # accepts one: absence may not be treated as proof of consumption.
+    return True
+
+
+def _append_authority_evidence_to_receipts(
+    store: GuardStore,
+    *,
+    after_rowid: int,
+    evaluation: Mapping[str, object],
+    evidence: Mapping[str, object],
+    approval_source: str,
+    source_actions: frozenset[str],
+    replace_existing_source: bool = False,
+) -> None:
+    """Attach runner-composed authority to receipts emitted by one evaluation."""
+
+    raw_artifacts = evaluation.get("artifacts")
+    if not isinstance(raw_artifacts, list):
+        return
+    artifact_ids = {
+        artifact_id
+        for item in raw_artifacts
+        if isinstance(item, Mapping)
+        for artifact_id in (item.get("artifact_id"),)
+        if isinstance(artifact_id, str) and artifact_id
+    }
+    if not artifact_ids:
+        return
+    reason_code = evidence.get("reason_code")
+    # Runtime detector authority is composed in this aggregate, so its receipt
+    # evidence is amended in the same local transaction boundary.
+    with store._connect() as connection:
+        rows = connection.execute(
+            """
+            select rowid, artifact_id, policy_decision, scanner_evidence_json, approval_source
+            from runtime_receipts
+            where rowid > ?
+            order by rowid asc
+            """,
+            (after_rowid,),
+        ).fetchall()
+        for row in rows:
+            if str(row["artifact_id"]) not in artifact_ids:
+                continue
+            try:
+                raw_evidence = json.loads(str(row["scanner_evidence_json"]))
+            except (TypeError, ValueError):
+                raw_evidence = []
+            scanner_evidence = list(raw_evidence) if isinstance(raw_evidence, list) else []
+            if replace_existing_source:
+                scanner_evidence = [
+                    item
+                    for item in scanner_evidence
+                    if not isinstance(item, Mapping) or item.get("source") != evidence.get("source")
+                ]
+            if not any(
+                isinstance(item, Mapping)
+                and item.get("source") == evidence.get("source")
+                and item.get("reason_code") == reason_code
+                for item in scanner_evidence
+            ):
+                scanner_evidence.append(dict(evidence))
+            current_source = row["approval_source"]
+            next_source = approval_source if str(row["policy_decision"]) in source_actions else current_source
+            connection.execute(
+                """
+                update runtime_receipts
+                set scanner_evidence_json = ?, approval_source = ?
+                where rowid = ?
+                """,
+                (json.dumps(scanner_evidence, sort_keys=True), next_source, int(row["rowid"])),
+            )
 
 
 _DEFAULT_DETECTOR_REGISTRY: tuple[Callable[[], tuple[Any, ...]], DetectorRegistry] | None = None
@@ -495,39 +1006,457 @@ def guard_run(
     default_action: str | None = None,
     interactive_resolver: Callable[[HarnessDetection, dict[str, Any]], dict[str, Any]] | None = None,
     blocked_resolver: Callable[[HarnessDetection, dict[str, Any]], dict[str, Any]] | None = None,
+    current_config_provider: Callable[[], GuardConfig] | None = None,
 ) -> dict[str, Any]:
     """Evaluate local harness state and optionally launch the harness."""
 
     detection = _detection_with_prompt_artifacts(detect_harness(harness, context), context, passthrough_args)
-    if blocked_resolver is None:
-        evaluation = evaluate_detection(detection, store, config, default_action=default_action, persist=True)
-    else:
-        evaluation = evaluate_detection(detection, store, config, default_action=default_action, persist=False)
-        if not evaluation["blocked"]:
-            evaluation = evaluate_detection(detection, store, config, default_action=default_action, persist=True)
+    launch_plan: _GuardRunLaunchPlan | None = None
+    pending_approval_claims: list[tuple[Mapping[str, object], str, str]] = []
+    base_evaluation = evaluate_detection(
+        detection,
+        store,
+        config,
+        default_action=default_action,
+        persist=False,
+        pending_approval_claims=pending_approval_claims,
+    )
 
     action_envelope = _guard_run_action_envelope(harness, context, passthrough_args)
-    if evaluation["blocked"]:
-        evaluation = _evaluation_with_action_envelope(evaluation, action_envelope)
-
-    if not dry_run and interactive_resolver is not None and evaluation["blocked"]:
-        evaluation = interactive_resolver(detection, evaluation)
-    elif not dry_run and blocked_resolver is not None and evaluation["blocked"]:
-        pending_evaluation = blocked_resolver(detection, evaluation)
-        detection = _detection_with_prompt_artifacts(detect_harness(harness, context), context, passthrough_args)
-        reevaluated = evaluate_detection(detection, store, config, default_action=default_action, persist=True)
-        if reevaluated["blocked"]:
-            reevaluated = _evaluation_with_action_envelope(reevaluated, action_envelope)
-        for key in _APPROVAL_METADATA_KEYS:
-            if key in pending_evaluation:
-                reevaluated[key] = pending_evaluation[key]
-        evaluation = reevaluated
-    evaluation = _evaluation_with_detector_registry(
-        evaluation,
+    detector_evaluation = _evaluation_with_detector_registry(
+        base_evaluation,
         action_envelope,
         context,
         config,
     )
+    detector_action, _detector_reason = _runtime_detector_authority(detector_evaluation)
+    detector_context = _runtime_detector_context(detector_evaluation)
+    authority_config = config
+    if detector_action in {"warn", "review"}:
+        # The first evaluation is deliberately non-consuming and exists only
+        # to recover each artifact's current policy action. Re-evaluate with
+        # nonterminal detector authority bound into the current authority
+        # before trusting or scheduling any saved approval claim.
+        authority_config = _config_with_current_authority(config, base_evaluation, detector_action)
+    if detector_context is not None:
+        pending_approval_claims = []
+        evaluation = evaluate_detection(
+            detection,
+            store,
+            authority_config,
+            default_action=default_action,
+            persist=False,
+            pending_approval_claims=pending_approval_claims,
+            runtime_detector_context=detector_context,
+        )
+        evaluation = _evaluation_with_recorded_detector_result(evaluation, detector_evaluation)
+    else:
+        evaluation = detector_evaluation
+    detector_block_reason = detector_evaluation.get("blocked_by_detector")
+    authoritative_detector_block = (
+        detector_block_reason if isinstance(detector_block_reason, str) and detector_block_reason else None
+    )
+    if evaluation["blocked"]:
+        evaluation = _evaluation_with_action_envelope(evaluation, action_envelope)
+
+    resolved_evaluation: dict[str, Any] | None = None
+    trusted_request_overrides: dict[str, str] = {}
+    trusted_request_override_labels: dict[str, str] = {}
+    if (
+        not dry_run
+        and authoritative_detector_block is None
+        and interactive_resolver is not None
+        and evaluation["blocked"]
+    ):
+        resolved_evaluation = interactive_resolver(detection, evaluation)
+        trusted_request_overrides, trusted_request_override_labels = _resolved_interactive_request_overrides(
+            resolved_evaluation
+        )
+    elif (
+        not dry_run and authoritative_detector_block is None and blocked_resolver is not None and evaluation["blocked"]
+    ):
+        resolved_evaluation = blocked_resolver(detection, evaluation)
+        trusted_request_overrides = _resolved_exact_request_overrides(resolved_evaluation)
+        trusted_request_override_labels = {artifact_id: "approval-center" for artifact_id in trusted_request_overrides}
+    if resolved_evaluation is not None:
+        # A terminal prompt or browser wait is an authority boundary even when
+        # the user chose the unpersisted ``allow-once`` path. Reload policy
+        # before applying that exact request override; post-claim refresh below
+        # cannot protect an approval that intentionally created no stored row.
+        resolution_config_refresh_failed = False
+        if current_config_provider is not None:
+            try:
+                provided_config = current_config_provider()
+            except Exception:
+                resolution_config_refresh_failed = True
+            else:
+                if isinstance(provided_config, GuardConfig):
+                    config = provided_config
+                else:
+                    resolution_config_refresh_failed = True
+        if resolution_config_refresh_failed:
+            trusted_request_overrides = {}
+            trusted_request_override_labels = {}
+        detection = _detection_with_prompt_artifacts(detect_harness(harness, context), context, passthrough_args)
+        base_evaluation = evaluate_detection(
+            detection,
+            store,
+            config,
+            default_action=default_action,
+            persist=False,
+        )
+        detector_evaluation = _evaluation_with_detector_registry(
+            base_evaluation,
+            action_envelope,
+            context,
+            config,
+        )
+        detector_action, _detector_reason = _runtime_detector_authority(detector_evaluation)
+        detector_context = _runtime_detector_context(detector_evaluation)
+        authority_config = config
+        if detector_action in {"warn", "review"}:
+            authority_config = _config_with_current_authority(config, base_evaluation, detector_action)
+        pending_approval_claims = []
+        evaluation = evaluate_detection(
+            detection,
+            store,
+            authority_config,
+            default_action=default_action,
+            persist=False,
+            trusted_request_overrides=trusted_request_overrides,
+            trusted_request_override_labels=trusted_request_override_labels,
+            pending_approval_claims=pending_approval_claims,
+            runtime_detector_context=detector_context,
+        )
+        evaluation = _evaluation_with_recorded_detector_result(evaluation, detector_evaluation)
+        detector_block_reason = detector_evaluation.get("blocked_by_detector")
+        authoritative_detector_block = (
+            detector_block_reason if isinstance(detector_block_reason, str) and detector_block_reason else None
+        )
+        if evaluation["blocked"]:
+            evaluation = _evaluation_with_action_envelope(evaluation, action_envelope)
+        for key in _APPROVAL_METADATA_KEYS:
+            if key in resolved_evaluation:
+                evaluation[key] = resolved_evaluation[key]
+    if evaluation["blocked"] or dry_run:
+        receipt_cursor = _receipt_rowid_cursor(store)
+        persisted = evaluate_detection(
+            detection,
+            store,
+            authority_config,
+            default_action=default_action,
+            persist=True,
+            trusted_request_overrides=trusted_request_overrides,
+            trusted_request_override_labels=trusted_request_override_labels,
+            runtime_detector_context=detector_context,
+            runtime_detector_block_reason=authoritative_detector_block,
+        )
+        if persisted["blocked"]:
+            persisted = _evaluation_with_action_envelope(persisted, action_envelope)
+        persisted = _evaluation_with_recorded_detector_result(persisted, detector_evaluation)
+        detector_evidence = _runtime_detector_nonterminal_evidence(detector_action, _detector_reason)
+        if detector_evidence is not None and detector_action is not None:
+            _append_authority_evidence_to_receipts(
+                store,
+                after_rowid=receipt_cursor,
+                evaluation=persisted,
+                evidence=detector_evidence,
+                approval_source="runtime-detector",
+                source_actions=frozenset({detector_action}),
+            )
+        if resolved_evaluation is not None:
+            for key in _APPROVAL_METADATA_KEYS:
+                if key in resolved_evaluation:
+                    persisted[key] = resolved_evaluation[key]
+        evaluation = persisted
+    else:
+        decisions_to_claim = [decision for decision, _artifact_id, _artifact_hash in pending_approval_claims]
+        preclaim_launch_previews: tuple[_GuardRunLaunchPlan, ...] = ()
+        preclaim_signature: tuple[object, ...] | None = None
+        preclaim_failure_reason: str | None = None
+        if decisions_to_claim:
+            try:
+                preclaim_launch_previews = _guard_run_launch_previews(harness, context, passthrough_args)
+            except Exception:
+                preclaim_launch_previews = ()
+            if preclaim_launch_previews and all(plan.reusable for plan in preclaim_launch_previews):
+                preclaim_signature = _guard_run_authority_signature(
+                    detection,
+                    evaluation,
+                    preclaim_launch_previews,
+                )
+            if preclaim_signature is None:
+                preclaim_failure_reason = APPROVAL_REUSE_LAUNCH_IDENTITY_UNVERIFIED
+            else:
+                try:
+                    claim_succeeded = store.claim_approval_reuse_decisions(decisions_to_claim, now=_now())
+                except Exception:
+                    claim_succeeded = False
+                if not claim_succeeded:
+                    preclaim_failure_reason = APPROVAL_REUSE_CLAIM_FAILED
+        if decisions_to_claim and preclaim_failure_reason is not None:
+            failed_ids = {artifact_id for _decision, artifact_id, _artifact_hash in pending_approval_claims}
+            failure_config = _config_with_current_authority(
+                authority_config,
+                evaluation,
+                "require-reapproval",
+                artifact_ids=failed_ids,
+            )
+            if preclaim_failure_reason == APPROVAL_REUSE_LAUNCH_IDENTITY_UNVERIFIED:
+                failure_reason = (
+                    "saved approval could not be reused because the harness launch identity was not stable "
+                    "and path-pinned"
+                )
+                claim_status = "rejected"
+                revalidation_status = "unverified"
+            else:
+                failure_reason = "saved approval could not be atomically claimed"
+                claim_status = "failed"
+                revalidation_status = "claim-failed"
+            receipt_cursor = _receipt_rowid_cursor(store)
+            evaluation = evaluate_detection(
+                detection,
+                store,
+                failure_config,
+                default_action=default_action,
+                persist=True,
+                trusted_request_overrides=trusted_request_overrides,
+                trusted_request_override_labels=trusted_request_override_labels,
+                runtime_detector_context=detector_context,
+                runtime_detector_block_reason=authoritative_detector_block,
+            )
+            evaluation = _evaluation_with_recorded_detector_result(evaluation, detector_evaluation)
+            evaluation = _evaluation_with_preclaim_failure(
+                evaluation,
+                affected_artifact_ids=failed_ids,
+                reason_code=preclaim_failure_reason,
+                reason=failure_reason,
+                claim_status=claim_status,
+                revalidation_status=revalidation_status,
+            )
+            detector_evidence = _runtime_detector_nonterminal_evidence(detector_action, _detector_reason)
+            if detector_evidence is not None and detector_action is not None:
+                _append_authority_evidence_to_receipts(
+                    store,
+                    after_rowid=receipt_cursor,
+                    evaluation=evaluation,
+                    evidence=detector_evidence,
+                    approval_source="runtime-detector",
+                    source_actions=frozenset({detector_action}),
+                )
+            _append_authority_evidence_to_receipts(
+                store,
+                after_rowid=receipt_cursor,
+                evaluation=evaluation,
+                evidence={
+                    "source": "approval_reuse",
+                    "status": "rejected",
+                    "reason_code": preclaim_failure_reason,
+                    "reason": failure_reason,
+                },
+                approval_source="approval-reuse",
+                source_actions=frozenset({"review", "require-reapproval", "sandbox-required", "block"}),
+                replace_existing_source=True,
+            )
+            if resolved_evaluation is not None:
+                for key in _APPROVAL_METADATA_KEYS:
+                    if key in resolved_evaluation:
+                        evaluation[key] = resolved_evaluation[key]
+            evaluation = _evaluation_with_action_envelope(evaluation, action_envelope)
+        else:
+            consumed_claim_overrides = {
+                artifact_id: artifact_hash
+                for decision, artifact_id, artifact_hash in pending_approval_claims
+                if not _saved_decision_is_retained(decision)
+            }
+            retained_claim_overrides = {
+                artifact_id: artifact_hash
+                for decision, artifact_id, artifact_hash in pending_approval_claims
+                if _saved_decision_is_retained(decision)
+            }
+            if decisions_to_claim:
+                config_refresh_failed = False
+                fresh_config = config
+                if current_config_provider is not None:
+                    try:
+                        provided_config = current_config_provider()
+                    except Exception:
+                        config_refresh_failed = True
+                    else:
+                        if isinstance(provided_config, GuardConfig):
+                            fresh_config = provided_config
+                        else:
+                            config_refresh_failed = True
+                detection = _detection_with_prompt_artifacts(
+                    detect_harness(harness, context),
+                    context,
+                    passthrough_args,
+                )
+                fresh_base_evaluation = evaluate_detection(
+                    detection,
+                    store,
+                    fresh_config,
+                    default_action=default_action,
+                    persist=False,
+                )
+                fresh_detector_evaluation = _evaluation_with_detector_registry(
+                    fresh_base_evaluation,
+                    action_envelope,
+                    context,
+                    fresh_config,
+                )
+                fresh_detector_action, fresh_detector_reason = _runtime_detector_authority(fresh_detector_evaluation)
+                fresh_detector_context = _runtime_detector_context(fresh_detector_evaluation)
+                fresh_authority_config = fresh_config
+                if fresh_detector_action in {"warn", "review"}:
+                    fresh_authority_config = _config_with_current_authority(
+                        fresh_config,
+                        fresh_base_evaluation,
+                        fresh_detector_action,
+                    )
+                fresh_evaluation = evaluate_detection(
+                    detection,
+                    store,
+                    fresh_authority_config,
+                    default_action=default_action,
+                    persist=False,
+                    trusted_request_overrides=trusted_request_overrides,
+                    trusted_request_override_labels=trusted_request_override_labels,
+                    claimed_saved_approval_overrides=consumed_claim_overrides,
+                    retained_saved_approval_overrides=retained_claim_overrides,
+                    runtime_detector_context=fresh_detector_context,
+                )
+                fresh_evaluation = _evaluation_with_recorded_detector_result(
+                    fresh_evaluation,
+                    fresh_detector_evaluation,
+                )
+                try:
+                    fresh_launch_previews = _guard_run_launch_previews(harness, context, passthrough_args)
+                except Exception:
+                    fresh_launch_previews = ()
+                postclaim_signature = (
+                    _guard_run_authority_signature(detection, fresh_evaluation, fresh_launch_previews)
+                    if fresh_launch_previews and all(plan.reusable for plan in fresh_launch_previews)
+                    else None
+                )
+                finalized_launch_plan: _GuardRunLaunchPlan | None = None
+                if (
+                    not config_refresh_failed
+                    and preclaim_signature is not None
+                    and postclaim_signature == preclaim_signature
+                ):
+                    try:
+                        finalized_launch_plan = _guard_run_finalize_authorized_launch_plan(
+                            harness,
+                            context,
+                            passthrough_args,
+                            fresh_launch_previews,
+                        )
+                    except Exception:
+                        finalized_launch_plan = None
+                if (
+                    config_refresh_failed
+                    or preclaim_signature is None
+                    or postclaim_signature != preclaim_signature
+                    or finalized_launch_plan is None
+                ):
+                    stale_config = _config_with_current_authority(
+                        fresh_authority_config,
+                        fresh_evaluation,
+                        "require-reapproval",
+                    )
+                    fresh_block_reason = fresh_detector_evaluation.get("blocked_by_detector")
+                    authoritative_fresh_block = (
+                        fresh_block_reason if isinstance(fresh_block_reason, str) and fresh_block_reason else None
+                    )
+                    receipt_cursor = _receipt_rowid_cursor(store)
+                    evaluation = evaluate_detection(
+                        detection,
+                        store,
+                        stale_config,
+                        default_action=default_action,
+                        persist=True,
+                        runtime_detector_context=fresh_detector_context,
+                        runtime_detector_block_reason=authoritative_fresh_block,
+                    )
+                    evaluation = _evaluation_with_recorded_detector_result(
+                        evaluation,
+                        fresh_detector_evaluation,
+                    )
+                    evaluation = _evaluation_with_claim_context_failure(
+                        evaluation,
+                        claimed_artifact_ids={
+                            artifact_id for _decision, artifact_id, _artifact_hash in pending_approval_claims
+                        },
+                    )
+                    fresh_detector_evidence = _runtime_detector_nonterminal_evidence(
+                        fresh_detector_action,
+                        fresh_detector_reason,
+                    )
+                    if fresh_detector_evidence is not None:
+                        _append_authority_evidence_to_receipts(
+                            store,
+                            after_rowid=receipt_cursor,
+                            evaluation=evaluation,
+                            evidence=fresh_detector_evidence,
+                            approval_source="runtime-detector",
+                            source_actions=frozenset(),
+                        )
+                    _append_authority_evidence_to_receipts(
+                        store,
+                        after_rowid=receipt_cursor,
+                        evaluation=evaluation,
+                        evidence={
+                            "source": "approval_reuse",
+                            "status": "rejected",
+                            "reason_code": _APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
+                            "reason": "launch authority changed after the saved approval was claimed",
+                        },
+                        approval_source="approval-reuse",
+                        source_actions=frozenset({"review", "require-reapproval", "sandbox-required", "block"}),
+                        replace_existing_source=True,
+                    )
+                    evaluation = _evaluation_with_action_envelope(evaluation, action_envelope)
+                else:
+                    detector_evaluation = fresh_detector_evaluation
+                    detector_action = fresh_detector_action
+                    _detector_reason = fresh_detector_reason
+                    detector_context = fresh_detector_context
+                    authority_config = fresh_authority_config
+                    evaluation = fresh_evaluation
+                    launch_plan = finalized_launch_plan
+
+            if not evaluation["blocked"]:
+                receipt_cursor = _receipt_rowid_cursor(store)
+                evaluation = evaluate_detection(
+                    detection,
+                    store,
+                    authority_config,
+                    default_action=default_action,
+                    persist=True,
+                    trusted_request_overrides=trusted_request_overrides,
+                    trusted_request_override_labels=trusted_request_override_labels,
+                    claimed_saved_approval_overrides=consumed_claim_overrides,
+                    retained_saved_approval_overrides=retained_claim_overrides,
+                    runtime_detector_context=detector_context,
+                )
+                if evaluation["blocked"]:
+                    evaluation = _evaluation_with_action_envelope(evaluation, action_envelope)
+                evaluation = _evaluation_with_recorded_detector_result(evaluation, detector_evaluation)
+                detector_evidence = _runtime_detector_nonterminal_evidence(detector_action, _detector_reason)
+                if detector_evidence is not None and detector_action is not None:
+                    _append_authority_evidence_to_receipts(
+                        store,
+                        after_rowid=receipt_cursor,
+                        evaluation=evaluation,
+                        evidence=detector_evidence,
+                        approval_source="runtime-detector",
+                        source_actions=frozenset({detector_action}),
+                    )
+                if resolved_evaluation is not None:
+                    for key in _APPROVAL_METADATA_KEYS:
+                        if key in resolved_evaluation:
+                            evaluation[key] = resolved_evaluation[key]
     if "config_paths" not in evaluation:
         evaluation["config_paths"] = list(detection.config_paths) or _guard_run_config_paths(
             detection=detection,
@@ -539,24 +1468,46 @@ def guard_run(
         evaluation["launch_command"] = []
         return evaluation
 
-    adapter = get_adapter(harness)
-    command = adapter.launch_command(context, passthrough_args)
+    if launch_plan is None:
+        try:
+            launch_previews = _guard_run_launch_previews(harness, context, passthrough_args)
+            launch_plan = (
+                _guard_run_finalize_authorized_launch_plan(
+                    harness,
+                    context,
+                    passthrough_args,
+                    launch_previews,
+                )
+                if launch_previews and all(plan.reusable for plan in launch_previews)
+                else None
+            )
+        except Exception as error:
+            evaluation["launched"] = False
+            evaluation["launch_command"] = []
+            evaluation["return_code"] = 127
+            evaluation["launch_error"] = str(error)
+            return evaluation
+    if launch_plan is None or not launch_plan.reusable:
+        evaluation["launched"] = False
+        evaluation["launch_command"] = []
+        evaluation["return_code"] = 127
+        evaluation["launch_error"] = "Guard could not resolve a stable, path-pinned harness launch command."
+        return evaluation
+    command = list(launch_plan.execution_command)
     evaluation["launch_command"] = command
-    environment = os.environ.copy()
-    environment["HOME"] = str(context.home_dir)
-    if os.name == "nt":
-        environment["USERPROFILE"] = str(context.home_dir)
-    environment = adapter.prepare_launch_environment(context, environment)
+    environment = dict(launch_plan.environment)
     if harness == "hermes":
         _hermes_token = _resolve_hermes_guard_access_token(store)
         if _hermes_token is not None:
-            # The token is needed by Hermes's guard_runtime_policy.py to call
-            # the Guard policy API.  It must NOT leak to user-configured MCP
-            # server subprocesses; the proxy layer scrubs it before launching
-            # those processes (see proxy._build_scrubbed_env).
-            environment["HERMES_GUARD_TOKEN"] = _hermes_token
+            # This is the sole intentional environment addition after the
+            # prepared environment was authority-hashed. It is a short-lived
+            # Guard credential resolved only at the execution boundary, not
+            # user-controlled launch configuration. It must NOT leak to
+            # user-configured MCP subprocesses; the proxy layer scrubs it
+            # before launch (see proxy._build_scrubbed_env).
+            environment[_HERMES_GUARD_TOKEN_ENV_KEY] = _hermes_token
     try:
-        result = subprocess.run(command, cwd=context.workspace_dir or Path.cwd(), check=False, env=environment)
+        result = subprocess.run(command, cwd=launch_plan.launch_cwd, check=False, env=environment)
     except FileNotFoundError as error:
         evaluation["launched"] = False
         evaluation["return_code"] = 127
@@ -656,19 +1607,228 @@ def _evaluation_with_detector_registry(
         "runtime_detector_signals_v2": [signal.to_dict() for signal in result.signals],
         "runtime_detector_telemetry": [item.to_dict() for item in result.telemetry],
     }
-    base_action: str = "block" if evaluation.get("blocked") else "allow"
-    composition = compose_action_from_signals(result.signals, base_action)  # type: ignore[arg-type]
+    # Compose detector authority independently from the base artifact result.
+    # Otherwise an already-reviewable artifact makes every detector result
+    # appear to be a block and prevents us from identifying a genuine terminal
+    # detector block before entering the approval flow.
+    composition = compose_action_from_signals(result.signals, "allow")
     next_evaluation["runtime_detector_composition"] = {
         "action": composition.action,
         "reason": composition.reason,
         "downgraded": composition.downgraded,
         "upgraded": composition.upgraded,
     }
-    if composition.action == "block" and not bool(evaluation.get("blocked")):
+    if composition.action == "block":
         next_evaluation["blocked"] = True
         next_evaluation["blocked_by_detector"] = composition.reason
     if trace_error is not None:
         next_evaluation["runtime_detector_trace_error"] = trace_error
+    return next_evaluation
+
+
+_RUNTIME_DETECTOR_RESULT_KEYS = (
+    "runtime_detector_signals_v2",
+    "runtime_detector_telemetry",
+    "runtime_detector_composition",
+    "runtime_detector_trace_error",
+)
+
+
+def _evaluation_with_recorded_detector_result(
+    evaluation: dict[str, Any],
+    detector_evaluation: Mapping[str, object],
+) -> dict[str, Any]:
+    """Carry one pre-launch detector result across persistence without rerunning it."""
+
+    next_evaluation = dict(evaluation)
+    for key in _RUNTIME_DETECTOR_RESULT_KEYS:
+        if key in detector_evaluation:
+            next_evaluation[key] = detector_evaluation[key]
+    blocked_by_detector = detector_evaluation.get("blocked_by_detector")
+    if isinstance(blocked_by_detector, str) and blocked_by_detector:
+        next_evaluation["blocked"] = True
+        next_evaluation["blocked_by_detector"] = blocked_by_detector
+    detector_action, detector_reason = _runtime_detector_authority(detector_evaluation)
+    evidence = _runtime_detector_nonterminal_evidence(detector_action, detector_reason)
+    if evidence is None:
+        return next_evaluation
+
+    raw_artifacts = next_evaluation.get("artifacts")
+    if not isinstance(raw_artifacts, list) or not raw_artifacts:
+        if detector_action == "review":
+            next_evaluation["blocked"] = True
+            next_evaluation["blocked_by_detector"] = evidence["reason"]
+        return next_evaluation
+    artifacts: list[object] = []
+    for raw_item in raw_artifacts:
+        if not isinstance(raw_item, Mapping):
+            artifacts.append(raw_item)
+            continue
+        item = dict(raw_item)
+        raw_scanner_evidence = item.get("scanner_evidence")
+        scanner_evidence: list[object] = (
+            [
+                dict(raw_evidence) if isinstance(raw_evidence, Mapping) else raw_evidence
+                for raw_evidence in raw_scanner_evidence
+            ]
+            if isinstance(raw_scanner_evidence, list)
+            else []
+        )
+        if not any(
+            isinstance(raw_evidence, Mapping)
+            and raw_evidence.get("source") == evidence["source"]
+            and raw_evidence.get("reason_code") == evidence["reason_code"]
+            for raw_evidence in scanner_evidence
+        ):
+            scanner_evidence.append(evidence)
+        item["scanner_evidence"] = scanner_evidence
+        composition = item.get("policy_composition")
+        item["policy_composition"] = {
+            **(dict(composition) if isinstance(composition, Mapping) else {}),
+            "runtime_detector_action": detector_action,
+            "runtime_detector_reason": evidence["reason"],
+        }
+        if item.get("policy_action") == detector_action:
+            decision = item.get("decision_v2_json")
+            if isinstance(decision, Mapping):
+                item["decision_v2_json"] = {**dict(decision), "reason": evidence["reason_code"]}
+        artifacts.append(item)
+    next_evaluation["artifacts"] = artifacts
+    return next_evaluation
+
+
+def _evaluation_with_preclaim_failure(
+    evaluation: dict[str, Any],
+    *,
+    affected_artifact_ids: set[str],
+    reason_code: str,
+    reason: str,
+    claim_status: str,
+    revalidation_status: str,
+) -> dict[str, Any]:
+    """Record a terminal, auditable failure before approval authority is claimed."""
+
+    evidence = {
+        "source": "approval_reuse",
+        "status": "rejected",
+        "reason_code": reason_code,
+        "reason": reason,
+    }
+    artifacts: list[object] = []
+    for raw_item in evaluation.get("artifacts", []):
+        if not isinstance(raw_item, Mapping) or raw_item.get("artifact_id") not in affected_artifact_ids:
+            artifacts.append(raw_item)
+            continue
+        item = dict(raw_item)
+        raw_scanner_evidence = item.get("scanner_evidence")
+        scanner_evidence: list[object] = (
+            [
+                dict(raw_evidence)
+                for raw_evidence in raw_scanner_evidence
+                if isinstance(raw_evidence, Mapping) and raw_evidence.get("source") != "approval_reuse"
+            ]
+            if isinstance(raw_scanner_evidence, list)
+            else []
+        )
+        scanner_evidence.append(evidence)
+        item["scanner_evidence"] = scanner_evidence
+        item["approval_reuse_status"] = "rejected"
+        item["approval_reuse_reason_code"] = reason_code
+        approval_reuse = item.get("approval_reuse")
+        item["approval_reuse"] = {
+            **(dict(approval_reuse) if isinstance(approval_reuse, Mapping) else {}),
+            "action": item.get("policy_action"),
+            "status": "rejected",
+            "reason_code": reason_code,
+            "should_claim": False,
+        }
+        composition = item.get("policy_composition")
+        item["policy_composition"] = {
+            **(dict(composition) if isinstance(composition, Mapping) else {}),
+            "claim_revalidation": revalidation_status,
+            "claim_revalidation_reason": reason_code,
+            "final_action": item.get("policy_action"),
+        }
+        decision = item.get("decision_v2_json")
+        if isinstance(decision, Mapping):
+            item["decision_v2_json"] = {**dict(decision), "reason": reason_code}
+        artifacts.append(item)
+    return {
+        **evaluation,
+        "artifacts": artifacts,
+        "blocked": True,
+        "approval_claim": {
+            "status": claim_status,
+            "reason_code": reason_code,
+            "artifact_ids": sorted(affected_artifact_ids),
+        },
+    }
+
+
+def _evaluation_with_claim_context_failure(
+    evaluation: dict[str, Any],
+    *,
+    claimed_artifact_ids: set[str],
+) -> dict[str, Any]:
+    """Make a changed post-claim authority terminal and auditable."""
+
+    evidence = {
+        "source": "approval_reuse",
+        "status": "rejected",
+        "reason_code": _APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
+        "reason": "launch authority changed after the saved approval was claimed",
+    }
+    artifacts: list[object] = []
+    for raw_item in evaluation.get("artifacts", []):
+        if not isinstance(raw_item, Mapping):
+            artifacts.append(raw_item)
+            continue
+        item = dict(raw_item)
+        raw_scanner_evidence = item.get("scanner_evidence")
+        scanner_evidence: list[object] = (
+            [
+                dict(raw_evidence)
+                for raw_evidence in raw_scanner_evidence
+                if isinstance(raw_evidence, Mapping) and raw_evidence.get("source") != "approval_reuse"
+            ]
+            if isinstance(raw_scanner_evidence, list)
+            else []
+        )
+        scanner_evidence.append(evidence)
+        item["scanner_evidence"] = scanner_evidence
+        item["approval_reuse_status"] = "rejected"
+        item["approval_reuse_reason_code"] = _APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM
+        approval_reuse = item.get("approval_reuse")
+        item["approval_reuse"] = {
+            **(dict(approval_reuse) if isinstance(approval_reuse, Mapping) else {}),
+            "action": item.get("policy_action"),
+            "status": "rejected",
+            "reason_code": _APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
+            "should_claim": False,
+        }
+        composition = item.get("policy_composition")
+        item["policy_composition"] = {
+            **(dict(composition) if isinstance(composition, Mapping) else {}),
+            "claim_revalidation": "changed",
+            "claim_revalidation_reason": _APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
+        }
+        decision = item.get("decision_v2_json")
+        if isinstance(decision, Mapping):
+            item["decision_v2_json"] = {
+                **dict(decision),
+                "reason": _APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
+            }
+        artifacts.append(item)
+    next_evaluation = {
+        **evaluation,
+        "artifacts": artifacts,
+        "blocked": True,
+        "approval_claim": {
+            "status": "rejected",
+            "reason_code": _APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
+            "artifact_ids": sorted(claimed_artifact_ids),
+        },
+    }
     return next_evaluation
 
 
@@ -3966,7 +5126,7 @@ def _should_emit_pain_signal(
         return warn_occurrences.get(warn_key, 0) >= 2
     if event_name == "changed_artifact_caught":
         policy_action = _optional_string(payload.get("policy_action"))
-        return policy_action in {"block", "sandbox-required", "require-reapproval"}
+        return policy_action in {"review", "require-reapproval", "sandbox-required", "block"}
     if event_name == "supply_chain_bundle_refresh_requested":
         reason = _optional_string(payload.get("reason"))
         return reason == "feed_stale"

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -79,6 +79,13 @@ _TIMEOUT_SECONDS = 1
 _RETRY_TIMEOUT_SECONDS = 1
 _CLOUD_INBOX_URL_RE = re.compile(r"https?://[^\s]+/guard/inbox/?", re.IGNORECASE)
 _LOCAL_REVIEW_INSTRUCTION = "Review this request in HOL Guard, then retry."
+_LOCAL_REVIEW_INSTRUCTION_RE = re.compile(re.escape(_LOCAL_REVIEW_INSTRUCTION), re.IGNORECASE)
+_LOCAL_APPROVAL_INSTRUCTION_RE = re.compile(
+    r"\s*Open HOL Guard to approve or keep this blocked:\s*https?://\S+"
+    r"(?:\s+After you choose,\s+retry the same .*? action\.)?",
+    re.IGNORECASE,
+)
+_LOCAL_APPROVAL_REQUEST_URL_RE = re.compile(r"https?://[^\s]+/requests(?:/[^\s]*)?", re.IGNORECASE)
 _LOCKFILE_PARSE_BUDGET_SECONDS = 0.2
 _TRANSITIVE_BLOCK_CONFIDENCE_THRESHOLD = 900
 _NPM_REGISTRY_METADATA_BASE_URL = "https://registry.npmjs.org"
@@ -631,19 +638,25 @@ def _cached_cloud_validation_error_has_saved_policy(
         )
     except (ImportError, TypeError, ValueError, OSError):
         return False
-    decision = store.resolve_policy_decision(
+    lookup = store.resolve_policy_decision_lookup(
         artifact.harness,
         artifact.artifact_id,
         artifact_hash,
         str(workspace_dir),
         artifact.publisher,
         now,
+        consume_one_shot=False,
     )
+    decision = lookup["decision"]
     if not isinstance(decision, dict):
         return False
     if _stored_package_policy_is_stale_policy_bundle_family(decision, store=store):
         return False
-    return decision.get("action") in {"allow", "block"}
+    # This cache-error probe does not have the current Guard/sandbox context,
+    # so it cannot establish exact v1 approval reuse. A stored block remains a
+    # conservative reason to keep the cached block; an allow must proceed to a
+    # full uncached evaluation and the normal current-context launch gate.
+    return decision.get("action") == "block"
 
 
 def _evaluation_has_reason_code(evaluation: PackageRequestEvaluation, code: str) -> bool:
@@ -1026,7 +1039,14 @@ def _normalize_package_user_copy(user_copy: SupplyChainUserCopy, *, policy_actio
     harness_message = _CLOUD_INBOX_URL_RE.sub("", user_copy.harness_message or "").strip()
     harness_message = " ".join(harness_message.split())
     harness_message = _strip_review_evidence_tail(harness_message)
-    needs_local_review = policy_action in {"review", "require-reapproval", "sandbox-required", "block"}
+    terminal_action = policy_action in {"sandbox-required", "block"}
+    if terminal_action:
+        dashboard_url = None
+        harness_message = _LOCAL_APPROVAL_INSTRUCTION_RE.sub("", harness_message)
+        harness_message = _LOCAL_APPROVAL_REQUEST_URL_RE.sub("", harness_message)
+        harness_message = _LOCAL_REVIEW_INSTRUCTION_RE.sub("", harness_message)
+        harness_message = " ".join(harness_message.split()).strip()
+    needs_local_review = policy_action in {"review", "require-reapproval"}
     if needs_local_review and _LOCAL_REVIEW_INSTRUCTION.lower() not in harness_message.lower():
         harness_message = f"{harness_message} {_LOCAL_REVIEW_INSTRUCTION}".strip()
     return replace(user_copy, dashboard_url=dashboard_url, harness_message=harness_message)
@@ -3815,7 +3835,7 @@ def _matching_policy_rule(
                     continue
             except ValueError:
                 pass
-        if rule.harness_selector is not None and rule.harness_selector != harness:
+        if rule.harness_selector not in {None, "*", harness}:
             continue
         if rule.ecosystem_selector is not None and rule.ecosystem_selector != target["ecosystem"]:
             continue

--- a/src/codex_plugin_scanner/guard/store_base.py
+++ b/src/codex_plugin_scanner/guard/store_base.py
@@ -54,6 +54,7 @@ from .policy_integrity import (
     verify_local_policy_row,
 )
 from .runtime.actions import GuardActionEnvelope
+from .runtime.approval_context import parse_approval_context_token
 from .runtime.scanner_cache import scanner_cache_key
 from .schemas.guard_event_v1 import GuardEventV1
 from .sqlite_tuning import SQLITE_BUSY_TIMEOUT_MS, SQLITE_CONNECT_TIMEOUT_SECONDS, SQLITE_WAL_BUSY_TIMEOUT_MS
@@ -205,6 +206,7 @@ class PolicyDecisionLookupResult(TypedDict):
     decision: dict[str, object] | None
     ignored_local_integrity: dict[str, object] | None
     trust_status: dict[str, object]
+    authority_revision: int
 
 
 _POLICY_INTEGRITY_KEY_REF = "guard-policy-integrity-key"
@@ -1349,6 +1351,10 @@ def _is_runtime_scoped_exact_match_key(value: str | None) -> bool:
     return isinstance(value, str) and value.startswith(_RUNTIME_SCOPED_EXACT_MATCH_PREFIX)
 
 
+def _is_approval_context_token(value: object) -> bool:
+    return parse_approval_context_token(value) is not None
+
+
 def _scoped_runtime_row_requires_exact_match(
     *,
     scope: str,
@@ -1356,6 +1362,7 @@ def _scoped_runtime_row_requires_exact_match(
     stored_artifact_hash: str | None,
     source: str,
     requested_artifact_id: str | None,
+    requested_artifact_hash: str | None = None,
     requested_runtime_exact_match_key: str | None = None,
 ) -> bool:
     if scope not in {"harness", "global"}:
@@ -1368,6 +1375,7 @@ def _scoped_runtime_row_requires_exact_match(
     expected_exact_keys = {
         key
         for key in (
+            requested_artifact_hash if _is_approval_context_token(requested_artifact_hash) else None,
             _runtime_scoped_exact_match_key(requested_artifact_id),
             requested_runtime_exact_match_key,
         )
@@ -1464,8 +1472,33 @@ def _chunks(values: Sequence[_ChunkT], size: int) -> Iterator[list[_ChunkT]]:
         yield list(values[index : index + size])
 
 
+def _parse_utc_timestamp(value: str) -> datetime:
+    candidate = value.strip()
+    if not candidate:
+        raise ValueError("timestamp must not be empty")
+    parsed = datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _canonical_utc_timestamp(value: str) -> str:
+    """Normalize an ISO-8601 timestamp for safe storage and comparison."""
+
+    return _parse_utc_timestamp(value).isoformat(timespec="microseconds")
+
+
+def _timestamp_has_expired(expires_at: str, *, now: str) -> bool:
+    """Return true at the expiry boundary and for malformed legacy values."""
+
+    try:
+        return _parse_utc_timestamp(expires_at) <= _parse_utc_timestamp(now)
+    except (TypeError, ValueError):
+        return True
+
+
 def _now() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return _canonical_utc_timestamp(datetime.now(timezone.utc).isoformat())
 
 
 def _lease_expiry(now: str, lease_seconds: int) -> str:

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -45,6 +45,80 @@ def _sleep_compat(seconds: float) -> None:
     sleep(seconds)
 
 
+_POLICY_INDEX_STATEMENTS = (
+    """
+    create index if not exists idx_policy_decisions_reuse_artifact
+    on policy_decisions (action, harness, artifact_id, updated_at desc, decision_id desc)
+    """,
+    """
+    create index if not exists idx_policy_decisions_reuse_hash
+    on policy_decisions (action, harness, artifact_hash, updated_at desc, decision_id desc)
+    """,
+    """
+    create index if not exists idx_policy_decisions_reuse_publisher
+    on policy_decisions (action, harness, publisher, updated_at desc, decision_id desc)
+    """,
+    """
+    create index if not exists idx_policy_decisions_lookup_artifact
+    on policy_decisions (artifact_id, harness, artifact_hash, updated_at desc, decision_id desc)
+    where scope = 'artifact'
+    """,
+    """
+    create index if not exists idx_policy_decisions_lookup_workspace
+    on policy_decisions (workspace, harness, artifact_id, artifact_hash, updated_at desc, decision_id desc)
+    where scope = 'workspace'
+    """,
+    """
+    create index if not exists idx_policy_decisions_lookup_publisher
+    on policy_decisions (publisher, harness, artifact_hash, updated_at desc, decision_id desc)
+    where scope = 'publisher'
+    """,
+    """
+    create index if not exists idx_policy_decisions_lookup_publisher_legacy
+    on policy_decisions (publisher, harness, artifact_hash, updated_at desc, decision_id desc)
+    where scope = 'publisher' and artifact_hash is not null
+      and artifact_hash not like 'guard-approval-context:v1:%'
+    """,
+    """
+    create index if not exists idx_policy_decisions_lookup_harness
+    on policy_decisions (harness, artifact_id, artifact_hash, updated_at desc, decision_id desc)
+    where scope = 'harness'
+    """,
+    """
+    create index if not exists idx_policy_decisions_lookup_harness_legacy
+    on policy_decisions (harness, artifact_id, artifact_hash, updated_at desc, decision_id desc)
+    where scope = 'harness' and artifact_hash is not null
+      and artifact_hash not like 'guard-approval-context:v1:%'
+    """,
+    """
+    create index if not exists idx_policy_decisions_lookup_global
+    on policy_decisions (harness, artifact_id, artifact_hash, updated_at desc, decision_id desc)
+    where scope = 'global'
+    """,
+    """
+    create index if not exists idx_policy_decisions_lookup_global_legacy
+    on policy_decisions (harness, artifact_id, artifact_hash, updated_at desc, decision_id desc)
+    where scope = 'global' and artifact_hash is not null
+      and artifact_hash not like 'guard-approval-context:v1:%'
+    """,
+    """
+    create index if not exists idx_policy_decisions_diagnostic_harness_broad
+    on policy_decisions (harness, updated_at desc, decision_id desc)
+    where scope = 'harness' and action = 'allow' and artifact_id is null
+    """,
+    """
+    create index if not exists idx_policy_decisions_diagnostic_global_broad
+    on policy_decisions (harness, updated_at desc, decision_id desc)
+    where scope = 'global' and action = 'allow' and artifact_id is null
+    """,
+    """
+    create index if not exists idx_policy_decisions_diagnostic_publisher
+    on policy_decisions (harness, publisher, updated_at desc, decision_id desc)
+    where scope = 'publisher' and action = 'allow'
+    """,
+)
+
+
 class StoreConnectionSchemaMixin:
     _startup_prefetched_policy_integrity_secret_material: object | tuple[bytes | None, str | None] = (
         _POLICY_INTEGRITY_LOOKUP_UNSET
@@ -334,12 +408,81 @@ class StoreConnectionSchemaMixin:
               action text not null,
               created_at text not null,
               expires_at text not null,
-              claimed_at text
+              claimed_at text,
+              integrity_version integer,
+              payload_hash text,
+              payload_mac text,
+              integrity_key_id text,
+              signed_at text
             )
             """,
             """
             create index if not exists idx_guard_local_once_approvals_lookup
             on guard_local_once_approvals (claimed_at, harness, artifact_id, artifact_hash, expires_at)
+            """,
+            """
+            create index if not exists idx_guard_local_once_reuse_artifact
+            on guard_local_once_approvals (action, harness, artifact_id, created_at desc, approval_id desc)
+            """,
+            """
+            create index if not exists idx_guard_local_once_reuse_hash
+            on guard_local_once_approvals (action, harness, artifact_hash, created_at desc, approval_id desc)
+            """,
+            """
+            create index if not exists idx_guard_local_once_diagnostic_artifact
+            on guard_local_once_approvals (harness, artifact_id, created_at desc, approval_id desc)
+            where claimed_at is null and action = 'allow'
+            """,
+            """
+            create index if not exists idx_guard_local_once_diagnostic_hash
+            on guard_local_once_approvals (harness, artifact_hash, created_at desc, approval_id desc)
+            where claimed_at is null and action = 'allow'
+            """,
+            """
+            create table if not exists guard_approval_authority_revision (
+              singleton integer primary key check (singleton = 1),
+              revision integer not null
+            )
+            """,
+            """
+            insert or ignore into guard_approval_authority_revision (singleton, revision)
+            values (1, 0)
+            """,
+            """
+            create trigger if not exists trg_policy_decisions_authority_insert
+            after insert on policy_decisions begin
+              update guard_approval_authority_revision set revision = revision + 1 where singleton = 1;
+            end
+            """,
+            """
+            create trigger if not exists trg_policy_decisions_authority_update
+            after update on policy_decisions begin
+              update guard_approval_authority_revision set revision = revision + 1 where singleton = 1;
+            end
+            """,
+            """
+            create trigger if not exists trg_policy_decisions_authority_delete
+            after delete on policy_decisions begin
+              update guard_approval_authority_revision set revision = revision + 1 where singleton = 1;
+            end
+            """,
+            """
+            create trigger if not exists trg_local_once_authority_insert
+            after insert on guard_local_once_approvals begin
+              update guard_approval_authority_revision set revision = revision + 1 where singleton = 1;
+            end
+            """,
+            """
+            create trigger if not exists trg_local_once_authority_update
+            after update on guard_local_once_approvals begin
+              update guard_approval_authority_revision set revision = revision + 1 where singleton = 1;
+            end
+            """,
+            """
+            create trigger if not exists trg_local_once_authority_delete
+            after delete on guard_local_once_approvals begin
+              update guard_approval_authority_revision set revision = revision + 1 where singleton = 1;
+            end
             """,
             """
             create table if not exists guard_cloud_events (
@@ -490,6 +633,13 @@ class StoreConnectionSchemaMixin:
             self._ensure_policy_column(connection, "payload_mac", "text")
             self._ensure_policy_column(connection, "integrity_key_id", "text")
             self._ensure_policy_column(connection, "signed_at", "text")
+            for index_statement in _POLICY_INDEX_STATEMENTS:
+                connection.execute(index_statement)
+            self._ensure_column(connection, "guard_local_once_approvals", "integrity_version", "integer")
+            self._ensure_column(connection, "guard_local_once_approvals", "payload_hash", "text")
+            self._ensure_column(connection, "guard_local_once_approvals", "payload_mac", "text")
+            self._ensure_column(connection, "guard_local_once_approvals", "integrity_key_id", "text")
+            self._ensure_column(connection, "guard_local_once_approvals", "signed_at", "text")
             self._ensure_runtime_receipts_column(connection, "capabilities_summary", "text not null default ''")
             self._ensure_runtime_receipts_column(connection, "scanner_evidence_json", "text not null default '[]'")
             self._ensure_runtime_receipts_column(connection, "diff_summary", "text")

--- a/src/codex_plugin_scanner/guard/store_event_receipts.py
+++ b/src/codex_plugin_scanner/guard/store_event_receipts.py
@@ -4,8 +4,13 @@
 
 from __future__ import annotations
 
+from .local_authority_integrity import sign_local_authority_payload, verify_local_authority_payload
+from .policy_integrity import PolicyIntegrityVerificationResult
+
 # ruff: noqa: F403,F405
 from .store_base import *
+
+_LOCAL_ONCE_INTEGRITY_PURPOSE = "guard-local-once-approval"
 
 
 def _local_once_approval_is_reusable(artifact_id: str) -> bool:
@@ -28,16 +33,44 @@ class StoreEventReceiptsMixin:
     ) -> str | None:
         if not artifact_id or not artifact_hash:
             return None
+        created_at = _canonical_utc_timestamp(created_at)
+        expires_at = _canonical_utc_timestamp(expires_at)
+        if _timestamp_has_expired(expires_at, now=created_at):
+            raise ValueError("local approval expiry must be after its creation time")
         approval_id = uuid4().hex
         workspace_key = _workspace_policy_key(workspace)
+        key, key_id = self._policy_integrity_secret_material(create=True)
+        if key is None or key_id is None:
+            return None
+        signing_row: dict[str, object] = {
+            "approval_id": approval_id,
+            "request_id": request_id,
+            "harness": harness,
+            "artifact_id": artifact_id,
+            "artifact_hash": artifact_hash,
+            "workspace": workspace_key,
+            "publisher": publisher,
+            "action": action,
+            "created_at": created_at,
+            "expires_at": expires_at,
+            "claimed_at": None,
+        }
+        integrity = sign_local_authority_payload(
+            signing_row,
+            key=key,
+            key_id=key_id,
+            purpose=_LOCAL_ONCE_INTEGRITY_PURPOSE,
+            signed_at=created_at,
+        )
         with self._connect() as connection:
             connection.execute(
                 """
                 insert into guard_local_once_approvals (
                   approval_id, request_id, harness, artifact_id, artifact_hash, workspace, publisher, action,
-                  created_at, expires_at, claimed_at
+                  created_at, expires_at, claimed_at, integrity_version, payload_hash, payload_mac,
+                  integrity_key_id, signed_at
                 )
-                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null)
+                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null, ?, ?, ?, ?, ?)
                 """,
                 (
                     approval_id,
@@ -50,9 +83,170 @@ class StoreEventReceiptsMixin:
                     action,
                     created_at,
                     expires_at,
+                    integrity["integrity_version"],
+                    integrity["payload_hash"],
+                    integrity["payload_mac"],
+                    integrity["integrity_key_id"],
+                    integrity["signed_at"],
                 ),
             )
         return approval_id
+
+    @staticmethod
+    def _peek_local_once_approval_lookup_locked(
+        connection: sqlite3.Connection,
+        *,
+        harness: str,
+        artifact_id: str | None,
+        artifact_hash: str | None,
+        workspace: str | None,
+        publisher: str | None,
+        now: str,
+        integrity_key: bytes | None = None,
+        integrity_key_id: str | None = None,
+    ) -> tuple[dict[str, object] | None, dict[str, object] | None]:
+        if not artifact_id or not artifact_hash:
+            return None, None
+        workspace_key = _workspace_policy_key(workspace)
+        row = connection.execute(
+            """
+            select approval_id, request_id, harness, artifact_id, artifact_hash, workspace, publisher, action,
+                   created_at, expires_at, claimed_at, integrity_version, payload_hash, payload_mac,
+                   integrity_key_id, signed_at
+            from guard_local_once_approvals
+            where claimed_at is null
+              and harness = ?
+              and artifact_id = ?
+              and artifact_hash = ?
+              and julianday(expires_at) > julianday(?)
+              and (workspace is null or workspace = ?)
+              and (publisher is null or publisher = ?)
+            order by created_at desc
+            limit 1
+            """,
+            (harness, artifact_id, artifact_hash, now, workspace_key, publisher),
+        ).fetchone()
+        if row is None:
+            return None, None
+        integrity_result = _verify_local_once_approval(
+            row,
+            key=integrity_key,
+            key_id=integrity_key_id,
+        )
+        if integrity_result.status != "valid":
+            return None, _local_once_approval_integrity_failure(row, integrity_result=integrity_result)
+        return _local_once_approval_payload(row), None
+
+    @staticmethod
+    def _peek_local_once_approval_locked(
+        connection: sqlite3.Connection,
+        *,
+        harness: str,
+        artifact_id: str | None,
+        artifact_hash: str | None,
+        workspace: str | None,
+        publisher: str | None,
+        now: str,
+        integrity_key: bytes | None = None,
+        integrity_key_id: str | None = None,
+    ) -> dict[str, object] | None:
+        decision, _integrity_failure = StoreEventReceiptsMixin._peek_local_once_approval_lookup_locked(
+            connection,
+            harness=harness,
+            artifact_id=artifact_id,
+            artifact_hash=artifact_hash,
+            workspace=workspace,
+            publisher=publisher,
+            now=now,
+            integrity_key=integrity_key,
+            integrity_key_id=integrity_key_id,
+        )
+        return decision
+
+    @staticmethod
+    def _claim_local_once_approval_by_id_locked(
+        connection: sqlite3.Connection,
+        *,
+        approval_id: str,
+        now: str,
+        expected_decision: Mapping[str, object] | None = None,
+        integrity_key: bytes | None = None,
+        integrity_key_id: str | None = None,
+        consume: bool = True,
+    ) -> dict[str, object] | None:
+        now = _canonical_utc_timestamp(now)
+        row = connection.execute(
+            """
+            select approval_id, request_id, harness, artifact_id, artifact_hash, workspace, publisher, action,
+                   created_at, expires_at, claimed_at, integrity_version, payload_hash, payload_mac,
+                   integrity_key_id, signed_at
+            from guard_local_once_approvals
+            where approval_id = ? and claimed_at is null
+              and julianday(expires_at) > julianday(?)
+            """,
+            (approval_id, now),
+        ).fetchone()
+        if row is None:
+            return None
+        integrity_result = _verify_local_once_approval(
+            row,
+            key=integrity_key,
+            key_id=integrity_key_id,
+        )
+        if integrity_result.status != "valid" or integrity_key is None or integrity_key_id is None:
+            return None
+        decision = _local_once_approval_payload(row)
+        identity_keys = (
+            "action",
+            "approval_id",
+            "artifact_hash",
+            "artifact_id",
+            "expires_at",
+            "harness",
+            "integrity_key_id",
+            "integrity_status",
+            "integrity_version",
+            "publisher",
+            "request_id",
+            "source",
+            "signed_at",
+            "updated_at",
+            "workspace",
+        )
+        if expected_decision is not None and any(
+            decision.get(key) != expected_decision.get(key) for key in identity_keys
+        ):
+            return None
+        if not consume:
+            return decision
+        claimed_row = {**_local_once_approval_signed_payload(row), "claimed_at": now}
+        claimed_integrity = sign_local_authority_payload(
+            claimed_row,
+            key=integrity_key,
+            key_id=integrity_key_id,
+            purpose=_LOCAL_ONCE_INTEGRITY_PURPOSE,
+            signed_at=now,
+        )
+        claim_cursor = connection.execute(
+            """
+            update guard_local_once_approvals
+            set claimed_at = ?, integrity_version = ?, payload_hash = ?, payload_mac = ?,
+                integrity_key_id = ?, signed_at = ?
+            where approval_id = ? and claimed_at is null
+            """,
+            (
+                now,
+                claimed_integrity["integrity_version"],
+                claimed_integrity["payload_hash"],
+                claimed_integrity["payload_mac"],
+                claimed_integrity["integrity_key_id"],
+                claimed_integrity["signed_at"],
+                approval_id,
+            ),
+        )
+        if claim_cursor.rowcount != 1:
+            return None
+        return decision
 
     @staticmethod
     def _claim_local_once_approval_locked(
@@ -64,53 +258,103 @@ class StoreEventReceiptsMixin:
         workspace: str | None,
         publisher: str | None,
         now: str,
+        integrity_key: bytes | None = None,
+        integrity_key_id: str | None = None,
     ) -> dict[str, object] | None:
-        if not artifact_id or not artifact_hash:
+        decision = StoreEventReceiptsMixin._peek_local_once_approval_locked(
+            connection,
+            harness=harness,
+            artifact_id=artifact_id,
+            artifact_hash=artifact_hash,
+            workspace=workspace,
+            publisher=publisher,
+            now=now,
+            integrity_key=integrity_key,
+            integrity_key_id=integrity_key_id,
+        )
+        if decision is None:
             return None
-        workspace_key = _workspace_policy_key(workspace)
-        row = connection.execute(
-            """
-            select approval_id, request_id, harness, artifact_id, artifact_hash, workspace, publisher, action,
-                   created_at, expires_at
-            from guard_local_once_approvals
-            where claimed_at is null
-              and harness = ?
-              and artifact_id = ?
-              and artifact_hash = ?
-              and expires_at > ?
-              and (workspace is null or workspace = ?)
-              and (publisher is null or publisher = ?)
-            order by created_at desc
-            limit 1
-            """,
-            (harness, artifact_id, artifact_hash, now, workspace_key, publisher),
-        ).fetchone()
-        if row is None:
-            return None
-        if not _local_once_approval_is_reusable(str(row["artifact_id"])):
-            claim_cursor = connection.execute(
-                "update guard_local_once_approvals set claimed_at = ? where approval_id = ? and claimed_at is null",
-                (now, str(row["approval_id"])),
+        # Preserve the legacy package replay behavior for existing consuming
+        # resolution callers. Current-policy-first callers explicitly claim a
+        # selected decision only after approval reuse is accepted.
+        decision_artifact_id = decision.get("artifact_id")
+        if isinstance(decision_artifact_id, str) and _local_once_approval_is_reusable(decision_artifact_id):
+            return decision
+        return StoreEventReceiptsMixin._claim_local_once_approval_by_id_locked(
+            connection,
+            approval_id=str(decision["approval_id"]),
+            now=now,
+            integrity_key=integrity_key,
+            integrity_key_id=integrity_key_id,
+        )
+
+    def peek_local_once_approval(
+        self,
+        *,
+        harness: str,
+        artifact_id: str | None,
+        artifact_hash: str | None,
+        workspace: str | None,
+        publisher: str | None,
+        now: str,
+    ) -> dict[str, object] | None:
+        """Return exact unexpired approval evidence without consuming it."""
+
+        integrity_key, integrity_key_id = self._policy_integrity_secret_material(create=False)
+        with self._connect() as connection:
+            return self._peek_local_once_approval_locked(
+                connection,
+                harness=harness,
+                artifact_id=artifact_id,
+                artifact_hash=artifact_hash,
+                workspace=workspace,
+                publisher=publisher,
+                now=now,
+                integrity_key=integrity_key,
+                integrity_key_id=integrity_key_id,
             )
-            if claim_cursor.rowcount != 1:
-                return None
-        return {
-            "action": str(row["action"]),
-            "approval_id": str(row["approval_id"]),
-            "artifact_hash": row["artifact_hash"],
-            "artifact_id": row["artifact_id"],
-            "decision_id": None,
-            "expires_at": row["expires_at"],
-            "harness": str(row["harness"]),
-            "owner": None,
-            "publisher": row["publisher"],
-            "reason": "approved once in review",
-            "request_id": str(row["request_id"]),
-            "scope": "artifact",
-            "source": "approval-gate-once",
-            "updated_at": str(row["created_at"]),
-            "workspace": row["workspace"],
-        }
+
+    def claim_local_once_approval(
+        self,
+        approval_id: str,
+        *,
+        claimed_at: str,
+        expected_decision: Mapping[str, object] | None = None,
+    ) -> bool:
+        """Atomically consume previously inspected approval evidence by id."""
+
+        integrity_key, integrity_key_id = self._policy_integrity_secret_material(create=False)
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            decision = self._claim_local_once_approval_by_id_locked(
+                connection,
+                approval_id=approval_id,
+                now=claimed_at,
+                expected_decision=expected_decision,
+                integrity_key=integrity_key,
+                integrity_key_id=integrity_key_id,
+            )
+            if decision is None:
+                return False
+            connection.execute(
+                """
+                insert into guard_events (event_name, payload_json, occurred_at)
+                values (?, ?, ?)
+                """,
+                (
+                    "approval.local_once_applied",
+                    json.dumps(
+                        {
+                            "approval_id": decision.get("approval_id"),
+                            "request_id": decision.get("request_id"),
+                            "harness": decision.get("harness"),
+                            "artifact_id": decision.get("artifact_id"),
+                        }
+                    ),
+                    claimed_at,
+                ),
+            )
+            return True
 
     def claim_remote_once_receipt(
         self,
@@ -211,3 +455,92 @@ class StoreEventReceiptsMixin:
                 }
             )
         return items
+
+
+def _local_once_approval_signed_payload(row: Mapping[str, object]) -> dict[str, object]:
+    return {
+        "approval_id": _row_value(row, "approval_id"),
+        "request_id": _row_value(row, "request_id"),
+        "harness": _row_value(row, "harness"),
+        "artifact_id": _row_value(row, "artifact_id"),
+        "artifact_hash": _row_value(row, "artifact_hash"),
+        "workspace": _row_value(row, "workspace"),
+        "publisher": _row_value(row, "publisher"),
+        "action": _row_value(row, "action"),
+        "created_at": _row_value(row, "created_at"),
+        "expires_at": _row_value(row, "expires_at"),
+        "claimed_at": _row_value(row, "claimed_at"),
+    }
+
+
+def _local_once_approval_integrity(row: Mapping[str, object]) -> dict[str, object]:
+    return {
+        "integrity_version": _row_value(row, "integrity_version"),
+        "payload_hash": _row_value(row, "payload_hash"),
+        "payload_mac": _row_value(row, "payload_mac"),
+        "integrity_key_id": _row_value(row, "integrity_key_id"),
+        "signed_at": _row_value(row, "signed_at"),
+    }
+
+
+def _verify_local_once_approval(
+    row: Mapping[str, object],
+    *,
+    key: bytes | None,
+    key_id: str | None,
+) -> PolicyIntegrityVerificationResult:
+    return verify_local_authority_payload(
+        _local_once_approval_signed_payload(row),
+        _local_once_approval_integrity(row),
+        key=key,
+        key_id=key_id,
+        purpose=_LOCAL_ONCE_INTEGRITY_PURPOSE,
+    )
+
+
+def _local_once_approval_integrity_failure(
+    row: Mapping[str, object],
+    *,
+    integrity_result: PolicyIntegrityVerificationResult,
+) -> dict[str, object]:
+    return {
+        "approval_id": _row_value(row, "approval_id"),
+        "decision_id": None,
+        "harness": _row_value(row, "harness"),
+        "artifact_id": _row_value(row, "artifact_id"),
+        "scope": "artifact",
+        "source": "approval-gate-once",
+        "integrity_status": integrity_result.status,
+        "integrity_message": integrity_result.message,
+    }
+
+
+def _local_once_approval_payload(row: Mapping[str, object]) -> dict[str, object]:
+    return {
+        "action": str(row["action"]),
+        "approval_id": str(row["approval_id"]),
+        "artifact_hash": row["artifact_hash"],
+        "artifact_id": row["artifact_id"],
+        "decision_id": None,
+        "expires_at": row["expires_at"],
+        "harness": str(row["harness"]),
+        "integrity_key_id": row["integrity_key_id"],
+        "integrity_status": "valid",
+        "integrity_version": row["integrity_version"],
+        "owner": None,
+        "publisher": row["publisher"],
+        "reason": "approved once in review",
+        "request_id": str(row["request_id"]),
+        "scope": "artifact",
+        "source": "approval-gate-once",
+        "signed_at": row["signed_at"],
+        "updated_at": str(row["created_at"]),
+        "workspace": row["workspace"],
+    }
+
+
+def _row_value(row: Mapping[str, object], key: str) -> object:
+    try:
+        return row[key]
+    except KeyError:
+        return None

--- a/src/codex_plugin_scanner/guard/store_policy.py
+++ b/src/codex_plugin_scanner/guard/store_policy.py
@@ -4,12 +4,548 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 # ruff: noqa: F403,F405
+from .action_lattice import guard_action_severity
 from .memory_pattern_fingerprint import (
     build_exact_command_memory_artifact_id,
     build_memory_pattern_fingerprint,
 )
+from .models import GUARD_ACTION_VALUES
+from .runtime.approval_context import approval_context_tokens_validation_reason
 from .store_base import *
+from .store_event_receipts import _local_once_approval_is_reusable, _verify_local_once_approval
+
+_NON_CONSUMING_POLICY_MATCH_LIMIT = 256
+_APPROVAL_REUSE_DIAGNOSTIC_LIMIT = 32
+_APPROVAL_CONTEXT_SQL_PATTERN = "guard-approval-context:v1:%"
+_POLICY_LOOKUP_COLUMNS = """
+    decision_id, harness, scope, artifact_id, action, artifact_hash, workspace, publisher, source,
+    reason, owner, expires_at, updated_at, integrity_version, integrity_generation,
+    payload_hash, payload_mac, integrity_key_id, signed_at
+"""
+_LOCAL_REUSE_DIAGNOSTIC_COLUMNS = """
+    approval_id, request_id, harness, artifact_id, artifact_hash, workspace, publisher,
+    action, created_at, expires_at, claimed_at, integrity_version, payload_hash, payload_mac,
+    integrity_key_id, signed_at
+"""
+_POLICY_REUSE_DIAGNOSTIC_COLUMNS = _POLICY_LOOKUP_COLUMNS
+
+_SqlProbe = tuple[str, tuple[object, ...], str]
+
+
+def _distinct_non_null(values: Sequence[str | None]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(value for value in values if value is not None))
+
+
+def _execute_unordered_bounded_probes(
+    connection: sqlite3.Connection,
+    *,
+    table: str,
+    columns: str,
+    probes: Sequence[_SqlProbe],
+    limit: int,
+    current_time: str,
+    explain: bool,
+) -> list[sqlite3.Row]:
+    """Execute exact probes while bounding each branch by the remaining cap."""
+
+    rows: list[sqlite3.Row] = []
+    for predicate, parameters, index_name in probes:
+        remaining = limit - len(rows)
+        query = f"""
+            select {columns}
+            from {table} indexed by {index_name}
+            where {predicate}
+              and (expires_at is null or julianday(expires_at) > julianday(?))
+            limit ?
+        """
+        if explain:
+            rows.extend(
+                connection.execute(
+                    f"explain query plan {query}",
+                    (*parameters, current_time, limit),
+                ).fetchall()
+            )
+            continue
+        if remaining <= 0:
+            break
+        rows.extend(connection.execute(query, (*parameters, current_time, remaining)).fetchall())
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def _execute_ordered_probe_groups(
+    connection: sqlite3.Connection,
+    *,
+    table: str,
+    columns: str,
+    probe_groups: Sequence[Sequence[_SqlProbe]],
+    order_column: str,
+    id_column: str,
+    limit: int,
+    explain: bool,
+) -> list[sqlite3.Row]:
+    """Merge indexed priority groups without a SQL CASE sort.
+
+    Probes within a group are disjoint (for example, the requested harness and
+    the wildcard harness).  Each can therefore read at most ``limit`` rows in
+    index order before the small in-memory merge.  Groups are concatenated in
+    the same precedence order previously expressed by ``ORDER BY CASE``.
+    """
+
+    rows: list[sqlite3.Row] = []
+    for probes in probe_groups:
+        group_rows: list[sqlite3.Row] = []
+        for predicate, parameters, index_name in probes:
+            query = f"""
+                select {columns}
+                from {table} indexed by {index_name}
+                where {predicate}
+                order by {order_column} desc, {id_column} desc
+                limit ?
+            """
+            if explain:
+                rows.extend(
+                    connection.execute(
+                        f"explain query plan {query}",
+                        (*parameters, limit),
+                    ).fetchall()
+                )
+                continue
+            group_rows.extend(connection.execute(query, (*parameters, limit)).fetchall())
+        if explain:
+            continue
+        group_rows.sort(
+            key=lambda row: (str(row[order_column]), row[id_column]),
+            reverse=True,
+        )
+        remaining = limit - len(rows)
+        if remaining <= 0:
+            break
+        rows.extend(group_rows[:remaining])
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def _hash_partition_probes(
+    *,
+    base_predicate: str,
+    base_parameters: tuple[object, ...],
+    exact_hashes: Sequence[str | None],
+    exact_index: str,
+    legacy_index: str | None,
+    exact_first: bool = False,
+) -> list[_SqlProbe]:
+    """Partition nullable, exact, and legacy hashes into disjoint probes.
+
+    ``exact_first`` is used for scopes whose equal-action precedence is exact
+    context, then family-bound context. Artifact and publisher probes retain
+    their established nullable-first ordering.
+    """
+
+    nullable_probe: _SqlProbe = (
+        f"{base_predicate} and artifact_hash is null",
+        base_parameters,
+        exact_index,
+    )
+    distinct_hashes = _distinct_non_null(exact_hashes)
+    exact_probes: list[_SqlProbe] = [
+        (
+            f"{base_predicate} and artifact_hash = ?",
+            (*base_parameters, exact_hash),
+            exact_index,
+        )
+        for exact_hash in distinct_hashes
+    ]
+    probes = [*exact_probes, nullable_probe] if exact_first else [nullable_probe, *exact_probes]
+    if legacy_index is not None:
+        legacy_predicate = (
+            f"{base_predicate} and artifact_hash is not null "
+            f"and artifact_hash not like '{_APPROVAL_CONTEXT_SQL_PATTERN}'"
+        )
+        legacy_parameters = list(base_parameters)
+        for exact_hash in distinct_hashes:
+            legacy_predicate += " and artifact_hash <> ?"
+            legacy_parameters.append(exact_hash)
+        probes.append((legacy_predicate, tuple(legacy_parameters), legacy_index))
+    return probes
+
+
+def _bounded_non_consuming_policy_rows(
+    connection: sqlite3.Connection,
+    *,
+    harness: str,
+    artifact_id: str | None,
+    artifact_hash: str | None,
+    runtime_exact_match_key: str | None,
+    workspace_key: str | None,
+    workspace: str | None,
+    publisher: str | None,
+    action_family_key: str | None,
+    current_time: str,
+    _explain: bool = False,
+) -> list[sqlite3.Row]:
+    """Read at most one-over-limit matches through disjoint exact probes.
+
+    Every branch fixes the scope, harness selector, scope selector, and hash
+    partition.  This prevents a miss for one artifact from walking all rows for
+    the same harness.  Within workspace, harness, and global scopes, exact
+    artifact selectors precede family selectors, exact hashes precede nullable
+    or legacy family matches, and broad selectors run last.  Legacy non-context
+    hashes use dedicated partial indexes, while nullable and exact hashes use
+    the regular scope indexes.
+    """
+
+    probes: list[_SqlProbe] = []
+    harness_selectors = _distinct_non_null((harness, "*"))
+    if artifact_id is not None:
+        for harness_selector in harness_selectors:
+            probes.extend(
+                _hash_partition_probes(
+                    base_predicate="scope = 'artifact' and artifact_id = ? and harness = ?",
+                    base_parameters=(artifact_id, harness_selector),
+                    exact_hashes=(artifact_hash, runtime_exact_match_key),
+                    exact_index="idx_policy_decisions_lookup_artifact",
+                    legacy_index=None,
+                )
+            )
+
+    workspace_selectors = _distinct_non_null((workspace_key, workspace))
+    for workspace_selector in workspace_selectors:
+        for harness_selector in harness_selectors:
+            for artifact_selector in _distinct_non_null((artifact_id, action_family_key)):
+                probes.extend(
+                    _hash_partition_probes(
+                        base_predicate=("scope = 'workspace' and workspace = ? and harness = ? and artifact_id = ?"),
+                        base_parameters=(workspace_selector, harness_selector, artifact_selector),
+                        exact_hashes=(artifact_hash,),
+                        exact_index="idx_policy_decisions_lookup_workspace",
+                        legacy_index=None,
+                        exact_first=True,
+                    )
+                )
+            probes.append(
+                (
+                    "scope = 'workspace' and workspace = ? and harness = ? and artifact_id is null",
+                    (workspace_selector, harness_selector),
+                    "idx_policy_decisions_lookup_workspace",
+                )
+            )
+
+    if publisher is not None:
+        for harness_selector in harness_selectors:
+            probes.extend(
+                _hash_partition_probes(
+                    base_predicate="scope = 'publisher' and publisher = ? and harness = ?",
+                    base_parameters=(publisher, harness_selector),
+                    exact_hashes=(artifact_hash,),
+                    exact_index="idx_policy_decisions_lookup_publisher",
+                    legacy_index="idx_policy_decisions_lookup_publisher_legacy",
+                )
+            )
+
+    for harness_selector in harness_selectors:
+        for artifact_selector in _distinct_non_null((artifact_id, action_family_key)):
+            probes.extend(
+                _hash_partition_probes(
+                    base_predicate="scope = 'harness' and harness = ? and artifact_id = ?",
+                    base_parameters=(harness_selector, artifact_selector),
+                    exact_hashes=(artifact_hash, runtime_exact_match_key),
+                    exact_index="idx_policy_decisions_lookup_harness",
+                    legacy_index="idx_policy_decisions_lookup_harness_legacy",
+                    exact_first=True,
+                )
+            )
+        probes.extend(
+            _hash_partition_probes(
+                base_predicate="scope = 'harness' and harness = ? and artifact_id is null",
+                base_parameters=(harness_selector,),
+                exact_hashes=(artifact_hash, runtime_exact_match_key),
+                exact_index="idx_policy_decisions_lookup_harness",
+                legacy_index="idx_policy_decisions_lookup_harness_legacy",
+                exact_first=True,
+            )
+        )
+
+    for harness_selector in harness_selectors:
+        for artifact_selector in _distinct_non_null((artifact_id, action_family_key)):
+            probes.extend(
+                _hash_partition_probes(
+                    base_predicate="scope = 'global' and harness = ? and artifact_id = ?",
+                    base_parameters=(harness_selector, artifact_selector),
+                    exact_hashes=(artifact_hash, runtime_exact_match_key),
+                    exact_index="idx_policy_decisions_lookup_global",
+                    legacy_index="idx_policy_decisions_lookup_global_legacy",
+                    exact_first=True,
+                )
+            )
+        probes.extend(
+            _hash_partition_probes(
+                base_predicate="scope = 'global' and harness = ? and artifact_id is null",
+                base_parameters=(harness_selector,),
+                exact_hashes=(artifact_hash, runtime_exact_match_key),
+                exact_index="idx_policy_decisions_lookup_global",
+                legacy_index="idx_policy_decisions_lookup_global_legacy",
+                exact_first=True,
+            )
+        )
+
+    return _execute_unordered_bounded_probes(
+        connection,
+        table="policy_decisions",
+        columns=_POLICY_LOOKUP_COLUMNS,
+        probes=probes,
+        limit=_NON_CONSUMING_POLICY_MATCH_LIMIT + 1,
+        current_time=current_time,
+        explain=_explain,
+    )
+
+
+def _append_exclusions(
+    predicate: str,
+    parameters: tuple[object, ...],
+    *,
+    column: str,
+    values: Sequence[str | None],
+) -> tuple[str, tuple[object, ...]]:
+    """Exclude nullable values without introducing an OR predicate."""
+
+    next_parameters = list(parameters)
+    for value in _distinct_non_null(values):
+        predicate += f" and {column} is not ?"
+        next_parameters.append(value)
+    return predicate, tuple(next_parameters)
+
+
+def _bounded_local_approval_reuse_diagnostic_rows(
+    connection: sqlite3.Connection,
+    *,
+    harness: str,
+    artifact_id: str,
+    artifact_family: str | None,
+    artifact_hash: str | None,
+    _explain: bool = False,
+) -> list[sqlite3.Row]:
+    """Return local near matches in legacy diagnostic precedence order."""
+
+    identity_selectors = _distinct_non_null((artifact_id, artifact_family))
+    probe_groups: list[list[_SqlProbe]] = [
+        [
+            (
+                "claimed_at is null and action = 'allow' and harness = ? and artifact_id = ?",
+                (harness, identity_selector),
+                "idx_guard_local_once_diagnostic_artifact",
+            )
+        ]
+        for identity_selector in identity_selectors
+    ]
+    if artifact_hash is not None:
+        hash_predicate, hash_parameters = _append_exclusions(
+            "claimed_at is null and action = 'allow' and harness = ? and artifact_hash = ?",
+            (harness, artifact_hash),
+            column="artifact_id",
+            values=identity_selectors,
+        )
+        probe_groups.append(
+            [
+                (
+                    hash_predicate,
+                    hash_parameters,
+                    "idx_guard_local_once_diagnostic_hash",
+                )
+            ]
+        )
+    return _execute_ordered_probe_groups(
+        connection,
+        table="guard_local_once_approvals",
+        columns=_LOCAL_REUSE_DIAGNOSTIC_COLUMNS,
+        probe_groups=probe_groups,
+        order_column="created_at",
+        id_column="approval_id",
+        limit=_APPROVAL_REUSE_DIAGNOSTIC_LIMIT,
+        explain=_explain,
+    )
+
+
+def _bounded_policy_approval_reuse_diagnostic_rows(
+    connection: sqlite3.Connection,
+    *,
+    harness: str,
+    artifact_id: str,
+    artifact_family: str | None,
+    artifact_hash: str | None,
+    publisher: str | None,
+    _explain: bool = False,
+) -> list[sqlite3.Row]:
+    """Return saved-policy near matches through ordered exact probes."""
+
+    harness_selectors = _distinct_non_null((harness, "*"))
+    identity_selectors = _distinct_non_null((artifact_id, artifact_family))
+    probe_groups: list[list[_SqlProbe]] = []
+    for identity_selector in identity_selectors:
+        probe_groups.append(
+            [
+                (
+                    "action = ? and harness = ? and artifact_id = ?",
+                    (action, harness_selector, identity_selector),
+                    "idx_policy_decisions_reuse_artifact",
+                )
+                for harness_selector in harness_selectors
+                for action in GUARD_ACTION_VALUES
+            ]
+        )
+
+    if artifact_hash is not None:
+        hash_probes: list[_SqlProbe] = []
+        for harness_selector in harness_selectors:
+            for action in GUARD_ACTION_VALUES:
+                hash_predicate, hash_parameters = _append_exclusions(
+                    "action = ? and harness = ? and artifact_hash = ?",
+                    (action, harness_selector, artifact_hash),
+                    column="artifact_id",
+                    values=identity_selectors,
+                )
+                hash_probes.append(
+                    (
+                        hash_predicate,
+                        hash_parameters,
+                        "idx_policy_decisions_reuse_hash",
+                    )
+                )
+        probe_groups.append(hash_probes)
+
+    broad_probes: list[_SqlProbe] = []
+    for harness_selector in harness_selectors:
+        for scope, index_name in (
+            ("harness", "idx_policy_decisions_diagnostic_harness_broad"),
+            ("global", "idx_policy_decisions_diagnostic_global_broad"),
+        ):
+            broad_predicate, broad_parameters = _append_exclusions(
+                f"scope = '{scope}' and action = 'allow' and artifact_id is null and harness = ?",
+                (harness_selector,),
+                column="artifact_hash",
+                values=(artifact_hash,),
+            )
+            broad_probes.append((broad_predicate, broad_parameters, index_name))
+            for action in GUARD_ACTION_VALUES:
+                if action == "allow":
+                    continue
+                non_allow_predicate, non_allow_parameters = _append_exclusions(
+                    f"scope = '{scope}' and action = ? and harness = ? and artifact_id is null",
+                    (action, harness_selector),
+                    column="artifact_hash",
+                    values=(artifact_hash,),
+                )
+                broad_probes.append(
+                    (
+                        non_allow_predicate,
+                        non_allow_parameters,
+                        "idx_policy_decisions_reuse_artifact",
+                    )
+                )
+        if publisher is not None:
+            publisher_predicate, publisher_parameters = _append_exclusions(
+                "scope = 'publisher' and action = 'allow' and harness = ? and publisher = ?",
+                (harness_selector, publisher),
+                column="artifact_id",
+                values=identity_selectors,
+            )
+            publisher_predicate, publisher_parameters = _append_exclusions(
+                publisher_predicate,
+                publisher_parameters,
+                column="artifact_hash",
+                values=(artifact_hash,),
+            )
+            broad_probes.append(
+                (
+                    publisher_predicate,
+                    publisher_parameters,
+                    "idx_policy_decisions_diagnostic_publisher",
+                )
+            )
+            for action in GUARD_ACTION_VALUES:
+                if action == "allow":
+                    continue
+                non_allow_publisher_predicate, non_allow_publisher_parameters = _append_exclusions(
+                    "scope = 'publisher' and action = ? and harness = ? and publisher = ?",
+                    (action, harness_selector, publisher),
+                    column="artifact_id",
+                    values=identity_selectors,
+                )
+                non_allow_publisher_predicate, non_allow_publisher_parameters = _append_exclusions(
+                    non_allow_publisher_predicate,
+                    non_allow_publisher_parameters,
+                    column="artifact_hash",
+                    values=(artifact_hash,),
+                )
+                broad_probes.append(
+                    (
+                        non_allow_publisher_predicate,
+                        non_allow_publisher_parameters,
+                        "idx_policy_decisions_reuse_publisher",
+                    )
+                )
+    probe_groups.append(broad_probes)
+
+    return _execute_ordered_probe_groups(
+        connection,
+        table="policy_decisions",
+        columns=_POLICY_REUSE_DIAGNOSTIC_COLUMNS,
+        probe_groups=probe_groups,
+        order_column="updated_at",
+        id_column="decision_id",
+        limit=_APPROVAL_REUSE_DIAGNOSTIC_LIMIT,
+        explain=_explain,
+    )
+
+
+def _most_restrictive_policy_lookup(
+    lookups: Sequence[PolicyDecisionLookupResult],
+) -> PolicyDecisionLookupResult:
+    """Compose non-consuming direct, exact-command, and memory matches."""
+
+    if not lookups:
+        raise ValueError("at least one policy lookup is required")
+    selected_lookup = lookups[0]
+    selected_decision = selected_lookup["decision"]
+    ignored_integrity = selected_lookup.get("ignored_local_integrity")
+    revisions = {lookup["authority_revision"] for lookup in lookups}
+    authority_revision = next(iter(revisions)) if len(revisions) == 1 else -1
+    for lookup in lookups[1:]:
+        decision = lookup["decision"]
+        if ignored_integrity is None and lookup.get("ignored_local_integrity") is not None:
+            ignored_integrity = lookup["ignored_local_integrity"]
+        if decision is None:
+            continue
+        if selected_decision is None or guard_action_severity(
+            decision.get("action"),
+            unknown_action="block",
+        ) > guard_action_severity(selected_decision.get("action"), unknown_action="block"):
+            selected_lookup = lookup
+            selected_decision = decision
+    if selected_decision is not None:
+        selected_decision = {
+            **selected_decision,
+            "_approval_authority_revision": authority_revision,
+        }
+    return {
+        "decision": selected_decision,
+        "ignored_local_integrity": ignored_integrity,
+        "trust_status": selected_lookup["trust_status"],
+        "authority_revision": authority_revision,
+    }
+
+
+def _approval_authority_revision(connection: sqlite3.Connection) -> int:
+    row = connection.execute("select revision from guard_approval_authority_revision where singleton = 1").fetchone()
+    if row is None:
+        return -1
+    revision = row["revision"]
+    return revision if isinstance(revision, int) and not isinstance(revision, bool) else -1
 
 
 class StorePolicyMixin:
@@ -21,6 +557,8 @@ class StorePolicyMixin:
         approval_gate_grant: ApprovalGateGrant | None = None,
         remote_write_authorized: bool = False,
     ) -> None:
+        now = _canonical_utc_timestamp(now)
+        expires_at = _canonical_utc_timestamp(decision.expires_at) if decision.expires_at is not None else None
         validate_policy_write_authority(
             decision,
             remote_write_authorized=remote_write_authorized,
@@ -75,7 +613,7 @@ class StorePolicyMixin:
                     decision.reason,
                     decision.owner,
                     decision.source,
-                    decision.expires_at,
+                    expires_at,
                     now,
                     None,
                     None,
@@ -113,6 +651,7 @@ class StorePolicyMixin:
         approval_gate_grant: ApprovalGateGrant | None = None,
         remote_write_authorized: bool = False,
     ) -> None:
+        now = _canonical_utc_timestamp(now)
         for decision in decisions:
             validate_policy_write_authority(
                 decision,
@@ -130,6 +669,7 @@ class StorePolicyMixin:
                 _REMOTE_POLICY_SOURCE_PARAMS,
             )
             for decision in decisions:
+                expires_at = _canonical_utc_timestamp(decision.expires_at) if decision.expires_at is not None else None
                 _validate_scoped_policy_artifact_target(decision.scope, decision.artifact_id)
                 artifact_id, artifact_hash, workspace, publisher = self._normalized_policy_keys(decision)
                 connection.execute(
@@ -152,7 +692,7 @@ class StorePolicyMixin:
                         decision.reason,
                         decision.owner,
                         decision.source,
-                        decision.expires_at,
+                        expires_at,
                         now,
                         None,
                         None,
@@ -175,6 +715,7 @@ class StorePolicyMixin:
         memory_command: str | None = None,
         memory_artifact_type: str | None = None,
         memory_artifact_name: str | None = None,
+        consume_one_shot: bool = True,
     ) -> str | None:
         lookup = self.resolve_policy_decision_lookup_with_memory_pattern(
             harness,
@@ -186,6 +727,7 @@ class StorePolicyMixin:
             memory_command=memory_command,
             memory_artifact_type=memory_artifact_type,
             memory_artifact_name=memory_artifact_name,
+            consume_one_shot=consume_one_shot,
         )
         decision = lookup["decision"]
         return str(decision["action"]) if decision is not None else None
@@ -203,6 +745,7 @@ class StorePolicyMixin:
         memory_command: str | None = None,
         memory_artifact_type: str | None = None,
         memory_artifact_name: str | None = None,
+        consume_one_shot: bool = True,
     ) -> PolicyDecisionLookupResult:
         direct_lookup = self.resolve_policy_decision_lookup(
             harness,
@@ -212,8 +755,12 @@ class StorePolicyMixin:
             publisher=publisher,
             now=now,
             runtime_exact_match_context=runtime_exact_match_context,
+            consume_one_shot=consume_one_shot,
         )
-        if direct_lookup["decision"] is not None or direct_lookup.get("ignored_local_integrity") is not None:
+        candidate_lookups = [direct_lookup]
+        if consume_one_shot and (
+            direct_lookup["decision"] is not None or direct_lookup.get("ignored_local_integrity") is not None
+        ):
             return direct_lookup
         exact_command_artifact_id = build_exact_command_memory_artifact_id(memory_command)
         if exact_command_artifact_id is not None and exact_command_artifact_id != artifact_id:
@@ -225,8 +772,10 @@ class StorePolicyMixin:
                 publisher=publisher,
                 now=now,
                 runtime_exact_match_context=runtime_exact_match_context,
+                consume_one_shot=consume_one_shot,
             )
-            if (
+            candidate_lookups.append(exact_command_lookup)
+            if consume_one_shot and (
                 exact_command_lookup["decision"] is not None
                 or exact_command_lookup.get("ignored_local_integrity") is not None
             ):
@@ -239,10 +788,10 @@ class StorePolicyMixin:
             harness=harness,
         )
         if memory_pattern is None:
-            return direct_lookup
+            return _most_restrictive_policy_lookup(candidate_lookups)
         memory_artifact_id = f"memory:{harness}:{memory_pattern.kind}:{memory_pattern.fingerprint}"
         if memory_artifact_id == artifact_id:
-            return direct_lookup
+            return _most_restrictive_policy_lookup(candidate_lookups)
         memory_lookup = self.resolve_policy_decision_lookup(
             harness,
             memory_artifact_id,
@@ -251,12 +800,16 @@ class StorePolicyMixin:
             publisher=publisher,
             now=now,
             runtime_exact_match_context=runtime_exact_match_context,
+            consume_one_shot=consume_one_shot,
         )
-        return (
-            memory_lookup
-            if (memory_lookup["decision"] is not None or memory_lookup.get("ignored_local_integrity") is not None)
-            else direct_lookup
-        )
+        candidate_lookups.append(memory_lookup)
+        if consume_one_shot:
+            return (
+                memory_lookup
+                if (memory_lookup["decision"] is not None or memory_lookup.get("ignored_local_integrity") is not None)
+                else direct_lookup
+            )
+        return _most_restrictive_policy_lookup(candidate_lookups)
 
     def resolve_policy_decision_lookup(
         self,
@@ -267,8 +820,9 @@ class StorePolicyMixin:
         publisher: str | None = None,
         now: str | None = None,
         runtime_exact_match_context: str | None = None,
+        consume_one_shot: bool = True,
     ) -> PolicyDecisionLookupResult:
-        current_time = now or _now()
+        current_time = _canonical_utc_timestamp(now or _now())
         workspace_key = _workspace_policy_key(workspace)
         action_family_key = _artifact_family_key(artifact_id)
         runtime_exact_match_key = (
@@ -279,13 +833,41 @@ class StorePolicyMixin:
         events: list[tuple[str, dict[str, object]]] = []
         selected_payload: dict[str, object] | None = None
         ignored_local_integrity: dict[str, object] | None = None
+        local_once_integrity_key: bytes | None = None
+        local_once_integrity_key_id: str | None = None
         with self._connect() as connection:
+            starting_authority_revision = _approval_authority_revision(connection)
+
+            def lookup_result(
+                decision: dict[str, object] | None,
+                *,
+                ignored_integrity: dict[str, object] | None,
+                trust_status: dict[str, object],
+            ) -> PolicyDecisionLookupResult:
+                ending_authority_revision = _approval_authority_revision(connection)
+                stable_revision = (
+                    starting_authority_revision if ending_authority_revision == starting_authority_revision else -1
+                )
+                if decision is not None and not consume_one_shot:
+                    decision = {
+                        **decision,
+                        "_approval_authority_revision": stable_revision,
+                    }
+                return {
+                    "decision": decision,
+                    "ignored_local_integrity": ignored_integrity,
+                    "trust_status": trust_status,
+                    "authority_revision": stable_revision,
+                }
+
             local_once_decision = None
+            local_once_hash: str | None = None
+            reported_local_once_failures: set[object] = set()
             local_once_hashes = tuple(
                 dict.fromkeys(hash_value for hash_value in (artifact_hash, runtime_exact_match_key) if hash_value)
             )
             for local_once_hash in local_once_hashes:
-                local_once_decision = self._claim_local_once_approval_locked(
+                local_once_decision, local_once_integrity_failure = self._peek_local_once_approval_lookup_locked(
                     connection,
                     harness=harness,
                     artifact_id=artifact_id,
@@ -294,23 +876,99 @@ class StorePolicyMixin:
                     publisher=publisher,
                     now=current_time,
                 )
+                if (
+                    local_once_decision is None
+                    and local_once_integrity_failure is not None
+                    and local_once_integrity_failure.get("integrity_status") == "unknown_key"
+                ):
+                    local_once_integrity_key, local_once_integrity_key_id = self._policy_integrity_secret_material(
+                        create=False
+                    )
+                    local_once_decision, local_once_integrity_failure = self._peek_local_once_approval_lookup_locked(
+                        connection,
+                        harness=harness,
+                        artifact_id=artifact_id,
+                        artifact_hash=local_once_hash,
+                        workspace=workspace,
+                        publisher=publisher,
+                        now=current_time,
+                        integrity_key=local_once_integrity_key,
+                        integrity_key_id=local_once_integrity_key_id,
+                    )
+                if local_once_integrity_failure is not None:
+                    if ignored_local_integrity is None:
+                        ignored_local_integrity = local_once_integrity_failure
+                    failure_id = local_once_integrity_failure.get("approval_id")
+                    if failure_id not in reported_local_once_failures:
+                        reported_local_once_failures.add(failure_id)
+                        events.append(
+                            (
+                                "rule.ignored.local_integrity",
+                                {
+                                    **local_once_integrity_failure,
+                                    "message": local_once_integrity_failure.get("integrity_message"),
+                                },
+                            )
+                        )
                 if local_once_decision is not None:
                     break
             if local_once_decision is not None:
                 selected_payload = local_once_decision
+
+            def claim_selected_local_once() -> None:
+                """Consume a selected one-shot only after stronger policy wins are known."""
+
+                nonlocal selected_payload
+                if (
+                    not consume_one_shot
+                    or local_once_decision is None
+                    or selected_payload is not local_once_decision
+                    or local_once_hash is None
+                ):
+                    return
+                claimed = self._claim_local_once_approval_locked(
+                    connection,
+                    harness=harness,
+                    artifact_id=artifact_id,
+                    artifact_hash=local_once_hash,
+                    workspace=workspace,
+                    publisher=publisher,
+                    now=current_time,
+                    integrity_key=local_once_integrity_key,
+                    integrity_key_id=local_once_integrity_key_id,
+                )
+                if claimed is None:
+                    selected_payload = None
+                    return
+                selected_payload = claimed
                 events.append(
                     (
                         "approval.local_once_applied",
                         {
-                            "approval_id": local_once_decision.get("approval_id"),
-                            "request_id": local_once_decision.get("request_id"),
+                            "approval_id": claimed.get("approval_id"),
+                            "request_id": claimed.get("request_id"),
                             "harness": harness,
                             "artifact_id": artifact_id,
                         },
                     )
                 )
-            rows = connection.execute(
-                """
+
+            if not consume_one_shot:
+                rows = _bounded_non_consuming_policy_rows(
+                    connection,
+                    harness=harness,
+                    artifact_id=artifact_id,
+                    artifact_hash=artifact_hash,
+                    runtime_exact_match_key=runtime_exact_match_key,
+                    workspace_key=workspace_key,
+                    workspace=workspace,
+                    publisher=publisher,
+                    action_family_key=action_family_key,
+                    current_time=current_time,
+                )
+            else:
+                rows = connection.execute(
+                    """
                 select decision_id, harness, scope, artifact_id, action, artifact_hash, workspace, publisher, source,
                        reason, owner, expires_at, updated_at, integrity_version, integrity_generation,
                        payload_hash, payload_mac,
@@ -332,10 +990,19 @@ class StorePolicyMixin:
                       )
                     )
                   )
-                  or (scope = 'publisher' and publisher = ?)
+                  or (
+                    scope = 'publisher' and publisher = ? and (
+                      artifact_hash is null or artifact_hash = ?
+                      or artifact_hash not like 'guard-approval-context:v1:%'
+                    )
+                  )
                   or (
                     scope = 'harness' and (
                       artifact_id is null or artifact_id = ?
+                    ) and (
+                      artifact_hash is null or artifact_hash = ?
+                      or (? is not null and artifact_hash = ?)
+                      or artifact_hash not like 'guard-approval-context:v1:%'
                     )
                   )
                     or (
@@ -343,10 +1010,14 @@ class StorePolicyMixin:
                         artifact_id is null
                         or artifact_id = ?
                         or artifact_id = ?
+                      ) and (
+                        artifact_hash is null or artifact_hash = ?
+                        or (? is not null and artifact_hash = ?)
+                        or artifact_hash not like 'guard-approval-context:v1:%'
                       )
                     )
                 )
-                and (expires_at is null or expires_at > ?)
+                and (expires_at is null or julianday(expires_at) > julianday(?))
                 order by case scope when 'artifact' then 0 when 'workspace' then 1 when 'publisher' then 2
                          when 'harness' then 3 else 4 end,
                          case
@@ -354,74 +1025,128 @@ class StorePolicyMixin:
                            else 1
                          end,
                          updated_at desc
+                limit ?
                 """,
-                (
-                    harness,
-                    artifact_id,
-                    artifact_hash,
-                    artifact_hash,
-                    runtime_exact_match_key,
-                    runtime_exact_match_key,
-                    workspace_key,
-                    workspace,
-                    artifact_id,
-                    artifact_hash,
-                    artifact_hash,
-                    publisher,
-                    action_family_key,
-                    artifact_id,
-                    action_family_key,
-                    current_time,
-                ),
-            ).fetchall()
+                    (
+                        harness,
+                        artifact_id,
+                        artifact_hash,
+                        artifact_hash,
+                        runtime_exact_match_key,
+                        runtime_exact_match_key,
+                        workspace_key,
+                        workspace,
+                        artifact_id,
+                        artifact_hash,
+                        artifact_hash,
+                        publisher,
+                        artifact_hash,
+                        action_family_key,
+                        artifact_hash,
+                        runtime_exact_match_key,
+                        runtime_exact_match_key,
+                        artifact_id,
+                        action_family_key,
+                        artifact_hash,
+                        runtime_exact_match_key,
+                        runtime_exact_match_key,
+                        current_time,
+                        _NON_CONSUMING_POLICY_MATCH_LIMIT + 1 if not consume_one_shot else -1,
+                    ),
+                ).fetchall()
+            policy_match_overflow = not consume_one_shot and len(rows) > _NON_CONSUMING_POLICY_MATCH_LIMIT
+            if policy_match_overflow:
+                rows = rows[:_NON_CONSUMING_POLICY_MATCH_LIMIT]
+                selected_payload = {
+                    "action": "block",
+                    "artifact_hash": artifact_hash,
+                    "artifact_id": artifact_id,
+                    "decision_id": None,
+                    "expires_at": None,
+                    "harness": harness,
+                    "owner": None,
+                    "publisher": publisher,
+                    "reason": "Guard policy match limit exceeded during approval reuse.",
+                    "scope": "global",
+                    "source": "guard-policy-match-cap",
+                    "updated_at": current_time,
+                    "workspace": workspace,
+                }
+                events.append(
+                    (
+                        "approval.policy_lookup_overflow",
+                        {
+                            "harness": harness,
+                            "artifact_id": artifact_id,
+                            "match_limit": _NON_CONSUMING_POLICY_MATCH_LIMIT,
+                            "authoritative_action": "block",
+                        },
+                    )
+                )
             cached_state = self._load_policy_integrity_state(connection) or {}
             cached_trust_status = TrustStatus.from_policy_integrity_state(cached_state).to_dict()
             if not rows and selected_payload is None:
-                return {
-                    "decision": None,
-                    "ignored_local_integrity": None,
-                    "trust_status": cached_trust_status,
-                }
+                for event_name, payload in events:
+                    connection.execute(
+                        """
+                        insert into guard_events (event_name, payload_json, occurred_at)
+                        values (?, ?, ?)
+                        """,
+                        (event_name, json.dumps(payload), current_time),
+                    )
+                if ignored_local_integrity is not None:
+                    ignored_local_integrity["trust_status"] = cached_trust_status
+                return lookup_result(
+                    None,
+                    ignored_integrity=ignored_local_integrity,
+                    trust_status=cached_trust_status,
+                )
             has_local_rows = any(not is_remote_policy_source(str(candidate["source"])) for candidate in rows)
             if not has_local_rows:
-                if selected_payload is None:
-                    for candidate in rows:
-                        if _scoped_runtime_row_requires_exact_match(
-                            scope=str(candidate["scope"]),
-                            stored_artifact_id=(
-                                str(candidate["artifact_id"]) if isinstance(candidate["artifact_id"], str) else None
-                            ),
-                            stored_artifact_hash=(
-                                str(candidate["artifact_hash"]) if isinstance(candidate["artifact_hash"], str) else None
-                            ),
-                            source=str(candidate["source"]),
-                            requested_artifact_id=artifact_id,
-                            requested_runtime_exact_match_key=runtime_exact_match_key,
-                        ):
-                            continue
-                        integrity_result = self._policy_integrity_result_for_row(
-                            candidate,
-                            mode=str((cached_state or {}).get("mode") or "degraded"),
-                            key=None,
-                            key_id=None,
-                            trusted_generation=_mapping_int(cached_state, "generation"),
-                        )
-                        if integrity_result.status != "valid":
-                            events.append(
-                                (
-                                    "policy_integrity_violation",
-                                    {
-                                        "decision_id": int(candidate["decision_id"]),
-                                        "harness": str(candidate["harness"]),
-                                        "artifact_id": candidate["artifact_id"],
-                                        "integrity_status": integrity_result.status,
-                                        "message": integrity_result.message,
-                                    },
-                                )
+                for candidate in rows:
+                    if _scoped_runtime_row_requires_exact_match(
+                        scope=str(candidate["scope"]),
+                        stored_artifact_id=(
+                            str(candidate["artifact_id"]) if isinstance(candidate["artifact_id"], str) else None
+                        ),
+                        stored_artifact_hash=(
+                            str(candidate["artifact_hash"]) if isinstance(candidate["artifact_hash"], str) else None
+                        ),
+                        source=str(candidate["source"]),
+                        requested_artifact_id=artifact_id,
+                        requested_artifact_hash=artifact_hash,
+                        requested_runtime_exact_match_key=runtime_exact_match_key,
+                    ):
+                        continue
+                    integrity_result = self._policy_integrity_result_for_row(
+                        candidate,
+                        mode=str((cached_state or {}).get("mode") or "degraded"),
+                        key=None,
+                        key_id=None,
+                        trusted_generation=_mapping_int(cached_state, "generation"),
+                    )
+                    if integrity_result.status != "valid":
+                        events.append(
+                            (
+                                "policy_integrity_violation",
+                                {
+                                    "decision_id": int(candidate["decision_id"]),
+                                    "harness": str(candidate["harness"]),
+                                    "artifact_id": candidate["artifact_id"],
+                                    "integrity_status": integrity_result.status,
+                                    "message": integrity_result.message,
+                                },
                             )
-                            continue
-                        selected_payload = self._policy_row_payload(candidate)
-                        if is_remote_policy_source(str(candidate["source"])):
+                        )
+                        continue
+                    candidate_payload = self._policy_row_payload(candidate)
+                    candidate_outranks_local_once = selected_payload is None or guard_action_severity(
+                        candidate_payload.get("action"),
+                        unknown_action="block",
+                    ) > guard_action_severity(selected_payload.get("action"), unknown_action="block")
+                    if candidate_outranks_local_once:
+                        selected_payload = candidate_payload
+                        if consume_one_shot and is_remote_policy_source(str(candidate["source"])):
                             events.append(
                                 (
                                     "policy.cloud.applied",
@@ -435,12 +1160,18 @@ class StorePolicyMixin:
                                     },
                                 )
                             )
-                        if _is_approval_gate_one_shot_policy(candidate):
+                        if consume_one_shot and _is_approval_gate_one_shot_policy(candidate):
                             connection.execute(
                                 "delete from policy_decisions where decision_id = ?",
                                 (int(candidate["decision_id"]),),
                             )
+                    # The first valid policy row retains the established scope
+                    # precedence for legacy consuming callers. Current-policy-
+                    # first callers inspect every valid match so a saved,
+                    # specific allow cannot hide a broader managed block.
+                    if consume_one_shot:
                         break
+                claim_selected_local_once()
                 for event_name, payload in events:
                     connection.execute(
                         """
@@ -449,15 +1180,17 @@ class StorePolicyMixin:
                         """,
                         (event_name, json.dumps(payload), current_time),
                     )
-                return {
-                    "decision": selected_payload,
-                    "ignored_local_integrity": None,
-                    "trust_status": cached_trust_status,
-                }
+                if ignored_local_integrity is not None:
+                    ignored_local_integrity["trust_status"] = cached_trust_status
+                return lookup_result(
+                    selected_payload,
+                    ignored_integrity=ignored_local_integrity,
+                    trust_status=cached_trust_status,
+                )
             state = self._refresh_policy_integrity_state(connection, now=current_time, create_key=True)
             trust_status = TrustStatus.from_policy_integrity_state(state).to_dict()
             key, key_id = self._policy_integrity_secret_material(create=True)
-            for candidate in rows if selected_payload is None else ():
+            for candidate in rows:
                 if _scoped_runtime_row_requires_exact_match(
                     scope=str(candidate["scope"]),
                     stored_artifact_id=(
@@ -468,6 +1201,7 @@ class StorePolicyMixin:
                     ),
                     source=str(candidate["source"]),
                     requested_artifact_id=artifact_id,
+                    requested_artifact_hash=artifact_hash,
                     requested_runtime_exact_match_key=runtime_exact_match_key,
                 ):
                     continue
@@ -483,12 +1217,22 @@ class StorePolicyMixin:
                     state,
                     source=str(candidate["source"]),
                 ):
-                    selected_payload = self._policy_row_payload(
+                    candidate_payload = self._policy_row_payload(
                         candidate,
                         integrity_result=integrity_result,
                         state=state,
                     )
-                    if is_remote_policy_source(str(candidate["source"])):
+                    candidate_outranks_local_once = selected_payload is None or guard_action_severity(
+                        candidate_payload.get("action"),
+                        unknown_action="block",
+                    ) > guard_action_severity(selected_payload.get("action"), unknown_action="block")
+                    if candidate_outranks_local_once:
+                        selected_payload = candidate_payload
+                    if (
+                        candidate_outranks_local_once
+                        and consume_one_shot
+                        and is_remote_policy_source(str(candidate["source"]))
+                    ):
                         events.append(
                             (
                                 "policy.cloud.applied",
@@ -502,12 +1246,18 @@ class StorePolicyMixin:
                                 },
                             )
                         )
-                    if _is_approval_gate_one_shot_policy(candidate):
+                    if (
+                        candidate_outranks_local_once
+                        and consume_one_shot
+                        and _is_approval_gate_one_shot_policy(candidate)
+                    ):
                         connection.execute(
                             "delete from policy_decisions where decision_id = ?",
                             (int(candidate["decision_id"]),),
                         )
-                    break
+                    if consume_one_shot:
+                        break
+                    continue
                 events.append(
                     (
                         "policy_integrity_violation",
@@ -551,6 +1301,7 @@ class StorePolicyMixin:
                     candidate["decision_id"],
                     integrity_result.status,
                 )
+            claim_selected_local_once()
             for event_name, payload in events:
                 connection.execute(
                     """
@@ -559,11 +1310,13 @@ class StorePolicyMixin:
                     """,
                     (event_name, json.dumps(payload), current_time),
                 )
-            return {
-                "decision": selected_payload,
-                "ignored_local_integrity": ignored_local_integrity,
-                "trust_status": trust_status,
-            }
+            if ignored_local_integrity is not None:
+                ignored_local_integrity.setdefault("trust_status", trust_status)
+            return lookup_result(
+                selected_payload,
+                ignored_integrity=ignored_local_integrity,
+                trust_status=trust_status,
+            )
 
     def resolve_policy_decision(
         self,
@@ -574,6 +1327,7 @@ class StorePolicyMixin:
         publisher: str | None = None,
         now: str | None = None,
         runtime_exact_match_context: str | None = None,
+        consume_one_shot: bool = True,
     ) -> dict[str, object] | None:
         lookup = self.resolve_policy_decision_lookup(
             harness,
@@ -583,8 +1337,377 @@ class StorePolicyMixin:
             publisher=publisher,
             now=now,
             runtime_exact_match_context=runtime_exact_match_context,
+            consume_one_shot=consume_one_shot,
         )
         return lookup["decision"]
+
+    def claim_approval_reuse_decision(
+        self,
+        decision: Mapping[str, object],
+        *,
+        now: str | None = None,
+    ) -> bool:
+        """Atomically validate and claim an accepted saved ``allow`` decision.
+
+        Returning ``False`` means the decision expired, changed, was consumed
+        by another evaluator, or was not an approval ``allow``. Callers must
+        then enforce the recomputed current action without saved evidence.
+        """
+
+        return self.claim_approval_reuse_decisions((decision,), now=now)
+
+    @staticmethod
+    def approval_reuse_claim_disposition(
+        decision: Mapping[str, object],
+    ) -> Literal["consumed", "retained"] | None:
+        """Describe what a successful claim does to this selected allow.
+
+        Package local-once approvals are reusable and remain in their table.
+        Expiring ``approval-gate`` policy rows are the only policy decisions
+        atomically deleted by the claim transaction. All other valid policy
+        allows remain authoritative and therefore must still exist when a
+        caller revalidates immediately before launch.
+        """
+
+        if decision.get("action") != "allow":
+            return None
+        approval_id = decision.get("approval_id")
+        if isinstance(approval_id, str) and approval_id:
+            artifact_id = decision.get("artifact_id")
+            if not isinstance(artifact_id, str) or not artifact_id:
+                return None
+            return "retained" if _local_once_approval_is_reusable(artifact_id) else "consumed"
+        decision_id = decision.get("decision_id")
+        if not isinstance(decision_id, int) or isinstance(decision_id, bool):
+            return None
+        if decision.get("source") == _APPROVAL_GATE_POLICY_SOURCE and decision.get("expires_at") is not None:
+            return "consumed"
+        return "retained"
+
+    def claim_approval_reuse_decisions(
+        self,
+        decisions: Sequence[Mapping[str, object]],
+        *,
+        now: str | None = None,
+    ) -> bool:
+        """Validate and claim a group of saved allows in one transaction.
+
+        A compound launch (for example, an MCP tool call that also installs a
+        package) may depend on more than one one-shot approval.  The launch is
+        authorized only when every selected row still matches the authority
+        revision observed during evaluation.  Any failed member rolls the
+        entire group back so a denied launch cannot consume a sibling grant.
+        """
+
+        current_time = _canonical_utc_timestamp(now or _now())
+        unique_decisions: list[Mapping[str, object]] = []
+        seen_keys: set[tuple[str, object]] = set()
+        expected_revision: int | None = None
+        has_local_once = False
+        for decision in decisions:
+            if decision.get("action") != "allow":
+                return False
+            revision = decision.get("_approval_authority_revision")
+            if not isinstance(revision, int) or isinstance(revision, bool) or revision < 0:
+                return False
+            if expected_revision is None:
+                expected_revision = revision
+            elif revision != expected_revision:
+                return False
+            approval_id = decision.get("approval_id")
+            decision_id = decision.get("decision_id")
+            if isinstance(approval_id, str) and approval_id:
+                decision_key: tuple[str, object] = ("approval", approval_id)
+                has_local_once = True
+            elif isinstance(decision_id, int) and not isinstance(decision_id, bool):
+                decision_key = ("policy", decision_id)
+            else:
+                return False
+            if decision_key in seen_keys:
+                continue
+            seen_keys.add(decision_key)
+            unique_decisions.append(decision)
+        if not unique_decisions:
+            return True
+        assert expected_revision is not None
+        local_integrity_key: bytes | None = None
+        local_integrity_key_id: str | None = None
+        if has_local_once:
+            local_integrity_key, local_integrity_key_id = self._policy_integrity_secret_material(create=False)
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            if _approval_authority_revision(connection) != expected_revision:
+                connection.rollback()
+                return False
+            for decision in unique_decisions:
+                if not self._claim_approval_reuse_decision_locked(
+                    connection,
+                    decision=decision,
+                    current_time=current_time,
+                    local_integrity_key=local_integrity_key,
+                    local_integrity_key_id=local_integrity_key_id,
+                ):
+                    connection.rollback()
+                    return False
+        return True
+
+    def _claim_approval_reuse_decision_locked(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        decision: Mapping[str, object],
+        current_time: str,
+        local_integrity_key: bytes | None,
+        local_integrity_key_id: str | None,
+    ) -> bool:
+        """Claim one prevalidated member of an open batch transaction."""
+
+        approval_id = decision.get("approval_id")
+        decision_id = decision.get("decision_id")
+        if isinstance(approval_id, str) and approval_id:
+            claim_disposition = self.approval_reuse_claim_disposition(decision)
+            if claim_disposition is None:
+                return False
+            claimed = self._claim_local_once_approval_by_id_locked(
+                connection,
+                approval_id=approval_id,
+                now=current_time,
+                expected_decision=decision,
+                integrity_key=local_integrity_key,
+                integrity_key_id=local_integrity_key_id,
+                consume=claim_disposition == "consumed",
+            )
+            if claimed is None:
+                return False
+            connection.execute(
+                """
+                insert into guard_events (event_name, payload_json, occurred_at)
+                values (?, ?, ?)
+                """,
+                (
+                    (
+                        "approval.local_once_reused"
+                        if claim_disposition == "retained"
+                        else "approval.local_once_applied"
+                    ),
+                    json.dumps(
+                        {
+                            "approval_id": claimed.get("approval_id"),
+                            "request_id": claimed.get("request_id"),
+                            "harness": claimed.get("harness"),
+                            "artifact_id": claimed.get("artifact_id"),
+                        }
+                    ),
+                    current_time,
+                ),
+            )
+            return True
+        if not isinstance(decision_id, int) or isinstance(decision_id, bool):
+            return False
+        row = connection.execute(
+            """
+            select decision_id, harness, scope, artifact_id, action, artifact_hash, workspace, publisher,
+                   source, reason, owner, expires_at, updated_at, integrity_version, integrity_generation,
+                   payload_hash, payload_mac, integrity_key_id, signed_at
+            from policy_decisions
+            where decision_id = ? and action = 'allow'
+              and (expires_at is null or julianday(expires_at) > julianday(?))
+            """,
+            (decision_id, current_time),
+        ).fetchone()
+        if row is None:
+            return False
+        source = str(row["source"])
+        if is_remote_policy_source(source):
+            integrity_result = self._policy_integrity_result_for_row(
+                row,
+                mode="protected",
+                key=None,
+                key_id=None,
+                trusted_generation=None,
+            )
+            integrity_state: dict[str, object] | None = None
+        else:
+            integrity_state = self._refresh_policy_integrity_state(connection, now=current_time, create_key=True) or {}
+            key, key_id = self._policy_integrity_secret_material(create=True)
+            generation = integrity_state.get("generation")
+            trusted_generation = (
+                generation if isinstance(generation, int) and not isinstance(generation, bool) else None
+            )
+            integrity_result = self._policy_integrity_result_for_row(
+                row,
+                mode=str(integrity_state.get("mode") or "degraded"),
+                key=key,
+                key_id=key_id,
+                trusted_generation=trusted_generation,
+            )
+        if integrity_result.status != "valid":
+            return False
+        current_payload = self._policy_row_payload(
+            row,
+            integrity_result=integrity_result,
+            state=integrity_state,
+        )
+        identity_keys = (
+            "action",
+            "artifact_hash",
+            "artifact_id",
+            "decision_id",
+            "expires_at",
+            "harness",
+            "integrity_enforcement",
+            "integrity_generation",
+            "integrity_key_id",
+            "integrity_mode",
+            "integrity_status",
+            "integrity_version",
+            "owner",
+            "publisher",
+            "reason",
+            "signed_at",
+            "scope",
+            "source",
+            "updated_at",
+            "workspace",
+        )
+        if any(current_payload.get(key) != decision.get(key) for key in identity_keys):
+            return False
+        claim_disposition = self.approval_reuse_claim_disposition(current_payload)
+        if claim_disposition is None:
+            return False
+        if claim_disposition == "consumed":
+            cursor = connection.execute(
+                "delete from policy_decisions where decision_id = ? and action = 'allow'",
+                (decision_id,),
+            )
+            if cursor.rowcount != 1:
+                return False
+        connection.execute(
+            """
+            insert into guard_events (event_name, payload_json, occurred_at)
+            values (?, ?, ?)
+            """,
+            (
+                "approval.policy_reuse_applied",
+                json.dumps(
+                    {
+                        "decision_id": decision_id,
+                        "harness": current_payload.get("harness"),
+                        "artifact_id": current_payload.get("artifact_id"),
+                        "scope": current_payload.get("scope"),
+                    }
+                ),
+                current_time,
+            ),
+        )
+        return True
+
+    def approval_reuse_validation_reason(
+        self,
+        harness: str,
+        artifact_id: str | None,
+        artifact_hash: str | None,
+        workspace: str | None,
+        publisher: str | None,
+        now: str | None = None,
+    ) -> str | None:
+        """Explain why otherwise relevant saved allow evidence did not match.
+
+        The normal resolver intentionally returns only usable authority.  This
+        read-only diagnostic pass is used after a miss so receipts can explain
+        stale content/context without treating a near match as permission.
+        """
+
+        if artifact_id is None:
+            return None
+        current_time = _canonical_utc_timestamp(now or _now())
+        workspace_key = _workspace_policy_key(workspace)
+        artifact_family = _artifact_family_key(artifact_id)
+        policy_integrity_state: dict[str, object] = {}
+        policy_integrity_key: bytes | None = None
+        policy_integrity_key_id: str | None = None
+        with self._connect() as connection:
+            local_rows = _bounded_local_approval_reuse_diagnostic_rows(
+                connection,
+                harness=harness,
+                artifact_id=artifact_id,
+                artifact_family=artifact_family,
+                artifact_hash=artifact_hash,
+            )
+            policy_rows = _bounded_policy_approval_reuse_diagnostic_rows(
+                connection,
+                harness=harness,
+                artifact_id=artifact_id,
+                artifact_family=artifact_family,
+                artifact_hash=artifact_hash,
+                publisher=publisher,
+            )
+            if any(not is_remote_policy_source(str(row["source"])) for row in policy_rows):
+                policy_integrity_state = self._refresh_policy_integrity_state(
+                    connection,
+                    now=current_time,
+                    create_key=False,
+                )
+                policy_integrity_key, policy_integrity_key_id = self._policy_integrity_secret_material(create=False)
+        if local_rows:
+            local_integrity_key, local_integrity_key_id = self._policy_integrity_secret_material(create=False)
+            for row in local_rows:
+                integrity_result = _verify_local_once_approval(
+                    dict(row),
+                    key=local_integrity_key,
+                    key_id=local_integrity_key_id,
+                )
+                if integrity_result.status != "valid":
+                    return "approval_reuse_integrity_failure"
+        for row in (*local_rows, *policy_rows):
+            row_keys = set(row.keys())
+            if "claimed_at" in row_keys and row["claimed_at"] is not None:
+                continue
+            stored_artifact_id = str(row["artifact_id"]) if row["artifact_id"] is not None else None
+            stored_artifact_hash = str(row["artifact_hash"]) if row["artifact_hash"] is not None else None
+            same_identity = stored_artifact_id in {artifact_id, artifact_family}
+            same_content = artifact_hash is not None and stored_artifact_hash == artifact_hash
+            broad_scope = "scope" in row_keys and str(row["scope"]) in {"harness", "global"}
+            publisher_scope = (
+                "scope" in row_keys
+                and str(row["scope"]) == "publisher"
+                and row["publisher"] is not None
+                and str(row["publisher"]) == publisher
+            )
+            if not (same_identity or same_content or publisher_scope or (broad_scope and stored_artifact_id is None)):
+                continue
+            if "decision_id" in row_keys and not is_remote_policy_source(str(row["source"])):
+                integrity_result = self._policy_integrity_result_for_row(
+                    row,
+                    mode=str(policy_integrity_state.get("mode") or "degraded"),
+                    key=policy_integrity_key,
+                    key_id=policy_integrity_key_id,
+                    trusted_generation=_mapping_int(policy_integrity_state, "generation"),
+                )
+                if integrity_result.status != "valid" and not _warn_only_policy_integrity_status(
+                    integrity_result.status,
+                    policy_integrity_state,
+                    source=str(row["source"]),
+                ):
+                    return "approval_reuse_integrity_failure"
+            expires_at = str(row["expires_at"]) if row["expires_at"] is not None else None
+            if expires_at is not None and _timestamp_has_expired(expires_at, now=current_time):
+                return "approval_reuse_expired"
+            if _is_approval_context_token(stored_artifact_hash) or _is_approval_context_token(artifact_hash):
+                context_reason = approval_context_tokens_validation_reason(stored_artifact_hash, artifact_hash)
+                if context_reason is not None:
+                    return context_reason
+            if stored_artifact_hash is not None and artifact_hash is not None and stored_artifact_hash != artifact_hash:
+                return "approval_reuse_content_changed"
+            stored_workspace = str(row["workspace"]) if row["workspace"] is not None else None
+            stored_publisher = str(row["publisher"]) if row["publisher"] is not None else None
+            if stored_workspace is not None and stored_workspace not in {workspace, workspace_key}:
+                return "approval_reuse_identity_changed"
+            if stored_publisher is not None and stored_publisher != publisher:
+                return "approval_reuse_identity_changed"
+            if not same_identity:
+                return "approval_reuse_identity_changed"
+        return None
 
     @staticmethod
     def _normalized_policy_keys(decision: PolicyDecision) -> tuple[str | None, str | None, str | None, str | None]:
@@ -594,7 +1717,9 @@ class StorePolicyMixin:
             artifact_id = decision.artifact_id if decision.scope in {"artifact", "workspace"} else None
         artifact_hash = (
             decision.artifact_hash
-            if decision.scope in {"artifact", "workspace"} or _is_runtime_scoped_exact_match_key(decision.artifact_hash)
+            if decision.scope in {"artifact", "workspace"}
+            or _is_runtime_scoped_exact_match_key(decision.artifact_hash)
+            or _is_approval_context_token(decision.artifact_hash)
             else None
         )
         workspace = _workspace_policy_key(decision.workspace) if decision.scope == "workspace" else None
@@ -619,7 +1744,7 @@ class StorePolicyMixin:
         import json
         from datetime import datetime, timezone
 
-        current_time = now or datetime.now(timezone.utc).isoformat()
+        current_time = _canonical_utc_timestamp(now or datetime.now(timezone.utc).isoformat())
         workspace_key = _workspace_policy_key(str(workspace) if workspace is not None else None)
         with self._connect() as connection:
             rows = connection.execute(
@@ -629,7 +1754,7 @@ class StorePolicyMixin:
                        payload_hash, payload_mac, integrity_key_id, signed_at
                 from policy_decisions
                 where (harness = ? or harness = '*')
-                  and (expires_at is null or expires_at > ?)
+                  and (expires_at is null or julianday(expires_at) > julianday(?))
                   and (
                     scope in ('global', 'harness', 'publisher', 'artifact')
                     or (scope = 'workspace' and (workspace = ? or workspace is null))

--- a/src/codex_plugin_scanner/guard/synced_policy.py
+++ b/src/codex_plugin_scanner/guard/synced_policy.py
@@ -1,0 +1,42 @@
+"""Read the effective policy payload persisted by Guard cloud sync."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class _SyncPayloadReader(Protocol):
+    """Minimal persistence interface needed to read synced policy state."""
+
+    def get_sync_payload(self, state_key: str) -> dict[str, object] | list[object] | None: ...
+
+
+def _optional_string(value: object | None) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def synced_policy_payload(store: _SyncPayloadReader) -> dict[str, object] | None:
+    """Return signed bundle defaults when present, otherwise legacy policy state."""
+
+    policy_bundle = store.get_sync_payload("policy_bundle")
+    if isinstance(policy_bundle, dict):
+        policy_defaults = policy_bundle.get("policyDefaults")
+        if isinstance(policy_defaults, dict):
+            payload = dict(policy_defaults)
+            issued_at = _optional_string(policy_bundle.get("issuedAt"))
+            bundle_hash = _optional_string(policy_bundle.get("bundleHash"))
+            bundle_version = _optional_string(policy_bundle.get("bundleVersion"))
+            if issued_at is not None:
+                payload["updatedAt"] = issued_at
+            if bundle_hash is not None:
+                payload["bundleHash"] = bundle_hash
+            if bundle_version is not None:
+                payload["bundleVersion"] = bundle_version
+            return payload
+    payload = store.get_sync_payload("policy")
+    return payload if isinstance(payload, dict) else None
+
+
+__all__ = ["synced_policy_payload"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import pytest
@@ -21,6 +21,41 @@ pythonpath_entries = [entry for entry in existing_pythonpath.split(os.pathsep) i
 pythonpath_prefix = [str(path) for path in (SUPPORT_PATH, SRC_PATH) if str(path) not in pythonpath_entries]
 if pythonpath_prefix:
     os.environ["PYTHONPATH"] = os.pathsep.join([*pythonpath_prefix, *pythonpath_entries])
+
+
+def _test_guard_homes_with_daemon_state(root: Path) -> set[Path]:
+    guard_homes: set[Path] = set()
+    pending = [root]
+    while pending:
+        directory = pending.pop()
+        try:
+            with os.scandir(directory) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            pending.append(Path(entry.path))
+                        elif entry.is_file(follow_symlinks=False) and entry.name == "daemon-state.json":
+                            guard_homes.add(Path(entry.path).parent)
+                    except OSError:
+                        continue
+        except OSError:
+            continue
+    return guard_homes
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None) -> Iterator[None]:
+    """Retire Guard daemons launched from the completed test's temporary tree."""
+    del nextitem
+    test_tmp_path = item.funcargs.get("tmp_path")
+    yield
+    if not isinstance(test_tmp_path, Path):
+        return
+
+    from codex_plugin_scanner.guard.daemon.manager import retire_all_guard_daemons_for_home
+
+    for guard_home in sorted(_test_guard_homes_with_daemon_state(test_tmp_path)):
+        retire_all_guard_daemons_for_home(guard_home)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_codex_remote_control.py
+++ b/tests/test_codex_remote_control.py
@@ -8,7 +8,29 @@ import stat
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.adapters import codex_remote_control
+
+
+def test_guarded_codex_launch_candidates_are_side_effect_free(tmp_path, monkeypatch):
+    def fail_subprocess(*_args, **_kwargs):
+        pytest.fail("launch preview must not start remote-control setup")
+
+    monkeypatch.setattr(codex_remote_control.subprocess, "run", fail_subprocess)
+    monkeypatch.setattr(codex_remote_control.subprocess, "Popen", fail_subprocess)
+
+    candidates = codex_remote_control.guarded_codex_launch_command_candidates(
+        executable="/usr/bin/codex",
+        home_dir=tmp_path / "home",
+        passthrough_args=["Fix it."],
+    )
+
+    socket_path = codex_remote_control.default_codex_control_socket(tmp_path / "home")
+    assert candidates == (
+        ["/usr/bin/codex", "--remote", f"unix://{socket_path}", "Fix it."],
+        ["/usr/bin/codex", "Fix it."],
+    )
 
 
 def test_guarded_codex_launch_starts_remote_control_and_connects_tui(
@@ -93,7 +115,7 @@ def test_guarded_codex_launch_starts_portable_app_server_when_managed_daemon_is_
     )
 
     socket_path = home_dir / ".codex" / "app-server-control" / "app-server-control.sock"
-    assert starts[0]["executable"] == "/usr/local/bin/codex"
+    assert starts[0]["executable_prefix"] == ["/usr/local/bin/codex"]
     assert starts[0]["socket_path"] == socket_path
     assert command == ["/usr/local/bin/codex", "--remote", f"unix://{socket_path}"]
 
@@ -217,17 +239,22 @@ def test_direct_app_server_uses_private_control_directory(
         pid = 4321
 
     wait_calls = 0
+    launch_commands: list[list[str]] = []
 
     def fake_wait(path: Path) -> bool:
         nonlocal wait_calls
         wait_calls += 1
         return wait_calls > 1 and path.parent.exists()
 
+    def fake_popen(command, **_kwargs):
+        launch_commands.append(list(command))
+        return FakeProcess()
+
     monkeypatch.setattr(codex_remote_control, "_wait_for_socket", fake_wait)
-    monkeypatch.setattr(codex_remote_control.subprocess, "Popen", lambda command, **kwargs: FakeProcess())
+    monkeypatch.setattr(codex_remote_control.subprocess, "Popen", fake_popen)
 
     started = codex_remote_control._start_direct_app_server(
-        executable="codex",
+        executable_prefix=("/usr/bin/env", "codex"),
         socket_path=socket_path,
         environment={},
     )
@@ -235,6 +262,7 @@ def test_direct_app_server_uses_private_control_directory(
     directory_mode = stat.S_IMODE(socket_path.parent.stat().st_mode)
     pid_mode = stat.S_IMODE((socket_path.parent / "hol-guard-app-server.pid").stat().st_mode)
     assert started is True
+    assert launch_commands == [["/usr/bin/env", "codex", "app-server", "--listen", f"unix://{socket_path}"]]
     assert directory_mode == 0o700
     assert pid_mode == 0o600
 
@@ -269,7 +297,7 @@ def test_direct_app_server_recovers_when_pid_marker_is_stale(
     monkeypatch.setattr(codex_remote_control.subprocess, "Popen", fake_popen)
 
     started = codex_remote_control._start_direct_app_server(
-        executable="codex",
+        executable_prefix=("codex",),
         socket_path=socket_path,
         environment={},
     )
@@ -316,7 +344,7 @@ def test_direct_app_server_stops_matching_dead_listener_before_replacement(
     monkeypatch.setattr(codex_remote_control.subprocess, "Popen", fake_popen)
 
     started = codex_remote_control._start_direct_app_server(
-        executable="codex",
+        executable_prefix=("codex",),
         socket_path=socket_path,
         environment={},
     )

--- a/tests/test_cursor_cli.py
+++ b/tests/test_cursor_cli.py
@@ -177,7 +177,7 @@ def test_guard_run_launches_cursor_agent_subcommand(
     )
 
     assert evaluation["launched"] is True
-    assert captured["command"] == [str(cursor_path), "agent", "--print", "hello"]
+    assert captured["command"] == [str(Path("/bin/sh").resolve()), str(cursor_path), "agent", "--print", "hello"]
 
 
 def test_cursor_cli_detected_without_shims_when_cursor_agent_subcommand_exists(

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path
@@ -566,6 +567,79 @@ def test_cursor_native_shell_session_allow_after_trusted_after_shell(tmp_path: P
     )
 
 
+def test_cursor_tampered_pending_shell_cannot_bootstrap_signed_native_allow(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    conversation_id = "conv-cursor-tampered-pending"
+    command = "rm -rf ./hol-guard-cursor-native-test-marker"
+    generation_id = "gen-cursor-tampered-pending"
+    _record_cursor_pending_for_test(
+        store=store,
+        guard_home=home_dir,
+        guard_commands_module=guard_commands_module,
+        conversation_id=conversation_id,
+        command=command,
+        workspace_dir=workspace_dir,
+        generation_id=generation_id,
+    )
+    pending_key = guard_commands_module._cursor_pending_shell_state_key(conversation_id, command)
+    with sqlite3.connect(store.path) as connection:
+        row = connection.execute(
+            "select payload_json from sync_state where state_key = ?",
+            (pending_key,),
+        ).fetchone()
+        assert row is not None
+        tampered = json.loads(str(row[0]))
+        tampered["artifact_hash"] = "forged-artifact-hash"
+        connection.execute(
+            "update sync_state set payload_json = ? where state_key = ?",
+            (json.dumps(tampered), pending_key),
+        )
+
+    saved = guard_commands_module._persist_cursor_native_permission_after_shell(
+        store=store,
+        payload=prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "generation_id": generation_id,
+                "hook_event_name": "afterShellExecution",
+                "command": command,
+                "cwd": str(workspace_dir),
+                "duration": 15,
+            }
+        ),
+        harness="cursor",
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace=workspace_dir,
+        hook_env=_trusted_cursor_after_shell_env(
+            home_dir,
+            conversation_id=conversation_id,
+            command=command,
+            workspace_dir=workspace_dir,
+            approval_binding=generation_id,
+        ),
+    )
+
+    assert saved is False
+    assert store.get_sync_payload(pending_key) is None
+    assert (
+        store.get_sync_payload(guard_commands_module._cursor_native_shell_allow_state_key(conversation_id, command))
+        is None
+    )
+    events = store.list_events(event_name="rule.ignored.local_integrity")
+    event_payloads = [event_payload for event in events if isinstance(event_payload := event.get("payload"), dict)]
+    assert any(
+        event_payload.get("source") == "cursor-pending-shell" and event_payload.get("integrity_status") == "tampered"
+        for event_payload in event_payloads
+    )
+
+
 def test_forged_after_shell_without_attestation_is_rejected(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
     from codex_plugin_scanner.guard.cli import commands as guard_commands_module
@@ -770,6 +844,7 @@ def test_normalize_cursor_shell_command_unwraps_lean_ctx_wrapper() -> None:
 
 def test_cursor_native_shell_is_approved_for_lean_ctx_wrapped_retry(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+    from codex_plugin_scanner.guard.cli.commands_hook_runtime_eval import _cursor_native_saved_approval_hash
     from codex_plugin_scanner.guard.store import GuardStore
 
     home_dir = tmp_path / "home"
@@ -778,8 +853,31 @@ def test_cursor_native_shell_is_approved_for_lean_ctx_wrapped_retry(tmp_path: Pa
     command = "gh api graphql -f query='query { viewer { login } }'"
     wrapped = "/path/to/lean-ctx -c 'gh api graphql -f query='\\''query { viewer { login } }'\\'''"
     now = guard_commands_module._now()
+    assert guard_commands_module._record_cursor_native_shell_allow_state(
+        store=store,
+        conversation_id=conversation_id,
+        command=command,
+        artifact=_cursor_shell_artifact(workspace_dir=tmp_path, command=command),
+        artifact_hash="hash-gh-viewer-login",
+        now=now,
+    )
+
+    payload = {"conversation_id": conversation_id, "command": wrapped}
+    assert guard_commands_module._cursor_native_shell_is_approved(store, payload)
+    assert _cursor_native_saved_approval_hash(store, payload) == "hash-gh-viewer-login"
+
+
+def test_unsigned_cursor_native_shell_allowance_fails_closed_with_integrity_event(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+    from codex_plugin_scanner.guard.cli.commands_hook_runtime_eval import _cursor_native_saved_approval_hash
+
+    store = GuardStore(tmp_path / "home")
+    conversation_id = "conv-cursor-unsigned-session-allow"
+    command = "gh api graphql -f query='query { viewer { login } }'"
+    now = guard_commands_module._now()
+    state_key = guard_commands_module._cursor_native_shell_allow_state_key(conversation_id, command)
     store.set_sync_payload(
-        guard_commands_module._cursor_native_shell_allow_state_key(conversation_id, command),
+        state_key,
         {
             "saved_at": now,
             "action": "allow",
@@ -792,13 +890,107 @@ def test_cursor_native_shell_is_approved_for_lean_ctx_wrapped_retry(tmp_path: Pa
         now,
     )
 
-    assert guard_commands_module._cursor_native_shell_is_approved(
-        store,
-        {
-            "conversation_id": conversation_id,
-            "command": wrapped,
-        },
+    payload = {"conversation_id": conversation_id, "command": command}
+    assert not guard_commands_module._cursor_native_shell_is_approved(store, payload)
+    assert _cursor_native_saved_approval_hash(store, payload) is None
+    assert store.get_sync_payload(state_key) is None
+    events = store.list_events(event_name="rule.ignored.local_integrity")
+    assert len(events) == 1
+    assert events[0]["payload"]["source"] == "cursor-native-session"
+    assert events[0]["payload"]["integrity_status"] == "missing_integrity"
+
+
+def test_tampered_cursor_native_shell_allowance_fails_closed_with_integrity_event(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+    from codex_plugin_scanner.guard.cli.commands_hook_runtime_eval import _cursor_native_saved_approval_hash
+
+    store = GuardStore(tmp_path / "home")
+    conversation_id = "conv-cursor-tampered-session-allow"
+    command = "rm -rf ./sensitive-directory"
+    now = guard_commands_module._now()
+    state_key = guard_commands_module._cursor_native_shell_allow_state_key(conversation_id, command)
+    assert guard_commands_module._record_cursor_native_shell_allow_state(
+        store=store,
+        conversation_id=conversation_id,
+        command=command,
+        artifact=_cursor_shell_artifact(workspace_dir=tmp_path, command=command),
+        artifact_hash="hash-before-tamper",
+        now=now,
     )
+    stored = store.get_sync_payload(state_key)
+    assert isinstance(stored, dict)
+    store.set_sync_payload(state_key, {**stored, "artifact_hash": "forged-hash"}, now)
+
+    payload = {"conversation_id": conversation_id, "command": command}
+    assert not guard_commands_module._cursor_native_shell_is_approved(store, payload)
+    assert _cursor_native_saved_approval_hash(store, payload) is None
+    events = store.list_events(event_name="rule.ignored.local_integrity")
+    assert len(events) == 1
+    assert events[0]["payload"]["integrity_status"] == "tampered"
+    assert events[0]["payload"]["message"] == "local_authority_integrity_payload_hash_mismatch"
+
+
+def test_signed_cursor_allowance_cannot_be_replayed_into_another_conversation(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+
+    store = GuardStore(tmp_path / "home")
+    approved_conversation = "conv-cursor-approved"
+    forged_conversation = "conv-cursor-forged-copy"
+    command = "rm -rf ./sensitive-directory"
+    now = guard_commands_module._now()
+    approved_state_key = guard_commands_module._cursor_native_shell_allow_state_key(approved_conversation, command)
+    forged_state_key = guard_commands_module._cursor_native_shell_allow_state_key(forged_conversation, command)
+    assert guard_commands_module._record_cursor_native_shell_allow_state(
+        store=store,
+        conversation_id=approved_conversation,
+        command=command,
+        artifact=_cursor_shell_artifact(workspace_dir=tmp_path, command=command),
+        artifact_hash="hash-approved-conversation",
+        now=now,
+    )
+    signed_allowance = store.get_sync_payload(approved_state_key)
+    assert isinstance(signed_allowance, dict)
+    store.set_sync_payload(forged_state_key, signed_allowance, now)
+
+    assert not guard_commands_module._cursor_native_shell_is_approved(
+        store,
+        {"conversation_id": forged_conversation, "command": command},
+    )
+    events = store.list_events(event_name="rule.ignored.local_integrity")
+    assert len(events) == 1
+    assert events[0]["payload"]["message"] == "local_authority_integrity_context_mismatch"
+
+
+def test_malformed_cursor_allowance_json_fails_closed_with_integrity_event(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+
+    store = GuardStore(tmp_path / "home")
+    conversation_id = "conv-cursor-malformed-json"
+    command = "rm -rf ./sensitive-directory"
+    now = guard_commands_module._now()
+    state_key = guard_commands_module._cursor_native_shell_allow_state_key(conversation_id, command)
+    assert guard_commands_module._record_cursor_native_shell_allow_state(
+        store=store,
+        conversation_id=conversation_id,
+        command=command,
+        artifact=_cursor_shell_artifact(workspace_dir=tmp_path, command=command),
+        artifact_hash="hash-before-json-tamper",
+        now=now,
+    )
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "update sync_state set payload_json = '{' where state_key = ?",
+            (state_key,),
+        )
+
+    assert not guard_commands_module._cursor_native_shell_is_approved(
+        store,
+        {"conversation_id": conversation_id, "command": command},
+    )
+    assert store.get_sync_payload(state_key) is None
+    events = store.list_events(event_name="rule.ignored.local_integrity")
+    assert len(events) == 1
+    assert events[0]["payload"]["message"] == "local_authority_integrity_payload_invalid_json"
 
 
 def test_cursor_native_shell_does_not_approve_unrelated_command(tmp_path: Path) -> None:
@@ -1228,6 +1420,8 @@ def test_cursor_hook_daemon_fast_path_rejects_empty_response(tmp_path: Path, mon
     # The fast path should reject the empty response and fall through to CLI.
     # The CLI path may fail (no real daemon), but it must not default-allow.
     assert proc.returncode in (0, 2)
+
+
 def test_cursor_hook_daemon_fast_path_rejects_spoofed_healthz(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Fast path returns None when a spoofed listener fails the HMAC challenge."""
     import http.server
@@ -1305,6 +1499,8 @@ def test_cursor_hook_daemon_fast_path_rejects_spoofed_healthz(tmp_path: Path, mo
     assert proc.returncode in (0, 2)
     assert "real-secret-token" not in proc.stdout
     assert "real-secret-token" not in proc.stderr
+
+
 def test_cursor_hook_daemon_fast_path_404_falls_through_to_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Fast path returns None when /v1/healthz/verify returns 404, falling through to CLI."""
     import http.server

--- a/tests/test_grok_adapter.py
+++ b/tests/test_grok_adapter.py
@@ -190,6 +190,10 @@ class TestGrokHookResponses:
         payload = grok_hook_response_from_guard(policy_action="block", reason="Blocked by HOL Guard.")
         assert payload == {"decision": "deny", "reason": "Blocked by HOL Guard."}
 
+    def test_unsatisfied_review_response_is_denied(self) -> None:
+        payload = grok_hook_response_from_guard(policy_action="review", reason="Review in HOL Guard.")
+        assert payload == {"decision": "deny", "reason": "Review in HOL Guard."}
+
     def test_emit_grok_hook_response_writes_json_line(self) -> None:
         stream = io.StringIO()
         emit_grok_hook_response(policy_action="allow", reason="", output_stream=stream)

--- a/tests/test_guard_approval_context.py
+++ b/tests/test_guard_approval_context.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.approval_context import (
+    APPROVAL_CONTEXT_TOKEN_PREFIX,
+    ApprovalContextToken,
+    approval_context_tokens_validation_reason,
+    approval_context_validation_reason,
+    build_approval_context_token,
+    build_runtime_executable_identity,
+    parse_approval_context_token,
+)
+
+
+def _context(**overrides: object) -> dict[str, object]:
+    context: dict[str, object] = {
+        "identity": {"artifact_id": "codex:project:tool:read", "workspace": "/private/workspace"},
+        "content": "artifact-hash:arbitrary:text",
+        "capabilities": ["filesystem:read", "network:none"],
+        "policy": {"action": "review", "fingerprint": "private-policy-fingerprint"},
+        "sandbox": {"mode": "workspace-write", "network": False},
+    }
+    context.update(overrides)
+    return context
+
+
+def _token(**overrides: object) -> str:
+    return build_approval_context_token(**_context(**overrides))
+
+
+def _encoded_payload(payload: object) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def test_token_is_deterministic_for_equivalent_structured_context() -> None:
+    first = _token(
+        identity={"workspace": "/private/workspace", "artifact_id": "codex:project:tool:read"},
+        sandbox={"network": False, "mode": "workspace-write"},
+    )
+    second = _token()
+
+    assert first == second
+    assert first.startswith(APPROVAL_CONTEXT_TOKEN_PREFIX)
+    assert parse_approval_context_token(first) == parse_approval_context_token(second)
+
+
+def test_token_serializes_only_component_hashes_and_not_source_values() -> None:
+    source_values = (
+        "codex:project:tool:read",
+        "/private/workspace",
+        "artifact-hash:arbitrary:text",
+        "filesystem:read",
+        "private-policy-fingerprint",
+        "workspace-write",
+    )
+    token = _token()
+    parsed = parse_approval_context_token(token)
+
+    assert parsed is not None
+    assert all(source not in token for source in source_values)
+    assert all(
+        len(component_hash) == 64 and component_hash.isascii() and component_hash.isalnum()
+        for component_hash in (
+            parsed.identity_hash,
+            parsed.content_hash,
+            parsed.capabilities_hash,
+            parsed.policy_hash,
+            parsed.sandbox_hash,
+        )
+    )
+
+
+def test_arbitrary_artifact_hash_text_is_bound_without_interpretation() -> None:
+    artifact_hash = "not-sha256:guard-approval-context:v1:\n☃\x00"
+    saved = _token(content=artifact_hash)
+
+    assert approval_context_validation_reason(saved, **_context(content=artifact_hash)) is None
+    assert (
+        approval_context_validation_reason(saved, **_context(content=f"{artifact_hash}:changed"))
+        == "approval_reuse_content_changed"
+    )
+
+
+@pytest.mark.parametrize(
+    ("changed_context", "expected_reason"),
+    (
+        ({"identity": {"artifact_id": "different"}}, "approval_reuse_identity_changed"),
+        ({"content": "changed-content"}, "approval_reuse_content_changed"),
+        ({"capabilities": ["filesystem:read", "network:egress"]}, "approval_reuse_capability_changed"),
+        ({"policy": {"action": "block"}}, "approval_reuse_policy_changed"),
+        ({"sandbox": {"mode": "host", "network": True}}, "approval_reuse_sandbox_changed"),
+    ),
+)
+def test_validator_reports_stable_changed_dimension(
+    changed_context: dict[str, object],
+    expected_reason: str,
+) -> None:
+    saved = _token()
+
+    assert approval_context_validation_reason(saved, **_context(**changed_context)) == expected_reason
+
+
+def test_validator_uses_stable_security_precedence_when_multiple_dimensions_change() -> None:
+    saved = _token()
+
+    assert (
+        approval_context_validation_reason(
+            saved,
+            **_context(identity="changed", content="changed", policy="changed", sandbox="changed"),
+        )
+        == "approval_reuse_identity_changed"
+    )
+
+
+def test_opaque_token_comparison_accepts_unchanged_context() -> None:
+    saved = _token()
+    current = _token()
+
+    assert approval_context_tokens_validation_reason(saved, current) is None
+
+
+@pytest.mark.parametrize(
+    "legacy_or_malformed",
+    (
+        None,
+        "sha256:legacy-artifact-hash",
+        "",
+        f"{APPROVAL_CONTEXT_TOKEN_PREFIX}not+base64url",
+        f"{APPROVAL_CONTEXT_TOKEN_PREFIX}{_encoded_payload({'version': 2})}",
+        f"{APPROVAL_CONTEXT_TOKEN_PREFIX}{_encoded_payload({'version': 1, 'identity': '0' * 64})}",
+    ),
+)
+def test_legacy_or_malformed_saved_value_fails_closed_as_changed_content(legacy_or_malformed: object) -> None:
+    assert approval_context_tokens_validation_reason(legacy_or_malformed, _token()) == "approval_reuse_content_changed"
+
+
+def test_even_equal_legacy_values_cannot_prove_structured_context_is_unchanged() -> None:
+    assert (
+        approval_context_tokens_validation_reason("sha256:legacy", "sha256:legacy") == "approval_reuse_content_changed"
+    )
+
+
+def test_parser_rejects_payload_with_unexpected_fields() -> None:
+    parsed = parse_approval_context_token(_token())
+    assert isinstance(parsed, ApprovalContextToken)
+    payload = {
+        "version": 1,
+        "identity": parsed.identity_hash,
+        "content": parsed.content_hash,
+        "capabilities": parsed.capabilities_hash,
+        "policy": parsed.policy_hash,
+        "sandbox": parsed.sandbox_hash,
+        "raw_secret": "must-not-be-accepted",
+    }
+
+    assert parse_approval_context_token(f"{APPROVAL_CONTEXT_TOKEN_PREFIX}{_encoded_payload(payload)}") is None
+
+
+def test_builder_rejects_non_json_context_without_leaking_its_value() -> None:
+    class Unsupported:
+        def __repr__(self) -> str:
+            return "very-private-value"
+
+    with pytest.raises(TypeError, match="component 'identity' must be JSON-compatible") as exc_info:
+        _token(identity=Unsupported())
+
+    assert "very-private-value" not in str(exc_info.value)
+
+
+def test_runtime_executable_identity_changes_after_same_path_byte_replacement(tmp_path) -> None:
+    executable = tmp_path / "guard-tool"
+    executable.write_bytes(b"#!/bin/sh\necho first\n")
+    executable.chmod(0o755)
+    first = build_runtime_executable_identity(str(executable))
+
+    replacement = tmp_path / "replacement"
+    replacement.write_bytes(b"#!/bin/sh\necho other\n")
+    replacement.chmod(0o755)
+    os.replace(replacement, executable)
+    second = build_runtime_executable_identity(str(executable))
+
+    assert first["status"] == second["status"] == "verified"
+    assert first["path"] == second["path"] == str(executable.resolve())
+    assert first["size"] == second["size"]
+    assert first["sha256"] != second["sha256"]
+    assert first != second
+
+
+def test_runtime_executable_identity_binds_security_relevant_mode(tmp_path) -> None:
+    executable = tmp_path / "guard-tool"
+    executable.write_bytes(b"#!/bin/sh\nexit 0\n")
+    executable.chmod(0o755)
+    executable_identity = build_runtime_executable_identity(str(executable))
+
+    executable.chmod(0o700)
+    restricted_identity = build_runtime_executable_identity(str(executable))
+
+    assert executable_identity["sha256"] == restricted_identity["sha256"]
+    assert executable_identity["mode"] == 0o755
+    assert restricted_identity["mode"] == 0o700
+    assert executable_identity != restricted_identity
+
+
+def test_runtime_executable_identity_binds_resolved_symlink_target(tmp_path) -> None:
+    first_target = tmp_path / "guard-tool-v1"
+    second_target = tmp_path / "guard-tool-v2"
+    first_target.write_bytes(b"#!/bin/sh\necho v1\n")
+    second_target.write_bytes(b"#!/bin/sh\necho v2\n")
+    first_target.chmod(0o755)
+    second_target.chmod(0o755)
+    executable_link = tmp_path / "guard-tool"
+    executable_link.symlink_to(first_target.name)
+    first = build_runtime_executable_identity(str(executable_link))
+
+    executable_link.unlink()
+    executable_link.symlink_to(second_target.name)
+    second = build_runtime_executable_identity(str(executable_link))
+
+    assert first["path"] == str(first_target.resolve())
+    assert second["path"] == str(second_target.resolve())
+    assert first["sha256"] != second["sha256"]
+    assert first != second
+
+
+def test_runtime_executable_identity_resolves_relative_path_from_launch_cwd(tmp_path) -> None:
+    guard_cwd = tmp_path / "guard-process"
+    launch_cwd = tmp_path / "runtime-workspace"
+    guard_cwd.mkdir()
+    launch_cwd.mkdir()
+    guard_executable = guard_cwd / "server"
+    runtime_executable = launch_cwd / "server"
+    guard_executable.write_bytes(b"#!/bin/sh\necho guard-process\n")
+    runtime_executable.write_bytes(b"#!/bin/sh\necho runtime-workspace\n")
+    guard_executable.chmod(0o755)
+    runtime_executable.chmod(0o755)
+
+    identity = build_runtime_executable_identity("./server", cwd=launch_cwd)
+
+    assert identity["status"] == "verified"
+    assert identity["path"] == str(runtime_executable.resolve())
+    assert identity["launch_cwd"] == str(launch_cwd.resolve())
+    assert identity["sha256"] != build_runtime_executable_identity(str(guard_executable))["sha256"]

--- a/tests/test_guard_approval_decisions.py
+++ b/tests/test_guard_approval_decisions.py
@@ -554,7 +554,7 @@ class TestPolicyScopePersistence:
 
 
 class TestEvaluateDetectionScopePersistence:
-    def test_unchanged_artifact_with_stored_allow_policy_is_not_blocked(self, tmp_path: Path) -> None:
+    def test_legacy_stored_allow_cannot_lower_current_reapproval(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
         config = _make_config(tmp_path)
         artifact = _make_artifact()
@@ -581,8 +581,10 @@ class TestEvaluateDetectionScopePersistence:
         result = evaluate_detection(detection, store, config, persist=False)
 
         artifact_result = result["artifacts"][0]
-        assert artifact_result["policy_action"] == "allow"
-        assert result["blocked"] is False
+        assert artifact_result["policy_action"] == "require-reapproval"
+        assert artifact_result["approval_reuse_status"] == "rejected"
+        assert artifact_result["approval_reuse_reason_code"] == "approval_reuse_content_changed"
+        assert result["blocked"] is True
 
     def test_changed_artifact_hash_without_stored_policy_triggers_reapproval(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -1925,8 +1925,7 @@ def test_approval_gate_allow_once_requires_password_prompt(tmp_path: Path, monke
     artifact_payload = resolved["artifacts"][0]
     assert artifact_payload["policy_action"] == "allow"
     assert artifact_payload["user_override"] == "allow-once"
-    receipts = store.list_receipts(limit=5)
-    assert any(item.get("user_override") == "allow-once" for item in receipts)
+    assert store.list_receipts(limit=5) == []
 
 
 def test_approval_gate_background_remote_policy_sync_fails_closed_without_crashing(

--- a/tests/test_guard_approval_policy_versions.py
+++ b/tests/test_guard_approval_policy_versions.py
@@ -1,0 +1,270 @@
+"""Approval tokens bind evaluator revisions without binding product UX versions."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner import version as product_version_module
+from codex_plugin_scanner.guard import mcp_tool_calls as mcp_tool_calls_module
+from codex_plugin_scanner.guard.cli import commands_hook_generic as generic_hook_module
+from codex_plugin_scanner.guard.cli import commands_support_runtime_policy as runtime_policy_module
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.models import GuardArtifact
+from codex_plugin_scanner.guard.proxy import stdio as stdio_module
+from codex_plugin_scanner.guard.runtime.approval_context import (
+    approval_context_tokens_validation_reason,
+    parse_approval_context_token,
+)
+
+
+def _config(tmp_path: Path) -> GuardConfig:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    return GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+        security_level="custom",
+        risk_actions={
+            "local_secret_read": "review",
+            "mcp_dangerous_tool": "review",
+        },
+    )
+
+
+def _ux_only_config_change(config: GuardConfig) -> GuardConfig:
+    return replace(
+        config,
+        approval_browser_delay_seconds=config.approval_browser_delay_seconds + 17,
+        approval_surface_policy="never-auto-open",
+        desktop_notifications=not config.desktop_notifications,
+        telemetry=not config.telemetry,
+    )
+
+
+def _workspace(config: GuardConfig) -> Path:
+    assert config.workspace is not None
+    return config.workspace
+
+
+def _assert_only_policy_component_changed(saved_token: str, current_token: str) -> None:
+    saved = parse_approval_context_token(saved_token)
+    current = parse_approval_context_token(current_token)
+
+    assert saved is not None
+    assert current is not None
+    assert saved.identity_hash == current.identity_hash
+    assert saved.content_hash == current.content_hash
+    assert saved.capabilities_hash == current.capabilities_hash
+    assert saved.policy_hash != current.policy_hash
+    assert saved.sandbox_hash == current.sandbox_hash
+    assert approval_context_tokens_validation_reason(saved_token, current_token) == "approval_reuse_policy_changed"
+
+
+def _runtime_hook_token(*, artifact: GuardArtifact, config: GuardConfig) -> str:
+    return runtime_policy_module._runtime_hook_approval_context_token(
+        artifact=artifact,
+        content_hash="unchanged-runtime-content",
+        runtime_workspace=config.workspace,
+        action_envelope=None,
+        config=config,
+        current_config_action="review",
+        trusted_cli_action=None,
+        untrusted_payload_action=None,
+        package_action=None,
+        data_flow_action=None,
+        scanner_action=None,
+        current_action="review",
+        data_flow_signals=(),
+        scanner_evidence=(),
+    )
+
+
+def test_runtime_hook_evaluator_policy_version_is_the_only_changed_component(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    artifact = GuardArtifact(
+        artifact_id="codex:project:runtime-policy-version",
+        name="runtime policy version fixture",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(_workspace(config) / ".codex" / "config.toml"),
+        metadata={"runtime_request_summary": "display copy v1"},
+    )
+    saved_token = _runtime_hook_token(artifact=artifact, config=config)
+
+    monkeypatch.setattr(product_version_module, "__version__", "999.0.0-ux-only")
+    assert (
+        _runtime_hook_token(
+            artifact=replace(artifact, metadata={"runtime_request_summary": "display copy v2"}),
+            config=_ux_only_config_change(config),
+        )
+        == saved_token
+    )
+
+    monkeypatch.setattr(
+        runtime_policy_module,
+        "_RUNTIME_HOOK_EVALUATOR_POLICY_VERSION",
+        "runtime-hook-evaluation-v2-test",
+    )
+    _assert_only_policy_component_changed(
+        saved_token,
+        _runtime_hook_token(artifact=artifact, config=config),
+    )
+
+
+def _generic_hook_token(*, config: GuardConfig, payload: dict[str, object]) -> str:
+    return generic_hook_module._generic_hook_approval_context_token(
+        action_envelope=None,
+        artifact_id="generic:project:policy-version",
+        artifact_name="generic policy version fixture",
+        config=config,
+        current_action="review",
+        current_config_action="review",
+        daemon_hint_disposition=None,
+        daemon_hint_reason_code=None,
+        daemon_status=None,
+        fail_mode=None,
+        harness="generic-test",
+        payload=payload,
+        publisher=None,
+        runtime_workspace=config.workspace,
+        trusted_cli_action=None,
+        untrusted_payload_action=None,
+        untrusted_payload_action_disposition=None,
+        untrusted_payload_action_reason=None,
+    )
+
+
+def test_generic_hook_evaluator_policy_version_is_the_only_changed_component(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    payload: dict[str, object] = {
+        "hook_event_name": "OpaqueHookEvent",
+        "tool_name": "opaque_tool",
+        "tool_input": {"target": "unchanged"},
+        "approval_delivery": {"ui_contract_version": "v1"},
+    }
+    saved_token = _generic_hook_token(config=config, payload=payload)
+
+    monkeypatch.setattr(product_version_module, "__version__", "999.0.0-ux-only")
+    assert (
+        _generic_hook_token(
+            config=_ux_only_config_change(config),
+            payload={**payload, "approval_delivery": {"ui_contract_version": "v2"}},
+        )
+        == saved_token
+    )
+
+    monkeypatch.setattr(
+        generic_hook_module,
+        "_GENERIC_HOOK_EVALUATOR_POLICY_VERSION",
+        "generic-hook-evaluation-v2-test",
+    )
+    _assert_only_policy_component_changed(
+        saved_token,
+        _generic_hook_token(config=config, payload=payload),
+    )
+
+
+def _tool_call_token(*, artifact: GuardArtifact, config: GuardConfig) -> str:
+    assert config.workspace is not None
+    return mcp_tool_calls_module.build_tool_call_hash(
+        artifact,
+        {"command": "rm unchanged-target"},
+        workspace=config.workspace,
+        config=config,
+    )
+
+
+def test_mcp_tool_call_evaluator_policy_version_is_the_only_changed_component(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    artifact = mcp_tool_calls_module.build_tool_call_artifact(
+        harness="codex",
+        server_name="policy-version-server",
+        tool_name="shell_exec",
+        source_scope="project",
+        config_path=str(_workspace(config) / ".mcp.json"),
+        transport="stdio",
+        tool_schema={"type": "object", "properties": {"command": {"type": "string"}}},
+    )
+    saved_token = _tool_call_token(artifact=artifact, config=config)
+
+    monkeypatch.setattr(product_version_module, "__version__", "999.0.0-ux-only")
+    assert (
+        _tool_call_token(
+            artifact=replace(artifact, metadata={**artifact.metadata, "ui_contract_version": "v2"}),
+            config=_ux_only_config_change(config),
+        )
+        == saved_token
+    )
+
+    monkeypatch.setattr(
+        mcp_tool_calls_module,
+        "_MCP_TOOL_CALL_EVALUATOR_POLICY_VERSION",
+        "mcp-tool-call-evaluation-v2-test",
+    )
+    _assert_only_policy_component_changed(
+        saved_token,
+        _tool_call_token(artifact=artifact, config=config),
+    )
+
+
+def _sensitive_read_token(*, artifact: GuardArtifact, config: GuardConfig) -> str:
+    return stdio_module.build_sensitive_read_approval_hash(
+        artifact,
+        config=config,
+        cwd=config.workspace,
+        current_action="review",
+    )
+
+
+def test_stdio_sensitive_read_evaluator_policy_version_is_the_only_changed_component(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    artifact = GuardArtifact(
+        artifact_id="codex:project:file-read:policy-version",
+        name="Read .env",
+        harness="codex",
+        artifact_type="file_read_request",
+        source_scope="project",
+        config_path=str(_workspace(config) / ".mcp.json"),
+        metadata={
+            "normalized_path": str(_workspace(config) / ".env"),
+            "path_class": "dotenv",
+            "tool_name": "read_file",
+        },
+    )
+    saved_token = _sensitive_read_token(artifact=artifact, config=config)
+
+    monkeypatch.setattr(product_version_module, "__version__", "999.0.0-ux-only")
+    assert (
+        _sensitive_read_token(
+            artifact=artifact,
+            config=_ux_only_config_change(config),
+        )
+        == saved_token
+    )
+
+    monkeypatch.setattr(
+        stdio_module,
+        "_STDIO_SENSITIVE_READ_EVALUATOR_POLICY_VERSION",
+        "stdio-sensitive-read-evaluation-v2-test",
+    )
+    _assert_only_policy_component_changed(
+        saved_token,
+        _sensitive_read_token(artifact=artifact, config=config),
+    )

--- a/tests/test_guard_approval_precedence_consumers.py
+++ b/tests/test_guard_approval_precedence_consumers.py
@@ -1,0 +1,1136 @@
+"""Cross-consumer regressions for saved-approval precedence (P44)."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+import codex_plugin_scanner.guard.local_supply_chain as local_supply_chain_module
+import codex_plugin_scanner.guard.runtime.supply_chain_package_eval as package_eval_module
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.consumer import artifact_hash
+from codex_plugin_scanner.guard.local_supply_chain import (
+    apply_stored_package_policy_override,
+    package_request_policy_hash,
+)
+from codex_plugin_scanner.guard.mcp_tool_calls import (
+    build_tool_call_artifact,
+    build_tool_call_hash,
+    claim_deferred_tool_call_approval,
+    evaluate_tool_call,
+)
+from codex_plugin_scanner.guard.models import GuardAction, GuardArtifact, PolicyDecision
+from codex_plugin_scanner.guard.package_execution_context import build_package_execution_context
+from codex_plugin_scanner.guard.proxy._env import _build_scrubbed_env
+from codex_plugin_scanner.guard.proxy.stdio import StdioGuardProxy, build_sensitive_read_approval_hash
+from codex_plugin_scanner.guard.runtime.approval_context import (
+    build_approval_context_token,
+    build_configured_environment_hash,
+    build_runtime_launch_identity,
+)
+from codex_plugin_scanner.guard.runtime.mcp_protection import build_mcp_server_identity
+from codex_plugin_scanner.guard.runtime.package_intent import PackageIntent, build_package_request_artifact
+from codex_plugin_scanner.guard.runtime.secret_file_requests import (
+    build_file_read_request_artifact,
+    extract_sensitive_file_read_request,
+)
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
+    PackageRequestEvaluation,
+    SupplyChainUserCopy,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+_EXACT_PACKAGE_CONTEXT_TOKEN = build_approval_context_token(
+    identity={"package": "guard-proof"},
+    content={"digest": "package-content"},
+    capabilities={"operation": "install"},
+    policy={"version": "policy-v2"},
+    sandbox={"analysis": "off"},
+)
+
+
+def _package_evaluation(action: GuardAction) -> PackageRequestEvaluation:
+    decision = "block" if action == "block" else "ask" if action not in {"allow", "warn"} else action
+    return PackageRequestEvaluation(
+        decision=decision,
+        policy_action=action,
+        enforcement="local",
+        entitlement_state="active",
+        cache_status="fresh",
+        package_intent_hash="intent-hash",
+        policy_version="policy-v2",
+        bundle_version="bundle-v2",
+        workspace_fingerprint="workspace-v2",
+        reasons=({"code": "current_package_result", "message": "Current package evaluation."},),
+        packages=({"name": "guard-proof", "decision": decision},),
+        risk_summary="Current package evaluation.",
+        user_copy=SupplyChainUserCopy(
+            title="Current package result",
+            summary="Current package evaluation.",
+            next_step=None,
+            dashboard_url=None,
+            harness_message="Current package evaluation.",
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "action",
+    ("allow", "warn", "review", "require-reapproval", "sandbox-required", "block"),
+)
+def test_package_protect_receipt_action_preserves_authoritative_action(action: GuardAction) -> None:
+    assert local_supply_chain_module._protect_action_for_policy_action(action) == action
+
+
+def _package_artifact(workspace: Path) -> GuardArtifact:
+    intent = PackageIntent(
+        package_manager="npm",
+        intent_kind="install",
+        command_tokens=("npm", "install", "guard-proof"),
+        redacted_command="npm install guard-proof",
+        targets=(),
+        manifest_paths=(),
+        lockfile_paths=(),
+    )
+    return build_package_request_artifact(
+        "guard-cli",
+        intent,
+        config_path=str(workspace / "package.json"),
+        source_scope="project",
+    )
+
+
+class _SavedPackagePolicyStore:
+    def __init__(self, action: GuardAction) -> None:
+        self.action = action
+        self.claimed = False
+
+    def resolve_policy_decision_lookup(self, *_args: object, **kwargs: object) -> dict[str, object]:
+        assert kwargs["consume_one_shot"] is False
+        return {
+            "decision": {
+                "action": self.action,
+                "scope": "artifact",
+                "source": "approval-gate",
+                "decision_id": 1,
+                "artifact_hash": _EXACT_PACKAGE_CONTEXT_TOKEN,
+            },
+            "ignored_local_integrity": None,
+            "trust_status": {},
+        }
+
+    def claim_approval_reuse_decision(self, _decision: object, *, now: str | None = None) -> bool:
+        assert now == "2026-07-17T00:00:00Z"
+        self.claimed = True
+        return True
+
+
+@pytest.mark.parametrize("current_action", ["require-reapproval", "sandbox-required", "block"])
+def test_package_saved_allow_never_lowers_stronger_current_action(
+    tmp_path: Path,
+    current_action: GuardAction,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _package_artifact(workspace)
+    context = build_package_execution_context(workspace_dir=workspace, artifact=artifact, executable="npm")
+    store = _SavedPackagePolicyStore("allow")
+
+    result = apply_stored_package_policy_override(
+        _package_evaluation(current_action),
+        store=store,
+        artifact=artifact,
+        artifact_hash=_EXACT_PACKAGE_CONTEXT_TOKEN,
+        workspace_dir=workspace,
+        now="2026-07-17T00:00:00Z",
+        execution_context=context,
+    )
+
+    assert result.policy_action == current_action
+    assert result.reasons[0]["code"] in {
+        "approval_reuse_reapproval_required",
+        "approval_reuse_sandbox_required",
+        "approval_reuse_current_block",
+    }
+    assert store.claimed is False
+
+
+def test_package_exact_saved_allow_satisfies_only_current_review(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _package_artifact(workspace)
+    context = build_package_execution_context(workspace_dir=workspace, artifact=artifact, executable="npm")
+    store = _SavedPackagePolicyStore("allow")
+
+    result = apply_stored_package_policy_override(
+        _package_evaluation("review"),
+        store=store,
+        artifact=artifact,
+        artifact_hash=_EXACT_PACKAGE_CONTEXT_TOKEN,
+        workspace_dir=workspace,
+        now="2026-07-17T00:00:00Z",
+        execution_context=context,
+    )
+
+    assert result.policy_action == "allow"
+    assert result.reasons[0]["code"] == "saved_package_approval"
+    assert store.claimed is True
+
+
+def test_package_reuse_uses_post_scanner_current_action_before_claim(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _package_artifact(workspace)
+    context = build_package_execution_context(workspace_dir=workspace, artifact=artifact, executable="npm")
+    store = _SavedPackagePolicyStore("allow")
+
+    result = apply_stored_package_policy_override(
+        _package_evaluation("review"),
+        store=store,
+        artifact=artifact,
+        artifact_hash=_EXACT_PACKAGE_CONTEXT_TOKEN,
+        workspace_dir=workspace,
+        now="2026-07-17T00:00:00Z",
+        execution_context=context,
+        current_action="block",
+    )
+
+    assert result.policy_action == "block"
+    assert result.reasons[0]["code"] == "approval_reuse_current_block"
+    assert store.claimed is False
+
+
+def test_package_weaker_supplied_current_action_cannot_erase_package_block(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _package_artifact(workspace)
+    context = build_package_execution_context(workspace_dir=workspace, artifact=artifact, executable="npm")
+    store = _SavedPackagePolicyStore("allow")
+
+    result = apply_stored_package_policy_override(
+        _package_evaluation("block"),
+        store=store,
+        artifact=artifact,
+        artifact_hash=_EXACT_PACKAGE_CONTEXT_TOKEN,
+        workspace_dir=workspace,
+        now="2026-07-17T00:00:00Z",
+        execution_context=context,
+        current_action="review",
+    )
+
+    assert result.policy_action == "block"
+    assert result.reasons[0]["code"] == "approval_reuse_current_block"
+    assert store.claimed is False
+
+
+def test_package_local_saved_allow_without_exact_hash_is_rejected(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _package_artifact(workspace)
+    context = build_package_execution_context(workspace_dir=workspace, artifact=artifact, executable="npm")
+    store = _SavedPackagePolicyStore("allow")
+    original_lookup = store.resolve_policy_decision_lookup
+
+    def lookup_without_hash(*args: object, **kwargs: object) -> dict[str, object]:
+        result = original_lookup(*args, **kwargs)
+        decision = result["decision"]
+        assert isinstance(decision, dict)
+        decision.pop("artifact_hash")
+        return result
+
+    store.resolve_policy_decision_lookup = lookup_without_hash  # type: ignore[method-assign]
+    result = apply_stored_package_policy_override(
+        _package_evaluation("review"),
+        store=store,
+        artifact=artifact,
+        artifact_hash=_EXACT_PACKAGE_CONTEXT_TOKEN,
+        workspace_dir=workspace,
+        now="2026-07-17T00:00:00Z",
+        execution_context=context,
+    )
+
+    assert result.policy_action == "review"
+    assert result.reasons[0]["code"] == "approval_reuse_content_changed"
+    assert store.claimed is False
+
+
+def test_package_equal_legacy_hash_cannot_prove_complete_approval_context(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _package_artifact(workspace)
+    context = build_package_execution_context(workspace_dir=workspace, artifact=artifact, executable="npm")
+    store = _SavedPackagePolicyStore("allow")
+    original_lookup = store.resolve_policy_decision_lookup
+
+    def lookup_with_legacy_hash(*args: object, **kwargs: object) -> dict[str, object]:
+        result = original_lookup(*args, **kwargs)
+        decision = result["decision"]
+        assert isinstance(decision, dict)
+        decision["artifact_hash"] = "equal-legacy-package-hash"
+        return result
+
+    store.resolve_policy_decision_lookup = lookup_with_legacy_hash  # type: ignore[method-assign]
+    result = apply_stored_package_policy_override(
+        _package_evaluation("review"),
+        store=store,
+        artifact=artifact,
+        artifact_hash="equal-legacy-package-hash",
+        workspace_dir=workspace,
+        now="2026-07-17T00:00:00Z",
+        execution_context=context,
+    )
+
+    assert result.policy_action == "review"
+    assert result.reasons[0]["code"] == "approval_reuse_content_changed"
+    assert store.claimed is False
+
+
+@pytest.mark.parametrize(
+    ("changed_dimension", "expected_reason"),
+    [
+        ("policy", "approval_reuse_policy_changed"),
+        ("sandbox", "approval_reuse_sandbox_changed"),
+    ],
+)
+def test_package_policy_and_sandbox_context_changes_invalidate_review_approval(
+    tmp_path: Path,
+    changed_dimension: str,
+    expected_reason: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _package_artifact(workspace)
+    context = build_package_execution_context(workspace_dir=workspace, artifact=artifact, executable="npm")
+    base_evaluation = _package_evaluation("review")
+    current_evaluation = (
+        replace(base_evaluation, policy_version="policy-v3") if changed_dimension == "policy" else base_evaluation
+    )
+    base_config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace, sandbox_analysis="off")
+    current_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        sandbox_analysis="strict" if changed_dimension == "sandbox" else "off",
+    )
+    old_digest = package_request_policy_hash(
+        artifact=artifact,
+        store=GuardStore(tmp_path / "guard-home"),
+        workspace_dir=workspace,
+        evaluation=base_evaluation,
+        execution_context=context,
+        config=base_config,
+    )
+    store = GuardStore(tmp_path / "guard-home")
+    new_digest = package_request_policy_hash(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace,
+        evaluation=current_evaluation,
+        execution_context=context,
+        config=current_config,
+    )
+    assert old_digest != new_digest
+    store.upsert_policy(
+        PolicyDecision(
+            harness=artifact.harness,
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=old_digest,
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+
+    result = apply_stored_package_policy_override(
+        current_evaluation,
+        store=store,
+        artifact=artifact,
+        artifact_hash=new_digest,
+        workspace_dir=workspace,
+        now="2026-07-17T00:00:00Z",
+        execution_context=context,
+    )
+
+    assert result.policy_action == "review"
+    assert result.reasons[0]["code"] == expected_reason
+
+
+@pytest.mark.parametrize(("saved_action", "expected"), [("allow", False), ("block", True)])
+def test_package_cache_error_probe_is_non_consuming_and_never_authorizes_saved_allow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    saved_action: GuardAction,
+    expected: bool,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _package_artifact(workspace)
+
+    class ProbeStore:
+        def resolve_policy_decision_lookup(self, *_args: object, **kwargs: object) -> dict[str, object]:
+            assert kwargs["consume_one_shot"] is False
+            return {
+                "decision": {
+                    "action": saved_action,
+                    "artifact_hash": "exact-v1-token",
+                    "scope": "artifact",
+                    "source": "approval-gate",
+                },
+                "ignored_local_integrity": None,
+                "trust_status": {},
+            }
+
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "package_request_policy_hash",
+        lambda **_kwargs: "exact-v1-token",
+    )
+
+    result = package_eval_module._cached_cloud_validation_error_has_saved_policy(
+        store=ProbeStore(),
+        artifact=artifact,
+        evaluation=_package_evaluation("block"),
+        workspace_dir=workspace,
+        now="2026-07-17T00:00:00Z",
+    )
+
+    assert result is expected
+
+
+def _dangerous_tool_artifact() -> GuardArtifact:
+    return build_tool_call_artifact(
+        harness="codex",
+        server_name="global-shell",
+        tool_name="shell_exec",
+        source_scope="global",
+        config_path="/shared/.mcp.json",
+        transport="stdio",
+    )
+
+
+def test_tool_call_local_saved_allow_without_exact_hash_is_rejected(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _dangerous_tool_artifact()
+    arguments = {"command": "rm relative-target"}
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace, mode="prompt")
+    digest = build_tool_call_hash(artifact, arguments, workspace=workspace, config=config)
+    store = GuardStore(tmp_path / "guard-home")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=None,
+            reason="legacy unbound allow",
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=artifact,
+        artifact_hash=digest,
+        arguments=arguments,
+    )
+
+    assert decision.action == "review"
+    assert decision.approval_reuse_reason_code == "approval_reuse_content_changed"
+
+
+def test_tool_call_equal_legacy_hash_cannot_prove_complete_approval_context(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _dangerous_tool_artifact()
+    arguments = {"command": "rm relative-target"}
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace, mode="prompt")
+    legacy_digest = build_tool_call_hash(artifact, arguments, workspace=workspace)
+    store = GuardStore(tmp_path / "guard-home")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=legacy_digest,
+            reason="legacy digest-only allow",
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=artifact,
+        artifact_hash=legacy_digest,
+        arguments=arguments,
+    )
+
+    assert decision.action == "review"
+    assert decision.approval_reuse_reason_code == "approval_reuse_content_changed"
+
+
+def test_tool_call_approval_hash_is_bound_to_workspace_and_reuses_unchanged_workspace(tmp_path: Path) -> None:
+    workspace_a = tmp_path / "workspace-a"
+    workspace_b = tmp_path / "workspace-b"
+    workspace_a.mkdir()
+    workspace_b.mkdir()
+    artifact = _dangerous_tool_artifact()
+    arguments = {"command": "rm relative-target"}
+    config_a = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace_a, mode="prompt")
+    config_b = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace_b, mode="prompt")
+    digest_a = build_tool_call_hash(artifact, arguments, workspace=workspace_a, config=config_a)
+    digest_b = build_tool_call_hash(artifact, arguments, workspace=workspace_b, config=config_b)
+    assert digest_a != digest_b
+    store = GuardStore(tmp_path / "guard-home")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=digest_a,
+            reason="workspace A exact approval",
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+
+    unchanged = evaluate_tool_call(
+        store=store,
+        config=config_a,
+        artifact=artifact,
+        artifact_hash=digest_a,
+        arguments=arguments,
+    )
+    changed_workspace = evaluate_tool_call(
+        store=store,
+        config=config_b,
+        artifact=artifact,
+        artifact_hash=digest_b,
+        arguments=arguments,
+    )
+
+    assert unchanged.action == "allow"
+    assert unchanged.approval_reuse_reason_code == "approval_reuse_accepted"
+    assert changed_workspace.action == "review"
+
+
+def test_tool_call_rebuilds_current_authority_after_atomic_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _dangerous_tool_artifact()
+    arguments = {"command": "rm relative-target"}
+    artifact_actions: dict[str, GuardAction] = {}
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        mode="prompt",
+        artifact_actions=artifact_actions,
+    )
+    digest = build_tool_call_hash(artifact, arguments, workspace=workspace, config=config)
+    store = GuardStore(tmp_path / "guard-home")
+    approval_id = store.record_local_once_approval(
+        request_id="tool-call-post-claim-policy-change",
+        harness=artifact.harness,
+        artifact_id=artifact.artifact_id,
+        artifact_hash=digest,
+        workspace=str(workspace),
+        publisher=artifact.publisher,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+    original_claim = store.claim_approval_reuse_decision
+
+    def claim_then_block(decision: object, *, now: str | None = None) -> bool:
+        claimed = original_claim(decision, now=now)
+        if claimed:
+            artifact_actions[artifact.artifact_id] = "block"
+        return claimed
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", claim_then_block)
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=artifact,
+        artifact_hash=digest,
+        arguments=arguments,
+    )
+
+    assert decision.action == "block"
+    assert decision.current_action == "block"
+    assert decision.approval_reuse_status == "rejected"
+    assert decision.approval_reuse_reason_code == ("approval_reuse_context_changed_after_claim")
+    assert (
+        store.resolve_policy_decision(
+            artifact.harness,
+            artifact.artifact_id,
+            digest,
+            str(workspace),
+            consume_one_shot=False,
+        )
+        is None
+    )
+
+
+def test_tool_call_missing_post_claim_authority_fails_closed(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _dangerous_tool_artifact()
+    arguments = {"command": "rm relative-target"}
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        mode="prompt",
+    )
+    digest = build_tool_call_hash(artifact, arguments, workspace=workspace, config=config)
+    store = GuardStore(tmp_path / "guard-home")
+    approval_id = store.record_local_once_approval(
+        request_id="tool-call-missing-post-claim-authority",
+        harness=artifact.harness,
+        artifact_id=artifact.artifact_id,
+        artifact_hash=digest,
+        workspace=str(workspace),
+        publisher=artifact.publisher,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=artifact,
+        artifact_hash=digest,
+        arguments=arguments,
+        fresh_authority_provider=lambda: None,
+    )
+
+    assert decision.action == "require-reapproval"
+    assert decision.approval_reuse_status == "rejected"
+    assert decision.approval_reuse_reason_code == ("approval_reuse_context_changed_after_claim")
+
+
+def test_tool_call_retained_policy_deleted_after_claim_requires_reapproval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _dangerous_tool_artifact()
+    arguments = {"command": "rm retained-target"}
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        mode="prompt",
+    )
+    digest = build_tool_call_hash(artifact, arguments, workspace=workspace, config=config)
+    store = GuardStore(tmp_path / "guard-home")
+    store.upsert_policy(
+        PolicyDecision(
+            harness=artifact.harness,
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=digest,
+            workspace=str(workspace),
+            publisher=artifact.publisher,
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00+00:00",
+    )
+    original_claim = store.claim_approval_reuse_decision
+
+    def claim_then_delete_retained_row(decision, *, now: str | None = None) -> bool:
+        assert store.approval_reuse_claim_disposition(decision) == "retained"
+        claimed = original_claim(decision, now=now)
+        if claimed:
+            decision_id = decision.get("decision_id")
+            assert isinstance(decision_id, int) and not isinstance(decision_id, bool)
+            with store._connect() as connection:
+                connection.execute("delete from policy_decisions where decision_id = ?", (decision_id,))
+        return claimed
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", claim_then_delete_retained_row)
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=artifact,
+        artifact_hash=digest,
+        arguments=arguments,
+    )
+
+    assert decision.action == "require-reapproval"
+    assert decision.post_claim_revalidated is True
+    assert decision.approval_reuse_claim_disposition == "retained"
+    assert decision.approval_reuse_reason_code == "approval_reuse_context_changed_after_claim"
+
+
+def test_deferred_tool_claim_without_postclaim_authority_fails_closed(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _dangerous_tool_artifact()
+    arguments = {"command": "rm deferred-target"}
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        mode="prompt",
+    )
+    digest = build_tool_call_hash(artifact, arguments, workspace=workspace, config=config)
+    store = GuardStore(tmp_path / "guard-home")
+    store.upsert_policy(
+        PolicyDecision(
+            harness=artifact.harness,
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=digest,
+            workspace=str(workspace),
+            publisher=artifact.publisher,
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00+00:00",
+    )
+    provisional = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=artifact,
+        artifact_hash=digest,
+        arguments=arguments,
+        claim_saved_approval=False,
+    )
+
+    assert provisional.action == "allow"
+    assert provisional.pending_approval_reuse_decision is not None
+    assert provisional.approval_reuse_claim_disposition == "retained"
+
+    claimed = claim_deferred_tool_call_approval(store=store, decision=provisional)
+
+    assert claimed.action == "require-reapproval"
+    assert claimed.post_claim_revalidated is True
+    assert claimed.approval_reuse_reason_code == "approval_reuse_context_changed_after_claim"
+
+
+@pytest.mark.parametrize(
+    ("changed_config_fields", "expected_reason"),
+    [
+        ({"managed_policy_hash": "policy-v2"}, "approval_reuse_policy_changed"),
+        ({"sandbox_analysis": "strict"}, "approval_reuse_sandbox_changed"),
+    ],
+)
+def test_tool_call_policy_and_sandbox_context_changes_invalidate_review_approval(
+    tmp_path: Path,
+    changed_config_fields: dict[str, object],
+    expected_reason: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _dangerous_tool_artifact()
+    arguments = {"command": "rm relative-target"}
+    base_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        mode="prompt",
+        managed_policy_hash="policy-v1",
+        sandbox_analysis="off",
+    )
+    changed_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        mode="prompt",
+        managed_policy_hash=str(changed_config_fields.get("managed_policy_hash", "policy-v1")),
+        sandbox_analysis=str(changed_config_fields.get("sandbox_analysis", "off")),
+    )
+    old_digest = build_tool_call_hash(artifact, arguments, workspace=workspace, config=base_config)
+    new_digest = build_tool_call_hash(artifact, arguments, workspace=workspace, config=changed_config)
+    assert old_digest != new_digest
+    store = GuardStore(tmp_path / "guard-home")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=old_digest,
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=changed_config,
+        artifact=artifact,
+        artifact_hash=new_digest,
+        arguments=arguments,
+    )
+
+    assert decision.action == "review"
+    assert decision.approval_reuse_reason_code == expected_reason
+
+
+def test_tool_call_server_capability_change_invalidates_review_approval(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace, mode="prompt")
+    arguments = {"command": "rm relative-target"}
+    old_identity = build_mcp_server_identity(
+        config_path="/shared/.mcp.json",
+        command="mcp-server",
+        args=("--stdio",),
+        transport="stdio",
+        env_keys=("SAFE_SETTING",),
+    )
+    new_identity = build_mcp_server_identity(
+        config_path="/shared/.mcp.json",
+        command="mcp-server",
+        args=("--stdio",),
+        transport="stdio",
+        env_keys=("SAFE_SETTING", "GITHUB_TOKEN"),
+    )
+    old_artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="global-shell",
+        tool_name="shell_exec",
+        source_scope="global",
+        config_path="/shared/.mcp.json",
+        transport="stdio",
+        server_id="stable-server-id",
+        server_identity=old_identity,
+    )
+    new_artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="global-shell",
+        tool_name="shell_exec",
+        source_scope="global",
+        config_path="/shared/.mcp.json",
+        transport="stdio",
+        server_id="stable-server-id",
+        server_identity=new_identity,
+    )
+    assert old_artifact.artifact_id == new_artifact.artifact_id
+    old_digest = build_tool_call_hash(old_artifact, arguments, workspace=workspace, config=config)
+    new_digest = build_tool_call_hash(new_artifact, arguments, workspace=workspace, config=config)
+    store = GuardStore(tmp_path / "guard-home")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=old_artifact.artifact_id,
+            artifact_hash=old_digest,
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=new_artifact,
+        artifact_hash=new_digest,
+        arguments=arguments,
+    )
+
+    assert decision.action == "review"
+    assert decision.approval_reuse_reason_code == "approval_reuse_capability_changed"
+
+
+def test_tool_call_resolved_executable_change_invalidates_review_approval(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace, mode="prompt")
+    arguments = {"command": "rm relative-target"}
+    artifacts = [
+        build_tool_call_artifact(
+            harness="codex",
+            server_name="global-shell",
+            tool_name="shell_exec",
+            source_scope="global",
+            config_path="/shared/.mcp.json",
+            transport="stdio",
+            server_id="stable-server-id",
+            server_fingerprint={"command": ["mcp-server"], "resolved_executable": executable},
+        )
+        for executable in ("/opt/mcp-v1/bin/server", "/opt/mcp-v2/bin/server")
+    ]
+    old_digest = build_tool_call_hash(artifacts[0], arguments, workspace=workspace, config=config)
+    new_digest = build_tool_call_hash(artifacts[1], arguments, workspace=workspace, config=config)
+    store = GuardStore(tmp_path / "guard-home")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifacts[0].artifact_id,
+            artifact_hash=old_digest,
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=artifacts[1],
+        artifact_hash=new_digest,
+        arguments=arguments,
+    )
+
+    assert decision.action == "review"
+    assert decision.approval_reuse_reason_code == "approval_reuse_identity_changed"
+
+
+def _sensitive_read_artifact(workspace: Path) -> tuple[GuardArtifact, str]:
+    request = extract_sensitive_file_read_request("read_file", {"path": ".env"}, cwd=workspace)
+    assert request is not None
+    artifact = build_file_read_request_artifact(
+        harness="codex",
+        request=request,
+        config_path=str(workspace / ".mcp.json"),
+        source_scope="project",
+    )
+    return artifact, artifact_hash(artifact)
+
+
+def _marker_child_command(marker: Path) -> list[str]:
+    return [
+        sys.executable,
+        "-u",
+        "-c",
+        "\n".join(
+            (
+                "import json, pathlib, sys",
+                "for line in sys.stdin:",
+                "    message = json.loads(line)",
+                f"    pathlib.Path({str(marker)!r}).write_text(json.dumps(message), encoding='utf-8')",
+                "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': {'ok': True}}))",
+                "    sys.stdout.flush()",
+            )
+        ),
+    ]
+
+
+def _save_sensitive_read_allow(
+    store: GuardStore,
+    workspace: Path,
+    config: GuardConfig,
+    command: list[str],
+) -> None:
+    artifact, _legacy_digest = _sensitive_read_artifact(workspace)
+    current_action = config.risk_actions["local_secret_read"] if config.risk_actions is not None else "review"
+    launch_env = _build_scrubbed_env()
+    digest = build_sensitive_read_approval_hash(
+        artifact,
+        config=config,
+        cwd=workspace,
+        current_action=current_action,
+        server_launch_identity=build_runtime_launch_identity(
+            command[0],
+            args=command[1:],
+            structured_command=True,
+            cwd=workspace,
+            launch_env=launch_env,
+        ),
+        configured_env_values_hash=build_configured_environment_hash(
+            launch_env,
+            configured_keys=(),
+        ),
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=digest,
+            reason="old exact approval",
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+
+
+def test_stdio_sensitive_read_exact_review_approval_is_reused_with_evidence(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+    )
+    marker = tmp_path / "forwarded.json"
+    command = _marker_child_command(marker)
+    _save_sensitive_read_allow(store, workspace, config, command)
+    proxy = StdioGuardProxy(
+        command=command,
+        cwd=workspace,
+        guard_store=store,
+        guard_config=config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+        current_config_provider=lambda: config,
+    )
+
+    result = proxy.run_session(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "read_file", "arguments": {"path": ".env"}},
+            }
+        ]
+    )
+
+    assert result["responses"][0]["result"]["ok"] is True
+    assert marker.exists()
+    assert result["events"][0]["approval_reuse_reason_code"] == "approval_reuse_accepted"
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == "allow"
+    receipt_evidence = receipt["scanner_evidence"]
+    assert isinstance(receipt_evidence, list)
+    assert isinstance(receipt_evidence[-1], dict)
+    assert receipt_evidence[-1]["reason_code"] == "approval_reuse_accepted"
+
+
+@pytest.mark.parametrize("current_action", ["require-reapproval", "sandbox-required", "block"])
+def test_stdio_sensitive_read_saved_allow_and_payload_hint_never_lower_current_action(
+    tmp_path: Path,
+    current_action: GuardAction,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": current_action},
+    )
+    marker = tmp_path / "must-not-forward.json"
+    command = _marker_child_command(marker)
+    _save_sensitive_read_allow(store, workspace, config, command)
+    proxy = StdioGuardProxy(
+        command=command,
+        cwd=workspace,
+        guard_store=store,
+        guard_config=config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+    )
+
+    result = proxy.run_session(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "read_file",
+                    "policy_action": "allow",
+                    "arguments": {"path": ".env"},
+                },
+            }
+        ]
+    )
+
+    assert result["responses"][0]["error"]["code"] == -32001
+    assert marker.exists() is False
+    event = result["events"][0]
+    assert event["approval_reuse_reason_code"] in {
+        "approval_reuse_reapproval_required",
+        "approval_reuse_sandbox_required",
+        "approval_reuse_current_block",
+    }
+    approvals = store.list_approval_requests(limit=1)
+    if current_action == "require-reapproval":
+        approval = approvals[0]
+        assert approval["policy_action"] == current_action
+        approval_evidence = approval["scanner_evidence"]
+        assert isinstance(approval_evidence, list)
+        assert isinstance(approval_evidence[-1], dict)
+        assert approval_evidence[-1]["reason_code"] == event["approval_reuse_reason_code"]
+    else:
+        assert approvals == []
+        assert "approval_requests" not in event
+
+
+@pytest.mark.parametrize(
+    ("changed_config_fields", "expected_reason"),
+    [
+        ({"managed_policy_hash": "policy-v2"}, "approval_reuse_policy_changed"),
+        ({"sandbox_analysis": "strict"}, "approval_reuse_sandbox_changed"),
+    ],
+)
+def test_stdio_sensitive_read_policy_and_sandbox_changes_invalidate_review_approval(
+    tmp_path: Path,
+    changed_config_fields: dict[str, object],
+    expected_reason: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    base_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+        managed_policy_hash="policy-v1",
+        sandbox_analysis="off",
+    )
+    changed_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+        managed_policy_hash=str(changed_config_fields.get("managed_policy_hash", "policy-v1")),
+        sandbox_analysis=str(changed_config_fields.get("sandbox_analysis", "off")),
+    )
+    marker = tmp_path / "must-not-forward.json"
+    command = _marker_child_command(marker)
+    _save_sensitive_read_allow(store, workspace, base_config, command)
+    proxy = StdioGuardProxy(
+        command=command,
+        cwd=workspace,
+        guard_store=store,
+        guard_config=changed_config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+    )
+
+    result = proxy.run_session(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "read_file", "arguments": {"path": ".env"}},
+            }
+        ]
+    )
+
+    assert marker.exists() is False
+    assert result["events"][0]["approval_reuse_reason_code"] == expected_reason
+    approval = store.list_approval_requests(limit=1)[0]
+    evidence = approval["scanner_evidence"]
+    assert isinstance(evidence, list)
+    assert isinstance(evidence[-1], dict)
+    assert evidence[-1]["reason_code"] == expected_reason

--- a/tests/test_guard_approval_precedence_generic_stdio.py
+++ b/tests/test_guard_approval_precedence_generic_stdio.py
@@ -1,0 +1,1192 @@
+"""Current-policy-first regressions for generic hooks and stdio secret reads."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.cli import commands_support as guard_commands_module
+from codex_plugin_scanner.guard.cli.commands_hook_generic import (
+    _generic_hook_approval_reuse,
+    _generic_hook_payload_digest,
+)
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.consumer import artifact_hash
+from codex_plugin_scanner.guard.models import GuardAction, GuardArtifact, PolicyDecision
+from codex_plugin_scanner.guard.proxy._env import _build_scrubbed_env
+from codex_plugin_scanner.guard.proxy.stdio import (
+    StdioGuardProxy,
+    _sensitive_read_current_action,
+    build_sensitive_read_approval_hash,
+)
+from codex_plugin_scanner.guard.runtime.approval_context import (
+    APPROVAL_CONTEXT_TOKEN_PREFIX,
+    build_configured_environment_hash,
+    build_runtime_launch_identity,
+)
+from codex_plugin_scanner.guard.runtime.secret_file_requests import (
+    build_file_read_request_artifact,
+    extract_sensitive_file_read_request,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+_GENERIC_HARNESS = "generic-test"
+_GENERIC_ARTIFACT_ID = "generic-test:project:opaque-request"
+
+
+def test_generic_hook_integrity_warning_does_not_hide_separate_valid_saved_block(tmp_path: Path) -> None:
+    reuse, saved_present = _generic_hook_approval_reuse(
+        artifact_hash="guard-approval-context:v1:current",
+        artifact_id=_GENERIC_ARTIFACT_ID,
+        current_action="review",
+        decision={"action": "block", "artifact_hash": None},
+        harness=_GENERIC_HARNESS,
+        ignored_integrity={"integrity_status": "tampered"},
+        publisher=None,
+        runtime_workspace=tmp_path,
+        store=GuardStore(tmp_path / "guard-home"),
+    )
+
+    assert saved_present is True
+    assert reuse.action == "block"
+    assert reuse.saved_action == "block"
+    assert reuse.reason_code == "approval_reuse_integrity_failure"
+
+
+def _generic_payload() -> dict[str, object]:
+    return {
+        "artifact_id": _GENERIC_ARTIFACT_ID,
+        "artifact_name": "opaque request",
+        "hook_event_name": "OpaqueHookEvent",
+        "source_scope": "project",
+        "tool_name": "opaque_tool",
+        "tool_input": {"target": "unchanged"},
+    }
+
+
+def test_generic_hook_payload_digest_ignores_delivery_ids_but_keeps_nested_action_ids() -> None:
+    first = {
+        **_generic_payload(),
+        "requestId": "request-first",
+        "session_id": "session-first",
+        "timestamp": "2026-07-17T00:00:00Z",
+        "toolUseId": "tool-first",
+    }
+    retried = {
+        **_generic_payload(),
+        "request_id": "request-second",
+        "sessionId": "session-second",
+        "timestamp": "2026-07-17T00:01:00Z",
+        "tool_use_id": "tool-second",
+    }
+    changed_argument = {
+        **retried,
+        "tool_input": {"target": "unchanged", "request_id": "action-argument"},
+    }
+
+    assert _generic_hook_payload_digest(first) == _generic_hook_payload_digest(retried)
+    assert _generic_hook_payload_digest(retried) != _generic_hook_payload_digest(changed_argument)
+
+
+def _run_generic_hook(
+    *,
+    capsys: pytest.CaptureFixture[str],
+    config: GuardConfig,
+    payload: dict[str, object],
+    store: GuardStore,
+    workspace: Path,
+    post_claim_revalidator: Callable[[str], int | None] | None = None,
+) -> tuple[int, dict[str, object]]:
+    args = argparse.Namespace(
+        artifact_id=None,
+        artifact_name=None,
+        harness=_GENERIC_HARNESS,
+        json=True,
+        policy_action=None,
+    )
+    rc = guard_commands_module._run_hook_generic_payload(
+        args,
+        action_envelope=None,
+        config=config,
+        home_dir=workspace.parent,
+        payload=payload,
+        runtime_workspace=workspace,
+        store=store,
+        post_claim_revalidator=post_claim_revalidator,
+    )
+    output = json.loads(capsys.readouterr().out)
+    assert isinstance(output, dict)
+    return rc, output
+
+
+def _record_generic_once_allow(
+    store: GuardStore,
+    *,
+    artifact_hash_value: str,
+    request_id: str,
+    workspace: Path,
+) -> str:
+    approval_id = store.record_local_once_approval(
+        request_id=request_id,
+        harness=_GENERIC_HARNESS,
+        artifact_id=_GENERIC_ARTIFACT_ID,
+        artifact_hash=artifact_hash_value,
+        workspace=str(workspace),
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+    return approval_id
+
+
+def test_generic_hook_exact_review_approval_uses_v1_context_and_late_claim(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+    )
+    payload = {
+        **_generic_payload(),
+        "request_id": "request-first",
+        "session_id": "session-first",
+        "timestamp": "2026-07-17T00:00:00Z",
+        "tool_use_id": "tool-first",
+    }
+
+    first_rc, first_output = _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+    assert first_rc == 1
+    assert first_output["policy_action"] == "review"
+    context_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+    assert context_token.startswith(APPROVAL_CONTEXT_TOKEN_PREFIX)
+    approval_id = _record_generic_once_allow(
+        store,
+        artifact_hash_value=context_token,
+        request_id="generic-exact-review",
+        workspace=workspace,
+    )
+
+    second_rc, second_output = _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload={
+            **payload,
+            "request_id": "request-retry",
+            "session_id": "session-retry",
+            "timestamp": "2026-07-17T00:01:00Z",
+            "tool_use_id": "tool-retry",
+        },
+        store=store,
+        workspace=workspace,
+    )
+
+    assert second_rc == 0
+    assert second_output["policy_action"] == "allow"
+    assert second_output["approval_reuse"]["reason_code"] == "approval_reuse_accepted"
+    assert second_output["policy_composition"]["current_composed_action"] == "review"
+    assert second_output["policy_composition"]["authoritative_action"] == "allow"
+    assert (
+        store.resolve_policy_decision(
+            _GENERIC_HARNESS,
+            _GENERIC_ARTIFACT_ID,
+            context_token,
+            str(workspace),
+            consume_one_shot=False,
+        )
+        is None
+    )
+    claim_events = store.list_events(event_name="approval.local_once_applied")
+    assert len(claim_events) == 1
+    assert claim_events[0]["payload"]["approval_id"] == approval_id
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == "allow"
+    assert receipt["artifact_hash"] == context_token
+    evidence = receipt["scanner_evidence"]
+    assert isinstance(evidence, list)
+    assert {item["source"] for item in evidence if isinstance(item, dict)} >= {
+        "approval_reuse",
+        "policy_composition",
+    }
+
+
+def test_generic_hook_rebuilds_current_policy_after_atomic_claim(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    artifact_actions: dict[str, GuardAction] = {}
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+        artifact_actions=artifact_actions,
+    )
+    payload = _generic_payload()
+    _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+    context_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+    _record_generic_once_allow(
+        store,
+        artifact_hash_value=context_token,
+        request_id="generic-post-claim-policy-change",
+        workspace=workspace,
+    )
+    original_claim = store.claim_approval_reuse_decision
+
+    def claim_then_block(decision: object, *, now: str | None = None) -> bool:
+        claimed = original_claim(decision, now=now)
+        if claimed:
+            artifact_actions[_GENERIC_ARTIFACT_ID] = "block"
+        return claimed
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", claim_then_block)
+
+    rc, output = _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+
+    assert rc == 1
+    assert output["policy_action"] == "block"
+    assert output["policy_composition"]["current_composed_action"] == "block"
+    assert output["policy_composition"]["authoritative_action"] == "block"
+    assert output["approval_reuse"]["status"] == "rejected"
+    assert output["approval_reuse"]["reason_code"] == ("approval_reuse_context_changed_after_claim")
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "block"
+
+
+def test_generic_hook_missing_post_claim_context_fails_closed(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+    )
+    payload = _generic_payload()
+    _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+    context_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+    _record_generic_once_allow(
+        store,
+        artifact_hash_value=context_token,
+        request_id="generic-missing-post-claim-context",
+        workspace=workspace,
+    )
+
+    rc, output = _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+        post_claim_revalidator=lambda _artifact_hash: None,
+    )
+
+    assert rc == 1
+    assert output["policy_action"] == "require-reapproval"
+    assert output["approval_reuse"]["reason_code"] == ("approval_reuse_context_changed_after_claim")
+
+
+@pytest.mark.parametrize("block_source", ["config", "payload"])
+def test_generic_hook_saved_allow_never_lowers_new_current_block(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    block_source: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    review_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+    )
+    original_payload = _generic_payload()
+    _run_generic_hook(
+        capsys=capsys,
+        config=review_config,
+        payload=original_payload,
+        store=store,
+        workspace=workspace,
+    )
+    approved_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+    _record_generic_once_allow(
+        store,
+        artifact_hash_value=approved_token,
+        request_id=f"generic-stale-{block_source}",
+        workspace=workspace,
+    )
+    current_config = (
+        replace(review_config, artifact_actions={_GENERIC_ARTIFACT_ID: "block"})
+        if block_source == "config"
+        else review_config
+    )
+    current_payload = {**original_payload, "policy_action": "block"} if block_source == "payload" else original_payload
+
+    rc, output = _run_generic_hook(
+        capsys=capsys,
+        config=current_config,
+        payload=current_payload,
+        store=store,
+        workspace=workspace,
+    )
+
+    assert rc == 1
+    assert output["policy_action"] == "block"
+    assert output["policy_composition"]["current_composed_action"] == "block"
+    assert output["policy_composition"]["authoritative_action"] == "block"
+    assert output["approval_reuse"]["status"] == "rejected"
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "block"
+    assert store.list_events(event_name="approval.policy_reuse_applied") == []
+    assert (
+        store.resolve_policy_decision(
+            _GENERIC_HARNESS,
+            _GENERIC_ARTIFACT_ID,
+            approved_token,
+            str(workspace),
+            consume_one_shot=False,
+        )
+        is not None
+    )
+
+
+@pytest.mark.parametrize(
+    ("saved_action", "expected_action", "expected_reason", "expected_rc"),
+    [
+        ("allow", "review", "approval_reuse_content_changed", 1),
+        ("block", "block", "approval_reuse_saved_block", 1),
+    ],
+)
+def test_generic_hook_legacy_allow_fails_closed_but_legacy_block_is_preserved(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    saved_action: GuardAction,
+    expected_action: GuardAction,
+    expected_reason: str,
+    expected_rc: int,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+    )
+    legacy_hash = "sha256:legacy-generic-hook"
+    payload = {**_generic_payload(), "artifact_hash": legacy_hash}
+    store.upsert_policy(
+        PolicyDecision(
+            harness=_GENERIC_HARNESS,
+            scope="artifact",
+            action=saved_action,
+            artifact_id=_GENERIC_ARTIFACT_ID,
+            artifact_hash=legacy_hash,
+            source="local",
+        ),
+        "2026-07-17T00:00:00+00:00",
+    )
+
+    rc, output = _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+
+    assert rc == expected_rc
+    assert output["policy_action"] == expected_action
+    assert output["approval_reuse"]["reason_code"] == expected_reason
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == expected_action
+    assert str(receipt["artifact_hash"]).startswith(APPROVAL_CONTEXT_TOKEN_PREFIX)
+
+
+def test_generic_hook_exact_v1_allow_cannot_hide_matching_legacy_block(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+    )
+    legacy_hash = "sha256:legacy-generic-block"
+    payload = {**_generic_payload(), "artifact_hash": legacy_hash}
+    _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+    context_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+    for action, digest in (("allow", context_token), ("block", legacy_hash)):
+        store.upsert_policy(
+            PolicyDecision(
+                harness=_GENERIC_HARNESS,
+                scope="artifact",
+                action=action,
+                artifact_id=_GENERIC_ARTIFACT_ID,
+                artifact_hash=digest,
+                source="local",
+            ),
+            "2026-07-17T00:00:00+00:00",
+        )
+
+    rc, output = _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+
+    assert rc == 1
+    assert output["policy_action"] == "block"
+    assert output["approval_reuse"]["reason_code"] == "approval_reuse_saved_block"
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "block"
+
+
+def _sensitive_read_artifact(workspace: Path, *, publisher: str | None = None) -> GuardArtifact:
+    request = extract_sensitive_file_read_request("read_file", {"path": ".env"}, cwd=workspace)
+    assert request is not None
+    artifact = build_file_read_request_artifact(
+        harness="codex",
+        request=request,
+        config_path=str(workspace / ".mcp.json"),
+        source_scope="project",
+    )
+    return replace(artifact, publisher=publisher) if publisher is not None else artifact
+
+
+def _marker_child_command(marker: Path) -> list[str]:
+    return [
+        sys.executable,
+        "-u",
+        "-c",
+        "\n".join(
+            (
+                "import json, pathlib, sys",
+                "for line in sys.stdin:",
+                "    message = json.loads(line)",
+                f"    pathlib.Path({str(marker)!r}).write_text(json.dumps(message), encoding='utf-8')",
+                "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': {'ok': True}}))",
+                "    sys.stdout.flush()",
+            )
+        ),
+    ]
+
+
+def _sensitive_read_message() -> dict[str, object]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "read_file", "arguments": {"path": ".env"}},
+    }
+
+
+def _save_sensitive_read_policy(
+    store: GuardStore,
+    *,
+    action: GuardAction,
+    artifact: GuardArtifact,
+    config: GuardConfig,
+    workspace: Path,
+    command: list[str],
+) -> str:
+    current_action = _sensitive_read_current_action(config, artifact=artifact, harness="codex")
+    launch_env = _build_scrubbed_env()
+    context_token = build_sensitive_read_approval_hash(
+        artifact,
+        config=config,
+        cwd=workspace,
+        current_action=current_action,
+        server_launch_identity=build_runtime_launch_identity(
+            command[0],
+            args=command[1:],
+            structured_command=True,
+            cwd=workspace,
+            launch_env=launch_env,
+        ),
+        configured_env_values_hash=build_configured_environment_hash(
+            launch_env,
+            configured_keys=(),
+        ),
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action=action,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_token,
+            source="local",
+        ),
+        "2026-07-17T00:00:00+00:00",
+    )
+    return context_token
+
+
+@pytest.mark.parametrize("override_scope", ["artifact", "harness", "publisher"])
+def test_sensitive_read_context_binds_exact_configured_override(
+    tmp_path: Path,
+    override_scope: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    publisher = "trusted-publisher" if override_scope == "publisher" else None
+    artifact = _sensitive_read_artifact(workspace, publisher=publisher)
+    base_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+    )
+    changed_kwargs: dict[str, object]
+    if override_scope == "artifact":
+        changed_kwargs = {"artifact_actions": {artifact.artifact_id: "block"}}
+    elif override_scope == "harness":
+        changed_kwargs = {"harness_actions": {"codex": "block"}}
+    else:
+        changed_kwargs = {"publisher_actions": {"trusted-publisher": "block"}}
+    changed_config = replace(base_config, **changed_kwargs)
+    base_action = _sensitive_read_current_action(base_config, artifact=artifact, harness="codex")
+    changed_action = _sensitive_read_current_action(changed_config, artifact=artifact, harness="codex")
+
+    base_token = build_sensitive_read_approval_hash(
+        artifact,
+        config=base_config,
+        cwd=workspace,
+        current_action=base_action,
+    )
+    changed_token = build_sensitive_read_approval_hash(
+        artifact,
+        config=changed_config,
+        cwd=workspace,
+        current_action=changed_action,
+    )
+
+    assert base_action == "review"
+    assert changed_action == "block"
+    assert base_token != changed_token
+
+
+def test_sensitive_read_exact_allow_overrides_global_block_before_independent_risk_review(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _sensitive_read_artifact(workspace)
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="block",
+        artifact_actions={artifact.artifact_id: "allow"},
+        risk_actions={"local_secret_read": "review"},
+    )
+
+    action = _sensitive_read_current_action(config, artifact=artifact, harness="codex")
+
+    assert action == "review"
+
+
+def test_sensitive_read_risk_block_outranks_exact_allow(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _sensitive_read_artifact(workspace)
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="block",
+        artifact_actions={artifact.artifact_id: "allow"},
+        risk_actions={"local_secret_read": "block"},
+    )
+
+    action = _sensitive_read_current_action(config, artifact=artifact, harness="codex")
+
+    assert action == "block"
+
+
+def test_stdio_sensitive_read_old_allow_cannot_survive_new_exact_artifact_block(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    artifact = _sensitive_read_artifact(workspace)
+    review_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+    )
+    marker = tmp_path / "must-not-forward.json"
+    command = _marker_child_command(marker)
+    _save_sensitive_read_policy(
+        store,
+        action="allow",
+        artifact=artifact,
+        config=review_config,
+        workspace=workspace,
+        command=command,
+    )
+    block_config = replace(review_config, artifact_actions={artifact.artifact_id: "block"})
+    proxy = StdioGuardProxy(
+        command=command,
+        cwd=workspace,
+        guard_store=store,
+        guard_config=block_config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+    )
+
+    result = proxy.run_session([_sensitive_read_message()])
+
+    assert result["responses"][0]["error"]["code"] == -32001
+    assert marker.exists() is False
+    event = result["events"][0]
+    assert event["decision"] == "block"
+    assert event["approval_reuse_status"] == "rejected"
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "block"
+    assert "approval_requests" not in event
+    assert store.list_approval_requests(limit=None) == []
+
+
+def test_stdio_sensitive_read_old_allow_cannot_survive_new_default_block(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    artifact = _sensitive_read_artifact(workspace)
+    review_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+    )
+    marker = tmp_path / "must-not-forward.json"
+    command = _marker_child_command(marker)
+    reviewed_hash = _save_sensitive_read_policy(
+        store,
+        action="allow",
+        artifact=artifact,
+        config=review_config,
+        workspace=workspace,
+        command=command,
+    )
+    block_config = replace(review_config, default_action="block")
+    launch_env = _build_scrubbed_env()
+    blocked_hash = build_sensitive_read_approval_hash(
+        artifact,
+        config=block_config,
+        cwd=workspace,
+        current_action="block",
+        server_launch_identity=build_runtime_launch_identity(
+            command[0],
+            args=command[1:],
+            structured_command=True,
+            cwd=workspace,
+            launch_env=launch_env,
+        ),
+        configured_env_values_hash=build_configured_environment_hash(
+            launch_env,
+            configured_keys=(),
+        ),
+    )
+    proxy = StdioGuardProxy(
+        command=command,
+        cwd=workspace,
+        guard_store=store,
+        guard_config=block_config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+    )
+
+    result = proxy.run_session([_sensitive_read_message()])
+
+    assert reviewed_hash != blocked_hash
+    assert result["responses"][0]["error"]["code"] == -32001
+    assert marker.exists() is False
+    event = result["events"][0]
+    assert event["approval_reuse_reason_code"] == "approval_reuse_policy_changed"
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "block"
+    assert "approval_requests" not in event
+    assert store.list_approval_requests(limit=None) == []
+
+
+@pytest.mark.parametrize("terminal_action", ["block", "sandbox-required"])
+def test_stdio_sensitive_read_fresh_terminal_action_never_queues_approval(
+    tmp_path: Path,
+    terminal_action: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    artifact = _sensitive_read_artifact(workspace)
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        artifact_actions={artifact.artifact_id: terminal_action},
+        risk_actions={"local_secret_read": "review"},
+    )
+    marker = tmp_path / "must-not-forward.json"
+    proxy = StdioGuardProxy(
+        command=_marker_child_command(marker),
+        cwd=workspace,
+        guard_store=store,
+        guard_config=config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+    )
+
+    result = proxy.run_session([_sensitive_read_message()])
+
+    assert result["responses"][0]["error"]["code"] == -32001
+    assert marker.exists() is False
+    event = result["events"][0]
+    assert event["approval_reuse_reason_code"] == "approval_reuse_no_saved_decision"
+    assert "approval_requests" not in event
+    assert store.list_approval_requests(limit=None) == []
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == terminal_action
+
+
+def test_stdio_sensitive_read_exact_saved_block_is_terminal_and_not_reapprovable(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+    )
+    artifact = _sensitive_read_artifact(workspace)
+    marker = tmp_path / "must-not-forward.json"
+    command = _marker_child_command(marker)
+    _save_sensitive_read_policy(
+        store,
+        action="block",
+        artifact=artifact,
+        config=config,
+        workspace=workspace,
+        command=command,
+    )
+    proxy = StdioGuardProxy(
+        command=command,
+        cwd=workspace,
+        guard_store=store,
+        guard_config=config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+    )
+
+    result = proxy.run_session([_sensitive_read_message()])
+
+    assert result["responses"][0]["error"]["code"] == -32001
+    assert marker.exists() is False
+    event = result["events"][0]
+    assert event["approval_reuse_reason_code"] == "approval_reuse_saved_block"
+    assert event["terminal_saved_block"] is True
+    assert "approval_requests" not in event
+    assert store.list_approval_requests() == []
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "block"
+
+
+def test_stdio_sensitive_read_valid_saved_block_remains_terminal_with_separate_integrity_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+    )
+    marker = tmp_path / "must-not-forward.json"
+    proxy = StdioGuardProxy(
+        command=_marker_child_command(marker),
+        cwd=workspace,
+        guard_store=store,
+        guard_config=config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+    )
+
+    monkeypatch.setattr(
+        store,
+        "resolve_policy_decision_lookup",
+        lambda *_args, **_kwargs: {
+            "decision": {
+                "action": "block",
+                "artifact_hash": None,
+                "decision_id": 1,
+                "source": "local",
+            },
+            "ignored_local_integrity": {
+                "decision_id": 2,
+                "integrity_status": "tampered",
+                "source": "local",
+            },
+            "trust_status": {},
+        },
+    )
+
+    result = proxy.run_session([_sensitive_read_message()])
+
+    assert result["responses"][0]["error"]["code"] == -32001
+    assert marker.exists() is False
+    event = result["events"][0]
+    assert event["approval_reuse_reason_code"] == "approval_reuse_integrity_failure"
+    assert event["terminal_saved_block"] is True
+    assert "approval_requests" not in event
+    assert store.list_approval_requests() == []
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "block"
+
+
+def test_stdio_sensitive_read_current_review_still_queues_approval(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+    )
+    marker = tmp_path / "must-not-forward.json"
+    proxy = StdioGuardProxy(
+        command=_marker_child_command(marker),
+        cwd=workspace,
+        guard_store=store,
+        guard_config=config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+    )
+
+    result = proxy.run_session([_sensitive_read_message()])
+
+    assert result["responses"][0]["error"]["code"] == -32001
+    assert marker.exists() is False
+    event = result["events"][0]
+    assert event["approval_reuse_reason_code"] == "approval_reuse_no_saved_decision"
+    assert len(event["approval_requests"]) == 1
+    assert store.list_approval_requests(limit=1)[0]["policy_action"] == "require-reapproval"
+
+
+def test_stdio_sensitive_read_unchanged_exact_one_shot_is_claimed_and_forwarded(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    artifact = _sensitive_read_artifact(workspace)
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+    )
+    marker = tmp_path / "unchanged-one-shot-forwarded.json"
+    command = _marker_child_command(marker)
+    launch_env = _build_scrubbed_env()
+    context_token = build_sensitive_read_approval_hash(
+        artifact,
+        config=config,
+        cwd=workspace,
+        current_action="review",
+        server_launch_identity=build_runtime_launch_identity(
+            command[0],
+            args=command[1:],
+            structured_command=True,
+            cwd=workspace,
+            launch_env=launch_env,
+        ),
+        configured_env_values_hash=build_configured_environment_hash(
+            launch_env,
+            configured_keys=(),
+        ),
+    )
+    approval_id = store.record_local_once_approval(
+        request_id="stdio-unchanged-one-shot",
+        harness="codex",
+        artifact_id=artifact.artifact_id,
+        artifact_hash=context_token,
+        workspace=str(workspace),
+        publisher=artifact.publisher,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+    proxy = StdioGuardProxy(
+        command=command,
+        cwd=workspace,
+        guard_store=store,
+        guard_config=config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+        current_config_provider=lambda: config,
+    )
+
+    result = proxy.run_session([_sensitive_read_message()])
+
+    assert marker.exists() is True
+    assert result["responses"][0]["result"]["ok"] is True
+    assert result["events"][0]["decision"] == "forward"
+    assert result["events"][0]["approval_reuse_reason_code"] == "approval_reuse_accepted"
+    claim_events = store.list_events(event_name="approval.local_once_applied")
+    assert len(claim_events) == 1
+    assert claim_events[0]["payload"]["approval_id"] == approval_id
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "allow"
+
+
+def test_stdio_sensitive_read_rebuilds_current_authority_after_exact_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    artifact = _sensitive_read_artifact(workspace)
+    review_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+    )
+    block_config = replace(
+        review_config,
+        artifact_actions={artifact.artifact_id: "block"},
+    )
+    current_config = [review_config]
+    marker = tmp_path / "postclaim-sensitive-read-must-not-forward.json"
+    command = _marker_child_command(marker)
+    launch_env = _build_scrubbed_env()
+    context_token = build_sensitive_read_approval_hash(
+        artifact,
+        config=review_config,
+        cwd=workspace,
+        current_action="review",
+        server_launch_identity=build_runtime_launch_identity(
+            command[0],
+            args=command[1:],
+            structured_command=True,
+            cwd=workspace,
+            launch_env=launch_env,
+        ),
+        configured_env_values_hash=build_configured_environment_hash(
+            launch_env,
+            configured_keys=(),
+        ),
+    )
+    approval_id = store.record_local_once_approval(
+        request_id="stdio-postclaim-freshness",
+        harness="codex",
+        artifact_id=artifact.artifact_id,
+        artifact_hash=context_token,
+        workspace=str(workspace),
+        publisher=artifact.publisher,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+    proxy = StdioGuardProxy(
+        command=command,
+        cwd=workspace,
+        guard_store=store,
+        guard_config=review_config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+        current_config_provider=lambda: current_config[0],
+    )
+    real_claim = store.claim_approval_reuse_decision
+
+    def claim_then_tighten_policy(decision: dict[str, object]) -> bool:
+        claimed = real_claim(decision)
+        if claimed:
+            current_config[0] = block_config
+        return claimed
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", claim_then_tighten_policy)
+
+    result = proxy.run_session([_sensitive_read_message()])
+
+    assert marker.exists() is False
+    assert result["responses"][0]["error"]["code"] == -32001
+    event = result["events"][0]
+    assert event["decision"] == "block"
+    assert event["approval_reuse_reason_code"] == "approval_reuse_policy_changed"
+    assert "approval_requests" not in event
+    claim_events = store.list_events(event_name="approval.local_once_applied")
+    assert len(claim_events) == 1
+    assert claim_events[0]["payload"]["approval_id"] == approval_id
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "block"
+
+
+def test_stdio_sensitive_read_fails_closed_when_postclaim_config_refresh_fails(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+    )
+    artifact = _sensitive_read_artifact(workspace)
+    marker = tmp_path / "config-refresh-failure-must-not-forward.json"
+    command = _marker_child_command(marker)
+    _save_sensitive_read_policy(
+        store,
+        action="allow",
+        artifact=artifact,
+        config=config,
+        workspace=workspace,
+        command=command,
+    )
+
+    def unavailable_config() -> GuardConfig:
+        raise OSError("current config unavailable")
+
+    proxy = StdioGuardProxy(
+        command=command,
+        cwd=workspace,
+        guard_store=store,
+        guard_config=config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+        current_config_provider=unavailable_config,
+    )
+
+    result = proxy.run_session([_sensitive_read_message()])
+
+    assert marker.exists() is False
+    assert result["responses"][0]["error"]["code"] == -32001
+    event = result["events"][0]
+    assert event["decision"] == "block"
+    assert event["approval_reuse_reason_code"] == "approval_reuse_current_config_refresh_failed"
+    assert len(event["approval_requests"]) == 1
+    approval_evidence = event["approval_requests"][0]["scanner_evidence"]
+    assert approval_evidence[-1] == {
+        "source": "approval_reuse",
+        "status": "rejected",
+        "reason_code": "approval_reuse_current_config_refresh_failed",
+        "effective_action": "require-reapproval",
+    }
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == "require-reapproval"
+    assert receipt["scanner_evidence"][-1] == approval_evidence[-1]
+
+
+def test_stdio_invalidated_saved_allow_with_current_review_never_reaches_child(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+    )
+    artifact = _sensitive_read_artifact(workspace)
+    marker = tmp_path / "must-not-forward.json"
+    reviewed_command = _marker_child_command(marker)
+    _save_sensitive_read_policy(
+        store,
+        action="allow",
+        artifact=artifact,
+        config=config,
+        workspace=workspace,
+        command=reviewed_command,
+    )
+    current_command = [*reviewed_command[:-1], f"{reviewed_command[-1]}\n# identity changed after review"]
+    proxy = StdioGuardProxy(
+        command=current_command,
+        cwd=workspace,
+        guard_store=store,
+        guard_config=config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+    )
+
+    result = proxy.run_session([_sensitive_read_message()])
+
+    assert result["responses"][0]["error"]["code"] == -32001
+    assert marker.exists() is False
+    event = result["events"][0]
+    assert event["decision"] == "block"
+    assert event["approval_reuse_status"] == "rejected"
+    assert event["approval_reuse_reason_code"] == "approval_reuse_identity_changed"
+    assert len(event["approval_requests"]) == 1
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "require-reapproval"
+
+
+def test_sensitive_read_legacy_artifact_digest_is_not_approval_authority(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _sensitive_read_artifact(workspace)
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+    )
+
+    context_token = build_sensitive_read_approval_hash(
+        artifact,
+        config=config,
+        cwd=workspace,
+        current_action="review",
+    )
+
+    assert context_token.startswith(APPROVAL_CONTEXT_TOKEN_PREFIX)
+    assert context_token != artifact_hash(artifact)

--- a/tests/test_guard_approval_reuse.py
+++ b/tests/test_guard_approval_reuse.py
@@ -1,0 +1,1708 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Mapping
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.approvals import apply_approval_resolution
+from codex_plugin_scanner.guard.cli.commands_support_runtime_policy import _runtime_saved_allow_validation_reason
+from codex_plugin_scanner.guard.memory_pattern_fingerprint import build_exact_command_memory_artifact_id
+from codex_plugin_scanner.guard.models import (
+    GUARD_ACTION_VALUES,
+    DecisionScope,
+    GuardAction,
+    GuardApprovalRequest,
+    GuardArtifact,
+    PolicyDecision,
+)
+from codex_plugin_scanner.guard.runtime.approval_context import build_approval_context_token
+from codex_plugin_scanner.guard.runtime.approval_reuse import (
+    APPROVAL_REUSE_ACCEPTED,
+    APPROVAL_REUSE_CLAIM_FAILED,
+    APPROVAL_REUSE_CURRENT_ACTION_NOT_REVIEW,
+    APPROVAL_REUSE_CURRENT_ACTION_UNKNOWN,
+    APPROVAL_REUSE_CURRENT_BLOCK,
+    APPROVAL_REUSE_NO_SAVED_DECISION,
+    APPROVAL_REUSE_REAPPROVAL_REQUIRED,
+    APPROVAL_REUSE_SANDBOX_REQUIRED,
+    APPROVAL_REUSE_SAVED_ACTION_NOT_ALLOW,
+    APPROVAL_REUSE_SAVED_ACTION_UNKNOWN,
+    APPROVAL_REUSE_SAVED_BLOCK,
+    ApprovalReuseValidationFailure,
+    evaluate_approval_reuse,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_policy import (
+    _bounded_local_approval_reuse_diagnostic_rows,
+    _bounded_non_consuming_policy_rows,
+    _bounded_policy_approval_reuse_diagnostic_rows,
+)
+
+
+def _approval_context_token(
+    *,
+    identity: object | None = None,
+    content: str = "sha256:content",
+    capabilities: object | None = None,
+    policy: object | None = None,
+    sandbox: object | None = None,
+) -> str:
+    return build_approval_context_token(
+        identity=identity
+        if identity is not None
+        else {"artifact_id": "codex:project:mcp-tool:read", "workspace": "/workspace/a"},
+        content=content,
+        capabilities=capabilities if capabilities is not None else ["filesystem:read"],
+        policy=policy if policy is not None else {"version": "policy-v1"},
+        sandbox=sandbox if sandbox is not None else {"profile": "workspace-read"},
+    )
+
+
+@pytest.mark.parametrize("current_action", GUARD_ACTION_VALUES)
+def test_no_saved_approval_preserves_recomputed_current_action(current_action: str) -> None:
+    result = evaluate_approval_reuse(current_action)
+
+    assert result.action == current_action
+    assert result.status == "not-applicable"
+    assert result.reason_code == APPROVAL_REUSE_NO_SAVED_DECISION
+    assert result.should_claim is False
+
+
+def test_exact_saved_allow_can_satisfy_only_current_review() -> None:
+    result = evaluate_approval_reuse("review", "allow")
+
+    assert result.action == "allow"
+    assert result.status == "accepted"
+    assert result.reason_code == APPROVAL_REUSE_ACCEPTED
+    assert result.should_claim is True
+
+
+@pytest.mark.parametrize(
+    ("current_action", "expected_reason"),
+    (
+        ("require-reapproval", APPROVAL_REUSE_REAPPROVAL_REQUIRED),
+        ("sandbox-required", APPROVAL_REUSE_SANDBOX_REQUIRED),
+        ("block", APPROVAL_REUSE_CURRENT_BLOCK),
+    ),
+)
+def test_saved_allow_never_lowers_stronger_current_action(current_action: str, expected_reason: str) -> None:
+    result = evaluate_approval_reuse(current_action, "allow")
+
+    assert result.action == current_action
+    assert result.status == "rejected"
+    assert result.reason_code == expected_reason
+    assert result.should_claim is False
+
+
+@pytest.mark.parametrize("current_action", ("allow", "warn"))
+def test_saved_allow_is_not_consumed_when_current_action_needs_no_review(current_action: str) -> None:
+    result = evaluate_approval_reuse(current_action, "allow")
+
+    assert result.action == current_action
+    assert result.status == "not-applicable"
+    assert result.reason_code == APPROVAL_REUSE_CURRENT_ACTION_NOT_REVIEW
+    assert result.should_claim is False
+
+
+def test_integrity_invalid_authority_requires_reapproval_even_when_current_action_allows() -> None:
+    result = evaluate_approval_reuse(
+        "allow",
+        "allow",
+        validation_reason="approval_reuse_integrity_failure",
+    )
+
+    assert result.action == "require-reapproval"
+    assert result.status == "rejected"
+    assert result.reason_code == "approval_reuse_integrity_failure"
+    assert result.should_claim is False
+
+
+@pytest.mark.parametrize("current_action", GUARD_ACTION_VALUES)
+def test_saved_block_remains_block_for_every_current_action(current_action: str) -> None:
+    result = evaluate_approval_reuse(current_action, "block")
+
+    assert result.action == "block"
+    assert result.status == "accepted"
+    assert result.reason_code == APPROVAL_REUSE_SAVED_BLOCK
+    assert result.should_claim is False
+
+
+def test_non_allow_saved_action_cannot_satisfy_review() -> None:
+    result = evaluate_approval_reuse("review", "warn")
+
+    assert result.action == "review"
+    assert result.status == "rejected"
+    assert result.reason_code == APPROVAL_REUSE_SAVED_ACTION_NOT_ALLOW
+
+
+@pytest.mark.parametrize(
+    ("validation_reason", "expected_action"),
+    (
+        ("approval_reuse_identity_changed", "review"),
+        ("approval_reuse_content_changed", "review"),
+        ("approval_reuse_capability_changed", "review"),
+        ("approval_reuse_policy_changed", "review"),
+        ("approval_reuse_sandbox_changed", "review"),
+        ("approval_reuse_expired", "review"),
+        ("approval_reuse_integrity_failure", "require-reapproval"),
+    ),
+)
+def test_invalidated_saved_allow_is_rejected_with_stable_reason(
+    validation_reason: ApprovalReuseValidationFailure,
+    expected_action: str,
+) -> None:
+    result = evaluate_approval_reuse(
+        "review",
+        "allow",
+        validation_reason=validation_reason,
+    )
+
+    assert result.action == expected_action
+    assert result.status == "rejected"
+    assert result.reason_code == validation_reason
+    assert result.should_claim is False
+
+
+def test_unknown_current_action_fails_closed_with_diagnostics() -> None:
+    result = evaluate_approval_reuse("future-permissive-action", "allow")
+
+    assert result.action == "block"
+    assert result.reason_code == APPROVAL_REUSE_CURRENT_ACTION_UNKNOWN
+    assert result.current_normalization_reason_code == "guard_action_unknown"
+    assert result.original_current_action == "future-permissive-action"
+    assert result.should_claim is False
+
+
+def test_present_malformed_saved_action_requires_reapproval_with_diagnostics() -> None:
+    result = evaluate_approval_reuse("review", None, saved_decision_present=True)
+
+    assert result.action == "require-reapproval"
+    assert result.reason_code == APPROVAL_REUSE_SAVED_ACTION_UNKNOWN
+    assert result.saved_normalization_reason_code == "guard_action_unknown"
+    assert result.original_saved_type == "NoneType"
+    assert result.to_evidence()["saved_action"] == "require-reapproval"
+
+
+def test_claim_failure_reason_takes_precedence_and_preserves_normalization_diagnostics() -> None:
+    result = evaluate_approval_reuse(
+        "review",
+        None,
+        saved_decision_present=True,
+        validation_reason=APPROVAL_REUSE_CLAIM_FAILED,
+    )
+
+    assert result.action == "require-reapproval"
+    assert result.reason_code == APPROVAL_REUSE_CLAIM_FAILED
+    assert result.saved_normalization_reason_code == "guard_action_unknown"
+
+
+def test_non_consuming_lookup_requires_explicit_atomic_claim(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    approval_id = store.record_local_once_approval(
+        request_id="req-once",
+        harness="codex",
+        artifact_id="codex:project:tool-action:exact",
+        artifact_hash="sha256:exact",
+        workspace=str(tmp_path),
+        publisher="publisher-a",
+        action="allow",
+        created_at="2026-07-17T12:00:00+00:00",
+        expires_at="2026-07-17T13:00:00+00:00",
+    )
+    assert approval_id is not None
+
+    first = store.resolve_policy_decision(
+        "codex",
+        "codex:project:tool-action:exact",
+        "sha256:exact",
+        str(tmp_path),
+        "publisher-a",
+        "2026-07-17T12:05:00+00:00",
+        consume_one_shot=False,
+    )
+    second = store.resolve_policy_decision(
+        "codex",
+        "codex:project:tool-action:exact",
+        "sha256:exact",
+        str(tmp_path),
+        "publisher-a",
+        "2026-07-17T12:06:00+00:00",
+        consume_one_shot=False,
+    )
+
+    assert first is not None and first["approval_id"] == approval_id
+    assert second is not None and second["approval_id"] == approval_id
+    assert store.list_events(event_name="approval.local_once_applied") == []
+    assert store.claim_approval_reuse_decision(first, now="2026-07-17T12:07:00+00:00") is True
+    assert store.claim_approval_reuse_decision(first, now="2026-07-17T12:08:00+00:00") is False
+    assert (
+        store.resolve_policy_decision(
+            "codex",
+            "codex:project:tool-action:exact",
+            "sha256:exact",
+            str(tmp_path),
+            "publisher-a",
+            "2026-07-17T12:09:00+00:00",
+            consume_one_shot=False,
+        )
+        is None
+    )
+    events = store.list_events(event_name="approval.local_once_applied")
+    assert len(events) == 1
+    payload = cast(Mapping[str, object], events[0]["payload"])
+    assert payload["approval_id"] == approval_id
+
+
+def test_batch_claim_consumes_two_exact_one_shot_approvals_atomically(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    selected: list[Mapping[str, object]] = []
+    approval_ids: list[str] = []
+    for suffix in ("outer", "package"):
+        artifact_id = f"codex:project:tool-action:{suffix}"
+        artifact_hash = _approval_context_token(content=f"sha256:{suffix}")
+        approval_id = store.record_local_once_approval(
+            request_id=f"request-{suffix}",
+            harness="codex",
+            artifact_id=artifact_id,
+            artifact_hash=artifact_hash,
+            workspace=str(tmp_path),
+            publisher=None,
+            action="allow",
+            created_at="2026-07-17T12:00:00+00:00",
+            expires_at="2026-07-17T13:00:00+00:00",
+        )
+        assert approval_id is not None
+        approval_ids.append(approval_id)
+    for suffix in ("outer", "package"):
+        decision = store.resolve_policy_decision(
+            "codex",
+            f"codex:project:tool-action:{suffix}",
+            _approval_context_token(content=f"sha256:{suffix}"),
+            str(tmp_path),
+            None,
+            "2026-07-17T12:05:00+00:00",
+            consume_one_shot=False,
+        )
+        assert decision is not None
+        selected.append(decision)
+
+    assert store.claim_approval_reuse_decisions(selected, now="2026-07-17T12:06:00+00:00")
+
+    with sqlite3.connect(store.path) as connection:
+        rows = connection.execute(
+            "select approval_id, claimed_at from guard_local_once_approvals order by approval_id"
+        ).fetchall()
+    assert {row[0] for row in rows} == set(approval_ids)
+    assert all(row[1] is not None for row in rows)
+
+
+def test_batch_claim_rolls_back_every_sibling_when_one_row_fails_integrity(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    selected: list[Mapping[str, object]] = []
+    approval_ids: list[str] = []
+    for suffix in ("outer", "package"):
+        artifact_id = f"codex:project:tool-action:rollback-{suffix}"
+        artifact_hash = _approval_context_token(content=f"sha256:rollback-{suffix}")
+        approval_id = store.record_local_once_approval(
+            request_id=f"request-rollback-{suffix}",
+            harness="codex",
+            artifact_id=artifact_id,
+            artifact_hash=artifact_hash,
+            workspace=str(tmp_path),
+            publisher=None,
+            action="allow",
+            created_at="2026-07-17T12:00:00+00:00",
+            expires_at="2026-07-17T13:00:00+00:00",
+        )
+        assert approval_id is not None
+        approval_ids.append(approval_id)
+    for suffix in ("outer", "package"):
+        decision = store.resolve_policy_decision(
+            "codex",
+            f"codex:project:tool-action:rollback-{suffix}",
+            _approval_context_token(content=f"sha256:rollback-{suffix}"),
+            str(tmp_path),
+            None,
+            "2026-07-17T12:05:00+00:00",
+            consume_one_shot=False,
+        )
+        assert decision is not None
+        selected.append(decision)
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "update guard_local_once_approvals set payload_mac = ? where approval_id = ?",
+            ("0" * 64, approval_ids[1]),
+        )
+
+    assert not store.claim_approval_reuse_decisions(selected, now="2026-07-17T12:06:00+00:00")
+
+    with sqlite3.connect(store.path) as connection:
+        rows = connection.execute(
+            "select claimed_at from guard_local_once_approvals where approval_id in (?, ?)",
+            tuple(approval_ids),
+        ).fetchall()
+    assert len(rows) == 2
+    assert all(row[0] is None for row in rows)
+
+
+def test_default_lookup_still_consumes_non_package_local_once_approval(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.record_local_once_approval(
+        request_id="req-compat",
+        harness="codex",
+        artifact_id="codex:project:tool-action:compat",
+        artifact_hash="sha256:compat",
+        workspace=None,
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T12:00:00+00:00",
+        expires_at="2026-07-17T13:00:00+00:00",
+    )
+
+    first = store.resolve_policy_decision(
+        "codex",
+        "codex:project:tool-action:compat",
+        "sha256:compat",
+        now="2026-07-17T12:05:00+00:00",
+    )
+    second = store.resolve_policy_decision(
+        "codex",
+        "codex:project:tool-action:compat",
+        "sha256:compat",
+        now="2026-07-17T12:06:00+00:00",
+    )
+
+    assert first is not None and first["action"] == "allow"
+    assert second is None
+
+
+@pytest.mark.parametrize("scope", ("artifact", "workspace", "publisher", "harness", "global"))
+def test_approval_resolution_preserves_exact_context_token_across_every_scope(tmp_path, scope: str) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    workspace = "/workspace/a"
+    artifact_id = "codex:project:mcp-tool:read"
+    current_token = _approval_context_token()
+    store.add_approval_request(
+        GuardApprovalRequest(
+            request_id=f"request-context-{scope}",
+            harness="codex",
+            artifact_id=artifact_id,
+            artifact_name="read",
+            artifact_type="tool_call",
+            artifact_hash=current_token,
+            publisher="trusted-publisher",
+            policy_action="review",
+            recommended_scope="artifact",
+            changed_fields=("tool_call",),
+            source_scope="project",
+            config_path="/workspace/a/.codex/config.toml",
+            workspace=workspace,
+            review_command="hol-guard approvals approve request-context",
+            approval_url="http://127.0.0.1:4455/approvals/request-context",
+        ),
+        "2026-07-17T12:00:00+00:00",
+    )
+    apply_approval_resolution(
+        store=store,
+        request_id=f"request-context-{scope}",
+        action="allow",
+        scope=scope,
+        workspace=workspace if scope == "workspace" else None,
+        reason="approved exact context",
+        now="2026-07-17T12:01:00+00:00",
+        persist_policy=True,
+    )
+
+    stored = store.list_policy_decisions()
+    assert len(stored) == 1
+    assert stored[0]["artifact_hash"] == current_token
+    assert (
+        store.resolve_policy(
+            "codex",
+            artifact_id,
+            current_token,
+            workspace=workspace,
+            publisher="trusted-publisher",
+            now="2026-07-17T12:02:00+00:00",
+            consume_one_shot=False,
+        )
+        == "allow"
+    )
+    changed_token = _approval_context_token(content="sha256:changed")
+    assert (
+        store.resolve_policy(
+            "codex",
+            artifact_id,
+            changed_token,
+            workspace=workspace,
+            publisher="trusted-publisher",
+            now="2026-07-17T12:03:00+00:00",
+            consume_one_shot=False,
+        )
+        is None
+    )
+    assert (
+        store.approval_reuse_validation_reason(
+            "codex",
+            artifact_id,
+            changed_token,
+            workspace,
+            "trusted-publisher",
+            "2026-07-17T12:03:00+00:00",
+        )
+        == "approval_reuse_content_changed"
+    )
+
+
+def test_broad_scope_exact_context_allow_does_not_resolve_or_authorize_other_context(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    first_token = _approval_context_token(content="sha256:first")
+    second_token = _approval_context_token(
+        identity={"artifact_id": "codex:project:mcp-tool:write", "workspace": "/workspace/a"},
+        content="sha256:second",
+        capabilities=["filesystem:write"],
+    )
+    for request_id, artifact_id, token in (
+        ("request-first", "codex:project:mcp-tool:read", first_token),
+        ("request-second", "codex:project:mcp-tool:write", second_token),
+    ):
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id=request_id,
+                harness="codex",
+                artifact_id=artifact_id,
+                artifact_name=artifact_id.rsplit(":", maxsplit=1)[-1],
+                artifact_type="tool_call",
+                artifact_hash=token,
+                policy_action="review",
+                recommended_scope="harness",
+                changed_fields=("tool_call",),
+                source_scope="project",
+                config_path="/workspace/a/.codex/config.toml",
+                workspace="/workspace/a",
+                review_command=f"hol-guard approvals approve {request_id}",
+                approval_url=f"http://127.0.0.1:4455/approvals/{request_id}",
+            ),
+            "2026-07-17T12:00:00+00:00",
+        )
+
+    apply_approval_resolution(
+        store=store,
+        request_id="request-first",
+        action="allow",
+        scope="harness",
+        workspace=None,
+        reason="approve only the reviewed context",
+        now="2026-07-17T12:01:00+00:00",
+    )
+
+    assert store.get_approval_request("request-first")["status"] == "resolved"
+    assert store.get_approval_request("request-second")["status"] == "pending"
+    assert (
+        store.resolve_policy(
+            "codex",
+            "codex:project:mcp-tool:read",
+            first_token,
+            now="2026-07-17T12:02:00+00:00",
+            consume_one_shot=False,
+        )
+        == "allow"
+    )
+    assert (
+        store.resolve_policy(
+            "codex",
+            "codex:project:mcp-tool:write",
+            second_token,
+            now="2026-07-17T12:02:00+00:00",
+            consume_one_shot=False,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("consume_one_shot", (False, True))
+def test_lookup_preserves_stored_block_over_local_once_allow(tmp_path, consume_one_shot: bool) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    artifact_id = "codex:project:tool-action:blocked-after-approval"
+    artifact_hash = "sha256:blocked-after-approval"
+    approval_id = store.record_local_once_approval(
+        request_id="req-stale-allow",
+        harness="codex",
+        artifact_id=artifact_id,
+        artifact_hash=artifact_hash,
+        workspace="/workspace/a",
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T12:00:00+00:00",
+        expires_at="2026-07-17T13:00:00+00:00",
+    )
+    store.replace_remote_policies(
+        [
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="block",
+                artifact_id=artifact_id,
+                artifact_hash=artifact_hash,
+                source="team-policy",
+            )
+        ],
+        "2026-07-17T12:01:00+00:00",
+        remote_write_authorized=True,
+    )
+
+    selected = store.resolve_policy_decision(
+        "codex",
+        artifact_id,
+        artifact_hash,
+        workspace="/workspace/a",
+        now="2026-07-17T12:02:00+00:00",
+        consume_one_shot=consume_one_shot,
+    )
+
+    assert selected is not None
+    assert selected["action"] == "block"
+    assert selected["source"] == "team-policy"
+    assert store.claim_local_once_approval(approval_id, claimed_at="2026-07-17T12:03:00+00:00") is True
+
+
+def test_non_consuming_runtime_lookup_composes_specific_allow_with_broader_managed_block(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    artifact_id = "codex:project:mcp-tool:managed-block"
+    approval_hash = _approval_context_token(content="sha256:managed-block")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact_id,
+            artifact_hash=approval_hash,
+            source="approval-gate",
+        ),
+        "2026-07-17T12:00:00+00:00",
+    )
+    store.replace_remote_policies(
+        [
+            PolicyDecision(
+                harness="codex",
+                scope="global",
+                action="block",
+                source="team-policy",
+            )
+        ],
+        "2026-07-17T12:01:00+00:00",
+        remote_write_authorized=True,
+    )
+
+    runtime_decision = store.resolve_policy_decision(
+        "codex",
+        artifact_id,
+        approval_hash,
+        now="2026-07-17T12:02:00+00:00",
+        consume_one_shot=False,
+    )
+    legacy_scope_precedence = store.resolve_policy_decision(
+        "codex",
+        artifact_id,
+        approval_hash,
+        now="2026-07-17T12:02:00+00:00",
+    )
+
+    assert runtime_decision is not None
+    assert runtime_decision["action"] == "block"
+    assert runtime_decision["source"] == "team-policy"
+    assert legacy_scope_precedence is not None
+    assert legacy_scope_precedence["action"] == "allow"
+    assert store.list_events(event_name="policy_integrity_violation") == []
+    assert store.list_events(event_name="rule.ignored.local_integrity") == []
+
+
+@pytest.mark.parametrize("scope", ("workspace", "harness", "global"))
+@pytest.mark.parametrize("source", ("local", "team-policy"))
+def test_non_consuming_scope_lookup_preserves_specificity_and_stronger_actions(
+    tmp_path,
+    scope: DecisionScope,
+    source: str,
+) -> None:
+    artifact_id = "codex:project:prompt-env-read:specificity"
+    workspace = "/workspace/specificity"
+    context_hash = _approval_context_token(
+        identity={"artifact_id": artifact_id, "workspace": workspace},
+        content="sha256:specificity",
+    )
+    policy_harness = "*" if scope == "global" else "codex"
+
+    def policy(*, action: GuardAction, reason: str, artifact_hash: str | None, broad: bool = False) -> PolicyDecision:
+        return PolicyDecision(
+            harness=policy_harness,
+            scope=scope,
+            action=action,
+            artifact_id=None if broad else artifact_id,
+            artifact_hash=artifact_hash,
+            workspace=workspace if scope == "workspace" else None,
+            reason=reason,
+            source=source,
+        )
+
+    def store_with_policies(name: str, decisions: list[PolicyDecision]) -> GuardStore:
+        store = GuardStore(tmp_path / name)
+        if source == "team-policy":
+            store.replace_remote_policies(
+                decisions,
+                "2026-07-18T12:03:00Z",
+                remote_write_authorized=True,
+            )
+        else:
+            for minute, decision in enumerate(decisions):
+                store.upsert_policy(decision, f"2026-07-18T12:0{minute}:00Z")
+        return store
+
+    exact_store = store_with_policies(
+        f"guard-home-{scope}-{source}-exact",
+        [
+            policy(action="allow", reason="exact context allow", artifact_hash=context_hash),
+            policy(action="allow", reason="family-bound allow", artifact_hash=None),
+            policy(action="allow", reason="broad allow", artifact_hash=None, broad=True),
+        ],
+    )
+    exact = exact_store.resolve_policy_decision(
+        "codex",
+        artifact_id,
+        context_hash,
+        workspace=workspace,
+        now="2026-07-18T12:04:00Z",
+        consume_one_shot=False,
+    )
+
+    assert exact is not None
+    assert exact["reason"] == "exact context allow"
+    if source == "local":
+        assert exact["integrity_status"] == "valid"
+
+    family_store = store_with_policies(
+        f"guard-home-{scope}-{source}-family",
+        [
+            policy(action="allow", reason="family-bound allow", artifact_hash=None),
+            policy(action="allow", reason="broad allow", artifact_hash=None, broad=True),
+        ],
+    )
+    family = family_store.resolve_policy_decision(
+        "codex",
+        artifact_id,
+        context_hash,
+        workspace=workspace,
+        now="2026-07-18T12:04:00Z",
+        consume_one_shot=False,
+    )
+
+    assert family is not None
+    assert family["reason"] == "family-bound allow"
+    if source == "local":
+        assert family["integrity_status"] == "valid"
+
+    stronger_store = store_with_policies(
+        f"guard-home-{scope}-{source}-stronger",
+        [
+            policy(action="allow", reason="exact context allow", artifact_hash=context_hash),
+            policy(action="allow", reason="family-bound allow", artifact_hash=None),
+            policy(action="block", reason="stronger broad block", artifact_hash=None, broad=True),
+        ],
+    )
+    stronger = stronger_store.resolve_policy_decision(
+        "codex",
+        artifact_id,
+        context_hash,
+        workspace=workspace,
+        now="2026-07-18T12:04:00Z",
+        consume_one_shot=False,
+    )
+
+    assert stronger is not None
+    assert stronger["action"] == "block"
+    assert stronger["reason"] == "stronger broad block"
+    if source == "local":
+        assert stronger["integrity_status"] == "valid"
+
+
+def test_non_consuming_runtime_lookup_composes_direct_allow_with_exact_command_block(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    artifact_id = "codex:project:tool-action:shell"
+    command = "deploy production"
+    exact_command_id = build_exact_command_memory_artifact_id(command)
+    assert exact_command_id is not None
+    approval_hash = _approval_context_token(content="sha256:deploy")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact_id,
+            artifact_hash=approval_hash,
+            source="approval-gate",
+        ),
+        "2026-07-17T12:00:00+00:00",
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="block",
+            artifact_id=exact_command_id,
+            artifact_hash=approval_hash,
+            source="manual",
+        ),
+        "2026-07-17T12:01:00+00:00",
+    )
+
+    lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
+        "codex",
+        artifact_id,
+        artifact_hash=approval_hash,
+        memory_command=command,
+        memory_artifact_type="tool_action_request",
+        memory_artifact_name="shell",
+        now="2026-07-17T12:02:00+00:00",
+        consume_one_shot=False,
+    )
+
+    assert lookup["decision"] is not None
+    assert lookup["decision"]["action"] == "block"
+    assert lookup["decision"]["artifact_id"] == exact_command_id
+
+
+def test_atomic_claim_rejects_changed_expected_local_once_identity_without_consuming(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.record_local_once_approval(
+        request_id="req-identity",
+        harness="codex",
+        artifact_id="codex:project:tool-action:identity",
+        artifact_hash="sha256:identity",
+        workspace=None,
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T12:00:00+00:00",
+        expires_at="2026-07-17T13:00:00+00:00",
+    )
+    selected = store.resolve_policy_decision(
+        "codex",
+        "codex:project:tool-action:identity",
+        "sha256:identity",
+        now="2026-07-17T12:01:00+00:00",
+        consume_one_shot=False,
+    )
+    assert selected is not None
+    changed = {**selected, "artifact_hash": "sha256:changed"}
+
+    assert store.claim_approval_reuse_decision(changed, now="2026-07-17T12:02:00+00:00") is False
+    assert store.claim_approval_reuse_decision(selected, now="2026-07-17T12:03:00+00:00") is True
+
+
+def test_claim_rejects_policy_row_replaced_after_non_consuming_lookup(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    allow = PolicyDecision(
+        harness="codex",
+        scope="artifact",
+        action="allow",
+        artifact_id="codex:project:tool-action:remote",
+        artifact_hash="sha256:remote",
+        source="team-policy",
+    )
+    store.replace_remote_policies(
+        [allow],
+        "2026-07-17T12:00:00+00:00",
+        remote_write_authorized=True,
+    )
+    selected = store.resolve_policy_decision(
+        "codex",
+        allow.artifact_id,
+        allow.artifact_hash,
+        now="2026-07-17T12:01:00+00:00",
+        consume_one_shot=False,
+    )
+    assert selected is not None
+
+    store.replace_remote_policies(
+        [
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="block",
+                artifact_id=allow.artifact_id,
+                artifact_hash=allow.artifact_hash,
+                source="team-policy",
+            )
+        ],
+        "2026-07-17T12:02:00+00:00",
+        remote_write_authorized=True,
+    )
+
+    assert store.claim_approval_reuse_decision(selected, now="2026-07-17T12:03:00+00:00") is False
+
+
+def test_claim_rejects_policy_integrity_tamper_after_non_consuming_lookup(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    allow = PolicyDecision(
+        harness="codex",
+        scope="artifact",
+        action="allow",
+        artifact_id="codex:project:tool-action:tamper-race",
+        artifact_hash="sha256:tamper-race",
+        source="approval-gate",
+    )
+    store.upsert_policy(allow, "2026-07-17T12:00:00+00:00")
+    selected = store.resolve_policy_decision(
+        "codex",
+        allow.artifact_id,
+        allow.artifact_hash,
+        now="2026-07-17T12:01:00+00:00",
+        consume_one_shot=False,
+    )
+    assert selected is not None
+
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "update policy_decisions set payload_mac = ? where decision_id = ?",
+            ("00", selected["decision_id"]),
+        )
+
+    assert store.claim_approval_reuse_decision(selected, now="2026-07-17T12:02:00+00:00") is False
+
+
+def test_claim_accepts_unchanged_persistent_policy_without_consuming_it(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    allow = PolicyDecision(
+        harness="codex",
+        scope="artifact",
+        action="allow",
+        artifact_id="codex:project:tool-action:persistent",
+        artifact_hash="sha256:persistent",
+        source="team-policy",
+    )
+    store.replace_remote_policies(
+        [allow],
+        "2026-07-17T12:00:00+00:00",
+        remote_write_authorized=True,
+    )
+    selected = store.resolve_policy_decision(
+        "codex",
+        allow.artifact_id,
+        allow.artifact_hash,
+        now="2026-07-17T12:01:00+00:00",
+        consume_one_shot=False,
+    )
+    assert selected is not None
+
+    assert store.claim_approval_reuse_decision(selected, now="2026-07-17T12:02:00+00:00") is True
+    assert (
+        store.resolve_policy(
+            "codex",
+            allow.artifact_id,
+            allow.artifact_hash,
+            now="2026-07-17T12:03:00+00:00",
+            consume_one_shot=False,
+        )
+        == "allow"
+    )
+    assert len(store.list_events(event_name="approval.policy_reuse_applied")) == 1
+
+
+def test_claim_rejects_allow_when_broader_block_is_inserted_after_lookup(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    artifact_id = "codex:project:tool-action:authority-race"
+    approval_hash = _approval_context_token(content="sha256:authority-race")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact_id,
+            artifact_hash=approval_hash,
+            source="approval-gate",
+        ),
+        "2026-07-17T12:00:00+00:00",
+    )
+    selected = store.resolve_policy_decision(
+        "codex",
+        artifact_id,
+        approval_hash,
+        now="2026-07-17T12:01:00+00:00",
+        consume_one_shot=False,
+    )
+    assert selected is not None
+
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="global",
+            action="block",
+            artifact_id=None,
+            artifact_hash=None,
+            source="manual",
+        ),
+        "2026-07-17T12:02:00+00:00",
+    )
+
+    assert store.claim_approval_reuse_decision(selected, now="2026-07-17T12:03:00+00:00") is False
+
+
+def test_claim_rejects_direct_allow_when_memory_block_is_inserted_after_lookup(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    artifact_id = "codex:project:tool-action:memory-race"
+    command = "deploy production"
+    approval_hash = _approval_context_token(content="sha256:memory-race")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact_id,
+            artifact_hash=approval_hash,
+            source="approval-gate",
+        ),
+        "2026-07-17T12:00:00+00:00",
+    )
+    lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
+        "codex",
+        artifact_id,
+        artifact_hash=approval_hash,
+        memory_command=command,
+        memory_artifact_type="tool_action_request",
+        memory_artifact_name="shell",
+        now="2026-07-17T12:01:00+00:00",
+        consume_one_shot=False,
+    )
+    selected = lookup["decision"]
+    assert selected is not None
+    memory_artifact_id = build_exact_command_memory_artifact_id(command)
+    assert memory_artifact_id is not None
+
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="block",
+            artifact_id=memory_artifact_id,
+            artifact_hash=approval_hash,
+            source="manual",
+        ),
+        "2026-07-17T12:02:00+00:00",
+    )
+
+    assert store.claim_approval_reuse_decision(selected, now="2026-07-17T12:03:00+00:00") is False
+
+
+def test_claim_rejects_local_once_when_policy_changes_and_keeps_it_unclaimed(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    artifact_id = "codex:project:tool-action:local-once-race"
+    approval_hash = _approval_context_token(content="sha256:local-once-race")
+    approval_id = store.record_local_once_approval(
+        request_id="request-local-once-race",
+        harness="codex",
+        artifact_id=artifact_id,
+        artifact_hash=approval_hash,
+        workspace=None,
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T12:00:00+00:00",
+        expires_at="2026-07-17T13:00:00+00:00",
+    )
+    selected = store.resolve_policy_decision(
+        "codex",
+        artifact_id,
+        approval_hash,
+        now="2026-07-17T12:01:00+00:00",
+        consume_one_shot=False,
+    )
+    assert selected is not None
+
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="harness",
+            action="block",
+            artifact_id=None,
+            artifact_hash=None,
+            source="manual",
+        ),
+        "2026-07-17T12:02:00+00:00",
+    )
+
+    assert store.claim_approval_reuse_decision(selected, now="2026-07-17T12:03:00+00:00") is False
+    with sqlite3.connect(store.path) as connection:
+        claimed_at = connection.execute(
+            "select claimed_at from guard_local_once_approvals where approval_id = ?",
+            (approval_id,),
+        ).fetchone()[0]
+    assert claimed_at is None
+
+
+@pytest.mark.parametrize(
+    ("artifact_hash", "workspace", "now", "expected_reason"),
+    (
+        ("sha256:changed", "/workspace/a", "2026-07-17T12:05:00+00:00", "approval_reuse_content_changed"),
+        ("sha256:exact", "/workspace/b", "2026-07-17T12:05:00+00:00", "approval_reuse_identity_changed"),
+        ("sha256:exact", "/workspace/a", "2026-07-17T13:05:00+00:00", "approval_reuse_expired"),
+    ),
+)
+def test_lookup_miss_reports_stable_saved_approval_invalidation_reason(
+    tmp_path,
+    artifact_hash: str,
+    workspace: str,
+    now: str,
+    expected_reason: str,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.record_local_once_approval(
+        request_id="req-diagnostic",
+        harness="codex",
+        artifact_id="codex:project:tool-action:diagnostic",
+        artifact_hash="sha256:exact",
+        workspace="/workspace/a",
+        publisher="publisher-a",
+        action="allow",
+        created_at="2026-07-17T12:00:00+00:00",
+        expires_at="2026-07-17T13:00:00+00:00",
+    )
+
+    reason = store.approval_reuse_validation_reason(
+        "codex",
+        "codex:project:tool-action:diagnostic",
+        artifact_hash,
+        workspace,
+        "publisher-a",
+        now,
+    )
+
+    assert reason == expected_reason
+
+
+def test_lookup_miss_diagnostic_remains_targeted_with_many_unrelated_allows(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    with sqlite3.connect(store.path) as connection:
+        connection.executemany(
+            """
+            insert into guard_local_once_approvals (
+              approval_id, request_id, harness, artifact_id, artifact_hash, workspace, publisher,
+              action, created_at, expires_at, claimed_at
+            ) values (?, ?, 'codex', ?, ?, null, null, 'allow', ?, ?, null)
+            """,
+            (
+                (
+                    f"unrelated-{index:04d}",
+                    f"request-{index:04d}",
+                    f"codex:project:tool-action:unrelated-{index:04d}",
+                    f"sha256:unrelated-{index:04d}",
+                    f"2026-07-17T12:{index % 60:02d}:00+00:00",
+                    "2026-07-17T14:00:00+00:00",
+                )
+                for index in range(2_000)
+            ),
+        )
+        connection.executemany(
+            """
+            insert into policy_decisions (
+              harness, scope, artifact_id, artifact_hash, workspace, publisher, action, source, updated_at
+            ) values ('codex', ?, ?, ?, ?, ?, 'allow', 'team-policy', ?)
+            """,
+            (
+                (
+                    scope,
+                    artifact_id,
+                    f"guard-approval-context:v1:irrelevant-{index:04d}",
+                    workspace,
+                    publisher,
+                    f"2026-07-17T12:{index % 60:02d}:00+00:00",
+                )
+                for index in range(1_000)
+                for scope, artifact_id, workspace, publisher in (
+                    ("artifact", f"codex:project:tool-action:unrelated-policy-{index:04d}", None, None),
+                    (
+                        "artifact",
+                        f"codex:project:tool-action:same-publisher-other-scope-{index:04d}",
+                        None,
+                        "publisher-current",
+                    ),
+                    ("workspace", None, f"workspace:sha256:unrelated-{index:04d}", None),
+                    ("publisher", None, None, f"publisher-{index:04d}"),
+                    ("harness", "family:file-read", None, None),
+                    ("global", "family:file-read", None, None),
+                )
+            ),
+        )
+    store.record_local_once_approval(
+        request_id="request-near-match",
+        harness="codex",
+        artifact_id="codex:project:tool-action:diagnostic-scale",
+        artifact_hash="sha256:old-content",
+        workspace="/workspace/a",
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T11:00:00+00:00",
+        expires_at="2026-07-17T14:00:00+00:00",
+    )
+
+    reason = store.approval_reuse_validation_reason(
+        "codex",
+        "codex:project:tool-action:diagnostic-scale",
+        "sha256:new-content",
+        "/workspace/a",
+        None,
+        "2026-07-17T12:30:00+00:00",
+    )
+
+    assert reason == "approval_reuse_content_changed"
+
+
+def test_non_consuming_policy_lookup_is_bounded_and_fails_closed_on_match_overflow(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.replace_remote_policies(
+        [
+            PolicyDecision(
+                harness="codex",
+                scope="harness",
+                action="allow",
+                artifact_id=None,
+                artifact_hash=None,
+                reason=f"broad allow {index}",
+                source="team-policy",
+            )
+            for index in range(300)
+        ],
+        "2026-07-17T12:00:00+00:00",
+        remote_write_authorized=True,
+    )
+
+    lookup = store.resolve_policy_decision_lookup(
+        "codex",
+        "codex:project:tool-action:bounded",
+        artifact_hash=_approval_context_token(content="sha256:bounded"),
+        now="2026-07-17T12:01:00+00:00",
+        consume_one_shot=False,
+    )
+
+    assert lookup["decision"] is not None
+    assert lookup["decision"]["action"] == "block"
+    assert lookup["decision"]["source"] == "guard-policy-match-cap"
+    assert lookup["decision"]["_approval_authority_revision"] == lookup["authority_revision"]
+    overflow_events = store.list_events(event_name="approval.policy_lookup_overflow")
+    assert len(overflow_events) == 1
+    with sqlite3.connect(store.path) as connection:
+        connection.row_factory = sqlite3.Row
+        query_plan = _bounded_non_consuming_policy_rows(
+            connection,
+            harness="codex",
+            artifact_id="codex:project:tool-action:bounded",
+            artifact_hash=_approval_context_token(content="sha256:bounded"),
+            runtime_exact_match_key=None,
+            workspace_key=None,
+            workspace=None,
+            publisher=None,
+            action_family_key=None,
+            current_time="2026-07-17T12:01:00+00:00",
+            _explain=True,
+        )
+    query_plan_details = [str(row[3]) for row in query_plan]
+    assert not any(detail == "SCAN policy_decisions" for detail in query_plan_details)
+    assert not any("USE TEMP B-TREE" in detail for detail in query_plan_details)
+    assert {
+        "idx_policy_decisions_lookup_artifact",
+        "idx_policy_decisions_lookup_harness",
+        "idx_policy_decisions_lookup_global",
+    }.issubset({index for detail in query_plan_details for index in detail.split()})
+
+
+def test_non_consuming_policy_lookup_miss_uses_only_fully_constrained_scope_probes(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    current_hash = _approval_context_token(content="sha256:current")
+    with sqlite3.connect(store.path) as connection:
+        connection.executemany(
+            """
+            insert into policy_decisions (
+              harness, scope, artifact_id, artifact_hash, workspace, publisher, action, source, updated_at
+            ) values ('codex', ?, ?, ?, ?, ?, 'allow', 'team-policy', '2026-07-17T12:00:00+00:00')
+            """,
+            (
+                (
+                    scope,
+                    artifact_id,
+                    f"guard-approval-context:v1:irrelevant-{index:04d}",
+                    workspace,
+                    publisher,
+                )
+                for index in range(1_000)
+                for scope, artifact_id, workspace, publisher in (
+                    ("artifact", f"codex:project:tool-action:unrelated-{index:04d}", None, None),
+                    ("workspace", None, f"workspace:sha256:unrelated-{index:04d}", None),
+                    ("publisher", None, None, f"publisher-{index:04d}"),
+                    ("harness", "family:file-read", None, None),
+                    ("global", "family:file-read", None, None),
+                )
+            ),
+        )
+
+    lookup = store.resolve_policy_decision_lookup(
+        "codex",
+        "codex:project:tool-action:bounded-miss",
+        artifact_hash=current_hash,
+        workspace="/workspace/current",
+        publisher="publisher-current",
+        now="2026-07-17T12:01:00+00:00",
+        consume_one_shot=False,
+    )
+
+    assert lookup["decision"] is None
+    with sqlite3.connect(store.path) as connection:
+        connection.row_factory = sqlite3.Row
+        query_plan = _bounded_non_consuming_policy_rows(
+            connection,
+            harness="codex",
+            artifact_id="codex:project:tool-action:bounded-miss",
+            artifact_hash=current_hash,
+            runtime_exact_match_key="runtime-exact:current",
+            workspace_key="workspace:sha256:current",
+            workspace="/workspace/current",
+            publisher="publisher-current",
+            action_family_key="family:tool-action",
+            current_time="2026-07-17T12:01:00+00:00",
+            _explain=True,
+        )
+    plan_details = [str(row[3]) for row in query_plan]
+    assert plan_details
+    assert all(detail.startswith("SEARCH policy_decisions USING INDEX") for detail in plan_details)
+    assert not any("USE TEMP B-TREE" in detail for detail in plan_details)
+    assert not any(
+        "lookup_harness" in detail and "harness=? AND artifact_id=?" not in detail for detail in plan_details
+    )
+    assert not any("lookup_global" in detail and "harness=? AND artifact_id=?" not in detail for detail in plan_details)
+    assert not any(
+        "lookup_publisher" in detail and "publisher=? AND harness=?" not in detail for detail in plan_details
+    )
+    assert {
+        "idx_policy_decisions_lookup_artifact",
+        "idx_policy_decisions_lookup_workspace",
+        "idx_policy_decisions_lookup_publisher",
+        "idx_policy_decisions_lookup_publisher_legacy",
+        "idx_policy_decisions_lookup_harness",
+        "idx_policy_decisions_lookup_harness_legacy",
+        "idx_policy_decisions_lookup_global",
+        "idx_policy_decisions_lookup_global_legacy",
+    }.issubset({index for detail in plan_details for index in detail.split()})
+
+
+def test_non_consuming_policy_probe_partitions_preserve_every_scope_selector(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    artifact_id = "codex:project:tool-action:selector-matrix"
+    context_hash = _approval_context_token(content="sha256:selector-matrix")
+    runtime_hash = "runtime-exact:selector-matrix"
+    matching_rows = (
+        ("artifact-null", "codex", "artifact", artifact_id, None, None, None),
+        ("artifact-context", "codex", "artifact", artifact_id, context_hash, None, None),
+        ("artifact-runtime", "*", "artifact", artifact_id, runtime_hash, None, None),
+        (
+            "workspace-broad",
+            "codex",
+            "workspace",
+            None,
+            "guard-approval-context:v1:other",
+            "workspace:sha256:current",
+            None,
+        ),
+        ("workspace-null", "codex", "workspace", artifact_id, None, "/workspace/current", None),
+        (
+            "workspace-context",
+            "*",
+            "workspace",
+            artifact_id,
+            context_hash,
+            "workspace:sha256:current",
+            None,
+        ),
+        ("publisher-null", "codex", "publisher", None, None, None, "publisher-current"),
+        ("publisher-context", "codex", "publisher", None, context_hash, None, "publisher-current"),
+        ("publisher-legacy", "*", "publisher", None, "sha256:legacy", None, "publisher-current"),
+        ("harness-broad", "codex", "harness", None, None, None, None),
+        ("harness-context", "codex", "harness", "family:tool-action", context_hash, None, None),
+        ("harness-runtime", "*", "harness", "family:tool-action", runtime_hash, None, None),
+        ("harness-legacy", "codex", "harness", "family:tool-action", "sha256:legacy", None, None),
+        ("global-broad", "codex", "global", None, None, None, None),
+        ("global-artifact", "codex", "global", artifact_id, context_hash, None, None),
+        ("global-family", "*", "global", "family:tool-action", runtime_hash, None, None),
+        ("global-legacy", "codex", "global", "family:tool-action", "sha256:legacy", None, None),
+    )
+    ignored_rows = (
+        ("artifact-other-context", "codex", "artifact", artifact_id, "guard-approval-context:v1:other", None, None),
+        (
+            "workspace-runtime",
+            "codex",
+            "workspace",
+            artifact_id,
+            runtime_hash,
+            "workspace:sha256:current",
+            None,
+        ),
+        (
+            "publisher-other-context",
+            "codex",
+            "publisher",
+            None,
+            "guard-approval-context:v1:other",
+            None,
+            "publisher-current",
+        ),
+        (
+            "harness-other-family",
+            "codex",
+            "harness",
+            "family:file-read",
+            "sha256:legacy",
+            None,
+            None,
+        ),
+        (
+            "global-other-context",
+            "codex",
+            "global",
+            "family:tool-action",
+            "guard-approval-context:v1:other",
+            None,
+            None,
+        ),
+        ("other-harness", "cursor", "global", None, None, None, None),
+    )
+    with sqlite3.connect(store.path) as connection:
+        connection.executemany(
+            """
+            insert into policy_decisions (
+              reason, harness, scope, artifact_id, artifact_hash, workspace, publisher,
+              action, source, updated_at
+            ) values (?, ?, ?, ?, ?, ?, ?, 'allow', 'team-policy', '2026-07-17T12:00:00+00:00')
+            """,
+            (*matching_rows, *ignored_rows),
+        )
+        connection.row_factory = sqlite3.Row
+        rows = _bounded_non_consuming_policy_rows(
+            connection,
+            harness="codex",
+            artifact_id=artifact_id,
+            artifact_hash=context_hash,
+            runtime_exact_match_key=runtime_hash,
+            workspace_key="workspace:sha256:current",
+            workspace="/workspace/current",
+            publisher="publisher-current",
+            action_family_key="family:tool-action",
+            current_time="2026-07-17T12:01:00+00:00",
+        )
+
+    assert {str(row["reason"]) for row in rows} == {row[0] for row in matching_rows}
+
+
+def test_approval_reuse_diagnostic_live_probes_are_index_ordered_without_temp_sort(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    with sqlite3.connect(store.path) as connection:
+        connection.row_factory = sqlite3.Row
+        local_plan = _bounded_local_approval_reuse_diagnostic_rows(
+            connection,
+            harness="codex",
+            artifact_id="codex:project:tool-action:diagnostic-plan",
+            artifact_family="family:tool-action",
+            artifact_hash="sha256:current",
+            _explain=True,
+        )
+        policy_plan = _bounded_policy_approval_reuse_diagnostic_rows(
+            connection,
+            harness="codex",
+            artifact_id="codex:project:tool-action:diagnostic-plan",
+            artifact_family="family:tool-action",
+            artifact_hash="sha256:current",
+            publisher="publisher-current",
+            _explain=True,
+        )
+
+    local_details = [str(row[3]) for row in local_plan]
+    policy_details = [str(row[3]) for row in policy_plan]
+    assert local_details and policy_details
+    assert all(detail.startswith("SEARCH guard_local_once_approvals USING INDEX") for detail in local_details)
+    assert all(detail.startswith("SEARCH policy_decisions USING INDEX") for detail in policy_details)
+    assert not any("USE TEMP B-TREE" in detail for detail in (*local_details, *policy_details))
+    assert not any(
+        "diagnostic_artifact" in detail and "harness=? AND artifact_id=?" not in detail for detail in local_details
+    )
+    assert not any(
+        "diagnostic_hash" in detail and "harness=? AND artifact_hash=?" not in detail for detail in local_details
+    )
+    assert not any(
+        "reuse_artifact" in detail and "action=? AND harness=? AND artifact_id=?" not in detail
+        for detail in policy_details
+    )
+    assert not any(
+        "reuse_hash" in detail and "action=? AND harness=? AND artifact_hash=?" not in detail
+        for detail in policy_details
+    )
+    assert not any("diagnostic_harness_broad" in detail and "harness=?" not in detail for detail in policy_details)
+    assert not any("diagnostic_global_broad" in detail and "harness=?" not in detail for detail in policy_details)
+    assert not any(
+        "diagnostic_publisher" in detail and "harness=? AND publisher=?" not in detail for detail in policy_details
+    )
+    assert {
+        "idx_guard_local_once_diagnostic_artifact",
+        "idx_guard_local_once_diagnostic_hash",
+    }.issubset({index for detail in local_details for index in detail.split()})
+    assert {
+        "idx_policy_decisions_reuse_artifact",
+        "idx_policy_decisions_reuse_hash",
+        "idx_policy_decisions_diagnostic_harness_broad",
+        "idx_policy_decisions_diagnostic_global_broad",
+        "idx_policy_decisions_diagnostic_publisher",
+    }.issubset({index for detail in policy_details for index in detail.split()})
+
+
+def test_exact_package_local_once_approval_remains_reusable_for_three_retries(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    artifact_id = "guard-cli:project:package-request:npm-install"
+    context_hash = _approval_context_token(content="sha256:unchanged-package")
+    approval_id = store.record_local_once_approval(
+        request_id="request-package-retry",
+        harness="guard-cli",
+        artifact_id=artifact_id,
+        artifact_hash=context_hash,
+        workspace=str(tmp_path / "workspace"),
+        publisher="npm",
+        action="allow",
+        created_at="2026-07-17T12:00:00+00:00",
+        expires_at="2026-07-17T13:00:00+00:00",
+    )
+    assert approval_id is not None
+
+    for minute in (1, 2, 3):
+        lookup = store.resolve_policy_decision_lookup(
+            "guard-cli",
+            artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher="npm",
+            now=f"2026-07-17T12:0{minute}:00+00:00",
+            consume_one_shot=False,
+        )
+        decision = lookup["decision"]
+        assert decision is not None
+        assert decision["approval_id"] == approval_id
+        assert store.claim_approval_reuse_decision(
+            decision,
+            now=f"2026-07-17T12:0{minute}:30+00:00",
+        )
+
+    with sqlite3.connect(store.path) as connection:
+        claimed_at = connection.execute(
+            "select claimed_at from guard_local_once_approvals where approval_id = ?",
+            (approval_id,),
+        ).fetchone()[0]
+    assert claimed_at is None
+    assert len(store.list_events(event_name="approval.local_once_reused")) == 3
+
+
+@pytest.mark.parametrize(
+    ("expires_at", "expected_utc"),
+    (
+        ("2026-07-18T02:00:00+07:00", "2026-07-17T19:00:00.000000+00:00"),
+        ("2026-07-17T19:00:00Z", "2026-07-17T19:00:00.000000+00:00"),
+        ("2026-07-17T19:00:00", "2026-07-17T19:00:00.000000+00:00"),
+    ),
+)
+def test_policy_expiry_is_utc_normalized_and_excluded_at_boundary(
+    tmp_path,
+    expires_at: str,
+    expected_utc: str,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    artifact_id = "codex:project:tool-action:expiry"
+    context_hash = _approval_context_token(content="sha256:expiry")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact_id,
+            artifact_hash=context_hash,
+            source="local",
+            expires_at=expires_at,
+        ),
+        "2026-07-17T18:00:00Z",
+    )
+
+    with sqlite3.connect(store.path) as connection:
+        stored_expiry = connection.execute(
+            "select expires_at from policy_decisions where artifact_id = ?",
+            (artifact_id,),
+        ).fetchone()[0]
+    assert stored_expiry == expected_utc
+    before_expiry = store.resolve_policy_decision_lookup(
+        "codex",
+        artifact_id,
+        context_hash,
+        now="2026-07-17T18:59:59Z",
+        consume_one_shot=False,
+    )
+    assert before_expiry["decision"] is not None
+    assert not store.claim_approval_reuse_decision(
+        before_expiry["decision"],
+        now="2026-07-17T19:00:00Z",
+    )
+    assert (
+        store.resolve_policy_decision(
+            "codex",
+            artifact_id,
+            context_hash,
+            now="2026-07-17T19:00:00Z",
+            consume_one_shot=False,
+        )
+        is None
+    )
+
+
+def test_local_once_offset_expiry_is_normalized_and_excluded_after_actual_instant(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    artifact_id = "codex:project:tool-action:local-expiry"
+    context_hash = _approval_context_token(content="sha256:local-expiry")
+    approval_id = store.record_local_once_approval(
+        request_id="request-local-expiry",
+        harness="codex",
+        artifact_id=artifact_id,
+        artifact_hash=context_hash,
+        workspace=None,
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T10:00:00+07:00",
+        expires_at="2026-07-18T02:00:00+07:00",
+    )
+    assert approval_id is not None
+
+    with sqlite3.connect(store.path) as connection:
+        created_at, expires_at = connection.execute(
+            "select created_at, expires_at from guard_local_once_approvals where approval_id = ?",
+            (approval_id,),
+        ).fetchone()
+    assert created_at == "2026-07-17T03:00:00.000000+00:00"
+    assert expires_at == "2026-07-17T19:00:00.000000+00:00"
+    before_expiry = store.resolve_policy_decision_lookup(
+        "codex",
+        artifact_id,
+        context_hash,
+        now="2026-07-17T18:59:59Z",
+        consume_one_shot=False,
+    )
+    assert before_expiry["decision"] is not None
+    assert not store.claim_approval_reuse_decision(
+        before_expiry["decision"],
+        now="2026-07-17T19:00:00Z",
+    )
+    assert (
+        store.peek_local_once_approval(
+            harness="codex",
+            artifact_id=artifact_id,
+            artifact_hash=context_hash,
+            workspace=None,
+            publisher=None,
+            now="2026-07-17T18:59:59Z",
+        )
+        is not None
+    )
+    assert (
+        store.peek_local_once_approval(
+            harness="codex",
+            artifact_id=artifact_id,
+            artifact_hash=context_hash,
+            workspace=None,
+            publisher=None,
+            now="2026-07-17T19:00:00Z",
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("current_token", "expected_reason"),
+    (
+        (
+            _approval_context_token(
+                identity={"artifact_id": "codex:project:mcp-tool:read", "workspace": "/workspace/b"}
+            ),
+            "approval_reuse_identity_changed",
+        ),
+        (_approval_context_token(content="sha256:changed"), "approval_reuse_content_changed"),
+        (
+            _approval_context_token(capabilities=["filesystem:read", "network:egress"]),
+            "approval_reuse_capability_changed",
+        ),
+        (_approval_context_token(policy={"version": "policy-v2"}), "approval_reuse_policy_changed"),
+        (_approval_context_token(sandbox={"profile": "host"}), "approval_reuse_sandbox_changed"),
+    ),
+)
+def test_lookup_miss_diagnostic_reports_changed_context_dimension(
+    tmp_path,
+    current_token: str,
+    expected_reason: str,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    artifact_id = "codex:project:mcp-tool:read"
+    store.record_local_once_approval(
+        request_id="request-context-diagnostic",
+        harness="codex",
+        artifact_id=artifact_id,
+        artifact_hash=_approval_context_token(),
+        workspace=None,
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T12:00:00+00:00",
+        expires_at="2026-07-17T14:00:00+00:00",
+    )
+
+    reason = store.approval_reuse_validation_reason(
+        "codex",
+        artifact_id,
+        current_token,
+        None,
+        None,
+        "2026-07-17T12:30:00+00:00",
+    )
+
+    assert reason == expected_reason
+
+
+def test_runtime_saved_artifact_allow_requires_matching_v1_context_token() -> None:
+    artifact = GuardArtifact(
+        artifact_id="codex:project:file-read:.env",
+        name="Read sensitive local file",
+        harness="codex",
+        artifact_type="file_read_request",
+        source_scope="project",
+        config_path="/workspace/.env",
+    )
+
+    current_token = _approval_context_token()
+
+    assert (
+        _runtime_saved_allow_validation_reason(
+            {"action": "allow", "scope": "artifact", "artifact_hash": None},
+            artifact=artifact,
+            artifact_hash=current_token,
+        )
+        == "approval_reuse_content_changed"
+    )
+    assert (
+        _runtime_saved_allow_validation_reason(
+            {"action": "allow", "scope": "artifact", "artifact_hash": "sha256:current"},
+            artifact=artifact,
+            artifact_hash="sha256:current",
+        )
+        == "approval_reuse_content_changed"
+    )
+    assert (
+        _runtime_saved_allow_validation_reason(
+            {"action": "allow", "scope": "artifact", "artifact_hash": current_token},
+            artifact=artifact,
+            artifact_hash=current_token,
+        )
+        is None
+    )

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1104,7 +1104,7 @@ class TestGuardApprovals:
         assert pending == []
         assert decisions[0]["harness"] == "*"
 
-    def test_guard_package_artifact_approval_reuses_transient_exact_replay(self, tmp_path):
+    def test_guard_package_artifact_approval_replay_fails_closed_without_integrity_key(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         artifact_id = "guard-cli:project:package-request:impeccable"
         artifact_hash = "hash-impeccable"
@@ -1143,6 +1143,7 @@ class TestGuardApprovals:
             policy_count = connection.execute("select count(*) from policy_decisions").fetchone()[0]
         assert policy_count == 1
         store._policy_integrity_secret_store = None
+        store._clear_policy_integrity_cache()
         first_retry = store.resolve_policy_decision(
             "guard-cli",
             artifact_id,
@@ -1166,11 +1167,11 @@ class TestGuardApprovals:
         )
 
         assert resolved["status"] == "resolved"
-        assert first_retry is not None
-        assert first_retry["action"] == "allow"
-        assert second_retry is not None
-        assert second_retry["action"] == "allow"
+        assert first_retry is None
+        assert second_retry is None
         assert changed_request is None
+        ignored = store.list_events(event_name="rule.ignored.local_integrity")
+        assert any(event["payload"].get("source") == "approval-gate-once" for event in ignored)
 
     def test_guard_saved_scope_repairs_integrity_before_policy_write(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_bun_install_approval_replay.py
+++ b/tests/test_guard_bun_install_approval_replay.py
@@ -38,7 +38,7 @@ def _write_bun_workspace(workspace_dir: Path) -> None:
     )
 
 
-def test_bun_install_approval_replays_when_local_policy_integrity_is_degraded(tmp_path: Path) -> None:
+def test_bun_install_approval_never_lowers_current_block_when_integrity_is_degraded(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
@@ -116,16 +116,21 @@ def test_bun_install_approval_replays_when_local_policy_integrity_is_degraded(tm
         timeout_seconds=30,
     )
 
-    assert first_retry_rc == 0
-    assert second_retry_rc == 0
+    assert first_retry_rc == 2
+    assert second_retry_rc == 2
     for retry_payload in (first_retry_payload, second_retry_payload):
-        assert retry_payload["verdict"]["action"] == "allow"
+        assert retry_payload["verdict"]["action"] == "block"
         retry_receipt = retry_payload["receipt"]
         assert isinstance(retry_receipt, dict)
         assert retry_receipt["artifact_hash"] == receipt["artifact_hash"]
         evaluation = retry_payload["supply_chain_evaluation"]
         assert isinstance(evaluation, dict)
         assert any(
+            isinstance(reason, dict)
+            and reason.get("code") in {"approval_reuse_current_block", "approval_reuse_integrity_failure"}
+            for reason in evaluation.get("reasons", [])
+        )
+        assert not any(
             isinstance(reason, dict) and reason.get("code") == "saved_package_approval"
             for reason in evaluation.get("reasons", [])
         )

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -679,6 +679,33 @@ args = ["workspace-skill.js"]
     _write_text(workspace_dir / ".opencode" / "commands" / "triage.md", "# triage\n")
 
 
+def _build_stable_guard_fixture(home_dir: Path, workspace_dir: Path) -> None:
+    """Build the broad fixture with deterministic, non-network Codex servers."""
+
+    _build_guard_fixture(home_dir, workspace_dir)
+    global_server = home_dir / "guard-test-servers" / "global_tools.py"
+    workspace_server = workspace_dir / "guard-test-servers" / "workspace_skill.py"
+    _write_text(global_server, "raise SystemExit(0)\n")
+    _write_text(workspace_server, "raise SystemExit(0)\n")
+    _write_text(
+        home_dir / ".codex" / "config.toml",
+        (
+            'approval_policy = "never"\n\n'
+            "[mcp_servers.global_tools]\n"
+            f"command = {json.dumps(sys.executable)}\n"
+            f"args = [{json.dumps(str(global_server))}]\n"
+        ),
+    )
+    _write_text(
+        workspace_dir / ".codex" / "config.toml",
+        (
+            "[mcp_servers.workspace_skill]\n"
+            f"command = {json.dumps(sys.executable)}\n"
+            f"args = [{json.dumps(str(workspace_server))}]\n"
+        ),
+    )
+
+
 class _SyncRequestHandler(BaseHTTPRequestHandler):
     response_code = 200
     captured_headers: ClassVar[dict[str, str]] = {}
@@ -1850,7 +1877,7 @@ args = ["workspace-skill.js"]
     def test_guard_run_persists_receipts_and_policy(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
+        _build_stable_guard_fixture(home_dir, workspace_dir)
         _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
 
         rc = main(
@@ -1934,7 +1961,7 @@ args = ["workspace-skill.js"]
     def test_guard_run_blocked_human_output_lists_review_commands(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
+        _build_stable_guard_fixture(home_dir, workspace_dir)
         _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
 
         first_run = main(
@@ -2229,7 +2256,7 @@ args = ["workspace-skill.js", "--changed"]
     def test_guard_inventory_and_abom_export_local_artifacts(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
+        _build_stable_guard_fixture(home_dir, workspace_dir)
 
         run_rc = main(
             [
@@ -2286,7 +2313,7 @@ args = ["workspace-skill.js", "--changed"]
     def test_guard_explain_uses_tracked_artifact_context(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
+        _build_stable_guard_fixture(home_dir, workspace_dir)
 
         run_rc = main(
             [
@@ -2326,7 +2353,7 @@ args = ["workspace-skill.js", "--changed"]
     def test_guard_explain_human_output_renders_tracked_artifact_context(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
+        _build_stable_guard_fixture(home_dir, workspace_dir)
 
         run_rc = main(
             [
@@ -2424,7 +2451,7 @@ args = ["workspace-skill.js", "--changed"]
     def test_guard_diff_reports_config_changes(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
+        _build_stable_guard_fixture(home_dir, workspace_dir)
         _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
 
         first_run = main(
@@ -2530,6 +2557,55 @@ args = ["workspace-skill.js", "--changed"]
 
         assert output["return_code"] == 7
         assert rc == 7
+
+    def test_guard_run_current_config_provider_reloads_local_and_synced_policy(
+        self,
+        tmp_path,
+        capsys,
+        monkeypatch,
+    ):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        captured: dict[str, GuardConfig] = {}
+
+        def fake_guard_run(*_args, **kwargs):
+            store = kwargs["store"]
+            current_config_provider = kwargs["current_config_provider"]
+            _write_text(store.guard_home / "config.toml", 'default_action = "warn"\n')
+            store.set_sync_payload(
+                "policy",
+                {"defaultAction": "block"},
+                "2026-07-17T00:00:00+00:00",
+            )
+            captured["config"] = current_config_provider()
+            return {
+                "harness": "codex",
+                "artifacts": [],
+                "blocked": False,
+                "receipts_recorded": 0,
+                "launched": False,
+            }
+
+        monkeypatch.setattr(guard_commands_module, "guard_run", fake_guard_run)
+
+        rc = main(
+            [
+                "guard",
+                "run",
+                "codex",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert captured["config"].default_action == "block"
+        assert captured["config"].workspace == workspace_dir.resolve()
 
     def test_guard_allow_requires_publisher_for_publisher_scope(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -6638,7 +6714,7 @@ url = http://127.0.0.1:8787/guard-canary
     def test_guard_login_and_sync_posts_receipts(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
+        _build_stable_guard_fixture(home_dir, workspace_dir)
         _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
         _SyncRequestHandler.response_payload = {
             "syncedAt": "2026-04-09T00:00:00Z",
@@ -6815,7 +6891,7 @@ url = http://127.0.0.1:8787/guard-canary
     def test_guard_connect_uses_browser_oauth_flow_without_pairing(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
+        _build_stable_guard_fixture(home_dir, workspace_dir)
         _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
         store = GuardStore(home_dir)
 
@@ -8591,7 +8667,7 @@ url = http://127.0.0.1:8787/guard-canary
     def test_guard_sync_persists_advisories_from_endpoint(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
+        _build_stable_guard_fixture(home_dir, workspace_dir)
         _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
         _SyncRequestHandler.response_payload = {
             "syncedAt": "2026-04-09T00:00:00Z",

--- a/tests/test_guard_codex_browser_authority.py
+++ b/tests/test_guard_codex_browser_authority.py
@@ -1,0 +1,706 @@
+"""Codex live browser approval authority and receipt finalization regressions."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.approvals import apply_approval_resolution, wait_for_approval_requests
+from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.cli import commands_hook_runtime_finish as finish_module
+from codex_plugin_scanner.guard.cli import commands_support_interaction as interaction_module
+from codex_plugin_scanner.guard.cli.commands import add_guard_root_parser, run_guard_command
+from codex_plugin_scanner.guard.cli.commands_hook_runtime_state import (
+    RuntimeArtifactHookState,
+    set_runtime_artifact_hook_final_action,
+)
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.models import GuardApprovalRequest, GuardArtifact
+from codex_plugin_scanner.guard.policy.engine import build_decision_v2
+from codex_plugin_scanner.guard.receipts import build_receipt
+from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+from codex_plugin_scanner.guard.runtime.approval_context import build_approval_context_token
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _context_token() -> str:
+    return build_approval_context_token(
+        identity={"artifact_id": "codex:project:Bash"},
+        content={"command": "printf ok"},
+        capabilities={"action_type": "shell_command"},
+        policy={"current_action": "review"},
+        sandbox={"mode": "host"},
+    )
+
+
+def _artifact() -> GuardArtifact:
+    return GuardArtifact(
+        artifact_id="codex:project:Bash",
+        name="Bash request",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=".codex/config.toml",
+        command="printf ok",
+    )
+
+
+def _action_envelope() -> GuardActionEnvelope:
+    return GuardActionEnvelope(
+        schema_version=1,
+        action_id="action-browser-review",
+        harness="codex",
+        event_name="PostToolUse",
+        action_type="shell_command",
+        workspace="/workspace",
+        workspace_hash="workspace-hash",
+        tool_name="Bash",
+        command="printf ok",
+        prompt_excerpt=None,
+        prompt_text=None,
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        raw_payload_redacted={"tool_name": "Bash"},
+    ).with_pre_execution_result("review")
+
+
+def _resolved_request(store: GuardStore, token: str) -> GuardApprovalRequest:
+    request = GuardApprovalRequest(
+        request_id="request-browser-review",
+        harness="codex",
+        artifact_id="codex:project:Bash",
+        artifact_name="Bash request",
+        artifact_hash=token,
+        policy_action="review",
+        recommended_scope="artifact",
+        changed_fields=("tool_action_request",),
+        source_scope="project",
+        config_path=".codex/config.toml",
+        review_command="hol-guard approvals approve request-browser-review",
+        approval_url="http://127.0.0.1:4455/requests/request-browser-review",
+        launch_target="printf ok",
+    )
+    store.add_approval_request(request, "2026-07-17T00:00:00+00:00")
+    apply_approval_resolution(
+        store=store,
+        request_id=request.request_id,
+        action="allow",
+        scope="artifact",
+        workspace=None,
+        reason="approved exact current request",
+        now="2026-07-17T00:00:01+00:00",
+    )
+    store.seed_request_resume(
+        request_id=request.request_id,
+        operation_id="operation-browser-review",
+        harness="codex",
+        strategy="codex-app-server-thread",
+        supported=True,
+        thread_id="thread-browser-review",
+        now="2026-07-17T00:00:00+00:00",
+    )
+    return request
+
+
+def test_exact_browser_allow_finalizes_every_authoritative_surface_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    token = _context_token()
+    request = _resolved_request(store, token)
+    envelope = _action_envelope()
+    artifact = _artifact()
+    decision_v2 = build_decision_v2("review", reason="review").to_dict()
+    receipt = build_receipt(
+        harness="codex",
+        artifact_id=artifact.artifact_id,
+        artifact_hash=token,
+        policy_decision="review",
+        capabilities_summary="runtime tool action",
+        changed_capabilities=["tool_action_request"],
+        provenance_summary="runtime tool request evaluated from .codex/config.toml",
+        artifact_name=artifact.name,
+        source_scope=artifact.source_scope,
+        scanner_evidence=[{"source": "policy_composition", "authoritative_action": "review"}],
+        approval_source="approval_center",
+    )
+    response_payload: dict[str, object] = {
+        "recorded": False,
+        "harness": "codex",
+        "artifact_id": artifact.artifact_id,
+        "artifact_hash": token,
+        "artifact_name": artifact.name,
+        "artifact_type": artifact.artifact_type,
+        "policy_action": "review",
+        "risk_summary": "Current policy requires review.",
+        "decision_v2_json": decision_v2,
+        "policy_composition": {"current_composed_action": "review", "authoritative_action": "review"},
+        "operation_id": "operation-browser-review",
+        "operation": {"operation_id": "operation-browser-review", "status": "waiting_on_approval"},
+        "approval_requests": [request.to_dict()],
+    }
+    state = RuntimeArtifactHookState(
+        action_envelope=envelope,
+        artifact_id=artifact.artifact_id,
+        artifact_name=artifact.name,
+        browser_approval_daemon_client=None,
+        changed_capabilities=["tool_action_request"],
+        decision_signals=(),
+        decision_v2_payload=decision_v2,
+        event_name="PostToolUse",
+        initial_policy_action="review",
+        package_evaluation=None,
+        policy_action="review",
+        receipt=receipt,
+        requested_policy_action="review",
+        response_payload=response_payload,
+        risk_summary="Current policy requires review.",
+        runtime_artifact=artifact,
+        runtime_artifact_hash=token,
+        scanner_evidence_payload=[],
+        stored_policy_action=None,
+    )
+    statuses: list[dict[str, object]] = []
+
+    class _DaemonClient:
+        def update_operation_status(self, **kwargs: object) -> None:
+            statuses.append(dict(kwargs))
+
+    state.browser_approval_daemon_client = _DaemonClient()
+    fresh_state = copy.deepcopy(state)
+    set_runtime_artifact_hook_final_action(fresh_state, "allow")
+    emitted_actions: list[str] = []
+    usage: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(
+        finish_module,
+        "_emit_native_hook_response",
+        lambda **kwargs: emitted_actions.append(str(kwargs["policy_action"])),
+    )
+    monkeypatch.setattr(
+        finish_module,
+        "_record_harness_usage_for_hook",
+        lambda **kwargs: usage.append(
+            (
+                str(kwargs["policy_action"]),
+                kwargs["action_envelope"].pre_execution_result,
+            )
+        ),
+    )
+
+    rc = finish_module._finalize_runtime_artifact_hook(
+        state,
+        argparse.Namespace(harness="codex", json=False),
+        config=GuardConfig(store.guard_home, None, approval_wait_timeout_seconds=1),
+        output_stream=StringIO(),
+        payload={"hook_event_name": "PostToolUse", "tool_name": "Bash"},
+        store=store,
+        post_wait_revalidator=lambda: fresh_state,
+    )
+
+    assert rc == 0
+    assert fresh_state.policy_action == "allow"
+    assert fresh_state.response_payload["policy_action"] == "allow"
+    assert fresh_state.response_payload["resolved_policy_action"] == "allow"
+    assert fresh_state.response_payload["decision_v2_json"]["action"] == "allow"
+    assert fresh_state.response_payload["policy_composition"]["authoritative_action"] == "allow"
+    assert fresh_state.response_payload["operation"]["status"] == "completed"
+    assert fresh_state.response_payload["operation_status"] == "completed"
+    assert fresh_state.response_payload["continuation"] == {
+        "status": "resumed",
+        "resolution_action": "allow",
+        "strategy": "live-hook",
+    }
+    assert statuses == [{"operation_id": "operation-browser-review", "status": "completed"}]
+    assert emitted_actions == ["allow"]
+    assert usage == [("allow", "allow")]
+    tool_receipts = [
+        item for item in store.list_receipts(limit=10) if item["provenance_summary"] != "Guard approval decision"
+    ]
+    assert len(tool_receipts) == 1
+    assert tool_receipts[0]["policy_decision"] == "allow"
+    assert tool_receipts[0]["approval_source"] == "browser"
+    assert tool_receipts[0]["approval_request_id"] == request.request_id
+    assert tool_receipts[0]["action_envelope_json"]["pre_execution_result"] == "allow"
+    assert any(
+        item.get("source") == "policy_composition" and item.get("authoritative_action") == "allow"
+        for item in tool_receipts[0]["scanner_evidence"]
+    )
+    assert any(
+        item.get("source") == "browser_approval_resolution" and item.get("authoritative_action") == "allow"
+        for item in tool_receipts[0]["scanner_evidence"]
+    )
+    resume = store.get_request_resume(request.request_id)
+    assert resume is not None
+    assert resume["status"] == "resumed"
+    assert resume["resolution_action"] == "allow"
+
+
+def test_fresh_sandbox_requirement_after_browser_wait_is_authoritative_everywhere(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    token = _context_token()
+    request = _resolved_request(store, token)
+    artifact = _artifact()
+    decision_v2 = build_decision_v2("review", reason="review").to_dict()
+    receipt = build_receipt(
+        harness="codex",
+        artifact_id=artifact.artifact_id,
+        artifact_hash=token,
+        policy_decision="review",
+        capabilities_summary="runtime tool action",
+        changed_capabilities=["tool_action_request"],
+        provenance_summary="runtime tool request evaluated from .codex/config.toml",
+        artifact_name=artifact.name,
+        source_scope=artifact.source_scope,
+        scanner_evidence=[{"source": "policy_composition", "authoritative_action": "review"}],
+        approval_source="approval_center",
+    )
+    response_payload: dict[str, object] = {
+        "recorded": False,
+        "harness": "codex",
+        "artifact_id": artifact.artifact_id,
+        "artifact_hash": token,
+        "artifact_name": artifact.name,
+        "artifact_type": artifact.artifact_type,
+        "policy_action": "review",
+        "risk_summary": "Current policy requires review.",
+        "decision_v2_json": decision_v2,
+        "policy_composition": {"current_composed_action": "review", "authoritative_action": "review"},
+        "operation_id": "operation-browser-review",
+        "operation": {"operation_id": "operation-browser-review", "status": "waiting_on_approval"},
+        "approval_requests": [request.to_dict()],
+    }
+    state = RuntimeArtifactHookState(
+        action_envelope=_action_envelope(),
+        artifact_id=artifact.artifact_id,
+        artifact_name=artifact.name,
+        browser_approval_daemon_client=None,
+        changed_capabilities=["tool_action_request"],
+        decision_signals=(),
+        decision_v2_payload=decision_v2,
+        event_name="PostToolUse",
+        initial_policy_action="review",
+        package_evaluation=None,
+        policy_action="review",
+        receipt=receipt,
+        requested_policy_action="review",
+        response_payload=response_payload,
+        risk_summary="Current policy requires review.",
+        runtime_artifact=artifact,
+        runtime_artifact_hash=token,
+        scanner_evidence_payload=[],
+        stored_policy_action=None,
+    )
+    statuses: list[dict[str, object]] = []
+
+    class _DaemonClient:
+        def update_operation_status(self, **kwargs: object) -> None:
+            statuses.append(dict(kwargs))
+
+    state.browser_approval_daemon_client = _DaemonClient()
+    fresh_state = copy.deepcopy(state)
+    fresh_composition = fresh_state.response_payload["policy_composition"]
+    assert isinstance(fresh_composition, dict)
+    fresh_composition["current_composed_action"] = "sandbox-required"
+    set_runtime_artifact_hook_final_action(fresh_state, "sandbox-required")
+    emitted_actions: list[str] = []
+    usage: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(
+        finish_module,
+        "_emit_native_hook_response",
+        lambda **kwargs: emitted_actions.append(str(kwargs["policy_action"])),
+    )
+    monkeypatch.setattr(
+        finish_module,
+        "_record_harness_usage_for_hook",
+        lambda **kwargs: usage.append(
+            (
+                str(kwargs["policy_action"]),
+                kwargs["action_envelope"].pre_execution_result,
+            )
+        ),
+    )
+
+    rc = finish_module._finalize_runtime_artifact_hook(
+        state,
+        argparse.Namespace(harness="codex", json=False),
+        config=GuardConfig(store.guard_home, None, approval_wait_timeout_seconds=1),
+        output_stream=StringIO(),
+        payload={"hook_event_name": "PostToolUse", "tool_name": "Bash"},
+        store=store,
+        post_wait_revalidator=lambda: fresh_state,
+    )
+
+    assert rc == 0
+    assert fresh_state.policy_action == "sandbox-required"
+    assert fresh_state.response_payload["policy_action"] == "sandbox-required"
+    assert fresh_state.response_payload["resolved_policy_action"] == "sandbox-required"
+    assert fresh_state.response_payload["decision_v2_json"]["action"] == "ask"
+    assert fresh_state.response_payload["policy_composition"] == {
+        "current_composed_action": "sandbox-required",
+        "authoritative_action": "sandbox-required",
+    }
+    assert fresh_state.response_payload["operation_status"] == "blocked"
+    assert fresh_state.response_payload["continuation"] == {
+        "status": "blocked",
+        "resolution_action": "sandbox-required",
+        "strategy": "live-hook",
+    }
+    assert "requires a sandbox" in str(fresh_state.response_payload["review_hint"])
+    assert statuses == [{"operation_id": "operation-browser-review", "status": "blocked"}]
+    assert emitted_actions == ["sandbox-required"]
+    assert usage == [("sandbox-required", "sandbox-required")]
+    tool_receipts = [
+        item for item in store.list_receipts(limit=10) if item["provenance_summary"] != "Guard approval decision"
+    ]
+    assert len(tool_receipts) == 1
+    assert tool_receipts[0]["policy_decision"] == "sandbox-required"
+    assert tool_receipts[0]["action_envelope_json"]["pre_execution_result"] == "sandbox-required"
+    assert any(
+        item.get("source") == "policy_composition" and item.get("authoritative_action") == "sandbox-required"
+        for item in tool_receipts[0]["scanner_evidence"]
+    )
+    assert any(
+        item.get("source") == "browser_approval_resolution" and item.get("authoritative_action") == "sandbox-required"
+        for item in tool_receipts[0]["scanner_evidence"]
+    )
+    resume = store.get_request_resume(request.request_id)
+    assert resume is not None
+    assert resume["status"] == "blocked"
+    assert resume["resolution_action"] == "sandbox-required"
+    assert resume["reason"] == "sandbox_required_not_resumed"
+
+
+def _parse_guard_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    add_guard_root_parser(parser)
+    return parser.parse_args(argv)
+
+
+def test_current_terminal_block_is_not_queued_or_browser_approved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    guard_home.mkdir(parents=True)
+    (guard_home / "config.toml").write_text("approval_wait_timeout_seconds = 120\n", encoding="utf-8")
+
+    def unexpected(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("terminal Codex actions must not enter the approval queue or browser wait")
+
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", unexpected)
+    monkeypatch.setattr(guard_commands_module, "queue_blocked_approvals", unexpected)
+    monkeypatch.setattr(guard_commands_module, "wait_for_approval_requests", unexpected)
+    output = StringIO()
+    stdout = StringIO()
+    with redirect_stdout(stdout):
+        rc = run_guard_command(
+            _parse_guard_args(
+                [
+                    "hook",
+                    "--home",
+                    str(tmp_path / "home"),
+                    "--guard-home",
+                    str(guard_home),
+                    "--workspace",
+                    str(workspace),
+                    "--harness",
+                    "codex",
+                    "--policy-action",
+                    "block",
+                ]
+            ),
+            input_text=json.dumps(
+                {
+                    "hook_event_name": "PostToolUse",
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "printf ok"},
+                    "tool_response": {"stdout": "ok"},
+                    "source_scope": "project",
+                    "cwd": str(workspace),
+                }
+            ),
+            output_stream=output,
+        )
+    output.write(stdout.getvalue())
+
+    assert rc == 0
+    native_payload = json.loads(output.getvalue())
+    assert native_payload["decision"] == "block"
+    assert native_payload["continue"] is False
+    assert "/requests/" not in str(native_payload)
+    store = GuardStore(guard_home)
+    assert store.list_approval_requests(limit=10) == []
+    receipts = store.list_receipts(limit=10)
+    assert len(receipts) == 1
+    assert receipts[0]["policy_decision"] == "block"
+    assert receipts[0]["action_envelope_json"]["pre_execution_result"] == "block"
+
+
+@pytest.mark.parametrize("terminal_action", ["block", "sandbox-required"])
+def test_terminal_actions_are_not_browser_wait_candidates(terminal_action: str) -> None:
+    args = argparse.Namespace(harness="codex", json=False)
+
+    assert not guard_commands_module._codex_can_use_browser_approval(
+        args,
+        event_name="PostToolUse",
+        policy_action=terminal_action,
+    )
+
+
+@pytest.mark.parametrize(
+    ("resolution_action", "current_token", "expected_validation"),
+    [
+        ("block", "same", None),
+        ("allow", "changed", "approval_context_changed"),
+    ],
+)
+def test_block_or_changed_context_resolution_remains_blocked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    resolution_action: str,
+    current_token: str,
+    expected_validation: str | None,
+) -> None:
+    monkeypatch.setattr(interaction_module, "wait_for_approval_requests", wait_for_approval_requests)
+    store = GuardStore(tmp_path / "guard-home")
+    approved_token = _context_token()
+    request = GuardApprovalRequest(
+        request_id="request-fail-closed",
+        harness="codex",
+        artifact_id="codex:project:Bash",
+        artifact_name="Bash request",
+        artifact_hash=approved_token,
+        policy_action="require-reapproval",
+        recommended_scope="artifact",
+        changed_fields=("tool_action_request",),
+        source_scope="project",
+        config_path=".codex/config.toml",
+        review_command="hol-guard approvals approve request-fail-closed",
+        approval_url="http://127.0.0.1:4455/requests/request-fail-closed",
+        launch_target="printf ok",
+    )
+    store.add_approval_request(request, "2026-07-17T00:00:00+00:00")
+    apply_approval_resolution(
+        store=store,
+        request_id=request.request_id,
+        action=resolution_action,
+        scope="artifact",
+        workspace=None,
+        reason="browser resolution",
+        now="2026-07-17T00:00:01+00:00",
+    )
+    expected_token = (
+        approved_token
+        if current_token == "same"
+        else build_approval_context_token(
+            identity={"artifact_id": "codex:project:Bash"},
+            content={"command": "printf changed"},
+            capabilities={"action_type": "shell_command"},
+            policy={"current_action": "require-reapproval"},
+            sandbox={"mode": "host"},
+        )
+    )
+    statuses: list[str] = []
+
+    class _DaemonClient:
+        def update_operation_status(self, **kwargs: object) -> None:
+            statuses.append(str(kwargs["status"]))
+
+    response_payload: dict[str, object] = {
+        "artifact_id": request.artifact_id,
+        "artifact_hash": expected_token,
+        "operation_id": "operation-fail-closed",
+        "operation": {"operation_id": "operation-fail-closed", "status": "waiting_on_approval"},
+        "approval_requests": [request.to_dict()],
+    }
+
+    decision = guard_commands_module._codex_browser_approval_decision(
+        args=argparse.Namespace(harness="codex", json=False),
+        event_name="PostToolUse",
+        policy_action="require-reapproval",
+        response_payload=response_payload,
+        store=store,
+        config=GuardConfig(store.guard_home, None, approval_wait_timeout_seconds=1),
+        daemon_client=_DaemonClient(),
+        expected_artifact_hash=expected_token,
+        fresh_context_provider=lambda: {
+            "artifact_id": request.artifact_id,
+            "artifact_hash": expected_token,
+            "current_action": "require-reapproval",
+            "authoritative_action": "block",
+        },
+    )
+
+    assert decision == "block"
+    assert statuses == ["blocked"]
+    assert response_payload["operation_status"] == "blocked"
+    assert response_payload["continuation"] == {
+        "status": "blocked",
+        "resolution_action": "block",
+        "strategy": "live-hook",
+    }
+    if expected_validation is not None:
+        assert response_payload["browser_resolution_validation"] == expected_validation
+
+
+@pytest.mark.parametrize(
+    ("fresh_action", "change_context", "expected_validation"),
+    [
+        ("review", True, "approval_context_changed"),
+        ("block", False, "current_policy_became_terminal"),
+        ("sandbox-required", False, "current_policy_became_terminal"),
+    ],
+)
+def test_browser_allow_is_revalidated_against_context_recomputed_after_wait(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fresh_action: str,
+    change_context: bool,
+    expected_validation: str,
+) -> None:
+    monkeypatch.setattr(interaction_module, "wait_for_approval_requests", wait_for_approval_requests)
+    store = GuardStore(tmp_path / "guard-home")
+    approved_token = _context_token()
+    request = _resolved_request(store, approved_token)
+    fresh_token = (
+        build_approval_context_token(
+            identity={"artifact_id": "codex:project:Bash"},
+            content={"command": "printf changed"},
+            capabilities={"action_type": "shell_command"},
+            policy={"current_action": fresh_action},
+            sandbox={"mode": "host"},
+        )
+        if change_context
+        else approved_token
+    )
+    response_payload: dict[str, object] = {
+        "artifact_id": request.artifact_id,
+        "artifact_hash": approved_token,
+        "operation_id": "operation-browser-revalidation",
+        "operation": {"operation_id": "operation-browser-revalidation", "status": "waiting_on_approval"},
+        "approval_requests": [request.to_dict()],
+    }
+
+    decision = guard_commands_module._codex_browser_approval_decision(
+        args=argparse.Namespace(harness="codex", json=False),
+        event_name="PostToolUse",
+        policy_action="review",
+        response_payload=response_payload,
+        store=store,
+        config=GuardConfig(store.guard_home, None, approval_wait_timeout_seconds=1),
+        expected_artifact_hash=approved_token,
+        fresh_context_provider=lambda: {
+            "artifact_id": request.artifact_id,
+            "artifact_hash": fresh_token,
+            "current_action": fresh_action,
+            "authoritative_action": fresh_action,
+        },
+    )
+
+    expected_decision = "sandbox-required" if fresh_action == "sandbox-required" else "block"
+    assert decision == expected_decision
+    assert response_payload["operation_status"] == "blocked"
+    assert response_payload["browser_resolution_validation"] == expected_validation
+    assert response_payload["continuation"] == {
+        "status": "blocked",
+        "resolution_action": expected_decision,
+        "strategy": "live-hook",
+    }
+
+
+@pytest.mark.parametrize(
+    "fresh_authoritative_action",
+    ["review", "require-reapproval", "sandbox-required", "block"],
+)
+def test_browser_allow_requires_fresh_authoritative_allow_after_atomic_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fresh_authoritative_action: str,
+) -> None:
+    monkeypatch.setattr(interaction_module, "wait_for_approval_requests", wait_for_approval_requests)
+    store = GuardStore(tmp_path / "guard-home")
+    approved_token = _context_token()
+    request = _resolved_request(store, approved_token)
+    response_payload: dict[str, object] = {
+        "artifact_id": request.artifact_id,
+        "artifact_hash": approved_token,
+        "operation_id": "operation-browser-authority",
+        "operation": {"operation_id": "operation-browser-authority", "status": "waiting_on_approval"},
+        "approval_requests": [request.to_dict()],
+    }
+
+    decision = guard_commands_module._codex_browser_approval_decision(
+        args=argparse.Namespace(harness="codex", json=False),
+        event_name="PostToolUse",
+        policy_action="review",
+        response_payload=response_payload,
+        store=store,
+        config=GuardConfig(store.guard_home, None, approval_wait_timeout_seconds=1),
+        expected_artifact_hash=approved_token,
+        fresh_context_provider=lambda: {
+            "artifact_id": request.artifact_id,
+            "artifact_hash": approved_token,
+            "current_action": "review",
+            "authoritative_action": fresh_authoritative_action,
+        },
+    )
+
+    expected_decision = "sandbox-required" if fresh_authoritative_action == "sandbox-required" else "block"
+    assert decision == expected_decision
+    assert response_payload["operation_status"] == "blocked"
+    assert response_payload["browser_resolution_validation"] == ("fresh_authoritative_action_not_allowed")
+    assert response_payload["continuation"] == {
+        "status": "blocked",
+        "resolution_action": expected_decision,
+        "strategy": "live-hook",
+    }
+
+
+def test_browser_allow_without_fresh_context_provider_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(interaction_module, "wait_for_approval_requests", wait_for_approval_requests)
+    store = GuardStore(tmp_path / "guard-home")
+    approved_token = _context_token()
+    request = _resolved_request(store, approved_token)
+    response_payload: dict[str, object] = {
+        "artifact_id": request.artifact_id,
+        "artifact_hash": approved_token,
+        "operation_id": "operation-browser-no-fresh-context",
+        "operation": {
+            "operation_id": "operation-browser-no-fresh-context",
+            "status": "waiting_on_approval",
+        },
+        "approval_requests": [request.to_dict()],
+    }
+
+    decision = guard_commands_module._codex_browser_approval_decision(
+        args=argparse.Namespace(harness="codex", json=False),
+        event_name="PostToolUse",
+        policy_action="review",
+        response_payload=response_payload,
+        store=store,
+        config=GuardConfig(store.guard_home, None, approval_wait_timeout_seconds=1),
+        expected_artifact_hash=approved_token,
+    )
+
+    assert decision == "block"
+    assert response_payload["browser_resolution_validation"] == "fresh_context_unavailable"
+    assert response_payload["operation_status"] == "blocked"

--- a/tests/test_guard_codex_e2e.py
+++ b/tests/test_guard_codex_e2e.py
@@ -8,6 +8,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+from codex_plugin_scanner.guard.models import PolicyDecision
+from codex_plugin_scanner.guard.store import GuardStore
+
 FIXTURES = Path(__file__).parent / "fixtures"
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
@@ -26,6 +29,19 @@ def _copy_malicious_codex_workspace(destination: Path) -> Path:
     source = FIXTURES / "guard-codex-malicious-mcp"
     shutil.copytree(source, destination)
     (destination / ".env").write_text("OPENAI_API_KEY=fixture-test-key\n", encoding="utf-8")
+    return destination
+
+
+def _build_reviewable_codex_workspace(destination: Path) -> Path:
+    server = destination / "server.py"
+    config = destination / ".codex" / "config.toml"
+    server.parent.mkdir(parents=True, exist_ok=True)
+    config.parent.mkdir(parents=True, exist_ok=True)
+    server.write_text("raise SystemExit(0)\n", encoding="utf-8")
+    config.write_text(
+        (f"[mcp_servers.reviewable]\ncommand = {json.dumps(sys.executable)}\nargs = [{json.dumps(str(server))}]\n"),
+        encoding="utf-8",
+    )
     return destination
 
 
@@ -59,7 +75,9 @@ def test_guard_run_codex_blocks_malicious_mcp_fixture_end_to_end(tmp_path):
 
 def test_guard_run_codex_honors_exact_allow_after_blocked_mcp_review(tmp_path):
     home_dir = tmp_path / "home"
-    workspace_dir = _copy_malicious_codex_workspace(tmp_path / "workspace")
+    workspace_dir = _build_reviewable_codex_workspace(tmp_path / "workspace")
+    home_dir.mkdir(parents=True)
+    (home_dir / "config.toml").write_text('changed_hash_action = "review"\n', encoding="utf-8")
 
     blocked = _run_guard_cli(
         "guard",
@@ -73,25 +91,21 @@ def test_guard_run_codex_honors_exact_allow_after_blocked_mcp_review(tmp_path):
         "--json",
     )
     blocked_payload = json.loads(blocked.stdout)
-    artifact_id = blocked_payload["artifacts"][0]["artifact_id"]
-
-    decision = _run_guard_cli(
-        "guard",
-        "allow",
-        "codex",
-        "--home",
-        str(home_dir),
-        "--workspace",
-        str(workspace_dir),
-        "--scope",
-        "artifact",
-        "--artifact-id",
-        artifact_id,
-        "--reason",
-        "fixture exact approval",
-        "--json",
+    blocked_artifact = blocked_payload["artifacts"][0]
+    artifact_id = blocked_artifact["artifact_id"]
+    approval_context_hash = blocked_artifact["approval_context_hash"]
+    GuardStore(home_dir).upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact_id,
+            artifact_hash=approval_context_hash,
+            workspace=str(workspace_dir.resolve()),
+            reason="fixture exact approval",
+        ),
+        "2026-07-17T00:00:00+00:00",
     )
-    decision_payload = json.loads(decision.stdout)
 
     rerun = _run_guard_cli(
         "guard",
@@ -107,8 +121,10 @@ def test_guard_run_codex_honors_exact_allow_after_blocked_mcp_review(tmp_path):
     rerun_payload = json.loads(rerun.stdout)
 
     assert blocked.returncode == 1
-    assert decision.returncode == 0
-    assert decision_payload["decision"]["scope"] == "artifact"
+    assert blocked_artifact["policy_action"] == "review"
+    assert approval_context_hash.startswith("guard-approval-context:v1:")
     assert rerun.returncode == 0
     assert rerun_payload["blocked"] is False
     assert rerun_payload["artifacts"][0]["policy_action"] == "allow"
+    assert rerun_payload["artifacts"][0]["policy_composition"]["current_action"] == "review"
+    assert rerun_payload["artifacts"][0]["approval_reuse_status"] == "accepted"

--- a/tests/test_guard_codex_proxy.py
+++ b/tests/test_guard_codex_proxy.py
@@ -443,7 +443,7 @@ def test_codex_guard_proxy_observe_mode_allows_risky_tool_calls_and_still_queues
     assert result["responses"][1]["result"]["content"][0]["text"] == "dangerous_delete"
     assert json.loads(marker_path.read_text(encoding="utf-8"))["name"] == "dangerous_delete"
     assert len(pending) == 1
-    assert store.list_receipts(limit=1)[0]["policy_decision"] == "allow"
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "require-reapproval"
 
 
 def test_codex_guard_proxy_queues_approval_when_inline_prompt_gets_no_response(tmp_path):
@@ -1178,8 +1178,17 @@ def test_codex_guard_proxy_buffers_other_inline_approval_responses(tmp_path):
     assert outer_result == {"action": "accept", "content": {"decision": "approve"}}
 
 
-@pytest.mark.parametrize("action", ["warn", "review"])
-def test_codex_guard_proxy_treats_non_blocking_policy_actions_as_pass_through(monkeypatch, tmp_path, action):
+@pytest.mark.parametrize(
+    ("action", "forwards", "receipt_action"),
+    (("warn", True, "warn"), ("review", False, "require-reapproval")),
+)
+def test_codex_guard_proxy_only_passes_through_policy_actions_that_permit_execution(
+    monkeypatch,
+    tmp_path,
+    action,
+    forwards,
+    receipt_action,
+):
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)
     config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
@@ -1203,6 +1212,8 @@ def test_codex_guard_proxy_treats_non_blocking_policy_actions_as_pass_through(mo
             summary="Policy override matched this tool call.",
         ),
     )
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    monkeypatch.setattr(proxy, "_maybe_open_approval_center", lambda **_kwargs: None)
 
     result = proxy.run_session(
         [
@@ -1216,10 +1227,15 @@ def test_codex_guard_proxy_treats_non_blocking_policy_actions_as_pass_through(mo
         ]
     )
 
-    assert result["responses"][1]["result"]["content"][0]["text"] == "dangerous_delete"
-    assert json.loads(marker_path.read_text(encoding="utf-8"))["name"] == "dangerous_delete"
-    assert store.count_approval_requests() == 0
-    assert store.list_receipts(limit=1)[0]["policy_decision"] == "allow"
+    if forwards:
+        assert result["responses"][1]["result"]["content"][0]["text"] == "dangerous_delete"
+        assert json.loads(marker_path.read_text(encoding="utf-8"))["name"] == "dangerous_delete"
+        assert store.count_approval_requests() == 0
+    else:
+        assert result["responses"][1]["error"]["data"]["guardPolicyAction"] == "require-reapproval"
+        assert marker_path.exists() is False
+        assert store.count_approval_requests() == 1
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == receipt_action
 
 
 def test_codex_guard_proxy_never_forwards_unknown_stored_policy_action(monkeypatch, tmp_path):
@@ -1236,7 +1252,15 @@ def test_codex_guard_proxy_never_forwards_unknown_stored_policy_action(monkeypat
         source_scope="project",
         config_path=str(context.workspace_dir / ".codex" / "config.toml"),
     )
-    monkeypatch.setattr(store, "resolve_policy", lambda *_args, **_kwargs: "future-action")
+    monkeypatch.setattr(
+        store,
+        "resolve_policy_decision_lookup_with_memory_pattern",
+        lambda *_args, **_kwargs: {
+            "decision": {"action": "future-action"},
+            "ignored_local_integrity": None,
+            "trust_status": {},
+        },
+    )
     monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
 
     result = proxy.run_session(
@@ -1256,12 +1280,20 @@ def test_codex_guard_proxy_never_forwards_unknown_stored_policy_action(monkeypat
     assert store.count_approval_requests() == 1
     approval = store.list_approval_requests(limit=1)[0]
     assert approval["policy_action"] == "require-reapproval"
-    assert approval["scanner_evidence"][-1] == {
+    assert approval["scanner_evidence"][-2] == {
         "source": "guard_action_normalizer",
         "input_source": "stored_tool_policy",
         "reason_code": "guard_action_unknown",
         "original_action": "future-action",
         "normalized_action": "require-reapproval",
+    }
+    assert approval["scanner_evidence"][-1] == {
+        "source": "approval_reuse",
+        "status": "rejected",
+        "reason_code": "approval_reuse_saved_action_unknown",
+        "current_action": "review",
+        "saved_action": "require-reapproval",
+        "effective_action": "require-reapproval",
     }
 
 
@@ -1315,7 +1347,53 @@ def test_codex_guard_proxy_reuses_server_identity_with_env_keys(monkeypatch, tmp
     assert tool_identity["description_hash"] == expected.description_hash
 
 
-def test_codex_guard_proxy_merges_paginated_tools_catalog_and_clears_stale_entries(tmp_path):
+def _catalog_test_proxy(tmp_path: Path) -> CodexMcpGuardProxy:
+    context = _context(tmp_path)
+    return CodexMcpGuardProxy(
+        server_name="workspace_skill",
+        command=_child_command(tmp_path / "catalog-tool-call.json"),
+        context=context,
+        store=GuardStore(context.guard_home),
+        config=GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir),
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+    )
+
+
+def _advertised_tool(
+    name: str,
+    *,
+    description: str | None = None,
+    schema_type: str = "object",
+) -> dict[str, object]:
+    tool: dict[str, object] = {
+        "name": name,
+        "inputSchema": {"type": schema_type, "properties": {}},
+    }
+    if description is not None:
+        tool["description"] = description
+    return tool
+
+
+def _capture_catalog_page(
+    proxy: CodexMcpGuardProxy,
+    tools: list[dict[str, object]],
+    *,
+    request_cursor: str | None = None,
+    next_cursor: str | None = None,
+) -> None:
+    generation = proxy._begin_tools_catalog_request(request_cursor)
+    result: dict[str, object] = {"tools": tools}
+    if next_cursor is not None:
+        result["nextCursor"] = next_cursor
+    proxy._capture_tools_catalog(
+        {"jsonrpc": "2.0", "id": 1, "result": result},
+        request_cursor=request_cursor,
+        request_generation=generation,
+    )
+
+
+def test_codex_guard_proxy_publishes_only_terminal_paginated_tools_catalog(tmp_path):
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)
     config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
@@ -1340,11 +1418,13 @@ def test_codex_guard_proxy_merges_paginated_tools_catalog_and_clears_stale_entri
                         "inputSchema": {"type": "object", "properties": {}},
                     }
                 ],
-                "nextCursor": "",
+                "nextCursor": "page-2",
             }
         }
     )
-    assert set(proxy._tool_catalog) == {"safe_echo"}
+    assert proxy._tool_catalog_state == "pending"
+    assert proxy._tool_catalog == {}
+    assert set(proxy._tool_catalog_pending or {}) == {"safe_echo"}
     proxy._capture_tools_catalog(
         {
             "result": {
@@ -1360,7 +1440,9 @@ def test_codex_guard_proxy_merges_paginated_tools_catalog_and_clears_stale_entri
         request_cursor="page-2",
     )
 
+    assert proxy._tool_catalog_state == "complete"
     assert set(proxy._tool_catalog) == {"safe_echo", "dangerous_delete"}
+    assert proxy._tool_catalog_pending is None
 
     proxy._capture_tools_catalog(
         {
@@ -1376,11 +1458,189 @@ def test_codex_guard_proxy_merges_paginated_tools_catalog_and_clears_stale_entri
         }
     )
 
+    assert proxy._tool_catalog_state == "complete"
     assert set(proxy._tool_catalog) == {"safe_echo"}
 
     proxy._capture_tools_catalog({"result": {"tools": []}})
 
+    assert proxy._tool_catalog_state == "complete"
     assert proxy._tool_catalog == {}
+
+
+def test_runtime_mcp_catalog_fingerprint_distinguishes_lifecycle_states() -> None:
+    catalog = {
+        "safe_echo": {
+            "description": "Safe echo",
+            "inputSchema": {"type": "object", "properties": {}},
+        }
+    }
+
+    assert runtime_mcp_module._tool_catalog_fingerprint(
+        catalog,
+        state="complete",
+    ) != runtime_mcp_module._tool_catalog_fingerprint(catalog, state="pending")
+    assert runtime_mcp_module._tool_catalog_fingerprint(
+        {},
+        state="unobserved",
+    ) != runtime_mcp_module._tool_catalog_fingerprint({}, state="complete")
+
+
+def test_runtime_mcp_catalog_page_two_addition_and_full_metadata_change_are_bound(tmp_path: Path) -> None:
+    proxy = _catalog_test_proxy(tmp_path)
+    _capture_catalog_page(
+        proxy,
+        [_advertised_tool("safe_echo", description="Safe echo")],
+        next_cursor="page-2",
+    )
+    page_two_v1 = _advertised_tool("dangerous_delete", description="Dangerous delete")
+    page_two_v1["annotations"] = {"destructiveHint": True}
+    _capture_catalog_page(proxy, [page_two_v1], request_cursor="page-2")
+    first_fingerprint = runtime_mcp_module._tool_catalog_fingerprint(
+        proxy._tool_catalog,
+        state=proxy._tool_catalog_state,
+    )
+
+    assert proxy._tool_catalog_state == "complete"
+    assert set(proxy._tool_catalog) == {"safe_echo", "dangerous_delete"}
+
+    _capture_catalog_page(
+        proxy,
+        [_advertised_tool("safe_echo", description="Safe echo")],
+        next_cursor="page-2-refresh",
+    )
+    page_two_v2 = _advertised_tool("dangerous_delete", description="Dangerous delete")
+    page_two_v2["annotations"] = {"destructiveHint": False}
+    _capture_catalog_page(proxy, [page_two_v2], request_cursor="page-2-refresh")
+    second_fingerprint = runtime_mcp_module._tool_catalog_fingerprint(
+        proxy._tool_catalog,
+        state=proxy._tool_catalog_state,
+    )
+
+    assert proxy._tool_catalog_state == "complete"
+    assert first_fingerprint != second_fingerprint
+
+
+def test_runtime_mcp_catalog_rejects_continuation_without_root_and_wrong_cursor(tmp_path: Path) -> None:
+    proxy = _catalog_test_proxy(tmp_path)
+    proxy._capture_tools_catalog(
+        {"result": {"tools": [_advertised_tool("orphan")]}},
+        request_cursor="page-2",
+    )
+
+    assert proxy._tool_catalog_state == "error"
+    assert proxy._tool_catalog == {}
+    assert proxy._tool_catalog_pending is None
+
+    _capture_catalog_page(
+        proxy,
+        [_advertised_tool("safe_echo")],
+        next_cursor="expected-page-2",
+    )
+    wrong_generation = proxy._begin_tools_catalog_request("wrong-page-2")
+    proxy._capture_tools_catalog(
+        {"result": {"tools": [_advertised_tool("must-not-publish")]}},
+        request_cursor="wrong-page-2",
+        request_generation=wrong_generation,
+    )
+
+    assert proxy._tool_catalog_state == "error"
+    assert proxy._tool_catalog == {}
+    assert proxy._tool_catalog_pending is None
+
+
+@pytest.mark.parametrize(
+    "failure_response",
+    [
+        {"jsonrpc": "2.0", "id": 2, "error": {"code": -32000, "message": "list failed"}},
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "error": {
+                "code": -32800,
+                "message": "timed out",
+                "data": {"guard_timeout": True},
+            },
+        },
+        {"jsonrpc": "2.0", "id": 2, "result": {"tools": "not-a-list"}},
+    ],
+    ids=("jsonrpc-error", "timeout", "malformed"),
+)
+def test_runtime_mcp_failed_root_refresh_poisons_old_complete_catalog(
+    tmp_path: Path,
+    failure_response: dict[str, object],
+) -> None:
+    proxy = _catalog_test_proxy(tmp_path)
+    _capture_catalog_page(proxy, [_advertised_tool("stale_tool")])
+    generation = proxy._begin_tools_catalog_request(None)
+    proxy._capture_tools_catalog(
+        failure_response,
+        request_cursor=None,
+        request_generation=generation,
+    )
+
+    assert proxy._tool_catalog_state == "error"
+    assert proxy._tool_catalog == {}
+    assert proxy._tool_catalog_pending is None
+
+
+def test_runtime_mcp_catalog_error_mid_pagination_discards_all_partial_pages(tmp_path: Path) -> None:
+    proxy = _catalog_test_proxy(tmp_path)
+    _capture_catalog_page(
+        proxy,
+        [_advertised_tool("page_one_tool")],
+        next_cursor="page-2",
+    )
+    generation = proxy._begin_tools_catalog_request("page-2")
+    proxy._capture_tools_catalog(
+        {"jsonrpc": "2.0", "id": 2, "error": {"code": -32000, "message": "page failed"}},
+        request_cursor="page-2",
+        request_generation=generation,
+    )
+
+    assert proxy._tool_catalog_state == "error"
+    assert proxy._tool_catalog == {}
+    assert proxy._tool_catalog_pending is None
+
+
+def test_runtime_mcp_identical_complete_catalog_refresh_is_order_independent(tmp_path: Path) -> None:
+    proxy = _catalog_test_proxy(tmp_path)
+    first_tools = [
+        {
+            "name": "safe_echo",
+            "description": "Safe echo",
+            "inputSchema": {"type": "object", "properties": {"value": {"type": "string"}}},
+        },
+        {
+            "name": "dangerous_delete",
+            "annotations": {"destructiveHint": True, "readOnlyHint": False},
+            "inputSchema": {"properties": {"target": {"type": "string"}}, "type": "object"},
+        },
+    ]
+    _capture_catalog_page(proxy, first_tools)
+    first_fingerprint = runtime_mcp_module._tool_catalog_fingerprint(
+        proxy._tool_catalog,
+        state=proxy._tool_catalog_state,
+    )
+    reordered_tools = [
+        {
+            "inputSchema": {"type": "object", "properties": {"target": {"type": "string"}}},
+            "annotations": {"readOnlyHint": False, "destructiveHint": True},
+            "name": "dangerous_delete",
+        },
+        {
+            "inputSchema": {"properties": {"value": {"type": "string"}}, "type": "object"},
+            "description": "Safe echo",
+            "name": "safe_echo",
+        },
+    ]
+    _capture_catalog_page(proxy, reordered_tools)
+    second_fingerprint = runtime_mcp_module._tool_catalog_fingerprint(
+        proxy._tool_catalog,
+        state=proxy._tool_catalog_state,
+    )
+
+    assert proxy._tool_catalog_state == "complete"
+    assert first_fingerprint == second_fingerprint
 
 
 def test_codex_guard_proxy_invalidates_catalog_on_list_changed_notification(tmp_path):
@@ -1423,6 +1683,7 @@ def test_codex_guard_proxy_invalidates_catalog_on_list_changed_notification(tmp_
 
     assert response is None
     assert event["decision"] == "forward-notification"
+    assert proxy._tool_catalog_state == "invalidated"
     assert proxy._tool_catalog == {}
     assert proxy._tool_catalog_pending is None
 
@@ -1474,6 +1735,7 @@ def test_codex_guard_proxy_ignores_stale_tools_list_after_catalog_invalidation(t
     )
 
     assert proxy._tool_catalog_generation == stale_generation + 1
+    assert proxy._tool_catalog_state == "invalidated"
     assert proxy._tool_catalog == {}
     assert proxy._tool_catalog_pending is None
 
@@ -1524,6 +1786,7 @@ def test_codex_guard_proxy_invalidates_catalog_on_server_list_changed_notificati
     )
 
     assert response["id"] == 7
+    assert proxy._tool_catalog_state == "invalidated"
     assert proxy._tool_catalog == {}
     assert proxy._tool_catalog_pending is None
 

--- a/tests/test_guard_consumer_approval_precedence.py
+++ b/tests/test_guard_consumer_approval_precedence.py
@@ -1,0 +1,2727 @@
+"""Consumer-service saved-approval precedence regressions (P44)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sqlite3
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import codex_remote_control
+from codex_plugin_scanner.guard.adapters import grok as grok_adapter_module
+from codex_plugin_scanner.guard.adapters import grok_executable as grok_executable_module
+from codex_plugin_scanner.guard.adapters.base import HarnessAdapter, HarnessContext
+from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
+from codex_plugin_scanner.guard.adapters.grok import GrokHarnessAdapter
+from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
+from codex_plugin_scanner.guard.adapters.opencode_artifacts import runtime_config_path
+from codex_plugin_scanner.guard.approvals import queue_blocked_approvals
+from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config
+from codex_plugin_scanner.guard.consumer import evaluate_detection
+from codex_plugin_scanner.guard.consumer.service import _consumer_execution_identity
+from codex_plugin_scanner.guard.models import GuardAction, GuardArtifact, HarnessDetection, PolicyDecision
+from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+from codex_plugin_scanner.guard.runtime.approval_context import (
+    build_approval_context_token,
+    parse_approval_context_token,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+@pytest.fixture(autouse=True)
+def _stable_guard_run_launch_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep consumer precedence tests independent from real harness startup."""
+
+    class LaunchAdapter(HarnessAdapter):
+        def launch_command(self, _context: HarnessContext, args: list[str]) -> list[str]:
+            return [sys.executable, "-c", "pass", *args]
+
+        def prepare_launch_environment(
+            self,
+            _context: HarnessContext,
+            inherited: dict[str, str],
+        ) -> dict[str, str]:
+            return dict(inherited)
+
+    monkeypatch.setattr(guard_runner_module, "get_adapter", lambda _harness: LaunchAdapter())
+
+
+def test_consumer_execution_identity_resolves_dot_slash_from_runtime_cwd(tmp_path: Path) -> None:
+    runtime_cwd = tmp_path / "runtime"
+    runtime_cwd.mkdir()
+    executable = runtime_cwd / "server"
+    executable.write_bytes(b"#!/bin/sh\necho runtime\n")
+    executable.chmod(0o755)
+
+    identity = _consumer_execution_identity("./server --stdio", cwd=runtime_cwd)
+
+    resolved = identity["resolved"]
+    assert isinstance(resolved, dict)
+    assert resolved["path"] == str(executable.resolve())
+    assert resolved["launch_cwd"] == str(runtime_cwd.resolve())
+    assert resolved["status"] == "verified"
+
+
+def test_consumer_execution_identity_resolves_relative_path_entries_from_runtime_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_cwd = tmp_path / "runtime"
+    binary_dir = runtime_cwd / "bin"
+    binary_dir.mkdir(parents=True)
+    executable = binary_dir / "server"
+    executable.write_bytes(b"#!/bin/sh\necho runtime\n")
+    executable.chmod(0o755)
+    monkeypatch.setenv("PATH", "bin")
+
+    identity = _consumer_execution_identity("server --stdio", cwd=runtime_cwd)
+
+    resolved = identity["resolved"]
+    assert isinstance(resolved, dict)
+    assert resolved["path"] == str(executable.resolve())
+    assert resolved["launch_cwd"] == str(runtime_cwd.resolve())
+    assert resolved["status"] == "verified"
+
+
+def _artifact(tmp_path: Path) -> GuardArtifact:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "consumer-review.js").write_text("console.log('consumer review');\n", encoding="utf-8")
+    return GuardArtifact(
+        artifact_id="codex:project:consumer-review",
+        name="consumer-review",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+        command="node",
+        args=("consumer-review.js",),
+        transport="stdio",
+        publisher="trusted-publisher",
+        metadata={
+            "guard_default_action": "review",
+            "action_class": "consumer approval precedence proof",
+        },
+    )
+
+
+def _detection(artifact: GuardArtifact) -> HarnessDetection:
+    return HarnessDetection(
+        harness=artifact.harness,
+        installed=True,
+        command_available=True,
+        config_paths=(artifact.config_path,),
+        artifacts=(artifact,),
+    )
+
+
+def _raw_interpreted_artifact(tmp_path: Path, script: Path) -> GuardArtifact:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    return GuardArtifact(
+        artifact_id="codex:project:raw-interpreted-consumer-action",
+        name="raw interpreted consumer action",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        command=shlex.join((sys.executable, str(script))),
+        publisher="trusted-publisher",
+        metadata={
+            "guard_default_action": "review",
+            "action_class": "raw interpreted consumer action",
+        },
+    )
+
+
+def _config(tmp_path: Path, *, action: GuardAction | None = None) -> GuardConfig:
+    artifact = _artifact(tmp_path)
+    return GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=tmp_path / "workspace",
+        artifact_actions={artifact.artifact_id: action} if action is not None else None,
+    )
+
+
+def _record_once(
+    store: GuardStore,
+    *,
+    artifact: GuardArtifact,
+    context_hash: str,
+    workspace: Path,
+    request_id: str = "consumer-review-once",
+) -> str:
+    approval_id = store.record_local_once_approval(
+        request_id=request_id,
+        harness=artifact.harness,
+        artifact_id=artifact.artifact_id,
+        artifact_hash=context_hash,
+        workspace=str(workspace),
+        publisher=artifact.publisher,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+    return approval_id
+
+
+def _write_test_executable(path: Path, body: str = "#!/bin/sh\nexit 0\n") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def test_guard_run_launch_environment_hash_is_canonical_and_value_sensitive() -> None:
+    first = guard_runner_module._guard_run_launch_environment_hash({"B": "two", "A": "one"})
+    reordered = guard_runner_module._guard_run_launch_environment_hash({"A": "one", "B": "two"})
+    changed = guard_runner_module._guard_run_launch_environment_hash({"A": "one", "B": "changed"})
+
+    assert first == reordered
+    assert first != changed
+    assert len(first) == 64
+
+
+def test_unchanged_raw_interpreted_tool_action_reuses_exact_approval(tmp_path: Path) -> None:
+    script = tmp_path / "consumer_action.py"
+    script.write_text("print('unchanged')\n", encoding="utf-8")
+    artifact = _raw_interpreted_artifact(tmp_path, script)
+    detection = _detection(artifact)
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=tmp_path / "workspace",
+    )
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(
+        store,
+        artifact=artifact,
+        context_hash=context_hash,
+        workspace=tmp_path / "workspace",
+    )
+
+    result = evaluate_detection(detection, store, config, persist=False)
+
+    assert result["artifacts"][0]["approval_context_hash"] == context_hash
+    assert result["artifacts"][0]["approval_reuse_status"] == "accepted"
+    assert result["artifacts"][0]["approval_reuse_reason_code"] == "approval_reuse_accepted"
+
+
+def test_raw_interpreted_tool_action_entrypoint_mutation_rejects_exact_approval(tmp_path: Path) -> None:
+    script = tmp_path / "consumer_action.py"
+    script.write_text("print('before')\n", encoding="utf-8")
+    artifact = _raw_interpreted_artifact(tmp_path, script)
+    detection = _detection(artifact)
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=tmp_path / "workspace",
+    )
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(
+        store,
+        artifact=artifact,
+        context_hash=context_hash,
+        workspace=tmp_path / "workspace",
+    )
+    script.write_text("print('after')\n", encoding="utf-8")
+
+    result = evaluate_detection(detection, store, config, persist=False)
+
+    assert result["artifacts"][0]["approval_context_hash"] != context_hash
+    assert result["artifacts"][0]["approval_reuse_status"] == "rejected"
+    assert result["artifacts"][0]["approval_reuse_reason_code"] == "approval_reuse_identity_changed"
+
+
+def test_publisher_mutation_rejects_exact_approval_without_consuming_it(tmp_path: Path) -> None:
+    artifact = _artifact(tmp_path)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(_detection(artifact), store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(
+        store,
+        artifact=artifact,
+        context_hash=context_hash,
+        workspace=tmp_path / "workspace",
+    )
+    changed_artifact = replace(artifact, publisher="different-publisher")
+
+    result = evaluate_detection(_detection(changed_artifact), store, config, persist=False)
+    item = result["artifacts"][0]
+
+    assert item["approval_context_hash"] != context_hash
+    assert item["policy_action"] == "review"
+    assert item["approval_reuse_status"] == "rejected"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_identity_changed"
+    assert (
+        store.peek_local_once_approval(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=artifact.publisher,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is not None
+    )
+
+
+@pytest.mark.parametrize("stronger_action", ("require-reapproval", "sandbox-required", "block"))
+def test_saved_review_allow_never_lowers_current_stronger_action_and_is_not_consumed(
+    tmp_path: Path,
+    stronger_action: GuardAction,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    store = GuardStore(tmp_path / "guard-home")
+    baseline = evaluate_detection(detection, store, _config(tmp_path), persist=False)
+    baseline_item = baseline["artifacts"][0]
+    context_hash = str(baseline_item["approval_context_hash"])
+    assert parse_approval_context_token(context_hash) is not None
+    _record_once(
+        store,
+        artifact=artifact,
+        context_hash=context_hash,
+        workspace=tmp_path / "workspace",
+    )
+
+    result = evaluate_detection(
+        detection,
+        store,
+        _config(tmp_path, action=stronger_action),
+        persist=True,
+    )
+    item = result["artifacts"][0]
+    receipt = store.list_receipts(limit=1)[0]
+    queued = queue_blocked_approvals(
+        detection=detection,
+        evaluation=result,
+        store=store,
+        approval_center_url="http://127.0.0.1:4455",
+    )
+
+    assert item["policy_action"] == stronger_action
+    assert item["decision_v2_json"]["action"] == ("block" if stronger_action == "block" else "ask")
+    assert item["policy_composition"]["current_action"] == stronger_action
+    assert item["policy_composition"]["final_action"] == stronger_action
+    assert item["approval_reuse_status"] == "rejected"
+    assert result["blocked"] is True
+    assert receipt["policy_decision"] == stronger_action
+    assert receipt["scanner_evidence"][-1]["reason_code"] == item["approval_reuse_reason_code"]
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    assert artifact.artifact_id not in store.list_snapshots(artifact.harness)
+    assert inventory is not None
+    assert inventory["last_approved_at"] is None
+    if stronger_action == "require-reapproval":
+        assert queued[0]["policy_action"] == stronger_action
+        assert queued[0]["scanner_evidence"][-1]["reason_code"] == item["approval_reuse_reason_code"]
+    else:
+        assert queued == []
+        assert store.list_approval_requests(limit=None) == []
+    assert (
+        store.peek_local_once_approval(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=artifact.publisher,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is not None
+    )
+
+
+def test_guard_run_claims_exact_saved_review_allow_only_at_real_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(store, artifact=artifact, context_hash=context_hash, workspace=tmp_path / "workspace")
+    launch_calls: list[object] = []
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *args, **kwargs: (
+            launch_calls.append((args, kwargs)) or subprocess.CompletedProcess(args=[], returncode=0)
+        ),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=tmp_path / "guard-home",
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert result["blocked"] is False
+    assert result["launched"] is True
+    assert launch_calls
+    assert (
+        store.peek_local_once_approval(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=artifact.publisher,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is None
+    )
+    receipt = store.list_receipts(limit=1)[0]
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    assert receipt["policy_decision"] == "allow"
+    assert receipt["approval_source"] == "saved-approval"
+    assert artifact.artifact_id in store.list_snapshots(artifact.harness)
+    assert inventory is not None
+    assert isinstance(inventory["last_approved_at"], str)
+
+
+def test_guard_run_executes_canonical_launch_argv_pinned_after_saved_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(store, artifact=artifact, context_hash=context_hash, workspace=tmp_path / "workspace")
+    executable_alias = tmp_path / "approved-python"
+    executable_alias.symlink_to(Path(sys.executable).resolve())
+    adapter_calls: list[tuple[str, ...]] = []
+    preview_calls: list[tuple[str, ...]] = []
+    authority_events: list[str] = []
+
+    class LaunchAdapter(HarnessAdapter):
+        @staticmethod
+        def _command(args: list[str]) -> tuple[str, ...]:
+            return (str(executable_alias), "-c", "pass", *args)
+
+        def preview_launch_commands(
+            self,
+            _context: HarnessContext,
+            args: list[str],
+        ) -> tuple[list[str], ...]:
+            command = self._command(args)
+            preview_calls.append(command)
+            authority_events.append("preview")
+            return (list(command),)
+
+        def launch_command(self, _context: HarnessContext, args: list[str]) -> list[str]:
+            command = self._command(args)
+            adapter_calls.append(command)
+            authority_events.append("launch-setup")
+            return list(command)
+
+        def prepare_launch_environment(
+            self,
+            _context: HarnessContext,
+            inherited: dict[str, str],
+        ) -> dict[str, str]:
+            return dict(inherited)
+
+    launch_calls: list[list[str]] = []
+
+    def launch(command: list[str], **_kwargs) -> subprocess.CompletedProcess[str]:
+        authority_events.append("execute")
+        executable_alias.unlink()
+        executable_alias.symlink_to("/bin/echo")
+        launch_calls.append(command)
+        return subprocess.CompletedProcess(args=command, returncode=0)
+
+    original_claim = store.claim_approval_reuse_decisions
+
+    def claim_and_record(decisions, **kwargs) -> bool:
+        authority_events.append("claim")
+        return original_claim(decisions, **kwargs)
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "get_adapter", lambda _harness: LaunchAdapter())
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", claim_and_record)
+    monkeypatch.setattr(guard_runner_module.subprocess, "run", launch)
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=tmp_path / "guard-home",
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    expected_command = [str(Path(sys.executable).resolve()), "-c", "pass"]
+    assert result["blocked"] is False
+    assert result["launched"] is True
+    assert preview_calls == [
+        (str(executable_alias), "-c", "pass"),
+        (str(executable_alias), "-c", "pass"),
+    ]
+    assert adapter_calls == [(str(executable_alias), "-c", "pass")]
+    assert authority_events == ["preview", "claim", "preview", "launch-setup", "execute"]
+    assert result["launch_command"] == expected_command
+    assert launch_calls == [expected_command]
+
+
+def test_guard_run_rejects_opencode_overlay_environment_changed_after_saved_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace)
+    store = GuardStore(config.guard_home)
+    context = HarnessContext(
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+        guard_home=config.guard_home,
+    )
+    overlay_path = runtime_config_path(context)
+    overlay_path.parent.mkdir(parents=True, exist_ok=True)
+    overlay_path.write_text(json.dumps({"permission": {"bash": "ask"}}), encoding="utf-8")
+    executable_alias = tmp_path / "bin" / "opencode"
+    executable_alias.parent.mkdir(parents=True)
+    executable_alias.symlink_to(Path(sys.executable).resolve())
+    monkeypatch.setenv("PATH", f"{executable_alias.parent}{os.pathsep}{os.environ.get('PATH', '')}")
+    monkeypatch.delenv("OPENCODE_CONFIG_CONTENT", raising=False)
+
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(store, artifact=artifact, context_hash=context_hash, workspace=workspace)
+    original_claim = store.claim_approval_reuse_decisions
+
+    def claim_then_mutate_overlay(decisions, **kwargs) -> bool:
+        claimed = original_claim(decisions, **kwargs)
+        if claimed:
+            overlay_path.write_text(
+                json.dumps({"permission": {"bash": "allow"}, "model": "attacker/model"}),
+                encoding="utf-8",
+            )
+        return claimed
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "get_adapter", lambda _harness: OpenCodeHarnessAdapter())
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", claim_then_mutate_overlay)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("a changed prepared launch environment must not execute"),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        context,
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    assert result["approval_claim"]["reason_code"] == "approval_reuse_context_changed_after_claim"
+
+
+def test_codex_postclaim_setup_uses_authorized_canonical_prefix_after_symlink_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(config.guard_home)
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(store, artifact=artifact, context_hash=context_hash, workspace=tmp_path / "workspace")
+
+    marker = tmp_path / "attacker-executed"
+    safe_codex = _write_test_executable(tmp_path / "safe" / "codex", "#!/bin/sh\nexit 1\n")
+    attacker_codex = _write_test_executable(
+        tmp_path / "attacker" / "codex",
+        f"#!/bin/sh\nprintf attacked > {shlex.quote(str(marker))}\nexit 0\n",
+    )
+    executable_alias = tmp_path / "bin" / "codex"
+    executable_alias.parent.mkdir(parents=True)
+    executable_alias.symlink_to(safe_codex)
+    monkeypatch.setenv("PATH", f"{executable_alias.parent}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    class SwapAtAuthorizedSetupAdapter(CodexHarnessAdapter):
+        def launch_command_from_authorized_plan(self, *args, **kwargs) -> list[str]:
+            executable_alias.unlink()
+            executable_alias.symlink_to(attacker_codex)
+            return super().launch_command_from_authorized_plan(*args, **kwargs)
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(
+        guard_runner_module,
+        "get_adapter",
+        lambda _harness: SwapAtAuthorizedSetupAdapter(),
+    )
+    monkeypatch.setattr(codex_remote_control, "_start_direct_app_server", lambda **_kwargs: False)
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=config.guard_home,
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert executable_alias.resolve() == attacker_codex.resolve()
+    assert marker.exists() is False
+    assert result["blocked"] is False
+    assert result["launched"] is True
+    assert result["launch_command"] == [str(Path("/bin/sh").resolve()), str(safe_codex.resolve())]
+
+
+def test_no_saved_codex_setup_uses_previewed_canonical_prefix_after_symlink_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path, action="allow")
+    store = GuardStore(config.guard_home)
+    marker = tmp_path / "no-saved-attacker-executed"
+    safe_codex = _write_test_executable(tmp_path / "safe-no-saved" / "codex", "#!/bin/sh\nexit 1\n")
+    attacker_codex = _write_test_executable(
+        tmp_path / "attacker-no-saved" / "codex",
+        f"#!/bin/sh\nprintf attacked > {shlex.quote(str(marker))}\nexit 0\n",
+    )
+    executable_alias = tmp_path / "bin-no-saved" / "codex"
+    executable_alias.parent.mkdir(parents=True)
+    executable_alias.symlink_to(safe_codex)
+    monkeypatch.setenv("PATH", f"{executable_alias.parent}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    class SwapAtAuthorizedSetupAdapter(CodexHarnessAdapter):
+        def launch_command_from_authorized_plan(self, *args, **kwargs) -> list[str]:
+            executable_alias.unlink()
+            executable_alias.symlink_to(attacker_codex)
+            return super().launch_command_from_authorized_plan(*args, **kwargs)
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(
+        guard_runner_module,
+        "get_adapter",
+        lambda _harness: SwapAtAuthorizedSetupAdapter(),
+    )
+    monkeypatch.setattr(codex_remote_control, "_start_direct_app_server", lambda **_kwargs: False)
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=config.guard_home,
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert executable_alias.resolve() == attacker_codex.resolve()
+    assert marker.exists() is False
+    assert result["blocked"] is False
+    assert result["launched"] is True
+    assert result["launch_command"] == [str(Path("/bin/sh").resolve()), str(safe_codex.resolve())]
+
+
+def test_guard_run_executes_in_previewed_canonical_cwd_after_workspace_symlink_retarget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    approved_workspace = tmp_path / "approved-workspace"
+    attacker_workspace = tmp_path / "attacker-workspace"
+    approved_workspace.mkdir()
+    attacker_workspace.mkdir()
+    workspace_alias = tmp_path / "workspace-alias"
+    workspace_alias.symlink_to(approved_workspace, target_is_directory=True)
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace_alias,
+        artifact_actions={artifact.artifact_id: "allow"},
+    )
+    store = GuardStore(config.guard_home)
+    cwd_marker = tmp_path / "executed-cwd"
+    command = [
+        sys.executable,
+        "-c",
+        f"from pathlib import Path; Path({str(cwd_marker)!r}).write_text(str(Path.cwd()), encoding='utf-8')",
+    ]
+    events: list[str] = []
+
+    class RetargetingAdapter:
+        def preview_launch_commands(
+            self,
+            _context: HarnessContext,
+            _args: list[str],
+        ) -> tuple[list[str], ...]:
+            events.append("preview")
+            return (list(command),)
+
+        def launch_command_from_authorized_plan(self, *_args, **_kwargs) -> list[str]:
+            events.append("finalize")
+            workspace_alias.unlink()
+            workspace_alias.symlink_to(attacker_workspace, target_is_directory=True)
+            return list(command)
+
+        def prepare_launch_environment(
+            self,
+            _context: HarnessContext,
+            inherited: dict[str, str],
+        ) -> dict[str, str]:
+            return dict(inherited)
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "get_adapter", lambda _harness: RetargetingAdapter())
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=workspace_alias,
+            guard_home=config.guard_home,
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert events == ["preview", "finalize"]
+    assert workspace_alias.resolve() == attacker_workspace.resolve()
+    assert cwd_marker.read_text(encoding="utf-8") == str(approved_workspace.resolve())
+    assert result["blocked"] is False
+    assert result["launched"] is True
+
+
+def test_no_saved_pure_default_finalizer_launches_once_in_canonical_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path, action="allow")
+    store = GuardStore(config.guard_home)
+    workspace = tmp_path / "workspace"
+    command_constructions: list[tuple[str, ...]] = []
+
+    class PureDefaultAdapter(HarnessAdapter):
+        def launch_command(self, _context: HarnessContext, args: list[str]) -> list[str]:
+            command = (sys.executable, "-c", "pass", *args)
+            command_constructions.append(command)
+            return list(command)
+
+        def prepare_launch_environment(
+            self,
+            _context: HarnessContext,
+            inherited: dict[str, str],
+        ) -> dict[str, str]:
+            return dict(inherited)
+
+    adapter = PureDefaultAdapter()
+    executions: list[tuple[list[str], Path]] = []
+
+    def execute(command: list[str], *, cwd: Path, **_kwargs) -> subprocess.CompletedProcess[str]:
+        executions.append((list(command), cwd))
+        return subprocess.CompletedProcess(args=command, returncode=0)
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "get_adapter", lambda _harness: adapter)
+    monkeypatch.setattr(guard_runner_module.subprocess, "run", execute)
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(home_dir=tmp_path, workspace_dir=workspace, guard_home=config.guard_home),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert len(command_constructions) == 2
+    assert executions == [([str(Path(sys.executable).resolve()), "-c", "pass"], workspace.resolve())]
+    assert result["blocked"] is False
+    assert result["launched"] is True
+
+
+def test_grok_previews_do_not_register_and_final_setup_registers_once_after_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    executable = _write_test_executable(tmp_path / "custom-tools" / "grok")
+    artifact = replace(
+        _artifact(tmp_path),
+        artifact_id="grok:project:consumer-review",
+        harness="grok",
+    )
+    detection = _detection(artifact)
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace)
+    store = GuardStore(config.guard_home)
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+        guard_home=config.guard_home,
+        executable_overrides={"grok": str(executable)},
+    )
+    registration = config.guard_home / "managed" / "grok" / "trusted-executable.json"
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(store, artifact=artifact, context_hash=context_hash, workspace=workspace)
+    events: list[str] = []
+
+    class RecordingGrokAdapter(GrokHarnessAdapter):
+        def preview_launch_commands(self, *args, **kwargs) -> tuple[list[str], ...]:
+            events.append("preview")
+            assert registration.exists() is False
+            return super().preview_launch_commands(*args, **kwargs)
+
+        def launch_command(self, *args, **kwargs) -> list[str]:
+            events.append("launch-setup")
+            return super().launch_command(*args, **kwargs)
+
+    original_register = grok_adapter_module.register_trusted_grok_executable
+
+    def register_once(*args, **kwargs):
+        events.append("register")
+        return original_register(*args, **kwargs)
+
+    original_claim = store.claim_approval_reuse_decisions
+
+    def claim_and_record(decisions, **kwargs) -> bool:
+        events.append("claim")
+        assert registration.exists() is False
+        return original_claim(decisions, **kwargs)
+
+    def execute(command, **_kwargs) -> subprocess.CompletedProcess[str]:
+        events.append("execute")
+        return subprocess.CompletedProcess(args=command, returncode=0)
+
+    monkeypatch.setattr(grok_executable_module, "_executable_security_error", lambda *_args: None)
+    monkeypatch.setattr(grok_adapter_module, "register_trusted_grok_executable", register_once)
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "get_adapter", lambda _harness: RecordingGrokAdapter())
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", claim_and_record)
+    monkeypatch.setattr(guard_runner_module.subprocess, "run", execute)
+
+    result = guard_runner_module.guard_run(
+        "grok",
+        context,
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=["--help"],
+    )
+
+    assert events == ["preview", "claim", "preview", "launch-setup", "register", "execute"]
+    assert registration.is_file()
+    assert result["blocked"] is False
+    assert result["launched"] is True
+
+
+def test_no_saved_grok_preview_registers_once_only_in_authorized_finalizer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    executable = _write_test_executable(tmp_path / "custom-tools-no-saved" / "grok")
+    artifact = replace(
+        _artifact(tmp_path),
+        artifact_id="grok:project:no-saved-consumer-review",
+        harness="grok",
+    )
+    detection = _detection(artifact)
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        artifact_actions={artifact.artifact_id: "allow"},
+    )
+    store = GuardStore(config.guard_home)
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+        guard_home=config.guard_home,
+        executable_overrides={"grok": str(executable)},
+    )
+    registration = config.guard_home / "managed" / "grok" / "trusted-executable.json"
+    events: list[str] = []
+
+    class RecordingGrokAdapter(GrokHarnessAdapter):
+        def preview_launch_commands(self, *args, **kwargs) -> tuple[list[str], ...]:
+            events.append("preview")
+            assert registration.exists() is False
+            return super().preview_launch_commands(*args, **kwargs)
+
+        def launch_command(self, *args, **kwargs) -> list[str]:
+            events.append("launch-setup")
+            return super().launch_command(*args, **kwargs)
+
+    original_register = grok_adapter_module.register_trusted_grok_executable
+
+    def register_once(*args, **kwargs):
+        events.append("register")
+        return original_register(*args, **kwargs)
+
+    def execute(command, **_kwargs) -> subprocess.CompletedProcess[str]:
+        events.append("execute")
+        return subprocess.CompletedProcess(args=command, returncode=0)
+
+    monkeypatch.setattr(grok_executable_module, "_executable_security_error", lambda *_args: None)
+    monkeypatch.setattr(grok_adapter_module, "register_trusted_grok_executable", register_once)
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "get_adapter", lambda _harness: RecordingGrokAdapter())
+    monkeypatch.setattr(guard_runner_module.subprocess, "run", execute)
+
+    result = guard_runner_module.guard_run(
+        "grok",
+        context,
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=["--help"],
+    )
+
+    assert events == ["preview", "launch-setup", "register", "execute"]
+    assert registration.is_file()
+    assert result["blocked"] is False
+    assert result["launched"] is True
+
+
+def test_guard_run_rejects_launch_plan_changed_after_saved_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(store, artifact=artifact, context_hash=context_hash, workspace=tmp_path / "workspace")
+    executable_alias = tmp_path / "claim-bound-python"
+    executable_alias.symlink_to(Path(sys.executable).resolve())
+    adapter_calls: list[tuple[str, ...]] = []
+
+    class LaunchAdapter(HarnessAdapter):
+        def launch_command(self, _context: HarnessContext, args: list[str]) -> list[str]:
+            command = (str(executable_alias), "-c", "pass", *args)
+            adapter_calls.append(command)
+            return list(command)
+
+        def prepare_launch_environment(
+            self,
+            _context: HarnessContext,
+            inherited: dict[str, str],
+        ) -> dict[str, str]:
+            return dict(inherited)
+
+    original_claim = store.claim_approval_reuse_decisions
+
+    def claim_then_replace_executable(decisions, **kwargs) -> bool:
+        claimed = original_claim(decisions, **kwargs)
+        if claimed:
+            executable_alias.unlink()
+            executable_alias.symlink_to("/bin/echo")
+        return claimed
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "get_adapter", lambda _harness: LaunchAdapter())
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", claim_then_replace_executable)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("a changed post-claim executable must not launch"),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=tmp_path / "guard-home",
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert adapter_calls == [
+        (str(executable_alias), "-c", "pass"),
+        (str(executable_alias), "-c", "pass"),
+    ]
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    assert result["approval_claim"]["reason_code"] == "approval_reuse_context_changed_after_claim"
+
+
+def test_guard_run_reloads_local_config_after_claim_before_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(store, artifact=artifact, context_hash=context_hash, workspace=tmp_path / "workspace")
+    config_path = store.guard_home / "config.toml"
+    original_claim = store.claim_approval_reuse_decisions
+
+    def claim_then_block(decisions, **kwargs) -> bool:
+        claimed = original_claim(decisions, **kwargs)
+        if claimed:
+            config_path.write_text(
+                f'[artifacts]\n"{artifact.artifact_id}" = "block"\n',
+                encoding="utf-8",
+            )
+        return claimed
+
+    config_refreshes: list[GuardConfig] = []
+
+    def current_config() -> GuardConfig:
+        fresh = load_guard_config(store.guard_home, workspace=tmp_path / "workspace")
+        config_refreshes.append(fresh)
+        return fresh
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", claim_then_block)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("a stronger refreshed config must not launch"),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=tmp_path / "guard-home",
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+        current_config_provider=current_config,
+    )
+
+    assert len(config_refreshes) == 1
+    assert config_refreshes[0].artifact_actions == {artifact.artifact_id: "block"}
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    assert result["approval_claim"]["reason_code"] == "approval_reuse_context_changed_after_claim"
+    assert result["artifacts"][0]["policy_action"] == "block"
+    assert result["artifacts"][0]["approval_reuse_reason_code"] == ("approval_reuse_context_changed_after_claim")
+
+
+@pytest.mark.parametrize("terminal_action", ("block", "sandbox-required"))
+def test_guard_run_reloads_current_config_after_unpersisted_interactive_allow_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    terminal_action: GuardAction,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    initial_config = _config(tmp_path)
+    current_config = _config(tmp_path, action=terminal_action)
+    store = GuardStore(tmp_path / "guard-home")
+    config_refreshes: list[GuardConfig] = []
+
+    def allow_once(_detection: HarnessDetection, evaluation: dict[str, object]) -> dict[str, object]:
+        items = evaluation.get("artifacts")
+        assert isinstance(items, list)
+        item = items[0]
+        assert isinstance(item, dict)
+        assert item["policy_action"] == "review"
+        item["policy_action"] = "allow"
+        item["user_override"] = "allow-once"
+        evaluation["blocked"] = False
+        return evaluation
+
+    def reload_current_config() -> GuardConfig:
+        config_refreshes.append(current_config)
+        return current_config
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("an allow-once approved under stale policy must not launch"),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=tmp_path / "guard-home",
+        ),
+        store,
+        initial_config,
+        dry_run=False,
+        passthrough_args=[],
+        interactive_resolver=allow_once,
+        current_config_provider=reload_current_config,
+    )
+
+    assert config_refreshes == [current_config]
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    item = result["artifacts"][0]
+    assert item["policy_action"] == terminal_action
+    assert item["decision_v2_json"]["action"] == ("ask" if terminal_action == "sandbox-required" else terminal_action)
+    assert item["policy_composition"]["current_action"] == terminal_action
+    assert item["policy_composition"]["trusted_request_override"] is False
+    assert item["trusted_request_override"]["applied"] is False
+    receipts = store.list_receipts(limit=10)
+    assert len(receipts) == 1
+    assert receipts[0]["policy_decision"] == terminal_action
+
+
+def test_guard_run_redetects_interpreted_entrypoint_after_claim_before_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    entrypoint = workspace / "claimed_entrypoint.py"
+    entrypoint.write_text("print('approved')\n", encoding="utf-8")
+    artifact = GuardArtifact(
+        artifact_id="codex:project:claim-time-entrypoint",
+        name="claim-time-entrypoint",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        command=sys.executable,
+        args=(str(entrypoint),),
+        publisher="trusted-publisher",
+        metadata={
+            "guard_default_action": "review",
+            "action_class": "claim-time entrypoint revalidation",
+        },
+    )
+    detection = _detection(artifact)
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    original_context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(store, artifact=artifact, context_hash=original_context_hash, workspace=workspace)
+    detect_calls: list[str] = []
+
+    def detect_current(harness: str, _context: HarnessContext) -> HarnessDetection:
+        detect_calls.append(harness)
+        return detection
+
+    original_claim = store.claim_approval_reuse_decisions
+
+    def claim_then_mutate(decisions, **kwargs) -> bool:
+        claimed = original_claim(decisions, **kwargs)
+        if claimed:
+            entrypoint.write_text("print('changed after claim')\n", encoding="utf-8")
+        return claimed
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", detect_current)
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", claim_then_mutate)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("changed post-claim entrypoint must not launch"),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=workspace,
+            guard_home=tmp_path / "guard-home",
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert detect_calls == ["codex", "codex"]
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    assert result["approval_claim"] == {
+        "status": "rejected",
+        "reason_code": "approval_reuse_context_changed_after_claim",
+        "artifact_ids": [artifact.artifact_id],
+    }
+    item = result["artifacts"][0]
+    assert item["approval_context_hash"] != original_context_hash
+    assert item["policy_action"] == "require-reapproval"
+    assert item["decision_v2_json"]["action"] == "ask"
+    assert item["decision_v2_json"]["reason"] == "approval_reuse_context_changed_after_claim"
+    assert item["approval_reuse_status"] == "rejected"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_context_changed_after_claim"
+    assert item["policy_composition"]["claim_revalidation"] == "changed"
+    assert item["scanner_evidence"][-1] == {
+        "source": "approval_reuse",
+        "status": "rejected",
+        "reason_code": "approval_reuse_context_changed_after_claim",
+        "reason": "launch authority changed after the saved approval was claimed",
+    }
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    assert inventory is not None
+    assert inventory["last_policy_action"] == "require-reapproval"
+    assert inventory["last_approved_at"] is None
+    assert store.get_snapshot("codex", artifact.artifact_id) is None
+    receipts = store.list_receipts(harness="codex")
+    assert len(receipts) == 1
+    assert receipts[0]["policy_decision"] == "require-reapproval"
+    assert receipts[0]["approval_source"] == "approval-reuse"
+    assert receipts[0]["scanner_evidence"][-1] == item["scanner_evidence"][-1]
+    assert (
+        store.peek_local_once_approval(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=original_context_hash,
+            workspace=str(workspace),
+            publisher=artifact.publisher,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is None
+    )
+
+
+def test_guard_run_redetects_changed_mcp_command_immediately_after_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    (workspace / "approved-server.js").write_text("console.log('approved');\n", encoding="utf-8")
+    (workspace / "changed-server.py").write_text("print('changed')\n", encoding="utf-8")
+    initial_artifact = GuardArtifact(
+        artifact_id="codex:project:mcp:claim-time-command",
+        name="claim-time-command",
+        harness="codex",
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        command="node",
+        args=("approved-server.js",),
+        transport="stdio",
+        publisher="trusted-publisher",
+    )
+    changed_artifact = replace(initial_artifact, command="python", args=("changed-server.py",))
+    initial_detection = _detection(initial_artifact)
+    changed_detection = _detection(changed_artifact)
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        artifact_actions={initial_artifact.artifact_id: "review"},
+    )
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(initial_detection, store, config, persist=False)
+    original_context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(
+        store,
+        artifact=initial_artifact,
+        context_hash=original_context_hash,
+        workspace=workspace,
+    )
+    claim_completed = False
+    detect_states: list[str] = []
+
+    def detect_current(_harness: str, _context: HarnessContext) -> HarnessDetection:
+        state = "post-claim" if claim_completed else "pre-claim"
+        detect_states.append(state)
+        return changed_detection if claim_completed else initial_detection
+
+    original_claim = store.claim_approval_reuse_decisions
+
+    def claim_and_expose_changed_config(decisions, **kwargs) -> bool:
+        nonlocal claim_completed
+        claimed = original_claim(decisions, **kwargs)
+        claim_completed = claimed
+        return claimed
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", detect_current)
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", claim_and_expose_changed_config)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("changed post-claim MCP command must not launch"),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(home_dir=tmp_path, workspace_dir=workspace, guard_home=tmp_path / "guard-home"),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert detect_states == ["pre-claim", "post-claim"]
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    assert result["approval_claim"]["reason_code"] == "approval_reuse_context_changed_after_claim"
+    item = result["artifacts"][0]
+    assert item["approval_context_hash"] != original_context_hash
+    assert item["policy_action"] == "require-reapproval"
+    inventory = store.find_inventory_item(initial_artifact.artifact_id)
+    assert inventory is not None
+    assert inventory["launch_command"] == "python changed-server.py"
+    assert inventory["last_policy_action"] == "require-reapproval"
+    receipt = store.list_receipts(harness="codex")[0]
+    assert receipt["policy_decision"] == "require-reapproval"
+    assert receipt["scanner_evidence"][-1]["reason_code"] == "approval_reuse_context_changed_after_claim"
+
+
+def test_guard_run_successful_persistent_exact_claim_finalizes_safe_persistence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    store.upsert_policy(
+        PolicyDecision(
+            harness=artifact.harness,
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=artifact.publisher,
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00+00:00",
+    )
+    launch_calls: list[object] = []
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *args, **kwargs: (
+            launch_calls.append((args, kwargs)) or subprocess.CompletedProcess(args=[], returncode=0)
+        ),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=tmp_path / "guard-home",
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    remaining = store.resolve_policy_decision(
+        artifact.harness,
+        artifact.artifact_id,
+        artifact_hash=context_hash,
+        workspace=str(tmp_path / "workspace"),
+        publisher=artifact.publisher,
+        now="2026-07-17T00:01:00+00:00",
+        consume_one_shot=False,
+    )
+    assert result["blocked"] is False
+    assert result["launched"] is True
+    assert launch_calls
+    assert remaining is not None, "persistent exact approval must remain reusable after claim"
+    assert artifact.artifact_id in store.list_snapshots(artifact.harness)
+    assert inventory is not None
+    assert isinstance(inventory["last_approved_at"], str)
+    assert any(event["event_name"] == "approval.policy_reuse_applied" for event in store.list_events(limit=20))
+
+
+def test_guard_run_retained_claim_disappearing_after_claim_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    store.upsert_policy(
+        PolicyDecision(
+            harness=artifact.harness,
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=artifact.publisher,
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00+00:00",
+    )
+    original_claim = store.claim_approval_reuse_decisions
+
+    def claim_then_delete_retained_row(decisions, **kwargs) -> bool:
+        claimed = original_claim(decisions, **kwargs)
+        if not claimed:
+            return False
+        decision_ids = [decision.get("decision_id") for decision in decisions]
+        with store._connect() as connection:
+            for decision_id in decision_ids:
+                if isinstance(decision_id, int) and not isinstance(decision_id, bool):
+                    connection.execute("delete from policy_decisions where decision_id = ?", (decision_id,))
+        return True
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", claim_then_delete_retained_row)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("missing retained approval must not be treated as consumed proof"),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=tmp_path / "guard-home",
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    assert result["approval_claim"]["reason_code"] == "approval_reuse_context_changed_after_claim"
+    item = result["artifacts"][0]
+    assert item["policy_action"] == "require-reapproval"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_context_changed_after_claim"
+    assert artifact.artifact_id not in store.list_snapshots(artifact.harness)
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    assert inventory is not None
+    assert inventory["last_approved_at"] is None
+    receipt = store.list_receipts(harness="codex")[0]
+    assert receipt["policy_decision"] == "require-reapproval"
+    assert receipt["scanner_evidence"][-1]["reason_code"] == "approval_reuse_context_changed_after_claim"
+
+
+def test_guard_run_successful_reusable_exact_claim_finalizes_safe_persistence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = replace(
+        _artifact(tmp_path),
+        artifact_id="codex:project:package-request:consumer-review",
+        name="reusable consumer review",
+    )
+    detection = _detection(artifact)
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=tmp_path / "workspace")
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(
+        store,
+        artifact=artifact,
+        context_hash=context_hash,
+        workspace=tmp_path / "workspace",
+        request_id="consumer-reusable-exact",
+    )
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *args, **_kwargs: subprocess.CompletedProcess(args=args, returncode=0),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=tmp_path / "guard-home",
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    remaining = store.peek_local_once_approval(
+        harness=artifact.harness,
+        artifact_id=artifact.artifact_id,
+        artifact_hash=context_hash,
+        workspace=str(tmp_path / "workspace"),
+        publisher=artifact.publisher,
+        now="2026-07-17T00:01:00+00:00",
+    )
+    assert result["blocked"] is False
+    assert result["launched"] is True
+    assert remaining is not None, "reusable local approval must remain available after claim"
+    assert artifact.artifact_id in store.list_snapshots(artifact.harness)
+    assert inventory is not None
+    assert isinstance(inventory["last_approved_at"], str)
+    assert any(event["event_name"] == "approval.local_once_reused" for event in store.list_events(limit=20))
+
+
+def test_guard_run_dry_run_never_claims_exact_saved_review_allow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(store, artifact=artifact, context_hash=context_hash, workspace=tmp_path / "workspace")
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=tmp_path / "guard-home",
+        ),
+        store,
+        config,
+        dry_run=True,
+        passthrough_args=[],
+    )
+
+    assert result["blocked"] is False
+    assert result["launched"] is False
+    assert artifact.artifact_id not in store.list_snapshots(artifact.harness)
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    assert inventory is not None
+    assert inventory["last_approved_at"] is None
+    assert (
+        store.peek_local_once_approval(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=artifact.publisher,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is not None
+    )
+
+
+def test_guard_run_blocked_sibling_leaves_saved_review_allow_unclaimed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    approved_artifact = _artifact(tmp_path)
+    blocked_artifact = replace(
+        approved_artifact,
+        artifact_id="codex:project:consumer-blocked-sibling",
+        name="consumer-blocked-sibling",
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(approved_artifact.config_path,),
+        artifacts=(approved_artifact, blocked_artifact),
+    )
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=tmp_path / "workspace",
+        artifact_actions={blocked_artifact.artifact_id: "block"},
+    )
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    approved_item = next(item for item in initial["artifacts"] if item["artifact_id"] == approved_artifact.artifact_id)
+    context_hash = str(approved_item["approval_context_hash"])
+    _record_once(
+        store,
+        artifact=approved_artifact,
+        context_hash=context_hash,
+        workspace=tmp_path / "workspace",
+    )
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("blocked aggregate must not launch"),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=tmp_path / "guard-home",
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    assert (
+        store.peek_local_once_approval(
+            harness=approved_artifact.harness,
+            artifact_id=approved_artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=approved_artifact.publisher,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is not None
+    )
+
+
+def test_guard_run_unverified_preclaim_launch_identity_is_persisted_separately_from_claim_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(store, artifact=artifact, context_hash=context_hash, workspace=tmp_path / "workspace")
+    claim_calls: list[object] = []
+
+    class MissingLaunchAdapter(HarnessAdapter):
+        def launch_command(self, _context: HarnessContext, args: list[str]) -> list[str]:
+            return [str(tmp_path / "missing-harness-executable"), *args]
+
+        def prepare_launch_environment(
+            self,
+            _context: HarnessContext,
+            inherited: dict[str, str],
+        ) -> dict[str, str]:
+            return dict(inherited)
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "get_adapter", lambda _harness: MissingLaunchAdapter())
+    monkeypatch.setattr(
+        store,
+        "claim_approval_reuse_decisions",
+        lambda *_args, **_kwargs: claim_calls.append(object()) or True,
+    )
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("an unverified launch identity must not launch"),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=tmp_path / "guard-home",
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert claim_calls == []
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    assert result["approval_claim"] == {
+        "status": "rejected",
+        "reason_code": "approval_reuse_launch_identity_unverified",
+        "artifact_ids": [artifact.artifact_id],
+    }
+    item = result["artifacts"][0]
+    assert item["policy_action"] == "require-reapproval"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_launch_identity_unverified"
+    assert item["policy_composition"]["claim_revalidation"] == "unverified"
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    assert inventory is not None
+    assert inventory["last_policy_action"] == "require-reapproval"
+    assert inventory["last_approved_at"] is None
+    receipt = store.list_receipts(harness="codex")[0]
+    assert receipt["policy_decision"] == "require-reapproval"
+    assert receipt["approval_source"] == "approval-reuse"
+    assert receipt["scanner_evidence"][-1]["reason_code"] == "approval_reuse_launch_identity_unverified"
+    assert (
+        store.peek_local_once_approval(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=artifact.publisher,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is not None
+    )
+
+
+def test_guard_run_atomic_claim_exception_is_persisted_without_error_disclosure_or_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(config.guard_home)
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(store, artifact=artifact, context_hash=context_hash, workspace=tmp_path / "workspace")
+    raw_database_error = "raw sqlite detail: guard_local_once_approvals disk image is malformed"
+
+    def raise_claim_error(*_args, **_kwargs) -> bool:
+        raise sqlite3.OperationalError(raw_database_error)
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", raise_claim_error)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("an exceptional approval claim must not launch"),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=config.guard_home,
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    assert result["launch_command"] == []
+    assert result["approval_claim"]["reason_code"] == "approval_reuse_claim_failed"
+    assert raw_database_error not in json.dumps(result, sort_keys=True, default=str)
+    receipt = store.list_receipts(harness="codex")[0]
+    assert receipt["policy_decision"] == "require-reapproval"
+    assert receipt["scanner_evidence"][-1]["reason_code"] == "approval_reuse_claim_failed"
+
+
+def test_guard_run_batch_claim_failure_consumes_no_saved_review_allow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_artifact = _artifact(tmp_path)
+    second_artifact = replace(
+        first_artifact,
+        artifact_id="codex:project:consumer-review-second",
+        name="consumer-review-second",
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(first_artifact.config_path,),
+        artifacts=(first_artifact, second_artifact),
+    )
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=tmp_path / "workspace")
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hashes = {str(item["artifact_id"]): str(item["approval_context_hash"]) for item in initial["artifacts"]}
+    for index, artifact in enumerate(detection.artifacts):
+        _record_once(
+            store,
+            artifact=artifact,
+            context_hash=context_hashes[artifact.artifact_id],
+            workspace=tmp_path / "workspace",
+            request_id=f"consumer-review-once-{index}",
+        )
+    claim_calls: list[tuple[object, ...]] = []
+
+    def fail_batch_claim(decisions, **_kwargs) -> bool:
+        claim_calls.append(tuple(decisions))
+        return False
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", fail_batch_claim)
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("failed approval claim must not launch"),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=tmp_path / "guard-home",
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    assert result["approval_claim"]["reason_code"] == "approval_reuse_claim_failed"
+    assert len(claim_calls) == 1
+    assert len(claim_calls[0]) == 2
+    for item in result["artifacts"]:
+        assert item["policy_action"] == "require-reapproval"
+        assert item["approval_reuse_status"] == "rejected"
+        assert item["approval_reuse_reason_code"] == "approval_reuse_claim_failed"
+        assert item["approval_reuse"]["action"] == "require-reapproval"
+        assert item["approval_reuse"]["should_claim"] is False
+        assert item["decision_v2_json"]["action"] == "ask"
+        assert item["decision_v2_json"]["reason"] == "approval_reuse_claim_failed"
+        assert item["policy_composition"]["final_action"] == "require-reapproval"
+        assert item["policy_composition"]["claim_revalidation"] == "claim-failed"
+        assert item["scanner_evidence"][-1]["reason_code"] == "approval_reuse_claim_failed"
+    for artifact in detection.artifacts:
+        inventory = store.find_inventory_item(artifact.artifact_id)
+        assert inventory is not None
+        assert inventory["last_policy_action"] == "require-reapproval"
+        assert inventory["last_approved_at"] is None
+        assert (
+            store.peek_local_once_approval(
+                harness=artifact.harness,
+                artifact_id=artifact.artifact_id,
+                artifact_hash=context_hashes[artifact.artifact_id],
+                workspace=str(tmp_path / "workspace"),
+                publisher=artifact.publisher,
+                now="2026-07-17T00:01:00+00:00",
+            )
+            is not None
+        )
+    assert store.list_snapshots("codex") == {}
+    receipts = store.list_receipts(harness="codex")
+    assert {receipt["artifact_id"] for receipt in receipts} == {
+        first_artifact.artifact_id,
+        second_artifact.artifact_id,
+    }
+    for receipt in receipts:
+        assert receipt["policy_decision"] == "require-reapproval"
+        assert receipt["approval_source"] == "approval-reuse"
+        assert receipt["scanner_evidence"][-1]["reason_code"] == "approval_reuse_claim_failed"
+
+
+def test_fresh_trusted_request_override_allows_only_the_exact_current_reapproval(
+    tmp_path: Path,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path, action="require-reapproval")
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+
+    result = evaluate_detection(
+        detection,
+        store,
+        config,
+        persist=True,
+        trusted_request_overrides={artifact.artifact_id: context_hash},
+    )
+    item = result["artifacts"][0]
+    receipt = store.list_receipts(limit=1)[0]
+
+    assert result["blocked"] is False
+    assert item["policy_action"] == "allow"
+    assert item["policy_composition"]["current_action"] == "require-reapproval"
+    assert item["policy_composition"]["trusted_request_override"] is True
+    assert item["approval_reuse_reason_code"] == "approval_reuse_no_saved_decision"
+    assert item["trusted_request_override"] == {
+        "applied": True,
+        "reason_code": "trusted_request_override_exact_context",
+    }
+    assert item["scanner_evidence"][-1]["reason_code"] == "trusted_request_override_exact_context"
+    assert receipt["policy_decision"] == "allow"
+    assert receipt["approval_source"] == "fresh-approval"
+
+
+@pytest.mark.parametrize("terminal_action", ("sandbox-required", "block"))
+def test_fresh_trusted_request_override_cannot_lower_terminal_current_action(
+    tmp_path: Path,
+    terminal_action: GuardAction,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path, action=terminal_action)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+
+    result = evaluate_detection(
+        detection,
+        store,
+        config,
+        persist=False,
+        trusted_request_overrides={artifact.artifact_id: context_hash},
+    )
+    item = result["artifacts"][0]
+
+    assert result["blocked"] is True
+    assert item["policy_action"] == terminal_action
+    assert item["policy_composition"]["trusted_request_override"] is False
+    assert item["trusted_request_override"]["applied"] is False
+
+
+def test_fresh_trusted_request_override_rejects_changed_context_token(tmp_path: Path) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    artifact_script = tmp_path / "workspace" / "consumer-review.js"
+    artifact_script.write_text("console.log('changed');\n", encoding="utf-8")
+
+    result = evaluate_detection(
+        detection,
+        store,
+        config,
+        persist=False,
+        trusted_request_overrides={artifact.artifact_id: context_hash},
+    )
+    item = result["artifacts"][0]
+
+    assert result["blocked"] is True
+    assert item["policy_action"] == "review"
+    assert item["approval_context_hash"] != context_hash
+    assert item["policy_composition"]["trusted_request_override"] is False
+
+
+@pytest.mark.parametrize(
+    ("stronger_action", "reason_code"),
+    (
+        ("require-reapproval", "approval_reuse_reapproval_required"),
+        ("sandbox-required", "approval_reuse_sandbox_required"),
+        ("block", "approval_reuse_current_block"),
+    ),
+)
+def test_matching_saved_allow_is_composed_non_consumingly_before_any_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stronger_action: GuardAction,
+    reason_code: str,
+) -> None:
+    artifact = _artifact(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+
+    def exact_saved_allow(*_args: object, **kwargs: object) -> dict[str, object]:
+        assert kwargs["consume_one_shot"] is False
+        return {
+            "decision": {
+                "action": "allow",
+                "artifact_hash": kwargs["artifact_hash"],
+                "decision_id": 777,
+                "source": "approval-gate",
+            },
+            "ignored_local_integrity": None,
+            "trust_status": {},
+        }
+
+    monkeypatch.setattr(store, "resolve_policy_decision_lookup_with_memory_pattern", exact_saved_allow)
+
+    def reject_early_claim(*_args: object, **_kwargs: object) -> bool:
+        raise AssertionError("strong current action must be composed before claim")
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", reject_early_claim)
+
+    result = evaluate_detection(
+        _detection(artifact),
+        store,
+        _config(tmp_path, action=stronger_action),
+        persist=False,
+    )
+    item = result["artifacts"][0]
+
+    assert item["policy_action"] == stronger_action
+    assert item["approval_reuse_status"] == "rejected"
+    assert item["approval_reuse_reason_code"] == reason_code
+
+
+def test_evaluation_records_exact_saved_allow_without_claiming_before_launch(
+    tmp_path: Path,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(
+        store,
+        artifact=artifact,
+        context_hash=context_hash,
+        workspace=tmp_path / "workspace",
+    )
+
+    preview = evaluate_detection(detection, store, config, persist=False)
+    preview_item = preview["artifacts"][0]
+    assert preview_item["policy_action"] == "allow"
+    assert preview_item["approval_reuse_status"] == "accepted"
+    assert (
+        store.peek_local_once_approval(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=artifact.publisher,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is not None
+    )
+
+    result = evaluate_detection(detection, store, config, persist=True)
+    item = result["artifacts"][0]
+    receipt = store.list_receipts(limit=1)[0]
+
+    assert item["approval_context_hash"] == context_hash
+    assert item["policy_action"] == "allow"
+    assert item["approval_reuse_status"] == "accepted"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_accepted"
+    assert item["policy_composition"] == {
+        "configured_action": None,
+        "current_action": "review",
+        "saved_action": "allow",
+        "saved_state_present": True,
+        "scanner_action": item["verdict_action"],
+        "scoring_recommendation": item["verdict_action"],
+        "final_action": "allow",
+        "trusted_request_override": False,
+    }
+    assert result["blocked"] is False
+    assert receipt["policy_decision"] == "allow"
+    assert receipt["approval_source"] == "saved-approval"
+    assert receipt["scanner_evidence"][-1]["reason_code"] == "approval_reuse_accepted"
+    assert artifact.artifact_id not in store.list_snapshots(artifact.harness)
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    assert inventory is not None
+    assert inventory["last_approved_at"] is None
+    assert (
+        store.peek_local_once_approval(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=artifact.publisher,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is not None
+    )
+
+
+def test_changed_context_cannot_use_stale_claim_proof_to_finalize_persistence(tmp_path: Path) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    old_context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(
+        store,
+        artifact=artifact,
+        context_hash=old_context_hash,
+        workspace=tmp_path / "workspace",
+    )
+    (tmp_path / "workspace" / "consumer-review.js").write_text(
+        "console.log('changed after claim');\n",
+        encoding="utf-8",
+    )
+
+    result = evaluate_detection(
+        detection,
+        store,
+        config,
+        persist=True,
+        claimed_saved_approval_overrides={artifact.artifact_id: old_context_hash},
+    )
+
+    item = result["artifacts"][0]
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    assert item["approval_context_hash"] != old_context_hash
+    assert item["policy_action"] == "review"
+    assert item["approval_reuse_status"] == "rejected"
+    assert artifact.artifact_id not in store.list_snapshots(artifact.harness)
+    assert inventory is not None
+    assert inventory["last_approved_at"] is None
+
+
+def test_exact_claim_proof_cannot_override_saved_block_visible_during_persistence(tmp_path: Path) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    store.upsert_policy(
+        PolicyDecision(
+            harness=artifact.harness,
+            scope="artifact",
+            action="block",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=artifact.publisher,
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00+00:00",
+    )
+
+    result = evaluate_detection(
+        detection,
+        store,
+        config,
+        persist=True,
+        claimed_saved_approval_overrides={artifact.artifact_id: context_hash},
+    )
+
+    item = result["artifacts"][0]
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    assert item["approval_context_hash"] == context_hash
+    assert item["policy_action"] == "block"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_saved_block"
+    assert artifact.artifact_id not in store.list_snapshots(artifact.harness)
+    assert inventory is not None
+    assert inventory["last_approved_at"] is None
+
+
+def test_retained_claim_proof_requires_fresh_exact_allow_during_persistence(
+    tmp_path: Path,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+
+    result = evaluate_detection(
+        detection,
+        store,
+        config,
+        persist=True,
+        retained_saved_approval_overrides={artifact.artifact_id: context_hash},
+    )
+
+    item = result["artifacts"][0]
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    assert item["approval_context_hash"] == context_hash
+    assert item["policy_action"] == "review"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_no_saved_decision"
+    assert artifact.artifact_id not in store.list_snapshots(artifact.harness)
+    assert inventory is not None
+    assert inventory["last_approved_at"] is None
+
+
+def _with_runtime_detector_telemetry(
+    evaluation: dict[str, object],
+    *,
+    status: str,
+    elapsed_ms: int,
+    error_type: str | None = None,
+) -> dict[str, object]:
+    return {
+        **evaluation,
+        "runtime_detector_signals_v2": [],
+        "runtime_detector_telemetry": [
+            {
+                "detector_id": "semantic.detector",
+                "categories": ["execution", "bypass"],
+                "status": status,
+                "elapsed_ms": elapsed_ms,
+                "error_type": error_type,
+                "semantic_revision": "v1",
+            }
+        ],
+        "runtime_detector_composition": {
+            "action": "allow",
+            "reason": "no detector signal",
+            "downgraded": False,
+            "upgraded": False,
+        },
+    }
+
+
+def test_runtime_detector_context_excludes_only_elapsed_and_normalizes_semantics() -> None:
+    context = guard_runner_module._runtime_detector_context(
+        _with_runtime_detector_telemetry(
+            {"blocked": False, "artifacts": []},
+            status="ok",
+            elapsed_ms=917,
+        )
+    )
+
+    assert context is not None
+    assert context["telemetry"] == [
+        {
+            "detector_id": "semantic.detector",
+            "categories": ["bypass", "execution"],
+            "status": "ok",
+            "error_type": None,
+            "semantic_revision": "v1",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("postclaim_status", "postclaim_error_type"),
+    (("timeout", None), ("error", "RuntimeError")),
+    ids=("ok-to-timeout", "ok-to-error"),
+)
+def test_runtime_detector_telemetry_status_change_after_claim_prevents_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    postclaim_status: str,
+    postclaim_error_type: str | None,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(config.guard_home)
+    initial_base = evaluate_detection(detection, store, config, persist=False)
+    initial_detector_evaluation = _with_runtime_detector_telemetry(
+        initial_base,
+        status="ok",
+        elapsed_ms=1,
+    )
+    initial_detector_context = guard_runner_module._runtime_detector_context(initial_detector_evaluation)
+    assert initial_detector_context is not None
+    initial = evaluate_detection(
+        detection,
+        store,
+        config,
+        persist=False,
+        runtime_detector_context=initial_detector_context,
+    )
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(store, artifact=artifact, context_hash=context_hash, workspace=tmp_path / "workspace")
+    detector_runs = iter((("ok", 12, None), (postclaim_status, 987, postclaim_error_type)))
+
+    def detector_evaluation(evaluation, *_args):
+        status, elapsed_ms, error_type = next(detector_runs)
+        return _with_runtime_detector_telemetry(
+            evaluation,
+            status=status,
+            elapsed_ms=elapsed_ms,
+            error_type=error_type,
+        )
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "_evaluation_with_detector_registry", detector_evaluation)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("changed detector execution status must prevent launch"),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=config.guard_home,
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    assert result["approval_claim"]["reason_code"] == "approval_reuse_context_changed_after_claim"
+    assert result["runtime_detector_telemetry"][0]["status"] == postclaim_status
+    assert result["runtime_detector_telemetry"][0]["error_type"] == postclaim_error_type
+
+
+def test_runtime_detector_unchanged_status_ignores_elapsed_ms_and_launches_after_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(config.guard_home)
+    initial_base = evaluate_detection(detection, store, config, persist=False)
+    initial_detector_evaluation = _with_runtime_detector_telemetry(
+        initial_base,
+        status="ok",
+        elapsed_ms=1,
+    )
+    initial_detector_context = guard_runner_module._runtime_detector_context(initial_detector_evaluation)
+    assert initial_detector_context is not None
+    initial = evaluate_detection(
+        detection,
+        store,
+        config,
+        persist=False,
+        runtime_detector_context=initial_detector_context,
+    )
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(store, artifact=artifact, context_hash=context_hash, workspace=tmp_path / "workspace")
+    elapsed_values = iter((19, 991))
+
+    def detector_evaluation(evaluation, *_args):
+        return _with_runtime_detector_telemetry(
+            evaluation,
+            status="ok",
+            elapsed_ms=next(elapsed_values),
+        )
+
+    launches: list[list[str]] = []
+
+    def launch(command: list[str], **_kwargs) -> subprocess.CompletedProcess[str]:
+        launches.append(list(command))
+        return subprocess.CompletedProcess(args=command, returncode=0)
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "_evaluation_with_detector_registry", detector_evaluation)
+    monkeypatch.setattr(guard_runner_module.subprocess, "run", launch)
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path / "workspace",
+            guard_home=config.guard_home,
+        ),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert result["blocked"] is False
+    assert result["launched"] is True
+    assert result["runtime_detector_telemetry"][0]["elapsed_ms"] == 991
+    assert len(launches) == 1
+
+
+def test_runtime_detector_signal_change_invalidates_exact_saved_approval(
+    tmp_path: Path,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    first_detector_context = {
+        "composition": {"action": "review", "reason": "persistence signal alpha"},
+        "signals": [{"detector_id": "persistence", "signal_id": "alpha"}],
+    }
+    second_detector_context = {
+        "composition": {"action": "review", "reason": "persistence signal beta"},
+        "signals": [{"detector_id": "persistence", "signal_id": "beta"}],
+    }
+    first = evaluate_detection(
+        detection,
+        store,
+        config,
+        persist=False,
+        runtime_detector_context=first_detector_context,
+    )
+    first_context_hash = str(first["artifacts"][0]["approval_context_hash"])
+    _record_once(
+        store,
+        artifact=artifact,
+        context_hash=first_context_hash,
+        workspace=tmp_path / "workspace",
+    )
+
+    unchanged = evaluate_detection(
+        detection,
+        store,
+        config,
+        persist=False,
+        runtime_detector_context=first_detector_context,
+    )
+    changed = evaluate_detection(
+        detection,
+        store,
+        config,
+        persist=False,
+        runtime_detector_context=second_detector_context,
+    )
+
+    assert unchanged["artifacts"][0]["approval_context_hash"] == first_context_hash
+    assert unchanged["artifacts"][0]["policy_action"] == "allow"
+    assert changed["artifacts"][0]["approval_context_hash"] != first_context_hash
+    assert changed["artifacts"][0]["policy_action"] == "review"
+    assert changed["artifacts"][0]["approval_reuse_reason_code"] == ("approval_reuse_capability_changed")
+    assert (
+        store.peek_local_once_approval(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=first_context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=artifact.publisher,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is not None
+    )
+
+
+def test_changed_sandbox_context_rejects_review_allow_without_consuming_it(tmp_path: Path) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    baseline_config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, baseline_config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(
+        store,
+        artifact=artifact,
+        context_hash=context_hash,
+        workspace=tmp_path / "workspace",
+    )
+    changed_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=tmp_path / "workspace",
+        sandbox_analysis="strict",
+    )
+
+    result = evaluate_detection(detection, store, changed_config, persist=False)
+    item = result["artifacts"][0]
+
+    assert item["policy_action"] == "review"
+    assert item["approval_reuse_status"] == "rejected"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_sandbox_changed"
+    assert (
+        store.peek_local_once_approval(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=artifact.publisher,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is not None
+    )
+
+
+def test_changed_effective_workspace_rejects_review_allow_as_identity_change(tmp_path: Path) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    baseline_config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, baseline_config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(
+        store,
+        artifact=artifact,
+        context_hash=context_hash,
+        workspace=tmp_path / "workspace",
+    )
+    changed_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=tmp_path / "different-workspace",
+    )
+
+    result = evaluate_detection(detection, store, changed_config, persist=False)
+    item = result["artifacts"][0]
+
+    assert item["policy_action"] == "review"
+    assert item["approval_reuse_status"] == "rejected"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_identity_changed"
+    assert (
+        store.peek_local_once_approval(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=artifact.publisher,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is not None
+    )
+
+
+def test_changed_scanner_provenance_rejects_review_allow_as_capability_change(tmp_path: Path) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    config = _config(tmp_path)
+    store = GuardStore(tmp_path / "guard-home")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    _record_once(
+        store,
+        artifact=artifact,
+        context_hash=context_hash,
+        workspace=tmp_path / "workspace",
+    )
+    store.cache_advisories(
+        [
+            {
+                "id": "consumer-provenance-block",
+                "publisher": artifact.publisher,
+                "severity": "high",
+                "action": "block",
+                "headline": "Publisher trust changed after approval.",
+            }
+        ],
+        "2026-07-17T00:01:00+00:00",
+    )
+
+    result = evaluate_detection(detection, store, config, persist=False)
+    item = result["artifacts"][0]
+
+    assert item["policy_action"] == "block"
+    assert item["policy_composition"]["current_action"] == "block"
+    assert item["policy_composition"]["scanner_action"] == "block"
+    assert item["approval_reuse_status"] == "rejected"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_capability_changed"
+    assert item["provenance"]["publisher_trust"] == "flagged"
+    assert result["blocked"] is True
+    assert (
+        store.peek_local_once_approval(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(tmp_path / "workspace"),
+            publisher=artifact.publisher,
+            now="2026-07-17T00:02:00+00:00",
+        )
+        is not None
+    )
+
+
+def test_saved_block_remains_authoritative_after_current_review_is_computed(tmp_path: Path) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    store = GuardStore(tmp_path / "guard-home")
+    store.upsert_policy(
+        PolicyDecision(
+            harness=artifact.harness,
+            scope="artifact",
+            action="block",
+            artifact_id=artifact.artifact_id,
+            reason="intentional saved block",
+        ),
+        "2026-07-17T00:00:00+00:00",
+    )
+
+    result = evaluate_detection(detection, store, _config(tmp_path), persist=False)
+    item = result["artifacts"][0]
+
+    assert item["policy_composition"]["current_action"] == "review"
+    assert item["policy_composition"]["saved_action"] == "block"
+    assert item["policy_action"] == "block"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_saved_block"
+    assert result["blocked"] is True
+
+
+def test_consumer_current_allow_and_exact_allow_do_not_hide_tampered_broader_authority(
+    tmp_path: Path,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    store = GuardStore(tmp_path / "guard-home")
+    config = _config(tmp_path, action="allow")
+    initial = evaluate_detection(detection, store, config, persist=False)
+    initial_item = initial["artifacts"][0]
+    context_hash = str(initial_item["approval_context_hash"])
+    assert initial_item["policy_composition"]["current_action"] == "allow"
+    approval_id = _record_once(
+        store,
+        artifact=artifact,
+        context_hash=context_hash,
+        workspace=tmp_path / "workspace",
+        request_id="consumer-current-allow-integrity-collision",
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness=artifact.harness,
+            scope="global",
+            action="block",
+            reason="tampered broader authority must not be ignored",
+            source="manual",
+        ),
+        "2026-07-17T00:01:00+00:00",
+    )
+    broader_block = next(
+        item
+        for item in store.list_policy_decisions(artifact.harness)
+        if item["scope"] == "global" and item["action"] == "block"
+    )
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "update policy_decisions set payload_mac = ? where decision_id = ?",
+            ("00", broader_block["decision_id"]),
+        )
+
+    result = evaluate_detection(detection, store, config, persist=False)
+    item = result["artifacts"][0]
+    with sqlite3.connect(store.path) as connection:
+        claimed_at = connection.execute(
+            "select claimed_at from guard_local_once_approvals where approval_id = ?",
+            (approval_id,),
+        ).fetchone()[0]
+
+    assert item["policy_composition"]["current_action"] == "allow"
+    assert item["policy_composition"]["saved_action"] == "allow"
+    assert item["policy_action"] == "require-reapproval"
+    assert item["approval_reuse_status"] == "rejected"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_integrity_failure"
+    assert result["blocked"] is True
+    assert claimed_at is None
+
+
+def test_consumer_current_allow_detects_tampered_block_moved_out_of_exact_lookup(
+    tmp_path: Path,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    store = GuardStore(tmp_path / "guard-home")
+    config = _config(tmp_path, action="allow")
+    initial_item = evaluate_detection(detection, store, config, persist=False)["artifacts"][0]
+    current_context = str(initial_item["approval_context_hash"])
+    store.upsert_policy(
+        PolicyDecision(
+            harness=artifact.harness,
+            scope="artifact",
+            action="block",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=current_context,
+            reason="signed block moved by local database tampering",
+            source="manual",
+        ),
+        "2026-07-17T00:01:00+00:00",
+    )
+    moved_context = build_approval_context_token(
+        identity={"artifact_id": artifact.artifact_id},
+        content={"artifact_hash": "tampered"},
+        capabilities={},
+        policy={},
+        sandbox={},
+    )
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            """
+            update policy_decisions
+            set action = 'allow', artifact_hash = ?
+            where artifact_id = ? and action = 'block'
+            """,
+            (moved_context, artifact.artifact_id),
+        )
+
+    item = evaluate_detection(detection, store, config, persist=False)["artifacts"][0]
+
+    assert item["policy_composition"]["current_action"] == "allow"
+    assert item["policy_action"] == "require-reapproval"
+    assert item["approval_reuse_status"] == "rejected"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_integrity_failure"
+
+
+def test_consumer_current_allow_ignores_tampered_nonmatching_local_row(tmp_path: Path) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    store = GuardStore(tmp_path / "guard-home")
+    config = _config(tmp_path, action="allow")
+    unrelated_context = build_approval_context_token(
+        identity={"artifact_id": "codex:project:unrelated"},
+        content={"artifact_hash": "unrelated"},
+        capabilities={},
+        policy={},
+        sandbox={},
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness=artifact.harness,
+            scope="artifact",
+            action="block",
+            artifact_id="codex:project:unrelated",
+            artifact_hash=unrelated_context,
+            reason="unrelated signed authority",
+            source="manual",
+        ),
+        "2026-07-17T00:01:00+00:00",
+    )
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            """
+            update policy_decisions
+            set action = 'allow', artifact_hash = 'guard-approval-context:v1:tampered'
+            where artifact_id = 'codex:project:unrelated'
+            """
+        )
+
+    item = evaluate_detection(detection, store, config, persist=False)["artifacts"][0]
+
+    assert item["policy_composition"]["current_action"] == "allow"
+    assert item["policy_action"] == "allow"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_no_saved_decision"
+
+
+@pytest.mark.parametrize("queued_action", ("review", "require-reapproval"))
+def test_approval_queue_persists_exact_v1_context_instead_of_legacy_content_hash(
+    tmp_path: Path,
+    queued_action: GuardAction,
+) -> None:
+    artifact = _artifact(tmp_path)
+    detection = _detection(artifact)
+    store = GuardStore(tmp_path / "guard-home")
+    config = _config(tmp_path, action=queued_action)
+    evaluation = evaluate_detection(detection, store, config, persist=False)
+
+    queued = queue_blocked_approvals(
+        detection=detection,
+        evaluation=evaluation,
+        store=store,
+        approval_center_url="http://127.0.0.1:4455",
+    )
+
+    assert len(queued) == 1
+    assert queued[0]["policy_action"] == queued_action
+    assert queued[0]["artifact_hash"] == evaluation["artifacts"][0]["approval_context_hash"]
+    assert parse_approval_context_token(queued[0]["artifact_hash"]) is not None
+    assert queued[0]["artifact_hash"] != evaluation["artifacts"][0]["artifact_hash"]
+    assert queued[0]["workspace"] == str((tmp_path / "workspace").resolve())

--- a/tests/test_guard_copilot_benign_policy_hint.py
+++ b/tests/test_guard_copilot_benign_policy_hint.py
@@ -1,0 +1,359 @@
+"""Trust-boundary regressions for Copilot generic hook policy hints."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.cli.commands_hook_generic import _run_hook_generic_payload
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.models import GuardAction, PolicyDecision
+from codex_plugin_scanner.guard.runtime import approval_context as approval_context_module
+from codex_plugin_scanner.guard.store import GuardStore
+
+_IGNORED_BENIGN_HINT_REASON = "untrusted_hook_payload_hint_ignored_guard_verified_benign"
+_BENIGN_COMMAND = (
+    "cd /tmp/hol-guard-fixtures/hashgraph-online && python - <<'PY'\n"
+    "from pathlib import Path\n"
+    "text = Path('bounty_submissions.txt').read_text()\n"
+    "print('bytes', len(text))\n"
+    "print('rows', text.count('data-testid=\"portal-grid-row\"'))\n"
+    "PY"
+)
+
+
+def _copilot_payload(
+    *,
+    command: str = _BENIGN_COMMAND,
+    policy_action: GuardAction = "block",
+) -> dict[str, object]:
+    return {
+        "hook_name": "preToolUse",
+        "tool_name": "bash",
+        "tool_input": {"command": command},
+        "policy_action": policy_action,
+        "source_scope": "project",
+    }
+
+
+def _run_copilot_generic_hook(
+    *,
+    config: GuardConfig,
+    payload: dict[str, object],
+    store: GuardStore,
+    workspace: Path,
+    cli_action: GuardAction | None = None,
+) -> tuple[int, dict[str, object], dict[str, object]]:
+    output = io.StringIO()
+    rc = _run_hook_generic_payload(
+        argparse.Namespace(
+            artifact_id=None,
+            artifact_name=None,
+            harness="copilot",
+            json=False,
+            policy_action=cli_action,
+        ),
+        action_envelope=None,
+        config=config,
+        home_dir=workspace.parent / "home",
+        output_stream=output,
+        payload=payload,
+        runtime_workspace=workspace,
+        store=store,
+    )
+    response_value = json.loads(output.getvalue())
+    assert isinstance(response_value, dict)
+    response = cast(dict[str, object], response_value)
+    receipt = store.list_receipts(limit=1)[0]
+    return rc, response, receipt
+
+
+def _receipt_evidence(receipt: dict[str, object], source: str) -> dict[str, object]:
+    evidence = receipt["scanner_evidence"]
+    assert isinstance(evidence, list)
+    for raw_item in cast(list[object], evidence):
+        if not isinstance(raw_item, dict):
+            continue
+        item = cast(dict[str, object], raw_item)
+        if item.get("source") == source:
+            return item
+    raise AssertionError(f"missing {source!r} scanner evidence")
+
+
+def _guard_config(
+    tmp_path: Path,
+    workspace: Path,
+    *,
+    default_action: GuardAction = "warn",
+) -> GuardConfig:
+    return GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action=default_action,
+    )
+
+
+def test_verified_benign_copilot_legacy_block_hint_stays_prompt_free_with_evidence(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+
+    rc, response, receipt = _run_copilot_generic_hook(
+        config=_guard_config(tmp_path, workspace),
+        payload=_copilot_payload(),
+        store=store,
+        workspace=workspace,
+    )
+
+    assert rc == 0
+    assert response == {"permissionDecision": "allow"}
+    assert receipt["policy_decision"] == "warn"
+    assert store.list_approval_requests() == []
+    composition = _receipt_evidence(receipt, "policy_composition")
+    assert composition["current_config_action"] == "warn"
+    assert composition["untrusted_hook_payload_hint"] == "block"
+    assert composition["untrusted_hook_payload_hint_disposition"] == "ignored"
+    assert composition["untrusted_hook_payload_hint_reason_code"] == _IGNORED_BENIGN_HINT_REASON
+    assert composition["current_composed_action"] == "warn"
+    assert composition["authoritative_action"] == "warn"
+    trust_evidence = _receipt_evidence(receipt, "hook_payload_trust")
+    assert trust_evidence == {
+        "source": "hook_payload_trust",
+        "input_source": "untrusted_hook_payload_hint",
+        "status": "ignored",
+        "reason_code": _IGNORED_BENIGN_HINT_REASON,
+        "classifier": "is_explicitly_benign_tool_action_request",
+    }
+
+
+def test_verified_benign_copilot_hint_cannot_lower_configured_block(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+
+    rc, response, receipt = _run_copilot_generic_hook(
+        config=_guard_config(tmp_path, workspace, default_action="block"),
+        payload=_copilot_payload(),
+        store=store,
+        workspace=workspace,
+    )
+
+    assert rc == 0
+    assert response["permissionDecision"] == "deny"
+    assert receipt["policy_decision"] == "block"
+    composition = _receipt_evidence(receipt, "policy_composition")
+    assert composition["untrusted_hook_payload_hint_disposition"] == "ignored"
+    assert composition["current_config_action"] == "block"
+    assert composition["current_composed_action"] == "block"
+    assert composition["authoritative_action"] == "block"
+
+
+def test_verified_benign_copilot_hint_cannot_lower_trusted_cli_block(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+
+    rc, response, receipt = _run_copilot_generic_hook(
+        config=_guard_config(tmp_path, workspace),
+        payload=_copilot_payload(),
+        store=store,
+        workspace=workspace,
+        cli_action="block",
+    )
+
+    assert rc == 0
+    assert response["permissionDecision"] == "deny"
+    composition = _receipt_evidence(receipt, "policy_composition")
+    assert composition["trusted_cli_override"] == "block"
+    assert composition["untrusted_hook_payload_hint_disposition"] == "ignored"
+    assert composition["current_composed_action"] == "block"
+    assert composition["authoritative_action"] == "block"
+
+
+def test_verified_benign_copilot_exact_stored_block_remains_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_which = approval_context_module.shutil.which
+
+    def which_without_external_cd(command: str, *args: object, **kwargs: object) -> str | None:
+        if command == "cd":
+            return None
+        return real_which(command, *args, **kwargs)
+
+    monkeypatch.setattr(approval_context_module.shutil, "which", which_without_external_cd)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = _guard_config(tmp_path, workspace)
+    payload = _copilot_payload()
+    _, first_response, first_receipt = _run_copilot_generic_hook(
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+    assert first_response == {"permissionDecision": "allow"}
+    store.upsert_policy(
+        PolicyDecision(
+            harness="copilot",
+            scope="artifact",
+            action="block",
+            artifact_id=str(first_receipt["artifact_id"]),
+            artifact_hash=str(first_receipt["artifact_hash"]),
+            source="local",
+        ),
+        "2026-07-17T00:00:00+00:00",
+    )
+
+    rc, response, receipt = _run_copilot_generic_hook(
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+
+    assert rc == 0
+    assert response["permissionDecision"] == "deny"
+    assert receipt["policy_decision"] == "block"
+    assert receipt["artifact_hash"] == first_receipt["artifact_hash"]
+    composition = _receipt_evidence(receipt, "policy_composition")
+    assert composition["current_composed_action"] == "warn"
+    assert composition["saved_policy_action"] == "block"
+    assert composition["authoritative_action"] == "block"
+    reuse = _receipt_evidence(receipt, "approval_reuse")
+    assert reuse["status"] == "accepted"
+    assert reuse["reason_code"] == "approval_reuse_saved_block"
+
+
+def test_unmodeled_copilot_payload_block_remains_conservative_deny(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+
+    rc, response, receipt = _run_copilot_generic_hook(
+        config=_guard_config(tmp_path, workspace),
+        payload=_copilot_payload(command="custom-dangerous-tool --write /tmp/file"),
+        store=store,
+        workspace=workspace,
+    )
+
+    assert rc == 0
+    assert response["permissionDecision"] == "deny"
+    assert receipt["policy_decision"] == "block"
+    composition = _receipt_evidence(receipt, "policy_composition")
+    assert composition["untrusted_hook_payload_hint"] == "block"
+    assert composition["untrusted_hook_payload_hint_disposition"] == "applied"
+    assert composition["untrusted_hook_payload_hint_reason_code"] is None
+    assert composition["current_composed_action"] == "block"
+    evidence = cast(list[object], receipt["scanner_evidence"])
+    evidence_dicts = [cast(dict[str, object], item) for item in evidence if isinstance(item, dict)]
+    assert not any(item.get("source") == "hook_payload_trust" for item in evidence_dicts)
+
+
+def test_copilot_payload_allow_cannot_lower_stronger_current_policy(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+
+    rc, response, receipt = _run_copilot_generic_hook(
+        config=_guard_config(tmp_path, workspace, default_action="sandbox-required"),
+        payload=_copilot_payload(policy_action="allow"),
+        store=store,
+        workspace=workspace,
+    )
+
+    assert rc == 0
+    assert response["permissionDecision"] == "deny"
+    assert receipt["policy_decision"] == "sandbox-required"
+    composition = _receipt_evidence(receipt, "policy_composition")
+    assert composition["current_config_action"] == "sandbox-required"
+    assert composition["untrusted_hook_payload_hint"] == "allow"
+    assert composition["untrusted_hook_payload_hint_disposition"] == "ignored"
+    assert composition["current_composed_action"] == "sandbox-required"
+    assert composition["authoritative_action"] == "sandbox-required"
+
+
+@pytest.mark.parametrize(
+    ("current_action", "expected_permission"),
+    (("review", "deny"), ("block", "deny")),
+)
+def test_untrusted_permissive_daemon_hint_never_lowers_current_policy(
+    tmp_path: Path,
+    current_action: GuardAction,
+    expected_permission: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    payload = {
+        **_copilot_payload(policy_action="allow"),
+        "daemon_status": "unreachable",
+        "fail_mode": "permissive",
+    }
+
+    rc, response, receipt = _run_copilot_generic_hook(
+        config=_guard_config(tmp_path, workspace, default_action=current_action),
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+
+    assert rc == 0
+    assert response["permissionDecision"] == expected_permission
+    assert receipt["policy_decision"] == current_action
+    composition = _receipt_evidence(receipt, "policy_composition")
+    assert composition["daemon_hint_trust"] == "untrusted_hook_payload"
+    assert composition["daemon_hint_disposition"] == "preserved_current_action"
+    assert composition["daemon_hint_reason_code"] == ("untrusted_daemon_permissive_hint_preserved_current_action")
+    assert composition["current_composed_action"] == current_action
+    assert composition["authoritative_action"] == current_action
+    daemon_evidence = _receipt_evidence(receipt, "daemon_hint_trust")
+    assert daemon_evidence == {
+        "source": "daemon_hint_trust",
+        "input_source": "untrusted_hook_payload",
+        "status": "monotonic-only",
+        "disposition": "preserved_current_action",
+        "reason_code": "untrusted_daemon_permissive_hint_preserved_current_action",
+    }
+
+
+def test_verified_benign_copilot_hint_cannot_bypass_strict_daemon_failure(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    payload = {
+        **_copilot_payload(),
+        "daemon_status": "unreachable",
+        "fail_mode": "strict",
+    }
+
+    rc, response, receipt = _run_copilot_generic_hook(
+        config=_guard_config(tmp_path, workspace),
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+
+    assert rc == 0
+    assert response["permissionDecision"] == "deny"
+    assert receipt["policy_decision"] == "block"
+    composition = _receipt_evidence(receipt, "policy_composition")
+    assert composition["untrusted_hook_payload_hint_disposition"] == "ignored"
+    assert composition["daemon_status"] == "unreachable"
+    assert composition["fail_mode"] == "strict"
+    assert composition["daemon_hint_trust"] == "untrusted_hook_payload"
+    assert composition["daemon_hint_disposition"] == "tightened_to_block"
+    assert composition["daemon_hint_reason_code"] == "untrusted_daemon_strict_hint_tightened_to_block"
+    assert composition["current_composed_action"] == "block"
+    assert composition["authoritative_action"] == "block"
+    daemon_evidence = _receipt_evidence(receipt, "daemon_hint_trust")
+    assert daemon_evidence["status"] == "monotonic-only"
+    assert daemon_evidence["disposition"] == "tightened_to_block"

--- a/tests/test_guard_decision_propagation.py
+++ b/tests/test_guard_decision_propagation.py
@@ -4,6 +4,7 @@ decision before harness retry resumes (T722-T724).
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution, queue_blocked_approvals
@@ -28,8 +29,12 @@ def _make_artifact(
         artifact_type="mcp_server",
         source_scope="project",
         config_path=config_path,
-        command="node",
-        args=("server.js",),
+        # Use a real, content-bound interpreter and stable inline entrypoint.
+        # An absent ``server.js`` intentionally receives a fresh fail-closed
+        # launch-identity nonce on every evaluation, which would turn this
+        # propagation test into an identity-change test.
+        command=sys.executable,
+        args=("-c", "pass"),
         transport="stdio",
     )
 
@@ -45,12 +50,10 @@ def _make_detection(artifact: GuardArtifact) -> HarnessDetection:
 
 
 class TestImmediateApproveDecisionPropagation:
-    """T722-T723: Browser approve writes decision before harness retry resumes."""
+    """T722-T723: Browser decisions propagate without bypassing current policy."""
 
-    def test_approve_decision_visible_to_evaluate_without_delay(self, tmp_path: Path) -> None:
-        """T723: After apply_approval_resolution(allow), re-running evaluate_detection
-        immediately returns an allowed evaluation with no pending approval request.
-        """
+    def test_approve_decision_is_visible_but_cannot_lower_current_reapproval(self, tmp_path: Path) -> None:
+        """T723: A propagated approval remains evidence, not stronger policy authority."""
         guard_home = tmp_path / "guard"
         store = GuardStore(guard_home)
         artifact = _make_artifact(name="sync_tool", config_path=str(tmp_path / "ws/.codex/config.toml"))
@@ -79,16 +82,17 @@ class TestImmediateApproveDecisionPropagation:
         )
 
         retry_eval = evaluate_detection(detection, store, config, persist=False)
-        assert retry_eval.get("blocked") is False, "T723: Evaluation immediately after approval must not be blocked"
+        assert retry_eval.get("blocked") is True
         artifact_result = (retry_eval.get("artifacts") or [{}])[0]
-        assert artifact_result.get("policy_action") == "allow", (
-            "T723: Evaluation immediately after approval must return allow policy"
-        )
+        assert artifact_result.get("policy_action") == "require-reapproval"
+        assert artifact_result.get("approval_reuse_status") == "rejected"
+        assert artifact_result.get("approval_reuse_reason_code") == "approval_reuse_reapproval_required"
+        assert artifact_result.get("policy_composition", {}).get("saved_action") == "allow"
 
     def test_approve_propagation_occurs_before_request_resolution_response(self, tmp_path: Path) -> None:
         """T722: apply_approval_resolution writes the policy before marking the
-        request resolved, so the harness can re-evaluate the moment the POST
-        response arrives.
+        request resolved. Re-evaluation can observe it immediately, while the
+        current reapproval result remains authoritative.
         """
         guard_home = tmp_path / "guard"
         store = GuardStore(guard_home)
@@ -119,7 +123,10 @@ class TestImmediateApproveDecisionPropagation:
         assert resolved["status"] == "resolved", "Request must be marked resolved after approval"
 
         immediate_eval = evaluate_detection(detection, store, config, persist=False)
-        assert immediate_eval.get("blocked") is False, "T722: Policy must be written before request is marked resolved"
+        artifact_result = (immediate_eval.get("artifacts") or [{}])[0]
+        assert immediate_eval.get("blocked") is True
+        assert artifact_result.get("policy_composition", {}).get("saved_action") == "allow"
+        assert artifact_result.get("approval_reuse_reason_code") == "approval_reuse_reapproval_required"
 
 
 def test_unknown_evaluation_action_queues_conservative_reapproval(tmp_path: Path) -> None:

--- a/tests/test_guard_events.py
+++ b/tests/test_guard_events.py
@@ -125,7 +125,7 @@ class TestGuardEvents:
             """
 [mcp_servers.shared_tools]
 command = "python"
-args = ["-m", "http.server", "9000"]
+args = ["-m", "shared_tools"]
 """.strip()
             + "\n",
         )

--- a/tests/test_guard_hashnet_mcp_canaries.py
+++ b/tests/test_guard_hashnet_mcp_canaries.py
@@ -142,7 +142,7 @@ class TestHashnetMcpKnownSafeRemote:
 
 
 class TestHashnetMcpChangedCapability:
-    """changed-capability scenario: tool schema drift is detected by Guard."""
+    """Changed server and tool capabilities produce distinct identities."""
 
     def _server_hash(self) -> str:
         return build_mcp_server_identity(
@@ -205,12 +205,9 @@ class TestHashnetMcpChangedCapability:
 class TestHashnetMcpChangedDomain:
     """changed-domain scenario: URL and args drift are detected by server identity.
 
-    Note: ``build_mcp_server_identity`` uses ``_command_name()`` which extracts
-    only the last URL path segment as the effective command name. Host-only
-    swaps (same path, different hostname) therefore produce the same
-    ``identity_hash`` — this is a known limitation of the current design.
-    Path changes (different last segment) are detected, as are stdio args
-    changes.
+    The display-oriented command name remains the final URL path segment, but
+    identity also binds a hash of the complete configured command. Host-only
+    swaps, path changes, and stdio argument changes are therefore detected.
     """
 
     def test_url_path_change_produces_different_identity(self) -> None:
@@ -228,7 +225,7 @@ class TestHashnetMcpChangedDomain:
         )
         assert real_identity.identity_hash != evil_identity.identity_hash
 
-    def test_host_only_swap_produces_same_identity_hash(self) -> None:
+    def test_host_only_swap_produces_different_identity_hash(self) -> None:
         real_identity = build_mcp_server_identity(
             config_path=_HASHNET_CONFIG_PATH,
             command=_HASHNET_REMOTE_URL,
@@ -241,11 +238,7 @@ class TestHashnetMcpChangedDomain:
             args=(),
             transport="http",
         )
-        assert real_identity.identity_hash == host_swapped.identity_hash, (
-            "Known limitation: _command_name() extracts only the last URL path "
-            "segment, so a host-only swap with the same path is not detected by "
-            "McpServerIdentity alone."
-        )
+        assert real_identity.identity_hash != host_swapped.identity_hash
 
     def test_args_drift_produces_different_stdio_identity(self) -> None:
         canonical = build_mcp_server_identity(

--- a/tests/test_guard_hook_executable_identity.py
+++ b/tests/test_guard_hook_executable_identity.py
@@ -1,0 +1,685 @@
+"""Executable and MCP configuration binding regressions for hook approvals."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.cli import commands_support as _commands_support  # noqa: F401
+from codex_plugin_scanner.guard.cli.commands_hook_generic import _run_hook_generic_payload
+from codex_plugin_scanner.guard.cli.commands_support_runtime_resolution import _copilot_runtime_tool_call
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.mcp_tool_calls import evaluate_tool_call
+from codex_plugin_scanner.guard.models import GuardArtifact, PolicyDecision
+from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+from codex_plugin_scanner.guard.runtime.approval_context import (
+    APPROVAL_CONTEXT_TOKEN_PREFIX,
+    approval_context_tokens_validation_reason,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+_GENERIC_HARNESS = "generic-executable-test"
+_GENERIC_ARTIFACT_ID = "generic-executable-test:project:server"
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _replace_executable(path: Path, content: bytes) -> None:
+    replacement = path.with_name(f"{path.name}.replacement")
+    replacement.parent.mkdir(parents=True, exist_ok=True)
+    replacement.write_bytes(content)
+    replacement.chmod(0o755)
+    replacement.replace(path)
+
+
+def _replace_file(path: Path, content: bytes) -> None:
+    replacement = path.with_name(f"{path.name}.replacement")
+    replacement.parent.mkdir(parents=True, exist_ok=True)
+    replacement.write_bytes(content)
+    replacement.replace(path)
+
+
+def _run_generic_hook(
+    *,
+    capsys: pytest.CaptureFixture[str],
+    config: GuardConfig,
+    payload: dict[str, object],
+    store: GuardStore,
+    workspace: Path,
+    action_envelope: GuardActionEnvelope | None = None,
+) -> tuple[int, dict[str, object]]:
+    args = argparse.Namespace(
+        artifact_id=None,
+        artifact_name=None,
+        harness=_GENERIC_HARNESS,
+        json=True,
+        policy_action=None,
+    )
+    rc = _run_hook_generic_payload(
+        args,
+        action_envelope=action_envelope,
+        config=config,
+        home_dir=workspace.parent,
+        payload=payload,
+        runtime_workspace=workspace,
+        store=store,
+    )
+    output = json.loads(capsys.readouterr().out)
+    assert isinstance(output, dict)
+    return rc, cast(dict[str, object], output)
+
+
+def _approval_reuse_reason(output: dict[str, object]) -> str:
+    approval_reuse = output.get("approval_reuse")
+    assert isinstance(approval_reuse, dict)
+    reason = approval_reuse.get("reason_code")
+    assert isinstance(reason, str)
+    return reason
+
+
+def _record_generic_allow(
+    store: GuardStore,
+    *,
+    artifact_hash: str,
+    request_id: str,
+    workspace: Path,
+) -> None:
+    approval_id = store.record_local_once_approval(
+        request_id=request_id,
+        harness=_GENERIC_HARNESS,
+        artifact_id=_GENERIC_ARTIFACT_ID,
+        artifact_hash=artifact_hash,
+        workspace=str(workspace),
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+
+
+def _generic_server_payload(command: str) -> dict[str, object]:
+    return {
+        "artifact_id": _GENERIC_ARTIFACT_ID,
+        "artifact_name": "workspace server",
+        "hook_event_name": "OpaqueHookEvent",
+        "source_scope": "project",
+        "tool_name": "shell",
+        "tool_input": {"command": command},
+    }
+
+
+def _generic_server_action_envelope(command: str, *, workspace: Path) -> GuardActionEnvelope:
+    return GuardActionEnvelope(
+        schema_version=1,
+        action_id="",
+        harness=_GENERIC_HARNESS,
+        event_name="PreToolUse",
+        action_type="shell_command",
+        workspace=str(workspace),
+        workspace_hash=None,
+        tool_name="shell",
+        command=command,
+        prompt_excerpt=None,
+        prompt_text=None,
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+    )
+
+
+def test_generic_hook_rejects_exact_allow_after_same_path_executable_replacement(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    outside_cwd = tmp_path / "outside"
+    workspace.mkdir()
+    outside_cwd.mkdir()
+    server = workspace / "server"
+    _replace_executable(server, b"#!/bin/sh\necho version-one\n")
+    monkeypatch.chdir(outside_cwd)
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+    )
+    payload = _generic_server_payload("./server --stdio")
+    action_envelope = _generic_server_action_envelope("./server --stdio", workspace=workspace)
+
+    first_rc, first_output = _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+        action_envelope=action_envelope,
+    )
+    approved_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+    assert first_rc == 1
+    assert first_output["policy_action"] == "review"
+    assert approved_token.startswith(APPROVAL_CONTEXT_TOKEN_PREFIX)
+    _record_generic_allow(
+        store,
+        artifact_hash=approved_token,
+        request_id="generic-server-v1",
+        workspace=workspace,
+    )
+
+    _replace_executable(server, b"#!/bin/sh\necho version-two\n")
+    second_rc, second_output = _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+        action_envelope=action_envelope,
+    )
+
+    assert second_rc == 1
+    assert second_output["policy_action"] == "review"
+    assert _approval_reuse_reason(second_output) == "approval_reuse_identity_changed"
+    current_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+    assert approval_context_tokens_validation_reason(approved_token, current_token) == (
+        "approval_reuse_identity_changed"
+    )
+    assert (
+        store.resolve_policy_decision(
+            _GENERIC_HARNESS,
+            _GENERIC_ARTIFACT_ID,
+            approved_token,
+            str(workspace),
+            consume_one_shot=False,
+        )
+        is not None
+    )
+
+
+@pytest.mark.parametrize(
+    ("launcher_name", "entrypoint_name", "version_one", "version_two"),
+    (
+        ("python", "server.py", b"print('version one')\n", b"print('version two')\n"),
+        ("node", "server.js", b"console.log('version one');\n", b"console.log('version two');\n"),
+    ),
+)
+def test_generic_hook_rejects_exact_allow_after_only_interpreted_entrypoint_changes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    launcher_name: str,
+    entrypoint_name: str,
+    version_one: bytes,
+    version_two: bytes,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    launcher = workspace / launcher_name
+    entrypoint = workspace / entrypoint_name
+    _replace_executable(launcher, b"fake native interpreter\n")
+    _replace_file(entrypoint, version_one)
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+    )
+    command = f"./{launcher_name} {entrypoint_name} --stdio"
+    payload = _generic_server_payload(command)
+    action_envelope = _generic_server_action_envelope(command, workspace=workspace)
+
+    _, first_output = _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+        action_envelope=action_envelope,
+    )
+    approved_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+    assert first_output["policy_action"] == "review"
+    _record_generic_allow(
+        store,
+        artifact_hash=approved_token,
+        request_id=f"generic-{launcher_name}-entrypoint-v1",
+        workspace=workspace,
+    )
+
+    _replace_file(entrypoint, version_two)
+    second_rc, second_output = _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+        action_envelope=action_envelope,
+    )
+
+    current_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+    assert second_rc == 1
+    assert second_output["policy_action"] == "review"
+    assert _approval_reuse_reason(second_output) == "approval_reuse_identity_changed"
+    assert approval_context_tokens_validation_reason(approved_token, current_token) == (
+        "approval_reuse_identity_changed"
+    )
+
+
+def test_generic_hook_resolved_interpreter_with_missing_entrypoint_never_reuses_allow(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _replace_executable(workspace / "python", b"fake native interpreter\n")
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+    )
+    command = "./python missing-server.py --stdio"
+    payload = _generic_server_payload(command)
+    action_envelope = _generic_server_action_envelope(command, workspace=workspace)
+
+    _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+        action_envelope=action_envelope,
+    )
+    approved_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+    _record_generic_allow(
+        store,
+        artifact_hash=approved_token,
+        request_id="generic-python-missing-entrypoint",
+        workspace=workspace,
+    )
+
+    second_rc, second_output = _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+        action_envelope=action_envelope,
+    )
+    current_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+
+    assert second_rc == 1
+    assert second_output["policy_action"] == "review"
+    assert _approval_reuse_reason(second_output) == "approval_reuse_identity_changed"
+    assert approved_token != current_token
+
+
+def test_generic_hook_unresolved_executable_never_reuses_exact_allow(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+    )
+    payload = _generic_server_payload("./missing-server --stdio")
+
+    _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+    approved_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+    _record_generic_allow(
+        store,
+        artifact_hash=approved_token,
+        request_id="generic-unresolved-server",
+        workspace=workspace,
+    )
+
+    second_rc, second_output = _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+    current_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+
+    assert second_rc == 1
+    assert second_output["policy_action"] == "review"
+    assert _approval_reuse_reason(second_output) == "approval_reuse_identity_changed"
+    assert approved_token != current_token
+    assert (
+        store.resolve_policy_decision(
+            _GENERIC_HARNESS,
+            _GENERIC_ARTIFACT_ID,
+            approved_token,
+            str(workspace),
+            consume_one_shot=False,
+        )
+        is not None
+    )
+
+
+def _copilot_server_config(command: str = "./server") -> dict[str, object]:
+    return {
+        "type": "local",
+        "command": command,
+        "args": ["--stdio", "--safe-mode"],
+        "env": {"SERVER_TOKEN": "version-one"},
+        "metadata": {"revision": 1},
+        "tools": {
+            "shell_exec": {
+                "description": "Execute a reviewed shell command.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"],
+                },
+            }
+        },
+    }
+
+
+def _resolve_copilot_tool(
+    *,
+    config: GuardConfig,
+    home_dir: Path,
+    workspace: Path,
+) -> tuple[GuardArtifact, str, object]:
+    resolved = _copilot_runtime_tool_call(
+        payload={
+            "tool_name": "mcp_danger_lab_shell_exec",
+            "tool_input": {"command": "rm relative-target"},
+            "source_scope": "project",
+        },
+        home_dir=home_dir,
+        workspace=workspace,
+        config=config,
+        preferred_workspace_config="ide",
+    )
+    assert resolved is not None
+    return resolved
+
+
+def test_copilot_mcp_exact_allow_is_invalid_after_server_executable_bytes_change(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    server = workspace / "server"
+    _replace_executable(server, b"#!/bin/sh\necho copilot-server-v1\n")
+    _write_json(
+        workspace / ".vscode" / "mcp.json",
+        {"servers": {"danger_lab": _copilot_server_config()}},
+    )
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"mcp_dangerous_tool": "review"},
+    )
+    old_artifact, old_token, arguments = _resolve_copilot_tool(
+        config=config,
+        home_dir=home_dir,
+        workspace=workspace,
+    )
+    unchanged_artifact, unchanged_token, _ = _resolve_copilot_tool(
+        config=config,
+        home_dir=home_dir,
+        workspace=workspace,
+    )
+    assert old_token == unchanged_token
+    assert old_artifact == unchanged_artifact
+    metadata = old_artifact.metadata
+    fingerprint = metadata.get("server_fingerprint")
+    assert isinstance(fingerprint, dict)
+    launch_identity = fingerprint.get("resolved_executable")
+    assert isinstance(launch_identity, dict)
+    executable_identity = launch_identity.get("executable")
+    assert isinstance(executable_identity, dict)
+    assert executable_identity["path"] == str(server.resolve())
+    assert executable_identity["sha256"] == hashlib.sha256(server.read_bytes()).hexdigest()
+    assert launch_identity["argv_sha256"]
+    assert launch_identity["entrypoint"]
+    server_identity = metadata.get("mcp_server_identity")
+    assert isinstance(server_identity, dict)
+    assert server_identity["transport"] == "stdio"
+    assert server_identity["env_keys"] == ["SERVER_TOKEN"]
+    assert isinstance(server_identity["env_values_hash"], str)
+    assert "version-one" not in json.dumps(metadata, sort_keys=True)
+    assert metadata["tool_description"] == "Execute a reviewed shell command."
+    tool_schema = metadata.get("tool_schema")
+    assert isinstance(tool_schema, dict)
+    assert tool_schema["required"] == ["command"]
+
+    store = GuardStore(tmp_path / "guard-home")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="copilot",
+            scope="artifact",
+            action="allow",
+            artifact_id=old_artifact.artifact_id,
+            artifact_hash=old_token,
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00+00:00",
+    )
+    _replace_executable(server, b"#!/bin/sh\necho copilot-server-v2\n")
+    new_artifact, new_token, _ = _resolve_copilot_tool(
+        config=config,
+        home_dir=home_dir,
+        workspace=workspace,
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=new_artifact,
+        artifact_hash=new_token,
+        arguments=arguments,
+    )
+
+    assert old_artifact.artifact_id == new_artifact.artifact_id
+    assert approval_context_tokens_validation_reason(old_token, new_token) == "approval_reuse_identity_changed"
+    assert decision.current_action == "review"
+    assert decision.action == "review"
+    assert decision.approval_reuse_reason_code == "approval_reuse_identity_changed"
+
+
+def test_copilot_mcp_exact_allow_is_invalid_after_only_python_entrypoint_bytes_change(
+    tmp_path: Path,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    launcher = workspace / "python"
+    entrypoint = workspace / "server.py"
+    _replace_executable(launcher, b"fake native python interpreter\n")
+    _replace_file(entrypoint, b"print('copilot server v1')\n")
+    configured_secret = "copilot-env-secret-must-not-leak"
+    server_config = _copilot_server_config(command="./python")
+    server_config["args"] = ["server.py", "--stdio"]
+    server_config["env"] = {"SERVER_TOKEN": configured_secret}
+    _write_json(
+        workspace / ".vscode" / "mcp.json",
+        {"servers": {"danger_lab": server_config}},
+    )
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"mcp_dangerous_tool": "review"},
+    )
+
+    old_artifact, old_token, arguments = _resolve_copilot_tool(
+        config=config,
+        home_dir=home_dir,
+        workspace=workspace,
+    )
+    unchanged_artifact, unchanged_token, _ = _resolve_copilot_tool(
+        config=config,
+        home_dir=home_dir,
+        workspace=workspace,
+    )
+    assert old_token == unchanged_token
+    assert old_artifact == unchanged_artifact
+    fingerprint = old_artifact.metadata.get("server_fingerprint")
+    assert isinstance(fingerprint, dict)
+    launch_identity = fingerprint.get("resolved_executable")
+    assert isinstance(launch_identity, dict)
+    executable_identity = launch_identity.get("executable")
+    entrypoint_identity = launch_identity.get("entrypoint")
+    assert isinstance(executable_identity, dict)
+    assert isinstance(entrypoint_identity, dict)
+    assert executable_identity["path"] == str(launcher.resolve())
+    assert entrypoint_identity["path"] == str(entrypoint.resolve())
+    assert entrypoint_identity["sha256"] == hashlib.sha256(entrypoint.read_bytes()).hexdigest()
+    serialized_metadata = json.dumps(old_artifact.metadata, sort_keys=True)
+    assert configured_secret not in serialized_metadata
+    server_identity = old_artifact.metadata.get("mcp_server_identity")
+    assert isinstance(server_identity, dict)
+    assert server_identity["env_keys"] == ["SERVER_TOKEN"]
+    assert isinstance(server_identity["env_values_hash"], str)
+
+    store = GuardStore(tmp_path / "guard-home")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="copilot",
+            scope="artifact",
+            action="allow",
+            artifact_id=old_artifact.artifact_id,
+            artifact_hash=old_token,
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00+00:00",
+    )
+    _replace_file(entrypoint, b"print('copilot server v2')\n")
+    new_artifact, new_token, _ = _resolve_copilot_tool(
+        config=config,
+        home_dir=home_dir,
+        workspace=workspace,
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=new_artifact,
+        artifact_hash=new_token,
+        arguments=arguments,
+    )
+
+    assert old_artifact.artifact_id == new_artifact.artifact_id
+    assert approval_context_tokens_validation_reason(old_token, new_token) == "approval_reuse_identity_changed"
+    assert decision.current_action == "review"
+    assert decision.action == "review"
+    assert decision.approval_reuse_reason_code == "approval_reuse_identity_changed"
+    assert configured_secret not in json.dumps(new_artifact.metadata, sort_keys=True)
+
+
+@pytest.mark.parametrize(
+    "change",
+    ["command", "full_config", "transport", "tool_contract"],
+)
+def test_copilot_mcp_server_and_tool_configuration_changes_invalidate_identity(
+    tmp_path: Path,
+    change: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _replace_executable(workspace / "server", b"#!/bin/sh\necho primary\n")
+    _replace_executable(workspace / "server-alt", b"#!/bin/sh\necho alternate\n")
+    config_path = workspace / ".vscode" / "mcp.json"
+    server_config = _copilot_server_config()
+    _write_json(config_path, {"servers": {"danger_lab": server_config}})
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"mcp_dangerous_tool": "review"},
+    )
+    old_artifact, old_token, old_arguments = _resolve_copilot_tool(
+        config=config,
+        home_dir=home_dir,
+        workspace=workspace,
+    )
+
+    changed_config = deepcopy(server_config)
+    if change == "command":
+        changed_config["command"] = "./server-alt"
+    elif change == "full_config":
+        changed_config["env"] = {"SERVER_TOKEN": "version-two"}
+        changed_config["metadata"] = {"revision": 2}
+    elif change == "transport":
+        changed_config["type"] = "sse"
+    else:
+        changed_tools = changed_config.get("tools")
+        assert isinstance(changed_tools, dict)
+        changed_tools["shell_exec"] = {
+            "description": "Execute a changed shell contract.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string"},
+                    "timeout": {"type": "integer"},
+                },
+                "required": ["command", "timeout"],
+            },
+        }
+    _write_json(config_path, {"servers": {"danger_lab": changed_config}})
+    new_artifact, new_token, new_arguments = _resolve_copilot_tool(
+        config=config,
+        home_dir=home_dir,
+        workspace=workspace,
+    )
+
+    assert old_artifact.artifact_id == new_artifact.artifact_id
+    assert old_arguments == new_arguments
+    assert old_token != new_token
+    expected_reuse_reasons = {
+        "approval_reuse_identity_changed",
+        "approval_reuse_capability_changed",
+    }
+    assert approval_context_tokens_validation_reason(old_token, new_token) in expected_reuse_reasons
+    store = GuardStore(tmp_path / "guard-home")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="copilot",
+            scope="artifact",
+            action="allow",
+            artifact_id=old_artifact.artifact_id,
+            artifact_hash=old_token,
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00+00:00",
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=new_artifact,
+        artifact_hash=new_token,
+        arguments=new_arguments,
+    )
+
+    assert decision.current_action == "review"
+    assert decision.action == "review"
+    assert decision.approval_reuse_reason_code in expected_reuse_reasons

--- a/tests/test_guard_hook_post_claim_freshness.py
+++ b/tests/test_guard_hook_post_claim_freshness.py
@@ -1,0 +1,1084 @@
+"""Post-claim freshness regressions for native runtime hook consumers."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import sqlite3
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.cli import commands_hook as hook_command
+from codex_plugin_scanner.guard.cli import commands_hook_copilot as copilot_hook
+from codex_plugin_scanner.guard.cli import commands_hook_runtime_finish as runtime_finish
+from codex_plugin_scanner.guard.cli.commands_hook_runtime_eval import (
+    _evaluate_runtime_artifact_hook,
+)
+from codex_plugin_scanner.guard.cli.commands_hook_runtime_review import (
+    _review_runtime_artifact_hook,
+)
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.mcp_tool_calls import (
+    ToolCallDecision,
+    build_tool_call_artifact,
+    build_tool_call_hash,
+    evaluate_tool_call,
+)
+from codex_plugin_scanner.guard.models import GuardAction, GuardArtifact, PolicyDecision
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _record_once_allow(
+    store: GuardStore,
+    *,
+    artifact: GuardArtifact,
+    artifact_hash: str,
+    workspace: Path,
+    request_id: str,
+) -> None:
+    approval_id = store.record_local_once_approval(
+        request_id=request_id,
+        harness=artifact.harness,
+        artifact_id=artifact.artifact_id,
+        artifact_hash=artifact_hash,
+        workspace=str(workspace),
+        publisher=artifact.publisher,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+
+
+def test_runtime_artifact_hook_rebuilds_policy_after_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(guard_home)
+    artifact_actions: dict[str, GuardAction] = {}
+    config = GuardConfig(
+        guard_home=guard_home,
+        workspace=workspace,
+        default_action="allow",
+        artifact_actions=artifact_actions,
+    )
+    artifact = GuardArtifact(
+        artifact_id="codex:project:tool-action:post-claim",
+        name="Codex post-claim action",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        command="echo",
+        args=("post-claim",),
+        metadata={"guard_default_action": "review"},
+    )
+    args = argparse.Namespace(harness="codex", policy_action=None, json=True)
+    context = HarnessContext(
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+        guard_home=guard_home,
+    )
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo post-claim"},
+        "source_scope": "project",
+    }
+    initial = _evaluate_runtime_artifact_hook(
+        args,
+        action_envelope=None,
+        config=config,
+        context=context,
+        data_flow_signals=(),
+        guard_home=guard_home,
+        payload=payload,
+        runtime_artifact=artifact,
+        runtime_workspace=workspace,
+        store=store,
+    )
+    assert not isinstance(initial, int)
+    assert initial.policy_action == "review"
+    _record_once_allow(
+        store,
+        artifact=artifact,
+        artifact_hash=initial.runtime_artifact_hash,
+        workspace=workspace,
+        request_id="runtime-hook-post-claim-policy-change",
+    )
+    original_claim = store.claim_approval_reuse_decision
+
+    def claim_then_block(decision: object, *, now: str | None = None) -> bool:
+        claimed = original_claim(decision, now=now)
+        if claimed:
+            artifact_actions[artifact.artifact_id] = "block"
+        return claimed
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", claim_then_block)
+
+    result = _evaluate_runtime_artifact_hook(
+        args,
+        action_envelope=None,
+        config=config,
+        context=context,
+        data_flow_signals=(),
+        guard_home=guard_home,
+        payload=payload,
+        runtime_artifact=artifact,
+        runtime_workspace=workspace,
+        store=store,
+    )
+
+    assert not isinstance(result, int)
+    assert result.policy_action == "block"
+    assert result.response_payload["policy_composition"]["authoritative_action"] == "block"
+    assert result.response_payload["approval_reuse"]["reason_code"] == ("approval_reuse_context_changed_after_claim")
+
+    _review_runtime_artifact_hook(
+        result,
+        args,
+        config=replace(config, mode="observe"),
+        context=context,
+        guard_home=guard_home,
+        managed_install=None,
+        output_stream=io.StringIO(),
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+    assert result.policy_action == "block"
+    assert result.response_payload["policy_action"] == "block"
+    assert result.response_payload["approval_requests"] == []
+
+
+def test_runtime_artifact_hook_missing_fresh_provider_fails_closed(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(guard_home)
+    config = GuardConfig(guard_home=guard_home, workspace=workspace, default_action="allow")
+    artifact = GuardArtifact(
+        artifact_id="codex:project:tool-action:missing-fresh-provider",
+        name="Codex missing fresh provider action",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        command="echo",
+        metadata={"guard_default_action": "review"},
+    )
+    args = argparse.Namespace(harness="codex", policy_action=None, json=True)
+    context = HarnessContext(tmp_path, workspace, guard_home)
+    payload = {"hook_event_name": "PreToolUse", "tool_name": "Bash"}
+    initial = _evaluate_runtime_artifact_hook(
+        args,
+        action_envelope=None,
+        config=config,
+        context=context,
+        data_flow_signals=(),
+        guard_home=guard_home,
+        payload=payload,
+        runtime_artifact=artifact,
+        runtime_workspace=workspace,
+        store=store,
+    )
+    assert not isinstance(initial, int)
+    _record_once_allow(
+        store,
+        artifact=artifact,
+        artifact_hash=initial.runtime_artifact_hash,
+        workspace=workspace,
+        request_id="runtime-hook-missing-fresh-provider",
+    )
+
+    result = _evaluate_runtime_artifact_hook(
+        args,
+        action_envelope=None,
+        config=config,
+        context=context,
+        data_flow_signals=(),
+        guard_home=guard_home,
+        payload=payload,
+        runtime_artifact=artifact,
+        runtime_workspace=workspace,
+        store=store,
+        post_claim_revalidator=lambda _artifact_hash, _trusted: None,
+    )
+
+    assert not isinstance(result, int)
+    assert result.policy_action == "require-reapproval"
+    assert result.response_payload["approval_reuse"]["reason_code"] == ("approval_reuse_context_changed_after_claim")
+
+
+@pytest.mark.parametrize("mode", ("prompt", "observe"))
+def test_copilot_pretool_uses_fresh_provider_after_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(guard_home)
+    artifact = build_tool_call_artifact(
+        harness="copilot",
+        server_name="danger-lab",
+        tool_name="shell_exec",
+        source_scope="project",
+        config_path=str(workspace / ".vscode" / "mcp.json"),
+        transport="stdio",
+    )
+    arguments = {"command": "rm relative-target"}
+    config = GuardConfig(
+        guard_home=guard_home,
+        workspace=workspace,
+        mode=mode,  # type: ignore[arg-type]
+        risk_actions={"mcp_dangerous_tool": "review"},
+    )
+    artifact_hash = build_tool_call_hash(
+        artifact,
+        arguments,
+        workspace=workspace,
+        config=config,
+    )
+    _record_once_allow(
+        store,
+        artifact=artifact,
+        artifact_hash=artifact_hash,
+        workspace=workspace,
+        request_id="copilot-post-claim-policy-change",
+    )
+    fresh_artifact = replace(
+        artifact,
+        name="fresh-danger-lab:fresh_shell_exec",
+        config_path=str(workspace / ".github" / "fresh-mcp.json"),
+    )
+    fresh_arguments = {"command": "rm fresh-relative-target"}
+    fresh_config = replace(config, artifact_actions={artifact.artifact_id: "block"})
+    fresh_hash = build_tool_call_hash(
+        fresh_artifact,
+        fresh_arguments,
+        workspace=workspace,
+        config=fresh_config,
+    )
+    output = io.StringIO()
+    monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
+
+    result = copilot_hook._run_hook_copilot_pretool(
+        argparse.Namespace(harness="copilot", json=False),
+        action_envelope=None,
+        config=config,
+        context=HarnessContext(tmp_path, workspace, guard_home),
+        copilot_hook_stage="pretooluse",
+        copilot_runtime_tool_call=(artifact, artifact_hash, arguments),
+        output_stream=output,
+        payload={"hook_event_name": "PreToolUse", "tool_name": "mcp_danger_lab_shell_exec"},
+        runtime_workspace=workspace,
+        store=store,
+        fresh_tool_call_authority_provider=lambda: (
+            fresh_config,
+            fresh_artifact,
+            fresh_hash,
+            fresh_arguments,
+        ),
+    )
+
+    response = json.loads(output.getvalue())
+    receipt = store.list_receipts(limit=1)[0]
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    event = store.list_events(limit=1, event_name="runtime_tool_call_blocked")[0]
+    assert result == 0
+    assert response["permissionDecision"] == "deny"
+    assert fresh_artifact.name in response["permissionDecisionReason"]
+    assert response["approval_reuse"]["status"] == "rejected"
+    assert response["approval_reuse"]["reason_code"] == ("approval_reuse_context_changed_after_claim")
+    assert receipt["policy_decision"] == "block"
+    assert receipt["artifact_hash"] == fresh_hash
+    assert receipt["artifact_name"] == fresh_artifact.name
+    assert receipt["raw_command_text"] == fresh_arguments["command"]
+    assert inventory is not None
+    assert inventory["artifact_hash"] == fresh_hash
+    assert inventory["artifact_name"] == fresh_artifact.name
+    assert inventory["config_path"] == fresh_artifact.config_path
+    assert inventory["last_policy_action"] == "block"
+    assert event["payload"]["artifact_hash"] == fresh_hash
+    assert event["payload"]["policy_action"] == "block"
+
+
+def _hook_args(harness: str, *, json_output: bool) -> argparse.Namespace:
+    return argparse.Namespace(
+        artifact_id=None,
+        artifact_name=None,
+        event_file=None,
+        harness=harness,
+        json=json_output,
+        policy_action=None,
+        runtime_harness=None,
+    )
+
+
+def _record_once_from_receipt(
+    store: GuardStore,
+    receipt: dict[str, object],
+    *,
+    request_id: str,
+    workspace: Path,
+) -> None:
+    approval_id = store.record_local_once_approval(
+        request_id=request_id,
+        harness=cast(str, receipt["harness"]),
+        artifact_id=cast(str, receipt["artifact_id"]),
+        artifact_hash=cast(str, receipt["artifact_hash"]),
+        workspace=str(workspace),
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+
+
+def _approval_reuse_reason(receipt: dict[str, object]) -> str | None:
+    evidence = receipt.get("scanner_evidence")
+    if not isinstance(evidence, list):
+        return None
+    for item in evidence:
+        if isinstance(item, dict) and item.get("source") == "approval_reuse":
+            reason = item.get("reason_code")
+            return reason if isinstance(reason, str) else None
+    return None
+
+
+def test_runtime_hook_reloads_synced_policy_after_atomic_claim(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(guard_home)
+    config = GuardConfig(
+        guard_home=guard_home,
+        workspace=workspace,
+        default_action="review",
+        approval_wait_timeout_seconds=0,
+    )
+    context = HarnessContext(tmp_path, workspace, guard_home)
+    artifact = GuardArtifact(
+        artifact_id="codex:project:tool-action:synced-runtime-post-claim",
+        name="Codex synced runtime post-claim action",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        command="echo",
+        args=("synced-runtime-post-claim",),
+        metadata={"guard_default_action": "review", "action_class": "test runtime action"},
+    )
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo synced-runtime-post-claim"},
+        "source_scope": "project",
+    }
+    args = _hook_args("codex", json_output=True)
+    monkeypatch.setattr(hook_command, "load_guard_config", lambda *_args, **_kwargs: config)
+    monkeypatch.setattr(hook_command, "_hook_runtime_artifact", lambda **_kwargs: artifact)
+    monkeypatch.setattr(hook_command, "_review_runtime_artifact_hook", lambda *_args, **_kwargs: None)
+
+    hook_command._run_guard_hook_command(
+        args,
+        guard_home=guard_home,
+        workspace=workspace,
+        context=context,
+        store=store,
+        config=config,
+        input_text=json.dumps(payload),
+    )
+    capsys.readouterr()
+    initial_receipt = store.list_receipts(limit=1)[0]
+    assert initial_receipt["policy_decision"] == "review"
+    _record_once_from_receipt(
+        store,
+        initial_receipt,
+        request_id="runtime-synced-policy-post-claim",
+        workspace=workspace,
+    )
+    original_claim = store.claim_approval_reuse_decision
+
+    def claim_then_sync_block(decision: object, *, now: str | None = None) -> bool:
+        claimed = original_claim(decision, now=now)
+        if claimed:
+            store.set_sync_payload(
+                "policy",
+                {"defaultAction": "block"},
+                "2026-07-17T00:01:00+00:00",
+            )
+        return claimed
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", claim_then_sync_block)
+
+    hook_command._run_guard_hook_command(
+        args,
+        guard_home=guard_home,
+        workspace=workspace,
+        context=context,
+        store=store,
+        config=config,
+        input_text=json.dumps(payload),
+    )
+    capsys.readouterr()
+
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == "block"
+    assert _approval_reuse_reason(receipt) == "approval_reuse_context_changed_after_claim"
+
+
+def test_generic_hook_reloads_synced_policy_after_atomic_claim(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(guard_home)
+    config = GuardConfig(
+        guard_home=guard_home,
+        workspace=workspace,
+        default_action="review",
+    )
+    context = HarnessContext(tmp_path, workspace, guard_home)
+    payload = {
+        "artifact_id": "generic-test:project:opaque-synced-request",
+        "artifact_name": "opaque synced request",
+        "hook_event_name": "OpaqueHookEvent",
+        "source_scope": "project",
+        "tool_name": "opaque_tool",
+        "tool_input": {"target": "unchanged"},
+    }
+    args = _hook_args("generic-test", json_output=True)
+    monkeypatch.setattr(hook_command, "load_guard_config", lambda *_args, **_kwargs: config)
+    monkeypatch.setattr(hook_command, "_hook_runtime_artifact", lambda **_kwargs: None)
+
+    hook_command._run_guard_hook_command(
+        args,
+        guard_home=guard_home,
+        workspace=workspace,
+        context=context,
+        store=store,
+        config=config,
+        input_text=json.dumps(payload),
+    )
+    capsys.readouterr()
+    initial_receipt = store.list_receipts(limit=1)[0]
+    assert initial_receipt["policy_decision"] == "review"
+    _record_once_from_receipt(
+        store,
+        initial_receipt,
+        request_id="generic-synced-policy-post-claim",
+        workspace=workspace,
+    )
+    original_claim = store.claim_approval_reuse_decision
+
+    def claim_then_sync_block(decision: object, *, now: str | None = None) -> bool:
+        claimed = original_claim(decision, now=now)
+        if claimed:
+            store.set_sync_payload(
+                "policy",
+                {"defaultAction": "block"},
+                "2026-07-17T00:01:00+00:00",
+            )
+        return claimed
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", claim_then_sync_block)
+
+    rc = hook_command._run_guard_hook_command(
+        args,
+        guard_home=guard_home,
+        workspace=workspace,
+        context=context,
+        store=store,
+        config=config,
+        input_text=json.dumps(payload),
+    )
+    output = json.loads(capsys.readouterr().out)
+    receipt = store.list_receipts(limit=1)[0]
+
+    assert rc == 1
+    assert output["policy_action"] == "block"
+    assert output["approval_reuse"]["reason_code"] == "approval_reuse_context_changed_after_claim"
+    assert receipt["policy_decision"] == "block"
+    assert _approval_reuse_reason(receipt) == "approval_reuse_context_changed_after_claim"
+
+
+def test_copilot_hook_reloads_synced_policy_after_atomic_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    vscode_dir = workspace / ".vscode"
+    vscode_dir.mkdir()
+    (vscode_dir / "mcp.json").write_text(
+        json.dumps(
+            {
+                "servers": {
+                    "danger-lab": {
+                        "type": "stdio",
+                        "command": sys.executable,
+                        "args": ["-c", "pass"],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    store = GuardStore(guard_home)
+    config = GuardConfig(
+        guard_home=guard_home,
+        workspace=workspace,
+        default_action="allow",
+        risk_actions={"mcp_dangerous_tool": "review"},
+    )
+    context = HarnessContext(tmp_path, workspace, guard_home)
+    payload = {
+        "hook_name": "preToolUse",
+        "tool_name": "danger-lab/shell_exec",
+        "tool_input": {"command": "rm synced-copilot-target"},
+        "source_scope": "project",
+    }
+    initial_tool_call = hook_command._copilot_runtime_tool_call(
+        payload=payload,
+        home_dir=tmp_path,
+        workspace=workspace,
+        config=config,
+        preferred_workspace_config="ide",
+    )
+    assert initial_tool_call is not None
+    artifact, artifact_hash, _arguments = initial_tool_call
+    _record_once_allow(
+        store,
+        artifact=artifact,
+        artifact_hash=artifact_hash,
+        workspace=workspace,
+        request_id="copilot-synced-policy-post-claim",
+    )
+    original_claim = store.claim_approval_reuse_decision
+
+    def claim_then_sync_block(decision: object, *, now: str | None = None) -> bool:
+        claimed = original_claim(decision, now=now)
+        if claimed:
+            store.set_sync_payload(
+                "policy",
+                {"defaultAction": "block"},
+                "2026-07-17T00:01:00+00:00",
+            )
+        return claimed
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", claim_then_sync_block)
+    monkeypatch.setattr(hook_command, "load_guard_config", lambda *_args, **_kwargs: config)
+    monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
+    output = io.StringIO()
+
+    rc = hook_command._run_guard_hook_command(
+        _hook_args("copilot", json_output=False),
+        guard_home=guard_home,
+        workspace=workspace,
+        context=context,
+        store=store,
+        config=config,
+        input_text=json.dumps(payload),
+        output_stream=output,
+    )
+
+    response = json.loads(output.getvalue())
+    receipt = store.list_receipts(limit=1)[0]
+    assert rc == 0
+    assert response["permissionDecision"] == "deny"
+    assert response["approval_reuse"]["reason_code"] == "approval_reuse_context_changed_after_claim"
+    assert receipt["policy_decision"] == "block"
+    assert _approval_reuse_reason(receipt) == "approval_reuse_context_changed_after_claim"
+
+
+def test_browser_post_wait_revalidation_reloads_synced_policy(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    secret_file = workspace / ".env"
+    secret_file.write_text("TOKEN=test-only\n", encoding="utf-8")
+    store = GuardStore(guard_home)
+    config = GuardConfig(
+        guard_home=guard_home,
+        workspace=workspace,
+        default_action="review",
+        approval_wait_timeout_seconds=0,
+    )
+    context = HarnessContext(tmp_path, workspace, guard_home)
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(secret_file)},
+        "source_scope": "project",
+    }
+    observed_fresh_context: dict[str, object] = {}
+    monkeypatch.setattr(hook_command, "load_guard_config", lambda *_args, **_kwargs: config)
+    monkeypatch.setattr(hook_command, "_review_runtime_artifact_hook", lambda *_args, **_kwargs: None)
+
+    def browser_decision(**kwargs: object) -> str:
+        store.set_sync_payload(
+            "policy",
+            {"defaultAction": "block"},
+            "2026-07-17T00:01:00+00:00",
+        )
+        provider = cast(object, kwargs["fresh_context_provider"])
+        assert callable(provider)
+        fresh_context = provider()
+        assert isinstance(fresh_context, dict)
+        observed_fresh_context.update(fresh_context)
+        return "block"
+
+    monkeypatch.setattr(runtime_finish, "_codex_browser_approval_decision", browser_decision)
+
+    hook_command._run_guard_hook_command(
+        _hook_args("codex", json_output=True),
+        guard_home=guard_home,
+        workspace=workspace,
+        context=context,
+        store=store,
+        config=config,
+        input_text=json.dumps(payload),
+    )
+    capsys.readouterr()
+
+    assert observed_fresh_context["current_action"] == "block"
+    assert observed_fresh_context["authoritative_action"] == "block"
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "block"
+
+
+def test_copilot_permission_postclaim_uses_fresh_authority_for_queue_and_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(guard_home)
+    artifact = build_tool_call_artifact(
+        harness="copilot",
+        server_name="danger-lab",
+        tool_name="shell_exec",
+        source_scope="project",
+        config_path=str(workspace / ".vscode" / "mcp.json"),
+        transport="stdio",
+    )
+    initial_arguments = {"command": "rm initial-permission-target"}
+    config = GuardConfig(
+        guard_home=guard_home,
+        workspace=workspace,
+        default_action="allow",
+        risk_actions={"mcp_dangerous_tool": "review"},
+    )
+    initial_hash = build_tool_call_hash(
+        artifact,
+        initial_arguments,
+        workspace=workspace,
+        config=config,
+    )
+    _record_once_allow(
+        store,
+        artifact=artifact,
+        artifact_hash=initial_hash,
+        workspace=workspace,
+        request_id="copilot-permission-complete-fresh-authority",
+    )
+    fresh_artifact = replace(
+        artifact,
+        name="fresh-danger-lab:fresh_shell_exec",
+        config_path=str(workspace / ".github" / "fresh-mcp.json"),
+    )
+    fresh_arguments = {"command": "rm fresh-permission-target"}
+    fresh_config = replace(
+        config,
+        mode="observe",
+        receipt_redaction_level="none",
+    )
+    fresh_hash = build_tool_call_hash(
+        fresh_artifact,
+        fresh_arguments,
+        workspace=workspace,
+        config=fresh_config,
+    )
+    observed_decisions: list[ToolCallDecision] = []
+    queue_call: dict[str, object] = {}
+    original_evaluate_tool_call = evaluate_tool_call
+
+    def capture_decision(**kwargs: object) -> ToolCallDecision:
+        decision = original_evaluate_tool_call(**kwargs)  # type: ignore[arg-type]
+        observed_decisions.append(decision)
+        return decision
+
+    def unavailable_daemon_client(_guard_home: Path) -> object:
+        raise RuntimeError("test uses the local approval queue")
+
+    def capture_queue(**kwargs: object) -> list[dict[str, object]]:
+        queue_call.update(kwargs)
+        return [
+            {
+                "artifact_id": fresh_artifact.artifact_id,
+                "request_id": "fresh-authority-request",
+                "review_url": "http://127.0.0.1:4455/approvals/fresh-authority-request",
+            }
+        ]
+
+    monkeypatch.setattr(copilot_hook, "evaluate_tool_call", capture_decision)
+    monkeypatch.setattr(copilot_hook, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(copilot_hook, "load_guard_surface_daemon_client", unavailable_daemon_client)
+    monkeypatch.setattr(copilot_hook, "queue_blocked_approvals", capture_queue)
+    monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
+    output = io.StringIO()
+
+    result = copilot_hook._run_hook_copilot_permission_request(
+        _hook_args("copilot", json_output=False),
+        action_envelope=None,
+        config=config,
+        context=HarnessContext(tmp_path, workspace, guard_home),
+        copilot_permission_request=(artifact, initial_hash, initial_arguments),
+        guard_home=guard_home,
+        managed_install=None,
+        output_stream=output,
+        payload={"hook_event_name": "permissionRequest", "tool_name": "danger-lab/shell_exec"},
+        runtime_workspace=workspace,
+        store=store,
+        fresh_tool_call_authority_provider=lambda: (
+            fresh_config,
+            fresh_artifact,
+            fresh_hash,
+            fresh_arguments,
+        ),
+    )
+
+    response = json.loads(output.getvalue())
+    decision = observed_decisions[-1]
+    authority = decision.post_claim_authority
+    receipt = store.list_receipts(limit=1)[0]
+    inventory = store.find_inventory_item(fresh_artifact.artifact_id)
+    event = store.list_events(limit=1, event_name="runtime_tool_call_blocked")[0]
+    evaluation = cast(dict[str, object], queue_call["evaluation"])
+    queued_artifact = cast(list[dict[str, object]], evaluation["artifacts"])[0]
+
+    assert result == 0
+    assert decision.action == "require-reapproval"
+    assert authority is not None
+    assert authority.config is fresh_config
+    assert authority.artifact is fresh_artifact
+    assert authority.artifact_hash == fresh_hash
+    assert authority.arguments is fresh_arguments
+    assert response["behavior"] == "deny"
+    assert response["interrupt"] is True
+    assert fresh_artifact.name in response["message"]
+    assert response["approval_reuse"]["reason_code"] == "approval_reuse_context_changed_after_claim"
+    assert queue_call["redaction_level"] == "none"
+    assert queued_artifact["artifact_name"] == fresh_artifact.name
+    assert queued_artifact["artifact_hash"] == fresh_hash
+    assert queued_artifact["config_path"] == fresh_artifact.config_path
+    assert queued_artifact["launch_target"] == json.dumps(fresh_arguments, sort_keys=True)
+    assert receipt["artifact_name"] == fresh_artifact.name
+    assert receipt["artifact_hash"] == fresh_hash
+    assert receipt["policy_decision"] == "require-reapproval"
+    assert receipt["raw_command_text"] == fresh_arguments["command"]
+    assert inventory is not None
+    assert inventory["artifact_name"] == fresh_artifact.name
+    assert inventory["artifact_hash"] == fresh_hash
+    assert inventory["config_path"] == fresh_artifact.config_path
+    assert inventory["last_policy_action"] == "require-reapproval"
+    assert event["payload"]["artifact_hash"] == fresh_hash
+    assert event["payload"]["policy_action"] == "require-reapproval"
+
+
+@pytest.mark.parametrize(
+    ("flow", "action"),
+    (
+        ("pretool", "sandbox-required"),
+        ("permission", "sandbox-required"),
+        ("permission", "require-reapproval"),
+    ),
+)
+def test_copilot_nonallow_action_is_consistent_across_native_receipt_inventory_and_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    flow: str,
+    action: GuardAction,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(guard_home)
+    artifact = build_tool_call_artifact(
+        harness="copilot",
+        server_name="consistency-lab",
+        tool_name="shell_exec",
+        source_scope="project",
+        config_path=str(workspace / ".vscode" / "mcp.json"),
+        transport="stdio",
+    )
+    arguments = {"command": f"rm {action}-target"}
+    artifact_hash = f"guard-approval-context:v1:{action}-consistency"
+    decision = ToolCallDecision(
+        action=action,
+        source="policy",
+        signals=("test consistency signal",),
+        summary=f"Current policy requires {action}.",
+        risk_categories=("command_execution",),
+        current_action=action,
+    )
+    queued: list[dict[str, object]] = []
+
+    def unavailable_daemon_client(_guard_home: Path) -> object:
+        raise RuntimeError("test uses the local approval queue")
+
+    def capture_queue(**kwargs: object) -> list[dict[str, object]]:
+        queued.append(cast(dict[str, object], kwargs["evaluation"]))
+        return [{"request_id": "consistent-request"}]
+
+    monkeypatch.setattr(copilot_hook, "evaluate_tool_call", lambda **_kwargs: decision)
+    monkeypatch.setattr(copilot_hook, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(copilot_hook, "load_guard_surface_daemon_client", unavailable_daemon_client)
+    monkeypatch.setattr(copilot_hook, "queue_blocked_approvals", capture_queue)
+    monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
+    output = io.StringIO()
+    args = _hook_args("copilot", json_output=False)
+    config = GuardConfig(guard_home=guard_home, workspace=workspace, mode="prompt")
+
+    if flow == "pretool":
+        result = copilot_hook._run_hook_copilot_pretool(
+            args,
+            action_envelope=None,
+            config=config,
+            context=HarnessContext(tmp_path, workspace, guard_home),
+            copilot_hook_stage="pretooluse",
+            copilot_runtime_tool_call=(artifact, artifact_hash, arguments),
+            output_stream=output,
+            payload={"hook_event_name": "PreToolUse", "tool_name": "consistency-lab/shell_exec"},
+            runtime_workspace=workspace,
+            store=store,
+        )
+    else:
+        result = copilot_hook._run_hook_copilot_permission_request(
+            args,
+            action_envelope=None,
+            config=config,
+            context=HarnessContext(tmp_path, workspace, guard_home),
+            copilot_permission_request=(artifact, artifact_hash, arguments),
+            guard_home=guard_home,
+            managed_install=None,
+            output_stream=output,
+            payload={"hook_event_name": "permissionRequest", "tool_name": "consistency-lab/shell_exec"},
+            runtime_workspace=workspace,
+            store=store,
+        )
+
+    response = json.loads(output.getvalue())
+    receipt = store.list_receipts(limit=1)[0]
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    event = store.list_events(limit=1, event_name="runtime_tool_call_blocked")[0]
+    native_action = response.get("permissionDecision", response.get("behavior"))
+
+    assert result == 0
+    assert native_action == "deny"
+    assert receipt["policy_decision"] == action
+    assert receipt["artifact_hash"] == artifact_hash
+    assert inventory is not None
+    assert inventory["last_policy_action"] == action
+    assert inventory["artifact_hash"] == artifact_hash
+    assert event["payload"]["policy_action"] == action
+    assert event["payload"]["artifact_hash"] == artifact_hash
+    assert bool(queued) is (action == "require-reapproval")
+
+
+def _insert_tampered_broader_block(
+    store: GuardStore,
+    *,
+    harness: str,
+) -> None:
+    store.upsert_policy(
+        PolicyDecision(
+            harness=harness,
+            scope="global",
+            action="block",
+            reason="tampered broader authority must not be ignored",
+            source="manual",
+        ),
+        "2026-07-17T00:01:00+00:00",
+    )
+    broader_block = next(
+        item for item in store.list_policy_decisions(harness) if item["scope"] == "global" and item["action"] == "block"
+    )
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "update policy_decisions set payload_mac = ? where decision_id = ?",
+            ("00", broader_block["decision_id"]),
+        )
+
+
+def test_runtime_hook_current_allow_and_exact_allow_do_not_hide_tampered_broader_authority(
+    tmp_path: Path,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(guard_home)
+    config = GuardConfig(
+        guard_home=guard_home,
+        workspace=workspace,
+        default_action="allow",
+    )
+    artifact = GuardArtifact(
+        artifact_id="codex:project:tool-action:allow-integrity-collision",
+        name="Codex allowed integrity collision action",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        command="echo",
+        args=("allow-integrity-collision",),
+        metadata={"guard_default_action": "allow", "action_class": "benign test action"},
+    )
+    args = argparse.Namespace(harness="codex", policy_action=None, json=True)
+    context = HarnessContext(tmp_path, workspace, guard_home)
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo allow-integrity-collision"},
+        "source_scope": "project",
+    }
+    initial = _evaluate_runtime_artifact_hook(
+        args,
+        action_envelope=None,
+        config=config,
+        context=context,
+        data_flow_signals=(),
+        guard_home=guard_home,
+        payload=payload,
+        runtime_artifact=artifact,
+        runtime_workspace=workspace,
+        store=store,
+    )
+    assert not isinstance(initial, int)
+    assert initial.response_payload["policy_composition"]["current_composed_action"] == "allow"
+    approval_id = store.record_local_once_approval(
+        request_id="runtime-current-allow-integrity-collision",
+        harness=artifact.harness,
+        artifact_id=artifact.artifact_id,
+        artifact_hash=initial.runtime_artifact_hash,
+        workspace=str(workspace),
+        publisher=artifact.publisher,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+    _insert_tampered_broader_block(store, harness="codex")
+
+    result = _evaluate_runtime_artifact_hook(
+        args,
+        action_envelope=None,
+        config=config,
+        context=context,
+        data_flow_signals=(),
+        guard_home=guard_home,
+        payload=payload,
+        runtime_artifact=artifact,
+        runtime_workspace=workspace,
+        store=store,
+    )
+    with sqlite3.connect(store.path) as connection:
+        claimed_at = connection.execute(
+            "select claimed_at from guard_local_once_approvals where approval_id = ?",
+            (approval_id,),
+        ).fetchone()[0]
+
+    assert not isinstance(result, int)
+    assert result.response_payload["policy_composition"]["current_composed_action"] == "allow"
+    assert result.policy_action == "require-reapproval"
+    assert result.response_payload["approval_reuse"]["current_action"] == "allow"
+    assert result.response_payload["approval_reuse"]["saved_action"] == "allow"
+    assert result.response_payload["approval_reuse"]["reason_code"] == "approval_reuse_integrity_failure"
+    assert claimed_at is None
+
+
+def test_mcp_current_allow_and_exact_allow_do_not_hide_tampered_broader_authority(
+    tmp_path: Path,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(guard_home)
+    config = GuardConfig(
+        guard_home=guard_home,
+        workspace=workspace,
+        default_action="allow",
+    )
+    artifact = build_tool_call_artifact(
+        harness="copilot",
+        server_name="status-lab",
+        tool_name="read_status",
+        source_scope="project",
+        config_path=str(workspace / ".vscode" / "mcp.json"),
+        transport="stdio",
+    )
+    arguments = {"status": "ok"}
+    artifact_hash = build_tool_call_hash(
+        artifact,
+        arguments,
+        workspace=workspace,
+        config=config,
+    )
+    approval_id = store.record_local_once_approval(
+        request_id="mcp-current-allow-integrity-collision",
+        harness=artifact.harness,
+        artifact_id=artifact.artifact_id,
+        artifact_hash=artifact_hash,
+        workspace=str(workspace),
+        publisher=artifact.publisher,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+    _insert_tampered_broader_block(store, harness="copilot")
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=artifact,
+        artifact_hash=artifact_hash,
+        arguments=arguments,
+    )
+    with sqlite3.connect(store.path) as connection:
+        claimed_at = connection.execute(
+            "select claimed_at from guard_local_once_approvals where approval_id = ?",
+            (approval_id,),
+        ).fetchone()[0]
+
+    assert decision.current_action == "allow"
+    assert decision.saved_action == "allow"
+    assert decision.action == "require-reapproval"
+    assert decision.approval_reuse_status == "rejected"
+    assert decision.approval_reuse_reason_code == "approval_reuse_integrity_failure"
+    assert claimed_at is None

--- a/tests/test_guard_hook_saved_block_terminal.py
+++ b/tests/test_guard_hook_saved_block_terminal.py
@@ -1,0 +1,446 @@
+"""Regression coverage for terminal saved blocks in hook-specific flows."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.cli import commands_hook_copilot as copilot_hook
+from codex_plugin_scanner.guard.cli import commands_hook_runtime_review as runtime_review
+from codex_plugin_scanner.guard.cli.commands_hook_runtime_state import RuntimeArtifactHookState
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.mcp_tool_calls import ToolCallDecision
+from codex_plugin_scanner.guard.models import GuardArtifact
+from codex_plugin_scanner.guard.receipts import build_receipt
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _artifact(tmp_path: Path) -> GuardArtifact:
+    return GuardArtifact(
+        artifact_id="copilot:project:tool-action:saved-block",
+        name="Copilot saved-block tool call",
+        harness="copilot",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(tmp_path / ".vscode" / "mcp.json"),
+        command="dangerous_delete",
+    )
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def _saved_block_decision() -> ToolCallDecision:
+    return ToolCallDecision(
+        action="block",
+        source="policy",
+        signals=("tool name implies destructive file or system changes",),
+        summary="Local Guard kept this tool call blocked by saved policy.",
+        risk_categories=("destructive_mutation",),
+        approval_reuse_status="accepted",
+        approval_reuse_reason_code="approval_reuse_saved_block",
+        current_action="review",
+        saved_action="block",
+    )
+
+
+def _fresh_block_decision() -> ToolCallDecision:
+    return ToolCallDecision(
+        action="block",
+        source="heuristic",
+        signals=("tool name implies destructive file or system changes",),
+        summary="The current call is destructive.",
+        risk_categories=("destructive_mutation",),
+    )
+
+
+def _saved_allow_decision() -> ToolCallDecision:
+    return ToolCallDecision(
+        action="allow",
+        source="policy",
+        signals=("tool name implies destructive file or system changes",),
+        summary="Local Guard reused an exact saved approval for this tool call.",
+        risk_categories=("destructive_mutation",),
+        approval_reuse_status="accepted",
+        approval_reuse_reason_code="approval_reuse_accepted",
+        current_action="review",
+        saved_action="allow",
+    )
+
+
+def _copilot_args(*, json_output: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(harness="copilot", json=json_output)
+
+
+def _fail_queue(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+    raise AssertionError("a terminal saved block must not be queued for approval")
+
+
+def _receipt_reuse_evidence(store: GuardStore) -> dict[str, object]:
+    receipt = store.list_receipts(limit=1)[0]
+    evidence = receipt["scanner_evidence"]
+    assert isinstance(evidence, list)
+    typed_evidence = [item for item in evidence if isinstance(item, dict)]
+    return next(item for item in typed_evidence if item.get("source") == "approval_reuse")
+
+
+def _runtime_receipt(artifact: GuardArtifact, artifact_hash: str, policy_action: str):
+    return build_receipt(
+        harness=artifact.harness,
+        artifact_id=artifact.artifact_id,
+        artifact_hash=artifact_hash,
+        policy_decision=policy_action,
+        capabilities_summary="runtime tool action",
+        changed_capabilities=["runtime_tool_call"],
+        provenance_summary=f"runtime tool request evaluated from {artifact.config_path}",
+        artifact_name=artifact.name,
+        source_scope=artifact.source_scope,
+    )
+
+
+def test_runtime_review_observe_mode_keeps_saved_block_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    context = _context(tmp_path)
+    artifact_hash = "guard-approval-context:v1:saved-block"
+    state = RuntimeArtifactHookState(
+        action_envelope=None,
+        artifact_id=artifact.artifact_id,
+        artifact_name=artifact.name,
+        browser_approval_daemon_client=None,
+        changed_capabilities=["runtime_tool_call"],
+        decision_signals=(),
+        decision_v2_payload={},
+        event_name="PreToolUse",
+        initial_policy_action="block",
+        package_evaluation=None,
+        policy_action="block",
+        receipt=_runtime_receipt(artifact, artifact_hash, "block"),
+        requested_policy_action=None,
+        response_payload={"policy_action": "block"},
+        risk_summary="Saved policy blocks this action.",
+        runtime_artifact=artifact,
+        runtime_artifact_hash=artifact_hash,
+        scanner_evidence_payload=[],
+        stored_policy_action="block",
+    )
+    emitted_actions: list[str] = []
+    monkeypatch.setattr(runtime_review, "_runtime_artifact_native_reason", lambda *_args, **_kwargs: "blocked")
+    monkeypatch.setattr(runtime_review, "_claude_prompt_additional_context", lambda **_kwargs: None)
+    monkeypatch.setattr(runtime_review, "_should_emit_copilot_hook_response", lambda _args: True)
+    monkeypatch.setattr(runtime_review, "_record_harness_usage_for_hook", lambda **_kwargs: None)
+    monkeypatch.setattr(runtime_review, "_copilot_hook_reason", lambda *_args: "blocked")
+    monkeypatch.setattr(
+        runtime_review,
+        "_emit_copilot_hook_response",
+        lambda **kwargs: emitted_actions.append(str(kwargs["policy_action"])),
+    )
+    monkeypatch.setattr(runtime_review, "ensure_guard_daemon", _fail_queue)
+    monkeypatch.setattr(runtime_review, "queue_blocked_approvals", _fail_queue)
+
+    result = runtime_review._review_runtime_artifact_hook(
+        state,
+        _copilot_args(),
+        config=GuardConfig(context.guard_home, context.workspace_dir, mode="observe"),
+        context=context,
+        guard_home=context.guard_home,
+        managed_install=None,
+        payload={"hook_event_name": "PreToolUse", "tool_name": "dangerous_delete"},
+        store=GuardStore(context.guard_home),
+        workspace=context.workspace_dir,
+    )
+
+    assert result == 0
+    assert state.policy_action == "block"
+    assert state.response_payload["policy_action"] == "block"
+    assert emitted_actions == ["block"]
+
+
+def test_runtime_review_observe_mode_allows_fresh_block_without_approval_queue(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    context = _context(tmp_path)
+    artifact_hash = "guard-approval-context:v1:fresh-block"
+    state = RuntimeArtifactHookState(
+        action_envelope=None,
+        artifact_id=artifact.artifact_id,
+        artifact_name=artifact.name,
+        browser_approval_daemon_client=None,
+        changed_capabilities=["runtime_tool_call"],
+        decision_signals=(),
+        decision_v2_payload={},
+        event_name="PreToolUse",
+        initial_policy_action="block",
+        package_evaluation=None,
+        policy_action="block",
+        receipt=_runtime_receipt(artifact, artifact_hash, "block"),
+        requested_policy_action=None,
+        response_payload={"policy_action": "block"},
+        risk_summary="The current call is destructive.",
+        runtime_artifact=artifact,
+        runtime_artifact_hash=artifact_hash,
+        scanner_evidence_payload=[],
+        stored_policy_action=None,
+    )
+    monkeypatch.setattr(runtime_review, "ensure_guard_daemon", _fail_queue)
+    monkeypatch.setattr(runtime_review, "queue_blocked_approvals", _fail_queue)
+
+    result = runtime_review._review_runtime_artifact_hook(
+        state,
+        _copilot_args(json_output=True),
+        config=GuardConfig(context.guard_home, context.workspace_dir, mode="observe"),
+        context=context,
+        guard_home=context.guard_home,
+        managed_install=None,
+        payload={"hook_event_name": "PreToolUse", "tool_name": "dangerous_delete"},
+        store=GuardStore(context.guard_home),
+        workspace=context.workspace_dir,
+    )
+
+    assert result is None
+    assert state.policy_action == "allow"
+    assert state.response_payload["policy_action"] == "allow"
+    assert state.response_payload["approval_requests"] == []
+    assert state.response_payload["observed_terminal_action"] == "block"
+
+
+def test_copilot_pretool_observe_mode_keeps_saved_block_terminal_with_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    output = io.StringIO()
+    monkeypatch.setattr(copilot_hook, "evaluate_tool_call", lambda **_kwargs: _saved_block_decision())
+    monkeypatch.setattr(copilot_hook, "_queue_observed_copilot_approval", _fail_queue)
+    monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
+
+    result = copilot_hook._run_hook_copilot_pretool(
+        _copilot_args(),
+        action_envelope=None,
+        config=GuardConfig(context.guard_home, context.workspace_dir, mode="observe"),
+        context=context,
+        copilot_hook_stage="pretooluse",
+        copilot_runtime_tool_call=(artifact, "saved-block-hash", {"target": "important.txt"}),
+        output_stream=output,
+        payload={"tool_name": "dangerous_delete"},
+        runtime_workspace=context.workspace_dir,
+        store=store,
+    )
+
+    response = cast(dict[str, object], json.loads(output.getvalue()))
+    assert result == 0
+    assert response["permissionDecision"] == "deny"
+    assert "approve" not in str(response["permissionDecisionReason"]).lower()
+    assert response["approval_reuse"] == {
+        "status": "accepted",
+        "reason_code": "approval_reuse_saved_block",
+        "current_action": "review",
+        "saved_action": "block",
+        "effective_action": "block",
+    }
+    approval_reuse = response["approval_reuse"]
+    scanner_evidence = response["scanner_evidence"]
+    assert isinstance(approval_reuse, dict)
+    assert isinstance(scanner_evidence, list)
+    assert scanner_evidence[0] == {"source": "approval_reuse", **approval_reuse}
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == "block"
+    assert _receipt_reuse_evidence(store) == {"source": "approval_reuse", **approval_reuse}
+    assert store.list_approval_requests(limit=10) == []
+
+
+def test_copilot_permission_request_saved_block_is_terminal_and_never_queued(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    output = io.StringIO()
+    monkeypatch.setattr(copilot_hook, "evaluate_tool_call", lambda **_kwargs: _saved_block_decision())
+    monkeypatch.setattr(copilot_hook, "_queue_observed_copilot_approval", _fail_queue)
+    monkeypatch.setattr(copilot_hook, "ensure_guard_daemon", _fail_queue)
+    monkeypatch.setattr(copilot_hook, "queue_blocked_approvals", _fail_queue)
+    monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
+
+    result = copilot_hook._run_hook_copilot_permission_request(
+        _copilot_args(),
+        action_envelope=None,
+        config=GuardConfig(context.guard_home, context.workspace_dir, mode="observe"),
+        context=context,
+        copilot_permission_request=(artifact, "saved-block-hash", {"target": "important.txt"}),
+        guard_home=context.guard_home,
+        managed_install=None,
+        output_stream=output,
+        payload={"tool_name": "dangerous_delete"},
+        runtime_workspace=context.workspace_dir,
+        store=store,
+    )
+
+    response = cast(dict[str, object], json.loads(output.getvalue()))
+    assert result == 0
+    assert response["behavior"] == "deny"
+    assert response["interrupt"] is True
+    assert "approve" not in str(response["message"]).lower()
+    approval_reuse = response["approval_reuse"]
+    scanner_evidence = response["scanner_evidence"]
+    assert isinstance(approval_reuse, dict)
+    assert isinstance(scanner_evidence, list)
+    assert approval_reuse["saved_action"] == "block"
+    assert approval_reuse["effective_action"] == "block"
+    first_evidence = scanner_evidence[0]
+    assert isinstance(first_evidence, dict)
+    assert first_evidence["reason_code"] == "approval_reuse_saved_block"
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == "block"
+    assert _receipt_reuse_evidence(store)["reason_code"] == "approval_reuse_saved_block"
+    assert store.list_approval_requests(limit=10) == []
+
+
+def test_copilot_permission_request_fresh_block_is_terminal_and_never_queued(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    output = io.StringIO()
+    monkeypatch.setattr(copilot_hook, "evaluate_tool_call", lambda **_kwargs: _fresh_block_decision())
+    monkeypatch.setattr(copilot_hook, "_queue_observed_copilot_approval", _fail_queue)
+    monkeypatch.setattr(copilot_hook, "ensure_guard_daemon", _fail_queue)
+    monkeypatch.setattr(copilot_hook, "queue_blocked_approvals", _fail_queue)
+    monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
+
+    result = copilot_hook._run_hook_copilot_permission_request(
+        _copilot_args(),
+        action_envelope=None,
+        config=GuardConfig(context.guard_home, context.workspace_dir, mode="prompt"),
+        context=context,
+        copilot_permission_request=(artifact, "fresh-block-hash", {"target": "important.txt"}),
+        guard_home=context.guard_home,
+        managed_install=None,
+        output_stream=output,
+        payload={"tool_name": "dangerous_delete"},
+        runtime_workspace=context.workspace_dir,
+        store=store,
+    )
+
+    response = cast(dict[str, object], json.loads(output.getvalue()))
+    assert result == 0
+    assert response["behavior"] == "deny"
+    assert response["interrupt"] is True
+    assert "approve" not in str(response["message"]).lower()
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == "block"
+    assert store.list_approval_requests(limit=10) == []
+
+
+def test_copilot_saved_allow_is_explained_in_native_response_and_allow_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    output = io.StringIO()
+    monkeypatch.setattr(copilot_hook, "evaluate_tool_call", lambda **_kwargs: _saved_allow_decision())
+    monkeypatch.setattr(copilot_hook, "_queue_observed_copilot_approval", _fail_queue)
+    monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
+
+    result = copilot_hook._run_hook_copilot_pretool(
+        _copilot_args(),
+        action_envelope=None,
+        config=GuardConfig(context.guard_home, context.workspace_dir, mode="observe"),
+        context=context,
+        copilot_hook_stage="pretooluse",
+        copilot_runtime_tool_call=(artifact, "saved-allow-hash", {"target": "approved.txt"}),
+        output_stream=output,
+        payload={"tool_name": "dangerous_delete"},
+        runtime_workspace=context.workspace_dir,
+        store=store,
+    )
+
+    response = cast(dict[str, object], json.loads(output.getvalue()))
+    approval_reuse = response["approval_reuse"]
+    assert isinstance(approval_reuse, dict)
+    assert result == 0
+    assert response["permissionDecision"] == "allow"
+    assert approval_reuse["status"] == "accepted"
+    assert approval_reuse["reason_code"] == "approval_reuse_accepted"
+    assert approval_reuse["current_action"] == "review"
+    assert approval_reuse["saved_action"] == "allow"
+    assert approval_reuse["effective_action"] == "allow"
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == "allow"
+    assert _receipt_reuse_evidence(store) == {"source": "approval_reuse", **approval_reuse}
+
+
+@pytest.mark.parametrize("flow", ("pretool", "permission-request"))
+def test_copilot_observe_mode_allows_fresh_block_without_approval_queue(
+    flow: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact(tmp_path)
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    output = io.StringIO()
+    monkeypatch.setattr(copilot_hook, "evaluate_tool_call", lambda **_kwargs: _fresh_block_decision())
+    monkeypatch.setattr(copilot_hook, "_queue_observed_copilot_approval", _fail_queue)
+    monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
+    config = GuardConfig(context.guard_home, context.workspace_dir, mode="observe")
+    if flow == "pretool":
+        result = copilot_hook._run_hook_copilot_pretool(
+            _copilot_args(),
+            action_envelope=None,
+            config=config,
+            context=context,
+            copilot_hook_stage="pretooluse",
+            copilot_runtime_tool_call=(artifact, "fresh-block-hash", {"target": "important.txt"}),
+            output_stream=output,
+            payload={"tool_name": "dangerous_delete"},
+            runtime_workspace=context.workspace_dir,
+            store=store,
+        )
+    else:
+        result = copilot_hook._run_hook_copilot_permission_request(
+            _copilot_args(),
+            action_envelope=None,
+            config=config,
+            context=context,
+            copilot_permission_request=(artifact, "fresh-block-hash", {"target": "important.txt"}),
+            guard_home=context.guard_home,
+            managed_install=None,
+            output_stream=output,
+            payload={"tool_name": "dangerous_delete"},
+            runtime_workspace=context.workspace_dir,
+            store=store,
+        )
+
+    response = cast(dict[str, object], json.loads(output.getvalue()))
+    assert result == 0
+    assert response.get("permissionDecision", response.get("behavior")) == "allow"
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == "allow"
+    scanner_evidence = receipt["scanner_evidence"]
+    assert isinstance(scanner_evidence, list)
+    assert not any(item.get("source") == "approval_reuse" for item in scanner_evidence if isinstance(item, dict))

--- a/tests/test_guard_interpreted_entrypoint_identity.py
+++ b/tests/test_guard_interpreted_entrypoint_identity.py
@@ -1,0 +1,669 @@
+"""Approval identity regressions for local interpreted entrypoints."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from codex_plugin_scanner.guard.cli.commands_support_runtime_policy import (
+    _runtime_hook_approval_context_token,
+)
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+from codex_plugin_scanner.guard.runtime import approval_context as approval_context_module
+from codex_plugin_scanner.guard.runtime.approval_context import (
+    approval_context_tokens_validation_reason,
+    build_runtime_launch_identity,
+    resolved_runtime_launch_argv,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _replace_file(path: Path, content: bytes, *, executable: bool = False) -> None:
+    replacement = path.with_name(f"{path.name}.replacement")
+    replacement.parent.mkdir(parents=True, exist_ok=True)
+    replacement.write_bytes(content)
+    if executable:
+        replacement.chmod(0o755)
+    os.replace(replacement, path)
+
+
+def _fake_launcher(workspace: Path, name: str) -> Path:
+    launcher = workspace / "bin" / name
+    _replace_file(launcher, b"fake interpreter binary\n", executable=True)
+    return launcher
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    assert isinstance(value, Mapping)
+    return value
+
+
+def _main_context_token(*, artifact: GuardArtifact, workspace: Path, config: GuardConfig) -> str:
+    return _runtime_hook_approval_context_token(
+        artifact=artifact,
+        content_hash="unchanged-artifact-content",
+        runtime_workspace=workspace,
+        action_envelope=None,
+        config=config,
+        current_config_action="review",
+        trusted_cli_action=None,
+        untrusted_payload_action=None,
+        package_action=None,
+        data_flow_action=None,
+        scanner_action=None,
+        current_action="review",
+        data_flow_signals=(),
+        scanner_evidence=(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("launcher_name", "launch_args", "entrypoint_relative"),
+    (
+        ("python", ("server.py", "--stdio"), "server.py"),
+        ("python", ("-m", "localpkg", "--stdio"), "localpkg/__main__.py"),
+        ("node", ("server.js", "--stdio"), "server.js"),
+        ("bash", ("server.sh", "--stdio"), "server.sh"),
+    ),
+)
+def test_main_runtime_context_rejects_saved_identity_after_only_interpreted_entrypoint_bytes_change(
+    tmp_path: Path,
+    launcher_name: str,
+    launch_args: tuple[str, ...],
+    entrypoint_relative: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    launcher = _fake_launcher(workspace, launcher_name)
+    entrypoint = workspace / entrypoint_relative
+    entrypoint.parent.mkdir(parents=True, exist_ok=True)
+    _replace_file(entrypoint, b"entrypoint version one\n")
+    artifact = GuardArtifact(
+        artifact_id=f"codex:project:{launcher_name}-entrypoint",
+        name=f"{launcher_name} entrypoint",
+        harness="codex",
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        command=str(launcher),
+        args=launch_args,
+        transport="stdio",
+    )
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+    )
+
+    approved_token = _main_context_token(artifact=artifact, workspace=workspace, config=config)
+    unchanged_token = _main_context_token(artifact=artifact, workspace=workspace, config=config)
+    assert approved_token == unchanged_token
+
+    _replace_file(entrypoint, b"entrypoint version two\n")
+    changed_token = _main_context_token(artifact=artifact, workspace=workspace, config=config)
+
+    assert changed_token != approved_token
+    assert approval_context_tokens_validation_reason(approved_token, changed_token) == (
+        "approval_reuse_identity_changed"
+    )
+
+
+def test_unresolved_interpreted_entrypoint_is_non_reusable_even_when_launch_vector_is_unchanged(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    launcher = _fake_launcher(workspace, "python")
+
+    first = build_runtime_launch_identity(
+        str(launcher),
+        args=("missing-server.py",),
+        cwd=workspace,
+    )
+    second = build_runtime_launch_identity(
+        str(launcher),
+        args=("missing-server.py",),
+        cwd=workspace,
+    )
+
+    assert first["executable"] == second["executable"]
+    assert first["entrypoint"] != second["entrypoint"]
+    assert _mapping(first["entrypoint"])["status"] == _mapping(second["entrypoint"])["status"] == "unreadable"
+    assert first != second
+
+
+def test_python_dash_e_module_ignores_pythonpath_and_binds_only_cwd_candidate(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    python_path_root = tmp_path / "python-path"
+    workspace.mkdir()
+    launcher = _fake_launcher(workspace, "python")
+    cwd_entrypoint = workspace / "localpkg" / "__main__.py"
+    python_path_entrypoint = python_path_root / "localpkg" / "__main__.py"
+    _replace_file(cwd_entrypoint, b"print('cwd module')\n")
+    _replace_file(python_path_entrypoint, b"print('pythonpath module one')\n")
+    launch_env = {"PYTHONPATH": str(python_path_root), "PYTHONINSPECT": "1"}
+
+    first = build_runtime_launch_identity(
+        str(launcher),
+        args=("-E", "-m", "localpkg"),
+        structured_command=True,
+        cwd=workspace,
+        launch_env=launch_env,
+    )
+    entrypoint = _mapping(first["entrypoint"])
+    assert entrypoint["status"] == "verified"
+    assert entrypoint["path"] == str(cwd_entrypoint.resolve())
+
+    _replace_file(python_path_entrypoint, b"print('pythonpath module two')\n")
+    python_path_changed = build_runtime_launch_identity(
+        str(launcher),
+        args=("-E", "-m", "localpkg"),
+        structured_command=True,
+        cwd=workspace,
+        launch_env=launch_env,
+    )
+    assert python_path_changed == first
+
+    _replace_file(cwd_entrypoint, b"print('cwd module changed')\n")
+    cwd_changed = build_runtime_launch_identity(
+        str(launcher),
+        args=("-E", "-m", "localpkg"),
+        structured_command=True,
+        cwd=workspace,
+        launch_env=launch_env,
+    )
+    assert cwd_changed != first
+
+
+def test_python_dash_e_module_does_not_hash_pythonpath_only_candidate(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    python_path_root = tmp_path / "python-path"
+    workspace.mkdir()
+    launcher = _fake_launcher(workspace, "python")
+    ignored_entrypoint = python_path_root / "externalpkg" / "__main__.py"
+    _replace_file(ignored_entrypoint, b"print('ignored module')\n")
+
+    identity = build_runtime_launch_identity(
+        str(launcher),
+        args=("-E", "-m", "externalpkg"),
+        structured_command=True,
+        cwd=workspace,
+        launch_env={"PYTHONPATH": str(python_path_root)},
+    )
+    entrypoint = _mapping(identity["entrypoint"])
+
+    assert entrypoint["status"] == "unproven"
+    assert entrypoint["reason"] == "module_entrypoint_unresolved"
+    assert "path" not in entrypoint
+    serialized = json.dumps(identity, sort_keys=True)
+    assert str(ignored_entrypoint.resolve()) not in serialized
+    assert hashlib.sha256(ignored_entrypoint.read_bytes()).hexdigest() not in serialized
+
+
+def test_python_isolated_module_resolution_ignores_cwd_and_pythonpath_and_fails_closed(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    python_path_root = tmp_path / "python-path"
+    workspace.mkdir()
+    launcher = _fake_launcher(workspace, "python")
+    _replace_file(workspace / "localpkg" / "__main__.py", b"print('cwd module')\n")
+    _replace_file(python_path_root / "localpkg" / "__main__.py", b"print('pythonpath module')\n")
+    launch_env = {"PYTHONPATH": str(python_path_root), "PYTHONINSPECT": "1"}
+
+    first = build_runtime_launch_identity(
+        str(launcher),
+        args=("-I", "-m", "localpkg"),
+        structured_command=True,
+        cwd=workspace,
+        launch_env=launch_env,
+    )
+    second = build_runtime_launch_identity(
+        str(launcher),
+        args=("-I", "-m", "localpkg"),
+        structured_command=True,
+        cwd=workspace,
+        launch_env=launch_env,
+    )
+    entrypoint = _mapping(first["entrypoint"])
+
+    assert entrypoint["status"] == "unproven"
+    assert entrypoint["reason"] == "isolated_module_resolution_unproven"
+    assert "path" not in entrypoint
+    serialized = json.dumps(first, sort_keys=True)
+    assert str((workspace / "localpkg" / "__main__.py").resolve()) not in serialized
+    assert str((python_path_root / "localpkg" / "__main__.py").resolve()) not in serialized
+    assert first != second
+
+
+def test_structured_executable_path_with_spaces_and_unicode_is_stable_and_content_bound(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    launcher = _fake_launcher(workspace / "runtime dir Δ", "node")
+    entrypoint = workspace / "server ü.js"
+    _replace_file(entrypoint, b"console.log('one');\n")
+
+    first = build_runtime_launch_identity(
+        str(launcher),
+        args=(entrypoint.name,),
+        structured_command=True,
+        cwd=workspace,
+    )
+    unchanged = build_runtime_launch_identity(
+        str(launcher),
+        args=(entrypoint.name,),
+        structured_command=True,
+        cwd=workspace,
+    )
+
+    assert first == unchanged
+    assert _mapping(first["executable"])["path"] == str(launcher.resolve())
+    assert _mapping(first["entrypoint"])["path"] == str(entrypoint.resolve())
+
+    _replace_file(entrypoint, b"console.log('two');\n")
+    changed = build_runtime_launch_identity(
+        str(launcher),
+        args=(entrypoint.name,),
+        structured_command=True,
+        cwd=workspace,
+    )
+    assert changed != first
+
+
+def test_main_runtime_context_handles_structured_mcp_executable_path_with_spaces(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    launcher = _fake_launcher(workspace / "runtime dir Δ", "node")
+    entrypoint = workspace / "server ü.js"
+    _replace_file(entrypoint, b"console.log('one');\n")
+    artifact = GuardArtifact(
+        artifact_id="codex:project:spaced-mcp-server",
+        name="spaced MCP server",
+        harness="codex",
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        command=str(launcher),
+        args=(entrypoint.name,),
+        transport="stdio",
+    )
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace, default_action="review")
+
+    first = _main_context_token(artifact=artifact, workspace=workspace, config=config)
+    unchanged = _main_context_token(artifact=artifact, workspace=workspace, config=config)
+    assert first == unchanged
+
+    _replace_file(entrypoint, b"console.log('two');\n")
+    assert _main_context_token(artifact=artifact, workspace=workspace, config=config) != first
+
+
+def test_main_runtime_context_binds_configured_environment_values_without_exposing_them(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    launcher = _fake_launcher(workspace, "node")
+    entrypoint = workspace / "server.js"
+    _replace_file(entrypoint, b"console.log('server');\n")
+    first_secret = "configured-secret-value-one"
+    second_secret = "configured-secret-value-two"
+    artifact = GuardArtifact(
+        artifact_id="codex:project:environment-bound-mcp-server",
+        name="environment-bound MCP server",
+        harness="codex",
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        command=str(launcher),
+        args=(entrypoint.name,),
+        transport="stdio",
+        metadata={"env": {"TOKEN": first_secret}, "env_keys": ["TOKEN"]},
+    )
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace, default_action="review")
+
+    first = _main_context_token(artifact=artifact, workspace=workspace, config=config)
+    unchanged = _main_context_token(artifact=artifact, workspace=workspace, config=config)
+    changed = _main_context_token(
+        artifact=replace(artifact, metadata={"env": {"TOKEN": second_secret}, "env_keys": ["TOKEN"]}),
+        workspace=workspace,
+        config=config,
+    )
+
+    assert first == unchanged
+    assert changed != first
+    assert first_secret not in first
+    assert second_secret not in changed
+
+
+def test_unavailable_code_loading_environment_value_disables_main_context_reuse(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    launcher = _fake_launcher(workspace, "node")
+    entrypoint = workspace / "server.js"
+    _replace_file(entrypoint, b"console.log('server');\n")
+    artifact = GuardArtifact(
+        artifact_id="claude-code:project:hidden-node-options",
+        name="hidden NODE_OPTIONS MCP server",
+        harness="claude-code",
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path=str(workspace / ".mcp.json"),
+        command=str(launcher),
+        args=(entrypoint.name,),
+        transport="stdio",
+        metadata={"env_keys": ["NODE_OPTIONS"], "env_values_hash": "a" * 64},
+    )
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace, default_action="review")
+
+    first = _main_context_token(artifact=artifact, workspace=workspace, config=config)
+    second = _main_context_token(artifact=artifact, workspace=workspace, config=config)
+
+    assert first != second
+
+
+@pytest.mark.parametrize(
+    ("launcher_name", "launch_args", "launch_env"),
+    (
+        ("python", ("-i", "server.py"), {}),
+        ("python", ("server.py",), {"PYTHONINSPECT": "1"}),
+        ("python", ("-X", "presite=local_bootstrap", "server.py"), {}),
+        ("node", ("--require", "./preload.js", "server.js"), {}),
+        ("node", ("server.js",), {"NODE_OPTIONS": "--require ./preload.js"}),
+        ("bash", ("--rcfile", "bootstrap.sh", "server.sh"), {}),
+        ("bash", ("-i", "server.sh"), {}),
+    ),
+)
+def test_unbound_interactive_or_code_loading_options_disable_reuse(
+    tmp_path: Path,
+    launcher_name: str,
+    launch_args: tuple[str, ...],
+    launch_env: dict[str, str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    launcher = _fake_launcher(workspace, launcher_name)
+    for filename in ("server.py", "server.js", "server.sh", "preload.js", "bootstrap.sh"):
+        _replace_file(workspace / filename, b"entrypoint\n")
+
+    first = build_runtime_launch_identity(
+        str(launcher),
+        args=launch_args,
+        structured_command=True,
+        cwd=workspace,
+        launch_env=launch_env,
+    )
+    second = build_runtime_launch_identity(
+        str(launcher),
+        args=launch_args,
+        structured_command=True,
+        cwd=workspace,
+        launch_env=launch_env,
+    )
+
+    assert _mapping(first["entrypoint"])["status"] == "unproven"
+    assert first != second
+
+
+def test_direct_env_shebang_binds_path_selected_interpreter_and_fails_closed_when_unresolved(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    first_bin = workspace / "first-bin"
+    second_bin = workspace / "second-bin"
+    first_bin.mkdir(parents=True)
+    second_bin.mkdir(parents=True)
+    direct_script = workspace / "server"
+    _replace_file(direct_script, b"#!/usr/bin/env python\nprint('server')\n", executable=True)
+    first_interpreter = first_bin / "python"
+    second_interpreter = second_bin / "python"
+    _replace_file(first_interpreter, b"fake python runtime\n", executable=True)
+    _replace_file(second_interpreter, b"fake python runtime\n", executable=True)
+
+    first_env = {"PATH": str(first_bin)}
+    first = build_runtime_launch_identity(
+        str(direct_script),
+        cwd=workspace,
+        launch_env=first_env,
+    )
+    unchanged = build_runtime_launch_identity(
+        str(direct_script),
+        cwd=workspace,
+        launch_env=first_env,
+    )
+    assert first == unchanged
+    first_entrypoint = _mapping(first["entrypoint"])
+    assert first_entrypoint["status"] == "verified"
+    assert _mapping(first_entrypoint["interpreter"])["path"] == str(first_interpreter.resolve())
+
+    _replace_file(first_interpreter, b"evil python runtime\n", executable=True)
+    changed_interpreter = build_runtime_launch_identity(
+        str(direct_script),
+        cwd=workspace,
+        launch_env=first_env,
+    )
+    assert changed_interpreter != first
+
+    changed_path = build_runtime_launch_identity(
+        str(direct_script),
+        cwd=workspace,
+        launch_env={"PATH": str(second_bin)},
+    )
+    assert changed_path != first
+    changed_path_entrypoint = _mapping(changed_path["entrypoint"])
+    assert _mapping(changed_path_entrypoint["interpreter"])["path"] == str(second_interpreter.resolve())
+
+    unresolved_first = build_runtime_launch_identity(
+        str(direct_script),
+        cwd=workspace,
+        launch_env={"PATH": str(workspace / "empty-bin")},
+    )
+    unresolved_second = build_runtime_launch_identity(
+        str(direct_script),
+        cwd=workspace,
+        launch_env={"PATH": str(workspace / "empty-bin")},
+    )
+    assert _mapping(unresolved_first["entrypoint"])["status"] == "unproven"
+    assert unresolved_first != unresolved_second
+
+
+def test_direct_package_script_launch_argv_pins_verified_env_interpreter(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    runtime_bin = workspace / "runtime-bin"
+    runtime_bin.mkdir(parents=True)
+    interpreter = runtime_bin / "python3"
+    _replace_file(interpreter, b"fake python runtime\n", executable=True)
+    manager = workspace / "npm"
+    _replace_file(manager, b"#!/usr/bin/env python3\nprint('manager')\n", executable=True)
+    identity = build_runtime_launch_identity(
+        str(manager),
+        args=("install", "demo"),
+        structured_command=True,
+        direct_executable=True,
+        cwd=workspace,
+        launch_env={"PATH": str(runtime_bin)},
+    )
+
+    pinned = resolved_runtime_launch_argv(identity, args=("install", "demo"))
+
+    assert pinned == (
+        str(interpreter.resolve()),
+        str(manager.resolve()),
+        "install",
+        "demo",
+    )
+
+
+def test_direct_package_script_launch_argv_fails_closed_for_unbound_nested_preload(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    runtime_bin = workspace / "runtime-bin"
+    runtime_bin.mkdir(parents=True)
+    interpreter = runtime_bin / "node"
+    _replace_file(interpreter, b"fake node runtime\n", executable=True)
+    manager = workspace / "npm"
+    _replace_file(
+        manager,
+        b"#!/usr/bin/env -S node --require ./preload.js\n",
+        executable=True,
+    )
+    _replace_file(workspace / "preload.js", b"module.exports = {};\n")
+
+    identity = build_runtime_launch_identity(
+        str(manager),
+        structured_command=True,
+        direct_executable=True,
+        cwd=workspace,
+        launch_env={"PATH": str(runtime_bin)},
+    )
+
+    assert _mapping(identity["entrypoint"])["status"] == "unproven"
+    assert resolved_runtime_launch_argv(identity) is None
+
+
+def test_launch_identity_never_exposes_raw_shebang_arguments(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    runtime_bin = workspace / "bin"
+    runtime_bin.mkdir(parents=True)
+    interpreter = runtime_bin / "python"
+    _replace_file(interpreter, b"fake python runtime\n", executable=True)
+    secret = "guard-shebang-secret-42"
+    direct_script = workspace / "server"
+    _replace_file(
+        direct_script,
+        f"#!/usr/bin/env -S python -u --api-key={secret}\nprint('server')\n".encode(),
+        executable=True,
+    )
+
+    executable_identity = approval_context_module.build_runtime_executable_identity(str(direct_script))
+    launch_identity = build_runtime_launch_identity(
+        str(direct_script),
+        cwd=workspace,
+        launch_env={"PATH": str(runtime_bin)},
+    )
+    serialized = json.dumps(
+        {"executable": executable_identity, "launch": launch_identity},
+        sort_keys=True,
+    )
+
+    assert secret not in serialized
+    assert "shebang" not in executable_identity
+    assert "shebang_sha256" in executable_identity
+
+
+def test_executable_hash_rechecks_descriptor_metadata_after_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "racing-tool"
+    _replace_file(executable, b"#!/bin/sh\nexit 0\n", executable=True)
+    real_fstat = os.fstat
+    fstat_calls = 0
+
+    def racing_fstat(descriptor: int) -> object:
+        nonlocal fstat_calls
+        observed = real_fstat(descriptor)
+        fstat_calls += 1
+        if fstat_calls < 2:
+            return observed
+        return SimpleNamespace(
+            st_dev=observed.st_dev,
+            st_ino=observed.st_ino,
+            st_size=observed.st_size,
+            st_mtime_ns=observed.st_mtime_ns,
+            st_ctime_ns=observed.st_ctime_ns + 1,
+            st_mode=observed.st_mode,
+        )
+
+    approval_context_module._cached_executable_hash.cache_clear()
+    monkeypatch.setattr(approval_context_module.os, "fstat", racing_fstat)
+    identity = approval_context_module.build_runtime_executable_identity(str(executable))
+
+    assert identity["status"] == "identity_raced"
+    assert "sha256" not in identity
+    assert "reuse_nonce" in identity
+    approval_context_module._cached_executable_hash.cache_clear()
+
+
+def test_consumer_saved_allow_is_rejected_after_only_node_entrypoint_bytes_change(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    launcher = _fake_launcher(workspace, "node")
+    entrypoint = workspace / "server.js"
+    _replace_file(entrypoint, b"console.log('version one');\n")
+    artifact = GuardArtifact(
+        artifact_id="codex:project:consumer-node-entrypoint",
+        name="consumer node entrypoint",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        command=str(launcher),
+        args=("server.js", "--stdio"),
+        transport="stdio",
+        metadata={
+            "action_class": "interpreted entrypoint identity proof",
+            "guard_default_action": "review",
+        },
+    )
+    detection = HarnessDetection(
+        harness=artifact.harness,
+        installed=True,
+        command_available=True,
+        config_paths=(artifact.config_path,),
+        artifacts=(artifact,),
+    )
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+    )
+    store = GuardStore(config.guard_home)
+    initial_artifact_hash = artifact_hash(artifact)
+
+    initial = evaluate_detection(detection, store, config, persist=False)
+    approved_token = str(initial["artifacts"][0]["approval_context_hash"])
+    approval_id = store.record_local_once_approval(
+        request_id="consumer-node-entrypoint-v1",
+        harness=artifact.harness,
+        artifact_id=artifact.artifact_id,
+        artifact_hash=approved_token,
+        workspace=str(workspace.resolve()),
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+
+    unchanged = evaluate_detection(detection, store, config, persist=False)
+    unchanged_item = unchanged["artifacts"][0]
+    assert unchanged_item["approval_context_hash"] == approved_token
+    assert unchanged_item["policy_action"] == "allow"
+    assert unchanged_item["approval_reuse_status"] == "accepted"
+
+    _replace_file(entrypoint, b"console.log('version two');\n")
+    changed = evaluate_detection(detection, store, config, persist=False)
+    changed_item = changed["artifacts"][0]
+
+    assert artifact_hash(artifact) == initial_artifact_hash
+    assert changed_item["approval_context_hash"] != approved_token
+    assert changed_item["policy_action"] == "review"
+    assert changed_item["approval_reuse_status"] == "rejected"
+    assert changed_item["approval_reuse_reason_code"] == "approval_reuse_identity_changed"
+    assert (
+        store.peek_local_once_approval(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            artifact_hash=approved_token,
+            workspace=str(workspace.resolve()),
+            publisher=None,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is not None
+    )

--- a/tests/test_guard_js_package_hook_phase11.py
+++ b/tests/test_guard_js_package_hook_phase11.py
@@ -17,6 +17,7 @@ from codex_plugin_scanner import install_integrity
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.runtime import supply_chain_package_eval as package_eval_module
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -76,7 +77,9 @@ def _fingerprint(public_key_pem: bytes) -> str:
     return hashlib.sha256(public_key_pem.decode("utf-8").strip().encode("utf-8")).hexdigest()
 
 
-def _bundle_response(*, package_name: str, version: str, namespace: str | None = None) -> dict[str, object]:
+def _bundle_response(
+    *, package_name: str, version: str, namespace: str | None = None, action: str = "block"
+) -> dict[str, object]:
     generated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)
     expires_at = generated_at + timedelta(hours=12)
     purl_name = f"{namespace}/{package_name}" if namespace is not None else package_name
@@ -104,7 +107,7 @@ def _bundle_response(*, package_name: str, version: str, namespace: str | None =
         "packages": [
             {
                 "confidence": 990,
-                "defaultAction": "block",
+                "defaultAction": action,
                 "ecosystem": "npm",
                 "exploitLevel": "active",
                 "knownExploited": True,
@@ -257,7 +260,10 @@ def test_guard_hook_requires_review_for_repository_local_vitest_run(
     (workspace_dir / "package.json").write_text(
         '{"name":"demo","devDependencies":{"vitest":"^4.1.8"}}\n', encoding="utf-8"
     )
-    (workspace_dir / "bun.lock").write_text('"vitest": "4.1.8"\n', encoding="utf-8")
+    (workspace_dir / "bun.lock").write_text(
+        '[[package]]\nname = "vitest"\nversion = "4.1.8"\nresolved = "npm:vitest@4.1.8"\ndependencies = []\n',
+        encoding="utf-8",
+    )
     runner = workspace_dir / "node_modules" / ".bin" / "vitest"
     runner.parent.mkdir(parents=True)
     runner.write_text("#!/bin/sh\n", encoding="utf-8")
@@ -267,6 +273,32 @@ def test_guard_hook_requires_review_for_repository_local_vitest_run(
     _write_codex_pre_tool_payload(payload_path, workspace_dir, command)
     store = GuardStore(home_dir)
     _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(package_name="vitest", version="4.1.8", action="allow"),
+        "2026-05-19T00:00:00Z",
+    )
+    (home_dir / "config.toml").write_text(
+        '[risk_actions]\npackage_script = "review"\n',
+        encoding="utf-8",
+    )
+
+    def raise_auth_expired(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
+        raise guard_commands_module.GuardSyncAuthorizationExpiredError(
+            "Guard authorization expired. Run `hol-guard connect` to sign in again."
+        )
+
+    evaluate_package_request = guard_commands_module.evaluate_package_request_artifact
+    monkeypatch.setattr(
+        package_eval_module,
+        "_resolve_guard_sync_auth_context",
+        raise_auth_expired,
+    )
+    monkeypatch.setattr(
+        guard_commands_module,
+        "evaluate_package_request_artifact",
+        lambda **kwargs: evaluate_package_request(**kwargs, now="2026-05-19T01:00:00Z"),
+    )
     monkeypatch.setattr(install_integrity, "warn_if_shadowed", lambda: None)
 
     rc = main(
@@ -287,13 +319,19 @@ def test_guard_hook_requires_review_for_repository_local_vitest_run(
 
     payload = json.loads(captured.out)
     assert rc == 0
-    assert "waiting for approval" in captured.err
+    assert captured.err == ""
     assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
-    assert "review" in payload["hookSpecificOutput"]["permissionDecisionReason"].lower()
-    assert store.list_approval_requests(limit=5)
+    decision_reason = payload["hookSpecificOutput"]["permissionDecisionReason"].lower()
+    assert "needs your approval" in decision_reason
+    assert "open hol guard to approve" in decision_reason
+    approval_requests = store.list_approval_requests(limit=5)
+    assert approval_requests
+    assert approval_requests[0]["policy_action"] == "review"
     evidence = store.list_evidence()
     assert evidence
     assert evidence[0]["category"] == "supply-chain"
+    assert evidence[0]["details"]["decision"] == "monitor"
+    assert any(reason["code"] == "cloud_auth_error" for reason in evidence[0]["details"]["reasons"])
 
     request_id = str(store.list_approval_requests(limit=5)[0]["request_id"])
     apply_approval_resolution(
@@ -346,5 +384,8 @@ def test_guard_hook_requires_review_for_repository_local_vitest_run(
 
     assert changed_rc == 0
     assert changed_payload["hookSpecificOutput"]["permissionDecision"] == "deny"
-    assert "waiting for approval" in changed_capture.err
-    assert len(store.list_approval_requests(status="pending", limit=5)) == 1
+    assert changed_capture.err == ""
+    assert "open hol guard to approve" in changed_payload["hookSpecificOutput"]["permissionDecisionReason"].lower()
+    changed_requests = store.list_approval_requests(status="pending", limit=5)
+    assert len(changed_requests) == 1
+    assert changed_requests[0]["policy_action"] == "review"

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -6,6 +6,7 @@ import contextlib
 import io
 import json
 import os
+import shutil
 from pathlib import Path
 
 import pytest
@@ -16,7 +17,9 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
     import tomli as tomllib
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.consumer.service import diff_artifact
 from codex_plugin_scanner.guard.policy_integrity import PolicyIntegrityVerificationResult
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.store import GuardStore
@@ -51,8 +54,8 @@ def _build_guard_fixture(home_dir: Path, workspace_dir: Path) -> None:
         home_dir / ".codex" / "config.toml",
         """
 [mcp_servers.global_tools]
-command = "python"
-args = ["-m", "http.server", "9000"]
+command = "/usr/bin/true"
+args = []
 """.strip()
         + "\n",
     )
@@ -109,6 +112,22 @@ def _make_fake_codex(fake_bin: Path, marker_path: Path) -> Path:
     return fake_codex
 
 
+def _make_pinnable_harness_executable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    executable: str,
+) -> Path:
+    """Install a native no-op executable so launch identity can be pinned."""
+
+    fake_bin = tmp_path / "pinnable-harness-bin"
+    fake_bin.mkdir(parents=True, exist_ok=True)
+    executable_path = fake_bin / executable
+    shutil.copyfile("/usr/bin/true", executable_path)
+    executable_path.chmod(executable_path.stat().st_mode | 0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}")
+    return executable_path.resolve()
+
+
 def _build_opencode_fixture(home_dir: Path, workspace_dir: Path) -> None:
     _write_json(
         home_dir / ".config" / "opencode" / "opencode.json",
@@ -130,14 +149,17 @@ def test_guard_run_launches_with_configured_home(monkeypatch, tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    fake_codex = _make_pinnable_harness_executable(tmp_path, monkeypatch, "codex")
     _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
     captured_env: dict[str, str] = {}
     captured_cwd: Path | None = None
+    captured_command: list[str] = []
 
-    def _fake_run(command, cwd=None, check=False, env=None):
-        del command, check
+    def _fake_run(command, cwd=None, check=False, env=None, **kwargs):
+        del check, kwargs
         nonlocal captured_cwd
         captured_cwd = cwd
+        captured_command.extend(command)
         captured_env.update(env or {})
         return _CompletedProcess(0)
 
@@ -160,6 +182,8 @@ def test_guard_run_launches_with_configured_home(monkeypatch, tmp_path, capsys):
 
     assert rc == 0
     assert output["launched"] is True
+    assert output["launch_command"] == [str(fake_codex), "--help"]
+    assert captured_command == [str(fake_codex), "--help"]
     assert captured_env["HOME"] == str(home_dir)
     assert captured_cwd == workspace_dir
 
@@ -177,16 +201,16 @@ def test_guard_run_launches_copilot_with_passthrough_args(monkeypatch, tmp_path,
     (home_dir / ".copilot").mkdir(parents=True, exist_ok=True)
     _write_text(
         home_dir / ".copilot" / "mcp-config.json",
-        json.dumps({"servers": {"global-tool": {"command": "npx", "args": ["server.js"]}}}),
+        json.dumps({"servers": {"global-tool": {"command": "/usr/bin/true", "args": []}}}),
     )
     _write_text(
         workspace_dir / ".mcp.json",
-        json.dumps({"mcpServers": {"danger_lab": {"command": "python3", "args": ["server.py"]}}}),
+        json.dumps({"mcpServers": {"safe-tool": {"command": "/usr/bin/true", "args": []}}}),
     )
     captured_command: list[str] = []
 
-    def _fake_run(command, cwd=None, check=False, env=None):
-        del cwd, check, env
+    def _fake_run(command, cwd=None, check=False, env=None, **kwargs):
+        del cwd, check, env, kwargs
         captured_command.extend(command)
         return _CompletedProcess(0)
 
@@ -212,8 +236,8 @@ def test_guard_run_launches_copilot_with_passthrough_args(monkeypatch, tmp_path,
 
     assert rc == 0
     assert output["launched"] is True
-    assert captured_command[0].endswith("/copilot")
-    assert captured_command[1:] == [
+    assert captured_command[:2] == [str(Path("/bin/sh").resolve()), str(local_copilot)]
+    assert captured_command[2:] == [
         "--additional-mcp-config",
         f"@{workspace_dir / '.mcp.json'}",
         "suggest",
@@ -221,7 +245,7 @@ def test_guard_run_launches_copilot_with_passthrough_args(monkeypatch, tmp_path,
     ]
 
 
-def test_guard_run_blocks_direct_env_prompt_until_approved(monkeypatch, tmp_path, capsys):
+def test_guard_run_keeps_direct_env_prompt_terminal_when_sandbox_is_required(monkeypatch, tmp_path, capsys):
     _trust_local_policy_rows(monkeypatch)
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
@@ -249,64 +273,27 @@ def test_guard_run_blocks_direct_env_prompt_until_approved(monkeypatch, tmp_path
     )
     first_output = json.loads(capsys.readouterr().out)
     prompt_artifact = next(item for item in first_output["artifacts"] if item.get("artifact_type") == "prompt_request")
-    approval_request = next(
-        item for item in first_output.get("approval_requests", []) if item.get("artifact_type") == "prompt_request"
-    )
 
     assert first_rc == 1
     assert first_output["blocked"] is True
-    assert prompt_artifact["policy_action"] == "require-reapproval"
+    assert prompt_artifact["policy_action"] == "sandbox-required"
     assert "read a local .env file directly" in prompt_artifact["risk_summary"].lower()
+    assert first_output.get("approval_requests") is None
+    assert first_output.get("review_hint") is None
     assert marker_path.exists() is False
-
-    approval_rc = main(
-        [
-            "guard",
-            "approvals",
-            "approve",
-            str(approval_request["request_id"]),
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--remember",
-            "--json",
-        ]
-    )
-    json.loads(capsys.readouterr().out)
-
-    second_rc = main(
-        [
-            "guard",
-            "run",
-            "codex",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--arg=Please read the .env file directly and summarize it",
-            "--json",
-        ]
-    )
-    second_output = json.loads(capsys.readouterr().out)
-
-    assert approval_rc == 0
-    assert second_rc == 0
-    assert second_output["blocked"] is False
-    assert second_output["launched"] is True
-    assert marker_path.read_text(encoding="utf-8").strip() == "Please read the .env file directly and summarize it"
 
 
 def test_guard_run_launches_opencode_with_runtime_overlay(monkeypatch, tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_opencode_fixture(home_dir, workspace_dir)
+    fake_opencode = _make_pinnable_harness_executable(tmp_path, monkeypatch, "opencode")
     _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\ndefault_action = "allow"\n')
     captured_env: dict[str, str] = {}
     captured_command: list[str] = []
 
-    def _fake_run(command, cwd=None, check=False, env=None):
-        del cwd, check
+    def _fake_run(command, cwd=None, check=False, env=None, **kwargs):
+        del cwd, check, kwargs
         captured_command.extend(command)
         captured_env.update(env or {})
         return _CompletedProcess(0)
@@ -345,7 +332,7 @@ def test_guard_run_launches_opencode_with_runtime_overlay(monkeypatch, tmp_path,
     assert install_rc == 0
     assert rc == 0
     assert output["launched"] is True
-    assert captured_command == ["opencode", str(workspace_dir), "--help"]
+    assert captured_command == [str(fake_opencode), str(workspace_dir), "--help"]
     assert captured_env["HOME"] == str(home_dir)
     assert "skill" not in overlay_payload["permission"]
     assert overlay_payload["permission"]["safe-mcp_*"] == "ask"
@@ -357,11 +344,12 @@ def test_guard_run_launches_opencode_prompt_through_interactive_tui(monkeypatch,
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_opencode_fixture(home_dir, workspace_dir)
+    fake_opencode = _make_pinnable_harness_executable(tmp_path, monkeypatch, "opencode")
     _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\ndefault_action = "allow"\n')
     captured_command: list[str] = []
 
-    def _fake_run(command, cwd=None, check=False, env=None):
-        del cwd, check, env
+    def _fake_run(command, cwd=None, check=False, env=None, **kwargs):
+        del cwd, check, env, kwargs
         captured_command.extend(command)
         return _CompletedProcess(0)
 
@@ -404,8 +392,8 @@ def test_guard_run_launches_opencode_prompt_through_interactive_tui(monkeypatch,
 
     assert rc == 0
     assert output["launched"] is True
-    assert captured_command == [
-        "opencode",
+    assert captured_command[0] == str(fake_opencode)
+    assert captured_command[1:] == [
         str(workspace_dir),
         "--prompt",
         "Use the danger_lab MCP tool dangerous_delete right now",
@@ -416,11 +404,12 @@ def test_guard_run_launches_opencode_prompt_with_flags_through_interactive_tui(m
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_opencode_fixture(home_dir, workspace_dir)
+    fake_opencode = _make_pinnable_harness_executable(tmp_path, monkeypatch, "opencode")
     _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\ndefault_action = "allow"\n')
     captured_command: list[str] = []
 
-    def _fake_run(command, cwd=None, check=False, env=None):
-        del cwd, check, env
+    def _fake_run(command, cwd=None, check=False, env=None, **kwargs):
+        del cwd, check, env, kwargs
         captured_command.extend(command)
         return _CompletedProcess(0)
 
@@ -465,8 +454,8 @@ def test_guard_run_launches_opencode_prompt_with_flags_through_interactive_tui(m
 
     assert rc == 0
     assert output["launched"] is True
-    assert captured_command == [
-        "opencode",
+    assert captured_command[0] == str(fake_opencode)
+    assert captured_command[1:] == [
         str(workspace_dir),
         "--model",
         "openai/gpt-5.4",
@@ -479,11 +468,12 @@ def test_guard_run_keeps_attach_and_file_flags_out_of_prompt(monkeypatch, tmp_pa
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_opencode_fixture(home_dir, workspace_dir)
+    fake_opencode = _make_pinnable_harness_executable(tmp_path, monkeypatch, "opencode")
     _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\ndefault_action = "allow"\n')
     captured_command: list[str] = []
 
-    def _fake_run(command, cwd=None, check=False, env=None):
-        del cwd, check, env
+    def _fake_run(command, cwd=None, check=False, env=None, **kwargs):
+        del cwd, check, env, kwargs
         captured_command.extend(command)
         return _CompletedProcess(0)
 
@@ -527,8 +517,8 @@ def test_guard_run_keeps_attach_and_file_flags_out_of_prompt(monkeypatch, tmp_pa
 
     assert rc == 0
     assert output["launched"] is True
-    assert captured_command == [
-        "opencode",
+    assert captured_command[0] == str(fake_opencode)
+    assert captured_command[1:] == [
         str(workspace_dir),
         "--attach",
         "http://127.0.0.1:4096",
@@ -543,12 +533,13 @@ def test_guard_run_keeps_explicit_opencode_run_args_unchanged(monkeypatch, tmp_p
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_opencode_fixture(home_dir, workspace_dir)
+    fake_opencode = _make_pinnable_harness_executable(tmp_path, monkeypatch, "opencode")
     _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\ndefault_action = "allow"\n')
     captured_command: list[str] = []
     captured_cwd: list[Path | None] = []
 
-    def _fake_run(command, cwd=None, check=False, env=None):
-        del check, env
+    def _fake_run(command, cwd=None, check=False, env=None, **kwargs):
+        del check, env, kwargs
         captured_command.extend(command)
         captured_cwd.append(Path(cwd) if cwd is not None else None)
         return _CompletedProcess(0)
@@ -590,8 +581,8 @@ def test_guard_run_keeps_explicit_opencode_run_args_unchanged(monkeypatch, tmp_p
 
     assert rc == 0
     assert output["launched"] is True
-    assert captured_command == [
-        "opencode",
+    assert captured_command[0] == str(fake_opencode)
+    assert captured_command[1:] == [
         "run",
         "--attach",
         "http://127.0.0.1:4096",
@@ -606,11 +597,14 @@ def test_guard_run_merges_existing_opencode_config_content(monkeypatch, tmp_path
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_opencode_fixture(home_dir, workspace_dir)
+    fake_opencode = _make_pinnable_harness_executable(tmp_path, monkeypatch, "opencode")
     _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\ndefault_action = "allow"\n')
     captured_env: dict[str, str] = {}
+    captured_command: list[str] = []
 
-    def _fake_run(command, cwd=None, check=False, env=None):
-        del command, cwd, check
+    def _fake_run(command, cwd=None, check=False, env=None, **kwargs):
+        del cwd, check, kwargs
+        captured_command.extend(command)
         captured_env.update(env or {})
         return _CompletedProcess(0)
 
@@ -651,6 +645,7 @@ def test_guard_run_merges_existing_opencode_config_content(monkeypatch, tmp_path
 
     assert rc == 0
     assert output["launched"] is True
+    assert captured_command == [str(fake_opencode), str(workspace_dir), "--help"]
     assert overlay_payload["model"] == "gpt-4.1"
     assert overlay_payload["permission"]["network"]["*"] == "allow"
     assert overlay_payload["permission"]["safe-mcp_*"] == "ask"
@@ -708,6 +703,8 @@ url = "https://workspace.example/mcp"
 def test_guard_run_launches_hermes_with_guard_overlay_paths(monkeypatch, tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True)
+    fake_hermes = _make_pinnable_harness_executable(tmp_path, monkeypatch, "hermes")
     _write_text(
         home_dir / ".hermes" / "config.yaml",
         'mcp_servers:\n  github:\n    command: "npx"\n    args: ["-y", "@modelcontextprotocol/server-github"]\n',
@@ -716,8 +713,8 @@ def test_guard_run_launches_hermes_with_guard_overlay_paths(monkeypatch, tmp_pat
     captured_env: dict[str, str] = {}
     captured_command: list[str] = []
 
-    def _fake_run(command, cwd=None, check=False, env=None):
-        del cwd, check
+    def _fake_run(command, cwd=None, check=False, env=None, **kwargs):
+        del cwd, check, kwargs
         captured_command.extend(command)
         captured_env.update(env or {})
         return _CompletedProcess(0)
@@ -755,7 +752,7 @@ def test_guard_run_launches_hermes_with_guard_overlay_paths(monkeypatch, tmp_pat
     assert install_rc == 0
     assert rc == 0
     assert output["launched"] is True
-    assert captured_command == ["hermes", "chat"]
+    assert captured_command == [str(fake_hermes), "chat"]
     assert captured_env["HOME"] == str(home_dir)
     assert captured_env["HERMES_GUARD_MCP_OVERLAY_PATH"].endswith("mcp-overlay.json")
     assert captured_env["HERMES_GUARD_PRETOOL_PATH"].endswith("pretool-hook.json")
@@ -864,23 +861,18 @@ def test_guard_run_opencode_reapproves_changed_plugin_and_skill_content(monkeypa
     _write_text(home_dir / "config.toml", 'changed_hash_action = "require-reapproval"\nmode = "prompt"\n')
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
     monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda _url: True)
-
-    first_rc = main(
-        [
-            "guard",
-            "run",
+    context = HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir)
+    baseline_detection = guard_runner_module.detect_harness("opencode", context)
+    store = GuardStore(home_dir)
+    for artifact in baseline_detection.artifacts:
+        artifact_diff = diff_artifact(None, artifact)
+        store.save_snapshot(
             "opencode",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--dry-run",
-            "--default-action",
-            "allow",
-            "--json",
-        ]
-    )
-    json.loads(capsys.readouterr().out)
+            artifact.artifact_id,
+            {**artifact_diff["current_snapshot"], "artifact_hash": artifact_diff["current_hash"]},
+            artifact_diff["current_hash"],
+            "2026-07-17T00:00:00+00:00",
+        )
     _write_text(
         workspace_dir / ".opencode" / "plugins" / "env-read-plugin.mjs",
         "export default { name: 'updated' };\n",
@@ -916,7 +908,6 @@ def test_guard_run_opencode_reapproves_changed_plugin_and_skill_content(monkeypa
         if item["artifact_id"] == "opencode:project:skill:opencode:skills/review-skill"
     )
 
-    assert first_rc == 0
     assert second_rc == 1
     assert second_output["blocked"] is True
     assert plugin_artifact["policy_action"] == "require-reapproval"
@@ -1046,7 +1037,7 @@ def test_guard_run_still_blocks_when_prompt_contains_negation_elsewhere(monkeypa
 
     assert rc == 1
     assert output["blocked"] is True
-    assert prompt_artifact["policy_action"] == "require-reapproval"
+    assert prompt_artifact["policy_action"] == "sandbox-required"
     assert marker_path.exists() is False
 
 
@@ -1080,11 +1071,11 @@ def test_guard_run_blocks_env_content_request_without_read_verb(monkeypatch, tmp
 
     assert rc == 1
     assert output["blocked"] is True
-    assert prompt_artifact["policy_action"] == "require-reapproval"
+    assert prompt_artifact["policy_action"] == "sandbox-required"
     assert marker_path.exists() is False
 
 
-def test_guard_prompt_artifact_workspace_scope_approval_targets_workspace(monkeypatch, tmp_path, capsys):
+def test_guard_prompt_artifact_terminal_sandbox_block_is_not_queued(monkeypatch, tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     fake_bin = tmp_path / "fake-bin"
@@ -1109,14 +1100,13 @@ def test_guard_prompt_artifact_workspace_scope_approval_targets_workspace(monkey
         ]
     )
     output = json.loads(capsys.readouterr().out)
-    approval_request = next(
-        item for item in output.get("approval_requests", []) if item.get("artifact_type") == "prompt_request"
-    )
+    prompt_artifact = next(item for item in output["artifacts"] if item.get("artifact_type") == "prompt_request")
 
-    assert approval_request["workspace"] == str(workspace_dir)
-    assert approval_request["approval_url"].startswith("http://127.0.0.1:4455/requests/")
-    assert approval_request["review_command"].startswith("hol-guard approvals approve ")
-    assert "http://127.0.0.1:4455" in output["review_hint"]
+    assert output["blocked"] is True
+    assert prompt_artifact["policy_action"] == "sandbox-required"
+    assert prompt_artifact["effective_workspace"] == str(workspace_dir)
+    assert output.get("approval_requests") is None
+    assert output.get("review_hint") is None
 
 
 def test_claude_prompt_hook_shows_hol_guard_branding(tmp_path, capsys):
@@ -1262,6 +1252,7 @@ def test_guard_run_allows_debug_prompt_for_wrapper_harnesses(
 ):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
+    _make_pinnable_harness_executable(tmp_path, monkeypatch, executable)
     _build_guard_fixture(home_dir, workspace_dir)
     _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\nmode = "prompt"\n')
     captured = _capture_launch(monkeypatch)

--- a/tests/test_guard_local_authority_integrity.py
+++ b/tests/test_guard_local_authority_integrity.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import sqlite3
+from hashlib import sha256
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.local_authority_integrity import (
+    sign_local_authority_payload,
+    verify_local_authority_payload,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_base import PolicyDecisionLookupResult
+
+_HARNESS = "codex"
+_ARTIFACT_ID = "codex:project:tool-action:local-integrity"
+_ARTIFACT_HASH = "sha256:local-integrity"
+_CREATED_AT = "2026-07-17T12:00:00+00:00"
+_EXPIRES_AT = "2026-07-17T14:00:00+00:00"
+
+
+def _record_local_once(store: GuardStore) -> str:
+    approval_id = store.record_local_once_approval(
+        request_id="request-local-integrity",
+        harness=_HARNESS,
+        artifact_id=_ARTIFACT_ID,
+        artifact_hash=_ARTIFACT_HASH,
+        workspace="/workspace/a",
+        publisher="publisher-a",
+        action="allow",
+        created_at=_CREATED_AT,
+        expires_at=_EXPIRES_AT,
+    )
+    assert approval_id is not None
+    return approval_id
+
+
+def _workspace_policy_key(workspace: str) -> str:
+    normalized = str(Path(workspace).expanduser().resolve())
+    return f"workspace:{sha256(normalized.encode('utf-8')).hexdigest()}"
+
+
+def _lookup(
+    store: GuardStore,
+    *,
+    now: str = "2026-07-17T12:30:00+00:00",
+) -> PolicyDecisionLookupResult:
+    return store.resolve_policy_decision_lookup(
+        _HARNESS,
+        _ARTIFACT_ID,
+        _ARTIFACT_HASH,
+        workspace="/workspace/a",
+        publisher="publisher-a",
+        now=now,
+        consume_one_shot=False,
+    )
+
+
+def test_local_authority_hmac_is_domain_and_purpose_separated() -> None:
+    key = b"k" * 32
+    payload = {"action": "allow", "artifact_id": _ARTIFACT_ID}
+    first = sign_local_authority_payload(
+        payload,
+        key=key,
+        key_id="key-1",
+        purpose="guard-local-once-approval",
+        signed_at=_CREATED_AT,
+    )
+    second = sign_local_authority_payload(
+        payload,
+        key=key,
+        key_id="key-1",
+        purpose="cursor-native-shell-allow",
+        signed_at=_CREATED_AT,
+    )
+
+    assert first["payload_mac"] != second["payload_mac"]
+    assert (
+        verify_local_authority_payload(
+            payload,
+            first,
+            key=key,
+            key_id="key-1",
+            purpose="guard-local-once-approval",
+        ).status
+        == "valid"
+    )
+    wrong_purpose = verify_local_authority_payload(
+        payload,
+        first,
+        key=key,
+        key_id="key-1",
+        purpose="cursor-native-shell-allow",
+    )
+    assert wrong_purpose.status == "tampered"
+    assert wrong_purpose.message == "local_authority_integrity_payload_hash_mismatch"
+
+
+def test_malformed_local_authority_payload_fails_closed_without_raising() -> None:
+    key = b"k" * 32
+    integrity = sign_local_authority_payload(
+        {"action": "allow"},
+        key=key,
+        key_id="key-1",
+        purpose="guard-local-once-approval",
+        signed_at=_CREATED_AT,
+    )
+
+    result = verify_local_authority_payload(
+        {"action": object()},
+        integrity,
+        key=key,
+        key_id="key-1",
+        purpose="guard-local-once-approval",
+    )
+
+    assert result.status == "tampered"
+    assert result.message == "local_authority_integrity_payload_invalid"
+
+
+def test_non_ascii_forged_integrity_metadata_fails_closed_without_raising() -> None:
+    key = b"k" * 32
+    payload = {"action": "allow"}
+    integrity = sign_local_authority_payload(
+        payload,
+        key=key,
+        key_id="key-1",
+        purpose="guard-local-once-approval",
+        signed_at=_CREATED_AT,
+    )
+
+    result = verify_local_authority_payload(
+        payload,
+        {**integrity, "payload_hash": "\N{BOMB}"},
+        key=key,
+        key_id="key-1",
+        purpose="guard-local-once-approval",
+    )
+
+    assert result.status == "tampered"
+    assert result.message == "local_authority_integrity_payload_hash_mismatch"
+
+
+def test_authentic_local_once_row_resolves_and_claims(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    approval_id = _record_local_once(store)
+
+    lookup = _lookup(store)
+
+    assert lookup["ignored_local_integrity"] is None
+    decision = lookup["decision"]
+    assert isinstance(decision, dict)
+    assert decision["approval_id"] == approval_id
+    assert decision["integrity_status"] == "valid"
+    assert store.claim_approval_reuse_decision(decision, now="2026-07-17T12:31:00+00:00")
+
+
+def test_local_once_lookup_reads_existing_integrity_key_without_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _ = _record_local_once(store)
+    original_lookup = store._policy_integrity_secret_material  # pyright: ignore[reportPrivateUsage]
+    create_flags: list[bool] = []
+
+    def tracked_lookup(*, create: bool) -> tuple[bytes | None, str | None]:
+        create_flags.append(create)
+        return original_lookup(create=create)
+
+    monkeypatch.setattr(store, "_policy_integrity_secret_material", tracked_lookup)
+
+    assert _lookup(store)["decision"] is not None
+    assert create_flags == [False]
+
+
+def test_unsigned_legacy_local_once_row_cannot_grant_and_reports_integrity(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    with sqlite3.connect(store.path) as connection:
+        _ = connection.execute(
+            """
+            insert into guard_local_once_approvals (
+              approval_id, request_id, harness, artifact_id, artifact_hash, workspace, publisher,
+              action, created_at, expires_at, claimed_at
+            ) values (?, ?, ?, ?, ?, ?, ?, 'allow', ?, ?, null)
+            """,
+            (
+                "legacy-unsigned",
+                "request-legacy-unsigned",
+                _HARNESS,
+                _ARTIFACT_ID,
+                _ARTIFACT_HASH,
+                _workspace_policy_key("/workspace/a"),
+                "publisher-a",
+                _CREATED_AT,
+                _EXPIRES_AT,
+            ),
+        )
+
+    lookup = _lookup(store)
+
+    assert lookup["decision"] is None
+    ignored = lookup["ignored_local_integrity"]
+    assert isinstance(ignored, dict)
+    assert ignored["integrity_status"] == "missing_integrity"
+    assert ignored["integrity_message"] == "local_authority_integrity_metadata_missing"
+    assert (
+        store.approval_reuse_validation_reason(
+            _HARNESS,
+            _ARTIFACT_ID,
+            _ARTIFACT_HASH,
+            "/workspace/a",
+            "publisher-a",
+            "2026-07-17T12:30:00+00:00",
+        )
+        == "approval_reuse_integrity_failure"
+    )
+    events = store.list_events(event_name="rule.ignored.local_integrity")
+    assert len(events) == 1
+    event_payload = events[0]["payload"]
+    assert isinstance(event_payload, dict)
+    assert event_payload["source"] == "approval-gate-once"
+    assert event_payload["integrity_status"] == "missing_integrity"
+
+
+def test_post_storage_local_once_tamper_cannot_grant(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    approval_id = _record_local_once(store)
+    with sqlite3.connect(store.path) as connection:
+        _ = connection.execute(
+            "update guard_local_once_approvals set action = 'block' where approval_id = ?",
+            (approval_id,),
+        )
+
+    lookup = _lookup(store)
+
+    assert lookup["decision"] is None
+    ignored = lookup["ignored_local_integrity"]
+    assert isinstance(ignored, dict)
+    assert ignored["integrity_status"] == "tampered"
+    assert ignored["integrity_message"] == "local_authority_integrity_payload_hash_mismatch"
+
+
+def test_forged_local_once_mac_cannot_grant(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    approval_id = _record_local_once(store)
+    with sqlite3.connect(store.path) as connection:
+        _ = connection.execute(
+            "update guard_local_once_approvals set payload_mac = ? where approval_id = ?",
+            ("00" * 32, approval_id),
+        )
+
+    lookup = _lookup(store)
+
+    assert lookup["decision"] is None
+    ignored = lookup["ignored_local_integrity"]
+    assert isinstance(ignored, dict)
+    assert ignored["integrity_status"] == "tampered"
+    assert ignored["integrity_message"] == "local_authority_integrity_mac_mismatch"
+
+
+def test_local_once_claim_revalidates_integrity_after_lookup(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    approval_id = _record_local_once(store)
+    lookup = _lookup(store)
+    decision = lookup["decision"]
+    assert isinstance(decision, dict)
+    with sqlite3.connect(store.path) as connection:
+        _ = connection.execute(
+            "update guard_local_once_approvals set payload_mac = ? where approval_id = ?",
+            ("forged-after-lookup", approval_id),
+        )
+
+    assert not store.claim_approval_reuse_decision(decision, now="2026-07-17T12:31:00+00:00")
+
+
+def test_resetting_claimed_at_cannot_replay_consumed_local_once_row(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    approval_id = _record_local_once(store)
+    decision = _lookup(store)["decision"]
+    assert isinstance(decision, dict)
+    assert store.claim_approval_reuse_decision(decision, now="2026-07-17T12:31:00+00:00")
+    with sqlite3.connect(store.path) as connection:
+        _ = connection.execute(
+            "update guard_local_once_approvals set claimed_at = null where approval_id = ?",
+            (approval_id,),
+        )
+
+    replay_lookup = _lookup(store, now="2026-07-17T12:32:00+00:00")
+
+    assert replay_lookup["decision"] is None
+    ignored = replay_lookup["ignored_local_integrity"]
+    assert isinstance(ignored, dict)
+    assert ignored["integrity_status"] == "tampered"
+
+
+def test_legacy_local_once_schema_is_migrated_without_trusting_existing_rows(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    with sqlite3.connect(guard_home / "guard.db") as connection:
+        _ = connection.execute(
+            """
+            create table guard_local_once_approvals (
+              approval_id text primary key,
+              request_id text not null,
+              harness text not null,
+              artifact_id text not null,
+              artifact_hash text not null,
+              workspace text,
+              publisher text,
+              action text not null,
+              created_at text not null,
+              expires_at text not null,
+              claimed_at text
+            )
+            """
+        )
+        _ = connection.execute(
+            """
+            insert into guard_local_once_approvals values (?, ?, ?, ?, ?, ?, ?, 'allow', ?, ?, null)
+            """,
+            (
+                "legacy-before-migration",
+                "request-before-migration",
+                _HARNESS,
+                _ARTIFACT_ID,
+                _ARTIFACT_HASH,
+                _workspace_policy_key("/workspace/a"),
+                "publisher-a",
+                _CREATED_AT,
+                _EXPIRES_AT,
+            ),
+        )
+
+    store = GuardStore(guard_home)
+    with sqlite3.connect(store.path) as connection:
+        column_rows = cast(
+            list[tuple[object, ...]],
+            connection.execute("pragma table_info(guard_local_once_approvals)").fetchall(),
+        )
+        columns = {str(row[1]) for row in column_rows}
+
+    assert {"integrity_version", "payload_hash", "payload_mac", "integrity_key_id", "signed_at"} <= columns
+    lookup = _lookup(store)
+    assert lookup["decision"] is None
+    ignored = lookup["ignored_local_integrity"]
+    assert isinstance(ignored, dict)
+    assert ignored["integrity_status"] == "missing_integrity"

--- a/tests/test_guard_local_supply_chain_phase15.py
+++ b/tests/test_guard_local_supply_chain_phase15.py
@@ -335,6 +335,14 @@ def test_guard_protect_receipt_keeps_matched_policy_rule_metadata(tmp_path: Path
     assert payload["supply_chain_evaluation"]["matched_rule_id"] == "policy-rule-1"
     action_envelope = dict(payload["receipt"]["action_envelope_json"])
     package_context = action_envelope.pop("package_execution_context")
+    assert action_envelope.pop("policy_action") == "warn"
+    assert action_envelope.pop("additional_policy_context") == {
+        "action": "allow",
+        "matched_advisories": [],
+        "reason": "Guard found no blocking advisory or risky install signal for this request.",
+        "risk_signals": [],
+        "version": 1,
+    }
     assert action_envelope == {
         "bundle_version": "1747612800000-deadbeef",
         "matched_rule_id": "policy-rule-1",

--- a/tests/test_guard_manifest_install_firewall.py
+++ b/tests/test_guard_manifest_install_firewall.py
@@ -3,20 +3,30 @@
 from __future__ import annotations
 
 import json
+import sqlite3
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
+import codex_plugin_scanner.guard.local_supply_chain as local_supply_chain_module
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution
 from codex_plugin_scanner.guard.cli.protect_approvals import _annotate_package_execution_context_change
+from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.local_supply_chain import (
     _package_policy_workspace_candidates,
     build_package_protect_payload,
+    compose_current_package_policy_action,
+    recompute_package_protect_artifact_hash,
 )
-from codex_plugin_scanner.guard.models import GuardApprovalRequest, PolicyDecision
+from codex_plugin_scanner.guard.models import GuardAction, GuardApprovalRequest, GuardArtifact, PolicyDecision
 from codex_plugin_scanner.guard.runtime.package_intent import build_package_request_artifact
 from codex_plugin_scanner.guard.runtime.package_intent_parser import parse_package_intent
-from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
+    PackageRequestEvaluation,
+    SupplyChainUserCopy,
+    evaluate_package_request_artifact,
+)
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -74,6 +84,1362 @@ def _install_fake_pnpm(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     home.mkdir()
     monkeypatch.setenv("PATH", str(executable_dir))
     monkeypatch.setenv("HOME", str(home))
+
+
+def _review_package_evaluation() -> PackageRequestEvaluation:
+    return PackageRequestEvaluation(
+        decision="ask",
+        policy_action="review",
+        enforcement="local",
+        entitlement_state="active",
+        cache_status="fresh",
+        package_intent_hash="package-intent-v1",
+        policy_version="feed-policy-v1",
+        bundle_version="feed-bundle-v1",
+        workspace_fingerprint="workspace-v1",
+        reasons=({"code": "feed_review", "message": "Current feed result requires review."},),
+        packages=({"name": "guard-proof", "decision": "ask"},),
+        risk_summary="Current feed result requires review.",
+        user_copy=SupplyChainUserCopy(
+            title="Review package request",
+            summary="Current feed result requires review.",
+            next_step="Review the package request.",
+            dashboard_url=None,
+            harness_message="Current feed result requires review.",
+        ),
+    )
+
+
+def _allow_package_evaluation() -> PackageRequestEvaluation:
+    return PackageRequestEvaluation(
+        decision="allow",
+        policy_action="allow",
+        enforcement="local",
+        entitlement_state="active",
+        cache_status="fresh",
+        package_intent_hash="package-intent-allow",
+        policy_version="feed-policy-allow",
+        bundle_version="feed-bundle-allow",
+        workspace_fingerprint="workspace-allow",
+        reasons=({"code": "feed_allow", "message": "Current feed allows execution."},),
+        packages=({"name": "guard-proof", "decision": "allow"},),
+        risk_summary="Current feed allows execution.",
+        user_copy=SupplyChainUserCopy(
+            title="Package allowed",
+            summary="Current feed allows execution.",
+            next_step="Continue.",
+            dashboard_url=None,
+            harness_message="Current feed allows execution.",
+        ),
+    )
+
+
+def _build_review_package_payload(
+    *,
+    store: GuardStore,
+    workspace_dir: Path,
+    config: GuardConfig,
+    now: str,
+) -> tuple[dict[str, object], int]:
+    result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=True,
+        now=now,
+        config=config,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert result is not None
+    return result
+
+
+def _package_policy_config(
+    *,
+    guard_home: Path,
+    workspace_dir: Path,
+    package_action: GuardAction = "review",
+    harness_action: GuardAction | None = None,
+    artifact_id: str | None = None,
+    artifact_action: GuardAction | None = None,
+) -> GuardConfig:
+    return GuardConfig(
+        guard_home=guard_home,
+        workspace=workspace_dir,
+        security_level="custom",
+        risk_actions={"package_script": package_action},
+        harness_actions={"guard-cli": harness_action} if harness_action is not None else None,
+        artifact_actions={artifact_id: artifact_action}
+        if artifact_id is not None and artifact_action is not None
+        else None,
+    )
+
+
+def _seed_exact_package_review_allow(
+    *,
+    store: GuardStore,
+    workspace_dir: Path,
+    config: GuardConfig,
+) -> dict[str, object]:
+    baseline_payload, baseline_rc = _build_review_package_payload(
+        store=store,
+        workspace_dir=workspace_dir,
+        config=config,
+        now="2026-07-17T00:00:00Z",
+    )
+    assert baseline_rc == 2
+    receipt = baseline_payload["receipt"]
+    assert isinstance(receipt, dict)
+    store.ensure_policy_integrity_ready_for_write(now="2026-07-17T00:00:00Z")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="guard-cli",
+            scope="artifact",
+            action="allow",
+            artifact_id=str(receipt["artifact_id"]),
+            artifact_hash=str(receipt["artifact_hash"]),
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+    return receipt
+
+
+def test_build_package_protect_payload_reuses_unchanged_exact_review_approval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _review_package_evaluation(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = _package_policy_config(
+        guard_home=store.guard_home,
+        workspace_dir=workspace_dir,
+    )
+    _seed_exact_package_review_allow(store=store, workspace_dir=workspace_dir, config=config)
+
+    retry_payload, retry_rc = _build_review_package_payload(
+        store=store,
+        workspace_dir=workspace_dir,
+        config=config,
+        now="2026-07-17T00:01:00Z",
+    )
+
+    assert retry_rc == 0
+    assert retry_payload["verdict"]["action"] == "allow"
+    assert retry_payload["executed"] is False
+    assert retry_payload["supply_chain_evaluation"]["reasons"][0]["code"] == "saved_package_approval"
+
+
+def test_recomputed_package_protect_hash_includes_the_same_final_launch_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _review_package_evaluation(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    npm = fake_bin / "npm"
+    npm.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    store = GuardStore(tmp_path / "guard-home")
+    config = _package_policy_config(guard_home=store.guard_home, workspace_dir=workspace_dir)
+    payload, returncode = _build_review_package_payload(
+        store=store,
+        workspace_dir=workspace_dir,
+        config=config,
+        now="2026-07-17T00:00:00Z",
+    )
+    receipt = payload["receipt"]
+    assert isinstance(receipt, dict)
+
+    recomputed = recompute_package_protect_artifact_hash(
+        ["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-07-17T00:00:00Z",
+        config=config,
+    )
+
+    assert returncode == 2
+    assert recomputed == receipt["artifact_hash"]
+
+
+def test_package_protect_dry_run_previews_one_shot_allow_then_launch_claims_it_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _review_package_evaluation(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "npm-launches.txt"
+    npm = fake_bin / "npm"
+    npm.write_text(f"#!/bin/sh\nprintf 'launch\\n' >> '{marker}'\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    store = GuardStore(tmp_path / "guard-home")
+    config = _package_policy_config(
+        guard_home=store.guard_home,
+        workspace_dir=workspace_dir,
+    )
+    baseline_payload, baseline_rc = _build_review_package_payload(
+        store=store,
+        workspace_dir=workspace_dir,
+        config=config,
+        now="2026-07-17T00:00:00Z",
+    )
+    assert baseline_rc == 2
+    receipt = baseline_payload["receipt"]
+    assert isinstance(receipt, dict)
+    store.ensure_policy_integrity_ready_for_write(now="2026-07-17T00:00:30Z")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="guard-cli",
+            scope="artifact",
+            action="allow",
+            artifact_id=str(receipt["artifact_id"]),
+            artifact_hash=str(receipt["artifact_hash"]),
+            source="approval-gate",
+            expires_at="2026-07-18T00:00:00Z",
+        ),
+        "2026-07-17T00:00:30Z",
+    )
+
+    preview_payload, preview_rc = _build_review_package_payload(
+        store=store,
+        workspace_dir=workspace_dir,
+        config=config,
+        now="2026-07-17T00:01:00Z",
+    )
+
+    assert preview_rc == 0
+    assert preview_payload["verdict"]["action"] == "allow"
+    assert preview_payload["executed"] is False
+    preview_lookup = store.resolve_policy_decision_lookup(
+        "guard-cli",
+        str(receipt["artifact_id"]),
+        str(receipt["artifact_hash"]),
+        None,
+        None,
+        "2026-07-17T00:01:00Z",
+        consume_one_shot=False,
+    )
+    assert preview_lookup["decision"] is not None
+    assert store.approval_reuse_claim_disposition(preview_lookup["decision"]) == "consumed"
+    assert marker.exists() is False
+
+    launch_result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:02:00Z",
+        config=config,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert launch_result is not None
+    launch_payload, launch_rc = launch_result
+
+    assert launch_rc == 0
+    assert launch_payload["verdict"]["action"] == "allow"
+    assert launch_payload["executed"] is True
+    assert marker.read_text(encoding="utf-8").splitlines() == ["launch"]
+    claimed_lookup = store.resolve_policy_decision_lookup(
+        "guard-cli",
+        str(receipt["artifact_id"]),
+        str(receipt["artifact_hash"]),
+        None,
+        None,
+        "2026-07-17T00:02:00Z",
+        consume_one_shot=False,
+    )
+    assert claimed_lookup["decision"] is None
+
+    denied_result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:03:00Z",
+        config=config,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert denied_result is not None
+    denied_payload, denied_rc = denied_result
+
+    assert denied_rc == 2
+    assert denied_payload["verdict"]["action"] == "review"
+    assert denied_payload["executed"] is False
+    assert marker.read_text(encoding="utf-8").splitlines() == ["launch"]
+
+
+def test_package_protect_claim_failure_blocks_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _review_package_evaluation(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "unexpected-npm-launch.txt"
+    npm = fake_bin / "npm"
+    npm.write_text(f"#!/bin/sh\nprintf 'launch\\n' >> '{marker}'\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    store = GuardStore(tmp_path / "guard-home")
+    config = _package_policy_config(
+        guard_home=store.guard_home,
+        workspace_dir=workspace_dir,
+    )
+    _seed_exact_package_review_allow(store=store, workspace_dir=workspace_dir, config=config)
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", lambda *_args, **_kwargs: False)
+
+    result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+        config=config,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert result is not None
+    payload, returncode = result
+
+    assert returncode == 2
+    assert payload["verdict"]["action"] == "review"
+    assert payload["executed"] is False
+    assert payload["supply_chain_evaluation"]["reasons"][0]["code"] == "approval_reuse_claim_failed"
+    assert marker.exists() is False
+
+
+def test_package_protect_retained_local_once_deletion_after_claim_blocks_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _review_package_evaluation(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "unexpected-retained-local-once-launch.txt"
+    npm = fake_bin / "npm"
+    npm.write_text(f"#!/bin/sh\nprintf 'launch\\n' >> '{marker}'\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    store = GuardStore(tmp_path / "guard-home")
+    config = _package_policy_config(guard_home=store.guard_home, workspace_dir=workspace_dir)
+    baseline_payload, baseline_rc = _build_review_package_payload(
+        store=store,
+        workspace_dir=workspace_dir,
+        config=config,
+        now="2026-07-17T00:00:00Z",
+    )
+    assert baseline_rc == 2
+    receipt = baseline_payload["receipt"]
+    assert isinstance(receipt, dict)
+    approval_id = store.record_local_once_approval(
+        request_id="package-retained-local-once",
+        harness="guard-cli",
+        artifact_id=str(receipt["artifact_id"]),
+        artifact_hash=str(receipt["artifact_hash"]),
+        workspace=None,
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T00:00:30Z",
+        expires_at="2026-07-18T00:00:00Z",
+    )
+    assert approval_id is not None
+    selected = store.resolve_policy_decision(
+        "guard-cli",
+        str(receipt["artifact_id"]),
+        str(receipt["artifact_hash"]),
+        now="2026-07-17T00:00:45Z",
+        consume_one_shot=False,
+    )
+    assert selected is not None
+    assert store.approval_reuse_claim_disposition(selected) == "retained"
+    original_claim = store.claim_approval_reuse_decision
+
+    def claim_then_delete(decision: dict[str, object], *, now: str) -> bool:
+        assert decision["approval_id"] == approval_id
+        assert store.approval_reuse_claim_disposition(decision) == "retained"
+        claimed = original_claim(decision, now=now)
+        assert claimed is True
+        with sqlite3.connect(store.path) as connection:
+            cursor = connection.execute(
+                "delete from guard_local_once_approvals where approval_id = ?",
+                (approval_id,),
+            )
+        assert cursor.rowcount == 1
+        return True
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", claim_then_delete)
+
+    result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+        config=config,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert result is not None
+    payload, returncode = result
+
+    assert returncode == 2
+    assert payload["verdict"]["action"] == "review"
+    assert payload["executed"] is False
+    assert payload["supply_chain_evaluation"]["reasons"][0]["code"] == ("approval_reuse_context_changed_after_claim")
+    assert marker.exists() is False
+
+
+def test_package_protect_retained_persistent_policy_deletion_after_claim_blocks_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _review_package_evaluation(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "unexpected-retained-policy-launch.txt"
+    npm = fake_bin / "npm"
+    npm.write_text(f"#!/bin/sh\nprintf 'launch\\n' >> '{marker}'\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    store = GuardStore(tmp_path / "guard-home")
+    config = _package_policy_config(guard_home=store.guard_home, workspace_dir=workspace_dir)
+    receipt = _seed_exact_package_review_allow(store=store, workspace_dir=workspace_dir, config=config)
+    selected = store.resolve_policy_decision(
+        "guard-cli",
+        str(receipt["artifact_id"]),
+        str(receipt["artifact_hash"]),
+        now="2026-07-17T00:00:45Z",
+        consume_one_shot=False,
+    )
+    assert selected is not None
+    assert store.approval_reuse_claim_disposition(selected) == "retained"
+    original_claim = store.claim_approval_reuse_decision
+
+    def claim_then_delete(decision: dict[str, object], *, now: str) -> bool:
+        assert store.approval_reuse_claim_disposition(decision) == "retained"
+        claimed = original_claim(decision, now=now)
+        assert claimed is True
+        decision_id = decision["decision_id"]
+        assert isinstance(decision_id, int)
+        with sqlite3.connect(store.path) as connection:
+            cursor = connection.execute(
+                "delete from policy_decisions where decision_id = ?",
+                (decision_id,),
+            )
+        assert cursor.rowcount == 1
+        return True
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", claim_then_delete)
+
+    result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+        config=config,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert result is not None
+    payload, returncode = result
+
+    assert returncode == 2
+    assert payload["verdict"]["action"] == "review"
+    assert payload["executed"] is False
+    assert payload["supply_chain_evaluation"]["reasons"][0]["code"] == ("approval_reuse_context_changed_after_claim")
+    assert marker.exists() is False
+
+
+def test_package_protect_reloads_saved_policy_after_claim_before_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _review_package_evaluation(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "unexpected-post-claim-policy-launch.txt"
+    npm = fake_bin / "npm"
+    npm.write_text(f"#!/bin/sh\nprintf 'launch\\n' >> '{marker}'\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    store = GuardStore(tmp_path / "guard-home")
+    config = _package_policy_config(guard_home=store.guard_home, workspace_dir=workspace_dir)
+    _seed_exact_package_review_allow(store=store, workspace_dir=workspace_dir, config=config)
+    original_claim = store.claim_approval_reuse_decision
+
+    def claim_then_block(decision: dict[str, object], *, now: str) -> bool:
+        claimed = original_claim(decision, now=now)
+        assert claimed is True
+        store.upsert_policy(
+            PolicyDecision(
+                harness=str(decision["harness"]),
+                scope="artifact",
+                action="block",
+                artifact_id=str(decision["artifact_id"]),
+                artifact_hash=str(decision["artifact_hash"]),
+                reason="policy changed to block during saved approval claim",
+                source="manual",
+            ),
+            now,
+        )
+        return True
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", claim_then_block)
+
+    result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+        config=config,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert result is not None
+    payload, returncode = result
+
+    assert returncode == 2
+    assert payload["verdict"]["action"] == "block"
+    assert payload["executed"] is False
+    assert payload["supply_chain_evaluation"]["reasons"][0]["code"] == "saved_package_block"
+    assert marker.exists() is False
+
+
+@pytest.mark.parametrize(
+    ("refresh_mode", "expected_returncode", "expected_action", "expected_launch"),
+    (
+        ("unchanged", 0, "allow", True),
+        ("block", 2, "block", False),
+        ("failure", 2, "block", False),
+    ),
+)
+def test_package_protect_refreshes_current_config_after_saved_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    refresh_mode: str,
+    expected_returncode: int,
+    expected_action: str,
+    expected_launch: bool,
+) -> None:
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _review_package_evaluation(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / f"config-refresh-{refresh_mode}-launch.txt"
+    npm = fake_bin / "npm"
+    npm.write_text(f"#!/bin/sh\nprintf 'launch\\n' >> '{marker}'\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    store = GuardStore(tmp_path / "guard-home")
+    config = _package_policy_config(guard_home=store.guard_home, workspace_dir=workspace_dir)
+    _seed_exact_package_review_allow(store=store, workspace_dir=workspace_dir, config=config)
+
+    def current_config() -> GuardConfig:
+        if refresh_mode == "failure":
+            raise RuntimeError("sensitive config provider failure")
+        return _package_policy_config(
+            guard_home=store.guard_home,
+            workspace_dir=workspace_dir,
+            package_action="block" if refresh_mode == "block" else "review",
+        )
+
+    result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+        config=config,
+        current_config_provider=current_config,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert result is not None
+    payload, returncode = result
+
+    assert returncode == expected_returncode
+    assert payload["verdict"]["action"] == expected_action
+    assert payload["executed"] is expected_launch
+    assert marker.exists() is expected_launch
+    if refresh_mode == "failure":
+        first_reason = payload["supply_chain_evaluation"]["reasons"][0]
+        assert first_reason["code"] == "approval_reuse_policy_changed"
+        assert "sensitive" not in json.dumps(payload)
+
+
+@pytest.mark.parametrize("final_action", ("allow", "warn"))
+def test_package_protect_rebuilds_every_permitted_final_projection_before_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    final_action: str,
+) -> None:
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _allow_package_evaluation(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / f"final-{final_action}-launch.txt"
+    npm = fake_bin / "npm"
+    npm.write_text(f"#!/bin/sh\nprintf 'launch\\n' >> '{marker}'\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    store = GuardStore(tmp_path / "guard-home")
+    initial_authority = local_supply_chain_module._build_package_protect_authority(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-07-17T00:01:00Z",
+        config=None,
+        additional_current_action=None,
+        additional_policy_context=None,
+    )
+    assert initial_authority is not None
+
+    def insert_final_policy() -> tuple[object | None, dict[str, object] | None]:
+        if final_action == "warn":
+            store.upsert_policy(
+                PolicyDecision(
+                    harness=initial_authority.artifact.harness,
+                    scope="artifact",
+                    action="warn",
+                    artifact_id=initial_authority.artifact.artifact_id,
+                    artifact_hash=initial_authority.artifact_hash,
+                    reason="warn inserted at the final authority boundary",
+                    source="manual",
+                ),
+                "2026-07-17T00:01:00Z",
+            )
+        return None, None
+
+    result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+        config=None,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+        additional_authority_provider=insert_final_policy,
+    )
+    assert result is not None
+    payload, returncode = result
+
+    assert returncode == 0
+    assert payload["executed"] is True
+    assert marker.read_text(encoding="utf-8").splitlines() == ["launch"]
+    evaluation = payload["supply_chain_evaluation"]
+    assert isinstance(evaluation, dict)
+    assert evaluation["policy_action"] == final_action
+    assert evaluation["decision"] == final_action
+    user_copy = evaluation["user_copy"]
+    assert isinstance(user_copy, dict)
+    assert payload["verdict"] == {
+        "action": final_action,
+        "reason": user_copy["summary"],
+        "risk_signals": [reason["message"] for reason in evaluation["reasons"]],
+        "matched_advisories": [],
+        "blocking": False,
+    }
+    receipt = payload["receipt"]
+    assert isinstance(receipt, dict)
+    assert receipt["policy_decision"] == final_action
+    assert receipt["capabilities_summary"] == user_copy["summary"]
+    assert receipt["provenance_summary"] == user_copy["harness_message"]
+    action_envelope = receipt["action_envelope_json"]
+    assert isinstance(action_envelope, dict)
+    assert action_envelope["policy_action"] == final_action
+
+    stored_receipts = store.list_receipts(limit=10, harness="guard-cli")
+    assert len(stored_receipts) == 1
+    stored_receipt = stored_receipts[0]
+    assert stored_receipt["receipt_id"] == receipt["receipt_id"]
+    assert stored_receipt["policy_decision"] == final_action
+    assert stored_receipt["capabilities_summary"] == user_copy["summary"]
+    assert stored_receipt["provenance_summary"] == user_copy["harness_message"]
+    assert stored_receipt["action_envelope_json"]["policy_action"] == final_action
+    final_events = store.list_events(event_name=f"install_time_{final_action}")
+    assert len(final_events) == 1
+    assert final_events[0]["payload"]["action"] == final_action
+    other_action = "warn" if final_action == "allow" else "allow"
+    assert store.list_events(event_name=f"install_time_{other_action}") == []
+
+
+def test_package_protect_current_warn_rewrites_every_final_package_projection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    feed_evaluation = replace(
+        _allow_package_evaluation(),
+        packages=(
+            {
+                "name": "guard-proof",
+                "version": "1.0.0",
+                "decision": "allow",
+                "related_advisory_ids": ["adv-feed-allow-current-warn"],
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: feed_evaluation,
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "current-warn-launches.txt"
+    npm = fake_bin / "npm"
+    npm.write_text(f"#!/bin/sh\nprintf 'launch\\n' >> '{marker}'\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    store = GuardStore(tmp_path / "guard-home")
+    config = _package_policy_config(
+        guard_home=store.guard_home,
+        workspace_dir=workspace_dir,
+        package_action="warn",
+    )
+
+    result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+        config=config,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert result is not None
+    payload, returncode = result
+
+    assert returncode == 0
+    assert payload["executed"] is True
+    assert marker.read_text(encoding="utf-8").splitlines() == ["launch"]
+    evaluation = payload["supply_chain_evaluation"]
+    assert isinstance(evaluation, dict)
+    assert evaluation["decision"] == "warn"
+    assert evaluation["policy_action"] == "warn"
+    packages = evaluation["packages"]
+    assert isinstance(packages, list)
+    assert packages
+    assert all(package["decision"] == "warn" for package in packages)
+    matched_advisories = payload["matched_advisories"]
+    assert matched_advisories == [
+        {
+            "advisory_id": "adv-feed-allow-current-warn",
+            "package_name": "guard-proof",
+            "version": "1.0.0",
+            "decision": "warn",
+        }
+    ]
+    assert payload["verdict"]["action"] == "warn"
+    assert payload["verdict"]["matched_advisories"] == matched_advisories
+    receipt = payload["receipt"]
+    assert isinstance(receipt, dict)
+    assert receipt["policy_decision"] == "warn"
+    assert receipt["action_envelope_json"]["policy_action"] == "warn"
+    stored_receipts = store.list_receipts(limit=10, harness="guard-cli")
+    assert len(stored_receipts) == 1
+    assert stored_receipts[0]["policy_decision"] == "warn"
+    assert stored_receipts[0]["action_envelope_json"]["policy_action"] == "warn"
+    events = store.list_events(event_name="install_time_warn")
+    assert len(events) == 1
+    assert events[0]["payload"]["action"] == "warn"
+
+
+@pytest.mark.parametrize(
+    ("current_action", "expected_package_decision"),
+    (("warn", "warn"), ("block", "block"), ("require-reapproval", "ask")),
+)
+def test_current_package_policy_rewrites_every_package_decision(
+    current_action: GuardAction,
+    expected_package_decision: str,
+) -> None:
+    evaluation = replace(
+        _allow_package_evaluation(),
+        packages=(
+            {"name": "first", "decision": "allow"},
+            {"name": "second", "decision": "allow"},
+        ),
+    )
+
+    rewritten = local_supply_chain_module._package_evaluation_with_current_policy_action(
+        evaluation,
+        current_action=current_action,
+    )
+
+    assert rewritten.policy_action == current_action
+    assert all(package["decision"] == expected_package_decision for package in rewritten.packages)
+
+
+def test_package_protect_launch_uses_final_canonical_workspace_after_symlink_retarget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _allow_package_evaluation(),
+    )
+    approved_workspace = tmp_path / "approved-workspace"
+    approved_workspace.mkdir()
+    attacker_workspace = tmp_path / "attacker-workspace"
+    attacker_workspace.mkdir()
+    workspace_alias = tmp_path / "workspace"
+    workspace_alias.symlink_to(approved_workspace, target_is_directory=True)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "launch-workspace.txt"
+    npm = fake_bin / "npm"
+    npm.write_text(f"#!/bin/sh\n/bin/pwd -P > '{marker}'\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    store = GuardStore(tmp_path / "guard-home")
+    original_resolved_argv = local_supply_chain_module.resolved_runtime_launch_argv
+
+    def retarget_workspace_after_final_identity(
+        identity: dict[str, object],
+        *,
+        args: tuple[str, ...],
+    ) -> tuple[str, ...] | None:
+        launch_command = original_resolved_argv(identity, args=args)
+        workspace_alias.unlink()
+        workspace_alias.symlink_to(attacker_workspace, target_is_directory=True)
+        return launch_command
+
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "resolved_runtime_launch_argv",
+        retarget_workspace_after_final_identity,
+    )
+
+    result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_alias,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+        config=None,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert result is not None
+    payload, returncode = result
+
+    assert returncode == 0
+    assert payload["executed"] is True
+    assert marker.read_text(encoding="utf-8").strip() == str(approved_workspace.resolve(strict=True))
+    assert workspace_alias.resolve(strict=True) == attacker_workspace.resolve(strict=True)
+
+
+def test_package_protect_launch_uses_final_environment_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _allow_package_evaluation(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "launch-registry.txt"
+    npm = fake_bin / "npm"
+    npm.write_text(f"#!/bin/sh\nprintf '%s\\n' \"$NPM_CONFIG_REGISTRY\" > '{marker}'\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    monkeypatch.setenv("NPM_CONFIG_REGISTRY", "https://approved.example.test/npm")
+    package_secret = "package-secret-must-not-appear"
+    monkeypatch.setenv("NPM_TOKEN", package_secret)
+    store = GuardStore(tmp_path / "guard-home")
+    original_resolved_argv = local_supply_chain_module.resolved_runtime_launch_argv
+
+    def mutate_environment_after_final_identity(
+        identity: dict[str, object],
+        *,
+        args: tuple[str, ...],
+    ) -> tuple[str, ...] | None:
+        launch_command = original_resolved_argv(identity, args=args)
+        monkeypatch.setenv("NPM_CONFIG_REGISTRY", "https://attacker.example.test/npm")
+        monkeypatch.setenv("NPM_TOKEN", "attacker-secret")
+        return launch_command
+
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "resolved_runtime_launch_argv",
+        mutate_environment_after_final_identity,
+    )
+
+    result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+        config=None,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert result is not None
+    payload, returncode = result
+
+    assert returncode == 0
+    assert payload["executed"] is True
+    assert marker.read_text(encoding="utf-8").strip() == "https://approved.example.test/npm"
+    assert package_secret not in json.dumps(payload)
+    assert package_secret not in json.dumps(store.list_receipts(limit=10))
+
+
+def test_package_protect_normal_launch_uses_captured_authority_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _allow_package_evaluation(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "normal-authority-launch.txt"
+    npm = fake_bin / "npm"
+    npm.write_text(f"#!/bin/sh\nprintf 'launch\\n' > '{marker}'\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    store = GuardStore(tmp_path / "guard-home")
+
+    result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+        config=None,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert result is not None
+    payload, returncode = result
+
+    assert returncode == 0
+    assert payload["verdict"]["action"] == "allow"
+    assert payload["executed"] is True
+    assert marker.read_text(encoding="utf-8").splitlines() == ["launch"]
+
+
+@pytest.mark.parametrize("mutation", ["manager", "manifest", "path"])
+def test_package_protect_revalidates_claim_time_execution_context_mutation_before_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+) -> None:
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _review_package_evaluation(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    manifest = workspace_dir / "package.json"
+    manifest.write_text('{"name":"demo","version":"1.0.0"}\n', encoding="utf-8")
+    first_bin = tmp_path / "first-bin"
+    second_bin = tmp_path / "second-bin"
+    first_bin.mkdir()
+    second_bin.mkdir()
+    marker = tmp_path / "unexpected-package-launch.txt"
+    first_npm = first_bin / "npm"
+    second_npm = second_bin / "npm"
+    first_npm.write_text(f"#!/bin/sh\nprintf 'first\\n' >> '{marker}'\n", encoding="utf-8")
+    second_npm.write_text(f"#!/bin/sh\nprintf 'second\\n' >> '{marker}'\n", encoding="utf-8")
+    first_npm.chmod(0o755)
+    second_npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(first_bin))
+    store = GuardStore(tmp_path / "guard-home")
+    config = _package_policy_config(
+        guard_home=store.guard_home,
+        workspace_dir=workspace_dir,
+    )
+    receipt = _seed_exact_package_review_allow(store=store, workspace_dir=workspace_dir, config=config)
+    store.upsert_policy(
+        PolicyDecision(
+            harness="guard-cli",
+            scope="artifact",
+            action="allow",
+            artifact_id=str(receipt["artifact_id"]),
+            artifact_hash=str(receipt["artifact_hash"]),
+            source="approval-gate",
+            expires_at="2026-07-18T00:00:00Z",
+        ),
+        "2026-07-17T00:00:30Z",
+    )
+    original_claim = store.claim_approval_reuse_decision
+
+    def claim_then_mutate(decision: dict[str, object], *, now: str) -> bool:
+        claimed = original_claim(decision, now=now)
+        assert claimed is True
+        if mutation == "manager":
+            first_npm.write_text(f"#!/bin/sh\nprintf 'changed\\n' >> '{marker}'\n", encoding="utf-8")
+            first_npm.chmod(0o755)
+        elif mutation == "manifest":
+            manifest.write_text('{"name":"demo","version":"2.0.0"}\n', encoding="utf-8")
+        else:
+            monkeypatch.setenv("PATH", str(second_bin))
+        return True
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", claim_then_mutate)
+
+    result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+        config=config,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert result is not None
+    payload, returncode = result
+
+    assert returncode == 2
+    assert payload["executed"] is False
+    assert marker.exists() is False
+    reasons = payload["supply_chain_evaluation"]["reasons"]
+    assert reasons[0]["code"] in {
+        "approval_reuse_identity_changed",
+        "approval_reuse_content_changed",
+        "approval_reuse_capability_changed",
+    }
+    consumed = store.resolve_policy_decision_lookup(
+        "guard-cli",
+        str(receipt["artifact_id"]),
+        str(receipt["artifact_hash"]),
+        None,
+        None,
+        "2026-07-17T00:01:00Z",
+        consume_one_shot=False,
+    )
+    assert consumed["decision"] is None
+
+
+def test_package_protect_revalidates_current_allow_immediately_before_every_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    allow_evaluation = PackageRequestEvaluation(
+        decision="allow",
+        policy_action="allow",
+        enforcement="local",
+        entitlement_state="active",
+        cache_status="fresh",
+        package_intent_hash="package-intent-allow",
+        policy_version="feed-policy-allow",
+        bundle_version="feed-bundle-allow",
+        workspace_fingerprint="workspace-allow",
+        reasons=({"code": "feed_allow", "message": "Current feed allows execution."},),
+        packages=({"name": "guard-proof", "decision": "allow"},),
+        risk_summary="Current feed allows execution.",
+        user_copy=SupplyChainUserCopy(
+            title="Package allowed",
+            summary="Current feed allows execution.",
+            next_step="Continue.",
+            dashboard_url=None,
+            harness_message="Current feed allows execution.",
+        ),
+    )
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: allow_evaluation,
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "unexpected-current-allow-launch.txt"
+    npm = fake_bin / "npm"
+    npm.write_text(f"#!/bin/sh\nprintf 'initial\\n' >> '{marker}'\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    store = GuardStore(tmp_path / "guard-home")
+
+    def mutate_before_final_rebuild() -> tuple[object | None, dict[str, object] | None]:
+        npm.write_text(f"#!/bin/sh\nprintf 'changed\\n' >> '{marker}'\n", encoding="utf-8")
+        npm.chmod(0o755)
+        return None, None
+
+    result = build_package_protect_payload(
+        command=["npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+        config=None,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+        additional_authority_provider=mutate_before_final_rebuild,
+    )
+    assert result is not None
+    payload, returncode = result
+
+    assert returncode == 2
+    assert payload["executed"] is False
+    assert marker.exists() is False
+    assert payload["supply_chain_evaluation"]["reasons"][0]["code"] == "approval_reuse_identity_changed"
+
+
+def test_package_protect_fails_closed_when_command_wrapper_launch_semantics_are_unbound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    allow_evaluation = PackageRequestEvaluation(
+        decision="allow",
+        policy_action="allow",
+        enforcement="local",
+        entitlement_state="active",
+        cache_status="fresh",
+        package_intent_hash="wrapped-package-intent",
+        policy_version="wrapped-package-policy",
+        bundle_version="wrapped-package-bundle",
+        workspace_fingerprint="wrapped-package-workspace",
+        reasons=({"code": "feed_allow", "message": "Current feed allows execution."},),
+        packages=({"name": "guard-proof", "decision": "allow"},),
+        risk_summary="Current feed allows execution.",
+        user_copy=SupplyChainUserCopy(
+            title="Package allowed",
+            summary="Current feed allows execution.",
+            next_step="Continue.",
+            dashboard_url=None,
+            harness_message="Current feed allows execution.",
+        ),
+    )
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: allow_evaluation,
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "unexpected-wrapper-launch.txt"
+    npm = fake_bin / "npm"
+    npm.write_text(f"#!/bin/sh\nprintf 'launch\\n' >> '{marker}'\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_bin))
+    store = GuardStore(tmp_path / "guard-home")
+
+    result = build_package_protect_payload(
+        command=["/usr/bin/env", "npm", "install", "guard-proof"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+        config=None,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert result is not None
+    payload, returncode = result
+
+    assert returncode == 2
+    assert payload["executed"] is False
+    assert marker.exists() is False
+    assert payload["supply_chain_evaluation"]["reasons"][0]["code"] == "approval_reuse_identity_changed"
+
+
+@pytest.mark.parametrize("blocking_policy", ["package_script", "harness", "package_artifact"])
+def test_build_package_protect_payload_old_review_approval_cannot_lower_current_config_block(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    blocking_policy: str,
+) -> None:
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _review_package_evaluation(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    base_config = _package_policy_config(
+        guard_home=store.guard_home,
+        workspace_dir=workspace_dir,
+    )
+    receipt = _seed_exact_package_review_allow(store=store, workspace_dir=workspace_dir, config=base_config)
+    artifact_id = str(receipt["artifact_id"])
+    changed_config = _package_policy_config(
+        guard_home=store.guard_home,
+        workspace_dir=workspace_dir,
+        package_action="block" if blocking_policy == "package_script" else "review",
+        harness_action="block" if blocking_policy == "harness" else None,
+        artifact_id=artifact_id if blocking_policy == "package_artifact" else None,
+        artifact_action="block" if blocking_policy == "package_artifact" else None,
+    )
+
+    retry_payload, retry_rc = _build_review_package_payload(
+        store=store,
+        workspace_dir=workspace_dir,
+        config=changed_config,
+        now="2026-07-17T00:01:00Z",
+    )
+
+    assert retry_rc == 2
+    assert retry_payload["verdict"]["action"] == "block"
+    assert retry_payload["executed"] is False
+    evaluation = retry_payload["supply_chain_evaluation"]
+    assert evaluation["policy_action"] == "block"
+    assert evaluation["reasons"][0]["code"] in {
+        "approval_reuse_current_block",
+        "approval_reuse_policy_changed",
+    }
+
+
+@pytest.mark.parametrize(
+    ("policy_input", "expected_action"),
+    (("harness_risk", "block"), ("publisher_override", "block"), ("exact_over_broader", "review")),
+)
+def test_current_package_policy_composes_every_relevant_config_scope(
+    tmp_path: Path,
+    policy_input: str,
+    expected_action: str,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    intent = parse_package_intent("npm install guard-proof", workspace=workspace_dir)
+    assert intent is not None
+    artifact = build_package_request_artifact(
+        "guard-cli",
+        intent,
+        config_path="hol-guard.toml",
+        source_scope="project",
+    )
+    if policy_input == "publisher_override":
+        artifact = GuardArtifact(
+            harness=artifact.harness,
+            artifact_id=artifact.artifact_id,
+            name=artifact.name,
+            artifact_type=artifact.artifact_type,
+            source_scope=artifact.source_scope,
+            config_path=artifact.config_path,
+            publisher="npm",
+            metadata=artifact.metadata,
+            transport=artifact.transport,
+        )
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace_dir,
+        security_level="custom",
+        risk_actions={"package_script": "review"},
+        harness_risk_actions={"guard-cli": {"package_script": "block"}} if policy_input == "harness_risk" else None,
+        publisher_actions={"npm": "block"} if policy_input == "publisher_override" else None,
+        artifact_actions={artifact.artifact_id: "allow"} if policy_input == "exact_over_broader" else None,
+        harness_actions={"guard-cli": "block"} if policy_input == "exact_over_broader" else None,
+    )
+
+    assert (
+        compose_current_package_policy_action(
+            artifact=artifact,
+            evaluation=_review_package_evaluation(),
+            config=config,
+        )
+        == expected_action
+    )
+
+
+def test_current_package_policy_harness_risk_override_replaces_global_risk_action(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    intent = parse_package_intent("npm install guard-proof", workspace=workspace_dir)
+    assert intent is not None
+    artifact = build_package_request_artifact(
+        "guard-cli",
+        intent,
+        config_path="hol-guard.toml",
+        source_scope="project",
+    )
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace_dir,
+        security_level="custom",
+        risk_actions={"package_script": "block"},
+        harness_risk_actions={"guard-cli": {"package_script": "allow"}},
+    )
+
+    assert (
+        compose_current_package_policy_action(
+            artifact=artifact,
+            evaluation=_review_package_evaluation(),
+            config=config,
+        )
+        == "review"
+    )
 
 
 def test_parse_package_intent_supports_pnpm_install_alias(tmp_path: Path) -> None:
@@ -171,7 +1537,7 @@ def test_build_package_protect_payload_reprompts_after_manifest_edit_despite_sav
     )
 
     assert retry_rc == 2
-    assert retry_payload["verdict"]["action"] == "review"
+    assert retry_payload["verdict"]["action"] == "require-reapproval"
     evaluation = retry_payload["supply_chain_evaluation"]
     assert isinstance(evaluation, dict)
     assert evaluation["decision"] == "ask"
@@ -181,7 +1547,7 @@ def test_build_package_protect_payload_reprompts_after_manifest_edit_despite_sav
     )
 
 
-def test_workspace_package_approval_reuses_same_context_across_linked_worktrees(
+def test_workspace_package_approval_cannot_lower_current_gate_across_linked_worktrees(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -255,8 +1621,8 @@ def test_workspace_package_approval_reuses_same_context_across_linked_worktrees(
         timeout_seconds=30,
     )
 
-    assert retry_rc == 0
-    assert retry_payload["verdict"]["action"] == "allow"
+    assert retry_rc == 2
+    assert retry_payload["verdict"]["action"] == "require-reapproval"
     retry_receipt = retry_payload["receipt"]
     assert isinstance(retry_receipt, dict)
     assert retry_receipt["artifact_id"] == receipt["artifact_id"]
@@ -264,6 +1630,10 @@ def test_workspace_package_approval_reuses_same_context_across_linked_worktrees(
     evaluation = retry_payload["supply_chain_evaluation"]
     assert isinstance(evaluation, dict)
     assert any(
+        isinstance(reason, dict) and reason.get("code") == "approval_reuse_reapproval_required"
+        for reason in evaluation.get("reasons", [])
+    )
+    assert not any(
         isinstance(reason, dict) and reason.get("code") == "saved_package_approval"
         for reason in evaluation.get("reasons", [])
     )
@@ -283,7 +1653,7 @@ def test_workspace_package_approval_reuses_same_context_across_linked_worktrees(
         timeout_seconds=30,
     )
     assert unrelated_rc == 2
-    assert unrelated_payload["verdict"]["action"] == "review"
+    assert unrelated_payload["verdict"]["action"] == "require-reapproval"
     unrelated_evaluation = unrelated_payload["supply_chain_evaluation"]
     assert isinstance(unrelated_evaluation, dict)
     assert not any(
@@ -387,7 +1757,7 @@ def test_legacy_v1_package_workspace_approval_is_not_reused(
     )
 
     assert retry_rc == 2
-    assert retry_payload["verdict"]["action"] == "review"
+    assert retry_payload["verdict"]["action"] == "require-reapproval"
     evaluation = retry_payload["supply_chain_evaluation"]
     assert isinstance(evaluation, dict)
     assert not any(
@@ -396,7 +1766,7 @@ def test_legacy_v1_package_workspace_approval_is_not_reused(
     )
 
 
-def test_private_registry_package_approval_is_not_reused_after_registry_change(
+def test_private_registry_package_approval_never_lowers_current_gate_or_registry_change(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -466,11 +1836,15 @@ def test_private_registry_package_approval_is_not_reused_after_registry_change(
         unsafe_raw_output=False,
         timeout_seconds=30,
     )
-    assert same_registry_rc == 0
-    assert same_registry_payload["verdict"]["action"] == "allow"
+    assert same_registry_rc == 2
+    assert same_registry_payload["verdict"]["action"] == "require-reapproval"
     same_evaluation = same_registry_payload["supply_chain_evaluation"]
     assert isinstance(same_evaluation, dict)
     assert any(
+        isinstance(reason, dict) and reason.get("code") == "approval_reuse_reapproval_required"
+        for reason in same_evaluation.get("reasons", [])
+    )
+    assert not any(
         isinstance(reason, dict) and reason.get("code") == "saved_package_approval"
         for reason in same_evaluation.get("reasons", [])
     )
@@ -488,7 +1862,7 @@ def test_private_registry_package_approval_is_not_reused_after_registry_change(
     )
 
     assert changed_registry_rc == 2
-    assert changed_registry_payload["verdict"]["action"] == "review"
+    assert changed_registry_payload["verdict"]["action"] == "require-reapproval"
     changed_receipt = changed_registry_payload["receipt"]
     assert isinstance(changed_receipt, dict)
     assert changed_receipt["artifact_hash"] != receipt["artifact_hash"]
@@ -576,7 +1950,7 @@ def test_workspace_package_approval_still_reprompts_when_worktree_lockfile_chang
     )
 
     assert retry_rc == 2
-    assert retry_payload["verdict"]["action"] == "review"
+    assert retry_payload["verdict"]["action"] == "require-reapproval"
     retry_receipt = retry_payload["receipt"]
     assert isinstance(retry_receipt, dict)
     assert retry_receipt["artifact_hash"] != receipt["artifact_hash"]

--- a/tests/test_guard_mcp_adapter_env_identity.py
+++ b/tests/test_guard_mcp_adapter_env_identity.py
@@ -1,0 +1,318 @@
+"""Configured MCP environment identity regressions across primary adapters."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
+from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
+from codex_plugin_scanner.guard.adapters.cursor import CursorHarnessAdapter
+from codex_plugin_scanner.guard.adapters.grok_config import append_mcp_artifacts as append_grok_mcp_artifacts
+from codex_plugin_scanner.guard.adapters.hermes import HermesHarnessAdapter
+from codex_plugin_scanner.guard.adapters.mcp_servers import managed_stdio_servers
+from codex_plugin_scanner.guard.adapters.zcode_config import append_cli_config_artifacts
+from codex_plugin_scanner.guard.consumer import artifact_hash
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def _detect_server(
+    adapter_name: str,
+    *,
+    context: HarnessContext,
+    configured_value: str,
+):
+    if adapter_name == "claude-code":
+        config_path = context.home_dir / ".claude" / "settings.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "environment-proof": {
+                            "command": "node",
+                            "args": ["server.js"],
+                            "env": {"MODE": configured_value},
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        detection = ClaudeCodeHarnessAdapter().detect(context)
+    elif adapter_name == "codex":
+        config_path = context.home_dir / ".codex" / "config.toml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
+            "\n".join(
+                (
+                    "[mcp_servers.environment-proof]",
+                    'command = "node"',
+                    'args = ["server.js"]',
+                    f"env = {{ MODE = {json.dumps(configured_value)} }}",
+                    "",
+                )
+            ),
+            encoding="utf-8",
+        )
+        detection = CodexHarnessAdapter().detect(context)
+    else:
+        config_path = context.home_dir / ".cursor" / "mcp.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "environment-proof": {
+                            "command": "node",
+                            "args": ["server.js"],
+                            "env": {"MODE": configured_value},
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        detection = CursorHarnessAdapter().detect(context)
+    artifact = next(item for item in detection.artifacts if item.artifact_type == "mcp_server")
+    return detection, artifact
+
+
+@pytest.mark.parametrize("adapter_name", ("claude-code", "codex", "cursor"))
+def test_mcp_adapter_binds_configured_env_values_without_serializing_them(
+    tmp_path: Path,
+    adapter_name: str,
+) -> None:
+    context = _context(tmp_path)
+    first_secret = f"{adapter_name}-configured-value-one"
+    second_secret = f"{adapter_name}-configured-value-two"
+    first_detection, first = _detect_server(
+        adapter_name,
+        context=context,
+        configured_value=first_secret,
+    )
+    _second_detection, second = _detect_server(
+        adapter_name,
+        context=context,
+        configured_value=second_secret,
+    )
+
+    first_env_hash = first.metadata["env_values_hash"]
+    second_env_hash = second.metadata["env_values_hash"]
+    assert isinstance(first_env_hash, str)
+    assert len(first_env_hash) == 64
+    assert isinstance(second_env_hash, str)
+    assert first_env_hash != second_env_hash
+    assert artifact_hash(first) != artifact_hash(second)
+
+    serialized = json.dumps(first.to_dict(), sort_keys=True)
+    assert first_secret not in serialized
+    assert first_env_hash in serialized
+
+    managed = managed_stdio_servers(first_detection)
+    assert len(managed) == 1
+    assert managed[0].env == {"MODE": first_secret}
+    assert managed[0].identity is not None
+    assert managed[0].identity.env_values_hash == first_env_hash
+
+
+def _secondary_mcp_artifact(
+    adapter_name: str,
+    *,
+    field: str,
+    configured_items: tuple[tuple[str, str], ...],
+):
+    server: dict[str, object] = {
+        "args": ["server.js"],
+        field: dict(configured_items),
+    }
+    if field == "headers":
+        server["url"] = "https://example.invalid/mcp"
+    else:
+        server["command"] = "node"
+
+    if adapter_name == "grok":
+        artifacts = []
+        append_grok_mcp_artifacts(
+            harness="grok",
+            artifacts=artifacts,
+            payload={"mcp_servers": {"value-proof": server}},
+            config_path=Path("/virtual/grok-config.toml"),
+            scope="global",
+        )
+        return artifacts[0]
+    if adapter_name == "hermes":
+        return HermesHarnessAdapter()._mcp_artifacts(
+            {"value-proof": server},
+            "/virtual/hermes-config.yaml",
+            source="yaml",
+        )[0]
+
+    artifacts = []
+    append_cli_config_artifacts(
+        harness="zcode",
+        artifacts=artifacts,
+        payload={"mcp": {"servers": {"value-proof": server}}},
+        config_path=Path("/virtual/zcode-config.json"),
+        scope="global",
+    )
+    return artifacts[0]
+
+
+def _claude_header_artifact(
+    *,
+    context: HarnessContext,
+    configured_items: tuple[tuple[str, str], ...],
+):
+    config_path = context.home_dir / ".claude" / "settings.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "header-proof": {
+                        "url": "https://example.invalid/mcp",
+                        "headers": dict(configured_items),
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    detection = ClaudeCodeHarnessAdapter().detect(context)
+    return next(item for item in detection.artifacts if item.artifact_type == "mcp_server")
+
+
+@pytest.mark.parametrize("adapter_name", ("grok", "hermes", "zcode"))
+@pytest.mark.parametrize(
+    ("field", "digest_key", "configured_items", "changed_items"),
+    (
+        (
+            "env",
+            "env_values_hash",
+            (("MODE", "configured-secret-one"), ("REGION", "us-east")),
+            (("MODE", "configured-secret-two"), ("REGION", "us-east")),
+        ),
+        (
+            "headers",
+            "header_values_hash",
+            (("Authorization", "Bearer configured-secret-one"), ("X-Tenant", "alpha")),
+            (("Authorization", "Bearer configured-secret-two"), ("X-Tenant", "alpha")),
+        ),
+    ),
+)
+def test_secondary_mcp_adapters_bind_secret_values_without_exposing_them(
+    adapter_name: str,
+    field: str,
+    digest_key: str,
+    configured_items: tuple[tuple[str, str], ...],
+    changed_items: tuple[tuple[str, str], ...],
+) -> None:
+    first = _secondary_mcp_artifact(
+        adapter_name,
+        field=field,
+        configured_items=configured_items,
+    )
+    reordered = _secondary_mcp_artifact(
+        adapter_name,
+        field=field,
+        configured_items=tuple(reversed(configured_items)),
+    )
+    changed = _secondary_mcp_artifact(
+        adapter_name,
+        field=field,
+        configured_items=changed_items,
+    )
+
+    first_digest = first.metadata[digest_key]
+    assert isinstance(first_digest, str)
+    assert len(first_digest) == 64
+    assert reordered.metadata[digest_key] == first_digest
+    assert changed.metadata[digest_key] != first_digest
+    assert artifact_hash(reordered) == artifact_hash(first)
+    assert artifact_hash(changed) != artifact_hash(first)
+
+    raw_metadata = json.dumps(first.metadata, sort_keys=True)
+    serialized = json.dumps(first.to_dict(), sort_keys=True)
+    for _key, secret_value in configured_items:
+        assert secret_value not in raw_metadata
+        assert secret_value not in serialized
+    assert first_digest in serialized
+
+
+@pytest.mark.parametrize(
+    ("adapter_name", "field", "key", "keys_field", "digest_key", "first_value", "second_value"),
+    (
+        (
+            "claude-code",
+            "headers",
+            "Authorization",
+            "headers_keys",
+            "header_values_hash",
+            "Bearer p44-first",
+            "Bearer p44-second",
+        ),
+        (
+            "hermes",
+            "env",
+            "MODE",
+            "env_keys",
+            "env_values_hash",
+            "p44_env_first",
+            "p44_env_second",
+        ),
+    ),
+)
+def test_mcp_adapters_canonicalize_padded_duplicate_configured_keys(
+    tmp_path: Path,
+    adapter_name: str,
+    field: str,
+    key: str,
+    keys_field: str,
+    digest_key: str,
+    first_value: str,
+    second_value: str,
+) -> None:
+    context = _context(tmp_path)
+
+    def artifact(configured_items: tuple[tuple[str, str], ...]):
+        if adapter_name == "claude-code":
+            return _claude_header_artifact(context=context, configured_items=configured_items)
+        return _secondary_mcp_artifact(
+            adapter_name,
+            field=field,
+            configured_items=configured_items,
+        )
+
+    padded_items = ((f"  {key}  ", first_value), (key, first_value), ("   ", "p44_blank_value"))
+    padded = artifact(padded_items)
+    reordered = artifact(tuple(reversed(padded_items)))
+    canonical = artifact(((key, first_value),))
+    changed = artifact(((f"  {key}  ", second_value), (key, second_value)))
+
+    assert padded.metadata[keys_field] == [key]
+    assert reordered.metadata[keys_field] == [key]
+    assert padded.metadata[digest_key] == reordered.metadata[digest_key]
+    assert padded.metadata[digest_key] == canonical.metadata[digest_key]
+    assert padded.metadata["content_hash"] == canonical.metadata["content_hash"]
+    assert artifact_hash(padded) == artifact_hash(reordered)
+    assert artifact_hash(padded) == artifact_hash(canonical)
+    assert changed.metadata[digest_key] != padded.metadata[digest_key]
+    assert changed.metadata["content_hash"] != padded.metadata["content_hash"]
+    assert artifact_hash(changed) != artifact_hash(padded)
+
+    raw_metadata = json.dumps(padded.metadata, sort_keys=True)
+    serialized = json.dumps(padded.to_dict(), sort_keys=True)
+    for raw_value in (first_value, second_value, "p44_blank_value"):
+        assert raw_value not in raw_metadata
+        assert raw_value not in serialized

--- a/tests/test_guard_mcp_package_proxy_phase14.py
+++ b/tests/test_guard_mcp_package_proxy_phase14.py
@@ -20,7 +20,7 @@ from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer.service import artifact_hash
 from codex_plugin_scanner.guard.local_supply_chain import package_request_policy_hash
 from codex_plugin_scanner.guard.mcp_tool_calls import ToolCallDecision
-from codex_plugin_scanner.guard.models import GuardArtifact, PolicyDecision
+from codex_plugin_scanner.guard.models import GuardAction, GuardArtifact, PolicyDecision
 from codex_plugin_scanner.guard.package_execution_context import build_package_execution_context
 from codex_plugin_scanner.guard.proxy import runtime_mcp as runtime_mcp_module
 from codex_plugin_scanner.guard.proxy.runtime_mcp import CodexMcpGuardProxy, RuntimeMcpGuardProxy
@@ -241,8 +241,13 @@ def _package_policy_key(
     context: HarnessContext,
     store: GuardStore,
     artifact: GuardArtifact,
+    config: GuardConfig | None = None,
 ) -> tuple[str, str]:
     assert context.workspace_dir is not None
+    effective_config = config or GuardConfig(
+        guard_home=context.guard_home,
+        workspace=context.workspace_dir,
+    )
     evaluation = evaluate_package_request_artifact(
         artifact=artifact,
         store=store,
@@ -258,6 +263,7 @@ def _package_policy_key(
         workspace_dir=context.workspace_dir,
         evaluation=evaluation,
         execution_context=execution_context,
+        config=effective_config,
     )
     workspace = package_request_runtime_workspace_scope(
         artifact_id=artifact.artifact_id,
@@ -282,8 +288,110 @@ def _allow_mcp_tool_calls(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+def _runtime_package_artifact(context: HarnessContext) -> GuardArtifact:
+    intent = extract_package_intent_request(
+        "run_terminal_command",
+        {"command": "npm install minimist@1.2.8"},
+        action_envelope_command="npm install minimist@1.2.8",
+        workspace=context.workspace_dir,
+    )
+    assert intent is not None
+    assert context.workspace_dir is not None
+    return build_package_request_artifact(
+        harness="cursor",
+        intent=intent,
+        config_path=str(context.workspace_dir / ".cursor" / "mcp.json"),
+        source_scope="project",
+    )
+
+
+def _runtime_package_policy_config(
+    *,
+    context: HarnessContext,
+    package_action: GuardAction = "review",
+    harness_action: GuardAction | None = None,
+    artifact_id: str | None = None,
+    artifact_action: GuardAction | None = None,
+) -> GuardConfig:
+    return GuardConfig(
+        guard_home=context.guard_home,
+        workspace=context.workspace_dir,
+        security_level="custom",
+        risk_actions={"package_script": package_action},
+        harness_actions={"cursor": harness_action} if harness_action is not None else None,
+        artifact_actions={artifact_id: artifact_action}
+        if artifact_id is not None and artifact_action is not None
+        else None,
+    )
+
+
+def _seed_runtime_package_review_allow(
+    *,
+    context: HarnessContext,
+    store: GuardStore,
+    artifact: GuardArtifact,
+    config: GuardConfig,
+) -> None:
+    package_digest, policy_workspace = _package_policy_key(
+        context=context,
+        store=store,
+        artifact=artifact,
+        config=config,
+    )
+    store.ensure_policy_integrity_ready_for_write(now="2026-05-19T00:00:00Z")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="cursor",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=package_digest,
+            workspace=policy_workspace,
+            publisher=artifact.publisher,
+            source="approval-gate",
+            reason="reviewed exact package request",
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+
+def _run_runtime_package_call(
+    *,
+    context: HarnessContext,
+    store: GuardStore,
+    config: GuardConfig,
+    marker_path: Path,
+) -> dict[str, object]:
+    proxy = RuntimeMcpGuardProxy(
+        harness="cursor",
+        server_name="workspace-tools",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        current_config_provider=lambda: config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".cursor" / "mcp.json"),
+    )
+    return proxy.run_session(
+        [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"capabilities": {}}},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "run_terminal_command",
+                    "arguments": {"command": "npm install minimist@1.2.8"},
+                },
+            },
+        ]
+    )
+
+
 @pytest.mark.parametrize("harness", ["cursor", "opencode", "hermes", "openclaw"])
-def test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call(
+def test_phase14_runtime_mcp_proxy_terminally_blocks_package_request_not_generic_tool_call(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     harness: str,
@@ -303,6 +411,7 @@ def test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call(
         context=context,
         store=store,
         config=config,
+        current_config_provider=lambda: config,
         source_scope="project",
         config_path=str(context.workspace_dir / f"{harness}.json"),
     )
@@ -328,13 +437,16 @@ def test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call(
         ]
     )
 
-    request = store.list_approval_requests(limit=5)[0]
-
     assert marker_path.exists() is False
-    assert result["responses"][2]["error"]["code"] == -32001
-    assert request["artifact_type"] == "package_request"
-    assert request["decision_v2_json"]["signals"]
-    assert "minimist" in str(request["risk_summary"]).lower()
+    response = result["responses"][2]
+    assert response["error"]["code"] == -32001
+    assert response["error"]["data"]["guardPolicyAction"] == "block"
+    assert response["error"]["data"]["approvalRequests"] == []
+    assert store.list_approval_requests(limit=5) == []
+    receipts = store.list_receipts(limit=10)
+    assert len(receipts) == 1
+    assert receipts[0]["artifact_id"].startswith(f"{harness}:project:package-request:")
+    assert receipts[0]["policy_decision"] == "block"
 
 
 def test_phase14_runtime_mcp_proxy_forwards_allowed_package_call(
@@ -379,6 +491,95 @@ def test_phase14_runtime_mcp_proxy_forwards_allowed_package_call(
     assert marker_path.exists() is True
     assert "error" not in result["responses"][2]
     assert store.list_approval_requests(limit=5) == []
+    receipts = store.list_receipts(limit=10)
+    assert len(receipts) == 1
+    assert receipts[0]["artifact_id"].startswith("cursor:project:package-request:")
+    assert receipts[0]["policy_decision"] == "warn"
+
+
+def test_runtime_mcp_reuses_unchanged_exact_package_review_approval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _allow_mcp_tool_calls(monkeypatch)
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
+    store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="allow"), "2026-05-19T00:00:00Z")
+    artifact = _runtime_package_artifact(context)
+    config = _runtime_package_policy_config(context=context)
+    _seed_runtime_package_review_allow(context=context, store=store, artifact=artifact, config=config)
+    marker_path = tmp_path / "cursor-mcp-unchanged-review.json"
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+
+    result = _run_runtime_package_call(
+        context=context,
+        store=store,
+        config=config,
+        marker_path=marker_path,
+    )
+
+    assert marker_path.exists() is True
+    assert "error" not in result["responses"][2]
+    assert store.list_approval_requests(limit=5) == []
+    package_events = [event for event in result["events"] if str(event.get("decision", "")).startswith("package-")]
+    assert package_events
+    assert package_events[-1]["decision"] == "package-allow"
+    receipts = store.list_receipts(limit=10)
+    assert len(receipts) == 1
+    assert receipts[0]["artifact_id"] == artifact.artifact_id
+    assert receipts[0]["policy_decision"] == "allow"
+
+
+@pytest.mark.parametrize("blocking_policy", ["package_script", "harness", "package_artifact"])
+def test_runtime_mcp_old_package_review_approval_cannot_lower_current_config_block(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    blocking_policy: str,
+) -> None:
+    _allow_mcp_tool_calls(monkeypatch)
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
+    store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="allow"), "2026-05-19T00:00:00Z")
+    artifact = _runtime_package_artifact(context)
+    base_config = _runtime_package_policy_config(context=context)
+    _seed_runtime_package_review_allow(context=context, store=store, artifact=artifact, config=base_config)
+    changed_config = _runtime_package_policy_config(
+        context=context,
+        package_action="block" if blocking_policy == "package_script" else "review",
+        harness_action="block" if blocking_policy == "harness" else None,
+        artifact_id=artifact.artifact_id if blocking_policy == "package_artifact" else None,
+        artifact_action="block" if blocking_policy == "package_artifact" else None,
+    )
+    marker_path = tmp_path / f"cursor-mcp-current-{blocking_policy}-block.json"
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+
+    result = _run_runtime_package_call(
+        context=context,
+        store=store,
+        config=changed_config,
+        marker_path=marker_path,
+    )
+
+    assert marker_path.exists() is False
+    response = result["responses"][2]
+    assert response["error"]["code"] == -32001
+    assert "block" in json.dumps(response).lower()
+    assert response["error"]["data"]["guardPolicyAction"] == "block"
+    assert response["error"]["data"]["approvalRequests"] == []
+    assert store.list_approval_requests(limit=1) == []
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == "block"
+    assert (
+        receipt["artifact_hash"]
+        != _package_policy_key(
+            context=context,
+            store=store,
+            artifact=artifact,
+            config=base_config,
+        )[0]
+    )
 
 
 def test_phase14_runtime_mcp_proxy_rejects_stored_allow_when_current_package_blocks(
@@ -453,16 +654,37 @@ def test_phase14_runtime_mcp_proxy_rejects_stored_allow_when_current_package_blo
 
     assert marker_path.exists() is False
     assert result["responses"][2]["error"]["code"] == -32001
-    assert store.list_approval_requests(limit=5)
+    assert result["responses"][2]["error"]["data"]["guardPolicyAction"] == "block"
+    assert store.list_approval_requests(limit=5) == []
 
 
 def test_phase14_runtime_mcp_proxy_rejects_stored_allow_without_workspace_when_current_package_blocks(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _allow_mcp_tool_calls(monkeypatch)
     context = _context_without_workspace(tmp_path)
     store = GuardStore(context.guard_home)
+    tool_claims: list[object] = []
+    monkeypatch.setattr(
+        runtime_mcp_module,
+        "evaluate_tool_call",
+        lambda **_kwargs: ToolCallDecision(
+            action="allow",
+            source="policy",
+            signals=("tool review",),
+            summary="provisionally accepted saved tool approval",
+            approval_reuse_status="accepted",
+            approval_reuse_reason_code="approval_reuse_accepted",
+            current_action="review",
+            saved_action="allow",
+            pending_approval_reuse_decision={"action": "allow", "decision_id": 999},
+        ),
+    )
+    monkeypatch.setattr(
+        store,
+        "claim_approval_reuse_decisions",
+        lambda decisions, **_kwargs: tool_claims.extend(decisions) is None,
+    )
     _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="block"), "2026-05-19T00:00:00Z")
     intent = extract_package_intent_request(
@@ -523,7 +745,9 @@ def test_phase14_runtime_mcp_proxy_rejects_stored_allow_without_workspace_when_c
 
     assert marker_path.exists() is False
     assert result["responses"][2]["error"]["code"] == -32001
-    assert store.list_approval_requests(limit=5)
+    assert result["responses"][2]["error"]["data"]["guardPolicyAction"] == "block"
+    assert store.list_approval_requests(limit=5) == []
+    assert tool_claims == []
 
 
 def test_phase14_runtime_mcp_proxy_skips_requeue_for_stored_package_block(
@@ -649,11 +873,15 @@ def test_phase14_runtime_mcp_proxy_preserves_tool_policy_for_package_calls(
         ]
     )
 
-    request = store.list_approval_requests(limit=5)[0]
-
     assert marker_path.exists() is False
-    assert result["responses"][2]["error"]["code"] == -32001
-    assert request["artifact_type"] == "tool_call"
+    response = result["responses"][2]
+    assert response["error"]["code"] == -32001
+    assert response["error"]["data"]["guardPolicyAction"] == "block"
+    assert response["error"]["data"]["approvalRequests"] == []
+    assert store.list_approval_requests(limit=5) == []
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == "block"
+    assert ":runtime:" in receipt["artifact_id"]
 
 
 def test_phase14_runtime_mcp_proxy_enforces_tool_policy_review_before_package_routing(
@@ -779,6 +1007,7 @@ def test_phase14_codex_package_inline_approval_is_remembered(
         context=context,
         store=store,
         config=config,
+        current_config_provider=lambda: config,
         source_scope="project",
         config_path=str(context.workspace_dir / ".codex" / "config.toml"),
     )
@@ -852,6 +1081,10 @@ def test_phase14_codex_package_inline_approval_is_remembered(
         )
         == "allow"
     )
+    receipts = store.list_receipts(limit=10)
+    assert len(receipts) == 2
+    assert {receipt["artifact_id"] for receipt in receipts} == {package_artifact.artifact_id}
+    assert {receipt["policy_decision"] for receipt in receipts} == {"warn"}
 
 
 def test_phase14_runtime_mcp_proxy_normalizes_stored_review_for_package_approval(

--- a/tests/test_guard_mcp_protection.py
+++ b/tests/test_guard_mcp_protection.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import PurePosixPath
+
+import pytest
 
 from codex_plugin_scanner.guard.adapters.mcp_servers import managed_stdio_servers
 from codex_plugin_scanner.guard.config import GuardConfig
@@ -11,12 +14,17 @@ from codex_plugin_scanner.guard.mcp_tool_calls import (
     _resolve_local_schema_ref,
     _schema_property_key_names,
     build_tool_call_artifact,
+    build_tool_call_hash,
     evaluate_tool_call,
     tool_call_risk_categories,
     tool_call_risk_signals,
 )
-from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
-from codex_plugin_scanner.guard.runtime.mcp_protection import build_mcp_server_identity, build_mcp_tool_identity
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection, PolicyDecision
+from codex_plugin_scanner.guard.runtime.mcp_protection import (
+    build_mcp_server_identity,
+    build_mcp_tool_identity,
+    mcp_server_identity_metadata,
+)
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -36,6 +44,41 @@ def test_mcp_server_identity_hashes_args_and_sorts_env_keys() -> None:
     assert identity.package_name == "@modelcontextprotocol/server-filesystem"
     assert identity.package_version == "1.2.3"
     assert len(identity.args_hash) == 64
+    assert len(identity.env_values_hash) == 64
+
+
+def test_mcp_server_identity_binds_configured_env_values_without_exposing_them() -> None:
+    secret_v1 = "mcp-secret-value-one"
+    secret_v2 = "mcp-secret-value-two"
+    first = build_mcp_server_identity(
+        config_path=".mcp.json",
+        command="node",
+        args=("server.js",),
+        transport="stdio",
+        env={"TOKEN": secret_v1, "MODE": "safe"},
+    )
+    reordered = build_mcp_server_identity(
+        config_path=".mcp.json",
+        command="node",
+        args=("server.js",),
+        transport="stdio",
+        env={"MODE": "safe", "TOKEN": secret_v1},
+    )
+    changed = build_mcp_server_identity(
+        config_path=".mcp.json",
+        command="node",
+        args=("server.js",),
+        transport="stdio",
+        env={"TOKEN": secret_v2, "MODE": "safe"},
+    )
+
+    assert first == reordered
+    assert first.env_values_hash != changed.env_values_hash
+    assert first.identity_hash != changed.identity_hash
+    serialized = str(mcp_server_identity_metadata(first))
+    assert secret_v1 not in serialized
+    assert secret_v2 not in serialized
+    assert mcp_server_identity_metadata(first)["env_values_hash"] == first.env_values_hash
 
 
 def test_managed_stdio_servers_emit_server_identity() -> None:
@@ -311,7 +354,15 @@ def test_evaluate_tool_call_unknown_stored_action_requires_review(
         transport="stdio",
     )
     store = GuardStore(tmp_path / "guard-home")
-    monkeypatch.setattr(store, "resolve_policy", lambda *_args, **_kwargs: "future-action")
+    monkeypatch.setattr(
+        store,
+        "resolve_policy_decision_lookup_with_memory_pattern",
+        lambda *_args, **_kwargs: {
+            "decision": {"action": "future-action"},
+            "ignored_local_integrity": None,
+            "trust_status": {},
+        },
+    )
 
     decision = evaluate_tool_call(
         store=store,
@@ -326,6 +377,263 @@ def test_evaluate_tool_call_unknown_stored_action_requires_review(
     assert "unknown policy action" in decision.summary
     assert decision.normalization_reason_code == "guard_action_unknown"
     assert decision.original_action == "future-action"
+
+
+def test_evaluate_tool_call_reuses_exact_allow_only_for_current_review(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="shell",
+        tool_name="shell_exec",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+    )
+    arguments = {"command": "rm /tmp/guard-proof"}
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace, mode="prompt")
+    digest = build_tool_call_hash(artifact, arguments, workspace=workspace, config=config)
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=digest,
+            reason="reviewed exact call",
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=artifact,
+        artifact_hash=digest,
+        arguments=arguments,
+    )
+
+    assert decision.current_action == "review"
+    assert decision.action == "allow"
+    assert decision.approval_reuse_status == "accepted"
+    assert decision.approval_reuse_reason_code == "approval_reuse_accepted"
+    assert decision.signals
+
+
+@pytest.mark.parametrize("current_action", ["require-reapproval", "sandbox-required", "block"])
+def test_evaluate_tool_call_saved_allow_never_lowers_stronger_current_action(
+    tmp_path,
+    current_action,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="shell",
+        tool_name="shell_exec",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+    )
+    arguments = {"command": "rm /tmp/guard-proof"}
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"mcp_dangerous_tool": current_action},
+    )
+    digest = build_tool_call_hash(artifact, arguments, workspace=workspace, config=config)
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=digest,
+            reason="old approval",
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=artifact,
+        artifact_hash=digest,
+        arguments=arguments,
+    )
+
+    assert decision.current_action == current_action
+    assert decision.action == current_action
+    assert decision.approval_reuse_status == "rejected"
+    assert decision.approval_reuse_reason_code in {
+        "approval_reuse_reapproval_required",
+        "approval_reuse_sandbox_required",
+        "approval_reuse_current_block",
+    }
+
+
+def test_evaluate_tool_call_preserves_saved_block_over_safe_current_call(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="metadata",
+        tool_name="read_metadata",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="block",
+            artifact_id=artifact.artifact_id,
+            artifact_hash="exact-tool-hash",
+            reason="blocked by operator",
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace),
+        artifact=artifact,
+        artifact_hash="exact-tool-hash",
+        arguments={"key": "public"},
+    )
+
+    assert decision.current_action == "warn"
+    assert decision.action == "block"
+    assert decision.approval_reuse_reason_code == "approval_reuse_saved_block"
+
+
+def test_evaluate_tool_call_old_allow_cannot_lower_new_default_block(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="metadata",
+        tool_name="read_metadata",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+    )
+    arguments = {"key": "public"}
+    review_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+    )
+    reviewed_hash = build_tool_call_hash(
+        artifact,
+        arguments,
+        workspace=workspace,
+        config=review_config,
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=reviewed_hash,
+            reason="old default review approval",
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+    block_config = replace(review_config, default_action="block")
+    blocked_hash = build_tool_call_hash(
+        artifact,
+        arguments,
+        workspace=workspace,
+        config=block_config,
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=block_config,
+        artifact=artifact,
+        artifact_hash=blocked_hash,
+        arguments=arguments,
+    )
+
+    assert reviewed_hash != blocked_hash
+    assert decision.current_action == "block"
+    assert decision.action == "block"
+    assert decision.approval_reuse_status == "rejected"
+    assert decision.approval_reuse_reason_code == "approval_reuse_policy_changed"
+
+
+def test_evaluate_tool_call_exact_allow_replaces_stricter_global_default(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="metadata",
+        tool_name="read_metadata",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+    )
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="block",
+        artifact_actions={artifact.artifact_id: "allow"},
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=artifact,
+        artifact_hash="exact-tool-hash",
+        arguments={"key": "public"},
+    )
+
+    assert decision.action == "allow"
+
+
+def test_evaluate_tool_call_exact_allow_cannot_lower_independent_risk_block(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="shell",
+        tool_name="execute_command",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+    )
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="allow",
+        artifact_actions={artifact.artifact_id: "allow"},
+        security_level="custom",
+        risk_actions={"mcp_dangerous_tool": "block"},
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=artifact,
+        artifact_hash="exact-tool-hash",
+        arguments={"command": "rm -rf ./fixture"},
+    )
+
+    assert decision.action == "block"
 
 
 def test_mcp_server_identity_reads_pnpm_package_selector_flag() -> None:

--- a/tests/test_guard_mcp_skill_firewall.py
+++ b/tests/test_guard_mcp_skill_firewall.py
@@ -38,7 +38,9 @@ def test_mcp_server_artifact_emits_mcp_skill_firewall_bundle() -> None:
     assert server["packageName"] == "@modelcontextprotocol/server-filesystem"
     assert server["commandHash"]
     assert server["transportHash"]
-    assert artifact.metadata["mcp_server_identity"]["identity_hash"] == server["identityHash"]
+    legacy_server = artifact.metadata["mcp_server_identity"]
+    assert isinstance(legacy_server, dict)
+    assert legacy_server["identity_hash"] == server["identityHash"]
 
 
 def test_tool_call_artifact_emits_mcp_skill_firewall_and_legacy_identities() -> None:
@@ -67,7 +69,62 @@ def test_tool_call_artifact_emits_mcp_skill_firewall_and_legacy_identities() -> 
     assert len(tools) == 1
     assert tools[0]["toolName"] == "read_file"
     assert tools[0]["hashScope"] == "full"
-    assert artifact.metadata["mcp_tool_identity"]["tool_name"] == "read_file"
+    server = firewall["mcpServer"]
+    assert isinstance(server, dict)
+    assert server["envValuesHash"] == server_identity.env_values_hash
+    legacy_server = artifact.metadata["mcp_server_identity"]
+    legacy_tool = artifact.metadata["mcp_tool_identity"]
+    assert isinstance(legacy_server, dict)
+    assert isinstance(legacy_tool, dict)
+    assert legacy_server["env_values_hash"] == server_identity.env_values_hash
+    assert legacy_tool["tool_name"] == "read_file"
+
+
+def test_legacy_tool_call_missing_environment_hash_gets_stable_non_secret_fallback() -> None:
+    legacy_artifact = GuardArtifact(
+        artifact_id="codex:mcp:filesystem:read_file",
+        name="filesystem:read_file",
+        harness="codex",
+        artifact_type="tool_call",
+        source_scope="project",
+        config_path=".mcp.json",
+        command="read_file",
+        transport="stdio",
+        metadata={
+            "mcp_server_identity": {
+                "args_hash": "args-hash",
+                "command": "python",
+                "env_keys": ["TOKEN"],
+                "identity_hash": "server-hash",
+                "transport": "stdio",
+            },
+            "mcp_tool_identity": {
+                "description_hash": "description-hash",
+                "identity_hash": "tool-hash",
+                "schema_hash": "schema-hash",
+                "server_hash": "server-hash",
+                "tool_name": "read_file",
+            },
+        },
+    )
+
+    first = enrich_artifact_with_mcp_skill_firewall(legacy_artifact)
+    second = enrich_artifact_with_mcp_skill_firewall(legacy_artifact)
+    first_firewall = first.metadata["mcpSkillFirewall"]
+    second_firewall = second.metadata["mcpSkillFirewall"]
+    assert isinstance(first_firewall, dict)
+    assert isinstance(second_firewall, dict)
+    first_server = first_firewall["mcpServer"]
+    second_server = second_firewall["mcpServer"]
+    assert isinstance(first_server, dict)
+    assert isinstance(second_server, dict)
+    fallback_hash = first_server["envValuesHash"]
+    assert isinstance(fallback_hash, str)
+    assert len(fallback_hash) == 64
+    assert fallback_hash == second_server["envValuesHash"]
+    legacy_server = first.metadata["mcp_server_identity"]
+    assert isinstance(legacy_server, dict)
+    assert legacy_server["env_values_hash"] == fallback_hash
 
 
 def test_skill_artifact_emits_skill_firewall_metadata(tmp_path) -> None:
@@ -94,7 +151,9 @@ def test_skill_artifact_emits_skill_firewall_metadata(tmp_path) -> None:
     assert skill["skillHash"] == identity.skill_hash
     metadata = skill_identity_metadata(identity)
     assert metadata["identity_hash"] == identity.identity_hash
-    assert portal_skill_identity(identity)["stableId"].startswith("skill:")
+    stable_id = portal_skill_identity(identity)["stableId"]
+    assert isinstance(stable_id, str)
+    assert stable_id.startswith("skill:")
 
 
 def test_append_artifact_enriches_mcp_server_metadata() -> None:

--- a/tests/test_guard_non_codex_resume.py
+++ b/tests/test_guard_non_codex_resume.py
@@ -161,6 +161,18 @@ def test_pi_hook_response_includes_resume_poll_metadata_for_pending_approval() -
     }
 
 
+def test_pi_hook_response_denies_unsatisfied_review() -> None:
+    payload = pi_hook_response_from_guard(
+        policy_action="review",
+        reason="Review in HOL Guard.",
+    )
+
+    assert payload == {
+        "decision": "deny",
+        "reason": "Review in HOL Guard.",
+    }
+
+
 class TestSafeResumeMetadata:
     """3 tests: union normalization, unsafe/blank dropping, merge precedence."""
 

--- a/tests/test_guard_package_execution_context.py
+++ b/tests/test_guard_package_execution_context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 from codex_plugin_scanner.guard.approval_scope_support import (
@@ -267,6 +268,105 @@ def test_lockfile_executable_and_proxy_environment_each_rekey_context(tmp_path: 
         proxy_changed,
         "environment_policy",
     )
+
+
+def test_script_backed_manager_binds_env_selected_interpreter_content_and_path(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    _write_repository(workspace)
+    _write_package_files(workspace)
+    manager_bin = tmp_path / "manager-bin"
+    first_runtime_bin = tmp_path / "first-runtime"
+    second_runtime_bin = tmp_path / "second-runtime"
+    for directory in (manager_bin, first_runtime_bin, second_runtime_bin):
+        directory.mkdir()
+    manager = manager_bin / "pnpm"
+    manager.write_text("#!/usr/bin/env node\n// package manager\n", encoding="utf-8")
+    manager.chmod(0o755)
+    first_node = first_runtime_bin / "node"
+    second_node = second_runtime_bin / "node"
+    first_node.write_bytes(b"node-runtime-v1\n")
+    second_node.write_bytes(b"node-runtime-v1\n")
+    first_node.chmod(0o755)
+    second_node.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    artifact = _artifact()
+    first_environment = {
+        "PATH": os.pathsep.join((str(manager_bin), str(first_runtime_bin))),
+        "HOME": str(home),
+    }
+    second_environment = {
+        "PATH": os.pathsep.join((str(manager_bin), str(second_runtime_bin))),
+        "HOME": str(home),
+    }
+
+    first = _context(workspace, artifact, first_environment)
+    unchanged = _context(workspace, artifact, first_environment)
+    path_changed = _context(workspace, artifact, second_environment)
+    first_node.write_bytes(b"node-runtime-v2\n")
+    first_node.chmod(0o755)
+    content_changed = _context(workspace, artifact, first_environment)
+
+    assert first.portable is True
+    assert first.digest == unchanged.digest
+    component = "package_manager_executable"
+    assert _component_digest(first, component) != _component_digest(path_changed, component)
+    assert _component_digest(first, component) != _component_digest(content_changed, component)
+
+
+def test_script_backed_manager_binds_nested_python_module_loaded_by_shebang(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    _write_repository(workspace)
+    _write_package_files(workspace)
+    runtime_bin = tmp_path / "runtime-bin"
+    runtime_bin.mkdir()
+    manager = runtime_bin / "pnpm"
+    manager.write_text("#!/usr/bin/env -S python -m bootstrap\n", encoding="utf-8")
+    manager.chmod(0o755)
+    python = runtime_bin / "python"
+    python.write_bytes(b"native-python-runtime\n")
+    python.chmod(0o755)
+    bootstrap = workspace / "bootstrap.py"
+    bootstrap.write_text("print('v1')\n", encoding="utf-8")
+    home = tmp_path / "home"
+    home.mkdir()
+    environment = {"PATH": str(runtime_bin), "HOME": str(home)}
+
+    before = _context(workspace, _artifact(), environment)
+    bootstrap.write_text("print('v2')\n", encoding="utf-8")
+    after = _context(workspace, _artifact(), environment)
+
+    assert before.portable is True
+    assert after.portable is True
+    assert _component_digest(before, "package_manager_executable") != _component_digest(
+        after,
+        "package_manager_executable",
+    )
+
+
+def test_unbound_nested_node_preload_in_shebang_disables_package_approval_reuse(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    _write_repository(workspace)
+    _write_package_files(workspace)
+    runtime_bin = tmp_path / "runtime-bin"
+    runtime_bin.mkdir()
+    manager = runtime_bin / "pnpm"
+    manager.write_text("#!/usr/bin/env -S node --require ./preload.js\n", encoding="utf-8")
+    manager.chmod(0o755)
+    node = runtime_bin / "node"
+    node.write_bytes(b"native-node-runtime\n")
+    node.chmod(0o755)
+    (workspace / "preload.js").write_text("module.exports = {};\n", encoding="utf-8")
+    home = tmp_path / "home"
+    home.mkdir()
+    environment = {"PATH": str(runtime_bin), "HOME": str(home)}
+
+    first = _context(workspace, _artifact(), environment)
+    second = _context(workspace, _artifact(), environment)
+
+    assert first.portable is False
+    assert first.non_portable_reason == "package_manager_launch_identity_unavailable"
+    assert first.digest != second.digest
 
 
 def test_oversized_or_dynamic_configuration_is_not_portable(tmp_path: Path) -> None:

--- a/tests/test_guard_package_hook.py
+++ b/tests/test_guard_package_hook.py
@@ -14,6 +14,7 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.approvals import apply_approval_resolution
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.runtime.signals import RiskSignalV2
 from codex_plugin_scanner.guard.store import GuardStore
@@ -226,7 +227,7 @@ def _data_flow_signal_v2() -> RiskSignalV2:
     )
 
 
-def test_guard_hook_blocks_package_request_before_execution_and_queues_cloud_sync(
+def test_guard_hook_terminal_package_block_is_not_queued_for_browser_approval(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -241,12 +242,13 @@ def test_guard_hook_blocks_package_request_before_execution_and_queues_cloud_syn
     store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="block"), "2026-05-19T00:00:00Z")
     (home_dir / "config.toml").write_text("approval_wait_timeout_seconds = 0\n", encoding="utf-8")
     monkeypatch.setenv("CODEX_MANAGED_BY_BUN", "1")
-    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
 
-    def fail_daemon(_home: Path) -> object:
-        raise RuntimeError("no daemon client")
+    def unexpected_browser_approval(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("terminal package block must not queue or wait for browser approval")
 
-    monkeypatch.setattr(guard_commands_module, "load_guard_surface_daemon_client", fail_daemon)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", unexpected_browser_approval)
+    monkeypatch.setattr(guard_commands_module, "queue_blocked_approvals", unexpected_browser_approval)
+    monkeypatch.setattr(guard_commands_module, "wait_for_approval_requests", unexpected_browser_approval)
 
     def fail_subprocess(*args: object, **kwargs: object) -> object:
         raise AssertionError("blocked package request must not launch a subprocess")
@@ -273,14 +275,18 @@ def test_guard_hook_blocks_package_request_before_execution_and_queues_cloud_syn
     assert rc == 0
     assert captured.err == ""
     assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
-    assert "blocked" in payload["hookSpecificOutput"]["permissionDecisionReason"].lower()
+    reason = str(payload["hookSpecificOutput"]["permissionDecisionReason"])
+    assert "blocked" in reason.lower()
+    assert "terminal policy decision" in reason
+    assert "Browser approval cannot override it" in reason
+    assert "/requests/" not in reason
     evidence = store.list_evidence()
     assert evidence
     assert evidence[0]["category"] == "supply-chain"
     queued_events = store.list_guard_events_v1(uploaded=False)
     assert queued_events
     assert any(event["event_type"] == "receipt.created" for event in queued_events)
-    assert store.list_approval_requests(limit=5)
+    assert store.list_approval_requests(limit=5) == []
 
 
 def test_guard_hook_ask_queues_package_approval_with_advisory_context(
@@ -390,15 +396,41 @@ def test_guard_hook_ask_package_live_wait_surfaces_approval_url(
 
     monkeypatch.setattr(guard_commands_module, "load_guard_surface_daemon_client", fail_daemon)
     opened_urls: list[str] = []
+    resolved_request_ids: list[str] = []
     monkeypatch.setattr(guard_commands_module.webbrowser, "open", opened_urls.append)
+
+    def resolve_actual_exact_request(**kwargs: object) -> dict[str, object]:
+        request_ids = kwargs.get("request_ids")
+        assert isinstance(request_ids, list)
+        assert request_ids
+        resolved_items: list[dict[str, object]] = []
+        for request_id_value in request_ids:
+            assert isinstance(request_id_value, str)
+            queued_request = store.get_approval_request(request_id_value)
+            assert queued_request is not None
+            assert str(queued_request["artifact_hash"]).startswith("guard-approval-context:v1:")
+            apply_approval_resolution(
+                store=store,
+                request_id=request_id_value,
+                action="allow",
+                scope="artifact",
+                workspace=None,
+                reason="approved exact package request",
+            )
+            resolved_request = store.get_approval_request(request_id_value)
+            assert resolved_request is not None
+            resolved_items.append(resolved_request)
+            resolved_request_ids.append(request_id_value)
+        return {
+            "resolved": True,
+            "pending_request_ids": [],
+            "items": resolved_items,
+        }
+
     monkeypatch.setattr(
         guard_commands_module,
         "wait_for_approval_requests",
-        lambda **_kwargs: {
-            "resolved": True,
-            "pending_request_ids": [],
-            "items": [{"request_id": "req-1", "resolution_action": "allow"}],
-        },
+        resolve_actual_exact_request,
     )
 
     rc = main(
@@ -419,6 +451,7 @@ def test_guard_hook_ask_package_live_wait_surfaces_approval_url(
 
     assert rc == 0
     assert captured.out == ""
+    assert len(resolved_request_ids) == 1
     assert opened_urls
     assert "/requests/" in opened_urls[0]
     assert opened_urls[0] in captured.err

--- a/tests/test_guard_package_hook_phase14.py
+++ b/tests/test_guard_package_hook_phase14.py
@@ -16,6 +16,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
 
+import codex_plugin_scanner.guard.runtime.supply_chain_package_eval as evaluator_module
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution
@@ -58,6 +59,25 @@ pytest_plugins = ["tests.bundle_first_cloud"]
 pytestmark = pytest.mark.usefixtures("bundle_first_cloud")
 
 WORKSPACE_ID = "workspace-alpha"
+EVALUATION_NOW = datetime(2026, 5, 19, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _freeze_package_evaluator_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            fixed = cls(
+                EVALUATION_NOW.year,
+                EVALUATION_NOW.month,
+                EVALUATION_NOW.day,
+                tzinfo=timezone.utc,
+            )
+            if tz is None:
+                return fixed.replace(tzinfo=None)
+            return fixed.astimezone(tz)
+
+    monkeypatch.setattr(evaluator_module, "datetime", _FixedDateTime)
 
 
 def _generate_key_pair() -> tuple[bytes, bytes]:
@@ -83,7 +103,7 @@ def _iso(value: datetime) -> str:
 
 
 def _bundle_response(*, action: str, policy_rules: list[dict[str, object]] | None = None) -> dict[str, object]:
-    generated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)
+    generated_at = EVALUATION_NOW
     expires_at = generated_at + timedelta(hours=12)
     bundle = {
         "advisories": [
@@ -290,6 +310,12 @@ def test_phase14_guard_hook_enriches_package_contract_for_managed_harnesses(
 
     assert rc == 1
     assert output["artifact_type"] == "package_request"
+    assert output["policy_action"] == "require-reapproval"
+    assert output["supply_chain_evaluation"]["decision"] == "ask"
+    assert output["supply_chain_evaluation"]["matched_rule_id"] == "policy-review-1"
+    assert output["approval_requests"]
+    assert output.get("terminal") is not True
+    assert output.get("terminal_action") is None
     assert pending
     assert pending[0]["artifact_type"] == "package_request"
     assert pending[0]["action_envelope_json"]["package_manager"] == "npm"
@@ -401,7 +427,7 @@ def test_phase14_package_hook_block_copy_stays_consistent_across_harnesses(
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir(parents=True, exist_ok=True)
-    _seed_block_bundle(home_dir)
+    store = _seed_block_bundle(home_dir)
     (home_dir / "config.toml").write_text("approval_wait_timeout_seconds = 0\n", encoding="utf-8")
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
     monkeypatch.setattr(
@@ -426,9 +452,15 @@ def test_phase14_package_hook_block_copy_stays_consistent_across_harnesses(
     assert decision["harness_message"].startswith("HOL Guard blocked")
     assert "Reason:" in decision["harness_message"]
     assert "Fix: install `npm install minimist@1.2.9` or choose a team exception." in decision["harness_message"]
-    assert (
-        "Open HOL Guard to approve or keep this blocked: http://127.0.0.1:5474/requests/" in decision["harness_message"]
-    )
+    assert output["policy_action"] == "block"
+    assert output["terminal_action"] == "block"
+    assert output["terminal"] is True
+    assert output["operation_status"] == "blocked"
+    assert output["approval_requests"] == []
+    assert store.count_approval_requests(status="pending") == 0
+    assert decision.get("retry_instruction") is None
+    assert "/requests/" not in decision["harness_message"]
+    assert "Review this request in HOL Guard, then retry." not in decision["harness_message"]
     assert "guard/inbox" not in decision["harness_message"]
 
 

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -22,6 +22,7 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
 from codex_plugin_scanner.guard import shims as guard_shims_module
 from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
@@ -583,7 +584,7 @@ def test_package_manager_shim_uses_trusted_guard_import_path(tmp_path: Path, cap
         ["npm", "install", "file:./vendor/guard"],
     ],
 )
-def test_guard_protect_requires_review_for_untrusted_package_sources_without_cloud(
+def test_guard_protect_requires_reapproval_for_untrusted_package_sources_without_cloud(
     tmp_path: Path,
     command: list[str],
 ) -> None:
@@ -603,7 +604,7 @@ def test_guard_protect_requires_review_for_untrusted_package_sources_without_clo
     assert exit_code == 2
     assert payload["executed"] is False
     assert payload["verdict"]["blocking"] is True
-    assert payload["verdict"]["action"] == "review"
+    assert payload["verdict"]["action"] == "require-reapproval"
 
 
 def test_package_manager_shim_runs_allowed_command_once_when_shim_dir_is_on_path(tmp_path: Path, capsys) -> None:
@@ -1388,7 +1389,7 @@ def test_guard_package_shim_preserves_argv_cwd_env_exitcode_and_stdio(tmp_path: 
     assert result.stdout.strip() == "fake-manager-stdout"
 
 
-def test_guard_protect_json_queues_local_approval_link_on_cloud_auth_error(
+def test_guard_protect_json_terminal_block_on_cloud_auth_error_does_not_queue_local_approval(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys,
@@ -1401,7 +1402,11 @@ def test_guard_protect_json_queues_local_approval_link_on_cloud_auth_error(
         package_name="minimist",
         evaluate_status=401,
     )
-    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    monkeypatch.setattr(
+        guard_commands_module,
+        "ensure_guard_daemon",
+        lambda _home: (_ for _ in ()).throw(AssertionError("terminal block must not start approval daemon")),
+    )
     try:
         _seed_bundle(
             home_dir=home_dir,
@@ -1431,20 +1436,16 @@ def test_guard_protect_json_queues_local_approval_link_on_cloud_auth_error(
         _stop_cloud_eval_server(server, thread)
 
     payload = json.loads(capsys.readouterr().out)
-    stored_receipt = GuardStore(home_dir).list_receipts(limit=1)[0]
+    store = GuardStore(home_dir)
+    stored_receipt = store.list_receipts(limit=1)[0]
 
     assert rc == 2
-    assert payload["approval_center_url"] == "http://127.0.0.1:5474"
-    assert payload["primary_approval_request_id"]
-    assert payload["primary_approval_url"].startswith("http://127.0.0.1:5474/requests/")
-    assert payload["approval_request_ids"] == [payload["primary_approval_request_id"]]
-    assert payload["receipt"]["approval_request_id"] == payload["primary_approval_request_id"]
-    assert stored_receipt["approval_request_id"] == payload["primary_approval_request_id"]
-    assert payload["supply_chain_evaluation"]["user_copy"]["dashboard_url"] == payload["primary_approval_url"]
-    assert (
-        "Open HOL Guard to approve or keep this blocked:"
-        in payload["supply_chain_evaluation"]["user_copy"]["harness_message"]
-    )
+    assert payload["verdict"]["action"] == "block"
+    assert "approval_center_url" not in payload
+    assert "primary_approval_request_id" not in payload
+    assert payload["receipt"]["approval_request_id"] is None
+    assert stored_receipt["approval_request_id"] is None
+    assert store.list_approval_requests(limit=None) == []
 
 
 def test_guard_protect_probe_skips_local_approval_queue_on_block(
@@ -1925,7 +1926,9 @@ def test_guard_protect_ignores_stale_policy_bundle_package_family_on_cloud_allow
     payload = json.loads(capsys.readouterr().out)
 
     assert rc == 0
-    assert payload["supply_chain_evaluation"]["decision"] == "allow"
+    # The cloud feed allows this package and the stale family block is ignored,
+    # while the current balanced package-script policy still contributes warn.
+    assert payload["supply_chain_evaluation"]["decision"] == "warn"
     reason_codes = {
         reason["code"]
         for reason in payload["supply_chain_evaluation"]["reasons"]
@@ -1935,7 +1938,7 @@ def test_guard_protect_ignores_stale_policy_bundle_package_family_on_cloud_allow
     assert "saved_package_block" not in reason_codes
 
 
-def test_guard_protect_retry_runs_after_local_package_approval(
+def test_guard_protect_terminal_current_package_gate_has_no_local_override(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     install_fake_system_keyring,
@@ -1990,14 +1993,8 @@ def test_guard_protect_retry_runs_after_local_package_approval(
         assert rc == 2
 
         store = GuardStore(home_dir)
-        apply_approval_resolution(
-            store=store,
-            request_id=str(payload["primary_approval_request_id"]),
-            action="allow",
-            scope="artifact",
-            workspace=None,
-            reason="reviewed",
-        )
+        assert "primary_approval_request_id" not in payload
+        assert store.list_approval_requests(limit=None) == []
 
         retry_payload, retry_exit_code = build_protect_payload(
             command=["npm", "install", "minimist@1.2.8"],
@@ -2009,13 +2006,13 @@ def test_guard_protect_retry_runs_after_local_package_approval(
     finally:
         _stop_cloud_eval_server(server, thread)
 
-    assert retry_exit_code == 0
-    assert retry_payload["executed"] is True
-    assert retry_payload["verdict"]["action"] == "allow"
-    assert marker_path.exists()
+    assert retry_exit_code == 2
+    assert retry_payload["executed"] is False
+    assert retry_payload["verdict"]["action"] == "block"
+    assert marker_path.exists() is False
 
 
-def test_guard_protect_retry_after_local_package_approval_reuses_recent_cloud_validation_error_cache(
+def test_guard_protect_cached_validation_error_still_requires_current_package_gate(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     install_fake_system_keyring,
@@ -2094,10 +2091,20 @@ def test_guard_protect_retry_after_local_package_approval_reuses_recent_cloud_va
         if server is not None and thread is not None:
             _stop_cloud_eval_server(server, thread)
 
-    assert retry_exit_code == 0
-    assert retry_payload["executed"] is True
-    assert retry_payload["verdict"]["action"] == "allow"
-    assert marker_path.exists()
+    assert retry_exit_code == 2
+    assert retry_payload["executed"] is False
+    assert retry_payload["verdict"]["action"] in {"block", "review"}
+    assert any(
+        isinstance(reason, dict)
+        and reason.get("code")
+        in {
+            "approval_reuse_current_block",
+            "approval_reuse_policy_changed",
+            "approval_reuse_reapproval_required",
+        }
+        for reason in retry_payload["supply_chain_evaluation"]["reasons"]
+    )
+    assert marker_path.exists() is False
     assert store.list_approval_requests(status="pending", limit=None) == []
 
 
@@ -2144,13 +2151,19 @@ def test_guard_protect_denied_retry_surfaces_saved_block_clear_command_without_r
         payload = json.loads(capsys.readouterr().out)
         store = GuardStore(home_dir)
         assert rc == 2
-        apply_approval_resolution(
-            store=store,
-            request_id=str(payload["primary_approval_request_id"]),
-            action="block",
-            scope="artifact",
-            workspace=None,
-            reason="keep blocked",
+        receipt = payload["receipt"]
+        assert isinstance(receipt, dict)
+        assert "primary_approval_request_id" not in payload
+        store.upsert_policy(
+            PolicyDecision(
+                harness="guard-cli",
+                scope="artifact",
+                action="block",
+                artifact_id=str(receipt["artifact_id"]),
+                artifact_hash=str(receipt["artifact_hash"]),
+                reason="keep blocked",
+            ),
+            "2026-05-19T00:00:00Z",
         )
         retry_rc = main(
             [
@@ -2187,10 +2200,10 @@ def test_guard_protect_denied_retry_surfaces_saved_block_clear_command_without_r
     assert "--artifact-id" in user_copy["next_step"]
     assert "--artifact-hash" in user_copy["next_step"]
     assert pending == []
-    assert len(resolved) == 1
+    assert resolved == []
 
 
-def test_guard_protect_json_queues_local_approval_when_cached_advisory_overrides_bundle_allow(
+def test_guard_protect_json_cached_advisory_terminal_block_does_not_queue_local_approval(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys,
@@ -2219,7 +2232,11 @@ def test_guard_protect_json_queues_local_approval_when_cached_advisory_overrides
         ],
         "2026-05-19T00:00:00Z",
     )
-    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    monkeypatch.setattr(
+        guard_commands_module,
+        "ensure_guard_daemon",
+        lambda _home: (_ for _ in ()).throw(AssertionError("terminal block must not start approval daemon")),
+    )
 
     rc = main(
         [
@@ -2242,10 +2259,8 @@ def test_guard_protect_json_queues_local_approval_when_cached_advisory_overrides
 
     assert rc == 2
     assert payload["verdict"]["action"] == "block"
-    assert payload["primary_approval_request_id"]
-    assert payload["primary_approval_url"].startswith("http://127.0.0.1:5474/requests/")
-    assert pending[0]["risk_summary"] == payload["verdict"]["reason"]
-    assert pending[0]["risk_summary"] != payload["supply_chain_evaluation"]["risk_summary"]
+    assert "primary_approval_request_id" not in payload
+    assert pending == []
 
 
 def test_guard_protect_denied_retry_with_cloud_block_surfaces_saved_block_clear_command_without_requeue(
@@ -2291,13 +2306,19 @@ def test_guard_protect_denied_retry_with_cloud_block_surfaces_saved_block_clear_
         payload = json.loads(capsys.readouterr().out)
 
         assert rc == 2
-        apply_approval_resolution(
-            store=store,
-            request_id=str(payload["primary_approval_request_id"]),
-            action="block",
-            scope="artifact",
-            workspace=None,
-            reason="keep blocked",
+        receipt = payload["receipt"]
+        assert isinstance(receipt, dict)
+        assert "primary_approval_request_id" not in payload
+        store.upsert_policy(
+            PolicyDecision(
+                harness="guard-cli",
+                scope="artifact",
+                action="block",
+                artifact_id=str(receipt["artifact_id"]),
+                artifact_hash=str(receipt["artifact_hash"]),
+                reason="keep blocked",
+            ),
+            "2026-05-19T00:00:00Z",
         )
 
         retry_rc = main(
@@ -2334,7 +2355,7 @@ def test_guard_protect_denied_retry_with_cloud_block_surfaces_saved_block_clear_
     assert "--artifact-id" in user_copy["next_step"]
     assert "--artifact-hash" in user_copy["next_step"]
     assert pending == []
-    assert len(resolved) == 1
+    assert resolved == []
 
 
 def test_guard_protect_saved_approval_does_not_bypass_new_bundle_block_for_unpinned_package(
@@ -2389,7 +2410,7 @@ def test_guard_protect_saved_approval_does_not_bypass_new_bundle_block_for_unpin
         )
 
         assert first_exit_code == 2
-        assert first_payload["verdict"]["action"] in {"block", "review"}
+        assert first_payload["verdict"]["action"] in {"block", "require-reapproval"}
         receipt = first_payload["receipt"]
         assert isinstance(receipt, dict)
         store.upsert_policy(
@@ -2452,7 +2473,7 @@ def test_guard_protect_saved_approval_does_not_bypass_new_bundle_block_for_unpin
     )
 
 
-def test_guard_protect_retry_runs_after_cached_advisory_package_approval(
+def test_guard_protect_saved_allow_never_lowers_current_cached_advisory_block(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys,
@@ -2507,13 +2528,19 @@ def test_guard_protect_retry_runs_after_cached_advisory_package_approval(
     payload = json.loads(capsys.readouterr().out)
 
     assert rc == 2
-    apply_approval_resolution(
-        store=store,
-        request_id=str(payload["primary_approval_request_id"]),
-        action="allow",
-        scope="artifact",
-        workspace=None,
-        reason="reviewed",
+    receipt = payload["receipt"]
+    assert isinstance(receipt, dict)
+    assert "primary_approval_request_id" not in payload
+    store.upsert_policy(
+        PolicyDecision(
+            harness="guard-cli",
+            scope="artifact",
+            action="allow",
+            artifact_id=str(receipt["artifact_id"]),
+            artifact_hash=str(receipt["artifact_hash"]),
+            reason="historical exact approval",
+        ),
+        "2026-05-19T00:00:00Z",
     )
 
     retry_payload, retry_exit_code = build_protect_payload(
@@ -2524,14 +2551,252 @@ def test_guard_protect_retry_runs_after_cached_advisory_package_approval(
         now="2026-05-19T00:00:00Z",
     )
 
-    assert retry_exit_code == 0
-    assert retry_payload["executed"] is True
-    assert retry_payload["verdict"]["action"] == "allow"
+    assert retry_exit_code == 2
+    assert retry_payload["executed"] is False
+    assert retry_payload["verdict"]["action"] == "block"
     assert any(
+        isinstance(reason, dict)
+        and reason.get("code")
+        in {
+            "approval_reuse_current_block",
+            "approval_reuse_policy_changed",
+            "approval_reuse_reapproval_required",
+            "approval_reuse_claim_failed",
+        }
+        for reason in retry_payload["supply_chain_evaluation"]["reasons"]
+    )
+    assert not any(
         isinstance(reason, dict) and reason.get("code") == "saved_package_approval"
         for reason in retry_payload["supply_chain_evaluation"]["reasons"]
     )
-    assert marker_path.exists()
+    assert marker_path.exists() is False
+
+
+def test_guard_protect_same_cached_advisory_id_review_to_block_changes_authority_before_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    install_fake_system_keyring,
+) -> None:
+    install_fake_system_keyring()
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True, exist_ok=True)
+    marker_path = tmp_path / "npm-cached-advisory-transition.json"
+    write_fake_manager_script(fake_bin=fake_bin, manager="npm", marker_path=marker_path, exit_code=0)
+    original_path = os.environ.get("PATH", "")
+    monkeypatch.setenv("PATH", os.pathsep.join(filter(None, [str(fake_bin), original_path])))
+    store = GuardStore(home_dir)
+    review_evaluation = supply_chain_package_eval_module.PackageRequestEvaluation(
+        decision="ask",
+        policy_action="review",
+        enforcement="local",
+        entitlement_state="active",
+        cache_status="fresh",
+        package_intent_hash="same-advisory-id-intent",
+        policy_version="same-advisory-id-policy",
+        bundle_version="same-advisory-id-bundle",
+        workspace_fingerprint="same-advisory-id-workspace",
+        reasons=({"code": "package_review", "message": "Review package."},),
+        packages=({"name": "badpkg", "requestedVersion": "1.0.0", "decision": "ask"},),
+        risk_summary="Review package.",
+        user_copy=supply_chain_package_eval_module.SupplyChainUserCopy(
+            title="Review package",
+            summary="Review package.",
+            next_step="Review the package request.",
+            dashboard_url=None,
+            harness_message="Review package.",
+        ),
+    )
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: review_evaluation,
+    )
+    advisory = {
+        "id": "adv-stable-id",
+        "ecosystem": "npm",
+        "package": "badpkg",
+        "severity": "medium",
+        "action": "review",
+        "headline": "Review this package before installation.",
+    }
+    store.cache_advisories([advisory], "2026-07-17T00:00:00Z")
+
+    preview_payload, preview_rc = build_protect_payload(
+        command=["npm", "install", "badpkg@1.0.0"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=True,
+        now="2026-07-17T00:00:00Z",
+    )
+    assert preview_rc == 2
+    assert preview_payload["verdict"]["action"] == "review"
+    receipt = preview_payload["receipt"]
+    assert isinstance(receipt, dict)
+    store.ensure_policy_integrity_ready_for_write(now="2026-07-17T00:00:30Z")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="guard-cli",
+            scope="artifact",
+            action="allow",
+            artifact_id=str(receipt["artifact_id"]),
+            artifact_hash=str(receipt["artifact_hash"]),
+            source="approval-gate",
+            expires_at="2026-07-18T00:00:00Z",
+        ),
+        "2026-07-17T00:00:30Z",
+    )
+
+    store.cache_advisories(
+        [
+            {
+                **advisory,
+                "severity": "critical",
+                "action": "block",
+                "headline": "Confirmed malicious package.",
+            }
+        ],
+        "2026-07-17T00:01:00Z",
+    )
+    retry_payload, retry_rc = build_protect_payload(
+        command=["npm", "install", "badpkg@1.0.0"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+    )
+
+    assert retry_rc == 2
+    assert retry_payload["verdict"]["action"] == "block"
+    assert retry_payload["executed"] is False
+    assert retry_payload["receipt"]["artifact_hash"] != receipt["artifact_hash"]
+    assert marker_path.exists() is False
+    old_approval_lookup = store.resolve_policy_decision_lookup(
+        "guard-cli",
+        str(receipt["artifact_id"]),
+        str(receipt["artifact_hash"]),
+        None,
+        None,
+        "2026-07-17T00:01:00Z",
+        consume_one_shot=False,
+    )
+    assert old_approval_lookup["decision"] is not None
+
+
+def test_guard_protect_reloads_cached_advisory_authority_after_atomic_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    install_fake_system_keyring,
+) -> None:
+    install_fake_system_keyring()
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True, exist_ok=True)
+    marker_path = tmp_path / "npm-claim-time-advisory.json"
+    write_fake_manager_script(fake_bin=fake_bin, manager="npm", marker_path=marker_path, exit_code=0)
+    original_path = os.environ.get("PATH", "")
+    monkeypatch.setenv("PATH", os.pathsep.join(filter(None, [str(fake_bin), original_path])))
+    store = GuardStore(home_dir)
+    review_evaluation = supply_chain_package_eval_module.PackageRequestEvaluation(
+        decision="ask",
+        policy_action="review",
+        enforcement="local",
+        entitlement_state="active",
+        cache_status="fresh",
+        package_intent_hash="claim-time-advisory-intent",
+        policy_version="claim-time-advisory-policy",
+        bundle_version="claim-time-advisory-bundle",
+        workspace_fingerprint="claim-time-advisory-workspace",
+        reasons=({"code": "package_review", "message": "Review package."},),
+        packages=({"name": "badpkg", "requestedVersion": "1.0.0", "decision": "ask"},),
+        risk_summary="Review package.",
+        user_copy=supply_chain_package_eval_module.SupplyChainUserCopy(
+            title="Review package",
+            summary="Review package.",
+            next_step="Review the package request.",
+            dashboard_url=None,
+            harness_message="Review package.",
+        ),
+    )
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: review_evaluation,
+    )
+    advisory = {
+        "id": "adv-claim-time-stable-id",
+        "ecosystem": "npm",
+        "package": "badpkg",
+        "severity": "medium",
+        "action": "review",
+        "headline": "Review this package before installation.",
+    }
+    store.cache_advisories([advisory], "2026-07-17T00:00:00Z")
+    preview_payload, preview_rc = build_protect_payload(
+        command=["npm", "install", "badpkg@1.0.0"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=True,
+        now="2026-07-17T00:00:00Z",
+    )
+    assert preview_rc == 2
+    receipt = preview_payload["receipt"]
+    assert isinstance(receipt, dict)
+    store.ensure_policy_integrity_ready_for_write(now="2026-07-17T00:00:30Z")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="guard-cli",
+            scope="artifact",
+            action="allow",
+            artifact_id=str(receipt["artifact_id"]),
+            artifact_hash=str(receipt["artifact_hash"]),
+            source="approval-gate",
+            expires_at="2026-07-18T00:00:00Z",
+        ),
+        "2026-07-17T00:00:30Z",
+    )
+    original_claim = store.claim_approval_reuse_decision
+
+    def claim_then_block(decision: dict[str, object], *, now: str) -> bool:
+        claimed = original_claim(decision, now=now)
+        assert claimed is True
+        store.cache_advisories(
+            [
+                {
+                    **advisory,
+                    "severity": "critical",
+                    "action": "block",
+                    "headline": "Confirmed malicious during approval claim.",
+                }
+            ],
+            now,
+        )
+        return True
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decision", claim_then_block)
+
+    retry_payload, retry_rc = build_protect_payload(
+        command=["npm", "install", "badpkg@1.0.0"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-07-17T00:01:00Z",
+    )
+
+    assert retry_rc == 2
+    assert retry_payload["executed"] is False
+    assert retry_payload["verdict"]["action"] == "block"
+    assert retry_payload["receipt"]["artifact_hash"] != receipt["artifact_hash"]
+    assert marker_path.exists() is False
+    assert any(
+        isinstance(reason, dict)
+        and reason.get("code") in {"approval_reuse_current_block", "approval_reuse_policy_changed"}
+        for reason in retry_payload["supply_chain_evaluation"]["reasons"]
+    )
 
 
 def test_guard_protect_blocks_npm_ci_before_install_from_lockfile(tmp_path: Path) -> None:
@@ -2568,7 +2833,7 @@ def test_guard_protect_blocks_npm_ci_before_install_from_lockfile(tmp_path: Path
     assert any(package["name"] == "minimist" for package in payload["supply_chain_evaluation"]["packages"])
 
 
-def test_guard_protect_npm_ci_requires_fresh_approval_after_lockfile_change(
+def test_guard_protect_npm_ci_terminal_block_stays_non_queueable_after_lockfile_change(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys,
@@ -2610,14 +2875,8 @@ def test_guard_protect_npm_ci_requires_fresh_approval_after_lockfile_change(
         first_payload = json.loads(capsys.readouterr().out)
 
         assert first_rc == 2
-        apply_approval_resolution(
-            store=store,
-            request_id=str(first_payload["primary_approval_request_id"]),
-            action="allow",
-            scope="artifact",
-            workspace=None,
-            reason="reviewed",
-        )
+        assert "primary_approval_request_id" not in first_payload
+        assert store.list_approval_requests(limit=None) == []
 
         _write_npm_ci_workspace(workspace_dir, package_name="badpkg", package_version="2.0.0")
 
@@ -2644,10 +2903,10 @@ def test_guard_protect_npm_ci_requires_fresh_approval_after_lockfile_change(
 
     assert second_rc == 2
     assert second_payload["verdict"]["action"] == "block"
-    assert second_payload["primary_approval_request_id"] != first_payload["primary_approval_request_id"]
+    assert "primary_approval_request_id" not in second_payload
     assert second_payload["receipt"]["artifact_hash"] != first_payload["receipt"]["artifact_hash"]
-    assert len(pending) == 1
-    assert len(resolved) == 1
+    assert pending == []
+    assert resolved == []
 
 
 def test_guard_package_shims_block_npm_ci_before_manager_execution_from_lockfile(tmp_path: Path, capsys) -> None:

--- a/tests/test_guard_phase04_harness_ux.py
+++ b/tests/test_guard_phase04_harness_ux.py
@@ -77,9 +77,11 @@ def _context(tmp_path: Path) -> HarnessContext:
 def _load_claude_pending_question_contract(tmp_path: Path, session_id: str) -> tuple[str, list[dict[str, str]]]:
     store = GuardStore(tmp_path / "guard-home")
     index_payload = store.get_sync_payload(f"claude_pending_permissions:{session_id}")
-    assert isinstance(index_payload, list)
-    assert index_payload
-    pending_payload = store.get_sync_payload(str(index_payload[0]))
+    assert isinstance(index_payload, dict)
+    pending_keys = index_payload.get("pending_keys")
+    assert isinstance(pending_keys, list)
+    assert pending_keys
+    pending_payload = store.get_sync_payload(str(pending_keys[0]))
     assert isinstance(pending_payload, dict)
     question = str(pending_payload["approval_question"])
     options = pending_payload.get("approval_options")
@@ -508,7 +510,7 @@ def test_gr084_claude_keep_blocked_persists_for_repeated_sensitive_read(tmp_path
     assert "HOL Guard blocked Claude" in str(repeat_payload["hookSpecificOutput"])
 
 
-def test_gr085_claude_allow_once_allows_same_action_and_reasks_changed_action(tmp_path: Path) -> None:
+def test_gr085_claude_allow_once_cannot_lower_current_reapproval(tmp_path: Path) -> None:
     event = _claude_sensitive_read_event("session-gr085", "~/.npmrc")
 
     first_exit_code, _first_output = _run_hook(tmp_path, harness="claude-code", payload=event)
@@ -541,12 +543,12 @@ def test_gr085_claude_allow_once_allows_same_action_and_reasks_changed_action(tm
     assert answer_exit_code == 0
     assert answer_output == ""
     assert retry_exit_code == 0
-    assert retry_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert retry_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
     assert changed_exit_code == 0
     assert changed_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
 
 
-def test_gr086_claude_session_allow_answer_unblocks_retried_action(tmp_path: Path) -> None:
+def test_gr086_claude_session_allow_cannot_lower_current_reapproval(tmp_path: Path) -> None:
     event = _claude_sensitive_read_event("session-gr086", "~/.npmrc")
 
     first_exit_code, _first_output = _run_hook(tmp_path, harness="claude-code", payload=event)
@@ -573,7 +575,7 @@ def test_gr086_claude_session_allow_answer_unblocks_retried_action(tmp_path: Pat
     assert answer_exit_code == 0
     assert answer_output == ""
     assert retry_exit_code == 0
-    assert retry_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert retry_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
 
 
 def test_gr087_opencode_managed_mcp_uses_native_ask_runtime_overlay(tmp_path: Path) -> None:

--- a/tests/test_guard_policy_dedup.py
+++ b/tests/test_guard_policy_dedup.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from codex_plugin_scanner.guard.approvals import queue_blocked_approvals
-from codex_plugin_scanner.guard.consumer.service import evaluate_detection
+from codex_plugin_scanner.guard.consumer.service import artifact_hash, evaluate_detection
 from codex_plugin_scanner.guard.models import (
     GuardApprovalRequest,
     GuardArtifact,
@@ -100,8 +100,8 @@ class TestPolicyDeduplication:
         store.save_snapshot(
             "codex",
             artifact.artifact_id,
-            {**artifact.to_dict(), "artifact_hash": "hash-test"},
-            "hash-test",
+            {**artifact.to_dict(), "artifact_hash": artifact_hash(artifact)},
+            artifact_hash(artifact),
             "2026-01-01T00:00:00+00:00",
         )
 
@@ -136,8 +136,8 @@ class TestPolicyDeduplication:
         store.save_snapshot(
             "codex",
             artifact.artifact_id,
-            {**artifact.to_dict(), "artifact_hash": "hash-test"},
-            "hash-test",
+            {**artifact.to_dict(), "artifact_hash": artifact_hash(artifact)},
+            artifact_hash(artifact),
             "2026-01-01T00:00:00+00:00",
         )
 
@@ -198,7 +198,7 @@ class TestDeniedCommandBehavior:
         )
 
         assert evaluation.get("blocked") is True, "Denied artifact must be blocked"
-        assert len(approvals) > 0, "Blocked artifact must still queue for user review in Guard"
+        assert approvals == [], "Terminal block decisions must not be presented as overridable approvals"
 
 
 class TestMeaningfulChangeAsksAgain:

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -35,8 +35,8 @@ def _build_guard_fixture(home_dir: Path, workspace_dir: Path) -> None:
         home_dir / ".codex" / "config.toml",
         """
 [mcp_servers.global_tools]
-command = "python"
-args = ["-m", "http.server", "9000"]
+command = "node"
+args = ["global-tool.js"]
 """.strip()
         + "\n",
     )
@@ -858,9 +858,25 @@ args = ["workspace-skill.js", "--changed"]
         env = os.environ.copy()
         env["PATH"] = f"{fake_bin}:{env['PATH']}"
 
-        result = subprocess.run([str(shim_path), "--help"], capture_output=True, text=True, env=env, check=False)
+        try:
+            result = subprocess.run(
+                [str(shim_path), "--help"],
+                capture_output=True,
+                text=True,
+                env=env,
+                check=False,
+                timeout=15,
+            )
+        except subprocess.TimeoutExpired as exc:
+            pytest.fail(
+                "guard-codex --help timed out after 15 seconds\n"
+                f"stdout:\n{exc.stdout or ''}\n"
+                f"stderr:\n{exc.stderr or ''}"
+            )
 
-        assert result.returncode == 0
+        assert result.returncode == 0, (
+            f"guard-codex --help exited with {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
         assert args_file.read_text(encoding="utf-8").strip() == "--help"
 
     def test_guard_shim_keeps_pythonpath_for_source_checkout_launches(self, tmp_path, capsys, monkeypatch):
@@ -905,18 +921,28 @@ args = ["workspace-skill.js", "--changed"]
         )
         install_output = json.loads(capsys.readouterr().out)
         shim_path = Path(install_output["managed_install"]["manifest"]["shim_path"])
-        result = subprocess.run(
-            [str(shim_path), "--help"],
-            capture_output=True,
-            text=True,
-            env={
-                "PATH": f"{fake_bin}:{os.environ['PATH']}",
-                "HOME": str(home_dir),
-                "PYTHONPATH": str(runtime_pythonpath),
-            },
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                [str(shim_path), "--help"],
+                capture_output=True,
+                text=True,
+                env={
+                    "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                    "HOME": str(home_dir),
+                    "PYTHONPATH": str(runtime_pythonpath),
+                },
+                check=False,
+                timeout=15,
+            )
+        except subprocess.TimeoutExpired as exc:
+            pytest.fail(
+                "guard-codex --help timed out after 15 seconds\n"
+                f"stdout:\n{exc.stdout or ''}\n"
+                f"stderr:\n{exc.stderr or ''}"
+            )
 
-        assert result.returncode == 0
+        assert result.returncode == 0, (
+            f"guard-codex --help exited with {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
         assert args_file.read_text(encoding="utf-8").strip() == "--help"
         assert env_file.read_text(encoding="utf-8") == os.pathsep.join((str(runtime_pythonpath), str(source_root)))

--- a/tests/test_guard_protect.py
+++ b/tests/test_guard_protect.py
@@ -14,6 +14,7 @@ from typing import ClassVar
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard import protect
 from codex_plugin_scanner.guard.advisory_model import ProtectTargetIdentity, advisory_matches_target
+from codex_plugin_scanner.guard.models import GuardReceipt
 from codex_plugin_scanner.guard.redaction import redact_text
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -825,14 +826,73 @@ class TestGuardProtect:
         assert payload["verdict"]["action"] == "block"
         assert payload["receipt"]["policy_decision"] == "block"
         assert any(item.get("id") == "adv-cached-block" for item in payload.get("matched_advisories", []))
-        stored_receipt = store.list_receipts(limit=1)[0]
+        stored_receipts = store.list_receipts(limit=10)
+        assert len(stored_receipts) == 1
+        stored_receipt = stored_receipts[0]
         assert stored_receipt["policy_decision"] == "block"
-        events = store.list_events(limit=10)
-        assert any(
-            event.get("event_name") == "install_time_block"
-            and event.get("payload", {}).get("cached_advisory_override") is True
-            for event in events
+        block_events = store.list_events(limit=10, event_name="install_time_block")
+        assert len(block_events) == 1
+        assert block_events[0]["payload"]["action"] == "block"
+        assert block_events[0]["payload"].get("cached_advisory_override") is not True
+
+    def test_cached_advisory_merge_preserves_action_change_receipt_and_event_contract(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store = GuardStore(tmp_path / "home")
+        now = _now()
+        receipt = GuardReceipt(
+            receipt_id="cached-action-change-receipt",
+            timestamp=now,
+            harness="guard-cli",
+            artifact_id="guard-cli:project:package-request:npm-change",
+            artifact_hash="sha256:cached-action-change",
+            policy_decision="allow",
+            capabilities_summary="Package allowed before cached advisory refresh.",
+            changed_capabilities=("badpkg@1.0.0",),
+            provenance_summary="Initial package authority allowed execution.",
+            artifact_name="npm install badpkg@1.0.0",
+            source_scope="project",
         )
+        store.add_receipt(receipt)
+        payload: dict[str, object] = {
+            "request": {"executor": "npm", "install_kind": "install"},
+            "verdict": {
+                "action": "allow",
+                "reason": "Initial package authority allowed execution.",
+                "risk_signals": [],
+                "matched_advisories": [],
+                "blocking": False,
+            },
+            "matched_advisories": [],
+            "executed": False,
+            "dry_run": False,
+            "receipt": receipt.to_dict(),
+        }
+        cached_verdict = protect.ProtectVerdict(
+            action="block",
+            reason="Cached advisory blocks execution.",
+            risk_signals=("Cached advisory blocks execution.",),
+            matched_advisories=({"id": "adv-action-change", "action": "block"},),
+        )
+
+        merged_payload, returncode = protect._merge_cached_advisory_into_package_payload(
+            (payload, 0),
+            cached_verdict=cached_verdict,
+            requested_dry_run=False,
+            store=store,
+            now=now,
+        )
+
+        assert returncode == 2
+        assert merged_payload["verdict"]["action"] == "block"
+        assert merged_payload["receipt"]["policy_decision"] == "block"
+        stored_receipts = store.list_receipts(limit=10)
+        assert len(stored_receipts) == 1
+        assert stored_receipts[0]["policy_decision"] == "block"
+        events = store.list_events(event_name="install_time_block")
+        assert len(events) == 1
+        assert events[0]["payload"]["cached_advisory_override"] is True
 
     def test_guard_protect_matches_review_advisory_by_remote_endpoint_indicator(
         self,

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -240,8 +240,7 @@ def test_guard_protect_render_uses_supply_chain_user_copy(capsys) -> None:
                     "harness_message": (
                         "HOL Guard blocked `minimist@1.2.5` before install.\n"
                         "Reason: Known exploited package.\n"
-                        "Fix: Install `minimist@1.2.9` instead.\n"
-                        "Review this request in HOL Guard, then retry."
+                        "Fix: Install `minimist@1.2.9` instead."
                     ),
                 },
             },
@@ -253,7 +252,7 @@ def test_guard_protect_render_uses_supply_chain_user_copy(capsys) -> None:
 
     assert "HOL Guard blocked" in output
     assert "Install `minimist@1.2.9` instead." in output
-    assert "Review this request in HOL Guard, then retry." in output
+    assert "Review this request in HOL Guard, then retry." not in output
 
 
 def test_guard_protect_render_uses_supply_chain_review_copy(capsys) -> None:

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -245,7 +245,7 @@ def test_queue_blocked_approvals_includes_risk_summary_and_signals(tmp_path):
                 "artifact_id": artifact.artifact_id,
                 "artifact_name": artifact.name,
                 "artifact_hash": "hash-1",
-                "policy_action": "block",
+                "policy_action": "require-reapproval",
                 "changed_fields": ["first_seen"],
             }
         ]
@@ -2458,7 +2458,7 @@ def test_tool_action_request_classifier_rejects_graphql_workflow_with_repo_copil
 def test_tool_action_request_classifier_rejects_graphql_workflow_with_symlink_target(tmp_path):
     link_path = tmp_path / "link"
     try:
-        link_path.symlink_to(Path.cwd(), target_is_directory=True)
+        link_path.symlink_to(Path.home(), target_is_directory=True)
     except OSError:
         pytest.skip("symlinks are not supported in this environment")
     query_path = link_path / "pr-threads-query.graphql"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9,6 +9,7 @@ import io
 import json
 import os
 import shlex
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -17,6 +18,7 @@ import urllib.error
 import urllib.request
 from base64 import urlsafe_b64decode
 from contextlib import contextmanager
+from dataclasses import replace
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -27,11 +29,15 @@ import pytest
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
-from codex_plugin_scanner.guard.approvals import apply_approval_resolution
+from codex_plugin_scanner.guard.approvals import apply_approval_resolution, wait_for_approval_requests
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.cli import commands_support_interaction as interaction_module
 from codex_plugin_scanner.guard.cli import render as guard_render_module
 from codex_plugin_scanner.guard.cli.commands_support_runtime_artifacts import (
     _codex_post_tool_output_artifact,
+)
+from codex_plugin_scanner.guard.cli.commands_support_runtime_policy import (
+    _runtime_hook_approval_context_token,
 )
 from codex_plugin_scanner.guard.cli.commands_support_runtime_resolution import _runtime_policy_path
 from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
@@ -40,6 +46,7 @@ from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.models import (
+    GuardAction,
     GuardApprovalRequest,
     GuardArtifact,
     GuardReceipt,
@@ -53,6 +60,12 @@ from codex_plugin_scanner.guard.proxy import stdio as stdio_proxy_module
 from codex_plugin_scanner.guard.receipts import build_receipt
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.runtime import secret_file_requests as secret_file_requests_module
+from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+from codex_plugin_scanner.guard.runtime.approval_context import (
+    APPROVAL_CONTEXT_TOKEN_PREFIX,
+    approval_context_tokens_validation_reason,
+    build_approval_context_token,
+)
 from codex_plugin_scanner.guard.runtime.package_intent import (
     build_package_request_artifact,
     extract_package_intent_request,
@@ -114,6 +127,22 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
 def _write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def _make_pinnable_harness_executable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    executable: str,
+) -> Path:
+    """Install a native no-op executable whose launch identity can be pinned."""
+
+    fake_bin = tmp_path / "pinnable-harness-bin"
+    fake_bin.mkdir(parents=True, exist_ok=True)
+    executable_path = fake_bin / executable
+    shutil.copyfile("/usr/bin/true", executable_path)
+    executable_path.chmod(executable_path.stat().st_mode | 0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}")
+    return executable_path.resolve()
 
 
 def _request_header(request: urllib.request.Request, name: str) -> str | None:
@@ -596,8 +625,10 @@ clearer UX and an implementation plan with technical references.
         )
         output = json.loads(capsys.readouterr().out)
 
-        assert rc == 0
+        assert rc == 1
         assert output["artifact_type"] == "tool_action_request"
+        assert output["policy_action"] == "require-reapproval"
+        assert output["policy_composition"]["untrusted_hook_payload_hint"] == "allow"
         assert "rm dangerous-marker.json" in output["launch_summary"]
         assert output["trigger_summary"].startswith("HOL Guard paused the native tool action")
 
@@ -4082,7 +4113,7 @@ clearer UX and an implementation plan with technical references.
 
         evaluation = evaluate_detection(detection, store, config, persist=False)
 
-        assert evaluation["blocked"] is False
+        assert evaluation["blocked"] is True
         assert evaluation["artifacts"][0]["policy_action"] == "review"
 
     def test_guard_run_keeps_prior_snapshot_when_reapproval_blocks(self, tmp_path):
@@ -8144,7 +8175,7 @@ def test_guard_hook_emits_claude_native_pretooluse_notice_on_stderr(tmp_path, ca
     assert "HOL Guard prompt" in captured_notice[0]
 
 
-def test_guard_hook_claude_posttooluse_persists_native_approval(tmp_path, capsys, monkeypatch):
+def test_guard_hook_claude_native_approval_does_not_lower_current_reapproval(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
@@ -8162,6 +8193,18 @@ def test_guard_hook_claude_posttooluse_persists_native_approval(tmp_path, capsys
         workspace_dir=workspace_dir,
         harness="claude-code",
         event=first_event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    prompt_rc, _ = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event={
+            **first_event,
+            "hook_event_name": "Notification",
+            "notification_type": "permission_prompt",
+        },
         capsys=capsys,
         monkeypatch=monkeypatch,
     )
@@ -8187,24 +8230,40 @@ def test_guard_hook_claude_posttooluse_persists_native_approval(tmp_path, capsys
         monkeypatch=monkeypatch,
     )
     first_payload = json.loads(first_output)
+    post_payload = json.loads(post_output)
     second_payload = json.loads(second_output)
-    receipts = GuardStore(home_dir).list_receipts(limit=20)
+    store = GuardStore(home_dir)
+    receipts = store.list_receipts(limit=20)
+    policies = store.list_policy_decisions("claude-code")
+    native_receipt = next(receipt for receipt in receipts if receipt["user_override"] == "claude-native-approve")
 
     assert first_rc == 0
     assert first_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert prompt_rc == 0
     assert post_rc == 0
-    assert post_output == ""
+    assert post_payload["decision"] == "block"
+    assert post_payload["continue"] is False
     assert second_rc == 0
-    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
-    assert any(receipt["user_override"] == "claude-native-approve" for receipt in receipts)
+    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert native_receipt["artifact_hash"].startswith(APPROVAL_CONTEXT_TOKEN_PREFIX)
+    assert native_receipt["policy_decision"] == "require-reapproval"
+    assert all(policy["source"] != "claude-native-approval" for policy in policies)
+    assert any(
+        evidence.get("source") == "claude_native_approval"
+        and evidence.get("authoritative_action") == "require-reapproval"
+        and evidence.get("reusable_policy_saved") is False
+        for evidence in native_receipt["scanner_evidence"]
+    )
 
 
 def _load_claude_pending_question_contract(home_dir: Path, session_id: str) -> tuple[str, list[dict[str, str]]]:
     store = GuardStore(home_dir)
     index_payload = store.get_sync_payload(f"claude_pending_permissions:{session_id}")
-    assert isinstance(index_payload, list)
-    assert index_payload
-    pending_payload = store.get_sync_payload(str(index_payload[0]))
+    assert isinstance(index_payload, dict)
+    pending_keys = index_payload.get("pending_keys")
+    assert isinstance(pending_keys, list)
+    assert pending_keys
+    pending_payload = store.get_sync_payload(str(pending_keys[0]))
     assert isinstance(pending_payload, dict)
     question = str(pending_payload["approval_question"])
     options = pending_payload.get("approval_options")
@@ -8213,7 +8272,7 @@ def _load_claude_pending_question_contract(home_dir: Path, session_id: str) -> t
     return question, [{"label": str(option)} for option in options]
 
 
-def test_guard_hook_claude_ask_user_question_allow_persists_approval(tmp_path, capsys, monkeypatch):
+def test_guard_hook_claude_ask_user_question_allow_does_not_lower_current_reapproval(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
@@ -8298,11 +8357,11 @@ def test_guard_hook_claude_ask_user_question_allow_persists_approval(tmp_path, c
     assert question_rc == 0
     assert question_output == ""
     assert second_rc == 0
-    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
     assert policies[0]["source"] == "claude-ask-user-question"
 
 
-def test_guard_hook_claude_ask_user_question_docker_retry_uses_exact_action_policy(
+def test_guard_hook_claude_docker_saved_allow_does_not_lower_current_reapproval(
     tmp_path,
     capsys,
     monkeypatch,
@@ -8419,16 +8478,16 @@ def test_guard_hook_claude_ask_user_question_docker_retry_uses_exact_action_poli
     assert question_rc == 0
     assert question_output == ""
     assert second_rc == 0
-    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
     assert other_workspace_rc == 0
     assert other_workspace_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
     assert policy["source"] == "claude-ask-user-question"
-    assert stored_hash.startswith("runtime-exact:")
+    assert stored_hash.startswith(APPROVAL_CONTEXT_TOKEN_PREFIX)
     assert stored_hash != _runtime_scoped_exact_match_key(artifact_id)
     assert legacy_context_decision is None
 
 
-def test_guard_hook_claude_notification_only_ask_user_question_persists_approval(tmp_path, capsys, monkeypatch):
+def test_guard_hook_claude_notification_saved_allow_does_not_lower_current_reapproval(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
@@ -8519,11 +8578,13 @@ def test_guard_hook_claude_notification_only_ask_user_question_persists_approval
     assert question_rc == 0
     assert question_output == ""
     assert second_rc == 0
-    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
     assert policies[0]["source"] == "claude-ask-user-question"
 
 
-def test_guard_hook_claude_repeated_notifications_keep_bound_question_contract(tmp_path, capsys, monkeypatch):
+def test_guard_hook_claude_repeated_notifications_keep_bound_question_without_lowering_reapproval(
+    tmp_path, capsys, monkeypatch
+):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
@@ -8626,7 +8687,7 @@ def test_guard_hook_claude_repeated_notifications_keep_bound_question_contract(t
     assert question_rc == 0
     assert question_output == ""
     assert second_rc == 0
-    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
     assert policies[0]["source"] == "claude-ask-user-question"
 
 
@@ -9041,7 +9102,150 @@ def test_guard_hook_claude_ask_user_question_accepts_dict_selected_answer():
     assert guard_commands_module._claude_guard_approval_answer(payload) == "allow"
 
 
-def test_guard_hook_claude_ask_user_question_legacy_pending_state_still_persists_decision(tmp_path):
+def test_guard_hook_claude_tampered_pending_state_cannot_bootstrap_signed_allow(tmp_path):
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    session_id = "session-claude-tampered-pending"
+    artifact = GuardArtifact(
+        artifact_id="claude-code:runtime:file-read:.env",
+        name="Read",
+        harness="claude-code",
+        artifact_type="file_read_request",
+        source_scope="project",
+        config_path="/workspace/.env",
+    )
+    guard_commands_module._record_claude_permission_notice(
+        store=store,
+        payload={"session_id": session_id, "tool_name": "Read"},
+        reason="HOL Guard intercepted Claude's attempt to read .env.",
+        artifact=artifact,
+        artifact_hash="hash-authentic",
+    )
+    index_payload = store.get_sync_payload(guard_commands_module._claude_pending_permission_index_key(session_id))
+    assert isinstance(index_payload, dict)
+    pending_keys = index_payload.get("pending_keys")
+    assert isinstance(pending_keys, list)
+    assert len(pending_keys) == 1
+    pending_key = str(pending_keys[0])
+    pending = store.get_sync_payload(pending_key)
+    assert isinstance(pending, dict)
+    approval_question = str(pending["approval_question"])
+    approval_options = pending["approval_options"]
+    assert isinstance(approval_options, list)
+    with sqlite3.connect(store.path) as connection:
+        tampered = dict(pending)
+        tampered["artifact_hash"] = "hash-forged"
+        connection.execute(
+            "update sync_state set payload_json = ? where state_key = ?",
+            (json.dumps(tampered), pending_key),
+        )
+
+    persisted = guard_commands_module._persist_claude_guard_question_decision(
+        store,
+        {
+            "session_id": session_id,
+            "hook_event_name": "PostToolUse",
+            "tool_name": "AskUserQuestion",
+            "tool_input": {
+                "questions": [
+                    {
+                        "header": "HOL Guard",
+                        "question": approval_question,
+                        "options": [{"label": str(option)} for option in approval_options],
+                    }
+                ]
+            },
+            "tool_response": {
+                "answers": {approval_question: "Allow once"},
+            },
+        },
+    )
+
+    assert persisted is False
+    assert store.list_policy_decisions("claude-code") == []
+    assert store.get_sync_payload(pending_key) is None
+    events = store.list_events(event_name="rule.ignored.local_integrity")
+    event_payloads = [event_payload for event in events if isinstance(event_payload := event.get("payload"), dict)]
+    assert any(
+        event_payload.get("source") == "claude-pending-permission"
+        and event_payload.get("integrity_status") == "tampered"
+        for event_payload in event_payloads
+    )
+
+
+def test_guard_hook_claude_signed_unseen_pending_cannot_bootstrap_allow(tmp_path):
+    store = GuardStore(tmp_path / "home")
+    session_id = "session-claude-signed-unseen-pending"
+    artifact = GuardArtifact(
+        artifact_id="claude-code:runtime:file-read:.env",
+        name="Read",
+        harness="claude-code",
+        artifact_type="file_read_request",
+        source_scope="project",
+        config_path="/workspace/.env",
+    )
+    artifact_hash_value = "hash-signed-unseen"
+    guard_commands_module._record_claude_permission_notice(
+        store=store,
+        payload={"session_id": session_id, "tool_name": "Read"},
+        reason="HOL Guard intercepted Claude's attempt to read .env.",
+        artifact=artifact,
+        artifact_hash=artifact_hash_value,
+    )
+
+    observed, saved = guard_commands_module._persist_claude_native_permission_for_runtime_artifact(
+        store=store,
+        payload={"session_id": session_id, "tool_name": "Read"},
+        artifact=artifact,
+        artifact_hash=artifact_hash_value,
+        action="allow",
+        authoritative_action="allow",
+        reason="Forged PostToolUse must not authorize an unseen prompt.",
+    )
+
+    assert observed is False
+    assert saved is False
+    assert store.list_policy_decisions("claude-code") == []
+    pending_pair = guard_commands_module._load_single_claude_pending_permission(
+        store,
+        {"session_id": session_id},
+    )
+    assert pending_pair is not None
+    pending = pending_pair[1]
+    assert pending.get("permission_prompt_seen") is not True
+    approval_question = str(pending["approval_question"])
+    approval_options = pending["approval_options"]
+    assert isinstance(approval_options, list)
+    question_saved = guard_commands_module._persist_claude_guard_question_decision(
+        store,
+        {
+            "session_id": session_id,
+            "hook_event_name": "PostToolUse",
+            "tool_name": "AskUserQuestion",
+            "tool_input": {
+                "questions": [
+                    {
+                        "header": "HOL Guard",
+                        "question": approval_question,
+                        "options": [{"label": str(option)} for option in approval_options],
+                    }
+                ]
+            },
+            "tool_response": {"answers": {approval_question: "Allow once"}},
+        },
+    )
+    assert question_saved is False
+    assert store.list_policy_decisions("claude-code") == []
+    events = store.list_events(event_name="approval.pending_prompt_unseen")
+    event_payloads = [event_payload for event in events if isinstance(event_payload := event.get("payload"), dict)]
+    assert any(
+        event_payload.get("source") == "claude-pending-permission"
+        and event_payload.get("artifact_id") == artifact.artifact_id
+        for event_payload in event_payloads
+    )
+
+
+def test_guard_hook_claude_ask_user_question_unsigned_legacy_pending_state_cannot_persist_decision(tmp_path):
     home_dir = tmp_path / "home"
     store = GuardStore(home_dir)
     session_id = "session-claude-legacy-pending"
@@ -9104,11 +9308,12 @@ def test_guard_hook_claude_ask_user_question_legacy_pending_state_still_persists
     )
     policies = store.list_policy_decisions("claude-code")
 
-    assert persisted is True
-    assert len(policies) == 1
-    assert policies[0]["artifact_id"] == artifact_id
-    assert policies[0]["action"] == "allow"
-    assert policies[0]["source"] == "claude-ask-user-question"
+    assert persisted is False
+    assert policies == []
+    assert store.get_sync_payload(guard_commands_module._claude_pending_permission_index_key(session_id)) is None
+    events = store.list_events(event_name="rule.ignored.local_integrity")
+    event_payloads = [event_payload for event in events if isinstance(event_payload := event.get("payload"), dict)]
+    assert any(event_payload.get("integrity_status") == "missing_integrity" for event_payload in event_payloads)
 
 
 def test_guard_hook_claude_native_denial_uses_contextual_tool_action_key(tmp_path):
@@ -9116,31 +9321,34 @@ def test_guard_hook_claude_native_denial_uses_contextual_tool_action_key(tmp_pat
     store = GuardStore(home_dir)
     session_id = "session-claude-deny"
     artifact_id = "claude-code:runtime:tool-action:bash"
-    now = "2026-04-24T00:00:00+00:00"
-    pending_key = guard_commands_module._claude_pending_permission_state_key(session_id, artifact_id)
     wrapper_chain = ["bash", "zsh"]
-    store.set_sync_payload(
-        pending_key,
-        {
-            "saved_at": now,
-            "reason": "HOL Guard intercepted Claude's shell action.",
-            "artifact_id": artifact_id,
-            "artifact_hash": "hash-denied",
-            "artifact_name": "Bash",
-            "artifact_type": "tool_action_request",
-            "tool_name": "Bash",
-            "config_path": "workspace/app/claude-settings.json",
-            "source_scope": "project",
+    artifact = GuardArtifact(
+        artifact_id=artifact_id,
+        name="Bash",
+        harness="claude-code",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path="workspace/app/claude-settings.json",
+        command="docker compose up -d postgres",
+        metadata={
             "raw_command_text": "docker compose up -d postgres",
             "wrapper_chain": wrapper_chain,
-            "permission_prompt_seen": True,
         },
-        now,
     )
-    store.set_sync_payload(
-        guard_commands_module._claude_pending_permission_index_key(session_id),
-        [pending_key],
-        now,
+    prompt_payload = {"session_id": session_id, "tool_name": "Bash"}
+    guard_commands_module._record_claude_permission_notice(
+        store=store,
+        payload=prompt_payload,
+        reason="HOL Guard intercepted Claude's shell action.",
+        artifact=artifact,
+        artifact_hash="hash-denied",
+    )
+    notice = guard_commands_module._peek_claude_permission_notice(store, prompt_payload)
+    assert notice is not None
+    guard_commands_module._mark_claude_pending_permission_prompt_seen(
+        store=store,
+        payload=prompt_payload,
+        notice=notice,
     )
 
     denied = guard_commands_module._persist_claude_pending_permission_denials(
@@ -9163,7 +9371,7 @@ def test_guard_hook_claude_native_denial_uses_contextual_tool_action_key(tmp_pat
     assert policies[0]["action"] == "block"
 
 
-def test_guard_hook_claude_ask_user_question_bound_pending_without_prompt_seen_still_persists_decision(tmp_path):
+def test_guard_hook_claude_ask_user_question_unsigned_bound_pending_cannot_persist_decision(tmp_path):
     home_dir = tmp_path / "home"
     store = GuardStore(home_dir)
     session_id = "session-claude-bound-no-seen"
@@ -9231,11 +9439,8 @@ def test_guard_hook_claude_ask_user_question_bound_pending_without_prompt_seen_s
     )
     policies = store.list_policy_decisions("claude-code")
 
-    assert persisted is True
-    assert len(policies) == 1
-    assert policies[0]["artifact_id"] == artifact_id
-    assert policies[0]["action"] == "allow"
-    assert policies[0]["source"] == "claude-ask-user-question"
+    assert persisted is False
+    assert policies == []
 
 
 def test_guard_hook_claude_native_cancel_does_not_persist_flat_block(tmp_path, capsys, monkeypatch):
@@ -9303,7 +9508,7 @@ def test_guard_hook_claude_native_cancel_does_not_persist_flat_block(tmp_path, c
     assert second_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
 
 
-def test_guard_hook_claude_alias_reuses_native_approval_policy_with_canonical_harness(tmp_path, capsys, monkeypatch):
+def test_guard_hook_claude_alias_saved_allow_does_not_lower_canonical_reapproval(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
@@ -9345,15 +9550,17 @@ def test_guard_hook_claude_alias_reuses_native_approval_policy_with_canonical_ha
         monkeypatch=monkeypatch,
     )
     first_payload = json.loads(first_output)
+    post_payload = json.loads(post_output)
     second_payload = json.loads(second_output)
     receipts = GuardStore(home_dir).list_receipts(limit=20)
 
     assert first_rc == 0
     assert first_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
     assert post_rc == 0
-    assert post_output == ""
+    assert post_payload["decision"] == "block"
+    assert post_payload["continue"] is False
     assert second_rc == 0
-    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
     assert any(receipt["harness"] == "claude-code" for receipt in receipts)
 
 
@@ -10396,12 +10603,18 @@ def test_guard_hook_emits_claude_native_permission_request_for_package_notice(
         monkeypatch=monkeypatch,
     )
     permission_payload = json.loads(permission_output)
+    pending_pair = guard_commands_module._load_single_claude_pending_permission(
+        GuardStore(home_dir),
+        {"session_id": "session-claude-package-permission-request"},
+    )
 
     assert pre_tool_rc == 0
     assert json.loads(pre_tool_output)["hookSpecificOutput"]["permissionDecision"] in {"ask", "deny"}
     assert permission_rc == 0
     assert "HOL Guard is reviewing Claude's approval prompt for Bash" in permission_payload["systemMessage"]
     assert "AskUserQuestion" not in json.dumps(permission_payload["hookSpecificOutput"])
+    assert pending_pair is not None
+    assert pending_pair[1]["permission_prompt_seen"] is True
 
 
 def test_guard_hook_emits_claude_permission_request_terminal_notice_stderr(
@@ -10765,7 +10978,7 @@ def test_guard_hook_explains_ignored_remembered_rule_when_local_trust_is_degrade
     assert "remembered local rule was ignored" in output["approval_requests"][0]["decision_v2_json"]["harness_message"]
 
 
-def test_guard_hook_does_not_override_cloud_allow_with_remembered_rule_review_copy(
+def test_guard_hook_cloud_allow_does_not_lower_current_package_reapproval(
     tmp_path,
     capsys,
     monkeypatch,
@@ -10846,12 +11059,12 @@ def test_guard_hook_does_not_override_cloud_allow_with_remembered_rule_review_co
         as_json=True,
     )
 
-    assert rc == 0
-    assert output["policy_action"] == "allow"
+    assert rc == 1
+    assert output["policy_action"] == "require-reapproval"
     assert output["trust_status"]["remembered_rules"] == "disabled_degraded"
     assert output["remembered_rule_rejection"]["integrity_status"] == "degraded_mode"
-    assert "remembered local rule was ignored" not in output["decision_v2_json"]["harness_message"]
-    assert "kept npm install minimist in review" not in output["risk_headline"]
+    assert output["supply_chain_evaluation"]["reasons"][0]["code"] == "approval_reuse_integrity_failure"
+    assert "remembered local rule was ignored" in output["decision_v2_json"]["harness_message"]
 
 
 def test_guard_hook_emits_claude_native_ask_for_sensitive_file_reads(
@@ -11066,9 +11279,11 @@ def test_guard_hook_claude_notification_stale_notice_falls_back_to_generic_conte
     store = GuardStore(home_dir)
     pending_index_key = guard_commands_module._claude_pending_permission_index_key(session_id)
     pending_index = store.get_sync_payload(pending_index_key)
-    assert isinstance(pending_index, list)
-    assert pending_index
-    store.delete_sync_payloads([str(pending_index[0]), pending_index_key])
+    assert isinstance(pending_index, dict)
+    pending_keys = pending_index.get("pending_keys")
+    assert isinstance(pending_keys, list)
+    assert pending_keys
+    store.delete_sync_payloads([str(pending_keys[0]), pending_index_key])
 
     notification_rc, notification_output = _run_guard_hook(
         home_dir=home_dir,
@@ -11278,10 +11493,13 @@ def test_guard_run_returns_structured_error_when_executable_missing(tmp_path, ca
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
     _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
+    _write_json(home_dir / ".claude" / "settings.json", {})
+    _write_json(workspace_dir / ".mcp.json", {"mcpServers": {}})
+    _make_pinnable_harness_executable(tmp_path, monkeypatch, "claude")
     monkeypatch.setattr(
         guard_runner_module.subprocess,
         "run",
-        lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError("codex not found")),
+        lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError("claude not found")),
     )
 
     rc = main(
@@ -11303,13 +11521,30 @@ def test_guard_run_returns_structured_error_when_executable_missing(tmp_path, ca
     assert rc == 127
     assert output["launched"] is False
     assert output["return_code"] == 127
-    assert "codex not found" in output["launch_error"]
+    assert "claude not found" in output["launch_error"]
 
 
 def test_guard_run_prompt_allow_once_launches_and_records_override(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    _make_pinnable_harness_executable(tmp_path, monkeypatch, "codex")
+    global_server = home_dir / "global-server.py"
+    workspace_server = workspace_dir / "workspace-server.py"
+    _write_text(global_server, "print('global server')\n")
+    _write_text(workspace_server, "print('workspace server')\n")
+    _write_text(
+        home_dir / ".codex" / "config.toml",
+        "[mcp_servers.global_tools]\n"
+        f"command = {json.dumps(sys.executable)}\n"
+        f"args = [{json.dumps(str(global_server))}]\n",
+    )
+    _write_text(
+        workspace_dir / ".codex" / "config.toml",
+        "[mcp_servers.workspace_skill]\n"
+        f"command = {json.dumps(sys.executable)}\n"
+        f"args = [{json.dumps(str(workspace_server))}]\n",
+    )
     answers = iter(["1", "1"])
     monkeypatch.setattr(guard_commands_module.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr("rich.console.Console.input", lambda self, prompt="": next(answers))
@@ -11335,6 +11570,7 @@ def test_guard_run_prompt_allow_once_launches_and_records_override(tmp_path, cap
 
     assert rc == 0
     assert "Launch allowed" in output
+    assert len(receipts) == 2
     assert any(item.get("user_override") == "allow-once" for item in receipts)
 
 
@@ -11342,6 +11578,23 @@ def test_guard_run_prompt_allow_artifact_persists_for_next_run(tmp_path, capsys,
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    _make_pinnable_harness_executable(tmp_path, monkeypatch, "codex")
+    global_server = home_dir / "global-server.py"
+    workspace_server = workspace_dir / "workspace-server.py"
+    _write_text(global_server, "print('global server')\n")
+    _write_text(workspace_server, "print('workspace server')\n")
+    _write_text(
+        home_dir / ".codex" / "config.toml",
+        "[mcp_servers.global_tools]\n"
+        f"command = {json.dumps(sys.executable)}\n"
+        f"args = [{json.dumps(str(global_server))}]\n",
+    )
+    _write_text(
+        workspace_dir / ".codex" / "config.toml",
+        "[mcp_servers.workspace_skill]\n"
+        f"command = {json.dumps(sys.executable)}\n"
+        f"args = [{json.dumps(str(workspace_server))}]\n",
+    )
     answers = iter(["2", "2"])
     monkeypatch.setattr(guard_commands_module.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr("rich.console.Console.input", lambda self, prompt="": next(answers))
@@ -11383,7 +11636,10 @@ def test_guard_run_prompt_allow_artifact_persists_for_next_run(tmp_path, capsys,
     assert "Launch allowed" in first_output
     assert second_rc == 0
     assert second_output["blocked"] is False
-    assert all(item["policy_action"] == "allow" for item in second_output["artifacts"])
+    assert {item["policy_action"] for item in second_output["artifacts"]} <= {"allow", "warn"}
+    persisted = GuardStore(home_dir).list_policy_decisions("codex")
+    assert len(persisted) == 2
+    assert all(str(item["artifact_hash"]).startswith(APPROVAL_CONTEXT_TOKEN_PREFIX) for item in persisted)
 
 
 def test_guard_run_headless_blocks_with_review_hint_without_opening_browser(tmp_path, capsys, monkeypatch):
@@ -12418,6 +12674,35 @@ def test_guard_run_headless_allow_persists_state_when_approval_center_is_availab
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    _make_pinnable_harness_executable(tmp_path, monkeypatch, "codex")
+    safe_detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(
+            str(home_dir / ".codex" / "config.toml"),
+            str(workspace_dir / ".codex" / "config.toml"),
+        ),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:global:global_tools",
+                name="global_tools",
+                harness="codex",
+                artifact_type="configuration",
+                source_scope="global",
+                config_path=str(home_dir / ".codex" / "config.toml"),
+            ),
+            GuardArtifact(
+                artifact_id="codex:project:workspace_skill",
+                name="workspace_skill",
+                harness="codex",
+                artifact_type="configuration",
+                source_scope="project",
+                config_path=str(workspace_dir / ".codex" / "config.toml"),
+            ),
+        ),
+    )
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: safe_detection)
     monkeypatch.setattr(
         guard_runner_module.subprocess,
         "run",
@@ -12455,7 +12740,16 @@ def test_guard_run_headless_waits_for_local_approval_and_resumes(tmp_path, capsy
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
-    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 8\n")
+    _make_pinnable_harness_executable(tmp_path, monkeypatch, "claude")
+    _write_text(workspace_dir / "guard-pre.py", "pass\n")
+    _write_json(
+        workspace_dir / ".mcp.json",
+        {"mcpServers": {"workspace-tools": {"command": sys.executable, "args": ["-c", "pass"]}}},
+    )
+    _write_text(
+        home_dir / "config.toml",
+        'approval_wait_timeout_seconds = 8\ndefault_action = "review"\nchanged_hash_action = "review"\n',
+    )
 
     store = GuardStore(home_dir)
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
@@ -12466,12 +12760,14 @@ def test_guard_run_headless_waits_for_local_approval_and_resumes(tmp_path, capsy
     )
 
     stop_resolver = threading.Event()
+    observed_actions: list[str] = []
 
     def resolve_pending() -> None:
         while not stop_resolver.is_set():
             pending = store.list_approval_requests(limit=10)
             if pending:
                 for request in pending:
+                    observed_actions.append(str(request["policy_action"]))
                     apply_approval_resolution(
                         store=store,
                         request_id=str(request["request_id"]),
@@ -12505,6 +12801,8 @@ def test_guard_run_headless_waits_for_local_approval_and_resumes(tmp_path, capsy
     assert rc == 0
     assert "Launch allowed" in output
     assert "Approval received" in output
+    assert observed_actions
+    assert "review" in observed_actions
 
 
 def test_guard_run_headless_redetects_before_persisted_resume(tmp_path, monkeypatch):
@@ -12625,9 +12923,175 @@ def test_guard_run_headless_redetects_before_persisted_resume(tmp_path, monkeypa
     )
 
     assert result["blocked"] is True
+    assert result["approval_wait"]["resolved"] is True
     assert result["artifacts"][0]["changed_fields"] == ["args"]
     assert result["artifacts"][0]["artifact_hash"] == artifact_hash(detections[-1].artifacts[0])
     assert call_count["detect"] >= 2
+
+
+def test_guard_run_interactive_allow_once_redetects_before_resume(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True)
+    artifact_id = "codex:project:interactive-redetect"
+    detections = [
+        HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(str(workspace_dir / ".codex" / "config.toml"),),
+            artifacts=(
+                GuardArtifact(
+                    artifact_id=artifact_id,
+                    name="interactive-redetect",
+                    harness="codex",
+                    artifact_type="tool_action_request",
+                    source_scope="project",
+                    config_path=str(workspace_dir / ".codex" / "config.toml"),
+                    command=sys.executable,
+                    args=("-c", "print('before')"),
+                ),
+            ),
+        ),
+        HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(str(workspace_dir / ".codex" / "config.toml"),),
+            artifacts=(
+                GuardArtifact(
+                    artifact_id=artifact_id,
+                    name="interactive-redetect",
+                    harness="codex",
+                    artifact_type="tool_action_request",
+                    source_scope="project",
+                    config_path=str(workspace_dir / ".codex" / "config.toml"),
+                    command=sys.executable,
+                    args=("-c", "print('after')"),
+                ),
+            ),
+        ),
+    ]
+    call_count = {"detect": 0}
+
+    def fake_detect(_harness: str, _context: HarnessContext) -> HarnessDetection:
+        index = min(call_count["detect"], len(detections) - 1)
+        call_count["detect"] += 1
+        return detections[index]
+
+    def allow_once(_detection: HarnessDetection, evaluation: dict[str, object]) -> dict[str, object]:
+        items = evaluation.get("artifacts")
+        assert isinstance(items, list)
+        item = items[0]
+        assert isinstance(item, dict)
+        item["policy_action"] = "allow"
+        item["user_override"] = "allow-once"
+        evaluation["blocked"] = False
+        return evaluation
+
+    launch_calls: list[object] = []
+    monkeypatch.setattr(guard_runner_module, "detect_harness", fake_detect)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *args, **kwargs: launch_calls.append((args, kwargs)),
+    )
+    store = GuardStore(home_dir)
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+        store,
+        GuardConfig(
+            guard_home=home_dir,
+            workspace=workspace_dir,
+            artifact_actions={artifact_id: "require-reapproval"},
+        ),
+        dry_run=False,
+        passthrough_args=[],
+        interactive_resolver=allow_once,
+    )
+
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    assert result["artifacts"][0]["policy_action"] == "require-reapproval"
+    assert result["artifacts"][0]["trusted_request_override"]["applied"] is False
+    assert call_count["detect"] >= 2
+    assert launch_calls == []
+    receipts = store.list_receipts(limit=10)
+    assert len(receipts) == 1
+    assert receipts[0]["policy_decision"] == "require-reapproval"
+    assert receipts[0]["user_override"] is None
+
+
+@pytest.mark.parametrize("terminal_action", ("sandbox-required", "block"))
+def test_guard_run_interactive_allow_once_cannot_lower_terminal_action(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    terminal_action: GuardAction,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True)
+    artifact_id = "codex:project:interactive-terminal"
+    artifact = GuardArtifact(
+        artifact_id=artifact_id,
+        name="interactive-terminal",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        command=sys.executable,
+        args=("-c", "pass"),
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(artifact.config_path,),
+        artifacts=(artifact,),
+    )
+
+    def allow_once(_detection: HarnessDetection, evaluation: dict[str, object]) -> dict[str, object]:
+        items = evaluation.get("artifacts")
+        assert isinstance(items, list)
+        item = items[0]
+        assert isinstance(item, dict)
+        item["policy_action"] = "allow"
+        item["user_override"] = "allow-once"
+        evaluation["blocked"] = False
+        return evaluation
+
+    launch_calls: list[object] = []
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *args, **kwargs: launch_calls.append((args, kwargs)),
+    )
+    store = GuardStore(home_dir)
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+        store,
+        GuardConfig(
+            guard_home=home_dir,
+            workspace=workspace_dir,
+            artifact_actions={artifact_id: terminal_action},
+        ),
+        dry_run=False,
+        passthrough_args=[],
+        interactive_resolver=allow_once,
+    )
+
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    assert result["artifacts"][0]["policy_action"] == terminal_action
+    assert result["artifacts"][0]["trusted_request_override"]["applied"] is False
+    assert launch_calls == []
+    receipts = store.list_receipts(limit=10)
+    assert len(receipts) == 1
+    assert receipts[0]["policy_decision"] == terminal_action
+    assert receipts[0]["user_override"] is None
 
 
 def test_guard_headless_blocked_run_persists_receipts_and_diffs(tmp_path, monkeypatch):
@@ -12788,7 +13252,16 @@ def test_guard_run_never_launches_for_unknown_stored_policy_action(tmp_path, mon
     )
     store = GuardStore(home_dir)
     launch_calls: list[object] = []
-    monkeypatch.setattr(store, "resolve_policy", lambda *_args, **_kwargs: "future-action")
+    monkeypatch.setattr(
+        store,
+        "resolve_policy_decision_lookup_with_memory_pattern",
+        lambda *_args, **_kwargs: {
+            "decision": {"action": "future-action"},
+            "ignored_local_integrity": None,
+            "trust_status": {},
+            "authority_revision": 0,
+        },
+    )
     monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
     monkeypatch.setattr(
         guard_runner_module.subprocess,
@@ -12867,7 +13340,788 @@ def test_guard_hook_invalid_policy_action_falls_back_to_reapproval(tmp_path, cap
     assert output["policy_action"] == "require-reapproval"
 
 
-def test_guard_hook_blocks_sensitive_runtime_file_read_until_exactly_approved(tmp_path, capsys, monkeypatch):
+def test_runtime_hook_saved_v1_allow_satisfies_exact_unchanged_current_review(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        home_dir / "config.toml",
+        'approval_wait_timeout_seconds = 0\n[risk_actions]\ndestructive_shell = "review"\n',
+    )
+    event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "rm -rf build-cache"},
+        "source_scope": "project",
+    }
+
+    first_rc, first_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+        as_json=True,
+    )
+    store = GuardStore(home_dir)
+    first_receipt = store.list_receipts(limit=1)[0]
+    context_token = str(first_receipt["artifact_hash"])
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=str(first_output["artifact_id"]),
+            artifact_hash=context_token,
+            reason="Reviewed exact hook context",
+            source="manual",
+        ),
+        "2026-07-17T12:00:00+00:00",
+    )
+
+    second_rc, second_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+        as_json=True,
+    )
+
+    assert first_rc == 1
+    assert first_output["policy_action"] == "review"
+    assert context_token.startswith(APPROVAL_CONTEXT_TOKEN_PREFIX)
+    assert second_rc == 0
+    assert second_output["policy_action"] == "allow"
+    assert second_output["approval_reuse"]["status"] == "accepted"
+    assert second_output["approval_reuse"]["reason_code"] == "approval_reuse_accepted"
+
+
+@pytest.mark.parametrize("scope", ("artifact", "workspace", "publisher", "harness", "global"))
+def test_runtime_hook_saved_v1_allow_matches_every_scope_in_actual_evaluator(tmp_path, scope: str) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    config = GuardConfig(
+        guard_home=home_dir,
+        workspace=workspace_dir,
+        default_action="allow",
+        approval_wait_timeout_seconds=0,
+    )
+    artifact = GuardArtifact(
+        artifact_id="codex:project:tool-action:scope-matrix",
+        name="Codex exact scope matrix action",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        command="echo",
+        args=("scope-matrix",),
+        publisher="publisher-a",
+        metadata={"guard_default_action": "review", "action_class": "routine shell command"},
+    )
+    args = argparse.Namespace(harness="codex", policy_action=None, json=True)
+    context = HarnessContext(home_dir=tmp_path, workspace_dir=workspace_dir, guard_home=home_dir)
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo scope-matrix"},
+        "source_scope": "project",
+    }
+
+    first = guard_commands_module._evaluate_runtime_artifact_hook(
+        args,
+        action_envelope=None,
+        config=config,
+        context=context,
+        data_flow_signals=(),
+        guard_home=home_dir,
+        payload=payload,
+        runtime_artifact=artifact,
+        runtime_workspace=workspace_dir,
+        store=store,
+    )
+    assert not isinstance(first, int)
+    assert first.policy_action == "review"
+    token = first.runtime_artifact_hash
+    policy_kwargs: dict[str, object] = {
+        "artifact_id": artifact.artifact_id if scope in {"artifact", "workspace", "harness", "global"} else None,
+        "artifact_hash": token,
+        "workspace": str(workspace_dir) if scope == "workspace" else None,
+        "publisher": artifact.publisher if scope == "publisher" else None,
+    }
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope=scope,
+            action="allow",
+            reason=f"reviewed exact v1 context at {scope} scope",
+            source="manual",
+            **policy_kwargs,  # type: ignore[arg-type]
+        ),
+        "2026-07-17T12:00:00+00:00",
+    )
+
+    second = guard_commands_module._evaluate_runtime_artifact_hook(
+        args,
+        action_envelope=None,
+        config=config,
+        context=context,
+        data_flow_signals=(),
+        guard_home=home_dir,
+        payload=payload,
+        runtime_artifact=artifact,
+        runtime_workspace=workspace_dir,
+        store=store,
+    )
+
+    assert not isinstance(second, int)
+    assert second.runtime_artifact_hash == token
+    assert second.policy_action == "allow"
+    assert second.response_payload["approval_reuse"]["status"] == "accepted"
+
+
+def test_runtime_hook_browser_exact_override_atomically_claims_one_waiter(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    config = GuardConfig(
+        guard_home=home_dir,
+        workspace=workspace_dir,
+        default_action="allow",
+        approval_wait_timeout_seconds=0,
+    )
+    artifact = GuardArtifact(
+        artifact_id="codex:project:tool-action:browser-claim",
+        name="Codex browser claim action",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        command="echo",
+        args=("browser-claim",),
+        metadata={
+            "guard_default_action": "require-reapproval",
+            "action_class": "sensitive shell command",
+        },
+    )
+    args = argparse.Namespace(harness="codex", policy_action=None, json=True)
+    context = HarnessContext(home_dir=tmp_path, workspace_dir=workspace_dir, guard_home=home_dir)
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo browser-claim"},
+        "source_scope": "project",
+    }
+    initial = guard_commands_module._evaluate_runtime_artifact_hook(
+        args,
+        action_envelope=None,
+        config=config,
+        context=context,
+        data_flow_signals=(),
+        guard_home=home_dir,
+        payload=payload,
+        runtime_artifact=artifact,
+        runtime_workspace=workspace_dir,
+        store=store,
+    )
+    assert not isinstance(initial, int)
+    assert initial.policy_action == "require-reapproval"
+    token = initial.runtime_artifact_hash
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=token,
+            reason="exact browser allow",
+            source="approval-gate",
+            expires_at="2099-07-17T12:00:00+00:00",
+        ),
+        "2026-07-17T12:00:00+00:00",
+    )
+
+    first_waiter = guard_commands_module._evaluate_runtime_artifact_hook(
+        args,
+        action_envelope=None,
+        config=config,
+        context=context,
+        data_flow_signals=(),
+        guard_home=home_dir,
+        payload=payload,
+        runtime_artifact=artifact,
+        runtime_workspace=workspace_dir,
+        store=store,
+        trusted_request_override_hash=token,
+    )
+    second_waiter = guard_commands_module._evaluate_runtime_artifact_hook(
+        args,
+        action_envelope=None,
+        config=config,
+        context=context,
+        data_flow_signals=(),
+        guard_home=home_dir,
+        payload=payload,
+        runtime_artifact=artifact,
+        runtime_workspace=workspace_dir,
+        store=store,
+        trusted_request_override_hash=token,
+    )
+
+    assert not isinstance(first_waiter, int)
+    assert not isinstance(second_waiter, int)
+    assert first_waiter.policy_action == "allow"
+    assert first_waiter.response_payload["policy_composition"]["trusted_request_override"] is True
+    assert second_waiter.policy_action == "require-reapproval"
+    assert second_waiter.response_payload["policy_composition"]["trusted_request_override"] is False
+    assert second_waiter.response_payload["policy_composition"]["trusted_request_override_reason"] == (
+        "trusted_request_override_allow_missing"
+    )
+
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="global",
+            action="block",
+            reason="saved block added while browser waits",
+            source="manual",
+        ),
+        "2026-07-17T12:01:00+00:00",
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=token,
+            reason="stale exact browser allow",
+            source="approval-gate",
+            expires_at="2099-07-17T12:00:00+00:00",
+        ),
+        "2026-07-17T12:02:00+00:00",
+    )
+    blocked_waiter = guard_commands_module._evaluate_runtime_artifact_hook(
+        args,
+        action_envelope=None,
+        config=config,
+        context=context,
+        data_flow_signals=(),
+        guard_home=home_dir,
+        payload=payload,
+        runtime_artifact=artifact,
+        runtime_workspace=workspace_dir,
+        store=store,
+        trusted_request_override_hash=token,
+    )
+
+    assert not isinstance(blocked_waiter, int)
+    assert blocked_waiter.policy_action == "block"
+    assert blocked_waiter.response_payload["policy_composition"]["trusted_request_override"] is False
+    with sqlite3.connect(store.path) as connection:
+        remaining_browser_allows = connection.execute(
+            "select count(*) from policy_decisions where action = 'allow' and source = 'approval-gate'"
+        ).fetchone()[0]
+    assert remaining_browser_allows == 1
+
+
+def test_runtime_hook_integrity_rejection_outranks_valid_exact_one_shot_allow(tmp_path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    config = GuardConfig(
+        guard_home=home_dir,
+        workspace=workspace_dir,
+        default_action="allow",
+        approval_wait_timeout_seconds=0,
+    )
+    artifact = GuardArtifact(
+        artifact_id="codex:project:tool-action:integrity-collision",
+        name="Codex integrity collision action",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        command="echo",
+        args=("integrity-collision",),
+        metadata={"guard_default_action": "review", "action_class": "routine shell command"},
+    )
+    args = argparse.Namespace(harness="codex", policy_action=None, json=True)
+    context = HarnessContext(home_dir=tmp_path, workspace_dir=workspace_dir, guard_home=home_dir)
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo integrity-collision"},
+        "source_scope": "project",
+    }
+    first = guard_commands_module._evaluate_runtime_artifact_hook(
+        args,
+        action_envelope=None,
+        config=config,
+        context=context,
+        data_flow_signals=(),
+        guard_home=home_dir,
+        payload=payload,
+        runtime_artifact=artifact,
+        runtime_workspace=workspace_dir,
+        store=store,
+    )
+    assert not isinstance(first, int)
+    approval_id = store.record_local_once_approval(
+        request_id="request-integrity-collision",
+        harness="codex",
+        artifact_id=artifact.artifact_id,
+        artifact_hash=first.runtime_artifact_hash,
+        workspace=str(workspace_dir),
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T12:00:00+00:00",
+        expires_at="2027-07-17T13:00:00+00:00",
+    )
+    assert approval_id is not None
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="global",
+            action="block",
+            artifact_id=None,
+            artifact_hash=None,
+            reason="tampered broader block must invalidate reuse",
+            source="manual",
+        ),
+        "2026-07-17T12:01:00+00:00",
+    )
+    broader_block = next(policy for policy in store.list_policy_decisions("codex") if policy["action"] == "block")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "update policy_decisions set payload_mac = ? where decision_id = ?",
+            ("00", broader_block["decision_id"]),
+        )
+
+    second = guard_commands_module._evaluate_runtime_artifact_hook(
+        args,
+        action_envelope=None,
+        config=config,
+        context=context,
+        data_flow_signals=(),
+        guard_home=home_dir,
+        payload=payload,
+        runtime_artifact=artifact,
+        runtime_workspace=workspace_dir,
+        store=store,
+        trusted_request_override_hash=first.runtime_artifact_hash,
+    )
+    with sqlite3.connect(store.path) as connection:
+        claimed_at = connection.execute(
+            "select claimed_at from guard_local_once_approvals where approval_id = ?",
+            (approval_id,),
+        ).fetchone()[0]
+
+    assert not isinstance(second, int)
+    assert second.policy_action == "require-reapproval"
+    assert second.response_payload["approval_reuse"]["status"] == "rejected"
+    assert second.response_payload["approval_reuse"]["reason_code"] == "approval_reuse_integrity_failure"
+    assert second.response_payload["remembered_rule_rejection"]["integrity_status"] == "tampered"
+    assert second.response_payload["policy_composition"]["trusted_request_override"] is False
+    assert second.response_payload["policy_composition"]["trusted_request_override_reason"] == (
+        "trusted_request_override_integrity_failure"
+    )
+    assert claimed_at is None
+
+
+def test_runtime_hook_saved_allow_invalidates_when_path_resolves_executable_elsewhere(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    first_bin = tmp_path / "bin-a"
+    second_bin = tmp_path / "bin-b"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        home_dir / "config.toml",
+        'approval_wait_timeout_seconds = 0\n[risk_actions]\ndestructive_shell = "review"\n',
+    )
+    execution_markers: list[Path] = []
+    for bin_dir, marker in ((first_bin, "first"), (second_bin, "second")):
+        executable = bin_dir / "rm"
+        execution_marker = tmp_path / f"{marker}-executable-ran"
+        execution_markers.append(execution_marker)
+        _write_text(executable, f"#!/bin/sh\nprintf ran > {shlex.quote(str(execution_marker))}\n")
+        executable.chmod(0o755)
+    event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "rm -rf build-cache"},
+        "source_scope": "project",
+    }
+    original_path = os.environ.get("PATH", "")
+    monkeypatch.setenv("PATH", f"{first_bin}{os.pathsep}{original_path}")
+
+    first_rc, first_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+        as_json=True,
+    )
+    store = GuardStore(home_dir)
+    first_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=str(first_output["artifact_id"]),
+            artifact_hash=first_token,
+            reason="Reviewed executable from first PATH entry",
+            source="manual",
+        ),
+        "2026-07-17T12:00:00+00:00",
+    )
+    monkeypatch.setenv("PATH", f"{second_bin}{os.pathsep}{original_path}")
+
+    second_rc, second_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+        as_json=True,
+    )
+
+    assert first_rc == 1
+    assert first_output["policy_action"] == "review"
+    assert second_rc == 1
+    assert second_output["policy_action"] == "review"
+    assert second_output["approval_reuse"]["status"] == "rejected"
+    assert second_output["approval_reuse"]["reason_code"] == "approval_reuse_identity_changed"
+    assert all(not marker.exists() for marker in execution_markers)
+
+
+@pytest.mark.parametrize(
+    ("changed_dimension", "expected_reason"),
+    (
+        ("workspace", "approval_reuse_identity_changed"),
+        ("content", "approval_reuse_content_changed"),
+        ("capability", "approval_reuse_capability_changed"),
+        ("scanner", "approval_reuse_capability_changed"),
+        ("policy", "approval_reuse_policy_changed"),
+        ("sandbox", "approval_reuse_sandbox_changed"),
+        ("unrelated_ux", None),
+    ),
+)
+def test_runtime_hook_approval_context_invalidates_one_changed_dimension(
+    tmp_path,
+    changed_dimension,
+    expected_reason,
+):
+    workspace = tmp_path / "workspace"
+    artifact = GuardArtifact(
+        artifact_id="codex:project:tool-action:stable",
+        name="Bash destructive shell command",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        command="rm -rf build-cache",
+        metadata={"action_class": "destructive shell command", "risk_classes": ["destructive_shell"]},
+    )
+    envelope = GuardActionEnvelope(
+        schema_version=1,
+        action_id="stable-action",
+        harness="codex",
+        event_name="PreToolUse",
+        action_type="shell_command",
+        workspace=str(workspace),
+        workspace_hash="workspace-hash",
+        tool_name="Bash",
+        command="rm -rf build-cache",
+        prompt_excerpt=None,
+        prompt_text=None,
+        target_paths=(str(workspace / "build-cache"),),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={},
+    )
+    config = GuardConfig(
+        guard_home=tmp_path / "home",
+        workspace=workspace,
+        risk_actions={"destructive_shell": "review"},
+    )
+
+    def _token(
+        *,
+        runtime_workspace=workspace,
+        content_hash="artifact-content-v1",
+        action_envelope=envelope,
+        effective_config=config,
+        scanner_evidence=(),
+    ):
+        return _runtime_hook_approval_context_token(
+            artifact=artifact,
+            content_hash=content_hash,
+            runtime_workspace=runtime_workspace,
+            action_envelope=action_envelope,
+            config=effective_config,
+            current_config_action="review",
+            trusted_cli_action=None,
+            untrusted_payload_action=None,
+            package_action=None,
+            data_flow_action=None,
+            scanner_action=None,
+            current_action="review",
+            data_flow_signals=(),
+            scanner_evidence=scanner_evidence,
+        )
+
+    saved_token = _token()
+    if changed_dimension == "workspace":
+        current_token = _token(runtime_workspace=tmp_path / "other-workspace")
+    elif changed_dimension == "content":
+        current_token = _token(content_hash="artifact-content-v2")
+    elif changed_dimension == "capability":
+        current_token = _token(
+            action_envelope=replace(
+                envelope,
+                target_paths=(*envelope.target_paths, str(workspace / "other-target")),
+            )
+        )
+    elif changed_dimension == "scanner":
+        current_token = _token(scanner_evidence=({"signal_id": "scanner:new-capability"},))
+    elif changed_dimension == "policy":
+        current_token = _token(effective_config=replace(config, new_network_domain_action="block"))
+    elif changed_dimension == "sandbox":
+        current_token = _token(effective_config=replace(config, sandbox_analysis="strict"))
+    else:
+        current_token = _token(
+            effective_config=replace(
+                config,
+                approval_browser_delay_seconds=99,
+                desktop_notifications=not config.desktop_notifications,
+                telemetry=not config.telemetry,
+            )
+        )
+
+    assert approval_context_tokens_validation_reason(saved_token, current_token) == expected_reason
+
+
+def test_runtime_hook_package_without_workspace_rejects_legacy_exact_allow(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
+        PackageRequestEvaluation,
+        SupplyChainUserCopy,
+    )
+
+    home_dir = tmp_path / "home"
+    cwd = tmp_path / "inherited-cwd"
+    cwd.mkdir()
+    _write_text(
+        home_dir / "config.toml",
+        'approval_wait_timeout_seconds = 0\n[risk_actions]\npackage_script = "review"\n',
+    )
+    event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "npm install minimist@1.2.8"},
+        "source_scope": "project",
+    }
+    action_envelope = guard_commands_module._hook_action_envelope(
+        harness="codex",
+        payload=event,
+        home_dir=home_dir,
+        workspace=None,
+    )
+    artifact = guard_commands_module._hook_runtime_artifact(
+        harness="codex",
+        payload=event,
+        action_envelope=action_envelope,
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace=None,
+    )
+    assert artifact is not None
+    assert artifact.artifact_type == "package_request"
+    GuardStore(home_dir).upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=artifact_hash(artifact),
+            reason="legacy exact package allow",
+            source="manual",
+        ),
+        "2026-07-17T12:00:00+00:00",
+    )
+    evaluation = PackageRequestEvaluation(
+        decision="review",
+        policy_action="review",
+        enforcement="policy",
+        entitlement_state="active",
+        cache_status="hit",
+        package_intent_hash="intent-hash",
+        policy_version="policy-v1",
+        bundle_version="bundle-v1",
+        workspace_fingerprint="no-workspace",
+        reasons=({"code": "package_review", "message": "Review package install."},),
+        packages=({"name": "minimist", "decision": "review", "reasons": ()},),
+        risk_summary="Review package install.",
+        user_copy=SupplyChainUserCopy(
+            title="Review package install",
+            summary="Review package install.",
+            next_step="Review the exact request.",
+            dashboard_url=None,
+            harness_message="Review package install.",
+        ),
+    )
+    monkeypatch.chdir(cwd)
+    monkeypatch.setattr(guard_commands_module, "evaluate_package_request_artifact", lambda **_kwargs: evaluation)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--harness",
+            "codex",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+    receipt = GuardStore(home_dir).list_receipts(limit=1)[0]
+
+    assert rc == 1
+    assert output["policy_action"] == "review"
+    assert output["approval_reuse"]["status"] == "rejected"
+    assert output["approval_reuse"]["reason_code"] == "approval_reuse_content_changed"
+    assert receipt["artifact_hash"].startswith(APPROVAL_CONTEXT_TOKEN_PREFIX)
+    assert receipt["artifact_hash"] != artifact_hash(artifact)
+
+
+def test_runtime_hook_package_without_workspace_invalidates_allow_after_lockfile_mutation(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
+        PackageRequestEvaluation,
+        SupplyChainUserCopy,
+    )
+
+    home_dir = tmp_path / "home"
+    cwd = tmp_path / "inherited-cwd"
+    cwd.mkdir()
+    _write_text(cwd / "package.json", '{"dependencies":{"minimist":"1.2.8"}}\n')
+    _write_text(cwd / "package-lock.json", '{"lockfileVersion":3,"packages":{}}\n')
+    _write_text(
+        home_dir / "config.toml",
+        'approval_wait_timeout_seconds = 0\n[risk_actions]\npackage_script = "review"\n',
+    )
+    event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "npm install minimist@1.2.8"},
+        "source_scope": "project",
+    }
+    evaluation = PackageRequestEvaluation(
+        decision="review",
+        policy_action="review",
+        enforcement="policy",
+        entitlement_state="active",
+        cache_status="hit",
+        package_intent_hash="intent-hash",
+        policy_version="policy-v1",
+        bundle_version="bundle-v1",
+        workspace_fingerprint="no-workspace",
+        reasons=({"code": "package_review", "message": "Review package install."},),
+        packages=({"name": "minimist", "decision": "review", "reasons": ()},),
+        risk_summary="Review package install.",
+        user_copy=SupplyChainUserCopy(
+            title="Review package install",
+            summary="Review package install.",
+            next_step="Review the exact request.",
+            dashboard_url=None,
+            harness_message="Review package install.",
+        ),
+    )
+    monkeypatch.chdir(cwd)
+    monkeypatch.setattr(guard_commands_module, "evaluate_package_request_artifact", lambda **_kwargs: evaluation)
+
+    def run_without_workspace() -> tuple[int, dict[str, object]]:
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        return rc, json.loads(capsys.readouterr().out)
+
+    first_rc, first_output = run_without_workspace()
+    store = GuardStore(home_dir)
+    first_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=str(first_output["artifact_id"]),
+            artifact_hash=first_token,
+            reason="Reviewed exact inherited-cwd package context",
+            source="manual",
+        ),
+        "2026-07-17T12:00:00+00:00",
+    )
+
+    unchanged_rc, unchanged_output = run_without_workspace()
+    _write_text(
+        cwd / "package-lock.json",
+        '{"lockfileVersion":3,"packages":{"node_modules/minimist":{"version":"1.2.8"}}}\n',
+    )
+    changed_rc, changed_output = run_without_workspace()
+    changed_token = str(store.list_receipts(limit=1)[0]["artifact_hash"])
+
+    assert first_rc == 1
+    assert first_output["policy_action"] == "review"
+    assert first_token.startswith(APPROVAL_CONTEXT_TOKEN_PREFIX)
+    assert unchanged_rc == 0
+    assert unchanged_output["policy_action"] == "allow"
+    assert unchanged_output["supply_chain_evaluation"]["policy_action"] == "allow"
+    assert unchanged_output["approval_reuse"]["status"] == "accepted"
+    assert changed_rc == 1
+    assert changed_output["policy_action"] == "review"
+    assert changed_output["supply_chain_evaluation"]["policy_action"] == "review"
+    assert changed_output["approval_reuse"]["status"] == "rejected"
+    assert changed_output["approval_reuse"]["reason_code"] == "approval_reuse_content_changed"
+    assert changed_token != first_token
+
+
+def test_guard_hook_saved_file_read_allow_does_not_lower_current_reapproval(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
@@ -12896,6 +14150,7 @@ def test_guard_hook_blocks_sensitive_runtime_file_read_until_exactly_approved(tm
     )
     first_output = json.loads(capsys.readouterr().out)
     approval_request = first_output["approval_requests"][0]
+    first_receipt = GuardStore(home_dir).list_receipts(limit=1)[0]
 
     approval_rc = main(
         [
@@ -12955,14 +14210,89 @@ def test_guard_hook_blocks_sensitive_runtime_file_read_until_exactly_approved(tm
     assert first_output["artifact_type"] == "file_read_request"
     assert "sensitive local file" in first_output["risk_summary"].lower()
     assert approval_request["recommended_scope"] == "artifact"
+    assert approval_request["artifact_hash"].startswith(APPROVAL_CONTEXT_TOKEN_PREFIX)
+    assert approval_request["artifact_hash"] == first_receipt["artifact_hash"]
     assert approval_rc == 0
-    assert second_rc == 0
-    assert second_output["policy_action"] == "allow"
+    assert second_rc == 1
+    assert second_output["policy_action"] == "require-reapproval"
+    assert second_output["approval_reuse"]["reason_code"] == "approval_reuse_reapproval_required"
     assert third_rc == 1
     assert third_output["policy_action"] == "require-reapproval"
 
 
-def test_guard_hook_keeps_artifact_approval_for_same_sensitive_tool_action_retry(tmp_path, capsys, monkeypatch):
+def test_guard_hook_exact_v1_allow_cannot_hide_matching_legacy_block(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+
+    def saved_decision_lookup(
+        _store: GuardStore,
+        _harness: str,
+        _artifact_id: str,
+        *,
+        artifact_hash: str,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        assert kwargs["consume_one_shot"] is False
+        action = "allow" if artifact_hash.startswith(APPROVAL_CONTEXT_TOKEN_PREFIX) else "block"
+        return {
+            "decision": {
+                "action": action,
+                "artifact_hash": artifact_hash,
+                "scope": "artifact",
+                "source": "local",
+            },
+            "ignored_local_integrity": None,
+            "trust_status": {},
+        }
+
+    monkeypatch.setattr(
+        GuardStore,
+        "resolve_policy_decision_lookup_with_memory_pattern",
+        saved_decision_lookup,
+    )
+    monkeypatch.setattr(
+        guard_commands_module,
+        "ensure_guard_daemon",
+        lambda _guard_home: (_ for _ in ()).throw(AssertionError("a saved block must not be queued")),
+    )
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(
+                {
+                    "event": "PreToolUse",
+                    "tool_name": "Read",
+                    "tool_input": {"file_path": ".env.local"},
+                    "source_scope": "project",
+                }
+            )
+        ),
+    )
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert output["policy_action"] == "block"
+    assert output["approval_reuse"]["reason_code"] == "approval_reuse_saved_block"
+    assert GuardStore(home_dir).list_receipts(limit=1)[0]["policy_decision"] == "block"
+
+
+def test_guard_hook_saved_artifact_approval_never_lowers_current_payload_block(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
@@ -12992,22 +14322,20 @@ def test_guard_hook_keeps_artifact_approval_for_same_sensitive_tool_action_retry
         ]
     )
     first_output = json.loads(capsys.readouterr().out)
-    approval_request = first_output["approval_requests"][0]
-
-    approval_rc = main(
-        [
-            "guard",
-            "approvals",
-            "approve",
-            str(approval_request["request_id"]),
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--json",
-        ]
+    store = GuardStore(home_dir)
+    first_receipt = store.list_receipts(limit=1)[0]
+    store.upsert_policy(
+        PolicyDecision(
+            harness="copilot",
+            scope="artifact",
+            action="allow",
+            artifact_id=str(first_output["artifact_id"]),
+            artifact_hash=str(first_receipt["artifact_hash"]),
+            reason="Reviewed exact artifact before current policy became terminal.",
+            source="manual",
+        ),
+        "2026-07-17T12:00:00+00:00",
     )
-    json.loads(capsys.readouterr().out)
 
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
     second_rc = main(
@@ -13051,16 +14379,17 @@ def test_guard_hook_keeps_artifact_approval_for_same_sensitive_tool_action_retry
 
     assert first_rc == 1
     assert first_output["policy_action"] == "block"
+    assert first_output["approval_requests"] == []
+    assert first_output["terminal"] is True
     assert first_output["artifact_type"] == "tool_action_request"
     assert "destructive shell command" in first_output["risk_summary"].lower()
-    assert approval_request["recommended_scope"] == "artifact"
-    assert approval_rc == 0
-    assert second_rc == 0
-    assert second_output["policy_action"] == "allow"
-    assert second_output.get("approval_requests") in (None, [])
+    assert second_rc == 1
+    assert second_output["policy_action"] == "block"
+    assert second_output["approval_reuse"]["status"] == "rejected"
+    assert second_output["approval_reuse"]["reason_code"] == "approval_reuse_current_block"
     assert third_rc == 1
     assert third_output["policy_action"] == "block"
-    assert len(third_output["approval_requests"]) == 1
+    assert third_output["approval_requests"] == []
 
 
 def test_guard_hook_codex_emits_native_deny_for_sensitive_bash_command(tmp_path, capsys, monkeypatch):
@@ -13189,7 +14518,7 @@ def test_guard_hook_codex_emits_no_native_output_for_safe_github_node_review_thr
     assert pending == []
 
 
-def test_guard_hook_codex_queues_approval_before_native_deny_output(tmp_path, capsys, monkeypatch):
+def test_guard_hook_codex_current_block_is_terminal_before_native_deny_output(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
@@ -13230,13 +14559,12 @@ def test_guard_hook_codex_queues_approval_before_native_deny_output(tmp_path, ca
     assert rc == 0
     assert captured.err == ""
     assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
-    assert len(pending) == 1
-    review_url = str(pending[0]["approval_url"])
+    assert pending == []
     reason = str(payload["hookSpecificOutput"]["permissionDecisionReason"])
-    assert "Open HOL Guard to approve or keep this blocked" in reason
-    assert review_url in reason
+    assert "terminal policy decision" in reason
+    assert "Browser approval cannot override it" in reason
+    assert "/requests/" not in reason
     assert "Approve it in HOL Guard, then retry." not in reason
-    assert pending[0]["artifact_type"] == "tool_action_request"
 
 
 def _install_fake_guard_surface_daemon(
@@ -13287,7 +14615,7 @@ def _install_fake_guard_surface_daemon(
     )
 
 
-def test_guard_hook_codex_pretooluse_browser_approval_resumes_original_tool(
+def test_guard_hook_codex_pretooluse_current_block_is_terminal_without_browser_approval(
     tmp_path,
     capsys,
     monkeypatch,
@@ -13297,9 +14625,13 @@ def test_guard_hook_codex_pretooluse_browser_approval_resumes_original_tool(
     _build_guard_fixture(home_dir, workspace_dir)
     _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 2\n")
     monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
-    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
     store = GuardStore(home_dir)
-    _install_fake_guard_surface_daemon(monkeypatch, store)
+
+    def unexpected_browser_approval(*_args, **_kwargs):
+        raise AssertionError("current block must not queue or wait for browser approval")
+
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", unexpected_browser_approval)
+    monkeypatch.setattr(guard_commands_module, "wait_for_approval_requests", unexpected_browser_approval)
     blocked_event = {
         "hook_event_name": "PreToolUse",
         "tool_name": "Bash",
@@ -13309,23 +14641,6 @@ def test_guard_hook_codex_pretooluse_browser_approval_resumes_original_tool(
         "cwd": str(workspace_dir),
     }
 
-    def approve_pending() -> None:
-        for _ in range(40):
-            pending = store.list_approval_requests(limit=10)
-            if pending:
-                apply_approval_resolution(
-                    store=store,
-                    request_id=str(pending[0]["request_id"]),
-                    action="allow",
-                    scope="artifact",
-                    workspace=None,
-                    reason="approved in browser",
-                )
-                return
-            threading.Event().wait(0.05)
-
-    worker = threading.Thread(target=approve_pending, daemon=True)
-    worker.start()
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
 
     rc = main(
@@ -13343,10 +14658,14 @@ def test_guard_hook_codex_pretooluse_browser_approval_resumes_original_tool(
     captured = capsys.readouterr()
 
     payload = json.loads(captured.out)
+    reason = str(payload["hookSpecificOutput"]["permissionDecisionReason"])
     assert rc == 0
     assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
     assert captured.err == ""
-    assert store.list_approval_requests(limit=10)
+    assert store.list_approval_requests(limit=10) == []
+    assert "terminal policy decision" in reason
+    assert "Browser approval cannot override it" in reason
+    assert "/requests/" not in reason
 
 
 def test_guard_hook_codex_pretooluse_browser_deny_keeps_tool_blocked(
@@ -13454,7 +14773,7 @@ def test_guard_hook_claude_native_block_does_not_queue_approval_center_request(t
     assert pending == []
 
 
-def test_guard_hook_codex_keeps_artifact_approval_for_same_sensitive_tool_action_retry(
+def test_guard_hook_codex_saved_artifact_approval_never_lowers_current_payload_block(
     tmp_path,
     capsys,
     monkeypatch,
@@ -13489,22 +14808,20 @@ def test_guard_hook_codex_keeps_artifact_approval_for_same_sensitive_tool_action
         ]
     )
     first_output = json.loads(capsys.readouterr().out)
-    approval_request = first_output["approval_requests"][0]
-
-    approval_rc = main(
-        [
-            "guard",
-            "approvals",
-            "approve",
-            str(approval_request["request_id"]),
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--json",
-        ]
+    store = GuardStore(home_dir)
+    first_receipt = store.list_receipts(limit=1)[0]
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=str(first_output["artifact_id"]),
+            artifact_hash=str(first_receipt["artifact_hash"]),
+            reason="Reviewed exact artifact before current policy became terminal.",
+            source="manual",
+        ),
+        "2026-07-17T12:00:00+00:00",
     )
-    json.loads(capsys.readouterr().out)
 
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
     second_rc = main(
@@ -13548,16 +14865,17 @@ def test_guard_hook_codex_keeps_artifact_approval_for_same_sensitive_tool_action
 
     assert first_rc == 1
     assert first_output["policy_action"] == "block"
+    assert first_output["approval_requests"] == []
+    assert first_output["terminal"] is True
     assert first_output["artifact_type"] == "tool_action_request"
     assert "destructive shell command" in first_output["risk_summary"].lower()
-    assert approval_request["recommended_scope"] == "artifact"
-    assert approval_rc == 0
-    assert second_rc == 0
-    assert second_output["policy_action"] == "allow"
-    assert second_output.get("approval_requests") in (None, [])
+    assert second_rc == 1
+    assert second_output["policy_action"] == "block"
+    assert second_output["approval_reuse"]["status"] == "rejected"
+    assert second_output["approval_reuse"]["reason_code"] == "approval_reuse_current_block"
     assert third_rc == 1
     assert third_output["policy_action"] == "block"
-    assert len(third_output["approval_requests"]) == 1
+    assert third_output["approval_requests"] == []
 
 
 def test_guard_hook_allows_non_sensitive_read_file_requests(tmp_path, capsys, monkeypatch):
@@ -13906,7 +15224,7 @@ def test_guard_hook_codex_user_prompt_submit_browser_approval_resumes_prompt(
     assert store.list_approval_requests(limit=10) == []
 
 
-def test_guard_hook_codex_user_prompt_submit_reuses_artifact_approval(
+def test_guard_hook_codex_user_prompt_saved_artifact_allow_does_not_lower_reapproval(
     tmp_path,
     capsys,
     monkeypatch,
@@ -13954,10 +15272,10 @@ def test_guard_hook_codex_user_prompt_submit_reuses_artifact_approval(
     assert rc == 0
     payload = json.loads(output)
     assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-    assert store.list_approval_requests(limit=10) == []
+    assert len(store.list_approval_requests(limit=10)) == 1
 
 
-def test_guard_hook_codex_user_prompt_submit_reuses_workspace_approval_for_same_prompt(
+def test_guard_hook_codex_user_prompt_saved_workspace_allow_does_not_lower_reapproval(
     tmp_path,
     capsys,
     monkeypatch,
@@ -14005,7 +15323,7 @@ def test_guard_hook_codex_user_prompt_submit_reuses_workspace_approval_for_same_
     assert rc == 0
     payload = json.loads(output)
     assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-    assert store.list_approval_requests(limit=10) == []
+    assert len(store.list_approval_requests(limit=10)) == 1
 
 
 def test_guard_hook_codex_user_prompt_submit_workspace_approval_stays_in_workspace(
@@ -15504,6 +16822,107 @@ def test_guard_runtime_tool_action_policy_does_not_let_warn_default_override_ris
     assert guard_commands_module._runtime_artifact_policy_action(config, artifact, "codex") == "require-reapproval"
 
 
+def test_guard_runtime_artifact_policy_includes_stronger_global_default(tmp_path):
+    artifact = GuardArtifact(
+        artifact_id="codex:test:tool-action:global-default",
+        name="Codex routine tool action",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path="/dev/null",
+        publisher="trusted-publisher",
+        metadata={"guard_default_action": "allow"},
+    )
+    config = GuardConfig(
+        guard_home=tmp_path,
+        workspace=None,
+        security_level="custom",
+        default_action="block",
+    )
+
+    assert guard_commands_module._runtime_artifact_policy_action(config, artifact, "codex") == "block"
+
+
+def test_guard_runtime_artifact_exact_allow_replaces_stricter_global_default(tmp_path):
+    artifact = GuardArtifact(
+        artifact_id="codex:test:tool-action:exact-allow",
+        name="Codex routine tool action",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path="/dev/null",
+        metadata={"guard_default_action": "allow"},
+    )
+    config = GuardConfig(
+        guard_home=tmp_path,
+        workspace=None,
+        security_level="custom",
+        default_action="block",
+        artifact_actions={artifact.artifact_id: "allow"},
+    )
+
+    assert guard_commands_module._runtime_artifact_policy_action(config, artifact, "codex") == "allow"
+
+
+def test_guard_runtime_artifact_exact_allow_cannot_lower_independent_risk_block(tmp_path):
+    artifact = GuardArtifact(
+        artifact_id="codex:test:tool-action:exact-allow-risk-block",
+        name="Codex credential exfiltration action",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path="/dev/null",
+        metadata={
+            "action_class": "credential exfiltration shell command",
+            "guard_default_action": "allow",
+        },
+    )
+    config = GuardConfig(
+        guard_home=tmp_path,
+        workspace=None,
+        security_level="custom",
+        default_action="allow",
+        artifact_actions={artifact.artifact_id: "allow"},
+        risk_actions={"credential_exfiltration": "block"},
+    )
+
+    assert guard_commands_module._runtime_artifact_policy_action(config, artifact, "codex") == "block"
+
+
+@pytest.mark.parametrize(
+    ("override_kwargs", "expected_action"),
+    (
+        ({"artifact_actions": {"codex:test:tool-action:override": "block"}}, "block"),
+        ({"publisher_actions": {"publisher-a": "sandbox-required"}}, "sandbox-required"),
+        ({"harness_actions": {"codex": "block"}}, "block"),
+    ),
+)
+def test_guard_runtime_artifact_policy_composes_exact_current_override(
+    tmp_path,
+    override_kwargs: dict[str, object],
+    expected_action: str,
+) -> None:
+    artifact = GuardArtifact(
+        artifact_id="codex:test:tool-action:override",
+        name="Codex routine tool action",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path="/dev/null",
+        publisher="publisher-a",
+        metadata={"guard_default_action": "allow"},
+    )
+    config = GuardConfig(
+        guard_home=tmp_path,
+        workspace=None,
+        security_level="custom",
+        default_action="allow",
+        **override_kwargs,  # type: ignore[arg-type]
+    )
+
+    assert guard_commands_module._runtime_artifact_policy_action(config, artifact, "codex") == expected_action
+
+
 def test_guard_hook_codex_user_prompt_submit_guard_bypass_hard_blocks_without_approval_url(
     tmp_path,
     capsys,
@@ -15897,8 +17316,9 @@ def test_guard_hook_codex_post_tool_use_explains_merged_stderr_capture(
     assert rc == 0
     assert payload["continue"] is False
     assert "Combined stdout/stderr looked credential-like before it reached Codex." in payload["stopReason"]
-    assert payload["stopReason"].count("Open HOL Guard to approve or keep this blocked") == 1
-    assert "http://127.0.0.1:4455/requests/" in payload["stopReason"]
+    assert payload["stopReason"].count("terminal policy decision") == 1
+    assert "Browser approval cannot override it" in payload["stopReason"]
+    assert "/requests/" not in payload["stopReason"]
 
 
 def test_codex_post_tool_output_allows_focused_pytest_fake_credential_fixture(tmp_path):
@@ -16062,8 +17482,9 @@ def test_guard_hook_codex_post_tool_use_blocks_focused_pytest_medium_secret_outp
     assert payload["continue"] is False
     assert "Focused pytest emitted credential-looking output before it reached Codex." in payload["stopReason"]
     assert "Pytest can execute repository-controlled code" in payload["stopReason"]
-    assert payload["stopReason"].count("Open HOL Guard to approve or keep this blocked") == 1
-    assert "http://127.0.0.1:4455/requests/" in payload["stopReason"]
+    assert payload["stopReason"].count("terminal policy decision") == 1
+    assert "Browser approval cannot override it" in payload["stopReason"]
+    assert "/requests/" not in payload["stopReason"]
 
 
 def test_guard_hook_codex_post_tool_use_browser_approval_resumes_result(
@@ -16122,21 +17543,110 @@ def test_guard_hook_codex_post_tool_use_browser_approval_resumes_result(
 
     assert rc == 0
     payload = json.loads(captured.out)
+    assert "hookSpecificOutput" in payload, (
+        payload,
+        store.list_receipts(limit=20),
+        store.list_approval_requests(limit=20),
+    )
     assert payload["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
     assert captured.err == ""
     assert store.list_approval_requests(limit=10) == []
 
 
-def test_codex_browser_approval_decision_updates_daemon_operation_status(tmp_path):
+def test_guard_hook_codex_browser_allow_rechecks_policy_changed_during_wait(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 2\n")
+    event = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "cat .authrc"},
+        "tool_response": {"stdout": "HOL_GUARD_FAKE_CREDENTIAL=fixture-only\n"},
+        "source_scope": "project",
+    }
+    monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    store = GuardStore(home_dir)
+    _install_fake_guard_surface_daemon(monkeypatch, store)
+
+    def tighten_policy_then_approve() -> None:
+        for _ in range(40):
+            pending = store.list_approval_requests(limit=10)
+            if pending:
+                _write_text(
+                    home_dir / "config.toml",
+                    ('approval_wait_timeout_seconds = 2\n[harnesses.codex]\ndefault_action = "block"\n'),
+                )
+                apply_approval_resolution(
+                    store=store,
+                    request_id=str(pending[0]["request_id"]),
+                    action="allow",
+                    scope="artifact",
+                    workspace=None,
+                    reason="approved stale browser request",
+                )
+                return
+            threading.Event().wait(0.05)
+
+    worker = threading.Thread(target=tighten_policy_then_approve, daemon=True)
+    worker.start()
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+        ]
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert rc == 0
+    assert payload["decision"] == "block"
+    assert payload["continue"] is False
+    tool_receipts = [
+        receipt
+        for receipt in store.list_receipts(limit=20)
+        if receipt["provenance_summary"] != "Guard approval decision"
+    ]
+    assert len(tool_receipts) == 1
+    assert tool_receipts[0]["policy_decision"] == "block"
+    assert tool_receipts[0]["approval_source"] == "browser"
+
+
+def _codex_browser_approval_context_token(*, current_action: str) -> str:
+    return build_approval_context_token(
+        identity={"artifact_id": "artifact-1", "harness": "codex"},
+        content={"command": "bash ./guard-canary.sh"},
+        capabilities={"action_type": "shell_command"},
+        policy={"current_action": current_action},
+        sandbox={"mode": "host"},
+    )
+
+
+def test_codex_browser_approval_decision_updates_daemon_operation_status(tmp_path, monkeypatch):
+    monkeypatch.setattr(interaction_module, "wait_for_approval_requests", wait_for_approval_requests)
     home_dir = tmp_path / "home"
     store = GuardStore(home_dir)
+    context_token = _codex_browser_approval_context_token(current_action="review")
     request = GuardApprovalRequest(
         request_id="request-1",
         harness="codex",
         artifact_id="artifact-1",
         artifact_name="Bash request",
-        artifact_hash="hash-1",
-        policy_action="block",
+        artifact_hash=context_token,
+        policy_action="review",
         recommended_scope="artifact",
         changed_fields=("command",),
         source_scope="project",
@@ -16161,34 +17671,48 @@ def test_codex_browser_approval_decision_updates_daemon_operation_status(tmp_pat
             statuses.append(dict(kwargs))
 
     payload: dict[str, object] = {
+        "artifact_id": "artifact-1",
+        "artifact_hash": context_token,
         "operation_id": "operation-1",
-        "approval_requests": [{"request_id": "request-1"}],
+        "operation": {"operation_id": "operation-1", "status": "waiting_on_approval"},
+        "approval_requests": [request.to_dict()],
     }
 
     decision = guard_commands_module._codex_browser_approval_decision(
         args=argparse.Namespace(harness="codex", json=False),
         event_name="PostToolUse",
-        policy_action="block",
+        policy_action="review",
         response_payload=payload,
         store=store,
         config=GuardConfig(home_dir, None, approval_wait_timeout_seconds=1),
         daemon_client=_FakeDaemonClient(),
+        expected_artifact_hash=context_token,
+        fresh_context_provider=lambda: {
+            "artifact_id": "artifact-1",
+            "artifact_hash": context_token,
+            "current_action": "review",
+            "authoritative_action": "allow",
+        },
     )
 
     assert decision == "allow"
     assert statuses == [{"operation_id": "operation-1", "status": "completed"}]
+    assert payload["operation"]["status"] == "completed"
+    assert payload["continuation"]["resolution_action"] == "allow"
 
 
-def test_codex_browser_block_decision_updates_daemon_operation_status(tmp_path):
+def test_codex_browser_block_decision_updates_daemon_operation_status(tmp_path, monkeypatch):
+    monkeypatch.setattr(interaction_module, "wait_for_approval_requests", wait_for_approval_requests)
     home_dir = tmp_path / "home"
     store = GuardStore(home_dir)
+    context_token = _codex_browser_approval_context_token(current_action="require-reapproval")
     request = GuardApprovalRequest(
         request_id="request-1",
         harness="codex",
         artifact_id="artifact-1",
         artifact_name="Bash request",
-        artifact_hash="hash-1",
-        policy_action="block",
+        artifact_hash=context_token,
+        policy_action="require-reapproval",
         recommended_scope="artifact",
         changed_fields=("command",),
         source_scope="project",
@@ -16213,22 +17737,28 @@ def test_codex_browser_block_decision_updates_daemon_operation_status(tmp_path):
             statuses.append(dict(kwargs))
 
     payload: dict[str, object] = {
+        "artifact_id": "artifact-1",
+        "artifact_hash": context_token,
         "operation_id": "operation-1",
-        "approval_requests": [{"request_id": "request-1"}],
+        "operation": {"operation_id": "operation-1", "status": "waiting_on_approval"},
+        "approval_requests": [request.to_dict()],
     }
 
     decision = guard_commands_module._codex_browser_approval_decision(
         args=argparse.Namespace(harness="codex", json=False),
         event_name="PostToolUse",
-        policy_action="block",
+        policy_action="require-reapproval",
         response_payload=payload,
         store=store,
         config=GuardConfig(home_dir, None, approval_wait_timeout_seconds=1),
         daemon_client=_FakeDaemonClient(),
+        expected_artifact_hash=context_token,
     )
 
     assert decision == "block"
     assert statuses == [{"operation_id": "operation-1", "status": "blocked"}]
+    assert payload["operation"]["status"] == "blocked"
+    assert payload["continuation"]["resolution_action"] == "block"
 
 
 def test_codex_browser_approval_uses_configured_wait_timeout(tmp_path, monkeypatch):
@@ -17286,7 +18816,9 @@ def test_guard_hook_strict_profile_blocks_data_flow_exfiltration_path(tmp_path, 
     assert rc == 1
     assert isinstance(output, dict)
     assert output["policy_action"] == "block"
-    assert output["approval_requests"][0]["decision_v2_json"]["action"] == "block"
+    assert output["decision_v2_json"]["action"] == "block"
+    assert output["approval_requests"] == []
+    assert output["terminal"] is True
 
 
 def test_guard_hook_flags_shell_variable_data_flow_without_legacy_runtime_artifact(tmp_path, capsys, monkeypatch):
@@ -17352,7 +18884,9 @@ def test_guard_hook_data_flow_policy_overrides_weaker_requested_action(tmp_path,
     assert rc == 1
     assert isinstance(output, dict)
     assert output["policy_action"] == "block"
-    assert output["approval_requests"][0]["decision_v2_json"]["action"] == "block"
+    assert output["decision_v2_json"]["action"] == "block"
+    assert output["approval_requests"] == []
+    assert output["terminal"] is True
 
 
 def test_runtime_data_flow_summary_names_non_network_sink() -> None:
@@ -18526,8 +20060,8 @@ def test_policy_bundle_exact_artifact_rules_apply_with_workspace_scope(tmp_path)
     assert next(iter(stored_workspaces)).startswith("workspace:")
     assert {item["artifact_id"] for item in exact_decisions} == {allow_artifact, block_artifact}
     assert {item["expires_at"] for item in exact_decisions} == {
-        "2026-12-01T00:00:00+00:00",
-        "2026-10-01T00:00:00+00:00",
+        "2026-12-01T00:00:00.000000+00:00",
+        "2026-10-01T00:00:00.000000+00:00",
     }
 
 
@@ -18992,18 +20526,19 @@ def test_policy_bundle_decision_resolves_before_receipt_persistence(tmp_path, mo
     )
 
     order: list[str] = []
-    original_resolve_policy = store.resolve_policy
+    original_resolve_policy = store.resolve_policy_decision_lookup_with_memory_pattern
     original_add_receipt = store.add_receipt
 
     def tracked_resolve_policy(*args, **kwargs):
-        order.append("resolve_policy")
+        assert kwargs.get("consume_one_shot") is False
+        order.append("resolve_policy_non_consuming")
         return original_resolve_policy(*args, **kwargs)
 
     def tracked_add_receipt(receipt):
         order.append("add_receipt")
         return original_add_receipt(receipt)
 
-    monkeypatch.setattr(store, "resolve_policy", tracked_resolve_policy)
+    monkeypatch.setattr(store, "resolve_policy_decision_lookup_with_memory_pattern", tracked_resolve_policy)
     monkeypatch.setattr(store, "add_receipt", tracked_add_receipt)
 
     detection = HarnessDetection(
@@ -19028,7 +20563,7 @@ def test_policy_bundle_decision_resolves_before_receipt_persistence(tmp_path, mo
     result = evaluate_detection(detection, store, config, persist=True)
 
     assert result["artifacts"][0]["policy_action"] == "block"
-    assert order.index("resolve_policy") < order.index("add_receipt")
+    assert order.index("resolve_policy_non_consuming") < order.index("add_receipt")
 
 
 def test_sync_runtime_session_retries_once_after_timeout(tmp_path, monkeypatch):

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -9,7 +9,7 @@ import pytest
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.config import GuardConfig
-from codex_plugin_scanner.guard.models import HarnessDetection
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope, normalize_codex_hook_payload
 from codex_plugin_scanner.guard.runtime.detectors import (
@@ -578,7 +578,9 @@ def test_guard_run_keeps_detector_results_after_blocked_resolver_reevaluation(tm
         blocked_resolver=blocked_resolver_stub,
     )
 
-    assert calls == ["secret.local"]
+    # The approval/resolver boundary must rerun detectors against the freshly
+    # loaded authority before preserving their evidence in the final result.
+    assert calls == ["secret.local", "secret.local"]
     assert result["runtime_detector_signals_v2"] == [_signal("secret:local", "secret").to_dict()]
     assert result["approval_delivery"] == "queued"
 
@@ -629,6 +631,359 @@ def test_detector_composition_can_block_unblocked_evaluation(tmp_path):
     assert result["blocked"] is True
     assert result["blocked_by_detector"] == "bypass signal 'guard.bypass' forces block"
     assert result["runtime_detector_composition"]["action"] == "block"
+
+
+def test_authoritative_detector_block_controls_artifact_persistence(tmp_path):
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    artifact = GuardArtifact(
+        artifact_id="codex:project:detector-persistence",
+        name="detector-persistence",
+        harness="codex",
+        artifact_type="instruction",
+        source_scope="project",
+        config_path=str(workspace_dir / "AGENTS.md"),
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(artifact.config_path,),
+        artifacts=(artifact,),
+    )
+    config = GuardConfig(guard_home=home_dir, workspace=workspace_dir, default_action="allow")
+    store = GuardStore(home_dir)
+    detector_reason = "bypass signal 'guard.bypass' forces block"
+
+    result = guard_runner_module.evaluate_detection(
+        detection,
+        store,
+        config,
+        default_action="allow",
+        persist=True,
+        runtime_detector_block_reason=detector_reason,
+    )
+
+    assert result["blocked"] is True
+    assert result["receipts_recorded"] == 1
+    artifact_result = result["artifacts"][0]
+    assert artifact_result["policy_action"] == "block"
+    assert artifact_result["decision_v2_json"]["action"] == "block"
+    assert artifact_result["decision_v2_json"]["reason"] == "runtime_detector_block"
+    assert artifact_result["policy_composition"]["final_action"] == "block"
+    assert artifact_result["policy_composition"]["runtime_detector_action"] == "block"
+    assert artifact_result["policy_composition"]["runtime_detector_reason"] == detector_reason
+    assert artifact_result["scanner_evidence"][-1] == {
+        "source": "runtime_detector_registry",
+        "status": "blocked",
+        "reason_code": "runtime_detector_block",
+        "reason": detector_reason,
+    }
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    assert inventory is not None
+    assert inventory["last_policy_action"] == "block"
+    assert inventory["last_approved_at"] is None
+    assert store.get_snapshot("codex", artifact.artifact_id) is None
+    receipts = store.list_receipts(harness="codex")
+    assert len(receipts) == 1
+    assert receipts[0]["policy_decision"] == "block"
+    assert receipts[0]["approval_source"] == "runtime-detector"
+    assert receipts[0]["scanner_evidence"][-1]["reason_code"] == "runtime_detector_block"
+
+
+def test_guard_run_detector_block_leaves_saved_review_allow_unclaimed(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    artifact = GuardArtifact(
+        artifact_id="codex:project:detector-claim-gate",
+        name="detector-claim-gate",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        metadata={"guard_default_action": "review", "action_class": "detector claim gate"},
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(artifact.config_path,),
+        artifacts=(artifact,),
+    )
+    config = GuardConfig(
+        guard_home=home_dir,
+        workspace=workspace_dir,
+        runtime_detector_registry=True,
+    )
+    store = GuardStore(home_dir)
+    initial = guard_runner_module.evaluate_detection(detection, store, config, persist=False)
+    context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    approval_id = store.record_local_once_approval(
+        request_id="detector-claim-gate",
+        harness="codex",
+        artifact_id=artifact.artifact_id,
+        artifact_hash=context_hash,
+        workspace=str(workspace_dir),
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+    bypass_signal = RiskSignalV2(
+        signal_id="bypass:claim-gate",
+        category="bypass",
+        severity="high",
+        confidence="strong",
+        detector="guard.bypass",
+        title="Guard bypass attempt",
+        plain_reason="Detector blocked the aggregate launch.",
+        technical_detail=None,
+        evidence_ref=None,
+        redaction_level="summary",
+        false_positive_hint=None,
+        advisory_id=None,
+    )
+    detector_calls: list[str] = []
+    detector = RecordingDetector("guard.bypass", ("bypass",), detector_calls, bypass_signal)
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "register_default_detectors", lambda: (detector,))
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("detector-blocked launch must not execute"),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert result["blocked"] is True
+    assert result["blocked_by_detector"] == "bypass signal 'guard.bypass' forces block"
+    assert result["launched"] is False
+    assert detector_calls == ["guard.bypass"]
+    artifact_result = result["artifacts"][0]
+    assert artifact_result["policy_action"] == "block"
+    assert artifact_result["decision_v2_json"]["action"] == "block"
+    assert artifact_result["decision_v2_json"]["reason"] == "runtime_detector_block"
+    assert artifact_result["policy_composition"]["final_action"] == "block"
+    assert artifact_result["policy_composition"]["runtime_detector_action"] == "block"
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    assert inventory is not None
+    assert inventory["last_policy_action"] == "block"
+    assert inventory["last_approved_at"] is None
+    assert store.get_snapshot("codex", artifact.artifact_id) is None
+    receipts = store.list_receipts(harness="codex")
+    assert len(receipts) == 1
+    assert receipts[0]["policy_decision"] == "block"
+    assert receipts[0]["approval_source"] == "runtime-detector"
+    assert (
+        store.peek_local_once_approval(
+            harness="codex",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=context_hash,
+            workspace=str(workspace_dir),
+            publisher=None,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is not None
+    )
+
+
+def test_guard_run_detector_review_precedes_saved_allow_reuse_and_persists_authority(
+    tmp_path,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    artifact = GuardArtifact(
+        artifact_id="codex:project:detector-review-claim-gate",
+        name="detector-review-claim-gate",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        metadata={"guard_default_action": "review", "action_class": "detector review claim gate"},
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(artifact.config_path,),
+        artifacts=(artifact,),
+    )
+    config = GuardConfig(
+        guard_home=home_dir,
+        workspace=workspace_dir,
+        runtime_detector_registry=True,
+    )
+    store = GuardStore(home_dir)
+    initial = guard_runner_module.evaluate_detection(detection, store, config, persist=False)
+    original_context_hash = str(initial["artifacts"][0]["approval_context_hash"])
+    approval_id = store.record_local_once_approval(
+        request_id="detector-review-claim-gate",
+        harness="codex",
+        artifact_id=artifact.artifact_id,
+        artifact_hash=original_context_hash,
+        workspace=str(workspace_dir),
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+    persistence_signal = RiskSignalV2(
+        signal_id="persistence:detector-review-claim-gate",
+        category="persistence",
+        severity="high",
+        confidence="likely",
+        detector="persistence.runtime",
+        title="Persistence requires review",
+        plain_reason="Detector found high-severity persistence behavior.",
+        technical_detail=None,
+        evidence_ref=None,
+        redaction_level="summary",
+        false_positive_hint=None,
+        advisory_id=None,
+    )
+    detector_calls: list[str] = []
+    detector = RecordingDetector(
+        "persistence.runtime",
+        ("persistence",),
+        detector_calls,
+        persistence_signal,
+    )
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "register_default_detectors", lambda: (detector,))
+    monkeypatch.setattr(
+        store,
+        "claim_approval_reuse_decisions",
+        lambda *_args, **_kwargs: pytest.fail("detector review must be current before any saved-allow claim"),
+    )
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("unresolved detector review must not launch"),
+    )
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+    )
+
+    assert result["blocked"] is True
+    assert result["launched"] is False
+    assert detector_calls == ["persistence.runtime"]
+    artifact_result = result["artifacts"][0]
+    assert artifact_result["approval_context_hash"] != original_context_hash
+    assert artifact_result["policy_action"] == "review"
+    assert artifact_result["decision_v2_json"]["action"] == "ask"
+    assert artifact_result["decision_v2_json"]["reason"] == "runtime_detector_review"
+    assert artifact_result["policy_composition"]["current_action"] == "review"
+    assert artifact_result["policy_composition"]["runtime_detector_action"] == "review"
+    assert artifact_result["policy_composition"]["final_action"] == "review"
+    assert artifact_result["scanner_evidence"][-1] == {
+        "source": "runtime_detector_registry",
+        "status": "review-required",
+        "reason_code": "runtime_detector_review",
+        "reason": "persistence signal 'persistence.runtime' requires review",
+    }
+    inventory = store.find_inventory_item(artifact.artifact_id)
+    assert inventory is not None
+    assert inventory["last_policy_action"] == "review"
+    assert inventory["last_approved_at"] is None
+    assert store.get_snapshot("codex", artifact.artifact_id) is None
+    receipts = store.list_receipts(harness="codex")
+    assert len(receipts) == 1
+    assert receipts[0]["policy_decision"] == "review"
+    assert receipts[0]["approval_source"] == "runtime-detector"
+    assert receipts[0]["scanner_evidence"][-1] == artifact_result["scanner_evidence"][-1]
+    assert (
+        store.peek_local_once_approval(
+            harness="codex",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=original_context_hash,
+            workspace=str(workspace_dir),
+            publisher=None,
+            now="2026-07-17T00:01:00+00:00",
+        )
+        is not None
+    )
+
+
+def test_guard_run_detector_block_is_terminal_before_any_review_resolver(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    artifact = GuardArtifact(
+        artifact_id="codex:project:detector-before-review",
+        name="detector-before-review",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        metadata={"guard_default_action": "review", "action_class": "detector before review"},
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(artifact.config_path,),
+        artifacts=(artifact,),
+    )
+    detector_calls: list[str] = []
+    detector = RecordingDetector(
+        "guard.bypass",
+        ("bypass",),
+        detector_calls,
+        RiskSignalV2(
+            signal_id="bypass:before-review",
+            category="bypass",
+            severity="high",
+            confidence="strong",
+            detector="guard.bypass",
+            title="Guard bypass attempt",
+            plain_reason="Detector block must precede approval resolution.",
+            technical_detail=None,
+            evidence_ref=None,
+            redaction_level="summary",
+            false_positive_hint=None,
+            advisory_id=None,
+        ),
+    )
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "register_default_detectors", lambda: (detector,))
+
+    def unexpected_resolver(*_args, **_kwargs):
+        pytest.fail("a terminal detector block must not enter an approval resolver")
+
+    result = guard_runner_module.guard_run(
+        "codex",
+        HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+        GuardStore(home_dir),
+        GuardConfig(guard_home=home_dir, workspace=workspace_dir, runtime_detector_registry=True),
+        dry_run=False,
+        passthrough_args=[],
+        interactive_resolver=unexpected_resolver,
+        blocked_resolver=unexpected_resolver,
+    )
+
+    assert result["blocked"] is True
+    assert result["blocked_by_detector"] == "bypass signal 'guard.bypass' forces block"
+    assert result["artifacts"][0]["policy_action"] == "block"
+    assert detector_calls == ["guard.bypass"]
 
 
 def test_guard_run_writes_detector_debug_trace_only_when_enabled(tmp_path, monkeypatch):

--- a/tests/test_guard_runtime_mcp_saved_blocks.py
+++ b/tests/test_guard_runtime_mcp_saved_blocks.py
@@ -1,0 +1,2310 @@
+"""Terminal saved-block regressions for the runtime MCP proxy."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import shutil
+import sqlite3
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Literal
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.approval_scope_support import package_request_runtime_workspace_scope
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.local_supply_chain import package_request_policy_hash
+from codex_plugin_scanner.guard.mcp_tool_calls import (
+    ToolCallDecision,
+    build_tool_call_artifact,
+    build_tool_call_hash,
+    evaluate_tool_call,
+)
+from codex_plugin_scanner.guard.models import GuardArtifact, PolicyDecision
+from codex_plugin_scanner.guard.package_execution_context import build_package_execution_context
+from codex_plugin_scanner.guard.proxy import CodexMcpGuardProxy, OpenCodeMcpGuardProxy
+from codex_plugin_scanner.guard.proxy import runtime_mcp as runtime_mcp_module
+from codex_plugin_scanner.guard.runtime.package_intent import (
+    build_package_request_artifact,
+    extract_package_intent_request,
+)
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.store import GuardStore
+
+pytest_plugins = ["tests.bundle_first_cloud"]
+pytestmark = pytest.mark.usefixtures("bundle_first_cloud")
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    home_dir.mkdir()
+    workspace_dir.mkdir()
+    guard_home.mkdir()
+    return HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=guard_home)
+
+
+def _child_command(marker_path: Path) -> list[str]:
+    return [
+        sys.executable,
+        "-u",
+        "-c",
+        "\n".join(
+            (
+                "import json",
+                "import sys",
+                "from pathlib import Path",
+                f"marker_path = Path({str(marker_path)!r})",
+                "for line in sys.stdin:",
+                "    message = json.loads(line)",
+                "    message_id = message.get('id')",
+                "    method = message.get('method')",
+                "    if method == 'initialize':",
+                "        result = {'protocolVersion': '2025-06-18', 'capabilities': {'tools': {}}, "
+                "                  'serverInfo': {'name': 'fixture', 'version': '1.0.0'}}",
+                "        print(json.dumps({'jsonrpc': '2.0', 'id': message_id, 'result': result}), flush=True)",
+                "        continue",
+                "    if method == 'tools/list':",
+                "        tools = [",
+                "            {'name': 'dangerous_delete', 'description': 'Dangerous delete', "
+                "             'inputSchema': {'type': 'object', 'properties': {'target': {'type': 'string'}}}},",
+                "            {'name': 'run_terminal_command', 'description': 'Run a terminal command.', "
+                "             'inputSchema': {'type': 'object', 'properties': {'command': {'type': 'string'}}}},",
+                "            {'name': 'safe_echo', 'description': 'Safe echo', "
+                "             'inputSchema': {'type': 'object', 'properties': {}}},",
+                "        ]",
+                "        response = {'jsonrpc': '2.0', 'id': message_id, 'result': {'tools': tools}}",
+                "        print(json.dumps(response), flush=True)",
+                "        continue",
+                "    if method == 'tools/call':",
+                "        marker_path.write_text(json.dumps(message.get('params', {})), encoding='utf-8')",
+                "        result = {'content': [{'type': 'text', 'text': 'forwarded'}]}",
+                "        print(json.dumps({'jsonrpc': '2.0', 'id': message_id, 'result': result}), flush=True)",
+                "        continue",
+                "    print(json.dumps({'jsonrpc': '2.0', 'id': message_id, 'result': {}}), flush=True)",
+            )
+        ),
+    ]
+
+
+def _idle_catalog_invalidation_child_command(
+    marker_path: Path,
+    session_counter_path: Path,
+) -> list[str]:
+    return [
+        sys.executable,
+        "-u",
+        "-c",
+        "\n".join(
+            (
+                "import json",
+                "import sys",
+                "from pathlib import Path",
+                f"marker_path = Path({str(marker_path)!r})",
+                f"counter_path = Path({str(session_counter_path)!r})",
+                "session = int(counter_path.read_text(encoding='utf-8')) + 1 if counter_path.exists() else 1",
+                "counter_path.write_text(str(session), encoding='utf-8')",
+                "for line in sys.stdin:",
+                "    message = json.loads(line)",
+                "    message_id = message.get('id')",
+                "    method = message.get('method')",
+                "    if method == 'initialize':",
+                "        result = {'protocolVersion': '2025-06-18', 'capabilities': {'tools': {}}, "
+                "                  'serverInfo': {'name': 'idle-invalidator', 'version': '1.0.0'}}",
+                "        print(json.dumps({'jsonrpc': '2.0', 'id': message_id, 'result': result}), flush=True)",
+                "        continue",
+                "    if method == 'tools/list':",
+                "        tools = [",
+                "            {'name': 'dangerous_delete', 'description': 'Dangerous delete', "
+                "             'inputSchema': {'type': 'object', 'properties': {'target': {'type': 'string'}}}},",
+                "        ]",
+                "        response = {'jsonrpc': '2.0', 'id': message_id, 'result': {'tools': tools}}",
+                "        print(json.dumps(response), flush=True)",
+                "        if session == 2:",
+                "            print(json.dumps({'jsonrpc': '2.0', "
+                "                              'method': 'notifications/tools/list_changed', 'params': {}}), "
+                "                  flush=True)",
+                "        continue",
+                "    if method == 'tools/call':",
+                "        marker_path.write_text(json.dumps(message.get('params', {})), encoding='utf-8')",
+                "        print(json.dumps({'jsonrpc': '2.0', 'id': message_id, "
+                "                          'result': {'content': [{'type': 'text', 'text': 'forwarded'}]}}), "
+                "              flush=True)",
+                "        continue",
+                "    print(json.dumps({'jsonrpc': '2.0', 'id': message_id, 'result': {}}), flush=True)",
+            )
+        ),
+    ]
+
+
+def _cross_session_buffer_child_command(session_counter_path: Path) -> list[str]:
+    return [
+        sys.executable,
+        "-u",
+        "-c",
+        "\n".join(
+            (
+                "import json",
+                "import sys",
+                "from pathlib import Path",
+                f"counter_path = Path({str(session_counter_path)!r})",
+                "session = int(counter_path.read_text(encoding='utf-8')) + 1 if counter_path.exists() else 1",
+                "counter_path.write_text(str(session), encoding='utf-8')",
+                "for line in sys.stdin:",
+                "    message = json.loads(line)",
+                "    message_id = message.get('id')",
+                "    method = message.get('method')",
+                "    if method == 'initialize':",
+                "        if session == 1:",
+                "            stale = {'tools': [{'name': 'stale_session_tool', 'description': 'stale', "
+                "                                  'inputSchema': {'type': 'object', 'properties': {}}}]} ",
+                "            print(json.dumps({'jsonrpc': '2.0', 'id': 2, 'result': stale}), flush=True)",
+                "        result = {'protocolVersion': '2025-06-18', 'capabilities': {'tools': {}}, "
+                "                  'serverInfo': {'name': 'buffer-reset', 'version': '1.0.0'}}",
+                "        print(json.dumps({'jsonrpc': '2.0', 'id': message_id, 'result': result}), flush=True)",
+                "        continue",
+                "    if method == 'tools/list':",
+                "        current = {'tools': [{'name': 'current_session_tool', 'description': 'current', "
+                "                                'inputSchema': {'type': 'object', 'properties': {}}}]} ",
+                "        print(json.dumps({'jsonrpc': '2.0', 'id': message_id, 'result': current}), flush=True)",
+                "        continue",
+                "    print(json.dumps({'jsonrpc': '2.0', 'id': message_id, 'result': {}}), flush=True)",
+            )
+        ),
+    ]
+
+
+def _child_tool_catalog_fingerprint() -> str:
+    return runtime_mcp_module._tool_catalog_fingerprint(
+        {
+            "dangerous_delete": {
+                "description": "Dangerous delete",
+                "input_schema": {"type": "object", "properties": {"target": {"type": "string"}}},
+            },
+            "run_terminal_command": {
+                "description": "Run a terminal command.",
+                "input_schema": {"type": "object", "properties": {"command": {"type": "string"}}},
+            },
+            "safe_echo": {
+                "description": "Safe echo",
+                "input_schema": {"type": "object", "properties": {}},
+            },
+        }
+    )
+
+
+def _messages(*, tool_name: str, arguments: dict[str, object], elicitation: bool) -> list[dict[str, Any]]:
+    capabilities = {"elicitation": {}} if elicitation else {}
+    return [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"capabilities": capabilities}},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        },
+    ]
+
+
+def _assert_terminal_block(
+    *,
+    result: dict[str, Any],
+    store: GuardStore,
+    marker_path: Path,
+    artifact_id: str,
+    event_decision: str,
+) -> None:
+    assert marker_path.exists() is False
+    response = result["responses"][2]
+    assert response["error"]["code"] == -32001
+    assert response["error"]["data"]["guardPolicyAction"] == "block"
+    assert response["error"]["data"]["approvalRequests"] == []
+    assert result["events"][2]["decision"] == event_decision
+    assert result["events"][2]["policy_action"] == "block"
+    assert result["events"][2]["approval_requests"] == []
+    assert store.list_approval_requests(limit=10) == []
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["artifact_id"] == artifact_id
+    assert receipt["policy_decision"] == "block"
+    event = store.list_events(limit=1, event_name="runtime_tool_call_blocked")[0]
+    event_payload = event["payload"]
+    assert isinstance(event_payload, dict)
+    assert event_payload["artifact_id"] == artifact_id
+    assert event_payload["decision_source"] == "policy-block"
+
+
+def _forbidden_daemon(_guard_home: Path) -> str:
+    raise AssertionError("a terminal saved block must not start or queue through the approval center")
+
+
+def _forbidden_inline(_request: dict[str, object]) -> dict[str, object]:
+    raise AssertionError("a terminal saved block must not invoke inline approval")
+
+
+def _seed_exact_tool_block(
+    *,
+    proxy: CodexMcpGuardProxy,
+    store: GuardStore,
+    config: GuardConfig,
+    arguments: dict[str, object],
+) -> str:
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace-tools",
+        tool_name="dangerous_delete",
+        source_scope="project",
+        config_path=proxy.config_path,
+        transport="stdio",
+        server_fingerprint={
+            "command": proxy.command,
+            "transport": "stdio",
+            "resolved_executable": runtime_mcp_module._resolved_executable_identity(
+                proxy.command[0],
+                launch_cwd=proxy.context.workspace_dir,
+                launch_args=proxy.command[1:],
+            ),
+            "tool_catalog_fingerprint": _child_tool_catalog_fingerprint(),
+        },
+        server_identity=proxy.server_identity,
+        tool_schema={"type": "object", "properties": {"target": {"type": "string"}}},
+        tool_description="Dangerous delete",
+    )
+    digest = build_tool_call_hash(
+        artifact,
+        arguments,
+        workspace=proxy.context.workspace_dir,
+        config=config,
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="block",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=digest,
+            reason="operator blocked exact call",
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+    return artifact.artifact_id
+
+
+def _package_artifact(*, context: HarnessContext, harness: str, config_path: str) -> GuardArtifact:
+    intent = extract_package_intent_request(
+        "run_terminal_command",
+        {"command": "npm install minimist@1.2.8"},
+        action_envelope_command="npm install minimist@1.2.8",
+        workspace=context.workspace_dir,
+    )
+    assert intent is not None
+    return build_package_request_artifact(
+        harness=harness,
+        intent=intent,
+        config_path=config_path,
+        source_scope="project",
+    )
+
+
+def _seed_exact_package_block(
+    *,
+    context: HarnessContext,
+    store: GuardStore,
+    config: GuardConfig,
+    artifact: GuardArtifact,
+) -> str:
+    assert context.workspace_dir is not None
+    evaluation = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=store,
+        workspace_dir=context.workspace_dir,
+    )
+    execution_context = build_package_execution_context(
+        workspace_dir=context.workspace_dir,
+        artifact=artifact,
+    )
+    digest = package_request_policy_hash(
+        artifact=artifact,
+        store=store,
+        workspace_dir=context.workspace_dir,
+        evaluation=evaluation,
+        execution_context=execution_context,
+        config=config,
+    )
+    policy_workspace = package_request_runtime_workspace_scope(
+        artifact_id=artifact.artifact_id,
+        artifact_hash=digest,
+        artifact_type=artifact.artifact_type,
+        execution_context=execution_context,
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness=artifact.harness,
+            scope="artifact",
+            action="block",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=digest,
+            workspace=policy_workspace,
+            publisher=artifact.publisher,
+            reason="operator blocked exact package request",
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+    return artifact.artifact_id
+
+
+def test_nonpackage_authenticated_saved_block_is_terminal_before_inline_observe_and_queue(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir, mode="observe")
+    marker_path = tmp_path / "nonpackage-forwarded.json"
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace-tools",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+    )
+    arguments: dict[str, object] = {"target": ".env"}
+    artifact_id = _seed_exact_tool_block(
+        proxy=proxy,
+        store=store,
+        config=config,
+        arguments=arguments,
+    )
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", _forbidden_daemon)
+
+    result = proxy.run_session(
+        _messages(tool_name="dangerous_delete", arguments=arguments, elicitation=True),
+        inline_approval_callback=_forbidden_inline,
+    )
+
+    _assert_terminal_block(
+        result=result,
+        store=store,
+        marker_path=marker_path,
+        artifact_id=artifact_id,
+        event_decision="block-stored-policy",
+    )
+
+
+@pytest.mark.parametrize("approval_surface", ["inline", "native"])
+def test_package_preliminary_saved_tool_block_is_terminal_before_package_or_approval_surfaces(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    approval_surface: str,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir, mode="observe")
+    marker_path = tmp_path / f"package-preliminary-{approval_surface}.json"
+    proxy_class = CodexMcpGuardProxy if approval_surface == "inline" else OpenCodeMcpGuardProxy
+    proxy = proxy_class(
+        server_name="workspace-tools",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / f".{approval_surface}" / "mcp.json"),
+    )
+    artifact_id = "codex:runtime:project:workspace-tools:run_terminal_command"
+    if approval_surface == "native":
+        artifact_id = "opencode:runtime:project:workspace-tools:run_terminal_command"
+        monkeypatch.setattr(
+            proxy,
+            "_allow_after_native_prompt",
+            lambda _decision: pytest.fail("a terminal saved block must not invoke native approval"),
+        )
+    monkeypatch.setattr(
+        runtime_mcp_module,
+        "evaluate_tool_call",
+        lambda **_kwargs: ToolCallDecision(
+            action="block",
+            source="policy",
+            signals=("command execution",),
+            summary="blocked by authenticated saved policy",
+            risk_categories=("command_execution",),
+            approval_reuse_status="rejected",
+            approval_reuse_reason_code="approval_reuse_saved_block",
+            current_action="review",
+            saved_action="block",
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_mcp_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: pytest.fail("the package phase must not run after a preliminary saved block"),
+    )
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", _forbidden_daemon)
+
+    result = proxy.run_session(
+        _messages(
+            tool_name="run_terminal_command",
+            arguments={"command": "npm install minimist@1.2.8"},
+            elicitation=approval_surface == "inline",
+        ),
+        inline_approval_callback=_forbidden_inline if approval_surface == "inline" else None,
+    )
+
+    _assert_terminal_block(
+        result=result,
+        store=store,
+        marker_path=marker_path,
+        artifact_id=artifact_id,
+        event_decision="block-stored-policy",
+    )
+
+
+@pytest.mark.parametrize("approval_surface", ["inline", "native"])
+def test_authenticated_saved_package_block_is_terminal_before_generic_approval_and_observe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    approval_surface: str,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir, mode="observe")
+    marker_path = tmp_path / f"package-final-{approval_surface}.json"
+    harness = "codex" if approval_surface == "inline" else "opencode"
+    config_path = str(context.workspace_dir / f".{harness}" / "mcp.json")
+    artifact = _package_artifact(context=context, harness=harness, config_path=config_path)
+    artifact_id = _seed_exact_package_block(
+        context=context,
+        store=store,
+        config=config,
+        artifact=artifact,
+    )
+    proxy_class = CodexMcpGuardProxy if approval_surface == "inline" else OpenCodeMcpGuardProxy
+    proxy = proxy_class(
+        server_name="workspace-tools",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=config_path,
+        current_config_provider=lambda: config,
+    )
+    monkeypatch.setattr(
+        runtime_mcp_module,
+        "evaluate_tool_call",
+        lambda **_kwargs: ToolCallDecision(
+            action="review",
+            source="risk-policy",
+            signals=("command execution",),
+            summary="generic tool review",
+            risk_categories=("command_execution",),
+        ),
+    )
+    if approval_surface == "native":
+        monkeypatch.setattr(
+            proxy,
+            "_allow_after_native_prompt",
+            lambda _decision: pytest.fail("a terminal package block must not invoke native approval"),
+        )
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", _forbidden_daemon)
+
+    result = proxy.run_session(
+        _messages(
+            tool_name="run_terminal_command",
+            arguments={"command": "npm install minimist@1.2.8"},
+            elicitation=approval_surface == "inline",
+        ),
+        inline_approval_callback=_forbidden_inline if approval_surface == "inline" else None,
+    )
+
+    _assert_terminal_block(
+        result=result,
+        store=store,
+        marker_path=marker_path,
+        artifact_id=artifact_id,
+        event_decision="package-block-stored",
+    )
+
+
+def test_package_retry_claims_inner_and_outer_exact_one_shot_allows_after_revision_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(
+        guard_home=context.guard_home,
+        workspace=context.workspace_dir,
+        security_level="custom",
+        risk_actions={
+            "mcp_dangerous_tool": "review",
+            "package_script": "review",
+        },
+    )
+    marker_path = tmp_path / "paired-one-shot-forwarded.json"
+    config_path = str(context.workspace_dir / ".codex" / "config.toml")
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace-tools",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=config_path,
+        current_config_provider=lambda: config,
+    )
+    arguments: dict[str, object] = {"command": "npm install minimist@1.2.8"}
+    package_artifact = _package_artifact(context=context, harness="codex", config_path=config_path)
+    package_evaluation = replace(
+        evaluate_package_request_artifact(
+            artifact=package_artifact,
+            store=store,
+            workspace_dir=context.workspace_dir,
+        ),
+        decision="allow",
+        policy_action="allow",
+    )
+    monkeypatch.setattr(
+        runtime_mcp_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: package_evaluation,
+    )
+    package_context = build_package_execution_context(
+        workspace_dir=context.workspace_dir,
+        artifact=package_artifact,
+    )
+    package_digest = package_request_policy_hash(
+        artifact=package_artifact,
+        store=store,
+        workspace_dir=context.workspace_dir,
+        evaluation=package_evaluation,
+        execution_context=package_context,
+        config=config,
+    )
+    package_workspace = package_request_runtime_workspace_scope(
+        artifact_id=package_artifact.artifact_id,
+        artifact_hash=package_digest,
+        artifact_type=package_artifact.artifact_type,
+        execution_context=package_context,
+    )
+    tool_artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace-tools",
+        tool_name="run_terminal_command",
+        source_scope="project",
+        config_path=config_path,
+        transport="stdio",
+        server_fingerprint={
+            "command": proxy.command,
+            "transport": "stdio",
+            "resolved_executable": runtime_mcp_module._resolved_executable_identity(
+                proxy.command[0],
+                launch_cwd=context.workspace_dir,
+                launch_args=proxy.command[1:],
+            ),
+            "tool_catalog_fingerprint": _child_tool_catalog_fingerprint(),
+        },
+        server_identity=proxy.server_identity,
+        tool_schema={"type": "object", "properties": {"command": {"type": "string"}}},
+        tool_description="Run a terminal command.",
+    )
+    tool_digest = build_tool_call_hash(
+        tool_artifact,
+        arguments,
+        workspace=context.workspace_dir,
+        config=config,
+    )
+    created_at = "2026-07-17T00:00:00+00:00"
+    expires_at = "2027-07-17T00:00:00+00:00"
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=tool_artifact.artifact_id,
+            artifact_hash=tool_digest,
+            workspace=str(context.workspace_dir),
+            publisher=tool_artifact.publisher,
+            reason="outer exact tool review",
+            source="approval-gate",
+            expires_at=expires_at,
+        ),
+        created_at,
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=package_artifact.artifact_id,
+            artifact_hash=package_digest,
+            workspace=package_workspace,
+            publisher=package_artifact.publisher,
+            reason="inner exact package review",
+            source="approval-gate",
+            expires_at=expires_at,
+        ),
+        created_at,
+    )
+    with store._connect() as connection:
+        one_shot_rows = connection.execute(
+            "select decision_id from policy_decisions where source = 'approval-gate'",
+        ).fetchall()
+    one_shot_ids = {int(row["decision_id"]) for row in one_shot_rows}
+    assert len(one_shot_ids) == 2
+    real_package_lookup = store.resolve_policy_decision_lookup
+    package_lookup_calls = 0
+    selected_package_decision: dict[str, object] | None = None
+
+    def resolve_package_decision_before_revocation(*args: Any, **kwargs: Any) -> Any:
+        nonlocal package_lookup_calls, selected_package_decision
+        package_lookup_calls += 1
+        if package_lookup_calls > 1:
+            # Model the selected row being revoked between evaluation and a
+            # second attempt to reconstruct the deferred claim.
+            return {
+                "decision": None,
+                "ignored_local_integrity": None,
+                "trust_status": {},
+                "authority_revision": -1,
+            }
+        lookup = real_package_lookup(*args, **kwargs)
+        decision = lookup["decision"]
+        assert isinstance(decision, dict)
+        selected_package_decision = decision
+        return lookup
+
+    with monkeypatch.context() as lookup_patch:
+        lookup_patch.setattr(store, "resolve_policy_decision_lookup", resolve_package_decision_before_revocation)
+        package_preflight = proxy._resolve_package_policy(artifact=package_artifact)
+    assert package_preflight.artifact_digest == package_digest
+    assert any(reason.get("code") == "saved_package_approval" for reason in package_preflight.evaluation.reasons)
+    assert package_lookup_calls == 1
+    assert package_preflight.pending_approval_reuse_decision is selected_package_decision
+
+    result = proxy.run_session(
+        _messages(
+            tool_name="run_terminal_command",
+            arguments=arguments,
+            elicitation=False,
+        )
+    )
+
+    assert marker_path.exists() is True
+    assert result["responses"][2]["result"]["content"][0]["text"] == "forwarded"
+    assert result["events"][2]["decision"] == "package-allow"
+    assert store.list_approval_requests(limit=10) == []
+    applied_events = store.list_events(limit=10, event_name="approval.policy_reuse_applied")
+    applied_ids = {
+        payload["decision_id"] for event in applied_events if isinstance((payload := event["payload"]), dict)
+    }
+    assert applied_ids == one_shot_ids
+    with store._connect() as connection:
+        remaining_rows = connection.execute(
+            "select decision_id from policy_decisions where source = 'approval-gate'",
+        ).fetchall()
+    assert remaining_rows == []
+
+
+@pytest.mark.parametrize(
+    (
+        "postclaim_digest",
+        "claim_disposition",
+        "postclaim_reselects_claimed_row",
+        "expected_forward",
+        "expected_context_matches",
+    ),
+    (
+        ("guard-approval-context:v1:changed-package", "consumed", False, False, False),
+        ("guard-approval-context:v1:preclaim-package", "retained", False, False, True),
+        ("guard-approval-context:v1:preclaim-package", "retained", True, True, True),
+    ),
+)
+def test_package_retry_validates_context_and_retained_authority_before_forward(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    postclaim_digest: str,
+    claim_disposition: Literal["consumed", "retained"],
+    postclaim_reselects_claimed_row: bool,
+    expected_forward: bool,
+    expected_context_matches: bool,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(
+        guard_home=context.guard_home,
+        workspace=context.workspace_dir,
+        security_level="custom",
+        risk_actions={"package_script": "review"},
+    )
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace-tools",
+        command=_child_command(tmp_path / "package-postclaim-must-not-forward.json"),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+        current_config_provider=lambda: config,
+    )
+    arguments: dict[str, object] = {"command": "npm install minimist@1.2.8"}
+    package_artifact = _package_artifact(
+        context=context,
+        harness="codex",
+        config_path=proxy.config_path,
+    )
+    base_evaluation = evaluate_package_request_artifact(
+        artifact=package_artifact,
+        store=store,
+        workspace_dir=context.workspace_dir,
+    )
+    allowed_evaluation = replace(
+        base_evaluation,
+        decision="allow",
+        policy_action="allow",
+    )
+    changed_evaluation = replace(
+        base_evaluation,
+        decision="review",
+        policy_action="review",
+    )
+    execution_context = build_package_execution_context(
+        workspace_dir=context.workspace_dir,
+        artifact=package_artifact,
+    )
+    pending_package_allow = {"action": "allow", "decision_id": 901}
+    preclaim_resolution = runtime_mcp_module._PackagePolicyResolution(
+        base_evaluation=base_evaluation,
+        evaluation=allowed_evaluation,
+        current_action="review",
+        workspace=context.workspace_dir,
+        execution_context=execution_context,
+        artifact_digest="guard-approval-context:v1:preclaim-package",
+        policy_workspace=str(context.workspace_dir),
+        saved_policy_blocks=False,
+        pending_approval_reuse_decision=pending_package_allow,
+        approval_reuse_claim_disposition=claim_disposition,
+    )
+    postclaim_resolution = runtime_mcp_module._PackagePolicyResolution(
+        base_evaluation=base_evaluation,
+        evaluation=changed_evaluation,
+        current_action="review",
+        workspace=context.workspace_dir,
+        execution_context=execution_context,
+        artifact_digest=postclaim_digest,
+        policy_workspace=str(context.workspace_dir),
+        saved_policy_blocks=False,
+        pending_approval_reuse_decision=(pending_package_allow if postclaim_reselects_claimed_row else None),
+        approval_reuse_claim_disposition=(claim_disposition if postclaim_reselects_claimed_row else None),
+    )
+    tool_artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace-tools",
+        tool_name="run_terminal_command",
+        source_scope="project",
+        config_path=proxy.config_path,
+        transport="stdio",
+    )
+    tool_decision = ToolCallDecision(
+        action="allow",
+        source="policy",
+        signals=(),
+        summary="current tool authority allows",
+        current_action="allow",
+    )
+    catalog_fingerprint = runtime_mcp_module._tool_catalog_fingerprint(
+        proxy._tool_catalog,
+        state=proxy._tool_catalog_state,
+    )
+    tool_authority = runtime_mcp_module._ToolCallAuthority(
+        artifact=tool_artifact,
+        artifact_hash="guard-approval-context:v1:tool",
+        decision=tool_decision,
+        catalog_generation=proxy._tool_catalog_generation,
+        catalog_state=proxy._tool_catalog_state,
+        catalog_fingerprint=catalog_fingerprint,
+    )
+    claim_completed = False
+
+    def resolve_package_policy(*, artifact: GuardArtifact) -> object:
+        assert artifact.artifact_id == package_artifact.artifact_id
+        return postclaim_resolution if claim_completed else preclaim_resolution
+
+    def claim_and_change_context(
+        decisions: tuple[dict[str, object], ...],
+        **_kwargs: object,
+    ) -> bool:
+        nonlocal claim_completed
+        assert decisions == (pending_package_allow,)
+        claim_completed = True
+        return True
+
+    queued: dict[str, object] = {}
+
+    def capture_package_queue(**kwargs: object) -> tuple[dict[str, Any], dict[str, Any]]:
+        queued.update(kwargs)
+        return (
+            {"jsonrpc": "2.0", "id": 3, "error": {"code": -32001}},
+            {"decision": "queue-package-approval"},
+        )
+
+    forwarded: dict[str, object] = {}
+
+    def capture_package_forward(**kwargs: object) -> tuple[dict[str, Any], dict[str, Any]]:
+        forwarded.update(kwargs)
+        return (
+            {"jsonrpc": "2.0", "id": 3, "result": {"content": [{"type": "text", "text": "forwarded"}]}},
+            {"decision": "forward-package"},
+        )
+
+    monkeypatch.setattr(runtime_mcp_module, "evaluate_tool_call", lambda **_kwargs: tool_decision)
+    monkeypatch.setattr(proxy, "_resolve_package_policy", resolve_package_policy)
+    monkeypatch.setattr(proxy, "_resolve_tool_call_authority", lambda **_kwargs: tool_authority)
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", claim_and_change_context)
+    monkeypatch.setattr(proxy, "_queue_package_approval_response", capture_package_queue)
+    monkeypatch.setattr(proxy, "_record_package_forward", capture_package_forward)
+
+    response, event = proxy._handle_package_request(
+        message={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "run_terminal_command", "arguments": arguments},
+        },
+        child_stdin=io.StringIO(),
+        child_stdout=io.StringIO(),
+        client_input=None,
+        server_output=None,
+        tool_name="run_terminal_command",
+        params={"name": "run_terminal_command", "arguments": arguments},
+        artifact=package_artifact,
+        tool_artifact=tool_artifact,
+        tool_artifact_hash=tool_authority.artifact_hash,
+        tool_decision=tool_decision,
+        tool_scanner_evidence=(),
+        package_resolution=preclaim_resolution,
+        expected_catalog_generation=proxy._tool_catalog_generation,
+        expected_catalog_state=proxy._tool_catalog_state,
+        expected_catalog_fingerprint=catalog_fingerprint,
+    )
+
+    assert claim_completed is True
+    if expected_forward:
+        assert response["result"]["content"][0]["text"] == "forwarded"
+        assert event["decision"] == "forward-package"
+        assert queued == {}
+        assert forwarded["policy_action"] == "allow"
+        return
+    assert response["error"]["code"] == -32001
+    assert event["decision"] == "queue-package-approval"
+    assert queued["artifact_hash"] == postclaim_resolution.artifact_digest
+    assert queued["policy_action"] == "require-reapproval"
+    scanner_evidence = queued["scanner_evidence"]
+    assert isinstance(scanner_evidence, tuple)
+    assert scanner_evidence[-1]["source"] == "approval_reuse"
+    assert scanner_evidence[-1]["status"] == "rejected"
+    assert scanner_evidence[-1]["reason_code"] == "approval_reuse_context_changed_after_claim"
+    assert scanner_evidence[-1]["context_matches"] is expected_context_matches
+    assert scanner_evidence[-1]["current_action"] == "review"
+    if claim_disposition == "retained":
+        assert scanner_evidence[-1]["claimed_authority_matches"] is False
+        assert scanner_evidence[-1]["effective_action"] == "require-reapproval"
+    else:
+        assert scanner_evidence[-1]["effective_action"] == "review"
+
+
+def test_mcp_executable_identity_uses_launch_cwd_and_stays_pinned_after_spawn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    process_cwd = tmp_path / "guard-process-cwd"
+    process_cwd.mkdir()
+    workspace_server = context.workspace_dir / "fixture-server"
+    decoy_server = process_cwd / "fixture-server"
+    replacement_source = f"#!{sys.executable}\nraise SystemExit(92)\n"
+    server_source = "\n".join(
+        (
+            f"#!{sys.executable}",
+            "import json",
+            "import sys",
+            "from pathlib import Path",
+            f"replacement_source = {replacement_source!r}",
+            "for line in sys.stdin:",
+            "    message = json.loads(line)",
+            "    method = message.get('method')",
+            "    if method == 'initialize':",
+            "        result = {'protocolVersion': '2025-06-18', 'capabilities': {'tools': {}}, "
+            "                  'serverInfo': {'name': 'relative', 'version': '1.0.0'}}",
+            "        Path(__file__).write_text(replacement_source, encoding='utf-8')",
+            "    elif method == 'tools/list':",
+            "        result = {'tools': [{'name': 'safe_echo', 'description': 'Safe echo', "
+            "                             'inputSchema': {'type': 'object', 'properties': {}}}]} ",
+            "    else:",
+            "        result = {'content': [{'type': 'text', 'text': 'workspace-server'}]}",
+            "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': result}), flush=True)",
+        )
+    )
+    workspace_server.write_text(server_source, encoding="utf-8")
+    workspace_server.chmod(0o755)
+    launched_digest = hashlib.sha256(workspace_server.read_bytes()).hexdigest()
+    decoy_server.write_text(f"#!{sys.executable}\nraise SystemExit(91)\n", encoding="utf-8")
+    decoy_server.chmod(0o755)
+    monkeypatch.chdir(process_cwd)
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
+    captured: dict[str, object] = {}
+
+    def _capture_tool_call(**kwargs: object) -> ToolCallDecision:
+        captured["artifact"] = kwargs["artifact"]
+        return ToolCallDecision(action="allow", source="heuristic", signals=(), summary="safe")
+
+    monkeypatch.setattr(runtime_mcp_module, "evaluate_tool_call", _capture_tool_call)
+    proxy = CodexMcpGuardProxy(
+        server_name="relative-server",
+        command=["./fixture-server"],
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+        current_config_provider=lambda: proxy.config,
+    )
+
+    result = proxy.run_session(_messages(tool_name="safe_echo", arguments={}, elicitation=False))
+
+    assert result["responses"][2]["result"]["content"][0]["text"] == "workspace-server"
+    captured_artifact = captured["artifact"]
+    assert isinstance(captured_artifact, GuardArtifact)
+    server_fingerprint = captured_artifact.metadata["server_fingerprint"]
+    assert isinstance(server_fingerprint, dict)
+    executable = server_fingerprint["resolved_executable"]
+    assert isinstance(executable, dict)
+    assert executable["path"] == str(workspace_server.resolve())
+    assert executable["launch_cwd"] == str(context.workspace_dir.resolve())
+    assert workspace_server.read_text(encoding="utf-8") == replacement_source
+    assert executable["sha256"] == launched_digest
+    assert executable["sha256"] != hashlib.sha256(workspace_server.read_bytes()).hexdigest()
+    assert executable["sha256"] != hashlib.sha256(decoy_server.read_bytes()).hexdigest()
+
+
+def test_interpreted_mcp_server_binds_script_bytes_and_pins_them_for_the_running_child(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    process_cwd = tmp_path / "guard-process-cwd"
+    process_cwd.mkdir()
+    server_script = context.workspace_dir / "server.py"
+    replacement_source = "raise SystemExit(93)\n"
+    server_source = "\n".join(
+        (
+            "import json",
+            "import sys",
+            "from pathlib import Path",
+            f"replacement_source = {replacement_source!r}",
+            "for line in sys.stdin:",
+            "    message = json.loads(line)",
+            "    method = message.get('method')",
+            "    if method == 'initialize':",
+            "        result = {'protocolVersion': '2025-06-18', 'capabilities': {'tools': {}}, "
+            "                  'serverInfo': {'name': 'interpreted', 'version': '1.0.0'}}",
+            "        Path(__file__).write_text(replacement_source, encoding='utf-8')",
+            "    elif method == 'tools/list':",
+            "        result = {'tools': [{'name': 'safe_echo', 'description': 'Safe echo', "
+            "                             'inputSchema': {'type': 'object', 'properties': {}}}]} ",
+            "    else:",
+            "        result = {'content': [{'type': 'text', 'text': 'interpreted-server'}]}",
+            "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': result}), flush=True)",
+        )
+    )
+    server_script.write_text(server_source, encoding="utf-8")
+    original_digest = hashlib.sha256(server_script.read_bytes()).hexdigest()
+    launch_args = ("-u", "server.py")
+    first_identity = runtime_mcp_module._resolved_executable_identity(
+        sys.executable,
+        launch_cwd=context.workspace_dir,
+        launch_args=launch_args,
+    )
+    unchanged_identity = runtime_mcp_module._resolved_executable_identity(
+        sys.executable,
+        launch_cwd=context.workspace_dir,
+        launch_args=launch_args,
+    )
+    assert first_identity == unchanged_identity
+    first_entrypoint = first_identity["entrypoint"]
+    assert isinstance(first_entrypoint, dict)
+    assert first_entrypoint["sha256"] == original_digest
+    server_script.write_text("raise SystemExit(94)\n", encoding="utf-8")
+    replaced_identity = runtime_mcp_module._resolved_executable_identity(
+        sys.executable,
+        launch_cwd=context.workspace_dir,
+        launch_args=launch_args,
+    )
+    replaced_entrypoint = replaced_identity["entrypoint"]
+    assert isinstance(replaced_entrypoint, dict)
+    assert replaced_entrypoint["sha256"] != first_entrypoint["sha256"]
+    server_script.write_text(server_source, encoding="utf-8")
+    monkeypatch.chdir(process_cwd)
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
+    captured: dict[str, object] = {}
+
+    def _capture_tool_call(**kwargs: object) -> ToolCallDecision:
+        captured["artifact"] = kwargs["artifact"]
+        return ToolCallDecision(action="allow", source="heuristic", signals=(), summary="safe")
+
+    monkeypatch.setattr(runtime_mcp_module, "evaluate_tool_call", _capture_tool_call)
+    proxy = CodexMcpGuardProxy(
+        server_name="interpreted-server",
+        command=[sys.executable, *launch_args],
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+        current_config_provider=lambda: config,
+    )
+
+    result = proxy.run_session(_messages(tool_name="safe_echo", arguments={}, elicitation=False))
+
+    assert result["responses"][2]["result"]["content"][0]["text"] == "interpreted-server"
+    captured_artifact = captured["artifact"]
+    assert isinstance(captured_artifact, GuardArtifact)
+    server_fingerprint = captured_artifact.metadata["server_fingerprint"]
+    assert isinstance(server_fingerprint, dict)
+    launch_identity = server_fingerprint["resolved_executable"]
+    assert isinstance(launch_identity, dict)
+    entrypoint = launch_identity["entrypoint"]
+    assert isinstance(entrypoint, dict)
+    assert entrypoint["kind"] == "python-script"
+    assert entrypoint["path"] == str(server_script.resolve())
+    assert entrypoint["sha256"] == original_digest
+    assert server_script.read_text(encoding="utf-8") == replacement_source
+    assert entrypoint["sha256"] != hashlib.sha256(server_script.read_bytes()).hexdigest()
+
+
+def test_python_module_entrypoint_is_content_bound_and_unresolved_package_launcher_disables_reuse(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    package_dir = workspace / "guard_server"
+    package_dir.mkdir(parents=True)
+    module_main = package_dir / "__main__.py"
+    module_main.write_text("print('version-one')\n", encoding="utf-8")
+    first_module_identity = runtime_mcp_module._resolved_executable_identity(
+        sys.executable,
+        launch_cwd=workspace,
+        launch_args=("-m", "guard_server"),
+    )
+    first_entrypoint = first_module_identity["entrypoint"]
+    assert isinstance(first_entrypoint, dict)
+    assert first_entrypoint["kind"] == "python-package-main"
+    assert first_entrypoint["path"] == str(module_main.resolve())
+    module_main.write_text("print('version-two')\n", encoding="utf-8")
+    changed_module_identity = runtime_mcp_module._resolved_executable_identity(
+        sys.executable,
+        launch_cwd=workspace,
+        launch_args=("-m", "guard_server"),
+    )
+    changed_entrypoint = changed_module_identity["entrypoint"]
+    assert isinstance(changed_entrypoint, dict)
+    assert changed_entrypoint["sha256"] != first_entrypoint["sha256"]
+
+    first_launcher_identity = runtime_mcp_module._resolved_executable_identity(
+        "npx",
+        launch_cwd=workspace,
+        launch_args=("-y", "@modelcontextprotocol/server-filesystem"),
+    )
+    second_launcher_identity = runtime_mcp_module._resolved_executable_identity(
+        "npx",
+        launch_cwd=workspace,
+        launch_args=("-y", "@modelcontextprotocol/server-filesystem"),
+    )
+    first_launcher_entrypoint = first_launcher_identity["entrypoint"]
+    second_launcher_entrypoint = second_launcher_identity["entrypoint"]
+    assert isinstance(first_launcher_entrypoint, dict)
+    assert isinstance(second_launcher_entrypoint, dict)
+    assert first_launcher_entrypoint["status"] == "unproven"
+    assert first_launcher_entrypoint["reason"] == "launcher_entrypoint_unresolved"
+    assert first_launcher_entrypoint["reuse_nonce"] != second_launcher_entrypoint["reuse_nonce"]
+
+
+def test_runtime_mcp_binds_only_configured_server_env_values_without_leaking_them(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(
+        guard_home=context.guard_home,
+        workspace=context.workspace_dir,
+        security_level="custom",
+        risk_actions={"mcp_dangerous_tool": "review"},
+    )
+    marker_path = tmp_path / "env-tool-call.json"
+
+    def capture_artifact(*, configured_value: str, ambient_value: str) -> GuardArtifact:
+        monkeypatch.setenv("MCP_CONFIGURED_TOKEN", configured_value)
+        monkeypatch.setenv("UNRELATED_AMBIENT_VALUE", ambient_value)
+        captured: dict[str, object] = {}
+
+        def capture_tool_call(**kwargs: object) -> ToolCallDecision:
+            captured["artifact"] = kwargs["artifact"]
+            return ToolCallDecision(action="allow", source="heuristic", signals=(), summary="captured")
+
+        monkeypatch.setattr(runtime_mcp_module, "evaluate_tool_call", capture_tool_call)
+        proxy = CodexMcpGuardProxy(
+            server_name="configured-env-server",
+            command=_child_command(marker_path),
+            context=context,
+            store=store,
+            config=config,
+            source_scope="project",
+            config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+            server_env_keys=("MCP_CONFIGURED_TOKEN",),
+        )
+        proxy.run_session(
+            _messages(
+                tool_name="dangerous_delete",
+                arguments={"target": "marker.json"},
+                elicitation=False,
+            )
+        )
+        artifact = captured["artifact"]
+        assert isinstance(artifact, GuardArtifact)
+        return artifact
+
+    secret_v1 = "runtime-mcp-secret-one"
+    secret_v2 = "runtime-mcp-secret-two"
+    first_artifact = capture_artifact(configured_value=secret_v1, ambient_value="ambient-one")
+    ambient_changed_artifact = capture_artifact(configured_value=secret_v1, ambient_value="ambient-two")
+    configured_changed_artifact = capture_artifact(configured_value=secret_v2, ambient_value="ambient-two")
+    arguments = {"target": "marker.json"}
+    first_hash = build_tool_call_hash(
+        first_artifact,
+        arguments,
+        workspace=context.workspace_dir,
+        config=config,
+    )
+    ambient_changed_hash = build_tool_call_hash(
+        ambient_changed_artifact,
+        arguments,
+        workspace=context.workspace_dir,
+        config=config,
+    )
+    configured_changed_hash = build_tool_call_hash(
+        configured_changed_artifact,
+        arguments,
+        workspace=context.workspace_dir,
+        config=config,
+    )
+
+    assert ambient_changed_hash == first_hash
+    assert configured_changed_hash != first_hash
+    serialized = json.dumps(configured_changed_artifact.metadata, sort_keys=True)
+    assert secret_v1 not in serialized
+    assert secret_v2 not in serialized
+    assert "UNRELATED_AMBIENT_VALUE" not in serialized
+    server_fingerprint = configured_changed_artifact.metadata["server_fingerprint"]
+    assert isinstance(server_fingerprint, dict)
+    assert len(str(server_fingerprint["configured_env_values_hash"])) == 64
+
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=first_artifact.artifact_id,
+            artifact_hash=first_hash,
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00+00:00",
+    )
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=configured_changed_artifact,
+        artifact_hash=configured_changed_hash,
+        arguments=arguments,
+    )
+
+    assert decision.action == "review"
+    assert decision.approval_reuse_reason_code == "approval_reuse_capability_changed"
+
+
+def test_runtime_mcp_start_passes_configured_code_loading_env_to_launch_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    node_command = shutil.which("node")
+    if node_command is None:
+        pytest.skip("node is required for the configured NODE_OPTIONS launch regression")
+    (context.workspace_dir / "configured-preload.js").write_text("// configured preload\n", encoding="utf-8")
+    (context.workspace_dir / "server.js").write_text("setInterval(() => {}, 1000);\n", encoding="utf-8")
+    configured_value = "--require ./configured-preload.js"
+    monkeypatch.setenv("NODE_OPTIONS", configured_value)
+    proxy = CodexMcpGuardProxy(
+        server_name="configured-code-loading-server",
+        command=[node_command, "server.js"],
+        context=context,
+        store=GuardStore(context.guard_home),
+        config=GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir),
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+        server_env_keys=("NODE_OPTIONS",),
+    )
+
+    process = proxy._start_process()
+    try:
+        launch_identity = proxy._active_executable_identity
+        assert isinstance(launch_identity, dict)
+        entrypoint = launch_identity["entrypoint"]
+        assert isinstance(entrypoint, dict)
+        assert entrypoint["status"] == "unproven"
+        assert entrypoint["reason"] == "environment_options_unresolved"
+        assert proxy._active_server_identity is not None
+        assert proxy._active_server_env_values_hash == proxy._active_server_identity.env_values_hash
+        serialized_identity = json.dumps(
+            {
+                "launch": launch_identity,
+                "server_env_values_hash": proxy._active_server_env_values_hash,
+            },
+            sort_keys=True,
+        )
+        assert configured_value not in serialized_identity
+    finally:
+        process.terminate()
+        process.wait(timeout=5)
+
+
+def test_policy_review_never_auto_forwards_and_all_surfaces_use_reapproval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    marker_path = tmp_path / "review-must-not-forward.json"
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace-tools",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir),
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+    )
+    monkeypatch.setattr(
+        runtime_mcp_module,
+        "evaluate_tool_call",
+        lambda **_kwargs: ToolCallDecision(
+            action="review",
+            source="policy",
+            signals=("current policy requires review",),
+            summary="review required",
+        ),
+    )
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    monkeypatch.setattr(proxy, "_maybe_open_approval_center", lambda **_kwargs: None)
+
+    result = proxy.run_session(_messages(tool_name="safe_echo", arguments={"value": "hello"}, elicitation=False))
+
+    assert marker_path.exists() is False
+    response = result["responses"][2]
+    assert response["error"]["data"]["guardPolicyAction"] == "require-reapproval"
+    event = result["events"][2]
+    assert event["policy_action"] == "require-reapproval"
+    request = store.list_approval_requests(limit=10)[0]
+    assert request["policy_action"] == "require-reapproval"
+    receipts = store.list_receipts(limit=10)
+    assert len(receipts) == 1
+    assert receipts[0]["policy_decision"] == "require-reapproval"
+
+
+@pytest.mark.parametrize("terminal_action", ["block", "sandbox-required"])
+def test_terminal_current_tool_action_is_not_downgraded_to_retryable_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    terminal_action: str,
+) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    marker_path = tmp_path / f"terminal-{terminal_action}.json"
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace-tools",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir),
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+    )
+    monkeypatch.setattr(
+        runtime_mcp_module,
+        "evaluate_tool_call",
+        lambda **_kwargs: ToolCallDecision(
+            action=terminal_action,  # type: ignore[arg-type]
+            source="policy",
+            signals=("terminal current policy",),
+            summary="terminal action",
+        ),
+    )
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", _forbidden_daemon)
+
+    result = proxy.run_session(_messages(tool_name="safe_echo", arguments={"value": "hello"}, elicitation=False))
+
+    assert marker_path.exists() is False
+    response = result["responses"][2]
+    assert response["error"]["data"] == {
+        "approvalRequests": [],
+        "guardPolicyAction": terminal_action,
+    }
+    event = result["events"][2]
+    assert event["policy_action"] == terminal_action
+    assert event["approval_requests"] == []
+    assert store.list_approval_requests(limit=10) == []
+    receipts = store.list_receipts(limit=10)
+    assert len(receipts) == 1
+    assert receipts[0]["policy_decision"] == terminal_action
+
+
+def test_runtime_mcp_redacts_secret_argument_fields_from_every_persisted_surface(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    marker_path = tmp_path / "secret-arguments-must-not-forward.json"
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace-tools",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir),
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+    )
+    monkeypatch.setattr(
+        runtime_mcp_module,
+        "evaluate_tool_call",
+        lambda **_kwargs: ToolCallDecision(
+            action="review",
+            source="policy",
+            signals=("review secret-shaped request",),
+            summary="review required",
+        ),
+    )
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    monkeypatch.setattr(proxy, "_maybe_open_approval_center", lambda **_kwargs: None)
+    secrets = {
+        "password": "password-value-unique",
+        "credential": "credential-value-unique",
+        "cookie": "cookie-value-unique",
+        "apiKey": "api-key-value-unique",
+        "token": "token-value-unique",
+    }
+    arguments: dict[str, object] = {
+        "endpoint": "https://example.invalid/run?apiKey=query-api-key-unique&mode=safe",
+        "nested": secrets,
+        "visible": "keep-this-label",
+    }
+
+    result = proxy.run_session(_messages(tool_name="safe_echo", arguments=arguments, elicitation=False))
+
+    persisted = {
+        "result": result,
+        "approval_requests": store.list_approval_requests(limit=10),
+        "receipts": store.list_receipts(limit=10),
+        "events": store.list_events(limit=20),
+    }
+    serialized = json.dumps(persisted, sort_keys=True, default=str)
+    for secret in (*secrets.values(), "query-api-key-unique"):
+        assert secret not in serialized
+    assert "keep-this-label" in serialized
+    assert "arguments-sha256:" in serialized
+    assert len(store.list_receipts(limit=10)) == 1
+
+
+def test_observe_mode_does_not_consume_exact_saved_tool_approval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(
+        guard_home=context.guard_home,
+        workspace=context.workspace_dir,
+        mode="observe",
+        security_level="custom",
+        risk_actions={"mcp_dangerous_tool": "review"},
+    )
+    marker_path = tmp_path / "observe-forwarded.json"
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace-tools",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+    )
+    arguments: dict[str, object] = {"target": ".env"}
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace-tools",
+        tool_name="dangerous_delete",
+        source_scope="project",
+        config_path=proxy.config_path,
+        transport="stdio",
+        server_fingerprint={
+            "command": proxy.command,
+            "configured_env_values_hash": proxy._session_server_env_values_hash(),
+            "transport": "stdio",
+            "resolved_executable": runtime_mcp_module._resolved_executable_identity(
+                proxy.command[0],
+                launch_cwd=context.workspace_dir,
+                launch_args=proxy.command[1:],
+            ),
+            "tool_catalog_fingerprint": _child_tool_catalog_fingerprint(),
+        },
+        server_identity=proxy.server_identity,
+        tool_schema={"type": "object", "properties": {"target": {"type": "string"}}},
+        tool_description="Dangerous delete",
+    )
+    artifact_hash = build_tool_call_hash(artifact, arguments, workspace=context.workspace_dir, config=config)
+    approval_id = store.record_local_once_approval(
+        request_id="observe-unused-approval",
+        harness="codex",
+        artifact_id=artifact.artifact_id,
+        artifact_hash=artifact_hash,
+        workspace=str(context.workspace_dir),
+        publisher=artifact.publisher,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2027-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    monkeypatch.setattr(proxy, "_maybe_open_approval_center", lambda **_kwargs: None)
+
+    result = proxy.run_session(_messages(tool_name="dangerous_delete", arguments=arguments, elicitation=False))
+
+    assert marker_path.exists()
+    assert result["events"][2]["decision"] == "observe-tool-call"
+    with sqlite3.connect(store.path) as connection:
+        claimed_at = connection.execute(
+            "select claimed_at from guard_local_once_approvals where approval_id = ?",
+            (approval_id,),
+        ).fetchone()[0]
+    assert claimed_at is None
+    assert store.list_events(event_name="approval.local_once_applied") == []
+
+
+def test_observe_mode_reprobes_terminal_tool_policy_immediately_before_forward(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(
+        guard_home=context.guard_home,
+        workspace=context.workspace_dir,
+        mode="observe",
+    )
+    marker_path = tmp_path / "observe-terminal-reprobe-must-not-forward.json"
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace-tools",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+    )
+    decisions = iter(
+        (
+            ToolCallDecision(
+                action="review",
+                source="policy",
+                signals=("initial review",),
+                summary="initial review",
+            ),
+            ToolCallDecision(
+                action="block",
+                source="policy",
+                signals=("terminal policy changed before launch",),
+                summary="terminal block",
+            ),
+        )
+    )
+    monkeypatch.setattr(runtime_mcp_module, "evaluate_tool_call", lambda **_kwargs: next(decisions))
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", _forbidden_daemon)
+
+    result = proxy.run_session(_messages(tool_name="safe_echo", arguments={"value": "hello"}, elicitation=False))
+
+    assert marker_path.exists() is False
+    response = result["responses"][2]
+    assert response["error"]["data"] == {
+        "approvalRequests": [],
+        "guardPolicyAction": "block",
+    }
+    assert result["events"][2]["decision"] == "terminal-block"
+    assert result["events"][2]["policy_action"] == "block"
+    assert store.list_approval_requests(limit=10) == []
+    receipts = store.list_receipts(limit=10)
+    assert len(receipts) == 1
+    assert receipts[0]["policy_decision"] == "block"
+
+
+def test_runtime_mcp_rebuilds_tool_authority_after_exact_claim_before_forward(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    store = GuardStore(context.guard_home)
+    review_config = GuardConfig(
+        guard_home=context.guard_home,
+        workspace=context.workspace_dir,
+        security_level="custom",
+        risk_actions={"mcp_dangerous_tool": "review"},
+    )
+    current_config = [review_config]
+    marker_path = tmp_path / "postclaim-tool-must-not-forward.json"
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace-tools",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=review_config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+        current_config_provider=lambda: current_config[0],
+    )
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    monkeypatch.setattr(proxy, "_maybe_open_approval_center", lambda **_kwargs: None)
+    messages = _messages(
+        tool_name="dangerous_delete",
+        arguments={"target": ".env"},
+        elicitation=False,
+    )
+
+    first = proxy.run_session(messages)
+
+    assert first["responses"][2]["error"]["code"] == -32001
+    assert marker_path.exists() is False
+    request = store.list_approval_requests(limit=1)[0]
+    artifact_id = str(request["artifact_id"])
+    artifact_hash = str(request["artifact_hash"])
+    approval_id = store.record_local_once_approval(
+        request_id="runtime-mcp-postclaim-freshness",
+        harness="codex",
+        artifact_id=artifact_id,
+        artifact_hash=artifact_hash,
+        workspace=str(context.workspace_dir),
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+    block_config = replace(
+        review_config,
+        artifact_actions={artifact_id: "block"},
+    )
+    real_claim = store.claim_approval_reuse_decisions
+
+    def claim_then_tighten_policy(
+        decisions: tuple[dict[str, object], ...],
+        **kwargs: object,
+    ) -> bool:
+        claimed = real_claim(decisions, **kwargs)
+        if claimed:
+            current_config[0] = block_config
+        return claimed
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", claim_then_tighten_policy)
+
+    second = proxy.run_session(messages)
+
+    assert marker_path.exists() is False
+    response = second["responses"][2]
+    assert response["error"]["data"] == {
+        "approvalRequests": [],
+        "guardPolicyAction": "block",
+    }
+    event = second["events"][2]
+    assert event["decision"] == "terminal-block"
+    assert event["policy_action"] == "block"
+    assert event["scanner_evidence"][-1] == {
+        "source": "approval_reuse",
+        "status": "rejected",
+        "reason_code": "approval_reuse_context_changed_after_claim",
+        "context_matches": False,
+        "current_action": "block",
+        "effective_action": "block",
+    }
+    claim_events = store.list_events(event_name="approval.local_once_applied")
+    assert len(claim_events) == 1
+    assert claim_events[0]["payload"]["approval_id"] == approval_id
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "block"
+
+
+@pytest.mark.parametrize("delete_after_claim", (False, True))
+def test_runtime_mcp_retained_tool_policy_requires_same_row_after_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    delete_after_claim: bool,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(
+        guard_home=context.guard_home,
+        workspace=context.workspace_dir,
+        security_level="custom",
+        risk_actions={"mcp_dangerous_tool": "review"},
+    )
+    marker_path = tmp_path / "retained-tool-policy-must-not-forward.json"
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace-tools",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+        current_config_provider=lambda: config,
+    )
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    monkeypatch.setattr(proxy, "_maybe_open_approval_center", lambda **_kwargs: None)
+    messages = _messages(
+        tool_name="dangerous_delete",
+        arguments={"target": ".env"},
+        elicitation=False,
+    )
+    first = proxy.run_session(messages)
+    assert first["responses"][2]["error"]["code"] == -32001
+    request = store.list_approval_requests(limit=1)[0]
+    artifact_id = str(request["artifact_id"])
+    artifact_hash = str(request["artifact_hash"])
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact_id,
+            artifact_hash=artifact_hash,
+            workspace=str(context.workspace_dir),
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00+00:00",
+    )
+    original_claim = store.claim_approval_reuse_decisions
+
+    def claim_then_delete_retained_row(
+        decisions: tuple[dict[str, object], ...],
+        **kwargs: object,
+    ) -> bool:
+        assert len(decisions) == 1
+        assert store.approval_reuse_claim_disposition(decisions[0]) == "retained"
+        claimed = original_claim(decisions, **kwargs)
+        if claimed and delete_after_claim:
+            decision_id = decisions[0].get("decision_id")
+            assert isinstance(decision_id, int) and not isinstance(decision_id, bool)
+            with store._connect() as connection:
+                connection.execute("delete from policy_decisions where decision_id = ?", (decision_id,))
+        return claimed
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", claim_then_delete_retained_row)
+
+    second = proxy.run_session(messages)
+
+    if not delete_after_claim:
+        assert marker_path.exists() is True
+        assert second["responses"][2]["result"]["content"][0]["text"] == "forwarded"
+        return
+    assert marker_path.exists() is False
+    response = second["responses"][2]
+    assert response["error"]["data"]["guardPolicyAction"] == "require-reapproval"
+    event = second["events"][2]
+    assert event["decision"] == "queue-approval"
+    assert event["scanner_evidence"][-1] == {
+        "source": "approval_reuse",
+        "status": "rejected",
+        "reason_code": "approval_reuse_context_changed_after_claim",
+        "context_matches": True,
+        "claimed_authority_matches": False,
+        "current_action": "review",
+        "effective_action": "require-reapproval",
+    }
+
+
+def _prepare_runtime_mcp_exact_review_retry(
+    *,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    marker_name: str,
+) -> tuple[
+    HarnessContext,
+    GuardStore,
+    CodexMcpGuardProxy,
+    Path,
+    list[dict[str, Any]],
+    str,
+    str,
+    str,
+]:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(
+        guard_home=context.guard_home,
+        workspace=context.workspace_dir,
+        security_level="custom",
+        risk_actions={"mcp_dangerous_tool": "review"},
+    )
+    marker_path = tmp_path / marker_name
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace-tools",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+        current_config_provider=lambda: config,
+    )
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    monkeypatch.setattr(proxy, "_maybe_open_approval_center", lambda **_kwargs: None)
+    messages = _messages(
+        tool_name="dangerous_delete",
+        arguments={"target": ".env"},
+        elicitation=False,
+    )
+    first = proxy.run_session(messages)
+    assert first["responses"][2]["error"]["code"] == -32001
+    assert marker_path.exists() is False
+    request = store.list_approval_requests(limit=1)[0]
+    artifact_id = str(request["artifact_id"])
+    artifact_hash = str(request["artifact_hash"])
+    approval_id = store.record_local_once_approval(
+        request_id=f"{marker_name}-approval",
+        harness="codex",
+        artifact_id=artifact_id,
+        artifact_hash=artifact_hash,
+        workspace=str(context.workspace_dir),
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+    return (
+        context,
+        store,
+        proxy,
+        marker_path,
+        messages,
+        artifact_id,
+        artifact_hash,
+        approval_id,
+    )
+
+
+def test_runtime_mcp_tool_catalog_fingerprint_is_canonical_and_complete() -> None:
+    first = {
+        "safe_echo": {
+            "description": "Safe echo",
+            "input_schema": {
+                "type": "object",
+                "properties": {"message": {"type": "string", "description": "Text"}},
+            },
+        },
+        "dangerous_delete": {
+            "description": "Dangerous delete",
+            "input_schema": {
+                "properties": {"target": {"type": "string"}},
+                "type": "object",
+            },
+        },
+    }
+    reordered = {
+        "dangerous_delete": {
+            "input_schema": {
+                "type": "object",
+                "properties": {"target": {"type": "string"}},
+            },
+            "description": "Dangerous delete",
+        },
+        "safe_echo": {
+            "input_schema": {
+                "properties": {"message": {"description": "Text", "type": "string"}},
+                "type": "object",
+            },
+            "description": "Safe echo",
+        },
+    }
+    changed_sibling_schema = {
+        **reordered,
+        "safe_echo": {
+            **reordered["safe_echo"],
+            "input_schema": {
+                "properties": {"message": {"description": "Text", "type": "number"}},
+                "type": "object",
+            },
+        },
+    }
+
+    baseline = runtime_mcp_module._tool_catalog_fingerprint(first)
+
+    assert baseline == runtime_mcp_module._tool_catalog_fingerprint(reordered)
+    assert baseline != runtime_mcp_module._tool_catalog_fingerprint(changed_sibling_schema)
+    assert baseline != runtime_mcp_module._tool_catalog_fingerprint(
+        {**reordered, "new_tool": {"description": "New", "input_schema": {"type": "object"}}}
+    )
+
+
+def test_runtime_mcp_saved_allow_is_not_reused_before_complete_catalog(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(
+        guard_home=context.guard_home,
+        workspace=context.workspace_dir,
+        security_level="custom",
+        risk_actions={"mcp_dangerous_tool": "review"},
+    )
+    marker_path = tmp_path / "unobserved-catalog-must-not-forward.json"
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace-tools",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+        current_config_provider=lambda: config,
+    )
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    monkeypatch.setattr(proxy, "_maybe_open_approval_center", lambda **_kwargs: None)
+    messages = [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"capabilities": {}}},
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "dangerous_delete", "arguments": {"target": ".env"}},
+        },
+    ]
+    first = proxy.run_session(messages)
+    assert first["responses"][1]["error"]["code"] == -32001
+    request = store.list_approval_requests(limit=1)[0]
+    approval_id = store.record_local_once_approval(
+        request_id="unobserved-catalog-approval",
+        harness="codex",
+        artifact_id=str(request["artifact_id"]),
+        artifact_hash=str(request["artifact_hash"]),
+        workspace=str(context.workspace_dir),
+        publisher=None,
+        action="allow",
+        created_at="2026-07-17T00:00:00+00:00",
+        expires_at="2099-07-17T00:00:00+00:00",
+    )
+    assert approval_id is not None
+
+    second = proxy.run_session(messages)
+
+    assert marker_path.exists() is False
+    assert second["responses"][1]["error"]["data"]["guardPolicyAction"] == "require-reapproval"
+    assert second["events"][1]["scanner_evidence"][-1]["reason_code"] == ("approval_reuse_tool_catalog_incomplete")
+    assert store.list_events(event_name="approval.local_once_applied") == []
+
+
+def test_runtime_mcp_drains_idle_list_changed_before_saved_approval_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(
+        guard_home=context.guard_home,
+        workspace=context.workspace_dir,
+        security_level="custom",
+        risk_actions={"mcp_dangerous_tool": "review"},
+    )
+    marker_path = tmp_path / "idle-invalidation-must-not-forward.json"
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace-tools",
+        command=_idle_catalog_invalidation_child_command(
+            marker_path,
+            tmp_path / "idle-invalidation-session.txt",
+        ),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+        current_config_provider=lambda: config,
+    )
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    monkeypatch.setattr(proxy, "_maybe_open_approval_center", lambda **_kwargs: None)
+    messages = _messages(
+        tool_name="dangerous_delete",
+        arguments={"target": ".env"},
+        elicitation=False,
+    )
+    first = proxy.run_session(messages)
+    assert first["responses"][2]["error"]["code"] == -32001
+    request = store.list_approval_requests(limit=1)[0]
+    approval_id = store.record_local_once_approval(
+        request_id="idle-list-changed-approval",
+        harness="codex",
+        artifact_id=str(request["artifact_id"]),
+        artifact_hash=str(request["artifact_hash"]),
+        workspace=str(context.workspace_dir),
+        publisher=None,
+        action="allow",
+        created_at="2026-07-18T00:00:00+00:00",
+        expires_at="2099-07-18T00:00:00+00:00",
+    )
+    assert approval_id is not None
+
+    second = proxy.run_session(messages)
+
+    assert marker_path.exists() is False
+    assert second["responses"][2]["error"]["data"]["guardPolicyAction"] == "require-reapproval"
+    assert second["events"][2]["decision"] == "queue-approval"
+    assert proxy._tool_catalog_state == "invalidated"
+    assert store.list_events(event_name="approval.local_once_applied") == []
+    with sqlite3.connect(store.path) as connection:
+        claimed_at = connection.execute(
+            "select claimed_at from guard_local_once_approvals where approval_id = ?",
+            (approval_id,),
+        ).fetchone()[0]
+    assert claimed_at is None
+
+
+def test_runtime_mcp_process_boundary_clears_cross_session_response_buffers(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace-tools",
+        command=_cross_session_buffer_child_command(tmp_path / "buffer-reset-session.txt"),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+    )
+
+    first = proxy.run_session([{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"capabilities": {}}}])
+    assert first["responses"][0]["id"] == 1
+    assert proxy._buffered_child_responses == {}
+    proxy._buffered_client_responses["2"] = [{"jsonrpc": "2.0", "id": 2, "result": {"stale": True}}]
+
+    second = proxy.run_session(
+        [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"capabilities": {}}},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        ]
+    )
+
+    tools = second["responses"][1]["result"]["tools"]
+    assert [tool["name"] for tool in tools] == ["current_session_tool"]
+    assert proxy._tool_catalog_state == "complete"
+    assert set(proxy._tool_catalog) == {"current_session_tool"}
+    assert proxy._buffered_child_responses == {}
+    assert proxy._buffered_client_responses == {}
+
+
+def test_runtime_mcp_final_prewrite_drain_catches_notification_after_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _context_value, store, proxy, marker_path, messages, _artifact_id, _artifact_hash, approval_id = (
+        _prepare_runtime_mcp_exact_review_retry(
+            tmp_path=tmp_path,
+            monkeypatch=monkeypatch,
+            marker_name="postclaim-notification-must-not-forward.json",
+        )
+    )
+    real_claim = store.claim_approval_reuse_decisions
+
+    def claim_then_emit_list_changed(
+        decisions: tuple[dict[str, object], ...],
+        **kwargs: object,
+    ) -> bool:
+        claimed = real_claim(decisions, **kwargs)
+        if claimed:
+            output_queue = proxy._child_output_queue
+            assert output_queue is not None
+            output_queue.put(
+                runtime_mcp_module._ChildOutputFrame(
+                    line=json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "notifications/tools/list_changed",
+                            "params": {},
+                        }
+                    )
+                    + "\n"
+                )
+            )
+        return claimed
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", claim_then_emit_list_changed)
+
+    result = proxy.run_session(messages)
+
+    assert marker_path.exists() is False
+    assert result["responses"][2]["error"]["data"]["guardPolicyAction"] == "require-reapproval"
+    boundary_evidence = result["events"][2]["scanner_evidence"][-1]
+    assert boundary_evidence["reason_code"] == "tool_catalog_changed_at_execution_boundary"
+    assert boundary_evidence["phase"] == "immediately_before_forward"
+    claim_events = store.list_events(event_name="approval.local_once_applied")
+    assert len(claim_events) == 1
+    assert claim_events[0]["payload"]["approval_id"] == approval_id
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "require-reapproval"
+
+
+def test_runtime_mcp_exact_claim_binds_unchanged_full_advertised_catalog(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _context_value, store, proxy, marker_path, messages, _artifact_id, _artifact_hash, approval_id = (
+        _prepare_runtime_mcp_exact_review_retry(
+            tmp_path=tmp_path,
+            monkeypatch=monkeypatch,
+            marker_name="unchanged-catalog-forwarded.json",
+        )
+    )
+
+    result = proxy.run_session(messages)
+
+    assert marker_path.exists() is True
+    assert result["responses"][2]["result"]["content"][0]["text"] == "forwarded"
+    assert result["events"][2]["decision"] == "policy-allow"
+    assert all(
+        evidence.get("reason_code") != "approval_reuse_context_changed_after_claim"
+        for evidence in result["events"][2].get("scanner_evidence", [])
+        if isinstance(evidence, dict)
+    )
+    claim_events = store.list_events(event_name="approval.local_once_applied")
+    assert len(claim_events) == 1
+    assert claim_events[0]["payload"]["approval_id"] == approval_id
+
+
+def test_runtime_mcp_exact_claim_fails_closed_when_current_config_refresh_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _context_value, store, proxy, marker_path, messages, _artifact_id, _artifact_hash, approval_id = (
+        _prepare_runtime_mcp_exact_review_retry(
+            tmp_path=tmp_path,
+            monkeypatch=monkeypatch,
+            marker_name="runtime-config-refresh-failure-must-not-forward.json",
+        )
+    )
+
+    def unavailable_config() -> GuardConfig:
+        raise OSError("current config unavailable")
+
+    proxy._current_config_provider = unavailable_config
+
+    result = proxy.run_session(messages)
+
+    assert marker_path.exists() is False
+    response = result["responses"][2]
+    assert response["error"]["data"]["guardPolicyAction"] == "require-reapproval"
+    event = result["events"][2]
+    assert event["decision"] == "queue-approval"
+    assert event["scanner_evidence"][-1] == {
+        "source": "approval_reuse",
+        "status": "rejected",
+        "reason_code": "approval_reuse_current_config_refresh_failed",
+        "effective_action": "require-reapproval",
+    }
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == "require-reapproval"
+    assert receipt["scanner_evidence"][-1] == event["scanner_evidence"][-1]
+    claim_events = store.list_events(event_name="approval.local_once_applied")
+    assert len(claim_events) == 1
+    assert claim_events[0]["payload"]["approval_id"] == approval_id
+
+
+def test_runtime_mcp_exact_claim_rejects_different_tool_catalog_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _context_value, store, proxy, marker_path, messages, _artifact_id, _artifact_hash, approval_id = (
+        _prepare_runtime_mcp_exact_review_retry(
+            tmp_path=tmp_path,
+            monkeypatch=monkeypatch,
+            marker_name="changed-sibling-tool-must-not-forward.json",
+        )
+    )
+    real_claim = store.claim_approval_reuse_decisions
+
+    def claim_then_change_sibling_tool(
+        decisions: tuple[dict[str, object], ...],
+        **kwargs: object,
+    ) -> bool:
+        claimed = real_claim(decisions, **kwargs)
+        if claimed:
+            safe_echo = dict(proxy._tool_catalog["safe_echo"])
+            safe_echo["description"] = "Safe echo with a changed advertised capability"
+            proxy._tool_catalog["safe_echo"] = safe_echo
+        return claimed
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", claim_then_change_sibling_tool)
+
+    result = proxy.run_session(messages)
+
+    assert marker_path.exists() is False
+    response = result["responses"][2]
+    assert response["error"]["data"]["guardPolicyAction"] == "require-reapproval"
+    event = result["events"][2]
+    assert event["decision"] == "queue-approval"
+    assert event["scanner_evidence"][-1] == {
+        "source": "approval_reuse",
+        "status": "rejected",
+        "reason_code": "approval_reuse_context_changed_after_claim",
+        "context_matches": False,
+        "current_action": "review",
+        "effective_action": "review",
+    }
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == "require-reapproval"
+    assert receipt["scanner_evidence"][-1] == event["scanner_evidence"][-1]
+    claim_events = store.list_events(event_name="approval.local_once_applied")
+    assert len(claim_events) == 1
+    assert claim_events[0]["payload"]["approval_id"] == approval_id
+
+
+def test_runtime_mcp_same_context_saved_block_after_claim_has_truthful_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context, store, proxy, marker_path, messages, artifact_id, artifact_hash, approval_id = (
+        _prepare_runtime_mcp_exact_review_retry(
+            tmp_path=tmp_path,
+            monkeypatch=monkeypatch,
+            marker_name="same-context-saved-block-must-not-forward.json",
+        )
+    )
+    assert context.workspace_dir is not None
+    real_claim = store.claim_approval_reuse_decisions
+
+    def claim_then_save_exact_block(
+        decisions: tuple[dict[str, object], ...],
+        **kwargs: object,
+    ) -> bool:
+        claimed = real_claim(decisions, **kwargs)
+        if claimed:
+            store.upsert_policy(
+                PolicyDecision(
+                    harness="codex",
+                    scope="artifact",
+                    action="block",
+                    artifact_id=artifact_id,
+                    artifact_hash=artifact_hash,
+                    workspace=str(context.workspace_dir),
+                    source="local",
+                    reason="fresh exact block after one-shot claim",
+                ),
+                "2026-07-17T00:01:00+00:00",
+            )
+        return claimed
+
+    monkeypatch.setattr(store, "claim_approval_reuse_decisions", claim_then_save_exact_block)
+
+    result = proxy.run_session(messages)
+
+    assert marker_path.exists() is False
+    response = result["responses"][2]
+    assert response["error"]["data"] == {
+        "approvalRequests": [],
+        "guardPolicyAction": "block",
+    }
+    event = result["events"][2]
+    assert event["decision"] == "block-stored-policy"
+    assert event["scanner_evidence"][-1]["reason_code"] == "approval_reuse_saved_block"
+    assert all(
+        evidence.get("reason_code") != "approval_reuse_context_changed_after_claim"
+        for evidence in event["scanner_evidence"]
+        if isinstance(evidence, dict)
+    )
+    receipt = store.list_receipts(limit=1)[0]
+    assert receipt["policy_decision"] == "block"
+    assert receipt["scanner_evidence"][-1]["reason_code"] == "approval_reuse_saved_block"
+    assert all(
+        evidence.get("reason_code") != "approval_reuse_context_changed_after_claim"
+        for evidence in receipt["scanner_evidence"]
+        if isinstance(evidence, dict)
+    )
+    claim_events = store.list_events(event_name="approval.local_once_applied")
+    assert len(claim_events) == 1
+    assert claim_events[0]["payload"]["approval_id"] == approval_id
+
+
+def test_runtime_mcp_quarantines_child_when_entrypoint_changes_during_spawn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    assert context.workspace_dir is not None
+    server_script = context.workspace_dir / "spawn-race-server.py"
+    server_script.write_text("import time\ntime.sleep(30)\n", encoding="utf-8")
+    proxy = CodexMcpGuardProxy(
+        server_name="spawn-race",
+        command=[sys.executable, str(server_script)],
+        context=context,
+        store=GuardStore(context.guard_home),
+        config=GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir),
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+    )
+    real_popen = runtime_mcp_module.subprocess.Popen
+    processes: list[Any] = []
+
+    def mutate_after_spawn(*args: Any, **kwargs: Any) -> Any:
+        process = real_popen(*args, **kwargs)
+        processes.append(process)
+        server_script.write_text("raise SystemExit(93)\n", encoding="utf-8")
+        return process
+
+    monkeypatch.setattr(runtime_mcp_module.subprocess, "Popen", mutate_after_spawn)
+
+    with pytest.raises(RuntimeError, match="launch identity changed"):
+        proxy._start_process()
+
+    assert processes and processes[0].poll() is not None
+    assert proxy._active_runtime_launch_identity is None
+    assert proxy._active_executable_identity is None

--- a/tests/test_guard_shim_intercept_proofs.py
+++ b/tests/test_guard_shim_intercept_proofs.py
@@ -12,6 +12,7 @@ import pytest
 from codex_plugin_scanner.guard import shims as shims_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.models import GUARD_ACTION_VALUES
 from codex_plugin_scanner.guard.shims import install_package_shims, probe_package_shim_intercepts
 from codex_plugin_scanner.guard.store import GuardStore
 from tests.shim_execution_helpers import (
@@ -131,7 +132,9 @@ def test_package_shim_intercept_probe_records_evaluator_evidence(
     assert manager_result["manager"] == "npm"
     assert manager_result["evaluator_invoked"] is True
     assert manager_result["intercept_ran"] is True
-    assert manager_result.get("protect_decision") in {"allow", "review", "block", "monitor"}
+    protect_decision = manager_result.get("protect_decision")
+    assert protect_decision in GUARD_ACTION_VALUES
+    assert manager_result["execution_permitted"] is (protect_decision in {"allow", "warn"})
     assert not (tmp_path / "npm-never-runs.json").exists()
 
 

--- a/tests/test_guard_stdio_launch_identity.py
+++ b/tests/test_guard_stdio_launch_identity.py
@@ -1,0 +1,255 @@
+"""Stdio proxy launch-context binding regressions."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.models import GuardArtifact
+from codex_plugin_scanner.guard.proxy import stdio as stdio_module
+from codex_plugin_scanner.guard.proxy.stdio import (
+    ProxyLaunchIdentityChangedError,
+    StdioGuardProxy,
+    _sensitive_read_current_action,
+    build_sensitive_read_approval_hash,
+)
+from codex_plugin_scanner.guard.runtime.approval_context import (
+    approval_context_tokens_validation_reason,
+)
+from codex_plugin_scanner.guard.runtime.secret_file_requests import (
+    build_file_read_request_artifact,
+    extract_sensitive_file_read_request,
+)
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.returncode: int | None = None
+        self.terminated = False
+        self.killed = False
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        return self.returncode or 0
+
+
+def _replace_file(path: Path, content: bytes, *, executable: bool = False) -> None:
+    replacement = path.with_name(f"{path.name}.replacement")
+    replacement.parent.mkdir(parents=True, exist_ok=True)
+    replacement.write_bytes(content)
+    if executable:
+        replacement.chmod(0o755)
+    replacement.replace(path)
+
+
+def _sensitive_artifact(workspace: Path) -> GuardArtifact:
+    request = extract_sensitive_file_read_request("read_file", {"path": ".env"}, cwd=workspace)
+    assert request is not None
+    return build_file_read_request_artifact(
+        harness="codex",
+        request=request,
+        config_path=str(workspace / ".mcp.json"),
+        source_scope="project",
+    )
+
+
+def _pinned_token(proxy: StdioGuardProxy, artifact: GuardArtifact, config: GuardConfig) -> str:
+    proxy._start_process()
+    launch_identity = proxy._active_launch_identity
+    env_values_hash = proxy._active_env_values_hash
+    assert launch_identity is not None
+    assert env_values_hash is not None
+    return build_sensitive_read_approval_hash(
+        artifact,
+        config=config,
+        cwd=proxy.cwd,
+        current_action=_sensitive_read_current_action(config, artifact=artifact, harness="codex"),
+        server_launch_identity=launch_identity,
+        configured_env_values_hash=env_values_hash,
+    )
+
+
+def test_stdio_sensitive_read_binds_pinned_executable_script_and_configured_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    launcher = workspace / "python"
+    script = workspace / "server.py"
+    _replace_file(launcher, b"fake-python-v1\n", executable=True)
+    _replace_file(script, b"print('server-v1')\n")
+    artifact = _sensitive_artifact(workspace)
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"local_secret_read": "review"},
+    )
+    monkeypatch.setattr(stdio_module.subprocess, "Popen", lambda *_args, **_kwargs: _FakeProcess())
+
+    def proxy(env_value: str) -> StdioGuardProxy:
+        return StdioGuardProxy(
+            [str(launcher), "server.py"],
+            cwd=workspace,
+            guard_config=config,
+            harness="codex",
+            env={"MCP_CONFIGURED_TOKEN": env_value},
+        )
+
+    secret_v1 = "stdio-secret-one"
+    secret_v2 = "stdio-secret-two"
+    baseline_proxy = proxy(secret_v1)
+    baseline = _pinned_token(baseline_proxy, artifact, config)
+    unchanged = _pinned_token(proxy(secret_v1), artifact, config)
+    assert baseline == unchanged
+
+    _replace_file(script, b"print('server-v2')\n")
+    script_changed = _pinned_token(proxy(secret_v1), artifact, config)
+    assert approval_context_tokens_validation_reason(baseline, script_changed) == ("approval_reuse_identity_changed")
+
+    _replace_file(script, b"print('server-v1')\n")
+    _replace_file(launcher, b"fake-python-v2\n", executable=True)
+    executable_changed = _pinned_token(proxy(secret_v1), artifact, config)
+    assert approval_context_tokens_validation_reason(baseline, executable_changed) == (
+        "approval_reuse_identity_changed"
+    )
+
+    _replace_file(launcher, b"fake-python-v1\n", executable=True)
+    env_changed_proxy = proxy(secret_v2)
+    env_changed = _pinned_token(env_changed_proxy, artifact, config)
+    assert approval_context_tokens_validation_reason(baseline, env_changed) == ("approval_reuse_identity_changed")
+    serialized_context = repr(
+        {
+            "launch": env_changed_proxy._active_launch_identity,
+            "env_hash": env_changed_proxy._active_env_values_hash,
+        }
+    )
+    assert secret_v1 not in serialized_context
+    assert secret_v2 not in serialized_context
+
+
+def test_stdio_launch_identity_change_during_spawn_is_quarantined_and_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    launcher = workspace / "python"
+    script = workspace / "server.py"
+    _replace_file(launcher, b"fake-python\n", executable=True)
+    _replace_file(script, b"print('before-spawn')\n")
+    proxy = StdioGuardProxy([str(launcher), "server.py"], cwd=workspace, env={"TOKEN": "one"})
+    spawned = _FakeProcess()
+
+    def mutate_during_spawn(*_args: object, **_kwargs: object) -> _FakeProcess:
+        _replace_file(script, b"print('after-spawn')\n")
+        return spawned
+
+    monkeypatch.setattr(stdio_module.subprocess, "Popen", mutate_during_spawn)
+    with pytest.raises(ProxyLaunchIdentityChangedError, match="launch identity changed"):
+        proxy._start_process()
+    assert spawned.terminated is True
+    assert spawned.killed is False
+    assert proxy._active_launch_identity is None
+    assert proxy._active_env_values_hash is None
+
+
+def test_stdio_launches_canonical_executable_and_rejects_symlink_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    original = workspace / "original-server"
+    replacement = workspace / "replacement-server"
+    launcher = workspace / "server"
+    _replace_file(original, b"#!/bin/sh\nwhile :; do :; done\n", executable=True)
+    _replace_file(replacement, b"#!/bin/sh\n# replacement\nwhile :; do :; done\n", executable=True)
+    launcher.symlink_to(original)
+    proxy = StdioGuardProxy([str(launcher)], cwd=workspace)
+    real_popen = subprocess.Popen
+    observed: dict[str, Any] = {}
+
+    def swap_then_spawn(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
+        observed["executable"] = kwargs.get("executable")
+        launcher.unlink()
+        launcher.symlink_to(replacement)
+        process = real_popen(*args, **kwargs)
+        observed["process"] = process
+        return process
+
+    monkeypatch.setattr(stdio_module.subprocess, "Popen", swap_then_spawn)
+    with pytest.raises(ProxyLaunchIdentityChangedError, match="launch identity changed"):
+        proxy._start_process()
+
+    process = observed["process"]
+    assert isinstance(process, real_popen)
+    assert observed["executable"] == str(original.resolve())
+    assert process.poll() is not None
+    assert proxy._active_launch_identity is None
+
+
+def test_stdio_rejects_real_interpreted_entrypoint_swap_before_traffic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    script = workspace / "server.py"
+    _replace_file(script, b"import time\ntime.sleep(60)\n")
+    proxy = StdioGuardProxy([sys.executable, str(script)], cwd=workspace)
+    real_popen = subprocess.Popen
+    observed: dict[str, subprocess.Popen[str]] = {}
+
+    def mutate_then_spawn(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
+        _replace_file(script, b"import time\n# changed\ntime.sleep(60)\n")
+        process = real_popen(*args, **kwargs)
+        observed["process"] = process
+        return process
+
+    monkeypatch.setattr(stdio_module.subprocess, "Popen", mutate_then_spawn)
+    with pytest.raises(ProxyLaunchIdentityChangedError, match="launch identity changed"):
+        proxy._start_process()
+
+    assert observed["process"].poll() is not None
+    assert proxy._active_launch_identity is None
+
+
+def test_stdio_launch_identity_is_cleared_on_spawn_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    launcher = workspace / "python"
+    script = workspace / "server.py"
+    _replace_file(launcher, b"fake-python\n", executable=True)
+    _replace_file(script, b"print('server')\n")
+
+    failing_proxy = StdioGuardProxy([str(launcher), "server.py"], cwd=workspace, env={"TOKEN": "one"})
+
+    def fail_spawn(*_args: object, **_kwargs: object) -> _FakeProcess:
+        raise OSError("spawn failed")
+
+    monkeypatch.setattr(stdio_module.subprocess, "Popen", fail_spawn)
+    with pytest.raises(OSError, match="spawn failed"):
+        failing_proxy._start_process()
+    assert failing_proxy._active_launch_identity is None
+    assert failing_proxy._active_env_values_hash is None

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -13,6 +13,7 @@ import types
 import pytest
 
 from codex_plugin_scanner.guard import store as guard_store_module
+from codex_plugin_scanner.guard.models import PolicyDecision
 from codex_plugin_scanner.guard.store import (
     EncryptedFileSecretStore,
     FallbackSecretStore,
@@ -448,6 +449,119 @@ def _incomplete_evidence_table(connection: sqlite3.Connection) -> None:
         )
         """
     )
+
+
+@pytest.mark.parametrize("include_artifact_hash", (False, True))
+def test_guard_store_migrates_historical_policy_columns_before_creating_indexes(
+    tmp_path,
+    include_artifact_hash: bool,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    database_path = guard_home / "guard.db"
+    artifact_hash_column = ", artifact_hash text" if include_artifact_hash else ""
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            f"""
+            create table policy_decisions (
+              decision_id integer primary key autoincrement,
+              harness text not null,
+              scope text not null,
+              artifact_id text,
+              workspace text,
+              action text not null,
+              reason text,
+              updated_at text not null
+              {artifact_hash_column}
+            )
+            """
+        )
+        connection.execute(
+            """
+            insert into policy_decisions (
+              harness, scope, artifact_id, workspace, action, reason, updated_at
+            ) values (
+              'codex', 'artifact', 'codex:project:legacy', null,
+              'allow', 'historical row', '2025-01-01T00:00:00Z'
+            )
+            """
+        )
+
+    store = GuardStore(guard_home, prime_policy_integrity=False)
+    GuardStore(guard_home, prime_policy_integrity=False)
+
+    migrated_columns = {
+        "publisher",
+        "artifact_hash",
+        "owner",
+        "source",
+        "expires_at",
+        "integrity_version",
+        "integrity_generation",
+        "payload_hash",
+        "payload_mac",
+        "integrity_key_id",
+        "signed_at",
+    }
+    expected_indexes = {
+        "idx_policy_decisions_reuse_artifact",
+        "idx_policy_decisions_reuse_hash",
+        "idx_policy_decisions_reuse_publisher",
+        "idx_policy_decisions_lookup_artifact",
+        "idx_policy_decisions_lookup_workspace",
+        "idx_policy_decisions_lookup_publisher",
+        "idx_policy_decisions_lookup_publisher_legacy",
+        "idx_policy_decisions_lookup_harness",
+        "idx_policy_decisions_lookup_harness_legacy",
+        "idx_policy_decisions_lookup_global",
+        "idx_policy_decisions_lookup_global_legacy",
+        "idx_policy_decisions_diagnostic_harness_broad",
+        "idx_policy_decisions_diagnostic_global_broad",
+        "idx_policy_decisions_diagnostic_publisher",
+    }
+    with sqlite3.connect(database_path) as connection:
+        columns = {str(row[1]) for row in connection.execute("pragma table_info(policy_decisions)")}
+        indexes = {
+            str(row[0])
+            for row in connection.execute(
+                "select name from sqlite_schema where type = 'index' and tbl_name = 'policy_decisions'"
+            )
+        }
+        historical_source = connection.execute(
+            "select source from policy_decisions where artifact_id = 'codex:project:legacy'"
+        ).fetchone()
+
+    assert migrated_columns.issubset(columns)
+    assert expected_indexes.issubset(indexes)
+    assert historical_source == ("local",)
+
+    current_artifact_id = "codex:project:tool-action:migrated-store"
+    store.replace_remote_policies(
+        [
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id=current_artifact_id,
+                artifact_hash="sha256:current",
+                source="team-policy",
+            )
+        ],
+        "2026-07-18T12:00:00Z",
+        remote_write_authorized=True,
+    )
+
+    selected = store.resolve_policy_decision(
+        "codex",
+        current_artifact_id,
+        "sha256:current",
+        now="2026-07-18T12:01:00Z",
+        consume_one_shot=False,
+    )
+
+    assert selected is not None
+    assert selected["source"] == "team-policy"
+    assert selected["artifact_id"] == current_artifact_id
 
 
 def test_guard_store_repairs_missing_evidence_table_when_schema_v4_is_applied(tmp_path):

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -22,6 +22,7 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generat
 
 import codex_plugin_scanner.guard.runtime.supply_chain_package_eval as evaluator_module
 from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+from codex_plugin_scanner.guard.models import GuardAction
 from codex_plugin_scanner.guard.runtime.package_intent_common import (
     PackageIntent,
     build_package_request_artifact,
@@ -446,7 +447,7 @@ def test_evaluate_package_request_artifact_posts_cloud_request_and_maps_block_re
     assert result.user_copy.dashboard_url is None
     assert "minimist@1.2.8" in result.user_copy.harness_message
     assert "npm install minimist@1.2.9" in result.user_copy.harness_message
-    assert "Review this request in HOL Guard, then retry." in result.user_copy.harness_message
+    assert "Review this request in HOL Guard, then retry." not in result.user_copy.harness_message
 
 
 def test_evaluate_package_request_artifact_posts_latest_range_for_unversioned_scoped_npm_request(
@@ -795,7 +796,52 @@ def test_evaluate_package_request_artifact_uses_cached_eval_before_network(
     assert result.user_copy.dashboard_url is None
     assert "guard/inbox" not in result.user_copy.harness_message
     assert "Review evidence:" not in result.user_copy.harness_message
-    assert "Review this request in HOL Guard, then retry." in result.user_copy.harness_message
+    assert "Review this request in HOL Guard, then retry." not in result.user_copy.harness_message
+
+
+@pytest.mark.parametrize("policy_action", ["block", "sandbox-required"])
+def test_normalize_package_user_copy_removes_review_routing_for_terminal_actions(
+    policy_action: GuardAction,
+) -> None:
+    result = evaluator_module._normalize_package_user_copy(
+        SupplyChainUserCopy(
+            title="Terminal action",
+            summary="HOL Guard stopped this package request.",
+            next_step="npm install minimist@1.2.9",
+            dashboard_url="http://127.0.0.1:5474/requests/request-1",
+            harness_message=(
+                "HOL Guard stopped this package request. "
+                "Open HOL Guard to approve or keep this blocked: "
+                "http://127.0.0.1:5474/requests/request-1. "
+                "After you choose, retry the same Codex action. "
+                "Review this request in HOL Guard, then retry."
+            ),
+        ),
+        policy_action=policy_action,
+    )
+
+    assert result.dashboard_url is None
+    assert result.harness_message == "HOL Guard stopped this package request."
+    assert "/requests/" not in result.harness_message
+    assert "Review this request in HOL Guard, then retry." not in result.harness_message
+
+
+@pytest.mark.parametrize("policy_action", ["review", "require-reapproval"])
+def test_normalize_package_user_copy_keeps_review_instruction_for_review_actions(
+    policy_action: GuardAction,
+) -> None:
+    result = evaluator_module._normalize_package_user_copy(
+        SupplyChainUserCopy(
+            title="Review required",
+            summary="HOL Guard paused this package request.",
+            next_step=None,
+            dashboard_url=None,
+            harness_message="HOL Guard paused this package request.",
+        ),
+        policy_action=policy_action,
+    )
+
+    assert result.harness_message.endswith("Review this request in HOL Guard, then retry.")
 
 
 def test_evaluate_package_request_artifact_skips_cached_eval_when_workspace_fingerprint_changes(
@@ -1364,6 +1410,102 @@ def test_evaluate_package_request_artifact_applies_policy_rule_override(
     assert result.policy_action == "warn"
     assert result.enforcement == "policy_override"
     assert result.matched_rule_id == "policy-rule-1"
+
+
+@pytest.mark.parametrize("harness_selector", [None, "*"])
+def test_evaluate_package_request_artifact_policy_rule_matches_unset_or_wildcard_harness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_selector: str | None,
+) -> None:
+    _force_cloud_fallback(monkeypatch)
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            )
+        ],
+        policy_rules=[
+            {
+                "action": "warn",
+                "ruleId": "all-harnesses-policy-rule",
+                "ecosystemSelector": "npm",
+                "enabled": True,
+                "expiresAt": "2099-01-01T00:00:00Z",
+                "harnessSelector": harness_selector,
+                "packageSelector": "minimist",
+                "priority": 1,
+                "severityThreshold": "low",
+                "versionRangeSelector": "1.2.8",
+            }
+        ],
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("minimist@1.2.8", harness="gemini"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "warn"
+    assert result.policy_action == "warn"
+    assert result.enforcement == "policy_override"
+    assert result.matched_rule_id == "all-harnesses-policy-rule"
+
+
+def test_evaluate_package_request_artifact_policy_rule_rejects_different_harness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _force_cloud_fallback(monkeypatch)
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            )
+        ],
+        policy_rules=[
+            {
+                "action": "warn",
+                "ruleId": "codex-only-policy-rule",
+                "ecosystemSelector": "npm",
+                "enabled": True,
+                "expiresAt": "2099-01-01T00:00:00Z",
+                "harnessSelector": "codex",
+                "packageSelector": "minimist",
+                "priority": 1,
+                "severityThreshold": "low",
+                "versionRangeSelector": "1.2.8",
+            }
+        ],
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("minimist@1.2.8", harness="gemini"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "block"
+    assert result.policy_action == "block"
+    assert result.enforcement == "offline_cached"
+    assert result.matched_rule_id is None
 
 
 def test_evaluate_package_request_artifact_respects_policy_severity_threshold(

--- a/tests/test_guard_verdicts.py
+++ b/tests/test_guard_verdicts.py
@@ -102,7 +102,7 @@ def test_evaluate_detection_tracks_capability_delta_on_changed_artifact(tmp_path
     assert item["policy_action"] in {"block", "sandbox-required", "require-reapproval", "warn"}
 
 
-def test_build_history_context_does_not_count_require_reapproval_as_prior_approval(tmp_path):
+def test_build_history_context_counts_review_and_reapproval_as_blocks_not_prior_approvals(tmp_path):
     store = GuardStore(tmp_path / "guard-home")
     store.add_receipt(
         GuardReceipt(
@@ -114,6 +114,19 @@ def test_build_history_context_does_not_count_require_reapproval_as_prior_approv
             policy_decision="allow",
             capabilities_summary="local tool",
             changed_capabilities=(),
+            provenance_summary="local",
+        )
+    )
+    store.add_receipt(
+        GuardReceipt(
+            receipt_id="receipt-review",
+            timestamp="2026-04-19T00:02:00+00:00",
+            harness="codex",
+            artifact_id="codex:project:test-artifact",
+            artifact_hash="hash-review",
+            policy_decision="review",
+            capabilities_summary="local tool awaiting approval",
+            changed_capabilities=("review",),
             provenance_summary="local",
         )
     )
@@ -134,4 +147,4 @@ def test_build_history_context_does_not_count_require_reapproval_as_prior_approv
     history = build_history_context(store, "codex", "codex:project:test-artifact", publisher=None)
 
     assert history.prior_approvals == 1
-    assert history.prior_blocks == 1
+    assert history.prior_blocks == 2

--- a/tests/test_guard_wrapper_flows.py
+++ b/tests/test_guard_wrapper_flows.py
@@ -1,7 +1,8 @@
 """Guard wrapper flow tests — P4.
 
 Covers:
-- wait_for_approval_requests resolves immediately when all items resolved
+- wait_for_approval_requests resolves immediately when all requested items resolve
+- wait_for_approval_requests fails closed when no approval request was queued
 - wait_for_approval_requests returns pending when timeout fires
 - _headless_approval_resolver with --json flag (noninteractive) skips waiting
 - _headless_approval_resolver timeout produces hint with pending request IDs
@@ -154,7 +155,7 @@ class TestWaitForApprovalRequests:
         assert pending_id in result["pending_request_ids"]
         assert resolved_id not in result["pending_request_ids"]
 
-    def test_empty_request_list_resolves_immediately(self, tmp_path: Path) -> None:
+    def test_empty_request_list_does_not_report_approval(self, tmp_path: Path) -> None:
         store = GuardStore(tmp_path / "guard")
         result = wait_for_approval_requests(
             store=store,
@@ -162,8 +163,9 @@ class TestWaitForApprovalRequests:
             timeout_seconds=5,
             poll_interval=0.01,
         )
-        assert result["resolved"] is True
+        assert result["resolved"] is False
         assert result["pending_request_ids"] == []
+        assert result["reason"] == "no_approval_requests"
 
 
 class TestHeadlessApprovalResolverNoninteractive:
@@ -205,12 +207,14 @@ class TestHeadlessApprovalResolverNoninteractive:
             config=config,
         ), store
 
+    @pytest.mark.parametrize("policy_action", ["review", "require-reapproval"])
     def test_json_flag_skips_wait_and_returns_unresolved_approval_wait(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
+        policy_action: str,
     ) -> None:
-        resolver, _store = self._make_resolver(tmp_path, monkeypatch, json_flag=True)
+        resolver, store = self._make_resolver(tmp_path, monkeypatch, json_flag=True)
         artifact = _make_artifact()
         payload: dict[str, Any] = {
             "blocked": True,
@@ -219,7 +223,7 @@ class TestHeadlessApprovalResolverNoninteractive:
                     "artifact_id": artifact.artifact_id,
                     "artifact_name": artifact.name,
                     "artifact_hash": "sha256-abc",
-                    "policy_action": "require-reapproval",
+                    "policy_action": policy_action,
                     "changed_fields": ["args"],
                     "artifact_type": artifact.artifact_type,
                     "source_scope": artifact.source_scope,
@@ -233,6 +237,69 @@ class TestHeadlessApprovalResolverNoninteractive:
 
         assert "approval_wait" in result
         assert result["approval_wait"]["resolved"] is False
+        assert len(store.list_approval_requests(limit=None)) == 1
+
+    @pytest.mark.parametrize("policy_action", ["block", "sandbox-required"])
+    @pytest.mark.parametrize("json_flag", [False, True])
+    def test_terminal_action_never_starts_or_waits_for_approval_flow(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        policy_action: str,
+        json_flag: bool,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        store = GuardStore(home_dir)
+        config = GuardConfig(
+            guard_home=home_dir,
+            workspace=workspace_dir,
+            approval_wait_timeout_seconds=1,
+        )
+
+        def unexpected_approval_flow(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("terminal actions must not create or wait on approval requests")
+
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", unexpected_approval_flow)
+        monkeypatch.setattr(guard_commands_module, "queue_blocked_approvals", unexpected_approval_flow)
+        monkeypatch.setattr(guard_commands_module, "wait_for_approval_requests", unexpected_approval_flow)
+        args = argparse.Namespace(harness="codex", json=json_flag)
+        context = HarnessContext(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            guard_home=home_dir,
+        )
+        resolver = guard_commands_module._headless_approval_resolver(
+            args=args,
+            context=context,
+            store=store,
+            config=config,
+        )
+        artifact = _make_artifact()
+        payload: dict[str, Any] = {
+            "blocked": True,
+            "artifacts": [
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "artifact_name": artifact.name,
+                    "artifact_hash": "sha256-terminal",
+                    "policy_action": policy_action,
+                    "changed_fields": ["args"],
+                    "artifact_type": artifact.artifact_type,
+                    "source_scope": artifact.source_scope,
+                    "config_path": artifact.config_path,
+                }
+            ],
+        }
+
+        result = resolver(_make_detection(artifact), payload)
+
+        assert result is payload
+        assert result["blocked"] is True
+        assert "approval_requests" not in result
+        assert "approval_wait" not in result
+        assert store.list_approval_requests(limit=None) == []
 
     def test_noninteractive_resolver_includes_approval_center_url(
         self,

--- a/tests/test_zcode_hooks.py
+++ b/tests/test_zcode_hooks.py
@@ -111,6 +111,7 @@ class TestZCodeHookResponses:
         assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
 
     def test_should_block_flags_blocking_actions(self) -> None:
+        assert zcode_hook_should_block(policy_action="review")
         assert zcode_hook_should_block(policy_action="block")
         assert zcode_hook_should_block(policy_action="sandbox-required")
         assert zcode_hook_should_block(policy_action="require-reapproval")


### PR DESCRIPTION
## Summary

- Backport the already-reviewed P44 approval-precedence fix onto `release/2.1` after the P29 action-lattice prerequisite.
- Recompute current artifact, policy, scanner, package, capability, and sandbox authority before considering saved approval evidence.
- Bind reusable approvals to the exact current context and ensure an old allow cannot lower `block`, `sandbox-required`, or `require-reapproval`.
- Keep response, approval UI, receipt, and launch behavior on the same authoritative action.

## Security invariant

Saved approval is evidence for an unchanged identity and context; it is never authority to weaken a stronger action computed from current policy or current evidence.

## Authority composition

```text
current artifact/content/capabilities
current config + managed policy
package/data-flow/scanner/detector results
                 |
                 v
       most-restrictive action lattice
                 |
                 v
      current authoritative action
                 |
saved decision --+--> integrity, expiry, scope, and exact-context validation
                 |
                 v
unchanged review may reuse allow; stronger current actions remain terminal
```

## Validation

- `.venv/bin/python -m pytest -q --tb=short tests/test_guard_approval_precedence_consumers.py tests/test_guard_runtime_mcp_saved_blocks.py tests/test_guard_mcp_adapter_env_identity.py tests/test_guard_claude_adapter.py tests/test_hermes_adapter.py tests/test_guard_consumer_approval_precedence.py tests/test_guard_codex_browser_authority.py tests/test_guard_runtime_detectors.py` — 320 passed.
- `.venv/bin/python -m pytest -q --tb=short tests/test_guard_approval_context.py tests/test_guard_approval_decisions.py tests/test_guard_approval_gate.py tests/test_guard_approval_policy_versions.py tests/test_guard_approval_precedence_generic_stdio.py tests/test_guard_approval_reuse.py tests/test_guard_hook_saved_block_terminal.py tests/test_guard_local_authority_integrity.py` — 240 passed.
- `.venv/bin/ruff check <116 changed Python files>` — passed.
- `.venv/bin/ruff format --check <116 changed Python files>` — passed.
- `.venv/bin/basedpyright --pythonversion 3.11 --level error <59 changed production files>` — 0 errors, warnings, or notes.
- `.venv/bin/python -m build` — wheel and sdist built successfully.

## Provenance

This is an isolated release backport of the reviewed P44 change merged to `main` in #1635. Its only base is `release/2.1`; it does not include unrelated commits from `main`.
