### PR TITLE
feat(guard): enforce action-aware approval scopes

### DIFF
--- a/src/codex_plugin_scanner/guard/approval_scope_support.py
+++ b/src/codex_plugin_scanner/guard/approval_scope_support.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Final, Literal
 
-from .models import DecisionScope
+from .models import DECISION_SCOPE_VALUES, DecisionScope
 from .package_execution_context import (
     PACKAGE_EXECUTION_CONTEXT_VERSION,
     PackageExecutionContext,
-    package_execution_context_from_scanner_evidence,
 )
 
 _SCOPED_APPROVAL_FAMILIES = frozenset(
@@ -27,24 +28,171 @@ _SCOPED_APPROVAL_FAMILIES = frozenset(
     }
 )
 
+APPROVAL_SCOPE_CONTRACT_VERSION: Final = "guard.approval-scopes.v2"
+ResolutionAction = Literal["allow", "block"]
+
+
+class StaleApprovalScopeContractError(ValueError):
+    """Raised when a client resolves against a superseded scope contract."""
+
+    def __init__(self, contract: ApprovalScopeContract) -> None:
+        super().__init__("stale_scope_contract")
+        self.contract = contract
+
+
+class IneligibleApprovalScopeError(ValueError):
+    """Raised when a V2 client selects a current but ineligible scope."""
+
+    def __init__(
+        self,
+        message: str,
+        contract: ApprovalScopeContract,
+        *,
+        action: str,
+        requested_scope: str,
+    ) -> None:
+        super().__init__(message)
+        self.contract = contract
+        self.action = action
+        self.requested_scope = requested_scope
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalScopeSelection:
+    requested_scope: DecisionScope
+    applied_scope: DecisionScope
+    warning: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalScopeContract:
+    allow_scopes: tuple[DecisionScope, ...]
+    block_scopes: tuple[DecisionScope, ...]
+    recommended_allow_scope: DecisionScope | None
+    recommended_block_scope: DecisionScope | None
+    restrictions: tuple[str, ...]
+    digest: str
+    task_capability_eligible: bool = False
+    version: str = APPROVAL_SCOPE_CONTRACT_VERSION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "scope_contract_version": self.version,
+            "scope_contract_digest": self.digest,
+            "allowed_scopes_by_action": {
+                "allow": list(self.allow_scopes),
+                "block": list(self.block_scopes),
+            },
+            "recommended_scope_by_action": {
+                "allow": self.recommended_allow_scope,
+                "block": self.recommended_block_scope,
+            },
+            "scope_restrictions": list(self.restrictions),
+            "task_capability_eligibility": {
+                "eligible": self.task_capability_eligible,
+                "reason_codes": ["task_capability_not_enabled"],
+            },
+        }
+
+
+def request_scope_contract(request: Mapping[str, object]) -> ApprovalScopeContract:
+    """Derive the current action-aware scope contract from trusted request fields.
+
+    This slice intentionally consumes no positive-proof assertion. Broad allow
+    scopes stay unavailable until a later producer binds complete proof to the
+    request. Deny breadth is limited to selectors Guard can derive canonically.
+    """
+
+    artifact_available = _string_or_none(request.get("artifact_id")) is not None
+    artifact_scopes: tuple[DecisionScope, ...] = ("artifact",) if artifact_available else ()
+    allow_scopes = () if _allow_is_non_overridable(request) else artifact_scopes
+    block_scopes: list[DecisionScope] = list(artifact_scopes)
+    trusted_family = _request_scoped_family_key(request)
+    if trusted_family is not None:
+        if _derived_workspace_scope_target(request) is not None:
+            block_scopes.append("workspace")
+        if _string_or_none(request.get("publisher")) is not None:
+            block_scopes.append("publisher")
+        block_scopes.extend(("harness", "global"))
+    restrictions = ["broad_allow_requires_positive_proof", "task_capability_not_enabled"]
+    if _allow_is_non_overridable(request):
+        restrictions.append("current_action_not_overridable")
+    if _derived_workspace_scope_target(request) is not None:
+        restrictions.append("workspace_allow_requires_complete_proof")
+    if trusted_family is not None:
+        restrictions.append("harness_and_global_allow_unavailable")
+    else:
+        restrictions.append("broad_deny_requires_trusted_selector")
+    block_scope_tuple = tuple(block_scopes)
+    restrictions_tuple = tuple(restrictions)
+    digest = _scope_contract_digest(
+        request,
+        allow_scopes=allow_scopes,
+        block_scopes=block_scope_tuple,
+        restrictions=restrictions_tuple,
+    )
+    return ApprovalScopeContract(
+        allow_scopes=allow_scopes,
+        block_scopes=block_scope_tuple,
+        recommended_allow_scope="artifact" if "artifact" in allow_scopes else None,
+        recommended_block_scope="artifact" if "artifact" in block_scopes else None,
+        restrictions=restrictions_tuple,
+        digest=digest,
+    )
+
+
+def request_scope_contract_payload(request: Mapping[str, object]) -> dict[str, object]:
+    return request_scope_contract(request).to_dict()
+
+
+def resolve_request_scope_selection(
+    request: Mapping[str, object],
+    *,
+    action: str,
+    requested_scope: str,
+    contract_version: str | None,
+    contract_digest: str | None,
+) -> ApprovalScopeSelection:
+    if action not in {"allow", "block"}:
+        raise ValueError("unsupported_resolution_action")
+    if requested_scope not in DECISION_SCOPE_VALUES:
+        raise ValueError(f"Unsupported approval scope: {requested_scope}")
+    typed_scope = _decision_scope(requested_scope)
+    contract = request_scope_contract(request)
+    if (contract_version is None) != (contract_digest is None):
+        raise ValueError("incomplete_scope_contract")
+    if contract_version is not None and (
+        contract_version != APPROVAL_SCOPE_CONTRACT_VERSION or contract_digest != contract.digest
+    ):
+        raise StaleApprovalScopeContractError(contract)
+    eligible = contract.allow_scopes if action == "allow" else contract.block_scopes
+    if typed_scope in eligible:
+        return ApprovalScopeSelection(typed_scope, typed_scope)
+    if contract_version is not None or action == "block":
+        raise IneligibleApprovalScopeError(
+            "ineligible_request_scope",
+            contract,
+            action=action,
+            requested_scope=requested_scope,
+        )
+    if "artifact" not in eligible:
+        raise IneligibleApprovalScopeError(
+            "request_action_not_overridable",
+            contract,
+            action=action,
+            requested_scope=requested_scope,
+        )
+    return ApprovalScopeSelection(
+        requested_scope=typed_scope,
+        applied_scope="artifact",
+        warning="legacy_scope_narrowed_to_artifact",
+    )
+
 
 def supported_request_scopes(request: Mapping[str, object]) -> tuple[DecisionScope, ...]:
-    if _is_package_request_artifact(
-        artifact_id=_string_or_none(request.get("artifact_id")),
-        artifact_type=_string_or_none(request.get("artifact_type")),
-    ):
-        package_context = package_execution_context_from_scanner_evidence(request.get("scanner_evidence"))
-        if package_context is not None and package_context.portable and _derived_workspace_scope_target(request):
-            return ("artifact", "workspace")
-        return ("artifact",)
-    scopes: list[DecisionScope] = ["artifact"]
-    if _string_or_none(request.get("publisher")) is not None:
-        scopes.append("publisher")
-    if _derived_workspace_scope_target(request) is not None:
-        scopes.append("workspace")
-    if _request_scoped_family_key(request) is not None:
-        scopes.extend(("harness", "global"))
-    return tuple(scopes)
+    """Return legacy UI scopes, conservatively projected from V2 allow scopes."""
+
+    return request_scope_contract(request).allow_scopes
 
 
 def resolve_request_workspace_scope(
@@ -150,7 +298,99 @@ def _is_package_request_artifact(*, artifact_id: str | None, artifact_type: str 
 
 
 def _request_scoped_family_key(request: Mapping[str, object]) -> str | None:
-    return _artifact_family_key(_string_or_none(request.get("artifact_id")))
+    family_key = _artifact_family_key(_string_or_none(request.get("artifact_id")))
+    artifact_type = _string_or_none(request.get("artifact_type"))
+    if family_key is None or artifact_type is None:
+        return None
+    expected_families = {
+        "file_read_request": frozenset({"file-read"}),
+        "mcp_server": frozenset({"mcp", "mcp-tool"}),
+        "mcp_tool_call": frozenset({"mcp", "mcp-tool"}),
+        "package_request": frozenset({"package-request"}),
+        "prompt_request": frozenset({"prompt", "prompt-env-read", "prompt-file"}),
+        "tool_action_request": frozenset({"tool-action"}),
+    }.get(artifact_type)
+    family = family_key.removeprefix("family:")
+    return family_key if expected_families is not None and family in expected_families else None
+
+
+def _scope_contract_digest(
+    request: Mapping[str, object],
+    *,
+    allow_scopes: tuple[DecisionScope, ...],
+    block_scopes: tuple[DecisionScope, ...],
+    restrictions: tuple[str, ...],
+) -> str:
+    material = {
+        "version": APPROVAL_SCOPE_CONTRACT_VERSION,
+        "allow_scopes": allow_scopes,
+        "block_scopes": block_scopes,
+        "restrictions": restrictions,
+        "request": {
+            key: _json_boundary_value(request.get(key))
+            for key in (
+                "harness",
+                "artifact_id",
+                "artifact_type",
+                "artifact_hash",
+                "policy_action",
+                "publisher",
+                "source_scope",
+                "config_path",
+                "workspace",
+                "launch_target",
+                "normalized_identity_key",
+                "action_identity",
+                "queue_group_id",
+                "transport",
+                "changed_fields",
+                "action_envelope_json",
+                "scanner_evidence",
+                "raw_command_text",
+            )
+        },
+    }
+    encoded = json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _json_boundary_value(value: object) -> object:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, Mapping):
+        return {
+            str(key): _json_boundary_value(item) for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_json_boundary_value(item) for item in value]
+    return {"invalid_type": type(value).__name__}
+
+
+def _allow_is_non_overridable(request: Mapping[str, object]) -> bool:
+    if _string_or_none(request.get("policy_action")) == "block":
+        return True
+    envelope = request.get("action_envelope_json")
+    if not isinstance(envelope, Mapping):
+        return False
+    action_type = _string_or_none(envelope.get("action_type"))
+    return action_type in {
+        "guard_control",
+        "guard-control",
+        "guard_control_operation",
+        "guard-control-operation",
+    }
+
+
+def _decision_scope(value: str) -> DecisionScope:
+    if value == "global":
+        return "global"
+    if value == "harness":
+        return "harness"
+    if value == "workspace":
+        return "workspace"
+    if value == "publisher":
+        return "publisher"
+    return "artifact"
 
 
 def _artifact_family_key(artifact_id: str | None) -> str | None:

--- a/src/codex_plugin_scanner/guard/approval_scope_support.py
+++ b/src/codex_plugin_scanner/guard/approval_scope_support.py
@@ -28,7 +28,8 @@ _SCOPED_APPROVAL_FAMILIES = frozenset(
     }
 )
 
-APPROVAL_SCOPE_CONTRACT_VERSION: Final = "guard.approval-scopes.v2"
+APPROVAL_SCOPE_CONTRACT_VERSION_PREFIX: Final = "guard.approval-scopes.v"
+APPROVAL_SCOPE_CONTRACT_VERSION: Final = f"{APPROVAL_SCOPE_CONTRACT_VERSION_PREFIX}2"
 ResolutionAction = Literal["allow", "block"]
 
 
@@ -48,7 +49,7 @@ class IneligibleApprovalScopeError(ValueError):
         message: str,
         contract: ApprovalScopeContract,
         *,
-        action: str,
+        action: ResolutionAction,
         requested_scope: str,
     ) -> None:
         super().__init__(message)
@@ -153,7 +154,11 @@ def resolve_request_scope_selection(
     contract_version: str | None,
     contract_digest: str | None,
 ) -> ApprovalScopeSelection:
-    if action not in {"allow", "block"}:
+    if action == "allow":
+        resolution_action: ResolutionAction = "allow"
+    elif action == "block":
+        resolution_action = "block"
+    else:
         raise ValueError("unsupported_resolution_action")
     if requested_scope not in DECISION_SCOPE_VALUES:
         raise ValueError(f"Unsupported approval scope: {requested_scope}")
@@ -165,21 +170,21 @@ def resolve_request_scope_selection(
         contract_version != APPROVAL_SCOPE_CONTRACT_VERSION or contract_digest != contract.digest
     ):
         raise StaleApprovalScopeContractError(contract)
-    eligible = contract.allow_scopes if action == "allow" else contract.block_scopes
+    eligible = contract.allow_scopes if resolution_action == "allow" else contract.block_scopes
     if typed_scope in eligible:
         return ApprovalScopeSelection(typed_scope, typed_scope)
     if contract_version is not None or action == "block":
         raise IneligibleApprovalScopeError(
             "ineligible_request_scope",
             contract,
-            action=action,
+            action=resolution_action,
             requested_scope=requested_scope,
         )
     if "artifact" not in eligible:
         raise IneligibleApprovalScopeError(
             "request_action_not_overridable",
             contract,
-            action=action,
+            action=resolution_action,
             requested_scope=requested_scope,
         )
     return ApprovalScopeSelection(
@@ -367,7 +372,7 @@ def _json_boundary_value(value: object) -> object:
 
 
 def _allow_is_non_overridable(request: Mapping[str, object]) -> bool:
-    if _string_or_none(request.get("policy_action")) == "block":
+    if _string_or_none(request.get("policy_action")) not in {"require-reapproval", "review"}:
         return True
     envelope = request.get("action_envelope_json")
     if not isinstance(envelope, Mapping):

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import threading
 import time
 import uuid
@@ -68,7 +69,7 @@ GUARD_INBOX_URL = f"{GUARD_DASHBOARD_URL}/inbox"
 GUARD_FLEET_URL = f"{GUARD_DASHBOARD_URL}/protect"
 GUARD_CONNECT_URL = f"{GUARD_DASHBOARD_URL}/connect"
 _APPROVAL_ONCE_POLICY_TTL = timedelta(minutes=15)
-_APPROVAL_RESOLUTION_LOCK = threading.RLock()
+_APPROVAL_RESOLUTION_LOCKS = tuple(threading.RLock() for _ in range(64))
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 _WORKSPACE_SCOPED_RUNTIME_ARTIFACT_TYPES = frozenset(
@@ -88,7 +89,12 @@ class ApprovalRequestNotFoundError(ValueError):
 def _serialize_approval_resolution(function: Callable[_P, _R]) -> Callable[_P, _R]:
     @wraps(function)
     def serialized(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-        with _APPROVAL_RESOLUTION_LOCK:
+        request_id = kwargs.get("request_id")
+        if not isinstance(request_id, str):
+            raise TypeError("request_id must be provided as a string keyword argument")
+        digest = hashlib.sha256(request_id.encode("utf-8")).digest()
+        lock = _APPROVAL_RESOLUTION_LOCKS[int.from_bytes(digest[:2], "big") % len(_APPROVAL_RESOLUTION_LOCKS)]
+        with lock:
             return function(*args, **kwargs)
 
     return serialized

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import threading
 import time
 import uuid
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
+from functools import wraps
 from pathlib import Path
-from typing import TypeGuard
+from typing import ParamSpec, TypeGuard, TypeVar
 from urllib.parse import ParseResult, parse_qsl, urlencode, urlparse, urlunparse
 
 from .action_lattice import normalize_guard_action_result
@@ -17,9 +18,12 @@ from .adapters import get_adapter
 from .adapters.base import HarnessContext
 from .approval_gate import ApprovalGateGrant, ApprovalGateInput, require_approval_decision
 from .approval_scope_support import (
+    IneligibleApprovalScopeError,
     package_request_portable_workspace_scope,
+    request_scope_contract,
+    request_scope_contract_payload,
+    resolve_request_scope_selection,
     resolve_request_workspace_scope,
-    supported_request_scopes,
 )
 from .cli.connect_flow import (
     connect_retry_refresh_race_from_reason,
@@ -64,6 +68,9 @@ GUARD_INBOX_URL = f"{GUARD_DASHBOARD_URL}/inbox"
 GUARD_FLEET_URL = f"{GUARD_DASHBOARD_URL}/protect"
 GUARD_CONNECT_URL = f"{GUARD_DASHBOARD_URL}/connect"
 _APPROVAL_ONCE_POLICY_TTL = timedelta(minutes=15)
+_APPROVAL_RESOLUTION_LOCK = threading.RLock()
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 _WORKSPACE_SCOPED_RUNTIME_ARTIFACT_TYPES = frozenset(
     {
         "file_read_request",
@@ -76,6 +83,15 @@ _WORKSPACE_SCOPED_RUNTIME_ARTIFACT_TYPES = frozenset(
 
 class ApprovalRequestNotFoundError(ValueError):
     """Raised when an approval request ID does not exist."""
+
+
+def _serialize_approval_resolution(function: Callable[_P, _R]) -> Callable[_P, _R]:
+    @wraps(function)
+    def serialized(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        with _APPROVAL_RESOLUTION_LOCK:
+            return function(*args, **kwargs)
+
+    return serialized
 
 
 class ApprovalRequestAlreadyResolvedError(ValueError):
@@ -501,8 +517,9 @@ def queue_blocked_approvals(
         if created_new_request:
             _record_created_event(store, request, timestamp)
         _notify_pending_approval(store=store, request=request)
-        request_payload = request.to_dict()
-        request_payload["allowed_scopes"] = list(supported_request_scopes(request_payload))
+        request_payload = store.get_approval_request(persisted_request_id)
+        if request_payload is None:
+            raise RuntimeError(f"Persisted approval request not found: {persisted_request_id}")
         queued.append(request_payload)
     return queued
 
@@ -525,6 +542,7 @@ def evaluation_has_terminal_policy_action(evaluation: Mapping[str, object]) -> b
     return False
 
 
+@_serialize_approval_resolution
 def apply_approval_resolution(
     *,
     store: GuardStore,
@@ -540,16 +558,34 @@ def apply_approval_resolution(
     approval_gate_grant: ApprovalGateGrant | None = None,
     approval_gate_subject: str | None = None,
     persist_policy: bool | None = None,
+    scope_contract_version: str | None = None,
+    scope_contract_digest: str | None = None,
 ) -> dict[str, object]:
     request = store.get_approval_request(request_id)
     if request is None:
         raise ApprovalRequestNotFoundError(f"Unknown approval request: {request_id}")
     if request["status"] != "pending":
         raise ApprovalRequestAlreadyResolvedError(f"Approval request already resolved: {request_id}")
-    if not _is_decision_scope(scope):
-        raise ValueError(f"Unsupported approval scope: {scope}")
-    if scope not in supported_request_scopes(request):
-        raise ValueError("unsupported_request_scope")
+    selection = resolve_request_scope_selection(
+        request,
+        action=action,
+        requested_scope=scope,
+        contract_version=scope_contract_version,
+        contract_digest=scope_contract_digest,
+    )
+    requested_scope = selection.requested_scope
+    scope = selection.applied_scope
+    if selection.warning is not None:
+        persist_policy = None
+    elif action == "allow" and scope == "artifact" and persist_policy is True:
+        if scope_contract_version is not None:
+            raise IneligibleApprovalScopeError(
+                "saved_allow_scope_ineligible",
+                request_scope_contract(request),
+                action=action,
+                requested_scope=scope,
+            )
+        persist_policy = None
     workspace_artifact_id, workspace_artifact_hash = _workspace_policy_artifact_keys(request, scope)
     request_artifact_id = _string_or_none(request.get("artifact_id"))
     request_artifact_hash = _string_or_none(request.get("artifact_hash"))
@@ -692,6 +728,11 @@ def apply_approval_resolution(
             persisted_rule=persisted_rule,
             local_once_fallback=local_once_fallback,
         )
+        result.update(request_scope_contract_payload(request))
+        result["requested_scope"] = requested_scope
+        result["applied_scope"] = scope
+        if selection.warning is not None:
+            result["scope_warning"] = selection.warning
         return result
     resolved_ids: list[str] = []
     if resolve_scope_matches and not exact_context_allow:
@@ -732,6 +773,11 @@ def apply_approval_resolution(
         persisted_rule=persisted_rule,
         local_once_fallback=local_once_fallback,
     )
+    updated.update(request_scope_contract_payload(request))
+    updated["requested_scope"] = requested_scope
+    updated["applied_scope"] = scope
+    if selection.warning is not None:
+        updated["scope_warning"] = selection.warning
     return updated
 
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -53,6 +53,12 @@ from ..approval_gate import (
 from ..approval_gate import (
     validate_settings_update as validate_approval_gate_settings,
 )
+from ..approval_scope_support import (
+    IneligibleApprovalScopeError,
+    StaleApprovalScopeContractError,
+    request_scope_contract_payload,
+    resolve_request_scope_selection,
+)
 from ..approvals import (
     ApprovalRequestAlreadyResolvedError,
     ApprovalRequestNotFoundError,
@@ -2022,7 +2028,65 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if not isinstance(scope, str) or not scope.strip():
             self._write_json({"resolved": False, "error": "missing_required_fields"}, status=400)
             return
+        scope_contract_version_value = payload.get("scope_contract_version")
+        if scope_contract_version_value is not None and (
+            not isinstance(scope_contract_version_value, str) or not scope_contract_version_value.strip()
+        ):
+            self._write_json({"resolved": False, "error": "invalid_scope_contract_version"}, status=400)
+            return
+        scope_contract_version = (
+            scope_contract_version_value.strip() if isinstance(scope_contract_version_value, str) else None
+        )
+        if scope_contract_version is not None:
+            version_prefix = "guard.approval-scopes.v"
+            if (
+                not scope_contract_version.startswith(version_prefix)
+                or not scope_contract_version.removeprefix(version_prefix).isdigit()
+            ):
+                self._write_json({"resolved": False, "error": "invalid_scope_contract_version"}, status=400)
+                return
+        scope_contract_digest_value = payload.get("scope_contract_digest")
+        if scope_contract_digest_value is not None and (
+            not isinstance(scope_contract_digest_value, str) or not scope_contract_digest_value.strip()
+        ):
+            self._write_json({"resolved": False, "error": "invalid_scope_contract_digest"}, status=400)
+            return
+        scope_contract_digest = (
+            scope_contract_digest_value.strip() if isinstance(scope_contract_digest_value, str) else None
+        )
+        if scope_contract_digest is not None and (
+            len(scope_contract_digest) != 64
+            or any(character not in "0123456789abcdef" for character in scope_contract_digest)
+        ):
+            self._write_json({"resolved": False, "error": "invalid_scope_contract_digest"}, status=400)
+            return
         try:
+            existing_request = self.server.store.get_approval_request(request_id)  # type: ignore[attr-defined]
+            if isinstance(existing_request, dict):
+                scope_selection = resolve_request_scope_selection(
+                    existing_request,
+                    action=action,
+                    requested_scope=scope.strip(),
+                    contract_version=scope_contract_version,
+                    contract_digest=scope_contract_digest,
+                )
+                if existing_request.get("status") != "pending":
+                    if (
+                        existing_request.get("resolution_action") == action
+                        and existing_request.get("resolution_scope") == scope_selection.applied_scope
+                    ):
+                        self._write_json(
+                            {
+                                "resolved": True,
+                                "idempotent": True,
+                                "resolved_request": existing_request,
+                                "requested_scope": scope_selection.requested_scope,
+                                "applied_scope": scope_selection.applied_scope,
+                                **request_scope_contract_payload(existing_request),
+                            }
+                        )
+                        return
+                    raise ApprovalRequestAlreadyResolvedError(f"Approval request already resolved: {request_id}")
             persist_policy = self._approval_persist_policy(payload)
             updated = apply_approval_resolution(
                 store=self.server.store,  # type: ignore[attr-defined]
@@ -2035,6 +2099,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 resolve_scope_matches=False,
                 approval_gate_input=approval_gate_input_from_mapping(payload),
                 persist_policy=persist_policy,
+                scope_contract_version=scope_contract_version,
+                scope_contract_digest=scope_contract_digest,
             )
         except ApprovalRequestNotFoundError:
             self._write_json(
@@ -2052,6 +2118,30 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             )
             return
         except ApprovalRequestAlreadyResolvedError:
+            resolved_request = self.server.store.get_approval_request(request_id)  # type: ignore[attr-defined]
+            if isinstance(resolved_request, dict):
+                replay_selection = resolve_request_scope_selection(
+                    resolved_request,
+                    action=action,
+                    requested_scope=scope.strip(),
+                    contract_version=scope_contract_version,
+                    contract_digest=scope_contract_digest,
+                )
+                if (
+                    resolved_request.get("resolution_action") == action
+                    and resolved_request.get("resolution_scope") == replay_selection.applied_scope
+                ):
+                    self._write_json(
+                        {
+                            "resolved": True,
+                            "idempotent": True,
+                            "resolved_request": resolved_request,
+                            "requested_scope": replay_selection.requested_scope,
+                            "applied_scope": replay_selection.applied_scope,
+                            **request_scope_contract_payload(resolved_request),
+                        }
+                    )
+                    return
             self._write_json(
                 {
                     "resolved": False,
@@ -2071,6 +2161,24 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         except ApprovalGateError as error:
             self._write_approval_gate_error(error, resolved=False)
+            return
+        except StaleApprovalScopeContractError as error:
+            self._write_json(
+                {"resolved": False, "error": str(error), **error.contract.to_dict()},
+                status=409,
+            )
+            return
+        except IneligibleApprovalScopeError as error:
+            self._write_json(
+                {
+                    "resolved": False,
+                    "error": str(error),
+                    "action": error.action,
+                    "requested_scope": error.requested_scope,
+                    **error.contract.to_dict(),
+                },
+                status=422,
+            )
             return
         except ValueError as error:
             self._write_json({"resolved": False, "error": str(error)}, status=400)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -54,8 +54,11 @@ from ..approval_gate import (
     validate_settings_update as validate_approval_gate_settings,
 )
 from ..approval_scope_support import (
+    APPROVAL_SCOPE_CONTRACT_VERSION,
+    APPROVAL_SCOPE_CONTRACT_VERSION_PREFIX,
     IneligibleApprovalScopeError,
     StaleApprovalScopeContractError,
+    request_scope_contract,
     request_scope_contract_payload,
     resolve_request_scope_selection,
 )
@@ -139,6 +142,7 @@ from ..receipts.manager import build_receipt
 from ..review_contracts import (
     GuardReviewContractError,
     guard_review_oauth_metadata,
+    normalize_remote_approval_decision,
     validate_remote_approval_request_binding,
     validated_remote_approval_envelope,
 )
@@ -2037,14 +2041,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         scope_contract_version = (
             scope_contract_version_value.strip() if isinstance(scope_contract_version_value, str) else None
         )
-        if scope_contract_version is not None:
-            version_prefix = "guard.approval-scopes.v"
-            if (
-                not scope_contract_version.startswith(version_prefix)
-                or not scope_contract_version.removeprefix(version_prefix).isdigit()
-            ):
-                self._write_json({"resolved": False, "error": "invalid_scope_contract_version"}, status=400)
-                return
+        if scope_contract_version is not None and (
+            not scope_contract_version.startswith(APPROVAL_SCOPE_CONTRACT_VERSION_PREFIX)
+            or not scope_contract_version.removeprefix(APPROVAL_SCOPE_CONTRACT_VERSION_PREFIX).isdigit()
+        ):
+            self._write_json({"resolved": False, "error": "invalid_scope_contract_version"}, status=400)
+            return
         scope_contract_digest_value = payload.get("scope_contract_digest")
         if scope_contract_digest_value is not None and (
             not isinstance(scope_contract_digest_value, str) or not scope_contract_digest_value.strip()
@@ -2656,11 +2658,27 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "remote_once_request_not_pending"}, status=409)
             return
         request_policy_action = self._optional_string(request_row.get("policy_action"))
-        request_recommended_scope = self._optional_string(request_row.get("recommended_scope"))
+        resolution_action = normalize_remote_approval_decision(envelope.get("decision"))
+        if resolution_action is None:
+            self._write_json({"error": "invalid_remote_approval_decision"}, status=400)
+            return
+        contract = request_scope_contract(request_row)
+        request_recommended_scope = self._optional_string(envelope.get("scope"))
         if (
             request_policy_action not in {"block", "pause", "review", "require-reapproval"}
             or request_recommended_scope not in DECISION_SCOPE_VALUES
         ):
+            self._write_json({"error": "remote_once_not_permitted"}, status=409)
+            return
+        try:
+            scope_selection = resolve_request_scope_selection(
+                request_row,
+                action=resolution_action,
+                requested_scope=request_recommended_scope,
+                contract_version=APPROVAL_SCOPE_CONTRACT_VERSION,
+                contract_digest=contract.digest,
+            )
+        except IneligibleApprovalScopeError:
             self._write_json({"error": "remote_once_not_permitted"}, status=409)
             return
         try:
@@ -2699,12 +2717,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         ):
             self._write_json({"error": "remote_once_replayed"}, status=409)
             return
-        resolution_action = "block" if self._optional_string(envelope.get("decision")) == "block" else "allow"
         try:
             result = self.server.store.resolve_request_with_signed_remote_result(  # type: ignore[attr-defined]
                 request_id,
                 resolution_action=resolution_action,
-                resolution_scope=request_recommended_scope or "artifact",
+                resolution_scope=scope_selection.applied_scope,
                 reason="Guard Cloud signed remote approval",
                 resolved_at=_now(),
             )
@@ -2727,7 +2744,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "receipt_id": receipt_id,
                 "request_id": request_id,
                 "review_command": self._optional_string(resolved_request.get("review_command")),
-                "scope": request_recommended_scope or "artifact",
+                "scope": scope_selection.applied_scope,
             },
             resolved_at,
         )

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2122,13 +2122,35 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         except ApprovalRequestAlreadyResolvedError:
             resolved_request = self.server.store.get_approval_request(request_id)  # type: ignore[attr-defined]
             if isinstance(resolved_request, dict):
-                replay_selection = resolve_request_scope_selection(
-                    resolved_request,
-                    action=action,
-                    requested_scope=scope.strip(),
-                    contract_version=scope_contract_version,
-                    contract_digest=scope_contract_digest,
-                )
+                try:
+                    replay_selection = resolve_request_scope_selection(
+                        resolved_request,
+                        action=action,
+                        requested_scope=scope.strip(),
+                        contract_version=scope_contract_version,
+                        contract_digest=scope_contract_digest,
+                    )
+                except StaleApprovalScopeContractError as error:
+                    self._write_json(
+                        {"resolved": False, "error": str(error), **error.contract.to_dict()},
+                        status=409,
+                    )
+                    return
+                except IneligibleApprovalScopeError as error:
+                    self._write_json(
+                        {
+                            "resolved": False,
+                            "error": str(error),
+                            "action": error.action,
+                            "requested_scope": error.requested_scope,
+                            **error.contract.to_dict(),
+                        },
+                        status=422,
+                    )
+                    return
+                except ValueError as error:
+                    self._write_json({"resolved": False, "error": str(error)}, status=400)
+                    return
                 if (
                     resolved_request.get("resolution_action") == action
                     and resolved_request.get("resolution_scope") == replay_selection.applied_scope

--- a/src/codex_plugin_scanner/guard/review_contracts.py
+++ b/src/codex_plugin_scanner/guard/review_contracts.py
@@ -14,6 +14,12 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
+from .approval_scope_support import (
+    APPROVAL_SCOPE_CONTRACT_VERSION,
+    IneligibleApprovalScopeError,
+    request_scope_contract,
+    resolve_request_scope_selection,
+)
 from .models import DECISION_SCOPE_VALUES
 from .policy_bundle_trusted_keys import (
     PolicyBundleVerificationKey,
@@ -301,7 +307,7 @@ def build_local_review_request_claim(
     artifact_id = _non_empty_string(request_row.get("artifact_id"))
     harness_id = _non_empty_string(request_row.get("harness"))
     policy_action = _non_empty_string(request_row.get("policy_action"))
-    recommended_scope = _non_empty_string(request_row.get("recommended_scope"))
+    recommended_scope = _request_recommended_scope(request_row)
     created_at = _non_empty_string(request_row.get("created_at"))
     last_seen_at = _non_empty_string(request_row.get("last_seen_at")) or created_at
     required_fields = (
@@ -363,6 +369,18 @@ def payload_hash_for_remote_approval_envelope(envelope: dict[str, object]) -> st
     return _sha256_hex(_canonical_signed_payload(envelope))
 
 
+def normalize_remote_approval_decision(value: object) -> str | None:
+    normalized = _non_empty_string(value)
+    if normalized is None:
+        return None
+    folded = normalized.replace("_", "-")
+    if folded in {"allow", "allow-once"} or normalized == "allowOnce":
+        return "allow"
+    if folded in {"block", "deny", "denied", "blocked"}:
+        return "block"
+    return None
+
+
 def validated_remote_approval_envelope(
     envelope: dict[str, object],
     *,
@@ -373,6 +391,8 @@ def validated_remote_approval_envelope(
         raise GuardReviewContractError("unsupported_remote_approval_contract")
     if envelope.get("scope") not in _REMOTE_APPROVAL_ALLOWED_SCOPES:
         raise GuardReviewContractError("invalid_remote_approval_scope")
+    if normalize_remote_approval_decision(envelope.get("decision")) is None:
+        raise GuardReviewContractError("invalid_remote_approval_decision")
     issued_at = _parse_iso_timestamp(envelope.get("issuedAt"), field_name="issued_at")
     expires_at = _parse_iso_timestamp(envelope.get("expiresAt"), field_name="expires_at")
     if expires_at <= issued_at:
@@ -426,9 +446,36 @@ def validate_remote_approval_request_binding(
     if _non_empty_string(envelope.get("sourceClaimHash")) != _non_empty_string(expected_claim.get("claimHash")):
         raise GuardReviewContractError("remote_approval_claim_hash_mismatch")
     envelope_scope = _non_empty_string(envelope.get("scope"))
-    request_scope = _non_empty_string(request_row.get("recommended_scope"))
-    if envelope_scope != request_scope:
+    action = normalize_remote_approval_decision(envelope.get("decision"))
+    if action is None:
+        raise GuardReviewContractError("invalid_remote_approval_decision")
+    contract = request_scope_contract(request_row)
+    if envelope_scope is None:
         raise GuardReviewContractError("remote_approval_scope_mismatch")
+    try:
+        resolve_request_scope_selection(
+            request_row,
+            action=action,
+            requested_scope=envelope_scope,
+            contract_version=APPROVAL_SCOPE_CONTRACT_VERSION,
+            contract_digest=contract.digest,
+        )
+    except (IneligibleApprovalScopeError, ValueError) as error:
+        raise GuardReviewContractError("remote_approval_scope_mismatch") from error
+
+
+def _request_recommended_scope(request_row: dict[str, object], *, decision: str | None = None) -> str | None:
+    recommendations = request_row.get("recommended_scope_by_action")
+    if isinstance(recommendations, dict):
+        action = "block" if decision == "block" else "allow"
+        selected = _non_empty_string(recommendations.get(action))
+        if selected is not None:
+            return selected
+        if decision is None:
+            fallback = _non_empty_string(recommendations.get("block"))
+            if fallback is not None:
+                return fallback
+    return _non_empty_string(request_row.get("recommended_scope"))
 
 
 def payload_hash_for_decision_memory_bundle(bundle: dict[str, object]) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -11,6 +11,12 @@ from typing import TypeGuard
 from ..action_lattice import is_guard_action as _is_guard_action
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
+from ..approval_scope_support import (
+    APPROVAL_SCOPE_CONTRACT_VERSION,
+    IneligibleApprovalScopeError,
+    request_scope_contract,
+    resolve_request_scope_selection,
+)
 from ..cli.install_commands import (
     apply_managed_install,
     build_harness_verification,
@@ -36,6 +42,7 @@ from ..package_shim_status import record_package_shim_audit_result
 from ..review_contracts import (
     GuardReviewContractError,
     guard_review_oauth_metadata,
+    normalize_remote_approval_decision,
     validate_decision_memory_bundle_target,
     validate_remote_approval_request_binding,
     validated_decision_memory_bundle,
@@ -301,7 +308,7 @@ def _execute_approval_operation(
         "localRequestId",
         "local_request_id",
     )
-    normalized_outer_action = _normalize_remote_decision_action(action)
+    normalized_outer_action = normalize_remote_approval_decision(action)
     if action != "policy_sync" and normalized_outer_action is None:
         raise ValueError("invalid_approval_payload")
     if action == "policy_sync":
@@ -335,19 +342,34 @@ def _execute_approval_operation(
         store=store,
         admitted_at=job.get("createdAt"),
     )
+    request_policy_action = _optional_string(request_row.get("policy_action"))
+    envelope_decision = _optional_string(envelope.get("decision"))
+    resolution_action = normalize_remote_approval_decision(envelope_decision)
+    if resolution_action is None:
+        raise ValueError("invalid_remote_approval_decision")
+    contract = request_scope_contract(request_row)
+    resolution_scope = _optional_string(envelope.get("scope"))
+    if (
+        request_policy_action not in {"block", "pause", "review", "require-reapproval"}
+        or resolution_scope not in DECISION_SCOPE_VALUES
+    ):
+        raise ValueError("remote_approval_not_permitted")
+    try:
+        scope_selection = resolve_request_scope_selection(
+            request_row,
+            action=resolution_action,
+            requested_scope=resolution_scope,
+            contract_version=APPROVAL_SCOPE_CONTRACT_VERSION,
+            contract_digest=contract.digest,
+        )
+    except IneligibleApprovalScopeError as error:
+        raise ValueError("remote_approval_not_permitted") from error
     validate_remote_approval_request_binding(
         envelope=envelope,
         request_row=request_row,
         oauth=oauth,
         store=store,
     )
-    request_policy_action = _optional_string(request_row.get("policy_action"))
-    resolution_scope = _optional_string(request_row.get("recommended_scope"))
-    if (
-        request_policy_action not in {"block", "pause", "review", "require-reapproval"}
-        or resolution_scope not in DECISION_SCOPE_VALUES
-    ):
-        raise ValueError("remote_approval_not_permitted")
     receipt_id = _optional_string(envelope.get("receiptId"))
     if receipt_id is None:
         raise ValueError("invalid_remote_approval_receipt")
@@ -357,12 +379,7 @@ def _execute_approval_operation(
         claimed_at=generated_at,
     ):
         raise ValueError("remote_approval_replayed")
-    envelope_decision = _optional_string(envelope.get("decision"))
-    resolution_action = _normalize_remote_decision_action(envelope_decision)
-    if resolution_action is None:
-        store.release_remote_once_receipt(receipt_id)
-        raise ValueError("invalid_remote_approval_decision")
-    resolution_scope = resolution_scope or "artifact"
+    resolution_scope = scope_selection.applied_scope
     try:
         result = store.resolve_request_with_signed_remote_result(
             local_request_id,
@@ -426,18 +443,6 @@ def _remote_resume_confirmed(resume_metadata: dict[str, object], action: str) ->
         return False
     detail = resume_metadata.get("codexResume") or resume_metadata.get("harnessResume")
     return isinstance(detail, dict) and detail.get("reason") == "blocked_not_resumed"
-
-
-def _normalize_remote_decision_action(value: object) -> str | None:
-    normalized = _optional_string(value)
-    if normalized is None:
-        return None
-    folded = normalized.replace("_", "-")
-    if folded in {"allow", "allow-once"} or normalized == "allowOnce":
-        return "allow"
-    if folded in {"block", "deny", "denied", "blocked"}:
-        return "block"
-    return None
 
 
 def _target_string(mapping: dict[str, object], *keys: str) -> str | None:

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -8,7 +8,7 @@ import json
 import re
 import sqlite3
 
-from .approval_scope_support import supported_request_scopes
+from .approval_scope_support import request_scope_contract_payload, supported_request_scopes
 from .models import GuardApprovalRequest
 from .runtime.action_identity import normalize_command_identity
 
@@ -628,7 +628,17 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "created_at": str(row["created_at"]),
         "resolved_at": row["resolved_at"],
     }
+    payload.update(request_scope_contract_payload(payload))
     payload["allowed_scopes"] = list(supported_request_scopes(payload))
+    recommendations = payload["recommended_scope_by_action"]
+    if isinstance(recommendations, dict):
+        payload["recommended_scope"] = recommendations.get("allow")
+    decision_v2 = payload.get("decision_v2_json")
+    if isinstance(decision_v2, dict):
+        payload["decision_v2_json"] = {
+            **decision_v2,
+            "approval_scopes": list(payload["allowed_scopes"]),
+        }
     return payload
 
 

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -291,7 +291,7 @@ def test_approval_gate_approve_once_does_not_persist_policy(
     assert store.list_policy_decisions("codex") == []
 
 
-def test_approval_gate_artifact_remember_persists_policy(
+def test_approval_gate_artifact_remember_stays_one_time_for_reapproval(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -313,9 +313,7 @@ def test_approval_gate_artifact_remember_persists_policy(
     )
 
     assert resolved["status"] == "resolved"
-    policy = store.list_policy_decisions("codex")[0]
-    assert policy["action"] == "allow"
-    assert policy["artifact_id"] == "codex:project:req-remember"
+    assert store.list_policy_decisions("codex") == []
     first_retry = store.resolve_policy_decision(
         "codex",
         "codex:project:req-remember",
@@ -329,11 +327,10 @@ def test_approval_gate_artifact_remember_persists_policy(
         now="2026-04-11T00:03:00+00:00",
     )
     assert first_retry is not None
-    assert second_retry is not None
     assert first_retry["action"] == "allow"
-    assert second_retry["action"] == "allow"
-    remembered_events = store.list_events(limit=20, event_name="rule.remembered.local")
-    assert any(event["payload"]["request_id"] == "req-remember" for event in remembered_events)
+    assert second_retry is None
+    once_events = store.list_events(limit=20, event_name="approval.once")
+    assert any(event["payload"]["request_id"] == "req-remember" for event in once_events)
 
 
 def test_approval_gate_workspace_scope_uses_request_workspace_without_cli_override(
@@ -365,10 +362,10 @@ def test_approval_gate_workspace_scope_uses_request_workspace_without_cli_overri
     resolved = apply_approval_resolution(
         store=store,
         request_id="req-workspace",
-        action="allow",
+        action="block",
         scope="workspace",
         workspace=None,
-        reason="remember this project",
+        reason="block this project",
         now="2026-04-11T00:01:00+00:00",
         approval_gate_input=ApprovalGateInput(password=PASSWORD),
     )
@@ -382,7 +379,7 @@ def test_approval_gate_workspace_scope_uses_request_workspace_without_cli_overri
             workspace=str(workspace),
             now="2026-04-11T00:02:00+00:00",
         )["action"]
-        == "allow"
+        == "block"
     )
 
 
@@ -415,7 +412,7 @@ def test_approval_gate_workspace_scope_rejects_tampered_workspace_override(
         apply_approval_resolution(
             store=store,
             request_id="req-workspace-mismatch",
-            action="allow",
+            action="block",
             scope="workspace",
             workspace=str(tmp_path / "workspace-b"),
             reason="tampered project scope",
@@ -424,25 +421,27 @@ def test_approval_gate_workspace_scope_rejects_tampered_workspace_override(
         )
 
 
-def test_approval_gate_rejects_unsupported_broad_scope_for_unscoped_request(tmp_path: Path) -> None:
+def test_approval_gate_narrows_legacy_broad_allow_for_unscoped_request(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _enable_gate(store)
     _add_request(store, "req-global")
 
-    with pytest.raises(ValueError, match="unsupported_request_scope"):
-        apply_approval_resolution(
-            store=store,
-            request_id="req-global",
-            action="allow",
-            scope="global",
-            workspace=None,
-            reason="too broad",
-            now="2026-04-11T00:01:00+00:00",
-            approval_gate_input=ApprovalGateInput(password=PASSWORD),
-        )
+    resolved = apply_approval_resolution(
+        store=store,
+        request_id="req-global",
+        action="allow",
+        scope="global",
+        workspace=None,
+        reason="too broad",
+        now="2026-04-11T00:01:00+00:00",
+        approval_gate_input=ApprovalGateInput(password=PASSWORD),
+    )
+
+    assert resolved["resolution_scope"] == "artifact"
+    assert resolved["scope_warning"] == "legacy_scope_narrowed_to_artifact"
 
 
-def test_approval_gate_rejects_unsupported_workspace_scope_without_bound_workspace(tmp_path: Path) -> None:
+def test_approval_gate_narrows_legacy_workspace_scope_without_bound_workspace(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _enable_gate(store)
     store.add_approval_request(
@@ -463,17 +462,19 @@ def test_approval_gate_rejects_unsupported_workspace_scope_without_bound_workspa
         "2026-04-11T00:00:00+00:00",
     )
 
-    with pytest.raises(ValueError, match="unsupported_request_scope"):
-        apply_approval_resolution(
-            store=store,
-            request_id="req-workspace-unsupported",
-            action="allow",
-            scope="workspace",
-            workspace=None,
-            reason="too broad",
-            now="2026-04-11T00:01:00+00:00",
-            approval_gate_input=ApprovalGateInput(password=PASSWORD),
-        )
+    resolved = apply_approval_resolution(
+        store=store,
+        request_id="req-workspace-unsupported",
+        action="allow",
+        scope="workspace",
+        workspace=None,
+        reason="too broad",
+        now="2026-04-11T00:01:00+00:00",
+        approval_gate_input=ApprovalGateInput(password=PASSWORD),
+    )
+
+    assert resolved["resolution_scope"] == "artifact"
+    assert resolved["scope_warning"] == "legacy_scope_narrowed_to_artifact"
 
 
 def test_approval_gate_cooldown_works_expires_and_revokes(tmp_path: Path) -> None:
@@ -1745,30 +1746,23 @@ def test_daemon_approval_defaults_artifact_scope_to_one_time(tmp_path: Path) -> 
     assert store.list_policy_decisions("codex") == []
 
 
-def test_daemon_approval_rejects_unsupported_request_scope(tmp_path: Path) -> None:
+def test_daemon_approval_narrows_legacy_unsupported_request_scope(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _add_request(store, "req-daemon-global")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
-        request = urllib.request.Request(
-            f"http://127.0.0.1:{daemon.port}/v1/requests/req-daemon-global/approve",
-            data=json.dumps({"scope": "global"}).encode("utf-8"),
-            headers={"Content-Type": "application/json", "X-Guard-Token": daemon._server.auth_token},
-            method="POST",
+        payload = _post_daemon_json(
+            daemon,
+            "/v1/requests/req-daemon-global/approve",
+            {"scope": "global"},
         )
-        try:
-            urllib.request.urlopen(request, timeout=5)
-        except urllib.error.HTTPError as error:
-            payload = json.loads(error.read().decode("utf-8"))
-            status = error.code
-        else:
-            raise AssertionError("expected HTTPError for unsupported request scope")
     finally:
         daemon.stop()
 
-    assert status == 400
-    assert payload["error"] == "unsupported_request_scope"
+    assert payload["resolved"] is True
+    assert payload["applied_scope"] == "artifact"
+    assert payload["scope_warning"] == "legacy_scope_narrowed_to_artifact"
 
 
 @pytest.mark.parametrize("field_name", ["remember", "persist_policy"])
@@ -1814,7 +1808,7 @@ def test_daemon_approval_false_artifact_scope_still_allows_once(
     )
 
 
-def test_daemon_approval_can_remember_exact_artifact_scope(tmp_path: Path) -> None:
+def test_daemon_reapproval_cannot_remember_exact_artifact_scope(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _add_request(store, "req-daemon-remember")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
@@ -1829,8 +1823,8 @@ def test_daemon_approval_can_remember_exact_artifact_scope(tmp_path: Path) -> No
         daemon.stop()
 
     assert body["resolved"] is True
-    policy = store.list_policy_decisions("codex")[0]
-    assert policy["artifact_id"] == "codex:project:req-daemon-remember"
+    assert body["applied_scope"] == "artifact"
+    assert store.list_policy_decisions("codex") == []
 
 
 def test_approval_gate_direct_lower_layers_cannot_bypass(tmp_path: Path) -> None:

--- a/tests/test_guard_approval_reuse.py
+++ b/tests/test_guard_approval_reuse.py
@@ -483,7 +483,7 @@ def test_approval_resolution_preserves_exact_context_token_across_every_scope(tm
         ),
         "2026-07-17T12:00:00+00:00",
     )
-    apply_approval_resolution(
+    resolved = apply_approval_resolution(
         store=store,
         request_id=f"request-context-{scope}",
         action="allow",
@@ -495,8 +495,10 @@ def test_approval_resolution_preserves_exact_context_token_across_every_scope(tm
     )
 
     stored = store.list_policy_decisions()
-    assert len(stored) == 1
-    assert stored[0]["artifact_hash"] == current_token
+    assert stored == []
+    assert resolved["applied_scope"] == "artifact"
+    if scope != "artifact":
+        assert resolved["scope_warning"] == "legacy_scope_narrowed_to_artifact"
     assert (
         store.resolve_policy(
             "codex",

--- a/tests/test_guard_approval_scope_contract.py
+++ b/tests/test_guard_approval_scope_contract.py
@@ -100,7 +100,7 @@ def _mapping(value: object) -> Mapping[str, object]:
     [
         ("require-reapproval", ("artifact",)),
         ("review", ("artifact",)),
-        ("sandbox-required", ("artifact",)),
+        ("sandbox-required", ()),
         ("block", ()),
     ],
 )
@@ -117,6 +117,24 @@ def test_guard_control_cannot_be_browser_allowed() -> None:
 
     assert contract.allow_scopes == ()
     assert "current_action_not_overridable" in contract.restrictions
+
+
+@pytest.mark.parametrize("policy_action", ["block", "sandbox-required"])
+def test_terminal_policy_action_cannot_be_browser_allowed(tmp_path: Path, policy_action: GuardAction) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    row = _store_request(store, _request("terminal", policy_action=policy_action))
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, response = _post(daemon, "/v1/requests/terminal/approve", _v2_selection(row, "artifact"))
+    finally:
+        daemon.stop()
+
+    assert status == 422
+    assert response["error"] == "ineligible_request_scope"
+    stored = store.get_approval_request("terminal")
+    assert stored is not None
+    assert stored["status"] == "pending"
 
 
 def test_artifact_family_text_cannot_spoof_canonical_broad_deny() -> None:
@@ -262,7 +280,11 @@ def test_malformed_resolution_contract_returns_400(tmp_path: Path, payload: dict
 
 @pytest.mark.parametrize(
     ("field", "value"),
-    [("scope_contract_version", "guard.approval-scopes.v1"), ("scope_contract_digest", "0" * 64)],
+    [
+        ("scope_contract_version", "guard.approval-scopes.v1"),
+        ("scope_contract_version", "guard.approval-scopes.v3"),
+        ("scope_contract_digest", "0" * 64),
+    ],
 )
 def test_stale_contract_returns_409_with_fresh_contract(
     tmp_path: Path,

--- a/tests/test_guard_approval_scope_contract.py
+++ b/tests/test_guard_approval_scope_contract.py
@@ -422,6 +422,59 @@ def test_same_resolution_replay_is_idempotent_and_conflict_is_409(tmp_path: Path
     assert conflict["error"] == "already_resolved"
 
 
+@pytest.mark.parametrize(
+    "case",
+    [
+        ("artifact", True, "require-reapproval", "changed", 409, "stale_scope_contract"),
+        ("global", False, "sandbox-required", None, 422, "request_action_not_overridable"),
+    ],
+)
+def test_raced_completed_replay_maps_scope_contract_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: tuple[str, bool, GuardAction, str | None, int, str],
+) -> None:
+    payload_scope, use_contract, third_policy_action, third_hash, expected_status, expected_error = case
+    store = GuardStore(tmp_path / "guard-home")
+    row = _store_request(store, _request("replay-race"))
+    store.resolve_approval_request(
+        "replay-race",
+        resolution_action="allow",
+        resolution_scope="artifact",
+        reason=None,
+        resolved_at="2026-07-19T00:00:01+00:00",
+    )
+    original_get = store.get_approval_request
+    call_count = 0
+
+    def raced_get(request_id: str) -> dict[str, object] | None:
+        nonlocal call_count
+        call_count += 1
+        current = original_get(request_id)
+        if current is None:
+            return None
+        if call_count == 1:
+            return {**current, "status": "pending"}
+        if call_count >= 3:
+            return {
+                **current,
+                "policy_action": third_policy_action,
+                "artifact_hash": third_hash or current["artifact_hash"],
+            }
+        return current
+
+    monkeypatch.setattr(store, "get_approval_request", raced_get)
+    payload = _v2_selection(row, payload_scope) if use_contract else {"scope": payload_scope}
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, response = _post(daemon, "/v1/requests/replay-race/approve", payload)
+    finally:
+        daemon.stop()
+    assert status == expected_status
+    assert response["error"] == expected_error
+
+
 def test_concurrent_same_resolution_has_one_effect_and_two_successes(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     row = _store_request(store, _request("race"))
@@ -441,6 +494,5 @@ def test_concurrent_same_resolution_has_one_effect_and_two_successes(tmp_path: P
             thread.join(timeout=5)
     finally:
         daemon.stop()
-
     assert sorted(status for status, _ in results) == [200, 200], results
     assert len(store.list_events(event_name="approval.resolved")) == 1

--- a/tests/test_guard_approval_scope_contract.py
+++ b/tests/test_guard_approval_scope_contract.py
@@ -1,0 +1,424 @@
+"""Action-aware approval-scope contract and resolution regressions."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import urllib.error
+import urllib.request
+from collections.abc import Mapping
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.approval_scope_support import (
+    APPROVAL_SCOPE_CONTRACT_VERSION,
+    request_scope_contract,
+    supported_request_scopes,
+)
+from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.models import GuardAction, GuardApprovalRequest
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _request(
+    request_id: str,
+    *,
+    artifact_id: str | None = None,
+    artifact_type: str = "tool_action_request",
+    policy_action: GuardAction = "require-reapproval",
+    action_type: str = "shell_command",
+    decision_scopes: list[str] | None = None,
+    publisher: str | None = "publisher-a",
+    artifact_hash: str | None = None,
+) -> GuardApprovalRequest:
+    return GuardApprovalRequest(
+        request_id=request_id,
+        harness="codex",
+        artifact_id=artifact_id or f"codex:project:tool-action:{request_id}",
+        artifact_name="Scoped action",
+        artifact_type=artifact_type,
+        artifact_hash=artifact_hash or f"hash-{request_id}",
+        publisher=publisher,
+        policy_action=policy_action,
+        recommended_scope="global",
+        changed_fields=("command",),
+        source_scope="project",
+        config_path="/workspace/repo/.guard/config.toml",
+        workspace="/workspace/repo",
+        launch_target="echo test",
+        action_envelope_json={"action_type": action_type, "command": "echo test"},
+        decision_v2_json={"action": "ask", "approval_scopes": decision_scopes or ["global"]},
+        review_command=f"hol-guard approvals approve {request_id}",
+        approval_url=f"http://127.0.0.1:5474/approvals/{request_id}",
+    )
+
+
+def _store_request(store: GuardStore, request: GuardApprovalRequest) -> dict[str, object]:
+    store.add_approval_request(request, "2026-07-19T00:00:00+00:00")
+    row = store.get_approval_request(request.request_id)
+    assert row is not None
+    return row
+
+
+def _post(
+    daemon: GuardDaemonServer,
+    path: str,
+    payload: Mapping[str, object],
+) -> tuple[int, dict[str, object]]:
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{daemon.port}{path}",
+        data=json.dumps(dict(payload)).encode("utf-8"),
+        headers={"Content-Type": "application/json", "X-Guard-Token": daemon._server.auth_token},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return response.status, json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        return error.code, json.loads(error.read().decode("utf-8"))
+
+
+def _v2_selection(row: Mapping[str, object], scope: str) -> dict[str, object]:
+    return {
+        "scope": scope,
+        "scope_contract_version": row["scope_contract_version"],
+        "scope_contract_digest": row["scope_contract_digest"],
+    }
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    assert isinstance(value, Mapping)
+    assert all(isinstance(key, str) for key in value)
+    return value
+
+
+@pytest.mark.parametrize(
+    ("policy_action", "expected_allow"),
+    [
+        ("require-reapproval", ("artifact",)),
+        ("review", ("artifact",)),
+        ("sandbox-required", ("artifact",)),
+        ("block", ()),
+    ],
+)
+def test_scope_contract_is_action_aware(policy_action: GuardAction, expected_allow: tuple[str, ...]) -> None:
+    contract = request_scope_contract(_request("matrix", policy_action=policy_action).to_dict())
+
+    assert contract.allow_scopes == expected_allow
+    assert contract.block_scopes == ("artifact", "workspace", "publisher", "harness", "global")
+    assert contract.task_capability_eligible is False
+
+
+def test_guard_control_cannot_be_browser_allowed() -> None:
+    contract = request_scope_contract(_request("guard-control", action_type="guard_control").to_dict())
+
+    assert contract.allow_scopes == ()
+    assert "current_action_not_overridable" in contract.restrictions
+
+
+def test_artifact_family_text_cannot_spoof_canonical_broad_deny() -> None:
+    request = _request(
+        "spoofed",
+        artifact_id="codex:project:tool-action:spoofed",
+        artifact_type="mcp_server",
+    ).to_dict()
+
+    assert request_scope_contract(request).block_scopes == ("artifact",)
+
+
+def test_package_context_never_invents_workspace_allow() -> None:
+    request = _request(
+        "package",
+        artifact_id="codex:project:package-request:package",
+        artifact_type="package_request",
+    ).to_dict()
+    request["scanner_evidence"] = [{"portable": True, "schema_version": "package-execution-context.v1"}]
+
+    assert supported_request_scopes(request) == ("artifact",)
+
+
+@pytest.mark.parametrize(
+    ("artifact_type", "family", "action_type"),
+    [
+        ("file_read_request", "file-read", "file_read"),
+        ("mcp_server", "mcp", "mcp_tool_call"),
+        ("package_request", "package-request", "package_install"),
+        ("prompt_request", "prompt", "prompt_submit"),
+        ("tool_action_request", "tool-action", "workspace_write"),
+        ("tool_action_request", "tool-action", "network_write"),
+        ("tool_action_request", "tool-action", "remote_state_mutation"),
+        ("tool_action_request", "tool-action", "destructive_operation"),
+        ("tool_action_request", "tool-action", "dynamic_unknown"),
+    ],
+)
+def test_request_type_matrix_never_infers_broad_allow(
+    artifact_type: str,
+    family: str,
+    action_type: str,
+) -> None:
+    request = _request(
+        "request-matrix",
+        artifact_id=f"codex:project:{family}:request-matrix",
+        artifact_type=artifact_type,
+        action_type=action_type,
+    ).to_dict()
+
+    assert request_scope_contract(request).allow_scopes == ("artifact",)
+
+
+def test_contract_digest_is_deterministic_and_binds_security_fields() -> None:
+    request = _request("digest").to_dict()
+    first = request_scope_contract(request)
+    reordered = dict(reversed(tuple(request.items())))
+
+    assert request_scope_contract(reordered).digest == first.digest
+    assert request_scope_contract({**request, "policy_action": "block"}).digest != first.digest
+    assert request_scope_contract({**request, "workspace": "/workspace/other"}).digest != first.digest
+    assert request_scope_contract({**request, "artifact_hash": "different"}).digest != first.digest
+    assert (
+        request_scope_contract(
+            {**request, "action_envelope_json": {"action_type": "shell_command", "command": "echo changed"}}
+        ).digest
+        != first.digest
+    )
+
+
+def test_deduped_request_identity_change_invalidates_scope_contract(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    row = _store_request(store, _request("deduped", artifact_hash="hash-old"))
+    stale_selection = _v2_selection(row, "artifact")
+
+    replacement = _request("replacement", artifact_hash="hash-new")
+    replacement = replace(replacement, artifact_id="codex:project:tool-action:deduped")
+    persisted_request_id = store.add_approval_request(replacement, "2026-07-19T00:00:01+00:00")
+    assert persisted_request_id == "deduped"
+    current = store.get_approval_request("deduped")
+    assert current is not None
+    assert current["artifact_hash"] == "hash-new"
+    assert current["scope_contract_digest"] != row["scope_contract_digest"]
+
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, response = _post(daemon, "/v1/requests/deduped/approve", stale_selection)
+    finally:
+        daemon.stop()
+
+    assert status == 409
+    assert response["error"] == "stale_scope_contract"
+    assert response["scope_contract_digest"] == current["scope_contract_digest"]
+    stored = store.get_approval_request("deduped")
+    assert stored is not None
+    assert stored["status"] == "pending"
+    assert store.list_policy_decisions() == []
+    assert store.list_events(event_name="approval.resolved") == []
+
+
+def test_stored_payload_overrides_untrusted_decision_scope_advertisement(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    row = _store_request(store, _request("sanitize", decision_scopes=["artifact", "global"]))
+
+    assert row["allowed_scopes"] == ["artifact"]
+    assert row["allowed_scopes_by_action"] == {
+        "allow": ["artifact"],
+        "block": ["artifact", "workspace", "publisher", "harness", "global"],
+    }
+    assert _mapping(row["decision_v2_json"])["approval_scopes"] == ["artifact"]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"scope": "not-a-scope"},
+        {"scope": "artifact", "scope_contract_version": APPROVAL_SCOPE_CONTRACT_VERSION},
+        {"scope": "artifact", "scope_contract_digest": "0" * 64},
+        {"scope": "artifact", "scope_contract_version": 2, "scope_contract_digest": "0" * 64},
+        {
+            "scope": "artifact",
+            "scope_contract_version": APPROVAL_SCOPE_CONTRACT_VERSION,
+            "scope_contract_digest": "not-a-digest",
+        },
+    ],
+)
+def test_malformed_resolution_contract_returns_400(tmp_path: Path, payload: dict[str, object]) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _store_request(store, _request("malformed"))
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, response = _post(daemon, "/v1/requests/malformed/approve", payload)
+    finally:
+        daemon.stop()
+
+    assert status == 400
+    assert response["resolved"] is False
+    stored = store.get_approval_request("malformed")
+    assert stored is not None
+    assert stored["status"] == "pending"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("scope_contract_version", "guard.approval-scopes.v1"), ("scope_contract_digest", "0" * 64)],
+)
+def test_stale_contract_returns_409_with_fresh_contract(
+    tmp_path: Path,
+    field: str,
+    value: str,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    row = _store_request(store, _request("stale"))
+    payload = _v2_selection(row, "artifact")
+    payload[field] = value
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, response = _post(daemon, "/v1/requests/stale/approve", payload)
+    finally:
+        daemon.stop()
+
+    assert status == 409
+    assert response["error"] == "stale_scope_contract"
+    assert response["scope_contract_digest"] == row["scope_contract_digest"]
+    stored = store.get_approval_request("stale")
+    assert stored is not None
+    assert stored["status"] == "pending"
+
+
+def test_v2_ineligible_scope_returns_422_without_policy_or_resolution(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    row = _store_request(store, _request("ineligible"))
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, response = _post(
+            daemon,
+            "/v1/requests/ineligible/approve",
+            _v2_selection(row, "global"),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 422
+    assert response["error"] == "ineligible_request_scope"
+    assert _mapping(response["allowed_scopes_by_action"])["allow"] == ["artifact"]
+    stored = store.get_approval_request("ineligible")
+    assert stored is not None
+    assert stored["status"] == "pending"
+    assert store.list_policy_decisions() == []
+
+
+def test_v2_saved_artifact_allow_is_rejected_as_ineligible(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    row = _store_request(store, _request("saved-allow"))
+    payload = {**_v2_selection(row, "artifact"), "persist_policy": True}
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, response = _post(daemon, "/v1/requests/saved-allow/approve", payload)
+    finally:
+        daemon.stop()
+
+    assert status == 422
+    assert response["error"] == "saved_allow_scope_ineligible"
+    stored = store.get_approval_request("saved-allow")
+    assert stored is not None
+    assert stored["status"] == "pending"
+
+
+def test_legacy_unknown_broad_deny_is_not_silently_narrowed(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _store_request(
+        store,
+        _request(
+            "unknown-deny",
+            artifact_id="codex:project:unknown:unknown-deny",
+            artifact_type="unknown_request",
+        ),
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, response = _post(
+            daemon,
+            "/v1/requests/unknown-deny/block",
+            {"scope": "global"},
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 422
+    assert response["error"] == "ineligible_request_scope"
+
+
+def test_legacy_global_allow_narrows_to_artifact_once(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _store_request(store, _request("legacy"))
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, response = _post(
+            daemon,
+            "/v1/requests/legacy/approve",
+            {"scope": "global", "persist_policy": True},
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert response["requested_scope"] == "global"
+    assert response["applied_scope"] == "artifact"
+    assert response["scope_warning"] == "legacy_scope_narrowed_to_artifact"
+    assert _mapping(response["resolved_request"])["resolution_scope"] == "artifact"
+    decisions = store.list_policy_decisions()
+    assert decisions == []
+    with sqlite3.connect(store.path) as connection:
+        stored_scope = connection.execute("select scope from policy_decisions").fetchone()
+    assert stored_scope == ("artifact",)
+
+
+def test_same_resolution_replay_is_idempotent_and_conflict_is_409(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    row = _store_request(store, _request("replay"))
+    payload = _v2_selection(row, "artifact")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        first_status, _ = _post(daemon, "/v1/requests/replay/approve", payload)
+        replay_status, replay = _post(daemon, "/v1/requests/replay/approve", payload)
+        conflict_status, conflict = _post(daemon, "/v1/requests/replay/block", payload)
+    finally:
+        daemon.stop()
+
+    assert first_status == 200
+    assert replay_status == 200
+    assert replay["idempotent"] is True
+    assert conflict_status == 409
+    assert conflict["error"] == "already_resolved"
+
+
+def test_concurrent_same_resolution_has_one_effect_and_two_successes(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    row = _store_request(store, _request("race"))
+    payload = _v2_selection(row, "artifact")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    results: list[tuple[int, dict[str, object]]] = []
+
+    def resolve() -> None:
+        results.append(_post(daemon, "/v1/requests/race/approve", payload))
+
+    threads = [threading.Thread(target=resolve) for _ in range(2)]
+    try:
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+    finally:
+        daemon.stop()
+
+    assert sorted(status for status, _ in results) == [200, 200], results
+    assert len(store.list_events(event_name="approval.resolved")) == 1

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -165,13 +165,14 @@ class TestGuardApprovals:
         assert pending[0]["approval_url"] == "http://127.0.0.1:4455/approvals/req-123"
         assert pending[0]["workspace"] == str(workspace_dir)
         assert pending[0]["action_envelope_json"] == action_envelope_json
-        assert pending[0]["decision_v2_json"] == decision_v2_json
+        expected_decision = {**decision_v2_json, "approval_scopes": ["artifact"]}
+        assert pending[0]["decision_v2_json"] == expected_decision
         assert resolved is not None
         assert resolved["status"] == "resolved"
         assert resolved["resolution_action"] == "allow"
         assert resolved["resolution_scope"] == "artifact"
         assert resolved["action_envelope_json"] == action_envelope_json
-        assert resolved["decision_v2_json"] == decision_v2_json
+        assert resolved["decision_v2_json"] == expected_decision
 
     def test_guard_store_runtime_snapshot_exposes_pending_request_payload_contract(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
@@ -205,7 +206,7 @@ class TestGuardApprovals:
         assert queue_summary["next_request_id"] == "req-snapshot-contract"
         assert isinstance(items, list)
         assert items[0]["request_id"] == "req-snapshot-contract"
-        assert items[0]["recommended_scope"] == "workspace"
+        assert items[0]["recommended_scope"] == "artifact"
         assert items[0]["review_command"] == "hol-guard approvals approve req-snapshot-contract"
         assert items[0]["approval_url"] == "http://127.0.0.1:4455/approvals/req-snapshot-contract"
 
@@ -1041,6 +1042,7 @@ class TestGuardApprovals:
                     harness="codex",
                     artifact_id=artifact_id,
                     artifact_name=artifact_id.rsplit(":", maxsplit=1)[-1],
+                    artifact_type="mcp_server",
                     artifact_hash=f"hash-{request_id}",
                     policy_action="require-reapproval",
                     recommended_scope="harness",
@@ -1056,10 +1058,10 @@ class TestGuardApprovals:
         resolved = apply_approval_resolution(
             store=store,
             request_id="req-a",
-            action="allow",
+            action="block",
             scope="harness",
             workspace=None,
-            reason="trusted in harness",
+            reason="blocked in harness",
             now="2026-04-11T00:02:00+00:00",
         )
 
@@ -1075,6 +1077,7 @@ class TestGuardApprovals:
                     harness=harness,
                     artifact_id=f"{harness}:project:mcp:item",
                     artifact_name=f"{harness}-item",
+                    artifact_type="mcp_server",
                     artifact_hash=f"hash-{request_id}",
                     policy_action="require-reapproval",
                     recommended_scope="global",
@@ -1090,10 +1093,10 @@ class TestGuardApprovals:
         resolved = apply_approval_resolution(
             store=store,
             request_id="req-codex",
-            action="allow",
+            action="block",
             scope="global",
             workspace=None,
-            reason="trusted globally",
+            reason="blocked globally",
             now="2026-04-11T00:02:00+00:00",
         )
 
@@ -1188,7 +1191,7 @@ class TestGuardApprovals:
                 harness="guard-cli",
                 artifact_id="guard-cli:project:mcp:impeccable",
                 artifact_name="impeccable",
-                artifact_type="mcp",
+                artifact_type="mcp_server",
                 artifact_hash="hash-impeccable",
                 policy_action="require-reapproval",
                 recommended_scope="global",
@@ -1215,8 +1218,7 @@ class TestGuardApprovals:
 
         decisions = store.list_policy_decisions()
         assert calls
-        assert decisions[0]["harness"] == "*"
-        assert decisions[0]["scope"] == "global"
+        assert decisions == []
 
     def test_guard_saved_scope_falls_back_to_once_when_integrity_repair_fails(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")
@@ -1228,7 +1230,7 @@ class TestGuardApprovals:
                 harness="guard-cli",
                 artifact_id=artifact_id,
                 artifact_name="impeccable",
-                artifact_type="mcp",
+                artifact_type="mcp_server",
                 artifact_hash="hash-impeccable",
                 policy_action="require-reapproval",
                 recommended_scope="global",
@@ -1267,7 +1269,7 @@ class TestGuardApprovals:
         )
 
         decisions = store.list_policy_decisions()
-        assert decisions[0]["scope"] == "global"
+        assert decisions == []
         assert first_retry is not None
         assert first_retry["action"] == "allow"
 
@@ -1316,6 +1318,7 @@ class TestGuardApprovals:
                     harness="codex",
                     artifact_id=f"codex:project:mcp:item-{index}",
                     artifact_name=f"item-{index}",
+                    artifact_type="mcp_server",
                     artifact_hash=f"hash-{index}",
                     policy_action="require-reapproval",
                     recommended_scope="harness",
@@ -1331,10 +1334,10 @@ class TestGuardApprovals:
         resolved = apply_approval_resolution(
             store=store,
             request_id="req-0",
-            action="allow",
+            action="block",
             scope="harness",
             workspace=None,
-            reason="trusted in harness",
+            reason="blocked in harness",
             now="2026-04-11T00:02:00+00:00",
         )
 
@@ -1403,7 +1406,11 @@ class TestGuardApprovals:
         request = store.get_approval_request("req-supported-scopes")
 
         assert request is not None
-        assert request["allowed_scopes"] == ["artifact", "publisher", "workspace", "harness", "global"]
+        assert request["allowed_scopes"] == ["artifact"]
+        assert request["allowed_scopes_by_action"] == {
+            "allow": ["artifact"],
+            "block": ["artifact", "workspace", "publisher", "harness", "global"],
+        }
 
     def test_guard_store_ignores_expired_policy_decisions_without_explicit_now(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
@@ -2338,7 +2345,8 @@ class TestGuardApprovals:
 
         assert status == 200
         assert payload["resolved"] is True
-        assert payload["resolved_request"]["resolution_scope"] == "workspace"
+        assert payload["resolved_request"]["resolution_scope"] == "artifact"
+        assert payload["scope_warning"] == "legacy_scope_narrowed_to_artifact"
 
     @pytest.mark.parametrize("action", ["approve", "block"])
     @pytest.mark.parametrize("scope", ["artifact", "workspace", "publisher", "harness", "global"])
@@ -2348,21 +2356,15 @@ class TestGuardApprovals:
         store = GuardStore(tmp_path / "guard-home")
         workspace = tmp_path / "workspace"
         request_id = f"req-{action}-{scope}"
-        artifact_family = "tool-action" if scope in {"harness", "global"} else scope
-        artifact_id = (
-            f"codex:project:{artifact_family}:{scope}" if scope in {"harness", "global"} else f"codex:project:{scope}"
-        )
-        other_artifact_id = (
-            f"codex:project:{artifact_family}:{scope}-other"
-            if scope in {"harness", "global"}
-            else f"codex:project:{scope}-other"
-        )
+        artifact_id = f"codex:project:tool-action:{scope}"
+        other_artifact_id = f"codex:project:tool-action:{scope}-other"
         store.add_approval_request(
             GuardApprovalRequest(
                 request_id=request_id,
                 harness="codex",
                 artifact_id=artifact_id,
                 artifact_name=f"{scope} action",
+                artifact_type="tool_action_request",
                 artifact_hash=f"hash-{action}-{scope}",
                 publisher="codex-local",
                 policy_action="require-reapproval",
@@ -2382,6 +2384,7 @@ class TestGuardApprovals:
                 harness="codex",
                 artifact_id=other_artifact_id,
                 artifact_name=f"{scope} other action",
+                artifact_type="tool_action_request",
                 artifact_hash=f"hash-{action}-{scope}-other",
                 publisher="codex-local",
                 policy_action="require-reapproval",
@@ -2418,7 +2421,9 @@ class TestGuardApprovals:
         assert payload["resolved"] is True
         assert payload["resolved_request"]["request_id"] == request_id
         assert payload["resolved_request"]["resolution_action"] == ("allow" if action == "approve" else "block")
-        assert payload["resolved_request"]["resolution_scope"] == scope
+        expected_scope = scope if action == "block" or scope == "artifact" else "artifact"
+        assert payload["resolved_request"]["resolution_scope"] == expected_scope
+        assert payload["applied_scope"] == expected_scope
         assert payload["resolved_request"]["approval_url"] == "http://127.0.0.1/pending"
         assert payload["resolved_request"]["review_command"] == f"hol-guard approvals {action} {request_id}"
         assert payload["remaining_pending_count"] == 1
@@ -3062,9 +3067,8 @@ class TestGuardApprovals:
 
         assert remember_rc == 0
         assert remember_output["resolved"] is True
-        policy = store.list_policy_decisions("codex")[0]
-        assert policy["action"] == "allow"
-        assert policy["artifact_hash"] == "hash-remember"
+        assert remember_output["item"]["applied_scope"] == "artifact"
+        assert store.list_policy_decisions("codex") == []
 
     def test_guard_policies_cli_clears_local_decisions_for_harness(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -3454,7 +3458,8 @@ class TestGuardApprovals:
         assert rc == 0
         assert captured.err == ""
         assert payload["resolved"] is True
-        assert payload["item"]["resolution_scope"] == "workspace"
+        assert payload["item"]["resolution_scope"] == "artifact"
+        assert payload["item"]["scope_warning"] == "legacy_scope_narrowed_to_artifact"
         assert store.get_approval_request("req-workspace")["status"] == "resolved"
 
     def test_guard_workspace_resolution_does_not_match_sibling_workspace(self, tmp_path):

--- a/tests/test_guard_bun_install_approval_replay.py
+++ b/tests/test_guard_bun_install_approval_replay.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard.approval_scope_support import IneligibleApprovalScopeError
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution
 from codex_plugin_scanner.guard.local_supply_chain import build_package_protect_payload
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
@@ -84,15 +85,16 @@ def test_bun_install_approval_never_lowers_current_block_when_integrity_is_degra
         ),
         "2026-06-14T00:00:30Z",
     )
-    apply_approval_resolution(
-        store=store,
-        request_id="req-bun-install",
-        action="allow",
-        scope="artifact",
-        workspace=None,
-        reason="same bun install",
-        now="2026-06-14T00:01:00Z",
-    )
+    with pytest.raises(IneligibleApprovalScopeError, match="request_action_not_overridable"):
+        apply_approval_resolution(
+            store=store,
+            request_id="req-bun-install",
+            action="allow",
+            scope="artifact",
+            workspace=None,
+            reason="same bun install",
+            now="2026-06-14T00:01:00Z",
+        )
     store._policy_integrity_secret_store = None
 
     first_retry_payload, first_retry_rc = build_package_protect_payload(
@@ -125,11 +127,6 @@ def test_bun_install_approval_never_lowers_current_block_when_integrity_is_degra
         assert retry_receipt["artifact_hash"] == receipt["artifact_hash"]
         evaluation = retry_payload["supply_chain_evaluation"]
         assert isinstance(evaluation, dict)
-        assert any(
-            isinstance(reason, dict)
-            and reason.get("code") in {"approval_reuse_current_block", "approval_reuse_integrity_failure"}
-            for reason in evaluation.get("reasons", [])
-        )
         assert not any(
             isinstance(reason, dict) and reason.get("code") == "saved_package_approval"
             for reason in evaluation.get("reasons", [])

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -2795,8 +2795,8 @@ def test_executor_releases_remote_once_receipt_on_invalid_signed_decision(tmp_pa
     )
 
     assert result["failureCode"] == "invalid_remote_approval_decision"
-    assert store.claimed_receipts == ["cloud-receipt-1"]
-    assert store.released_receipts == ["cloud-receipt-1"]
+    assert store.claimed_receipts == []
+    assert store.released_receipts == []
 
 
 def test_executor_syncs_policy_without_local_request_id(tmp_path: Path) -> None:
@@ -3081,8 +3081,7 @@ def test_executor_rejects_remote_approval_for_removed_one_time_scope(tmp_path: P
     assert store.resolved == []
 
 
-def test_executor_resolves_block_policy_action_with_workspace_allow(tmp_path: Path) -> None:
-    """Prove policy_action='block' can be remotely allowed with the requested scope."""
+def test_executor_rejects_block_policy_action_with_workspace_allow(tmp_path: Path) -> None:
 
     class WorkspaceAllowStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:
@@ -3142,16 +3141,9 @@ def test_executor_resolves_block_policy_action_with_workspace_allow(tmp_path: Pa
         now=lambda: "2026-06-13T00:00:00+00:00",
     )
 
-    assert result["generatedAt"] == "2026-06-13T00:00:00+00:00"
-    assert result["data"]["status"] == "completed"
-    assert store.resolved == [
-        {
-            "request_id": "request-workspace-allow",
-            "resolution_action": "allow",
-            "resolution_scope": "workspace",
-        }
-    ]
-    assert len(store.claimed_receipts) == 1
+    assert result["failureCode"] == "remote_approval_not_permitted"
+    assert store.resolved == []
+    assert store.claimed_receipts == []
 
 
 def test_executor_resolves_harness_scope_with_block(tmp_path: Path) -> None:
@@ -3162,9 +3154,11 @@ def test_executor_resolves_harness_scope_with_block(tmp_path: Path) -> None:
             super().__init__(guard_home)
             self.request_row = _approval_request_row(
                 "request-harness-block",
+                artifact_id="cursor:project:tool-action:request-harness-block",
                 policy_action="require-reapproval",
                 recommended_scope="harness",
             )
+            self.request_row["artifact_type"] = "tool_action_request"
             self.resolved: list[dict[str, object]] = []
             self.claimed_receipts: list[dict[str, str]] = []
 
@@ -3585,6 +3579,6 @@ def test_executor_rejects_remote_approval_envelope_scope_mismatch(tmp_path: Path
         store=store,  # type: ignore[arg-type]
         now=lambda: "2026-06-13T00:00:00+00:00",
     )
-    assert result["failureCode"] == "remote_approval_scope_mismatch"
+    assert result["failureCode"] == "remote_approval_not_permitted"
     assert store.claimed_receipts == []
     assert store.resolved == []

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -32,6 +32,7 @@ from codex_plugin_scanner.guard.review_contracts import (
     guard_review_oauth_metadata,
     payload_hash_for_remote_approval_envelope,
 )
+from codex_plugin_scanner.guard.runtime import command_executors
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.runtime.runner import (
     GuardSyncAuthorizationExpiredError,
@@ -2977,11 +2978,7 @@ def test_headless_api_rejects_missing_auth_and_bad_harness(tmp_path: Path) -> No
 def test_headless_remote_once_applies_pending_request_and_records_receipt(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     _seed_guard_cloud(store, workspace_id="workspace-1", now="2026-06-13T00:00:00+00:00")
-    request = _remote_once_request(
-        "req-remote-once",
-        policy_action="block",
-        recommended_scope="workspace",
-    )
+    request = _remote_once_request("req-remote-once")
     store.add_approval_request(request, "2026-05-14T11:59:00+00:00")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -3011,7 +3008,7 @@ def test_headless_remote_once_applies_pending_request_and_records_receipt(tmp_pa
     assert payload["operation"] == "remote_once"
     assert payload["status"] == "completed"
     assert payload["resolved_request"]["request_id"] == "req-remote-once"
-    assert payload["resolved_request"]["resolution_scope"] == "workspace"
+    assert payload["resolved_request"]["resolution_scope"] == "artifact"
     assert payload["codex_resume"]["status"] == "skipped"
     events = store.list_events(limit=5, event_name="approval.remote_once_applied")
     assert events[0]["payload"]["receipt_id"] == "cloud-receipt-1"
@@ -3025,6 +3022,147 @@ def test_headless_remote_once_applies_pending_request_and_records_receipt(tmp_pa
         workspace=request.workspace,
     )
     assert persisted_action is None
+
+
+def test_headless_remote_once_cannot_allow_current_block(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-1", now="2026-06-13T00:00:00+00:00")
+    request = _remote_once_request("req-remote-block", policy_action="block", recommended_scope="workspace")
+    store.add_approval_request(request, "2026-05-14T11:59:00+00:00")
+    remote_approval = _signed_remote_approval_for_request(
+        store,
+        "req-remote-block",
+        receipt_id="cloud-receipt-block",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/requests/remote-once",
+                token=_dashboard_token_for(store),
+                payload={
+                    "harness": "codex",
+                    "operation": "remote_once",
+                    "remoteApproval": json.dumps(remote_approval),
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 409
+    assert payload["error"] == "remote_once_not_permitted"
+    stored = store.get_approval_request("req-remote-block")
+    assert stored is not None
+    assert stored["status"] == "pending"
+    assert store.list_events(event_name="approval.remote_once_applied") == []
+
+
+def test_headless_remote_once_rejects_unknown_signed_decision_before_claim(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-1", now="2026-06-13T00:00:00+00:00")
+    store.add_approval_request(_remote_once_request("req-remote-unknown"), "2026-05-14T11:59:00+00:00")
+    remote_approval = _signed_remote_approval_for_request(
+        store,
+        "req-remote-unknown",
+        receipt_id="receipt-unknown",
+    )
+    remote_approval["decision"] = "definitely-not-allow"
+    remote_approval["payloadHash"] = payload_hash_for_remote_approval_envelope(remote_approval)
+    remote_approval["signature"] = sign_review_payload(remote_approval)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/requests/remote-once",
+                token=_dashboard_token_for(store),
+                payload={
+                    "harness": "codex",
+                    "operation": "remote_once",
+                    "remoteApproval": json.dumps(remote_approval),
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 400
+    assert payload["error"] == "invalid_remote_approval_decision"
+    stored = store.get_approval_request("req-remote-unknown")
+    assert stored is not None
+    assert stored["status"] == "pending"
+    assert store.has_remote_once_receipt("receipt-unknown") is False
+
+
+def _execute_remote_decision(
+    store: GuardStore,
+    tmp_path: Path,
+    *,
+    request_id: str,
+    action: str,
+    remote_approval: dict[str, object],
+) -> dict[str, object]:
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    return command_executors.execute_guard_command_job(
+        {
+            "createdAt": now,
+            "operation": "guard.approval.resolve",
+            "payload": {
+                "action": action,
+                "localRequestId": request_id,
+                "remoteApproval": remote_approval,
+            },
+        },
+        context=HarnessContext(home_dir=tmp_path, workspace_dir=None, guard_home=store.guard_home),
+        store=store,
+        now=lambda: now,
+    )
+
+
+@pytest.mark.parametrize(("decision", "action"), [("allow_once", "allow_once"), ("block", "block")])
+def test_command_executor_uses_action_specific_scope_for_current_block(
+    tmp_path: Path,
+    decision: str,
+    action: str,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-1", now="2026-06-13T00:00:00+00:00")
+    request_id = f"req-command-{decision}"
+    store.add_approval_request(
+        _remote_once_request(request_id, policy_action="block", recommended_scope="workspace"),
+        "2026-05-14T11:59:00+00:00",
+    )
+    result = _execute_remote_decision(
+        store,
+        tmp_path,
+        request_id=request_id,
+        action=action,
+        remote_approval=_signed_remote_approval_for_request(
+            store,
+            request_id,
+            decision=decision,
+            receipt_id=f"receipt-{decision}",
+        ),
+    )
+    stored = store.get_approval_request(request_id)
+    assert stored is not None
+
+    if decision == "allow_once":
+        assert result["failureCode"] == "remote_approval_not_permitted"
+        assert stored["status"] == "pending"
+        assert store.has_remote_once_receipt(f"receipt-{decision}") is False
+    else:
+        data = result["data"]
+        assert isinstance(data, dict)
+        assert data["status"] == "completed"
+        assert stored["status"] == "resolved"
+        assert stored["resolution_action"] == "block"
+        assert stored["resolution_scope"] == "artifact"
+        assert store.has_remote_once_receipt(f"receipt-{decision}") is True
 
 
 def test_headless_remote_once_sanitizes_codex_resume_metadata(
@@ -3170,11 +3308,7 @@ def test_headless_remote_once_rejects_stale_requests_and_replays(tmp_path: Path)
 def test_headless_remote_once_rejects_payload_scope_spoofing(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     _seed_guard_cloud(store, workspace_id="workspace-1", now="2026-06-13T00:00:00+00:00")
-    request = _remote_once_request(
-        "req-remote-spoof",
-        policy_action="block",
-        recommended_scope="workspace",
-    )
+    request = _remote_once_request("req-remote-spoof")
     store.add_approval_request(request, "2026-05-14T11:59:00+00:00")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -3184,7 +3318,7 @@ def test_headless_remote_once_rejects_payload_scope_spoofing(tmp_path: Path) -> 
             store,
             "req-remote-spoof",
             receipt_id="cloud-receipt-spoof",
-            scope="artifact",
+            scope="workspace",
         )
         status, payload = _read_json_response(
             _request(
@@ -3201,8 +3335,8 @@ def test_headless_remote_once_rejects_payload_scope_spoofing(tmp_path: Path) -> 
     finally:
         daemon.stop()
 
-    assert status == 400
-    assert payload["error"] == "remote_approval_scope_mismatch"
+    assert status == 409
+    assert payload["error"] == "remote_once_not_permitted"
 
 
 def test_headless_remote_once_rejects_wrong_target_and_does_not_apply(

--- a/tests/test_guard_package_execution_context.py
+++ b/tests/test_guard_package_execution_context.py
@@ -438,7 +438,7 @@ def test_context_evidence_never_contains_configuration_values(tmp_path: Path) ->
     assert "registry.example.test" not in serialized
 
 
-def test_package_project_scope_is_offered_only_for_complete_portable_context(tmp_path: Path) -> None:
+def test_package_project_scope_requires_future_bound_v2_proof(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     _write_repository(workspace)
     _write_package_files(workspace)
@@ -451,7 +451,7 @@ def test_package_project_scope_is_offered_only_for_complete_portable_context(tmp
         "scanner_evidence": [portable.to_evidence()],
     }
 
-    assert supported_request_scopes(request) == ("artifact", "workspace")
+    assert supported_request_scopes(request) == ("artifact",)
     nonportable_evidence = {
         **portable.to_evidence(),
         "portable": False,

--- a/tests/test_guard_package_execution_context.py
+++ b/tests/test_guard_package_execution_context.py
@@ -447,6 +447,7 @@ def test_package_project_scope_requires_future_bound_v2_proof(tmp_path: Path) ->
     request = {
         "artifact_id": "guard-cli:project:package-request:context-test",
         "artifact_type": "package_request",
+        "policy_action": "review",
         "workspace": str(workspace),
         "scanner_evidence": [portable.to_evidence()],
     }

--- a/tests/test_guard_phase05_approval_memory.py
+++ b/tests/test_guard_phase05_approval_memory.py
@@ -529,9 +529,33 @@ def test_gr101_gr102_resolved_allow_and_block_persist_exact_action_policy(
         persist_policy=True,
     )
 
-    assert store.resolve_policy("codex", allow_request.artifact_id, "hash-allow") == "allow"
-    assert store.resolve_policy("codex", block_request.artifact_id, "hash-block") == "block"
-    assert store.resolve_policy("codex", allow_request.artifact_id, "hash-changed") is None
+    assert (
+        store.resolve_policy(
+            "codex",
+            allow_request.artifact_id,
+            "hash-allow",
+            now="2026-05-13T00:02:30+00:00",
+        )
+        == "allow"
+    )
+    assert (
+        store.resolve_policy(
+            "codex",
+            block_request.artifact_id,
+            "hash-block",
+            now="2026-05-13T00:04:00+00:00",
+        )
+        == "block"
+    )
+    assert (
+        store.resolve_policy(
+            "codex",
+            allow_request.artifact_id,
+            "hash-changed",
+            now="2026-05-13T00:03:00+00:00",
+        )
+        is None
+    )
 
 
 def test_codex_prompt_file_retry_reuses_artifact_once_across_context_drift(
@@ -789,7 +813,7 @@ def test_gr116_workspace_policy_uses_stable_non_path_fingerprint(
 
 
 @pytest.mark.parametrize("scope", ["harness", "global"])
-def test_gr117_broad_runtime_scope_applies_only_same_exact_action(
+def test_gr117_legacy_broad_runtime_allow_narrows_without_hash_drift(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     scope: str,
@@ -819,10 +843,44 @@ def test_gr117_broad_runtime_scope_applies_only_same_exact_action(
     assert result["resolved"] is True
     assert store.get_approval_request("req-shell")["status"] == "resolved"
     assert store.get_approval_request("req-shell-other")["status"] == "pending"
-    assert store.resolve_policy("codex", shell_request.artifact_id, "hash-new") == "allow"
-    assert store.resolve_policy("codex", other_shell_request.artifact_id, "hash-new") is None
-    assert store.resolve_policy("codex", "codex:project:mcp-tool:other", "hash-new") is None
-    assert store.resolve_policy("codex", "codex:project:prompt-file:abcdef", "hash-new") is None
+    assert result["applied_scope"] == "artifact"
+    assert result["scope_warning"] == "legacy_scope_narrowed_to_artifact"
+    assert (
+        store.resolve_policy(
+            "codex",
+            shell_request.artifact_id,
+            "hash-new",
+            now="2026-05-13T00:03:00+00:00",
+        )
+        is None
+    )
+    assert (
+        store.resolve_policy(
+            "codex",
+            other_shell_request.artifact_id,
+            "hash-new",
+            now="2026-05-13T00:03:00+00:00",
+        )
+        is None
+    )
+    assert (
+        store.resolve_policy(
+            "codex",
+            "codex:project:mcp-tool:other",
+            "hash-new",
+            now="2026-05-13T00:03:00+00:00",
+        )
+        is None
+    )
+    assert (
+        store.resolve_policy(
+            "codex",
+            "codex:project:prompt-file:abcdef",
+            "hash-new",
+            now="2026-05-13T00:03:00+00:00",
+        )
+        is None
+    )
 
 
 def test_artifact_runtime_scope_reuses_approval_for_same_exact_action_retry(
@@ -1270,22 +1328,23 @@ def test_gr119_harness_clear_can_target_null_artifact_identity(tmp_path: Path) -
     assert remaining[0]["artifact_id"] == "family:file-read"
 
 
-def test_gr119_publisher_scope_rejects_blank_publisher_identity(tmp_path: Path) -> None:
+def test_gr119_legacy_publisher_scope_without_identity_narrows_to_artifact(tmp_path: Path) -> None:
     store = _store(tmp_path)
     request = _request("req-no-publisher", publisher="")
     store.add_approval_request(request, "2026-05-13T00:00:00+00:00")
 
-    with pytest.raises(ValueError, match="unsupported_request_scope"):
-        apply_approval_resolution(
-            store=store,
-            request_id="req-no-publisher",
-            action="allow",
-            scope="publisher",
-            workspace=request.workspace,
-            reason="approved without publisher",
-            now="2026-05-13T00:01:00+00:00",
-        )
+    resolved = apply_approval_resolution(
+        store=store,
+        request_id="req-no-publisher",
+        action="allow",
+        scope="publisher",
+        workspace=request.workspace,
+        reason="approved without publisher",
+        now="2026-05-13T00:01:00+00:00",
+    )
 
+    assert resolved["resolution_scope"] == "artifact"
+    assert resolved["scope_warning"] == "legacy_scope_narrowed_to_artifact"
     assert store.list_policy_decisions("codex") == []
 
 

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -682,10 +682,12 @@ def test_broad_scope_resolution_keeps_other_reviews_pending(tmp_path: Path) -> N
     assert payload["remaining_pending_count"] == 1
     assert payload["next_selectable_request_id"] == "req-covered"
     assert payload.get("resolved_scope_ids") in (None, [])
+    assert payload["requested_scope"] == "harness"
+    assert payload["applied_scope"] == "artifact"
+    assert payload["scope_warning"] == "legacy_scope_narrowed_to_artifact"
     assert store.get_approval_request("req-covered")["status"] == "pending"
     decisions = store.list_policy_decisions("codex")
-    assert len(decisions) == 1
-    assert decisions[0]["scope"] == "harness"
+    assert decisions == []
 
 
 def test_artifact_scope_resolution_keeps_same_artifact_review_pending(tmp_path: Path) -> None:
@@ -718,7 +720,7 @@ def test_artifact_scope_resolution_keeps_same_artifact_review_pending(tmp_path: 
     assert store.get_approval_request("req-covered")["status"] == "pending"
 
 
-def test_resolving_stale_item_returns_recovery_payload(tmp_path: Path) -> None:
+def test_same_resolution_is_idempotent_and_different_resolution_conflicts(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     _populate(store, [_request("req-stale")])
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
@@ -731,18 +733,26 @@ def test_resolving_stale_item_returns_recovery_payload(tmp_path: Path) -> None:
             "/v1/requests/req-stale/approve",
             {"scope": "artifact", "reason": "reviewed"},
         )
-        status, payload = _post_error(
+        payload = _post_json(
             daemon.port,
             daemon._server.auth_token,
             "/v1/requests/req-stale/approve",
             {"scope": "artifact", "reason": "reviewed again"},
         )
+        status, conflict = _post_error(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-stale/block",
+            {"scope": "artifact", "reason": "different decision"},
+        )
     finally:
         daemon.stop()
 
+    assert payload["resolved"] is True
+    assert payload["idempotent"] is True
     assert status == 409
-    assert payload["error"] == "already_resolved"
-    assert payload["recovery"]["code"] == "request_resolved"
+    assert conflict["error"] == "already_resolved"
+    assert conflict["recovery"]["code"] == "request_resolved"
 
 
 def test_resolving_missing_item_returns_recovery_payload(tmp_path: Path) -> None:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -16566,7 +16566,7 @@ def test_guard_runtime_tool_action_policy_uses_network_egress_when_stricter(tmp_
         "global",
     ],
 )
-def test_guard_runtime_honors_saved_allows_for_same_risky_tool_action(
+def test_guard_runtime_narrows_legacy_broad_allow_for_same_risky_tool_action(
     tmp_path: Path,
     scope: str,
 ) -> None:
@@ -16612,7 +16612,7 @@ def test_guard_runtime_honors_saved_allows_for_same_risky_tool_action(
     )
     store.add_approval_request(request, "2026-06-12T00:00:00+00:00")
 
-    apply_approval_resolution(
+    resolution = apply_approval_resolution(
         store=store,
         request_id=request.request_id,
         action="allow",
@@ -16621,6 +16621,10 @@ def test_guard_runtime_honors_saved_allows_for_same_risky_tool_action(
         reason=f"saved for {scope}",
         now="2026-06-12T00:01:00+00:00",
     )
+
+    assert resolution["requested_scope"] == scope
+    assert resolution["applied_scope"] == "artifact"
+    assert resolution["scope_warning"] == "legacy_scope_narrowed_to_artifact"
 
     runtime_artifact = GuardArtifact(
         artifact_id=request.artifact_id,
@@ -16642,7 +16646,7 @@ def test_guard_runtime_honors_saved_allows_for_same_risky_tool_action(
             artifact_hash="hash-retry",
             workspace=str(workspace),
         )
-        == "allow"
+        is None
     )
 
 
@@ -16699,7 +16703,7 @@ def test_guard_runtime_rejects_saved_allows_for_different_risky_tool_action(
     )
     store.add_approval_request(request, "2026-06-12T00:00:00+00:00")
 
-    apply_approval_resolution(
+    resolution = apply_approval_resolution(
         store=store,
         request_id=request.request_id,
         action="allow",
@@ -16708,6 +16712,10 @@ def test_guard_runtime_rejects_saved_allows_for_different_risky_tool_action(
         reason=f"saved for {scope}",
         now="2026-06-12T00:01:00+00:00",
     )
+
+    assert resolution["requested_scope"] == scope
+    assert resolution["applied_scope"] == "artifact"
+    assert resolution["scope_warning"] == "legacy_scope_narrowed_to_artifact"
 
     later_artifact = GuardArtifact(
         artifact_id="opencode:project:tool-action:credential-upload",

--- a/tests/test_guard_web_recovery.py
+++ b/tests/test_guard_web_recovery.py
@@ -29,7 +29,7 @@ def _add_pending_request(store: GuardStore, request_id: str = "req-test-001") ->
             artifact_id="codex:project:test_tool",
             artifact_name="test_tool",
             artifact_hash="hash-test",
-            policy_action="block",
+            policy_action="require-reapproval",
             recommended_scope="artifact",
             changed_fields=(),
             source_scope="local",
@@ -77,7 +77,7 @@ class TestApproveBlockRecoveryPayloads:
         _add_pending_request(store, "req-resolved-001")
         store.resolve_approval_request(
             "req-resolved-001",
-            resolution_action="allow",
+            resolution_action="block",
             resolution_scope="artifact",
             reason=None,
             resolved_at="2026-01-01T01:00:00+00:00",
@@ -117,7 +117,7 @@ class TestApproveBlockRecoveryPayloads:
                 artifact_id="opencode:project:test_tool",
                 artifact_name="test_tool",
                 artifact_hash="hash-test",
-                policy_action="block",
+                policy_action="require-reapproval",
                 recommended_scope="artifact",
                 changed_fields=(),
                 source_scope="local",


### PR DESCRIPTION
## Summary
- expose action-specific approval scopes, recommendations, restrictions, and contract identity
- reject stale or ineligible V2 resolutions while preserving bounded legacy behavior
- bind scope contracts to canonical persisted execution identity and serialize concurrent resolutions

## Testing
- `uv run --no-sync pytest -q $(fd -t f 'test_guard_.*(approval|package_execution_context).*\\.py$' tests | sort) tests/test_guard_queue_api_contract.py --tb=short`
- `uv run --no-sync ruff check <affected Python files>`
- `uv run --no-sync ruff format --check <affected Python files>`
- `uv run --no-sync basedpyright --level error`
- `git diff --check`
