### PR TITLE
fix(runtime): model effective cwd across shell segments

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -54,6 +54,7 @@ from ..runtime.approval_reuse import (
     ApprovalReuseValidationFailure,
     evaluate_approval_reuse,
 )
+from ..runtime.signals import GuardRiskSignalV3
 from ..shims import package_shim_status
 from ._commands_shared import *
 from .commands_hook_runtime_state import RuntimeArtifactHookState
@@ -183,6 +184,33 @@ def _runtime_external_archive_has_digest_binding_sink(
     except (OSError, RuntimeError):
         return False
     return resolved_executable == shim_path
+
+
+def _runtime_cisco_scanner_evidence(
+    action_envelope: GuardActionEnvelope,
+    *,
+    runtime_workspace: Path | None,
+    raw_shell_cwds: object,
+) -> tuple[GuardRiskSignalV3, ...]:
+    """Scan every distinct proven shell cwd that may resolve a relative target."""
+
+    workspaces: list[Path | None] = []
+    if isinstance(raw_shell_cwds, list):
+        for value in raw_shell_cwds:
+            if not isinstance(value, str) or not value.strip():
+                continue
+            candidate = Path(value).expanduser().resolve(strict=False)
+            if candidate not in workspaces:
+                workspaces.append(candidate)
+    if not workspaces:
+        workspaces.append(runtime_workspace)
+
+    evidence: list[GuardRiskSignalV3] = []
+    for workspace in workspaces:
+        for signal in scan_action_for_cisco_evidence(action_envelope, workspace=workspace):
+            if signal not in evidence:
+                evidence.append(signal)
+    return tuple(evidence)
 
 
 def _evaluate_runtime_artifact_hook(
@@ -343,9 +371,22 @@ def _evaluate_runtime_artifact_hook(
         current_action_inputs.append(payload_action_normalization.action)
     policy_action = most_restrictive_guard_action(*current_action_inputs)
     changed_capabilities = [runtime_artifact.artifact_type]
+    artifact_metadata = runtime_artifact.metadata if isinstance(runtime_artifact.metadata, dict) else {}
+    raw_shell_cwds = artifact_metadata.get("shell_execution_effective_cwds")
+    shell_context_incomplete = (
+        bool(
+            artifact_metadata.get("shell_execution_context_hash")
+            or artifact_metadata.get("shell_execution_context_hashes")
+        )
+        and artifact_metadata.get("shell_execution_context_complete") is False
+    )
     scanner_evidence = (
-        scan_action_for_cisco_evidence(action_envelope, workspace=runtime_workspace)
-        if action_envelope is not None
+        _runtime_cisco_scanner_evidence(
+            action_envelope,
+            runtime_workspace=runtime_workspace,
+            raw_shell_cwds=raw_shell_cwds,
+        )
+        if action_envelope is not None and not shell_context_incomplete
         else ()
     )
     scanner_evidence_payload = [signal.to_dict() for signal in scanner_evidence]

--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_reads.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_reads.py
@@ -25,17 +25,20 @@ if TYPE_CHECKING:
         _codex_fd_exec_is_bounded_read_only,
         _codex_fd_targets,
         _codex_fd_targets_are_source_like,
-        _codex_resolve_source_like_path,
         _codex_search_target_is_external_source_like,
         _codex_search_target_is_source_like,
         _codex_search_targets,
         _codex_search_targets_are_source_like,
         _git_grep_uses_external_execution,
-        _path_contains_symlink,
         _shell_wrapper_script_index,
     )
 
 
+from ..runtime.shell_execution_context import (
+    ShellExecutionContext,
+    model_shell_execution_context,
+    validate_shell_execution_segment,
+)
 from ._commands_shared import *
 from .commands_parser_helpers import *
 
@@ -138,16 +141,17 @@ def _codex_command_is_read_only_source_inspection(
             return False
         # External targets are allowed only for one direct plain grep command.
         return _codex_command_is_read_only_source_search(command, cwd=cwd, home_dir=home_dir)
+    execution_context = model_shell_execution_context(command, cwd=cwd, workspace_root=cwd)
+    if execution_context.directory_change_present:
+        return _codex_contextual_source_inspection_is_read_only(
+            execution_context,
+            home_dir=home_dir,
+        )
     chained_segments = _split_codex_safe_read_only_chain(command)
     if chained_segments is not None:
-        current_cwd = cwd
         saw_source_inspection = False
         for segment in chained_segments:
-            cd_cwd = _codex_safe_source_cd_cwd(segment, cwd=current_cwd, home_dir=home_dir)
-            if cd_cwd is not None:
-                current_cwd = cd_cwd
-                continue
-            if not _codex_command_is_read_only_source_inspection(segment, cwd=current_cwd, home_dir=home_dir):
+            if not _codex_command_is_read_only_source_inspection(segment, cwd=cwd, home_dir=home_dir):
                 return False
             saw_source_inspection = True
         return saw_source_inspection
@@ -169,25 +173,44 @@ def _codex_command_is_read_only_source_inspection(
     return all(_codex_command_is_bounded_read_only_filter(segment) for segment in filter_segments)
 
 
-def _codex_safe_source_cd_cwd(command_text: str, *, cwd: Path | None, home_dir: Path | None) -> Path | None:
-    try:
-        parts = shlex.split(command_text)
-    except ValueError:
-        return None
-    if len(parts) != 2 or parts[0] != "cd":
-        return None
-    base_dir = (cwd or Path.cwd()).resolve()
-    target = _codex_resolve_source_like_path(parts[1], cwd=cwd, home_dir=home_dir)
-    if target is None or not target.exists() or not target.is_dir():
-        return None
-    target = target.resolve()
-    try:
-        target.relative_to(base_dir)
-    except ValueError:
-        return None
-    if _path_contains_symlink(target, base_dir=base_dir):
-        return None
-    return target
+def _codex_contextual_source_inspection_is_read_only(
+    context: ShellExecutionContext,
+    *,
+    home_dir: Path | None,
+) -> bool:
+    if not context.complete:
+        return False
+    saw_source_inspection = False
+    pipeline_open = False
+    for segment in context.segments:
+        controls = (*segment.control_before, *segment.control_after)
+        if any(operator in {"||", "&"} for operator in controls):
+            return False
+        if segment.directory_operation is not None:
+            pipeline_open = False
+            continue
+        segment_cwd, reason = validate_shell_execution_segment(context, segment)
+        if segment_cwd is None or reason is not None:
+            return False
+        if pipeline_open:
+            if not _codex_command_is_bounded_read_only_filter(segment.command_text):
+                return False
+        elif not (
+            _codex_command_is_read_only_source_search(
+                segment.command_text,
+                cwd=segment_cwd,
+                home_dir=home_dir,
+            )
+            or _codex_command_is_read_only_source_view(
+                segment.command_text,
+                cwd=segment_cwd,
+                home_dir=home_dir,
+            )
+        ):
+            return False
+        saw_source_inspection = True
+        pipeline_open = segment.control_operator in {"|", "|&"}
+    return saw_source_inspection and not pipeline_open
 
 
 def _split_codex_safe_read_only_chain(command: str) -> list[str] | None:
@@ -576,7 +599,6 @@ __all__ = [
     "_codex_command_uses_untrusted_search_binary",
     "_codex_head_tail_args_are_bounded_filter",
     "_codex_head_tail_targets_are_source_like",
-    "_codex_safe_source_cd_cwd",
     "_codex_sed_args_are_bounded_filter",
     "_codex_sed_targets_are_read_only_source_like",
     "_codex_source_inspection_target_tokens",

--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_tool_output.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_tool_output.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from ..runtime.shell_execution_context import model_shell_execution_context, validate_shell_execution_segment
 from ._commands_shared import *
 from .commands_parser_helpers import *
 from .commands_support_codex_paths import _PROMPT_PATH_TOKEN_PATTERN, _codex_search_target_is_source_like
@@ -181,7 +182,27 @@ def _codex_command_targets_secret_like_source_name(
     *,
     cwd: Path | None = None,
     home_dir: Path | None = None,
+    _execution_context_applied: bool = False,
 ) -> bool:
+    if not _execution_context_applied:
+        execution_context = model_shell_execution_context(command_text, cwd=cwd, workspace_root=cwd)
+        if execution_context.directory_change_present:
+            if not execution_context.complete:
+                return True
+            for segment in execution_context.segments:
+                if segment.directory_operation is not None:
+                    continue
+                segment_cwd, reason = validate_shell_execution_segment(execution_context, segment)
+                if segment_cwd is None or reason is not None:
+                    return True
+                if _codex_command_targets_secret_like_source_name(
+                    segment.command_text,
+                    cwd=segment_cwd,
+                    home_dir=home_dir,
+                    _execution_context_applied=True,
+                ):
+                    return True
+            return False
     chained_segments = _split_codex_safe_read_only_chain(command_text)
     if chained_segments is not None:
         return any(
@@ -226,7 +247,32 @@ def _codex_command_references_sensitive_local_source(command_text: str, *, cwd: 
     return bool(_codex_sensitive_local_source_matches(command_text, cwd=cwd))
 
 
-def _codex_sensitive_local_source_matches(command_text: str, *, cwd: Path | None) -> list[SecretPathMatch]:
+def _codex_sensitive_local_source_matches(
+    command_text: str,
+    *,
+    cwd: Path | None,
+    _execution_context_applied: bool = False,
+) -> list[SecretPathMatch]:
+    if not _execution_context_applied:
+        execution_context = model_shell_execution_context(command_text, cwd=cwd, workspace_root=cwd)
+        if execution_context.directory_change_present:
+            if not execution_context.complete:
+                return []
+            contextual_matches: list[SecretPathMatch] = []
+            for segment in execution_context.segments:
+                if segment.directory_operation is not None:
+                    continue
+                segment_cwd, reason = validate_shell_execution_segment(execution_context, segment)
+                if segment_cwd is None or reason is not None:
+                    return []
+                contextual_matches.extend(
+                    _codex_sensitive_local_source_matches(
+                        segment.command_text,
+                        cwd=segment_cwd,
+                        _execution_context_applied=True,
+                    )
+                )
+            return _dedupe_codex_secret_path_matches(contextual_matches)
     matches = _codex_sensitive_path_matches_in_text(command_text, cwd=cwd)
     try:
         parts = shlex.split(command_text)

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
@@ -29,11 +29,28 @@ if TYPE_CHECKING:
     )
     from .commands_support_hook_payload import _coalesce_string
     from .commands_support_runtime_policy import _runtime_data_flow_summary
-    from .commands_support_runtime_resolution import _canonical_harness_name, _runtime_policy_path
+
+    # These helpers are injected by commands_support's shared registry at
+    # runtime. Local signatures retain type safety without introducing a
+    # type-only import cycle with commands_support_runtime_resolution.
+    def _canonical_harness_name(value: str) -> str: ...
+
+    def _runtime_policy_path(
+        harness: str,
+        home_dir: Path,
+        workspace: Path | None,
+        *,
+        payload: dict[str, object] | None = None,
+    ) -> Path: ...
 
 
 from ..runtime.kubernetes_commands import kubernetes_secret_read_source
 from ..runtime.shell_command_wrappers import normalize_transparent_shell_command
+from ..runtime.shell_execution_context import (
+    model_shell_execution_context,
+    shell_execution_context_metadata,
+    validate_shell_execution_segment,
+)
 from ._commands_shared import *
 from .commands_parser_helpers import *
 from .commands_support_codex_commands import (
@@ -443,12 +460,16 @@ def _codex_post_tool_output_artifact(
         return None
     merged_output_capture = _codex_command_captures_combined_shell_output(command_text)
     focused_pytest = _codex_command_is_focused_pytest_verification(command_text)
+    execution_context = model_shell_execution_context(command_text, cwd=cwd, workspace_root=cwd)
     fingerprint = hashlib.sha256(
         json.dumps(
             {
                 "tool_name": tool_name,
                 "command_text": command_text,
                 "output_class": "credential-looking output",
+                "shell_execution_context_hash": (
+                    execution_context.context_hash if execution_context.directory_change_present else None
+                ),
             },
             sort_keys=True,
         ).encode("utf-8")
@@ -507,6 +528,8 @@ def _codex_post_tool_output_artifact(
             merged_output_capture=merged_output_capture,
         ),
     }
+    if execution_context.directory_change_present:
+        metadata.update(shell_execution_context_metadata(execution_context))
     if merged_output_capture:
         metadata["output_capture_mode"] = "merged-stderr"
     if local_secret_source is not None:
@@ -543,6 +566,19 @@ def _codex_text_contains_sensitive_path_token(text: str, *, cwd: Path | None) ->
 
 
 def _codex_command_may_read_local_content(command_text: str, *, cwd: Path | None) -> bool:
+    execution_context = model_shell_execution_context(command_text, cwd=cwd, workspace_root=cwd)
+    if execution_context.directory_change_present:
+        if not execution_context.complete:
+            return True
+        for segment in execution_context.segments:
+            if segment.directory_operation is not None:
+                continue
+            segment_cwd, reason = validate_shell_execution_segment(execution_context, segment)
+            if segment_cwd is None or reason is not None:
+                return True
+            if _codex_command_may_read_local_content(segment.command_text, cwd=segment_cwd):
+                return True
+        return False
     if _codex_command_references_sensitive_local_source(command_text, cwd=cwd):
         return True
     if _codex_command_reads_environment_pipeline(command_text):

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -440,7 +440,28 @@ def _runtime_hook_approval_context_token(
     never serialized into the stored token itself.
     """
 
-    effective_cwd = _normalized_runtime_context_path(runtime_workspace or Path.cwd())
+    metadata = artifact.metadata if isinstance(artifact.metadata, dict) else {}
+    shell_context_present = bool(
+        metadata.get("shell_execution_context_hash") or metadata.get("shell_execution_context_hashes")
+    )
+    # Reuse requires the producer's explicit completeness proof.  Missing or
+    # malformed legacy metadata fails closed instead of being inferred from a
+    # separate reason-code field.
+    shell_context_complete = metadata.get("shell_execution_context_complete") is True
+    raw_effective_cwds = metadata.get("shell_execution_effective_cwds")
+    effective_cwd_values = raw_effective_cwds if isinstance(raw_effective_cwds, list) else []
+    shell_effective_cwds = tuple(
+        _normalized_runtime_context_path(Path(value))
+        for value in effective_cwd_values
+        if isinstance(value, str) and value.strip()
+    )
+    launch_cwd = Path(shell_effective_cwds[-1]) if shell_effective_cwds else runtime_workspace or Path.cwd()
+    if shell_effective_cwds:
+        effective_cwd = shell_effective_cwds[-1]
+    elif shell_context_present:
+        effective_cwd = None
+    else:
+        effective_cwd = _normalized_runtime_context_path(runtime_workspace or Path.cwd())
     configured_workspace = (
         _normalized_runtime_context_path(config.workspace) if config.workspace is not None else None
     )
@@ -449,7 +470,37 @@ def _runtime_hook_approval_context_token(
         if action_envelope is not None and action_envelope.workspace is not None
         else None
     )
-    metadata = artifact.metadata if isinstance(artifact.metadata, dict) else {}
+    executable_identity: object
+    shell_executable_identities: tuple[dict[str, object], ...] | None = None
+    if shell_context_present and not shell_context_complete:
+        executable_identity = {
+            "status": "unresolved_shell_execution_context",
+            "reason_code": metadata.get("shell_execution_context_reason_code")
+            or metadata.get("shell_execution_context_reason_codes"),
+            "reuse_nonce": secrets.token_hex(16),
+        }
+        shell_executable_identities = (
+            {
+                "cwd": None,
+                "identity": executable_identity,
+            },
+        )
+    else:
+        executable_identity = _runtime_hook_executable_identity(
+            artifact,
+            launch_cwd=launch_cwd,
+        )
+        if shell_context_present:
+            shell_executable_identities = tuple(
+                {
+                    "cwd": cwd,
+                    "identity": _runtime_hook_executable_identity(
+                        artifact,
+                        launch_cwd=Path(cwd),
+                    ),
+                }
+                for cwd in shell_effective_cwds
+            )
     return build_approval_context_token(
         identity={
             "artifact_id": artifact.artifact_id,
@@ -458,12 +509,11 @@ def _runtime_hook_approval_context_token(
             "config_path": artifact.config_path,
             "configured_workspace": configured_workspace,
             "cwd": effective_cwd,
+            "shell_effective_cwds": shell_effective_cwds,
+            "shell_executables": shell_executable_identities,
             "envelope_workspace": envelope_workspace,
             "envelope_workspace_hash": action_envelope.workspace_hash if action_envelope is not None else None,
-            "executable": _runtime_hook_executable_identity(
-                artifact,
-                launch_cwd=runtime_workspace or Path.cwd(),
-            ),
+            "executable": executable_identity,
             "guard_home": _normalized_runtime_context_path(config.guard_home),
             "harness": artifact.harness,
             "publisher": artifact.publisher,
@@ -472,6 +522,10 @@ def _runtime_hook_approval_context_token(
         content={
             "artifact_content_hash": content_hash,
             "command_security_identity": metadata.get("command_security_identity"),
+            "shell_execution_context_hash": metadata.get("shell_execution_context_hash"),
+            "shell_execution_context_hashes": metadata.get("shell_execution_context_hashes"),
+            "shell_execution_context_reason_code": metadata.get("shell_execution_context_reason_code"),
+            "shell_execution_context_reason_codes": metadata.get("shell_execution_context_reason_codes"),
         },
         capabilities={
             "action_envelope": _runtime_hook_action_capabilities(action_envelope),

--- a/src/codex_plugin_scanner/guard/runtime/_shell_execution_context_support.py
+++ b/src/codex_plugin_scanner/guard/runtime/_shell_execution_context_support.py
@@ -1,0 +1,490 @@
+"""Private lexer and path helpers for shell execution-context modeling."""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+from .shell_structure import extract_heredocs
+
+SHELL_CWD_UNRESOLVED_EXPRESSION = "shell_cwd_unresolved_expression"
+SHELL_CWD_MISSING_DIRECTORY = "shell_cwd_missing_directory"
+SHELL_CWD_NOT_DIRECTORY = "shell_cwd_not_directory"
+SHELL_CWD_UNREADABLE_DIRECTORY = "shell_cwd_unreadable_directory"
+SHELL_CWD_AMBIGUOUS_STACK = "shell_cwd_ambiguous_stack"
+SHELL_CWD_STACK_LIMIT = "shell_cwd_stack_limit"
+SHELL_CWD_WORKSPACE_ESCAPE = "shell_cwd_workspace_escape"
+SHELL_CWD_SYMLINK_ESCAPE = "shell_cwd_symlink_escape"
+SHELL_CWD_UNRESOLVED_CONTROL_FLOW = "shell_cwd_unresolved_control_flow"
+SHELL_CWD_UNRESOLVED_PARENT_SHELL = "shell_cwd_unresolved_parent_shell_effect"
+SHELL_CWD_UNRESOLVED_SYNTAX = "shell_cwd_unresolved_syntax"
+SHELL_CWD_PATH_CHANGED = "shell_cwd_path_changed"
+
+DIRECTORY_COMMANDS = frozenset({"cd", "pushd", "popd"})
+_UNMODELED_SHELL_CONTROL_WORDS = frozenset({"do", "elif", "else", "if", "then", "until", "while"})
+FLOW_OPERATORS = frozenset({"&&", "||", ";", "\n", "|", "|&", "&"})
+GROUP_OPERATORS = frozenset({"(", ")", "{", "}"})
+CONTROL_TOKENS = FLOW_OPERATORS | GROUP_OPERATORS
+MAX_DIRECTORY_STACK_DEPTH = 32
+_NEWLINE_SENTINEL = "__HOL_GUARD_SHELL_NEWLINE__"
+_FD_AMPERSAND_SENTINEL = "__HOL_GUARD_SHELL_FD_AMPERSAND__"
+_SHELL_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
+SHELL_DIRECTORY_COMMAND = re.compile(
+    r"(?:^|(?:&&|\|\||[;|&(){}\n]))\s*"
+    r"(?:(?:builtin|command|time)\s+(?:-[^\s]+\s+)*|function\s+|!\s+)?"
+    r"(?:cd|pushd|popd)\b"
+)
+_REDIRECTION_TOKEN = re.compile(r"^(?:[012]?(?:>|>>|<|<<|<>).*)$")
+
+
+@dataclass(frozen=True, slots=True)
+class ShellPathIdentity:
+    """Filesystem identity captured without retaining an open descriptor."""
+
+    device: int
+    inode: int
+    mode: int
+    change_time_ns: int
+
+    @classmethod
+    def from_stat(cls, value: os.stat_result) -> ShellPathIdentity:
+        return cls(
+            device=value.st_dev,
+            inode=value.st_ino,
+            mode=stat.S_IFMT(value.st_mode),
+            change_time_ns=value.st_ctime_ns,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ShellPathProof:
+    """A lexical directory path bound to the target observed during modeling."""
+
+    lexical_path: Path
+    resolved_path: Path
+    identity: ShellPathIdentity
+
+
+@dataclass(frozen=True, slots=True)
+class DirectoryOperation:
+    name: str
+    operand: str | None
+    reason_code: str | None = None
+
+
+def split_shell_tokens(command_text: str) -> tuple[str, ...]:
+    command_text = _mask_heredoc_bodies(command_text)
+    command_text = _protect_fd_redirection_ampersands(command_text)
+    lexer = shlex.shlex(
+        _replace_unquoted_newlines(command_text),
+        posix=True,
+        punctuation_chars=";&|(){}",
+    )
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    tokens: list[str] = []
+    for token in lexer:
+        if token == _NEWLINE_SENTINEL:
+            tokens.append("\n")
+        elif token and all(character in ";&|(){}" for character in token):
+            tokens.extend(_split_punctuation_run(token))
+        else:
+            tokens.append(token.replace(_FD_AMPERSAND_SENTINEL, "&"))
+    return tuple(tokens)
+
+
+def _protect_fd_redirection_ampersands(command_text: str) -> str:
+    if _FD_AMPERSAND_SENTINEL in command_text:
+        raise ValueError("reserved shell parsing sentinel")
+    result: list[str] = []
+    quote: str | None = None
+    escaped = False
+    index = 0
+    while index < len(command_text):
+        character = command_text[index]
+        if escaped:
+            result.append(character)
+            escaped = False
+            index += 1
+            continue
+        if character == "\\":
+            result.append(character)
+            escaped = True
+            index += 1
+            continue
+        if quote is None and character in {"'", '"', "`"}:
+            quote = character
+            result.append(character)
+            index += 1
+            continue
+        if quote == character:
+            quote = None
+            result.append(character)
+            index += 1
+            continue
+        if quote is None and character == "&" and _is_adjacent_fd_duplication(command_text, index):
+            result.append(_FD_AMPERSAND_SENTINEL)
+        else:
+            result.append(character)
+        index += 1
+    return "".join(result)
+
+
+def _is_adjacent_fd_duplication(command_text: str, ampersand_index: int) -> bool:
+    if ampersand_index == 0 or command_text[ampersand_index - 1] not in {"<", ">"}:
+        return False
+    if ampersand_index >= 2 and command_text[ampersand_index - 2] in {"<", ">"}:
+        return False
+    target_index = ampersand_index + 1
+    if target_index >= len(command_text):
+        return False
+    if command_text[target_index] == "-":
+        target_end = target_index + 1
+    elif command_text[target_index].isdigit():
+        target_end = target_index + 1
+        while target_end < len(command_text) and command_text[target_end].isdigit():
+            target_end += 1
+    else:
+        return False
+    return (
+        target_end == len(command_text) or command_text[target_end].isspace() or command_text[target_end] in ";&|(){}"
+    )
+
+
+def _mask_heredoc_bodies(command_text: str) -> str:
+    heredocs = extract_heredocs(command_text)
+    if not heredocs:
+        return command_text
+    characters = list(command_text)
+    for heredoc in heredocs:
+        start = max(0, heredoc.body_start - 1)
+        for index in range(start, min(heredoc.end, len(characters))):
+            characters[index] = " "
+        if heredoc.end > 0 and heredoc.end <= len(command_text) and command_text[heredoc.end - 1] == "\n":
+            characters[heredoc.end - 1] = "\n"
+    return "".join(characters)
+
+
+def _split_punctuation_run(token: str) -> tuple[str, ...]:
+    result: list[str] = []
+    index = 0
+    while index < len(token):
+        pair = token[index : index + 2]
+        if pair in {"&&", "||", "|&"}:
+            result.append(pair)
+            index += 2
+            continue
+        result.append(token[index])
+        index += 1
+    return tuple(result)
+
+
+def _replace_unquoted_newlines(command_text: str) -> str:
+    result: list[str] = []
+    quote: str | None = None
+    escaped = False
+    for character in command_text:
+        if escaped:
+            result.append(character)
+            escaped = False
+            continue
+        if character == "\\":
+            result.append(character)
+            escaped = True
+            continue
+        if quote is None and character in {"'", '"', "`"}:
+            quote = character
+            result.append(character)
+            continue
+        if quote == character:
+            quote = None
+            result.append(character)
+            continue
+        if quote is None and character in {"\n", "\r"}:
+            result.extend((" ", _NEWLINE_SENTINEL, " "))
+            continue
+        result.append(character)
+    return "".join(result)
+
+
+def ordered_segments(
+    tokens: tuple[str, ...],
+) -> tuple[tuple[tuple[tuple[str, ...], tuple[str, ...]], ...], tuple[str, ...]]:
+    segments: list[tuple[tuple[str, ...], tuple[str, ...]]] = []
+    current: list[str] = []
+    pending_controls: list[str] = []
+    controls_before: tuple[str, ...] = ()
+    for token in tokens:
+        if token in CONTROL_TOKENS or _is_unknown_control_token(token):
+            if current:
+                segments.append((tuple(current), controls_before))
+                current = []
+                controls_before = ()
+            pending_controls.append(token)
+            continue
+        if not current:
+            controls_before = tuple(pending_controls)
+            pending_controls = []
+        current.append(token)
+    if current:
+        segments.append((tuple(current), controls_before))
+        pending_controls = []
+    return tuple(segments), tuple(pending_controls)
+
+
+def parent_shell_cwd_construct_reason(
+    segments: tuple[tuple[tuple[str, ...], tuple[str, ...]], ...],
+    trailing_controls: tuple[str, ...],
+) -> str | None:
+    """Reject parent-shell constructs whose cwd effects cannot be modeled safely."""
+
+    for index, (tokens, _controls_before) in enumerate(segments):
+        controls_after = segments[index + 1][1] if index + 1 < len(segments) else trailing_controls
+        if _is_function_definition(tokens, controls_after) and _function_body_may_change_cwd(segments, index):
+            return SHELL_CWD_UNRESOLVED_PARENT_SHELL
+        if _segment_has_unmodeled_parent_cwd_effect(tokens):
+            return SHELL_CWD_UNRESOLVED_PARENT_SHELL
+    return None
+
+
+def _is_function_definition(tokens: tuple[str, ...], controls_after: tuple[str, ...]) -> bool:
+    if "{" not in controls_after:
+        return False
+    if len(tokens) >= 2 and tokens[0] == "function":
+        return bool(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", tokens[1]))
+    return (
+        len(tokens) == 1
+        and bool(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", tokens[0]))
+        and "(" in controls_after
+        and ")" in controls_after
+    )
+
+
+def _function_body_may_change_cwd(
+    segments: tuple[tuple[tuple[str, ...], tuple[str, ...]], ...],
+    definition_index: int,
+) -> bool:
+    brace_depth = 0
+    for tokens, controls_before in segments[definition_index + 1 :]:
+        for control in controls_before:
+            if control == "{":
+                brace_depth += 1
+            elif control == "}":
+                brace_depth -= 1
+        if brace_depth <= 0:
+            return False
+        if directory_operation(tokens) is not None or _segment_has_unmodeled_parent_cwd_effect(tokens):
+            return True
+    return False
+
+
+def _segment_has_unmodeled_parent_cwd_effect(tokens: tuple[str, ...]) -> bool:
+    index = 0
+    while index < len(tokens) and _SHELL_ASSIGNMENT.match(tokens[index]):
+        index += 1
+    if index >= len(tokens):
+        return False
+    command = tokens[index]
+    if command in {".", "eval", "source"}:
+        return True
+    if command != "trap" or index + 2 >= len(tokens):
+        return False
+    handler = tokens[index + 1]
+    signals = {token.upper().removeprefix("SIG") for token in tokens[index + 2 :]}
+    return "DEBUG" in signals and handler not in {"", "-"}
+
+
+def _is_unknown_control_token(token: str) -> bool:
+    return bool(token) and all(character in ";&|(){}" for character in token)
+
+
+def control_sequence_reason(controls: tuple[str, ...], *, trailing: bool = False) -> str | None:
+    if any(control not in CONTROL_TOKENS for control in controls):
+        return SHELL_CWD_UNRESOLVED_SYNTAX
+    flows: list[str] = []
+    for index, control in enumerate(controls):
+        if control not in FLOW_OPERATORS:
+            continue
+        next_control = controls[index + 1] if index + 1 < len(controls) else None
+        if next_control in {
+            ")",
+            "}",
+        }:
+            if control not in {";", "\n", "&"}:
+                return SHELL_CWD_UNRESOLVED_SYNTAX
+            continue
+        flows.append(control)
+    if trailing:
+        if not flows:
+            return None
+        if len(flows) == 1 and flows[0] in {";", "\n", "&"}:
+            return None
+        return SHELL_CWD_UNRESOLVED_SYNTAX
+    if len(flows) > 1:
+        return SHELL_CWD_UNRESOLVED_SYNTAX
+    return None
+
+
+def directory_operation(tokens: tuple[str, ...]) -> DirectoryOperation | None:
+    index = 0
+    while index < len(tokens) and _SHELL_ASSIGNMENT.match(tokens[index]):
+        index += 1
+    if index >= len(tokens):
+        return None
+    command = tokens[index]
+    if command in _UNMODELED_SHELL_CONTROL_WORDS:
+        embedded_command = next((token for token in tokens[index + 1 :] if token in DIRECTORY_COMMANDS), None)
+        if embedded_command is not None:
+            return DirectoryOperation(embedded_command, None, SHELL_CWD_UNRESOLVED_CONTROL_FLOW)
+    if command in {"!", "builtin", "command", "function", "time"}:
+        wrapped_index = next(
+            (candidate for candidate in range(index + 1, len(tokens)) if tokens[candidate] in DIRECTORY_COMMANDS),
+            None,
+        )
+        if wrapped_index is None:
+            return None
+        if command in {"command", "time"} and wrapped_index == index + 1:
+            index = wrapped_index
+            command = tokens[index]
+        else:
+            return DirectoryOperation(tokens[wrapped_index], None, SHELL_CWD_UNRESOLVED_EXPRESSION)
+    if command not in DIRECTORY_COMMANDS:
+        return None
+    arguments = _directory_arguments(tokens[index + 1 :])
+    if arguments is None:
+        return DirectoryOperation(command, None, SHELL_CWD_UNRESOLVED_EXPRESSION)
+    if command == "popd":
+        if arguments:
+            return DirectoryOperation(command, None, SHELL_CWD_AMBIGUOUS_STACK)
+        return DirectoryOperation(command, None)
+    if command == "cd" and arguments[:1] == ("--",):
+        arguments = arguments[1:]
+    elif arguments and arguments[0].startswith("-"):
+        return DirectoryOperation(command, None, SHELL_CWD_UNRESOLVED_EXPRESSION)
+    if len(arguments) != 1 or _operand_is_dynamic(arguments[0]):
+        return DirectoryOperation(command, None, SHELL_CWD_UNRESOLVED_EXPRESSION)
+    if command == "pushd" and re.fullmatch(r"[+-]\d+", arguments[0]):
+        return DirectoryOperation(command, None, SHELL_CWD_AMBIGUOUS_STACK)
+    return DirectoryOperation(command, arguments[0])
+
+
+def _directory_arguments(tokens: tuple[str, ...]) -> tuple[str, ...] | None:
+    arguments: list[str] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if _REDIRECTION_TOKEN.match(token):
+            if token in {">", ">>", "<", "<<", "0>", "1>", "2>"}:
+                if index + 1 >= len(tokens):
+                    return None
+                index += 2
+            else:
+                index += 1
+            continue
+        arguments.append(token)
+        index += 1
+    return tuple(arguments)
+
+
+def _operand_is_dynamic(value: str) -> bool:
+    if not value or "\x00" in value or value.startswith("~"):
+        return True
+    return any(character in value for character in ("$", "`", "*", "?", "[", "]", "{", "}", "<", ">"))
+
+
+def resolve_directory_operand(
+    value: str,
+    *,
+    current_cwd: Path,
+    workspace_root: Path,
+) -> tuple[Path | None, ShellPathIdentity | None, ShellPathProof | None, str | None]:
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        candidate = current_cwd / candidate
+    lexical_candidate = Path(os.path.abspath(candidate))
+    try:
+        resolved = candidate.resolve(strict=True)
+    except (FileNotFoundError, NotADirectoryError):
+        return None, None, None, SHELL_CWD_MISSING_DIRECTORY
+    except (OSError, RuntimeError):
+        return None, None, None, SHELL_CWD_UNREADABLE_DIRECTORY
+    try:
+        value_stat = resolved.stat()
+    except OSError:
+        return None, None, None, SHELL_CWD_UNREADABLE_DIRECTORY
+    if not stat.S_ISDIR(value_stat.st_mode):
+        return None, None, None, SHELL_CWD_NOT_DIRECTORY
+    if not _directory_is_readable(resolved, value_stat.st_mode):
+        return None, None, None, SHELL_CWD_UNREADABLE_DIRECTORY
+    if not is_within(resolved, workspace_root):
+        reason = (
+            SHELL_CWD_SYMLINK_ESCAPE
+            if is_within(lexical_candidate, workspace_root)
+            and _path_contains_symlink(lexical_candidate, workspace_root=workspace_root)
+            else SHELL_CWD_WORKSPACE_ESCAPE
+        )
+        return None, None, None, reason
+    identity = ShellPathIdentity.from_stat(value_stat)
+    proof = ShellPathProof(lexical_path=lexical_candidate, resolved_path=resolved, identity=identity)
+    return resolved, identity, proof, None
+
+
+def existing_directory(path: Path) -> tuple[Path | None, ShellPathIdentity | None, str | None]:
+    try:
+        resolved = path.expanduser().resolve(strict=True)
+    except (FileNotFoundError, NotADirectoryError):
+        return None, None, SHELL_CWD_MISSING_DIRECTORY
+    except (OSError, RuntimeError):
+        return None, None, SHELL_CWD_UNREADABLE_DIRECTORY
+    try:
+        value_stat = resolved.stat()
+    except OSError:
+        return None, None, SHELL_CWD_UNREADABLE_DIRECTORY
+    if not stat.S_ISDIR(value_stat.st_mode):
+        return None, None, SHELL_CWD_NOT_DIRECTORY
+    if not _directory_is_readable(resolved, value_stat.st_mode):
+        return None, None, SHELL_CWD_UNREADABLE_DIRECTORY
+    return resolved, ShellPathIdentity.from_stat(value_stat), None
+
+
+def _directory_is_readable(path: Path, mode: int) -> bool:
+    if not (mode & 0o444) or not (mode & 0o111):
+        return False
+    try:
+        return os.access(path, os.R_OK | os.X_OK, effective_ids=True)
+    except (NotImplementedError, TypeError):
+        return os.access(path, os.R_OK | os.X_OK)
+
+
+def _path_contains_symlink(path: Path, *, workspace_root: Path) -> bool:
+    try:
+        relative = path.relative_to(workspace_root)
+    except ValueError:
+        relative = path
+    current = workspace_root if not relative.is_absolute() else Path(relative.anchor)
+    for part in relative.parts:
+        if part in {relative.anchor, "", ".", ".."}:
+            continue
+        current = current / part
+        try:
+            if current.is_symlink():
+                return True
+        except OSError:
+            return True
+    return False
+
+
+def is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def last_flow_operator(controls: tuple[str, ...]) -> str | None:
+    return next((control for control in reversed(controls) if control in FLOW_OPERATORS), None)

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
@@ -103,6 +103,9 @@ class PackageIntent:
     flags: tuple[str, ...] = ()
     notes: tuple[str, ...] = ()
     local_executions: tuple[LocalPackageExecutionEvidence, ...] = ()
+    execution_context_hashes: tuple[str, ...] = ()
+    execution_context_cwds: tuple[str, ...] = ()
+    execution_context_reason_codes: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         payload = asdict(self)
@@ -148,6 +151,9 @@ def build_package_request_artifact(
                 "manifest_paths": list(manifest_paths),
                 "lockfile_paths": list(lockfile_paths),
                 "local_executions": [evidence.to_dict() for evidence in intent.local_executions],
+                "execution_context_hashes": list(intent.execution_context_hashes),
+                "execution_context_cwds": list(intent.execution_context_cwds),
+                "execution_context_reason_codes": list(intent.execution_context_reason_codes),
             },
             sort_keys=True,
         ).encode("utf-8")
@@ -170,6 +176,11 @@ def build_package_request_artifact(
             "flags": list(intent.flags),
             "notes": list(intent.notes),
             "local_executions": [evidence.to_dict() for evidence in intent.local_executions],
+            "shell_execution_context_hashes": list(intent.execution_context_hashes),
+            "shell_execution_effective_cwds": list(intent.execution_context_cwds),
+            "shell_execution_context_reason_codes": list(intent.execution_context_reason_codes),
+            "shell_execution_context_complete": not intent.execution_context_reason_codes,
+            "effective_cwd": intent.execution_context_cwds[-1] if intent.execution_context_cwds else None,
             "redacted_command": intent.redacted_command,
             "request_summary": package_request_summary(intent),
             "runtime_request_signals": [f"invokes a package {intent.intent_kind} request via {intent.package_manager}"],

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from ..protect import _collect_package_specs
+from ._shell_execution_context_support import ShellPathIdentity
 from .command_model import CanonicalCommand
 from .homebrew_intent import parse_brew_intent
 from .mcp_protection import _command_name, _package_token
@@ -38,12 +39,19 @@ from .package_intent_common import (
 )
 from .package_manager_command import strip_package_manager_global_options
 from .secret_file_requests import _SHELL_TOOL_NAMES, _candidate_command_texts, _normalize_tool_name
+from .shell_execution_context import (
+    ShellExecutionContext,
+    ShellExecutionSegment,
+    model_shell_execution_context,
+    validate_shell_execution_segment,
+)
 
 _CONTROL_TOKENS = {"&&", "||", ";", "|", "|&", "&"}
 _CONTROL_CONTEXT_LABELS = {
     "&&": "and",
     "||": "or",
     ";": "sequence",
+    "\n": "sequence",
     "|": "pipe",
     "|&": "pipe-stderr",
     "&": "background",
@@ -94,9 +102,11 @@ class _CommandSegment:
     redacted_tokens: tuple[str, ...]
     effective_path: str | None
     path_source: str
-    effective_cwd: Path
+    effective_cwd: Path | None
     cwd_source: str
     context_hash: str
+    context_complete: bool
+    context_reason_code: str | None
 
 
 def parse_package_intent(
@@ -147,6 +157,7 @@ def parse_package_intent(
         handler = handlers.get(command_name)
         if handler is None:
             continue
+        segment_workspace = segment.effective_cwd if segment.context_complete else None
         if command_name in _LOCAL_EXECUTION_COMMANDS:
             intent = _parse_exec_intent(
                 segment.tokens,
@@ -156,10 +167,24 @@ def parse_package_intent(
                 effective_cwd=segment.effective_cwd,
                 cwd_source=segment.cwd_source,
                 execution_context_hash=segment.context_hash,
+                execution_context_complete=segment.context_complete,
             )
         else:
-            intent = handler(segment.tokens, workspace=workspace)
+            intent = handler(segment.tokens, workspace=segment_workspace)
         if intent is not None:
+            if segment.context_complete and segment_workspace is not None:
+                intent = _rebase_intent_paths(intent, from_directory=segment_workspace, workspace=workspace)
+            elif segment.context_reason_code is not None:
+                intent = replace(intent, notes=(*intent.notes, segment.context_reason_code))
+            if segment.cwd_source.startswith(("shell_", "env_chdir")) or segment.context_reason_code is not None:
+                intent = replace(
+                    intent,
+                    execution_context_hashes=(segment.context_hash,),
+                    execution_context_cwds=((str(segment.effective_cwd),) if segment.effective_cwd is not None else ()),
+                    execution_context_reason_codes=(
+                        (segment.context_reason_code,) if segment.context_reason_code is not None else ()
+                    ),
+                )
             intents.append(replace(intent, redacted_command=redacted_command(segment.redacted_tokens)))
     return _combine_package_intents(tuple(intents))
 
@@ -279,6 +304,7 @@ def _parse_exec_intent(
     effective_cwd: Path | None = None,
     cwd_source: str = "not_applicable",
     execution_context_hash: str = "not_applicable",
+    execution_context_complete: bool = True,
 ) -> PackageIntent | None:
     package_token = _exec_package_spec(tokens)
     if package_token is None:
@@ -288,12 +314,13 @@ def _parse_exec_intent(
     target = python_target(package_token) if ecosystem == "pypi" else js_target(package_token)
     manifest_candidates = ("package.json",) if command in _LOCAL_EXECUTION_COMMANDS else ()
     lockfile_candidates = _JS_LOCKFILE_NAMES if command in _LOCAL_EXECUTION_COMMANDS else ()
+    intent_workspace = effective_cwd if command in _LOCAL_EXECUTION_COMMANDS else workspace
     intent = _build_intent(
         command,
         "execute",
         tokens,
         (target,),
-        workspace=workspace,
+        workspace=intent_workspace if execution_context_complete else None,
         manifest_candidates=manifest_candidates,
         lockfile_candidates=lockfile_candidates,
     )
@@ -305,7 +332,7 @@ def _parse_exec_intent(
         workspace=workspace,
         effective_path=effective_path,
         path_source=path_source,
-        effective_cwd=effective_cwd or workspace or Path.cwd(),
+        effective_cwd=effective_cwd if execution_context_complete else None,
         cwd_source=cwd_source,
         execution_context_hash=execution_context_hash,
         manifest_paths=intent.manifest_paths,
@@ -369,13 +396,17 @@ def _lockfiles_record_typescript(lockfiles: tuple[PackageExecutionFileEvidence, 
 
 
 def _is_read_only_typescript_argument(token: str) -> bool:
-    if token in _TSC_READ_ONLY_FLAGS or token == "2>":
+    if token in _TSC_READ_ONLY_FLAGS or token == "2>" or _is_safe_fd_duplication_redirect(token):
         return True
     if re.match(r"^\d*(?:>>?|<<?)", token):
         return False
     if token.startswith("-"):
         return False
     return token.endswith((".cts", ".mts", ".ts", ".tsx"))
+
+
+def _is_safe_fd_duplication_redirect(token: str) -> bool:
+    return re.fullmatch(r"[012]?[<>]&(?:[012]|-)", token) is not None
 
 
 def _local_execution_disables_install(tokens: tuple[str, ...]) -> bool:
@@ -453,7 +484,7 @@ def _local_package_execution_evidence(
     workspace: Path | None,
     effective_path: str | None,
     path_source: str,
-    effective_cwd: Path,
+    effective_cwd: Path | None,
     cwd_source: str,
     execution_context_hash: str,
     manifest_paths: tuple[str, ...],
@@ -461,6 +492,21 @@ def _local_package_execution_evidence(
 ) -> LocalPackageExecutionEvidence:
     package_spec = _exec_package_spec(tokens)
     package_name = js_target(package_spec).package_name if package_spec is not None else None
+    if effective_cwd is None:
+        return LocalPackageExecutionEvidence(
+            manager_name=command,
+            path_source=path_source,
+            effective_cwd="<unresolved>",
+            cwd_source=cwd_source,
+            manager_is_guard_shim=False,
+            local_only_requested=_local_execution_disables_install(tokens),
+            context_hash=execution_context_hash,
+            package_name=package_name,
+            executable_name=None,
+            declared_version=None,
+            manager=None,
+            local_executable=None,
+        )
     executable_name = _local_executable_name(
         tokens,
         package_name=package_name,
@@ -610,11 +656,11 @@ def _local_context_file_evidence(
     candidates: list[tuple[Path, str]] = []
     seen: set[Path] = set()
     for relative_path in declared_paths:
-        candidate = workspace / relative_path
+        candidate = effective_cwd / relative_path
         normalized = candidate.absolute()
         if normalized not in seen:
             seen.add(normalized)
-            candidates.append((candidate, relative_path))
+            candidates.append((candidate, _execution_display_path(workspace, candidate)))
     for root in _node_resolution_roots(workspace, effective_cwd):
         for name in candidate_names:
             candidate = root / name
@@ -1060,6 +1106,39 @@ def _build_intent(
     )
 
 
+def _rebase_intent_paths(
+    intent: PackageIntent,
+    *,
+    from_directory: Path,
+    workspace: Path | None,
+) -> PackageIntent:
+    if workspace is None:
+        return intent
+    workspace_root = workspace.expanduser().resolve()
+
+    def rebase(paths: tuple[str, ...]) -> tuple[str, ...]:
+        result: list[str] = []
+        for path_text in paths:
+            candidate = Path(path_text)
+            if not candidate.is_absolute():
+                candidate = from_directory / candidate
+            try:
+                # Preserve a declared path that was removed or has not been
+                # created yet, while still resolving every existing ancestor
+                # so symlink and lexical workspace escapes remain excluded.
+                normalized = candidate.resolve(strict=False).relative_to(workspace_root).as_posix()
+            except (OSError, RuntimeError, ValueError):
+                continue
+            result.append(normalized)
+        return tuple(dict.fromkeys(result))
+
+    return replace(
+        intent,
+        manifest_paths=rebase(intent.manifest_paths),
+        lockfile_paths=rebase(intent.lockfile_paths),
+    )
+
+
 def _collect_specs(tokens: tuple[str, ...], *, skip_value_options: set[str]) -> tuple[str, ...]:
     specs: list[str] = []
     index = 0
@@ -1113,26 +1192,35 @@ def _normalized_command_segments(
     *,
     workspace: Path | None = None,
 ) -> tuple[_CommandSegment, ...]:
-    try:
-        tokens = _split_shell_tokens(command_text)
-    except ValueError:
-        return ()
+    execution_context = model_shell_execution_context(
+        command_text,
+        cwd=workspace,
+        workspace_root=workspace,
+    )
+    control_shape = tuple(
+        _CONTROL_CONTEXT_LABELS[context_segment.control_operator] for context_segment in execution_context.segments
+    )
     segments: list[_CommandSegment] = []
-    effective_shell_cwd = (workspace or Path.cwd()).expanduser().resolve()
-    shell_cwd_source = "workspace" if workspace is not None else "process"
-    raw_segments = _raw_command_segments_with_operators(tokens)
-    control_shape = tuple(_CONTROL_CONTEXT_LABELS[operator] for _segment, operator in raw_segments)
-    for segment_index, (raw_segment, following_operator) in enumerate(raw_segments):
+    for context_segment in execution_context.segments:
+        raw_segment = list(context_segment.tokens)
         normalized_tokens = _normalize_segment(raw_segment)
         if not normalized_tokens:
             continue
         redacted_tokens = _redacted_segment(raw_segment)
-        effective_path, path_source, effective_cwd, cwd_source = _effective_execution_context(
-            raw_segment,
-            workspace=workspace,
-            initial_cwd=effective_shell_cwd,
-            initial_cwd_source=shell_cwd_source,
-        )
+        modeled_cwd, validation_reason = validate_shell_execution_segment(execution_context, context_segment)
+        if modeled_cwd is None:
+            effective_path = None
+            path_source = "cwd_unresolved"
+            effective_cwd = None
+            cwd_source = validation_reason or context_segment.reason_code or "cwd_unresolved"
+        else:
+            effective_path, path_source, effective_cwd, cwd_source = _effective_execution_context(
+                raw_segment,
+                workspace=workspace,
+                initial_cwd=modeled_cwd,
+                initial_cwd_source=context_segment.cwd_source,
+            )
+        context_complete = validation_reason is None and context_segment.complete
         segments.append(
             _CommandSegment(
                 tuple(normalized_tokens),
@@ -1142,22 +1230,22 @@ def _normalized_command_segments(
                 effective_cwd,
                 cwd_source,
                 _execution_context_hash(
-                    control_shape,
-                    segment_index,
+                    execution_context,
+                    context_segment,
+                    control_shape=control_shape,
+                    effective_cwd=effective_cwd,
+                    cwd_source=cwd_source,
+                    path_source=path_source,
                     opaque_context_binding=_opaque_unresolved_context_binding(
                         raw_segment,
                         path_source=path_source,
                         cwd_source=cwd_source,
                     ),
                 ),
+                context_complete,
+                validation_reason or context_segment.reason_code,
             )
         )
-        if following_operator in {"&&", ";"}:
-            effective_shell_cwd, shell_cwd_source = _cwd_after_shell_cd(
-                raw_segment,
-                current_cwd=effective_shell_cwd,
-                current_source=shell_cwd_source,
-            )
     return tuple(segments)
 
 
@@ -1180,26 +1268,57 @@ def _opaque_unresolved_context_binding(
     return hmac.new(_EXECUTION_CONTEXT_HMAC_KEY, sensitive_context, hashlib.sha256).hexdigest()
 
 
+def _shell_path_identity_payload(identity: ShellPathIdentity | None) -> dict[str, int] | None:
+    if identity is None:
+        return None
+    return {
+        "change_time_ns": identity.change_time_ns,
+        "device": identity.device,
+        "inode": identity.inode,
+        "mode": identity.mode,
+    }
+
+
 def _execution_context_hash(
-    control_shape: tuple[str, ...],
-    segment_index: int,
+    context: ShellExecutionContext,
+    segment: ShellExecutionSegment,
     *,
-    opaque_context_binding: str | None = None,
+    control_shape: tuple[str, ...],
+    effective_cwd: Path | None,
+    cwd_source: str,
+    path_source: str,
+    opaque_context_binding: str | None,
 ) -> str:
-    """Fingerprint only non-secret compound-command structure.
+    """Bind modeled filesystem context without hashing secret-bearing raw argv.
 
     Exact package targets, redacted command shape, resolved executables, and
     workspace evidence are bound elsewhere in the artifact. Unresolved context
-    receives a process-ephemeral HMAC so distinct uncertain commands cannot
-    share approval identity, while stored hashes cannot be brute-forced as an
-    offline oracle for credentials embedded in arguments or source URLs.
+    receives a process-ephemeral HMAC so stored hashes cannot become an offline
+    oracle for credentials embedded in arguments or source URLs.
     """
 
     payload = json.dumps(
         {
             "schema": "local-package-execution-context-v2",
             "control_shape": control_shape,
-            "segment_index": segment_index,
+            "segment_index": segment.segment_index,
+            "control_before": segment.control_before,
+            "control_after": segment.control_after,
+            "workspace_root": str(context.workspace_root) if context.workspace_root is not None else None,
+            "workspace_identity": _shell_path_identity_payload(context.workspace_identity),
+            "effective_cwd": str(effective_cwd) if effective_cwd is not None else None,
+            "cwd_identity": _shell_path_identity_payload(segment.cwd_identity),
+            "cwd_path_proofs": [
+                {
+                    "lexical_path": str(proof.lexical_path),
+                    "resolved_path": str(proof.resolved_path),
+                    "identity": _shell_path_identity_payload(proof.identity),
+                }
+                for proof in segment.cwd_path_proofs
+            ],
+            "directory_stack": [str(path) for path in segment.directory_stack],
+            "cwd_source": cwd_source,
+            "path_source": path_source,
             "opaque_context_binding": opaque_context_binding,
         },
         sort_keys=True,
@@ -1227,38 +1346,6 @@ def _raw_command_segments_with_operators(
     if segment:
         segments.append((segment, None))
     return tuple(segments)
-
-
-def _cwd_after_shell_cd(
-    raw_segment: list[str],
-    *,
-    current_cwd: Path,
-    current_source: str,
-) -> tuple[Path, str]:
-    segment = _normalize_segment(raw_segment)
-    if not segment or _command_name(segment[0]) != "cd":
-        return current_cwd, current_source
-    arguments = list(segment[1:])
-    while arguments and arguments[0] in {"-L", "-P"}:
-        arguments.pop(0)
-    if arguments and arguments[0] == "--":
-        arguments.pop(0)
-    if len(arguments) > 1:
-        return current_cwd, "shell_cd_unresolved"
-    value = arguments[0] if arguments else str(Path.home())
-    expanded = os.path.expandvars(value)
-    if not expanded or "$" in expanded or "\x00" in expanded:
-        return current_cwd, "shell_cd_unresolved"
-    candidate = Path(expanded).expanduser()
-    if not candidate.is_absolute():
-        candidate = current_cwd / candidate
-    try:
-        resolved = candidate.resolve(strict=True)
-    except (OSError, RuntimeError):
-        return current_cwd, "shell_cd_failed"
-    if not resolved.is_dir():
-        return current_cwd, "shell_cd_failed"
-    return resolved, "shell_cd"
 
 
 def _normalize_segment(raw_segment: list[str]) -> list[str]:
@@ -1522,6 +1609,11 @@ def _combine_package_intents(intents: tuple[PackageIntent, ...]) -> PackageInten
         flags=_unique_joined_strings(intent.flags for intent in intents),
         notes=_unique_joined_strings((*[intent.notes for intent in intents], ("multiple-package-segments",))),
         local_executions=tuple(evidence for intent in intents for evidence in intent.local_executions),
+        execution_context_hashes=_unique_joined_strings(intent.execution_context_hashes for intent in intents),
+        execution_context_cwds=_unique_joined_strings(intent.execution_context_cwds for intent in intents),
+        execution_context_reason_codes=_unique_joined_strings(
+            intent.execution_context_reason_codes for intent in intents
+        ),
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -45,6 +45,11 @@ from .self_approval import (
     is_guard_approval_mutation_command,
 )
 from .shell_command_wrappers import normalize_transparent_shell_command
+from .shell_execution_context import (
+    ShellExecutionContext,
+    model_shell_execution_context,
+    validate_shell_execution_segment,
+)
 
 _FILE_READ_TOOL_NAMES = frozenset(
     {
@@ -651,6 +656,9 @@ class ToolActionRequestMatch:
     raw_command_text: str | None = None
     wrapper_chain: tuple[str, ...] = ()
     canonical_command: CanonicalCommand | None = None
+    shell_execution_context_hash: str | None = None
+    shell_execution_context_reason_code: str | None = None
+    shell_execution_effective_cwds: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -931,6 +939,11 @@ def extract_sensitive_tool_action_request(
             command_text=command_text,
         )
         if docker_sensitive_request is not None:
+            docker_sensitive_request = _request_with_shell_execution_context(
+                docker_sensitive_request,
+                command_text=command_text,
+                cwd=cwd,
+            )
             if wrapper_chain:
                 docker_sensitive_request = _request_with_wrapper_context(
                     docker_sensitive_request,
@@ -945,6 +958,11 @@ def extract_sensitive_tool_action_request(
                 command_text=raw_command_text,
             )
             if docker_sensitive_request is not None:
+                docker_sensitive_request = _request_with_shell_execution_context(
+                    docker_sensitive_request,
+                    command_text=normalized_command_text,
+                    cwd=cwd,
+                )
                 if wrapper_chain:
                     docker_sensitive_request = _request_with_wrapper_context(
                         replace(
@@ -963,6 +981,11 @@ def extract_sensitive_tool_action_request(
             home_dir=home_dir,
         )
         if docker_config_request is not None:
+            docker_config_request = _request_with_shell_execution_context(
+                docker_config_request,
+                command_text=command_text,
+                cwd=cwd,
+            )
             if wrapper_chain:
                 docker_config_request = _request_with_wrapper_context(
                     docker_config_request,
@@ -982,6 +1005,11 @@ def extract_sensitive_tool_action_request(
                     "they can expose cluster credentials or application secrets before the user confirms the action."
                 ),
             )
+            kubernetes_secret_request = _request_with_shell_execution_context(
+                kubernetes_secret_request,
+                command_text=command_text,
+                cwd=cwd,
+            )
             if wrapper_chain:
                 kubernetes_secret_request = _request_with_wrapper_context(
                     kubernetes_secret_request,
@@ -989,6 +1017,11 @@ def extract_sensitive_tool_action_request(
                     wrapper_chain=wrapper_chain,
                 )
             return kubernetes_secret_request
+        destructive_execution_context = model_shell_execution_context(
+            command_text,
+            cwd=cwd,
+            workspace_root=cwd,
+        )
         destructive_shell_request = _destructive_shell_tool_action_request(
             tool_name=requested_tool_name,
             normalized_tool_name=effective_tool_name,
@@ -1001,8 +1034,15 @@ def extract_sensitive_tool_action_request(
                 else None
             ),
             raw_command_text=raw_command_text,
+            execution_context=destructive_execution_context,
         )
         if destructive_shell_request is not None:
+            destructive_shell_request = _request_with_shell_execution_context(
+                destructive_shell_request,
+                command_text=command_text,
+                cwd=cwd,
+                context=destructive_execution_context,
+            )
             if wrapper_chain:
                 destructive_shell_request = _request_with_wrapper_context(
                     destructive_shell_request,
@@ -1011,6 +1051,11 @@ def extract_sensitive_tool_action_request(
                 )
             return destructive_shell_request
         if wrapper_chain:
+            raw_execution_context = model_shell_execution_context(
+                raw_command_text,
+                cwd=cwd,
+                workspace_root=cwd,
+            )
             destructive_shell_request = _destructive_shell_tool_action_request(
                 tool_name=requested_tool_name,
                 normalized_tool_name=effective_tool_name,
@@ -1019,8 +1064,14 @@ def extract_sensitive_tool_action_request(
                 home_dir=home_dir,
                 canonical_command=candidate_canonical,
                 raw_command_text=raw_command_text,
+                execution_context=raw_execution_context,
             )
             if destructive_shell_request is not None:
+                destructive_shell_request = _request_with_shell_execution_context(
+                    destructive_shell_request,
+                    command_text=normalized_command_text,
+                    cwd=cwd,
+                )
                 destructive_shell_request = _request_with_wrapper_context(
                     replace(
                         destructive_shell_request,
@@ -1119,10 +1170,16 @@ def _destructive_shell_tool_action_request(
     home_dir: Path | None,
     canonical_command: CanonicalCommand | None = None,
     raw_command_text: str | None = None,
+    execution_context: ShellExecutionContext | None = None,
 ) -> ToolActionRequestMatch | None:
     if normalized_tool_name not in _SHELL_TOOL_NAMES:
         return None
     canonical_command = canonical_command or parse_shell_command(command_text, cwd=cwd, home_dir=home_dir)
+    execution_context = execution_context or model_shell_execution_context(
+        command_text,
+        cwd=cwd,
+        workspace_root=cwd,
+    )
     detection_command_text = command_text
     if is_guard_approval_mutation_command(detection_command_text):
         return ToolActionRequestMatch(
@@ -1197,7 +1254,29 @@ def _destructive_shell_tool_action_request(
             reason=rule.description,
             canonical_command=canonical_command,
         )
-    if _looks_destructive_shell_command(detection_command_text, cwd=cwd, home_dir=home_dir):
+    execution_context_reason = _shell_execution_context_validation_reason(execution_context)
+    if execution_context.directory_change_present and execution_context_reason is not None:
+        return ToolActionRequestMatch(
+            tool_name=tool_name,
+            normalized_tool_name=normalized_tool_name,
+            command_text=command_text,
+            action_class="unresolved shell execution context",
+            reason=(
+                "Guard could not prove the working directory for every shell segment and requires one "
+                f"conservative decision ({execution_context_reason}). Use a literal, existing in-workspace directory "
+                "with deterministic cd/pushd/popd control flow, or run the command from the intended directory."
+            ),
+            canonical_command=canonical_command,
+            shell_execution_context_hash=execution_context.context_hash,
+            shell_execution_context_reason_code=execution_context_reason,
+            shell_execution_effective_cwds=tuple(str(path) for path in execution_context.effective_cwds),
+        )
+    if _looks_destructive_shell_command(
+        detection_command_text,
+        cwd=cwd,
+        home_dir=home_dir,
+        execution_context=execution_context,
+    ):
         return ToolActionRequestMatch(
             tool_name=tool_name,
             normalized_tool_name=normalized_tool_name,
@@ -1208,6 +1287,15 @@ def _destructive_shell_tool_action_request(
                 "the local machine before the user confirms the action."
             ),
             canonical_command=canonical_command,
+            shell_execution_context_hash=(
+                execution_context.context_hash if execution_context.directory_change_present else None
+            ),
+            shell_execution_context_reason_code=execution_context.reason_code,
+            shell_execution_effective_cwds=(
+                tuple(str(path) for path in execution_context.effective_cwds)
+                if execution_context.directory_change_present
+                else ()
+            ),
         )
     github_assessment = _github_shell_capability_assessment(
         detection_command_text,
@@ -1244,6 +1332,16 @@ def _destructive_shell_tool_action_request(
             reason=rule.description,
             canonical_command=canonical_command,
         )
+    return None
+
+
+def _shell_execution_context_validation_reason(context: ShellExecutionContext) -> str | None:
+    if not context.complete:
+        return context.reason_code
+    for segment in context.segments:
+        _effective_cwd, reason = validate_shell_execution_segment(context, segment)
+        if reason is not None:
+            return reason
     return None
 
 
@@ -3881,6 +3979,7 @@ def build_tool_action_request_artifact(
                 "tool_name": request.normalized_tool_name,
                 "command_text": request.command_text,
                 "action_class": request.action_class,
+                "shell_execution_context_hash": request.shell_execution_context_hash,
             },
             sort_keys=True,
         ).encode("utf-8")
@@ -3898,6 +3997,16 @@ def build_tool_action_request_artifact(
             f"Guard normalized the transparent wrapper chain {' -> '.join(wrapper_chain)} "
             f"before evaluation. {request.reason}"
         )
+    execution_context_metadata: dict[str, object] = {}
+    if request.shell_execution_context_hash is not None:
+        effective_cwds = list(request.shell_execution_effective_cwds)
+        execution_context_metadata = {
+            "shell_execution_context_hash": request.shell_execution_context_hash,
+            "shell_execution_context_complete": request.shell_execution_context_reason_code is None,
+            "shell_execution_context_reason_code": request.shell_execution_context_reason_code,
+            "shell_execution_effective_cwds": effective_cwds,
+            "effective_cwd": effective_cwds[-1] if effective_cwds else None,
+        }
     return GuardArtifact(
         artifact_id=f"{harness}:{source_scope}:tool-action:{fingerprint}",
         name=f"{request.tool_name} {request.action_class}",
@@ -3921,6 +4030,7 @@ def build_tool_action_request_artifact(
             "risk_classes": list(evaluation.risk_classes),
             "command_parse_confidence": evaluation.command.confidence,
             "command_uncertainty_reason": evaluation.command.uncertainty_reason,
+            **execution_context_metadata,
         },
     )
 
@@ -3940,6 +4050,28 @@ def _request_with_wrapper_context(
         raw_command_text=raw_command_text,
         wrapper_chain=wrapper_chain,
         canonical_command=request.canonical_command,
+        shell_execution_context_hash=request.shell_execution_context_hash,
+        shell_execution_context_reason_code=request.shell_execution_context_reason_code,
+        shell_execution_effective_cwds=request.shell_execution_effective_cwds,
+    )
+
+
+def _request_with_shell_execution_context(
+    request: ToolActionRequestMatch,
+    *,
+    command_text: str,
+    cwd: Path | None,
+    context: ShellExecutionContext | None = None,
+) -> ToolActionRequestMatch:
+    context = context or model_shell_execution_context(command_text, cwd=cwd, workspace_root=cwd)
+    if not context.directory_change_present:
+        return request
+    reason_code = _shell_execution_context_validation_reason(context)
+    return replace(
+        request,
+        shell_execution_context_hash=context.context_hash,
+        shell_execution_context_reason_code=reason_code,
+        shell_execution_effective_cwds=tuple(str(path) for path in context.effective_cwds),
     )
 
 
@@ -4708,10 +4840,62 @@ def _looks_destructive_shell_command(
     *,
     cwd: Path | None = None,
     home_dir: Path | None = None,
+    execution_context: ShellExecutionContext | None = None,
+    _execution_context_applied: bool = False,
 ) -> bool:
     normalized = command_text.strip()
     if not normalized:
         return False
+    if not _execution_context_applied:
+        execution_context = execution_context or model_shell_execution_context(
+            normalized,
+            cwd=cwd,
+            workspace_root=cwd,
+        )
+        if execution_context.directory_change_present:
+            if not execution_context.complete:
+                return True
+            has_heredoc = bool(extract_heredocs(normalized))
+            heredoc_segment_cwds: list[Path] = []
+            for context_segment in execution_context.segments:
+                if context_segment.directory_operation is not None:
+                    continue
+                segment_cwd, validation_reason = validate_shell_execution_segment(
+                    execution_context,
+                    context_segment,
+                )
+                if segment_cwd is None or validation_reason is not None:
+                    return True
+                command_name, command_index = _shell_segment_primary_command(list(context_segment.tokens))
+                if (
+                    command_name in _SAFE_STATIC_SHELL_COMMANDS
+                    and command_index is not None
+                    and not _static_shell_segment_is_safe(list(context_segment.tokens[command_index + 1 :]))
+                ):
+                    return True
+                segment_has_heredoc = any(token.startswith("<<") for token in context_segment.tokens)
+                if segment_has_heredoc:
+                    heredoc_segment_cwds.append(segment_cwd)
+                elif _looks_destructive_shell_command(
+                    context_segment.command_text,
+                    cwd=segment_cwd,
+                    home_dir=home_dir,
+                    _execution_context_applied=True,
+                ):
+                    return True
+            if has_heredoc:
+                if len(heredoc_segment_cwds) != 1:
+                    return True
+                return _looks_destructive_shell_command(
+                    normalized,
+                    cwd=heredoc_segment_cwds[0],
+                    home_dir=home_dir,
+                    _execution_context_applied=True,
+                )
+            contextual_parts = _split_shell_parts(normalized)
+            return _contains_prior_pytest_state_mutation(contextual_parts) or _contains_pytest_env_shell_script_wrapper(
+                contextual_parts
+            )
     if _is_literal_cat_heredoc_to_stdout(normalized):
         return False
     for substitution_payload in _shell_command_substitution_payloads(normalized):

--- a/src/codex_plugin_scanner/guard/runtime/shell_execution_context.py
+++ b/src/codex_plugin_scanner/guard/runtime/shell_execution_context.py
@@ -1,0 +1,476 @@
+"""Side-effect-free shell working-directory execution context modeling."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shlex
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from ._shell_execution_context_support import (
+    MAX_DIRECTORY_STACK_DEPTH,
+    SHELL_CWD_AMBIGUOUS_STACK,
+    SHELL_CWD_MISSING_DIRECTORY,
+    SHELL_CWD_NOT_DIRECTORY,
+    SHELL_CWD_PATH_CHANGED,
+    SHELL_CWD_STACK_LIMIT,
+    SHELL_CWD_SYMLINK_ESCAPE,
+    SHELL_CWD_UNREADABLE_DIRECTORY,
+    SHELL_CWD_UNRESOLVED_CONTROL_FLOW,
+    SHELL_CWD_UNRESOLVED_EXPRESSION,
+    SHELL_CWD_UNRESOLVED_PARENT_SHELL,
+    SHELL_CWD_UNRESOLVED_SYNTAX,
+    SHELL_CWD_WORKSPACE_ESCAPE,
+    SHELL_DIRECTORY_COMMAND,
+    DirectoryOperation,
+    ShellPathIdentity,
+    ShellPathProof,
+    control_sequence_reason,
+    directory_operation,
+    existing_directory,
+    is_within,
+    last_flow_operator,
+    ordered_segments,
+    parent_shell_cwd_construct_reason,
+    resolve_directory_operand,
+    split_shell_tokens,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ShellExecutionSegment:
+    """The proven execution directory for one ordered shell segment."""
+
+    tokens: tuple[str, ...]
+    segment_index: int
+    control_before: tuple[str, ...]
+    control_after: tuple[str, ...]
+    effective_cwd: Path | None
+    cwd_identity: ShellPathIdentity | None
+    cwd_path_proofs: tuple[ShellPathProof, ...]
+    cwd_source: str
+    directory_stack: tuple[Path, ...]
+    complete: bool
+    reason_code: str | None = None
+    directory_operation: str | None = None
+
+    @property
+    def command_text(self) -> str:
+        return shlex.join(self.tokens)
+
+    @property
+    def control_operator(self) -> str | None:
+        return last_flow_operator(self.control_after)
+
+
+@dataclass(frozen=True, slots=True)
+class ShellExecutionContext:
+    """Canonical, immutable directory context for an entire shell command."""
+
+    command_text: str
+    initial_cwd: Path | None
+    workspace_root: Path | None
+    workspace_identity: ShellPathIdentity | None
+    segments: tuple[ShellExecutionSegment, ...]
+    complete: bool
+    reason_code: str | None
+    directory_change_present: bool
+
+    @property
+    def effective_cwds(self) -> tuple[Path, ...]:
+        result: list[Path] = []
+        for segment in self.segments:
+            if segment.directory_operation is not None or not segment.complete or segment.effective_cwd is None:
+                continue
+            if segment.effective_cwd not in result:
+                result.append(segment.effective_cwd)
+        return tuple(result)
+
+    @property
+    def context_hash(self) -> str:
+        return shell_execution_context_hash(self)
+
+
+@dataclass(frozen=True, slots=True)
+class _ShellState:
+    cwd: Path | None
+    cwd_identity: ShellPathIdentity | None
+    cwd_path_proofs: tuple[ShellPathProof, ...]
+    cwd_source: str
+    stack: tuple[_DirectoryStackEntry, ...]
+    reason_code: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _DirectoryStackEntry:
+    cwd: Path
+    cwd_identity: ShellPathIdentity
+    cwd_path_proofs: tuple[ShellPathProof, ...]
+
+
+def model_shell_execution_context(
+    command_text: str,
+    *,
+    cwd: Path | None = None,
+    workspace_root: Path | None = None,
+) -> ShellExecutionContext:
+    """Model literal shell directory changes without executing shell code."""
+
+    directory_change_present = bool(SHELL_DIRECTORY_COMMAND.search(command_text))
+    initial_input = cwd or Path.cwd()
+    root_input = workspace_root or initial_input
+    initial_cwd, initial_identity, initial_reason = existing_directory(initial_input)
+    root, root_identity, root_reason = existing_directory(root_input)
+    reason_code = initial_reason or root_reason
+    if reason_code is None and initial_cwd is not None and root is not None and not is_within(initial_cwd, root):
+        reason_code = SHELL_CWD_WORKSPACE_ESCAPE
+    try:
+        tokens = split_shell_tokens(command_text)
+    except ValueError:
+        return ShellExecutionContext(
+            command_text=command_text,
+            initial_cwd=initial_cwd,
+            workspace_root=root,
+            workspace_identity=root_identity,
+            segments=(),
+            complete=not directory_change_present,
+            reason_code=SHELL_CWD_UNRESOLVED_SYNTAX if directory_change_present else None,
+            directory_change_present=directory_change_present,
+        )
+
+    raw_segments, trailing_controls = ordered_segments(tokens)
+    parent_shell_reason = parent_shell_cwd_construct_reason(raw_segments, trailing_controls)
+    if parent_shell_reason is not None:
+        reason_code = reason_code or parent_shell_reason
+        directory_change_present = True
+    if not raw_segments:
+        return ShellExecutionContext(
+            command_text=command_text,
+            initial_cwd=initial_cwd,
+            workspace_root=root,
+            workspace_identity=root_identity,
+            segments=(),
+            complete=reason_code is None and not directory_change_present,
+            reason_code=reason_code or (SHELL_CWD_UNRESOLVED_SYNTAX if directory_change_present else None),
+            directory_change_present=directory_change_present,
+        )
+
+    state = _ShellState(
+        cwd=initial_cwd if reason_code is None else None,
+        cwd_identity=initial_identity if reason_code is None else None,
+        cwd_path_proofs=(),
+        cwd_source="workspace" if cwd is not None else "process",
+        stack=(),
+        reason_code=reason_code,
+    )
+    group_states: list[tuple[str, _ShellState | None]] = []
+    segments: list[ShellExecutionSegment] = []
+    first_reason = reason_code
+
+    for index, (segment_tokens, controls_before) in enumerate(raw_segments):
+        controls_after = raw_segments[index + 1][1] if index + 1 < len(raw_segments) else trailing_controls
+        state, boundary_reason = _apply_group_boundaries_before_segment(
+            state,
+            controls_before,
+            group_states=group_states,
+        )
+        segment_reason = state.reason_code or boundary_reason or control_sequence_reason(controls_before)
+        operation = directory_operation(segment_tokens)
+        if operation is not None:
+            directory_change_present = True
+            flow_before = last_flow_operator(controls_before)
+            previous_segment = segments[-1] if segments else None
+            if flow_before in {"&&", "||"} and (
+                previous_segment is None
+                or previous_segment.directory_operation is None
+                or not previous_segment.complete
+                or flow_before == "||"
+            ):
+                operation = replace(operation, reason_code=SHELL_CWD_UNRESOLVED_CONTROL_FLOW)
+            segment_reason = segment_reason or operation.reason_code
+        segment = ShellExecutionSegment(
+            tokens=segment_tokens,
+            segment_index=index,
+            control_before=controls_before,
+            control_after=controls_after,
+            effective_cwd=state.cwd,
+            cwd_identity=state.cwd_identity,
+            cwd_path_proofs=state.cwd_path_proofs,
+            cwd_source=state.cwd_source,
+            directory_stack=tuple(entry.cwd for entry in state.stack),
+            complete=segment_reason is None,
+            reason_code=segment_reason,
+            directory_operation=operation.name if operation is not None else None,
+        )
+        if operation is not None:
+            state, operation_reason = _apply_directory_operation(
+                operation,
+                state,
+                workspace_root=root,
+                controls_before=controls_before,
+                controls_after=controls_after,
+            )
+            if operation_reason is not None:
+                segment = replace(segment, complete=False, reason_code=operation_reason)
+                segment_reason = operation_reason
+        segments.append(segment)
+        if first_reason is None and segment_reason is not None:
+            first_reason = segment_reason
+
+    _trailing_state, trailing_boundary_reason = _apply_group_boundaries_before_segment(
+        state,
+        trailing_controls,
+        group_states=group_states,
+    )
+    trailing_reason = trailing_boundary_reason or control_sequence_reason(trailing_controls, trailing=True)
+    if trailing_reason is None and any(token in {"(", "{"} for token in trailing_controls):
+        trailing_reason = SHELL_CWD_UNRESOLVED_SYNTAX
+    if group_states:
+        trailing_reason = trailing_reason or SHELL_CWD_UNRESOLVED_SYNTAX
+    if first_reason is None and trailing_reason is not None and directory_change_present:
+        first_reason = trailing_reason
+    complete = first_reason is None
+    if directory_change_present and trailing_reason is not None and segments:
+        segments[-1] = replace(segments[-1], complete=False, reason_code=trailing_reason)
+        complete = False
+    return ShellExecutionContext(
+        command_text=command_text,
+        initial_cwd=initial_cwd,
+        workspace_root=root,
+        workspace_identity=root_identity,
+        segments=tuple(segments),
+        complete=complete,
+        reason_code=first_reason,
+        directory_change_present=directory_change_present,
+    )
+
+
+def validate_shell_execution_segment(
+    context: ShellExecutionContext,
+    segment: ShellExecutionSegment,
+) -> tuple[Path | None, str | None]:
+    """Revalidate a modeled cwd immediately before a filesystem-sensitive use."""
+
+    if not segment.complete or segment.effective_cwd is None or segment.cwd_identity is None:
+        return None, segment.reason_code or context.reason_code or SHELL_CWD_PATH_CHANGED
+    if context.workspace_root is None or context.workspace_identity is None:
+        return None, context.reason_code or SHELL_CWD_PATH_CHANGED
+    root, root_identity, root_reason = existing_directory(context.workspace_root)
+    if root_reason is not None or root_identity != context.workspace_identity:
+        return None, SHELL_CWD_PATH_CHANGED
+    current, current_identity, current_reason = existing_directory(segment.effective_cwd)
+    if current_reason is not None or current_identity != segment.cwd_identity:
+        return None, SHELL_CWD_PATH_CHANGED
+    if root is None or current is None or not is_within(current, root):
+        return None, SHELL_CWD_WORKSPACE_ESCAPE
+    for proof in segment.cwd_path_proofs:
+        proof_current, proof_identity, proof_reason = existing_directory(proof.lexical_path)
+        if proof_reason is not None or proof_current != proof.resolved_path or proof_identity != proof.identity:
+            return None, SHELL_CWD_PATH_CHANGED
+    return current, None
+
+
+def shell_execution_segment_hash(
+    context: ShellExecutionContext,
+    segment: ShellExecutionSegment,
+) -> str:
+    """Return an approval-safe identity for one segment and its full command."""
+
+    payload = {
+        "schema": "shell-execution-context-v1",
+        "command": context.command_text,
+        "workspace_root": str(context.workspace_root) if context.workspace_root is not None else None,
+        "workspace_identity": _identity_payload(context.workspace_identity),
+        "segment": _segment_payload(segment),
+    }
+    return _sha256_payload(payload)
+
+
+def shell_execution_context_hash(context: ShellExecutionContext) -> str:
+    payload = {
+        "schema": "shell-execution-context-v1",
+        "command": context.command_text,
+        "initial_cwd": str(context.initial_cwd) if context.initial_cwd is not None else None,
+        "workspace_root": str(context.workspace_root) if context.workspace_root is not None else None,
+        "workspace_identity": _identity_payload(context.workspace_identity),
+        "complete": context.complete,
+        "reason_code": context.reason_code,
+        "segments": [_segment_payload(segment) for segment in context.segments],
+    }
+    return _sha256_payload(payload)
+
+
+def shell_execution_context_metadata(context: ShellExecutionContext) -> dict[str, object]:
+    """Return bounded metadata suitable for runtime artifacts and approval identity."""
+
+    effective_cwds = [str(path) for path in context.effective_cwds]
+    return {
+        "shell_execution_context_hash": context.context_hash,
+        "shell_execution_context_complete": context.complete,
+        "shell_execution_context_reason_code": context.reason_code,
+        "shell_execution_effective_cwds": effective_cwds,
+        "effective_cwd": effective_cwds[-1] if effective_cwds else None,
+    }
+
+
+def _apply_group_boundaries_before_segment(
+    state: _ShellState,
+    controls: tuple[str, ...],
+    *,
+    group_states: list[tuple[str, _ShellState | None]],
+) -> tuple[_ShellState, str | None]:
+    reason: str | None = None
+    for control in controls:
+        if control == "(":
+            group_states.append(("(", state))
+        elif control == "{":
+            group_states.append(("{", None))
+        elif control == ")":
+            if not group_states or group_states[-1][0] != "(":
+                reason = SHELL_CWD_UNRESOLVED_SYNTAX
+            else:
+                _group, saved_state = group_states.pop()
+                if saved_state is not None:
+                    state = saved_state
+        elif control == "}":
+            if not group_states or group_states[-1][0] != "{":
+                reason = SHELL_CWD_UNRESOLVED_SYNTAX
+            else:
+                group_states.pop()
+    return state, reason
+
+
+def _apply_directory_operation(
+    operation: DirectoryOperation,
+    state: _ShellState,
+    *,
+    workspace_root: Path | None,
+    controls_before: tuple[str, ...],
+    controls_after: tuple[str, ...],
+) -> tuple[_ShellState, str | None]:
+    if operation.reason_code is not None:
+        return replace(state, cwd=None, cwd_identity=None, reason_code=operation.reason_code), operation.reason_code
+    if state.cwd is None or state.cwd_identity is None or workspace_root is None:
+        reason = state.reason_code or SHELL_CWD_UNRESOLVED_CONTROL_FLOW
+        return replace(state, reason_code=reason), reason
+    if operation.name == "popd":
+        if not state.stack:
+            reason = SHELL_CWD_AMBIGUOUS_STACK
+            return replace(state, cwd=None, cwd_identity=None, reason_code=reason), reason
+        stack_entry = state.stack[-1]
+        next_state = _ShellState(
+            cwd=stack_entry.cwd,
+            cwd_identity=stack_entry.cwd_identity,
+            cwd_path_proofs=stack_entry.cwd_path_proofs,
+            cwd_source="shell_popd",
+            stack=state.stack[:-1],
+        )
+    else:
+        if operation.operand is None:
+            return replace(state, cwd=None, cwd_identity=None, reason_code=SHELL_CWD_UNRESOLVED_EXPRESSION), (
+                SHELL_CWD_UNRESOLVED_EXPRESSION
+            )
+        destination, destination_identity, destination_proof, reason = resolve_directory_operand(
+            operation.operand,
+            current_cwd=state.cwd,
+            workspace_root=workspace_root,
+        )
+        if reason is not None or destination is None or destination_identity is None or destination_proof is None:
+            failure_reason = reason or SHELL_CWD_MISSING_DIRECTORY
+            return replace(state, cwd=None, cwd_identity=None, reason_code=failure_reason), failure_reason
+        stack = state.stack
+        if operation.name == "pushd":
+            if len(stack) >= MAX_DIRECTORY_STACK_DEPTH:
+                return replace(state, cwd=None, cwd_identity=None, reason_code=SHELL_CWD_STACK_LIMIT), (
+                    SHELL_CWD_STACK_LIMIT
+                )
+            stack = (
+                *stack,
+                _DirectoryStackEntry(
+                    cwd=state.cwd,
+                    cwd_identity=state.cwd_identity,
+                    cwd_path_proofs=state.cwd_path_proofs,
+                ),
+            )
+        next_state = _ShellState(
+            cwd=destination,
+            cwd_identity=destination_identity,
+            cwd_path_proofs=(*state.cwd_path_proofs, destination_proof),
+            cwd_source=f"shell_{operation.name}",
+            stack=stack,
+        )
+    flow_before = last_flow_operator(controls_before)
+    flow = last_flow_operator(controls_after)
+    if flow_before in {"|", "|&"}:
+        return state, None
+    if flow in {"|", "|&", "&"}:
+        return state, None
+    if flow == "||":
+        reason = SHELL_CWD_UNRESOLVED_CONTROL_FLOW
+        return replace(next_state, cwd=None, cwd_identity=None, reason_code=reason), reason
+    return next_state, None
+
+
+def _identity_payload(identity: ShellPathIdentity | None) -> dict[str, int] | None:
+    if identity is None:
+        return None
+    return {
+        "change_time_ns": identity.change_time_ns,
+        "device": identity.device,
+        "inode": identity.inode,
+        "mode": identity.mode,
+    }
+
+
+def _segment_payload(segment: ShellExecutionSegment) -> dict[str, object]:
+    return {
+        "tokens": list(segment.tokens),
+        "segment_index": segment.segment_index,
+        "control_before": list(segment.control_before),
+        "control_after": list(segment.control_after),
+        "effective_cwd": str(segment.effective_cwd) if segment.effective_cwd is not None else None,
+        "cwd_identity": _identity_payload(segment.cwd_identity),
+        "cwd_path_proofs": [
+            {
+                "lexical_path": str(proof.lexical_path),
+                "resolved_path": str(proof.resolved_path),
+                "identity": _identity_payload(proof.identity),
+            }
+            for proof in segment.cwd_path_proofs
+        ],
+        "cwd_source": segment.cwd_source,
+        "directory_stack": [str(path) for path in segment.directory_stack],
+        "complete": segment.complete,
+        "reason_code": segment.reason_code,
+        "directory_operation": segment.directory_operation,
+    }
+
+
+def _sha256_payload(payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+__all__ = [
+    "SHELL_CWD_AMBIGUOUS_STACK",
+    "SHELL_CWD_MISSING_DIRECTORY",
+    "SHELL_CWD_NOT_DIRECTORY",
+    "SHELL_CWD_PATH_CHANGED",
+    "SHELL_CWD_STACK_LIMIT",
+    "SHELL_CWD_SYMLINK_ESCAPE",
+    "SHELL_CWD_UNREADABLE_DIRECTORY",
+    "SHELL_CWD_UNRESOLVED_CONTROL_FLOW",
+    "SHELL_CWD_UNRESOLVED_EXPRESSION",
+    "SHELL_CWD_UNRESOLVED_PARENT_SHELL",
+    "SHELL_CWD_UNRESOLVED_SYNTAX",
+    "SHELL_CWD_WORKSPACE_ESCAPE",
+    "ShellExecutionContext",
+    "ShellExecutionSegment",
+    "model_shell_execution_context",
+    "shell_execution_context_hash",
+    "shell_execution_context_metadata",
+    "shell_execution_segment_hash",
+    "validate_shell_execution_segment",
+]

--- a/tests/test_guard_package_intent.py
+++ b/tests/test_guard_package_intent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,7 @@ from codex_plugin_scanner.guard.runtime.package_intent import (
     parse_manifest_dependency_changes,
     parse_package_intent,
 )
+from codex_plugin_scanner.guard.runtime.shell_execution_context import model_shell_execution_context
 
 
 def _write_text(path: Path, text: str) -> None:
@@ -116,6 +118,7 @@ def test_parse_package_intent_detects_package_command_after_control_operator() -
     commands = {
         "true && npx attacker-package": ("npx", "attacker-package"),
         "echo ok; npm install attacker-package": ("npm", "attacker-package"),
+        "echo ok\nnpm install attacker-package": ("npm", "attacker-package"),
         "false || pnpm dlx attacker-package": ("pnpm", "attacker-package"),
         "echo ok | bunx attacker-package": ("bunx", "attacker-package"),
         "echo ok & pip install attacker-package": ("pip", "attacker-package"),
@@ -131,16 +134,54 @@ def test_parse_package_intent_detects_package_command_after_control_operator() -
     assert parse_package_intent("echo safe && grep foo src/file.ts") is None
 
 
-def test_local_execution_context_hash_contains_no_raw_command_or_secret() -> None:
-    first = package_intent_parser._execution_context_hash(("and", "end"), 1)
-    repeated = package_intent_parser._execution_context_hash(("and", "end"), 1)
-    different_operator = package_intent_parser._execution_context_hash(("sequence", "end"), 1)
-    different_segment = package_intent_parser._execution_context_hash(("and", "end"), 0)
+def test_local_execution_context_hash_contains_no_raw_command_or_secret(tmp_path: Path) -> None:
+    def _hash(command: str, segment_index: int) -> str:
+        context = model_shell_execution_context(command, cwd=tmp_path, workspace_root=tmp_path)
+        segment = context.segments[segment_index]
+        return package_intent_parser._execution_context_hash(
+            context,
+            segment,
+            control_shape=tuple(
+                operator for modeled_segment in context.segments for operator in modeled_segment.control_after
+            ),
+            effective_cwd=segment.effective_cwd,
+            cwd_source=segment.cwd_source,
+            path_source="inherited",
+            opaque_context_binding=None,
+        )
+
+    first = _hash("true && npm install fixture", 1)
+    repeated = _hash("true && npm install fixture", 1)
+    different_operator = _hash("true; npm install fixture", 1)
+    different_segment = _hash("npm install fixture && true", 0)
 
     assert first == repeated
     assert first.startswith("sha256:")
     assert first != different_operator
     assert first != different_segment
+
+
+def test_rebase_preserves_declared_paths_that_disappear_or_do_not_exist(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    requirements = project / "requirements.txt"
+    _write_text(requirements, "fixture==1.0\n")
+    intent = package_intent_parser._parse_pip_intent(
+        ("pip", "install", "-r", "requirements.txt"),
+        workspace=project,
+    )
+    assert intent is not None
+    requirements.unlink()
+    intent = replace(intent, lockfile_paths=("future.lock",))
+
+    rebased = package_intent_parser._rebase_intent_paths(
+        intent,
+        from_directory=project,
+        workspace=tmp_path,
+    )
+
+    assert rebased.manifest_paths == ("project/requirements.txt",)
+    assert rebased.lockfile_paths == ("project/future.lock",)
 
 
 def test_unresolved_context_uses_process_ephemeral_keyed_identity() -> None:

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 from pathlib import Path
 
 import pytest
@@ -1047,6 +1048,7 @@ def test_tool_action_request_classifier_blocks_mutating_python_module_invocation
 
 
 def test_tool_action_request_classifier_allows_safe_ruff_fix_invocations(tmp_path):
+    (tmp_path / "repo").mkdir()
     for command in (
         "python -m ruff check --fix .",
         "python -m ruff check --fix-only .",
@@ -1138,7 +1140,8 @@ def test_tool_action_request_classifier_skips_perl_sleep_wait():
     assert request is None
 
 
-def test_tool_action_request_classifier_skips_git_commit_with_coauthored_by_trailer():
+def test_tool_action_request_classifier_skips_git_commit_with_coauthored_by_trailer(tmp_path):
+    (tmp_path / "hol-guard").mkdir()
     request = extract_sensitive_tool_action_request(
         "bash",
         {
@@ -1151,6 +1154,7 @@ def test_tool_action_request_classifier_skips_git_commit_with_coauthored_by_trai
                 'Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>" 2>&1'
             )
         },
+        cwd=tmp_path,
     )
 
     assert request is None
@@ -1551,7 +1555,8 @@ NODE"""
     )
 
     assert request is not None
-    assert request.action_class == "destructive shell command"
+    assert request.action_class == "unresolved shell execution context"
+    assert request.shell_execution_context_reason_code == "shell_cwd_workspace_escape"
 
 
 def test_tool_action_request_classifier_detects_node_heredoc_setup_command_substitution():
@@ -1566,7 +1571,8 @@ NODE"""
     )
 
     assert request is not None
-    assert request.action_class == "destructive shell command"
+    assert request.action_class == "unresolved shell execution context"
+    assert request.shell_execution_context_reason_code == "shell_cwd_unresolved_expression"
 
 
 def test_tool_action_request_classifier_detects_node_heredoc_dynamic_path_traversal_placeholder():
@@ -2628,12 +2634,15 @@ def test_tool_action_request_classifier_allows_read_only_python_heredoc_debuggin
     assert request is None
 
 
-def test_tool_action_request_classifier_allows_read_only_python_heredoc_debugging_after_cd():
+def test_tool_action_request_classifier_allows_read_only_python_heredoc_debugging_after_cd(tmp_path):
+    fixture_dir = tmp_path / "hashgraph-online"
+    fixture_dir.mkdir()
+    (fixture_dir / "bounty_submissions.txt").write_text("fixture row\n", encoding="utf-8")
     request = extract_sensitive_tool_action_request(
         "bash",
         {
             "command": (
-                "cd /tmp/hol-guard-fixtures/hashgraph-online && python - <<'PY'\n"
+                f"cd {shlex.quote(str(fixture_dir))} && python - <<'PY'\n"
                 "from pathlib import Path\n"
                 "text = Path('bounty_submissions.txt').read_text()\n"
                 "print('bytes', len(text))\n"
@@ -2641,6 +2650,7 @@ def test_tool_action_request_classifier_allows_read_only_python_heredoc_debuggin
                 "PY"
             )
         },
+        cwd=tmp_path,
     )
 
     assert request is None

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -6853,12 +6853,15 @@ def test_guard_hook_emits_copilot_native_allow_response_for_benign_python_heredo
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    fixture_dir = workspace_dir / "hashgraph-online"
+    fixture_dir.mkdir()
+    _write_text(fixture_dir / "bounty_submissions.txt", "fixture row\n")
     event = {
         "hookName": "preToolUse",
         "toolName": "bash",
         "toolArgs": {
             "command": (
-                "cd /tmp/hol-guard-fixtures/hashgraph-online && python - <<'PY'\n"
+                f"cd {shlex.quote(str(fixture_dir))} && python - <<'PY'\n"
                 "from pathlib import Path\n"
                 "text = Path('bounty_submissions.txt').read_text()\n"
                 "print('bytes', len(text))\n"
@@ -15792,6 +15795,7 @@ def test_guard_runtime_ignores_patch_syntax_for_other_write_tools(tmp_path):
 
 
 def test_guard_runtime_allows_cd_prefixed_pytest_module_invocation(tmp_path):
+    (tmp_path / "tests").mkdir()
     match = extract_sensitive_tool_action_request(
         "Bash",
         {
@@ -15818,6 +15822,7 @@ def test_guard_runtime_allows_ruff_check_and_fix_module_invocations(tmp_path):
 
 
 def test_guard_runtime_allows_chained_cd_and_ruff_dev_workflow(tmp_path):
+    (tmp_path / "tests").mkdir()
     command = (
         "cd tests && PYTHONPATH=src python3 -m ruff check --fix ../src/foo.py 2>&1 && "
         "PYTHONPATH=src python3 -m ruff check ../src/foo.py 2>&1"
@@ -15885,7 +15890,8 @@ def test_guard_runtime_blocks_unsafe_cd_before_pytest_module_invocation(tmp_path
     )
 
     assert match is not None
-    assert match.action_class == "destructive shell command"
+    assert match.action_class == "unresolved shell execution context"
+    assert match.shell_execution_context_reason_code == "shell_cwd_unresolved_expression"
 
 
 def test_guard_runtime_blocks_pythonpath_ruff_module_shadow(tmp_path):
@@ -16308,6 +16314,7 @@ def test_guard_runtime_checks_selected_test_path_ancestor_pytest_config_addopts(
 
 
 def test_guard_runtime_allows_prior_cd_before_pytest(tmp_path):
+    (tmp_path / "sub").mkdir()
     match = extract_sensitive_tool_action_request(
         "Bash",
         {"command": "cd sub && pytest -q"},
@@ -16318,6 +16325,7 @@ def test_guard_runtime_allows_prior_cd_before_pytest(tmp_path):
 
 
 def test_guard_runtime_allows_prior_pushd_before_pytest(tmp_path):
+    (tmp_path / "sub").mkdir()
     match = extract_sensitive_tool_action_request(
         "Bash",
         {"command": "pushd sub >/dev/null; pytest -q"},
@@ -16463,6 +16471,7 @@ def test_guard_hook_codex_does_not_block_simple_pytest_command(tmp_path, capsys,
 
 
 def test_guard_runtime_allows_literal_exit_code_echo_after_safe_pytest(tmp_path):
+    (tmp_path / "sub").mkdir()
     match = extract_sensitive_tool_action_request(
         "Bash",
         {
@@ -16482,6 +16491,7 @@ def test_guard_hook_codex_does_not_block_safe_pytest_exit_code_echo(tmp_path, ca
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    (workspace_dir / "sub").mkdir()
     event = {
         "event": "PreToolUse",
         "tool_name": "Bash",
@@ -16520,6 +16530,7 @@ def test_guard_hook_codex_does_not_block_safe_pytest_exit_code_echo(tmp_path, ca
     ],
 )
 def test_guard_runtime_keeps_static_shell_expansions_blocked_after_safe_pytest(tmp_path, command_suffix):
+    (tmp_path / "sub").mkdir()
     match = extract_sensitive_tool_action_request(
         "Bash",
         {

--- a/tests/test_guard_shell_execution_context.py
+++ b/tests/test_guard_shell_execution_context.py
@@ -1,0 +1,728 @@
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.cli import commands_hook_runtime_eval as runtime_eval_module
+from codex_plugin_scanner.guard.cli.commands_support_codex_reads import (
+    _codex_command_is_read_only_source_inspection,
+)
+from codex_plugin_scanner.guard.cli.commands_support_codex_tool_output import (
+    _codex_sensitive_local_source_matches,
+)
+from codex_plugin_scanner.guard.cli.commands_support_runtime_artifacts import (
+    _codex_post_tool_output_artifact,
+)
+from codex_plugin_scanner.guard.cli.commands_support_runtime_policy import (
+    _runtime_hook_approval_context_token,
+)
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.consumer import artifact_hash
+from codex_plugin_scanner.guard.models import GuardArtifact
+from codex_plugin_scanner.guard.runtime import secret_file_requests as secret_file_requests_module
+from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+from codex_plugin_scanner.guard.runtime.package_intent import (
+    build_package_request_artifact,
+    parse_package_intent,
+)
+from codex_plugin_scanner.guard.runtime.secret_file_requests import (
+    extract_sensitive_tool_action_request,
+)
+from codex_plugin_scanner.guard.runtime.shell_execution_context import (
+    SHELL_CWD_AMBIGUOUS_STACK,
+    SHELL_CWD_MISSING_DIRECTORY,
+    SHELL_CWD_PATH_CHANGED,
+    SHELL_CWD_STACK_LIMIT,
+    SHELL_CWD_SYMLINK_ESCAPE,
+    SHELL_CWD_UNREADABLE_DIRECTORY,
+    SHELL_CWD_UNRESOLVED_CONTROL_FLOW,
+    SHELL_CWD_UNRESOLVED_EXPRESSION,
+    SHELL_CWD_UNRESOLVED_PARENT_SHELL,
+    SHELL_CWD_WORKSPACE_ESCAPE,
+    model_shell_execution_context,
+    validate_shell_execution_segment,
+)
+from codex_plugin_scanner.guard.runtime.signals import GuardRiskSignalV3
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_executable(path: Path) -> Path:
+    _write(path, "#!/bin/sh\nexit 0\n")
+    path.chmod(0o755)
+    return path
+
+
+def _approval_token(artifact: GuardArtifact, *, workspace: Path, config: GuardConfig) -> str:
+    return _runtime_hook_approval_context_token(
+        artifact=artifact,
+        content_hash=artifact_hash(artifact),
+        runtime_workspace=workspace,
+        action_envelope=None,
+        config=config,
+        current_config_action="review",
+        trusted_cli_action=None,
+        untrusted_payload_action=None,
+        package_action=None,
+        data_flow_action=None,
+        scanner_action=None,
+        current_action="review",
+        data_flow_signals=(),
+        scanner_evidence=(),
+    )
+
+
+@pytest.mark.parametrize(
+    "operand",
+    [
+        "project-b",
+        "./project-b",
+        "project-a/../project-b",
+        "project with spaces",
+        "prøject-雪",
+    ],
+)
+def test_literal_cd_forms_resolve_against_the_prior_effective_cwd(tmp_path: Path, operand: str) -> None:
+    destination = tmp_path / Path(operand).name
+    if "../" in operand:
+        destination = tmp_path / "project-b"
+        (tmp_path / "project-a").mkdir()
+    destination.mkdir()
+
+    context = model_shell_execution_context(
+        f"cd -- {shlex.quote(operand)} && pytest -q",
+        cwd=tmp_path,
+    )
+
+    assert context.complete
+    assert context.reason_code is None
+    assert context.segments[1].effective_cwd == destination.resolve()
+    assert context.segments[1].control_before == ("&&",)
+
+
+def test_absolute_cd_and_newline_boundaries_preserve_full_command_identity(tmp_path: Path) -> None:
+    destination = tmp_path / "project-b"
+    destination.mkdir()
+    command = f"cd {shlex.quote(str(destination))}\npytest -q"
+
+    context = model_shell_execution_context(command, cwd=tmp_path)
+
+    assert context.complete
+    assert context.command_text == command
+    assert context.segments[0].control_after == ("\n",)
+    assert context.segments[1].effective_cwd == destination.resolve()
+
+
+def test_nested_pushd_popd_tracks_a_bounded_explicit_stack(tmp_path: Path) -> None:
+    nested = tmp_path / "services" / "auth"
+    nested.mkdir(parents=True)
+
+    context = model_shell_execution_context(
+        "pushd services; pushd auth; ruff check .; popd; pytest -q; popd; pytest -q",
+        cwd=tmp_path,
+    )
+
+    assert context.complete
+    assert context.segments[2].effective_cwd == nested.resolve()
+    assert context.segments[2].directory_stack == (tmp_path.resolve(), (tmp_path / "services").resolve())
+    assert context.segments[4].effective_cwd == (tmp_path / "services").resolve()
+    assert context.segments[6].effective_cwd == tmp_path.resolve()
+
+
+def test_directory_stack_depth_is_bounded_and_fails_closed(tmp_path: Path) -> None:
+    command = "; ".join((*(["pushd ."] * 33), "pytest -q"))
+
+    context = model_shell_execution_context(command, cwd=tmp_path)
+
+    assert not context.complete
+    assert context.reason_code == SHELL_CWD_STACK_LIMIT
+    assert context.segments[-1].effective_cwd is None
+
+
+def test_subshell_group_restores_the_outer_working_directory(tmp_path: Path) -> None:
+    destination = tmp_path / "project-b"
+    destination.mkdir()
+
+    context = model_shell_execution_context("(cd project-b && pytest -q); pytest -q", cwd=tmp_path)
+
+    assert context.complete
+    assert context.segments[1].effective_cwd == destination.resolve()
+    assert context.segments[2].effective_cwd == tmp_path.resolve()
+    assert context.segments[2].control_before == (
+        ")",
+        ";",
+    )
+
+
+def test_brace_group_keeps_the_changed_directory_and_accepts_required_separator(tmp_path: Path) -> None:
+    destination = tmp_path / "project-b"
+    destination.mkdir()
+
+    context = model_shell_execution_context("{ cd project-b; pytest -q; }; ruff check .", cwd=tmp_path)
+
+    assert context.complete
+    assert context.segments[1].effective_cwd == destination.resolve()
+    assert context.segments[2].effective_cwd == destination.resolve()
+    assert context.segments[2].control_before == (";", "}", ";")
+
+
+def test_trailing_list_separator_does_not_make_literal_cd_incomplete(tmp_path: Path) -> None:
+    destination = tmp_path / "project-b"
+    destination.mkdir()
+
+    context = model_shell_execution_context("cd project-b;", cwd=tmp_path)
+
+    assert context.complete
+    assert context.reason_code is None
+
+
+def test_fd_duplication_is_preserved_as_a_redirection_not_background_control(tmp_path: Path) -> None:
+    destination = tmp_path / "project-b"
+    destination.mkdir()
+
+    context = model_shell_execution_context("cd project-b 2>&1 && pytest -q", cwd=tmp_path)
+
+    assert context.complete
+    assert context.segments[0].control_operator == "&&"
+    assert context.segments[1].effective_cwd == destination.resolve()
+
+
+def test_missing_directory_redirection_target_fails_closed(tmp_path: Path) -> None:
+    (tmp_path / "project-b").mkdir()
+
+    context = model_shell_execution_context("cd project-b > && pytest -q", cwd=tmp_path)
+
+    assert not context.complete
+    assert context.reason_code == SHELL_CWD_UNRESOLVED_EXPRESSION
+    assert context.segments[1].effective_cwd is None
+
+
+def test_pipeline_directory_change_does_not_leak_from_its_subprocess(tmp_path: Path) -> None:
+    (tmp_path / "project-b").mkdir()
+
+    context = model_shell_execution_context("cd project-b | pytest -q", cwd=tmp_path)
+
+    assert context.complete
+    assert context.segments[0].control_operator == "|"
+    assert context.segments[1].effective_cwd == tmp_path.resolve()
+
+    right_hand_change = model_shell_execution_context("echo ready | cd project-b && pytest -q", cwd=tmp_path)
+    assert right_hand_change.complete
+    assert right_hand_change.segments[-1].effective_cwd == tmp_path.resolve()
+
+
+def test_conditionally_executed_directory_change_is_not_assumed(tmp_path: Path) -> None:
+    (tmp_path / "project-b").mkdir()
+
+    context = model_shell_execution_context("pytest -q && cd project-b; ruff check .", cwd=tmp_path)
+
+    assert not context.complete
+    assert context.reason_code == "shell_cwd_unresolved_control_flow"
+    assert context.segments[-1].effective_cwd is None
+
+
+@pytest.mark.parametrize(
+    ("command", "reason_code"),
+    [
+        ("cd missing && pytest -q", SHELL_CWD_MISSING_DIRECTORY),
+        ("cd $PROJECT && pytest -q", SHELL_CWD_UNRESOLVED_EXPRESSION),
+        ("cd $(pwd) && pytest -q", SHELL_CWD_UNRESOLVED_EXPRESSION),
+        ("cd project-* && pytest -q", SHELL_CWD_UNRESOLVED_EXPRESSION),
+        ("popd; pytest -q", SHELL_CWD_AMBIGUOUS_STACK),
+        ("pushd +1; pytest -q", SHELL_CWD_AMBIGUOUS_STACK),
+        ("function cd; cd project-b && pytest -q", SHELL_CWD_UNRESOLVED_EXPRESSION),
+        ("if cd project-b; then pytest -q; fi", SHELL_CWD_UNRESOLVED_CONTROL_FLOW),
+    ],
+)
+def test_unresolved_directory_contexts_have_stable_fail_closed_reasons(
+    tmp_path: Path,
+    command: str,
+    reason_code: str,
+) -> None:
+    context = model_shell_execution_context(command, cwd=tmp_path)
+
+    assert not context.complete
+    assert context.reason_code == reason_code
+    assert context.segments[-1].effective_cwd is None
+    request = extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=tmp_path)
+    assert request is not None
+    assert request.action_class == "unresolved shell execution context"
+    assert request.shell_execution_context_reason_code == reason_code
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "f() { cd project-b; }; f; pytest -q",
+        "function f { cd project-b; }; f; pytest -q",
+        "source setup.sh; pytest -q",
+        ". setup.sh; pytest -q",
+        'eval "cd project-b"; pytest -q',
+        "trap 'cd project-b' DEBUG; pytest -q",
+    ],
+)
+def test_parent_shell_cwd_effects_fail_closed_with_a_stable_reason(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    (tmp_path / "project-b").mkdir()
+
+    context = model_shell_execution_context(command, cwd=tmp_path)
+    request = extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=tmp_path)
+
+    assert not context.complete
+    assert context.reason_code == SHELL_CWD_UNRESOLVED_PARENT_SHELL
+    assert all(segment.effective_cwd is None for segment in context.segments)
+    assert request is not None
+    assert request.action_class == "unresolved shell execution context"
+    assert request.shell_execution_context_reason_code == SHELL_CWD_UNRESOLVED_PARENT_SHELL
+
+
+def test_empty_debug_trap_does_not_poison_a_literal_directory_change(tmp_path: Path) -> None:
+    destination = tmp_path / "project-b"
+    destination.mkdir()
+
+    context = model_shell_execution_context("trap '' DEBUG; cd project-b; pytest -q", cwd=tmp_path)
+
+    assert context.complete
+    assert context.segments[-1].effective_cwd == destination.resolve()
+
+
+@pytest.mark.parametrize("wrapper", ["command", "time"])
+def test_transparent_builtin_wrappers_preserve_literal_cd_context(tmp_path: Path, wrapper: str) -> None:
+    destination = tmp_path / "project-b"
+    destination.mkdir()
+
+    context = model_shell_execution_context(f"{wrapper} cd project-b && pytest -q", cwd=tmp_path)
+
+    assert context.complete
+    assert context.segments[1].effective_cwd == destination.resolve()
+
+
+def test_workspace_and_symlink_escapes_are_distinguished(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    symlink = workspace / "linked"
+    try:
+        symlink.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("directory symlinks are unavailable")
+
+    lexical_escape = model_shell_execution_context("cd .. && pytest -q", cwd=workspace)
+    symlink_escape = model_shell_execution_context("cd linked && pytest -q", cwd=workspace)
+
+    assert lexical_escape.reason_code == SHELL_CWD_WORKSPACE_ESCAPE
+    assert symlink_escape.reason_code == SHELL_CWD_SYMLINK_ESCAPE
+
+
+def test_unreadable_directory_fails_closed_without_shell_execution(tmp_path: Path) -> None:
+    destination = tmp_path / "unreadable"
+    destination.mkdir()
+    destination.chmod(0)
+    try:
+        context = model_shell_execution_context("cd unreadable && pytest -q", cwd=tmp_path)
+    finally:
+        destination.chmod(0o700)
+
+    assert not context.complete
+    assert context.reason_code == SHELL_CWD_UNREADABLE_DIRECTORY
+
+
+@pytest.mark.parametrize("replacement", ["remove", "swap"])
+def test_modeled_directory_is_revalidated_against_path_replacement(
+    tmp_path: Path,
+    replacement: str,
+) -> None:
+    destination = tmp_path / "project-b"
+    destination.mkdir()
+    context = model_shell_execution_context("cd project-b && pytest -q", cwd=tmp_path)
+    command_segment = context.segments[1]
+    destination.rmdir()
+    if replacement == "swap":
+        destination.mkdir()
+
+    effective_cwd, reason = validate_shell_execution_segment(context, command_segment)
+
+    assert effective_cwd is None
+    assert reason == SHELL_CWD_PATH_CHANGED
+
+
+def test_modeled_symlink_route_is_revalidated_against_retargeting(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    link = tmp_path / "project"
+    try:
+        link.symlink_to(first, target_is_directory=True)
+    except OSError:
+        pytest.skip("directory symlinks are unavailable")
+    context = model_shell_execution_context("cd project && pytest -q", cwd=tmp_path)
+    command_segment = context.segments[1]
+    link.unlink()
+    link.symlink_to(second, target_is_directory=True)
+
+    effective_cwd, reason = validate_shell_execution_segment(context, command_segment)
+
+    assert effective_cwd is None
+    assert reason == SHELL_CWD_PATH_CHANGED
+
+
+def test_python_safety_checks_use_project_b_not_the_launch_project(tmp_path: Path) -> None:
+    project_a = tmp_path / "project-a"
+    project_b = project_a / "project-b"
+    project_b.mkdir(parents=True)
+    _write(project_a / "pytest.py", "raise SystemExit('project-a shadow')\n")
+
+    safe_request = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "cd project-b && python -m pytest -q"},
+        cwd=project_a,
+    )
+    _write(project_b / "pytest.py", "raise SystemExit('project-b shadow')\n")
+    unsafe_request = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "cd project-b && python -m pytest -q"},
+        cwd=project_a,
+    )
+
+    assert safe_request is None
+    assert unsafe_request is not None
+    assert unsafe_request.shell_execution_effective_cwds == (str(project_b.resolve()),)
+
+
+def test_pytest_config_discovery_uses_the_effective_project(tmp_path: Path) -> None:
+    project_a = tmp_path / "project-a"
+    project_b = project_a / "project-b"
+    project_b.mkdir(parents=True)
+    _write(project_a / "pyproject.toml", '[tool.pytest.ini_options]\naddopts = "-q"\n')
+    _write(project_b / "pyproject.toml", '[tool.pytest.ini_options]\naddopts = "-p evil"\n')
+
+    request = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "cd project-b && pytest -q"},
+        cwd=project_a,
+    )
+
+    assert request is not None
+    assert request.shell_execution_effective_cwds == (str(project_b.resolve()),)
+
+
+def test_heredoc_does_not_make_an_earlier_project_use_the_last_effective_cwd(tmp_path: Path) -> None:
+    project_a = tmp_path / "project-a"
+    project_b = project_a / "project-b"
+    project_b.mkdir(parents=True)
+    _write(project_a / "pyproject.toml", '[tool.pytest.ini_options]\naddopts = "-p evil"\n')
+    command = "python -m pytest -q; cd project-b && python - <<'PY'\nprint('safe')\nPY\n"
+
+    request = extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=project_a)
+
+    assert request is not None
+    assert request.shell_execution_effective_cwds == (
+        str(project_a.resolve()),
+        str(project_b.resolve()),
+    )
+
+
+def test_literal_pushd_and_ruff_remain_prompt_free_in_the_effective_project(tmp_path: Path) -> None:
+    project = tmp_path / "services" / "auth"
+    project.mkdir(parents=True)
+
+    safe_request = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pushd services/auth && python -m ruff check ."},
+        cwd=tmp_path,
+    )
+    _write(project / "ruff.py", "raise SystemExit('shadowed ruff')\n")
+    unsafe_request = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pushd services/auth && python -m ruff check ."},
+        cwd=tmp_path,
+    )
+
+    assert safe_request is None
+    assert unsafe_request is not None
+    assert unsafe_request.shell_execution_effective_cwds == (str(project.resolve()),)
+
+
+def test_source_inspection_and_package_evidence_use_project_b(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_a = tmp_path / "project-a"
+    project_b = project_a / "project-b"
+    _write(project_a / "package.json", '{"devDependencies":{"vitest":"^3.0.0"}}\n')
+    _write(project_a / "package-lock.json", '{"packages":{"node_modules/vitest":{"version":"3.0.0"}}}\n')
+    project_a_runner = _write_executable(project_a / "node_modules" / ".bin" / "vitest")
+    _write(project_b / "src" / "safe.py", "SAFE = True\n")
+    _write(project_b / "package.json", '{"devDependencies":{"vitest":"^4.0.0"}}\n')
+    _write(project_b / "package-lock.json", '{"packages":{"node_modules/vitest":{"version":"4.0.0"}}}\n')
+    local_runner = _write_executable(project_b / "node_modules" / ".bin" / "vitest")
+    manager = _write_executable(tmp_path / "bin" / "npx")
+    monkeypatch.setenv("PATH", str(manager.parent))
+
+    assert _codex_command_is_read_only_source_inspection(
+        "cd project-b && sed -n '1,20p' src/safe.py",
+        cwd=project_a,
+    )
+    intent = parse_package_intent(
+        "cd project-b && npx --no-install vitest --help",
+        workspace=project_a,
+    )
+
+    assert intent is not None
+    evidence = intent.local_executions[0]
+    assert evidence.effective_cwd == str(project_b.resolve())
+    assert evidence.local_executable is not None
+    assert evidence.local_executable.resolved_path == str(local_runner.resolve())
+    assert evidence.local_executable.resolved_path != str(project_a_runner.resolve())
+    assert intent.manifest_paths == ("project-b/package.json",)
+
+
+def test_secret_source_output_artifact_uses_the_effective_project(tmp_path: Path) -> None:
+    project_a = tmp_path / "project-a"
+    project_b = project_a / "project-b"
+    _write(project_b / ".env", "API_KEY=project-b-secret\n")
+    command = "cd project-b && cat .env"
+
+    matches = _codex_sensitive_local_source_matches(command, cwd=project_a)
+    artifact = _codex_post_tool_output_artifact(
+        payload={
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {"stdout": "API_KEY=project-b-secret\n"},
+        },
+        config_path=str(project_a / ".codex" / "config.toml"),
+        source_scope="project",
+        cwd=project_a,
+    )
+
+    assert matches
+    assert matches[0].normalized_path == str((project_b / ".env").resolve())
+    assert artifact is not None
+    assert artifact.metadata["effective_cwd"] == str(project_b.resolve())
+
+
+def test_approval_tokens_are_partitioned_by_effective_project(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    project_a = workspace / "project-a"
+    project_b = workspace / "project-b"
+    _write(project_a / "package.json", '{"dependencies":{"left-pad":"1.3.0"}}\n')
+    _write(project_b / "package.json", '{"dependencies":{"left-pad":"1.1.0"}}\n')
+    _write(project_a / "conftest.py", "PROJECT = 'a'\n")
+    _write(project_b / "conftest.py", "PROJECT = 'b'\n")
+    _write(project_a / "pyproject.toml", '[tool.pytest.ini_options]\naddopts = "-q"\n')
+    _write(project_b / "pyproject.toml", '[tool.pytest.ini_options]\naddopts = "-ra"\n')
+    config = GuardConfig(guard_home=tmp_path / "home", workspace=workspace)
+
+    def token(project: str) -> str:
+        intent = parse_package_intent(f"cd {project} && npm install left-pad", workspace=workspace)
+        assert intent is not None
+        artifact = build_package_request_artifact(
+            "codex",
+            intent,
+            config_path=str(workspace / ".codex" / "config.toml"),
+            source_scope="project",
+        )
+        return _approval_token(artifact, workspace=workspace, config=config)
+
+    assert token("project-a") != token("project-b")
+
+
+def test_approval_token_binds_executables_from_every_effective_project(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    project_a = workspace / "project-a"
+    project_b = workspace / "project-b"
+    runner_a = _write_executable(project_a / "runner")
+    _write_executable(project_b / "runner")
+    config = GuardConfig(guard_home=tmp_path / "home", workspace=workspace)
+    artifact = GuardArtifact(
+        artifact_id="codex:project:multi-cwd-runner",
+        name="multi-cwd runner",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        command="./runner",
+        metadata={
+            "shell_execution_context_hash": "stable-command-context",
+            "shell_execution_context_complete": True,
+            "shell_execution_effective_cwds": [str(project_a), str(project_b)],
+        },
+    )
+
+    first = _approval_token(artifact, workspace=workspace, config=config)
+    _write(runner_a, "#!/bin/sh\nexit 7\n")
+    runner_a.chmod(0o755)
+    second = _approval_token(artifact, workspace=workspace, config=config)
+
+    assert first != second
+
+
+def test_cisco_preflight_scans_every_distinct_effective_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_a = tmp_path / "project-a"
+    project_b = tmp_path / "project-b"
+    project_a.mkdir()
+    project_b.mkdir()
+    calls: list[Path | None] = []
+    signal = GuardRiskSignalV3(
+        signal_id="cisco:test",
+        source="cisco_skill",
+        source_version="test",
+        category="skill",
+        severity="high",
+        confidence="strong",
+        title="fixture",
+        plain_language_summary="fixture",
+        technical_detail=None,
+        evidence_ref=None,
+        scanner_name="fixture",
+        scanner_status="enabled",
+        scanner_rule_id="fixture",
+        redaction_level="summary",
+        source_path=None,
+        source_line=None,
+        data_source=None,
+        data_sink=None,
+        recommended_action=None,
+    )
+    action = GuardActionEnvelope(
+        schema_version=1,
+        action_id="fixture",
+        harness="codex",
+        event_name="PreToolUse",
+        action_type="file_write",
+        workspace=str(tmp_path),
+        workspace_hash="fixture",
+        tool_name="Write",
+        command=None,
+        prompt_excerpt=None,
+        prompt_text=None,
+        target_paths=("skills/demo/SKILL.md",),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={},
+    )
+
+    def fake_scan(
+        _action: GuardActionEnvelope,
+        *,
+        workspace: Path | str | None,
+    ) -> tuple[GuardRiskSignalV3, ...]:
+        calls.append(Path(workspace) if workspace is not None else None)
+        return (signal,)
+
+    monkeypatch.setattr(runtime_eval_module, "scan_action_for_cisco_evidence", fake_scan)
+
+    evidence = runtime_eval_module._runtime_cisco_scanner_evidence(
+        action,
+        runtime_workspace=tmp_path,
+        raw_shell_cwds=[str(project_a), str(project_b), str(project_a), ""],
+    )
+
+    assert calls == [project_a.resolve(), project_b.resolve()]
+    assert evidence == (signal,)
+
+
+def test_unresolved_execution_context_cannot_reuse_an_approval_token(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = GuardConfig(guard_home=tmp_path / "home", workspace=workspace)
+    intent = parse_package_intent("cd $PROJECT && npm install left-pad", workspace=workspace)
+    assert intent is not None
+    artifact = build_package_request_artifact(
+        "codex",
+        intent,
+        config_path=str(workspace / ".codex" / "config.toml"),
+        source_scope="project",
+    )
+
+    first = _approval_token(artifact, workspace=workspace, config=config)
+    second = _approval_token(artifact, workspace=workspace, config=config)
+
+    assert artifact.metadata["shell_execution_context_complete"] is False
+    assert first != second
+
+
+def test_missing_explicit_execution_context_completeness_cannot_reuse_token(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = GuardConfig(guard_home=tmp_path / "home", workspace=workspace)
+    artifact = GuardArtifact(
+        artifact_id="codex:project:legacy-shell-context",
+        name="legacy shell context",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        command="rm marker",
+        metadata={
+            "shell_execution_context_hash": "legacy-context-without-completeness",
+            "shell_execution_effective_cwds": [str(workspace)],
+        },
+    )
+
+    first = _approval_token(artifact, workspace=workspace, config=config)
+    second = _approval_token(artifact, workspace=workspace, config=config)
+
+    assert first != second
+
+
+def test_destructive_shell_request_models_each_command_context_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    original_model = secret_file_requests_module.model_shell_execution_context
+    calls: list[str] = []
+
+    def counting_model(
+        command_text: str,
+        *,
+        cwd: Path | None = None,
+        workspace_root: Path | None = None,
+    ):
+        calls.append(command_text)
+        return original_model(command_text, cwd=cwd, workspace_root=workspace_root)
+
+    monkeypatch.setattr(secret_file_requests_module, "model_shell_execution_context", counting_model)
+
+    request = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "cd project && rm marker"},
+        cwd=tmp_path,
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+    assert calls == ["cd project && rm marker"]
+
+
+def test_path_hash_changes_when_effective_directory_identity_changes(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    first = model_shell_execution_context("cd project && pytest -q", cwd=tmp_path)
+    old = tmp_path / "old-project"
+    project.rename(old)
+    project.mkdir()
+    second = model_shell_execution_context("cd project && pytest -q", cwd=tmp_path)
+
+    assert first.context_hash != second.context_hash
+    assert os.stat(old).st_ino != os.stat(project).st_ino


### PR DESCRIPTION
## Summary

- model the effective working directory for every ordered shell segment, including literal `cd`, `pushd`, and `popd`
- preserve subshell, pipeline, grouping, newline/semicolon control flow, bounded directory-stack, path-identity, workspace-containment, and symlink-containment semantics
- bind filesystem change time alongside device, inode, and file type so rapid Linux inode reuse cannot make a removed-and-recreated directory pass pre-use revalidation
- pass proven per-segment directories into Python/pytest/package/source/executable checks, Cisco preflight roots, runtime metadata, and approval identity
- fail the complete command closed when dynamic parent-shell constructs (`source`, `.`, `eval`, cwd-changing functions, or non-empty `DEBUG` traps) can change later execution state
- preserve the merged `release/2.1` secret-safety boundary: modeled filesystem context is hashed directly, while unresolved secret-bearing argv receives only a process-ephemeral HMAC binding
- bind reusable approvals to every distinct effective directory and every directory-relative executable identity, not only the final directory
- preserve declared manifest/lockfile evidence that is removed or not created yet while still resolving existing symlink ancestors for workspace containment
- require the producer's explicit shell-context completeness boolean for approval reuse and compute each destructive command's execution context once

## Stable fail-closed reasons

- `shell_cwd_unresolved_expression`
- `shell_cwd_missing_directory`
- `shell_cwd_not_directory`
- `shell_cwd_unreadable_directory`
- `shell_cwd_ambiguous_stack`
- `shell_cwd_stack_limit`
- `shell_cwd_workspace_escape`
- `shell_cwd_symlink_escape`
- `shell_cwd_unresolved_control_flow`
- `shell_cwd_unresolved_parent_shell_effect`
- `shell_cwd_unresolved_syntax`
- `shell_cwd_path_changed`

## Validation

- `1,227 passed` — all three affected risk/runtime/shell-context test modules after the final Kilo review fixes
- `198 passed` — combined package-intent and external-archive regression suites after the final review fixes
- focused `123 passed` rerun covers missing completeness metadata, missing declared paths, and one-model-per-command behavior
- full local suite before the final replay: `9061 passed`, `23 skipped`, `5 deselected`; the sole failure was the known host credential-store availability test, outside this change
- Ruff formatting and lint passed for all changed files
- Basedpyright passed with `0 errors` for the changed production modules
- `uv build` produced the sdist and wheel successfully

## Attribution and target

- target branch: `release/2.1`
- commit author/committer: `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>`
