### PR TITLE
fix(guard): authenticate managed Codex hook identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,20 @@ jobs:
         with:
           enable-cache: true
       - run: uv sync --frozen --extra dev --python ${{ matrix.python-version }}
+      - name: Secure the CI virtualenv interpreter
+        shell: bash
+        run: |
+          interpreter="$(uv run --no-sync python -c 'import sys; print(sys.executable)')"
+          target="$(realpath "$interpreter")"
+          mode="$(stat -c '%a' "$target")"
+          if (( (8#$mode & 2) != 0 )); then
+            replacement="${interpreter}.guard-ci"
+            cp --dereference "$target" "$replacement"
+            chmod 0755 "$replacement"
+            mv "$replacement" "$target"
+          fi
+          secured_mode="$(stat -c '%a' "$(realpath "$interpreter")")"
+          (( (8#$secured_mode & 2) == 0 ))
       - run: uv run --no-sync python -m ruff check src/
       - run: uv run --no-sync python -m ruff format --check src/
       - if: matrix.python-version == '3.12'

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -14,12 +14,45 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlencode
 
+from ...version import __version__
 from ..aibom_detection import (
     enrich_mcp_server_metadata,
     extend_codex_runtime_inventory,
     extend_detection_with_workspace_aibom,
 )
 from ..codex_config import dump_toml, read_toml_payload, write_toml_payload
+from ..codex_hook_file_integrity import split_hook_command, validate_regular_file
+from ..codex_hook_integrity import (
+    atomic_write_text,
+    hook_manifest_path,
+    hook_secret_path,
+    remove_hook_manifest,
+    remove_hook_secret_if_unused,
+    restore_private_file,
+    snapshot_regular_file,
+    write_hook_manifest,
+)
+from ..codex_hook_manifest import (
+    MANAGED_CODEX_HOOK_EVENTS as _MANAGED_HOOK_EVENTS,
+)
+from ..codex_hook_manifest import (
+    CodexHookManifestSpec,
+    build_authenticated_hook_manifest,
+    load_hook_manifest_baseline,
+    verify_live_hook_manifest,
+)
+from ..codex_hook_manifest import (
+    assert_package_reauthentication_is_safe as _assert_package_reauthentication_is_safe,
+)
+from ..codex_hook_manifest import (
+    manifest_bindings as _manifest_bindings,
+)
+from ..codex_hook_registration import (
+    exact_legacy_hook_bindings,
+)
+from ..codex_hook_registration import (
+    remove_manifest_bound_hook_events as _remove_manifest_bound_hook_events,
+)
 from ..config import MAX_APPROVAL_WAIT_TIMEOUT_SECONDS, load_guard_config, resolve_guard_home
 from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
@@ -219,7 +252,13 @@ def _local_hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
             guard_args.extend(["--guard-home", str(context.guard_home)])
     if context.workspace_dir is not None:
         guard_args.extend(["--workspace", str(context.workspace_dir)])
-    return (sys.executable, "-m", "codex_plugin_scanner.cli", *guard_args)
+    return (_guard_python_executable(), "-m", "codex_plugin_scanner.cli", *guard_args)
+
+
+def _guard_python_executable() -> str:
+    """Use an absolute interpreter invocation while preserving virtualenv identity."""
+
+    return str(Path(sys.executable).expanduser().absolute())
 
 
 def _runtime_guard_home(context: HarnessContext) -> Path:
@@ -237,7 +276,7 @@ def _daemon_start_command(guard_home: Path) -> tuple[str, ...]:
         "from codex_plugin_scanner.guard.daemon import ensure_guard_daemon;"
         f"ensure_guard_daemon(Path({str(guard_home)!r}))"
     )
-    return (sys.executable, "-c", code)
+    return (_guard_python_executable(), "-c", code)
 
 
 def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
@@ -260,8 +299,8 @@ def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
             "PostToolUse": long_timeout,
         },
     }
-    bridge_path = Path(__file__).with_name("codex_daemon_hook_bridge.py")
-    return (sys.executable, str(bridge_path), json.dumps(config, separators=(",", ":")))
+    bridge_path = Path(__file__).with_name("codex_daemon_hook_bridge.py").resolve()
+    return (_guard_python_executable(), str(bridge_path), json.dumps(config, separators=(",", ":")))
 
 
 def _hook_command(context: HarnessContext) -> str:
@@ -347,14 +386,69 @@ def _managed_hook_groups(context: HarnessContext) -> dict[str, dict[str, object]
     }
 
 
-def _split_hook_command(command: object) -> list[str] | None:
-    if not isinstance(command, str):
-        return None
-    try:
-        tokens = shlex.split(command)
-    except ValueError:
-        return None
-    return tokens
+def _manifest_event_bindings(context: HarnessContext) -> list[dict[str, object]]:
+    argv = list(_hook_command_parts(context))
+    bindings: list[dict[str, object]] = []
+    for event_name, group in _managed_hook_groups(context).items():
+        handlers = group.get("hooks")
+        if not isinstance(handlers, list) or len(handlers) != 1 or not isinstance(handlers[0], dict):
+            raise RuntimeError(f"Guard's {event_name} hook definition is not canonical.")
+        bindings.append(
+            {
+                "argv": argv,
+                "event": event_name,
+                "group": deepcopy(group),
+                "group_matcher": group.get("matcher"),
+                "handler": deepcopy(handlers[0]),
+                "handler_id": f"codex:{event_name}:guard-handler-v1",
+                "handler_index": 0,
+            }
+        )
+    return bindings
+
+
+def _hook_packaged_file_paths() -> tuple[tuple[str, Path], ...]:
+    scanner_root = Path(__file__).resolve().parents[2]
+    daemon_root = Path(__file__).resolve().parents[1] / "daemon"
+    return (
+        ("bridge", Path(__file__).with_name("codex_daemon_hook_bridge.py").resolve()),
+        ("fallback_entrypoint", scanner_root / "cli.py"),
+        ("daemon_entrypoint", daemon_root / "__init__.py"),
+        ("daemon_manager", daemon_root / "manager.py"),
+    )
+
+
+def _hook_manifest_spec(context: HarnessContext) -> CodexHookManifestSpec:
+    return CodexHookManifestSpec(
+        guard_home=context.guard_home,
+        home_dir=context.home_dir,
+        runtime_guard_home=_runtime_guard_home(context),
+        workspace_dir=context.workspace_dir,
+        config_path=CodexHarnessAdapter._hook_config_path(context),
+        interpreter_path=Path(_guard_python_executable()),
+        package_version=__version__,
+        packaged_file_paths=_hook_packaged_file_paths(),
+        fallback_argv=_local_hook_command_parts(context),
+        daemon_start_argv=_daemon_start_command(_runtime_guard_home(context)),
+        event_bindings=tuple(_manifest_event_bindings(context)),
+    )
+
+
+def _build_authenticated_hook_manifest(context: HarnessContext) -> dict[str, object]:
+    return build_authenticated_hook_manifest(_hook_manifest_spec(context))
+
+
+def _current_install_legacy_bindings(context: HarnessContext, hooks: dict[str, object]) -> list[dict[str, object]]:
+    """Select exact current bridge entries for explicit legacy re-adoption only."""
+
+    current_argv = list(_hook_command_parts(context))
+    return exact_legacy_hook_bindings(
+        hooks,
+        expected_bindings=_manifest_event_bindings(context),
+        current_argv=current_argv,
+        legacy_argv=[sys.executable, *current_argv[1:]],
+        legacy_status_messages=_LEGACY_MANAGED_HOOK_STATUS_MESSAGES,
+    )
 
 
 def _tokens_are_managed_hook_command(tokens: list[str]) -> bool:
@@ -375,7 +469,7 @@ def _tokens_are_managed_hook_command(tokens: list[str]) -> bool:
 
 
 def _is_managed_hook_command(command: object) -> bool:
-    tokens = _split_hook_command(command)
+    tokens = split_hook_command(command)
     if tokens is None:
         return False
     return _tokens_are_managed_hook_command(tokens)
@@ -438,7 +532,7 @@ def _tokens_are_unambiguously_managed_hook_command(tokens: list[str]) -> bool:
 
 
 def _is_unambiguously_managed_hook_command(command: object) -> bool:
-    tokens = _split_hook_command(command)
+    tokens = split_hook_command(command)
     if tokens is None:
         return False
     return _tokens_are_unambiguously_managed_hook_command(tokens)
@@ -531,7 +625,7 @@ def _is_managed_hook_entry(entry: object) -> bool:
         return False
     if entry.get("type") != "command":
         return False
-    tokens = _split_hook_command(entry.get("command"))
+    tokens = split_hook_command(entry.get("command"))
     if tokens is None or not _tokens_are_managed_hook_command(tokens):
         return False
     # Bridge/wrapper commands are uniquely Guard-owned.
@@ -562,10 +656,6 @@ def _remove_managed_hook_entries(group: object) -> object | None:
     updated_group = dict(group)
     updated_group["hooks"] = remaining_hooks
     return updated_group
-
-
-def _merge_hook_groups(groups: object, managed_group: dict[str, object]) -> list[object]:
-    return [*_remove_hook_groups(groups), managed_group]
 
 
 def _remove_hook_groups(groups: object) -> list[object]:
@@ -606,14 +696,22 @@ def _append_unique_hook_groups(existing_groups: object, incoming_groups: object)
     return merged
 
 
-def _migrate_hooks_json_into_config(config_payload: dict[str, object], hooks_payload: dict[str, object]) -> bool:
+def _migrate_hooks_json_into_config(
+    config_payload: dict[str, object],
+    hooks_payload: dict[str, object],
+    *,
+    context: HarnessContext,
+    owned_bindings: Sequence[Mapping[str, object]] = (),
+) -> bool:
     json_hooks = hooks_payload.get("hooks")
     if not isinstance(json_hooks, dict):
         return False
     config_hooks = config_payload.get("hooks")
     if not isinstance(config_hooks, dict):
         config_hooks = {}
-    cleaned_json_hooks, _ = _remove_managed_hook_events(json_hooks)
+    cleaned_json_hooks, _ = _remove_manifest_bound_hook_events(json_hooks, owned_bindings)
+    legacy_bindings = _current_install_legacy_bindings(context, cleaned_json_hooks)
+    cleaned_json_hooks, _ = _remove_manifest_bound_hook_events(cleaned_json_hooks, legacy_bindings)
     changed = False
     for event_name, groups in cleaned_json_hooks.items():
         merged_groups = _append_unique_hook_groups(config_hooks.get(event_name), groups)
@@ -625,11 +723,18 @@ def _migrate_hooks_json_into_config(config_payload: dict[str, object], hooks_pay
     return changed
 
 
-def _hooks_payload_has_unmanaged_entries(hooks_payload: dict[str, object]) -> bool:
+def _hooks_payload_has_unmanaged_entries(
+    hooks_payload: dict[str, object],
+    *,
+    context: HarnessContext,
+    owned_bindings: Sequence[Mapping[str, object]] = (),
+) -> bool:
     hooks = hooks_payload.get("hooks")
     if not isinstance(hooks, dict):
         return False
-    cleaned_hooks, _ = _remove_managed_hook_events(hooks)
+    cleaned_hooks, _ = _remove_manifest_bound_hook_events(hooks, owned_bindings)
+    legacy_bindings = _current_install_legacy_bindings(context, cleaned_hooks)
+    cleaned_hooks, _ = _remove_manifest_bound_hook_events(cleaned_hooks, legacy_bindings)
     return any(
         isinstance(cleaned_hooks.get(event_name), list) and bool(cleaned_hooks.get(event_name))
         for event_name in ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse")
@@ -718,6 +823,26 @@ end
 """
 
 
+def _hooks_have_registered_entries(hooks: object) -> bool:
+    if not isinstance(hooks, dict):
+        return False
+    return any(
+        isinstance(hooks.get(event_name), list) and bool(hooks[event_name]) for event_name in _MANAGED_HOOK_EVENTS
+    )
+
+
+def _verify_live_hook_manifest(
+    context: HarnessContext,
+    *,
+    config_path: Path,
+    hooks: object,
+) -> dict[str, object]:
+    spec = _hook_manifest_spec(context)
+    if spec.config_path != config_path:
+        raise RuntimeError("Codex hook verification received a non-canonical config target.")
+    return verify_live_hook_manifest(spec, hooks=hooks)
+
+
 def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
     config_path = CodexHarnessAdapter._hook_config_path(context)
     hooks_path = CodexHarnessAdapter._hooks_path(context)
@@ -727,24 +852,15 @@ def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
     hooks_payload = _json_object(hooks_path)
     json_hooks = hooks_payload.get("hooks") if isinstance(hooks_payload, dict) else None
     hooks = toml_hooks if isinstance(toml_hooks, dict) else json_hooks
-    pre_tool_groups = hooks.get("PreToolUse") if isinstance(hooks, dict) else None
-    permission_groups = hooks.get("PermissionRequest") if isinstance(hooks, dict) else None
-    prompt_groups = hooks.get("UserPromptSubmit") if isinstance(hooks, dict) else None
-    post_tool_groups = hooks.get("PostToolUse") if isinstance(hooks, dict) else None
-    pre_tool_hook_installed = isinstance(pre_tool_groups, list) and any(
-        _is_managed_hook_group(group) for group in pre_tool_groups
-    )
-    permission_hook_installed = isinstance(permission_groups, list) and any(
-        _is_managed_hook_group(group) for group in permission_groups
-    )
-    prompt_hook_installed = isinstance(prompt_groups, list) and any(
-        _is_managed_hook_group(group) for group in prompt_groups
-    )
-    post_tool_hook_installed = isinstance(post_tool_groups, list) and any(
-        _is_managed_hook_group(group) for group in post_tool_groups
-    )
-    managed_hook_installed = (
-        pre_tool_hook_installed and permission_hook_installed and prompt_hook_installed and post_tool_hook_installed
+    integrity = _verify_live_hook_manifest(context, config_path=config_path, hooks=hooks)
+    event_matches_value = integrity.get("event_matches")
+    event_matches = event_matches_value if isinstance(event_matches_value, dict) else {}
+    pre_tool_hook_installed = event_matches.get("PreToolUse") is True
+    permission_hook_installed = event_matches.get("PermissionRequest") is True
+    prompt_hook_installed = event_matches.get("UserPromptSubmit") is True
+    post_tool_hook_installed = event_matches.get("PostToolUse") is True
+    managed_hook_installed = all(
+        (pre_tool_hook_installed, permission_hook_installed, prompt_hook_installed, post_tool_hook_installed)
     )
     features_is_table = isinstance(features, dict)
     hooks_feature_enabled = not features_is_table or features.get("hooks") is not False
@@ -760,10 +876,7 @@ def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
             for event_name in ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse")
         ),
         "json_hooks_present": isinstance(json_hooks, dict)
-        and any(
-            bool(json_hooks.get(event_name))
-            for event_name in ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse")
-        ),
+        and any(bool(json_hooks.get(event_name)) for event_name in _MANAGED_HOOK_EVENTS),
         "hooks_enabled": hooks_feature_enabled,
         "codex_hooks_enabled": hooks_feature_enabled,
         "legacy_codex_hooks_enabled": legacy_codex_hooks_enabled,
@@ -772,7 +885,10 @@ def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
         "managed_prompt_hook_installed": prompt_hook_installed,
         "managed_post_tool_hook_installed": post_tool_hook_installed,
         "managed_hook_installed": managed_hook_installed,
-        "protection_active": hooks_feature_enabled and managed_hook_installed,
+        "protection_active": hooks_feature_enabled
+        and managed_hook_installed
+        and integrity.get("integrity_status") == "valid",
+        **{key: value for key, value in integrity.items() if key != "event_matches"},
     }
 
 
@@ -991,6 +1107,8 @@ class CodexHarnessAdapter(HarnessAdapter):
         skipped_servers = skipped_stdio_server_names(detection)
         target_config_path = self._target_config_path(context)
         hook_config_path = self._hook_config_path(context)
+        previous_manifest = load_hook_manifest_baseline(_hook_manifest_spec(context))
+        owned_bindings = _manifest_bindings(previous_manifest)
         hook_payloads = self._load_hook_payloads(context)
         original_text = target_config_path.read_text(encoding="utf-8") if target_config_path.is_file() else None
         payload = read_toml_payload(target_config_path)
@@ -1005,8 +1123,11 @@ class CodexHarnessAdapter(HarnessAdapter):
                 hook_config_payload = hook_payload
             else:
                 hook_config_payload = read_toml_payload(config_path)
+            config_owned_bindings = owned_bindings if config_path == hook_config_path else ()
             if not _payload_has_hooks_feature_enabled(hook_config_payload) and _hooks_payload_has_unmanaged_entries(
-                json_hook_payload
+                json_hook_payload,
+                context=context,
+                owned_bindings=config_owned_bindings,
             ):
                 raise RuntimeError(
                     "Guard refused to enable existing Codex hook entries without explicit approval. "
@@ -1014,7 +1135,12 @@ class CodexHarnessAdapter(HarnessAdapter):
                 )
         target_hooks_path = self._hooks_path(context)
         target_hook_payload = hook_payloads.get(target_hooks_path, {})
-        target_hooks_migrated = _migrate_hooks_json_into_config(hook_payload, target_hook_payload)
+        target_hooks_migrated = _migrate_hooks_json_into_config(
+            hook_payload,
+            target_hook_payload,
+            context=context,
+            owned_bindings=owned_bindings,
+        )
         backup_path = self._backup_path(context)
         if not backup_path.exists():
             backup_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1029,7 +1155,7 @@ class CodexHarnessAdapter(HarnessAdapter):
         features.pop("codex_hooks", None)
         features["hooks"] = True
         hook_payload["features"] = features
-        self._install_config_hooks(hook_payload, context)
+        self._install_config_hooks(hook_payload, context, owned_bindings=owned_bindings)
         workspace_payload = (
             read_toml_payload(context.workspace_dir / ".codex" / "config.toml")
             if context.workspace_dir is not None
@@ -1051,13 +1177,19 @@ class CodexHarnessAdapter(HarnessAdapter):
                 continue
             mcp_servers[server.name] = self._proxy_server_entry(context, server)
         payload["mcp_servers"] = mcp_servers
-        write_toml_payload(target_config_path, payload)
+        hook_state = self._write_authenticated_hook_config(
+            context,
+            config_path=target_config_path,
+            payload=payload,
+            previous_manifest=previous_manifest,
+        )
         if hook_config_path != target_config_path:
-            write_toml_payload(hook_config_path, hook_payload)
+            raise RuntimeError("Codex hook authentication currently requires one canonical global config target.")
         self._migrate_alternate_hook_configs(
             context,
             payloads=hook_payloads,
             skip_config_path=hook_config_path,
+            owned_bindings=(),
         )
         self._remove_managed_hooks_from_alternate_configs(context, skip_config_path=hook_config_path)
         self._remove_managed_mcp_servers_from_alternate_configs(
@@ -1076,6 +1208,8 @@ class CodexHarnessAdapter(HarnessAdapter):
             "mode": "codex-mcp-proxy",
             "managed_config_path": str(target_config_path),
             "managed_hook_config_path": str(hook_config_path),
+            "managed_hook_manifest_path": str(hook_state["manifest_path"]),
+            "managed_hook_integrity": str(hook_state["integrity_status"]),
             "managed_hooks_path": str(hooks_path),
             "managed_shell_guard_path": str(shell_guard_paths["zsh"]),
             "managed_shell_guard_paths": {shell: str(path) for shell, path in shell_guard_paths.items()},
@@ -1088,15 +1222,27 @@ class CodexHarnessAdapter(HarnessAdapter):
     def uninstall(self, context: HarnessContext) -> dict[str, object]:
         target_config_path = self._target_config_path(context)
         hook_config_path = self._hook_config_path(context)
+        authenticated_manifest = load_hook_manifest_baseline(_hook_manifest_spec(context))
+        owned_bindings = _manifest_bindings(authenticated_manifest)
         backup_path = self._backup_path(context)
         if backup_path.is_file():
             original_text = backup_path.read_text(encoding="utf-8")
             if original_text:
-                target_config_path.parent.mkdir(parents=True, exist_ok=True)
-                target_config_path.write_text(original_text, encoding="utf-8")
+                atomic_write_text(target_config_path, original_text, mode=0o600)
             elif target_config_path.is_file():
                 target_config_path.unlink()
             backup_path.unlink()
+        elif target_config_path.is_file() and owned_bindings:
+            target_payload = read_toml_payload(target_config_path)
+            target_hooks = target_payload.get("hooks")
+            if isinstance(target_hooks, dict):
+                cleaned_hooks, managed_removed = _remove_manifest_bound_hook_events(target_hooks, owned_bindings)
+                if managed_removed:
+                    if cleaned_hooks:
+                        target_payload["hooks"] = cleaned_hooks
+                    else:
+                        target_payload.pop("hooks", None)
+                    atomic_write_text(target_config_path, dump_toml(target_payload), mode=0o600)
         hooks_path = self._remove_hooks(context)
         self._remove_managed_hooks_from_alternate_configs(context, skip_config_path=target_config_path)
         self._remove_managed_mcp_servers_from_alternate_configs(
@@ -1104,6 +1250,8 @@ class CodexHarnessAdapter(HarnessAdapter):
             managed_servers=(),
             skip_config_path=target_config_path,
         )
+        remove_hook_manifest(context.guard_home, hook_config_path)
+        remove_hook_secret_if_unused(context.guard_home)
         self._uninstall_shell_guard(context)
         shim_manifest = remove_guard_shim(self.harness, context)
         return {
@@ -1197,6 +1345,7 @@ class CodexHarnessAdapter(HarnessAdapter):
         *,
         payloads: dict[Path, dict[str, object]],
         skip_config_path: Path,
+        owned_bindings: Sequence[Mapping[str, object]] = (),
     ) -> None:
         for config_path, hooks_path in self._config_hook_pairs(context):
             if config_path == skip_config_path:
@@ -1205,8 +1354,16 @@ class CodexHarnessAdapter(HarnessAdapter):
             if not hooks_payload:
                 continue
             config_payload = read_toml_payload(config_path)
-            if _migrate_hooks_json_into_config(config_payload, hooks_payload) and config_payload:
-                write_toml_payload(config_path, config_payload)
+            if (
+                _migrate_hooks_json_into_config(
+                    config_payload,
+                    hooks_payload,
+                    context=context,
+                    owned_bindings=owned_bindings,
+                )
+                and config_payload
+            ):
+                atomic_write_text(config_path, dump_toml(config_payload), mode=0o600)
 
     def _remove_managed_hooks_from_alternate_configs(
         self,
@@ -1214,36 +1371,37 @@ class CodexHarnessAdapter(HarnessAdapter):
         *,
         skip_config_path: Path,
     ) -> None:
+        # No authenticated manifest is issued for alternate Codex configs.
+        # Only an exact current bridge can be re-adopted during explicit repair;
+        # basename, status-message, and path-suffix matches remain untouched.
         for config_path, _hooks_path in self._config_hook_pairs(context):
             if config_path == skip_config_path or not config_path.is_file():
                 continue
             config_payload = read_toml_payload(config_path)
             hooks = config_payload.get("hooks")
-            if not isinstance(hooks, dict):
+            changed = False
+            if isinstance(hooks, dict):
+                legacy_bindings = _current_install_legacy_bindings(context, hooks)
+                cleaned_hooks, managed_removed = _remove_manifest_bound_hook_events(hooks, legacy_bindings)
+                if managed_removed:
+                    changed = True
+                    if cleaned_hooks:
+                        config_payload["hooks"] = cleaned_hooks
+                    else:
+                        config_payload.pop("hooks", None)
+            if not _hooks_have_registered_entries(config_payload.get("hooks")):
                 features = config_payload.get("features")
                 if isinstance(features, dict):
-                    features.pop("hooks", None)
-                    features.pop("codex_hooks", None)
+                    for feature_name in ("codex_hooks", "hooks"):
+                        if feature_name in features:
+                            features.pop(feature_name, None)
+                            changed = True
                     if features:
                         config_payload["features"] = features
                     else:
                         config_payload.pop("features", None)
-                    write_toml_payload(config_path, config_payload)
-                continue
-            cleaned_hooks, managed_removed = _remove_managed_hook_events(hooks)
-            if not managed_removed:
-                continue
-            if cleaned_hooks:
-                config_payload["hooks"] = cleaned_hooks
-            else:
-                config_payload.pop("hooks", None)
-                features = config_payload.get("features")
-                if isinstance(features, dict):
-                    features.pop("hooks", None)
-                    features.pop("codex_hooks", None)
-                    if not features:
-                        config_payload.pop("features", None)
-            write_toml_payload(config_path, config_payload)
+            if changed:
+                atomic_write_text(config_path, dump_toml(config_payload), mode=0o600)
 
     def _remove_managed_mcp_servers_from_alternate_configs(
         self,
@@ -1307,7 +1465,8 @@ class CodexHarnessAdapter(HarnessAdapter):
             hooks = payload.get("hooks")
             if not isinstance(hooks, dict):
                 hooks = {}
-            cleaned_hooks, managed_removed = _remove_managed_hook_events(hooks)
+            legacy_bindings = _current_install_legacy_bindings(context, hooks)
+            cleaned_hooks, managed_removed = _remove_manifest_bound_hook_events(hooks, legacy_bindings)
             if not managed_removed:
                 payload = deepcopy(original_payload)
             elif cleaned_hooks:
@@ -1318,14 +1477,78 @@ class CodexHarnessAdapter(HarnessAdapter):
         return target_hooks_path
 
     @staticmethod
-    def _install_config_hooks(payload: dict[str, object], context: HarnessContext) -> None:
+    def _install_config_hooks(
+        payload: dict[str, object],
+        context: HarnessContext,
+        *,
+        owned_bindings: Sequence[Mapping[str, object]] = (),
+    ) -> None:
         hooks = payload.get("hooks")
         if not isinstance(hooks, dict):
             hooks = {}
-        cleaned_hooks, _ = _remove_managed_hook_events(hooks)
+        cleaned_hooks, _ = _remove_manifest_bound_hook_events(hooks, owned_bindings)
+        legacy_bindings = _current_install_legacy_bindings(context, cleaned_hooks)
+        cleaned_hooks, _ = _remove_manifest_bound_hook_events(cleaned_hooks, legacy_bindings)
         for event_name, managed_group in _managed_hook_groups(context).items():
-            cleaned_hooks[event_name] = _merge_hook_groups(cleaned_hooks.get(event_name), managed_group)
+            existing_groups = cleaned_hooks.get(event_name)
+            cleaned_hooks[event_name] = [
+                *(existing_groups if isinstance(existing_groups, list) else []),
+                managed_group,
+            ]
         payload["hooks"] = cleaned_hooks
+
+    @staticmethod
+    def _write_authenticated_hook_config(
+        context: HarnessContext,
+        *,
+        config_path: Path,
+        payload: dict[str, object],
+        previous_manifest: dict[str, object] | None,
+    ) -> dict[str, object]:
+        """Commit manifest first, then config, rolling both back on any failure.
+
+        During the short manifest-first window an old config fails closed against
+        the new manifest.  Codex never observes a newly registered hook before
+        its complete authenticated identity has been durably committed.
+        """
+
+        if config_path.exists() or config_path.is_symlink():
+            validate_regular_file(config_path, role="config_target", executable_required=False)
+            original_config = config_path.read_text(encoding="utf-8")
+        else:
+            original_config = None
+        manifest_path = hook_manifest_path(context.guard_home, config_path)
+        secret_path = hook_secret_path(context.guard_home)
+        original_manifest = snapshot_regular_file(manifest_path)
+        original_secret = snapshot_regular_file(secret_path)
+        try:
+            manifest = _build_authenticated_hook_manifest(context)
+            _assert_package_reauthentication_is_safe(previous_manifest, manifest)
+            write_hook_manifest(context.guard_home, config_path, manifest)
+            atomic_write_text(config_path, dump_toml(payload), mode=0o600)
+            state = codex_native_hook_state(context)
+            if not bool(state.get("protection_active")):
+                reason = str(state.get("integrity_reason") or "codex_hook_integrity_readback_failed")
+                raise RuntimeError(f"Codex hook authentication readback failed: {reason}")
+            return state
+        except BaseException:
+            rollback_error: BaseException | None = None
+            try:
+                if original_config is None:
+                    if config_path.is_symlink():
+                        raise RuntimeError("Guard refused to unlink a symlink while rolling back Codex config.")
+                    config_path.unlink(missing_ok=True)
+                else:
+                    atomic_write_text(config_path, original_config, mode=0o600)
+                restore_private_file(manifest_path, original_manifest)
+                restore_private_file(secret_path, original_secret)
+            except BaseException as exc:  # pragma: no cover - catastrophic local I/O failure
+                rollback_error = exc
+            if rollback_error is not None:
+                raise RuntimeError(
+                    "Codex hook transaction failed and rollback could not be completed."
+                ) from rollback_error
+            raise
 
     @staticmethod
     def _install_shell_guards(context: HarnessContext) -> dict[str, Path]:
@@ -1438,22 +1661,9 @@ class CodexHarnessAdapter(HarnessAdapter):
 
     def _remove_hooks(self, context: HarnessContext, *, payloads: dict[Path, dict[str, object]] | None = None) -> Path:
         target_hooks_path = self._hooks_path(context)
-        hook_payloads = payloads or {}
-        for hooks_path in self._all_hook_paths(context):
-            original_payload = deepcopy(hook_payloads.get(hooks_path, _json_object(hooks_path)))
-            payload = deepcopy(original_payload)
-            if not payload and hooks_path.exists():
-                continue
-            hooks = payload.get("hooks")
-            if isinstance(hooks, dict):
-                cleaned_hooks, managed_removed = _remove_managed_hook_events(hooks)
-                if not managed_removed:
-                    payload = deepcopy(original_payload)
-                elif cleaned_hooks:
-                    payload["hooks"] = cleaned_hooks
-                else:
-                    payload.pop("hooks", None)
-            self._write_hooks_payload(hooks_path, payload, original_payload=original_payload)
+        # JSON hook files created after install are foreign to the authenticated
+        # TOML registration and must be preserved byte-for-byte on uninstall.
+        del payloads
         return target_hooks_path
 
     @staticmethod

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -2042,7 +2042,7 @@ def _repair_codex_install(
         hook_state = codex_native_hook_state(repair_context)
     except (OSError, RuntimeError) as error:
         return None, f"Could not inspect Codex protection during update: {error}"
-    if bool(hook_state["protection_active"]):
+    if bool(hook_state["protection_active"]) and hook_state.get("integrity_status") == "valid":
         return None, None
     try:
         payload = apply_managed_install(
@@ -2056,6 +2056,13 @@ def _repair_codex_install(
         )
     except (OSError, RuntimeError, json.JSONDecodeError, sqlite3.Error) as error:
         return None, f"Could not repair Codex protection during update: {error}"
+    try:
+        repaired_state = codex_native_hook_state(repair_context)
+    except (OSError, RuntimeError) as error:
+        return None, f"Could not verify repaired Codex protection during update: {error}"
+    if not bool(repaired_state.get("protection_active")) or repaired_state.get("integrity_status") != "valid":
+        reason = str(repaired_state.get("integrity_reason") or "codex_hook_integrity_readback_failed")
+        return None, f"Could not verify repaired Codex protection during update: {reason}"
     managed_install = payload.get("managed_install")
     return (managed_install if isinstance(managed_install, dict) else None), None
 

--- a/src/codex_plugin_scanner/guard/codex_hook_file_integrity.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_file_integrity.py
@@ -1,0 +1,291 @@
+"""Live file and interpreter attestation for Guard-managed Codex hooks.
+
+Authenticated manifests establish the expected hook identity.  This module
+describes trusted local files for those manifests and verifies that the live
+filesystem still matches the authenticated identity exactly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import shlex
+import stat
+from pathlib import Path
+
+
+class CodexHookIntegrityError(RuntimeError):
+    """One stable, non-secret integrity failure suitable for status output."""
+
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.message = message
+
+
+def split_hook_command(command: object) -> list[str] | None:
+    """Parse one persisted hook command without accepting malformed shell text."""
+
+    if not isinstance(command, str):
+        return None
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return None
+
+
+def canonical_path(path: Path) -> str:
+    """Return the non-strict canonical absolute spelling used in identities."""
+
+    return str(path.expanduser().resolve(strict=False))
+
+
+def describe_regular_file(path: Path, *, role: str, executable_required: bool) -> dict[str, object]:
+    canonical = Path(canonical_path(path))
+    metadata = validate_regular_file(canonical, role=role, executable_required=executable_required)
+    return {
+        "executable_required": executable_required,
+        "mode": stat.S_IMODE(metadata.st_mode),
+        "owner_uid": metadata.st_uid if hasattr(metadata, "st_uid") else None,
+        "path": str(canonical),
+        "role": role,
+        "sha256": _sha256_file(canonical),
+        "size": metadata.st_size,
+    }
+
+
+def describe_executable_file(path: Path, *, role: str) -> dict[str, object]:
+    """Describe an executable invocation and its canonical regular target.
+
+    Virtual-environment interpreters are commonly symlinks.  Executing only the
+    resolved target can silently escape that environment, so the manifest binds
+    both the absolute invocation path and the canonical target instead.
+    """
+
+    invocation = path.expanduser().absolute()
+    try:
+        invocation_metadata = invocation.lstat()
+        target = invocation.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_missing",
+            f"The Codex hook {role} is missing; repair the installation.",
+        ) from exc
+    is_symlink = stat.S_ISLNK(invocation_metadata.st_mode)
+    if not is_symlink and not stat.S_ISREG(invocation_metadata.st_mode):
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_not_regular",
+            f"The Codex hook {role} invocation must be a regular file or symlink to one.",
+        )
+    if os.name != "nt":
+        current_uid = os.getuid() if hasattr(os, "getuid") else None
+        if current_uid is not None and invocation_metadata.st_uid not in {current_uid, 0}:
+            raise CodexHookIntegrityError(
+                f"codex_hook_{role}_owner_untrusted",
+                f"The Codex hook {role} invocation has an unexpected owner; repair the installation.",
+            )
+    if not os.access(invocation, os.X_OK):
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_not_executable",
+            f"The Codex hook {role} is not executable; repair the installation.",
+        )
+    link_target = os.readlink(invocation) if is_symlink else None
+    return {
+        "invocation_mode": stat.S_IMODE(invocation_metadata.st_mode),
+        "invocation_owner_uid": invocation_metadata.st_uid if hasattr(invocation_metadata, "st_uid") else None,
+        "invocation_path": str(invocation),
+        "link_target": link_target,
+        "role": role,
+        "target": describe_regular_file(target, role=role, executable_required=True),
+    }
+
+
+def verify_regular_file_identity(identity: object) -> None:
+    if not isinstance(identity, dict):
+        raise CodexHookIntegrityError(
+            "codex_hook_file_identity_invalid",
+            "The Codex hook manifest has an invalid packaged-file identity; repair the installation.",
+        )
+    role_value = identity.get("role")
+    role = role_value if isinstance(role_value, str) and role_value else "file"
+    path_value = identity.get("path")
+    digest_value = identity.get("sha256")
+    mode_value = identity.get("mode")
+    size_value = identity.get("size")
+    executable_required = identity.get("executable_required") is True
+    if (
+        not isinstance(path_value, str)
+        or not Path(path_value).is_absolute()
+        or not isinstance(digest_value, str)
+        or not isinstance(mode_value, int)
+        or isinstance(mode_value, bool)
+        or not isinstance(size_value, int)
+        or isinstance(size_value, bool)
+    ):
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_identity_invalid",
+            f"The Codex hook {role} identity is invalid; repair the installation.",
+        )
+    path = Path(path_value)
+    metadata = validate_regular_file(path, role=role, executable_required=executable_required)
+    if canonical_path(path) != path_value:
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_path_mismatch",
+            f"The Codex hook {role} path is no longer canonical; repair the installation.",
+        )
+    if stat.S_IMODE(metadata.st_mode) != mode_value:
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_mode_mismatch",
+            f"The Codex hook {role} permissions changed; repair the installation.",
+        )
+    if metadata.st_size != size_value or not hmac.compare_digest(_sha256_file(path), digest_value):
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_hash_mismatch",
+            f"The Codex hook {role} content changed; repair the installation.",
+        )
+    expected_owner = identity.get("owner_uid")
+    if os.name != "nt" and isinstance(expected_owner, int) and metadata.st_uid != expected_owner:
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_owner_mismatch",
+            f"The Codex hook {role} owner changed; repair the installation.",
+        )
+
+
+def verify_executable_file_identity(identity: object) -> None:
+    if not isinstance(identity, dict):
+        raise CodexHookIntegrityError(
+            "codex_hook_interpreter_identity_invalid",
+            "The Codex hook interpreter identity is invalid; repair the installation.",
+        )
+    role_value = identity.get("role")
+    role = role_value if isinstance(role_value, str) and role_value else "interpreter"
+    invocation_value = identity.get("invocation_path")
+    invocation_mode = identity.get("invocation_mode")
+    if (
+        not isinstance(invocation_value, str)
+        or not Path(invocation_value).is_absolute()
+        or not isinstance(invocation_mode, int)
+        or isinstance(invocation_mode, bool)
+    ):
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_identity_invalid",
+            f"The Codex hook {role} identity is invalid; repair the installation.",
+        )
+    invocation = Path(invocation_value)
+    try:
+        metadata = invocation.lstat()
+    except OSError as exc:
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_missing",
+            f"The Codex hook {role} is missing; repair the installation.",
+        ) from exc
+    if stat.S_IMODE(metadata.st_mode) != invocation_mode:
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_invocation_mode_mismatch",
+            f"The Codex hook {role} invocation permissions changed; repair the installation.",
+        )
+    expected_owner = identity.get("invocation_owner_uid")
+    if os.name != "nt" and isinstance(expected_owner, int) and metadata.st_uid != expected_owner:
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_invocation_owner_mismatch",
+            f"The Codex hook {role} invocation owner changed; repair the installation.",
+        )
+    expected_link_target = identity.get("link_target")
+    is_symlink = stat.S_ISLNK(metadata.st_mode)
+    if expected_link_target is None:
+        if is_symlink or not stat.S_ISREG(metadata.st_mode):
+            raise CodexHookIntegrityError(
+                f"codex_hook_{role}_invocation_type_mismatch",
+                f"The Codex hook {role} invocation type changed; repair the installation.",
+            )
+    elif not isinstance(expected_link_target, str) or not is_symlink:
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_invocation_type_mismatch",
+            f"The Codex hook {role} invocation type changed; repair the installation.",
+        )
+    elif os.readlink(invocation) != expected_link_target:
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_symlink_target_mismatch",
+            f"The Codex hook {role} symlink target changed; repair the installation.",
+        )
+    if not os.access(invocation, os.X_OK):
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_not_executable",
+            f"The Codex hook {role} is not executable; repair the installation.",
+        )
+    target = identity.get("target")
+    verify_regular_file_identity(target)
+    if not isinstance(target, dict) or target.get("path") != canonical_path(invocation):
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_target_path_mismatch",
+            f"The Codex hook {role} target changed; repair the installation.",
+        )
+
+
+def validate_regular_file(path: Path, *, role: str, executable_required: bool) -> os.stat_result:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_missing",
+            f"The Codex hook {role} is missing; repair the installation.",
+        ) from exc
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_not_regular",
+            f"The Codex hook {role} must be a regular file, not a symlink; repair the installation.",
+        )
+    mode = stat.S_IMODE(metadata.st_mode)
+    if os.name != "nt":
+        current_uid = os.getuid() if hasattr(os, "getuid") else None
+        if current_uid is not None and metadata.st_uid not in {current_uid, 0}:
+            raise CodexHookIntegrityError(
+                f"codex_hook_{role}_owner_untrusted",
+                f"The Codex hook {role} has an unexpected owner; repair the installation.",
+            )
+        trusted_interpreter_group_write = role == "interpreter" and (
+            (current_uid is not None and metadata.st_uid == current_uid)
+            # Members of gid 0 already have the privilege needed to replace a
+            # root-owned interpreter regardless of its group-write bit.  The
+            # GitHub-hosted Python toolcache uses this conventional 0775,
+            # root:root layout.
+            or (metadata.st_uid == 0 and metadata.st_gid == 0)
+        )
+        unsafe_group_write = bool(mode & stat.S_IWGRP) and not trusted_interpreter_group_write
+        if mode & stat.S_IWOTH or unsafe_group_write:
+            raise CodexHookIntegrityError(
+                f"codex_hook_{role}_permissions_unsafe",
+                f"The Codex hook {role} is writable by another user; repair the installation.",
+            )
+        if executable_required and not mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
+            raise CodexHookIntegrityError(
+                f"codex_hook_{role}_not_executable",
+                f"The Codex hook {role} is not executable; repair the installation.",
+            )
+    elif executable_required and not os.access(path, os.X_OK):
+        raise CodexHookIntegrityError(
+            f"codex_hook_{role}_not_executable",
+            f"The Codex hook {role} is not executable; repair the installation.",
+        )
+    return metadata
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+__all__ = [
+    "CodexHookIntegrityError",
+    "canonical_path",
+    "describe_executable_file",
+    "describe_regular_file",
+    "split_hook_command",
+    "validate_regular_file",
+    "verify_executable_file_identity",
+    "verify_regular_file_identity",
+]

--- a/src/codex_plugin_scanner/guard/codex_hook_integrity.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_integrity.py
@@ -1,0 +1,426 @@
+"""Authenticated local identity records for Guard-managed Codex hooks.
+
+The Codex configuration is user-editable and therefore cannot establish Guard
+ownership by itself.  This module keeps the ownership authority in a private,
+Guard-owned key file and authenticates canonical manifests with HMAC-SHA256.
+Manifests contain only public identity material; the HMAC key is never copied
+into Codex configuration or returned by status APIs.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import stat
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .codex_hook_file_integrity import CodexHookIntegrityError, canonical_path
+from .local_authority_integrity import (
+    LOCAL_AUTHORITY_INTEGRITY_MAC_ALGORITHM,
+    sign_local_authority_payload,
+    verify_local_authority_payload,
+)
+
+HOOK_MANIFEST_SCHEMA_VERSION = 1
+HOOK_MANIFEST_MAC_ALGORITHM = LOCAL_AUTHORITY_INTEGRITY_MAC_ALGORITHM
+_HOOK_SECRET_SCHEMA_VERSION = 1
+_HOOK_KEY_BYTES = 32
+_HOOK_MANIFEST_INTEGRITY_PURPOSE = "codex-managed-hook-manifest"
+_PRIVATE_FILE_MODE = 0o600
+
+
+@dataclass(frozen=True, slots=True)
+class HookSecretMaterial:
+    installation_id: str
+    key_id: str
+    key: bytes = field(repr=False)
+
+
+def hook_manifest_path(guard_home: Path, config_path: Path) -> Path:
+    target_hash = hashlib.sha256(canonical_path(config_path).encode("utf-8")).hexdigest()[:24]
+    return guard_home / "managed" / "codex" / f"hooks-{target_hash}.manifest.json"
+
+
+def hook_secret_path(guard_home: Path) -> Path:
+    return guard_home / "managed" / "codex" / "hook-manifest.key"
+
+
+def canonical_manifest_bytes(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def load_or_create_hook_secret(guard_home: Path) -> HookSecretMaterial:
+    path = hook_secret_path(guard_home)
+    _ensure_private_directory(path.parent, repair_mode=True)
+    if path.exists() or path.is_symlink():
+        return load_hook_secret(guard_home)
+
+    payload = {
+        "installation_id": secrets.token_hex(16),
+        "key": base64.urlsafe_b64encode(secrets.token_bytes(_HOOK_KEY_BYTES)).decode("ascii"),
+        "key_id": secrets.token_hex(12),
+        "schema_version": _HOOK_SECRET_SCHEMA_VERSION,
+    }
+    encoded = canonical_manifest_bytes(payload) + b"\n"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags, _PRIVATE_FILE_MODE)
+    except FileExistsError:
+        return load_hook_secret(guard_home)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(path, _PRIVATE_FILE_MODE)
+        _fsync_directory(path.parent)
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+    return _parse_hook_secret_payload(payload)
+
+
+def load_hook_secret(guard_home: Path) -> HookSecretMaterial:
+    path = hook_secret_path(guard_home)
+    if not path.exists() and not path.is_symlink():
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_secret_missing",
+            "The private Codex hook authentication key is missing; run `hol-guard install codex` to repair it.",
+        )
+    _ensure_private_directory(path.parent, repair_mode=False)
+    _validate_private_regular_file(
+        path,
+        reason_prefix="codex_hook_manifest_secret",
+        label="Codex hook authentication key",
+    )
+    try:
+        value: object = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_secret_invalid",
+            "The private Codex hook authentication key is unreadable; repair the Codex installation.",
+        ) from exc
+    if not isinstance(value, dict):
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_secret_invalid",
+            "The private Codex hook authentication key has an invalid format; repair the Codex installation.",
+        )
+    return _parse_hook_secret_payload(value)
+
+
+def sign_hook_manifest(unsigned_manifest: dict[str, object], secret: HookSecretMaterial) -> dict[str, object]:
+    if "authentication" in unsigned_manifest:
+        raise ValueError("Unsigned Codex hook manifests must not contain authentication metadata.")
+    generated_at = unsigned_manifest.get("generated_at")
+    if not isinstance(generated_at, str) or not generated_at:
+        raise ValueError("Unsigned Codex hook manifests require a generation time.")
+    payload = dict(unsigned_manifest)
+    payload["authentication"] = {
+        "algorithm": HOOK_MANIFEST_MAC_ALGORITHM,
+        **sign_local_authority_payload(
+            payload,
+            key=secret.key,
+            key_id=secret.key_id,
+            purpose=_HOOK_MANIFEST_INTEGRITY_PURPOSE,
+            signed_at=generated_at,
+        ),
+    }
+    return payload
+
+
+def load_authenticated_hook_manifest(
+    guard_home: Path,
+    config_path: Path,
+) -> dict[str, object]:
+    path = hook_manifest_path(guard_home, config_path)
+    if not path.exists() and not path.is_symlink():
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_missing",
+            "The authenticated Codex hook manifest is missing; run `hol-guard install codex` to repair it.",
+        )
+    _validate_private_regular_file(path, reason_prefix="codex_hook_manifest", label="Codex hook manifest")
+    try:
+        value: object = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_invalid",
+            "The authenticated Codex hook manifest is unreadable; run `hol-guard install codex` to repair it.",
+        ) from exc
+    if not isinstance(value, dict):
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_invalid",
+            "The authenticated Codex hook manifest has an invalid format; repair the Codex installation.",
+        )
+    manifest = {str(key): item for key, item in value.items() if isinstance(key, str)}
+    authentication = manifest.get("authentication")
+    if not isinstance(authentication, dict):
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_authentication_missing",
+            "The Codex hook manifest is not authenticated; run `hol-guard install codex` to repair it.",
+        )
+    algorithm = authentication.get("algorithm")
+    if algorithm != HOOK_MANIFEST_MAC_ALGORITHM:
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_authentication_invalid",
+            "The Codex hook manifest authentication metadata is invalid; repair the Codex installation.",
+        )
+
+    secret = load_hook_secret(guard_home)
+    unsigned = dict(manifest)
+    unsigned.pop("authentication", None)
+    verification = verify_local_authority_payload(
+        unsigned,
+        authentication,
+        key=secret.key,
+        key_id=secret.key_id,
+        purpose=_HOOK_MANIFEST_INTEGRITY_PURPOSE,
+    )
+    if verification.status == "missing_integrity":
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_authentication_invalid",
+            "The Codex hook manifest authentication metadata is invalid; repair the Codex installation.",
+        )
+    if verification.status == "unknown_key":
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_key_mismatch",
+            "The Codex hook manifest belongs to another Guard installation; run `hol-guard install codex`.",
+        )
+    if verification.status != "valid":
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_mac_invalid",
+            "The Codex hook manifest authentication failed; run `hol-guard install codex` to repair it.",
+        )
+    installation_id = manifest.get("installation_id")
+    if not isinstance(installation_id, str) or not hmac.compare_digest(installation_id, secret.installation_id):
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_installation_mismatch",
+            "The Codex hook manifest belongs to another Guard installation; run `hol-guard install codex`.",
+        )
+    if authentication.get("signed_at") != manifest.get("generated_at"):
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_authentication_invalid",
+            "The Codex hook manifest generation binding is invalid; repair the Codex installation.",
+        )
+    return manifest
+
+
+def write_hook_manifest(guard_home: Path, config_path: Path, manifest: dict[str, object]) -> Path:
+    path = hook_manifest_path(guard_home, config_path)
+    _ensure_private_directory(path.parent, repair_mode=True)
+    atomic_write_bytes(path, canonical_manifest_bytes(manifest) + b"\n", mode=_PRIVATE_FILE_MODE, private=True)
+    return path
+
+
+def remove_hook_manifest(guard_home: Path, config_path: Path) -> None:
+    path = hook_manifest_path(guard_home, config_path)
+    if path.is_symlink():
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_not_regular",
+            "Guard refused to remove a symlink in place of the Codex hook manifest.",
+        )
+    if path.exists():
+        path.unlink()
+
+
+def remove_hook_secret_if_unused(guard_home: Path) -> None:
+    """Remove the private key after an explicit uninstall removes its last manifest."""
+
+    path = hook_secret_path(guard_home)
+    managed_directory = path.parent
+    if not managed_directory.is_dir():
+        return
+    if any(
+        candidate.exists() or candidate.is_symlink() for candidate in managed_directory.glob("hooks-*.manifest.json")
+    ):
+        return
+    if not path.exists() and not path.is_symlink():
+        return
+    _validate_private_regular_file(
+        path,
+        reason_prefix="codex_hook_manifest_secret",
+        label="Codex hook authentication key",
+    )
+    path.unlink()
+    _fsync_directory(managed_directory)
+
+
+def snapshot_regular_file(path: Path) -> bytes | None:
+    if not path.exists() and not path.is_symlink():
+        return None
+    if path.is_symlink() or not path.is_file():
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_not_regular",
+            "Guard refused to replace a non-regular Codex hook manifest.",
+        )
+    return path.read_bytes()
+
+
+def restore_private_file(path: Path, payload: bytes | None) -> None:
+    if payload is None:
+        if path.is_symlink():
+            raise CodexHookIntegrityError(
+                "codex_hook_manifest_not_regular",
+                "Guard refused to replace a symlink in place of the Codex hook manifest.",
+            )
+        path.unlink(missing_ok=True)
+        return
+    atomic_write_bytes(path, payload, mode=_PRIVATE_FILE_MODE, private=True)
+
+
+def atomic_write_text(path: Path, text: str, *, mode: int = _PRIVATE_FILE_MODE) -> None:
+    atomic_write_bytes(path, text.encode("utf-8"), mode=mode, private=False)
+
+
+def atomic_write_bytes(path: Path, payload: bytes, *, mode: int, private: bool) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink() or (path.exists() and not path.is_file()):
+        raise CodexHookIntegrityError(
+            "codex_hook_transaction_target_not_regular",
+            f"Guard refused to replace a non-regular managed file at {path}.",
+        )
+    if private:
+        _ensure_private_directory(path.parent, repair_mode=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            fchmod = getattr(os, "fchmod", None)
+            if fchmod is not None:
+                fchmod(handle.fileno(), mode)
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+        os.chmod(path, mode)
+        _fsync_directory(path.parent)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def _parse_hook_secret_payload(payload: dict[str, Any]) -> HookSecretMaterial:
+    version = payload.get("schema_version")
+    installation_id = payload.get("installation_id")
+    key_id = payload.get("key_id")
+    encoded_key = payload.get("key")
+    if (
+        version != _HOOK_SECRET_SCHEMA_VERSION
+        or not isinstance(installation_id, str)
+        or len(installation_id) < 32
+        or not isinstance(key_id, str)
+        or len(key_id) < 24
+        or not isinstance(encoded_key, str)
+    ):
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_secret_invalid",
+            "The private Codex hook authentication key has an invalid format; repair the installation.",
+        )
+    try:
+        key = base64.urlsafe_b64decode(encoded_key.encode("ascii"))
+    except (ValueError, UnicodeEncodeError) as exc:
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_secret_invalid",
+            "The private Codex hook authentication key has invalid encoding; repair the installation.",
+        ) from exc
+    if len(key) != _HOOK_KEY_BYTES:
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_secret_invalid",
+            "The private Codex hook authentication key has an invalid length; repair the installation.",
+        )
+    return HookSecretMaterial(installation_id=installation_id, key_id=key_id, key=key)
+
+
+def _ensure_private_directory(path: Path, *, repair_mode: bool) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    metadata = path.lstat()
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_directory_unsafe",
+            "The Codex managed-hook directory is not a private regular directory.",
+        )
+    if os.name == "nt":
+        return
+    current_uid = os.getuid() if hasattr(os, "getuid") else None
+    if current_uid is not None and metadata.st_uid != current_uid:
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_directory_owner_mismatch",
+            "The Codex managed-hook directory has an unexpected owner.",
+        )
+    mode = stat.S_IMODE(metadata.st_mode)
+    if mode & 0o077:
+        if not repair_mode:
+            raise CodexHookIntegrityError(
+                "codex_hook_manifest_directory_permissions_unsafe",
+                "The Codex managed-hook directory permissions are not owner-only.",
+            )
+        # Owner-only access is required for this secret-bearing directory; the
+        # generic file-permission rule incorrectly recommends world-readable
+        # 0644, which is both unsuitable for a directory and less restrictive.
+        os.chmod(path, 0o700)  # nosemgrep
+
+
+def _validate_private_regular_file(path: Path, *, reason_prefix: str, label: str) -> None:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise CodexHookIntegrityError(f"{reason_prefix}_missing", f"The {label} is missing.") from exc
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise CodexHookIntegrityError(
+            f"{reason_prefix}_not_regular",
+            f"The {label} must be a private regular file, not a symlink.",
+        )
+    if os.name == "nt":
+        return
+    current_uid = os.getuid() if hasattr(os, "getuid") else None
+    if current_uid is not None and metadata.st_uid != current_uid:
+        raise CodexHookIntegrityError(
+            f"{reason_prefix}_owner_mismatch",
+            f"The {label} has an unexpected owner.",
+        )
+    if stat.S_IMODE(metadata.st_mode) & 0o077:
+        raise CodexHookIntegrityError(
+            f"{reason_prefix}_permissions_unsafe",
+            f"The {label} permissions are not owner-only.",
+        )
+
+
+def _fsync_directory(path: Path) -> None:
+    if os.name == "nt":
+        return
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+__all__ = [
+    "HOOK_MANIFEST_MAC_ALGORITHM",
+    "HOOK_MANIFEST_SCHEMA_VERSION",
+    "CodexHookIntegrityError",
+    "HookSecretMaterial",
+    "atomic_write_text",
+    "canonical_path",
+    "hook_manifest_path",
+    "hook_secret_path",
+    "load_authenticated_hook_manifest",
+    "load_or_create_hook_secret",
+    "remove_hook_manifest",
+    "remove_hook_secret_if_unused",
+    "restore_private_file",
+    "sign_hook_manifest",
+    "snapshot_regular_file",
+    "write_hook_manifest",
+]

--- a/src/codex_plugin_scanner/guard/codex_hook_manifest.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_manifest.py
@@ -1,0 +1,483 @@
+"""Build and verify authenticated identities for Guard-managed Codex hooks.
+
+This module owns the manifest trust model without importing the Codex adapter.
+The adapter supplies one complete expected specification, which keeps command
+construction at the harness boundary and prevents a circular dependency.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import NoReturn
+
+from .codex_hook_file_integrity import (
+    CodexHookIntegrityError,
+    canonical_path,
+    describe_executable_file,
+    describe_regular_file,
+    split_hook_command,
+    validate_regular_file,
+    verify_executable_file_identity,
+    verify_regular_file_identity,
+)
+from .codex_hook_integrity import (
+    HOOK_MANIFEST_SCHEMA_VERSION,
+    hook_manifest_path,
+    hook_secret_path,
+    load_authenticated_hook_manifest,
+    load_or_create_hook_secret,
+    sign_hook_manifest,
+)
+
+MANAGED_CODEX_HOOK_EVENTS = ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse")
+
+
+@dataclass(frozen=True, slots=True)
+class CodexHookManifestSpec:
+    """Complete live identity expected for one Codex hook installation."""
+
+    guard_home: Path
+    home_dir: Path
+    runtime_guard_home: Path
+    workspace_dir: Path | None
+    config_path: Path
+    interpreter_path: Path
+    package_version: str
+    packaged_file_paths: tuple[tuple[str, Path], ...]
+    fallback_argv: tuple[str, ...]
+    daemon_start_argv: tuple[str, ...]
+    event_bindings: tuple[Mapping[str, object], ...]
+
+
+def build_authenticated_hook_manifest(spec: CodexHookManifestSpec) -> dict[str, object]:
+    secret = load_or_create_hook_secret(spec.guard_home)
+    interpreter = describe_executable_file(spec.interpreter_path, role="interpreter")
+    packaged_files = [
+        describe_regular_file(path, role=role, executable_required=False) for role, path in spec.packaged_file_paths
+    ]
+    packaged_by_role = {
+        identity.get("role"): identity for identity in packaged_files if isinstance(identity.get("role"), str)
+    }
+    bridge = packaged_by_role.get("bridge")
+    if not isinstance(bridge, dict) or len(packaged_by_role) != len(spec.packaged_file_paths):
+        raise CodexHookIntegrityError(
+            "codex_hook_manifest_packaged_files_invalid",
+            "Guard cannot authenticate an incomplete Codex hook package identity.",
+        )
+    generated_at = datetime.now(timezone.utc).isoformat()
+    unsigned_manifest: dict[str, object] = {
+        "config": {"scope": "global", "target": canonical_path(spec.config_path)},
+        "context": _expected_context(spec),
+        "daemon_start": {
+            "argv": list(spec.daemon_start_argv),
+            "interpreter": interpreter,
+            "package_roles": ["daemon_entrypoint", "daemon_manager"],
+        },
+        "events": [dict(binding) for binding in spec.event_bindings],
+        "fallback": {
+            "argv": list(spec.fallback_argv),
+            "interpreter": interpreter,
+            "package_roles": ["fallback_entrypoint"],
+        },
+        "generated_at": generated_at,
+        "harness": "codex",
+        "installation_id": secret.installation_id,
+        "interpreter": interpreter,
+        "package_version": spec.package_version,
+        "packaged_files": packaged_files,
+        "schema_version": HOOK_MANIFEST_SCHEMA_VERSION,
+        "transport": {"bridge": bridge, "wrapper": None},
+    }
+    return sign_hook_manifest(unsigned_manifest, secret)
+
+
+def load_hook_manifest_baseline(spec: CodexHookManifestSpec) -> dict[str, object] | None:
+    """Load a prior authenticated baseline or prove this is a clean install.
+
+    No manifest and no secret is the only unauthenticated state that may create
+    a baseline. It covers both a first install and explicit migration of a
+    pre-manifest exact legacy hook. If either modern artifact exists, every
+    authenticity and ownership check must pass before current package bytes can
+    be signed again.
+    """
+
+    manifest_path = hook_manifest_path(spec.guard_home, spec.config_path)
+    secret_path = hook_secret_path(spec.guard_home)
+    manifest_exists = manifest_path.exists() or manifest_path.is_symlink()
+    secret_exists = secret_path.exists() or secret_path.is_symlink()
+    if not manifest_exists and not secret_exists:
+        return None
+    try:
+        manifest = load_authenticated_hook_manifest(spec.guard_home, spec.config_path)
+    except (CodexHookIntegrityError, OSError) as exc:
+        raise _untrusted_baseline_error() from exc
+    if not _manifest_has_owned_installation_context(manifest, spec):
+        raise _untrusted_baseline_error()
+    return manifest
+
+
+def authenticated_manifest_for_ownership(spec: CodexHookManifestSpec) -> dict[str, object] | None:
+    """Return exact authenticated ownership evidence for conservative cleanup."""
+
+    try:
+        manifest = load_authenticated_hook_manifest(spec.guard_home, spec.config_path)
+    except (CodexHookIntegrityError, OSError):
+        return None
+    return manifest if _manifest_has_owned_installation_context(manifest, spec) else None
+
+
+def assert_package_reauthentication_is_safe(
+    previous_manifest: dict[str, object] | None,
+    replacement_manifest: dict[str, object],
+) -> None:
+    """Refuse to bless changed executable identities at the same package version."""
+
+    if previous_manifest is None:
+        return
+    if previous_manifest.get("schema_version") != HOOK_MANIFEST_SCHEMA_VERSION:
+        return
+    if previous_manifest.get("package_version") != replacement_manifest.get("package_version"):
+        return
+    if previous_manifest.get("interpreter") != replacement_manifest.get("interpreter") or previous_manifest.get(
+        "packaged_files"
+    ) != replacement_manifest.get("packaged_files"):
+        raise CodexHookIntegrityError(
+            "codex_hook_package_reauthentication_refused",
+            "Guard refused to authenticate changed same-version hook code or interpreter bytes. "
+            "Reinstall hol-guard from a trusted package, then run `hol-guard install codex` again.",
+        )
+
+
+def manifest_bindings(manifest: object) -> list[dict[str, object]]:
+    if not isinstance(manifest, dict):
+        return []
+    events = manifest.get("events")
+    if not isinstance(events, list):
+        return []
+    return [dict(binding) for binding in events if isinstance(binding, dict)]
+
+
+def verify_live_hook_manifest(
+    spec: CodexHookManifestSpec,
+    *,
+    hooks: object,
+) -> dict[str, object]:
+    event_matches = {event_name: False for event_name in MANAGED_CODEX_HOOK_EVENTS}
+    manifest_path = hook_manifest_path(spec.guard_home, spec.config_path)
+    try:
+        manifest = load_authenticated_hook_manifest(spec.guard_home, spec.config_path)
+        _verify_manifest_header(manifest, spec)
+        validate_regular_file(spec.config_path, role="config_target", executable_required=False)
+        interpreter = manifest.get("interpreter")
+        verify_executable_file_identity(interpreter)
+        if not isinstance(interpreter, dict) or interpreter.get("invocation_path") != str(spec.interpreter_path):
+            _raise_manifest_failure(
+                "codex_hook_interpreter_path_mismatch",
+                "The Codex hook interpreter does not match this Guard installation; repair it.",
+            )
+        packaged_by_role = _verify_packaged_files(manifest, spec)
+        _verify_launch_identities(manifest, spec, interpreter, packaged_by_role)
+        bindings = manifest_bindings(manifest)
+        expected_bindings = [dict(binding) for binding in spec.event_bindings]
+        if bindings != expected_bindings:
+            _raise_manifest_failure(
+                "codex_hook_manifest_registration_stale",
+                "The authenticated Codex hook registration no longer matches this Guard version; run repair.",
+            )
+        if not isinstance(hooks, dict):
+            _raise_manifest_failure(
+                "codex_hook_registration_missing",
+                "The authenticated Codex hooks are missing from Codex configuration; run repair.",
+            )
+        matched_group_indexes = _verify_event_bindings(bindings, spec, hooks, event_matches)
+        if not all(event_matches.values()):
+            _raise_manifest_failure(
+                "codex_hook_registration_mismatch",
+                "One or more authenticated Codex hook handlers changed or disappeared; run repair.",
+            )
+        foreign_count = sum(
+            max(0, len(groups) - (1 if event_name in matched_group_indexes else 0))
+            for event_name in MANAGED_CODEX_HOOK_EVENTS
+            if isinstance((groups := hooks.get(event_name)), list)
+        )
+        return {
+            "event_matches": event_matches,
+            "foreign_hook_entries_present": foreign_count > 0,
+            "foreign_hook_group_count": foreign_count,
+            "integrity_message": "Authenticated manifest and live Codex hook identities are valid.",
+            "integrity_reason": "codex_hook_manifest_valid",
+            "integrity_status": "valid",
+            "manifest_path": str(manifest_path),
+            "manifest_schema_version": HOOK_MANIFEST_SCHEMA_VERSION,
+            "manifest_package_version": manifest.get("package_version"),
+        }
+    except (CodexHookIntegrityError, OSError) as exc:
+        if isinstance(exc, CodexHookIntegrityError):
+            reason, message = exc.reason, exc.message
+        else:
+            reason = "codex_hook_integrity_io_error"
+            message = "Guard could not verify the Codex hook installation; run repair and inspect file permissions."
+        return {
+            "event_matches": event_matches,
+            "foreign_hook_entries_present": _hooks_have_registered_entries(hooks),
+            "foreign_hook_group_count": sum(
+                len(groups)
+                for event_name in MANAGED_CODEX_HOOK_EVENTS
+                if isinstance(hooks, dict) and isinstance((groups := hooks.get(event_name)), list)
+            ),
+            "integrity_message": message,
+            "integrity_reason": reason,
+            "integrity_status": _manifest_failure_status(reason),
+            "manifest_path": str(manifest_path),
+            "manifest_schema_version": None,
+            "manifest_package_version": None,
+        }
+
+
+def _expected_context(spec: CodexHookManifestSpec) -> dict[str, object]:
+    return {
+        "guard_home": canonical_path(spec.guard_home),
+        "home_dir": canonical_path(spec.home_dir),
+        "runtime_guard_home": canonical_path(spec.runtime_guard_home),
+        "workspace_dir": canonical_path(spec.workspace_dir) if spec.workspace_dir is not None else None,
+    }
+
+
+def _manifest_has_owned_installation_context(
+    manifest: Mapping[str, object],
+    spec: CodexHookManifestSpec,
+) -> bool:
+    config = manifest.get("config")
+    context = manifest.get("context")
+    return (
+        manifest.get("harness") == "codex"
+        and isinstance(config, dict)
+        and config.get("scope") == "global"
+        and config.get("target") == canonical_path(spec.config_path)
+        and isinstance(context, dict)
+        and context == _expected_context(spec)
+    )
+
+
+def _untrusted_baseline_error() -> CodexHookIntegrityError:
+    return CodexHookIntegrityError(
+        "codex_hook_manifest_baseline_untrusted",
+        "Guard refused to authenticate hook package bytes because the existing managed-hook baseline is "
+        "missing, invalid, or belongs to another installation. Reinstall hol-guard from a trusted package, "
+        "then run `hol-guard install codex` again.",
+    )
+
+
+def _verify_manifest_header(manifest: Mapping[str, object], spec: CodexHookManifestSpec) -> None:
+    if manifest.get("schema_version") != HOOK_MANIFEST_SCHEMA_VERSION:
+        _raise_manifest_failure(
+            "codex_hook_manifest_schema_unsupported",
+            "The Codex hook manifest schema is stale; run `hol-guard install codex` to refresh it.",
+        )
+    if manifest.get("harness") != "codex":
+        _raise_manifest_failure(
+            "codex_hook_manifest_context_mismatch",
+            "The authenticated hook manifest is not bound to the Codex harness; repair the installation.",
+        )
+    config = manifest.get("config")
+    if (
+        not isinstance(config, dict)
+        or config.get("scope") != "global"
+        or config.get("target") != canonical_path(spec.config_path)
+    ):
+        _raise_manifest_failure(
+            "codex_hook_manifest_config_target_mismatch",
+            "The Codex hook manifest is bound to another configuration target; repair the installation.",
+        )
+    if manifest.get("context") != _expected_context(spec):
+        _raise_manifest_failure(
+            "codex_hook_manifest_context_mismatch",
+            "The Codex hook manifest is bound to another Guard home or workspace; repair the installation.",
+        )
+    if manifest.get("package_version") != spec.package_version:
+        _raise_manifest_failure(
+            "codex_hook_manifest_package_version_stale",
+            "The Codex hook manifest was generated by another Guard package version; run repair.",
+        )
+    generated_at = manifest.get("generated_at")
+    try:
+        generated_time = datetime.fromisoformat(generated_at) if isinstance(generated_at, str) else None
+    except ValueError:
+        generated_time = None
+    if generated_time is None or generated_time.tzinfo is None:
+        _raise_manifest_failure(
+            "codex_hook_manifest_generated_at_invalid",
+            "The Codex hook manifest generation time is invalid; repair the installation.",
+        )
+
+
+def _verify_packaged_files(
+    manifest: Mapping[str, object],
+    spec: CodexHookManifestSpec,
+) -> dict[str, dict[str, object]]:
+    packaged_files = manifest.get("packaged_files")
+    if not isinstance(packaged_files, list):
+        _raise_manifest_failure(
+            "codex_hook_manifest_packaged_files_invalid",
+            "The Codex hook manifest has no valid packaged-file identities; repair the installation.",
+        )
+    packaged_by_role: dict[str, dict[str, object]] = {}
+    for item in packaged_files:
+        if not isinstance(item, dict):
+            continue
+        role = item.get("role")
+        if not isinstance(role, str):
+            continue
+        identity: dict[str, object] = {key: value for key, value in item.items() if isinstance(key, str)}
+        packaged_by_role[role] = identity
+    for identity in packaged_by_role.values():
+        verify_regular_file_identity(identity)
+    expected_paths = {role: canonical_path(path) for role, path in spec.packaged_file_paths}
+    if set(packaged_by_role) != set(expected_paths) or any(
+        packaged_by_role[role].get("path") != expected_path for role, expected_path in expected_paths.items()
+    ):
+        _raise_manifest_failure(
+            "codex_hook_manifest_packaged_files_stale",
+            "The Codex hook packaged-file paths changed; run repair to authenticate the new installation.",
+        )
+    return packaged_by_role
+
+
+def _verify_launch_identities(
+    manifest: Mapping[str, object],
+    spec: CodexHookManifestSpec,
+    interpreter: dict[str, object],
+    packaged_by_role: Mapping[str, dict[str, object]],
+) -> None:
+    transport = manifest.get("transport")
+    if (
+        not isinstance(transport, dict)
+        or transport.get("wrapper") is not None
+        or transport.get("bridge") != packaged_by_role.get("bridge")
+    ):
+        _raise_manifest_failure(
+            "codex_hook_manifest_transport_invalid",
+            "The Codex hook bridge identity is invalid; repair the installation.",
+        )
+    fallback = manifest.get("fallback")
+    if (
+        not isinstance(fallback, dict)
+        or fallback.get("argv") != list(spec.fallback_argv)
+        or fallback.get("interpreter") != interpreter
+        or fallback.get("package_roles") != ["fallback_entrypoint"]
+    ):
+        _raise_manifest_failure(
+            "codex_hook_manifest_fallback_mismatch",
+            "The Codex hook fallback identity changed; repair the installation.",
+        )
+    daemon_start = manifest.get("daemon_start")
+    if (
+        not isinstance(daemon_start, dict)
+        or daemon_start.get("argv") != list(spec.daemon_start_argv)
+        or daemon_start.get("interpreter") != interpreter
+        or daemon_start.get("package_roles") != ["daemon_entrypoint", "daemon_manager"]
+    ):
+        _raise_manifest_failure(
+            "codex_hook_manifest_daemon_start_mismatch",
+            "The Codex daemon-start identity changed; repair the installation.",
+        )
+
+
+def _verify_event_bindings(
+    bindings: list[dict[str, object]],
+    spec: CodexHookManifestSpec,
+    hooks: dict[str, object],
+    event_matches: dict[str, bool],
+) -> dict[str, int]:
+    matched_group_indexes: dict[str, int] = {}
+    expected_argv_value = spec.event_bindings[0].get("argv", ()) if spec.event_bindings else ()
+    if not isinstance(expected_argv_value, (list, tuple)) or not all(
+        isinstance(token, str) for token in expected_argv_value
+    ):
+        _raise_manifest_failure(
+            "codex_hook_manifest_registration_invalid",
+            "The expected Codex hook registration has an invalid argv identity; repair the installation.",
+        )
+    expected_argv = [token for token in expected_argv_value if isinstance(token, str)]
+    for binding in bindings:
+        event_name = binding.get("event")
+        expected_group = binding.get("group")
+        argv = binding.get("argv")
+        handler = binding.get("handler")
+        if (
+            not isinstance(event_name, str)
+            or event_name not in event_matches
+            or not isinstance(expected_group, dict)
+            or not isinstance(handler, dict)
+            or not isinstance(argv, list)
+            or not all(isinstance(token, str) for token in argv)
+            or binding.get("handler_index") != 0
+            or binding.get("handler_id") != f"codex:{event_name}:guard-handler-v1"
+        ):
+            _raise_manifest_failure(
+                "codex_hook_manifest_registration_invalid",
+                "The Codex hook manifest contains an invalid event identity; repair the installation.",
+            )
+        if split_hook_command(handler.get("command")) != argv or argv != expected_argv:
+            _raise_manifest_failure(
+                "codex_hook_manifest_argv_mismatch",
+                "The Codex hook manifest argv identity changed; repair the installation.",
+            )
+        groups = hooks.get(event_name)
+        if not isinstance(groups, list):
+            continue
+        matching_index = next((index for index, group in enumerate(groups) if group == expected_group), None)
+        if matching_index is not None:
+            event_matches[event_name] = True
+            matched_group_indexes[event_name] = matching_index
+    return matched_group_indexes
+
+
+def _hooks_have_registered_entries(hooks: object) -> bool:
+    return isinstance(hooks, dict) and any(
+        isinstance(hooks.get(event_name), list) and bool(hooks[event_name]) for event_name in MANAGED_CODEX_HOOK_EVENTS
+    )
+
+
+def _manifest_failure_status(reason: str) -> str:
+    if reason in {
+        "codex_hook_config_target_missing",
+        "codex_hook_manifest_missing",
+        "codex_hook_manifest_secret_missing",
+        "codex_hook_registration_missing",
+    }:
+        return "missing"
+    if reason in {
+        "codex_hook_manifest_key_mismatch",
+        "codex_hook_manifest_installation_mismatch",
+        "codex_hook_manifest_context_mismatch",
+        "codex_hook_manifest_config_target_mismatch",
+    }:
+        return "foreign"
+    if reason in {
+        "codex_hook_manifest_schema_unsupported",
+        "codex_hook_manifest_package_version_stale",
+        "codex_hook_manifest_registration_stale",
+        "codex_hook_manifest_packaged_files_stale",
+    }:
+        return "stale"
+    return "tampered"
+
+
+def _raise_manifest_failure(reason: str, message: str) -> NoReturn:
+    raise CodexHookIntegrityError(reason, message)
+
+
+__all__ = [
+    "MANAGED_CODEX_HOOK_EVENTS",
+    "CodexHookManifestSpec",
+    "assert_package_reauthentication_is_safe",
+    "authenticated_manifest_for_ownership",
+    "build_authenticated_hook_manifest",
+    "load_hook_manifest_baseline",
+    "manifest_bindings",
+    "verify_live_hook_manifest",
+]

--- a/src/codex_plugin_scanner/guard/codex_hook_registration.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_registration.py
@@ -1,0 +1,108 @@
+"""Exact ownership and legacy-adoption operations for Codex hook groups."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+
+from .codex_hook_file_integrity import split_hook_command
+from .codex_hook_manifest import MANAGED_CODEX_HOOK_EVENTS
+
+
+def remove_manifest_bound_hook_events(
+    hooks: dict[str, object],
+    bindings: Sequence[Mapping[str, object]],
+) -> tuple[dict[str, object], bool]:
+    """Remove only handlers whose exact identity is authenticated by a manifest."""
+
+    updated_hooks = deepcopy(hooks)
+    changed = False
+    for binding in bindings:
+        event_name = binding.get("event")
+        expected_group = binding.get("group")
+        expected_handler = binding.get("handler")
+        if (
+            not isinstance(event_name, str)
+            or event_name not in MANAGED_CODEX_HOOK_EVENTS
+            or not isinstance(expected_group, dict)
+            or not isinstance(expected_handler, dict)
+        ):
+            continue
+        groups = updated_hooks.get(event_name)
+        if not isinstance(groups, list):
+            continue
+        remaining_groups: list[object] = []
+        removed_for_binding = False
+        for group in groups:
+            if removed_for_binding or not isinstance(group, dict):
+                remaining_groups.append(group)
+                continue
+            if group == expected_group:
+                removed_for_binding = True
+                changed = True
+                continue
+            if group.get("matcher") != expected_group.get("matcher"):
+                remaining_groups.append(group)
+                continue
+            handlers = group.get("hooks")
+            if not isinstance(handlers, list) or expected_handler not in handlers:
+                remaining_groups.append(group)
+                continue
+            remaining_handlers = list(handlers)
+            remaining_handlers.remove(expected_handler)
+            removed_for_binding = True
+            changed = True
+            if remaining_handlers:
+                updated_group = dict(group)
+                updated_group["hooks"] = remaining_handlers
+                remaining_groups.append(updated_group)
+        if remaining_groups:
+            updated_hooks[event_name] = remaining_groups
+        else:
+            updated_hooks.pop(event_name, None)
+    return updated_hooks, changed
+
+
+def exact_legacy_hook_bindings(
+    hooks: Mapping[str, object],
+    *,
+    expected_bindings: Sequence[Mapping[str, object]],
+    current_argv: Sequence[str],
+    legacy_argv: Sequence[str],
+    legacy_status_messages: set[str],
+) -> list[dict[str, object]]:
+    """Select exact current-package entries for explicit pre-manifest adoption."""
+
+    expected_by_event = {
+        event: binding for binding in expected_bindings if isinstance((event := binding.get("event")), str)
+    }
+    bindings: list[dict[str, object]] = []
+    for event_name in MANAGED_CODEX_HOOK_EVENTS:
+        groups = hooks.get(event_name)
+        expected = expected_by_event.get(event_name)
+        expected_group = expected.get("group") if isinstance(expected, Mapping) else None
+        if not isinstance(groups, list) or not isinstance(expected_group, dict):
+            continue
+        for group in groups:
+            if not isinstance(group, dict) or group.get("matcher") != expected_group.get("matcher"):
+                continue
+            handlers = group.get("hooks")
+            if not isinstance(handlers, list):
+                continue
+            handler = next(
+                (
+                    item
+                    for item in handlers
+                    if isinstance(item, dict)
+                    and split_hook_command(item.get("command")) in (list(current_argv), list(legacy_argv))
+                    and item.get("statusMessage") in legacy_status_messages
+                ),
+                None,
+            )
+            if handler is not None:
+                bindings.append({"event": event_name, "group": group, "handler": handler})
+                break
+    return bindings
+
+
+__all__ = ["exact_legacy_hook_bindings", "remove_manifest_bound_hook_events"]

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -24,6 +24,7 @@ except ModuleNotFoundError:
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters import claude_code as claude_adapter_module
+from codex_plugin_scanner.guard.adapters import codex as codex_adapter_module
 from codex_plugin_scanner.guard.adapters import cursor as cursor_adapter_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.claude_code import CLAUDE_GUARD_DAEMON_HOOK_MARKER, ClaudeCodeHarnessAdapter
@@ -4305,6 +4306,163 @@ args = ["-lc", "echo hi"]
         assert "hooks = true" in config_text
         assert "codex_hooks" not in config_text
         assert hooks_payload["PreToolUse"]
+
+    def test_guard_update_repairs_authenticated_codex_hook_tampering_despite_shape_match(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        home_dir = tmp_path / "home"
+        install_rc = main(["guard", "install", "codex", "--home", str(home_dir), "--json"])
+        json.loads(capsys.readouterr().out)
+        config_path = home_dir / ".codex" / "config.toml"
+        config_payload = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        managed_handler = config_payload["hooks"]["PreToolUse"][-1]["hooks"][0]
+        managed_handler["statusMessage"] = "HOL Guard checking tool action (tampered)"
+        _write_text(config_path, codex_adapter_module.dump_toml(config_payload))
+        context = HarnessContext(home_dir=home_dir, workspace_dir=Path.cwd(), guard_home=home_dir)
+
+        before = codex_adapter_module.codex_native_hook_state(context)
+
+        assert install_rc == 0
+        assert codex_adapter_module._is_managed_hook_entry(managed_handler) is True
+        assert before["protection_active"] is False
+        assert before["integrity_reason"] == "codex_hook_registration_mismatch"
+
+        monkeypatch.setattr(
+            guard_update_commands_module.subprocess,
+            "run",
+            lambda command, **_: subprocess.CompletedProcess(
+                command,
+                0,
+                stdout="hol-guard is already at latest version 2.0.39",
+                stderr="",
+            ),
+        )
+        monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+        monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.39")
+        monkeypatch.setattr(
+            guard_update_commands_module, "_current_version_from_subprocess", lambda *_args, **_kwargs: "2.0.39"
+        )
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.39")
+
+        update_rc = main(["guard", "update", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+        repaired = codex_adapter_module.codex_native_hook_state(context)
+
+        assert update_rc == 0
+        assert output["managed_install"]["active"] is True
+        assert repaired["protection_active"] is True
+        assert repaired["integrity_status"] == "valid"
+
+    def test_guard_update_refuses_to_replace_altered_codex_identity_record(self, tmp_path, monkeypatch, capsys):
+        home_dir = tmp_path / "home"
+        assert main(["guard", "install", "codex", "--home", str(home_dir), "--json"]) == 0
+        json.loads(capsys.readouterr().out)
+        context = HarnessContext(home_dir=home_dir, workspace_dir=Path.cwd(), guard_home=home_dir)
+        installed_state = codex_adapter_module.codex_native_hook_state(context)
+        manifest_path = Path(str(installed_state["manifest_path"]))
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        bridge_identity = next(item for item in manifest["packaged_files"] if item["role"] == "bridge")
+        bridge_identity["sha256"] = "0" * 64
+        _write_text(manifest_path, json.dumps(manifest, sort_keys=True) + "\n")
+        altered_manifest = manifest_path.read_bytes()
+
+        altered_state = codex_adapter_module.codex_native_hook_state(context)
+
+        assert altered_state["protection_active"] is False
+        assert altered_state["integrity_status"] == "tampered"
+        assert altered_state["integrity_reason"] == "codex_hook_manifest_mac_invalid"
+
+        monkeypatch.setattr(
+            guard_update_commands_module.subprocess,
+            "run",
+            lambda command, **_: subprocess.CompletedProcess(
+                command,
+                0,
+                stdout="hol-guard is already at latest version 2.0.39",
+                stderr="",
+            ),
+        )
+        monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+        monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.39")
+        monkeypatch.setattr(
+            guard_update_commands_module, "_current_version_from_subprocess", lambda *_args, **_kwargs: "2.0.39"
+        )
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.39")
+
+        update_rc = main(["guard", "update", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+        final_state = codex_adapter_module.codex_native_hook_state(context)
+
+        assert update_rc == 0
+        assert "managed_install" not in output
+        assert any("Reinstall hol-guard from a trusted package" in note for note in output["notes"])
+        assert manifest_path.read_bytes() == altered_manifest
+        assert final_state["protection_active"] is False
+        assert final_state["integrity_reason"] == "codex_hook_manifest_mac_invalid"
+
+    def test_guard_update_does_not_reauthenticate_same_version_tampered_packaged_hook(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        home_dir = tmp_path / "home"
+        bridge_path = tmp_path / "package" / "codex_daemon_hook_bridge.py"
+        bridge_path.parent.mkdir(parents=True)
+        original_bridge = Path(codex_adapter_module.__file__).with_name("codex_daemon_hook_bridge.py").read_bytes()
+        bridge_path.write_bytes(original_bridge)
+        bridge_path.chmod(0o644)
+        original_command_parts = codex_adapter_module._hook_command_parts
+        original_packaged_paths = codex_adapter_module._hook_packaged_file_paths
+
+        def relocated_command_parts(hook_context: HarnessContext) -> tuple[str, ...]:
+            parts = list(original_command_parts(hook_context))
+            parts[1] = str(bridge_path)
+            return tuple(parts)
+
+        def relocated_packaged_paths() -> tuple[tuple[str, Path], ...]:
+            return tuple((role, bridge_path if role == "bridge" else path) for role, path in original_packaged_paths())
+
+        monkeypatch.setattr(codex_adapter_module, "_hook_command_parts", relocated_command_parts)
+        monkeypatch.setattr(codex_adapter_module, "_hook_packaged_file_paths", relocated_packaged_paths)
+        assert main(["guard", "install", "codex", "--home", str(home_dir), "--json"]) == 0
+        json.loads(capsys.readouterr().out)
+        context = HarnessContext(home_dir=home_dir, workspace_dir=Path.cwd(), guard_home=home_dir)
+        installed_state = codex_adapter_module.codex_native_hook_state(context)
+        manifest_path = Path(str(installed_state["manifest_path"]))
+        original_manifest = manifest_path.read_bytes()
+        tampered_bridge = original_bridge + b"\n# local tamper\n"
+        bridge_path.write_bytes(tampered_bridge)
+
+        altered_state = codex_adapter_module.codex_native_hook_state(context)
+
+        assert altered_state["protection_active"] is False
+        assert altered_state["integrity_reason"] == "codex_hook_bridge_hash_mismatch"
+
+        def fake_update(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout="hol-guard is already at latest version 2.0.39",
+                stderr="",
+            )
+
+        monkeypatch.setattr(guard_update_commands_module.subprocess, "run", fake_update)
+        monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+        monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.39")
+        monkeypatch.setattr(
+            guard_update_commands_module, "_current_version_from_subprocess", lambda *_args, **_kwargs: "2.0.39"
+        )
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.39")
+
+        update_rc = main(["guard", "update", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+        final_state = codex_adapter_module.codex_native_hook_state(context)
+
+        assert update_rc == 0
+        assert "managed_install" not in output
+        assert any("refused to authenticate changed same-version hook code" in note for note in output["notes"])
+        assert bridge_path.read_bytes() == tampered_bridge
+        assert manifest_path.read_bytes() == original_manifest
+        assert final_state["protection_active"] is False
+        assert final_state["integrity_reason"] == "codex_hook_bridge_hash_mismatch"
 
     def test_guard_update_repairs_missing_codex_config_for_managed_install(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 try:
     import tomllib
 except ModuleNotFoundError:
@@ -19,12 +21,89 @@ from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
 from codex_plugin_scanner.guard.adapters.mcp_servers import managed_stdio_servers
 from codex_plugin_scanner.guard.codex_config import dump_toml
+from codex_plugin_scanner.guard.codex_hook_file_integrity import (
+    CodexHookIntegrityError,
+    describe_executable_file,
+    describe_regular_file,
+    validate_regular_file,
+)
+from codex_plugin_scanner.guard.codex_hook_integrity import (
+    hook_secret_path,
+    load_or_create_hook_secret,
+    sign_hook_manifest,
+    write_hook_manifest,
+)
 from codex_plugin_scanner.guard.config import MAX_APPROVAL_WAIT_TIMEOUT_SECONDS
 
 
 def _write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission modes are required")
+def test_interpreter_identity_accepts_current_owner_group_write_but_rejects_world_write(tmp_path: Path) -> None:
+    interpreter = tmp_path / "python"
+    interpreter.write_bytes(b"interpreter fixture")
+    interpreter.chmod(0o775)
+
+    identity = describe_executable_file(interpreter, role="interpreter")
+
+    target = identity["target"]
+    assert isinstance(target, dict)
+    assert target["mode"] == 0o775
+    interpreter.chmod(0o777)
+    with pytest.raises(CodexHookIntegrityError, match="writable by another user"):
+        describe_executable_file(interpreter, role="interpreter")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission modes are required")
+def test_interpreter_identity_accepts_root_owned_root_group_toolchain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    interpreter = tmp_path / "python"
+    interpreter.write_bytes(b"interpreter fixture")
+    interpreter.chmod(0o775)
+    real_lstat = Path.lstat
+    real_metadata = interpreter.lstat()
+    root_owned_metadata = os.stat_result(
+        (
+            real_metadata.st_mode,
+            real_metadata.st_ino,
+            real_metadata.st_dev,
+            real_metadata.st_nlink,
+            0,
+            0,
+            real_metadata.st_size,
+            real_metadata.st_atime,
+            real_metadata.st_mtime,
+            real_metadata.st_ctime,
+        )
+    )
+
+    def root_owned_lstat(path: Path) -> os.stat_result:
+        if path == interpreter:
+            return root_owned_metadata
+        return real_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", root_owned_lstat)
+    monkeypatch.setattr(os, "getuid", lambda: 1000)
+
+    metadata = validate_regular_file(interpreter, role="interpreter", executable_required=True)
+
+    assert metadata.st_uid == 0
+    assert metadata.st_gid == 0
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission modes are required")
+def test_packaged_hook_identity_still_rejects_current_owner_group_write(tmp_path: Path) -> None:
+    bridge = tmp_path / "codex_hook_bridge.py"
+    bridge.write_bytes(b"bridge fixture")
+    bridge.chmod(0o664)
+
+    with pytest.raises(CodexHookIntegrityError, match="writable by another user"):
+        describe_regular_file(bridge, role="bridge", executable_required=False)
 
 
 def _build_guard_fixture(home_dir: Path, workspace_dir: Path) -> None:
@@ -94,12 +173,536 @@ def test_guard_codex_hook_command_uses_lightweight_authenticated_daemon_bridge(t
     assert bridge_config["state_path"] == str(guard_home / "daemon-state.json")
     assert bridge_config["query"].startswith("guard-home=")
     assert bridge_config["fallback_command"][:3] == [
-        sys.executable,
+        str(Path(sys.executable).absolute()),
         "-m",
         "codex_plugin_scanner.cli",
     ]
-    assert bridge_config["start_command"][0] == sys.executable
+    assert bridge_config["start_command"][0] == str(Path(sys.executable).absolute())
     assert bridge_config["hook_timeouts"]["PreToolUse"] > bridge_config["hook_timeouts"]["UserPromptSubmit"]
+
+
+def test_guard_codex_native_hook_state_requires_authenticated_manifest(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    context = HarnessContext(home_dir=home_dir, workspace_dir=None, guard_home=home_dir / ".hol-guard")
+    direct_argv = list(codex_adapter._local_hook_command_parts(context))
+    bridge_config = json.dumps({"fallback_command": direct_argv}, separators=(",", ":"))
+    forged_commands = [
+        codex_adapter._hook_command(context),
+        shlex.join([str(tmp_path / "hol-guard-codex-hook.sh"), "--forged"]),
+        shlex.join(
+            [
+                "python3",
+                str(
+                    tmp_path
+                    / "site-packages"
+                    / "codex_plugin_scanner"
+                    / "guard"
+                    / "adapters"
+                    / "codex_daemon_hook_bridge.py"
+                ),
+                bridge_config,
+            ]
+        ),
+        shlex.join(
+            [
+                "python3",
+                "-c",
+                "from codex_plugin_scanner.cli import main;main(['guard','hook','--harness','codex'])",
+            ]
+        ),
+    ]
+
+    for command in forged_commands:
+        forged_entry = {
+            "type": "command",
+            "command": command,
+            "timeout": 30,
+            "statusMessage": "HOL Guard checking tool action",
+        }
+        _write_text(
+            home_dir / ".codex" / "config.toml",
+            dump_toml(
+                {
+                    "features": {"hooks": True},
+                    "hooks": {
+                        event_name: [{"matcher": ".*", "hooks": [forged_entry]}]
+                        for event_name in ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse")
+                    },
+                },
+            ),
+        )
+
+        state = codex_adapter.codex_native_hook_state(context)
+
+        assert state["protection_active"] is False
+        assert state["managed_hook_installed"] is False
+        assert state["integrity_status"] == "missing"
+        assert state["integrity_reason"] == "codex_hook_manifest_missing"
+        assert state["foreign_hook_entries_present"] is True
+
+
+def test_guard_codex_native_hook_state_detects_registered_handler_tampering(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home = home_dir / ".hol-guard"
+    context = HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=guard_home)
+    _build_guard_fixture(home_dir, workspace_dir)
+
+    CodexHarnessAdapter().install(context)
+    valid_state = codex_adapter.codex_native_hook_state(context)
+    payload = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    payload["hooks"]["PreToolUse"][-1]["hooks"][0]["statusMessage"] = "HOL Guard checking tool action (forged)"
+    _write_text(home_dir / ".codex" / "config.toml", dump_toml(payload))
+
+    tampered_state = codex_adapter.codex_native_hook_state(context)
+
+    assert valid_state["protection_active"] is True
+    assert valid_state["integrity_status"] == "valid"
+    assert tampered_state["protection_active"] is False
+    assert tampered_state["managed_hook_installed"] is False
+    assert tampered_state["integrity_status"] == "tampered"
+    assert tampered_state["integrity_reason"] == "codex_hook_registration_mismatch"
+
+
+def test_guard_codex_native_hook_state_reports_missing_config_target(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    context = HarnessContext(home_dir=home_dir, workspace_dir=None, guard_home=home_dir / ".hol-guard")
+    adapter = CodexHarnessAdapter()
+    adapter.install(context)
+    (home_dir / ".codex" / "config.toml").unlink()
+
+    state = codex_adapter.codex_native_hook_state(context)
+
+    assert state["protection_active"] is False
+    assert state["integrity_status"] == "missing"
+    assert state["integrity_reason"] == "codex_hook_config_target_missing"
+
+
+def test_guard_codex_native_hook_state_reports_missing_registration(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    context = HarnessContext(home_dir=home_dir, workspace_dir=None, guard_home=home_dir / ".hol-guard")
+    adapter = CodexHarnessAdapter()
+    adapter.install(context)
+    config_path = home_dir / ".codex" / "config.toml"
+    payload = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    payload.pop("hooks")
+    _write_text(config_path, dump_toml(payload))
+
+    state = codex_adapter.codex_native_hook_state(context)
+
+    assert state["protection_active"] is False
+    assert state["integrity_status"] == "missing"
+    assert state["integrity_reason"] == "codex_hook_registration_missing"
+
+
+def test_guard_codex_install_refuses_to_replace_bad_manifest_mac(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    context = HarnessContext(home_dir=home_dir, workspace_dir=None, guard_home=home_dir / ".hol-guard")
+
+    adapter = CodexHarnessAdapter()
+    adapter.install(context)
+    valid_state = codex_adapter.codex_native_hook_state(context)
+    manifest_path = Path(str(valid_state["manifest_path"]))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["authentication"]["payload_mac"] = "0" * 64
+    _write_text(manifest_path, json.dumps(manifest, sort_keys=True) + "\n")
+    tampered_manifest = manifest_path.read_bytes()
+
+    state = codex_adapter.codex_native_hook_state(context)
+    with pytest.raises(CodexHookIntegrityError, match="Reinstall hol-guard from a trusted package") as error:
+        adapter.install(context)
+
+    assert state["protection_active"] is False
+    assert state["integrity_status"] == "tampered"
+    assert state["integrity_reason"] == "codex_hook_manifest_mac_invalid"
+    assert error.value.reason == "codex_hook_manifest_baseline_untrusted"
+    assert manifest_path.read_bytes() == tampered_manifest
+    assert codex_adapter.codex_native_hook_state(context)["protection_active"] is False
+
+
+def test_guard_codex_native_hook_state_rejects_manifest_copied_from_another_guard_home(tmp_path: Path) -> None:
+    first_context = HarnessContext(
+        home_dir=tmp_path / "first-home",
+        workspace_dir=None,
+        guard_home=tmp_path / "first-guard",
+    )
+    second_context = HarnessContext(
+        home_dir=tmp_path / "second-home",
+        workspace_dir=None,
+        guard_home=tmp_path / "second-guard",
+    )
+    adapter = CodexHarnessAdapter()
+    adapter.install(first_context)
+    adapter.install(second_context)
+    first_state = codex_adapter.codex_native_hook_state(first_context)
+    second_state = codex_adapter.codex_native_hook_state(second_context)
+    first_manifest = Path(str(first_state["manifest_path"]))
+    second_manifest = Path(str(second_state["manifest_path"]))
+    _write_text(second_manifest, first_manifest.read_text(encoding="utf-8"))
+    foreign_manifest = second_manifest.read_bytes()
+
+    copied_state = codex_adapter.codex_native_hook_state(second_context)
+    with pytest.raises(CodexHookIntegrityError, match="Reinstall hol-guard from a trusted package") as error:
+        adapter.install(second_context)
+
+    assert copied_state["protection_active"] is False
+    assert copied_state["integrity_status"] == "foreign"
+    assert copied_state["integrity_reason"] == "codex_hook_manifest_key_mismatch"
+    assert error.value.reason == "codex_hook_manifest_baseline_untrusted"
+    assert second_manifest.read_bytes() == foreign_manifest
+
+
+def test_guard_codex_install_and_uninstall_reject_manifest_from_another_workspace(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    guard_home = tmp_path / "guard-home"
+    first_context = HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=tmp_path / "first-workspace",
+        guard_home=guard_home,
+    )
+    second_context = HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=tmp_path / "second-workspace",
+        guard_home=guard_home,
+    )
+    adapter = CodexHarnessAdapter()
+    adapter.install(first_context)
+    config_path = CodexHarnessAdapter._hook_config_path(first_context)
+    state = codex_adapter.codex_native_hook_state(first_context)
+    manifest_path = Path(str(state["manifest_path"]))
+    original_config = config_path.read_bytes()
+    original_manifest = manifest_path.read_bytes()
+
+    with pytest.raises(CodexHookIntegrityError) as install_error:
+        adapter.install(second_context)
+    with pytest.raises(CodexHookIntegrityError) as uninstall_error:
+        adapter.uninstall(second_context)
+
+    assert install_error.value.reason == "codex_hook_manifest_baseline_untrusted"
+    assert uninstall_error.value.reason == "codex_hook_manifest_baseline_untrusted"
+    assert config_path.read_bytes() == original_config
+    assert manifest_path.read_bytes() == original_manifest
+    assert codex_adapter.codex_native_hook_state(first_context)["protection_active"] is True
+
+
+def test_guard_codex_install_refuses_missing_manifest_when_modern_secret_remains(tmp_path: Path) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+    adapter = CodexHarnessAdapter()
+    adapter.install(context)
+    state = codex_adapter.codex_native_hook_state(context)
+    Path(str(state["manifest_path"])).unlink()
+
+    with pytest.raises(CodexHookIntegrityError, match="Reinstall hol-guard from a trusted package") as error:
+        adapter.install(context)
+
+    missing_state = codex_adapter.codex_native_hook_state(context)
+    assert error.value.reason == "codex_hook_manifest_baseline_untrusted"
+    assert missing_state["protection_active"] is False
+    assert missing_state["integrity_reason"] == "codex_hook_manifest_missing"
+
+
+def test_guard_codex_native_hook_state_rejects_signed_stale_package_version_and_repair_refreshes_it(
+    tmp_path: Path,
+) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+    adapter = CodexHarnessAdapter()
+    adapter.install(context)
+    valid_state = codex_adapter.codex_native_hook_state(context)
+    manifest_path = Path(str(valid_state["manifest_path"]))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest.pop("authentication")
+    manifest["package_version"] = "0.0.0-stale"
+    secret = load_or_create_hook_secret(context.guard_home)
+    stale_manifest = sign_hook_manifest(manifest, secret)
+    write_hook_manifest(
+        context.guard_home,
+        CodexHarnessAdapter._hook_config_path(context),
+        stale_manifest,
+    )
+
+    stale_state = codex_adapter.codex_native_hook_state(context)
+    adapter.install(context)
+    repaired_state = codex_adapter.codex_native_hook_state(context)
+
+    assert stale_state["protection_active"] is False
+    assert stale_state["integrity_status"] == "stale"
+    assert stale_state["integrity_reason"] == "codex_hook_manifest_package_version_stale"
+    assert repaired_state["protection_active"] is True
+    assert repaired_state["integrity_status"] == "valid"
+
+
+def test_guard_codex_native_hook_state_detects_bridge_content_mode_and_symlink_changes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+    bridge_path = tmp_path / "package" / "codex_daemon_hook_bridge.py"
+    bridge_path.parent.mkdir(parents=True)
+    bridge_path.write_bytes(Path(codex_adapter.__file__).with_name("codex_daemon_hook_bridge.py").read_bytes())
+    bridge_path.chmod(0o644)
+    original_command_parts = codex_adapter._hook_command_parts
+    original_packaged_paths = codex_adapter._hook_packaged_file_paths
+
+    def relocated_command_parts(hook_context: HarnessContext) -> tuple[str, ...]:
+        parts = list(original_command_parts(hook_context))
+        parts[1] = str(bridge_path)
+        return tuple(parts)
+
+    def relocated_packaged_paths() -> tuple[tuple[str, Path], ...]:
+        return tuple((role, bridge_path if role == "bridge" else path) for role, path in original_packaged_paths())
+
+    monkeypatch.setattr(codex_adapter, "_hook_command_parts", relocated_command_parts)
+    monkeypatch.setattr(codex_adapter, "_hook_packaged_file_paths", relocated_packaged_paths)
+    adapter = CodexHarnessAdapter()
+    adapter.install(context)
+
+    original_bytes = bridge_path.read_bytes()
+    bridge_path.write_bytes(original_bytes + b"\n# tampered\n")
+    content_state = codex_adapter.codex_native_hook_state(context)
+    bridge_path.write_bytes(original_bytes)
+    bridge_path.chmod(0o744)
+    mode_state = codex_adapter.codex_native_hook_state(context)
+    bridge_path.chmod(0o644)
+    bridge_original = bridge_path.with_suffix(".original.py")
+    bridge_path.rename(bridge_original)
+    bridge_path.symlink_to(bridge_original)
+    symlink_state = codex_adapter.codex_native_hook_state(context)
+
+    assert content_state["integrity_reason"] == "codex_hook_bridge_hash_mismatch"
+    assert mode_state["integrity_reason"] == "codex_hook_bridge_mode_mismatch"
+    assert symlink_state["integrity_reason"] == "codex_hook_bridge_not_regular"
+    assert content_state["protection_active"] is False
+    assert mode_state["protection_active"] is False
+    assert symlink_state["protection_active"] is False
+
+
+def test_guard_codex_repair_refuses_to_authenticate_changed_same_version_bridge(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+    bridge_path = tmp_path / "package" / "codex_daemon_hook_bridge.py"
+    bridge_path.parent.mkdir(parents=True)
+    bridge_path.write_bytes(Path(codex_adapter.__file__).with_name("codex_daemon_hook_bridge.py").read_bytes())
+    bridge_path.chmod(0o644)
+    original_command_parts = codex_adapter._hook_command_parts
+    original_packaged_paths = codex_adapter._hook_packaged_file_paths
+
+    def relocated_command_parts(hook_context: HarnessContext) -> tuple[str, ...]:
+        parts = list(original_command_parts(hook_context))
+        parts[1] = str(bridge_path)
+        return tuple(parts)
+
+    def relocated_packaged_paths() -> tuple[tuple[str, Path], ...]:
+        return tuple((role, bridge_path if role == "bridge" else path) for role, path in original_packaged_paths())
+
+    monkeypatch.setattr(codex_adapter, "_hook_command_parts", relocated_command_parts)
+    monkeypatch.setattr(codex_adapter, "_hook_packaged_file_paths", relocated_packaged_paths)
+    adapter = CodexHarnessAdapter()
+    adapter.install(context)
+    valid_state = codex_adapter.codex_native_hook_state(context)
+    manifest_path = Path(str(valid_state["manifest_path"]))
+    original_manifest = manifest_path.read_bytes()
+    bridge_path.write_bytes(bridge_path.read_bytes() + b"\n# attacker-controlled mutation\n")
+
+    with pytest.raises(
+        CodexHookIntegrityError,
+        match="refused to authenticate changed same-version hook code",
+    ) as error:
+        adapter.install(context)
+
+    state = codex_adapter.codex_native_hook_state(context)
+    assert error.value.reason == "codex_hook_package_reauthentication_refused"
+    assert manifest_path.read_bytes() == original_manifest
+    assert state["protection_active"] is False
+    assert state["integrity_reason"] == "codex_hook_bridge_hash_mismatch"
+
+
+def test_guard_codex_native_hook_state_binds_interpreter_invocation_symlink_target(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    if os.name == "nt":
+        return
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+    interpreter_link = tmp_path / "guard-python"
+    interpreter_link.symlink_to(Path(sys.executable).resolve(strict=True))
+    replacement = tmp_path / "replacement-python"
+    replacement.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    replacement.chmod(0o755)
+    monkeypatch.setattr(codex_adapter.sys, "executable", str(interpreter_link))
+
+    CodexHarnessAdapter().install(context)
+    valid_state = codex_adapter.codex_native_hook_state(context)
+    interpreter_link.unlink()
+    interpreter_link.symlink_to(replacement)
+
+    swapped_state = codex_adapter.codex_native_hook_state(context)
+
+    assert valid_state["protection_active"] is True
+    assert swapped_state["protection_active"] is False
+    assert swapped_state["integrity_status"] == "tampered"
+    assert swapped_state["integrity_reason"] == "codex_hook_interpreter_symlink_target_mismatch"
+
+
+def test_guard_codex_install_safely_readopts_exact_current_legacy_bridge(tmp_path: Path) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+    config_path = CodexHarnessAdapter._hook_config_path(context)
+    legacy_group = codex_adapter._managed_hook_groups(context)["PreToolUse"]
+    _write_text(
+        config_path,
+        dump_toml({"features": {"hooks": True}, "hooks": {"PreToolUse": [legacy_group]}}),
+    )
+
+    CodexHarnessAdapter().install(context)
+    installed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    state = codex_adapter.codex_native_hook_state(context)
+
+    assert len(installed["hooks"]["PreToolUse"]) == 1
+    assert state["protection_active"] is True
+    assert state["foreign_hook_entries_present"] is False
+
+
+def test_guard_codex_install_preserves_ambiguous_foreign_direct_hook(tmp_path: Path) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+    config_path = CodexHarnessAdapter._hook_config_path(context)
+    foreign_command = shlex.join(codex_adapter._local_hook_command_parts(context))
+    foreign_group = {
+        "matcher": codex_adapter._CODEX_GUARD_TOOL_MATCHER,
+        "hooks": [
+            {
+                "type": "command",
+                "command": foreign_command,
+                "statusMessage": "HOL Guard checking tool action",
+            }
+        ],
+    }
+    _write_text(
+        config_path,
+        dump_toml({"features": {"hooks": True}, "hooks": {"PreToolUse": [foreign_group]}}),
+    )
+
+    CodexHarnessAdapter().install(context)
+    installed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    state = codex_adapter.codex_native_hook_state(context)
+    commands = [handler["command"] for group in installed["hooks"]["PreToolUse"] for handler in group["hooks"]]
+
+    assert foreign_command in commands
+    assert len(installed["hooks"]["PreToolUse"]) == 2
+    assert state["protection_active"] is True
+    assert state["foreign_hook_entries_present"] is True
+
+
+def test_guard_codex_authenticated_hook_transaction_rolls_back_after_partial_config_write(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+    adapter = CodexHarnessAdapter()
+    adapter.install(context)
+    config_path = CodexHarnessAdapter._hook_config_path(context)
+    state = codex_adapter.codex_native_hook_state(context)
+    manifest_path = Path(str(state["manifest_path"]))
+    original_config = config_path.read_bytes()
+    original_manifest = manifest_path.read_bytes()
+    original_atomic_write = codex_adapter.atomic_write_text
+    failed_once = False
+
+    def fail_first_config_write(path: Path, text: str, *, mode: int = 0o600) -> None:
+        nonlocal failed_once
+        if path == config_path and not failed_once:
+            failed_once = True
+            raise OSError("injected config write failure")
+        original_atomic_write(path, text, mode=mode)
+
+    monkeypatch.setattr(codex_adapter, "atomic_write_text", fail_first_config_write)
+
+    try:
+        adapter.install(context)
+    except OSError as error:
+        assert str(error) == "injected config write failure"
+    else:  # pragma: no cover - the injected failure must escape after rollback
+        raise AssertionError("Expected the injected config write failure")
+
+    rolled_back_state = codex_adapter.codex_native_hook_state(context)
+
+    assert config_path.read_bytes() == original_config
+    assert manifest_path.read_bytes() == original_manifest
+    assert rolled_back_state["protection_active"] is True
+    assert rolled_back_state["integrity_status"] == "valid"
+
+
+def test_guard_codex_first_install_failure_rolls_back_new_hook_secret(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+    adapter = CodexHarnessAdapter()
+    config_path = CodexHarnessAdapter._hook_config_path(context)
+    manifest_path = codex_adapter.hook_manifest_path(context.guard_home, config_path)
+    secret_path = hook_secret_path(context.guard_home)
+    original_atomic_write = codex_adapter.atomic_write_text
+    failed_once = False
+
+    def fail_first_config_write(path: Path, text: str, *, mode: int = 0o600) -> None:
+        nonlocal failed_once
+        if path == config_path and not failed_once:
+            failed_once = True
+            raise OSError("injected first-install config failure")
+        original_atomic_write(path, text, mode=mode)
+
+    monkeypatch.setattr(codex_adapter, "atomic_write_text", fail_first_config_write)
+
+    with pytest.raises(OSError, match="injected first-install config failure"):
+        adapter.install(context)
+
+    assert not config_path.exists()
+    assert not manifest_path.exists()
+    assert not secret_path.exists()
+
+    installed = adapter.install(context)
+    state = codex_adapter.codex_native_hook_state(context)
+
+    assert installed["active"] is True
+    assert secret_path.is_file()
+    assert state["protection_active"] is True
+    assert state["integrity_status"] == "valid"
 
 
 def test_guard_codex_launch_uses_remote_control_for_dashboard_continuation(tmp_path, monkeypatch):
@@ -217,12 +820,7 @@ def test_guard_codex_detects_direct_hook_with_python_runtime_flags() -> None:
 
 def test_guard_codex_detects_bridge_hook_with_python_runtime_flags(tmp_path: Path) -> None:
     bridge_path = (
-        tmp_path
-        / "site-packages"
-        / "codex_plugin_scanner"
-        / "guard"
-        / "adapters"
-        / "codex_daemon_hook_bridge.py"
+        tmp_path / "site-packages" / "codex_plugin_scanner" / "guard" / "adapters" / "codex_daemon_hook_bridge.py"
     )
     bridge_path.parent.mkdir(parents=True, exist_ok=True)
     bridge_path.write_text("# bridge\n", encoding="utf-8")
@@ -250,7 +848,7 @@ def test_guard_codex_detects_bridge_hook_with_python_runtime_flags(tmp_path: Pat
     assert codex_adapter._is_managed_hook_entry(entry) is True
 
 
-def test_guard_install_and_repair_codex_reconcile_legacy_post_tool_hooks(
+def test_guard_install_and_repair_codex_preserve_ambiguous_legacy_post_tool_hooks(
     tmp_path,
     capsys,
     monkeypatch,
@@ -395,7 +993,7 @@ def test_guard_install_and_repair_codex_reconcile_legacy_post_tool_hooks(
         for hook in group["hooks"]
         if hook["type"] == "command"
     ]
-    assert stale_direct_command not in connected_commands
+    assert stale_direct_command in connected_commands
     connected_payload["hooks"]["PostToolUse"].append(
         {
             "matcher": "Bash",
@@ -433,18 +1031,23 @@ def test_guard_install_and_repair_codex_reconcile_legacy_post_tool_hooks(
         if hook["type"] == "command"
     ]
     command_tokens = [shlex.split(command) for command in commands]
-    bridge_commands = [tokens for tokens in command_tokens if Path(tokens[1]).name == "codex_daemon_hook_bridge.py"]
+    current_bridge_path = Path(codex_adapter.__file__).with_name("codex_daemon_hook_bridge.py").resolve()
+    authenticated_bridge_commands = [
+        tokens for tokens in command_tokens if len(tokens) > 1 and Path(tokens[1]).resolve() == current_bridge_path
+    ]
+    final_state = codex_adapter.codex_native_hook_state(
+        HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=guard_home)
+    )
 
     assert install_rc == 0
     assert connect_rc == 0
     assert repair_rc == 0
     assert lean_command in commands
-    assert stale_bridge_command not in commands
-    assert all(tokens[1:3] != ["-m", "codex_plugin_scanner.cli"] for tokens in command_tokens)
-    assert len(bridge_commands) == 1
-    assert Path(bridge_commands[0][1]).resolve() == Path(codex_adapter.__file__).with_name(
-        "codex_daemon_hook_bridge.py"
-    ).resolve()
+    assert stale_bridge_command in commands
+    assert stale_direct_command in commands
+    assert len(authenticated_bridge_commands) == 1
+    assert final_state["protection_active"] is True
+    assert final_state["foreign_hook_entries_present"] is True
 
 
 def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_path, capsys, monkeypatch):
@@ -741,6 +1344,38 @@ def test_guard_uninstall_codex_deletes_managed_only_shell_startup_files(tmp_path
     assert (home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish").exists() is False
 
 
+def test_guard_codex_uninstall_removes_authenticated_baseline_before_reinstall(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home = home_dir / ".hol-guard"
+    _build_guard_fixture(home_dir, workspace_dir)
+    context = HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=guard_home,
+    )
+    adapter = CodexHarnessAdapter()
+
+    adapter.install(context)
+    first_state = codex_adapter.codex_native_hook_state(context)
+    manifest_path = Path(str(first_state["manifest_path"]))
+    secret_path = hook_secret_path(guard_home)
+    assert first_state["integrity_status"] == "valid"
+    assert manifest_path.is_file()
+    assert secret_path.is_file()
+
+    adapter.uninstall(context)
+    assert manifest_path.exists() is False
+    assert secret_path.exists() is False
+
+    adapter.install(context)
+    reinstalled_state = codex_adapter.codex_native_hook_state(context)
+    assert reinstalled_state["integrity_status"] == "valid"
+    assert reinstalled_state["integrity_reason"] == "codex_hook_manifest_valid"
+    assert Path(str(reinstalled_state["manifest_path"])).is_file()
+    assert secret_path.is_file()
+
+
 def test_guard_codex_shell_guards_block_zsh_and_bash_secret_reads(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
@@ -1010,20 +1645,8 @@ def test_guard_install_codex_migrates_global_and_workspace_hooks_to_toml(tmp_pat
     workspace_dir = tmp_path / "workspace"
     _write_text(home_dir / ".codex" / "config.toml", 'model = "gpt-5.3-codex"\n')
     _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
-    context = HarnessContext(home_dir=home_dir, guard_home=home_dir / ".hol-guard", workspace_dir=workspace_dir)
-    legacy_group = {
-        "matcher": "Bash",
-        "hooks": [
-            {
-                "type": "command",
-                "command": (
-                    f"python -m codex_plugin_scanner.cli guard hook --guard-home {context.guard_home} --harness codex"
-                ),
-                "timeoutSec": 30,
-                "statusMessage": "HOL Guard checking Bash command",
-            }
-        ],
-    }
+    context = HarnessContext(home_dir=home_dir, guard_home=home_dir, workspace_dir=workspace_dir)
+    legacy_group = codex_adapter._managed_hook_groups(context)["PreToolUse"]
     _write_text(
         home_dir / ".codex" / "hooks.json",
         json.dumps(
@@ -1075,20 +1698,8 @@ def test_guard_install_codex_migrates_legacy_bash_only_managed_hook(tmp_path, ca
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
-    context = HarnessContext(home_dir=home_dir, guard_home=home_dir / ".hol-guard", workspace_dir=workspace_dir)
-    legacy_group = {
-        "matcher": "Bash",
-        "hooks": [
-            {
-                "type": "command",
-                "command": (
-                    f"python -m codex_plugin_scanner.cli guard hook --guard-home {context.guard_home} --harness codex"
-                ),
-                "timeoutSec": 30,
-                "statusMessage": "HOL Guard checking Bash command",
-            }
-        ],
-    }
+    context = HarnessContext(home_dir=home_dir, guard_home=home_dir, workspace_dir=workspace_dir)
+    legacy_group = codex_adapter._managed_hook_groups(context)["PreToolUse"]
     _write_text(
         workspace_dir / ".codex" / "hooks.json",
         json.dumps({"hooks": {"PreToolUse": [legacy_group]}}, indent=2) + "\n",
@@ -1211,7 +1822,7 @@ def test_guard_install_codex_post_tool_use_hook_timeout_covers_max_browser_wait(
     assert hook_timeout == MAX_APPROVAL_WAIT_TIMEOUT_SECONDS + codex_adapter._MANAGED_HOOK_TIMEOUT_GRACE_SECONDS
 
 
-def test_guard_install_codex_migrates_stale_python_c_managed_hooks(tmp_path, capsys):
+def test_guard_install_codex_refuses_ambiguous_stale_python_c_hook(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     stale_worktree = tmp_path / "deleted-worktree"
@@ -1275,22 +1886,20 @@ def test_guard_install_codex_migrates_stale_python_c_managed_hooks(tmp_path, cap
             "--json",
         ]
     )
-    json.loads(capsys.readouterr().out)
-    config_payload = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
-    workspace_config = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    captured = capsys.readouterr()
+    preserved_hooks = json.loads((workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8"))["hooks"]
+    preserved_commands = [
+        handler["command"] for groups in preserved_hooks.values() for group in groups for handler in group["hooks"]
+    ]
 
-    assert install_rc == 0
-    assert (workspace_dir / ".codex" / "hooks.json").exists() is False
-    assert "hooks" not in workspace_config
-    assert len(config_payload["hooks"]["PreToolUse"]) == 1
-    assert len(config_payload["hooks"]["UserPromptSubmit"]) == 1
-    assert len(config_payload["hooks"]["PermissionRequest"]) == 1
-    assert len(config_payload["hooks"]["PostToolUse"]) == 1
-    all_commands = json.dumps(config_payload["hooks"])
-    assert str(stale_worktree) not in all_commands
+    assert install_rc == 1
+    assert "Guard refused to enable existing Codex hook entries without explicit approval" in captured.err
+    assert stale_command in preserved_commands
+    assert (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8") == 'approval_policy = "never"\n'
+    assert (home_dir / ".codex" / "config.toml").exists() is False
 
 
-def test_guard_install_codex_migrates_legacy_wrapper_script_hook(tmp_path, capsys):
+def test_guard_install_codex_refuses_ambiguous_legacy_wrapper_script_hook(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
@@ -1357,22 +1966,16 @@ def test_guard_install_codex_migrates_legacy_wrapper_script_hook(tmp_path, capsy
             "--json",
         ]
     )
-    json.loads(capsys.readouterr().out)
-    config_payload = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
-    workspace_config = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    captured = capsys.readouterr()
 
-    assert install_rc == 0
-    assert (workspace_dir / ".codex" / "hooks.json").exists() is False
-    assert "hooks" not in workspace_config
-    assert len(config_payload["hooks"]["PreToolUse"]) == 1
-    assert len(config_payload["hooks"]["PermissionRequest"]) == 1
-    assert len(config_payload["hooks"]["UserPromptSubmit"]) == 1
-    assert len(config_payload["hooks"]["PostToolUse"]) == 1
-    all_commands = json.dumps(config_payload["hooks"])
-    assert wrapper_command not in all_commands
+    assert install_rc == 1
+    assert "Guard refused to enable existing Codex hook entries without explicit approval" in captured.err
+    assert wrapper_command in (workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8")
+    assert (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8") == 'approval_policy = "never"\n'
+    assert (home_dir / ".codex" / "config.toml").exists() is False
 
 
-def test_guard_install_codex_workspace_cleans_stale_global_managed_hook(tmp_path, capsys):
+def test_guard_install_codex_workspace_refuses_to_rebind_global_managed_hook(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _write_text(
@@ -1405,14 +2008,15 @@ def test_guard_install_codex_workspace_cleans_stale_global_managed_hook(tmp_path
             "--json",
         ]
     )
-    json.loads(capsys.readouterr().out)
+    workspace_output = capsys.readouterr()
 
     home_hooks_path = home_dir / ".codex" / "hooks.json"
     home_config = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
     workspace_config = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
 
     assert global_install_rc == 0
-    assert workspace_install_rc == 0
+    assert workspace_install_rc == 1
+    assert workspace_output.out == ""
     assert home_hooks_path.exists() is False
     assert "hooks" not in workspace_config
     assert len(home_config["hooks"]["PreToolUse"]) == 1
@@ -1424,7 +2028,7 @@ def test_guard_install_codex_workspace_cleans_stale_global_managed_hook(tmp_path
     assert "codex_plugin_scanner.cli" in managed_group["hooks"][0]["command"]
 
 
-def test_guard_install_codex_workspace_preserves_global_user_hooks_while_removing_managed_hooks(tmp_path, capsys):
+def test_guard_install_codex_workspace_context_mismatch_preserves_all_global_hooks(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _write_text(home_dir / ".codex" / "config.toml", 'model = "gpt-5.3-codex"\n')
@@ -1467,11 +2071,12 @@ def test_guard_install_codex_workspace_preserves_global_user_hooks_while_removin
             "--json",
         ]
     )
-    json.loads(capsys.readouterr().out)
+    workspace_output = capsys.readouterr()
     final_home_config = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
 
     assert global_install_rc == 0
-    assert workspace_install_rc == 0
+    assert workspace_install_rc == 1
+    assert workspace_output.out == ""
     assert final_home_config["model"] == "gpt-5.3-codex"
     hooks = final_home_config["hooks"]
     assert hooks["SessionStart"] == [
@@ -1788,6 +2393,35 @@ def test_guard_uninstall_codex_preserves_migrated_alternate_hook_config(tmp_path
     assert home_hooks_path.exists() is False
     home_config = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
     assert home_config["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "python3 custom-pre.py"
+
+
+def test_guard_install_codex_disables_empty_alternate_hook_config(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    context = HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=home_dir / ".hol-guard",
+    )
+    alternate_config_path = workspace_dir / ".codex" / "config.toml"
+    _write_text(
+        alternate_config_path,
+        dump_toml(
+            {
+                "features": {"experimental": True, "hooks": True},
+                "hooks": {
+                    event_name: [group]
+                    for event_name, group in codex_adapter._managed_hook_groups(context).items()
+                },
+            }
+        ),
+    )
+
+    CodexHarnessAdapter().install(context)
+
+    alternate_config = tomllib.loads(alternate_config_path.read_text(encoding="utf-8"))
+    assert alternate_config["features"] == {"experimental": True}
+    assert "hooks" not in alternate_config
 
 
 def test_guard_install_codex_removes_empty_alternate_hook_file(tmp_path, capsys):

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -374,8 +374,10 @@ def test_codex_doctor_marks_partial_native_hook_install_as_broken(tmp_path: Path
     payload = get_adapter("codex").diagnostics(context)
 
     assert payload["setup_status"] == "broken"
-    assert payload["native_hook_state"]["managed_pre_tool_hook_installed"] is True
+    assert payload["native_hook_state"]["managed_pre_tool_hook_installed"] is False
     assert payload["native_hook_state"]["managed_hook_installed"] is False
+    assert payload["native_hook_state"]["integrity_status"] == "missing"
+    assert payload["native_hook_state"]["foreign_hook_entries_present"] is True
     assert any("managed Codex hooks are missing" in warning for warning in payload["warnings"])
 
 


### PR DESCRIPTION
## Summary

- replace heuristic managed-Codex-hook ownership with an authenticated, versioned HMAC manifest stored separately from its Guard-owned secret
- bind installation ID, harness, config target/scope, canonical argv, interpreter identity, wrapper/bridge identities, hook file bytes, generation metadata, and package version
- verify MAC, context binding, exact registered paths/argv, regular-file and symlink state, portable permissions, executable mode, and content hashes before calling a hook managed
- accept current-owner `0775` interpreters and conventional root-owned, root-group `0775` toolchains, where group 0 adds no replacement capability beyond root; continue rejecting world-writable interpreters and all group/world-writable Guard-packaged hook files
- make install/repair transactional across the config, manifest, and signing key with final readback, precise missing/stale/tampered/foreign states, conservative legacy migration, and repair even when the previous coarse state said protection was active
- classify missing config and hook registration as missing rather than tampered, remove stale hook-enable flags from emptied alternate configs, and share one strict persisted-command parser across ownership paths
- require the complete authenticated Guard/runtime/workspace context before install, rebind, uninstall, or cleanup can claim an existing manifest
- remove the authenticated manifest and its now-unused secret on uninstall; reinstall establishes a fresh valid baseline
- when GitHub's Linux toolcache exposes a world-writable Python 3.10 target, replace the resolved CI interpreter target with a mode-0755 copy while preserving any venv symlink, then assert the resulting target is not world-writable; production validation remains strict

## Adversarial coverage

- spoofed basenames/path suffixes/source substrings and foreign user-authored hooks
- copied manifests, bad MACs, changed argv or bytes, executable-bit changes, symlink swaps, stale package identity, and relocated installations
- partial-write failure on both existing and first installs, signing-key rollback, immediate retry, idempotent recheck, legitimate update/repair, legacy migration, uninstall, and reinstall
- missing canonical config, missing live registration, alternate-config cleanup, and preservation of unrelated feature flags
- cross-workspace install/uninstall mismatch with byte-for-byte preservation of the original config and authenticated manifest
- current-owner, root:root hosted-toolchain, group-writable packaged-file, and world-writable interpreter permission boundaries

## Validation

- `131 passed` — Codex install/state/repair/uninstall/update and phase-03 regression selection after the signing-key rollback and full-context ownership fixes
- `2 passed` — focused existing-install and first-install transaction rollback regressions
- `3 passed` — focused missing-state and alternate-config cleanup regressions
- `5 passed, 64 deselected` — final focused secret rollback, full-context mismatch, transaction, and workspace preservation selection
- `412 passed` — CI-failure-equivalent affected module selection after the hosted-toolchain correction; the sole remaining local failure is the known unavailable macOS credential-store test, unrelated to this change
- initial hosted matrix: Python 3.11, 3.12, and 3.13 passed; Python 3.10 exposed a mode-0777 toolcache interpreter and correctly failed closed, motivating the CI-only secured copy
- workflow YAML parses successfully; the fresh hosted matrix is the authoritative Linux validation for the GNU `realpath`, `stat`, and `cp` step
- Ruff formatting and lint passed for all changed files
- Basedpyright passed with `0 errors` for the changed production modules
- `uv build` produced the `2.0.1113` sdist and wheel successfully before the final review fixes

## Attribution and target

- target branch: `release/2.1`
- commit author/committer: `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>`
