### PR TITLE
fix(guard): isolate OpenCode interpreter probes

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/hook_python.py
+++ b/src/codex_plugin_scanner/guard/adapters/hook_python.py
@@ -1,27 +1,119 @@
-"""Stable Python interpreter resolution for generated harness hook plugins."""
+"""Attest the already-running Guard Python for persisted harness hooks.
+
+The OpenCode integration never discovers a second interpreter.  It resolves
+the Python that is already running Guard, derives every trusted import path in
+the parent, and probes the resolved executable with site initialization
+disabled.  Child output is accepted only when it exactly matches the complete
+parent-derived record.
+"""
 
 from __future__ import annotations
 
+import hashlib
+import importlib.metadata
+import json
 import os
-import shutil
-import subprocess
+import stat
 import sys
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Final, cast
 
+import codex_plugin_scanner
+
+from ...version import __version__
 from .base import HarnessContext
+from .hook_python_probe_code import PROBE_CODE as _PROBE_CODE
+from .hook_python_subprocess import run_probe as _run_probe
 
 _WORKTREE_MARKERS = ("/.worktrees/", "/worktrees/")
 _WORKTREE_SEGMENT_PREFIXES = ("hol-guard-wt-",)
-_PROBE_ENV_KEYS = (
-    "PATH",
-    "HOME",
-    "VIRTUAL_ENV",
-    "PYTHONPATH",
-    "PYTHONHOME",
-    "UV_PROJECT_ENVIRONMENT",
-    "UV_PYTHON",
-    "CONDA_PREFIX",
+_PROBE_SCHEMA: Final = 2
+_EXPECTED_ENTRY_POINT: Final = "codex_plugin_scanner.cli:main"
+_PROBE_INHERITED_ENV_KEYS: Final = (
+    "SYSTEMROOT",
+    "WINDIR",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+    "LANG",
+    "LC_ALL",
 )
+
+
+@dataclass(frozen=True, slots=True)
+class HookPythonFileMetadata:
+    """Filesystem fields persisted in the generated TypeScript plugin."""
+
+    device: int
+    inode: int
+    mode: int
+    size: int
+    mtime_ns: int
+
+
+@dataclass(frozen=True, slots=True)
+class HookPythonExecutableIdentity:
+    """Stable invocation and canonical-target identity for Guard Python."""
+
+    invocation_path: Path
+    invocation_type: str
+    invocation_link_target: str | None
+    invocation_stat: HookPythonFileMetadata
+    target_path: Path
+    target_stat: HookPythonFileMetadata
+    target_sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class HookPythonAttestation:
+    """Exact parent-derived identity confirmed by the isolated child."""
+
+    identity: HookPythonExecutableIdentity
+    package_file: Path
+    package_root: Path
+    cryptography_file: Path
+    import_roots: tuple[Path, ...]
+    hol_distribution_root: Path | None
+    cryptography_distribution_root: Path
+    version: str
+    entry_point: str
+
+    @property
+    def executable(self) -> Path:
+        return self.identity.invocation_path
+
+    @property
+    def executable_target(self) -> Path:
+        return self.identity.target_path
+
+
+@dataclass(frozen=True, slots=True)
+class _ParentExpectation:
+    package_file: Path
+    package_root: Path
+    cryptography_file: Path
+    import_roots: tuple[Path, ...]
+    hol_distribution_root: Path | None
+    cryptography_distribution_root: Path
+
+    def probe_record(self, target: Path) -> dict[str, object]:
+        return {
+            "schema": _PROBE_SCHEMA,
+            "resolved_executable": str(target),
+            "package_file": str(self.package_file),
+            "package_root": str(self.package_root),
+            "cryptography_file": str(self.cryptography_file),
+            "import_roots": [str(root) for root in self.import_roots],
+            "hol_distribution_root": (
+                str(self.hol_distribution_root) if self.hol_distribution_root is not None else None
+            ),
+            "cryptography_distribution_root": str(self.cryptography_distribution_root),
+            "version": __version__,
+            "entry_point": _EXPECTED_ENTRY_POINT,
+        }
 
 
 def _path_looks_like_worktree(path: Path) -> bool:
@@ -32,12 +124,12 @@ def _path_looks_like_worktree(path: Path) -> bool:
 
 
 def filter_worktree_path_entries(entries: list[str]) -> list[str]:
+    """Return stable, unique path entries for legacy callers."""
+
     filtered: list[str] = []
     for entry in entries:
         trimmed = entry.strip()
-        if not trimmed:
-            continue
-        if _path_looks_like_worktree(Path(trimmed)):
+        if not trimmed or _path_looks_like_worktree(Path(trimmed)):
             continue
         if trimmed not in filtered:
             filtered.append(trimmed)
@@ -45,130 +137,353 @@ def filter_worktree_path_entries(entries: list[str]) -> list[str]:
 
 
 def _guard_hook_python_candidates(context: HarnessContext) -> list[Path]:
-    candidates: list[Path] = []
-    pipx_python = Path.home() / ".local" / "pipx" / "venvs" / "hol-guard" / "bin" / "python"
-    if pipx_python.is_file():
-        candidates.append(pipx_python.resolve())
-    hol_guard = shutil.which("hol-guard")
-    if hol_guard:
-        shim = Path(hol_guard).resolve()
-        if shim.is_file() and not _path_looks_like_worktree(shim):
-            interpreter = _python_from_launcher_shim(shim)
-            if interpreter is not None and interpreter.is_file():
-                candidates.append(interpreter.resolve())
-    if context.workspace_dir is not None:
-        for name in (".venv", "venv"):
-            python_path = context.workspace_dir / name / "bin" / "python"
-            if python_path.is_file() and not _path_looks_like_worktree(python_path):
-                candidates.append(python_path.resolve())
-    executable = Path(sys.executable).resolve()
-    if executable.is_file() and not _path_looks_like_worktree(executable):
-        candidates.append(executable)
-    deduped: list[Path] = []
-    for candidate in candidates:
-        if candidate not in deduped:
-            deduped.append(candidate)
-    return deduped
+    """Compatibility seam returning only the Python already running Guard."""
+
+    del context
+    return [Path(sys.executable).absolute()]
 
 
-def _python_from_launcher_shim(shim: Path) -> Path | None:
+def _probe_environment(neutral_cwd: Path) -> dict[str, str]:
+    env = {key: os.environ[key] for key in _PROBE_INHERITED_ENV_KEYS if key in os.environ}
+    env.update(
+        {
+            "HOME": str(neutral_cwd),
+            "USERPROFILE": str(neutral_cwd),
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONNOUSERSITE": "1",
+            "PYTHONSAFEPATH": "1",
+        }
+    )
+    return env
+
+
+def _private_probe_cwd(context: HarnessContext) -> Path:
+    context.guard_home.mkdir(mode=0o700, parents=True, exist_ok=True)
+    guard_home = context.guard_home.resolve(strict=True)
+    if not _path_is_owned_directory(guard_home) or (
+        os.name != "nt" and stat.S_IMODE(guard_home.stat().st_mode) & 0o022 != 0
+    ):
+        raise RuntimeError("guard_hook_python_neutral_cwd_unavailable")
+    runtime_dir = guard_home / "runtime"
+    probe_dir = runtime_dir / "python-probe"
+    for directory in (runtime_dir, probe_dir):
+        directory.mkdir(mode=0o700, exist_ok=True)
+        if directory.is_symlink() or not _path_is_owned_directory(directory):
+            raise RuntimeError("guard_hook_python_neutral_cwd_unavailable")
+        try:
+            directory.chmod(0o700)
+        except OSError:
+            if os.name != "nt":
+                raise RuntimeError("guard_hook_python_neutral_cwd_unavailable") from None
+        if not _path_is_owned_private_directory(directory):
+            raise RuntimeError("guard_hook_python_neutral_cwd_unavailable")
+    return probe_dir.resolve(strict=True)
+
+
+def _path_is_owned_private_directory(path: Path) -> bool:
+    return _path_is_owned_directory(path) and (os.name == "nt" or stat.S_IMODE(path.stat().st_mode) & 0o077 == 0)
+
+
+def _path_is_owned_directory(path: Path) -> bool:
     try:
-        lines = shim.read_text(encoding="utf-8").splitlines()
-        if not lines:
-            return None
-        first_line = lines[0]
-    except (OSError, ValueError):
-        return None
-    if not first_line.startswith("#!"):
-        return None
-    parts = first_line[2:].strip().split(maxsplit=1)
-    if not parts:
-        return None
-    interpreter = Path(parts[0])
-    return interpreter if interpreter.is_file() else None
+        metadata = path.stat()
+    except OSError:
+        return False
+    getuid = getattr(os, "getuid", None)
+    return stat.S_ISDIR(metadata.st_mode) and (getuid is None or metadata.st_uid == getuid())
 
 
-def _hook_python_probe_env() -> dict[str, str]:
-    return {key: os.environ[key] for key in _PROBE_ENV_KEYS if key in os.environ}
+def _active_package_paths() -> tuple[Path, Path]:
+    package_file = getattr(codex_plugin_scanner, "__file__", None)
+    if not isinstance(package_file, str) or not package_file:
+        raise RuntimeError("guard_hook_python_active_package_unavailable")
+    resolved_file = Path(package_file).resolve(strict=True)
+    package_root = resolved_file.parent.parent
+    if not package_root.is_dir():
+        raise RuntimeError("guard_hook_python_active_package_unavailable")
+    return resolved_file, package_root
 
 
-def _current_interpreter_can_import_guard() -> bool:
+def _active_package_root() -> Path:
+    return _active_package_paths()[1]
+
+
+def _file_metadata(value: os.stat_result) -> HookPythonFileMetadata:
+    return HookPythonFileMetadata(
+        device=value.st_dev,
+        inode=value.st_ino,
+        mode=value.st_mode,
+        size=value.st_size,
+        mtime_ns=value.st_mtime_ns,
+    )
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _executable_identity(path: Path) -> HookPythonExecutableIdentity:
+    invocation = path.expanduser().absolute()
     try:
-        import cryptography  # noqa: F401
+        invocation_before = invocation.lstat()
+        target = invocation.resolve(strict=True)
+        target_before = target.stat()
+        link_target = os.readlink(invocation) if stat.S_ISLNK(invocation_before.st_mode) else None
+    except (OSError, RuntimeError) as error:
+        raise RuntimeError("guard_hook_python_interpreter_unavailable") from error
+    if stat.S_ISLNK(invocation_before.st_mode):
+        invocation_type = "symlink"
+    elif stat.S_ISREG(invocation_before.st_mode):
+        invocation_type = "file"
+    else:
+        raise RuntimeError("guard_hook_python_interpreter_untrusted")
+    if not stat.S_ISREG(target_before.st_mode) or not os.access(invocation, os.X_OK):
+        raise RuntimeError("guard_hook_python_interpreter_untrusted")
+    try:
+        target_sha256 = _file_sha256(target)
+        invocation_after = invocation.lstat()
+        target_after_path = invocation.resolve(strict=True)
+        target_after = target_after_path.stat()
+    except (OSError, RuntimeError) as error:
+        raise RuntimeError("guard_hook_python_interpreter_changed") from error
+    if (
+        _file_metadata(invocation_before) != _file_metadata(invocation_after)
+        or target_after_path != target
+        or _file_metadata(target_before) != _file_metadata(target_after)
+    ):
+        raise RuntimeError("guard_hook_python_interpreter_changed")
+    return HookPythonExecutableIdentity(
+        invocation_path=invocation,
+        invocation_type=invocation_type,
+        invocation_link_target=link_target,
+        invocation_stat=_file_metadata(invocation_before),
+        target_path=target,
+        target_stat=_file_metadata(target_before),
+        target_sha256=target_sha256,
+    )
 
-        import codex_plugin_scanner  # noqa: F401
-    except ImportError:
+
+def _identity_is_unchanged(identity: HookPythonExecutableIdentity) -> bool:
+    try:
+        return _executable_identity(identity.invocation_path) == identity
+    except RuntimeError:
+        return False
+
+
+def _distribution_root(name: str) -> Path:
+    try:
+        distribution = importlib.metadata.distribution(name)
+        root = Path(str(distribution.locate_file(""))).resolve(strict=True)
+    except (importlib.metadata.PackageNotFoundError, OSError, RuntimeError) as error:
+        raise RuntimeError(f"guard_hook_python_{name.replace('-', '_')}_distribution_unavailable") from error
+    if not root.is_dir():
+        raise RuntimeError(f"guard_hook_python_{name.replace('-', '_')}_distribution_unavailable")
+    return root
+
+
+def _is_explicit_editable_source_root(package_root: Path) -> bool:
+    return (
+        package_root.name == "src"
+        and (package_root / "codex_plugin_scanner" / "__init__.py").is_file()
+        and (package_root.parent / "pyproject.toml").is_file()
+    )
+
+
+def _editable_distribution_source_root(
+    distribution: importlib.metadata.Distribution,
+) -> Path | None:
+    raw_direct_url = distribution.read_text("direct_url.json")
+    if not raw_direct_url:
+        return None
+    try:
+        value: object = json.loads(raw_direct_url)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(value, dict):
+        return None
+    direct_url = cast(dict[str, object], value)
+    directory_info = direct_url.get("dir_info")
+    url = direct_url.get("url")
+    if not isinstance(directory_info, dict) or directory_info.get("editable") is not True or not isinstance(url, str):
+        return None
+    parsed = urllib.parse.urlparse(url)
+    if (
+        parsed.scheme != "file"
+        or parsed.netloc not in {"", "localhost"}
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        return None
+    try:
+        return Path(urllib.request.url2pathname(urllib.parse.unquote(parsed.path))).resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+
+
+def _parent_expectation() -> _ParentExpectation:
+    package_file, package_root = _active_package_paths()
+    cryptography_distribution_root = _distribution_root("cryptography")
+    try:
+        crypto_file = (cryptography_distribution_root / "cryptography" / "__init__.py").resolve(strict=True)
+    except (OSError, RuntimeError) as error:
+        raise RuntimeError("guard_hook_python_cryptography_unavailable") from error
+    if not crypto_file.is_file() or not _path_within(crypto_file, cryptography_distribution_root):
+        raise RuntimeError("guard_hook_python_cryptography_distribution_mismatch")
+    try:
+        hol_distribution = importlib.metadata.distribution("hol-guard")
+    except importlib.metadata.PackageNotFoundError:
+        if not _is_explicit_editable_source_root(package_root):
+            raise RuntimeError("guard_hook_python_hol_guard_distribution_unavailable") from None
+        hol_distribution_root = None
+    else:
+        try:
+            hol_distribution_root = Path(str(hol_distribution.locate_file(""))).resolve(strict=True)
+        except (OSError, RuntimeError) as error:
+            raise RuntimeError("guard_hook_python_hol_guard_distribution_unavailable") from error
+        entry_points = {
+            item.name: item.value for item in hol_distribution.entry_points if item.group == "console_scripts"
+        }
+        if hol_distribution.version != __version__ or entry_points.get("hol-guard") != _EXPECTED_ENTRY_POINT:
+            raise RuntimeError("guard_hook_python_hol_guard_distribution_mismatch")
+        if not _path_within(package_file, hol_distribution_root):
+            editable_root = _editable_distribution_source_root(hol_distribution)
+            if (
+                editable_root is None
+                or package_root != editable_root / "src"
+                or not _is_explicit_editable_source_root(package_root)
+            ):
+                raise RuntimeError("guard_hook_python_hol_guard_distribution_mismatch")
+    import_roots: list[Path] = []
+    for root in (package_root, hol_distribution_root, cryptography_distribution_root):
+        if root is not None and root not in import_roots:
+            import_roots.append(root)
+    return _ParentExpectation(
+        package_file=package_file,
+        package_root=package_root,
+        cryptography_file=crypto_file,
+        import_roots=tuple(import_roots),
+        hol_distribution_root=hol_distribution_root,
+        cryptography_distribution_root=cryptography_distribution_root,
+    )
+
+
+def _attest_python(
+    python: Path,
+    *,
+    neutral_cwd: Path,
+    expected_package_root: Path | None = None,
+) -> HookPythonAttestation:
+    current = Path(sys.executable).absolute()
+    if python.expanduser().absolute() != current:
+        raise RuntimeError("guard_hook_python_not_running_interpreter")
+    identity = _executable_identity(current)
+    expectation = _parent_expectation()
+    if expected_package_root is not None and expected_package_root.resolve(strict=True) != expectation.package_root:
+        raise RuntimeError("guard_hook_python_package_root_mismatch")
+    expected_record = expectation.probe_record(identity.target_path)
+    result = _run_probe(
+        [
+            str(identity.target_path),
+            "-I",
+            "-S",
+            "-s",
+            "-c",
+            _PROBE_CODE,
+            json.dumps(expected_record, sort_keys=True, separators=(",", ":")),
+        ],
+        cwd=neutral_cwd,
+        env=_probe_environment(neutral_cwd),
+    )
+    if result.timed_out:
+        raise RuntimeError("guard_hook_python_probe_timeout")
+    if result.output_overflow:
+        raise RuntimeError("guard_hook_python_probe_output_limit")
+    if result.capture_incomplete:
+        raise RuntimeError("guard_hook_python_probe_capture_incomplete")
+    if result.returncode != 0:
+        raise RuntimeError("guard_hook_python_probe_rejected")
+    if not _identity_is_unchanged(identity):
+        raise RuntimeError("guard_hook_python_interpreter_changed")
+    try:
+        text = result.stdout.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        raise RuntimeError("guard_hook_python_probe_output_invalid") from error
+    lines = text.splitlines()
+    if len(lines) != 1 or not lines[0]:
+        raise RuntimeError("guard_hook_python_probe_output_invalid")
+    try:
+        payload = cast(object, json.loads(lines[0]))
+    except json.JSONDecodeError as error:
+        raise RuntimeError("guard_hook_python_probe_output_invalid") from error
+    if not isinstance(payload, dict) or cast(dict[str, object], payload) != expected_record:
+        raise RuntimeError("guard_hook_python_probe_identity_mismatch")
+    return HookPythonAttestation(
+        identity=identity,
+        package_file=expectation.package_file,
+        package_root=expectation.package_root,
+        cryptography_file=expectation.cryptography_file,
+        import_roots=expectation.import_roots,
+        hol_distribution_root=expectation.hol_distribution_root,
+        cryptography_distribution_root=expectation.cryptography_distribution_root,
+        version=__version__,
+        entry_point=_EXPECTED_ENTRY_POINT,
+    )
+
+
+def _path_within(path: Path, root: Path) -> bool:
+    try:
+        _ = path.relative_to(root)
+    except ValueError:
         return False
     return True
 
 
-def _python_can_import_guard(python: Path) -> bool:
-    current = Path(sys.executable).resolve()
-    if python == current and _current_interpreter_can_import_guard():
-        return True
-    probe = "import codex_plugin_scanner; import cryptography"
-    try:
-        completed = subprocess.run(
-            [str(python), "-c", probe],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=15,
-            env=_hook_python_probe_env(),
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    return completed.returncode == 0
+def attest_guard_hook_python(context: HarnessContext) -> HookPythonAttestation:
+    """Attest only the interpreter already running this Guard process."""
+
+    return _attest_python(
+        Path(sys.executable).absolute(),
+        neutral_cwd=_private_probe_cwd(context),
+        expected_package_root=_active_package_root(),
+    )
 
 
 def resolve_guard_hook_python(context: HarnessContext) -> Path:
-    for candidate in _guard_hook_python_candidates(context):
-        if _python_can_import_guard(candidate):
-            return candidate
-    current = Path(sys.executable).resolve()
-    if current.is_file() and _python_can_import_guard(current):
-        return current
-    raise RuntimeError(
-        "Guard could not find a Python interpreter with codex_plugin_scanner and cryptography. "
-        "Install hol-guard with pipx and re-run `hol-guard install opencode`."
-    )
+    """Return the invocation path for the attested running Guard Python."""
 
-
-def package_root_from_python(python: Path) -> str:
-    current = Path(sys.executable).resolve()
-    if python == current and _current_interpreter_can_import_guard():
-        import pathlib
-
-        import codex_plugin_scanner
-
-        return str(pathlib.Path(codex_plugin_scanner.__file__).resolve().parent.parent)
-    probe = (
-        "import pathlib;"
-        "import codex_plugin_scanner;"
-        "print(pathlib.Path(codex_plugin_scanner.__file__).resolve().parent.parent)"
-    )
     try:
-        completed = subprocess.run(
-            [str(python), "-c", probe],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=15,
-            env=_hook_python_probe_env(),
+        return attest_guard_hook_python(context).executable
+    except RuntimeError as error:
+        message = (
+            "Guard could not attest its running Python interpreter. Reinstall hol-guard with pipx or uv, "
+            "then re-run `hol-guard install opencode`."
         )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        raise RuntimeError("Guard could not resolve codex_plugin_scanner from the hook Python.") from exc
-    if completed.returncode != 0:
-        raise RuntimeError(
-            completed.stderr.strip() or "Guard could not resolve codex_plugin_scanner from the hook Python."
-        )
-    root = completed.stdout.strip()
-    if not root:
-        raise RuntimeError("Guard could not resolve codex_plugin_scanner from the hook Python.")
-    return root
+        raise RuntimeError(message) from error
+
+
+def package_root_from_python(python: Path, context: HarnessContext) -> str:
+    """Return the active Guard root after re-attesting the running Python."""
+
+    return str(
+        _attest_python(
+            python,
+            neutral_cwd=_private_probe_cwd(context),
+            expected_package_root=_active_package_root(),
+        ).package_root
+    )
 
 
 __all__ = [
+    "HookPythonAttestation",
+    "HookPythonExecutableIdentity",
+    "HookPythonFileMetadata",
+    "attest_guard_hook_python",
     "filter_worktree_path_entries",
     "package_root_from_python",
     "resolve_guard_hook_python",

--- a/src/codex_plugin_scanner/guard/adapters/hook_python_probe_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/hook_python_probe_code.py
@@ -1,0 +1,60 @@
+"""In-process source for the isolated hook-interpreter identity probe."""
+
+from __future__ import annotations
+
+PROBE_CODE = r"""
+import importlib
+import importlib.metadata
+import json
+import pathlib
+import sys
+
+expected = json.loads(sys.argv[1])
+import_roots = expected["import_roots"]
+for root in reversed(import_roots):
+    sys.path.insert(0, root)
+
+package = importlib.import_module("codex_plugin_scanner")
+crypto = importlib.import_module("cryptography")
+cli = importlib.import_module("codex_plugin_scanner.cli")
+version_module = importlib.import_module("codex_plugin_scanner.version")
+
+package_file = pathlib.Path(package.__file__).resolve(strict=True)
+package_root = package_file.parent.parent
+crypto_file = pathlib.Path(crypto.__file__).resolve(strict=True)
+crypto_distribution = importlib.metadata.distribution("cryptography")
+crypto_distribution_root = pathlib.Path(crypto_distribution.locate_file("")).resolve(strict=True)
+
+try:
+    hol_distribution = importlib.metadata.distribution("hol-guard")
+except importlib.metadata.PackageNotFoundError:
+    hol_distribution = None
+
+if hol_distribution is None:
+    hol_distribution_root = None
+    entry_point = "codex_plugin_scanner.cli:main" if callable(getattr(cli, "main", None)) else ""
+else:
+    hol_distribution_root = pathlib.Path(hol_distribution.locate_file("")).resolve(strict=True)
+    entry_points = {
+        item.name: item.value
+        for item in hol_distribution.entry_points
+        if item.group == "console_scripts"
+    }
+    entry_point = entry_points.get("hol-guard", "")
+
+payload = {
+    "schema": 2,
+    "resolved_executable": str(pathlib.Path(sys.executable).resolve(strict=True)),
+    "package_file": str(package_file),
+    "package_root": str(package_root),
+    "cryptography_file": str(crypto_file),
+    "import_roots": import_roots,
+    "hol_distribution_root": str(hol_distribution_root) if hol_distribution_root is not None else None,
+    "cryptography_distribution_root": str(crypto_distribution_root),
+    "version": str(version_module.__version__),
+    "entry_point": entry_point,
+}
+sys.stdout.write(json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n")
+"""
+
+__all__ = ["PROBE_CODE"]

--- a/src/codex_plugin_scanner/guard/adapters/hook_python_subprocess.py
+++ b/src/codex_plugin_scanner/guard/adapters/hook_python_subprocess.py
@@ -1,0 +1,97 @@
+"""Bounded subprocess runner for the Guard interpreter probe."""
+
+from __future__ import annotations
+
+import contextlib
+import subprocess
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, Final
+
+_PROBE_TIMEOUT_SECONDS: Final = 15
+_PROBE_OUTPUT_LIMIT_BYTES: Final = 64 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeResult:
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+    timed_out: bool
+    output_overflow: bool
+    capture_incomplete: bool = False
+
+
+def _read_bounded_stream(
+    stream: BinaryIO,
+    chunks: list[bytes],
+    overflow: threading.Event,
+    process: subprocess.Popen[bytes],
+) -> None:
+    total = 0
+    while True:
+        chunk = stream.read(4096)
+        if not chunk:
+            return
+        remaining = _PROBE_OUTPUT_LIMIT_BYTES - total
+        if remaining > 0:
+            chunks.append(chunk[:remaining])
+        total += len(chunk)
+        if total > _PROBE_OUTPUT_LIMIT_BYTES:
+            overflow.set()
+            with contextlib.suppress(OSError):
+                process.kill()
+            return
+
+
+def run_probe(command: list[str], *, cwd: Path, env: dict[str, str]) -> ProbeResult:
+    """Run a probe with no stdin and strictly bounded output and duration."""
+
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as error:
+        raise RuntimeError("guard_hook_python_probe_execution_failed") from error
+    assert process.stdout is not None
+    assert process.stderr is not None
+    stdout_chunks: list[bytes] = []
+    stderr_chunks: list[bytes] = []
+    overflow = threading.Event()
+    readers = (
+        threading.Thread(
+            target=_read_bounded_stream, args=(process.stdout, stdout_chunks, overflow, process), daemon=True
+        ),
+        threading.Thread(
+            target=_read_bounded_stream, args=(process.stderr, stderr_chunks, overflow, process), daemon=True
+        ),
+    )
+    for reader in readers:
+        reader.start()
+    timed_out = False
+    try:
+        _ = process.wait(timeout=_PROBE_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        process.kill()
+        _ = process.wait()
+    for reader in readers:
+        reader.join(timeout=2)
+    capture_incomplete = any(reader.is_alive() for reader in readers)
+    return ProbeResult(
+        returncode=process.returncode,
+        stdout=b"".join(stdout_chunks),
+        stderr=b"".join(stderr_chunks),
+        timed_out=timed_out,
+        output_overflow=overflow.is_set(),
+        capture_incomplete=capture_incomplete,
+    )
+
+
+__all__ = ["ProbeResult", "run_probe"]

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 from .base import HarnessContext
-from .hook_python import package_root_from_python, resolve_guard_hook_python
+from .hook_python import (
+    HookPythonExecutableIdentity,
+    HookPythonFileMetadata,
+    attest_guard_hook_python,
+)
 
 PLUGIN_FILENAME = "hol-guard-pretool.ts"
 _INTERCEPT_TOOLS = ("bash", "ctx_shell", "shell", "sh", "zsh", "terminal")
@@ -15,7 +18,9 @@ _HOOK_ARGV_ENV = "HOL_GUARD_HOOK_ARGV"
 _INHERIT_ENV_KEYS = ("PATH", "HOME", "USER", "TMPDIR", "TEMP", "TMP", "LANG", "LC_ALL", "SYSTEMROOT")
 
 _PLUGIN_TEMPLATE = """// Managed by HOL Guard. Re-run `hol-guard install opencode` after moving Guard home.
+import { createHash } from "node:crypto";
 import { spawn as nodeSpawn } from "node:child_process";
+import { lstatSync, readFileSync, readlinkSync, realpathSync } from "node:fs";
 
 const GUARD_HOME = __GUARD_HOME__;
 const GUARD_PYTHON = __GUARD_PYTHON__;
@@ -23,6 +28,69 @@ const GUARD_HOOK_LAUNCHER = __GUARD_HOOK_LAUNCHER__;
 const GUARD_HOOK_ENV = __GUARD_HOOK_ENV__;
 const GUARD_INHERIT_ENV_KEYS = __GUARD_INHERIT_ENV_KEYS__;
 const INTERCEPT_TOOLS = new Set(__INTERCEPT_TOOLS__);
+
+type GuardFileMetadata = {
+  device: string;
+  inode: string;
+  mode: string;
+  size: string;
+  mtimeNs: string;
+};
+
+function metadataMatches(
+  actual: { dev: bigint; ino: bigint; mode: bigint; size: bigint; mtimeNs: bigint },
+  expected: GuardFileMetadata,
+): boolean {
+  return (
+    actual.dev.toString() === expected.device &&
+    actual.ino.toString() === expected.inode &&
+    actual.mode.toString() === expected.mode &&
+    actual.size.toString() === expected.size &&
+    actual.mtimeNs.toString() === expected.mtimeNs
+  );
+}
+
+export function verifyGuardPythonIdentity(): void {
+  try {
+    const invocationStat = lstatSync(GUARD_PYTHON.invocationPath, { bigint: true });
+    let invocationType = "other";
+    if (invocationStat.isSymbolicLink()) {
+      invocationType = "symlink";
+    } else if (invocationStat.isFile()) {
+      invocationType = "file";
+    }
+    if (
+      invocationType !== GUARD_PYTHON.invocationType ||
+      !metadataMatches(invocationStat, GUARD_PYTHON.invocationStat)
+    ) {
+      throw new Error("invocation metadata changed");
+    }
+    const linkTarget = invocationStat.isSymbolicLink() ? readlinkSync(GUARD_PYTHON.invocationPath) : null;
+    if (linkTarget !== GUARD_PYTHON.invocationLinkTarget) {
+      throw new Error("invocation link changed");
+    }
+    if (realpathSync(GUARD_PYTHON.invocationPath) !== GUARD_PYTHON.targetPath) {
+      throw new Error("resolved target changed");
+    }
+    const targetStat = lstatSync(GUARD_PYTHON.targetPath, { bigint: true });
+    if (
+      !targetStat.isFile() ||
+      realpathSync(GUARD_PYTHON.targetPath) !== GUARD_PYTHON.targetPath ||
+      !metadataMatches(targetStat, GUARD_PYTHON.targetStat)
+    ) {
+      throw new Error("target metadata changed");
+    }
+    const digest = createHash("sha256").update(readFileSync(GUARD_PYTHON.targetPath)).digest("hex");
+    if (digest !== GUARD_PYTHON.targetSha256) {
+      throw new Error("target content changed");
+    }
+  } catch {
+    throw new Error(
+      "HOL Guard Python changed after this OpenCode plugin was generated. " +
+        "Re-run `hol-guard install opencode` before retrying.",
+    );
+  }
+}
 
 function hookProcessEnv(guardArgv: string[]) {
   const env: Record<string, string> = { ...GUARD_HOOK_ENV };
@@ -47,13 +115,19 @@ function normalizeCommand(command: unknown): string | null {
 }
 
 async function spawnGuardProcess(options: {
-  command: string[];
+  args: string[];
   cwd: string;
   env: Record<string, string>;
   stdin: string;
 }): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    const proc = nodeSpawn(options.command[0], options.command.slice(1), {
+    try {
+      verifyGuardPythonIdentity();
+    } catch (error) {
+      reject(error);
+      return;
+    }
+    const proc = nodeSpawn(GUARD_PYTHON.targetPath, options.args, {
       cwd: options.cwd,
       env: options.env,
       stdio: ["pipe", "pipe", "pipe"],
@@ -91,7 +165,7 @@ async function runGuardHook(directory: string, payload: Record<string, unknown>)
     "--json",
   ];
   return spawnGuardProcess({
-    command: [GUARD_PYTHON, "-c", GUARD_HOOK_LAUNCHER],
+    args: ["-I", "-S", "-s", "-c", GUARD_HOOK_LAUNCHER],
     cwd: GUARD_HOME,
     env: hookProcessEnv(guardArgv),
     stdin: JSON.stringify(payload),
@@ -242,24 +316,31 @@ def _trusted_pythonpath_entries(package_root: str) -> list[str]:
     return [trimmed] if trimmed else []
 
 
-def _pretool_hook_launcher_code(*, package_root: str) -> str:
-    trusted_entries = _trusted_pythonpath_entries(package_root)
+def _pretool_hook_launcher_code(
+    *,
+    import_roots: tuple[str, ...] = (),
+    package_root: str | None = None,
+) -> str:
+    trusted_entries = list(import_roots)
+    if not trusted_entries and package_root is not None:
+        trusted_entries = _trusted_pythonpath_entries(package_root)
     return (
         "import json,os,sys;"
         f"trusted={json.dumps(trusted_entries)};"
-        "sys.path=[entry for entry in sys.path if entry and os.path.realpath(entry) != os.path.realpath(os.getcwd())];"
         "sys.path[:0]=trusted;"
         "from codex_plugin_scanner.cli import main;"
         f"raise SystemExit(main(json.loads(os.environ[{_HOOK_ARGV_ENV!r}])))"
     )
 
 
-def _pretool_hook_env(*, package_root: str) -> dict[str, str]:
-    entries = _trusted_pythonpath_entries(package_root)
-    env = {"PYTHONSAFEPATH": "1", "PYTHONNOUSERSITE": "1"}
-    if entries:
-        env["PYTHONPATH"] = os.pathsep.join(entries)
-    return env
+def _pretool_hook_env(*, package_root: str | None = None) -> dict[str, str]:
+    del package_root
+    return {
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONIOENCODING": "utf-8",
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONSAFEPATH": "1",
+    }
 
 
 def managed_plugin_path(context: HarnessContext) -> Path:
@@ -270,15 +351,37 @@ def global_plugin_path(context: HarnessContext) -> Path:
     return context.home_dir / ".config" / "opencode" / "plugins" / PLUGIN_FILENAME
 
 
+def _metadata_payload(metadata: HookPythonFileMetadata) -> dict[str, str]:
+    return {
+        "device": str(metadata.device),
+        "inode": str(metadata.inode),
+        "mode": str(metadata.mode),
+        "size": str(metadata.size),
+        "mtimeNs": str(metadata.mtime_ns),
+    }
+
+
+def _python_identity_payload(identity: HookPythonExecutableIdentity) -> dict[str, object]:
+    return {
+        "invocationPath": str(identity.invocation_path),
+        "invocationType": identity.invocation_type,
+        "invocationLinkTarget": identity.invocation_link_target,
+        "invocationStat": _metadata_payload(identity.invocation_stat),
+        "targetPath": str(identity.target_path),
+        "targetStat": _metadata_payload(identity.target_stat),
+        "targetSha256": identity.target_sha256,
+    }
+
+
 def pretool_plugin_source(context: HarnessContext) -> str:
-    guard_python = resolve_guard_hook_python(context)
-    package_root = package_root_from_python(guard_python)
+    attestation = attest_guard_hook_python(context)
+    import_roots = tuple(str(root) for root in attestation.import_roots)
     template = _PLUGIN_TEMPLATE.replace("__HOOK_ARGV_ENV__", _HOOK_ARGV_ENV)
     return (
         template.replace("__GUARD_HOME__", json.dumps(str(context.guard_home.resolve())))
-        .replace("__GUARD_PYTHON__", json.dumps(str(guard_python)))
-        .replace("__GUARD_HOOK_LAUNCHER__", json.dumps(_pretool_hook_launcher_code(package_root=package_root)))
-        .replace("__GUARD_HOOK_ENV__", json.dumps(_pretool_hook_env(package_root=package_root)))
+        .replace("__GUARD_PYTHON__", json.dumps(_python_identity_payload(attestation.identity)))
+        .replace("__GUARD_HOOK_LAUNCHER__", json.dumps(_pretool_hook_launcher_code(import_roots=import_roots)))
+        .replace("__GUARD_HOOK_ENV__", json.dumps(_pretool_hook_env()))
         .replace("__GUARD_INHERIT_ENV_KEYS__", json.dumps(list(_INHERIT_ENV_KEYS)))
         .replace("__INTERCEPT_TOOLS__", json.dumps(list(_INTERCEPT_TOOLS)))
     )

--- a/tests/test_opencode_hook_python.py
+++ b/tests/test_opencode_hook_python.py
@@ -1,15 +1,13 @@
-"""Tests for stable OpenCode hook Python and PYTHONPATH resolution."""
+"""Tests for attested OpenCode hook-interpreter resolution."""
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
-
-import pytest
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.hook_python import (
     _guard_hook_python_candidates,
+    attest_guard_hook_python,
     filter_worktree_path_entries,
     resolve_guard_hook_python,
 )
@@ -53,19 +51,16 @@ def test_guard_hook_python_candidates_skip_worktree_venv(tmp_path: Path) -> None
     assert venv_python.resolve() not in candidates
 
 
-def test_pretool_plugin_source_omits_worktree_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.adapters.opencode_pretool.resolve_guard_hook_python",
-        lambda _context: Path(sys.executable).resolve(),
-    )
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.adapters.opencode_pretool.package_root_from_python",
-        lambda _python: "/Users/me/.local/pipx/venvs/hol-guard/lib/python3.12/site-packages",
-    )
-    source = pretool_plugin_source(_ctx(tmp_path))
-    assert "hol-guard-wt" not in source
-    assert ".worktrees" not in source
-    assert "/worktrees/" not in source
+def test_pretool_plugin_source_uses_parent_attested_import_roots(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    attestation = attest_guard_hook_python(context)
+
+    source = pretool_plugin_source(context)
+
+    assert str(attestation.package_root) in source
+    assert str(attestation.cryptography_distribution_root) in source
+    assert str(attestation.identity.target_path) in source
+    assert attestation.identity.target_sha256 in source
 
 
 def test_resolve_guard_hook_python_finds_current_interpreter(tmp_path: Path) -> None:

--- a/tests/test_opencode_hook_python_isolation.py
+++ b/tests/test_opencode_hook_python_isolation.py
@@ -1,0 +1,231 @@
+"""Security regressions for isolated OpenCode hook-interpreter attestation."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import hook_python
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.hook_python_subprocess import ProbeResult
+
+
+def _context(tmp_path: Path, *, workspace: Path | None = None) -> HarnessContext:
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+        guard_home=tmp_path / "Guard home with spaces",
+    )
+
+
+def test_probe_environment_drops_python_virtualenv_and_loader_controls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hostile = {
+        "PATH": str(tmp_path / "fake-bin"),
+        "PYTHONPATH": str(tmp_path / "fake-package"),
+        "PYTHONHOME": str(tmp_path / "fake-home"),
+        "PYTHONSTARTUP": str(tmp_path / "startup.py"),
+        "PYTHONINSPECT": "1",
+        "PYTHONWARNINGS": "error",
+        "PYTHONBREAKPOINT": "evil.breakpoint",
+        "VIRTUAL_ENV": str(tmp_path / "workspace" / ".venv"),
+        "UV_PROJECT_ENVIRONMENT": str(tmp_path / "uv-project"),
+        "UV_PYTHON": str(tmp_path / "uv-python"),
+        "CONDA_PREFIX": str(tmp_path / "conda"),
+        "__PYVENV_LAUNCHER__": str(tmp_path / "launcher"),
+        "LD_PRELOAD": str(tmp_path / "preload.so"),
+        "DYLD_INSERT_LIBRARIES": str(tmp_path / "inject.dylib"),
+    }
+    for key, value in hostile.items():
+        monkeypatch.setenv(key, value)
+
+    neutral = tmp_path / "neutral"
+    neutral.mkdir()
+    env = hook_python._probe_environment(neutral)
+
+    assert hostile.keys().isdisjoint(env)
+    assert env["HOME"] == str(neutral)
+    assert env["USERPROFILE"] == str(neutral)
+    assert env["PYTHONNOUSERSITE"] == "1"
+    assert env["PYTHONSAFEPATH"] == "1"
+
+
+def test_workspace_shadow_modules_and_sitecustomize_never_execute(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    marker = tmp_path / "workspace-imported.marker"
+    marker_literal = repr(str(marker))
+    package = workspace / "codex_plugin_scanner"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        f"from pathlib import Path\nPath({marker_literal}).write_text('package')\n",
+        encoding="utf-8",
+    )
+    (workspace / "cryptography.py").write_text(
+        f"from pathlib import Path\nPath({marker_literal}).write_text('cryptography')\n",
+        encoding="utf-8",
+    )
+    (workspace / "sitecustomize.py").write_text(
+        f"from pathlib import Path\nPath({marker_literal}).write_text('sitecustomize')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PYTHONPATH", str(workspace))
+    monkeypatch.setenv("VIRTUAL_ENV", str(workspace / ".venv"))
+    monkeypatch.chdir(workspace)
+
+    resolved = hook_python.resolve_guard_hook_python(_context(tmp_path, workspace=workspace))
+
+    assert resolved == Path(sys.executable).absolute()
+    assert not marker.exists()
+
+
+def test_candidates_ignore_path_collision_and_workspace_virtualenv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    workspace_python = workspace / ".venv" / "bin" / "python"
+    workspace_python.parent.mkdir(parents=True)
+    workspace_python.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
+    workspace_python.chmod(0o755)
+    for name in ("hol-guard", "plugin-guard"):
+        collision = fake_bin / name
+        collision.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
+        collision.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    candidates = hook_python._guard_hook_python_candidates(_context(tmp_path, workspace=workspace))
+
+    assert candidates[0] == Path(sys.executable).absolute()
+    assert workspace_python not in candidates
+    assert all(candidate.parent != fake_bin for candidate in candidates)
+
+
+def test_probe_rejects_noisy_stdout_before_parsing_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        hook_python,
+        "_run_probe",
+        lambda *_args, **_kwargs: ProbeResult(
+            returncode=0,
+            stdout=b"noise\n{}\n",
+            stderr=b"",
+            timed_out=False,
+            output_overflow=False,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="guard_hook_python_probe_output_invalid"):
+        hook_python._attest_python(
+            Path(sys.executable),
+            neutral_cwd=tmp_path,
+            expected_package_root=hook_python._active_package_root(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("result", "reason"),
+    [
+        (
+            ProbeResult(1, b"", b"private path", True, False),
+            "guard_hook_python_probe_timeout",
+        ),
+        (
+            ProbeResult(1, b"", b"private path", False, True),
+            "guard_hook_python_probe_output_limit",
+        ),
+        (
+            ProbeResult(0, b'{"status":"ok"}\n', b"private path", False, False, True),
+            "guard_hook_python_probe_capture_incomplete",
+        ),
+    ],
+)
+def test_probe_execution_failures_have_redacted_reason_codes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    result: ProbeResult,
+    reason: str,
+) -> None:
+    monkeypatch.setattr(hook_python, "_run_probe", lambda *_args, **_kwargs: result)
+
+    with pytest.raises(RuntimeError, match=reason) as error:
+        hook_python._attest_python(
+            Path(sys.executable),
+            neutral_cwd=tmp_path,
+            expected_package_root=hook_python._active_package_root(),
+        )
+
+    assert "private path" not in str(error.value)
+
+
+def test_interpreter_symlink_identity_is_canonicalized_without_losing_invocation_path(tmp_path: Path) -> None:
+    link = tmp_path / "python-link"
+    try:
+        link.symlink_to(Path(sys.executable).absolute())
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable")
+
+    identity = hook_python._executable_identity(link)
+
+    assert identity.invocation_path == link.absolute()
+    assert identity.target_path == Path(sys.executable).resolve(strict=True)
+    assert hook_python._identity_is_unchanged(identity)
+
+
+def test_nonrunning_interpreter_is_rejected_with_stable_reason(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="guard_hook_python_not_running_interpreter"):
+        hook_python._attest_python(
+            tmp_path / "missing-python",
+            neutral_cwd=tmp_path,
+            expected_package_root=hook_python._active_package_root(),
+        )
+
+
+def test_moved_or_unexpected_package_root_is_rejected(tmp_path: Path) -> None:
+    unexpected_root = tmp_path / "moved-package-root"
+    unexpected_root.mkdir()
+
+    with pytest.raises(RuntimeError, match="guard_hook_python_package_root_mismatch"):
+        hook_python._attest_python(
+            Path(sys.executable),
+            neutral_cwd=tmp_path,
+            expected_package_root=unexpected_root,
+        )
+
+
+def test_only_the_running_guard_interpreter_is_a_candidate(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    pipx_python = context.home_dir / ".local" / "pipx" / "venvs" / "hol-guard" / "bin" / "python"
+    uv_python = context.home_dir / ".local" / "share" / "uv" / "tools" / "hol-guard" / "bin" / "python"
+    for candidate in (pipx_python, uv_python):
+        candidate.parent.mkdir(parents=True, exist_ok=True)
+        candidate.write_text("placeholder", encoding="utf-8")
+
+    candidates = hook_python._guard_hook_python_candidates(context)
+
+    assert candidates == [Path(sys.executable).absolute()]
+    assert pipx_python.absolute() not in candidates
+    assert uv_python.absolute() not in candidates
+
+
+def test_probe_uses_private_guard_owned_neutral_directory(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+
+    neutral = hook_python._private_probe_cwd(context)
+
+    assert neutral == (context.guard_home / "runtime" / "python-probe").resolve(strict=True)
+    assert neutral.is_dir()
+    if os.name != "nt":
+        assert neutral.stat().st_mode & 0o077 == 0

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -161,7 +161,7 @@ def test_pretool_hook_launcher_ignores_workspace_package_hijack(
     guard_home.mkdir()
     ctx = HarnessContext(home_dir=tmp_path / "home", workspace_dir=workspace, guard_home=guard_home)
     guard_python = resolve_guard_hook_python(ctx)
-    package_root = package_root_from_python(guard_python)
+    package_root = package_root_from_python(guard_python, ctx)
     launcher = _pretool_hook_launcher_code(package_root=package_root)
     inherit_env = {key: os.environ[key] for key in ("PATH", "HOME") if key in os.environ}
     env = {**inherit_env, **_pretool_hook_env(package_root=package_root), _HOOK_ARGV_ENV: '["guard","hook","--json"]'}
@@ -181,11 +181,15 @@ def test_pretool_hook_launcher_ignores_workspace_package_hijack(
 def test_pretool_hook_env_blocks_workspace_import_shadowing(tmp_path: Path) -> None:
     ctx = _ctx(tmp_path)
     guard_python = resolve_guard_hook_python(ctx)
-    package_root = package_root_from_python(guard_python)
+    package_root = package_root_from_python(guard_python, ctx)
     env = _pretool_hook_env(package_root=package_root)
     assert env["PYTHONSAFEPATH"] == "1"
     assert env["PYTHONNOUSERSITE"] == "1"
-    assert package_root in env["PYTHONPATH"]
+    assert "PYTHONPATH" not in env
+    source = pretool_plugin_source(ctx)
+    assert 'args: ["-I", "-S", "-s", "-c", GUARD_HOOK_LAUNCHER]' in source
+    assert "verifyGuardPythonIdentity();" in source
+    assert "nodeSpawn(GUARD_PYTHON.targetPath, options.args" in source
 
 
 def test_pretool_plugin_source_does_not_spawn_python_m_module(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- restrict OpenCode hook Python selection to the interpreter already running Guard; workspace `.venv`, `venv`, and ambient `PATH` candidates are no longer probed
- derive and attest the interpreter, active Guard distribution/editable source root, and `cryptography` distribution without importing project-shadowable packages in the parent process
- execute the child probe with `-I -S -s`, a minimal scrubbed environment, a private neutral Guard directory, bounded output, and a timeout
- require exact one-line canonical JSON readback matching the parent-provided interpreter, package, distribution, and import-root identities
- embed the verified interpreter/target identity in the generated OpenCode TypeScript and synchronously revalidate it immediately before launch

## Adversarial coverage

- project `codex_plugin_scanner.py`, `cryptography.py`, and `sitecustomize.py` shadows
- hostile `PYTHONPATH` and project virtual environments
- noisy/malformed probe output, timeout, missing interpreter, symlink/target replacement, moved package root, and mismatched distribution metadata
- development editable installs and paths containing spaces
- Python 3.10 and Python 3.12

## Validation

- `39 passed` — focused isolation and pretool regressions on Python 3.12
- `132 passed` — affected OpenCode adapter, proxy, pretool, and hook-Python suites after the `release/2.1` replay
- `39 passed` — focused isolation and pretool regressions on Python 3.10
- Ruff formatting and lint passed for all changed files
- Basedpyright passed with `0 errors` for all changed production modules
- `uv build` produced the `2.0.1113` sdist and wheel successfully

## Attribution and target

- target branch: `release/2.1`
- commit author/committer: `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>`
