### PR TITLE
feat(guard): add dormant workflow capability kernel

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -36,10 +36,12 @@ from .store_workflow_capabilities import StoreWorkflowCapabilitiesMixin
 from .store_workflow_capability_lookup import StoreWorkflowCapabilityLookupMixin
 from .store_workflow_capability_receipt_lookup import StoreWorkflowCapabilityReceiptLookupMixin
 from .store_workflow_capability_revocation import StoreWorkflowCapabilityRevocationMixin
+from .store_workflow_capability_secret_control import StoreWorkflowCapabilitySecretControlMixin
 
 
 class GuardStore(
     StoreSecretPolicyIntegrityMixin,
+    StoreWorkflowCapabilitySecretControlMixin,
     StoreConnectionSchemaMixin,
     StoreCommandActivityMixin,
     StoreCommandActivityApiMixin,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -32,6 +32,10 @@ from .store_secret_policy_integrity import (
     _POLICY_INTEGRITY_LOOKUP_UNSET,
 )
 from .store_sessions import StoreSessionsMixin
+from .store_workflow_capabilities import StoreWorkflowCapabilitiesMixin
+from .store_workflow_capability_lookup import StoreWorkflowCapabilityLookupMixin
+from .store_workflow_capability_receipt_lookup import StoreWorkflowCapabilityReceiptLookupMixin
+from .store_workflow_capability_revocation import StoreWorkflowCapabilityRevocationMixin
 
 
 class GuardStore(
@@ -54,6 +58,10 @@ class GuardStore(
     StoreSessionsMixin,
     StoreEvidenceMixin,
     StoreReadStateMixin,
+    StoreWorkflowCapabilitiesMixin,
+    StoreWorkflowCapabilityLookupMixin,
+    StoreWorkflowCapabilityReceiptLookupMixin,
+    StoreWorkflowCapabilityRevocationMixin,
 ):
     """Local SQLite store for Guard state."""
 

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -14,6 +14,7 @@ from .store_command_activity_maintenance_schema import ensure_command_activity_m
 from .store_command_activity_schema import ensure_command_activity_schema
 from .store_live_request_outbox import ensure_live_request_outbox_schema, seed_live_request_outbox
 from .store_secret_policy_integrity import _POLICY_INTEGRITY_LOOKUP_UNSET
+from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
 
 
 def _facade_store_attr(name: str, fallback: object) -> object:
@@ -191,6 +192,16 @@ class StoreConnectionSchemaMixin:
             timeout_seconds=timeout_seconds,
             poll_seconds=_OAUTH_CREDENTIAL_LOCK_POLL_SECONDS,
             timeout_message="Timed out waiting for Guard OAuth credential lock.",
+        ):
+            yield
+
+    @contextmanager
+    def hold_workflow_capability_authority_lock(self) -> Iterator[None]:
+        with self._hold_advisory_file_lock(
+            path=self.guard_home / "workflow-capability-authority.lock",
+            timeout_seconds=30.0,
+            poll_seconds=0.05,
+            timeout_message="Timed out waiting for the workflow capability authority lock.",
         ):
             yield
 
@@ -624,6 +635,7 @@ class StoreConnectionSchemaMixin:
             ensure_command_activity_maintenance_schema(connection, applied_at=_now())
             ensure_command_activity_api_schema(connection, applied_at=_now())
             ensure_evidence_schema(connection)
+            ensure_workflow_capability_schema(connection, applied_at=_now())
             if not self._schema_version_applied(connection, version=4):
                 self._record_schema_version(connection, version=4)
             for idx_stmt in supply_chain_index_statements():

--- a/src/codex_plugin_scanner/guard/store_secret_policy_integrity.py
+++ b/src/codex_plugin_scanner/guard/store_secret_policy_integrity.py
@@ -452,6 +452,24 @@ class StoreSecretPolicyIntegrityMixin:
     def _finalize_policy_integrity_control_state(self, payload: Mapping[str, object]) -> None:
         self._store_policy_integrity_control_state(payload)
 
+    def _load_workflow_capability_control(self) -> str | None:
+        secret_store = self._policy_integrity_secret_store
+        if secret_store is None or self._should_skip_policy_integrity_keychain_access(secret_store):
+            return None
+        reference = self._build_scoped_secret_ref("guard-workflow-capability-control")
+        return self._get_policy_integrity_secret_from_store(reference)
+
+    def _store_workflow_capability_control(self, encoded: str) -> bool:
+        secret_store = self._policy_integrity_secret_store
+        if secret_store is None or self._should_skip_policy_integrity_keychain_access(secret_store):
+            return False
+        reference = self._build_scoped_secret_ref("guard-workflow-capability-control")
+        try:
+            secret_store.set_secret(reference, encoded)
+        except Exception:
+            return False
+        return self._get_policy_integrity_secret_from_store(reference) == encoded
+
     def _policy_integrity_path_warnings(self) -> list[str]:
         warnings: list[str] = []
         if self.guard_home.is_symlink():

--- a/src/codex_plugin_scanner/guard/store_secret_policy_integrity.py
+++ b/src/codex_plugin_scanner/guard/store_secret_policy_integrity.py
@@ -452,24 +452,6 @@ class StoreSecretPolicyIntegrityMixin:
     def _finalize_policy_integrity_control_state(self, payload: Mapping[str, object]) -> None:
         self._store_policy_integrity_control_state(payload)
 
-    def _load_workflow_capability_control(self) -> str | None:
-        secret_store = self._policy_integrity_secret_store
-        if secret_store is None or self._should_skip_policy_integrity_keychain_access(secret_store):
-            return None
-        reference = self._build_scoped_secret_ref("guard-workflow-capability-control")
-        return self._get_policy_integrity_secret_from_store(reference)
-
-    def _store_workflow_capability_control(self, encoded: str) -> bool:
-        secret_store = self._policy_integrity_secret_store
-        if secret_store is None or self._should_skip_policy_integrity_keychain_access(secret_store):
-            return False
-        reference = self._build_scoped_secret_ref("guard-workflow-capability-control")
-        try:
-            secret_store.set_secret(reference, encoded)
-        except Exception:
-            return False
-        return self._get_policy_integrity_secret_from_store(reference) == encoded
-
     def _policy_integrity_path_warnings(self) -> list[str]:
         warnings: list[str] = []
         if self.guard_home.is_symlink():

--- a/src/codex_plugin_scanner/guard/store_workflow_capabilities.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capabilities.py
@@ -23,7 +23,6 @@ from .store_workflow_capability_common import (
     _private_reference,
     _require_store_key,
     _validate_claim_row,
-    _validate_public_identifier,
     _workflow_capability_event_payload,
 )
 from .store_workflow_capability_control import (
@@ -41,6 +40,7 @@ from .workflow_capabilities import (
     WorkflowCapabilityError,
     WorkflowCapabilityReceipt,
     sign_workflow_capability_receipt,
+    validate_workflow_capability_identifier,
     verify_workflow_capability,
     workflow_capability_claim_sha256,
 )
@@ -50,6 +50,9 @@ class StoreWorkflowCapabilitiesMixin:
     """Persist and atomically consume exact signed workflow capabilities."""
 
     def _connect(self) -> AbstractContextManager[sqlite3.Connection]:
+        raise NotImplementedError
+
+    def hold_workflow_capability_authority_lock(self) -> AbstractContextManager[None]:
         raise NotImplementedError
 
     def _policy_integrity_secret_material(self, *, create: bool) -> tuple[bytes | None, str | None]:
@@ -74,7 +77,7 @@ class StoreWorkflowCapabilitiesMixin:
         if type(signed) is not SignedWorkflowCapability:
             raise WorkflowCapabilityError("invalid_signed_capability")
         claim = signed.claim
-        _validate_public_identifier("approval_provenance_id", approval_provenance_id)
+        validate_workflow_capability_identifier("approval_provenance_id", approval_provenance_id)
         if approval_provenance_id != claim.approval_provenance_id:
             raise WorkflowCapabilityError("capability_approval_binding_mismatch")
         key, key_id = _require_store_key(self, create=False)
@@ -162,15 +165,15 @@ class StoreWorkflowCapabilitiesMixin:
         now = WORKFLOW_CAPABILITY_STORE_CLOCK.now()
         if type(expected_binding) is not WorkflowCapabilityBinding:
             raise WorkflowCapabilityError("invalid_expected_capability_binding")
-        _validate_public_identifier("capability_id", capability_id)
-        _validate_public_identifier("invocation_id", invocation_id)
+        validate_workflow_capability_identifier("capability_id", capability_id)
+        validate_workflow_capability_identifier("invocation_id", invocation_id)
         for name, value in (
             ("expected_subject_id", expected_subject_id),
             ("expected_task_id", expected_task_id),
             ("expected_issuer_id", expected_issuer_id),
             ("expected_approval_provenance_id", expected_approval_provenance_id),
         ):
-            _validate_public_identifier(name, value)
+            validate_workflow_capability_identifier(name, value)
         key, key_id = _require_store_key(self, create=False)
         with self._connect() as connection:
             connection.execute("begin immediate")

--- a/src/codex_plugin_scanner/guard/store_workflow_capabilities.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capabilities.py
@@ -5,13 +5,8 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
-import re
 import sqlite3
 from contextlib import AbstractContextManager
-from datetime import datetime, timezone
-from typing import Protocol
 from uuid import uuid4
 
 from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
@@ -19,6 +14,17 @@ from .store_workflow_capability_authority import (
     advance_authority_state,
     create_authority_state,
     load_and_validate_authority,
+)
+from .store_workflow_capability_common import (
+    WORKFLOW_CAPABILITY_STORE_CLOCK,
+    _canonical_json,
+    _claim_event_extra,
+    _decode_signed_claim,
+    _private_reference,
+    _require_store_key,
+    _validate_claim_row,
+    _validate_public_identifier,
+    _workflow_capability_event_payload,
 )
 from .store_workflow_capability_control import (
     finalize_control_transition,
@@ -34,23 +40,10 @@ from .workflow_capabilities import (
     WorkflowCapabilityBinding,
     WorkflowCapabilityError,
     WorkflowCapabilityReceipt,
-    canonical_framed_payload,
-    format_utc_timestamp,
     sign_workflow_capability_receipt,
     verify_workflow_capability,
-    verify_workflow_capability_signature,
     workflow_capability_claim_sha256,
 )
-
-
-class _WorkflowCapabilityStoreBoundary(Protocol):
-    def _connect(self) -> AbstractContextManager[sqlite3.Connection]: ...
-
-    def _policy_integrity_secret_material(self, *, create: bool) -> tuple[bytes | None, str | None]: ...
-
-    def _load_workflow_capability_control(self) -> str | None: ...
-
-    def _store_workflow_capability_control(self, encoded: str) -> bool: ...
 
 
 class StoreWorkflowCapabilitiesMixin:
@@ -77,7 +70,7 @@ class StoreWorkflowCapabilitiesMixin:
         *,
         approval_provenance_id: str,
     ) -> SignedWorkflowCapability:
-        now = _workflow_capability_store_now()
+        now = WORKFLOW_CAPABILITY_STORE_CLOCK.now()
         if type(signed) is not SignedWorkflowCapability:
             raise WorkflowCapabilityError("invalid_signed_capability")
         claim = signed.claim
@@ -166,7 +159,7 @@ class StoreWorkflowCapabilitiesMixin:
         expected_issuer_id: str,
         expected_approval_provenance_id: str,
     ) -> SignedWorkflowCapabilityReceipt:
-        now = _workflow_capability_store_now()
+        now = WORKFLOW_CAPABILITY_STORE_CLOCK.now()
         if type(expected_binding) is not WorkflowCapabilityBinding:
             raise WorkflowCapabilityError("invalid_expected_capability_binding")
         _validate_public_identifier("capability_id", capability_id)
@@ -341,123 +334,3 @@ class StoreWorkflowCapabilitiesMixin:
         if cursor.lastrowid is None:
             raise WorkflowCapabilityError("capability_event_link_failed")
         return int(cursor.lastrowid)
-
-
-def _require_store_key(store: _WorkflowCapabilityStoreBoundary, *, create: bool = True) -> tuple[bytes, str]:
-    key, key_id = store._policy_integrity_secret_material(create=create)
-    if key is None or key_id is None:
-        raise WorkflowCapabilityError("capability_key_unavailable")
-    return key, key_id
-
-
-def _workflow_capability_store_now() -> str:
-    return format_utc_timestamp(datetime.now(timezone.utc))
-
-
-def _decode_signed_claim(encoded: str) -> SignedWorkflowCapability:
-    try:
-        payload = json.loads(encoded)
-    except json.JSONDecodeError as error:
-        raise WorkflowCapabilityError("capability_payload_invalid") from error
-    signed = SignedWorkflowCapability.from_dict(payload)
-    if _canonical_json(signed.to_dict()) != encoded:
-        raise WorkflowCapabilityError("capability_payload_not_canonical")
-    return signed
-
-
-def _decode_signed_receipt(encoded: str) -> SignedWorkflowCapabilityReceipt:
-    try:
-        payload = json.loads(encoded)
-    except json.JSONDecodeError as error:
-        raise WorkflowCapabilityError("receipt_payload_invalid") from error
-    signed = SignedWorkflowCapabilityReceipt.from_dict(payload)
-    if _canonical_json(signed.to_dict()) != encoded:
-        raise WorkflowCapabilityError("receipt_payload_not_canonical")
-    return signed
-
-
-def _verify_persisted_claim_signature(signed: SignedWorkflowCapability, *, key: bytes, key_id: str) -> None:
-    verify_workflow_capability_signature(signed, key=key, key_id=key_id)
-
-
-def _validate_claim_row(signed: SignedWorkflowCapability, row: sqlite3.Row, capability_id: str) -> None:
-    claim = signed.claim
-    expected = (
-        capability_id,
-        claim.approval_provenance_id,
-        claim.nonce,
-        signed.key_id,
-        claim.issued_at,
-        claim.not_before,
-        claim.expires_at,
-        claim.max_uses,
-    )
-    actual = (
-        claim.capability_id,
-        str(row["approval_provenance_id"]),
-        str(row["nonce"]),
-        str(row["key_id"]),
-        str(row["issued_at"]),
-        str(row["not_before"]),
-        str(row["expires_at"]),
-        int(row["max_uses"]),
-    )
-    if actual != expected:
-        raise WorkflowCapabilityError("capability_row_binding_invalid")
-
-
-def _private_reference(purpose: str, value: str) -> str:
-    return hashlib.sha256(canonical_framed_payload(f"audit-{purpose}", value)).hexdigest()
-
-
-def _workflow_capability_event_payload(
-    capability_id: str, invocation_id: str | None, extra: dict[str, object]
-) -> dict[str, object]:
-    payload: dict[str, object] = {
-        "capability_ref": _private_reference("capability", capability_id),
-        **extra,
-    }
-    if invocation_id is not None:
-        payload["invocation_ref"] = _private_reference("invocation", invocation_id)
-    return payload
-
-
-def _claim_event_extra(
-    *, approval_provenance_id: str, receipt_id: str, task_id: str, use_number: int
-) -> dict[str, object]:
-    return {
-        "approval_provenance_ref": _private_reference("approval-provenance", approval_provenance_id),
-        "receipt_ref": _private_reference("receipt", receipt_id),
-        "task_ref": _private_reference("task", task_id),
-        "use_number": use_number,
-    }
-
-
-def _claim_event_payload(receipt: WorkflowCapabilityReceipt) -> dict[str, object]:
-    return {
-        "capability_ref": _private_reference("capability", receipt.capability_id),
-        "invocation_ref": _private_reference("invocation", receipt.invocation_id),
-        **_claim_event_extra(
-            approval_provenance_id=receipt.approval_provenance_id,
-            receipt_id=receipt.receipt_id,
-            task_id=receipt.task_id,
-            use_number=receipt.use_number,
-        ),
-    }
-
-
-def _canonical_json(payload: object) -> str:
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
-
-
-def _validate_public_identifier(name: str, value: str) -> None:
-    # Reuse the strict contract parser without exporting its internal validator.
-    if type(value) is not str or not value or len(value) > 256 or value.strip() != value or "*" in value:
-        raise WorkflowCapabilityError(f"invalid_{name}")
-    if any(character.isspace() or ord(character) < 33 or ord(character) > 126 for character in value):
-        raise WorkflowCapabilityError(f"invalid_{name}")
-
-
-def _validate_reason_code(value: str) -> None:
-    if type(value) is not str or re.fullmatch(r"[a-z][a-z0-9_.-]{0,63}", value) is None:
-        raise WorkflowCapabilityError("invalid_reason_code")

--- a/src/codex_plugin_scanner/guard/store_workflow_capabilities.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capabilities.py
@@ -1,0 +1,463 @@
+"""GuardStore boundary for dormant workflow-capability persistence."""
+
+# pyright: reportAny=false, reportPrivateUsage=false, reportUnnecessaryIsInstance=false
+# pyright: reportUnusedCallResult=false, reportUnusedFunction=false
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+from contextlib import AbstractContextManager
+from datetime import datetime, timezone
+from typing import Protocol
+from uuid import uuid4
+
+from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
+from .store_workflow_capability_authority import (
+    advance_authority_state,
+    create_authority_state,
+    load_and_validate_authority,
+)
+from .store_workflow_capability_control import (
+    finalize_control_transition,
+    load_validate_and_observe_control,
+    prepare_control_transition,
+)
+from .store_workflow_capability_lock import serialized_workflow_capability_authority
+from .store_workflow_capability_transitions import append_authority_transition, build_authority_transition
+from .workflow_capabilities import (
+    WORKFLOW_CAPABILITY_RECEIPT_SCHEMA,
+    SignedWorkflowCapability,
+    SignedWorkflowCapabilityReceipt,
+    WorkflowCapabilityBinding,
+    WorkflowCapabilityError,
+    WorkflowCapabilityReceipt,
+    canonical_framed_payload,
+    format_utc_timestamp,
+    sign_workflow_capability_receipt,
+    verify_workflow_capability,
+    verify_workflow_capability_signature,
+    workflow_capability_claim_sha256,
+)
+
+
+class _WorkflowCapabilityStoreBoundary(Protocol):
+    def _connect(self) -> AbstractContextManager[sqlite3.Connection]: ...
+
+    def _policy_integrity_secret_material(self, *, create: bool) -> tuple[bytes | None, str | None]: ...
+
+    def _load_workflow_capability_control(self) -> str | None: ...
+
+    def _store_workflow_capability_control(self, encoded: str) -> bool: ...
+
+
+class StoreWorkflowCapabilitiesMixin:
+    """Persist and atomically consume exact signed workflow capabilities."""
+
+    def _connect(self) -> AbstractContextManager[sqlite3.Connection]:
+        raise NotImplementedError
+
+    def _policy_integrity_secret_material(self, *, create: bool) -> tuple[bytes | None, str | None]:
+        _ = create
+        raise NotImplementedError
+
+    def _load_workflow_capability_control(self) -> str | None:
+        raise NotImplementedError
+
+    def _store_workflow_capability_control(self, encoded: str) -> bool:
+        _ = encoded
+        raise NotImplementedError
+
+    @serialized_workflow_capability_authority
+    def issue_workflow_capability(
+        self,
+        signed: SignedWorkflowCapability,
+        *,
+        approval_provenance_id: str,
+    ) -> SignedWorkflowCapability:
+        now = _workflow_capability_store_now()
+        if type(signed) is not SignedWorkflowCapability:
+            raise WorkflowCapabilityError("invalid_signed_capability")
+        claim = signed.claim
+        _validate_public_identifier("approval_provenance_id", approval_provenance_id)
+        if approval_provenance_id != claim.approval_provenance_id:
+            raise WorkflowCapabilityError("capability_approval_binding_mismatch")
+        key, key_id = _require_store_key(self, create=False)
+        verify_workflow_capability(
+            signed,
+            key=key,
+            key_id=key_id,
+            now=now,
+            expected_binding=claim.binding,
+        )
+        encoded = _canonical_json(signed.to_dict())
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            ensure_workflow_capability_schema(connection, applied_at=now)
+            control = load_validate_and_observe_control(self, connection, key=key, key_id=key_id, now=now, create=True)
+            try:
+                connection.execute(
+                    """
+                    insert into guard_workflow_capabilities (
+                      capability_id, approval_provenance_id, nonce, signed_claim_json, key_id, issued_at, not_before,
+                      expires_at, max_uses, used_count, revoked_at, revocation_code
+                    ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, null, null)
+                    """,
+                    (
+                        claim.capability_id,
+                        approval_provenance_id,
+                        claim.nonce,
+                        encoded,
+                        key_id,
+                        claim.issued_at,
+                        claim.not_before,
+                        claim.expires_at,
+                        claim.max_uses,
+                    ),
+                )
+            except sqlite3.IntegrityError as error:
+                raise WorkflowCapabilityError("capability_already_exists") from error
+            event_extra: dict[str, object] = {
+                "approval_provenance_ref": _private_reference("approval-provenance", approval_provenance_id),
+                "max_uses": claim.max_uses,
+                "task_ref": _private_reference("task", claim.task_id),
+            }
+            event_id = self._insert_workflow_capability_event(
+                connection,
+                event_name="workflow_capability.issued",
+                capability_id=claim.capability_id,
+                invocation_id=None,
+                occurred_at=now,
+                extra=event_extra,
+            )
+            signed_state = create_authority_state(connection, signed, key=key, key_id=key_id, now=now)
+            transition = build_authority_transition(
+                signed,
+                signed_state,
+                sequence=control.committed_sequence + 1,
+                previous_transition_sha256=control.committed_head_sha256,
+                transition_kind="issued",
+                event_id=event_id,
+                event_name="workflow_capability.issued",
+                event_payload=_workflow_capability_event_payload(claim.capability_id, None, event_extra),
+                occurred_at=now,
+                use_number=None,
+                receipt_id=None,
+                revocation_id=None,
+                key=key,
+                key_id=key_id,
+            )
+            pending_control = prepare_control_transition(self, control, transition)
+            append_authority_transition(connection, transition)
+        finalize_control_transition(self, pending_control)
+        return signed
+
+    @serialized_workflow_capability_authority
+    def claim_workflow_capability(
+        self,
+        capability_id: str,
+        *,
+        invocation_id: str,
+        expected_binding: WorkflowCapabilityBinding,
+        expected_subject_id: str,
+        expected_task_id: str,
+        expected_issuer_id: str,
+        expected_approval_provenance_id: str,
+    ) -> SignedWorkflowCapabilityReceipt:
+        now = _workflow_capability_store_now()
+        if type(expected_binding) is not WorkflowCapabilityBinding:
+            raise WorkflowCapabilityError("invalid_expected_capability_binding")
+        _validate_public_identifier("capability_id", capability_id)
+        _validate_public_identifier("invocation_id", invocation_id)
+        for name, value in (
+            ("expected_subject_id", expected_subject_id),
+            ("expected_task_id", expected_task_id),
+            ("expected_issuer_id", expected_issuer_id),
+            ("expected_approval_provenance_id", expected_approval_provenance_id),
+        ):
+            _validate_public_identifier(name, value)
+        key, key_id = _require_store_key(self, create=False)
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            ensure_workflow_capability_schema(connection, applied_at=now)
+            control = load_validate_and_observe_control(self, connection, key=key, key_id=key_id, now=now, create=False)
+            row = connection.execute(
+                """
+                select signed_claim_json, key_id, issued_at, not_before, expires_at,
+                       max_uses, used_count, revoked_at, revocation_code, approval_provenance_id, nonce
+                from guard_workflow_capabilities where capability_id = ?
+                """,
+                (capability_id,),
+            ).fetchone()
+            if row is None:
+                raise WorkflowCapabilityError("capability_not_found")
+            signed = _decode_signed_claim(str(row["signed_claim_json"]))
+            _validate_claim_row(signed, row, capability_id)
+            state = load_and_validate_authority(
+                connection,
+                signed,
+                key=key,
+                key_id=key_id,
+                used_count=int(row["used_count"]),
+                revoked_at=row["revoked_at"],
+                revocation_code=row["revocation_code"],
+            )
+            verify_workflow_capability(
+                signed,
+                key=key,
+                key_id=key_id,
+                now=now,
+                expected_binding=expected_binding,
+            )
+            claim = signed.claim
+            if (
+                claim.subject_id != expected_subject_id
+                or claim.task_id != expected_task_id
+                or claim.issuer_id != expected_issuer_id
+                or claim.approval_provenance_id != expected_approval_provenance_id
+            ):
+                raise WorkflowCapabilityError("capability_claimant_context_mismatch")
+            if state.revocation_id is not None:
+                raise WorkflowCapabilityError("capability_revoked")
+            used_count = int(row["used_count"])
+            if used_count >= signed.claim.max_uses:
+                raise WorkflowCapabilityError("capability_exhausted")
+            if (
+                connection.execute(
+                    "select 1 from guard_workflow_capability_receipts where invocation_id = ?",
+                    (invocation_id,),
+                ).fetchone()
+                is not None
+            ):
+                raise WorkflowCapabilityError("capability_invocation_replayed")
+
+            use_number = used_count + 1
+            receipt_id = f"wcr-{uuid4().hex}"
+            updated = connection.execute(
+                """
+                update guard_workflow_capabilities set used_count = ?
+                where capability_id = ? and used_count = ? and revoked_at is null
+                """,
+                (use_number, capability_id, used_count),
+            )
+            if updated.rowcount != 1:
+                raise WorkflowCapabilityError("capability_claim_conflict")
+            event_extra = _claim_event_extra(
+                approval_provenance_id=signed.claim.approval_provenance_id,
+                receipt_id=receipt_id,
+                task_id=signed.claim.task_id,
+                use_number=use_number,
+            )
+            event_id = self._insert_workflow_capability_event(
+                connection,
+                event_name="workflow_capability.claimed",
+                capability_id=capability_id,
+                invocation_id=invocation_id,
+                occurred_at=now,
+                extra=event_extra,
+            )
+            receipt = WorkflowCapabilityReceipt(
+                schema_version=WORKFLOW_CAPABILITY_RECEIPT_SCHEMA,
+                receipt_id=receipt_id,
+                capability_id=capability_id,
+                task_id=signed.claim.task_id,
+                invocation_id=invocation_id,
+                approval_provenance_id=signed.claim.approval_provenance_id,
+                claim_sha256=workflow_capability_claim_sha256(signed),
+                binding=expected_binding,
+                use_number=use_number,
+                event_id=event_id,
+                claimed_at=now,
+            )
+            signed_receipt = sign_workflow_capability_receipt(receipt, key=key, key_id=key_id)
+            try:
+                connection.execute(
+                    """
+                    insert into guard_workflow_capability_receipts (
+                      receipt_id, capability_id, task_id, invocation_id, approval_provenance_id, signed_receipt_json,
+                      claimed_at, use_number, event_id
+                    ) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        receipt.receipt_id,
+                        capability_id,
+                        receipt.task_id,
+                        invocation_id,
+                        receipt.approval_provenance_id,
+                        _canonical_json(signed_receipt.to_dict()),
+                        now,
+                        use_number,
+                        event_id,
+                    ),
+                )
+            except sqlite3.IntegrityError as error:
+                raise WorkflowCapabilityError("capability_claim_conflict") from error
+            signed_state = advance_authority_state(
+                connection,
+                state,
+                key=key,
+                key_id=key_id,
+                now=now,
+                use_high_water=use_number,
+            )
+            transition = build_authority_transition(
+                signed,
+                signed_state,
+                sequence=control.committed_sequence + 1,
+                previous_transition_sha256=control.committed_head_sha256,
+                transition_kind="claimed",
+                event_id=event_id,
+                event_name="workflow_capability.claimed",
+                event_payload=_workflow_capability_event_payload(capability_id, invocation_id, event_extra),
+                occurred_at=now,
+                use_number=use_number,
+                receipt_id=receipt_id,
+                revocation_id=None,
+                key=key,
+                key_id=key_id,
+            )
+            pending_control = prepare_control_transition(self, control, transition)
+            append_authority_transition(connection, transition)
+        finalize_control_transition(self, pending_control)
+        return signed_receipt
+
+    @staticmethod
+    def _insert_workflow_capability_event(
+        connection: sqlite3.Connection,
+        *,
+        event_name: str,
+        capability_id: str,
+        invocation_id: str | None,
+        occurred_at: str,
+        extra: dict[str, object],
+    ) -> int:
+        payload = _workflow_capability_event_payload(capability_id, invocation_id, extra)
+        cursor = connection.execute(
+            "insert into guard_events (event_name, payload_json, occurred_at) values (?, ?, ?)",
+            (event_name, _canonical_json(payload), occurred_at),
+        )
+        if cursor.lastrowid is None:
+            raise WorkflowCapabilityError("capability_event_link_failed")
+        return int(cursor.lastrowid)
+
+
+def _require_store_key(store: _WorkflowCapabilityStoreBoundary, *, create: bool = True) -> tuple[bytes, str]:
+    key, key_id = store._policy_integrity_secret_material(create=create)
+    if key is None or key_id is None:
+        raise WorkflowCapabilityError("capability_key_unavailable")
+    return key, key_id
+
+
+def _workflow_capability_store_now() -> str:
+    return format_utc_timestamp(datetime.now(timezone.utc))
+
+
+def _decode_signed_claim(encoded: str) -> SignedWorkflowCapability:
+    try:
+        payload = json.loads(encoded)
+    except json.JSONDecodeError as error:
+        raise WorkflowCapabilityError("capability_payload_invalid") from error
+    signed = SignedWorkflowCapability.from_dict(payload)
+    if _canonical_json(signed.to_dict()) != encoded:
+        raise WorkflowCapabilityError("capability_payload_not_canonical")
+    return signed
+
+
+def _decode_signed_receipt(encoded: str) -> SignedWorkflowCapabilityReceipt:
+    try:
+        payload = json.loads(encoded)
+    except json.JSONDecodeError as error:
+        raise WorkflowCapabilityError("receipt_payload_invalid") from error
+    signed = SignedWorkflowCapabilityReceipt.from_dict(payload)
+    if _canonical_json(signed.to_dict()) != encoded:
+        raise WorkflowCapabilityError("receipt_payload_not_canonical")
+    return signed
+
+
+def _verify_persisted_claim_signature(signed: SignedWorkflowCapability, *, key: bytes, key_id: str) -> None:
+    verify_workflow_capability_signature(signed, key=key, key_id=key_id)
+
+
+def _validate_claim_row(signed: SignedWorkflowCapability, row: sqlite3.Row, capability_id: str) -> None:
+    claim = signed.claim
+    expected = (
+        capability_id,
+        claim.approval_provenance_id,
+        claim.nonce,
+        signed.key_id,
+        claim.issued_at,
+        claim.not_before,
+        claim.expires_at,
+        claim.max_uses,
+    )
+    actual = (
+        claim.capability_id,
+        str(row["approval_provenance_id"]),
+        str(row["nonce"]),
+        str(row["key_id"]),
+        str(row["issued_at"]),
+        str(row["not_before"]),
+        str(row["expires_at"]),
+        int(row["max_uses"]),
+    )
+    if actual != expected:
+        raise WorkflowCapabilityError("capability_row_binding_invalid")
+
+
+def _private_reference(purpose: str, value: str) -> str:
+    return hashlib.sha256(canonical_framed_payload(f"audit-{purpose}", value)).hexdigest()
+
+
+def _workflow_capability_event_payload(
+    capability_id: str, invocation_id: str | None, extra: dict[str, object]
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "capability_ref": _private_reference("capability", capability_id),
+        **extra,
+    }
+    if invocation_id is not None:
+        payload["invocation_ref"] = _private_reference("invocation", invocation_id)
+    return payload
+
+
+def _claim_event_extra(
+    *, approval_provenance_id: str, receipt_id: str, task_id: str, use_number: int
+) -> dict[str, object]:
+    return {
+        "approval_provenance_ref": _private_reference("approval-provenance", approval_provenance_id),
+        "receipt_ref": _private_reference("receipt", receipt_id),
+        "task_ref": _private_reference("task", task_id),
+        "use_number": use_number,
+    }
+
+
+def _claim_event_payload(receipt: WorkflowCapabilityReceipt) -> dict[str, object]:
+    return {
+        "capability_ref": _private_reference("capability", receipt.capability_id),
+        "invocation_ref": _private_reference("invocation", receipt.invocation_id),
+        **_claim_event_extra(
+            approval_provenance_id=receipt.approval_provenance_id,
+            receipt_id=receipt.receipt_id,
+            task_id=receipt.task_id,
+            use_number=receipt.use_number,
+        ),
+    }
+
+
+def _canonical_json(payload: object) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _validate_public_identifier(name: str, value: str) -> None:
+    # Reuse the strict contract parser without exporting its internal validator.
+    if type(value) is not str or not value or len(value) > 256 or value.strip() != value or "*" in value:
+        raise WorkflowCapabilityError(f"invalid_{name}")
+    if any(character.isspace() or ord(character) < 33 or ord(character) > 126 for character in value):
+        raise WorkflowCapabilityError(f"invalid_{name}")
+
+
+def _validate_reason_code(value: str) -> None:
+    if type(value) is not str or re.fullmatch(r"[a-z][a-z0-9_.-]{0,63}", value) is None:
+        raise WorkflowCapabilityError("invalid_reason_code")

--- a/src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py
@@ -1,0 +1,211 @@
+"""Crash-safe validated SQLite schema for dormant workflow capabilities."""
+
+# pyright: reportAny=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from typing import Final
+
+WORKFLOW_CAPABILITY_MIGRATION_VERSION: Final = 14
+
+_SCHEMA_STATEMENTS: Final = (
+    """create table if not exists guard_workflow_capabilities (
+      capability_id text primary key,
+      approval_provenance_id text not null,
+      nonce text not null unique,
+      signed_claim_json text not null,
+      key_id text not null,
+      issued_at text not null,
+      not_before text not null,
+      expires_at text not null,
+      max_uses integer not null check (max_uses between 1 and 50),
+      used_count integer not null default 0 check (used_count between 0 and max_uses),
+      revoked_at text,
+      revocation_code text,
+      check ((revoked_at is null and revocation_code is null) or
+             (revoked_at is not null and revocation_code is not null))
+    ) strict""",
+    """create table if not exists guard_workflow_capability_authority_state (
+      capability_id text primary key,
+      signed_state_json text not null,
+      key_id text not null,
+      revision integer not null check (revision >= 0),
+      use_high_water integer not null check (use_high_water >= 0),
+      observed_at text not null,
+      revocation_id text
+    ) strict""",
+    """create table if not exists guard_workflow_capability_revocations (
+      revocation_id text primary key,
+      capability_id text not null unique,
+      signed_revocation_json text not null,
+      key_id text not null,
+      revoked_at text not null
+    ) strict""",
+    """create table if not exists guard_workflow_capability_receipts (
+      receipt_id text primary key,
+      capability_id text not null references guard_workflow_capabilities(capability_id),
+      task_id text not null,
+      invocation_id text not null unique,
+      approval_provenance_id text not null,
+      signed_receipt_json text not null,
+      claimed_at text not null,
+      use_number integer not null check (use_number >= 1),
+      event_id integer not null references guard_events(event_id),
+      unique (capability_id, use_number)
+    ) strict""",
+    """create table if not exists guard_workflow_capability_authority_transitions (
+      sequence integer primary key,
+      capability_id text not null references guard_workflow_capabilities(capability_id),
+      revision integer not null check (revision >= 0),
+      transition_kind text not null,
+      previous_transition_sha256 text not null,
+      signed_transition_json text not null,
+      key_id text not null,
+      event_id integer not null unique references guard_events(event_id),
+      unique (capability_id, revision)
+    ) strict""",
+    """create index if not exists idx_guard_workflow_capability_expiry
+    on guard_workflow_capabilities (revoked_at, expires_at, capability_id)""",
+    """create index if not exists idx_guard_workflow_receipt_capability
+    on guard_workflow_capability_receipts (capability_id, use_number)""",
+    """create trigger if not exists trg_guard_workflow_capability_claim_immutable
+    before update of capability_id, approval_provenance_id, nonce, signed_claim_json, key_id,
+      issued_at, not_before, expires_at, max_uses on guard_workflow_capabilities
+    begin select raise(abort, 'workflow_capability_claim_immutable'); end""",
+    """create trigger if not exists trg_guard_workflow_capability_no_delete
+    before delete on guard_workflow_capabilities
+    begin select raise(abort, 'workflow_capability_delete_forbidden'); end""",
+    """create trigger if not exists trg_guard_workflow_receipt_immutable_update
+    before update on guard_workflow_capability_receipts
+    begin select raise(abort, 'workflow_capability_receipt_immutable'); end""",
+    """create trigger if not exists trg_guard_workflow_receipt_immutable_delete
+    before delete on guard_workflow_capability_receipts
+    begin select raise(abort, 'workflow_capability_receipt_delete_forbidden'); end""",
+    """create trigger if not exists trg_guard_workflow_receipt_require_parents
+    before insert on guard_workflow_capability_receipts
+    begin
+      select case when not exists (
+        select 1 from guard_workflow_capabilities where capability_id = new.capability_id
+      ) then raise(abort, 'workflow_capability_parent_missing') end;
+      select case when not exists (
+        select 1 from guard_events where event_id = new.event_id
+      ) then raise(abort, 'workflow_capability_event_missing') end;
+    end""",
+    """create trigger if not exists trg_guard_workflow_event_preserve_link
+    before delete on guard_events when exists (
+      select 1 from guard_workflow_capability_receipts where event_id = old.event_id
+      union all
+      select 1 from guard_workflow_capability_authority_transitions where event_id = old.event_id
+    ) begin select raise(abort, 'workflow_capability_event_referenced'); end""",
+    """create trigger if not exists trg_guard_workflow_authority_state_no_delete
+    before delete on guard_workflow_capability_authority_state
+    begin select raise(abort, 'workflow_capability_authority_state_delete_forbidden'); end""",
+    """create trigger if not exists trg_guard_workflow_revocation_immutable_update
+    before update on guard_workflow_capability_revocations
+    begin select raise(abort, 'workflow_capability_revocation_immutable'); end""",
+    """create trigger if not exists trg_guard_workflow_revocation_immutable_delete
+    before delete on guard_workflow_capability_revocations
+    begin select raise(abort, 'workflow_capability_revocation_delete_forbidden'); end""",
+    """create trigger if not exists trg_guard_workflow_revocation_require_parent
+    before insert on guard_workflow_capability_revocations when not exists (
+      select 1 from guard_workflow_capabilities where capability_id = new.capability_id
+    ) begin select raise(abort, 'workflow_capability_revocation_parent_missing'); end""",
+    """create trigger if not exists trg_guard_workflow_transition_immutable_update
+    before update on guard_workflow_capability_authority_transitions
+    begin select raise(abort, 'workflow_capability_transition_immutable'); end""",
+    """create trigger if not exists trg_guard_workflow_transition_immutable_delete
+    before delete on guard_workflow_capability_authority_transitions
+    begin select raise(abort, 'workflow_capability_transition_delete_forbidden'); end""",
+    """create trigger if not exists trg_guard_workflow_transition_require_parents
+    before insert on guard_workflow_capability_authority_transitions
+    begin
+      select case when not exists (
+        select 1 from guard_workflow_capabilities where capability_id = new.capability_id
+      ) then raise(abort, 'workflow_capability_transition_parent_missing') end;
+      select case when new.event_id is not null and not exists (
+        select 1 from guard_events where event_id = new.event_id
+      ) then raise(abort, 'workflow_capability_transition_event_missing') end;
+    end""",
+)
+_OBJECT_NAMES: Final = (
+    ("table", "guard_workflow_capabilities"),
+    ("table", "guard_workflow_capability_authority_state"),
+    ("table", "guard_workflow_capability_revocations"),
+    ("table", "guard_workflow_capability_receipts"),
+    ("table", "guard_workflow_capability_authority_transitions"),
+    ("index", "idx_guard_workflow_capability_expiry"),
+    ("index", "idx_guard_workflow_receipt_capability"),
+    ("trigger", "trg_guard_workflow_capability_claim_immutable"),
+    ("trigger", "trg_guard_workflow_capability_no_delete"),
+    ("trigger", "trg_guard_workflow_receipt_immutable_update"),
+    ("trigger", "trg_guard_workflow_receipt_immutable_delete"),
+    ("trigger", "trg_guard_workflow_receipt_require_parents"),
+    ("trigger", "trg_guard_workflow_event_preserve_link"),
+    ("trigger", "trg_guard_workflow_authority_state_no_delete"),
+    ("trigger", "trg_guard_workflow_revocation_immutable_update"),
+    ("trigger", "trg_guard_workflow_revocation_immutable_delete"),
+    ("trigger", "trg_guard_workflow_revocation_require_parent"),
+    ("trigger", "trg_guard_workflow_transition_immutable_update"),
+    ("trigger", "trg_guard_workflow_transition_immutable_delete"),
+    ("trigger", "trg_guard_workflow_transition_require_parents"),
+)
+
+
+def ensure_workflow_capability_schema(connection: sqlite3.Connection, *, applied_at: str) -> None:
+    """Apply migration 14 atomically and validate every owned schema object."""
+    connection.execute("savepoint workflow_capability_schema_v14")
+    try:
+        for statement in _SCHEMA_STATEMENTS:
+            connection.execute(statement)
+        _validate_schema_objects(connection)
+        connection.execute(
+            "insert or ignore into schema_migrations (version, applied_at) values (?, ?)",
+            (WORKFLOW_CAPABILITY_MIGRATION_VERSION, applied_at),
+        )
+        version = connection.execute(
+            "select applied_at from schema_migrations where version = ?",
+            (WORKFLOW_CAPABILITY_MIGRATION_VERSION,),
+        ).fetchone()
+        if version is None or not str(version[0]):
+            raise RuntimeError("workflow_capability_migration_not_recorded")
+    except sqlite3.DatabaseError as error:
+        connection.execute("rollback to workflow_capability_schema_v14")
+        connection.execute("release workflow_capability_schema_v14")
+        raise RuntimeError("invalid_workflow_capability_schema:migration") from error
+    except Exception:
+        connection.execute("rollback to workflow_capability_schema_v14")
+        connection.execute("release workflow_capability_schema_v14")
+        raise
+    connection.execute("release workflow_capability_schema_v14")
+
+
+def _validate_schema_objects(connection: sqlite3.Connection) -> None:
+    expected = {
+        (object_type, name): _normalized_sql(statement)
+        for (object_type, name), statement in zip(_OBJECT_NAMES, _SCHEMA_STATEMENTS, strict=True)
+    }
+    rows = connection.execute(
+        """
+        select type, name, sql from sqlite_master
+        where name like 'guard_workflow_capabilit%'
+           or name like 'idx_guard_workflow_%'
+           or name like 'trg_guard_workflow_%'
+        """
+    ).fetchall()
+    actual = {
+        (str(row[0]), str(row[1])): _normalized_sql(str(row[2]))
+        for row in rows
+        if row[2] is not None and not str(row[1]).startswith("sqlite_autoindex")
+    }
+    if set(actual) != set(expected):
+        raise RuntimeError("invalid_workflow_capability_schema:owned_objects")
+    for identity, expected_sql in expected.items():
+        if actual.get(identity) != expected_sql:
+            raise RuntimeError(f"invalid_workflow_capability_schema:{identity[0]}:{identity[1]}")
+
+
+def _normalized_sql(statement: str) -> str:
+    normalized = re.sub(r"\s+", " ", statement.strip().lower())
+    return normalized.replace(" if not exists", "")

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_authority.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_authority.py
@@ -1,0 +1,323 @@
+"""Authenticated workflow-capability authority persistence validation."""
+
+# pyright: reportAny=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import replace
+
+from .store_workflow_capability_transitions import validate_capability_transition_projection
+from .workflow_capabilities import (
+    SignedWorkflowCapability,
+    SignedWorkflowCapabilityReceipt,
+    WorkflowCapabilityError,
+    WorkflowCapabilityReceipt,
+    canonical_framed_payload,
+    parse_utc_timestamp,
+    verify_workflow_capability_receipt,
+    workflow_capability_claim_sha256,
+)
+from .workflow_capability_authority_state import (
+    AUTHORITY_STATE_SCHEMA,
+    REVOCATION_SCHEMA,
+    SignedAuthorityState,
+    WorkflowCapabilityAuthorityState,
+    WorkflowCapabilityRevocation,
+    decode_signed_authority_state,
+    decode_signed_revocation,
+    encode_signed_authority_state,
+    encode_signed_revocation,
+    sign_authority_state,
+    sign_revocation,
+    verify_authority_state,
+    verify_revocation,
+)
+
+
+def create_authority_state(
+    connection: sqlite3.Connection,
+    signed_claim: SignedWorkflowCapability,
+    *,
+    key: bytes,
+    key_id: str,
+    now: str,
+) -> SignedAuthorityState:
+    state = WorkflowCapabilityAuthorityState(
+        schema_version=AUTHORITY_STATE_SCHEMA,
+        capability_id=signed_claim.claim.capability_id,
+        claim_sha256=workflow_capability_claim_sha256(signed_claim),
+        use_high_water=0,
+        observed_at=now,
+        revision=0,
+        revocation_id=None,
+        revoked_at=None,
+    )
+    signed_state = sign_authority_state(state, key=key, key_id=key_id)
+    _write_state(connection, signed_state, insert=True)
+    return signed_state
+
+
+def load_and_validate_authority(
+    connection: sqlite3.Connection,
+    signed_claim: SignedWorkflowCapability,
+    *,
+    key: bytes,
+    key_id: str,
+    used_count: int,
+    revoked_at: object,
+    revocation_code: object,
+) -> WorkflowCapabilityAuthorityState:
+    capability_id = signed_claim.claim.capability_id
+    row = connection.execute(
+        """
+        select signed_state_json, key_id, revision, use_high_water, observed_at, revocation_id
+        from guard_workflow_capability_authority_state where capability_id = ?
+        """,
+        (capability_id,),
+    ).fetchone()
+    if row is None:
+        raise WorkflowCapabilityError("capability_authority_state_missing")
+    signed_state = decode_signed_authority_state(str(row["signed_state_json"]))
+    verify_authority_state(signed_state, key=key, key_id=key_id)
+    state = signed_state.state
+    duplicated = (
+        capability_id,
+        key_id,
+        int(row["revision"]),
+        int(row["use_high_water"]),
+        str(row["observed_at"]),
+        str(row["revocation_id"]) if row["revocation_id"] is not None else None,
+    )
+    authenticated = (
+        state.capability_id,
+        signed_state.key_id,
+        state.revision,
+        state.use_high_water,
+        state.observed_at,
+        state.revocation_id,
+    )
+    if duplicated != authenticated or state.claim_sha256 != workflow_capability_claim_sha256(signed_claim):
+        raise WorkflowCapabilityError("capability_authority_state_binding_invalid")
+    receipt_count = _validate_receipt_history(connection, signed_claim, key=key, key_id=key_id)
+    if state.use_high_water != receipt_count or used_count != receipt_count:
+        raise WorkflowCapabilityError("capability_use_high_water_invalid")
+    revocation = _load_revocation(connection, signed_claim, key=key, key_id=key_id)
+    if revocation is None:
+        if state.revocation_id is not None or revoked_at is not None or revocation_code is not None:
+            raise WorkflowCapabilityError("capability_revocation_state_invalid")
+    elif (
+        state.revocation_id != revocation.revocation_id
+        or state.revoked_at != revocation.revoked_at
+        or revoked_at != revocation.revoked_at
+        or revocation_code != revocation.reason_code
+    ):
+        raise WorkflowCapabilityError("capability_revocation_state_invalid")
+    validate_capability_transition_projection(
+        connection,
+        signed_claim,
+        signed_state,
+        receipt_count=receipt_count,
+        revocation_id=revocation.revocation_id if revocation is not None else None,
+        key=key,
+        key_id=key_id,
+    )
+    return state
+
+
+def advance_authority_state(
+    connection: sqlite3.Connection,
+    state: WorkflowCapabilityAuthorityState,
+    *,
+    key: bytes,
+    key_id: str,
+    now: str,
+    use_high_water: int | None = None,
+    revocation_id: str | None = None,
+    revoked_at: str | None = None,
+) -> SignedAuthorityState:
+    if parse_utc_timestamp(now) < parse_utc_timestamp(state.observed_at):
+        raise WorkflowCapabilityError("capability_clock_rollback")
+    updated = replace(
+        state,
+        observed_at=now,
+        revision=state.revision + 1,
+        use_high_water=state.use_high_water if use_high_water is None else use_high_water,
+        revocation_id=state.revocation_id if revocation_id is None else revocation_id,
+        revoked_at=state.revoked_at if revoked_at is None else revoked_at,
+    )
+    signed_state = sign_authority_state(updated, key=key, key_id=key_id)
+    _write_state(connection, signed_state, insert=False)
+    return signed_state
+
+
+def append_revocation(
+    connection: sqlite3.Connection,
+    signed_claim: SignedWorkflowCapability,
+    *,
+    reason_code: str,
+    revoked_at: str,
+    revocation_id: str,
+    key: bytes,
+    key_id: str,
+) -> WorkflowCapabilityRevocation:
+    revocation = WorkflowCapabilityRevocation(
+        schema_version=REVOCATION_SCHEMA,
+        revocation_id=revocation_id,
+        capability_id=signed_claim.claim.capability_id,
+        claim_sha256=workflow_capability_claim_sha256(signed_claim),
+        reason_code=reason_code,
+        revoked_at=revoked_at,
+    )
+    signed = sign_revocation(revocation, key=key, key_id=key_id)
+    connection.execute(
+        """
+        insert into guard_workflow_capability_revocations
+          (revocation_id, capability_id, signed_revocation_json, key_id, revoked_at)
+        values (?, ?, ?, ?, ?)
+        """,
+        (revocation_id, revocation.capability_id, encode_signed_revocation(signed), key_id, revoked_at),
+    )
+    return revocation
+
+
+def _write_state(connection: sqlite3.Connection, signed: SignedAuthorityState, *, insert: bool) -> None:
+    state = signed.state
+    payload = (
+        encode_signed_authority_state(signed),
+        signed.key_id,
+        state.revision,
+        state.use_high_water,
+        state.observed_at,
+        state.revocation_id,
+        state.capability_id,
+    )
+    if insert:
+        connection.execute(
+            """
+            insert into guard_workflow_capability_authority_state
+              (signed_state_json, key_id, revision, use_high_water, observed_at, revocation_id, capability_id)
+            values (?, ?, ?, ?, ?, ?, ?)
+            """,
+            payload,
+        )
+        return
+    cursor = connection.execute(
+        """
+        update guard_workflow_capability_authority_state
+        set signed_state_json = ?, key_id = ?, revision = ?, use_high_water = ?,
+            observed_at = ?, revocation_id = ?
+        where capability_id = ?
+        """,
+        payload,
+    )
+    if cursor.rowcount != 1:
+        raise WorkflowCapabilityError("capability_authority_state_update_failed")
+
+
+def _load_revocation(
+    connection: sqlite3.Connection,
+    signed_claim: SignedWorkflowCapability,
+    *,
+    key: bytes,
+    key_id: str,
+) -> WorkflowCapabilityRevocation | None:
+    rows = connection.execute(
+        """
+        select revocation_id, signed_revocation_json, key_id, revoked_at
+        from guard_workflow_capability_revocations where capability_id = ?
+        """,
+        (signed_claim.claim.capability_id,),
+    ).fetchall()
+    if not rows:
+        return None
+    if len(rows) != 1:
+        raise WorkflowCapabilityError("capability_revocation_history_invalid")
+    row = rows[0]
+    signed = decode_signed_revocation(str(row["signed_revocation_json"]))
+    verify_revocation(signed, key=key, key_id=key_id)
+    revocation = signed.revocation
+    if (
+        str(row["revocation_id"]) != revocation.revocation_id
+        or str(row["key_id"]) != signed.key_id
+        or str(row["revoked_at"]) != revocation.revoked_at
+        or revocation.capability_id != signed_claim.claim.capability_id
+        or revocation.claim_sha256 != workflow_capability_claim_sha256(signed_claim)
+    ):
+        raise WorkflowCapabilityError("capability_revocation_binding_invalid")
+    return revocation
+
+
+def _validate_receipt_history(
+    connection: sqlite3.Connection,
+    signed_claim: SignedWorkflowCapability,
+    *,
+    key: bytes,
+    key_id: str,
+) -> int:
+    rows = connection.execute(
+        """
+        select r.receipt_id, r.task_id, r.invocation_id, r.approval_provenance_id,
+               r.signed_receipt_json, r.claimed_at, r.use_number, r.event_id,
+               e.event_name, e.payload_json, e.occurred_at
+        from guard_workflow_capability_receipts r
+        left join guard_events e on e.event_id = r.event_id
+        where r.capability_id = ? order by r.use_number
+        """,
+        (signed_claim.claim.capability_id,),
+    ).fetchall()
+    for expected_use, row in enumerate(rows, start=1):
+        signed = _decode_receipt(str(row["signed_receipt_json"]))
+        verify_workflow_capability_receipt(signed, key=key, key_id=key_id)
+        receipt = signed.receipt
+        if (
+            receipt.use_number != expected_use
+            or int(row["use_number"]) != expected_use
+            or receipt.receipt_id != str(row["receipt_id"])
+            or receipt.task_id != str(row["task_id"])
+            or receipt.invocation_id != str(row["invocation_id"])
+            or receipt.approval_provenance_id != str(row["approval_provenance_id"])
+            or receipt.claimed_at != str(row["claimed_at"])
+            or receipt.event_id != int(row["event_id"])
+            or receipt.capability_id != signed_claim.claim.capability_id
+            or receipt.claim_sha256 != workflow_capability_claim_sha256(signed_claim)
+            or receipt.binding != signed_claim.claim.binding
+        ):
+            raise WorkflowCapabilityError("capability_receipt_history_invalid")
+        if str(row["event_name"]) != "workflow_capability.claimed" or str(row["occurred_at"]) != receipt.claimed_at:
+            raise WorkflowCapabilityError("capability_receipt_event_history_invalid")
+        if str(row["payload_json"]) != _canonical(_event_payload(receipt)):
+            raise WorkflowCapabilityError("capability_receipt_event_history_invalid")
+    return len(rows)
+
+
+def _decode_receipt(encoded: str) -> SignedWorkflowCapabilityReceipt:
+    try:
+        payload = json.loads(encoded)
+    except json.JSONDecodeError as error:
+        raise WorkflowCapabilityError("receipt_payload_invalid") from error
+    signed = SignedWorkflowCapabilityReceipt.from_dict(payload)
+    if _canonical(signed.to_dict()) != encoded:
+        raise WorkflowCapabilityError("receipt_payload_not_canonical")
+    return signed
+
+
+def _event_payload(receipt: WorkflowCapabilityReceipt) -> dict[str, object]:
+    return {
+        "approval_provenance_ref": _private("approval-provenance", receipt.approval_provenance_id),
+        "capability_ref": _private("capability", receipt.capability_id),
+        "invocation_ref": _private("invocation", receipt.invocation_id),
+        "receipt_ref": _private("receipt", receipt.receipt_id),
+        "task_ref": _private("task", receipt.task_id),
+        "use_number": receipt.use_number,
+    }
+
+
+def _private(purpose: str, value: str) -> str:
+    return hashlib.sha256(canonical_framed_payload(f"audit-{purpose}", value)).hexdigest()
+
+
+def _canonical(payload: object) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_common.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_common.py
@@ -137,13 +137,6 @@ def _canonical_json(payload: object) -> str:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
 
 
-def _validate_public_identifier(name: str, value: str) -> None:
-    if type(value) is not str or not value or len(value) > 256 or value.strip() != value or "*" in value:
-        raise WorkflowCapabilityError(f"invalid_{name}")
-    if any(character.isspace() or ord(character) < 33 or ord(character) > 126 for character in value):
-        raise WorkflowCapabilityError(f"invalid_{name}")
-
-
 def _validate_reason_code(value: str) -> None:
     if type(value) is not str or re.fullmatch(r"[a-z][a-z0-9_.-]{0,63}", value) is None:
         raise WorkflowCapabilityError("invalid_reason_code")

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_common.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_common.py
@@ -1,0 +1,149 @@
+"""Dependency-only helpers shared by workflow-capability store mixins."""
+
+# pyright: reportAny=false, reportPrivateUsage=false
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+from datetime import datetime, timezone
+from typing import Protocol
+
+from .workflow_capabilities import (
+    SignedWorkflowCapability,
+    SignedWorkflowCapabilityReceipt,
+    WorkflowCapabilityError,
+    WorkflowCapabilityReceipt,
+    canonical_framed_payload,
+    format_utc_timestamp,
+    verify_workflow_capability_signature,
+)
+
+
+class _WorkflowCapabilityStoreBoundary(Protocol):
+    def _policy_integrity_secret_material(self, *, create: bool) -> tuple[bytes | None, str | None]: ...
+
+
+def _require_store_key(store: _WorkflowCapabilityStoreBoundary, *, create: bool = True) -> tuple[bytes, str]:
+    key, key_id = store._policy_integrity_secret_material(create=create)
+    if key is None or key_id is None:
+        raise WorkflowCapabilityError("capability_key_unavailable")
+    return key, key_id
+
+
+class WorkflowCapabilityStoreClock:
+    def now(self) -> str:
+        return format_utc_timestamp(datetime.now(timezone.utc))
+
+
+WORKFLOW_CAPABILITY_STORE_CLOCK = WorkflowCapabilityStoreClock()
+
+
+def _decode_signed_claim(encoded: str) -> SignedWorkflowCapability:
+    try:
+        payload = json.loads(encoded)
+    except json.JSONDecodeError as error:
+        raise WorkflowCapabilityError("capability_payload_invalid") from error
+    signed = SignedWorkflowCapability.from_dict(payload)
+    if _canonical_json(signed.to_dict()) != encoded:
+        raise WorkflowCapabilityError("capability_payload_not_canonical")
+    return signed
+
+
+def _decode_signed_receipt(encoded: str) -> SignedWorkflowCapabilityReceipt:
+    try:
+        payload = json.loads(encoded)
+    except json.JSONDecodeError as error:
+        raise WorkflowCapabilityError("receipt_payload_invalid") from error
+    signed = SignedWorkflowCapabilityReceipt.from_dict(payload)
+    if _canonical_json(signed.to_dict()) != encoded:
+        raise WorkflowCapabilityError("receipt_payload_not_canonical")
+    return signed
+
+
+def _verify_persisted_claim_signature(signed: SignedWorkflowCapability, *, key: bytes, key_id: str) -> None:
+    verify_workflow_capability_signature(signed, key=key, key_id=key_id)
+
+
+def _validate_claim_row(signed: SignedWorkflowCapability, row: sqlite3.Row, capability_id: str) -> None:
+    claim = signed.claim
+    expected = (
+        capability_id,
+        claim.approval_provenance_id,
+        claim.nonce,
+        signed.key_id,
+        claim.issued_at,
+        claim.not_before,
+        claim.expires_at,
+        claim.max_uses,
+    )
+    actual = (
+        claim.capability_id,
+        str(row["approval_provenance_id"]),
+        str(row["nonce"]),
+        str(row["key_id"]),
+        str(row["issued_at"]),
+        str(row["not_before"]),
+        str(row["expires_at"]),
+        int(row["max_uses"]),
+    )
+    if actual != expected:
+        raise WorkflowCapabilityError("capability_row_binding_invalid")
+
+
+def _private_reference(purpose: str, value: str) -> str:
+    return hashlib.sha256(canonical_framed_payload(f"audit-{purpose}", value)).hexdigest()
+
+
+def _workflow_capability_event_payload(
+    capability_id: str, invocation_id: str | None, extra: dict[str, object]
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "capability_ref": _private_reference("capability", capability_id),
+        **extra,
+    }
+    if invocation_id is not None:
+        payload["invocation_ref"] = _private_reference("invocation", invocation_id)
+    return payload
+
+
+def _claim_event_extra(
+    *, approval_provenance_id: str, receipt_id: str, task_id: str, use_number: int
+) -> dict[str, object]:
+    return {
+        "approval_provenance_ref": _private_reference("approval-provenance", approval_provenance_id),
+        "receipt_ref": _private_reference("receipt", receipt_id),
+        "task_ref": _private_reference("task", task_id),
+        "use_number": use_number,
+    }
+
+
+def _claim_event_payload(receipt: WorkflowCapabilityReceipt) -> dict[str, object]:
+    return {
+        "capability_ref": _private_reference("capability", receipt.capability_id),
+        "invocation_ref": _private_reference("invocation", receipt.invocation_id),
+        **_claim_event_extra(
+            approval_provenance_id=receipt.approval_provenance_id,
+            receipt_id=receipt.receipt_id,
+            task_id=receipt.task_id,
+            use_number=receipt.use_number,
+        ),
+    }
+
+
+def _canonical_json(payload: object) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _validate_public_identifier(name: str, value: str) -> None:
+    if type(value) is not str or not value or len(value) > 256 or value.strip() != value or "*" in value:
+        raise WorkflowCapabilityError(f"invalid_{name}")
+    if any(character.isspace() or ord(character) < 33 or ord(character) > 126 for character in value):
+        raise WorkflowCapabilityError(f"invalid_{name}")
+
+
+def _validate_reason_code(value: str) -> None:
+    if type(value) is not str or re.fullmatch(r"[a-z][a-z0-9_.-]{0,63}", value) is None:
+        raise WorkflowCapabilityError("invalid_reason_code")

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_control.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_control.py
@@ -1,0 +1,209 @@
+"""External monotonic control for the workflow-capability authority ledger."""
+
+# pyright: reportAny=false, reportPrivateUsage=false, reportUnknownArgumentType=false
+# pyright: reportUnknownVariableType=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import asdict, dataclass, replace
+from typing import Protocol, cast
+
+from .store_workflow_capability_transitions import validate_global_authority_ledger
+from .workflow_capabilities import WorkflowCapabilityError, parse_utc_timestamp
+from .workflow_capability_transitions import (
+    ZERO_TRANSITION_SHA256,
+    SignedAuthorityTransition,
+    authority_transition_sha256,
+)
+
+_CONTROL_VERSION = 1
+
+
+class _ControlStore(Protocol):
+    def _load_workflow_capability_control(self) -> str | None: ...
+
+    def _store_workflow_capability_control(self, encoded: str) -> bool: ...
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowCapabilityControl:
+    version: int
+    committed_sequence: int
+    committed_head_sha256: str
+    pending_sequence: int | None
+    pending_head_sha256: str | None
+    observed_at: str
+
+    def __post_init__(self) -> None:
+        if self.version != _CONTROL_VERSION:
+            raise WorkflowCapabilityError("unsupported_capability_control_version")
+        if type(self.committed_sequence) is not int or self.committed_sequence < 0:
+            raise WorkflowCapabilityError("invalid_capability_control_sequence")
+        _digest("committed_head_sha256", self.committed_head_sha256)
+        if (self.pending_sequence is None) != (self.pending_head_sha256 is None):
+            raise WorkflowCapabilityError("invalid_capability_control_pending")
+        if self.pending_sequence is not None:
+            if type(self.pending_sequence) is not int or self.pending_sequence != self.committed_sequence + 1:
+                raise WorkflowCapabilityError("invalid_capability_control_pending")
+            _digest("pending_head_sha256", cast(str, self.pending_head_sha256))
+        parse_utc_timestamp(self.observed_at)
+
+
+def load_validate_and_observe_control(
+    store: _ControlStore,
+    connection: sqlite3.Connection,
+    *,
+    key: bytes,
+    key_id: str,
+    now: str,
+    create: bool,
+) -> WorkflowCapabilityControl:
+    sequence, head = validate_global_authority_ledger(connection, key=key, key_id=key_id)
+    encoded = store._load_workflow_capability_control()
+    if encoded is None:
+        if _has_authority_data(connection):
+            raise WorkflowCapabilityError("capability_control_bootstrap_refused")
+        if not create:
+            raise WorkflowCapabilityError("capability_control_unavailable")
+        control = WorkflowCapabilityControl(
+            version=_CONTROL_VERSION,
+            committed_sequence=0,
+            committed_head_sha256=ZERO_TRANSITION_SHA256,
+            pending_sequence=None,
+            pending_head_sha256=None,
+            observed_at=now,
+        )
+        _store_control(store, control)
+    else:
+        control = _decode_control(encoded)
+    if control.pending_sequence is not None:
+        if sequence != control.pending_sequence or head != control.pending_head_sha256:
+            raise WorkflowCapabilityError("capability_control_pending_unresolved")
+        control = WorkflowCapabilityControl(
+            version=_CONTROL_VERSION,
+            committed_sequence=sequence,
+            committed_head_sha256=head,
+            pending_sequence=None,
+            pending_head_sha256=None,
+            observed_at=control.observed_at,
+        )
+        _store_control(store, control)
+    if sequence != control.committed_sequence or head != control.committed_head_sha256:
+        raise WorkflowCapabilityError("capability_control_rollback_detected")
+    if parse_utc_timestamp(now) < parse_utc_timestamp(control.observed_at):
+        raise WorkflowCapabilityError("capability_clock_rollback")
+    if now != control.observed_at:
+        control = replace(control, observed_at=now)
+        _store_control(store, control)
+    return control
+
+
+def prepare_control_transition(
+    store: _ControlStore,
+    control: WorkflowCapabilityControl,
+    signed_transition: SignedAuthorityTransition,
+) -> WorkflowCapabilityControl:
+    transition = signed_transition.transition
+    head = authority_transition_sha256(signed_transition)
+    if (
+        control.pending_sequence is not None
+        or transition.sequence != control.committed_sequence + 1
+        or transition.previous_transition_sha256 != control.committed_head_sha256
+    ):
+        raise WorkflowCapabilityError("capability_control_transition_invalid")
+    pending = replace(
+        control,
+        pending_sequence=transition.sequence,
+        pending_head_sha256=head,
+        observed_at=transition.occurred_at,
+    )
+    _store_control(store, pending)
+    return pending
+
+
+def finalize_control_transition(store: _ControlStore, pending: WorkflowCapabilityControl) -> None:
+    if pending.pending_sequence is None or pending.pending_head_sha256 is None:
+        raise WorkflowCapabilityError("capability_control_pending_missing")
+    finalized = WorkflowCapabilityControl(
+        version=_CONTROL_VERSION,
+        committed_sequence=pending.pending_sequence,
+        committed_head_sha256=pending.pending_head_sha256,
+        pending_sequence=None,
+        pending_head_sha256=None,
+        observed_at=pending.observed_at,
+    )
+    _store_control(store, finalized)
+
+
+def _has_authority_data(connection: sqlite3.Connection) -> bool:
+    counts = connection.execute(
+        """
+        select
+          (select count(*) from guard_workflow_capabilities) +
+          (select count(*) from guard_workflow_capability_authority_transitions) +
+          (select count(*) from guard_events where event_name in (
+            'workflow_capability.issued', 'workflow_capability.claimed', 'workflow_capability.revoked'
+          ))
+        """
+    ).fetchone()
+    return counts is not None and int(counts[0]) != 0
+
+
+def _decode_control(encoded: str) -> WorkflowCapabilityControl:
+    try:
+        payload = json.loads(encoded)
+    except json.JSONDecodeError as error:
+        raise WorkflowCapabilityError("capability_control_invalid") from error
+    if type(payload) is not dict or set(payload) != set(WorkflowCapabilityControl.__dataclass_fields__):
+        raise WorkflowCapabilityError("capability_control_invalid")
+    typed = cast(dict[str, object], payload)
+    try:
+        control = WorkflowCapabilityControl(
+            version=_integer(typed["version"]),
+            committed_sequence=_integer(typed["committed_sequence"]),
+            committed_head_sha256=_string(typed["committed_head_sha256"]),
+            pending_sequence=_optional_integer(typed["pending_sequence"]),
+            pending_head_sha256=_optional_string(typed["pending_head_sha256"]),
+            observed_at=_string(typed["observed_at"]),
+        )
+    except (KeyError, TypeError) as error:
+        raise WorkflowCapabilityError("capability_control_invalid") from error
+    if _encode_control(control) != encoded:
+        raise WorkflowCapabilityError("capability_control_invalid")
+    return control
+
+
+def _store_control(store: _ControlStore, control: WorkflowCapabilityControl) -> None:
+    if not store._store_workflow_capability_control(_encode_control(control)):
+        raise WorkflowCapabilityError("capability_control_unavailable")
+
+
+def _encode_control(control: WorkflowCapabilityControl) -> str:
+    return json.dumps(asdict(control), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _digest(name: str, value: str) -> None:
+    if type(value) is not str or len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise WorkflowCapabilityError(f"invalid_{name}")
+
+
+def _string(value: object) -> str:
+    if type(value) is not str:
+        raise WorkflowCapabilityError("capability_control_invalid")
+    return value
+
+
+def _optional_string(value: object) -> str | None:
+    return None if value is None else _string(value)
+
+
+def _integer(value: object) -> int:
+    if type(value) is not int:
+        raise WorkflowCapabilityError("capability_control_invalid")
+    return value
+
+
+def _optional_integer(value: object) -> int | None:
+    return None if value is None else _integer(value)

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_control.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_control.py
@@ -10,6 +10,7 @@ import sqlite3
 from dataclasses import asdict, dataclass, replace
 from typing import Protocol, cast
 
+from .store_workflow_capability_time import validate_monotonic_workflow_capability_time
 from .store_workflow_capability_transitions import validate_global_authority_ledger
 from .workflow_capabilities import WorkflowCapabilityError, parse_utc_timestamp
 from .workflow_capability_transitions import (
@@ -92,9 +93,7 @@ def load_validate_and_observe_control(
         _store_control(store, control)
     if sequence != control.committed_sequence or head != control.committed_head_sha256:
         raise WorkflowCapabilityError("capability_control_rollback_detected")
-    if parse_utc_timestamp(now) < parse_utc_timestamp(control.observed_at):
-        raise WorkflowCapabilityError("capability_clock_rollback")
-    if now != control.observed_at:
+    if validate_monotonic_workflow_capability_time(now=now, observed_at=control.observed_at):
         control = replace(control, observed_at=now)
         _store_control(store, control)
     return control

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_lock.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_lock.py
@@ -5,15 +5,17 @@ from __future__ import annotations
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from functools import wraps
-from typing import Concatenate, ParamSpec, Protocol, TypeVar, cast
+from typing import Concatenate, ParamSpec, Protocol, TypeVar
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
-_T = TypeVar("_T")
 
 
-class _WorkflowCapabilityLockBoundary(Protocol):
+class WorkflowCapabilityLockBoundary(Protocol):
     def hold_workflow_capability_authority_lock(self) -> AbstractContextManager[None]: ...
+
+
+_T = TypeVar("_T", bound=WorkflowCapabilityLockBoundary)
 
 
 def serialized_workflow_capability_authority(
@@ -21,8 +23,7 @@ def serialized_workflow_capability_authority(
 ) -> Callable[Concatenate[_T, _P], _R]:
     @wraps(method)
     def wrapped(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R:
-        boundary = cast(_WorkflowCapabilityLockBoundary, cast(object, self))
-        with boundary.hold_workflow_capability_authority_lock():
+        with self.hold_workflow_capability_authority_lock():
             return method(self, *args, **kwargs)
 
     return wrapped

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_lock.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_lock.py
@@ -1,0 +1,28 @@
+"""Cross-process serialization for workflow-capability control transitions."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from functools import wraps
+from typing import Concatenate, ParamSpec, Protocol, TypeVar, cast
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+_T = TypeVar("_T")
+
+
+class _WorkflowCapabilityLockBoundary(Protocol):
+    def hold_workflow_capability_authority_lock(self) -> AbstractContextManager[None]: ...
+
+
+def serialized_workflow_capability_authority(
+    method: Callable[Concatenate[_T, _P], _R],
+) -> Callable[Concatenate[_T, _P], _R]:
+    @wraps(method)
+    def wrapped(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+        boundary = cast(_WorkflowCapabilityLockBoundary, cast(object, self))
+        with boundary.hold_workflow_capability_authority_lock():
+            return method(self, *args, **kwargs)
+
+    return wrapped

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_lookup.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_lookup.py
@@ -14,16 +14,22 @@ from .store_workflow_capability_common import (
     _decode_signed_claim,
     _require_store_key,
     _validate_claim_row,
-    _validate_public_identifier,
     _verify_persisted_claim_signature,
 )
 from .store_workflow_capability_control import load_validate_and_observe_control
 from .store_workflow_capability_lock import serialized_workflow_capability_authority
-from .workflow_capabilities import SignedWorkflowCapability, WorkflowCapabilityError
+from .workflow_capabilities import (
+    SignedWorkflowCapability,
+    WorkflowCapabilityError,
+    validate_workflow_capability_identifier,
+)
 
 
 class StoreWorkflowCapabilityLookupMixin:
     def _connect(self) -> AbstractContextManager[sqlite3.Connection]:
+        raise NotImplementedError
+
+    def hold_workflow_capability_authority_lock(self) -> AbstractContextManager[None]:
         raise NotImplementedError
 
     def _policy_integrity_secret_material(self, *, create: bool) -> tuple[bytes | None, str | None]:
@@ -39,7 +45,7 @@ class StoreWorkflowCapabilityLookupMixin:
 
     @serialized_workflow_capability_authority
     def lookup_workflow_capability(self, capability_id: str) -> SignedWorkflowCapability | None:
-        _validate_public_identifier("capability_id", capability_id)
+        validate_workflow_capability_identifier("capability_id", capability_id)
         key, key_id = _require_store_key(self, create=False)
         with self._connect() as connection:
             connection.execute("begin")

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_lookup.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_lookup.py
@@ -7,16 +7,16 @@ from __future__ import annotations
 import sqlite3
 from contextlib import AbstractContextManager
 
-from . import store_workflow_capabilities as workflow_capability_store
-from .store_workflow_capabilities import (
+from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
+from .store_workflow_capability_authority import load_and_validate_authority
+from .store_workflow_capability_common import (
+    WORKFLOW_CAPABILITY_STORE_CLOCK,
     _decode_signed_claim,
     _require_store_key,
     _validate_claim_row,
     _validate_public_identifier,
     _verify_persisted_claim_signature,
 )
-from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
-from .store_workflow_capability_authority import load_and_validate_authority
 from .store_workflow_capability_control import load_validate_and_observe_control
 from .store_workflow_capability_lock import serialized_workflow_capability_authority
 from .workflow_capabilities import SignedWorkflowCapability, WorkflowCapabilityError
@@ -43,7 +43,7 @@ class StoreWorkflowCapabilityLookupMixin:
         key, key_id = _require_store_key(self, create=False)
         with self._connect() as connection:
             connection.execute("begin")
-            now = workflow_capability_store._workflow_capability_store_now()
+            now = WORKFLOW_CAPABILITY_STORE_CLOCK.now()
             ensure_workflow_capability_schema(connection, applied_at=now)
             load_validate_and_observe_control(self, connection, key=key, key_id=key_id, now=now, create=False)
             return load_validated_workflow_capability(

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_lookup.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_lookup.py
@@ -1,0 +1,100 @@
+"""Authenticated workflow-capability lookup and authority validation."""
+
+# pyright: reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import AbstractContextManager
+
+from . import store_workflow_capabilities as workflow_capability_store
+from .store_workflow_capabilities import (
+    _decode_signed_claim,
+    _require_store_key,
+    _validate_claim_row,
+    _validate_public_identifier,
+    _verify_persisted_claim_signature,
+)
+from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
+from .store_workflow_capability_authority import load_and_validate_authority
+from .store_workflow_capability_control import load_validate_and_observe_control
+from .store_workflow_capability_lock import serialized_workflow_capability_authority
+from .workflow_capabilities import SignedWorkflowCapability, WorkflowCapabilityError
+
+
+class StoreWorkflowCapabilityLookupMixin:
+    def _connect(self) -> AbstractContextManager[sqlite3.Connection]:
+        raise NotImplementedError
+
+    def _policy_integrity_secret_material(self, *, create: bool) -> tuple[bytes | None, str | None]:
+        _ = create
+        raise NotImplementedError
+
+    def _load_workflow_capability_control(self) -> str | None:
+        raise NotImplementedError
+
+    def _store_workflow_capability_control(self, encoded: str) -> bool:
+        _ = encoded
+        raise NotImplementedError
+
+    @serialized_workflow_capability_authority
+    def lookup_workflow_capability(self, capability_id: str) -> SignedWorkflowCapability | None:
+        _validate_public_identifier("capability_id", capability_id)
+        key, key_id = _require_store_key(self, create=False)
+        with self._connect() as connection:
+            connection.execute("begin")
+            now = workflow_capability_store._workflow_capability_store_now()
+            ensure_workflow_capability_schema(connection, applied_at=now)
+            load_validate_and_observe_control(self, connection, key=key, key_id=key_id, now=now, create=False)
+            return load_validated_workflow_capability(
+                connection,
+                capability_id,
+                key=key,
+                key_id=key_id,
+            )
+
+
+def load_validated_workflow_capability(
+    connection: sqlite3.Connection,
+    capability_id: str,
+    *,
+    key: bytes,
+    key_id: str,
+) -> SignedWorkflowCapability | None:
+    row = connection.execute(
+        """
+        select signed_claim_json, approval_provenance_id, nonce, key_id,
+               issued_at, not_before, expires_at, max_uses, used_count,
+               revoked_at, revocation_code
+        from guard_workflow_capabilities where capability_id = ?
+        """,
+        (capability_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    signed = _decode_signed_claim(str(row["signed_claim_json"]))
+    _validate_claim_row(signed, row, capability_id)
+    _verify_persisted_claim_signature(signed, key=key, key_id=key_id)
+    load_and_validate_authority(
+        connection,
+        signed,
+        key=key,
+        key_id=key_id,
+        used_count=int(row["used_count"]),
+        revoked_at=row["revoked_at"],
+        revocation_code=row["revocation_code"],
+    )
+    return signed
+
+
+def require_validated_workflow_capability(
+    connection: sqlite3.Connection,
+    capability_id: str,
+    *,
+    key: bytes,
+    key_id: str,
+) -> SignedWorkflowCapability:
+    signed = load_validated_workflow_capability(connection, capability_id, key=key, key_id=key_id)
+    if signed is None:
+        raise WorkflowCapabilityError("receipt_claim_missing")
+    return signed

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_receipt_lookup.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_receipt_lookup.py
@@ -7,15 +7,15 @@ from __future__ import annotations
 import sqlite3
 from contextlib import AbstractContextManager
 
-from . import store_workflow_capabilities as workflow_capability_store
-from .store_workflow_capabilities import (
+from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
+from .store_workflow_capability_common import (
+    WORKFLOW_CAPABILITY_STORE_CLOCK,
     _canonical_json,
     _claim_event_payload,
     _decode_signed_receipt,
     _require_store_key,
     _validate_public_identifier,
 )
-from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
 from .store_workflow_capability_control import load_validate_and_observe_control
 from .store_workflow_capability_lock import serialized_workflow_capability_authority
 from .store_workflow_capability_lookup import require_validated_workflow_capability
@@ -59,7 +59,7 @@ class StoreWorkflowCapabilityReceiptLookupMixin:
         key, key_id = _require_store_key(self, create=False)
         with self._connect() as connection:
             connection.execute("begin")
-            now = workflow_capability_store._workflow_capability_store_now()
+            now = WORKFLOW_CAPABILITY_STORE_CLOCK.now()
             ensure_workflow_capability_schema(connection, applied_at=now)
             load_validate_and_observe_control(self, connection, key=key, key_id=key_id, now=now, create=False)
             row = connection.execute(

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_receipt_lookup.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_receipt_lookup.py
@@ -14,7 +14,6 @@ from .store_workflow_capability_common import (
     _claim_event_payload,
     _decode_signed_receipt,
     _require_store_key,
-    _validate_public_identifier,
 )
 from .store_workflow_capability_control import load_validate_and_observe_control
 from .store_workflow_capability_lock import serialized_workflow_capability_authority
@@ -22,6 +21,7 @@ from .store_workflow_capability_lookup import require_validated_workflow_capabil
 from .workflow_capabilities import (
     SignedWorkflowCapabilityReceipt,
     WorkflowCapabilityError,
+    validate_workflow_capability_identifier,
     verify_workflow_capability_receipt,
     workflow_capability_claim_sha256,
 )
@@ -29,6 +29,9 @@ from .workflow_capabilities import (
 
 class StoreWorkflowCapabilityReceiptLookupMixin:
     def _connect(self) -> AbstractContextManager[sqlite3.Connection]:
+        raise NotImplementedError
+
+    def hold_workflow_capability_authority_lock(self) -> AbstractContextManager[None]:
         raise NotImplementedError
 
     def _policy_integrity_secret_material(self, *, create: bool) -> tuple[bytes | None, str | None]:
@@ -55,7 +58,7 @@ class StoreWorkflowCapabilityReceiptLookupMixin:
         selector_value = receipt_id if receipt_id is not None else invocation_id
         if selector_value is None:
             raise WorkflowCapabilityError("receipt_lookup_requires_exact_selector")
-        _validate_public_identifier(selector_name, selector_value)
+        validate_workflow_capability_identifier(selector_name, selector_value)
         key, key_id = _require_store_key(self, create=False)
         with self._connect() as connection:
             connection.execute("begin")

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_receipt_lookup.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_receipt_lookup.py
@@ -1,0 +1,125 @@
+"""Persisted workflow-capability receipt lookup and revalidation."""
+
+# pyright: reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import AbstractContextManager
+
+from . import store_workflow_capabilities as workflow_capability_store
+from .store_workflow_capabilities import (
+    _canonical_json,
+    _claim_event_payload,
+    _decode_signed_receipt,
+    _require_store_key,
+    _validate_public_identifier,
+)
+from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
+from .store_workflow_capability_control import load_validate_and_observe_control
+from .store_workflow_capability_lock import serialized_workflow_capability_authority
+from .store_workflow_capability_lookup import require_validated_workflow_capability
+from .workflow_capabilities import (
+    SignedWorkflowCapabilityReceipt,
+    WorkflowCapabilityError,
+    verify_workflow_capability_receipt,
+    workflow_capability_claim_sha256,
+)
+
+
+class StoreWorkflowCapabilityReceiptLookupMixin:
+    def _connect(self) -> AbstractContextManager[sqlite3.Connection]:
+        raise NotImplementedError
+
+    def _policy_integrity_secret_material(self, *, create: bool) -> tuple[bytes | None, str | None]:
+        _ = create
+        raise NotImplementedError
+
+    def _load_workflow_capability_control(self) -> str | None:
+        raise NotImplementedError
+
+    def _store_workflow_capability_control(self, encoded: str) -> bool:
+        _ = encoded
+        raise NotImplementedError
+
+    @serialized_workflow_capability_authority
+    def lookup_workflow_capability_receipt(
+        self,
+        *,
+        receipt_id: str | None = None,
+        invocation_id: str | None = None,
+    ) -> SignedWorkflowCapabilityReceipt | None:
+        if (receipt_id is None) == (invocation_id is None):
+            raise WorkflowCapabilityError("receipt_lookup_requires_exact_selector")
+        selector_name = "receipt_id" if receipt_id is not None else "invocation_id"
+        selector_value = receipt_id if receipt_id is not None else invocation_id
+        if selector_value is None:
+            raise WorkflowCapabilityError("receipt_lookup_requires_exact_selector")
+        _validate_public_identifier(selector_name, selector_value)
+        key, key_id = _require_store_key(self, create=False)
+        with self._connect() as connection:
+            connection.execute("begin")
+            now = workflow_capability_store._workflow_capability_store_now()
+            ensure_workflow_capability_schema(connection, applied_at=now)
+            load_validate_and_observe_control(self, connection, key=key, key_id=key_id, now=now, create=False)
+            row = connection.execute(
+                f"""
+                select r.receipt_id, r.capability_id, r.task_id, r.invocation_id,
+                       r.approval_provenance_id as receipt_approval_provenance_id,
+                       r.signed_receipt_json, r.claimed_at, r.use_number, r.event_id,
+                       e.event_name, e.payload_json as event_payload_json, e.occurred_at
+                from guard_workflow_capability_receipts r
+                left join guard_events e on e.event_id = r.event_id
+                where r.{selector_name} = ?
+                """,
+                (selector_value,),
+            ).fetchone()
+            if row is None:
+                return None
+            signed_claim = require_validated_workflow_capability(
+                connection,
+                str(row["capability_id"]),
+                key=key,
+                key_id=key_id,
+            )
+            signed_receipt = _decode_signed_receipt(str(row["signed_receipt_json"]))
+            verify_workflow_capability_receipt(signed_receipt, key=key, key_id=key_id)
+            receipt = signed_receipt.receipt
+            duplicated = (
+                str(row["receipt_id"]),
+                str(row["capability_id"]),
+                str(row["task_id"]),
+                str(row["invocation_id"]),
+                str(row["receipt_approval_provenance_id"]),
+                str(row["claimed_at"]),
+                int(row["use_number"]),
+                int(row["event_id"]),
+            )
+            signed_values = (
+                receipt.receipt_id,
+                receipt.capability_id,
+                receipt.task_id,
+                receipt.invocation_id,
+                receipt.approval_provenance_id,
+                receipt.claimed_at,
+                receipt.use_number,
+                receipt.event_id,
+            )
+            if duplicated != signed_values:
+                raise WorkflowCapabilityError("receipt_row_binding_invalid")
+            claim = signed_claim.claim
+            if (
+                receipt.capability_id != claim.capability_id
+                or receipt.task_id != claim.task_id
+                or receipt.approval_provenance_id != claim.approval_provenance_id
+                or receipt.binding != claim.binding
+                or receipt.claim_sha256 != workflow_capability_claim_sha256(signed_claim)
+            ):
+                raise WorkflowCapabilityError("receipt_claim_binding_invalid")
+            if (
+                str(row["event_name"]) != "workflow_capability.claimed"
+                or str(row["occurred_at"]) != receipt.claimed_at
+                or str(row["event_payload_json"]) != _canonical_json(_claim_event_payload(receipt))
+            ):
+                raise WorkflowCapabilityError("receipt_event_binding_invalid")
+            return signed_receipt

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_revocation.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_revocation.py
@@ -1,0 +1,155 @@
+"""Workflow-capability revocation authority operation."""
+
+# pyright: reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+# pyright: reportUnusedParameter=false
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import AbstractContextManager
+from uuid import uuid4
+
+from . import store_workflow_capabilities as workflow_capability_store
+from .store_workflow_capabilities import (
+    _decode_signed_claim,
+    _private_reference,
+    _require_store_key,
+    _validate_claim_row,
+    _validate_public_identifier,
+    _validate_reason_code,
+    _verify_persisted_claim_signature,
+    _workflow_capability_event_payload,
+)
+from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
+from .store_workflow_capability_authority import (
+    advance_authority_state,
+    append_revocation,
+    load_and_validate_authority,
+)
+from .store_workflow_capability_control import (
+    finalize_control_transition,
+    load_validate_and_observe_control,
+    prepare_control_transition,
+)
+from .store_workflow_capability_lock import serialized_workflow_capability_authority
+from .store_workflow_capability_transitions import append_authority_transition, build_authority_transition
+
+
+class StoreWorkflowCapabilityRevocationMixin:
+    def _connect(self) -> AbstractContextManager[sqlite3.Connection]:
+        raise NotImplementedError
+
+    def _policy_integrity_secret_material(self, *, create: bool) -> tuple[bytes | None, str | None]:
+        _ = create
+        raise NotImplementedError
+
+    def _load_workflow_capability_control(self) -> str | None:
+        raise NotImplementedError
+
+    def _store_workflow_capability_control(self, encoded: str) -> bool:
+        _ = encoded
+        raise NotImplementedError
+
+    @staticmethod
+    def _insert_workflow_capability_event(
+        connection: sqlite3.Connection,
+        *,
+        event_name: str,
+        capability_id: str,
+        invocation_id: str | None,
+        occurred_at: str,
+        extra: dict[str, object],
+    ) -> int:
+        raise NotImplementedError
+
+    @serialized_workflow_capability_authority
+    def revoke_workflow_capability(self, capability_id: str, *, reason_code: str) -> bool:
+        now = workflow_capability_store._workflow_capability_store_now()
+        _validate_public_identifier("capability_id", capability_id)
+        _validate_reason_code(reason_code)
+        key, key_id = _require_store_key(self, create=False)
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            ensure_workflow_capability_schema(connection, applied_at=now)
+            control = load_validate_and_observe_control(self, connection, key=key, key_id=key_id, now=now, create=False)
+            row = connection.execute(
+                """
+                select signed_claim_json, key_id, issued_at, not_before, expires_at, max_uses,
+                       used_count, revoked_at, revocation_code, approval_provenance_id, nonce
+                from guard_workflow_capabilities where capability_id = ?
+                """,
+                (capability_id,),
+            ).fetchone()
+            if row is None:
+                return False
+            signed = _decode_signed_claim(str(row["signed_claim_json"]))
+            _validate_claim_row(signed, row, capability_id)
+            _verify_persisted_claim_signature(signed, key=key, key_id=key_id)
+            state = load_and_validate_authority(
+                connection,
+                signed,
+                key=key,
+                key_id=key_id,
+                used_count=int(row["used_count"]),
+                revoked_at=row["revoked_at"],
+                revocation_code=row["revocation_code"],
+            )
+            if state.revocation_id is not None:
+                return False
+            revocation_id = f"wcv-{uuid4().hex}"
+            append_revocation(
+                connection,
+                signed,
+                reason_code=reason_code,
+                revoked_at=now,
+                revocation_id=revocation_id,
+                key=key,
+                key_id=key_id,
+            )
+            cursor = connection.execute(
+                """
+                update guard_workflow_capabilities set revoked_at = ?, revocation_code = ?
+                where capability_id = ? and revoked_at is null
+                """,
+                (now, reason_code, capability_id),
+            )
+            if cursor.rowcount != 1:
+                return False
+            event_extra: dict[str, object] = {"revocation_ref": _private_reference("revocation-code", reason_code)}
+            event_id = self._insert_workflow_capability_event(
+                connection,
+                event_name="workflow_capability.revoked",
+                capability_id=capability_id,
+                invocation_id=None,
+                occurred_at=now,
+                extra=event_extra,
+            )
+            signed_state = advance_authority_state(
+                connection,
+                state,
+                key=key,
+                key_id=key_id,
+                now=now,
+                revocation_id=revocation_id,
+                revoked_at=now,
+            )
+            transition = build_authority_transition(
+                signed,
+                signed_state,
+                sequence=control.committed_sequence + 1,
+                previous_transition_sha256=control.committed_head_sha256,
+                transition_kind="revoked",
+                event_id=event_id,
+                event_name="workflow_capability.revoked",
+                event_payload=_workflow_capability_event_payload(capability_id, None, event_extra),
+                occurred_at=now,
+                use_number=None,
+                receipt_id=None,
+                revocation_id=revocation_id,
+                key=key,
+                key_id=key_id,
+            )
+            pending_control = prepare_control_transition(self, control, transition)
+            append_authority_transition(connection, transition)
+        finalize_control_transition(self, pending_control)
+        return True

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_revocation.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_revocation.py
@@ -21,7 +21,6 @@ from .store_workflow_capability_common import (
     _private_reference,
     _require_store_key,
     _validate_claim_row,
-    _validate_public_identifier,
     _validate_reason_code,
     _verify_persisted_claim_signature,
     _workflow_capability_event_payload,
@@ -33,10 +32,14 @@ from .store_workflow_capability_control import (
 )
 from .store_workflow_capability_lock import serialized_workflow_capability_authority
 from .store_workflow_capability_transitions import append_authority_transition, build_authority_transition
+from .workflow_capabilities import validate_workflow_capability_identifier
 
 
 class StoreWorkflowCapabilityRevocationMixin:
     def _connect(self) -> AbstractContextManager[sqlite3.Connection]:
+        raise NotImplementedError
+
+    def hold_workflow_capability_authority_lock(self) -> AbstractContextManager[None]:
         raise NotImplementedError
 
     def _policy_integrity_secret_material(self, *, create: bool) -> tuple[bytes | None, str | None]:
@@ -65,7 +68,7 @@ class StoreWorkflowCapabilityRevocationMixin:
     @serialized_workflow_capability_authority
     def revoke_workflow_capability(self, capability_id: str, *, reason_code: str) -> bool:
         now = WORKFLOW_CAPABILITY_STORE_CLOCK.now()
-        _validate_public_identifier("capability_id", capability_id)
+        validate_workflow_capability_identifier("capability_id", capability_id)
         _validate_reason_code(reason_code)
         key, key_id = _require_store_key(self, create=False)
         with self._connect() as connection:

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_revocation.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_revocation.py
@@ -9,8 +9,14 @@ import sqlite3
 from contextlib import AbstractContextManager
 from uuid import uuid4
 
-from . import store_workflow_capabilities as workflow_capability_store
-from .store_workflow_capabilities import (
+from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
+from .store_workflow_capability_authority import (
+    advance_authority_state,
+    append_revocation,
+    load_and_validate_authority,
+)
+from .store_workflow_capability_common import (
+    WORKFLOW_CAPABILITY_STORE_CLOCK,
     _decode_signed_claim,
     _private_reference,
     _require_store_key,
@@ -19,12 +25,6 @@ from .store_workflow_capabilities import (
     _validate_reason_code,
     _verify_persisted_claim_signature,
     _workflow_capability_event_payload,
-)
-from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
-from .store_workflow_capability_authority import (
-    advance_authority_state,
-    append_revocation,
-    load_and_validate_authority,
 )
 from .store_workflow_capability_control import (
     finalize_control_transition,
@@ -64,7 +64,7 @@ class StoreWorkflowCapabilityRevocationMixin:
 
     @serialized_workflow_capability_authority
     def revoke_workflow_capability(self, capability_id: str, *, reason_code: str) -> bool:
-        now = workflow_capability_store._workflow_capability_store_now()
+        now = WORKFLOW_CAPABILITY_STORE_CLOCK.now()
         _validate_public_identifier("capability_id", capability_id)
         _validate_reason_code(reason_code)
         key, key_id = _require_store_key(self, create=False)

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_secret_control.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_secret_control.py
@@ -1,0 +1,44 @@
+"""Credential-store boundary for external workflow-capability control."""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from .store_base import SecretStore, SystemKeyringSecretStore
+
+
+class StoreWorkflowCapabilitySecretControlMixin:
+    @property
+    def _policy_integrity_secret_store(self) -> SystemKeyringSecretStore | None:
+        raise NotImplementedError
+
+    @staticmethod
+    def _should_skip_policy_integrity_keychain_access(secret_store: SecretStore) -> bool:
+        _ = secret_store
+        raise NotImplementedError
+
+    def _build_scoped_secret_ref(self, prefix: str) -> str:
+        _ = prefix
+        raise NotImplementedError
+
+    def _get_policy_integrity_secret_from_store(self, secret_id: str) -> str | None:
+        _ = secret_id
+        raise NotImplementedError
+
+    def _load_workflow_capability_control(self) -> str | None:
+        secret_store = self._policy_integrity_secret_store
+        if secret_store is None or self._should_skip_policy_integrity_keychain_access(secret_store):
+            return None
+        reference = self._build_scoped_secret_ref("guard-workflow-capability-control")
+        return self._get_policy_integrity_secret_from_store(reference)
+
+    def _store_workflow_capability_control(self, encoded: str) -> bool:
+        secret_store = self._policy_integrity_secret_store
+        if secret_store is None or self._should_skip_policy_integrity_keychain_access(secret_store):
+            return False
+        reference = self._build_scoped_secret_ref("guard-workflow-capability-control")
+        try:
+            secret_store.set_secret(reference, encoded)
+        except Exception:
+            return False
+        return self._get_policy_integrity_secret_from_store(reference) == encoded

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_time.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_time.py
@@ -1,0 +1,50 @@
+"""Monotonic workflow-capability time high-water persistence."""
+
+# pyright: reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import AbstractContextManager
+from typing import Protocol
+
+from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
+from .store_workflow_capability_control import load_validate_and_observe_control
+from .store_workflow_capability_lock import serialized_workflow_capability_authority
+from .workflow_capabilities import WorkflowCapabilityError
+
+
+class _WorkflowCapabilityTimeBoundary(Protocol):
+    def _connect(self) -> AbstractContextManager[sqlite3.Connection]: ...
+
+    def _load_workflow_capability_control(self) -> str | None: ...
+
+    def _store_workflow_capability_control(self, encoded: str) -> bool: ...
+
+
+@serialized_workflow_capability_authority
+def record_workflow_capability_time_high_water(
+    store: _WorkflowCapabilityTimeBoundary,
+    capability_id: str,
+    *,
+    now: str,
+    key: bytes,
+    key_id: str,
+) -> None:
+    with store._connect() as connection:
+        connection.execute("begin immediate")
+        ensure_workflow_capability_schema(connection, applied_at=now)
+        load_validate_and_observe_control(
+            store,
+            connection,
+            key=key,
+            key_id=key_id,
+            now=now,
+            create=False,
+        )
+        row = connection.execute(
+            "select 1 from guard_workflow_capabilities where capability_id = ?",
+            (capability_id,),
+        ).fetchone()
+        if row is None:
+            raise WorkflowCapabilityError("capability_not_found")

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_time.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_time.py
@@ -1,50 +1,16 @@
-"""Monotonic workflow-capability time high-water persistence."""
+"""Pure monotonic-time validation for workflow-capability control."""
 
 # pyright: reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
 
 from __future__ import annotations
 
-import sqlite3
-from contextlib import AbstractContextManager
-from typing import Protocol
-
-from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
-from .store_workflow_capability_control import load_validate_and_observe_control
-from .store_workflow_capability_lock import serialized_workflow_capability_authority
-from .workflow_capabilities import WorkflowCapabilityError
+from .workflow_capabilities import WorkflowCapabilityError, parse_utc_timestamp
 
 
-class _WorkflowCapabilityTimeBoundary(Protocol):
-    def _connect(self) -> AbstractContextManager[sqlite3.Connection]: ...
-
-    def _load_workflow_capability_control(self) -> str | None: ...
-
-    def _store_workflow_capability_control(self, encoded: str) -> bool: ...
-
-
-@serialized_workflow_capability_authority
-def record_workflow_capability_time_high_water(
-    store: _WorkflowCapabilityTimeBoundary,
-    capability_id: str,
-    *,
-    now: str,
-    key: bytes,
-    key_id: str,
-) -> None:
-    with store._connect() as connection:
-        connection.execute("begin immediate")
-        ensure_workflow_capability_schema(connection, applied_at=now)
-        load_validate_and_observe_control(
-            store,
-            connection,
-            key=key,
-            key_id=key_id,
-            now=now,
-            create=False,
-        )
-        row = connection.execute(
-            "select 1 from guard_workflow_capabilities where capability_id = ?",
-            (capability_id,),
-        ).fetchone()
-        if row is None:
-            raise WorkflowCapabilityError("capability_not_found")
+def validate_monotonic_workflow_capability_time(*, now: str, observed_at: str) -> bool:
+    """Reject rollback and report whether the external high-water must advance."""
+    current = parse_utc_timestamp(now)
+    observed = parse_utc_timestamp(observed_at)
+    if current < observed:
+        raise WorkflowCapabilityError("capability_clock_rollback")
+    return current > observed

--- a/src/codex_plugin_scanner/guard/store_workflow_capability_transitions.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capability_transitions.py
@@ -1,0 +1,242 @@
+"""Signed append-only workflow-capability authority transition ledger."""
+
+# pyright: reportAny=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from typing import cast
+
+from .workflow_capabilities import (
+    SignedWorkflowCapability,
+    WorkflowCapabilityError,
+    canonical_framed_payload,
+    workflow_capability_claim_sha256,
+)
+from .workflow_capability_authority_state import SignedAuthorityState, encode_signed_authority_state
+from .workflow_capability_transitions import (
+    AUTHORITY_TRANSITION_ALGORITHM,
+    AUTHORITY_TRANSITION_SCHEMA,
+    ZERO_TRANSITION_SHA256,
+    SignedAuthorityTransition,
+    WorkflowCapabilityAuthorityTransition,
+    authority_transition_sha256,
+    decode_signed_authority_transition,
+    encode_signed_authority_transition,
+    sign_authority_transition,
+    verify_authority_transition,
+)
+
+
+def build_authority_transition(
+    signed_claim: SignedWorkflowCapability,
+    signed_state: SignedAuthorityState,
+    *,
+    sequence: int,
+    previous_transition_sha256: str,
+    transition_kind: str,
+    event_id: int,
+    event_name: str,
+    event_payload: dict[str, object],
+    occurred_at: str,
+    use_number: int | None,
+    receipt_id: str | None,
+    revocation_id: str | None,
+    key: bytes,
+    key_id: str,
+) -> SignedAuthorityTransition:
+    transition = WorkflowCapabilityAuthorityTransition(
+        schema_version=AUTHORITY_TRANSITION_SCHEMA,
+        algorithm=AUTHORITY_TRANSITION_ALGORITHM,
+        sequence=sequence,
+        capability_id=signed_claim.claim.capability_id,
+        claim_sha256=workflow_capability_claim_sha256(signed_claim),
+        revision=signed_state.state.revision,
+        transition_kind=transition_kind,
+        previous_transition_sha256=previous_transition_sha256,
+        signed_state_sha256=_state_sha256(signed_state),
+        event_id=event_id,
+        event_name=event_name,
+        event_payload_sha256=_event_payload_sha256(event_payload),
+        occurred_at=occurred_at,
+        use_number=use_number,
+        receipt_id=receipt_id,
+        revocation_id=revocation_id,
+    )
+    return sign_authority_transition(transition, key=key, key_id=key_id)
+
+
+def append_authority_transition(connection: sqlite3.Connection, signed: SignedAuthorityTransition) -> None:
+    transition = signed.transition
+    connection.execute(
+        """
+        insert into guard_workflow_capability_authority_transitions
+          (sequence, capability_id, revision, transition_kind, previous_transition_sha256,
+           signed_transition_json, key_id, event_id)
+        values (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            transition.sequence,
+            transition.capability_id,
+            transition.revision,
+            transition.transition_kind,
+            transition.previous_transition_sha256,
+            encode_signed_authority_transition(signed),
+            signed.key_id,
+            transition.event_id,
+        ),
+    )
+
+
+def validate_global_authority_ledger(connection: sqlite3.Connection, *, key: bytes, key_id: str) -> tuple[int, str]:
+    rows = connection.execute(
+        """
+        select sequence, capability_id, revision, transition_kind, previous_transition_sha256,
+               signed_transition_json, key_id, event_id
+        from guard_workflow_capability_authority_transitions order by sequence
+        """
+    ).fetchall()
+    previous = ZERO_TRANSITION_SHA256
+    transition_event_ids: set[int] = set()
+    for expected_sequence, row in enumerate(rows, start=1):
+        signed = decode_signed_authority_transition(str(row["signed_transition_json"]))
+        verify_authority_transition(signed, key=key, key_id=key_id)
+        transition = signed.transition
+        if transition.event_id is None:
+            raise WorkflowCapabilityError("capability_authority_transition_chain_invalid")
+        duplicated = (
+            int(row["sequence"]),
+            str(row["capability_id"]),
+            int(row["revision"]),
+            str(row["transition_kind"]),
+            str(row["previous_transition_sha256"]),
+            str(row["key_id"]),
+            int(row["event_id"]),
+        )
+        authenticated = (
+            transition.sequence,
+            transition.capability_id,
+            transition.revision,
+            transition.transition_kind,
+            transition.previous_transition_sha256,
+            signed.key_id,
+            transition.event_id,
+        )
+        if (
+            duplicated != authenticated
+            or transition.sequence != expected_sequence
+            or transition.previous_transition_sha256 != previous
+        ):
+            raise WorkflowCapabilityError("capability_authority_transition_chain_invalid")
+        _validate_transition_event(connection, transition)
+        transition_event_ids.add(int(transition.event_id))
+        previous = authority_transition_sha256(signed)
+    event_rows = connection.execute(
+        """
+        select event_id from guard_events
+        where event_name in ('workflow_capability.issued', 'workflow_capability.claimed',
+                             'workflow_capability.revoked')
+        """
+    ).fetchall()
+    if {int(row["event_id"]) for row in event_rows} != transition_event_ids or len(event_rows) != len(rows):
+        raise WorkflowCapabilityError("capability_authority_event_cardinality_invalid")
+    return len(rows), previous
+
+
+def validate_capability_transition_projection(
+    connection: sqlite3.Connection,
+    signed_claim: SignedWorkflowCapability,
+    signed_state: SignedAuthorityState,
+    *,
+    receipt_count: int,
+    revocation_id: str | None,
+    key: bytes,
+    key_id: str,
+) -> None:
+    rows = connection.execute(
+        """
+        select signed_transition_json from guard_workflow_capability_authority_transitions
+        where capability_id = ? order by revision
+        """,
+        (signed_claim.claim.capability_id,),
+    ).fetchall()
+    if not rows:
+        raise WorkflowCapabilityError("capability_authority_transition_missing")
+    transitions: list[WorkflowCapabilityAuthorityTransition] = []
+    for expected_revision, row in enumerate(rows):
+        signed = decode_signed_authority_transition(str(row["signed_transition_json"]))
+        verify_authority_transition(signed, key=key, key_id=key_id)
+        transition = signed.transition
+        if (
+            transition.revision != expected_revision
+            or transition.capability_id != signed_claim.claim.capability_id
+            or transition.claim_sha256 != workflow_capability_claim_sha256(signed_claim)
+        ):
+            raise WorkflowCapabilityError("capability_authority_transition_projection_invalid")
+        transitions.append(transition)
+    if transitions[0].transition_kind != "issued" or any(
+        transition.transition_kind == "issued" for transition in transitions[1:]
+    ):
+        raise WorkflowCapabilityError("capability_authority_transition_projection_invalid")
+    claims = [transition for transition in transitions if transition.transition_kind == "claimed"]
+    if [transition.use_number for transition in claims] != list(range(1, receipt_count + 1)):
+        raise WorkflowCapabilityError("capability_authority_transition_projection_invalid")
+    receipt_rows = connection.execute(
+        """select receipt_id, use_number, event_id from guard_workflow_capability_receipts
+        where capability_id = ? order by use_number""",
+        (signed_claim.claim.capability_id,),
+    ).fetchall()
+    if [(transition.receipt_id, transition.use_number, transition.event_id) for transition in claims] != [
+        (str(row["receipt_id"]), int(row["use_number"]), int(row["event_id"])) for row in receipt_rows
+    ]:
+        raise WorkflowCapabilityError("capability_authority_transition_projection_invalid")
+    revokes = [transition for transition in transitions if transition.transition_kind == "revoked"]
+    if len(revokes) != (1 if revocation_id is not None else 0):
+        raise WorkflowCapabilityError("capability_authority_transition_projection_invalid")
+    if revokes and (revokes[0].revocation_id != revocation_id or revokes[0] is not transitions[-1]):
+        raise WorkflowCapabilityError("capability_authority_transition_projection_invalid")
+    if transitions[-1].revision != signed_state.state.revision or transitions[-1].signed_state_sha256 != _state_sha256(
+        signed_state
+    ):
+        raise WorkflowCapabilityError("capability_authority_transition_projection_invalid")
+
+
+def _validate_transition_event(
+    connection: sqlite3.Connection, transition: WorkflowCapabilityAuthorityTransition
+) -> None:
+    row = connection.execute(
+        "select event_name, payload_json, occurred_at from guard_events where event_id = ?",
+        (transition.event_id,),
+    ).fetchone()
+    if row is None or (
+        str(row["event_name"]) != transition.event_name
+        or str(row["occurred_at"]) != transition.occurred_at
+        or _event_payload_sha256(_decode_event_payload(str(row["payload_json"]))) != transition.event_payload_sha256
+    ):
+        raise WorkflowCapabilityError("capability_authority_transition_event_invalid")
+
+
+def _decode_event_payload(encoded: str) -> dict[str, object]:
+    try:
+        payload = json.loads(encoded)
+    except json.JSONDecodeError as error:
+        raise WorkflowCapabilityError("capability_authority_transition_event_invalid") from error
+    if (
+        type(payload) is not dict
+        or json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True) != encoded
+    ):
+        raise WorkflowCapabilityError("capability_authority_transition_event_invalid")
+    return cast(dict[str, object], payload)
+
+
+def _state_sha256(signed: SignedAuthorityState) -> str:
+    return hashlib.sha256(
+        canonical_framed_payload("authority-state-digest", encode_signed_authority_state(signed))
+    ).hexdigest()
+
+
+def _event_payload_sha256(payload: dict[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical_framed_payload("authority-event", encoded)).hexdigest()

--- a/src/codex_plugin_scanner/guard/workflow_capabilities.py
+++ b/src/codex_plugin_scanner/guard/workflow_capabilities.py
@@ -37,8 +37,8 @@ class WorkflowCapabilityRuleBinding:
     rule_version: str
 
     def __post_init__(self) -> None:
-        _validate_identifier("rule_id", self.rule_id)
-        _validate_identifier("rule_version", self.rule_version)
+        validate_workflow_capability_identifier("rule_id", self.rule_id)
+        validate_workflow_capability_identifier("rule_version", self.rule_version)
 
     @classmethod
     def from_dict(cls, payload: object) -> WorkflowCapabilityRuleBinding:
@@ -81,7 +81,7 @@ class WorkflowCapabilityBinding:
             "decision_id",
             "decision_version",
         ):
-            _validate_identifier(name, getattr(self, name))
+            validate_workflow_capability_identifier(name, getattr(self, name))
         for name in (
             "resource_sha256",
             "repository_sha256",
@@ -132,7 +132,7 @@ class WorkflowCapabilityClaim:
         if type(self.binding) is not WorkflowCapabilityBinding:
             raise WorkflowCapabilityError("invalid_capability_binding")
         for name in ("capability_id", "approval_provenance_id", "task_id", "issuer_id", "subject_id"):
-            _validate_identifier(name, getattr(self, name))
+            validate_workflow_capability_identifier(name, getattr(self, name))
         if type(self.nonce) is not str or not re.fullmatch(r"[0-9a-f]{32,64}", self.nonce):
             raise WorkflowCapabilityError("invalid_nonce")
         issued = parse_utc_timestamp(self.issued_at)
@@ -183,7 +183,7 @@ class SignedWorkflowCapability:
             raise WorkflowCapabilityError("unsupported_capability_envelope")
         if self.algorithm != WORKFLOW_CAPABILITY_ALGORITHM or self.algorithm != self.claim.algorithm:
             raise WorkflowCapabilityError("unsupported_capability_algorithm")
-        _validate_identifier("key_id", self.key_id)
+        validate_workflow_capability_identifier("key_id", self.key_id)
         _validate_sha256("signature", self.signature)
 
     def to_dict(self) -> dict[str, object]:
@@ -221,7 +221,7 @@ class WorkflowCapabilityReceipt:
         if self.schema_version != WORKFLOW_CAPABILITY_RECEIPT_SCHEMA:
             raise WorkflowCapabilityError("unsupported_receipt_schema")
         for name in ("receipt_id", "capability_id", "task_id", "invocation_id", "approval_provenance_id"):
-            _validate_identifier(name, getattr(self, name))
+            validate_workflow_capability_identifier(name, getattr(self, name))
         _validate_sha256("claim_sha256", self.claim_sha256)
         parse_utc_timestamp(self.claimed_at)
         if type(self.use_number) is not int or self.use_number < 1:
@@ -268,7 +268,7 @@ class SignedWorkflowCapabilityReceipt:
             raise WorkflowCapabilityError("unsupported_receipt_envelope")
         if self.algorithm != WORKFLOW_CAPABILITY_ALGORITHM:
             raise WorkflowCapabilityError("unsupported_receipt_algorithm")
-        _validate_identifier("key_id", self.key_id)
+        validate_workflow_capability_identifier("key_id", self.key_id)
         _validate_sha256("signature", self.signature)
 
     def to_dict(self) -> dict[str, object]:
@@ -301,7 +301,7 @@ def canonical_framed_payload(purpose: str, payload: object) -> bytes:
 
 def sign_workflow_capability(claim: WorkflowCapabilityClaim, *, key: bytes, key_id: str) -> SignedWorkflowCapability:
     _validate_key(key)
-    _validate_identifier("key_id", key_id)
+    validate_workflow_capability_identifier("key_id", key_id)
     claim = _validated_claim(claim)
     authenticated = {
         "algorithm": WORKFLOW_CAPABILITY_ALGORITHM,
@@ -358,7 +358,7 @@ def _verify_workflow_capability_signature_fields(signed: SignedWorkflowCapabilit
         raise WorkflowCapabilityError("unsupported_capability_schema")
     if signed.algorithm != WORKFLOW_CAPABILITY_ALGORITHM or signed.claim.algorithm != signed.algorithm:
         raise WorkflowCapabilityError("unsupported_capability_algorithm")
-    _validate_identifier("key_id", signed.key_id)
+    validate_workflow_capability_identifier("key_id", signed.key_id)
     _validate_sha256("signature", signed.signature)
     if signed.key_id != key_id:
         raise WorkflowCapabilityError("capability_key_mismatch")
@@ -371,7 +371,7 @@ def sign_workflow_capability_receipt(
     receipt: WorkflowCapabilityReceipt, *, key: bytes, key_id: str
 ) -> SignedWorkflowCapabilityReceipt:
     _validate_key(key)
-    _validate_identifier("key_id", key_id)
+    validate_workflow_capability_identifier("key_id", key_id)
     receipt = _validated_receipt(receipt)
     authenticated = {
         "algorithm": WORKFLOW_CAPABILITY_ALGORITHM,
@@ -410,7 +410,7 @@ def _verify_workflow_capability_receipt_fields(
         raise WorkflowCapabilityError("unsupported_receipt_schema")
     if signed.algorithm != WORKFLOW_CAPABILITY_ALGORITHM:
         raise WorkflowCapabilityError("unsupported_receipt_algorithm")
-    _validate_identifier("key_id", signed.key_id)
+    validate_workflow_capability_identifier("key_id", signed.key_id)
     _validate_sha256("signature", signed.signature)
     if signed.key_id != key_id:
         raise WorkflowCapabilityError("receipt_key_mismatch")
@@ -473,7 +473,7 @@ def _require_string(name: str, value: object) -> str:
     return value
 
 
-def _validate_identifier(name: str, value: str) -> None:
+def validate_workflow_capability_identifier(name: str, value: str) -> None:
     if type(value) is not str or not _IDENTIFIER_PATTERN.fullmatch(value) or "*" in value:
         raise WorkflowCapabilityError(f"invalid_{name}")
 

--- a/src/codex_plugin_scanner/guard/workflow_capabilities.py
+++ b/src/codex_plugin_scanner/guard/workflow_capabilities.py
@@ -1,0 +1,466 @@
+"""Dormant signed workflow-capability contracts.
+
+This module deliberately has no dependency on Guard policy evaluation or command
+execution. Callers must inject key material and an exact expected binding.
+"""
+
+# pyright: reportAny=false, reportUnnecessaryIsInstance=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Final, cast
+
+WORKFLOW_CAPABILITY_SCHEMA: Final = "hol-guard.workflow-capability.v1"
+WORKFLOW_CAPABILITY_ENVELOPE_SCHEMA: Final = "hol-guard.workflow-capability-envelope.v1"
+WORKFLOW_CAPABILITY_RECEIPT_SCHEMA: Final = "hol-guard.workflow-capability-receipt.v1"
+WORKFLOW_CAPABILITY_RECEIPT_ENVELOPE_SCHEMA: Final = "hol-guard.workflow-capability-receipt-envelope.v1"
+WORKFLOW_CAPABILITY_ALGORITHM: Final = "hmac-sha256"
+_FRAME_MAGIC: Final = b"hol-guard.workflow-capability\x00"
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_TIMESTAMP_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$")
+_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255}$")
+
+
+class WorkflowCapabilityError(ValueError):
+    """Raised when a capability contract fails closed."""
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class WorkflowCapabilityRuleBinding:
+    rule_id: str
+    rule_version: str
+
+    def __post_init__(self) -> None:
+        _validate_identifier("rule_id", self.rule_id)
+        _validate_identifier("rule_version", self.rule_version)
+
+    @classmethod
+    def from_dict(cls, payload: object) -> WorkflowCapabilityRuleBinding:
+        values = _strict_object(payload, set(cls.__dataclass_fields__))
+        return cls(
+            rule_id=_require_string("rule_id", values["rule_id"]),
+            rule_version=_require_string("rule_version", values["rule_version"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowCapabilityBinding:
+    """Exact immutable execution and authority context."""
+
+    operation_id: str
+    resource_type: str
+    resource_sha256: str
+    repository_sha256: str
+    workspace_sha256: str
+    executable_sha256: str
+    launch_sha256: str
+    policy_id: str
+    policy_version: str
+    effect_id: str
+    effect_version: str
+    decision_id: str
+    decision_version: str
+    rules: tuple[WorkflowCapabilityRuleBinding, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.rules) is not tuple or not all(type(rule) is WorkflowCapabilityRuleBinding for rule in self.rules):
+            raise WorkflowCapabilityError("invalid_rule_bindings")
+        for name in (
+            "operation_id",
+            "resource_type",
+            "policy_id",
+            "policy_version",
+            "effect_id",
+            "effect_version",
+            "decision_id",
+            "decision_version",
+        ):
+            _validate_identifier(name, getattr(self, name))
+        for name in (
+            "resource_sha256",
+            "repository_sha256",
+            "workspace_sha256",
+            "executable_sha256",
+            "launch_sha256",
+        ):
+            _validate_sha256(name, getattr(self, name))
+        if not self.rules or len(self.rules) > 32 or self.rules != tuple(sorted(set(self.rules))):
+            raise WorkflowCapabilityError("invalid_rule_bindings")
+
+    @classmethod
+    def from_dict(cls, payload: object) -> WorkflowCapabilityBinding:
+        values = _strict_object(payload, set(cls.__dataclass_fields__))
+        rules = values.pop("rules")
+        if type(rules) is not list:
+            raise WorkflowCapabilityError("invalid_rule_bindings")
+        typed_rules = cast(list[object], rules)
+        return cls(
+            **{key: _require_string(key, value) for key, value in values.items()},
+            rules=tuple(WorkflowCapabilityRuleBinding.from_dict(rule) for rule in typed_rules),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowCapabilityClaim:
+    """Unsigned immutable claim; signing turns it into persisted authority."""
+
+    schema_version: str
+    algorithm: str
+    capability_id: str
+    approval_provenance_id: str
+    task_id: str
+    nonce: str
+    issuer_id: str
+    subject_id: str
+    binding: WorkflowCapabilityBinding
+    issued_at: str
+    not_before: str
+    expires_at: str
+    max_uses: int
+
+    def __post_init__(self) -> None:
+        if self.schema_version != WORKFLOW_CAPABILITY_SCHEMA:
+            raise WorkflowCapabilityError("unsupported_capability_schema")
+        if self.algorithm != WORKFLOW_CAPABILITY_ALGORITHM:
+            raise WorkflowCapabilityError("unsupported_capability_algorithm")
+        if type(self.binding) is not WorkflowCapabilityBinding:
+            raise WorkflowCapabilityError("invalid_capability_binding")
+        for name in ("capability_id", "approval_provenance_id", "task_id", "issuer_id", "subject_id"):
+            _validate_identifier(name, getattr(self, name))
+        if type(self.nonce) is not str or not re.fullmatch(r"[0-9a-f]{32,64}", self.nonce):
+            raise WorkflowCapabilityError("invalid_nonce")
+        issued = parse_utc_timestamp(self.issued_at)
+        not_before = parse_utc_timestamp(self.not_before)
+        expires = parse_utc_timestamp(self.expires_at)
+        if not issued <= not_before < expires:
+            raise WorkflowCapabilityError("invalid_capability_time_window")
+        if (expires - issued).total_seconds() > 86_400:
+            raise WorkflowCapabilityError("capability_ttl_exceeds_alpha_limit")
+        if type(self.max_uses) is not int or not 1 <= self.max_uses <= 50:
+            raise WorkflowCapabilityError("invalid_capability_max_uses")
+
+    @classmethod
+    def from_dict(cls, payload: object) -> WorkflowCapabilityClaim:
+        values = _strict_object(payload, set(cls.__dataclass_fields__))
+        max_uses = values["max_uses"]
+        if type(max_uses) is not int:
+            raise WorkflowCapabilityError("invalid_capability_max_uses")
+        return cls(
+            schema_version=_require_string("schema_version", values["schema_version"]),
+            algorithm=_require_string("algorithm", values["algorithm"]),
+            capability_id=_require_string("capability_id", values["capability_id"]),
+            approval_provenance_id=_require_string("approval_provenance_id", values["approval_provenance_id"]),
+            task_id=_require_string("task_id", values["task_id"]),
+            nonce=_require_string("nonce", values["nonce"]),
+            issuer_id=_require_string("issuer_id", values["issuer_id"]),
+            subject_id=_require_string("subject_id", values["subject_id"]),
+            binding=WorkflowCapabilityBinding.from_dict(values["binding"]),
+            issued_at=_require_string("issued_at", values["issued_at"]),
+            not_before=_require_string("not_before", values["not_before"]),
+            expires_at=_require_string("expires_at", values["expires_at"]),
+            max_uses=max_uses,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SignedWorkflowCapability:
+    envelope_schema: str
+    algorithm: str
+    claim: WorkflowCapabilityClaim
+    key_id: str
+    signature: str
+
+    def __post_init__(self) -> None:
+        if type(self.claim) is not WorkflowCapabilityClaim:
+            raise WorkflowCapabilityError("invalid_capability_claim")
+        if self.envelope_schema != WORKFLOW_CAPABILITY_ENVELOPE_SCHEMA:
+            raise WorkflowCapabilityError("unsupported_capability_envelope")
+        if self.algorithm != WORKFLOW_CAPABILITY_ALGORITHM or self.algorithm != self.claim.algorithm:
+            raise WorkflowCapabilityError("unsupported_capability_algorithm")
+        _validate_identifier("key_id", self.key_id)
+        _validate_sha256("signature", self.signature)
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: object) -> SignedWorkflowCapability:
+        values = _strict_object(payload, set(cls.__dataclass_fields__))
+        return cls(
+            envelope_schema=_require_string("envelope_schema", values["envelope_schema"]),
+            algorithm=_require_string("algorithm", values["algorithm"]),
+            claim=WorkflowCapabilityClaim.from_dict(values["claim"]),
+            key_id=_require_string("key_id", values["key_id"]),
+            signature=_require_string("signature", values["signature"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowCapabilityReceipt:
+    schema_version: str
+    receipt_id: str
+    capability_id: str
+    task_id: str
+    invocation_id: str
+    approval_provenance_id: str
+    claim_sha256: str
+    binding: WorkflowCapabilityBinding
+    use_number: int
+    event_id: int
+    claimed_at: str
+
+    def __post_init__(self) -> None:
+        if type(self.binding) is not WorkflowCapabilityBinding:
+            raise WorkflowCapabilityError("invalid_receipt_binding")
+        if self.schema_version != WORKFLOW_CAPABILITY_RECEIPT_SCHEMA:
+            raise WorkflowCapabilityError("unsupported_receipt_schema")
+        for name in ("receipt_id", "capability_id", "task_id", "invocation_id", "approval_provenance_id"):
+            _validate_identifier(name, getattr(self, name))
+        _validate_sha256("claim_sha256", self.claim_sha256)
+        parse_utc_timestamp(self.claimed_at)
+        if type(self.use_number) is not int or self.use_number < 1:
+            raise WorkflowCapabilityError("invalid_receipt_use_number")
+        if type(self.event_id) is not int or self.event_id < 1:
+            raise WorkflowCapabilityError("invalid_receipt_event_id")
+
+    @classmethod
+    def from_dict(cls, payload: object) -> WorkflowCapabilityReceipt:
+        values = _strict_object(payload, set(cls.__dataclass_fields__))
+        use_number = values["use_number"]
+        event_id = values["event_id"]
+        if type(use_number) is not int:
+            raise WorkflowCapabilityError("invalid_receipt_use_number")
+        if type(event_id) is not int:
+            raise WorkflowCapabilityError("invalid_receipt_event_id")
+        return cls(
+            schema_version=_require_string("schema_version", values["schema_version"]),
+            receipt_id=_require_string("receipt_id", values["receipt_id"]),
+            capability_id=_require_string("capability_id", values["capability_id"]),
+            task_id=_require_string("task_id", values["task_id"]),
+            invocation_id=_require_string("invocation_id", values["invocation_id"]),
+            approval_provenance_id=_require_string("approval_provenance_id", values["approval_provenance_id"]),
+            claim_sha256=_require_string("claim_sha256", values["claim_sha256"]),
+            binding=WorkflowCapabilityBinding.from_dict(values["binding"]),
+            use_number=use_number,
+            event_id=event_id,
+            claimed_at=_require_string("claimed_at", values["claimed_at"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SignedWorkflowCapabilityReceipt:
+    envelope_schema: str
+    algorithm: str
+    receipt: WorkflowCapabilityReceipt
+    key_id: str
+    signature: str
+
+    def __post_init__(self) -> None:
+        if type(self.receipt) is not WorkflowCapabilityReceipt:
+            raise WorkflowCapabilityError("invalid_capability_receipt")
+        if self.envelope_schema != WORKFLOW_CAPABILITY_RECEIPT_ENVELOPE_SCHEMA:
+            raise WorkflowCapabilityError("unsupported_receipt_envelope")
+        if self.algorithm != WORKFLOW_CAPABILITY_ALGORITHM:
+            raise WorkflowCapabilityError("unsupported_receipt_algorithm")
+        _validate_identifier("key_id", self.key_id)
+        _validate_sha256("signature", self.signature)
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: object) -> SignedWorkflowCapabilityReceipt:
+        values = _strict_object(payload, set(cls.__dataclass_fields__))
+        return cls(
+            envelope_schema=_require_string("envelope_schema", values["envelope_schema"]),
+            algorithm=_require_string("algorithm", values["algorithm"]),
+            receipt=WorkflowCapabilityReceipt.from_dict(values["receipt"]),
+            key_id=_require_string("key_id", values["key_id"]),
+            signature=_require_string("signature", values["signature"]),
+        )
+
+
+def canonical_framed_payload(purpose: str, payload: object) -> bytes:
+    """Serialize a typed payload with unambiguous length-delimited framing."""
+    purpose_bytes = purpose.encode("ascii", errors="strict")
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return (
+        _FRAME_MAGIC
+        + len(purpose_bytes).to_bytes(4, "big")
+        + purpose_bytes
+        + len(canonical).to_bytes(8, "big")
+        + canonical
+    )
+
+
+def sign_workflow_capability(claim: WorkflowCapabilityClaim, *, key: bytes, key_id: str) -> SignedWorkflowCapability:
+    _validate_key(key)
+    _validate_identifier("key_id", key_id)
+    claim = _validated_claim(claim)
+    authenticated = {
+        "algorithm": WORKFLOW_CAPABILITY_ALGORITHM,
+        "claim": asdict(claim),
+        "envelope_schema": WORKFLOW_CAPABILITY_ENVELOPE_SCHEMA,
+        "key_id": key_id,
+    }
+    signature = hmac.new(key, canonical_framed_payload("claim-envelope", authenticated), hashlib.sha256).hexdigest()
+    return SignedWorkflowCapability(
+        envelope_schema=WORKFLOW_CAPABILITY_ENVELOPE_SCHEMA,
+        algorithm=WORKFLOW_CAPABILITY_ALGORITHM,
+        claim=claim,
+        key_id=key_id,
+        signature=signature,
+    )
+
+
+def verify_workflow_capability(
+    signed: SignedWorkflowCapability,
+    *,
+    key: bytes,
+    key_id: str,
+    now: str,
+    expected_binding: WorkflowCapabilityBinding,
+) -> None:
+    if type(expected_binding) is not WorkflowCapabilityBinding:
+        raise WorkflowCapabilityError("invalid_expected_capability_binding")
+    verify_workflow_capability_signature(signed, key=key, key_id=key_id)
+    current = parse_utc_timestamp(now)
+    if current < parse_utc_timestamp(signed.claim.not_before):
+        raise WorkflowCapabilityError("capability_not_yet_valid")
+    if current >= parse_utc_timestamp(signed.claim.expires_at):
+        raise WorkflowCapabilityError("capability_expired")
+    if signed.claim.binding != expected_binding:
+        raise WorkflowCapabilityError("capability_context_mismatch")
+
+
+def verify_workflow_capability_signature(signed: SignedWorkflowCapability, *, key: bytes, key_id: str) -> None:
+    _validate_key(key)
+    if type(signed) is not SignedWorkflowCapability or type(signed.claim) is not WorkflowCapabilityClaim:
+        raise WorkflowCapabilityError("invalid_signed_capability")
+    if signed.envelope_schema != WORKFLOW_CAPABILITY_ENVELOPE_SCHEMA:
+        raise WorkflowCapabilityError("unsupported_capability_envelope")
+    if signed.claim.schema_version != WORKFLOW_CAPABILITY_SCHEMA:
+        raise WorkflowCapabilityError("unsupported_capability_schema")
+    if signed.algorithm != WORKFLOW_CAPABILITY_ALGORITHM or signed.claim.algorithm != signed.algorithm:
+        raise WorkflowCapabilityError("unsupported_capability_algorithm")
+    _validate_identifier("key_id", signed.key_id)
+    _validate_sha256("signature", signed.signature)
+    if signed.key_id != key_id:
+        raise WorkflowCapabilityError("capability_key_mismatch")
+    expected = sign_workflow_capability(signed.claim, key=key, key_id=key_id).signature
+    if not hmac.compare_digest(expected, signed.signature):
+        raise WorkflowCapabilityError("capability_signature_invalid")
+
+
+def sign_workflow_capability_receipt(
+    receipt: WorkflowCapabilityReceipt, *, key: bytes, key_id: str
+) -> SignedWorkflowCapabilityReceipt:
+    _validate_key(key)
+    _validate_identifier("key_id", key_id)
+    receipt = _validated_receipt(receipt)
+    authenticated = {
+        "algorithm": WORKFLOW_CAPABILITY_ALGORITHM,
+        "envelope_schema": WORKFLOW_CAPABILITY_RECEIPT_ENVELOPE_SCHEMA,
+        "key_id": key_id,
+        "receipt": asdict(receipt),
+    }
+    signature = hmac.new(key, canonical_framed_payload("receipt-envelope", authenticated), hashlib.sha256).hexdigest()
+    return SignedWorkflowCapabilityReceipt(
+        envelope_schema=WORKFLOW_CAPABILITY_RECEIPT_ENVELOPE_SCHEMA,
+        algorithm=WORKFLOW_CAPABILITY_ALGORITHM,
+        receipt=receipt,
+        key_id=key_id,
+        signature=signature,
+    )
+
+
+def verify_workflow_capability_receipt(signed: SignedWorkflowCapabilityReceipt, *, key: bytes, key_id: str) -> None:
+    _validate_key(key)
+    if signed.envelope_schema != WORKFLOW_CAPABILITY_RECEIPT_ENVELOPE_SCHEMA:
+        raise WorkflowCapabilityError("unsupported_receipt_envelope")
+    if signed.receipt.schema_version != WORKFLOW_CAPABILITY_RECEIPT_SCHEMA:
+        raise WorkflowCapabilityError("unsupported_receipt_schema")
+    if signed.algorithm != WORKFLOW_CAPABILITY_ALGORITHM:
+        raise WorkflowCapabilityError("unsupported_receipt_algorithm")
+    _validate_identifier("key_id", signed.key_id)
+    _validate_sha256("signature", signed.signature)
+    if signed.key_id != key_id:
+        raise WorkflowCapabilityError("receipt_key_mismatch")
+    expected = sign_workflow_capability_receipt(signed.receipt, key=key, key_id=key_id).signature
+    if not hmac.compare_digest(expected, signed.signature):
+        raise WorkflowCapabilityError("receipt_signature_invalid")
+
+
+def workflow_capability_claim_sha256(signed: SignedWorkflowCapability) -> str:
+    return hashlib.sha256(canonical_framed_payload("signed-claim", signed.to_dict())).hexdigest()
+
+
+def _validated_claim(claim: WorkflowCapabilityClaim) -> WorkflowCapabilityClaim:
+    if type(claim) is not WorkflowCapabilityClaim:
+        raise WorkflowCapabilityError("invalid_capability_claim")
+    payload = json.loads(json.dumps(asdict(claim), sort_keys=True, separators=(",", ":")))
+    return WorkflowCapabilityClaim.from_dict(payload)
+
+
+def _validated_receipt(receipt: WorkflowCapabilityReceipt) -> WorkflowCapabilityReceipt:
+    if type(receipt) is not WorkflowCapabilityReceipt:
+        raise WorkflowCapabilityError("invalid_capability_receipt")
+    payload = json.loads(json.dumps(asdict(receipt), sort_keys=True, separators=(",", ":")))
+    return WorkflowCapabilityReceipt.from_dict(payload)
+
+
+def format_utc_timestamp(value: datetime) -> str:
+    if value.tzinfo is None:
+        raise WorkflowCapabilityError("timestamp_timezone_required")
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def parse_utc_timestamp(value: str) -> datetime:
+    if type(value) is not str or not _TIMESTAMP_PATTERN.fullmatch(value):
+        raise WorkflowCapabilityError("invalid_canonical_timestamp")
+    try:
+        parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError as error:
+        raise WorkflowCapabilityError("invalid_canonical_timestamp") from error
+    return parsed.replace(tzinfo=timezone.utc)
+
+
+def _strict_object(payload: object, expected_keys: set[str]) -> dict[str, object]:
+    if type(payload) is not dict:
+        raise WorkflowCapabilityError("invalid_contract_keys")
+    raw = cast(dict[object, object], payload)
+    typed: dict[str, object] = {}
+    for key, value in raw.items():
+        if type(key) is not str:
+            raise WorkflowCapabilityError("invalid_contract_keys")
+        typed[key] = value
+    if set(typed) != expected_keys:
+        raise WorkflowCapabilityError("invalid_contract_keys")
+    return typed
+
+
+def _require_string(name: str, value: object) -> str:
+    if type(value) is not str:
+        raise WorkflowCapabilityError(f"invalid_{name}")
+    return value
+
+
+def _validate_identifier(name: str, value: str) -> None:
+    if type(value) is not str or not _IDENTIFIER_PATTERN.fullmatch(value) or "*" in value:
+        raise WorkflowCapabilityError(f"invalid_{name}")
+
+
+def _validate_sha256(name: str, value: str) -> None:
+    if type(value) is not str or not _SHA256_PATTERN.fullmatch(value):
+        raise WorkflowCapabilityError(f"invalid_{name}")
+
+
+def _validate_key(key: bytes) -> None:
+    if type(key) is not bytes or len(key) < 32:
+        raise WorkflowCapabilityError("invalid_capability_key")

--- a/src/codex_plugin_scanner/guard/workflow_capabilities.py
+++ b/src/codex_plugin_scanner/guard/workflow_capabilities.py
@@ -340,6 +340,15 @@ def verify_workflow_capability(
 
 
 def verify_workflow_capability_signature(signed: SignedWorkflowCapability, *, key: bytes, key_id: str) -> None:
+    try:
+        _verify_workflow_capability_signature_fields(signed, key=key, key_id=key_id)
+    except WorkflowCapabilityError:
+        raise
+    except Exception as error:
+        raise WorkflowCapabilityError("invalid_signed_capability") from error
+
+
+def _verify_workflow_capability_signature_fields(signed: SignedWorkflowCapability, *, key: bytes, key_id: str) -> None:
     _validate_key(key)
     if type(signed) is not SignedWorkflowCapability or type(signed.claim) is not WorkflowCapabilityClaim:
         raise WorkflowCapabilityError("invalid_signed_capability")
@@ -381,7 +390,20 @@ def sign_workflow_capability_receipt(
 
 
 def verify_workflow_capability_receipt(signed: SignedWorkflowCapabilityReceipt, *, key: bytes, key_id: str) -> None:
+    try:
+        _verify_workflow_capability_receipt_fields(signed, key=key, key_id=key_id)
+    except WorkflowCapabilityError:
+        raise
+    except Exception as error:
+        raise WorkflowCapabilityError("invalid_signed_receipt") from error
+
+
+def _verify_workflow_capability_receipt_fields(
+    signed: SignedWorkflowCapabilityReceipt, *, key: bytes, key_id: str
+) -> None:
     _validate_key(key)
+    if type(signed) is not SignedWorkflowCapabilityReceipt or type(signed.receipt) is not WorkflowCapabilityReceipt:
+        raise WorkflowCapabilityError("invalid_signed_receipt")
     if signed.envelope_schema != WORKFLOW_CAPABILITY_RECEIPT_ENVELOPE_SCHEMA:
         raise WorkflowCapabilityError("unsupported_receipt_envelope")
     if signed.receipt.schema_version != WORKFLOW_CAPABILITY_RECEIPT_SCHEMA:

--- a/src/codex_plugin_scanner/guard/workflow_capability_authority_state.py
+++ b/src/codex_plugin_scanner/guard/workflow_capability_authority_state.py
@@ -11,11 +11,15 @@ import re
 from dataclasses import asdict, dataclass
 from typing import Final, cast
 
-from .workflow_capabilities import WorkflowCapabilityError, canonical_framed_payload, parse_utc_timestamp
+from .workflow_capabilities import (
+    WorkflowCapabilityError,
+    canonical_framed_payload,
+    parse_utc_timestamp,
+    validate_workflow_capability_identifier,
+)
 
 AUTHORITY_STATE_SCHEMA: Final = "hol-guard.workflow-capability-authority-state.v1"
 REVOCATION_SCHEMA: Final = "hol-guard.workflow-capability-revocation.v1"
-_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255}$")
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
 
 
@@ -33,7 +37,7 @@ class WorkflowCapabilityAuthorityState:
     def __post_init__(self) -> None:
         if self.schema_version != AUTHORITY_STATE_SCHEMA:
             raise WorkflowCapabilityError("unsupported_authority_state_schema")
-        _identifier("capability_id", self.capability_id)
+        validate_workflow_capability_identifier("capability_id", self.capability_id)
         _digest("claim_sha256", self.claim_sha256)
         parse_utc_timestamp(self.observed_at)
         if type(self.use_high_water) is not int or self.use_high_water < 0:
@@ -43,7 +47,7 @@ class WorkflowCapabilityAuthorityState:
         if (self.revocation_id is None) != (self.revoked_at is None):
             raise WorkflowCapabilityError("invalid_authority_revocation_binding")
         if self.revocation_id is not None:
-            _identifier("revocation_id", self.revocation_id)
+            validate_workflow_capability_identifier("revocation_id", self.revocation_id)
             parse_utc_timestamp(cast(str, self.revoked_at))
 
     @classmethod
@@ -73,8 +77,8 @@ class WorkflowCapabilityRevocation:
     def __post_init__(self) -> None:
         if self.schema_version != REVOCATION_SCHEMA:
             raise WorkflowCapabilityError("unsupported_revocation_schema")
-        _identifier("revocation_id", self.revocation_id)
-        _identifier("capability_id", self.capability_id)
+        validate_workflow_capability_identifier("revocation_id", self.revocation_id)
+        validate_workflow_capability_identifier("capability_id", self.capability_id)
         _digest("claim_sha256", self.claim_sha256)
         if type(self.reason_code) is not str or re.fullmatch(r"[a-z][a-z0-9_.-]{0,63}", self.reason_code) is None:
             raise WorkflowCapabilityError("invalid_reason_code")
@@ -177,7 +181,7 @@ def decode_signed_revocation(encoded: str) -> SignedRevocation:
 def _mac(purpose: str, payload: object, *, key: bytes, key_id: str) -> str:
     if type(key) is not bytes or len(key) < 32:
         raise WorkflowCapabilityError("invalid_capability_key")
-    _identifier("key_id", key_id)
+    validate_workflow_capability_identifier("key_id", key_id)
     authenticated = {"key_id": key_id, "payload": payload}
     return hmac.new(key, canonical_framed_payload(purpose, authenticated), hashlib.sha256).hexdigest()
 
@@ -208,11 +212,6 @@ def _strict(payload: object, keys: set[str]) -> dict[str, object]:
     if set(typed) != keys or not all(type(key) is str for key in typed):
         raise WorkflowCapabilityError("invalid_contract_keys")
     return typed
-
-
-def _identifier(name: str, value: str) -> None:
-    if type(value) is not str or _ID.fullmatch(value) is None or "*" in value:
-        raise WorkflowCapabilityError(f"invalid_{name}")
 
 
 def _digest(name: str, value: str) -> None:

--- a/src/codex_plugin_scanner/guard/workflow_capability_authority_state.py
+++ b/src/codex_plugin_scanner/guard/workflow_capability_authority_state.py
@@ -1,0 +1,218 @@
+"""Authenticated mutable state and append-only revocation contracts."""
+
+# pyright: reportAny=false, reportUnnecessaryIsInstance=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+from dataclasses import asdict, dataclass
+from typing import Final, cast
+
+from .workflow_capabilities import WorkflowCapabilityError, canonical_framed_payload, parse_utc_timestamp
+
+AUTHORITY_STATE_SCHEMA: Final = "hol-guard.workflow-capability-authority-state.v1"
+REVOCATION_SCHEMA: Final = "hol-guard.workflow-capability-revocation.v1"
+_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowCapabilityAuthorityState:
+    schema_version: str
+    capability_id: str
+    claim_sha256: str
+    use_high_water: int
+    observed_at: str
+    revision: int
+    revocation_id: str | None
+    revoked_at: str | None
+
+    def __post_init__(self) -> None:
+        if self.schema_version != AUTHORITY_STATE_SCHEMA:
+            raise WorkflowCapabilityError("unsupported_authority_state_schema")
+        _identifier("capability_id", self.capability_id)
+        _digest("claim_sha256", self.claim_sha256)
+        parse_utc_timestamp(self.observed_at)
+        if type(self.use_high_water) is not int or self.use_high_water < 0:
+            raise WorkflowCapabilityError("invalid_authority_use_high_water")
+        if type(self.revision) is not int or self.revision < 0:
+            raise WorkflowCapabilityError("invalid_authority_revision")
+        if (self.revocation_id is None) != (self.revoked_at is None):
+            raise WorkflowCapabilityError("invalid_authority_revocation_binding")
+        if self.revocation_id is not None:
+            _identifier("revocation_id", self.revocation_id)
+            parse_utc_timestamp(cast(str, self.revoked_at))
+
+    @classmethod
+    def from_dict(cls, payload: object) -> WorkflowCapabilityAuthorityState:
+        values = _strict(payload, set(cls.__dataclass_fields__))
+        return cls(
+            schema_version=_string("schema_version", values["schema_version"]),
+            capability_id=_string("capability_id", values["capability_id"]),
+            claim_sha256=_string("claim_sha256", values["claim_sha256"]),
+            use_high_water=_integer("use_high_water", values["use_high_water"]),
+            observed_at=_string("observed_at", values["observed_at"]),
+            revision=_integer("revision", values["revision"]),
+            revocation_id=_optional_string("revocation_id", values["revocation_id"]),
+            revoked_at=_optional_string("revoked_at", values["revoked_at"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowCapabilityRevocation:
+    schema_version: str
+    revocation_id: str
+    capability_id: str
+    claim_sha256: str
+    reason_code: str
+    revoked_at: str
+
+    def __post_init__(self) -> None:
+        if self.schema_version != REVOCATION_SCHEMA:
+            raise WorkflowCapabilityError("unsupported_revocation_schema")
+        _identifier("revocation_id", self.revocation_id)
+        _identifier("capability_id", self.capability_id)
+        _digest("claim_sha256", self.claim_sha256)
+        if type(self.reason_code) is not str or re.fullmatch(r"[a-z][a-z0-9_.-]{0,63}", self.reason_code) is None:
+            raise WorkflowCapabilityError("invalid_reason_code")
+        parse_utc_timestamp(self.revoked_at)
+
+    @classmethod
+    def from_dict(cls, payload: object) -> WorkflowCapabilityRevocation:
+        values = _strict(payload, set(cls.__dataclass_fields__))
+        return cls(**{name: _string(name, value) for name, value in values.items()})
+
+
+@dataclass(frozen=True, slots=True)
+class SignedAuthorityState:
+    state: WorkflowCapabilityAuthorityState
+    key_id: str
+    signature: str
+
+
+@dataclass(frozen=True, slots=True)
+class SignedRevocation:
+    revocation: WorkflowCapabilityRevocation
+    key_id: str
+    signature: str
+
+
+def sign_authority_state(state: WorkflowCapabilityAuthorityState, *, key: bytes, key_id: str) -> SignedAuthorityState:
+    signature = _mac("authority-state", asdict(state), key=key, key_id=key_id)
+    return SignedAuthorityState(state=state, key_id=key_id, signature=signature)
+
+
+def verify_authority_state(signed: SignedAuthorityState, *, key: bytes, key_id: str) -> None:
+    if type(signed) is not SignedAuthorityState or type(signed.state) is not WorkflowCapabilityAuthorityState:
+        raise WorkflowCapabilityError("invalid_signed_authority_state")
+    expected = sign_authority_state(signed.state, key=key, key_id=key_id)
+    _verify_envelope(signed.key_id, signed.signature, expected.signature, key_id, "authority_state")
+
+
+def sign_revocation(revocation: WorkflowCapabilityRevocation, *, key: bytes, key_id: str) -> SignedRevocation:
+    signature = _mac("revocation", asdict(revocation), key=key, key_id=key_id)
+    return SignedRevocation(revocation=revocation, key_id=key_id, signature=signature)
+
+
+def verify_revocation(signed: SignedRevocation, *, key: bytes, key_id: str) -> None:
+    if type(signed) is not SignedRevocation or type(signed.revocation) is not WorkflowCapabilityRevocation:
+        raise WorkflowCapabilityError("invalid_signed_revocation")
+    expected = sign_revocation(signed.revocation, key=key, key_id=key_id)
+    _verify_envelope(signed.key_id, signed.signature, expected.signature, key_id, "revocation")
+
+
+def encode_signed_authority_state(signed: SignedAuthorityState) -> str:
+    return _canonical({"key_id": signed.key_id, "signature": signed.signature, "state": asdict(signed.state)})
+
+
+def decode_signed_authority_state(encoded: str) -> SignedAuthorityState:
+    payload = _decode(encoded, {"key_id", "signature", "state"}, "authority_state")
+    signed = SignedAuthorityState(
+        state=WorkflowCapabilityAuthorityState.from_dict(payload["state"]),
+        key_id=_string("key_id", payload["key_id"]),
+        signature=_string("signature", payload["signature"]),
+    )
+    if encode_signed_authority_state(signed) != encoded:
+        raise WorkflowCapabilityError("authority_state_not_canonical")
+    return signed
+
+
+def encode_signed_revocation(signed: SignedRevocation) -> str:
+    return _canonical({"key_id": signed.key_id, "revocation": asdict(signed.revocation), "signature": signed.signature})
+
+
+def decode_signed_revocation(encoded: str) -> SignedRevocation:
+    payload = _decode(encoded, {"key_id", "revocation", "signature"}, "revocation")
+    signed = SignedRevocation(
+        revocation=WorkflowCapabilityRevocation.from_dict(payload["revocation"]),
+        key_id=_string("key_id", payload["key_id"]),
+        signature=_string("signature", payload["signature"]),
+    )
+    if encode_signed_revocation(signed) != encoded:
+        raise WorkflowCapabilityError("revocation_not_canonical")
+    return signed
+
+
+def _mac(purpose: str, payload: object, *, key: bytes, key_id: str) -> str:
+    if type(key) is not bytes or len(key) < 32:
+        raise WorkflowCapabilityError("invalid_capability_key")
+    _identifier("key_id", key_id)
+    authenticated = {"key_id": key_id, "payload": payload}
+    return hmac.new(key, canonical_framed_payload(purpose, authenticated), hashlib.sha256).hexdigest()
+
+
+def _verify_envelope(actual_key: str, actual: str, expected: str, key_id: str, purpose: str) -> None:
+    if actual_key != key_id:
+        raise WorkflowCapabilityError(f"{purpose}_key_mismatch")
+    _digest("signature", actual)
+    if not hmac.compare_digest(actual, expected):
+        raise WorkflowCapabilityError(f"{purpose}_signature_invalid")
+
+
+def _decode(encoded: str, keys: set[str], purpose: str) -> dict[str, object]:
+    try:
+        return _strict(json.loads(encoded), keys)
+    except json.JSONDecodeError as error:
+        raise WorkflowCapabilityError(f"{purpose}_payload_invalid") from error
+
+
+def _canonical(payload: object) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _strict(payload: object, keys: set[str]) -> dict[str, object]:
+    if type(payload) is not dict:
+        raise WorkflowCapabilityError("invalid_contract_keys")
+    typed = cast(dict[str, object], payload)
+    if set(typed) != keys or not all(type(key) is str for key in typed):
+        raise WorkflowCapabilityError("invalid_contract_keys")
+    return typed
+
+
+def _identifier(name: str, value: str) -> None:
+    if type(value) is not str or _ID.fullmatch(value) is None or "*" in value:
+        raise WorkflowCapabilityError(f"invalid_{name}")
+
+
+def _digest(name: str, value: str) -> None:
+    if type(value) is not str or _SHA256.fullmatch(value) is None:
+        raise WorkflowCapabilityError(f"invalid_{name}")
+
+
+def _string(name: str, value: object) -> str:
+    if type(value) is not str:
+        raise WorkflowCapabilityError(f"invalid_{name}")
+    return value
+
+
+def _optional_string(name: str, value: object) -> str | None:
+    return None if value is None else _string(name, value)
+
+
+def _integer(name: str, value: object) -> int:
+    if type(value) is not int:
+        raise WorkflowCapabilityError(f"invalid_{name}")
+    return value

--- a/src/codex_plugin_scanner/guard/workflow_capability_authority_state.py
+++ b/src/codex_plugin_scanner/guard/workflow_capability_authority_state.py
@@ -106,6 +106,15 @@ def sign_authority_state(state: WorkflowCapabilityAuthorityState, *, key: bytes,
 
 
 def verify_authority_state(signed: SignedAuthorityState, *, key: bytes, key_id: str) -> None:
+    try:
+        _verify_authority_state_fields(signed, key=key, key_id=key_id)
+    except WorkflowCapabilityError:
+        raise
+    except Exception as error:
+        raise WorkflowCapabilityError("invalid_signed_authority_state") from error
+
+
+def _verify_authority_state_fields(signed: SignedAuthorityState, *, key: bytes, key_id: str) -> None:
     if type(signed) is not SignedAuthorityState or type(signed.state) is not WorkflowCapabilityAuthorityState:
         raise WorkflowCapabilityError("invalid_signed_authority_state")
     expected = sign_authority_state(signed.state, key=key, key_id=key_id)
@@ -118,6 +127,15 @@ def sign_revocation(revocation: WorkflowCapabilityRevocation, *, key: bytes, key
 
 
 def verify_revocation(signed: SignedRevocation, *, key: bytes, key_id: str) -> None:
+    try:
+        _verify_revocation_fields(signed, key=key, key_id=key_id)
+    except WorkflowCapabilityError:
+        raise
+    except Exception as error:
+        raise WorkflowCapabilityError("invalid_signed_revocation") from error
+
+
+def _verify_revocation_fields(signed: SignedRevocation, *, key: bytes, key_id: str) -> None:
     if type(signed) is not SignedRevocation or type(signed.revocation) is not WorkflowCapabilityRevocation:
         raise WorkflowCapabilityError("invalid_signed_revocation")
     expected = sign_revocation(signed.revocation, key=key, key_id=key_id)

--- a/src/codex_plugin_scanner/guard/workflow_capability_transitions.py
+++ b/src/codex_plugin_scanner/guard/workflow_capability_transitions.py
@@ -111,6 +111,15 @@ def sign_authority_transition(
 
 
 def verify_authority_transition(signed: SignedAuthorityTransition, *, key: bytes, key_id: str) -> None:
+    try:
+        _verify_authority_transition_fields(signed, key=key, key_id=key_id)
+    except WorkflowCapabilityError:
+        raise
+    except Exception as error:
+        raise WorkflowCapabilityError("invalid_signed_authority_transition") from error
+
+
+def _verify_authority_transition_fields(signed: SignedAuthorityTransition, *, key: bytes, key_id: str) -> None:
     if (
         type(signed) is not SignedAuthorityTransition
         or type(signed.transition) is not WorkflowCapabilityAuthorityTransition

--- a/src/codex_plugin_scanner/guard/workflow_capability_transitions.py
+++ b/src/codex_plugin_scanner/guard/workflow_capability_transitions.py
@@ -10,7 +10,12 @@ import json
 from dataclasses import asdict, dataclass
 from typing import Final, cast
 
-from .workflow_capabilities import WorkflowCapabilityError, canonical_framed_payload, parse_utc_timestamp
+from .workflow_capabilities import (
+    WorkflowCapabilityError,
+    canonical_framed_payload,
+    parse_utc_timestamp,
+    validate_workflow_capability_identifier,
+)
 
 AUTHORITY_TRANSITION_SCHEMA: Final = "hol-guard.workflow-capability-authority-transition.v1"
 AUTHORITY_TRANSITION_ALGORITHM: Final = "hmac-sha256"
@@ -46,7 +51,7 @@ class WorkflowCapabilityAuthorityTransition:
             raise WorkflowCapabilityError("invalid_authority_transition_sequence")
         if type(self.revision) is not int or self.revision < 0:
             raise WorkflowCapabilityError("invalid_authority_transition_revision")
-        _identifier("capability_id", self.capability_id)
+        validate_workflow_capability_identifier("capability_id", self.capability_id)
         _digest("claim_sha256", self.claim_sha256)
         _digest("previous_transition_sha256", self.previous_transition_sha256)
         _digest("signed_state_sha256", self.signed_state_sha256)
@@ -55,14 +60,14 @@ class WorkflowCapabilityAuthorityTransition:
             raise WorkflowCapabilityError("invalid_authority_transition_kind")
         if type(self.event_id) is not int or self.event_id < 1:
             raise WorkflowCapabilityError("invalid_authority_transition_event")
-        _identifier("event_name", cast(str, self.event_name))
+        validate_workflow_capability_identifier("event_name", cast(str, self.event_name))
         _digest("event_payload_sha256", cast(str, self.event_payload_sha256))
         if self.use_number is not None and (type(self.use_number) is not int or self.use_number < 1):
             raise WorkflowCapabilityError("invalid_authority_transition_use_number")
         if self.receipt_id is not None:
-            _identifier("receipt_id", self.receipt_id)
+            validate_workflow_capability_identifier("receipt_id", self.receipt_id)
         if self.revocation_id is not None:
-            _identifier("revocation_id", self.revocation_id)
+            validate_workflow_capability_identifier("revocation_id", self.revocation_id)
         if (self.transition_kind == "claimed") != (self.receipt_id is not None):
             raise WorkflowCapabilityError("invalid_authority_transition_receipt")
         if (self.transition_kind == "claimed") != (self.use_number is not None):
@@ -104,7 +109,7 @@ def sign_authority_transition(
     transition: WorkflowCapabilityAuthorityTransition, *, key: bytes, key_id: str
 ) -> SignedAuthorityTransition:
     _key(key)
-    _identifier("key_id", key_id)
+    validate_workflow_capability_identifier("key_id", key_id)
     payload = {"key_id": key_id, "transition": asdict(transition)}
     signature = hmac.new(key, canonical_framed_payload("authority-transition", payload), hashlib.sha256).hexdigest()
     return SignedAuthorityTransition(transition=transition, key_id=key_id, signature=signature)
@@ -169,13 +174,6 @@ def _strict(payload: object, keys: set[str]) -> dict[str, object]:
     if set(typed) != keys:
         raise WorkflowCapabilityError("invalid_contract_keys")
     return typed
-
-
-def _identifier(name: str, value: str) -> None:
-    if type(value) is not str or not value or len(value) > 256 or value.strip() != value or "*" in value:
-        raise WorkflowCapabilityError(f"invalid_{name}")
-    if any(character.isspace() or ord(character) < 33 or ord(character) > 126 for character in value):
-        raise WorkflowCapabilityError(f"invalid_{name}")
 
 
 def _digest(name: str, value: str) -> None:

--- a/src/codex_plugin_scanner/guard/workflow_capability_transitions.py
+++ b/src/codex_plugin_scanner/guard/workflow_capability_transitions.py
@@ -1,0 +1,199 @@
+"""Signed workflow-capability authority transition contracts."""
+
+# pyright: reportAny=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import asdict, dataclass
+from typing import Final, cast
+
+from .workflow_capabilities import WorkflowCapabilityError, canonical_framed_payload, parse_utc_timestamp
+
+AUTHORITY_TRANSITION_SCHEMA: Final = "hol-guard.workflow-capability-authority-transition.v1"
+AUTHORITY_TRANSITION_ALGORITHM: Final = "hmac-sha256"
+ZERO_TRANSITION_SHA256: Final = "0" * 64
+_KINDS: Final = frozenset({"issued", "claimed", "revoked"})
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowCapabilityAuthorityTransition:
+    schema_version: str
+    algorithm: str
+    sequence: int
+    capability_id: str
+    claim_sha256: str
+    revision: int
+    transition_kind: str
+    previous_transition_sha256: str
+    signed_state_sha256: str
+    event_id: int | None
+    event_name: str | None
+    event_payload_sha256: str | None
+    occurred_at: str
+    use_number: int | None
+    receipt_id: str | None
+    revocation_id: str | None
+
+    def __post_init__(self) -> None:
+        if self.schema_version != AUTHORITY_TRANSITION_SCHEMA:
+            raise WorkflowCapabilityError("unsupported_authority_transition_schema")
+        if self.algorithm != AUTHORITY_TRANSITION_ALGORITHM:
+            raise WorkflowCapabilityError("unsupported_authority_transition_algorithm")
+        if type(self.sequence) is not int or self.sequence < 1:
+            raise WorkflowCapabilityError("invalid_authority_transition_sequence")
+        if type(self.revision) is not int or self.revision < 0:
+            raise WorkflowCapabilityError("invalid_authority_transition_revision")
+        _identifier("capability_id", self.capability_id)
+        _digest("claim_sha256", self.claim_sha256)
+        _digest("previous_transition_sha256", self.previous_transition_sha256)
+        _digest("signed_state_sha256", self.signed_state_sha256)
+        parse_utc_timestamp(self.occurred_at)
+        if self.transition_kind not in _KINDS:
+            raise WorkflowCapabilityError("invalid_authority_transition_kind")
+        if type(self.event_id) is not int or self.event_id < 1:
+            raise WorkflowCapabilityError("invalid_authority_transition_event")
+        _identifier("event_name", cast(str, self.event_name))
+        _digest("event_payload_sha256", cast(str, self.event_payload_sha256))
+        if self.use_number is not None and (type(self.use_number) is not int or self.use_number < 1):
+            raise WorkflowCapabilityError("invalid_authority_transition_use_number")
+        if self.receipt_id is not None:
+            _identifier("receipt_id", self.receipt_id)
+        if self.revocation_id is not None:
+            _identifier("revocation_id", self.revocation_id)
+        if (self.transition_kind == "claimed") != (self.receipt_id is not None):
+            raise WorkflowCapabilityError("invalid_authority_transition_receipt")
+        if (self.transition_kind == "claimed") != (self.use_number is not None):
+            raise WorkflowCapabilityError("invalid_authority_transition_use_number")
+        if (self.transition_kind == "revoked") != (self.revocation_id is not None):
+            raise WorkflowCapabilityError("invalid_authority_transition_revocation")
+
+    @classmethod
+    def from_dict(cls, payload: object) -> WorkflowCapabilityAuthorityTransition:
+        values = _strict(payload, set(cls.__dataclass_fields__))
+        return cls(
+            schema_version=_string("schema_version", values["schema_version"]),
+            algorithm=_string("algorithm", values["algorithm"]),
+            sequence=_integer("sequence", values["sequence"]),
+            capability_id=_string("capability_id", values["capability_id"]),
+            claim_sha256=_string("claim_sha256", values["claim_sha256"]),
+            revision=_integer("revision", values["revision"]),
+            transition_kind=_string("transition_kind", values["transition_kind"]),
+            previous_transition_sha256=_string("previous_transition_sha256", values["previous_transition_sha256"]),
+            signed_state_sha256=_string("signed_state_sha256", values["signed_state_sha256"]),
+            event_id=_optional_integer("event_id", values["event_id"]),
+            event_name=_optional_string("event_name", values["event_name"]),
+            event_payload_sha256=_optional_string("event_payload_sha256", values["event_payload_sha256"]),
+            occurred_at=_string("occurred_at", values["occurred_at"]),
+            use_number=_optional_integer("use_number", values["use_number"]),
+            receipt_id=_optional_string("receipt_id", values["receipt_id"]),
+            revocation_id=_optional_string("revocation_id", values["revocation_id"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SignedAuthorityTransition:
+    transition: WorkflowCapabilityAuthorityTransition
+    key_id: str
+    signature: str
+
+
+def sign_authority_transition(
+    transition: WorkflowCapabilityAuthorityTransition, *, key: bytes, key_id: str
+) -> SignedAuthorityTransition:
+    _key(key)
+    _identifier("key_id", key_id)
+    payload = {"key_id": key_id, "transition": asdict(transition)}
+    signature = hmac.new(key, canonical_framed_payload("authority-transition", payload), hashlib.sha256).hexdigest()
+    return SignedAuthorityTransition(transition=transition, key_id=key_id, signature=signature)
+
+
+def verify_authority_transition(signed: SignedAuthorityTransition, *, key: bytes, key_id: str) -> None:
+    if (
+        type(signed) is not SignedAuthorityTransition
+        or type(signed.transition) is not WorkflowCapabilityAuthorityTransition
+    ):
+        raise WorkflowCapabilityError("invalid_signed_authority_transition")
+    if signed.key_id != key_id:
+        raise WorkflowCapabilityError("authority_transition_key_mismatch")
+    _digest("signature", signed.signature)
+    expected = sign_authority_transition(signed.transition, key=key, key_id=key_id).signature
+    if not hmac.compare_digest(signed.signature, expected):
+        raise WorkflowCapabilityError("authority_transition_signature_invalid")
+
+
+def encode_signed_authority_transition(signed: SignedAuthorityTransition) -> str:
+    return _canonical({"key_id": signed.key_id, "signature": signed.signature, "transition": asdict(signed.transition)})
+
+
+def decode_signed_authority_transition(encoded: str) -> SignedAuthorityTransition:
+    try:
+        payload = _strict(json.loads(encoded), {"key_id", "signature", "transition"})
+    except json.JSONDecodeError as error:
+        raise WorkflowCapabilityError("authority_transition_payload_invalid") from error
+    signed = SignedAuthorityTransition(
+        transition=WorkflowCapabilityAuthorityTransition.from_dict(payload["transition"]),
+        key_id=_string("key_id", payload["key_id"]),
+        signature=_string("signature", payload["signature"]),
+    )
+    if encode_signed_authority_transition(signed) != encoded:
+        raise WorkflowCapabilityError("authority_transition_not_canonical")
+    return signed
+
+
+def authority_transition_sha256(signed: SignedAuthorityTransition) -> str:
+    return hashlib.sha256(
+        canonical_framed_payload("authority-transition-digest", encode_signed_authority_transition(signed))
+    ).hexdigest()
+
+
+def _canonical(payload: object) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _strict(payload: object, keys: set[str]) -> dict[str, object]:
+    if type(payload) is not dict:
+        raise WorkflowCapabilityError("invalid_contract_keys")
+    typed = cast(dict[str, object], payload)
+    if set(typed) != keys:
+        raise WorkflowCapabilityError("invalid_contract_keys")
+    return typed
+
+
+def _identifier(name: str, value: str) -> None:
+    if type(value) is not str or not value or len(value) > 256 or value.strip() != value or "*" in value:
+        raise WorkflowCapabilityError(f"invalid_{name}")
+    if any(character.isspace() or ord(character) < 33 or ord(character) > 126 for character in value):
+        raise WorkflowCapabilityError(f"invalid_{name}")
+
+
+def _digest(name: str, value: str) -> None:
+    if type(value) is not str or len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise WorkflowCapabilityError(f"invalid_{name}")
+
+
+def _key(value: bytes) -> None:
+    if type(value) is not bytes or len(value) < 32:
+        raise WorkflowCapabilityError("invalid_capability_key")
+
+
+def _string(name: str, value: object) -> str:
+    if type(value) is not str:
+        raise WorkflowCapabilityError(f"invalid_{name}")
+    return value
+
+
+def _optional_string(name: str, value: object) -> str | None:
+    return None if value is None else _string(name, value)
+
+
+def _integer(name: str, value: object) -> int:
+    if type(value) is not int:
+        raise WorkflowCapabilityError(f"invalid_{name}")
+    return value
+
+
+def _optional_integer(name: str, value: object) -> int | None:
+    return None if value is None else _integer(name, value)

--- a/tests/test_guard_workflow_capabilities.py
+++ b/tests/test_guard_workflow_capabilities.py
@@ -18,9 +18,9 @@ from typing import cast
 
 import pytest
 
-from codex_plugin_scanner.guard import store_workflow_capabilities as workflow_store_module
 from codex_plugin_scanner.guard.store import GuardStore
 from codex_plugin_scanner.guard.store_workflow_capabilities import StoreWorkflowCapabilitiesMixin
+from codex_plugin_scanner.guard.store_workflow_capability_common import WORKFLOW_CAPABILITY_STORE_CLOCK
 from codex_plugin_scanner.guard.workflow_capabilities import (
     WORKFLOW_CAPABILITY_ALGORITHM,
     WORKFLOW_CAPABILITY_RECEIPT_SCHEMA,
@@ -51,7 +51,7 @@ def _fixed_policy_integrity_key(monkeypatch: pytest.MonkeyPatch) -> None:
         "_policy_integrity_secret_material",
         lambda self, *, create: (_KEY, _KEY_ID),
     )
-    monkeypatch.setattr(workflow_store_module, "_workflow_capability_store_now", _now)
+    monkeypatch.setattr(WORKFLOW_CAPABILITY_STORE_CLOCK, "now", _now)
 
 
 def _binding(**changes: object) -> WorkflowCapabilityBinding:

--- a/tests/test_guard_workflow_capabilities.py
+++ b/tests/test_guard_workflow_capabilities.py
@@ -1,0 +1,439 @@
+"""Focused tests for the dormant workflow-capability kernel."""
+
+# pyright: reportAny=false, reportMissingParameterType=false, reportUnknownArgumentType=false
+# pyright: reportUnknownLambdaType=false, reportUnknownMemberType=false, reportUnknownParameterType=false
+# pyright: reportUnknownVariableType=false, reportUnusedCallResult=false, reportUnusedParameter=false
+# pyright: reportUntypedFunctionDecorator=false, reportUnusedFunction=false
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard import store_workflow_capabilities as workflow_store_module
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_workflow_capabilities import StoreWorkflowCapabilitiesMixin
+from codex_plugin_scanner.guard.workflow_capabilities import (
+    WORKFLOW_CAPABILITY_ALGORITHM,
+    WORKFLOW_CAPABILITY_RECEIPT_SCHEMA,
+    WORKFLOW_CAPABILITY_SCHEMA,
+    SignedWorkflowCapability,
+    WorkflowCapabilityBinding,
+    WorkflowCapabilityClaim,
+    WorkflowCapabilityError,
+    WorkflowCapabilityReceipt,
+    WorkflowCapabilityRuleBinding,
+    canonical_framed_payload,
+    format_utc_timestamp,
+    sign_workflow_capability,
+    sign_workflow_capability_receipt,
+    verify_workflow_capability,
+    verify_workflow_capability_receipt,
+)
+
+_KEY = b"k" * 32
+_KEY_ID = "guard-policy-integrity-key:test"
+_ISSUED = datetime(2026, 7, 19, 12, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _fixed_policy_integrity_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        GuardStore,
+        "_policy_integrity_secret_material",
+        lambda self, *, create: (_KEY, _KEY_ID),
+    )
+    monkeypatch.setattr(workflow_store_module, "_workflow_capability_store_now", _now)
+
+
+def _binding(**changes: object) -> WorkflowCapabilityBinding:
+    values: dict[str, object] = {
+        "operation_id": "test.run",
+        "resource_type": "test-file-set",
+        "resource_sha256": "1" * 64,
+        "repository_sha256": "2" * 64,
+        "workspace_sha256": "3" * 64,
+        "executable_sha256": "4" * 64,
+        "launch_sha256": "5" * 64,
+        "policy_id": "local.command-policy",
+        "policy_version": "policy.v7",
+        "effect_id": "command.effect",
+        "effect_version": "effect.v2",
+        "decision_id": "decision.exact-local",
+        "decision_version": "decision.v3",
+        "rules": (
+            WorkflowCapabilityRuleBinding("command.exact", "v2"),
+            WorkflowCapabilityRuleBinding("workspace.bound", "v1"),
+        ),
+    }
+    values.update(changes)
+    return WorkflowCapabilityBinding(
+        operation_id=cast(str, values["operation_id"]),
+        resource_type=cast(str, values["resource_type"]),
+        resource_sha256=cast(str, values["resource_sha256"]),
+        repository_sha256=cast(str, values["repository_sha256"]),
+        workspace_sha256=cast(str, values["workspace_sha256"]),
+        executable_sha256=cast(str, values["executable_sha256"]),
+        launch_sha256=cast(str, values["launch_sha256"]),
+        policy_id=cast(str, values["policy_id"]),
+        policy_version=cast(str, values["policy_version"]),
+        effect_id=cast(str, values["effect_id"]),
+        effect_version=cast(str, values["effect_version"]),
+        decision_id=cast(str, values["decision_id"]),
+        decision_version=cast(str, values["decision_version"]),
+        rules=cast(tuple[WorkflowCapabilityRuleBinding, ...], values["rules"]),
+    )
+
+
+def _claim(*, capability_id: str = "wc-test-1", max_uses: int = 1, **changes: object) -> WorkflowCapabilityClaim:
+    values: dict[str, object] = {
+        "schema_version": WORKFLOW_CAPABILITY_SCHEMA,
+        "algorithm": WORKFLOW_CAPABILITY_ALGORITHM,
+        "capability_id": capability_id,
+        "approval_provenance_id": f"provenance-{capability_id}",
+        "task_id": "task-local-check",
+        "nonce": hashlib.sha256(capability_id.encode("ascii")).hexdigest(),
+        "issuer_id": "guard.local",
+        "subject_id": "codex.local",
+        "binding": _binding(),
+        "issued_at": format_utc_timestamp(_ISSUED),
+        "not_before": format_utc_timestamp(_ISSUED),
+        "expires_at": format_utc_timestamp(_ISSUED + timedelta(hours=1)),
+        "max_uses": max_uses,
+    }
+    values.update(changes)
+    return WorkflowCapabilityClaim(
+        schema_version=cast(str, values["schema_version"]),
+        algorithm=cast(str, values["algorithm"]),
+        capability_id=cast(str, values["capability_id"]),
+        approval_provenance_id=cast(str, values["approval_provenance_id"]),
+        task_id=cast(str, values["task_id"]),
+        nonce=cast(str, values["nonce"]),
+        issuer_id=cast(str, values["issuer_id"]),
+        subject_id=cast(str, values["subject_id"]),
+        binding=cast(WorkflowCapabilityBinding, values["binding"]),
+        issued_at=cast(str, values["issued_at"]),
+        not_before=cast(str, values["not_before"]),
+        expires_at=cast(str, values["expires_at"]),
+        max_uses=cast(int, values["max_uses"]),
+    )
+
+
+def _now(minutes: int = 1) -> str:
+    return format_utc_timestamp(_ISSUED + timedelta(minutes=minutes))
+
+
+def _store(tmp_path: Path) -> GuardStore:
+    return GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+
+
+def _issue(
+    store: GuardStore,
+    claim: WorkflowCapabilityClaim,
+    *,
+    approval_provenance_id: str | None = None,
+) -> SignedWorkflowCapability:
+    signed = sign_workflow_capability(claim, key=_KEY, key_id=_KEY_ID)
+    return store.issue_workflow_capability(
+        signed,
+        approval_provenance_id=approval_provenance_id or claim.approval_provenance_id,
+    )
+
+
+def _claim_capability(
+    store: GuardStore,
+    claim: WorkflowCapabilityClaim,
+    *,
+    invocation_id: str,
+    expected_binding: WorkflowCapabilityBinding | None = None,
+):
+    return store.claim_workflow_capability(
+        claim.capability_id,
+        invocation_id=invocation_id,
+        expected_binding=claim.binding if expected_binding is None else expected_binding,
+        expected_subject_id=claim.subject_id,
+        expected_task_id=claim.task_id,
+        expected_issuer_id=claim.issuer_id,
+        expected_approval_provenance_id=claim.approval_provenance_id,
+    )
+
+
+def test_framing_and_signatures_are_deterministic_and_tamper_evident() -> None:
+    claim = _claim()
+    first = sign_workflow_capability(claim, key=_KEY, key_id=_KEY_ID)
+    second = sign_workflow_capability(claim, key=_KEY, key_id=_KEY_ID)
+
+    assert first == second
+    assert canonical_framed_payload("ab", {"c": 1}) != canonical_framed_payload("a", {"bc": 1})
+    verify_workflow_capability(first, key=_KEY, key_id=_KEY_ID, now=_now(), expected_binding=claim.binding)
+
+    tampered = replace(first, claim=replace(claim, subject_id="other.subject"))
+    with pytest.raises(WorkflowCapabilityError, match="signature_invalid"):
+        verify_workflow_capability(tampered, key=_KEY, key_id=_KEY_ID, now=_now(), expected_binding=claim.binding)
+
+
+def test_contract_rejects_unknown_null_wildcard_bool_and_noncanonical_rules() -> None:
+    signed = sign_workflow_capability(_claim(), key=_KEY, key_id=_KEY_ID)
+    payload = signed.to_dict()
+    payload["unknown"] = "field"
+    with pytest.raises(WorkflowCapabilityError, match="contract_keys"):
+        type(signed).from_dict(payload)
+    with pytest.raises(WorkflowCapabilityError, match="operation_id"):
+        _binding(operation_id="*")
+    with pytest.raises(WorkflowCapabilityError, match="resource_sha256"):
+        _binding(resource_sha256="not-a-digest")
+    with pytest.raises(WorkflowCapabilityError, match="rule_bindings"):
+        _binding(rules=tuple(reversed(_binding().rules)))
+    with pytest.raises(WorkflowCapabilityError, match="max_uses"):
+        _claim(max_uses=True)
+
+
+def test_direct_construction_rejects_nested_type_forgeries() -> None:
+    with pytest.raises(WorkflowCapabilityError, match="rule_bindings"):
+        _binding(rules=cast(tuple[WorkflowCapabilityRuleBinding, ...], ("bad",)))
+    claim = _claim()
+    with pytest.raises(WorkflowCapabilityError, match="capability_binding"):
+        replace(claim, binding=cast(WorkflowCapabilityBinding, object()))
+    signed = sign_workflow_capability(claim, key=_KEY, key_id=_KEY_ID)
+    with pytest.raises(WorkflowCapabilityError, match="capability_claim"):
+        replace(signed, claim=cast(WorkflowCapabilityClaim, object()))
+    receipt = WorkflowCapabilityReceipt(
+        schema_version=WORKFLOW_CAPABILITY_RECEIPT_SCHEMA,
+        receipt_id="wcr-direct",
+        capability_id=claim.capability_id,
+        task_id=claim.task_id,
+        invocation_id="invocation-direct",
+        approval_provenance_id=claim.approval_provenance_id,
+        claim_sha256="f" * 64,
+        binding=claim.binding,
+        use_number=1,
+        event_id=1,
+        claimed_at=_now(),
+    )
+    with pytest.raises(WorkflowCapabilityError, match="receipt_binding"):
+        replace(receipt, binding=cast(WorkflowCapabilityBinding, object()))
+    signed_receipt = sign_workflow_capability_receipt(receipt, key=_KEY, key_id=_KEY_ID)
+    with pytest.raises(WorkflowCapabilityError, match="capability_receipt"):
+        replace(signed_receipt, receipt=cast(WorkflowCapabilityReceipt, object()))
+
+
+def test_time_and_alpha_bounds_fail_closed() -> None:
+    signed = sign_workflow_capability(_claim(), key=_KEY, key_id=_KEY_ID)
+    with pytest.raises(WorkflowCapabilityError, match="not_yet_valid"):
+        verify_workflow_capability(signed, key=_KEY, key_id=_KEY_ID, now=_now(-1), expected_binding=_binding())
+    with pytest.raises(WorkflowCapabilityError, match="expired"):
+        verify_workflow_capability(signed, key=_KEY, key_id=_KEY_ID, now=_now(60), expected_binding=_binding())
+    with pytest.raises(WorkflowCapabilityError, match="ttl_exceeds"):
+        _claim(expires_at=format_utc_timestamp(_ISSUED + timedelta(hours=25)))
+    with pytest.raises(WorkflowCapabilityError, match="max_uses"):
+        _claim(max_uses=51)
+
+
+def test_issue_lookup_claim_and_reopen(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(approval_provenance_id="provenance-054")
+    issued = _issue(store, claim)
+    receipt = _claim_capability(
+        store,
+        claim,
+        invocation_id="invocation-1",
+    )
+
+    assert store.lookup_workflow_capability(claim.capability_id) == issued
+    assert receipt.receipt.task_id == claim.task_id
+    assert receipt.receipt.approval_provenance_id == "provenance-054"
+    verify_workflow_capability_receipt(receipt, key=_KEY, key_id=_KEY_ID)
+    assert _store(tmp_path).lookup_workflow_capability(claim.capability_id) == issued
+    issue_events = store.list_events(event_name="workflow_capability.issued")
+    assert issue_events[0]["occurred_at"] == _now()
+    assert issue_events[0]["occurred_at"] != claim.issued_at
+
+
+def test_replay_and_max_use_are_independent_failures(tmp_path) -> None:
+    store = _store(tmp_path)
+    first = _claim(capability_id="wc-first", max_uses=2)
+    second = _claim(capability_id="wc-second", max_uses=1)
+    _issue(store, first)
+    _issue(store, second)
+    _claim_capability(store, first, invocation_id="invocation-shared")
+
+    with pytest.raises(WorkflowCapabilityError, match="replayed"):
+        _claim_capability(store, second, invocation_id="invocation-shared")
+    _claim_capability(store, first, invocation_id="invocation-2")
+    with pytest.raises(WorkflowCapabilityError, match="exhausted"):
+        _claim_capability(store, first, invocation_id="invocation-3")
+
+
+def test_issue_rejects_approval_drift_and_nonce_reuse(tmp_path) -> None:
+    store = _store(tmp_path)
+    first = _claim(capability_id="wc-nonce-first")
+    with pytest.raises(WorkflowCapabilityError, match="approval_binding_mismatch"):
+        _issue(store, first, approval_provenance_id="provenance-other")
+    _issue(store, first)
+    replay = _claim(capability_id="wc-nonce-replay", nonce=first.nonce)
+    with pytest.raises(WorkflowCapabilityError, match="already_exists"):
+        _issue(store, replay)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("policy_version", "policy.v8"),
+        ("policy_id", "local.other-policy"),
+        ("effect_version", "effect.v3"),
+        ("effect_id", "command.other-effect"),
+        ("decision_version", "decision.v4"),
+        ("decision_id", "decision.other"),
+        ("operation_id", "test.lint"),
+        ("resource_type", "source-file-set"),
+        ("resource_sha256", "6" * 64),
+        ("repository_sha256", "0" * 64),
+        ("workspace_sha256", "9" * 64),
+        ("executable_sha256", "8" * 64),
+        ("launch_sha256", "7" * 64),
+        ("rules", (WorkflowCapabilityRuleBinding("command.other", "v1"),)),
+    ],
+)
+def test_every_context_drift_fails_closed(tmp_path, field: str, value: object) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id=f"wc-drift-{field}")
+    _issue(store, claim)
+    with pytest.raises(WorkflowCapabilityError, match="context_mismatch"):
+        _claim_capability(
+            store,
+            claim,
+            invocation_id=f"invocation-{field}",
+            expected_binding=replace(claim.binding, **{field: value}),
+        )
+
+
+def test_concurrent_claims_never_exceed_exact_use_limit(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-concurrent", max_uses=8)
+    _issue(store, claim)
+
+    def attempt(invocation_id: str) -> str:
+        contender = _store(tmp_path)
+        try:
+            _claim_capability(
+                contender,
+                claim,
+                invocation_id=invocation_id,
+            )
+        except WorkflowCapabilityError as error:
+            return str(error)
+        return "claimed"
+
+    with ThreadPoolExecutor(max_workers=32) as executor:
+        results = list(executor.map(attempt, (f"invocation-{index}" for index in range(32))))
+    assert results.count("claimed") == 8
+    assert results.count("capability_exhausted") == 24
+    with sqlite3.connect(store.path) as connection:
+        use_row = connection.execute(
+            "select used_count from guard_workflow_capabilities where capability_id = ?",
+            (claim.capability_id,),
+        ).fetchone()
+        receipt_row = connection.execute("select count(*) from guard_workflow_capability_receipts").fetchone()
+        transition_rows = connection.execute(
+            "select sequence from guard_workflow_capability_authority_transitions order by sequence"
+        ).fetchall()
+    assert use_row == (8,)
+    assert receipt_row == (8,)
+    assert transition_rows == [(index,) for index in range(1, 10)]
+
+
+def test_claim_rolls_back_use_and_event_when_audit_link_fails(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-rollback")
+    _issue(store, claim)
+
+    def fail_event(*args: object, **kwargs: object) -> int:
+        raise RuntimeError("forced_event_failure")
+
+    monkeypatch.setattr(StoreWorkflowCapabilitiesMixin, "_insert_workflow_capability_event", fail_event)
+    with pytest.raises(RuntimeError, match="forced_event_failure"):
+        _claim_capability(
+            store,
+            claim,
+            invocation_id="invocation-rollback",
+        )
+    with sqlite3.connect(store.path) as connection:
+        used_count = connection.execute(
+            "select used_count from guard_workflow_capabilities where capability_id = ?", (claim.capability_id,)
+        ).fetchone()
+        receipt_count = connection.execute("select count(*) from guard_workflow_capability_receipts").fetchone()
+    assert used_count == (0,)
+    assert receipt_count == (0,)
+
+
+def test_revocation_blocks_claim_and_is_idempotent(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-revoked")
+    _issue(store, claim)
+    with pytest.raises(WorkflowCapabilityError, match="reason_code"):
+        store.revoke_workflow_capability(claim.capability_id, reason_code="https://example.invalid/private")
+    assert store.revoke_workflow_capability(claim.capability_id, reason_code="operator.revoked")
+    assert not store.revoke_workflow_capability(claim.capability_id, reason_code="operator.revoked")
+    with pytest.raises(WorkflowCapabilityError, match="revoked"):
+        _claim_capability(
+            store,
+            claim,
+            invocation_id="invocation-revoked",
+        )
+
+
+def test_audit_is_privacy_safe_and_receipt_is_linked_and_immutable(tmp_path) -> None:
+    store = _store(tmp_path)
+    approval_id = "approval-private"
+    claim = _claim(capability_id="wc-private", approval_provenance_id=approval_id)
+    invocation_id = "invocation-private"
+    _issue(store, claim, approval_provenance_id=approval_id)
+    _claim_capability(
+        store,
+        claim,
+        invocation_id=invocation_id,
+    )
+    events = store.list_events(event_name="workflow_capability.claimed")
+    payload = json.dumps(events, sort_keys=True)
+    for private_value in (claim.capability_id, claim.task_id, approval_id, invocation_id):
+        assert private_value not in payload
+
+    with sqlite3.connect(store.path) as connection:
+        linked = connection.execute(
+            """
+            select r.event_id = e.event_id from guard_workflow_capability_receipts r
+            join guard_events e on e.event_id = r.event_id
+            """
+        ).fetchone()
+        assert linked == (1,)
+        with pytest.raises(sqlite3.IntegrityError, match="receipt_immutable"):
+            connection.execute("update guard_workflow_capability_receipts set use_number = 2")
+
+
+def test_existing_invalid_schema_fails_closed(tmp_path) -> None:
+    home = tmp_path / "guard-home"
+    home.mkdir()
+    database = home / "guard.db"
+    with sqlite3.connect(database) as connection:
+        connection.execute("create table guard_workflow_capabilities (capability_id text primary key)")
+    with pytest.raises(RuntimeError, match="invalid_workflow_capability_schema"):
+        GuardStore(home, prime_policy_integrity=False)
+    with sqlite3.connect(database) as connection:
+        version = connection.execute("select 1 from schema_migrations where version = 14").fetchone()
+    assert version is None
+
+
+def test_extra_owned_schema_object_fails_closed(tmp_path) -> None:
+    store = _store(tmp_path)
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("create index idx_guard_workflow_hostile on guard_workflow_capabilities (key_id)")
+    with pytest.raises(RuntimeError, match="owned_objects"):
+        GuardStore(store.guard_home, prime_policy_integrity=False)

--- a/tests/test_guard_workflow_capability_authority_tamper.py
+++ b/tests/test_guard_workflow_capability_authority_tamper.py
@@ -15,10 +15,27 @@ import pytest
 from codex_plugin_scanner.guard.store import GuardStore
 from codex_plugin_scanner.guard.store_workflow_capability_common import WORKFLOW_CAPABILITY_STORE_CLOCK
 from codex_plugin_scanner.guard.workflow_capabilities import (
+    SignedWorkflowCapability,
+    SignedWorkflowCapabilityReceipt,
     WorkflowCapabilityBinding,
     WorkflowCapabilityError,
     sign_workflow_capability,
     verify_workflow_capability,
+    verify_workflow_capability_receipt,
+    verify_workflow_capability_signature,
+)
+from codex_plugin_scanner.guard.workflow_capability_authority_state import (
+    SignedAuthorityState,
+    SignedRevocation,
+    decode_signed_authority_state,
+    decode_signed_revocation,
+    verify_authority_state,
+    verify_revocation,
+)
+from codex_plugin_scanner.guard.workflow_capability_transitions import (
+    SignedAuthorityTransition,
+    decode_signed_authority_transition,
+    verify_authority_transition,
 )
 from tests.test_guard_workflow_capabilities import (
     _KEY,
@@ -52,6 +69,109 @@ def test_expected_binding_requires_exact_contract_type() -> None:
             now=_now(),
             expected_binding=cast(WorkflowCapabilityBinding, object()),
         )
+
+
+def test_uninitialized_signed_claim_fails_closed() -> None:
+    signed = object.__new__(SignedWorkflowCapability)
+    with pytest.raises(WorkflowCapabilityError, match="invalid_signed_capability"):
+        verify_workflow_capability_signature(signed, key=_KEY, key_id=_KEY_ID)
+
+
+def test_uninitialized_signed_receipt_fails_closed() -> None:
+    signed = object.__new__(SignedWorkflowCapabilityReceipt)
+    with pytest.raises(WorkflowCapabilityError, match="invalid_signed_receipt"):
+        verify_workflow_capability_receipt(signed, key=_KEY, key_id=_KEY_ID)
+
+
+def test_uninitialized_signed_authority_state_fails_closed() -> None:
+    signed = object.__new__(SignedAuthorityState)
+    with pytest.raises(WorkflowCapabilityError, match="invalid_signed_authority_state"):
+        verify_authority_state(signed, key=_KEY, key_id=_KEY_ID)
+
+
+def test_uninitialized_signed_revocation_fails_closed() -> None:
+    signed = object.__new__(SignedRevocation)
+    with pytest.raises(WorkflowCapabilityError, match="invalid_signed_revocation"):
+        verify_revocation(signed, key=_KEY, key_id=_KEY_ID)
+
+
+def test_uninitialized_signed_authority_transition_fails_closed() -> None:
+    signed = object.__new__(SignedAuthorityTransition)
+    with pytest.raises(WorkflowCapabilityError, match="invalid_signed_authority_transition"):
+        verify_authority_transition(signed, key=_KEY, key_id=_KEY_ID)
+
+
+def _cyclic_value() -> list[object]:
+    value: list[object] = []
+    value.append(value)
+    return value
+
+
+@pytest.mark.parametrize("invalid_value", [object(), _cyclic_value()])
+def test_malformed_present_claim_value_fails_closed(invalid_value: object) -> None:
+    signed = sign_workflow_capability(_claim(capability_id="wc-malformed-claim-value"), key=_KEY, key_id=_KEY_ID)
+    object.__setattr__(signed.claim, "capability_id", invalid_value)
+    with pytest.raises(WorkflowCapabilityError, match="invalid_signed_capability"):
+        verify_workflow_capability_signature(signed, key=_KEY, key_id=_KEY_ID)
+
+
+@pytest.mark.parametrize("invalid_value", [object(), _cyclic_value()])
+def test_malformed_present_receipt_value_fails_closed(tmp_path, invalid_value: object) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-malformed-receipt-value")
+    _issue(store, claim)
+    signed = _claim_capability(store, claim, invocation_id="invocation-malformed-receipt-value")
+    object.__setattr__(signed.receipt, "capability_id", invalid_value)
+    with pytest.raises(WorkflowCapabilityError, match="invalid_signed_receipt"):
+        verify_workflow_capability_receipt(signed, key=_KEY, key_id=_KEY_ID)
+
+
+@pytest.mark.parametrize("invalid_value", [object(), _cyclic_value()])
+def test_malformed_present_authority_state_value_fails_closed(tmp_path, invalid_value: object) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-malformed-state-value")
+    _issue(store, claim)
+    with sqlite3.connect(store.path) as connection:
+        encoded = connection.execute(
+            "select signed_state_json from guard_workflow_capability_authority_state where capability_id = ?",
+            (claim.capability_id,),
+        ).fetchone()[0]
+    signed = decode_signed_authority_state(encoded)
+    object.__setattr__(signed.state, "capability_id", invalid_value)
+    with pytest.raises(WorkflowCapabilityError, match="invalid_signed_authority_state"):
+        verify_authority_state(signed, key=_KEY, key_id=_KEY_ID)
+
+
+@pytest.mark.parametrize("invalid_value", [object(), _cyclic_value()])
+def test_malformed_present_revocation_value_fails_closed(tmp_path, invalid_value: object) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-malformed-revocation-value")
+    _issue(store, claim)
+    assert store.revoke_workflow_capability(claim.capability_id, reason_code="operator.revoked")
+    with sqlite3.connect(store.path) as connection:
+        encoded = connection.execute(
+            "select signed_revocation_json from guard_workflow_capability_revocations where capability_id = ?",
+            (claim.capability_id,),
+        ).fetchone()[0]
+    signed = decode_signed_revocation(encoded)
+    object.__setattr__(signed.revocation, "capability_id", invalid_value)
+    with pytest.raises(WorkflowCapabilityError, match="invalid_signed_revocation"):
+        verify_revocation(signed, key=_KEY, key_id=_KEY_ID)
+
+
+@pytest.mark.parametrize("invalid_value", [object(), _cyclic_value()])
+def test_malformed_present_transition_value_fails_closed(tmp_path, invalid_value: object) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-malformed-transition-value")
+    _issue(store, claim)
+    with sqlite3.connect(store.path) as connection:
+        encoded = connection.execute(
+            "select signed_transition_json from guard_workflow_capability_authority_transitions where sequence = 1"
+        ).fetchone()[0]
+    signed = decode_signed_authority_transition(encoded)
+    object.__setattr__(signed.transition, "capability_id", invalid_value)
+    with pytest.raises(WorkflowCapabilityError, match="invalid_signed_authority_transition"):
+        verify_authority_transition(signed, key=_KEY, key_id=_KEY_ID)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_workflow_capability_authority_tamper.py
+++ b/tests/test_guard_workflow_capability_authority_tamper.py
@@ -20,6 +20,7 @@ from codex_plugin_scanner.guard.workflow_capabilities import (
     WorkflowCapabilityBinding,
     WorkflowCapabilityError,
     sign_workflow_capability,
+    validate_workflow_capability_identifier,
     verify_workflow_capability,
     verify_workflow_capability_receipt,
     verify_workflow_capability_signature,
@@ -68,6 +69,31 @@ def test_expected_binding_requires_exact_contract_type() -> None:
             key_id=_KEY_ID,
             now=_now(),
             expected_binding=cast(WorkflowCapabilityBinding, object()),
+        )
+
+
+def test_all_public_identifier_boundaries_use_canonical_alphabet(tmp_path) -> None:
+    store = _store(tmp_path)
+    with pytest.raises(WorkflowCapabilityError, match="invalid_capability_id"):
+        store.lookup_workflow_capability("!capability")
+    with pytest.raises(WorkflowCapabilityError, match="invalid_capability_id"):
+        store.revoke_workflow_capability("!capability", reason_code="operator.revoked")
+    with pytest.raises(WorkflowCapabilityError, match="invalid_receipt_id"):
+        store.lookup_workflow_capability_receipt(receipt_id="!receipt")
+    with pytest.raises(WorkflowCapabilityError, match="invalid_event_name"):
+        validate_workflow_capability_identifier("event_name", "event!name")
+
+    claim = _claim(capability_id="wc-canonical-identifiers")
+    _issue(store, claim)
+    with pytest.raises(WorkflowCapabilityError, match="invalid_expected_subject_id"):
+        store.claim_workflow_capability(
+            claim.capability_id,
+            invocation_id="invocation-canonical-identifiers",
+            expected_binding=claim.binding,
+            expected_subject_id="subject!invalid",
+            expected_task_id=claim.task_id,
+            expected_issuer_id=claim.issuer_id,
+            expected_approval_provenance_id=claim.approval_provenance_id,
         )
 
 

--- a/tests/test_guard_workflow_capability_authority_tamper.py
+++ b/tests/test_guard_workflow_capability_authority_tamper.py
@@ -1,0 +1,225 @@
+"""Adversarial persistence tests for workflow-capability authority state."""
+
+# pyright: reportAny=false, reportMissingParameterType=false, reportPrivateUsage=false
+# pyright: reportUnknownArgumentType=false, reportUnknownLambdaType=false, reportUnknownMemberType=false
+# pyright: reportUnknownParameterType=false, reportUnusedCallResult=false, reportUnusedFunction=false
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard import store_workflow_capabilities as workflow_store_module
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.workflow_capabilities import (
+    WorkflowCapabilityBinding,
+    WorkflowCapabilityError,
+    sign_workflow_capability,
+    verify_workflow_capability,
+)
+from tests.test_guard_workflow_capabilities import (
+    _KEY,
+    _KEY_ID,
+    _claim,
+    _claim_capability,
+    _issue,
+    _now,
+    _store,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fixed_authority(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        GuardStore,
+        "_policy_integrity_secret_material",
+        lambda self, *, create: (_KEY, _KEY_ID),
+    )
+    monkeypatch.setattr(workflow_store_module, "_workflow_capability_store_now", _now)
+
+
+def test_expected_binding_requires_exact_contract_type() -> None:
+    claim = _claim(capability_id="wc-exact-binding")
+    signed = sign_workflow_capability(claim, key=_KEY, key_id=_KEY_ID)
+    with pytest.raises(WorkflowCapabilityError, match="invalid_expected_capability_binding"):
+        verify_workflow_capability(
+            signed,
+            key=_KEY,
+            key_id=_KEY_ID,
+            now=_now(),
+            expected_binding=cast(WorkflowCapabilityBinding, object()),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("expected_subject_id", "subject.other"),
+        ("expected_task_id", "task.other"),
+        ("expected_issuer_id", "issuer.other"),
+        ("expected_approval_provenance_id", "provenance-other"),
+    ],
+)
+def test_claim_rejects_every_expected_authority_identity(tmp_path, field: str, value: str) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id=f"wc-identity-{field}")
+    _issue(store, claim)
+    expected = {
+        "expected_subject_id": claim.subject_id,
+        "expected_task_id": claim.task_id,
+        "expected_issuer_id": claim.issuer_id,
+        "expected_approval_provenance_id": claim.approval_provenance_id,
+    }
+    expected[field] = value
+    with pytest.raises(WorkflowCapabilityError, match="capability_claimant_context_mismatch"):
+        store.claim_workflow_capability(
+            claim.capability_id,
+            invocation_id="invocation-identity",
+            expected_binding=claim.binding,
+            **expected,
+        )
+    _claim_capability(store, claim, invocation_id="invocation-identity")
+
+
+def test_legacy_use_counter_reset_cannot_revive_exhausted_capability(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-use-reset")
+    _issue(store, claim)
+    _claim_capability(store, claim, invocation_id="invocation-first")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "update guard_workflow_capabilities set used_count = 0 where capability_id = ?",
+            (claim.capability_id,),
+        )
+    with pytest.raises(WorkflowCapabilityError, match="capability_use_high_water_invalid"):
+        _claim_capability(store, claim, invocation_id="invocation-revived")
+
+
+def test_legacy_revocation_reset_cannot_revive_revoked_capability(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-revocation-reset")
+    _issue(store, claim)
+    assert store.revoke_workflow_capability(claim.capability_id, reason_code="operator.revoked")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "update guard_workflow_capabilities set revoked_at = null, revocation_code = null where capability_id = ?",
+            (claim.capability_id,),
+        )
+    with pytest.raises(WorkflowCapabilityError, match="capability_revocation_state_invalid"):
+        _claim_capability(store, claim, invocation_id="invocation-revived")
+
+
+def test_authenticated_state_tamper_is_detected(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-state-tamper")
+    _issue(store, claim)
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "update guard_workflow_capability_authority_state set revision = revision + 1 where capability_id = ?",
+            (claim.capability_id,),
+        )
+    with pytest.raises(WorkflowCapabilityError, match="capability_authority_state_binding_invalid"):
+        _claim_capability(store, claim, invocation_id="invocation-state-tamper")
+
+
+def test_prior_valid_state_cannot_roll_back_signed_receipt_history(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-state-rollback", max_uses=2)
+    _issue(store, claim)
+    with sqlite3.connect(store.path) as connection:
+        prior = connection.execute(
+            "select * from guard_workflow_capability_authority_state where capability_id = ?",
+            (claim.capability_id,),
+        ).fetchone()
+    assert prior is not None
+    _claim_capability(store, claim, invocation_id="invocation-first")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            """
+            update guard_workflow_capability_authority_state
+            set signed_state_json = ?, key_id = ?, revision = ?, use_high_water = ?,
+                observed_at = ?, revocation_id = ? where capability_id = ?
+            """,
+            (prior[1], prior[2], prior[3], prior[4], prior[5], prior[6], claim.capability_id),
+        )
+    with pytest.raises(WorkflowCapabilityError, match="capability_use_high_water_invalid"):
+        _claim_capability(store, claim, invocation_id="invocation-second")
+
+
+def test_forged_receipt_history_is_fully_revalidated(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-forged-history", max_uses=3)
+    _issue(store, claim)
+    receipt = _claim_capability(store, claim, invocation_id="invocation-legitimate")
+    with sqlite3.connect(store.path) as connection:
+        event_id = connection.execute(
+            "insert into guard_events (event_name, payload_json, occurred_at) values (?, ?, ?)",
+            ("workflow_capability.claimed", "{}", _now()),
+        ).lastrowid
+        connection.execute(
+            """
+            insert into guard_workflow_capability_receipts
+              (receipt_id, capability_id, task_id, invocation_id, approval_provenance_id,
+               signed_receipt_json, claimed_at, use_number, event_id)
+            values (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "wcr-forged",
+                claim.capability_id,
+                claim.task_id,
+                "invocation-forged",
+                claim.approval_provenance_id,
+                "{}",
+                _now(),
+                2,
+                event_id,
+            ),
+        )
+    with pytest.raises(WorkflowCapabilityError, match="capability_authority_event_cardinality_invalid"):
+        store.lookup_workflow_capability(claim.capability_id)
+    with pytest.raises(WorkflowCapabilityError, match="capability_authority_event_cardinality_invalid"):
+        store.lookup_workflow_capability_receipt(receipt_id=receipt.receipt.receipt_id)
+    with pytest.raises(WorkflowCapabilityError, match="capability_authority_event_cardinality_invalid"):
+        _claim_capability(store, claim, invocation_id="invocation-real")
+
+
+def test_each_authority_operation_revalidates_owned_schema(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-schema-revalidation", max_uses=2)
+    _issue(store, claim)
+    receipt = _claim_capability(store, claim, invocation_id="invocation-before-schema-tamper")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("drop trigger trg_guard_workflow_revocation_immutable_delete")
+        connection.execute(
+            """create trigger trg_guard_workflow_revocation_immutable_delete
+            before delete on guard_workflow_capability_revocations begin select 1; end"""
+        )
+    with pytest.raises(RuntimeError, match="invalid_workflow_capability_schema:trigger"):
+        store.lookup_workflow_capability(claim.capability_id)
+    with pytest.raises(RuntimeError, match="invalid_workflow_capability_schema:trigger"):
+        store.lookup_workflow_capability_receipt(receipt_id=receipt.receipt.receipt_id)
+    with pytest.raises(RuntimeError, match="invalid_workflow_capability_schema:trigger"):
+        _claim_capability(store, claim, invocation_id="invocation-schema")
+    with pytest.raises(RuntimeError, match="invalid_workflow_capability_schema:trigger"):
+        store.revoke_workflow_capability(claim.capability_id, reason_code="operator.revoked")
+
+
+def test_expired_denial_commits_monotonic_time_high_water(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-clock-high-water")
+    _issue(store, claim)
+    monkeypatch.setattr(workflow_store_module, "_workflow_capability_store_now", lambda: _now(61))
+    with pytest.raises(WorkflowCapabilityError, match="capability_expired"):
+        _claim_capability(store, claim, invocation_id="invocation-expired")
+    encoded = store._load_workflow_capability_control()
+    assert encoded is not None
+    assert json.loads(encoded)["observed_at"] == _now(61)
+
+    monkeypatch.setattr(workflow_store_module, "_workflow_capability_store_now", lambda: _now(1))
+    with pytest.raises(WorkflowCapabilityError, match="capability_clock_rollback"):
+        _claim_capability(store, claim, invocation_id="invocation-backdated")
+    with sqlite3.connect(store.path) as connection:
+        assert connection.execute("select count(*) from guard_workflow_capability_receipts").fetchone() == (0,)

--- a/tests/test_guard_workflow_capability_authority_tamper.py
+++ b/tests/test_guard_workflow_capability_authority_tamper.py
@@ -12,8 +12,8 @@ from typing import cast
 
 import pytest
 
-from codex_plugin_scanner.guard import store_workflow_capabilities as workflow_store_module
 from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_workflow_capability_common import WORKFLOW_CAPABILITY_STORE_CLOCK
 from codex_plugin_scanner.guard.workflow_capabilities import (
     WorkflowCapabilityBinding,
     WorkflowCapabilityError,
@@ -38,7 +38,7 @@ def _fixed_authority(monkeypatch: pytest.MonkeyPatch) -> None:
         "_policy_integrity_secret_material",
         lambda self, *, create: (_KEY, _KEY_ID),
     )
-    monkeypatch.setattr(workflow_store_module, "_workflow_capability_store_now", _now)
+    monkeypatch.setattr(WORKFLOW_CAPABILITY_STORE_CLOCK, "now", _now)
 
 
 def test_expected_binding_requires_exact_contract_type() -> None:
@@ -211,14 +211,14 @@ def test_expired_denial_commits_monotonic_time_high_water(tmp_path, monkeypatch:
     store = _store(tmp_path)
     claim = _claim(capability_id="wc-clock-high-water")
     _issue(store, claim)
-    monkeypatch.setattr(workflow_store_module, "_workflow_capability_store_now", lambda: _now(61))
+    monkeypatch.setattr(WORKFLOW_CAPABILITY_STORE_CLOCK, "now", lambda: _now(61))
     with pytest.raises(WorkflowCapabilityError, match="capability_expired"):
         _claim_capability(store, claim, invocation_id="invocation-expired")
     encoded = store._load_workflow_capability_control()
     assert encoded is not None
     assert json.loads(encoded)["observed_at"] == _now(61)
 
-    monkeypatch.setattr(workflow_store_module, "_workflow_capability_store_now", lambda: _now(1))
+    monkeypatch.setattr(WORKFLOW_CAPABILITY_STORE_CLOCK, "now", lambda: _now(1))
     with pytest.raises(WorkflowCapabilityError, match="capability_clock_rollback"):
         _claim_capability(store, claim, invocation_id="invocation-backdated")
     with sqlite3.connect(store.path) as connection:

--- a/tests/test_guard_workflow_capability_hardening.py
+++ b/tests/test_guard_workflow_capability_hardening.py
@@ -184,6 +184,25 @@ def test_receipt_schema_tamper_fails_closed(tmp_path) -> None:
         verify_workflow_capability_receipt(signed, key=_KEY, key_id=_KEY_ID)
 
 
+def test_malformed_receipt_verifier_input_fails_closed() -> None:
+    with pytest.raises(WorkflowCapabilityError, match="invalid_signed_receipt"):
+        verify_workflow_capability_receipt(
+            cast(SignedWorkflowCapabilityReceipt, object()),
+            key=_KEY,
+            key_id=_KEY_ID,
+        )
+
+
+def test_malformed_nested_receipt_verifier_input_fails_closed(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-malformed-nested-receipt")
+    _issue(store, claim)
+    signed = _claim_capability(store, claim, invocation_id="invocation-malformed-nested-receipt")
+    object.__setattr__(signed, "receipt", object())
+    with pytest.raises(WorkflowCapabilityError, match="invalid_signed_receipt"):
+        verify_workflow_capability_receipt(signed, key=_KEY, key_id=_KEY_ID)
+
+
 def test_claim_and_revoke_race_is_serializable(tmp_path) -> None:
     store = _store(tmp_path)
     claim = _claim(capability_id="wc-claim-revoke-race")

--- a/tests/test_guard_workflow_capability_hardening.py
+++ b/tests/test_guard_workflow_capability_hardening.py
@@ -1,0 +1,446 @@
+"""Adversarial hardening tests for dormant workflow capabilities."""
+
+# pyright: reportAny=false, reportMissingParameterType=false, reportPrivateUsage=false
+# pyright: reportUnknownArgumentType=false, reportUnknownLambdaType=false, reportUnknownMemberType=false
+# pyright: reportUnknownParameterType=false, reportUnusedCallResult=false, reportUnusedFunction=false
+# pyright: reportUntypedFunctionDecorator=false
+
+from __future__ import annotations
+
+import inspect
+import json
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard import store_workflow_capabilities as workflow_store_module
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.workflow_capabilities import (
+    WORKFLOW_CAPABILITY_ALGORITHM,
+    WORKFLOW_CAPABILITY_ENVELOPE_SCHEMA,
+    WORKFLOW_CAPABILITY_RECEIPT_ENVELOPE_SCHEMA,
+    SignedWorkflowCapability,
+    SignedWorkflowCapabilityReceipt,
+    WorkflowCapabilityError,
+    sign_workflow_capability,
+    verify_workflow_capability,
+    verify_workflow_capability_receipt,
+)
+from tests.test_guard_workflow_capabilities import (
+    _KEY,
+    _KEY_ID,
+    _binding,
+    _claim,
+    _claim_capability,
+    _issue,
+    _now,
+    _store,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fixed_policy_integrity_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        GuardStore,
+        "_policy_integrity_secret_material",
+        lambda self, *, create: (_KEY, _KEY_ID),
+    )
+    monkeypatch.setattr(workflow_store_module, "_workflow_capability_store_now", _now)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("capability_id", "wc-tampered"),
+        ("approval_provenance_id", "provenance-tampered"),
+        ("task_id", "task-tampered"),
+        ("nonce", "b" * 64),
+        ("issuer_id", "issuer.tampered"),
+        ("subject_id", "subject.tampered"),
+        ("issued_at", "2026-07-19T11:59:00.000000Z"),
+        ("not_before", "2026-07-19T12:01:00.000000Z"),
+        ("expires_at", "2026-07-19T13:01:00.000000Z"),
+        ("max_uses", 2),
+    ],
+)
+def test_every_claim_authority_field_is_signature_bound(field: str, value: object) -> None:
+    claim = _claim()
+    signed = sign_workflow_capability(claim, key=_KEY, key_id=_KEY_ID)
+    tampered = replace(signed, claim=replace(claim, **{field: value}))
+    with pytest.raises(WorkflowCapabilityError, match="signature_invalid"):
+        verify_workflow_capability(
+            tampered,
+            key=_KEY,
+            key_id=_KEY_ID,
+            now=_now(),
+            expected_binding=claim.binding,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        ("envelope_schema", "wrong.envelope.v1", "unsupported_capability_envelope"),
+        ("algorithm", "hmac-sha512", "unsupported_capability_algorithm"),
+        ("key_id", "guard-policy-integrity-key:other", "capability_key_mismatch"),
+        ("signature", "0" * 64, "capability_signature_invalid"),
+    ],
+)
+def test_claim_envelope_tamper_fails_closed(field: str, value: str, error: str) -> None:
+    claim = _claim()
+    signed = sign_workflow_capability(claim, key=_KEY, key_id=_KEY_ID)
+    object.__setattr__(signed, field, value)
+    with pytest.raises(WorkflowCapabilityError, match=error):
+        verify_workflow_capability(
+            signed,
+            key=_KEY,
+            key_id=_KEY_ID,
+            now=_now(),
+            expected_binding=claim.binding,
+        )
+
+
+def test_claim_schema_tamper_fails_closed() -> None:
+    claim = _claim()
+    signed = sign_workflow_capability(claim, key=_KEY, key_id=_KEY_ID)
+    object.__setattr__(signed.claim, "schema_version", "wrong.claim.v1")
+    with pytest.raises(WorkflowCapabilityError, match="unsupported_capability_schema"):
+        verify_workflow_capability(
+            signed,
+            key=_KEY,
+            key_id=_KEY_ID,
+            now=_now(),
+            expected_binding=claim.binding,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("receipt_id", "wcr-tampered"),
+        ("capability_id", "wc-tampered"),
+        ("task_id", "task-tampered"),
+        ("invocation_id", "invocation-tampered"),
+        ("approval_provenance_id", "provenance-tampered"),
+        ("claim_sha256", "0" * 64),
+        ("binding", _binding(policy_version="policy.v99")),
+        ("use_number", 2),
+        ("event_id", 999),
+        ("claimed_at", "2026-07-19T12:02:00.000000Z"),
+    ],
+)
+def test_every_receipt_field_is_signature_bound(tmp_path, field: str, value: object) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id=f"wc-receipt-tamper-{field}")
+    _issue(store, claim)
+    signed = _claim_capability(
+        store,
+        claim,
+        invocation_id=f"invocation-{field}",
+    )
+    tampered = replace(signed, receipt=replace(signed.receipt, **{field: value}))
+    with pytest.raises(WorkflowCapabilityError, match="receipt_signature_invalid"):
+        verify_workflow_capability_receipt(tampered, key=_KEY, key_id=_KEY_ID)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        ("envelope_schema", "wrong.receipt.v1", "unsupported_receipt_envelope"),
+        ("algorithm", "hmac-sha512", "unsupported_receipt_algorithm"),
+        ("key_id", "guard-policy-integrity-key:other", "receipt_key_mismatch"),
+        ("signature", "0" * 64, "receipt_signature_invalid"),
+    ],
+)
+def test_receipt_envelope_tamper_fails_closed(tmp_path, field: str, value: str, error: str) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id=f"wc-receipt-envelope-{field}")
+    _issue(store, claim)
+    signed = _claim_capability(
+        store,
+        claim,
+        invocation_id=f"invocation-{field}",
+    )
+    object.__setattr__(signed, field, value)
+    with pytest.raises(WorkflowCapabilityError, match=error):
+        verify_workflow_capability_receipt(signed, key=_KEY, key_id=_KEY_ID)
+
+
+def test_receipt_schema_tamper_fails_closed(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-receipt-schema")
+    _issue(store, claim)
+    signed = _claim_capability(
+        store,
+        claim,
+        invocation_id="invocation-receipt-schema",
+    )
+    object.__setattr__(signed.receipt, "schema_version", "wrong.receipt.v1")
+    with pytest.raises(WorkflowCapabilityError, match="unsupported_receipt_schema"):
+        verify_workflow_capability_receipt(signed, key=_KEY, key_id=_KEY_ID)
+
+
+def test_claim_and_revoke_race_is_serializable(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-claim-revoke-race")
+    _issue(store, claim)
+    barrier = threading.Barrier(2)
+
+    def claim_once() -> str:
+        barrier.wait()
+        try:
+            _claim_capability(
+                _store(tmp_path),
+                claim,
+                invocation_id="invocation-race",
+            )
+        except WorkflowCapabilityError as error:
+            return str(error)
+        return "claimed"
+
+    def revoke_once() -> str:
+        barrier.wait()
+        return (
+            "revoked"
+            if _store(tmp_path).revoke_workflow_capability(claim.capability_id, reason_code="operator.revoked")
+            else "not-revoked"
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        claim_future = executor.submit(claim_once)
+        revoke_future = executor.submit(revoke_once)
+    claim_result = claim_future.result()
+    assert revoke_future.result() == "revoked"
+    assert claim_result in {"claimed", "capability_revoked"}
+    with sqlite3.connect(store.path) as connection:
+        row = connection.execute(
+            """
+            select used_count, revoked_at is not null,
+                   (select count(*) from guard_workflow_capability_receipts)
+            from guard_workflow_capabilities where capability_id = ?
+            """,
+            (claim.capability_id,),
+        ).fetchone()
+    expected_uses = 1 if claim_result == "claimed" else 0
+    assert row == (expected_uses, 1, expected_uses)
+
+
+def test_store_rejects_every_unauthorized_issue_without_persistence(tmp_path) -> None:
+    store = _store(tmp_path)
+    base = _claim(capability_id="wc-issue-base")
+    with pytest.raises(WorkflowCapabilityError, match="invalid_signed_capability"):
+        store.issue_workflow_capability(
+            cast(SignedWorkflowCapability, cast(object, base)),
+            approval_provenance_id=base.approval_provenance_id,
+        )
+    with pytest.raises(WorkflowCapabilityError, match="invalid_signed_capability"):
+        store.issue_workflow_capability(
+            cast(SignedWorkflowCapability, object()),
+            approval_provenance_id=base.approval_provenance_id,
+        )
+
+    wrong_key = sign_workflow_capability(base, key=b"x" * 32, key_id=_KEY_ID)
+    with pytest.raises(WorkflowCapabilityError, match="signature_invalid"):
+        store.issue_workflow_capability(wrong_key, approval_provenance_id=base.approval_provenance_id)
+    future = _claim(capability_id="wc-issue-future", not_before=_now(10))
+    with pytest.raises(WorkflowCapabilityError, match="not_yet_valid"):
+        _issue(store, future)
+    expired = _claim(
+        capability_id="wc-issue-expired",
+        issued_at="2026-07-19T10:00:00.000000Z",
+        not_before="2026-07-19T10:00:00.000000Z",
+        expires_at="2026-07-19T11:00:00.000000Z",
+    )
+    with pytest.raises(WorkflowCapabilityError, match="expired"):
+        _issue(store, expired)
+    with pytest.raises(WorkflowCapabilityError, match="approval_binding_mismatch"):
+        _issue(store, base, approval_provenance_id="provenance-drift")
+    tampered = replace(
+        sign_workflow_capability(base, key=_KEY, key_id=_KEY_ID),
+        signature="0" * 64,
+    )
+    with pytest.raises(WorkflowCapabilityError, match="signature_invalid"):
+        store.issue_workflow_capability(tampered, approval_provenance_id=base.approval_provenance_id)
+
+    with sqlite3.connect(store.path) as connection:
+        capability_count = connection.execute("select count(*) from guard_workflow_capabilities").fetchone()
+        issue_event_count = connection.execute(
+            "select count(*) from guard_events where event_name = 'workflow_capability.issued'"
+        ).fetchone()
+    assert capability_count == (0,)
+    assert issue_event_count == (0,)
+
+
+def test_store_clock_cannot_be_backdated_after_expiry(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-clock-expiry")
+    _issue(store, claim)
+    monkeypatch.setattr(workflow_store_module, "_workflow_capability_store_now", lambda: _now(61))
+    with pytest.raises(WorkflowCapabilityError, match="expired"):
+        _claim_capability(
+            store,
+            claim,
+            invocation_id="invocation-expired",
+        )
+    for method_name in (
+        "issue_workflow_capability",
+        "claim_workflow_capability",
+        "revoke_workflow_capability",
+    ):
+        assert "now" not in inspect.signature(getattr(store, method_name)).parameters
+    with sqlite3.connect(store.path) as connection:
+        assert connection.execute("select count(*) from guard_workflow_capability_receipts").fetchone() == (0,)
+
+
+def test_key_rotation_and_context_failure_do_not_create_replay_state(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-key-context", max_uses=2)
+    _issue(store, claim)
+    monkeypatch.setattr(
+        GuardStore,
+        "_policy_integrity_secret_material",
+        lambda self, *, create: (b"r" * 32, "guard-policy-integrity-key:rotated"),
+    )
+    with pytest.raises(WorkflowCapabilityError, match="key_mismatch"):
+        _claim_capability(
+            store,
+            claim,
+            invocation_id="invocation-retry",
+        )
+    monkeypatch.setattr(
+        GuardStore,
+        "_policy_integrity_secret_material",
+        lambda self, *, create: (_KEY, _KEY_ID),
+    )
+    with pytest.raises(WorkflowCapabilityError, match="context_mismatch"):
+        _claim_capability(
+            store,
+            claim,
+            invocation_id="invocation-retry",
+            expected_binding=replace(claim.binding, policy_version="policy.v99"),
+        )
+    _claim_capability(
+        store,
+        claim,
+        invocation_id="invocation-retry",
+    )
+    with pytest.raises(WorkflowCapabilityError, match="replayed"):
+        _claim_capability(
+            store,
+            claim,
+            invocation_id="invocation-retry",
+        )
+
+
+def test_receipt_lookup_reverifies_reopen_rows_events_and_current_key(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-receipt-lookup")
+    _issue(store, claim)
+    receipt = _claim_capability(
+        store,
+        claim,
+        invocation_id="invocation-lookup",
+    )
+    reopened = _store(tmp_path)
+    assert reopened.lookup_workflow_capability_receipt(receipt_id=receipt.receipt.receipt_id) == receipt
+    assert reopened.lookup_workflow_capability_receipt(invocation_id=receipt.receipt.invocation_id) == receipt
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("drop trigger trg_guard_workflow_receipt_immutable_update")
+        connection.execute("update guard_workflow_capability_receipts set invocation_id = 'invocation-row-tampered'")
+    with pytest.raises(WorkflowCapabilityError, match="capability_receipt_history_invalid"):
+        reopened.lookup_workflow_capability_receipt(receipt_id=receipt.receipt.receipt_id)
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "update guard_workflow_capability_receipts set invocation_id = ?",
+            (receipt.receipt.invocation_id,),
+        )
+        connection.execute(
+            "update guard_events set payload_json = ? where event_name = 'workflow_capability.claimed'",
+            (json.dumps({"tampered": True}),),
+        )
+    with pytest.raises(WorkflowCapabilityError, match="capability_authority_transition_event_invalid"):
+        reopened.lookup_workflow_capability_receipt(receipt_id=receipt.receipt.receipt_id)
+    monkeypatch.setattr(
+        GuardStore,
+        "_policy_integrity_secret_material",
+        lambda self, *, create: (b"r" * 32, "guard-policy-integrity-key:rotated"),
+    )
+    with pytest.raises(WorkflowCapabilityError, match="key_mismatch"):
+        reopened.lookup_workflow_capability_receipt(receipt_id=receipt.receipt.receipt_id)
+
+
+def test_receipt_lookup_rejects_noncanonical_persisted_json(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-receipt-noncanonical")
+    _issue(store, claim)
+    receipt = _claim_capability(
+        store,
+        claim,
+        invocation_id="invocation-noncanonical",
+    )
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("drop trigger trg_guard_workflow_receipt_immutable_update")
+        connection.execute(
+            """
+            update guard_workflow_capability_receipts
+            set signed_receipt_json = signed_receipt_json || ' '
+            where receipt_id = ?
+            """,
+            (receipt.receipt.receipt_id,),
+        )
+    with pytest.raises(WorkflowCapabilityError, match="not_canonical"):
+        store.lookup_workflow_capability_receipt(receipt_id=receipt.receipt.receipt_id)
+
+
+def test_receipt_parent_and_event_links_are_trigger_enforced(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-link-parent")
+    _issue(store, claim)
+    receipt = _claim_capability(
+        store,
+        claim,
+        invocation_id="invocation-link",
+    )
+    with sqlite3.connect(store.path) as connection:
+        event_id = connection.execute(
+            "select event_id from guard_workflow_capability_receipts where receipt_id = ?",
+            (receipt.receipt.receipt_id,),
+        ).fetchone()[0]
+        with pytest.raises(sqlite3.IntegrityError, match="parent_missing"):
+            connection.execute(
+                """
+                insert into guard_workflow_capability_receipts
+                  (receipt_id, capability_id, task_id, invocation_id, approval_provenance_id,
+                   signed_receipt_json, claimed_at, use_number, event_id)
+                values ('orphan-parent', 'missing', 'task', 'invocation-orphan-parent',
+                        'approval', '{}', ?, 1, ?)
+                """,
+                (_now(), event_id),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="event_missing"):
+            connection.execute(
+                """
+                insert into guard_workflow_capability_receipts
+                  (receipt_id, capability_id, task_id, invocation_id, approval_provenance_id,
+                   signed_receipt_json, claimed_at, use_number, event_id)
+                values ('orphan-event', ?, 'task', 'invocation-orphan-event',
+                        'approval', '{}', ?, 2, 99999999)
+                """,
+                (claim.capability_id, _now()),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="event_referenced"):
+            connection.execute("delete from guard_events where event_id = ?", (event_id,))
+
+
+def test_envelope_constants_remain_explicit() -> None:
+    assert WORKFLOW_CAPABILITY_ALGORITHM == "hmac-sha256"
+    assert WORKFLOW_CAPABILITY_ENVELOPE_SCHEMA.endswith("envelope.v1")
+    assert WORKFLOW_CAPABILITY_RECEIPT_ENVELOPE_SCHEMA.endswith("receipt-envelope.v1")
+    assert SignedWorkflowCapability.__dataclass_fields__["algorithm"] is not None
+    assert SignedWorkflowCapabilityReceipt.__dataclass_fields__["algorithm"] is not None

--- a/tests/test_guard_workflow_capability_hardening.py
+++ b/tests/test_guard_workflow_capability_hardening.py
@@ -17,8 +17,8 @@ from typing import cast
 
 import pytest
 
-from codex_plugin_scanner.guard import store_workflow_capabilities as workflow_store_module
 from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_workflow_capability_common import WORKFLOW_CAPABILITY_STORE_CLOCK
 from codex_plugin_scanner.guard.workflow_capabilities import (
     WORKFLOW_CAPABILITY_ALGORITHM,
     WORKFLOW_CAPABILITY_ENVELOPE_SCHEMA,
@@ -49,7 +49,7 @@ def _fixed_policy_integrity_key(monkeypatch: pytest.MonkeyPatch) -> None:
         "_policy_integrity_secret_material",
         lambda self, *, create: (_KEY, _KEY_ID),
     )
-    monkeypatch.setattr(workflow_store_module, "_workflow_capability_store_now", _now)
+    monkeypatch.setattr(WORKFLOW_CAPABILITY_STORE_CLOCK, "now", _now)
 
 
 @pytest.mark.parametrize(
@@ -279,7 +279,7 @@ def test_store_clock_cannot_be_backdated_after_expiry(tmp_path, monkeypatch: pyt
     store = _store(tmp_path)
     claim = _claim(capability_id="wc-clock-expiry")
     _issue(store, claim)
-    monkeypatch.setattr(workflow_store_module, "_workflow_capability_store_now", lambda: _now(61))
+    monkeypatch.setattr(WORKFLOW_CAPABILITY_STORE_CLOCK, "now", lambda: _now(61))
     with pytest.raises(WorkflowCapabilityError, match="expired"):
         _claim_capability(
             store,

--- a/tests/test_guard_workflow_capability_rollback.py
+++ b/tests/test_guard_workflow_capability_rollback.py
@@ -12,8 +12,9 @@ import sqlite3
 
 import pytest
 
-from codex_plugin_scanner.guard import store_workflow_capabilities as workflow_store_module
+from codex_plugin_scanner.guard import store_workflow_capabilities as workflow_capability_store_mixin
 from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_workflow_capability_common import WORKFLOW_CAPABILITY_STORE_CLOCK
 from codex_plugin_scanner.guard.workflow_capabilities import (
     WorkflowCapabilityError,
     sign_workflow_capability,
@@ -40,7 +41,7 @@ def _fixed_authority(monkeypatch: pytest.MonkeyPatch) -> None:
         "_policy_integrity_secret_material",
         lambda self, *, create: (_KEY, _KEY_ID),
     )
-    monkeypatch.setattr(workflow_store_module, "_workflow_capability_store_now", _now)
+    monkeypatch.setattr(WORKFLOW_CAPABILITY_STORE_CLOCK, "now", _now)
 
 
 def _state_row(connection: sqlite3.Connection, capability_id: str) -> tuple[object, ...]:
@@ -226,7 +227,7 @@ def test_pre_commit_failure_leaves_forward_only_pending_control_blocked(
     def fail_transition(*args: object, **kwargs: object) -> None:
         raise RuntimeError("forced_transition_failure")
 
-    monkeypatch.setattr(workflow_store_module, "append_authority_transition", fail_transition)
+    monkeypatch.setattr(workflow_capability_store_mixin, "append_authority_transition", fail_transition)
     with pytest.raises(RuntimeError, match="forced_transition_failure"):
         _issue(store, claim)
     with pytest.raises(WorkflowCapabilityError, match="capability_control_pending_unresolved"):

--- a/tests/test_guard_workflow_capability_rollback.py
+++ b/tests/test_guard_workflow_capability_rollback.py
@@ -1,0 +1,279 @@
+"""Rollback and crash-boundary tests for workflow-capability authority."""
+
+# pyright: reportAny=false, reportMissingParameterType=false, reportPrivateUsage=false
+# pyright: reportUnknownArgumentType=false, reportUnknownLambdaType=false, reportUnknownMemberType=false
+# pyright: reportUnknownParameterType=false, reportUnusedCallResult=false, reportUnusedFunction=false
+# pyright: reportUnusedParameter=false
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from codex_plugin_scanner.guard import store_workflow_capabilities as workflow_store_module
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.workflow_capabilities import (
+    WorkflowCapabilityError,
+    sign_workflow_capability,
+)
+from codex_plugin_scanner.guard.workflow_capability_transitions import (
+    authority_transition_sha256,
+    decode_signed_authority_transition,
+)
+from tests.test_guard_workflow_capabilities import (
+    _KEY,
+    _KEY_ID,
+    _claim,
+    _claim_capability,
+    _issue,
+    _now,
+    _store,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fixed_authority(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        GuardStore,
+        "_policy_integrity_secret_material",
+        lambda self, *, create: (_KEY, _KEY_ID),
+    )
+    monkeypatch.setattr(workflow_store_module, "_workflow_capability_store_now", _now)
+
+
+def _state_row(connection: sqlite3.Connection, capability_id: str) -> tuple[object, ...]:
+    row = connection.execute(
+        """
+        select signed_state_json, key_id, revision, use_high_water, observed_at, revocation_id
+        from guard_workflow_capability_authority_state where capability_id = ?
+        """,
+        (capability_id,),
+    ).fetchone()
+    assert row is not None
+    return tuple(row)
+
+
+def _restore_state(connection: sqlite3.Connection, capability_id: str, state: tuple[object, ...]) -> None:
+    connection.execute(
+        """
+        update guard_workflow_capability_authority_state
+        set signed_state_json = ?, key_id = ?, revision = ?, use_high_water = ?,
+            observed_at = ?, revocation_id = ? where capability_id = ?
+        """,
+        (*state, capability_id),
+    )
+
+
+def test_receipt_counter_and_signed_state_rollback_fails_after_reopen(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-combined-rollback")
+    _issue(store, claim)
+    with sqlite3.connect(store.path) as connection:
+        prior_state = _state_row(connection, claim.capability_id)
+    _claim_capability(store, claim, invocation_id="invocation-first")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("drop trigger trg_guard_workflow_receipt_immutable_delete")
+        connection.execute("delete from guard_workflow_capability_receipts")
+        connection.execute("update guard_workflow_capabilities set used_count = 0")
+        _restore_state(connection, claim.capability_id, prior_state)
+
+    reopened = _store(tmp_path)
+    with pytest.raises(WorkflowCapabilityError, match="capability_authority_transition_projection_invalid"):
+        _claim_capability(reopened, claim, invocation_id="invocation-second")
+    assert len(reopened.list_events(event_name="workflow_capability.claimed")) == 1
+
+
+def test_revocation_evidence_and_signed_state_rollback_fails_after_reopen(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-revocation-rollback")
+    _issue(store, claim)
+    with sqlite3.connect(store.path) as connection:
+        prior_state = _state_row(connection, claim.capability_id)
+    assert store.revoke_workflow_capability(claim.capability_id, reason_code="operator.revoked")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("drop trigger trg_guard_workflow_revocation_immutable_delete")
+        connection.execute("delete from guard_workflow_capability_revocations")
+        connection.execute("update guard_workflow_capabilities set revoked_at = null, revocation_code = null")
+        _restore_state(connection, claim.capability_id, prior_state)
+
+    reopened = _store(tmp_path)
+    with pytest.raises(WorkflowCapabilityError, match="capability_authority_transition_projection_invalid"):
+        _claim_capability(reopened, claim, invocation_id="invocation-after-revoke")
+
+
+def test_whole_authority_history_rollback_fails_external_head_after_reopen(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-whole-history-rollback")
+    _issue(store, claim)
+    with sqlite3.connect(store.path) as connection:
+        prior_state = _state_row(connection, claim.capability_id)
+    _claim_capability(store, claim, invocation_id="invocation-first")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("drop trigger trg_guard_workflow_transition_immutable_delete")
+        connection.execute("drop trigger trg_guard_workflow_receipt_immutable_delete")
+        connection.execute("drop trigger trg_guard_workflow_event_preserve_link")
+        connection.execute("delete from guard_workflow_capability_authority_transitions where sequence = 2")
+        connection.execute("delete from guard_workflow_capability_receipts")
+        connection.execute("delete from guard_events where event_name = 'workflow_capability.claimed'")
+        connection.execute("update guard_workflow_capabilities set used_count = 0")
+        _restore_state(connection, claim.capability_id, prior_state)
+
+    reopened = _store(tmp_path)
+    with pytest.raises(WorkflowCapabilityError, match="capability_control_rollback_detected"):
+        _claim_capability(reopened, claim, invocation_id="invocation-second")
+
+
+@pytest.mark.parametrize("event_name", ["workflow_capability.issued", "workflow_capability.revoked"])
+def test_issued_and_revoked_event_rewrite_fails_lookup(tmp_path, event_name: str) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id=f"wc-event-rewrite-{event_name.rsplit('.', 1)[-1]}")
+    _issue(store, claim)
+    if event_name.endswith("revoked"):
+        assert store.revoke_workflow_capability(claim.capability_id, reason_code="operator.revoked")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "update guard_events set payload_json = '{}' where event_name = ?",
+            (event_name,),
+        )
+    with pytest.raises(WorkflowCapabilityError, match="capability_authority_transition_event_invalid"):
+        store.lookup_workflow_capability(claim.capability_id)
+
+
+@pytest.mark.parametrize("event_name", ["workflow_capability.issued", "workflow_capability.revoked"])
+def test_issued_and_revoked_event_deletion_fails_lookup_after_reopen(tmp_path, event_name: str) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id=f"wc-event-delete-{event_name.rsplit('.', 1)[-1]}")
+    _issue(store, claim)
+    if event_name.endswith("revoked"):
+        assert store.revoke_workflow_capability(claim.capability_id, reason_code="operator.revoked")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("drop trigger trg_guard_workflow_event_preserve_link")
+        connection.execute("delete from guard_events where event_name = ?", (event_name,))
+    with pytest.raises(WorkflowCapabilityError, match="capability_authority_transition_event_invalid"):
+        _store(tmp_path).lookup_workflow_capability(claim.capability_id)
+
+
+def test_pending_control_only_recovers_forward_to_matching_database_head(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-pending-forward")
+    _issue(store, claim)
+    _claim_capability(store, claim, invocation_id="invocation-first")
+    encoded = store._load_workflow_capability_control()
+    assert encoded is not None
+    control = json.loads(encoded)
+    with sqlite3.connect(store.path) as connection:
+        first_encoded = connection.execute(
+            "select signed_transition_json from guard_workflow_capability_authority_transitions where sequence = 1"
+        ).fetchone()[0]
+    control["committed_sequence"] = 1
+    control["committed_head_sha256"] = authority_transition_sha256(decode_signed_authority_transition(first_encoded))
+    control["pending_sequence"] = 2
+    control["pending_head_sha256"] = json.loads(encoded)["committed_head_sha256"]
+    assert store._store_workflow_capability_control(json.dumps(control, sort_keys=True, separators=(",", ":")))
+
+    assert store.lookup_workflow_capability(claim.capability_id) is not None
+    recovered_encoded = store._load_workflow_capability_control()
+    assert recovered_encoded is not None
+    recovered = json.loads(recovered_encoded)
+    assert recovered["committed_sequence"] == 2
+    assert recovered["pending_sequence"] is None
+
+
+def test_pending_control_never_clears_backward_to_old_database(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-pending-old-db")
+    _issue(store, claim)
+    encoded = store._load_workflow_capability_control()
+    assert encoded is not None
+    control = json.loads(encoded)
+    control["pending_sequence"] = 2
+    control["pending_head_sha256"] = "f" * 64
+    assert store._store_workflow_capability_control(json.dumps(control, sort_keys=True, separators=(",", ":")))
+    with pytest.raises(WorkflowCapabilityError, match="capability_control_pending_unresolved"):
+        store.lookup_workflow_capability(claim.capability_id)
+
+
+def test_post_commit_finalize_failure_recovers_only_from_matching_database(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-finalize-recovery")
+    original_store = store._store_workflow_capability_control
+    calls = 0
+
+    def fail_finalize(encoded: str) -> bool:
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            return False
+        return original_store(encoded)
+
+    monkeypatch.setattr(store, "_store_workflow_capability_control", fail_finalize)
+    with pytest.raises(WorkflowCapabilityError, match="capability_control_unavailable"):
+        _issue(store, claim)
+    assert calls == 3
+    assert _store(tmp_path).lookup_workflow_capability(claim.capability_id) is not None
+
+
+def test_pre_commit_failure_leaves_forward_only_pending_control_blocked(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-precommit-pending")
+
+    def fail_transition(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("forced_transition_failure")
+
+    monkeypatch.setattr(workflow_store_module, "append_authority_transition", fail_transition)
+    with pytest.raises(RuntimeError, match="forced_transition_failure"):
+        _issue(store, claim)
+    with pytest.raises(WorkflowCapabilityError, match="capability_control_pending_unresolved"):
+        store.lookup_workflow_capability(claim.capability_id)
+
+
+def test_missing_external_control_never_blesses_nonempty_sqlite(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-control-missing")
+    _issue(store, claim)
+    monkeypatch.setattr(GuardStore, "_load_workflow_capability_control", lambda self: None)
+    with pytest.raises(WorkflowCapabilityError, match="capability_control_bootstrap_refused"):
+        store.lookup_workflow_capability(claim.capability_id)
+
+
+def test_missing_control_refuses_nonempty_legacy_sqlite_without_transition_history(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-legacy-bootstrap")
+    signed = sign_workflow_capability(claim, key=_KEY, key_id=_KEY_ID)
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            """
+            insert into guard_workflow_capabilities
+              (capability_id, approval_provenance_id, nonce, signed_claim_json, key_id,
+               issued_at, not_before, expires_at, max_uses, used_count, revoked_at, revocation_code)
+            values (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, null, null)
+            """,
+            (
+                claim.capability_id,
+                claim.approval_provenance_id,
+                claim.nonce,
+                json.dumps(signed.to_dict(), sort_keys=True, separators=(",", ":")),
+                _KEY_ID,
+                claim.issued_at,
+                claim.not_before,
+                claim.expires_at,
+                claim.max_uses,
+            ),
+        )
+    with pytest.raises(WorkflowCapabilityError, match="capability_control_bootstrap_refused"):
+        store.lookup_workflow_capability(claim.capability_id)
+
+
+def test_unavailable_external_control_blocks_first_issue(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-control-unavailable")
+    monkeypatch.setattr(GuardStore, "_load_workflow_capability_control", lambda self: None)
+    monkeypatch.setattr(GuardStore, "_store_workflow_capability_control", lambda self, encoded: False)
+    with pytest.raises(WorkflowCapabilityError, match="capability_control_unavailable"):
+        _issue(store, claim)


### PR DESCRIPTION
## Summary
- add strict signed, short-lived, revocable, and use-limited workflow capability contracts
- persist authority through an externally anchored signed transition ledger with atomic claims and fail-closed rollback detection
- keep the capability kernel dormant with no runtime policy or command-enablement changes

## Testing
- `uv run --no-sync pytest -q tests/test_guard_workflow_capabilities.py tests/test_guard_workflow_capability_hardening.py tests/test_guard_workflow_capability_authority_tamper.py tests/test_guard_workflow_capability_rollback.py tests/test_guard_store_migrations.py tests/test_guard_policy_integrity.py tests/test_guard_effect_decision.py tests/test_guard_approval_reuse.py --tb=short`
- `uv run --no-sync ruff check <changed Python files>`
- `uv run --no-sync ruff format --check <changed Python files>`
- `uv run --no-sync basedpyright <new workflow capability modules and tests>`
- `git diff --check`
