### PR TITLE
fix(hermes): separate complete inputs from bounded previews

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -6,8 +6,6 @@ configured in the Hermes config directory (default ~/.hermes, or $HERMES_HOME).
 
 from __future__ import annotations
 
-import ast
-import hashlib
 import json
 import os
 import re
@@ -15,22 +13,27 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import yaml as _yaml  # type: ignore[import-untyped]
+
 from ..aibom_detection import enrich_mcp_server_metadata
 from ..inventory_cisco import run_cisco_inventory_scans
 from ..inventory_contract import GuardAgentInventorySnapshot, inventory_snapshot_from_detection
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
+from ..skill_directory_identity import (
+    inspect_skill_directory,
+    skill_directory_identity_metadata,
+)
 from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload, _run_command_probe
 from .cloud_identity import cloud_agent_identity_environment, cloud_agent_identity_hints
-
-# Optional: PyYAML is preferred when available for robust YAML parsing.
-# The adapter works without it via a line-based fallback parser.
-try:
-    import yaml as _yaml_mod  # type: ignore[import-untyped]
-
-    _yaml: Any = _yaml_mod
-except ImportError:
-    _yaml = None
+from .hermes_file_inspection import (
+    HermesConfigInspection,
+    HermesFileInspection,
+    file_inspection_metadata,
+    inspect_hermes_config,
+    inspect_hermes_text_file,
+    parse_hermes_yaml_mapping,
+)
 
 # Subdirectories within a skill that may contain executable or injectable content.
 _SKILL_SUBDIRS = ("references", "templates", "scripts", "assets")
@@ -56,8 +59,6 @@ _SCANNABLE_EXTENSIONS = {
 # Filenames (no extension) that should be scanned in skill subdirectories.
 _SCANNABLE_NAMES = {".env", "Makefile", "Dockerfile", "Procfile"}
 
-# Maximum bytes read from any single file for risk analysis.
-_MAX_FILE_READ = 64 * 1024
 _HERMES_MANAGED_APPROVAL_TIER = "native-or-center"
 _HERMES_MANAGED_PROMPT_CHANNEL = "native"
 
@@ -122,7 +123,10 @@ def _hermes_home_has_artifacts(hermes_home: Path) -> bool:
             if _parse_mcp_from_yaml(yaml_path):
                 return True
         except (ValueError, OSError):
-            pass
+            # An unreadable or malformed primary config is still an artifact.
+            # Treat it as populated so an incomplete sandbox cannot inherit
+            # unrelated MCP configuration from a host-home mirror.
+            return True
     json_path = hermes_home / "mcp_servers.json"
     if json_path.is_file():
         try:
@@ -130,7 +134,7 @@ def _hermes_home_has_artifacts(hermes_home: Path) -> bool:
             if servers:
                 return True
         except (ValueError, OSError):
-            pass
+            return True
     skills_dir = hermes_home / "skills"
     if skills_dir.is_dir():
         try:
@@ -164,6 +168,15 @@ class HermesHarnessAdapter(HarnessAdapter):
     fallback_hint = "Configure Hermes to use Guard-launched sessions for skill execution."
 
     def install(self, context: HarnessContext) -> dict[str, object]:
+        hermes_home = _hermes_home(context)
+        source_configs = _load_mcp_server_sources(hermes_home)
+        # Only consult the mirror for a minimal sandbox, matching detect().
+        host_home = _hermes_host_home(context)
+        if host_home and host_home.resolve() != hermes_home.resolve() and not _hermes_home_has_artifacts(hermes_home):
+            for key, config in _load_mcp_server_sources(host_home).items():
+                source_configs.setdefault(key, config)
+
+        # Parse every source completely before making any installation change.
         shim_manifest = install_guard_shim(self.harness, context)
         managed_root = _managed_root(context)
         manifest_path = managed_root / "manifest.json"
@@ -176,13 +189,6 @@ class HermesHarnessAdapter(HarnessAdapter):
             overlay_path=overlay_path,
             pretool_path=pretool_path,
         )
-        hermes_home = _hermes_home(context)
-        source_configs = _load_mcp_server_sources(hermes_home)
-        # Only consult the mirror for a minimal sandbox, matching detect().
-        host_home = _hermes_host_home(context)
-        if host_home and host_home.resolve() != hermes_home.resolve() and not _hermes_home_has_artifacts(hermes_home):
-            for key, config in _load_mcp_server_sources(host_home).items():
-                source_configs.setdefault(key, config)
         overlay_servers = _overlay_servers(context=context, source_configs=source_configs)
         cloud_identity = cloud_agent_identity_hints(context, runtime=self.harness)
         overlay_path.write_text(json.dumps(overlay_servers, indent=2) + "\n", encoding="utf-8")
@@ -349,6 +355,7 @@ class HermesHarnessAdapter(HarnessAdapter):
         hermes_home = _hermes_home(context)
         artifacts: list[GuardArtifact] = []
         found_paths: list[str] = []
+        warnings: list[str] = []
 
         # Detect Hermes installation signals.
         for config_name in ("config.yaml", "config.toml"):
@@ -377,16 +384,24 @@ class HermesHarnessAdapter(HarnessAdapter):
                     if not skill_md.is_file():
                         continue
                     found_paths.append(str(skill_md))
-                    artifacts.extend(self._scan_skill(category_dir, skill_dir, skill_md))
+                    artifacts.extend(
+                        self._scan_skill(
+                            category_dir,
+                            skill_dir,
+                            skill_md,
+                            identity_scope_root=skills_dir,
+                            warnings=warnings,
+                        )
+                    )
 
         # Discover MCP servers from both config.yaml and mcp_servers.json.
-        artifacts.extend(self._scan_mcp_servers(hermes_home, found_paths))
+        artifacts.extend(self._scan_mcp_servers(hermes_home, found_paths, warnings))
 
         # Container fallback: use an explicit or persisted host-home mirror
         # when the sandbox has only empty skills and trivial config.
         host_home = _hermes_host_home(context)
         if host_home and host_home.resolve() != hermes_home.resolve() and not _hermes_home_has_artifacts(hermes_home):
-            artifacts.extend(self._scan_host_home(host_home, found_paths))
+            artifacts.extend(self._scan_host_home(host_home, found_paths, warnings))
 
         # Manifest fallback: when no MCP servers were discovered from config
         # files, fall back to the Guard-managed manifest.json.  This covers
@@ -401,6 +416,7 @@ class HermesHarnessAdapter(HarnessAdapter):
             command_available=_command_available(self.executable),
             artifacts=tuple(artifacts),
             config_paths=tuple(found_paths),
+            warnings=tuple(dict.fromkeys(warnings)),
         )
 
     def inventory_snapshot(
@@ -437,11 +453,15 @@ class HermesHarnessAdapter(HarnessAdapter):
         category_dir: Path,
         skill_dir: Path,
         skill_md: Path,
+        *,
+        identity_scope_root: Path,
+        warnings: list[str],
     ) -> list[GuardArtifact]:
         """Produce artifacts for SKILL.md and any scannable subdirectory files."""
         artifacts: list[GuardArtifact] = []
 
-        content = _safe_read(skill_md)
+        inspection = inspect_hermes_text_file(skill_md, scope_root=skill_dir)
+        content = inspection.preview
         frontmatter = _parse_frontmatter(content)
         code_blocks = _extract_code_blocks(content)
 
@@ -464,17 +484,31 @@ class HermesHarnessAdapter(HarnessAdapter):
                     if isinstance(hermes_related, str):
                         related = hermes_related
 
-        content_hash = _primary_content_hash(skill_md, fallback_content=content)
         env_mentions = _extract_env_mentions(content)
-
-        metadata: dict[str, object] = {
-            "category": category_dir.name,
-            "description": description[:200] if description else "",
-            "content_hash": content_hash,
-            "has_code_blocks": bool(code_blocks),
-            "related_skills": related,
-            "env_mentions": sorted(env_mentions),
-        }
+        identity = inspect_skill_directory(skill_md, scope_root=identity_scope_root)
+        metadata = skill_directory_identity_metadata(
+            identity,
+            version_label=f"{category_dir.name}/{skill_dir.name}",
+        )
+        metadata.update(
+            {
+                "category": category_dir.name,
+                "description": description[:200] if description else "",
+                "has_code_blocks": bool(code_blocks),
+                "related_skills": related,
+                "env_mentions": sorted(env_mentions),
+                **file_inspection_metadata(inspection),
+            }
+        )
+        signals = _inspection_signals(inspection, label="Hermes skill")
+        if identity.status != "complete":
+            signals.append("Hermes skill directory identity is incomplete; review is required.")
+            warnings.append(
+                f"Hermes skill directory identity is incomplete ({identity.failure_reason or 'unknown'}); "
+                "approval reuse is disabled."
+            )
+        if signals:
+            metadata["runtime_request_signals"] = signals
 
         # Include both fenced code blocks AND non-fenced plain text for risk
         # analysis.  Mixed files may have a benign fenced snippet plus malicious
@@ -514,9 +548,8 @@ class HermesHarnessAdapter(HarnessAdapter):
                     continue
                 if not _is_scannable(file_path):
                     continue
-                file_content = _safe_read(file_path)
-                if not file_content:
-                    continue
+                file_inspection = inspect_hermes_text_file(file_path, scope_root=skill_dir)
+                file_content = file_inspection.preview
                 file_blocks = _extract_code_blocks(file_content)
                 file_env = _extract_env_mentions(file_content)
                 rel_path = file_path.relative_to(skill_dir)
@@ -529,6 +562,16 @@ class HermesHarnessAdapter(HarnessAdapter):
                 if file_plain:
                     file_risk_args = (*file_risk_args, file_plain)
 
+                file_metadata: dict[str, object] = {
+                    "parent_skill": skill_name,
+                    "subdir": subdir_name,
+                    "has_code_blocks": bool(file_blocks),
+                    "env_mentions": sorted(file_env),
+                    **file_inspection_metadata(file_inspection),
+                }
+                file_signals = _inspection_signals(file_inspection, label="Hermes skill file")
+                if file_signals:
+                    file_metadata["runtime_request_signals"] = file_signals
                 artifacts.append(
                     GuardArtifact(
                         artifact_id=(f"hermes:skill:{category_dir.name}:{skill_dir.name}:{rel_path}"),
@@ -541,13 +584,7 @@ class HermesHarnessAdapter(HarnessAdapter):
                         url=None,
                         transport=None,
                         args=file_risk_args,
-                        metadata={
-                            "parent_skill": skill_name,
-                            "subdir": subdir_name,
-                            "content_hash": _content_hash(file_content),
-                            "has_code_blocks": bool(file_blocks),
-                            "env_mentions": sorted(file_env),
-                        },
+                        metadata=file_metadata,
                     )
                 )
 
@@ -561,6 +598,7 @@ class HermesHarnessAdapter(HarnessAdapter):
         self,
         hermes_home: Path,
         found_paths: list[str],
+        warnings: list[str],
     ) -> list[GuardArtifact]:
         """Read MCP server configs from config.yaml and mcp_servers.json."""
         artifacts: list[GuardArtifact] = []
@@ -569,15 +607,29 @@ class HermesHarnessAdapter(HarnessAdapter):
         yaml_path = hermes_home / "config.yaml"
         if yaml_path.is_file():
             found_paths.append(str(yaml_path))
-            yaml_servers = _parse_mcp_from_yaml(yaml_path)
-            artifacts.extend(self._mcp_artifacts(yaml_servers, str(yaml_path), source="yaml"))
+            inspection = inspect_hermes_config(yaml_path, syntax="yaml")
+            if inspection.complete and inspection.payload is not None:
+                yaml_servers = _mcp_servers_from_payload(inspection.payload)
+                artifacts.extend(self._mcp_artifacts(yaml_servers, str(yaml_path), source="yaml"))
+            else:
+                artifacts.append(_config_failure_artifact(yaml_path, source="yaml", inspection=inspection))
+                warnings.append(_config_failure_warning(yaml_path, inspection))
 
         # Source 2: mcp_servers.json (legacy / alternative).
         json_path = hermes_home / "mcp_servers.json"
         if json_path.is_file():
             found_paths.append(str(json_path))
-            json_servers = _parse_mcp_from_json(json_path)
-            artifacts.extend(self._mcp_artifacts(json_servers, str(json_path), source="json"))
+            inspection = inspect_hermes_config(json_path, syntax="json")
+            if inspection.complete and inspection.payload is not None:
+                json_servers = {
+                    name: config
+                    for name, config in inspection.payload.items()
+                    if isinstance(name, str) and isinstance(config, dict)
+                }
+                artifacts.extend(self._mcp_artifacts(json_servers, str(json_path), source="json"))
+            else:
+                artifacts.append(_config_failure_artifact(json_path, source="json", inspection=inspection))
+                warnings.append(_config_failure_warning(json_path, inspection))
 
         return artifacts
 
@@ -585,6 +637,7 @@ class HermesHarnessAdapter(HarnessAdapter):
         self,
         host_home: Path,
         found_paths: list[str],
+        warnings: list[str],
     ) -> list[GuardArtifact]:
         """Scan the host's real Hermes home when running inside a container.
 
@@ -616,10 +669,18 @@ class HermesHarnessAdapter(HarnessAdapter):
                     if not skill_md.is_file():
                         continue
                     found_paths.append(str(skill_md))
-                    artifacts.extend(self._scan_skill(category_dir, skill_dir, skill_md))
+                    artifacts.extend(
+                        self._scan_skill(
+                            category_dir,
+                            skill_dir,
+                            skill_md,
+                            identity_scope_root=skills_dir,
+                            warnings=warnings,
+                        )
+                    )
 
         # Discover MCP servers from the host's config files.
-        artifacts.extend(self._scan_mcp_servers(host_home, found_paths))
+        artifacts.extend(self._scan_mcp_servers(host_home, found_paths, warnings))
 
         return artifacts
 
@@ -779,6 +840,60 @@ class HermesHarnessAdapter(HarnessAdapter):
 # ------------------------------------------------------------------
 
 
+class _HermesConfigInspectionError(ValueError):
+    def __init__(self, path: Path, inspection: HermesConfigInspection) -> None:
+        reason = inspection.reason or "config_parse_error"
+        super().__init__(f"Hermes config inspection failed for {path}: {reason}")
+        self.inspection = inspection
+
+
+def _inspection_signals(inspection: HermesFileInspection, *, label: str) -> list[str]:
+    if not inspection.complete:
+        reason = inspection.reason or "unknown"
+        return [f"{label} inspection is incomplete ({reason}); unseen content cannot be treated as safe."]
+    if inspection.analysis_truncated:
+        return [f"{label} risk preview is truncated; review the complete content before approval."]
+    return []
+
+
+def _config_failure_artifact(
+    path: Path,
+    *,
+    source: str,
+    inspection: HermesConfigInspection,
+) -> GuardArtifact:
+    reason = inspection.reason or "config_parse_error"
+    metadata = {
+        **file_inspection_metadata(inspection.file),
+        "config_parse_complete": False,
+        "config_reason": reason,
+        "runtime_request_signals": [
+            f"Hermes {source.upper()} configuration inspection is incomplete ({reason}); review is required."
+        ],
+    }
+    return GuardArtifact(
+        artifact_id=f"hermes:config:{source}:incomplete",
+        name=f"Incomplete Hermes {source.upper()} configuration",
+        harness="hermes",
+        artifact_type="configuration",
+        source_scope="global",
+        config_path=str(path),
+        metadata=metadata,
+    )
+
+
+def _config_failure_warning(path: Path, inspection: HermesConfigInspection) -> str:
+    reason = inspection.reason or "config_parse_error"
+    return f"Hermes config {path.name} was not accepted ({reason}); no partial configuration was applied."
+
+
+def _mcp_servers_from_payload(payload: dict[str, object]) -> dict[str, dict[str, object]]:
+    mcp = payload.get("mcp_servers")
+    if not isinstance(mcp, dict):
+        return {}
+    return {name: config for name, config in mcp.items() if isinstance(name, str) and isinstance(config, dict)}
+
+
 def _is_scannable(file_path: Path) -> bool:
     """Check whether a file should be scanned based on extension or name."""
     if file_path.suffix.lower() in _SCANNABLE_EXTENSIONS:
@@ -796,11 +911,7 @@ def _is_scannable(file_path: Path) -> bool:
 
 
 def _parse_frontmatter(content: str) -> dict[str, object]:
-    """Parse YAML frontmatter from SKILL.md content.
-
-    Prefers PyYAML when available for correct nested-structure handling.
-    Falls back to a simple line-based parser that extracts top-level keys.
-    """
+    """Parse complete, bounded YAML frontmatter from the retained preview."""
     if not content.startswith("---"):
         return {}
     parts = content[3:].split("---", 1)
@@ -808,24 +919,11 @@ def _parse_frontmatter(content: str) -> dict[str, object]:
         return {}
     raw = parts[0].strip()
 
-    # Try PyYAML first for robust nested-structure support.
-    if _yaml is not None:
-        try:
-            parsed = _yaml.safe_load(raw)
-            if isinstance(parsed, dict):
-                # Flatten values to strings for consistent downstream handling.
-                return {k: _flatten_yaml_value(v) for k, v in parsed.items()}
-        except Exception:
-            pass
-
-    # Fallback: simple line-based parser for top-level keys only.
-    frontmatter: dict[str, object] = {}
-    for line in raw.split("\n"):
-        if not line or ":" not in line:
-            continue
-        key, _, value = line.partition(":")
-        frontmatter[key.strip()] = value.strip()
-    return frontmatter
+    parsed = parse_hermes_yaml_mapping(raw)
+    if parsed is not None:
+        # Flatten values to strings for consistent downstream handling.
+        return {key: _flatten_yaml_value(value) for key, value in parsed.items()}
+    return {}
 
 
 def _flatten_yaml_value(value: object) -> str:
@@ -885,41 +983,6 @@ def _extract_env_mentions(content: str) -> list[str]:
     return sorted(mentions)
 
 
-def _content_hash(content: str) -> str:
-    """Deterministic hash for change detection (truncated SHA-256)."""
-    return hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
-
-
-def _primary_content_hash(path: Path, *, fallback_content: str) -> str:
-    """Hash the exact primary artifact body using the cloud content format."""
-    digest = hashlib.sha256()
-    try:
-        with path.open("rb") as handle:
-            while chunk := handle.read(64 * 1024):
-                digest.update(chunk)
-    except OSError:
-        digest = hashlib.sha256(fallback_content.encode("utf-8"))
-    return f"sha256:{digest.hexdigest()}"
-
-
-def _safe_read(path: Path) -> str:
-    """Read file content with error handling and size enforcement.
-
-    Checks file size before reading to avoid loading oversized files
-    into memory.  Returns at most _MAX_FILE_READ bytes of content.
-    """
-    try:
-        # Check file size before reading to avoid OOM on huge files.
-        size = path.stat().st_size
-        if size > _MAX_FILE_READ:
-            # Read only the leading portion of large files.
-            with path.open("r", encoding="utf-8") as f:
-                return f.read(_MAX_FILE_READ)
-        return path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return ""
-
-
 def _looks_like_secret(value: str) -> bool:
     """Heuristic: does this value look like a secret/token?"""
     if len(value) < 8:
@@ -945,254 +1008,22 @@ def _looks_like_secret(value: str) -> bool:
     )
 
 
-def _unquote(value: str) -> str:
-    """Remove surrounding quotes from a YAML value."""
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
-        return value[1:-1]
-    return value
-
-
-def _server_list_value(target: dict[str, object], key: str) -> list[str]:
-    value = target.get(key)
-    if isinstance(value, list):
-        return value
-    values: list[str] = []
-    target[key] = values
-    return values
-
-
-def _server_mapping_value(target: dict[str, object], key: str) -> dict[str, object]:
-    value = target.get(key)
-    if isinstance(value, dict):
-        return value
-    mapping: dict[str, object] = {}
-    target[key] = mapping
-    return mapping
-
-
 def _parse_mcp_from_yaml(yaml_path: Path) -> dict[str, dict[str, object]]:
-    """Extract mcp_servers entries from config.yaml.
+    """Extract MCP entries only from a complete, bounded YAML mapping."""
 
-    Uses PyYAML when available for full nested-structure support.
-    Falls back to a line-based indent parser that handles env/headers
-    blocks by tracking nesting depth.
-    """
-    # Try PyYAML first for robust parsing.
-    if _yaml is not None:
-        try:
-            content = _safe_read(yaml_path)
-            if not content:
-                return {}
-            parsed = _yaml.safe_load(content)
-            if not isinstance(parsed, dict):
-                return {}
-            mcp = parsed.get("mcp_servers")
-            if not isinstance(mcp, dict):
-                return {}
-            # Normalise to plain dicts with string keys.
-            servers: dict[str, dict[str, object]] = {}
-            for name, config in mcp.items():
-                if isinstance(name, str) and isinstance(config, dict):
-                    servers[name] = config
-            return servers
-        except Exception:
-            pass
-
-    # Fallback: indent-aware line-based parser.
-    return _parse_mcp_yaml_fallback(yaml_path)
-
-
-def _parse_mcp_yaml_fallback(yaml_path: Path) -> dict[str, dict[str, object]]:
-    """Line-based YAML parser with indent tracking for nested env/headers blocks."""
-    content = _safe_read(yaml_path)
-    if not content:
-        return {}
-
-    servers: dict[str, dict[str, object]] = {}
-    lines = content.splitlines()
-    in_mcp_section = False
-    current_server: str | None = None
-    server_indent = 0
-    # Track which nested block we are inside (e.g. "env", "headers", "sampling").
-    nested_block: str | None = None
-    nested_indent = 0
-    # Track block-style args list (args:\n  - value1\n  - value2).
-    in_args_block = False
-    args_indent = 0
-    # Track multiline scalar args (- | or - >)
-    multiline_continue = False
-    multiline_buffer = ""
-    multiline_start_indent = 0
-
-    for line in lines:
-        stripped = line.lstrip()
-        if not stripped or stripped.startswith("#"):
-            continue
-
-        indent = len(line) - len(stripped)
-
-        if stripped.startswith("mcp_servers:") and indent == 0:
-            in_mcp_section = True
-            current_server = None
-            nested_block = None
-            in_args_block = False
-            continue
-
-        if indent == 0 and in_mcp_section:
-            in_mcp_section = False
-            current_server = None
-            nested_block = None
-            in_args_block = False
-            continue
-
-        if not in_mcp_section:
-            continue
-
-        # Server name line: any key ending with ":" that is deeper than
-        # the mcp_servers: line but shallower than server properties.
-        if (
-            stripped.endswith(":")
-            and not stripped.startswith("-")
-            and (current_server is None or indent <= server_indent)
-        ):
-            server_name = stripped.rstrip(":").strip()
-            if server_name and server_name not in ("mcp_servers",):
-                current_server = server_name
-                server_indent = indent
-                servers[server_name] = {}
-                nested_block = None
-                in_args_block = False
-                continue
-
-        if not current_server or indent <= server_indent:
-            nested_block = None
-            in_args_block = False
-            continue
-
-        # Check for nested block headers (env:, headers:, sampling:).
-        if stripped.endswith(":") and stripped.count(":") == 1:
-            block_name = stripped.rstrip(":").strip()
-            if block_name in ("env", "headers", "sampling"):
-                nested_block = block_name
-                nested_indent = indent
-                servers[current_server].setdefault(block_name, {})
-                in_args_block = False
-                continue
-            # args: without inline value starts a block-style list.
-            if block_name == "args":
-                in_args_block = True
-                args_indent = indent
-                servers[current_server].setdefault("args", [])
-                nested_block = None
-                continue
-
-        # Inside a block-style args list (  - value1).
-        if in_args_block and indent > args_indent and stripped.startswith("- "):
-            # Check for multiline scalar indicator (- | or - >)
-            if stripped[2:].strip() in ("|", ">"):
-                # Start collecting multiline content
-                multiline_start_indent = indent + 2
-                multiline_continue = True
-                multiline_buffer = ""
-                continue
-            arg_val = _unquote(stripped[2:].strip())
-            _server_list_value(servers[current_server], "args").append(arg_val)
-            continue
-
-        # Inside a nested block (env/headers key: value pairs).
-        if nested_block and indent > nested_indent:
-            if nested_block in ("env", "headers"):
-                if ":" in stripped:
-                    k, _, v = stripped.partition(":")
-                    _server_mapping_value(servers[current_server], nested_block)[k.strip()] = _unquote(v.strip())
-                continue
-            if nested_block == "sampling":
-                if ":" in stripped:
-                    k, _, v = stripped.partition(":")
-                    _server_mapping_value(servers[current_server], "sampling")[k.strip()] = _unquote(v.strip())
-                continue
-
-        # Exit nested block if indent drops back.
-        if nested_block and indent <= nested_indent:
-            nested_block = None
-        if in_args_block and indent <= args_indent:
-            in_args_block = False
-
-        # Handle multiline scalar args continuation (- | or - >)
-        if multiline_continue:
-            if indent < multiline_start_indent or (not stripped and indent == 0):
-                # Multiline block ended - save collected content
-                if multiline_buffer and current_server:
-                    _server_list_value(servers[current_server], "args").append(multiline_buffer.strip())
-                multiline_continue = False
-                multiline_buffer = ""
-                # Don't continue - let the dedented line be parsed below
-            else:
-                # Collect continuation line
-                multiline_buffer += stripped + "\n"
-                continue
-
-        # Top-level server property.
-        _parse_yaml_property(stripped, servers[current_server])
-
-    # Flush any remaining multiline buffer
-    if multiline_continue and multiline_buffer and current_server:
-        _server_list_value(servers[current_server], "args").append(multiline_buffer.strip())
-
-    return servers
-
-
-def _parse_yaml_property(line: str, target: dict[str, object]) -> None:
-    """Parse a single YAML key: value property into target dict."""
-    if ":" not in line:
-        return
-    key, _, value = line.partition(":")
-    key = key.strip()
-    value = value.strip()
-
-    if key in ("command", "url"):
-        target[key] = _unquote(value)
-    elif key in ("enabled",):
-        # Strip inline comments before boolean coercion.
-        # e.g. "false # disabled for prod" -> "false"
-        bare_value = value.split("#", 1)[0].strip()
-        if bare_value.lower() in ("false", "no", "off"):
-            target[key] = False
-        elif bare_value.lower() in ("true", "yes", "on"):
-            target[key] = True
-        else:
-            target[key] = _unquote(bare_value)
-    elif key in ("env", "headers"):
-        # Handle inline map syntax: env: {KEY: value}
-        inline_match = re.match(r"^\{(.+)\}$", value)
-        if inline_match:
-            try:
-                # Parse as Python dict literal (YAML keys are unquoted by this point)
-                parsed = ast.literal_eval("{" + inline_match.group(1) + "}")
-                if isinstance(parsed, dict):
-                    target[key] = parsed
-            except (ValueError, SyntaxError):
-                pass
-    elif key == "args":
-        # Handle JSON array: args: [value1, value2]
-        if value.startswith("["):
-            try:
-                parsed = json.loads(value)
-                if isinstance(parsed, list):
-                    target[key] = parsed
-            except json.JSONDecodeError:
-                pass
-        # Handle single quoted string: args: 'value' (fallback for simple cases)
-        elif value.startswith("'") or value.startswith('"'):
-            target[key] = [_unquote(value)]
+    inspection = inspect_hermes_config(yaml_path, syntax="yaml")
+    if not inspection.complete or inspection.payload is None:
+        raise _HermesConfigInspectionError(yaml_path, inspection)
+    return _mcp_servers_from_payload(inspection.payload)
 
 
 def _parse_mcp_from_json(json_path: Path) -> dict[str, dict[str, object]]:
-    """Parse MCP servers from mcp_servers.json."""
-    payload = _json_payload(json_path)
-    if not isinstance(payload, dict):
-        return {}
-    return {name: config for name, config in payload.items() if isinstance(name, str) and isinstance(config, dict)}
+    """Parse MCP servers only from a complete, bounded JSON mapping."""
+
+    inspection = inspect_hermes_config(json_path, syntax="json")
+    if not inspection.complete or inspection.payload is None:
+        raise _HermesConfigInspectionError(json_path, inspection)
+    return {name: config for name, config in inspection.payload.items() if isinstance(config, dict)}
 
 
 def _managed_root(context: HarnessContext) -> Path:
@@ -1474,31 +1305,17 @@ def _write_guard_to_hermes_config_yaml(
     ``previous_guard_section`` is the user's existing ``guard`` section (or
     ``None`` if there wasn't one) so that ``uninstall()`` can restore it.
     ``config_written`` is ``True`` if config.yaml was written, ``False`` if the
-    write bailed out (parse error, missing PyYAML).
+    existing configuration could not be inspected completely.
     """
     config_yaml_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Load existing config.
     existing: dict[str, Any] = {}
-    if _yaml is None:
-        # Without PyYAML we can't safely read or round-trip YAML; bail out
-        # without claiming to have written anything.
-        return [], None, False
-
     if config_yaml_path.exists():
-        try:
-            raw = _yaml.safe_load(config_yaml_path.read_text(encoding="utf-8"))
-            if isinstance(raw, dict):
-                existing = raw
-            elif raw is None:
-                # Empty YAML document — treat as empty config, not a clobber risk.
-                pass
-            else:
-                # Config contains a scalar/list — bail out, don't risk clobbering.
-                return [], None, False
-        except Exception:
-            # Parse error — bail out rather than overwriting the user's config.
+        inspection = inspect_hermes_config(config_yaml_path, syntax="yaml")
+        if not inspection.complete or inspection.payload is None:
             return [], None, False
+        existing = inspection.payload
 
     # Capture the user's existing guard section so uninstall can restore it.
     previous_guard = existing.get(_GUARD_CONFIG_KEY)
@@ -1557,15 +1374,10 @@ def _remove_guard_from_hermes_config_yaml(
     """
     if not config_yaml_path.exists():
         return
-    if _yaml is None:
+    inspection = inspect_hermes_config(config_yaml_path, syntax="yaml")
+    if not inspection.complete or inspection.payload is None:
         return
-
-    try:
-        raw = _yaml.safe_load(config_yaml_path.read_text(encoding="utf-8"))
-    except Exception:
-        return
-    if not isinstance(raw, dict):
-        return
+    raw = inspection.payload
 
     managed_set = set(managed_names)
     mcp_servers = raw.get("mcp_servers")

--- a/src/codex_plugin_scanner/guard/adapters/hermes_file_inspection.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes_file_inspection.py
@@ -1,0 +1,413 @@
+"""Bounded previews, complete hashes, and fail-closed Hermes config parsing."""
+
+from __future__ import annotations
+
+import codecs
+import hashlib
+import json
+import math
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import yaml  # type: ignore[import-untyped]
+
+from ..windows_paths import open_windows_locked_regular_descriptor
+
+HERMES_PREVIEW_BYTES = 64 * 1024
+HERMES_CONFIG_MAX_BYTES = 2 * 1024 * 1024
+HERMES_CONFIG_MAX_DEPTH = 32
+HERMES_CONFIG_MAX_NODES = 20_000
+HERMES_CONFIG_MAX_ALIASES = 0
+_HASH_CHUNK_BYTES = 64 * 1024
+
+HermesFileInspectionReason = Literal[
+    "file_missing",
+    "file_not_regular",
+    "file_symlink_unsupported",
+    "file_symlink_escape",
+    "file_unreadable",
+    "file_invalid_utf8",
+    "file_too_large",
+    "file_changed_during_read",
+]
+HermesConfigInspectionReason = (
+    HermesFileInspectionReason
+    | Literal[
+        "config_parser_unavailable",
+        "config_parse_error",
+        "config_duplicate_key",
+        "config_alias_limit_exceeded",
+        "config_depth_limit_exceeded",
+        "config_node_limit_exceeded",
+        "config_not_mapping",
+        "config_value_invalid",
+    ]
+)
+
+
+@dataclass(frozen=True, slots=True)
+class HermesFileInspection:
+    """One complete byte identity plus a separately bounded UTF-8 preview."""
+
+    preview: str
+    content: str | None
+    content_hash: str | None
+    size_bytes: int
+    readable: bool
+    complete: bool
+    analysis_truncated: bool
+    reason: HermesFileInspectionReason | None
+
+
+@dataclass(frozen=True, slots=True)
+class HermesConfigInspection:
+    """A complete, bounded config mapping or an explicit failure."""
+
+    file: HermesFileInspection
+    payload: dict[str, object] | None
+    complete: bool
+    reason: HermesConfigInspectionReason | None
+
+
+class _HermesConfigLimitError(ValueError):
+    def __init__(self, reason: HermesConfigInspectionReason) -> None:
+        super().__init__(reason)
+        self.reason: HermesConfigInspectionReason = reason
+
+
+def inspect_hermes_text_file(
+    path: Path,
+    *,
+    scope_root: Path | None = None,
+    content_limit_bytes: int | None = None,
+) -> HermesFileInspection:
+    """Stream a regular file once, hashing all bytes while retaining a preview.
+
+    ``content_limit_bytes`` controls whether complete text is retained for a
+    parser. It never limits hashing: oversized inputs are still streamed to a
+    complete digest, but are marked incomplete for parsing.
+    """
+
+    logical_path = Path(path)
+    try:
+        before = os.lstat(logical_path)
+    except FileNotFoundError:
+        return _file_failure("file_missing")
+    except OSError:
+        return _file_failure("file_unreadable")
+    if stat.S_ISLNK(before.st_mode):
+        return _file_failure("file_symlink_unsupported", size_bytes=before.st_size)
+    if not stat.S_ISREG(before.st_mode):
+        return _file_failure("file_not_regular", size_bytes=before.st_size)
+    if scope_root is not None and not _resolves_within(logical_path, scope_root):
+        return _file_failure("file_symlink_escape", size_bytes=before.st_size)
+
+    try:
+        descriptor = (
+            open_windows_locked_regular_descriptor(logical_path)
+            if os.name == "nt"
+            else os.open(
+                logical_path,
+                os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+            )
+        )
+    except FileNotFoundError:
+        return _file_failure("file_changed_during_read", size_bytes=before.st_size)
+    except OSError:
+        return _file_failure("file_unreadable", size_bytes=before.st_size)
+
+    preview = bytearray()
+    retained = bytearray()
+    digest = hashlib.sha256()
+    decoder = codecs.getincrementaldecoder("utf-8")("strict")
+    total = 0
+    invalid_utf8 = False
+    changed = False
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or _stat_key(opened) != _stat_key(before):
+            changed = True
+        while not changed:
+            try:
+                chunk = os.read(descriptor, _HASH_CHUNK_BYTES)
+            except OSError:
+                return _file_failure("file_unreadable", size_bytes=total)
+            if not chunk:
+                break
+            total += len(chunk)
+            digest.update(chunk)
+            if len(preview) < HERMES_PREVIEW_BYTES:
+                preview.extend(chunk[: HERMES_PREVIEW_BYTES - len(preview)])
+            if content_limit_bytes is not None and len(retained) < content_limit_bytes:
+                # Keep the parse buffer at the exact configured ceiling even
+                # when the final read chunk crosses it.  The full stream is
+                # still decoded and hashed before oversized input fails.
+                retained.extend(chunk[: content_limit_bytes - len(retained)])
+            try:
+                decoder.decode(chunk, final=False)
+            except UnicodeDecodeError:
+                invalid_utf8 = True
+        if not invalid_utf8 and not changed:
+            try:
+                decoder.decode(b"", final=True)
+            except UnicodeDecodeError:
+                invalid_utf8 = True
+        final_opened = os.fstat(descriptor)
+        if total != opened.st_size or _stat_key(final_opened) != _stat_key(opened):
+            changed = True
+    finally:
+        os.close(descriptor)
+
+    try:
+        after = os.lstat(logical_path)
+    except OSError:
+        changed = True
+    else:
+        if _stat_key(after) != _stat_key(before):
+            changed = True
+    preview_text = bytes(preview).decode("utf-8", errors="ignore")
+    truncated = total > len(preview)
+    if changed:
+        return _file_failure(
+            "file_changed_during_read",
+            preview=preview_text,
+            size_bytes=total,
+            analysis_truncated=truncated,
+        )
+
+    content_hash = f"sha256:{digest.hexdigest()}"
+    if invalid_utf8:
+        return HermesFileInspection(
+            preview=preview_text,
+            content=None,
+            content_hash=content_hash,
+            size_bytes=total,
+            readable=True,
+            complete=False,
+            analysis_truncated=truncated,
+            reason="file_invalid_utf8",
+        )
+    if content_limit_bytes is not None and total > content_limit_bytes:
+        return HermesFileInspection(
+            preview=preview_text,
+            content=None,
+            content_hash=content_hash,
+            size_bytes=total,
+            readable=True,
+            complete=False,
+            analysis_truncated=truncated,
+            reason="file_too_large",
+        )
+    full_content = bytes(retained).decode("utf-8") if content_limit_bytes is not None else None
+    return HermesFileInspection(
+        preview=preview_text,
+        content=full_content,
+        content_hash=content_hash,
+        size_bytes=total,
+        readable=True,
+        complete=True,
+        analysis_truncated=truncated,
+        reason=None,
+    )
+
+
+def inspect_hermes_config(path: Path, *, syntax: Literal["json", "yaml"]) -> HermesConfigInspection:
+    """Parse a complete bounded config without accepting a prefix."""
+
+    file = inspect_hermes_text_file(path, content_limit_bytes=HERMES_CONFIG_MAX_BYTES)
+    if not file.complete or file.content is None:
+        return HermesConfigInspection(file=file, payload=None, complete=False, reason=file.reason)
+    try:
+        if syntax == "json":
+            parsed = json.loads(file.content, object_pairs_hook=_unique_json_mapping)
+        else:
+            parsed = _load_yaml(file.content)
+        _validate_config_value(parsed)
+    except _HermesConfigLimitError as exc:
+        return HermesConfigInspection(file=file, payload=None, complete=False, reason=exc.reason)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return HermesConfigInspection(file=file, payload=None, complete=False, reason="config_parse_error")
+    if parsed is None and syntax == "yaml":
+        parsed = {}
+    if not isinstance(parsed, dict):
+        return HermesConfigInspection(file=file, payload=None, complete=False, reason="config_not_mapping")
+    return HermesConfigInspection(file=file, payload=parsed, complete=True, reason=None)
+
+
+def parse_hermes_yaml_mapping(content: str) -> dict[str, object] | None:
+    """Safely parse bounded in-memory YAML used for skill frontmatter."""
+
+    if len(content.encode("utf-8")) > HERMES_PREVIEW_BYTES:
+        return None
+    try:
+        parsed = _load_yaml(content)
+        _validate_config_value(parsed)
+    except (TypeError, ValueError, _HermesConfigLimitError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def file_inspection_metadata(inspection: HermesFileInspection) -> dict[str, object]:
+    """Return non-content metadata suitable for artifact identity and UI."""
+
+    metadata: dict[str, object] = {
+        "analysis_truncated": inspection.analysis_truncated,
+        "inspection_complete": inspection.complete,
+        "inspection_readable": inspection.readable,
+        "preview_bytes": len(inspection.preview.encode("utf-8")),
+        "size_bytes": inspection.size_bytes,
+    }
+    if inspection.content_hash is not None:
+        metadata["content_hash"] = inspection.content_hash
+    if inspection.reason is not None:
+        metadata["inspection_reason"] = inspection.reason
+    return metadata
+
+
+def _load_yaml(content: str) -> object:
+    alias_count = 0
+    depth = 0
+    nodes = 0
+    try:
+        for event in yaml.parse(content, Loader=yaml.SafeLoader):
+            if isinstance(event, yaml.events.AliasEvent):
+                alias_count += 1
+                if alias_count > HERMES_CONFIG_MAX_ALIASES:
+                    raise _HermesConfigLimitError("config_alias_limit_exceeded")
+            if isinstance(event, (yaml.events.MappingStartEvent, yaml.events.SequenceStartEvent)):
+                depth += 1
+                nodes += 1
+                if depth > HERMES_CONFIG_MAX_DEPTH:
+                    raise _HermesConfigLimitError("config_depth_limit_exceeded")
+            elif isinstance(event, (yaml.events.MappingEndEvent, yaml.events.SequenceEndEvent)):
+                depth -= 1
+            elif isinstance(event, yaml.events.ScalarEvent):
+                nodes += 1
+            if nodes > HERMES_CONFIG_MAX_NODES:
+                raise _HermesConfigLimitError("config_node_limit_exceeded")
+        return yaml.load(content, Loader=_UniqueKeySafeLoader)
+    except _HermesConfigLimitError:
+        raise
+    except yaml.YAMLError as exc:
+        raise ValueError("invalid Hermes YAML") from exc
+
+
+class _UniqueKeySafeLoader(yaml.SafeLoader):  # type: ignore[misc]
+    pass
+
+
+def _construct_unique_mapping(loader: object, node: object, deep: bool = False) -> dict[object, object]:
+    if not isinstance(loader, yaml.SafeLoader) or not isinstance(node, yaml.nodes.MappingNode):
+        raise ValueError("invalid YAML mapping")
+    loader.flatten_mapping(node)
+    mapping: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as exc:
+            raise _HermesConfigLimitError("config_value_invalid") from exc
+        if duplicate:
+            raise _HermesConfigLimitError("config_duplicate_key")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeySafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+def _unique_json_mapping(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    mapping: dict[str, object] = {}
+    for key, value in pairs:
+        if key in mapping:
+            raise _HermesConfigLimitError("config_duplicate_key")
+        mapping[key] = value
+    return mapping
+
+
+def _validate_config_value(value: object) -> None:
+    stack: list[tuple[object, int]] = [(value, 1)]
+    nodes = 0
+    while stack:
+        current, depth = stack.pop()
+        nodes += 1
+        if nodes > HERMES_CONFIG_MAX_NODES:
+            raise _HermesConfigLimitError("config_node_limit_exceeded")
+        if depth > HERMES_CONFIG_MAX_DEPTH:
+            raise _HermesConfigLimitError("config_depth_limit_exceeded")
+        if isinstance(current, dict):
+            for key, item in current.items():
+                if not isinstance(key, str):
+                    raise _HermesConfigLimitError("config_value_invalid")
+                stack.append((item, depth + 1))
+        elif isinstance(current, list):
+            stack.extend((item, depth + 1) for item in current)
+        elif (isinstance(current, float) and not math.isfinite(current)) or (
+            current is not None and not isinstance(current, (str, int, float, bool))
+        ):
+            raise _HermesConfigLimitError("config_value_invalid")
+
+
+def _file_failure(
+    reason: HermesFileInspectionReason,
+    *,
+    preview: str = "",
+    size_bytes: int = 0,
+    analysis_truncated: bool = False,
+) -> HermesFileInspection:
+    return HermesFileInspection(
+        preview=preview,
+        content=None,
+        content_hash=None,
+        size_bytes=size_bytes,
+        readable=False,
+        complete=False,
+        analysis_truncated=analysis_truncated,
+        reason=reason,
+    )
+
+
+def _resolves_within(path: Path, root: Path) -> bool:
+    try:
+        resolved = path.resolve(strict=True)
+        resolved_root = root.resolve(strict=True)
+        _ = resolved.relative_to(resolved_root)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return True
+
+
+def _stat_key(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        int(metadata.st_dev),
+        int(metadata.st_ino),
+        int(metadata.st_mode),
+        int(metadata.st_nlink),
+        int(metadata.st_size),
+        int(getattr(metadata, "st_mtime_ns", int(metadata.st_mtime * 1_000_000_000))),
+        int(getattr(metadata, "st_ctime_ns", int(metadata.st_ctime * 1_000_000_000))),
+        int(getattr(metadata, "st_file_attributes", 0)),
+    )
+
+
+__all__ = [
+    "HERMES_CONFIG_MAX_ALIASES",
+    "HERMES_CONFIG_MAX_BYTES",
+    "HERMES_CONFIG_MAX_DEPTH",
+    "HERMES_CONFIG_MAX_NODES",
+    "HERMES_PREVIEW_BYTES",
+    "HermesConfigInspection",
+    "HermesConfigInspectionReason",
+    "HermesFileInspection",
+    "HermesFileInspectionReason",
+    "file_inspection_metadata",
+    "inspect_hermes_config",
+    "inspect_hermes_text_file",
+    "parse_hermes_yaml_mapping",
+]

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -519,6 +519,8 @@ def _skill_directory_identity_reusable(
         return None
     if "skillDirectoryIdentity" not in metadata:
         return None
+    if metadata.get("inspection_complete") is False:
+        return False
     return validated_complete_skill_directory_hash(metadata) is not None
 
 

--- a/src/codex_plugin_scanner/guard/risk.py
+++ b/src/codex_plugin_scanner/guard/risk.py
@@ -421,6 +421,35 @@ def _env_keys(artifact: GuardArtifact) -> list[str]:
 
 def _metadata_signals(artifact: GuardArtifact) -> list[GuardSignal]:
     signals: list[GuardSignal] = []
+    if artifact.metadata.get("inspection_complete") is False or artifact.metadata.get("config_parse_complete") is False:
+        reason = artifact.metadata.get("inspection_reason") or artifact.metadata.get("config_reason") or "unknown"
+        signals.append(
+            GuardSignal(
+                signal_id="inspection:incomplete",
+                family="execution",
+                severity=8,
+                confidence=0.98,
+                evidence_source="artifact",
+                matched_text=str(reason),
+                explanation="artifact inspection is incomplete",
+                remediation="Repair or reduce the input, then run a complete inspection before approval.",
+                rule_version=_RULE_VERSION,
+            )
+        )
+    elif artifact.metadata.get("analysis_truncated") is True:
+        signals.append(
+            GuardSignal(
+                signal_id="inspection:analysis-truncated",
+                family="execution",
+                severity=6,
+                confidence=0.95,
+                evidence_source="artifact",
+                matched_text=None,
+                explanation="artifact risk preview is truncated",
+                remediation="Review the complete content before approval.",
+                rule_version=_RULE_VERSION,
+            )
+        )
     for key in ("runtime_request_signals", "prompt_signals"):
         value = artifact.metadata.get(key)
         if not isinstance(value, list):

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -726,7 +726,8 @@ class TestSkillSubdirectoryScanning:
         instruction = next(item for item in snapshot.items if item.metadata.get("artifactType") == "instruction")
 
         assert "skill_file" not in artifact_types
-        assert primary_skill.content_hash == f"sha256:{hashlib.sha256(skill_body.encode()).hexdigest()}"
+        assert primary_skill.content_hash == primary_skill.metadata["directory_hash"]
+        assert primary_skill.metadata["content_hash"] == f"sha256:{hashlib.sha256(skill_body.encode()).hexdigest()}"
         assert instruction.content_hash == f"sha256:{hashlib.sha256(instruction_body.encode()).hexdigest()}"
 
     def test_discovers_script_files(self, tmp_path: Path):
@@ -1568,6 +1569,25 @@ class TestInstallHostHomeAwareness:
 
 class TestHostHomeFallbackEdgeCases:
     """Edge cases for the HERMES_HOST_HOME fallback."""
+
+    def test_malformed_primary_config_disables_host_home_fallback(self, tmp_path: Path, monkeypatch):
+        """Incomplete primary inspection must not inherit mirror artifacts."""
+        _write(
+            tmp_path / ".hermes" / "config.yaml",
+            "mcp_servers:\n  duplicate: {command: node}\n  duplicate: {command: python}\n",
+        )
+        host_home = tmp_path / "host-hermes"
+        _write(
+            host_home / "config.yaml",
+            "mcp_servers:\n  host-server:\n    command: python\n",
+        )
+
+        monkeypatch.setenv("HERMES_HOST_HOME", str(host_home))
+        detection = HermesHarnessAdapter().detect(_ctx(tmp_path))
+
+        assert not any(artifact.artifact_type == "mcp_server" for artifact in detection.artifacts)
+        issue = next(artifact for artifact in detection.artifacts if artifact.artifact_type == "configuration")
+        assert issue.metadata["config_reason"] == "config_duplicate_key"
 
     def test_small_config_with_mcp_servers_not_treated_as_empty(self, tmp_path: Path, monkeypatch):
         """A small config.yaml with real MCP servers should NOT trigger

--- a/tests/test_hermes_complete_inspection.py
+++ b/tests/test_hermes_complete_inspection.py
@@ -1,0 +1,329 @@
+"""Security regressions for complete Hermes parsing, hashing, and previews."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import hermes_file_inspection as inspection_module
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.hermes import HermesHarnessAdapter
+from codex_plugin_scanner.guard.adapters.hermes_file_inspection import (
+    HERMES_CONFIG_MAX_BYTES,
+    HERMES_CONFIG_MAX_DEPTH,
+    HERMES_CONFIG_MAX_NODES,
+    HERMES_PREVIEW_BYTES,
+    inspect_hermes_config,
+    inspect_hermes_text_file,
+)
+from codex_plugin_scanner.guard.consumer import artifact_hash
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+from codex_plugin_scanner.guard.risk import artifact_risk_signals_typed
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    return HarnessContext(
+        home_dir=tmp_path,
+        workspace_dir=tmp_path / "workspace",
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _skill(tmp_path: Path) -> Path:
+    return _write(
+        tmp_path / ".hermes" / "skills" / "dev" / "complete" / "SKILL.md",
+        "---\nname: complete\n---\n# Complete\n",
+    )
+
+
+def _artifact(detection: HarnessDetection, artifact_type: str) -> GuardArtifact:
+    return next(item for item in detection.artifacts if item.artifact_type == artifact_type)
+
+
+def test_skill_subfile_suffix_changes_full_hash_and_parent_directory_identity(tmp_path: Path) -> None:
+    skill = _skill(tmp_path)
+    script = _write(
+        skill.parent / "scripts" / "large.sh",
+        "# safe preview\n" + ("# padding\n" * 8_000) + "echo first-suffix\n",
+    )
+    adapter = HermesHarnessAdapter()
+
+    before = adapter.detect(_context(tmp_path))
+    before_file = _artifact(before, "skill_file")
+    before_skill = _artifact(before, "skill")
+    script.write_text(script.read_text(encoding="utf-8").replace("first-suffix", "other-suffix"), encoding="utf-8")
+    after = adapter.detect(_context(tmp_path))
+    after_file = _artifact(after, "skill_file")
+    after_skill = _artifact(after, "skill")
+
+    assert before_file.metadata["analysis_truncated"] is True
+    before_preview_bytes = before_file.metadata["preview_bytes"]
+    assert isinstance(before_preview_bytes, int)
+    assert before_preview_bytes <= HERMES_PREVIEW_BYTES
+    assert "first-suffix" not in " ".join(before_file.args)
+    assert before_file.metadata["content_hash"] != after_file.metadata["content_hash"]
+    assert before_skill.metadata["directory_hash"] != after_skill.metadata["directory_hash"]
+    assert artifact_hash(before_file) != artifact_hash(after_file)
+    assert any(
+        signal.signal_id == "inspection:analysis-truncated" for signal in artifact_risk_signals_typed(before_file)
+    )
+
+
+def test_yaml_server_after_old_preview_limit_is_parsed_from_complete_config(tmp_path: Path) -> None:
+    config = _write(
+        tmp_path / ".hermes" / "config.yaml",
+        ("# bounded preview padding\n" * 3_000)
+        + "mcp_servers:\n  suffix-server:\n    command: python\n    args: ['-m', 'suffix']\n",
+    )
+
+    detection = HermesHarnessAdapter().detect(_context(tmp_path))
+
+    server = next(item for item in detection.artifacts if item.artifact_type == "mcp_server")
+    assert config.stat().st_size > HERMES_PREVIEW_BYTES
+    assert server.name == "suffix-server"
+    assert server.args == ("-m", "suffix")
+
+
+def test_json_server_after_old_preview_limit_is_parsed_from_complete_config(tmp_path: Path) -> None:
+    config = _write(
+        tmp_path / ".hermes" / "mcp_servers.json",
+        json.dumps(
+            {
+                "padding": {"enabled": False, "description": "x" * (HERMES_PREVIEW_BYTES + 1)},
+                "suffix-server": {"command": "node", "args": ["suffix.js"]},
+            }
+        ),
+    )
+
+    detection = HermesHarnessAdapter().detect(_context(tmp_path))
+
+    servers = [item for item in detection.artifacts if item.artifact_type == "mcp_server"]
+    assert config.stat().st_size > HERMES_PREVIEW_BYTES
+    assert [item.name for item in servers] == ["suffix-server"]
+
+
+def test_oversized_config_is_hashed_but_never_partially_parsed(tmp_path: Path) -> None:
+    config = _write(
+        tmp_path / ".hermes" / "config.yaml",
+        ("# xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n" * 40_000)
+        + "mcp_servers:\n  hidden:\n    command: bash\n",
+    )
+    assert config.stat().st_size > HERMES_CONFIG_MAX_BYTES
+
+    detection = HermesHarnessAdapter().detect(_context(tmp_path))
+    issue = next(item for item in detection.artifacts if item.artifact_type == "configuration")
+
+    assert not any(item.artifact_type == "mcp_server" for item in detection.artifacts)
+    assert issue.metadata["config_reason"] == "file_too_large"
+    assert issue.metadata["content_hash"] == f"sha256:{hashlib.sha256(config.read_bytes()).hexdigest()}"
+    preview_bytes = issue.metadata["preview_bytes"]
+    assert isinstance(preview_bytes, int)
+    assert preview_bytes <= HERMES_PREVIEW_BYTES
+    assert any("no partial configuration" in warning for warning in detection.warnings)
+
+
+def test_config_parse_buffer_enforces_exact_byte_limit(tmp_path: Path) -> None:
+    at_limit = _write(
+        tmp_path / "at-limit.json",
+        (" " * (HERMES_CONFIG_MAX_BYTES - 2)) + "{}",
+    )
+    over_limit = _write(
+        tmp_path / "over-limit.json",
+        (" " * (HERMES_CONFIG_MAX_BYTES - 2)) + "{} ",
+    )
+
+    accepted = inspect_hermes_config(at_limit, syntax="json")
+    rejected = inspect_hermes_config(over_limit, syntax="json")
+
+    assert accepted.complete is True
+    assert accepted.file.size_bytes == HERMES_CONFIG_MAX_BYTES
+    assert accepted.payload == {}
+    assert rejected.complete is False
+    assert rejected.file.size_bytes == HERMES_CONFIG_MAX_BYTES + 1
+    assert rejected.file.content is None
+    assert rejected.reason == "file_too_large"
+
+
+@pytest.mark.parametrize(
+    ("name", "content", "reason"),
+    [
+        (
+            "duplicate.yaml",
+            "mcp_servers:\n  same: {command: python}\n  same: {command: bash}\n",
+            "config_duplicate_key",
+        ),
+        (
+            "alias.yaml",
+            "defaults: &defaults {command: python}\nmcp_servers: {same: *defaults}\n",
+            "config_alias_limit_exceeded",
+        ),
+        (
+            "duplicate.json",
+            '{"same":{"command":"python"},"same":{"command":"bash"}}',
+            "config_duplicate_key",
+        ),
+    ],
+)
+def test_duplicate_keys_and_yaml_aliases_fail_closed(
+    tmp_path: Path,
+    name: str,
+    content: str,
+    reason: str,
+) -> None:
+    path = _write(tmp_path / name, content)
+    syntax = "json" if path.suffix == ".json" else "yaml"
+
+    inspection = inspect_hermes_config(path, syntax=syntax)  # type: ignore[arg-type]
+
+    assert inspection.complete is False
+    assert inspection.reason == reason
+    assert inspection.payload is None
+
+
+def test_excessive_json_depth_fails_closed(tmp_path: Path) -> None:
+    value = "null"
+    for _ in range(HERMES_CONFIG_MAX_DEPTH + 2):
+        value = '{"nested":' + value + "}"
+    path = _write(tmp_path / "deep.json", value)
+
+    inspection = inspect_hermes_config(path, syntax="json")
+
+    assert inspection.complete is False
+    assert inspection.reason == "config_depth_limit_exceeded"
+
+
+def test_excessive_json_node_count_fails_closed(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "many-nodes.json",
+        json.dumps({"items": [None] * HERMES_CONFIG_MAX_NODES}),
+    )
+
+    inspection = inspect_hermes_config(path, syntax="json")
+
+    assert inspection.complete is False
+    assert inspection.reason == "config_node_limit_exceeded"
+
+
+@pytest.mark.parametrize("constant", ("NaN", "Infinity", "-Infinity"))
+def test_nonfinite_json_numbers_fail_closed(tmp_path: Path, constant: str) -> None:
+    path = _write(tmp_path / "nonfinite.json", f'{{"value":{constant}}}')
+
+    inspection = inspect_hermes_config(path, syntax="json")
+
+    assert inspection.complete is False
+    assert inspection.reason == "config_value_invalid"
+
+
+@pytest.mark.parametrize(
+    "content",
+    (
+        "mcp_servers:\n  same: {command: python}\n  same: {command: bash}\n",
+        "# padding\n" * (HERMES_CONFIG_MAX_BYTES // 10 + 1),
+    ),
+)
+def test_install_refuses_incomplete_config_without_writing_managed_bundle(
+    tmp_path: Path,
+    content: str,
+) -> None:
+    config = _write(tmp_path / ".hermes" / "config.yaml", content)
+    original = config.read_bytes()
+    context = _context(tmp_path)
+
+    with pytest.raises(ValueError, match="Hermes config inspection failed"):
+        HermesHarnessAdapter().install(context)
+
+    managed_root = context.guard_home / "hermes"
+    assert config.read_bytes() == original
+    assert not (managed_root / "mcp-overlay.json").exists()
+    assert not (managed_root / "pretool-hook.json").exists()
+    assert not (managed_root / "manifest.json").exists()
+    assert not (context.guard_home / "bin" / "guard-hermes").exists()
+    assert not (context.guard_home / "bin" / "guard-hermes.cmd").exists()
+
+
+def test_invalid_utf8_skill_is_explicitly_incomplete_and_non_reusable(tmp_path: Path) -> None:
+    skill = _skill(tmp_path)
+    skill.write_bytes(b"---\nname: invalid\n---\n\xff")
+
+    artifact = _artifact(HermesHarnessAdapter().detect(_context(tmp_path)), "skill")
+
+    assert artifact.metadata["inspection_complete"] is False
+    assert artifact.metadata["inspection_reason"] == "file_invalid_utf8"
+    assert artifact.metadata["content_hash"] == f"sha256:{hashlib.sha256(skill.read_bytes()).hexdigest()}"
+    assert any(signal.signal_id == "inspection:incomplete" for signal in artifact_risk_signals_typed(artifact))
+
+
+def test_skill_symlink_escape_marks_directory_identity_incomplete(tmp_path: Path) -> None:
+    skill = _skill(tmp_path)
+    outside = _write(tmp_path / "outside.sh", "echo outside\n")
+    link = skill.parent / "scripts" / "outside.sh"
+    link.parent.mkdir()
+    try:
+        link.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    detection = HermesHarnessAdapter().detect(_context(tmp_path))
+    primary = _artifact(detection, "skill")
+    subfile = _artifact(detection, "skill_file")
+
+    identity = primary.metadata["skillDirectoryIdentity"]
+    assert isinstance(identity, dict)
+    assert identity["status"] == "incomplete"
+    assert identity["reason"] == "symlink_escape"
+    assert subfile.metadata["inspection_reason"] == "file_symlink_unsupported"
+    assert detection.warnings
+
+
+def test_file_change_during_streaming_hash_is_not_reported_complete(tmp_path: Path, monkeypatch) -> None:
+    path = _write(tmp_path / "large.md", "a" * (HERMES_PREVIEW_BYTES * 2))
+    original_read = inspection_module.os.read
+    changed = False
+
+    def replacing_read(descriptor: int, amount: int) -> bytes:
+        nonlocal changed
+        chunk = original_read(descriptor, amount)
+        if chunk and not changed:
+            changed = True
+            path.write_text("replacement", encoding="utf-8")
+        return chunk
+
+    monkeypatch.setattr(inspection_module.os, "read", replacing_read)
+
+    inspection = inspect_hermes_text_file(path)
+
+    assert inspection.complete is False
+    assert inspection.reason == "file_changed_during_read"
+    assert inspection.content_hash is None
+
+
+def test_unreadable_file_failure_is_typed(tmp_path: Path, monkeypatch) -> None:
+    path = _write(tmp_path / "unreadable.md", "content")
+    original_open = inspection_module.os.open
+
+    def denied_open(
+        candidate: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        flags: int,
+        mode: int = 0o777,
+    ) -> int:
+        if Path(os.fsdecode(candidate)) == path:
+            raise PermissionError("denied")
+        return original_open(candidate, flags, mode)
+
+    monkeypatch.setattr(inspection_module.os, "open", denied_open)
+
+    inspection = inspect_hermes_text_file(path)
+
+    assert inspection.complete is False
+    assert inspection.readable is False
+    assert inspection.reason == "file_unreadable"


### PR DESCRIPTION
## Summary

- stream every Hermes skill/config file to a complete SHA-256 identity while retaining a separate 64 KiB risk-analysis preview
- parse YAML and JSON only from complete UTF-8 inputs bounded to exactly 2 MiB; reject duplicate keys, YAML aliases, excessive depth/node counts, non-finite values, invalid roots, symlinks, unreadable inputs, and files that change during inspection
- use the complete skill-directory identity for primary skill inventory and approval reuse, including every nested file; disable reuse whenever primary inspection or directory identity is incomplete
- emit explicit incomplete/truncated artifacts, warnings, metadata, and risk signals instead of treating unread or unseen suffixes as empty/safe
- parse all install sources before writing the launcher, overlays, manifests, or Hermes config, so malformed and oversized config fails closed without a partial installation
- remove permissive prefix YAML/config fallbacks and preserve complete parsing for install, detect, proxy source loading, config updates, and uninstall cleanup
- treat malformed or unreadable primary configuration as a populated Hermes home so host-mirror fallback cannot inject unrelated MCP artifacts after incomplete inspection

## Limits and failure modes

- risk preview: 64 KiB per text file, with `analysis_truncated` and a review signal when the full file is larger
- configuration parse size: exactly 2 MiB; a crossing read chunk is sliced to the remaining retention budget while the entire input is still streamed and hashed
- configuration depth: 32
- configuration nodes: 20,000
- YAML aliases: 0
- complete stat identity is checked before open, after open, at EOF, and again by path; POSIX reads use `O_NOFOLLOW`

## Regression coverage

- malicious/changed suffixes beyond the old preview limit change both per-file and parent-directory identity
- YAML and JSON MCP servers after 64 KiB are parsed from complete content
- exactly 2 MiB parses and 2 MiB + 1 byte fails with `file_too_large` and no retained content
- oversized, duplicate-key, alias, excessive-depth/node, non-finite, invalid-UTF-8, symlink-escape, unreadable, and mid-read-change cases fail explicitly
- malformed/oversized install input leaves the original config and managed Hermes bundle untouched
- malformed primary config blocks host-home mirror fallback and emits only the fail-closed configuration artifact
- existing Hermes discovery, install/update/uninstall, inventory, risk, skill-directory identity, and saved-approval behavior remains covered

## Validation

- `672 passed, 3 skipped` — Hermes adapter/inspection plus affected directory identity, consumer reuse, inventory contract, and risk suites after replaying onto the current `release/2.1`
- `22 passed` — focused host-home fallback and complete-inspection regression suite after both review fixes
- Ruff formatting and lint passed for all changed files
- Basedpyright passed with `0 errors` for the changed production modules and new regression module
- `uv build` produced the `2.0.1113` sdist and wheel successfully

## Attribution and target

- target branch: `release/2.1`
- commit author/committer: `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>`
