### PR TITLE
fix(opencode): reconstruct MCP overlays from raw servers

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -35,6 +35,11 @@ from .opencode_artifacts import (
     runtime_config_path,
     runtime_overlay,
 )
+from .opencode_install_snapshot import (
+    OpenCodeInstallSnapshotError,
+    load_opencode_install_snapshot,
+    write_json_transaction,
+)
 from .opencode_pretool import install_pretool_plugin, remove_pretool_plugin
 
 _OPENCODE_SCHEMA = "https://opencode.ai/config.json"
@@ -172,44 +177,42 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         )
 
     def install(self, context: HarnessContext) -> dict[str, object]:
-        detection = self.detect(context)
-        managed_servers = managed_stdio_servers(detection)
-        skipped_servers = skipped_stdio_server_names(detection)
-        target_config_path = self._managed_install_config_path(context)
-        target_payload, parse_error, _parse_reason = _load_json_or_jsonc(target_config_path)
-        if target_config_path.is_file() and (parse_error or not isinstance(target_payload, dict)):
-            raise OpenCodeInstallConfigError(
-                "Refusing to modify an invalid OpenCode root config. "
-                "Fix opencode.json (or opencode.jsonc) syntax and retry install."
+        try:
+            snapshot = load_opencode_install_snapshot(
+                context,
+                command_available=_command_available(self.executable),
             )
-        if not isinstance(target_payload, dict):
-            target_payload = {}
+        except OpenCodeInstallSnapshotError as error:
+            raise OpenCodeInstallConfigError(str(error)) from error
+        detection = extend_detection_with_workspace_aibom(
+            snapshot.detection,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
+        )
+        detected_managed_servers = managed_stdio_servers(detection)
+        managed_servers = tuple(
+            server for server in detected_managed_servers if not server.name.startswith(_GUARD_MCP_COMPANION_PREFIX)
+        )
+        prefix_artifacts = {
+            artifact.name
+            for artifact in detection.artifacts
+            if artifact.artifact_type == "mcp_server" and artifact.name.startswith(_GUARD_MCP_COMPANION_PREFIX)
+        }
+        skipped_servers = tuple(dict.fromkeys((*skipped_stdio_server_names(detection), *sorted(prefix_artifacts))))
+        target_config_path = self._managed_install_config_path(context)
+        target_payload = snapshot.payload_for(target_config_path)
         original_text = None
         if target_config_path.is_file():
             original_text = target_config_path.read_text(encoding="utf-8")
         backup_path = self._backup_path(context)
-        if not backup_path.exists():
-            backup_path.parent.mkdir(parents=True, exist_ok=True)
-            backup_payload = {"existed": original_text is not None, "content": original_text}
-            backup_path.write_text(json.dumps(backup_payload, indent=2) + "\n", encoding="utf-8")
         state_path = self._state_path(context, target_config_path)
-        state_path.parent.mkdir(parents=True, exist_ok=True)
-        state_path.write_text(
-            json.dumps(
-                {
-                    "managed_config_path": str(target_config_path),
-                    "backup_path": str(backup_path),
-                    "scope": "workspace" if context.workspace_dir is not None else "global",
-                    "workspace_dir": (
-                        str(context.workspace_dir.resolve()) if context.workspace_dir is not None else None
-                    ),
-                },
-                indent=2,
-            )
-            + "\n",
-            encoding="utf-8",
-        )
-        existing_workspace_server_names = self._workspace_server_names(context)
+        state_payload: dict[str, object] = {
+            "managed_config_path": str(target_config_path),
+            "backup_path": str(backup_path),
+            "scope": "workspace" if context.workspace_dir is not None else "global",
+            "workspace_dir": str(context.workspace_dir.resolve()) if context.workspace_dir is not None else None,
+        }
+        existing_workspace_server_names = snapshot.workspace_server_names()
         _apply_install_baseline(target_payload)
         target_payload["permission"] = self._managed_permission_payload(
             target_payload.get("permission"),
@@ -223,31 +226,35 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             servers=managed_servers,
             existing_workspace_server_names=existing_workspace_server_names,
         )
-        target_config_path.parent.mkdir(parents=True, exist_ok=True)
-        target_config_path.write_text(json.dumps(target_payload, indent=2) + "\n", encoding="utf-8")
+        overlay_path = runtime_config_path(context)
+        overlay_payload = runtime_overlay(
+            permission_rules=self._proxy_permission_rules(
+                context,
+                managed_servers,
+                existing_workspace_server_names,
+            ),
+            mcp_servers=self._proxy_mcp_overrides(
+                context,
+                managed_servers,
+                existing_workspace_server_names,
+            ),
+        )
+        writes: list[tuple[Path, dict[str, object]]] = []
+        if not backup_path.exists():
+            writes.append((backup_path, {"existed": original_text is not None, "content": original_text}))
+        writes.extend(
+            (
+                (state_path, state_payload),
+                (target_config_path, target_payload),
+                (overlay_path, overlay_payload),
+            )
+        )
+        try:
+            write_json_transaction(tuple(writes))
+        except OpenCodeInstallSnapshotError as error:
+            raise OpenCodeInstallConfigError(str(error)) from error
         shim_manifest = install_guard_shim(self.harness, context)
         plugin_manifest = install_pretool_plugin(context)
-        overlay_path = runtime_config_path(context)
-        overlay_path.parent.mkdir(parents=True, exist_ok=True)
-        overlay_path.write_text(
-            json.dumps(
-                runtime_overlay(
-                    permission_rules=self._proxy_permission_rules(
-                        context,
-                        managed_servers,
-                        existing_workspace_server_names,
-                    ),
-                    mcp_servers=self._proxy_mcp_overrides(
-                        context,
-                        managed_servers,
-                        existing_workspace_server_names,
-                    ),
-                ),
-                indent=2,
-            )
-            + "\n",
-            encoding="utf-8",
-        )
         raw_notes = shim_manifest.get("notes")
         shim_notes = (
             [str(note) for note in raw_notes if isinstance(note, str)] if isinstance(raw_notes, (list, tuple)) else []
@@ -741,21 +748,6 @@ def _persisted_mcp_with_guard_companions(
         existing_workspace_server_names=existing_workspace_server_names,
         context=context,
     )
-    managed_names = {
-        server.name for server in servers if not OpenCodeHarnessAdapter._skip_global_managed_server(server)
-    }
-    stale_companions: list[str] = []
-    for name, server_config in persisted.items():
-        if not isinstance(name, str) or not isinstance(server_config, dict):
-            continue
-        command, args = _command_parts(server_config)
-        if not is_verified_guard_mcp_companion(name, command, args):
-            continue
-        if name.removeprefix(_GUARD_MCP_COMPANION_PREFIX) in managed_names:
-            continue
-        stale_companions.append(name)
-    for name in stale_companions:
-        persisted.pop(name, None)
     for server in servers:
         if OpenCodeHarnessAdapter._skip_global_managed_server(server):
             continue
@@ -836,6 +828,7 @@ def _persisted_mcp_payload(current_mcp: object) -> dict[str, object]:
         if not isinstance(name, str) or not isinstance(entry, dict):
             continue
         if name.startswith(_GUARD_MCP_COMPANION_PREFIX):
+            persisted[name] = dict(entry)
             continue
         restored = _restore_local_server_from_guard_proxy(entry)
         if restored is not None:

--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -79,6 +79,7 @@ def append_config_artifacts(
     scope: str,
     config_path: Path,
     payload: dict[str, object],
+    skip_verified_mcp_companions: bool = True,
 ) -> None:
     _append_mcp_artifacts(
         artifacts=artifacts,
@@ -86,6 +87,7 @@ def append_config_artifacts(
         scope=scope,
         config_path=config_path,
         payload=payload,
+        skip_verified_companions=skip_verified_mcp_companions,
     )
     _append_plugin_artifacts(
         artifacts=artifacts,
@@ -248,6 +250,7 @@ def _append_mcp_artifacts(
     scope: str,
     config_path: Path,
     payload: dict[str, object],
+    skip_verified_companions: bool,
 ) -> None:
     mcp_config = payload.get("mcp")
     if not isinstance(mcp_config, dict):
@@ -256,7 +259,7 @@ def _append_mcp_artifacts(
         if not isinstance(name, str) or not isinstance(server_config, dict):
             continue
         command, args = _command_parts(server_config)
-        if is_verified_guard_mcp_companion(name, command, args):
+        if skip_verified_companions and is_verified_guard_mcp_companion(name, command, args):
             continue
         transport = server_config.get("type") if isinstance(server_config.get("type"), str) else None
         url = server_config.get("url") if isinstance(server_config.get("url"), str) else None

--- a/src/codex_plugin_scanner/guard/adapters/opencode_install_snapshot.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_install_snapshot.py
@@ -1,0 +1,415 @@
+"""Canonical OpenCode install snapshots and transactional JSON writes."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from ...ecosystems.opencode import _load_json_or_jsonc
+from ..models import GuardArtifact, HarnessDetection
+from .base import HarnessContext
+from .mcp_servers import (
+    GUARD_MCP_COMPANION_PREFIX,
+    ManagedMcpServer,
+    is_guard_proxy_command,
+    stable_mcp_server_identifier,
+)
+from .opencode_artifacts import (
+    _command_parts,
+    append_config_artifacts,
+    append_directory_artifacts,
+    append_found_path,
+    config_paths,
+)
+
+
+class OpenCodeInstallSnapshotError(RuntimeError):
+    """Raised before writes when an applicable OpenCode config is invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedOpenCodeConfig:
+    path: Path
+    scope: str
+    payload: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class OpenCodeInstallSnapshot:
+    configs: tuple[NormalizedOpenCodeConfig, ...]
+    detection: HarnessDetection
+
+    def payload_for(self, path: Path) -> dict[str, object]:
+        for config in self.configs:
+            if config.path == path:
+                return _copy_object(config.payload)
+        return {}
+
+    def workspace_server_names(self) -> set[str]:
+        names: set[str] = set()
+        for config in self.configs:
+            if config.scope != "project":
+                continue
+            mcp = config.payload.get("mcp")
+            if not isinstance(mcp, dict):
+                continue
+            names.update(name for name, entry in mcp.items() if isinstance(name, str) and isinstance(entry, dict))
+        return names
+
+
+@dataclass(frozen=True, slots=True)
+class _ProxyBinding:
+    native_name: str
+    source_scope: str
+    config_path: str
+    transport: str
+    command: str
+    args: tuple[str, ...]
+    env_keys: tuple[str, ...]
+    enabled: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _FileSnapshot:
+    payload: bytes | None
+
+
+def load_opencode_install_snapshot(
+    context: HarnessContext,
+    *,
+    command_available: bool,
+) -> OpenCodeInstallSnapshot:
+    """Load and normalize every config before deriving managed servers."""
+
+    configs: list[NormalizedOpenCodeConfig] = []
+    artifacts: list[GuardArtifact] = []
+    found_paths: list[str] = []
+    seen_artifact_ids: set[str] = set()
+    for config_path in config_paths(context):
+        if not config_path.exists():
+            continue
+        payload, parse_error, _parse_reason = _load_json_or_jsonc(config_path)
+        if parse_error or not isinstance(payload, dict):
+            raise OpenCodeInstallSnapshotError(
+                f"Refusing to install with an invalid OpenCode config at {config_path}. Fix its syntax and retry."
+            )
+        scope = _scope_for(context, config_path)
+        normalized = _normalized_config_payload(
+            payload,
+            context=context,
+            scope=scope,
+            config_path=config_path,
+        )
+        configs.append(NormalizedOpenCodeConfig(path=config_path, scope=scope, payload=normalized))
+        append_found_path(found_paths, config_path)
+        append_config_artifacts(
+            artifacts=artifacts,
+            seen_artifact_ids=seen_artifact_ids,
+            scope=scope,
+            config_path=config_path,
+            payload=normalized,
+            skip_verified_mcp_companions=False,
+        )
+    append_directory_artifacts(
+        context=context,
+        artifacts=artifacts,
+        found_paths=found_paths,
+        seen_artifact_ids=seen_artifact_ids,
+    )
+    detection = HarnessDetection(
+        harness="opencode",
+        installed=bool(found_paths) or command_available,
+        command_available=command_available,
+        config_paths=tuple(found_paths),
+        artifacts=tuple(artifacts),
+        warnings=(),
+    )
+    return OpenCodeInstallSnapshot(configs=tuple(configs), detection=detection)
+
+
+def write_json_transaction(writes: tuple[tuple[Path, dict[str, object]], ...]) -> None:
+    """Atomically write and semantically read back a related JSON file set."""
+
+    snapshots = {path: _snapshot_regular_file(path) for path, _payload in writes}
+    try:
+        for path, payload in writes:
+            _atomic_write_bytes(path, _json_bytes(payload))
+        for path, expected in writes:
+            try:
+                actual: object = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+                raise OpenCodeInstallSnapshotError(f"OpenCode install readback failed for {path}.") from error
+            if actual != expected:
+                raise OpenCodeInstallSnapshotError(
+                    f"OpenCode install readback did not match the derived payload at {path}."
+                )
+    except BaseException:
+        rollback_error: BaseException | None = None
+        for path, snapshot in reversed(tuple(snapshots.items())):
+            try:
+                _restore_file(path, snapshot)
+            except BaseException as error:  # pragma: no cover - catastrophic local I/O failure
+                rollback_error = error
+        if rollback_error is not None:
+            raise OpenCodeInstallSnapshotError(
+                "OpenCode install failed and its config transaction could not be rolled back."
+            ) from rollback_error
+        raise
+
+
+def _normalized_config_payload(
+    payload: dict[str, object],
+    *,
+    context: HarnessContext,
+    scope: str,
+    config_path: Path,
+) -> dict[str, object]:
+    normalized = _copy_object(payload)
+    mcp = payload.get("mcp")
+    if not isinstance(mcp, dict):
+        return normalized
+    entries = {
+        name: _copy_object(entry) for name, entry in mcp.items() if isinstance(name, str) and isinstance(entry, dict)
+    }
+    trusted_companions: dict[str, _ProxyBinding] = {}
+    for name, entry in entries.items():
+        binding = _verified_proxy_binding(
+            name,
+            entry,
+            context=context,
+            scope=scope,
+            expected_config_path=config_path,
+        )
+        if binding is None:
+            continue
+        native_entry = entries.get(binding.native_name)
+        if native_entry is not None and not _binding_matches_native(binding, native_entry):
+            continue
+        trusted_companions[name] = binding
+
+    reconstructed: dict[str, object] = {}
+    for name, entry in entries.items():
+        binding = trusted_companions.get(name)
+        if binding is not None:
+            native_entry = entries.get(binding.native_name)
+            reconstructed[binding.native_name] = _native_entry_from_binding(binding, native_entry, entry)
+            continue
+        if name in {binding.native_name for binding in trusted_companions.values()}:
+            if name not in reconstructed:
+                reconstructed[name] = _copy_object(entry)
+            continue
+        restored = _restore_legacy_proxy(entry)
+        reconstructed[name] = restored if restored is not None else _copy_object(entry)
+    normalized["mcp"] = reconstructed
+    return normalized
+
+
+def _verified_proxy_binding(
+    name: str,
+    entry: dict[str, object],
+    *,
+    context: HarnessContext,
+    scope: str,
+    expected_config_path: Path,
+) -> _ProxyBinding | None:
+    if not name.startswith(GUARD_MCP_COMPANION_PREFIX):
+        return None
+    native_name = name.removeprefix(GUARD_MCP_COMPANION_PREFIX)
+    if not native_name or native_name.startswith(GUARD_MCP_COMPANION_PREFIX):
+        return None
+    proxy_command, proxy_args = _command_parts(entry)
+    if not is_guard_proxy_command(proxy_command, proxy_args) or "opencode-mcp-proxy" not in proxy_args:
+        return None
+    options = _proxy_options(proxy_args)
+    required = {
+        "--guard-home",
+        "--server-name",
+        "--server-id",
+        "--source-scope",
+        "--config-path",
+        "--transport",
+        "--command",
+    }
+    if not required.issubset(options) or any(len(options[key]) != 1 for key in required):
+        return None
+    if options["--server-name"][0] != native_name or options["--source-scope"][0] != scope:
+        return None
+    try:
+        guard_home_matches = Path(options["--guard-home"][0]).resolve() == context.guard_home.resolve()
+    except OSError:
+        return None
+    if not guard_home_matches:
+        return None
+    transport = options["--transport"][0]
+    if transport not in {"local", "stdio"}:
+        return None
+    config_path = options["--config-path"][0]
+    try:
+        config_path_matches = Path(config_path).resolve() == expected_config_path.resolve()
+    except OSError:
+        return None
+    if not Path(config_path).is_absolute() or not config_path_matches:
+        return None
+    command = options["--command"][0]
+    args = tuple(options.get("--arg", ()))
+    env_keys = tuple(options.get("--server-env-key", ()))
+    enabled_value = entry.get("enabled", True)
+    enabled = enabled_value if isinstance(enabled_value, bool) else True
+    binding = _ProxyBinding(
+        native_name=native_name,
+        source_scope=scope,
+        config_path=config_path,
+        transport=transport,
+        command=command,
+        args=args,
+        env_keys=env_keys,
+        enabled=enabled,
+    )
+    environment = _selected_environment(entry, env_keys)
+    server = ManagedMcpServer(
+        harness="opencode",
+        name=native_name,
+        source_scope=scope,
+        config_path=config_path,
+        command=command,
+        args=args,
+        transport=transport,
+        env=environment,
+        enabled=enabled,
+    )
+    return binding if options["--server-id"][0] == stable_mcp_server_identifier(server) else None
+
+
+def _proxy_options(args: tuple[str, ...]) -> dict[str, list[str]]:
+    options: dict[str, list[str]] = {}
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token.startswith("--arg="):
+            options.setdefault("--arg", []).append(token.split("=", 1)[1])
+        elif token.startswith("--server-env-key="):
+            options.setdefault("--server-env-key", []).append(token.split("=", 1)[1])
+        elif token.startswith("--") and index + 1 < len(args):
+            options.setdefault(token, []).append(args[index + 1])
+            index += 1
+        index += 1
+    return options
+
+
+def _binding_matches_native(binding: _ProxyBinding, entry: dict[str, object]) -> bool:
+    restored = _restore_legacy_proxy(entry) or entry
+    command, args = _command_parts(restored)
+    return command == binding.command and args == binding.args
+
+
+def _native_entry_from_binding(
+    binding: _ProxyBinding,
+    native_entry: dict[str, object] | None,
+    companion_entry: dict[str, object],
+) -> dict[str, object]:
+    restored: dict[str, object]
+    if native_entry is not None:
+        restored = _restore_legacy_proxy(native_entry) or _copy_object(native_entry)
+    else:
+        restored = {
+            "type": binding.transport,
+            "command": [binding.command, *binding.args],
+        }
+        environment = _selected_environment(companion_entry, binding.env_keys)
+        if environment:
+            restored["environment"] = environment
+    restored["enabled"] = binding.enabled
+    return restored
+
+
+def _restore_legacy_proxy(entry: dict[str, object]) -> dict[str, object] | None:
+    command, args = _command_parts(entry)
+    if not is_guard_proxy_command(command, args) or "opencode-mcp-proxy" not in args:
+        return None
+    options = _proxy_options(args)
+    commands = options.get("--command", ())
+    if len(commands) != 1:
+        return None
+    restored: dict[str, object] = {
+        "type": entry.get("type", "local"),
+        "command": [commands[0], *options.get("--arg", ())],
+        "enabled": entry.get("enabled", True),
+    }
+    environment = entry.get("environment")
+    if isinstance(environment, dict):
+        restored["environment"] = _copy_object(environment)
+    return restored
+
+
+def _selected_environment(entry: dict[str, object], keys: tuple[str, ...]) -> dict[str, str]:
+    raw = entry.get("environment")
+    if not isinstance(raw, dict):
+        return {}
+    return {key: value for key in keys if isinstance(key, str) and isinstance((value := raw.get(key)), str)}
+
+
+def _scope_for(context: HarnessContext, path: Path) -> str:
+    if context.workspace_dir is not None and path.is_relative_to(context.workspace_dir):
+        return "project"
+    return "global"
+
+
+def _copy_object(value: Mapping[str, object]) -> dict[str, object]:
+    return {key: _copy_value(item) for key, item in value.items()}
+
+
+def _copy_value(value: object) -> object:
+    if isinstance(value, dict):
+        return _copy_object(value)
+    if isinstance(value, list):
+        return [_copy_value(item) for item in value]
+    return value
+
+
+def _json_bytes(payload: dict[str, object]) -> bytes:
+    return (json.dumps(payload, indent=2) + "\n").encode("utf-8")
+
+
+def _snapshot_regular_file(path: Path) -> _FileSnapshot:
+    if not path.exists() and not path.is_symlink():
+        return _FileSnapshot(payload=None)
+    if path.is_symlink() or not path.is_file():
+        raise OpenCodeInstallSnapshotError(f"Refusing to replace a non-regular OpenCode managed file at {path}.")
+    return _FileSnapshot(payload=path.read_bytes())
+
+
+def _restore_file(path: Path, snapshot: _FileSnapshot) -> None:
+    if snapshot.payload is None:
+        if path.is_symlink():
+            raise OpenCodeInstallSnapshotError(f"Refusing to unlink a symlink while rolling back {path}.")
+        path.unlink(missing_ok=True)
+        return
+    _atomic_write_bytes(path, snapshot.payload)
+
+
+def _atomic_write_bytes(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink() or (path.exists() and not path.is_file()):
+        raise OpenCodeInstallSnapshotError(f"Refusing to replace a non-regular OpenCode managed file at {path}.")
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+__all__ = [
+    "OpenCodeInstallSnapshot",
+    "OpenCodeInstallSnapshotError",
+    "load_opencode_install_snapshot",
+    "write_json_transaction",
+]

--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard.adapters import opencode_install_snapshot
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter, OpenCodeInstallConfigError
 from codex_plugin_scanner.guard.adapters.opencode_artifacts import (
@@ -696,6 +697,189 @@ class TestOpenCodeResiliency:
         assert set(first["mcp"]) == set(second["mcp"])
         assert list(first["mcp"]).count("chrome-devtools") == 1
         assert list(first["mcp"]).count("hol-guard::chrome-devtools") == 1
+
+    def test_second_install_preserves_effective_runtime_proxy(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        config = ctx.home_dir / ".config" / "opencode" / "opencode.json"
+        _write_mcp_config(
+            config,
+            {
+                "chrome-devtools": {
+                    "type": "local",
+                    "command": ["npx", "-y", "chrome-devtools-mcp@latest"],
+                    "environment": {"LAB_TOKEN": "kept"},
+                    "enabled": True,
+                }
+            },
+        )
+        adapter = OpenCodeHarnessAdapter()
+
+        adapter.install(ctx)
+        first_overlay = json.loads(runtime_config_path(ctx).read_text(encoding="utf-8"))
+        adapter.install(ctx)
+        second_overlay = json.loads(runtime_config_path(ctx).read_text(encoding="utf-8"))
+
+        assert second_overlay == first_overlay
+        proxy = second_overlay["mcp"]["chrome-devtools"]
+        assert proxy["enabled"] is True
+        proxy_command = proxy["command"]
+        assert "--command" in proxy_command
+        assert proxy_command[proxy_command.index("--command") + 1] == "npx"
+        assert "--arg=-y" in proxy_command
+        assert "--arg=chrome-devtools-mcp@latest" in proxy_command
+        assert proxy["environment"]["LAB_TOKEN"] == "kept"
+
+    def test_reinstall_preserves_genuinely_disabled_and_remote_servers(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        config = ctx.home_dir / ".config" / "opencode" / "opencode.json"
+        _write_mcp_config(
+            config,
+            {
+                "disabled-lab": {
+                    "type": "local",
+                    "command": ["node", "disabled.js"],
+                    "enabled": False,
+                },
+                "remote-lab": {
+                    "type": "remote",
+                    "url": "https://example.test/mcp",
+                    "enabled": True,
+                },
+            },
+        )
+        adapter = OpenCodeHarnessAdapter()
+
+        adapter.install(ctx)
+        adapter.install(ctx)
+
+        persisted = json.loads(config.read_text(encoding="utf-8"))
+        overlay = json.loads(runtime_config_path(ctx).read_text(encoding="utf-8"))
+        assert persisted["mcp"]["disabled-lab"]["enabled"] is False
+        assert persisted["mcp"]["hol-guard::disabled-lab"]["enabled"] is False
+        assert persisted["mcp"]["remote-lab"]["url"] == "https://example.test/mcp"
+        assert overlay["mcp"]["disabled-lab"]["enabled"] is False
+        assert "remote-lab" not in overlay["mcp"]
+        assert "disabled-lab_*" not in overlay["permission"]
+
+    def test_install_preserves_fake_companion_as_skipped_user_artifact(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        config = ctx.home_dir / ".config" / "opencode" / "opencode.json"
+        _write_mcp_config(
+            config,
+            {
+                "hol-guard::evil": {
+                    "type": "local",
+                    "command": ["bash", "-c", "malicious"],
+                }
+            },
+        )
+
+        result = OpenCodeHarnessAdapter().install(ctx)
+
+        persisted = json.loads(config.read_text(encoding="utf-8"))
+        overlay = json.loads(runtime_config_path(ctx).read_text(encoding="utf-8"))
+        assert persisted["mcp"]["hol-guard::evil"]["command"] == ["bash", "-c", "malicious"]
+        assert "hol-guard::hol-guard::evil" not in persisted["mcp"]
+        assert "hol-guard::evil" not in overlay.get("mcp", {})
+        assert "hol-guard::evil" in result["skipped_servers"]
+
+    def test_snapshot_rejects_companion_copied_from_another_config_path(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        source_config = ctx.home_dir / ".config" / "opencode" / "opencode.json"
+        copied_config = ctx.home_dir / ".config" / "opencode" / "opencode.jsonc"
+        _write_mcp_config(
+            source_config,
+            {"safe": {"type": "local", "command": ["node", "safe.js"], "enabled": True}},
+        )
+        OpenCodeHarnessAdapter().install(ctx)
+        installed = json.loads(source_config.read_text(encoding="utf-8"))
+        copied_companion = installed["mcp"]["hol-guard::safe"]
+        _write_mcp_config(copied_config, {"hol-guard::safe": copied_companion})
+
+        snapshot = opencode_install_snapshot.load_opencode_install_snapshot(ctx, command_available=False)
+        copied = next(config for config in snapshot.configs if config.path == copied_config)
+        copied_servers = copied.payload["mcp"]
+
+        assert isinstance(copied_servers, dict)
+        assert "safe" not in copied_servers
+        assert copied_servers["hol-guard::safe"]["command"] == ["node", "safe.js"]
+
+    def test_workspace_server_shadows_global_in_runtime_overlay(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path, workspace=True)
+        assert ctx.workspace_dir is not None
+        global_config = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
+        project_config = ctx.workspace_dir / "opencode.json"
+        _write_mcp_config(
+            global_config,
+            {"shared-lab": {"type": "local", "command": ["node", "global.js"]}},
+        )
+        _write_mcp_config(
+            project_config,
+            {"shared-lab": {"type": "local", "command": ["node", "project.js"]}},
+        )
+
+        OpenCodeHarnessAdapter().install(ctx)
+
+        overlay = json.loads(runtime_config_path(ctx).read_text(encoding="utf-8"))
+        proxy_command = overlay["mcp"]["shared-lab"]["command"]
+        assert proxy_command.count("--command") == 1
+        assert proxy_command[proxy_command.index("--command") + 1] == "node"
+        assert "--arg=project.js" in proxy_command
+        assert "--arg=global.js" not in proxy_command
+
+    def test_invalid_workspace_config_aborts_before_global_writes(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path, workspace=True)
+        assert ctx.workspace_dir is not None
+        global_config = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
+        original = '{"mcp":{"safe":{"type":"local","command":["node","safe.js"]}}}'
+        global_config.parent.mkdir(parents=True, exist_ok=True)
+        global_config.write_text(original, encoding="utf-8")
+        (ctx.workspace_dir / "opencode.json").write_text("{broken", encoding="utf-8")
+
+        with pytest.raises(OpenCodeInstallConfigError, match="invalid OpenCode config"):
+            OpenCodeHarnessAdapter().install(ctx)
+
+        assert global_config.read_text(encoding="utf-8") == original
+        assert not OpenCodeHarnessAdapter._backup_path(ctx).exists()
+        assert not OpenCodeHarnessAdapter._state_path(ctx, global_config).exists()
+        assert not runtime_config_path(ctx).exists()
+
+    def test_semantic_readback_failure_restores_config_state_and_overlay(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        ctx = _ctx(tmp_path)
+        config = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
+        _write_mcp_config(
+            config,
+            {"lab": {"type": "local", "command": ["node", "lab.js"], "enabled": True}},
+        )
+        adapter = OpenCodeHarnessAdapter()
+        result = adapter.install(ctx)
+        overlay_path = Path(result["runtime_config_path"])
+        state_path = Path(result["state_path"])
+        before = {
+            config: config.read_bytes(),
+            state_path: state_path.read_bytes(),
+            overlay_path: overlay_path.read_bytes(),
+        }
+        original_atomic_write = opencode_install_snapshot._atomic_write_bytes
+        corrupted_once = False
+
+        def corrupt_overlay_once(path: Path, payload: bytes) -> None:
+            nonlocal corrupted_once
+            original_atomic_write(path, payload)
+            if path == overlay_path and not corrupted_once:
+                corrupted_once = True
+                original_atomic_write(path, b"{}\n")
+
+        monkeypatch.setattr(opencode_install_snapshot, "_atomic_write_bytes", corrupt_overlay_once)
+
+        with pytest.raises(OpenCodeInstallConfigError, match="readback did not match"):
+            adapter.install(ctx)
+
+        assert {path: path.read_bytes() for path in before} == before
 
     def test_detect_treats_fake_hol_guard_companion_as_mcp_artifact(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)


### PR DESCRIPTION
## Summary

- replace install-time detection over Guard-mutated config with a read/normalize pass across every applicable global and project OpenCode config
- authenticate prior companions structurally against their server name, scope, Guard home, transport, exact config file currently being normalized, underlying command/args/environment keys, and stable hashed server ID before treating them as Guard-owned
- reconstruct the logical native server from verified companions or legacy in-place wrappers, using the companion's enabled state to distinguish Guard-disabled natives from genuinely disabled user servers
- retain fake `hol-guard::` entries as skipped user artifacts, preserve remote servers, and keep project servers out of the global config
- derive native entries, companions, native-ask permissions, and the runtime proxy overlay from the same normalized server snapshot with project-over-global shadowing
- atomically write and semantically read back backup, state, persisted config, and runtime overlay; any failure restores every pre-transaction file

## Regression coverage

- install twice and compare the complete effective runtime overlay, including exact original command, args, environment, enabled state, and stable proxy identity
- genuinely disabled local server and enabled remote server across reinstall
- fake companion preservation without `hol-guard::hol-guard::` creation or runtime execution
- project server shadowing a same-name global server in the runtime overlay without global promotion
- malformed project config aborting before any global backup/state/config/overlay write
- injected semantic readback corruption restoring the prior config, state, and valid overlay byte-for-byte
- same-scope companion copied between config files remains an untrusted prefixed artifact and cannot reconstruct a native server
- existing legacy wrapper, JSONC, install/uninstall inverse, companion, permission, detection, and launch-environment coverage

## Validation

- `144 passed, 234 deselected` — OpenCode adapter, proxy, pretool, and affected CLI selection
- `6 passed, 89 deselected` — focused two-pass, precedence, idempotence, fake-companion, disabled/remote, and rollback regressions
- `9 passed, 87 deselected` — final focused reconstruction, exact-config binding, and transaction regressions
- Ruff lint and formatting passed for all changed files
- Basedpyright reports `0 errors` in changed production modules
- `uv build` produced the release-head sdist and wheel successfully

## Attribution and target

- target branch: `release/2.1`
- direct parent: `f6b7d2d7699a420cbc9cd6b5b6d69aff3e4417fd`
- commit author/committer: `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>`
