### PR TITLE
fix(cursor): attest managed hook CLI identity

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor.py
@@ -201,6 +201,8 @@ class CursorHarnessAdapter(HarnessAdapter):
             "managed_config_path": editor_manifest.get("managed_config_path"),
             "backup_path": editor_manifest.get("backup_path"),
             "state_path": editor_manifest.get("state_path"),
+            "guard_cli_identity": editor_manifest.get("guard_cli_identity"),
+            "hook_script_sha256": editor_manifest.get("hook_script_sha256"),
             "shim_path": cli_manifest.get("shim_path"),
             "shim_command": cli_manifest.get("shim_command"),
         }
@@ -289,6 +291,8 @@ class CursorHarnessAdapter(HarnessAdapter):
             "skipped_servers": list(skipped_servers),
             "managed_hooks_path": hooks_manifest.get("managed_hooks_path"),
             "managed_hook_script_path": hooks_manifest.get("managed_hook_script_path"),
+            "guard_cli_identity": hooks_manifest.get("guard_cli_identity"),
+            "hook_script_sha256": hooks_manifest.get("hook_script_sha256"),
             "notes": notes,
         }
 

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_config.py
@@ -97,9 +97,7 @@ def _managed_hooks_payload(payload: dict[str, object]) -> dict[str, object]:
         }
         return normalized
     normalized["hooks"] = {
-        str(name): list(entries)
-        for name, entries in payload.items()
-        if name != "version" and name not in _MANAGED_HOOK_EVENTS and isinstance(entries, list)
+        str(name): list(entries) for name, entries in payload.items() if name != "version" and isinstance(entries, list)
     }
     return normalized
 

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_config.py
@@ -1,0 +1,158 @@
+"""Cursor managed-hook configuration helpers."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import stat
+from hashlib import sha256
+from pathlib import Path
+
+from .base import HarnessContext
+
+HOOK_SCRIPT_NAME = "hol-guard-cursor-hook.py"
+_BLOCKING_MANAGED_HOOK_EVENTS = (
+    "beforeShellExecution",
+    "beforeMCPExecution",
+    "beforeReadFile",
+)
+_OBSERVER_MANAGED_HOOK_EVENTS = ("afterShellExecution", "afterMCPExecution")
+_MANAGED_HOOK_EVENTS = _BLOCKING_MANAGED_HOOK_EVENTS + _OBSERVER_MANAGED_HOOK_EVENTS
+_MANAGED_HOOK_TIMEOUT_SECONDS = 45
+
+
+def _managed_hook_entry(
+    context: HarnessContext,
+    *,
+    script_path: Path,
+    event_name: str,
+) -> dict[str, object]:
+    del context
+    entry: dict[str, object] = {
+        "command": str(script_path.resolve()),
+        "timeout": _MANAGED_HOOK_TIMEOUT_SECONDS,
+        "failClosed": event_name in _BLOCKING_MANAGED_HOOK_EVENTS,
+    }
+    return entry
+
+
+def _strip_managed_hook_entries(entries: object, *, script_path: Path) -> list[object]:
+    if not isinstance(entries, list):
+        return []
+    command = str(script_path.resolve())
+    return [entry for entry in entries if not _is_managed_hook_entry(entry, command=command)]
+
+
+def _merge_hook_entries(entries: object, hook_entry: dict[str, object], *, event_name: str) -> list[object]:
+    del event_name
+    normalized = list(entries) if isinstance(entries, list) else []
+    command = str(hook_entry.get("command", ""))
+    preserved = [entry for entry in normalized if not _is_managed_hook_entry(entry, command=command)]
+    return [*preserved, hook_entry]
+
+
+def _is_managed_hook_entry(entry: object, *, command: str) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    entry_command = entry.get("command")
+    if isinstance(entry_command, str) and entry_command == command:
+        return True
+    return _is_managed_hook_command(entry_command)
+
+
+def _is_managed_hook_command(command: object) -> bool:
+    if not isinstance(command, str):
+        return False
+    lowered = command.lower()
+    if "hol-guard-cursor-hook" in lowered:
+        return True
+    if HOOK_SCRIPT_NAME.lower() in lowered:
+        return True
+    if "hol_guard_hook_argv" not in lowered.replace("-", "_"):
+        return False
+    if "--harness" not in lowered or "cursor" not in lowered:
+        return False
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    if tokens and Path(tokens[0]).name == HOOK_SCRIPT_NAME:
+        return True
+    return Path(tokens[0]).name.lower().startswith("python") if tokens else False
+
+
+def _is_managed_hook_script(source: str) -> bool:
+    return "Managed by HOL Guard" in source and HOOK_SCRIPT_NAME in source
+
+
+def _managed_hooks_payload(payload: dict[str, object]) -> dict[str, object]:
+    normalized: dict[str, object] = {"version": 1, "hooks": {}}
+    version = payload.get("version")
+    if isinstance(version, int):
+        normalized["version"] = version
+    hooks = payload.get("hooks")
+    if isinstance(hooks, dict):
+        normalized["hooks"] = {
+            str(name): list(entries) if isinstance(entries, list) else entries for name, entries in hooks.items()
+        }
+        return normalized
+    normalized["hooks"] = {
+        str(name): list(entries)
+        for name, entries in payload.items()
+        if name != "version" and name not in _MANAGED_HOOK_EVENTS and isinstance(entries, list)
+    }
+    return normalized
+
+
+def _inline_hooks(payload: dict[str, object]) -> dict[str, object]:
+    hooks = payload.get("hooks")
+    if isinstance(hooks, dict):
+        normalized = {
+            str(hook_name): list(entries) if isinstance(entries, list) else entries
+            for hook_name, entries in hooks.items()
+        }
+        payload["hooks"] = normalized
+        return normalized
+    normalized: dict[str, object] = {}
+    payload["hooks"] = normalized
+    return normalized
+
+
+def _json_object(path: Path, *, recover_missing: bool) -> dict[str, object]:
+    if not path.is_file():
+        if recover_missing:
+            return {}
+        raise RuntimeError(f"Guard refused to overwrite missing Cursor hooks config at {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Guard refused to overwrite unreadable Cursor hooks config at {path}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Guard refused to overwrite non-object Cursor hooks config at {path}")
+    return payload
+
+
+def _hooks_backup_path(target_path: Path, context: HarnessContext) -> Path:
+    digest = sha256(str(target_path.resolve()).encode("utf-8")).hexdigest()[:12]
+    return context.guard_home / "managed" / "cursor" / f"hooks-{digest}.backup.json"
+
+
+def _hooks_state_path(target_path: Path, context: HarnessContext) -> Path:
+    digest = sha256(str(target_path.resolve()).encode("utf-8")).hexdigest()[:12]
+    return context.guard_home / "managed" / "cursor" / f"hooks-{digest}.state.json"
+
+
+def _backup_payload(backup_path: Path) -> dict[str, str | bool | None]:
+    try:
+        payload = json.loads(backup_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"readable": False, "existed": False, "content": None}
+    if not isinstance(payload, dict):
+        return {"readable": False, "existed": False, "content": None}
+    existed = payload.get("existed") is True
+    content = payload.get("content")
+    return {"readable": True, "existed": existed, "content": content if isinstance(content, str) else None}
+
+
+def _make_executable(path: Path) -> None:
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_payload.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_payload.py
@@ -1,0 +1,227 @@
+"""Cursor hook payload normalization and response mapping."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+from ..action_lattice import is_guard_action
+
+
+def _infer_cursor_hook_event_name(payload: Mapping[str, object]) -> dict[str, object]:
+    normalized = dict(payload)
+    if _raw_hook_event_name(normalized):
+        return normalized
+    file_path = normalized.get("file_path")
+    if isinstance(file_path, str) and file_path.strip():
+        normalized["hook_event_name"] = "beforeReadFile"
+        return normalized
+    command = normalized.get("command")
+    if isinstance(command, str) and command.strip():
+        normalized["hook_event_name"] = "beforeShellExecution"
+        return normalized
+    if normalized.get("tool_name") is not None or normalized.get("tool_input") is not None:
+        normalized["hook_event_name"] = "preToolUse"
+    return normalized
+
+
+# Payload normalizers below are mirrored inside _HOOK_SCRIPT_TEMPLATE for the installed
+# Cursor hook script. Keep both copies in sync when changing observer or MCP behavior.
+
+
+def _cursor_shell_hook_payload(normalized: dict[str, object], *, hook_event_name: str) -> dict[str, object]:
+    payload = dict(normalized)
+    payload["hook_event_name"] = hook_event_name
+    payload.setdefault("tool_name", "Shell")
+    tool_input = _tool_input_dict(payload.get("tool_input"))
+    command = payload.get("command")
+    if isinstance(command, str) and command.strip():
+        tool_input.setdefault("command", command.strip())
+    cwd = payload.get("cwd")
+    if isinstance(cwd, str) and cwd.strip():
+        tool_input.setdefault("working_directory", cwd.strip())
+    payload["tool_input"] = tool_input
+    return payload
+
+
+def _cursor_mcp_hook_payload(normalized: dict[str, object], *, hook_event_name: str) -> dict[str, object]:
+    payload = dict(normalized)
+    payload["hook_event_name"] = hook_event_name
+    tool_input = _tool_input_dict(payload.get("tool_input"))
+    payload["tool_input"] = tool_input
+    tool_name = payload.get("tool_name")
+    if isinstance(tool_name, str) and tool_name.strip():
+        payload["tool_name"] = tool_name.strip()
+    else:
+        payload.setdefault("tool_name", "MCP")
+    return payload
+
+
+def prepare_cursor_hook_payload(payload: Mapping[str, object]) -> dict[str, object]:
+    """Map Cursor hook stdin JSON into Guard hook normalization shape."""
+
+    normalized = _infer_cursor_hook_event_name(payload)
+    raw_event = _raw_hook_event_name(normalized)
+    if raw_event == "aftershellexecution":
+        return _cursor_shell_hook_payload(normalized, hook_event_name="afterShellExecution")
+    if raw_event == "aftermcpexecution":
+        return _cursor_mcp_hook_payload(normalized, hook_event_name="afterMCPExecution")
+    if raw_event == "beforeshellexecution":
+        prepared = _cursor_shell_hook_payload(normalized, hook_event_name="PreToolUse")
+        prepared["cursor_source_hook_event"] = "beforeShellExecution"
+        return prepared
+    if raw_event == "beforemcpexecution":
+        prepared = _cursor_mcp_hook_payload(normalized, hook_event_name="PreToolUse")
+        tool_input = _tool_input_dict(prepared.get("tool_input"))
+        for key in ("url", "command"):
+            value = normalized.get(key)
+            if isinstance(value, str) and value.strip():
+                tool_input.setdefault(key, value.strip())
+        prepared["tool_input"] = tool_input
+        prepared["cursor_source_hook_event"] = "beforeMCPExecution"
+        return prepared
+    if raw_event == "beforereadfile":
+        normalized["hook_event_name"] = "PreToolUse"
+        normalized.setdefault("tool_name", "Read")
+        tool_input = _tool_input_dict(normalized.get("tool_input"))
+        file_path = normalized.get("file_path")
+        if isinstance(file_path, str) and file_path.strip():
+            tool_input.setdefault("file_path", file_path.strip())
+            tool_input.setdefault("path", file_path.strip())
+        normalized["tool_input"] = tool_input
+        return normalized
+    if raw_event == "pretooluse":
+        normalized["hook_event_name"] = "PreToolUse"
+    return normalized
+
+
+def _validated_hol_guard_src_path(path_str: str) -> str | None:
+    """Accept only directories that look like a hol-guard source tree."""
+
+    try:
+        if not isinstance(path_str, str) or not path_str.strip():
+            return None
+        candidate = Path(path_str.strip()).expanduser().resolve()
+    except (OSError, RuntimeError, ValueError, TypeError):
+        return None
+    if not candidate.is_dir():
+        return None
+    if not (candidate / "codex_plugin_scanner").is_dir():
+        return None
+    return str(candidate)
+
+
+def cursor_hook_would_prompt_user(
+    *,
+    policy_action: str,
+    guard_payload: Mapping[str, object] | None = None,
+) -> bool:
+    """Return True when Guard maps this hook result to Cursor permission ask."""
+
+    del guard_payload
+    return policy_action in {"require-reapproval", "review"}
+
+
+def cursor_hook_requires_approval_center_queue(
+    *,
+    policy_action: str,
+    guard_payload: Mapping[str, object] | None = None,
+) -> bool:
+    """Return True when Cursor native prompts should also appear in the approval center.
+
+    Currently equivalent to ``cursor_hook_would_prompt_user``; kept separate so the
+    two concepts can diverge without touching call sites.
+    """
+
+    return cursor_hook_would_prompt_user(
+        policy_action=policy_action,
+        guard_payload=guard_payload,
+    )
+
+
+def cursor_hook_response_from_guard(
+    *,
+    policy_action: str,
+    guard_payload: Mapping[str, object],
+    hook_event_name: str,
+) -> dict[str, object]:
+    """Translate Guard hook JSON into Cursor hook stdout JSON."""
+
+    permission = _cursor_permission_for_policy(policy_action, guard_payload)
+    reason = _cursor_block_reason(guard_payload)
+    raw_event = hook_event_name.strip().lower()
+    if raw_event == "beforereadfile":
+        read_permission = _cursor_read_file_permission(permission)
+        response: dict[str, object] = {"permission": read_permission}
+        if read_permission == "deny":
+            response["user_message"] = reason
+        return {key: value for key, value in response.items() if value is not None}
+    response: dict[str, object] = {"permission": permission}
+    if permission != "allow":
+        response["user_message"] = reason
+        response["agent_message"] = reason
+    return {key: value for key, value in response.items() if value is not None}
+
+
+def cursor_hook_should_block(*, policy_action: str) -> bool:
+    return policy_action in {"block", "sandbox-required"}
+
+
+def _raw_hook_event_name(payload: Mapping[str, object]) -> str:
+    for key in ("hook_event_name", "hookEventName", "hook_name", "hookName", "event", "eventName"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+    return ""
+
+
+def _tool_input_dict(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, list):
+        return {"arguments": list(value)}
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {"raw": value.strip()}
+        if isinstance(parsed, dict):
+            return dict(parsed)
+        if isinstance(parsed, list):
+            return {"arguments": list(parsed)}
+    return {}
+
+
+def _cursor_permission_for_policy(
+    policy_action: str,
+    guard_payload: Mapping[str, object] | None = None,
+) -> str:
+    del guard_payload
+    if not is_guard_action(policy_action):
+        return "deny"
+    if policy_action in {"block", "sandbox-required"}:
+        return "deny"
+    if policy_action in {"require-reapproval", "review"}:
+        return "ask"
+    return "allow"
+
+
+def _cursor_read_file_permission(permission: str) -> str:
+    if permission in {"deny", "ask"}:
+        return "deny"
+    return "allow"
+
+
+def _cursor_block_reason(guard_payload: Mapping[str, object]) -> str:
+    for key in ("review_hint", "risk_summary", "why_now", "risk_headline"):
+        value = guard_payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    decision = guard_payload.get("decision_v2_json")
+    if isinstance(decision, Mapping):
+        for key in ("harness_message", "retry_instruction", "user_body", "user_title"):
+            value = decision.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return "HOL Guard blocked this Cursor action."

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_head.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_head.py
@@ -1,0 +1,397 @@
+"""First half of the generated Cursor hook script template."""
+
+from __future__ import annotations
+
+HOOK_SCRIPT_TEMPLATE_HEAD = '''#!/usr/bin/env python3
+"""Managed by HOL Guard. Re-run `hol-guard install cursor` after moving Guard home."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import shlex
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from pathlib import Path
+
+GUARD_HOME = __GUARD_HOME__
+GUARD_CLI = __GUARD_CLI__
+GUARD_HOOK_ARGV = __GUARD_HOOK_ARGV__
+GUARD_INHERIT_ENV_KEYS = __GUARD_INHERIT_ENV_KEYS__
+GUARD_HOOK_TIMEOUT_SECONDS = __GUARD_HOOK_TIMEOUT_SECONDS__
+GUARD_ACTIONS = frozenset({"allow", "warn", "review", "require-reapproval", "sandbox-required", "block"})
+
+
+def _hook_process_env() -> dict[str, str]:
+    env: dict[str, str] = {}
+    for key in GUARD_INHERIT_ENV_KEYS:
+        value = os.environ.get(key)
+        if isinstance(value, str) and value:
+            env[key] = value
+    dev_src = os.environ.get("HOL_GUARD_SRC")
+    validated = _validated_hol_guard_src_path(dev_src) if isinstance(dev_src, str) else None
+    if validated is not None:
+        env["PYTHONPATH"] = validated
+    else:
+        dev_src_file = Path(GUARD_HOME) / "cursor-dev-src"
+        if dev_src_file.is_file():
+            try:
+                configured_src = dev_src_file.read_text(encoding="utf-8").strip()
+            except OSError:
+                configured_src = ""
+            validated = _validated_hol_guard_src_path(configured_src)
+            if validated is not None:
+                env["PYTHONPATH"] = validated
+    return env
+
+
+def _guard_hook_arg_value(flag: str) -> str | None:
+    try:
+        index = GUARD_HOOK_ARGV.index(flag)
+    except ValueError:
+        return None
+    if index + 1 >= len(GUARD_HOOK_ARGV):
+        return None
+    value = GUARD_HOOK_ARGV[index + 1]
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _daemon_hook_env_overlay(guard_env: Mapping[str, str]) -> dict[str, str]:
+    overlay: dict[str, str] = {}
+    for key in (
+        "HOL_GUARD_MANAGED_CURSOR_HOOK",
+        "HOL_GUARD_CURSOR_APPROVAL_BINDING",
+        "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF",
+        "CURSOR_PROJECT_DIR",
+        "CURSOR_VERSION",
+        "CURSOR_TRACE_ID",
+        "CURSOR_SESSION_ID",
+        "CURSOR_TRANSCRIPT_PATH",
+    ):
+        value = guard_env.get(key)
+        if isinstance(value, str) and value:
+            overlay[key] = value
+    return overlay
+
+
+def _daemon_hook_result(
+    payload_json: str,
+    *,
+    workspace: str | None,
+    hook_env_overlay: Mapping[str, str] | None = None,
+) -> tuple[int, str, str] | None:
+    state_path = Path(GUARD_HOME) / "daemon-state.json"
+    token_path = Path(GUARD_HOME) / "daemon-auth-token"
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        auth_token = token_path.read_text(encoding="utf-8").strip()
+    except (OSError, ValueError):
+        return None
+    if not isinstance(state, dict):
+        return None
+    port = state.get("port")
+    if not isinstance(port, int) or port <= 0 or not auth_token:
+        return None
+    # Validate the recorded PID is still alive before trusting the state file.
+    # A stale state file after a crash could point at an attacker-controlled listener.
+    pid = state.get("pid")
+    if not isinstance(pid, int) or pid <= 0:
+        return None
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return None
+    # Probe /healthz before sending the hook payload and auth token.
+    # Ensures the listener is actually the Guard daemon, not a spoofed process.
+    # Validate the response body — not just HTTP 200 — so an attacker listener
+    # that returns 200 but doesn't know the daemon's compatibility version is rejected.
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    try:
+        health_req = urllib.request.Request(f"http://127.0.0.1:{port}/healthz", method="GET")
+        with opener.open(health_req, timeout=2) as health_response:
+            if health_response.status != 200:
+                return None
+            health_body = health_response.read().decode("utf-8", errors="replace")
+    except (OSError, urllib.error.URLError):
+        return None
+    try:
+        health_json = json.loads(health_body)
+    except ValueError:
+        return None
+    if not isinstance(health_json, dict) or health_json.get("ok") is not True:
+        return None
+    state_compat = state.get("compatibility_version")
+    if isinstance(state_compat, str) and health_json.get("compatibility_version") != state_compat:
+        return None
+    # Challenge-response: prove the listener knows the auth_token before sending it.
+    # A spoofed listener can return public healthz values but cannot forge the HMAC.
+    # The proof is bound to the daemon's listening port so a relay attacker cannot
+    # proxy the nonce to the real daemon and reuse its proof from a different port.
+    # Old daemons without /v1/healthz/verify fail with HTTPError — return None to
+    # fall through to the CLI path. Never bypass the HMAC challenge.
+    nonce = os.urandom(16).hex()
+    proof_message = f"{port}:{nonce}"
+    try:
+        verify_req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/v1/healthz/verify",
+            data=json.dumps({"nonce": nonce}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with opener.open(verify_req, timeout=2) as verify_response:
+            verify_body = verify_response.read().decode("utf-8", errors="replace")
+            try:
+                verify_json = json.loads(verify_body)
+            except ValueError:
+                return None
+            if not isinstance(verify_json, dict) or not isinstance(verify_json.get("proof"), str):
+                return None
+            expected_proof = hmac.new(
+                auth_token.encode("utf-8"),
+                proof_message.encode("utf-8"),
+                hashlib.sha256,
+            ).hexdigest()
+            if not hmac.compare_digest(verify_json["proof"], expected_proof):
+                return None
+    except (urllib.error.HTTPError, OSError, urllib.error.URLError):
+        return None
+    params = [("guard-home", GUARD_HOME)]
+    if workspace:
+        params.append(("workspace", workspace))
+    home_dir = _guard_hook_arg_value("--home")
+    if home_dir:
+        params.append(("home", home_dir))
+    try:
+        request_payload = json.loads(payload_json)
+    except ValueError:
+        return None
+    if not isinstance(request_payload, dict):
+        return None
+    if hook_env_overlay:
+        request_payload["hook_env"] = dict(hook_env_overlay)
+    query = urllib.parse.urlencode(params)
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}/v1/hooks/cursor?{query}",
+        data=json.dumps(request_payload).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "X-Guard-Token": auth_token,
+        },
+        method="POST",
+    )
+    try:
+        with opener.open(request, timeout=max(GUARD_HOOK_TIMEOUT_SECONDS - 2, 1)) as response:
+            body = response.read().decode("utf-8", errors="replace")
+    except (OSError, urllib.error.URLError):
+        return None
+    # Reject empty or non-dict responses — they default policy_action to "allow".
+    # Fall through to the CLI subprocess path instead of trusting a malformed response.
+    body_stripped = body.strip()
+    if not body_stripped:
+        return None
+    try:
+        parsed_body = json.loads(body_stripped)
+    except ValueError:
+        return None
+    if not isinstance(parsed_body, dict):
+        return None
+    raw_event_name = _raw_hook_event_name(request_payload)
+    if raw_event_name not in {"aftershellexecution", "aftermcpexecution"}:
+        policy_action = parsed_body.get("policy_action")
+        if not isinstance(policy_action, str) or policy_action not in GUARD_ACTIONS:
+            return None
+    return (0, body_stripped, "")
+
+
+def _validated_hol_guard_src_path(path_str: str) -> str | None:
+    try:
+        if not isinstance(path_str, str) or not path_str.strip():
+            return None
+        candidate = Path(path_str.strip()).expanduser().resolve()
+    except (OSError, RuntimeError, ValueError, TypeError):
+        return None
+    if not candidate.is_dir():
+        return None
+    if not (candidate / "codex_plugin_scanner").is_dir():
+        return None
+    return str(candidate)
+
+
+def _workspace_from_cursor_input(payload: dict[str, object]) -> str | None:
+    project_dir = os.environ.get("CURSOR_PROJECT_DIR")
+    if isinstance(project_dir, str) and project_dir.strip():
+        candidate = project_dir.strip()
+        if Path(candidate).is_dir():
+            return candidate
+    roots = payload.get("workspace_roots") or payload.get("workspaceRoots")
+    if isinstance(roots, list):
+        for item in roots:
+            if isinstance(item, str) and item.strip():
+                candidate = item.strip()
+                if Path(candidate).is_dir():
+                    return candidate
+    cwd = payload.get("cwd")
+    if isinstance(cwd, str) and cwd.strip():
+        candidate = cwd.strip()
+        if Path(candidate).is_dir():
+            return candidate
+    return None
+
+
+def _tool_input_dict(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, list):
+        return {"arguments": list(value)}
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {"raw": value.strip()}
+        if isinstance(parsed, dict):
+            return dict(parsed)
+        if isinstance(parsed, list):
+            return {"arguments": list(parsed)}
+    return {}
+
+
+def _raw_hook_event_name(payload: dict[str, object]) -> str:
+    for key in ("hook_event_name", "hookEventName", "hook_name", "hookName", "event", "eventName"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+    return ""
+
+
+def _infer_cursor_hook_event_name(payload: dict[str, object]) -> dict[str, object]:
+    normalized = dict(payload)
+    if _raw_hook_event_name(normalized):
+        return normalized
+    file_path = normalized.get("file_path")
+    if isinstance(file_path, str) and file_path.strip():
+        normalized["hook_event_name"] = "beforeReadFile"
+        return normalized
+    command = normalized.get("command")
+    if isinstance(command, str) and command.strip():
+        normalized["hook_event_name"] = "beforeShellExecution"
+        return normalized
+    if normalized.get("tool_name") is not None or normalized.get("tool_input") is not None:
+        normalized["hook_event_name"] = "preToolUse"
+    return normalized
+
+
+def _cursor_shell_hook_payload(normalized: dict[str, object], hook_event_name: str) -> dict[str, object]:
+    payload = dict(normalized)
+    payload["hook_event_name"] = hook_event_name
+    payload.setdefault("tool_name", "Shell")
+    tool_input = _tool_input_dict(payload.get("tool_input"))
+    command = payload.get("command")
+    if isinstance(command, str) and command.strip():
+        tool_input.setdefault("command", command.strip())
+    cwd = payload.get("cwd")
+    if isinstance(cwd, str) and cwd.strip():
+        tool_input.setdefault("working_directory", cwd.strip())
+    payload["tool_input"] = tool_input
+    return payload
+
+
+def _cursor_mcp_hook_payload(normalized: dict[str, object], hook_event_name: str) -> dict[str, object]:
+    payload = dict(normalized)
+    payload["hook_event_name"] = hook_event_name
+    tool_input = _tool_input_dict(payload.get("tool_input"))
+    payload["tool_input"] = tool_input
+    tool_name = payload.get("tool_name")
+    if isinstance(tool_name, str) and tool_name.strip():
+        payload["tool_name"] = tool_name.strip()
+    else:
+        payload.setdefault("tool_name", "MCP")
+    return payload
+
+
+def _prepare_cursor_hook_payload(payload: dict[str, object]) -> dict[str, object]:
+    normalized = _infer_cursor_hook_event_name(payload)
+    raw_event = _raw_hook_event_name(normalized)
+    if raw_event == "aftershellexecution":
+        return _cursor_shell_hook_payload(normalized, "afterShellExecution")
+    if raw_event == "aftermcpexecution":
+        return _cursor_mcp_hook_payload(normalized, "afterMCPExecution")
+    if raw_event == "beforeshellexecution":
+        prepared = _cursor_shell_hook_payload(normalized, "PreToolUse")
+        prepared["cursor_source_hook_event"] = "beforeShellExecution"
+        return prepared
+    if raw_event == "beforemcpexecution":
+        prepared = _cursor_mcp_hook_payload(normalized, "PreToolUse")
+        tool_input = _tool_input_dict(prepared.get("tool_input"))
+        for key in ("url", "command"):
+            value = normalized.get(key)
+            if isinstance(value, str) and value.strip():
+                tool_input.setdefault(key, value.strip())
+        prepared["tool_input"] = tool_input
+        prepared["cursor_source_hook_event"] = "beforeMCPExecution"
+        return prepared
+    if raw_event == "beforereadfile":
+        normalized["hook_event_name"] = "PreToolUse"
+        normalized.setdefault("tool_name", "Read")
+        tool_input = _tool_input_dict(normalized.get("tool_input"))
+        file_path = normalized.get("file_path")
+        if isinstance(file_path, str) and file_path.strip():
+            tool_input.setdefault("file_path", file_path.strip())
+            tool_input.setdefault("path", file_path.strip())
+        normalized["tool_input"] = tool_input
+        return normalized
+    if raw_event == "pretooluse":
+        normalized["hook_event_name"] = "PreToolUse"
+    return normalized
+
+
+def _cursor_permission(policy_action: str, guard_payload: dict[str, object]) -> str:
+    del guard_payload
+    if policy_action not in GUARD_ACTIONS:
+        return "deny"
+    if policy_action in {"block", "sandbox-required"}:
+        return "deny"
+    if policy_action in {"require-reapproval", "review"}:
+        return "ask"
+    return "allow"
+
+
+def _cursor_read_file_permission(permission: str) -> str:
+    if permission in {"deny", "ask"}:
+        return "deny"
+    return "allow"
+
+
+def _cursor_reason(guard_payload: dict[str, object]) -> str:
+    primary_url = guard_payload.get("primary_approval_url")
+    reason: str | None = None
+    for key in ("review_hint", "risk_summary", "why_now", "risk_headline"):
+        value = guard_payload.get(key)
+        if isinstance(value, str) and value.strip():
+            reason = value.strip()
+            break
+    if reason is None:
+        decision = guard_payload.get("decision_v2_json")
+        if isinstance(decision, Mapping):
+            for key in ("harness_message", "retry_instruction", "user_body", "user_title"):
+                value = decision.get(key)
+                if isinstance(value, str) and value.strip():
+                    reason = value.strip()
+                    break
+    if reason is None:
+        if isinstance(primary_url, str) and primary_url.strip():
+            return f"HOL Guard needs approval for this Cursor action. Review it at {primary_url.strip()}."
+        return "HOL Guard blocked this Cursor action."
+    if isinstance(primary_url, str) and primary_url.strip():
+        url_str = primary_url.strip()
+        if url_str in reason:
+            return reason
+        return f"{reason} Review: {url_str}"
+    return reason
+
+
+'''

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
@@ -1,0 +1,339 @@
+"""Second half of the generated Cursor hook script template."""
+
+from __future__ import annotations
+
+HOOK_SCRIPT_TEMPLATE_TAIL = """def _emit_cursor_response(
+    *,
+    hook_event_name: str,
+    policy_action: str,
+    guard_payload: dict[str, object],
+) -> tuple[dict[str, object], int]:
+    permission = _cursor_permission(policy_action, guard_payload)
+    reason = _cursor_reason(guard_payload)
+    if hook_event_name.strip().lower() == "beforereadfile":
+        read_permission = "deny" if permission in {"deny", "ask"} else "allow"
+        response = {
+            "permission": read_permission,
+        }
+        if read_permission == "deny":
+            response["user_message"] = reason
+        return response, 2 if read_permission == "deny" else 0
+    response: dict[str, object] = {"permission": permission}
+    if permission != "allow":
+        response["user_message"] = reason
+        response["agent_message"] = reason
+    exit_code = 2 if permission == "deny" else 0
+    return response, exit_code
+
+
+def _cursor_generation_id(payload: Mapping[str, object]) -> str | None:
+    for key in ("generation_id", "generationId"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _cursor_conversation_id(payload: Mapping[str, object]) -> str | None:
+    for key in ("conversation_id", "conversationId", "session_id", "sessionId"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    session_id = os.environ.get("CURSOR_SESSION_ID")
+    if isinstance(session_id, str) and session_id.strip():
+        return session_id.strip()
+    return None
+
+
+def _normalize_cursor_shell_command(command: str) -> str:
+    stripped = command.strip()
+    if not stripped or len(stripped) > 8192:
+        return stripped
+    lowered = stripped.lower()
+    needle = "lean-ctx"
+    start = 0
+    while True:
+        idx = lowered.find(needle, start)
+        if idx == -1:
+            return stripped
+        if idx == 0 or stripped[idx - 1] == "/":
+            tail = stripped[idx + len(needle) :].lstrip()
+            if tail.startswith("-c"):
+                rest = tail[2:].lstrip()
+                try:
+                    tokens = shlex.split(rest, posix=True, comments=False)
+                except ValueError:
+                    tokens = None
+                if tokens:
+                    inner = tokens[0]
+                    suffix = tokens[1:]
+                    return " ".join((inner, *suffix)) if suffix else inner
+                if rest.startswith("'"):
+                    parts = []
+                    index = 1
+                    while index < len(rest):
+                        character = rest[index]
+                        if character != "'":
+                            parts.append(character)
+                            index += 1
+                            continue
+                        if index + 3 < len(rest) and rest[index : index + 4] == "'\\''":
+                            parts.append("'")
+                            index += 4
+                            continue
+                        inner = "".join(parts)
+                        suffix = rest[index + 1 :].lstrip()
+                        return " ".join((inner, suffix)) if suffix else inner
+                return stripped
+        start = idx + 1
+    return stripped
+
+
+# Installed hook helpers below mirror cursor_native_approval.py; keep both copies in sync.
+
+
+def _cursor_hook_payload_is_mcp_execution(payload: Mapping[str, object]) -> bool:
+    source_event = payload.get("cursor_source_hook_event")
+    if isinstance(source_event, str) and source_event.strip().lower() == "beforemcpexecution":
+        return True
+    for key in ("hook_event_name", "hookEventName", "hook_name", "hookName", "event", "eventName"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"beforemcpexecution", "aftermcpexecution"}:
+                return True
+    return False
+
+
+def _is_shell_wrapper_command(command: str) -> bool:
+    stripped = command.strip()
+    if not stripped:
+        return False
+    try:
+        parts = shlex.split(stripped, posix=True, comments=False)
+    except ValueError:
+        return False
+    if not parts:
+        return False
+    binary = Path(parts[0]).name.lower()
+    if binary == "lean-ctx":
+        return True
+    if binary not in {"ash", "bash", "dash", "fish", "sh", "zsh"}:
+        return False
+    return len(parts) > 1 and parts[1] == "-c"
+
+
+def _nested_cursor_shell_command(tool_input: Mapping[str, object]) -> str | None:
+    for key in ("command", "cmd", "shell_command", "shellCommand"):
+        value = tool_input.get(key)
+        if isinstance(value, str) and value.strip():
+            return _normalize_cursor_shell_command(value)
+    return None
+
+
+def _cursor_shell_command(payload: Mapping[str, object]) -> str | None:
+    tool_input = payload.get("tool_input")
+    nested_command: str | None = None
+    if isinstance(tool_input, dict):
+        nested_command = _nested_cursor_shell_command(tool_input)
+    command = payload.get("command")
+    top_level: str | None = None
+    if isinstance(command, str) and command.strip():
+        top_level = _normalize_cursor_shell_command(command)
+    if _cursor_hook_payload_is_mcp_execution(payload):
+        if nested_command is not None:
+            return nested_command
+        return top_level
+    if nested_command is not None and (
+        top_level is None or (isinstance(command, str) and _is_shell_wrapper_command(command))
+    ):
+        return nested_command
+    if top_level is not None:
+        return top_level
+    return nested_command
+
+
+def _cursor_shell_binding_path(conversation_id: str, command: str) -> Path:
+    cleaned = conversation_id.strip()
+    if not cleaned or "/" in cleaned or "\\\\" in cleaned or cleaned in {".", ".."}:
+        segment = hashlib.sha256(cleaned.encode("utf-8")).hexdigest()[:32] if cleaned else "missing-conversation"
+    else:
+        segment = cleaned
+    normalized_command = _normalize_cursor_shell_command(command)
+    fingerprint = hashlib.sha256(normalized_command.encode("utf-8")).hexdigest()[:24]
+    return Path(GUARD_HOME) / "cursor-shell-bindings" / segment / fingerprint
+
+
+def _read_cursor_shell_binding_file(conversation_id: str, command: str) -> str | None:
+    binding_path = _cursor_shell_binding_path(conversation_id, command)
+    try:
+        binding = binding_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return binding or None
+
+
+def _resolve_approval_binding(payload: Mapping[str, object]) -> str | None:
+    binding = _cursor_generation_id(payload)
+    if binding is not None:
+        return binding
+    conversation_id = _cursor_conversation_id(payload)
+    command = _cursor_shell_command(payload)
+    if conversation_id is None or command is None:
+        return None
+    return _read_cursor_shell_binding_file(conversation_id, command)
+
+
+def _load_cursor_hook_attestation_secret() -> bytes | None:
+    secret_path = Path(GUARD_HOME) / "secrets" / "cursor-hook-attestation.key"
+    try:
+        secret = secret_path.read_bytes()
+    except OSError:
+        return None
+    return secret or None
+
+
+def _compute_cursor_after_observer_proof(
+    payload: Mapping[str, object],
+    observer_event: str,
+    approval_binding: str | None = None,
+) -> str | None:
+    conversation_id = _cursor_conversation_id(payload)
+    command = _cursor_shell_command(payload)
+    resolved_binding = approval_binding or _resolve_approval_binding(payload)
+    secret = _load_cursor_hook_attestation_secret()
+    if conversation_id is None or command is None or resolved_binding is None or secret is None:
+        return None
+    message = chr(0).join(
+        (conversation_id, command, resolved_binding, observer_event.strip())
+    ).encode("utf-8")
+    return hmac.new(secret, message, hashlib.sha256).hexdigest()
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print(json.dumps({"permission": "deny", "user_message": "HOL Guard received empty Cursor hook input."}))
+        return 2
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        print(json.dumps({"permission": "deny", "user_message": "HOL Guard could not parse Cursor hook input."}))
+        return 2
+    if not isinstance(payload, dict):
+        print(json.dumps({"permission": "deny", "user_message": "HOL Guard received invalid Cursor hook input."}))
+        return 2
+    inferred = _infer_cursor_hook_event_name(payload)
+    hook_event_name = str(inferred.get("hook_event_name") or inferred.get("hookEventName") or "preToolUse")
+    prepared = _prepare_cursor_hook_payload(inferred)
+    workspace = _workspace_from_cursor_input(prepared)
+    guard_argv = list(GUARD_HOOK_ARGV)
+    if workspace:
+        if "--workspace" in guard_argv:
+            workspace_index = guard_argv.index("--workspace")
+            if workspace_index + 1 < len(guard_argv):
+                guard_argv[workspace_index + 1] = workspace
+        else:
+            guard_argv.extend(["--workspace", workspace])
+    guard_env = _hook_process_env()
+    guard_env["HOL_GUARD_MANAGED_CURSOR_HOOK"] = "1"
+    if hook_event_name.strip().lower() in {"aftershellexecution", "aftermcpexecution"}:
+        approval_binding = _resolve_approval_binding(prepared)
+        proof = _compute_cursor_after_observer_proof(prepared, hook_event_name, approval_binding)
+        if approval_binding:
+            guard_env["HOL_GUARD_CURSOR_APPROVAL_BINDING"] = approval_binding
+        if proof:
+            guard_env["HOL_GUARD_CURSOR_AFTER_SHELL_PROOF"] = proof
+    payload_json = json.dumps(prepared)
+    daemon_result = _daemon_hook_result(
+        payload_json,
+        workspace=workspace,
+        hook_env_overlay=_daemon_hook_env_overlay(guard_env),
+    )
+    try:
+        if daemon_result is not None:
+            proc = subprocess.CompletedProcess(
+                [*GUARD_CLI, *guard_argv],
+                daemon_result[0],
+                stdout=daemon_result[1],
+                stderr=daemon_result[2],
+            )
+        else:
+            proc = subprocess.run(
+                [*GUARD_CLI, *guard_argv],
+                input=payload_json,
+                capture_output=True,
+                text=True,
+                cwd=GUARD_HOME,
+                env=guard_env,
+                timeout=GUARD_HOOK_TIMEOUT_SECONDS,
+            )
+    except subprocess.TimeoutExpired:
+        print(
+            json.dumps(
+                {
+                    "permission": "deny",
+                    "user_message": (
+                        f"HOL Guard hook timed out after {GUARD_HOOK_TIMEOUT_SECONDS}s. "
+                        "Open the Guard approval center or native Cursor prompt, resolve pending requests, then retry."
+                    ),
+                }
+            )
+        )
+        return 2
+    except Exception as exc:
+        print(
+            json.dumps(
+                {
+                    "permission": "deny",
+                    "user_message": f"HOL Guard hook execution failed: {exc}",
+                }
+            )
+        )
+        return 2
+    guard_payload: dict[str, object] = {}
+    if proc.stdout.strip():
+        try:
+            parsed = json.loads(proc.stdout)
+            if isinstance(parsed, dict):
+                guard_payload = parsed
+        except json.JSONDecodeError:
+            guard_payload = {}
+    if hook_event_name.strip().lower() in {"aftershellexecution", "aftermcpexecution"}:
+        print("{}")
+        return 0
+    raw_policy_action = guard_payload.get("policy_action")
+    if not isinstance(raw_policy_action, str) or raw_policy_action not in GUARD_ACTIONS:
+        print(
+            json.dumps(
+                {
+                    "permission": "deny",
+                    "user_message": "HOL Guard returned an invalid policy action and failed closed.",
+                }
+            )
+        )
+        return 2
+    policy_action = raw_policy_action
+    if proc.returncode != 0 and not guard_payload:
+        print(
+            json.dumps(
+                {
+                    "permission": "deny",
+                    "user_message": (proc.stderr or "HOL Guard hook failed.").strip()
+                    or "HOL Guard hook failed.",
+                }
+            )
+        )
+        return 2
+    response, exit_code = _emit_cursor_response(
+        hook_event_name=hook_event_name,
+        policy_action=policy_action,
+        guard_payload=guard_payload,
+    )
+    print(json.dumps(response))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+"""

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -3,192 +3,60 @@
 from __future__ import annotations
 
 import json
-import shlex
-import shutil
+import os
 import stat
-import sys
-from collections.abc import Mapping
 from hashlib import sha256
 from pathlib import Path
 
-from ..action_lattice import is_guard_action
 from .base import HarnessContext
+from .cursor_hook_config import (
+    _MANAGED_HOOK_EVENTS,
+    _MANAGED_HOOK_TIMEOUT_SECONDS,
+    HOOK_SCRIPT_NAME,
+    _backup_payload,
+    _hooks_backup_path,
+    _hooks_state_path,
+    _inline_hooks,
+    _is_managed_hook_entry,
+    _is_managed_hook_script,
+    _json_object,
+    _make_executable,
+    _managed_hook_entry,
+    _managed_hooks_payload,
+    _merge_hook_entries,
+    _strip_managed_hook_entries,
+)
+from .cursor_hook_payload import (
+    _validated_hol_guard_src_path,
+    cursor_hook_requires_approval_center_queue,
+    cursor_hook_response_from_guard,
+    cursor_hook_should_block,
+    cursor_hook_would_prompt_user,
+    prepare_cursor_hook_payload,
+)
+from .cursor_hook_script_template_head import HOOK_SCRIPT_TEMPLATE_HEAD
+from .cursor_hook_script_template_tail import HOOK_SCRIPT_TEMPLATE_TAIL
 from .cursor_native_approval import ensure_cursor_hook_attestation_secret
+from .guard_cli_attestation import resolve_attested_guard_cli
 
-HOOK_SCRIPT_NAME = "hol-guard-cursor-hook.py"
-_BLOCKING_MANAGED_HOOK_EVENTS = (
-    "beforeShellExecution",
-    "beforeMCPExecution",
-    "beforeReadFile",
+_HOOK_SCRIPT_TEMPLATE = HOOK_SCRIPT_TEMPLATE_HEAD + HOOK_SCRIPT_TEMPLATE_TAIL
+_INHERIT_ENV_KEYS = (
+    "PATH",
+    "HOME",
+    "USER",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "LANG",
+    "LC_ALL",
+    "SYSTEMROOT",
+    "CURSOR_PROJECT_DIR",
+    "CURSOR_VERSION",
+    "CURSOR_TRACE_ID",
+    "CURSOR_SESSION_ID",
+    "CURSOR_TRANSCRIPT_PATH",
+    "HOL_GUARD_SRC",
 )
-_OBSERVER_MANAGED_HOOK_EVENTS = ("afterShellExecution", "afterMCPExecution")
-_MANAGED_HOOK_EVENTS = _BLOCKING_MANAGED_HOOK_EVENTS + _OBSERVER_MANAGED_HOOK_EVENTS
-_MANAGED_HOOK_TIMEOUT_SECONDS = 45
-_LEGACY_MANAGED_COMMAND_MARKERS = (
-    "hol-guard-cursor-hook.py",
-    "HOL_GUARD_HOOK_ARGV",
-    "--harness",
-    "cursor",
-)
-
-
-def _infer_cursor_hook_event_name(payload: Mapping[str, object]) -> dict[str, object]:
-    normalized = dict(payload)
-    if _raw_hook_event_name(normalized):
-        return normalized
-    file_path = normalized.get("file_path")
-    if isinstance(file_path, str) and file_path.strip():
-        normalized["hook_event_name"] = "beforeReadFile"
-        return normalized
-    command = normalized.get("command")
-    if isinstance(command, str) and command.strip():
-        normalized["hook_event_name"] = "beforeShellExecution"
-        return normalized
-    if normalized.get("tool_name") is not None or normalized.get("tool_input") is not None:
-        normalized["hook_event_name"] = "preToolUse"
-    return normalized
-
-
-# Payload normalizers below are mirrored inside _HOOK_SCRIPT_TEMPLATE for the installed
-# Cursor hook script. Keep both copies in sync when changing observer or MCP behavior.
-
-
-def _cursor_shell_hook_payload(normalized: dict[str, object], *, hook_event_name: str) -> dict[str, object]:
-    payload = dict(normalized)
-    payload["hook_event_name"] = hook_event_name
-    payload.setdefault("tool_name", "Shell")
-    tool_input = _tool_input_dict(payload.get("tool_input"))
-    command = payload.get("command")
-    if isinstance(command, str) and command.strip():
-        tool_input.setdefault("command", command.strip())
-    cwd = payload.get("cwd")
-    if isinstance(cwd, str) and cwd.strip():
-        tool_input.setdefault("working_directory", cwd.strip())
-    payload["tool_input"] = tool_input
-    return payload
-
-
-def _cursor_mcp_hook_payload(normalized: dict[str, object], *, hook_event_name: str) -> dict[str, object]:
-    payload = dict(normalized)
-    payload["hook_event_name"] = hook_event_name
-    tool_input = _tool_input_dict(payload.get("tool_input"))
-    payload["tool_input"] = tool_input
-    tool_name = payload.get("tool_name")
-    if isinstance(tool_name, str) and tool_name.strip():
-        payload["tool_name"] = tool_name.strip()
-    else:
-        payload.setdefault("tool_name", "MCP")
-    return payload
-
-
-def prepare_cursor_hook_payload(payload: Mapping[str, object]) -> dict[str, object]:
-    """Map Cursor hook stdin JSON into Guard hook normalization shape."""
-
-    normalized = _infer_cursor_hook_event_name(payload)
-    raw_event = _raw_hook_event_name(normalized)
-    if raw_event == "aftershellexecution":
-        return _cursor_shell_hook_payload(normalized, hook_event_name="afterShellExecution")
-    if raw_event == "aftermcpexecution":
-        return _cursor_mcp_hook_payload(normalized, hook_event_name="afterMCPExecution")
-    if raw_event == "beforeshellexecution":
-        prepared = _cursor_shell_hook_payload(normalized, hook_event_name="PreToolUse")
-        prepared["cursor_source_hook_event"] = "beforeShellExecution"
-        return prepared
-    if raw_event == "beforemcpexecution":
-        prepared = _cursor_mcp_hook_payload(normalized, hook_event_name="PreToolUse")
-        tool_input = _tool_input_dict(prepared.get("tool_input"))
-        for key in ("url", "command"):
-            value = normalized.get(key)
-            if isinstance(value, str) and value.strip():
-                tool_input.setdefault(key, value.strip())
-        prepared["tool_input"] = tool_input
-        prepared["cursor_source_hook_event"] = "beforeMCPExecution"
-        return prepared
-    if raw_event == "beforereadfile":
-        normalized["hook_event_name"] = "PreToolUse"
-        normalized.setdefault("tool_name", "Read")
-        tool_input = _tool_input_dict(normalized.get("tool_input"))
-        file_path = normalized.get("file_path")
-        if isinstance(file_path, str) and file_path.strip():
-            tool_input.setdefault("file_path", file_path.strip())
-            tool_input.setdefault("path", file_path.strip())
-        normalized["tool_input"] = tool_input
-        return normalized
-    if raw_event == "pretooluse":
-        normalized["hook_event_name"] = "PreToolUse"
-    return normalized
-
-
-def _validated_hol_guard_src_path(path_str: str) -> str | None:
-    """Accept only directories that look like a hol-guard source tree."""
-
-    try:
-        if not isinstance(path_str, str) or not path_str.strip():
-            return None
-        candidate = Path(path_str.strip()).expanduser().resolve()
-    except (OSError, RuntimeError, ValueError, TypeError):
-        return None
-    if not candidate.is_dir():
-        return None
-    if not (candidate / "codex_plugin_scanner").is_dir():
-        return None
-    return str(candidate)
-
-
-def cursor_hook_would_prompt_user(
-    *,
-    policy_action: str,
-    guard_payload: Mapping[str, object] | None = None,
-) -> bool:
-    """Return True when Guard maps this hook result to Cursor permission ask."""
-
-    del guard_payload
-    return policy_action in {"require-reapproval", "review"}
-
-
-def cursor_hook_requires_approval_center_queue(
-    *,
-    policy_action: str,
-    guard_payload: Mapping[str, object] | None = None,
-) -> bool:
-    """Return True when Cursor native prompts should also appear in the approval center.
-
-    Currently equivalent to ``cursor_hook_would_prompt_user``; kept separate so the
-    two concepts can diverge without touching call sites.
-    """
-
-    return cursor_hook_would_prompt_user(
-        policy_action=policy_action,
-        guard_payload=guard_payload,
-    )
-
-
-def cursor_hook_response_from_guard(
-    *,
-    policy_action: str,
-    guard_payload: Mapping[str, object],
-    hook_event_name: str,
-) -> dict[str, object]:
-    """Translate Guard hook JSON into Cursor hook stdout JSON."""
-
-    permission = _cursor_permission_for_policy(policy_action, guard_payload)
-    reason = _cursor_block_reason(guard_payload)
-    raw_event = hook_event_name.strip().lower()
-    if raw_event == "beforereadfile":
-        read_permission = _cursor_read_file_permission(permission)
-        response: dict[str, object] = {"permission": read_permission}
-        if read_permission == "deny":
-            response["user_message"] = reason
-        return {key: value for key, value in response.items() if value is not None}
-    response: dict[str, object] = {"permission": permission}
-    if permission != "allow":
-        response["user_message"] = reason
-        response["agent_message"] = reason
-    return {key: value for key, value in response.items() if value is not None}
-
-
-def cursor_hook_should_block(*, policy_action: str) -> bool:
-    return policy_action in {"block", "sandbox-required"}
 
 
 def cursor_hooks_path(context: HarnessContext) -> Path:
@@ -216,11 +84,12 @@ def managed_hook_script_path(context: HarnessContext) -> Path:
 def install_cursor_hooks(context: HarnessContext) -> dict[str, object]:
     """Install Guard-managed Cursor hooks and bridge script."""
 
+    guard_cli = resolve_attested_guard_cli(context)
     hooks_path = cursor_hooks_path(context)
     script_path = cursor_hook_script_path(context)
     managed_script_path = managed_hook_script_path(context)
     managed_script_path.parent.mkdir(parents=True, exist_ok=True)
-    script_source = cursor_hook_script_source(context)
+    script_source = cursor_hook_script_source(context, guard_cli=list(guard_cli.command))
     managed_script_path.write_text(script_source, encoding="utf-8")
     _make_executable(managed_script_path)
     script_path.parent.mkdir(parents=True, exist_ok=True)
@@ -244,6 +113,8 @@ def install_cursor_hooks(context: HarnessContext) -> dict[str, object]:
             {
                 "managed_hooks_path": str(hooks_path),
                 "managed_hook_script_path": str(script_path),
+                "guard_cli_identity": guard_cli.manifest_payload(),
+                "hook_script_sha256": sha256(script_source.encode("utf-8")).hexdigest(),
                 "backup_path": str(backup_path),
                 "workspace_dir": workspace_dir,
             },
@@ -269,10 +140,16 @@ def install_cursor_hooks(context: HarnessContext) -> dict[str, object]:
     hooks_path.parent.mkdir(parents=True, exist_ok=True)
     hooks_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     _cleanup_legacy_project_cursor_hooks(context)
+    hook_state = cursor_native_hook_state(context)
+    if hook_state["protection_active"] is not True:
+        reason = hook_state.get("reason")
+        raise RuntimeError(f"guard_cursor_hook_install_verification_failed:{reason}")
     return {
         "managed_hooks_path": str(hooks_path),
         "managed_hook_script_path": str(script_path),
         "managed_hook_events": list(_MANAGED_HOOK_EVENTS),
+        "guard_cli_identity": guard_cli.manifest_payload(),
+        "hook_script_sha256": sha256(script_source.encode("utf-8")).hexdigest(),
         "backup_path": str(backup_path),
         "state_path": str(state_path),
     }
@@ -441,16 +318,10 @@ def _remove_managed_hook_entries(*, hooks_path: Path, script_path: Path) -> bool
     return True
 
 
-def _resolve_guard_cli_command() -> list[str]:
-    """Prefer the installed guard-only CLI so hooks use the leanest runtime."""
+def _resolve_guard_cli_command(context: HarnessContext) -> list[str]:
+    """Return only the isolated CLI bound to the running Guard distribution."""
 
-    plugin_guard = shutil.which("plugin-guard")
-    if plugin_guard:
-        return [plugin_guard]
-    hol_guard = shutil.which("hol-guard")
-    if hol_guard:
-        return [hol_guard]
-    return [sys.executable, "-m", "codex_plugin_scanner.cli"]
+    return list(resolve_attested_guard_cli(context).command)
 
 
 def _uses_top_level_hook_command(guard_cli: list[str]) -> bool:
@@ -476,8 +347,12 @@ def _embedded_guard_hook_argv(context: HarnessContext) -> list[str]:
     return guard_argv
 
 
-def cursor_hook_script_source(context: HarnessContext) -> str:
-    guard_cli = _resolve_guard_cli_command()
+def cursor_hook_script_source(
+    context: HarnessContext,
+    *,
+    guard_cli: list[str] | None = None,
+) -> str:
+    guard_cli = list(guard_cli) if guard_cli is not None else _resolve_guard_cli_command(context)
     guard_argv = _embedded_guard_hook_argv(context)
     if not _uses_top_level_hook_command(guard_cli):
         guard_argv = ["guard", *guard_argv]
@@ -499,954 +374,117 @@ def cursor_hook_script_source(context: HarnessContext) -> str:
     )
 
 
-_INHERIT_ENV_KEYS = (
-    "PATH",
-    "HOME",
-    "USER",
-    "TMPDIR",
-    "TEMP",
-    "TMP",
-    "LANG",
-    "LC_ALL",
-    "SYSTEMROOT",
-    "CURSOR_PROJECT_DIR",
-    "CURSOR_VERSION",
-    "CURSOR_TRACE_ID",
-    "CURSOR_SESSION_ID",
-    "CURSOR_TRANSCRIPT_PATH",
-    "HOL_GUARD_SRC",
-)
+def cursor_native_hook_state(context: HarnessContext) -> dict[str, object]:
+    """Verify Cursor registration, scripts, and the current attested CLI identity."""
 
-_HOOK_SCRIPT_TEMPLATE = '''#!/usr/bin/env python3
-"""Managed by HOL Guard. Re-run `hol-guard install cursor` after moving Guard home."""
-from __future__ import annotations
-
-import hashlib
-import hmac
-import json
-import os
-import shlex
-import subprocess
-import sys
-import urllib.error
-import urllib.parse
-import urllib.request
-from collections.abc import Mapping
-from pathlib import Path
-
-GUARD_HOME = __GUARD_HOME__
-GUARD_CLI = __GUARD_CLI__
-GUARD_HOOK_ARGV = __GUARD_HOOK_ARGV__
-GUARD_INHERIT_ENV_KEYS = __GUARD_INHERIT_ENV_KEYS__
-GUARD_HOOK_TIMEOUT_SECONDS = __GUARD_HOOK_TIMEOUT_SECONDS__
-GUARD_ACTIONS = frozenset({"allow", "warn", "review", "require-reapproval", "sandbox-required", "block"})
-
-
-def _hook_process_env() -> dict[str, str]:
-    env: dict[str, str] = {}
-    for key in GUARD_INHERIT_ENV_KEYS:
-        value = os.environ.get(key)
-        if isinstance(value, str) and value:
-            env[key] = value
-    dev_src = os.environ.get("HOL_GUARD_SRC")
-    validated = _validated_hol_guard_src_path(dev_src) if isinstance(dev_src, str) else None
-    if validated is not None:
-        env["PYTHONPATH"] = validated
-    else:
-        dev_src_file = Path(GUARD_HOME) / "cursor-dev-src"
-        if dev_src_file.is_file():
-            try:
-                configured_src = dev_src_file.read_text(encoding="utf-8").strip()
-            except OSError:
-                configured_src = ""
-            validated = _validated_hol_guard_src_path(configured_src)
-            if validated is not None:
-                env["PYTHONPATH"] = validated
-    return env
-
-
-def _guard_hook_arg_value(flag: str) -> str | None:
     try:
-        index = GUARD_HOOK_ARGV.index(flag)
-    except ValueError:
-        return None
-    if index + 1 >= len(GUARD_HOOK_ARGV):
-        return None
-    value = GUARD_HOOK_ARGV[index + 1]
-    return value if isinstance(value, str) and value.strip() else None
-
-
-def _daemon_hook_env_overlay(guard_env: Mapping[str, str]) -> dict[str, str]:
-    overlay: dict[str, str] = {}
-    for key in (
-        "HOL_GUARD_MANAGED_CURSOR_HOOK",
-        "HOL_GUARD_CURSOR_APPROVAL_BINDING",
-        "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF",
-        "CURSOR_PROJECT_DIR",
-        "CURSOR_VERSION",
-        "CURSOR_TRACE_ID",
-        "CURSOR_SESSION_ID",
-        "CURSOR_TRANSCRIPT_PATH",
-    ):
-        value = guard_env.get(key)
-        if isinstance(value, str) and value:
-            overlay[key] = value
-    return overlay
-
-
-def _daemon_hook_result(
-    payload_json: str,
-    *,
-    workspace: str | None,
-    hook_env_overlay: Mapping[str, str] | None = None,
-) -> tuple[int, str, str] | None:
-    state_path = Path(GUARD_HOME) / "daemon-state.json"
-    token_path = Path(GUARD_HOME) / "daemon-auth-token"
+        guard_cli = resolve_attested_guard_cli(context)
+        expected_source = cursor_hook_script_source(context, guard_cli=list(guard_cli.command))
+    except RuntimeError:
+        return {
+            "protection_active": False,
+            "integrity_status": "attestation-unavailable",
+            "reason": "guard_cursor_cli_attestation_unavailable",
+        }
+    hooks_path = cursor_hooks_path(context)
+    script_path = cursor_hook_script_path(context)
+    managed_script_path = managed_hook_script_path(context)
+    state_path = _hooks_state_path(hooks_path, context)
     try:
         state = json.loads(state_path.read_text(encoding="utf-8"))
-        auth_token = token_path.read_text(encoding="utf-8").strip()
-    except (OSError, ValueError):
-        return None
-    if not isinstance(state, dict):
-        return None
-    port = state.get("port")
-    if not isinstance(port, int) or port <= 0 or not auth_token:
-        return None
-    # Validate the recorded PID is still alive before trusting the state file.
-    # A stale state file after a crash could point at an attacker-controlled listener.
-    pid = state.get("pid")
-    if not isinstance(pid, int) or pid <= 0:
-        return None
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return None
-    # Probe /healthz before sending the hook payload and auth token.
-    # Ensures the listener is actually the Guard daemon, not a spoofed process.
-    # Validate the response body — not just HTTP 200 — so an attacker listener
-    # that returns 200 but doesn't know the daemon's compatibility version is rejected.
-    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
-    try:
-        health_req = urllib.request.Request(f"http://127.0.0.1:{port}/healthz", method="GET")
-        with opener.open(health_req, timeout=2) as health_response:
-            if health_response.status != 200:
-                return None
-            health_body = health_response.read().decode("utf-8", errors="replace")
-    except (OSError, urllib.error.URLError):
-        return None
-    try:
-        health_json = json.loads(health_body)
-    except ValueError:
-        return None
-    if not isinstance(health_json, dict) or health_json.get("ok") is not True:
-        return None
-    state_compat = state.get("compatibility_version")
-    if isinstance(state_compat, str) and health_json.get("compatibility_version") != state_compat:
-        return None
-    # Challenge-response: prove the listener knows the auth_token before sending it.
-    # A spoofed listener can return public healthz values but cannot forge the HMAC.
-    # The proof is bound to the daemon's listening port so a relay attacker cannot
-    # proxy the nonce to the real daemon and reuse its proof from a different port.
-    # Old daemons without /v1/healthz/verify fail with HTTPError — return None to
-    # fall through to the CLI path. Never bypass the HMAC challenge.
-    nonce = os.urandom(16).hex()
-    proof_message = f"{port}:{nonce}"
-    try:
-        verify_req = urllib.request.Request(
-            f"http://127.0.0.1:{port}/v1/healthz/verify",
-            data=json.dumps({"nonce": nonce}).encode("utf-8"),
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with opener.open(verify_req, timeout=2) as verify_response:
-            verify_body = verify_response.read().decode("utf-8", errors="replace")
-            try:
-                verify_json = json.loads(verify_body)
-            except ValueError:
-                return None
-            if not isinstance(verify_json, dict) or not isinstance(verify_json.get("proof"), str):
-                return None
-            expected_proof = hmac.new(
-                auth_token.encode("utf-8"),
-                proof_message.encode("utf-8"),
-                hashlib.sha256,
-            ).hexdigest()
-            if not hmac.compare_digest(verify_json["proof"], expected_proof):
-                return None
-    except (urllib.error.HTTPError, OSError, urllib.error.URLError):
-        return None
-    params = [("guard-home", GUARD_HOME)]
-    if workspace:
-        params.append(("workspace", workspace))
-    home_dir = _guard_hook_arg_value("--home")
-    if home_dir:
-        params.append(("home", home_dir))
-    try:
-        request_payload = json.loads(payload_json)
-    except ValueError:
-        return None
-    if not isinstance(request_payload, dict):
-        return None
-    if hook_env_overlay:
-        request_payload["hook_env"] = dict(hook_env_overlay)
-    query = urllib.parse.urlencode(params)
-    request = urllib.request.Request(
-        f"http://127.0.0.1:{port}/v1/hooks/cursor?{query}",
-        data=json.dumps(request_payload).encode("utf-8"),
-        headers={
-            "Content-Type": "application/json",
-            "X-Guard-Token": auth_token,
-        },
-        method="POST",
-    )
-    try:
-        with opener.open(request, timeout=max(GUARD_HOOK_TIMEOUT_SECONDS - 2, 1)) as response:
-            body = response.read().decode("utf-8", errors="replace")
-    except (OSError, urllib.error.URLError):
-        return None
-    # Reject empty or non-dict responses — they default policy_action to "allow".
-    # Fall through to the CLI subprocess path instead of trusting a malformed response.
-    body_stripped = body.strip()
-    if not body_stripped:
-        return None
-    try:
-        parsed_body = json.loads(body_stripped)
-    except ValueError:
-        return None
-    if not isinstance(parsed_body, dict):
-        return None
-    raw_event_name = _raw_hook_event_name(request_payload)
-    if raw_event_name not in {"aftershellexecution", "aftermcpexecution"}:
-        policy_action = parsed_body.get("policy_action")
-        if not isinstance(policy_action, str) or policy_action not in GUARD_ACTIONS:
-            return None
-    return (0, body_stripped, "")
-
-
-def _validated_hol_guard_src_path(path_str: str) -> str | None:
-    try:
-        if not isinstance(path_str, str) or not path_str.strip():
-            return None
-        candidate = Path(path_str.strip()).expanduser().resolve()
-    except (OSError, RuntimeError, ValueError, TypeError):
-        return None
-    if not candidate.is_dir():
-        return None
-    if not (candidate / "codex_plugin_scanner").is_dir():
-        return None
-    return str(candidate)
-
-
-def _workspace_from_cursor_input(payload: dict[str, object]) -> str | None:
-    project_dir = os.environ.get("CURSOR_PROJECT_DIR")
-    if isinstance(project_dir, str) and project_dir.strip():
-        candidate = project_dir.strip()
-        if Path(candidate).is_dir():
-            return candidate
-    roots = payload.get("workspace_roots") or payload.get("workspaceRoots")
-    if isinstance(roots, list):
-        for item in roots:
-            if isinstance(item, str) and item.strip():
-                candidate = item.strip()
-                if Path(candidate).is_dir():
-                    return candidate
-    cwd = payload.get("cwd")
-    if isinstance(cwd, str) and cwd.strip():
-        candidate = cwd.strip()
-        if Path(candidate).is_dir():
-            return candidate
-    return None
-
-
-def _tool_input_dict(value: object) -> dict[str, object]:
-    if isinstance(value, dict):
-        return dict(value)
-    if isinstance(value, list):
-        return {"arguments": list(value)}
-    if isinstance(value, str) and value.strip():
-        try:
-            parsed = json.loads(value)
-        except json.JSONDecodeError:
-            return {"raw": value.strip()}
-        if isinstance(parsed, dict):
-            return dict(parsed)
-        if isinstance(parsed, list):
-            return {"arguments": list(parsed)}
-    return {}
-
-
-def _raw_hook_event_name(payload: dict[str, object]) -> str:
-    for key in ("hook_event_name", "hookEventName", "hook_name", "hookName", "event", "eventName"):
-        value = payload.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip().lower()
-    return ""
-
-
-def _infer_cursor_hook_event_name(payload: dict[str, object]) -> dict[str, object]:
-    normalized = dict(payload)
-    if _raw_hook_event_name(normalized):
-        return normalized
-    file_path = normalized.get("file_path")
-    if isinstance(file_path, str) and file_path.strip():
-        normalized["hook_event_name"] = "beforeReadFile"
-        return normalized
-    command = normalized.get("command")
-    if isinstance(command, str) and command.strip():
-        normalized["hook_event_name"] = "beforeShellExecution"
-        return normalized
-    if normalized.get("tool_name") is not None or normalized.get("tool_input") is not None:
-        normalized["hook_event_name"] = "preToolUse"
-    return normalized
-
-
-def _cursor_shell_hook_payload(normalized: dict[str, object], hook_event_name: str) -> dict[str, object]:
-    payload = dict(normalized)
-    payload["hook_event_name"] = hook_event_name
-    payload.setdefault("tool_name", "Shell")
-    tool_input = _tool_input_dict(payload.get("tool_input"))
-    command = payload.get("command")
-    if isinstance(command, str) and command.strip():
-        tool_input.setdefault("command", command.strip())
-    cwd = payload.get("cwd")
-    if isinstance(cwd, str) and cwd.strip():
-        tool_input.setdefault("working_directory", cwd.strip())
-    payload["tool_input"] = tool_input
-    return payload
-
-
-def _cursor_mcp_hook_payload(normalized: dict[str, object], hook_event_name: str) -> dict[str, object]:
-    payload = dict(normalized)
-    payload["hook_event_name"] = hook_event_name
-    tool_input = _tool_input_dict(payload.get("tool_input"))
-    payload["tool_input"] = tool_input
-    tool_name = payload.get("tool_name")
-    if isinstance(tool_name, str) and tool_name.strip():
-        payload["tool_name"] = tool_name.strip()
-    else:
-        payload.setdefault("tool_name", "MCP")
-    return payload
-
-
-def _prepare_cursor_hook_payload(payload: dict[str, object]) -> dict[str, object]:
-    normalized = _infer_cursor_hook_event_name(payload)
-    raw_event = _raw_hook_event_name(normalized)
-    if raw_event == "aftershellexecution":
-        return _cursor_shell_hook_payload(normalized, "afterShellExecution")
-    if raw_event == "aftermcpexecution":
-        return _cursor_mcp_hook_payload(normalized, "afterMCPExecution")
-    if raw_event == "beforeshellexecution":
-        prepared = _cursor_shell_hook_payload(normalized, "PreToolUse")
-        prepared["cursor_source_hook_event"] = "beforeShellExecution"
-        return prepared
-    if raw_event == "beforemcpexecution":
-        prepared = _cursor_mcp_hook_payload(normalized, "PreToolUse")
-        tool_input = _tool_input_dict(prepared.get("tool_input"))
-        for key in ("url", "command"):
-            value = normalized.get(key)
-            if isinstance(value, str) and value.strip():
-                tool_input.setdefault(key, value.strip())
-        prepared["tool_input"] = tool_input
-        prepared["cursor_source_hook_event"] = "beforeMCPExecution"
-        return prepared
-    if raw_event == "beforereadfile":
-        normalized["hook_event_name"] = "PreToolUse"
-        normalized.setdefault("tool_name", "Read")
-        tool_input = _tool_input_dict(normalized.get("tool_input"))
-        file_path = normalized.get("file_path")
-        if isinstance(file_path, str) and file_path.strip():
-            tool_input.setdefault("file_path", file_path.strip())
-            tool_input.setdefault("path", file_path.strip())
-        normalized["tool_input"] = tool_input
-        return normalized
-    if raw_event == "pretooluse":
-        normalized["hook_event_name"] = "PreToolUse"
-    return normalized
-
-
-def _cursor_permission(policy_action: str, guard_payload: dict[str, object]) -> str:
-    del guard_payload
-    if policy_action not in GUARD_ACTIONS:
-        return "deny"
-    if policy_action in {"block", "sandbox-required"}:
-        return "deny"
-    if policy_action in {"require-reapproval", "review"}:
-        return "ask"
-    return "allow"
-
-
-def _cursor_read_file_permission(permission: str) -> str:
-    if permission in {"deny", "ask"}:
-        return "deny"
-    return "allow"
-
-
-def _cursor_reason(guard_payload: dict[str, object]) -> str:
-    primary_url = guard_payload.get("primary_approval_url")
-    reason: str | None = None
-    for key in ("review_hint", "risk_summary", "why_now", "risk_headline"):
-        value = guard_payload.get(key)
-        if isinstance(value, str) and value.strip():
-            reason = value.strip()
-            break
-    if reason is None:
-        decision = guard_payload.get("decision_v2_json")
-        if isinstance(decision, Mapping):
-            for key in ("harness_message", "retry_instruction", "user_body", "user_title"):
-                value = decision.get(key)
-                if isinstance(value, str) and value.strip():
-                    reason = value.strip()
-                    break
-    if reason is None:
-        if isinstance(primary_url, str) and primary_url.strip():
-            return f"HOL Guard needs approval for this Cursor action. Review it at {primary_url.strip()}."
-        return "HOL Guard blocked this Cursor action."
-    if isinstance(primary_url, str) and primary_url.strip():
-        url_str = primary_url.strip()
-        if url_str in reason:
-            return reason
-        return f"{reason} Review: {url_str}"
-    return reason
-
-
-def _emit_cursor_response(
-    *,
-    hook_event_name: str,
-    policy_action: str,
-    guard_payload: dict[str, object],
-) -> tuple[dict[str, object], int]:
-    permission = _cursor_permission(policy_action, guard_payload)
-    reason = _cursor_reason(guard_payload)
-    if hook_event_name.strip().lower() == "beforereadfile":
-        read_permission = "deny" if permission in {"deny", "ask"} else "allow"
-        response = {
-            "permission": read_permission,
-        }
-        if read_permission == "deny":
-            response["user_message"] = reason
-        return response, 2 if read_permission == "deny" else 0
-    response: dict[str, object] = {"permission": permission}
-    if permission != "allow":
-        response["user_message"] = reason
-        response["agent_message"] = reason
-    exit_code = 2 if permission == "deny" else 0
-    return response, exit_code
-
-
-def _cursor_generation_id(payload: Mapping[str, object]) -> str | None:
-    for key in ("generation_id", "generationId"):
-        value = payload.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    return None
-
-
-def _cursor_conversation_id(payload: Mapping[str, object]) -> str | None:
-    for key in ("conversation_id", "conversationId", "session_id", "sessionId"):
-        value = payload.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    session_id = os.environ.get("CURSOR_SESSION_ID")
-    if isinstance(session_id, str) and session_id.strip():
-        return session_id.strip()
-    return None
-
-
-def _normalize_cursor_shell_command(command: str) -> str:
-    stripped = command.strip()
-    if not stripped or len(stripped) > 8192:
-        return stripped
-    lowered = stripped.lower()
-    needle = "lean-ctx"
-    start = 0
-    while True:
-        idx = lowered.find(needle, start)
-        if idx == -1:
-            return stripped
-        if idx == 0 or stripped[idx - 1] == "/":
-            tail = stripped[idx + len(needle) :].lstrip()
-            if tail.startswith("-c"):
-                rest = tail[2:].lstrip()
-                try:
-                    tokens = shlex.split(rest, posix=True, comments=False)
-                except ValueError:
-                    tokens = None
-                if tokens:
-                    inner = tokens[0]
-                    suffix = tokens[1:]
-                    return " ".join((inner, *suffix)) if suffix else inner
-                if rest.startswith("'"):
-                    parts = []
-                    index = 1
-                    while index < len(rest):
-                        character = rest[index]
-                        if character != "'":
-                            parts.append(character)
-                            index += 1
-                            continue
-                        if index + 3 < len(rest) and rest[index : index + 4] == "'\\''":
-                            parts.append("'")
-                            index += 4
-                            continue
-                        inner = "".join(parts)
-                        suffix = rest[index + 1 :].lstrip()
-                        return " ".join((inner, suffix)) if suffix else inner
-                return stripped
-        start = idx + 1
-    return stripped
-
-
-# Installed hook helpers below mirror cursor_native_approval.py; keep both copies in sync.
-
-
-def _cursor_hook_payload_is_mcp_execution(payload: Mapping[str, object]) -> bool:
-    source_event = payload.get("cursor_source_hook_event")
-    if isinstance(source_event, str) and source_event.strip().lower() == "beforemcpexecution":
-        return True
-    for key in ("hook_event_name", "hookEventName", "hook_name", "hookName", "event", "eventName"):
-        value = payload.get(key)
-        if isinstance(value, str):
-            lowered = value.strip().lower()
-            if lowered in {"beforemcpexecution", "aftermcpexecution"}:
-                return True
-    return False
-
-
-def _is_shell_wrapper_command(command: str) -> bool:
-    stripped = command.strip()
-    if not stripped:
-        return False
-    try:
-        parts = shlex.split(stripped, posix=True, comments=False)
-    except ValueError:
-        return False
-    if not parts:
-        return False
-    binary = Path(parts[0]).name.lower()
-    if binary == "lean-ctx":
-        return True
-    if binary not in {"ash", "bash", "dash", "fish", "sh", "zsh"}:
-        return False
-    return len(parts) > 1 and parts[1] == "-c"
-
-
-def _nested_cursor_shell_command(tool_input: Mapping[str, object]) -> str | None:
-    for key in ("command", "cmd", "shell_command", "shellCommand"):
-        value = tool_input.get(key)
-        if isinstance(value, str) and value.strip():
-            return _normalize_cursor_shell_command(value)
-    return None
-
-
-def _cursor_shell_command(payload: Mapping[str, object]) -> str | None:
-    tool_input = payload.get("tool_input")
-    nested_command: str | None = None
-    if isinstance(tool_input, dict):
-        nested_command = _nested_cursor_shell_command(tool_input)
-    command = payload.get("command")
-    top_level: str | None = None
-    if isinstance(command, str) and command.strip():
-        top_level = _normalize_cursor_shell_command(command)
-    if _cursor_hook_payload_is_mcp_execution(payload):
-        if nested_command is not None:
-            return nested_command
-        return top_level
-    if nested_command is not None and (
-        top_level is None or (isinstance(command, str) and _is_shell_wrapper_command(command))
-    ):
-        return nested_command
-    if top_level is not None:
-        return top_level
-    return nested_command
-
-
-def _cursor_shell_binding_path(conversation_id: str, command: str) -> Path:
-    cleaned = conversation_id.strip()
-    if not cleaned or "/" in cleaned or "\\\\" in cleaned or cleaned in {".", ".."}:
-        segment = hashlib.sha256(cleaned.encode("utf-8")).hexdigest()[:32] if cleaned else "missing-conversation"
-    else:
-        segment = cleaned
-    normalized_command = _normalize_cursor_shell_command(command)
-    fingerprint = hashlib.sha256(normalized_command.encode("utf-8")).hexdigest()[:24]
-    return Path(GUARD_HOME) / "cursor-shell-bindings" / segment / fingerprint
-
-
-def _read_cursor_shell_binding_file(conversation_id: str, command: str) -> str | None:
-    binding_path = _cursor_shell_binding_path(conversation_id, command)
-    try:
-        binding = binding_path.read_text(encoding="utf-8").strip()
-    except OSError:
-        return None
-    return binding or None
-
-
-def _resolve_approval_binding(payload: Mapping[str, object]) -> str | None:
-    binding = _cursor_generation_id(payload)
-    if binding is not None:
-        return binding
-    conversation_id = _cursor_conversation_id(payload)
-    command = _cursor_shell_command(payload)
-    if conversation_id is None or command is None:
-        return None
-    return _read_cursor_shell_binding_file(conversation_id, command)
-
-
-def _load_cursor_hook_attestation_secret() -> bytes | None:
-    secret_path = Path(GUARD_HOME) / "secrets" / "cursor-hook-attestation.key"
-    try:
-        secret = secret_path.read_bytes()
-    except OSError:
-        return None
-    return secret or None
-
-
-def _compute_cursor_after_observer_proof(
-    payload: Mapping[str, object],
-    observer_event: str,
-    approval_binding: str | None = None,
-) -> str | None:
-    conversation_id = _cursor_conversation_id(payload)
-    command = _cursor_shell_command(payload)
-    resolved_binding = approval_binding or _resolve_approval_binding(payload)
-    secret = _load_cursor_hook_attestation_secret()
-    if conversation_id is None or command is None or resolved_binding is None or secret is None:
-        return None
-    message = chr(0).join(
-        (conversation_id, command, resolved_binding, observer_event.strip())
-    ).encode("utf-8")
-    return hmac.new(secret, message, hashlib.sha256).hexdigest()
-
-
-def main() -> int:
-    raw = sys.stdin.read()
-    if not raw.strip():
-        print(json.dumps({"permission": "deny", "user_message": "HOL Guard received empty Cursor hook input."}))
-        return 2
-    try:
-        payload = json.loads(raw)
-    except json.JSONDecodeError:
-        print(json.dumps({"permission": "deny", "user_message": "HOL Guard could not parse Cursor hook input."}))
-        return 2
-    if not isinstance(payload, dict):
-        print(json.dumps({"permission": "deny", "user_message": "HOL Guard received invalid Cursor hook input."}))
-        return 2
-    inferred = _infer_cursor_hook_event_name(payload)
-    hook_event_name = str(inferred.get("hook_event_name") or inferred.get("hookEventName") or "preToolUse")
-    prepared = _prepare_cursor_hook_payload(inferred)
-    workspace = _workspace_from_cursor_input(prepared)
-    guard_argv = list(GUARD_HOOK_ARGV)
-    if workspace:
-        if "--workspace" in guard_argv:
-            workspace_index = guard_argv.index("--workspace")
-            if workspace_index + 1 < len(guard_argv):
-                guard_argv[workspace_index + 1] = workspace
-        else:
-            guard_argv.extend(["--workspace", workspace])
-    guard_env = _hook_process_env()
-    guard_env["HOL_GUARD_MANAGED_CURSOR_HOOK"] = "1"
-    if hook_event_name.strip().lower() in {"aftershellexecution", "aftermcpexecution"}:
-        approval_binding = _resolve_approval_binding(prepared)
-        proof = _compute_cursor_after_observer_proof(prepared, hook_event_name, approval_binding)
-        if approval_binding:
-            guard_env["HOL_GUARD_CURSOR_APPROVAL_BINDING"] = approval_binding
-        if proof:
-            guard_env["HOL_GUARD_CURSOR_AFTER_SHELL_PROOF"] = proof
-    payload_json = json.dumps(prepared)
-    daemon_result = _daemon_hook_result(
-        payload_json,
-        workspace=workspace,
-        hook_env_overlay=_daemon_hook_env_overlay(guard_env),
-    )
-    try:
-        if daemon_result is not None:
-            proc = subprocess.CompletedProcess(
-                [*GUARD_CLI, *guard_argv],
-                daemon_result[0],
-                stdout=daemon_result[1],
-                stderr=daemon_result[2],
-            )
-        else:
-            proc = subprocess.run(
-                [*GUARD_CLI, *guard_argv],
-                input=payload_json,
-                capture_output=True,
-                text=True,
-                cwd=GUARD_HOME,
-                env=guard_env,
-                timeout=GUARD_HOOK_TIMEOUT_SECONDS,
-            )
-    except subprocess.TimeoutExpired:
-        print(
-            json.dumps(
-                {
-                    "permission": "deny",
-                    "user_message": (
-                        f"HOL Guard hook timed out after {GUARD_HOOK_TIMEOUT_SECONDS}s. "
-                        "Open the Guard approval center or native Cursor prompt, resolve pending requests, then retry."
-                    ),
-                }
-            )
-        )
-        return 2
-    except Exception as exc:
-        print(
-            json.dumps(
-                {
-                    "permission": "deny",
-                    "user_message": f"HOL Guard hook execution failed: {exc}",
-                }
-            )
-        )
-        return 2
-    guard_payload: dict[str, object] = {}
-    if proc.stdout.strip():
-        try:
-            parsed = json.loads(proc.stdout)
-            if isinstance(parsed, dict):
-                guard_payload = parsed
-        except json.JSONDecodeError:
-            guard_payload = {}
-    if hook_event_name.strip().lower() in {"aftershellexecution", "aftermcpexecution"}:
-        print("{}")
-        return 0
-    raw_policy_action = guard_payload.get("policy_action")
-    if not isinstance(raw_policy_action, str) or raw_policy_action not in GUARD_ACTIONS:
-        print(
-            json.dumps(
-                {
-                    "permission": "deny",
-                    "user_message": "HOL Guard returned an invalid policy action and failed closed.",
-                }
-            )
-        )
-        return 2
-    policy_action = raw_policy_action
-    if proc.returncode != 0 and not guard_payload:
-        print(
-            json.dumps(
-                {
-                    "permission": "deny",
-                    "user_message": (proc.stderr or "HOL Guard hook failed.").strip()
-                    or "HOL Guard hook failed.",
-                }
-            )
-        )
-        return 2
-    response, exit_code = _emit_cursor_response(
-        hook_event_name=hook_event_name,
-        policy_action=policy_action,
-        guard_payload=guard_payload,
-    )
-    print(json.dumps(response))
-    return exit_code
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())
-'''
-
-
-def _managed_hook_entry(
-    context: HarnessContext,
-    *,
-    script_path: Path,
-    event_name: str,
-) -> dict[str, object]:
-    del context
-    entry: dict[str, object] = {
-        "command": str(script_path.resolve()),
-        "timeout": _MANAGED_HOOK_TIMEOUT_SECONDS,
-        "failClosed": event_name in _BLOCKING_MANAGED_HOOK_EVENTS,
-    }
-    return entry
-
-
-def _strip_managed_hook_entries(entries: object, *, script_path: Path) -> list[object]:
-    if not isinstance(entries, list):
-        return []
-    command = str(script_path.resolve())
-    return [entry for entry in entries if not _is_managed_hook_entry(entry, command=command)]
-
-
-def _merge_hook_entries(entries: object, hook_entry: dict[str, object], *, event_name: str) -> list[object]:
-    del event_name
-    normalized = list(entries) if isinstance(entries, list) else []
-    command = str(hook_entry.get("command", ""))
-    preserved = [entry for entry in normalized if not _is_managed_hook_entry(entry, command=command)]
-    return [*preserved, hook_entry]
-
-
-def _is_managed_hook_entry(entry: object, *, command: str) -> bool:
-    if not isinstance(entry, dict):
-        return False
-    entry_command = entry.get("command")
-    if isinstance(entry_command, str) and entry_command == command:
-        return True
-    return _is_managed_hook_command(entry_command)
-
-
-def _is_managed_hook_command(command: object) -> bool:
-    if not isinstance(command, str):
-        return False
-    lowered = command.lower()
-    if "hol-guard-cursor-hook" in lowered:
-        return True
-    if HOOK_SCRIPT_NAME.lower() in lowered:
-        return True
-    if "hol_guard_hook_argv" not in lowered.replace("-", "_"):
-        return False
-    if "--harness" not in lowered or "cursor" not in lowered:
-        return False
-    try:
-        tokens = shlex.split(command)
-    except ValueError:
-        tokens = command.split()
-    if tokens and Path(tokens[0]).name == HOOK_SCRIPT_NAME:
-        return True
-    return Path(tokens[0]).name.lower().startswith("python") if tokens else False
-
-
-def _is_managed_hook_script(source: str) -> bool:
-    return "Managed by HOL Guard" in source and HOOK_SCRIPT_NAME in source
-
-
-def _managed_hooks_payload(payload: dict[str, object]) -> dict[str, object]:
-    normalized: dict[str, object] = {"version": 1, "hooks": {}}
-    version = payload.get("version")
-    if isinstance(version, int):
-        normalized["version"] = version
-    hooks = payload.get("hooks")
-    if isinstance(hooks, dict):
-        normalized["hooks"] = {
-            str(name): list(entries) if isinstance(entries, list) else entries for name, entries in hooks.items()
-        }
-        return normalized
-    normalized["hooks"] = {
-        str(name): list(entries)
-        for name, entries in payload.items()
-        if name != "version" and name not in _MANAGED_HOOK_EVENTS and isinstance(entries, list)
-    }
-    return normalized
-
-
-def _inline_hooks(payload: dict[str, object]) -> dict[str, object]:
-    hooks = payload.get("hooks")
-    if isinstance(hooks, dict):
-        normalized = {
-            str(hook_name): list(entries) if isinstance(entries, list) else entries
-            for hook_name, entries in hooks.items()
-        }
-        payload["hooks"] = normalized
-        return normalized
-    normalized: dict[str, object] = {}
-    payload["hooks"] = normalized
-    return normalized
-
-
-def _raw_hook_event_name(payload: Mapping[str, object]) -> str:
-    for key in ("hook_event_name", "hookEventName", "hook_name", "hookName", "event", "eventName"):
-        value = payload.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip().lower()
-    return ""
-
-
-def _tool_input_dict(value: object) -> dict[str, object]:
-    if isinstance(value, dict):
-        return dict(value)
-    if isinstance(value, list):
-        return {"arguments": list(value)}
-    if isinstance(value, str) and value.strip():
-        try:
-            parsed = json.loads(value)
-        except json.JSONDecodeError:
-            return {"raw": value.strip()}
-        if isinstance(parsed, dict):
-            return dict(parsed)
-        if isinstance(parsed, list):
-            return {"arguments": list(parsed)}
-    return {}
-
-
-def _cursor_permission_for_policy(
-    policy_action: str,
-    guard_payload: Mapping[str, object] | None = None,
-) -> str:
-    del guard_payload
-    if not is_guard_action(policy_action):
-        return "deny"
-    if policy_action in {"block", "sandbox-required"}:
-        return "deny"
-    if policy_action in {"require-reapproval", "review"}:
-        return "ask"
-    return "allow"
-
-
-def _cursor_read_file_permission(permission: str) -> str:
-    if permission in {"deny", "ask"}:
-        return "deny"
-    return "allow"
-
-
-def _cursor_block_reason(guard_payload: Mapping[str, object]) -> str:
-    for key in ("review_hint", "risk_summary", "why_now", "risk_headline"):
-        value = guard_payload.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    decision = guard_payload.get("decision_v2_json")
-    if isinstance(decision, Mapping):
-        for key in ("harness_message", "retry_instruction", "user_body", "user_title"):
-            value = decision.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-    return "HOL Guard blocked this Cursor action."
-
-
-def _json_object(path: Path, *, recover_missing: bool) -> dict[str, object]:
-    if not path.is_file():
-        if recover_missing:
-            return {}
-        raise RuntimeError(f"Guard refused to overwrite missing Cursor hooks config at {path}")
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"Guard refused to overwrite unreadable Cursor hooks config at {path}") from exc
-    if not isinstance(payload, dict):
-        raise RuntimeError(f"Guard refused to overwrite non-object Cursor hooks config at {path}")
-    return payload
-
-
-def _hooks_backup_path(target_path: Path, context: HarnessContext) -> Path:
-    digest = sha256(str(target_path.resolve()).encode("utf-8")).hexdigest()[:12]
-    return context.guard_home / "managed" / "cursor" / f"hooks-{digest}.backup.json"
-
-
-def _hooks_state_path(target_path: Path, context: HarnessContext) -> Path:
-    digest = sha256(str(target_path.resolve()).encode("utf-8")).hexdigest()[:12]
-    return context.guard_home / "managed" / "cursor" / f"hooks-{digest}.state.json"
-
-
-def _backup_payload(backup_path: Path) -> dict[str, str | bool | None]:
-    try:
-        payload = json.loads(backup_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return {"readable": False, "existed": False, "content": None}
-    if not isinstance(payload, dict):
-        return {"readable": False, "existed": False, "content": None}
-    existed = payload.get("existed") is True
-    content = payload.get("content")
-    return {"readable": True, "existed": existed, "content": content if isinstance(content, str) else None}
+        return {
+            "protection_active": False,
+            "integrity_status": "missing",
+            "reason": "guard_cursor_hook_state_missing",
+        }
+    if not isinstance(state, dict) or state.get("guard_cli_identity") != guard_cli.manifest_payload():
+        return {
+            "protection_active": False,
+            "integrity_status": "tampered",
+            "reason": "guard_cursor_cli_identity_mismatch",
+        }
+    expected_hash = sha256(expected_source.encode("utf-8")).hexdigest()
+    if state.get("hook_script_sha256") != expected_hash:
+        return {
+            "protection_active": False,
+            "integrity_status": "stale",
+            "reason": "guard_cursor_hook_script_identity_stale",
+        }
+    for candidate in (script_path, managed_script_path):
+        try:
+            metadata = candidate.lstat()
+            source = candidate.read_text(encoding="utf-8")
+        except OSError:
+            return {
+                "protection_active": False,
+                "integrity_status": "missing",
+                "reason": "guard_cursor_hook_script_missing",
+            }
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(metadata.st_mode)
+            or not _hook_script_mode_is_executable(metadata.st_mode)
+            or source != expected_source
+        ):
+            return {
+                "protection_active": False,
+                "integrity_status": "tampered",
+                "reason": "guard_cursor_hook_script_tampered",
+            }
+    try:
+        hooks_payload = _json_object(hooks_path, recover_missing=False)
+    except RuntimeError:
+        return {
+            "protection_active": False,
+            "integrity_status": "missing",
+            "reason": "guard_cursor_hook_registration_missing",
+        }
+    hooks = hooks_payload.get("hooks")
+    if not isinstance(hooks, dict):
+        return {
+            "protection_active": False,
+            "integrity_status": "tampered",
+            "reason": "guard_cursor_hook_registration_mismatch",
+        }
+    for event_name in _MANAGED_HOOK_EVENTS:
+        entries = hooks.get(event_name)
+        expected_entry = _managed_hook_entry(context, script_path=script_path, event_name=event_name)
+        if not isinstance(entries, list) or sum(entry == expected_entry for entry in entries) != 1:
+            return {
+                "protection_active": False,
+                "integrity_status": "tampered",
+                "reason": "guard_cursor_hook_registration_mismatch",
+            }
+    return {
+        "protection_active": True,
+        "integrity_status": "valid",
+        "reason": None,
+        "guard_cli_identity": guard_cli.manifest_payload(),
+    }
 
 
-def _make_executable(path: Path) -> None:
-    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+def _hook_script_mode_is_executable(mode: int) -> bool:
+    """Use POSIX execute bits only on platforms where they govern launch."""
+
+    # Keep this compatibility wrapper in the public module so existing test and
+    # integration monkeypatches of cursor_hooks.os.name continue to work.
+    return os.name == "nt" or bool(mode & stat.S_IXUSR)
 
 
 __all__ = [
     "HOOK_SCRIPT_NAME",
+    "_hook_script_mode_is_executable",
+    "_resolve_guard_cli_command",
+    "_strip_managed_hook_entries",
+    "_validated_hol_guard_src_path",
+    "cursor_hook_requires_approval_center_queue",
     "cursor_hook_response_from_guard",
+    "cursor_hook_script_source",
     "cursor_hook_should_block",
+    "cursor_hook_would_prompt_user",
     "cursor_hooks_path",
+    "cursor_native_hook_state",
     "install_cursor_hooks",
     "prepare_cursor_hook_payload",
     "uninstall_cursor_hooks",

--- a/src/codex_plugin_scanner/guard/adapters/guard_cli_attestation.py
+++ b/src/codex_plugin_scanner/guard/adapters/guard_cli_attestation.py
@@ -1,0 +1,75 @@
+"""Attest the isolated Guard CLI command embedded in managed hooks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import HarnessContext
+from .hook_python import HookPythonAttestation, HookPythonFileMetadata, attest_guard_hook_python
+
+
+@dataclass(frozen=True, slots=True)
+class GuardCliAttestation:
+    """One isolated CLI command bound to the active Guard distribution."""
+
+    command: tuple[str, ...]
+    python: HookPythonAttestation
+
+    def manifest_payload(self) -> dict[str, object]:
+        """Return the complete identity persisted by managed harnesses."""
+
+        identity = self.python.identity
+        return {
+            "schema": 1,
+            "command": list(self.command),
+            "entry_point": self.python.entry_point,
+            "guard_version": self.python.version,
+            "package_file": str(self.python.package_file),
+            "package_root": str(self.python.package_root),
+            "hol_distribution_root": (
+                str(self.python.hol_distribution_root) if self.python.hol_distribution_root is not None else None
+            ),
+            "interpreter": {
+                "invocation_path": str(identity.invocation_path),
+                "invocation_type": identity.invocation_type,
+                "invocation_link_target": identity.invocation_link_target,
+                "invocation_stat": _file_metadata_payload(identity.invocation_stat),
+                "target_path": str(identity.target_path),
+                "target_stat": _file_metadata_payload(identity.target_stat),
+                "target_sha256": identity.target_sha256,
+            },
+        }
+
+
+def _file_metadata_payload(value: HookPythonFileMetadata) -> dict[str, int]:
+    return {
+        "device": value.device,
+        "inode": value.inode,
+        "mode": value.mode,
+        "size": value.size,
+        "mtime_ns": value.mtime_ns,
+    }
+
+
+def resolve_attested_guard_cli(context: HarnessContext) -> GuardCliAttestation:
+    """Resolve Guard's CLI without consulting PATH or the caller's import cwd."""
+
+    try:
+        python = attest_guard_hook_python(context)
+    except RuntimeError as error:
+        message = (
+            "Guard could not attest its CLI runtime. Reinstall hol-guard with pipx or uv, "
+            "then re-run the harness installation."
+        )
+        raise RuntimeError(message) from error
+    command = (
+        str(python.executable),
+        "-I",
+        "-s",
+        "-m",
+        "codex_plugin_scanner.cli",
+    )
+    return GuardCliAttestation(command=command, python=python)
+
+
+__all__ = ["GuardCliAttestation", "resolve_attested_guard_cli"]

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -26,6 +26,7 @@ from packaging.version import InvalidVersion, Version
 
 from ..adapters.base import HarnessContext
 from ..adapters.codex import CodexHarnessAdapter, codex_native_hook_state
+from ..adapters.cursor_hooks import cursor_native_hook_state
 from ..adapters.opencode_pretool import (
     global_plugin_path,
     install_pretool_plugin,
@@ -1971,10 +1972,63 @@ def _repair_supported_harnesses_in_process(
     )
     repaired_installs = [repaired_codex] if repaired_codex is not None else []
     repair_notes = [codex_warning] if codex_warning is not None else []
+    repaired_cursor, cursor_warning = _repair_cursor_install(
+        context=context,
+        store=store,
+        workspace=workspace,
+        now=now,
+    )
+    if repaired_cursor is not None:
+        repaired_installs.append(repaired_cursor)
+    if cursor_warning is not None:
+        repair_notes.append(cursor_warning)
     opencode_note = _refresh_opencode_pretool_plugin(context=context, store=store)
     if opencode_note is not None:
         repair_notes.append(opencode_note)
     return repaired_installs, repair_notes
+
+
+def _repair_cursor_install(
+    *,
+    context: HarnessContext,
+    store: GuardStore,
+    workspace: str | None,
+    now: str,
+) -> tuple[dict[str, object] | None, str | None]:
+    try:
+        managed_install = store.get_managed_install("cursor")
+    except (json.JSONDecodeError, sqlite3.Error):
+        return None, None
+    if managed_install is None or not bool(managed_install.get("active")):
+        return None, None
+    manifest = managed_install.get("manifest")
+    if not isinstance(manifest, dict):
+        return None, "Could not inspect Cursor protection during update: managed manifest is invalid"
+    surface_value = manifest.get("surface")
+    surface = surface_value if surface_value in {"editor", "all"} else None
+    if surface is None:
+        return None, None
+    repair_context, repair_workspace = _repair_context_from_managed_install(context, managed_install)
+    hook_state = cursor_native_hook_state(repair_context)
+    if hook_state["protection_active"] is True:
+        return None, None
+    try:
+        payload = apply_managed_install(
+            "install",
+            "cursor",
+            False,
+            repair_context,
+            store,
+            repair_workspace or workspace,
+            now,
+            surface=surface,
+        )
+    except (OSError, RuntimeError, json.JSONDecodeError, sqlite3.Error) as error:
+        return None, f"Could not repair Cursor protection during update: {error}"
+    repaired = payload.get("managed_install")
+    if not isinstance(repaired, dict):
+        return None, "Could not repair Cursor protection during update: managed install was not recorded"
+    return repaired, None
 
 
 def _refresh_opencode_pretool_plugin(

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -2008,8 +2008,11 @@ def _repair_cursor_install(
     surface = surface_value if surface_value in {"editor", "all"} else None
     if surface is None:
         return None, None
-    repair_context, repair_workspace = _repair_context_from_managed_install(context, managed_install)
-    hook_state = cursor_native_hook_state(repair_context)
+    try:
+        repair_context, repair_workspace = _repair_context_from_managed_install(context, managed_install)
+        hook_state = cursor_native_hook_state(repair_context)
+    except (OSError, RuntimeError, json.JSONDecodeError, sqlite3.Error) as error:
+        return None, f"Could not inspect Cursor protection during update: {error}"
     if hook_state["protection_active"] is True:
         return None, None
     try:

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -467,6 +467,40 @@ def test_cursor_update_repairs_stale_attested_cli_identity(tmp_path: Path) -> No
     assert cursor_native_hook_state(context)["protection_active"] is True
 
 
+def test_cursor_update_reports_context_resolution_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = HarnessContext(home_dir=tmp_path / "home", guard_home=tmp_path / "guard", workspace_dir=None)
+    store = GuardStore(context.guard_home)
+    store.set_managed_install(
+        "cursor",
+        True,
+        str(tmp_path / "workspace"),
+        {"surface": "editor"},
+        "2026-07-20T00:00:00+00:00",
+    )
+
+    def _fail_context_resolution(*_args: object, **_kwargs: object) -> tuple[HarnessContext, str | None]:
+        raise RuntimeError("invalid repair context")
+
+    monkeypatch.setattr(
+        guard_update_commands_module,
+        "_repair_context_from_managed_install",
+        _fail_context_resolution,
+    )
+
+    repaired, warning = guard_update_commands_module._repair_cursor_install(
+        context=context,
+        store=store,
+        workspace=None,
+        now="2026-07-20T00:01:00+00:00",
+    )
+
+    assert repaired is None
+    assert warning == "Could not inspect Cursor protection during update: invalid repair context"
+
+
 def test_cursor_install_is_idempotent_across_path_changes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -15,13 +15,17 @@ from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.cursor_hooks import (
     _MANAGED_HOOK_EVENTS,
     _MANAGED_HOOK_TIMEOUT_SECONDS,
+    _hook_script_mode_is_executable,
     _strip_managed_hook_entries,
     cursor_hook_response_from_guard,
     cursor_hook_should_block,
+    cursor_hooks_path,
+    cursor_native_hook_state,
     install_cursor_hooks,
     prepare_cursor_hook_payload,
     uninstall_cursor_hooks,
 )
+from codex_plugin_scanner.guard.cli import update_commands as guard_update_commands_module
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.models import GuardArtifact
 from codex_plugin_scanner.guard.store import GuardStore
@@ -37,6 +41,15 @@ def _cursor_shell_artifact(*, workspace_dir: Path, command: str) -> GuardArtifac
         config_path=str(workspace_dir / ".cursor" / "mcp.json"),
         command=command,
     )
+
+
+def test_cursor_hook_executable_mode_is_platform_portable(monkeypatch) -> None:
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor_hooks.os.name", "nt")
+    assert _hook_script_mode_is_executable(0o600) is True
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor_hooks.os.name", "posix")
+    assert _hook_script_mode_is_executable(0o600) is False
+    assert _hook_script_mode_is_executable(0o700) is True
 
 
 def _record_cursor_pending_for_test(
@@ -188,7 +201,7 @@ def test_cursor_hook_script_source_routes_hook_argv_by_cli_entrypoint(
     context = HarnessContext(home_dir=tmp_path / "home", guard_home=tmp_path / "guard", workspace_dir=tmp_path)
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
-        lambda: ["hol-guard"],
+        lambda _context: ["hol-guard"],
     )
     hol_guard_source = cursor_hook_script_source(context)
     assert 'GUARD_HOOK_ARGV = ["hook"' in hol_guard_source
@@ -196,7 +209,7 @@ def test_cursor_hook_script_source_routes_hook_argv_by_cli_entrypoint(
 
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
-        lambda: [sys.executable, "-m", "codex_plugin_scanner.cli"],
+        lambda _context: [sys.executable, "-m", "codex_plugin_scanner.cli"],
     )
     module_source = cursor_hook_script_source(context)
     assert 'GUARD_HOOK_ARGV = ["guard", "hook"' in module_source
@@ -229,7 +242,7 @@ def test_cursor_hook_script_uses_daemon_fast_path(tmp_path: Path, monkeypatch: p
     try:
         monkeypatch.setattr(
             "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
-            lambda: [sys.executable, "-m", "codex_plugin_scanner.cli"],
+            lambda _context: [sys.executable, "-m", "codex_plugin_scanner.cli"],
         )
         context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=workspace_dir)
         script_path = tmp_path / "cursor-hook.py"
@@ -286,7 +299,7 @@ def test_generated_cursor_hook_fails_closed_for_missing_or_unknown_guard_action(
     )
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
-        lambda: [sys.executable, str(fake_guard)],
+        lambda _context: [sys.executable, str(fake_guard)],
     )
     context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=workspace_dir)
     script_path = tmp_path / "cursor-hook.py"
@@ -314,19 +327,173 @@ def test_generated_cursor_hook_fails_closed_for_missing_or_unknown_guard_action(
     assert "failed closed" in response["user_message"]
 
 
-def test_cursor_resolve_guard_cli_command_prefers_plugin_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cursor_resolve_guard_cli_command_ignores_path_collisions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import _resolve_guard_cli_command
 
-    def fake_which(command: str) -> str | None:
-        if command == "plugin-guard":
-            return "/usr/local/bin/plugin-guard"
-        if command == "hol-guard":
-            return "/usr/local/bin/hol-guard"
-        return None
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "path-collision-ran"
+    for name in ("plugin-guard", "hol-guard"):
+        collision = fake_bin / name
+        collision.write_text(f"#!/bin/sh\ntouch {marker}\n", encoding="utf-8")
+        collision.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}")
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        guard_home=tmp_path / "guard",
+        workspace_dir=tmp_path / "workspace",
+    )
 
-    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor_hooks.shutil.which", fake_which)
+    command = _resolve_guard_cli_command(context)
 
-    assert _resolve_guard_cli_command() == ["/usr/local/bin/plugin-guard"]
+    assert command == [str(Path(sys.executable).absolute()), "-I", "-s", "-m", "codex_plugin_scanner.cli"]
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize("collision_kind", ["executable", "symlink", "non-executable", "other-venv"])
+def test_cursor_install_persists_only_attested_cli_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    collision_kind: str,
+) -> None:
+    fake_bin = tmp_path / ("other-venv" if collision_kind == "other-venv" else "fake-bin") / "bin"
+    fake_bin.mkdir(parents=True)
+    marker = tmp_path / "path-collision-ran"
+    target = fake_bin / "collision-target"
+    target.write_text(f"#!/bin/sh\ntouch {marker}\n", encoding="utf-8")
+    target.chmod(0o755)
+    for name in ("plugin-guard", "hol-guard"):
+        collision = fake_bin / name
+        if collision_kind == "symlink":
+            collision.symlink_to(target)
+        else:
+            collision.write_text(target.read_text(encoding="utf-8"), encoding="utf-8")
+            collision.chmod(0o644 if collision_kind == "non-executable" else 0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}")
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    context = HarnessContext(home_dir=home, guard_home=tmp_path / "guard", workspace_dir=workspace)
+
+    manifest = install_cursor_hooks(context)
+
+    identity = manifest["guard_cli_identity"]
+    assert isinstance(identity, dict)
+    assert identity["command"] == [
+        str(Path(sys.executable).absolute()),
+        "-I",
+        "-s",
+        "-m",
+        "codex_plugin_scanner.cli",
+    ]
+    assert identity["entry_point"] == "codex_plugin_scanner.cli:main"
+    assert identity["package_root"] == str(Path(__file__).resolve().parents[1] / "src")
+    interpreter = identity["interpreter"]
+    assert isinstance(interpreter, dict)
+    assert Path(str(interpreter["target_path"])).is_absolute()
+    assert len(str(interpreter["target_sha256"])) == 64
+    assert not marker.exists()
+    assert cursor_native_hook_state(context)["protection_active"] is True
+
+
+def test_cursor_update_repairs_tampered_cli_binding(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    context = HarnessContext(home_dir=home, guard_home=tmp_path / "guard", workspace_dir=workspace)
+    hooks_manifest = install_cursor_hooks(context)
+    store = GuardStore(context.guard_home)
+    store.set_managed_install(
+        "cursor",
+        True,
+        str(workspace),
+        {"surface": "editor", **hooks_manifest},
+        "2026-07-20T00:00:00+00:00",
+    )
+    script_path = Path(str(hooks_manifest["managed_hook_script_path"]))
+    original_source = script_path.read_text(encoding="utf-8")
+    script_path.write_text(
+        original_source.replace("codex_plugin_scanner.cli", "attacker_controlled.cli", 1),
+        encoding="utf-8",
+    )
+    assert cursor_native_hook_state(context)["reason"] == "guard_cursor_hook_script_tampered"
+
+    repaired, warning = guard_update_commands_module._repair_cursor_install(
+        context=context,
+        store=store,
+        workspace=str(workspace),
+        now="2026-07-20T00:01:00+00:00",
+    )
+
+    assert warning is None
+    assert repaired is not None
+    assert cursor_native_hook_state(context)["protection_active"] is True
+    assert script_path.read_text(encoding="utf-8") == original_source
+
+
+def test_cursor_update_repairs_stale_attested_cli_identity(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    context = HarnessContext(home_dir=home, guard_home=tmp_path / "guard", workspace_dir=workspace)
+    hooks_manifest = install_cursor_hooks(context)
+    store = GuardStore(context.guard_home)
+    store.set_managed_install(
+        "cursor",
+        True,
+        str(workspace),
+        {"surface": "editor", **hooks_manifest},
+        "2026-07-20T00:00:00+00:00",
+    )
+    state_path = Path(str(hooks_manifest["state_path"]))
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["guard_cli_identity"]["guard_version"] = "0.0.0-stale"
+    state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+    stale = cursor_native_hook_state(context)
+
+    repaired, warning = guard_update_commands_module._repair_cursor_install(
+        context=context,
+        store=store,
+        workspace=str(workspace),
+        now="2026-07-20T00:01:00+00:00",
+    )
+
+    assert stale["reason"] == "guard_cursor_cli_identity_mismatch"
+    assert warning is None
+    assert repaired is not None
+    assert cursor_native_hook_state(context)["protection_active"] is True
+
+
+def test_cursor_install_is_idempotent_across_path_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    context = HarnessContext(home_dir=home, guard_home=tmp_path / "guard", workspace_dir=workspace)
+    markers: list[Path] = []
+    manifests: list[dict[str, object]] = []
+    for index in range(2):
+        fake_bin = tmp_path / f"fake-bin-{index}"
+        fake_bin.mkdir()
+        marker = tmp_path / f"path-collision-{index}-ran"
+        markers.append(marker)
+        for name in ("plugin-guard", "hol-guard"):
+            collision = fake_bin / name
+            collision.write_text(f"#!/bin/sh\ntouch {marker}\n", encoding="utf-8")
+            collision.chmod(0o755)
+        monkeypatch.setenv("PATH", str(fake_bin))
+        manifests.append(install_cursor_hooks(context))
+
+    hooks = json.loads(cursor_hooks_path(context).read_text(encoding="utf-8"))["hooks"]
+    assert manifests[0]["guard_cli_identity"] == manifests[1]["guard_cli_identity"]
+    assert all(len(hooks[event_name]) == 1 for event_name in _MANAGED_HOOK_EVENTS)
+    assert not any(marker.exists() for marker in markers)
+    assert cursor_native_hook_state(context)["protection_active"] is True
 
 
 def test_strip_managed_hook_entries_removes_hol_guard_pretooluse(tmp_path: Path) -> None:
@@ -378,7 +545,7 @@ def test_install_cursor_hooks_strips_legacy_pretooluse_entry(tmp_path: Path, mon
     )
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
-        lambda: ["hol-guard"],
+        lambda _context: ["hol-guard"],
     )
     context = HarnessContext(home_dir=home, guard_home=guard_home, workspace_dir=workspace)
     result = install_cursor_hooks(context)
@@ -559,7 +726,7 @@ def test_install_cursor_hooks_registers_after_shell_observer(tmp_path: Path, mon
     hooks_path.write_text('{"version": 1, "hooks": {}}\n', encoding="utf-8")
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
-        lambda: ["hol-guard"],
+        lambda _context: ["hol-guard"],
     )
     context = HarnessContext(home_dir=home, guard_home=guard_home, workspace_dir=workspace)
     install_cursor_hooks(context)
@@ -1368,7 +1535,7 @@ def test_uninstall_cursor_hooks_restores_backup(tmp_path: Path, monkeypatch: pyt
     hooks_path.write_text('{"version": 1, "hooks": {"preToolUse": []}}\n', encoding="utf-8")
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
-        lambda: ["hol-guard"],
+        lambda _context: ["hol-guard"],
     )
     context = HarnessContext(home_dir=home, guard_home=guard_home, workspace_dir=workspace)
     install_cursor_hooks(context)
@@ -1388,7 +1555,7 @@ def test_cursor_hook_daemon_fast_path_rejects_stale_pid(tmp_path: Path, monkeypa
 
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
-        lambda: [sys.executable, "-m", "codex_plugin_scanner.cli"],
+        lambda _context: [sys.executable, "-m", "codex_plugin_scanner.cli"],
     )
     context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=workspace_dir)
     script_path = tmp_path / "cursor-hook.py"
@@ -1458,7 +1625,7 @@ def test_cursor_hook_daemon_fast_path_rejects_empty_response(tmp_path: Path, mon
     try:
         monkeypatch.setattr(
             "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
-            lambda: [sys.executable, "-m", "codex_plugin_scanner.cli"],
+            lambda _context: [sys.executable, "-m", "codex_plugin_scanner.cli"],
         )
         context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=workspace_dir)
         script_path = tmp_path / "cursor-hook.py"
@@ -1535,7 +1702,7 @@ def test_cursor_hook_daemon_fast_path_rejects_spoofed_healthz(tmp_path: Path, mo
     try:
         monkeypatch.setattr(
             "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
-            lambda: [sys.executable, "-m", "codex_plugin_scanner.cli"],
+            lambda _context: [sys.executable, "-m", "codex_plugin_scanner.cli"],
         )
         context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=workspace_dir)
         script_path = tmp_path / "cursor-hook.py"
@@ -1611,7 +1778,7 @@ def test_cursor_hook_daemon_fast_path_404_falls_through_to_cli(tmp_path: Path, m
     try:
         monkeypatch.setattr(
             "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
-            lambda: [sys.executable, "-m", "codex_plugin_scanner.cli"],
+            lambda _context: [sys.executable, "-m", "codex_plugin_scanner.cli"],
         )
         context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=workspace_dir)
         script_path = tmp_path / "cursor-hook.py"

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -15,6 +15,7 @@ from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.cursor_hooks import (
     _MANAGED_HOOK_EVENTS,
     _MANAGED_HOOK_TIMEOUT_SECONDS,
+    HOOK_SCRIPT_NAME,
     _hook_script_mode_is_executable,
     _strip_managed_hook_entries,
     cursor_hook_response_from_guard,
@@ -592,6 +593,32 @@ def test_install_cursor_hooks_strips_legacy_pretooluse_entry(tmp_path: Path, mon
     for event_name in _MANAGED_HOOK_EVENTS:
         entry = installed["hooks"][event_name][-1]
         assert entry["timeout"] == _MANAGED_HOOK_TIMEOUT_SECONDS
+
+
+def test_install_cursor_hooks_preserves_top_level_event_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hooks_path = home / ".cursor" / "hooks.json"
+    hooks_path.parent.mkdir(parents=True)
+    existing_entries = {event_name: [{"command": f"user-{event_name}"}] for event_name in _MANAGED_HOOK_EVENTS}
+    hooks_path.write_text(json.dumps({"version": 1, **existing_entries}) + "\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
+        lambda _context: ["hol-guard"],
+    )
+
+    install_cursor_hooks(HarnessContext(home_dir=home, guard_home=guard_home, workspace_dir=workspace))
+    installed = json.loads(hooks_path.read_text(encoding="utf-8"))
+
+    for event_name in _MANAGED_HOOK_EVENTS:
+        entries = installed["hooks"][event_name]
+        assert entries[0] == existing_entries[event_name][0]
+        assert entries[-1]["command"].endswith(HOOK_SCRIPT_NAME)
 
 
 def test_prepare_cursor_hook_payload_maps_before_mcp_execution() -> None:


### PR DESCRIPTION
## Summary

- replace Cursor hook installation's ambient `PATH` lookup with the already-running, isolated Guard interpreter attestation shared by the OpenCode hook boundary
- persist an absolute `python -I -s -m codex_plugin_scanner.cli` command plus interpreter invocation/target metadata and hash, package/distribution identity, expected entry point/version, and generated hook-script hash
- isolate CLI-attestation serialization and resolution in a focused 75-line module, leaving the shared interpreter-attestation module below the 500-line ceiling
- verify both installed script copies, exact executable bytes/mode/type, managed registrations, state, and current CLI identity before reporting Cursor protection active
- enforce owner-executable mode on POSIX while retaining Windows' native regular-file/content checks, where POSIX execute bits do not govern launch
- make in-process update repair stale CLI identity, script tampering, missing registrations, and relocated installations while preserving the originally installed `editor` or `all` surface

## Adversarial coverage

- marker-writing `plugin-guard` and `hol-guard` collisions first on `PATH`
- executable, symlinked, non-executable, and unrelated-virtualenv basename collisions
- `PATH` changes between idempotent installs; neither collision is selected or executed
- altered embedded module binding and stale persisted distribution identity, both repaired from the active attested installation
- exact single-registration readback for every managed Cursor hook event

## Validation

- `78 passed` — Cursor hook plus shared interpreter-attestation suites, including the portable executable-mode boundary
- `3 passed, 20 deselected` — Windows-updater failure-equivalent phase-03 doctor/install selection after the portable mode correction
- `9 passed, 246 deselected` — affected update/Codex repair integration selection
- `2 passed, 59 deselected` — focused stale-identity repair and PATH-change idempotency regressions
- Ruff lint and formatting checks passed for all changed files
- Basedpyright passed with `0 errors` for changed production modules
- `uv build` produced the release-head sdist and wheel successfully

## Stable failure reasons

- `guard_cursor_cli_attestation_unavailable`
- `guard_cursor_hook_state_missing`
- `guard_cursor_cli_identity_mismatch`
- `guard_cursor_hook_script_identity_stale`
- `guard_cursor_hook_script_missing`
- `guard_cursor_hook_script_tampered`
- `guard_cursor_hook_registration_missing`
- `guard_cursor_hook_registration_mismatch`

## Attribution and target

- target branch: `release/2.1`
- direct parent at creation: `f6b7d2d7699a420cbc9cd6b5b6d69aff3e4417fd`
- commit author/committer: `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>`
