### PR TITLE
fix(supply-chain): canonicalize scoped package identities

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/manifest_dependency_targets.py
+++ b/src/codex_plugin_scanner/guard/runtime/manifest_dependency_targets.py
@@ -94,7 +94,7 @@ def unsynced_manifest_dependency_targets(
             normalized_name = package_eval._normalize_package_name(ecosystem, package_name)
             if normalized_name in lockfile_names:
                 continue
-            namespace, name = package_eval._split_namespace_name(package_name)
+            namespace, name = package_eval._split_namespace_name(package_name, ecosystem=ecosystem)
             exact_version = package_eval._manifest_exact_version(ecosystem, specifier)
             unsynced_targets.append(
                 {

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_models.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_models.py
@@ -20,6 +20,12 @@ from .supply_chain_bundle_base import (
     _require_string,
     _require_string_array,
 )
+from .supply_chain_bundle_package_identity import _deduplicate_bundle_packages
+from .supply_chain_package_identity import (
+    PackageIdentityError,
+    normalize_ecosystem,
+    parse_package_identity,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -178,15 +184,29 @@ class SupplyChainBundlePackage:
         normalized_severity = _require_string(data, "normalizedSeverity")
         if normalized_severity not in _SEVERITY_VALUES:
             raise SupplyChainBundleMalformedError(f"Unsupported package normalizedSeverity: {normalized_severity!r}")
+        ecosystem = normalize_ecosystem(_require_string(data, "ecosystem"))
+        name = _require_string(data, "name")
+        namespace = _optional_string(data, "namespace")
+        if ecosystem == "packagist" and namespace is None and name.count("/") == 1:
+            try:
+                legacy_identity = parse_package_identity(
+                    ecosystem=ecosystem,
+                    package_name=name,
+                    version="*",
+                )
+            except PackageIdentityError as error:
+                raise SupplyChainBundleMalformedError(f"Invalid package identity: {error}") from error
+            namespace = legacy_identity.namespace
+            name = legacy_identity.name
         return SupplyChainBundlePackage(
             confidence=_require_int(data, "confidence"),
             default_action=default_action,
-            ecosystem=_require_string(data, "ecosystem"),
+            ecosystem=ecosystem,
             exploit_level=exploit_level,
             known_exploited=_require_bool(data, "knownExploited"),
             malware_state=malware_state,
-            name=_require_string(data, "name"),
-            namespace=_optional_string(data, "namespace"),
+            name=name,
+            namespace=namespace,
             normalized_severity=normalized_severity,
             package_age_state=_require_string(data, "packageAgeState"),
             purl=_require_string(data, "purl"),
@@ -284,7 +304,7 @@ class SupplyChainBundleEmergencyDeny:
         if reason not in {"critical_active_exploit", "known_exploited", "known_malware"}:
             raise SupplyChainBundleMalformedError(f"Unsupported emergency deny reason: {reason!r}")
         return SupplyChainBundleEmergencyDeny(
-            ecosystem=_require_string(data, "ecosystem"),
+            ecosystem=normalize_ecosystem(_require_string(data, "ecosystem")),
             name=_require_string(data, "name"),
             namespace=_optional_string(data, "namespace"),
             reason=reason,
@@ -388,6 +408,10 @@ class SupplyChainBundle:
             raise SupplyChainBundleMalformedError("Bundle policyRules must be a list")
         if not isinstance(raw_source_hashes, list):
             raise SupplyChainBundleMalformedError("Bundle sourceHashes must be a list")
+        parsed_packages = tuple(
+            SupplyChainBundlePackage.from_dict(item) for item in raw_packages if isinstance(item, dict)
+        )
+        packages = _deduplicate_bundle_packages(parsed_packages)
         bundle = SupplyChainBundle(
             advisories=tuple(
                 SupplyChainBundleAdvisory.from_dict(item) for item in raw_advisories if isinstance(item, dict)
@@ -402,7 +426,7 @@ class SupplyChainBundle:
             feed_snapshot_hash=_require_string(data, "feedSnapshotHash"),
             generated_at=_require_string(data, "generatedAt"),
             key_id=_require_string(data, "keyId"),
-            packages=tuple(SupplyChainBundlePackage.from_dict(item) for item in raw_packages if isinstance(item, dict)),
+            packages=packages,
             policy_hash=_require_string(data, "policyHash"),
             policy_rules=tuple(
                 SupplyChainBundlePolicyRule.from_dict(item) for item in raw_policy_rules if isinstance(item, dict)
@@ -418,7 +442,7 @@ class SupplyChainBundle:
             raise SupplyChainBundleMalformedError("Bundle advisories must contain only objects")
         if len(bundle.emergency_denylist) != len(raw_emergency_denylist):
             raise SupplyChainBundleMalformedError("Bundle emergencyDenylist must contain only objects")
-        if len(bundle.packages) != len(raw_packages):
+        if len(parsed_packages) != len(raw_packages):
             raise SupplyChainBundleMalformedError("Bundle packages must contain only objects")
         if len(bundle.policy_rules) != len(raw_policy_rules):
             raise SupplyChainBundleMalformedError("Bundle policyRules must contain only objects")

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_package_identity.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_package_identity.py
@@ -1,0 +1,54 @@
+"""Canonical identity validation for supply-chain bundle packages."""
+
+from __future__ import annotations
+
+from typing import Protocol, TypeVar
+
+from .supply_chain_bundle_base import SupplyChainBundleMalformedError
+from .supply_chain_package_identity import PackageIdentityError, canonical_package_identity
+
+
+class _BundlePackage(Protocol):
+    @property
+    def ecosystem(self) -> str: ...
+
+    @property
+    def namespace(self) -> str | None: ...
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def version(self) -> str: ...
+
+
+_BundlePackageT = TypeVar("_BundlePackageT", bound=_BundlePackage)
+
+
+def _deduplicate_bundle_packages(
+    packages: tuple[_BundlePackageT, ...],
+) -> tuple[_BundlePackageT, ...]:
+    """Deduplicate exact records and reject order-dependent canonical collisions."""
+
+    by_identity: dict[object, _BundlePackageT] = {}
+    ordered: list[_BundlePackageT] = []
+    for package in packages:
+        try:
+            identity = canonical_package_identity(
+                ecosystem=package.ecosystem,
+                namespace=package.namespace,
+                name=package.name,
+                version=package.version,
+            )
+        except PackageIdentityError as error:
+            raise SupplyChainBundleMalformedError(f"Invalid package identity: {error}") from error
+        existing = by_identity.get(identity)
+        if existing is None:
+            by_identity[identity] = package
+            ordered.append(package)
+            continue
+        if existing != package:
+            raise SupplyChainBundleMalformedError(
+                f"Conflicting package records for canonical identity {identity.display}"
+            )
+    return tuple(ordered)

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
@@ -35,6 +35,7 @@ from .supply_chain_bundle_models import (
 from .supply_chain_package_identity import (
     PackageIdentityError,
     canonical_package_identity,
+    normalize_ecosystem,
     parse_package_identity,
 )
 
@@ -287,10 +288,14 @@ def evaluate_cached_supply_chain_bundle(
         check_supply_chain_bundle_freshness(response.bundle, now=now)
     except SupplyChainBundleExpiredError:
         stale = True
+    try:
+        normalized_ecosystem = normalize_ecosystem(ecosystem) if ecosystem is not None else None
+    except PackageIdentityError:
+        normalized_ecosystem = ""
     deny_entries = _matching_emergency_deny_entries(
         response.bundle,
         package_name=package_name,
-        ecosystem=ecosystem,
+        ecosystem=normalized_ecosystem,
     )
     if deny_entries:
         deny_entry = deny_entries[0]
@@ -306,7 +311,8 @@ def evaluate_cached_supply_chain_bundle(
     matches = [
         item
         for item in response.bundle.packages
-        if (ecosystem is None or item.ecosystem == ecosystem) and _package_matches(item, package_name, package_version)
+        if (normalized_ecosystem is None or item.ecosystem == normalized_ecosystem)
+        and _package_matches(item, package_name, package_version)
     ]
     if not matches:
         return OfflineSupplyChainDecision(

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
-import re
 import time
 from dataclasses import dataclass
 
@@ -32,6 +31,11 @@ from .supply_chain_bundle_models import (
     SupplyChainBundlePackage,
     SupplyChainBundleResponse,
     SupplyChainVerificationKey,
+)
+from .supply_chain_package_identity import (
+    PackageIdentityError,
+    canonical_package_identity,
+    parse_package_identity,
 )
 
 
@@ -211,25 +215,23 @@ def _package_identity_matches(
     name: str,
     package_name: str,
 ) -> bool:
-    normalized_name = _normalize_package_name(ecosystem, package_name)
-    namespace_name = _normalize_package_name(ecosystem, f"{namespace}/{name}") if namespace is not None else None
-    leaf_name = _normalize_package_name(ecosystem, name)
-    if normalized_name.startswith("@"):
-        return namespace_name == normalized_name
-    return namespace is None and leaf_name == normalized_name
+    try:
+        package_identity = canonical_package_identity(
+            ecosystem=ecosystem,
+            namespace=namespace,
+            name=name,
+            version="*",
+        )
+        target_identity = parse_package_identity(ecosystem=ecosystem, package_name=package_name, version="*")
+    except PackageIdentityError:
+        return False
+    return package_identity == target_identity
 
 
 def _package_matches(package: SupplyChainBundlePackage, package_name: str, package_version: str | None) -> bool:
     if not _package_identity_matches(package.ecosystem, package.namespace, package.name, package_name):
         return False
     return package_version is None or package.version == package_version
-
-
-def _normalize_package_name(ecosystem: str, package_name: str) -> str:
-    normalized = package_name.strip().lower()
-    if ecosystem == "pypi":
-        return re.sub(r"[-_.]+", "-", normalized)
-    return normalized
 
 
 def _emergency_deny_identity_matches(entry: SupplyChainBundleEmergencyDeny, package_name: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -4455,15 +4455,16 @@ def _should_record_package(package: dict[str, object], decision: str) -> bool:
 
 
 def _evidence_id(package_intent_hash: str, package: dict[str, object]) -> str:
-    package_name = _package_display_name(package)
-    ecosystem = _optional_string(package.get("ecosystem")) or "unknown"
     decision = str(package.get("decision") or "monitor")
-    resolved_version = _optional_string(package.get("resolvedVersion")) or _optional_string(
-        package.get("requestedVersion")
-    )
     dependency_path = _optional_string(package.get("dependencyPath")) or "direct"
-    identity = f"{package_intent_hash}:{ecosystem}:{package_name}:{resolved_version}:{dependency_path}:{decision}"
-    return f"evidence-{stable_digest_hex(identity.encode(), length=16)}"
+    identity_payload = {
+        "decision": decision,
+        "dependency_path": dependency_path,
+        "package_identity": _result_package_identity(package),
+        "package_intent_hash": package_intent_hash,
+    }
+    encoded = json.dumps(identity_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"evidence-{stable_digest_hex(encoded, length=16)}"
 
 
 def _result_package_identity(package: dict[str, object]) -> tuple[str, str, str, str, str, str]:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -3983,6 +3983,8 @@ def _bundle_package_name_matches(package: SupplyChainBundlePackage, target: dict
     if target_ecosystem is not None and package.ecosystem != normalize_ecosystem(target_ecosystem):
         return False
     try:
+        # Bundle ingestion has already canonicalized package fields; the target
+        # remains case-sensitive for ecosystems such as Go.
         package_identity = canonical_package_identity(
             ecosystem=package.ecosystem,
             namespace=package.namespace,
@@ -4464,20 +4466,33 @@ def _evidence_id(package_intent_hash: str, package: dict[str, object]) -> str:
     return f"evidence-{stable_digest_hex(identity.encode(), length=16)}"
 
 
-def _result_package_identity(package: dict[str, object]) -> object:
-    ecosystem = _optional_string(package.get("ecosystem")) or "unknown"
+def _result_package_identity(package: dict[str, object]) -> tuple[str, str, str, str, str, str]:
+    ecosystem = _optional_string(package.get("ecosystem"))
     name = _optional_string(package.get("name")) or "package"
     namespace = _optional_string(package.get("namespace"))
     version = _optional_string(package.get("resolvedVersion")) or _optional_string(package.get("requestedVersion"))
-    try:
-        return canonical_package_identity(
-            ecosystem=ecosystem,
-            namespace=namespace,
-            name=name,
-            version=version or "*",
-        )
-    except PackageIdentityError:
-        return (ecosystem, namespace, name, version)
+    if ecosystem is not None:
+        try:
+            identity = canonical_package_identity(
+                ecosystem=ecosystem,
+                namespace=namespace,
+                name=name,
+                version=version or "*",
+            )
+            return (
+                "canonical",
+                identity.ecosystem,
+                identity.namespace or "",
+                identity.name,
+                identity.version,
+                "",
+            )
+        except PackageIdentityError:
+            pass
+    opaque_sha256 = stable_digest_hex(
+        json.dumps(package, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    )
+    return ("opaque", ecosystem or "", namespace or "", name, version or "", opaque_sha256)
 
 
 def _with_additional_reason(

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -77,6 +77,14 @@ from .supply_chain_bundle_models import (
     SupplyChainBundleResponse,
 )
 from .supply_chain_bundle_runtime import _is_high_confidence_block
+from .supply_chain_package_identity import (
+    CanonicalPackageIdentity,
+    PackageIdentityError,
+    canonical_package_identity,
+    normalize_ecosystem,
+    normalize_qualified_package_name,
+    parse_package_identity,
+)
 from .supply_chain_support import ecosystem_support_metadata
 from .workspace_path_guard import (
     read_bytes_within_workspace,
@@ -1530,14 +1538,7 @@ def _evaluate_with_bundle(
             resolved_version=resolved_version,
         )
         packages.append(package)
-    direct_identities = {
-        (
-            _optional_string(package.get("namespace")),
-            str(package.get("name") or ""),
-            _optional_string(package.get("resolvedVersion")),
-        )
-        for package in packages
-    }
+    direct_identities = {_result_package_identity(package) for package in packages}
     packages.extend(
         package
         for package in _transitive_lockfile_results(
@@ -1546,12 +1547,7 @@ def _evaluate_with_bundle(
             workspace_dir=workspace_dir,
             now_timestamp=now_timestamp,
         )
-        if (
-            _optional_string(package.get("namespace")),
-            str(package.get("name") or ""),
-            _optional_string(package.get("resolvedVersion")),
-        )
-        not in direct_identities
+        if _result_package_identity(package) not in direct_identities
     )
     if not packages:
         return None
@@ -1879,7 +1875,7 @@ def _targets_from_artifact(artifact: GuardArtifact) -> tuple[dict[str, object], 
         package_name = _optional_string(item.get("package_name"))
         if package_name is None:
             continue
-        namespace, name = _split_namespace_name(package_name)
+        namespace, name = _split_namespace_name(package_name, ecosystem=ecosystem)
         requested = _optional_string(item.get("requested_specifier"))
         raw_spec = _optional_string(item.get("raw_spec")) or package_name
         source_url = _optional_string(item.get("source_url"))
@@ -2219,6 +2215,7 @@ def _transitive_lockfile_results(
             downgraded_low_confidence = (
                 decision == "warn" and _normalize_bundle_action(package_match.default_action) == "block"
             )
+            package_label = _bundle_package_label(package_match, version=version)
             results.append(
                 {
                     "decision": decision,
@@ -2240,11 +2237,14 @@ def _transitive_lockfile_results(
                             else "transitive_lockfile_match",
                             "message": (
                                 (
-                                    "Existing lockfile includes transitive dependency path "
+                                    f"Existing lockfile includes {package_label} at transitive dependency path "
                                     f"{dependency_path} with lower-confidence risk signals."
                                 )
                                 if downgraded_low_confidence
-                                else f"Existing lockfile already includes vulnerable dependency path {dependency_path}."
+                                else (
+                                    f"Existing lockfile already includes vulnerable {package_label} "
+                                    f"at dependency path {dependency_path}."
+                                )
                             ),
                             "severity": package_match.normalized_severity,
                             "source": "lockfile",
@@ -2278,19 +2278,29 @@ def _is_bundle_stale(bundle_response: SupplyChainBundleResponse, *, now_timestam
 
 def _bundle_package_index(
     bundle_response: SupplyChainBundleResponse,
-) -> dict[tuple[str, str, str], SupplyChainBundlePackage]:
-    index: dict[tuple[str, str, str], SupplyChainBundlePackage] = {}
+) -> dict[CanonicalPackageIdentity, SupplyChainBundlePackage]:
+    index: dict[CanonicalPackageIdentity, SupplyChainBundlePackage] = {}
     for package in bundle_response.bundle.packages:
-        normalized_name = _normalize_package_name(package.ecosystem, package.name)
-        index[(package.ecosystem, normalized_name, package.version)] = package
-        if package.namespace is not None:
-            qualified_name = _normalize_package_name(package.ecosystem, f"{package.namespace}/{package.name}")
-            index[(package.ecosystem, qualified_name, package.version)] = package
+        try:
+            identity = canonical_package_identity(
+                ecosystem=package.ecosystem,
+                namespace=package.namespace,
+                name=package.name,
+                version=package.version,
+            )
+        except PackageIdentityError as error:
+            raise SupplyChainBundleMalformedError(f"Invalid package identity: {error}") from error
+        existing = index.get(identity)
+        if existing is not None and existing != package:
+            raise SupplyChainBundleMalformedError(
+                f"Conflicting package records for canonical identity {identity.display}"
+            )
+        index.setdefault(identity, package)
     return index
 
 
 def _bundle_package_from_index(
-    index: dict[tuple[str, str, str], SupplyChainBundlePackage],
+    index: dict[CanonicalPackageIdentity, SupplyChainBundlePackage],
     *,
     package_name: str,
     package_version: str,
@@ -2298,8 +2308,15 @@ def _bundle_package_from_index(
 ) -> SupplyChainBundlePackage | None:
     if ecosystem is None:
         return None
-    normalized_name = _normalize_package_name(ecosystem, package_name)
-    return index.get((ecosystem, normalized_name, package_version))
+    try:
+        identity = parse_package_identity(
+            ecosystem=ecosystem,
+            package_name=package_name,
+            version=package_version,
+        )
+    except PackageIdentityError:
+        return None
+    return index.get(identity)
 
 
 def _transitive_lockfile_timeout_warning(
@@ -2684,7 +2701,10 @@ def _local_package_manifest_result(
     manifest_target = dict(target)
     manifest_package_name = _manifest_package_name(manifest_text)
     if manifest_package_name is not None:
-        namespace, name = _split_namespace_name(manifest_package_name)
+        namespace, name = _split_namespace_name(
+            manifest_package_name,
+            ecosystem=_optional_string(target.get("ecosystem")) or "npm",
+        )
         manifest_target["namespace"] = namespace
         manifest_target["name"] = name
     if _artifact_has_flag(artifact, "--ignore-scripts"):
@@ -3960,20 +3980,24 @@ def _bundle_package_versions(bundle_response: SupplyChainBundleResponse, target:
 
 def _bundle_package_name_matches(package: SupplyChainBundlePackage, target: dict[str, object]) -> bool:
     target_ecosystem = _optional_string(target.get("ecosystem"))
-    if target_ecosystem is not None and package.ecosystem != target_ecosystem:
+    if target_ecosystem is not None and package.ecosystem != normalize_ecosystem(target_ecosystem):
         return False
-    full_name = (
-        _normalize_package_name(package.ecosystem, f"{package.namespace}/{package.name}")
-        if package.namespace is not None
-        else _normalize_package_name(package.ecosystem, package.name)
-    )
-    target_name = str(target["normalized_name"])
-    target_namespace = _optional_string(target.get("namespace"))
-    if target_namespace is not None:
-        return target_name == full_name
-    if package.namespace is not None:
+    try:
+        package_identity = canonical_package_identity(
+            ecosystem=package.ecosystem,
+            namespace=package.namespace,
+            name=package.name,
+            version="*",
+        )
+        target_identity = canonical_package_identity(
+            ecosystem=target_ecosystem or package.ecosystem,
+            namespace=_optional_string(target.get("namespace")),
+            name=str(target["name"]),
+            version="*",
+        )
+    except PackageIdentityError:
         return False
-    return target_name == _normalize_package_name(package.ecosystem, package.name)
+    return package_identity == target_identity
 
 
 def _recommended_fix_allow_package_result(
@@ -4271,11 +4295,12 @@ def _string_tuple(value: object) -> tuple[str, ...]:
     return tuple(item for item in value if isinstance(item, str))
 
 
-def _split_namespace_name(value: str) -> tuple[str | None, str]:
-    if value.startswith("@") and "/" in value:
-        namespace, name = value.split("/", 1)
-        return namespace, name
-    return None, value
+def _split_namespace_name(value: str, *, ecosystem: str) -> tuple[str | None, str]:
+    try:
+        identity = parse_package_identity(ecosystem=ecosystem, package_name=value, version="*")
+    except PackageIdentityError:
+        return None, value
+    return identity.namespace, identity.name
 
 
 def _exact_version(value: str | None) -> str | None:
@@ -4366,10 +4391,10 @@ def _package_display_name(package: dict[str, object]) -> str:
 
 
 def _normalize_package_name(ecosystem: str, package_name: str) -> str:
-    normalized = package_name.strip().lower()
-    if ecosystem == "pypi":
-        return re.sub(r"[-_.]+", "-", normalized)
-    return normalized
+    try:
+        return normalize_qualified_package_name(ecosystem, package_name)
+    except PackageIdentityError:
+        return package_name.strip()
 
 
 def _target_candidate_names(target: dict[str, object]) -> tuple[str, ...]:
@@ -4429,13 +4454,30 @@ def _should_record_package(package: dict[str, object], decision: str) -> bool:
 
 def _evidence_id(package_intent_hash: str, package: dict[str, object]) -> str:
     package_name = _package_display_name(package)
+    ecosystem = _optional_string(package.get("ecosystem")) or "unknown"
     decision = str(package.get("decision") or "monitor")
     resolved_version = _optional_string(package.get("resolvedVersion")) or _optional_string(
         package.get("requestedVersion")
     )
     dependency_path = _optional_string(package.get("dependencyPath")) or "direct"
-    identity = f"{package_intent_hash}:{package_name}:{resolved_version}:{dependency_path}:{decision}"
+    identity = f"{package_intent_hash}:{ecosystem}:{package_name}:{resolved_version}:{dependency_path}:{decision}"
     return f"evidence-{stable_digest_hex(identity.encode(), length=16)}"
+
+
+def _result_package_identity(package: dict[str, object]) -> object:
+    ecosystem = _optional_string(package.get("ecosystem")) or "unknown"
+    name = _optional_string(package.get("name")) or "package"
+    namespace = _optional_string(package.get("namespace"))
+    version = _optional_string(package.get("resolvedVersion")) or _optional_string(package.get("requestedVersion"))
+    try:
+        return canonical_package_identity(
+            ecosystem=ecosystem,
+            namespace=namespace,
+            name=name,
+            version=version or "*",
+        )
+    except PackageIdentityError:
+        return (ecosystem, namespace, name, version)
 
 
 def _with_additional_reason(
@@ -4511,7 +4553,7 @@ def _bundle_reason_message(
     reason: str,
     stale: bool,
 ) -> str:
-    package_label = f"{package.name}@{package.version}"
+    package_label = _bundle_package_label(package)
     if stale:
         if decision == "block":
             return f"Cached bundle is stale, but Guard still blocked {package_label} from advisory intelligence."
@@ -4525,3 +4567,8 @@ def _bundle_reason_message(
     if reason == "maintainer_compromise":
         return f"Cached bundle flagged {package_label} for probable maintainer compromise."
     return f"Cached bundle matched {package_label}."
+
+
+def _bundle_package_label(package: SupplyChainBundlePackage, *, version: str | None = None) -> str:
+    package_name = f"{package.namespace}/{package.name}" if package.namespace is not None else package.name
+    return f"{package_name}@{version or package.version}"

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_identity.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_identity.py
@@ -6,6 +6,7 @@ import re
 from dataclasses import dataclass
 
 _LOWERCASE_ECOSYSTEMS = frozenset({"npm", "packagist", "pypi"})
+_NPM_SCOPE_RE = re.compile(r"^@[^/@]+$")
 
 
 class PackageIdentityError(ValueError):
@@ -71,9 +72,7 @@ def canonical_package_identity(
     )
     normalized_name = normalize_package_component(normalized_ecosystem, name)
     if normalized_ecosystem == "npm":
-        if normalized_namespace is not None and (
-            not normalized_namespace.startswith("@") or normalized_namespace == "@" or "/" in normalized_namespace
-        ):
+        if normalized_namespace is not None and _NPM_SCOPE_RE.fullmatch(normalized_namespace) is None:
             raise PackageIdentityError("npm namespace must be one non-empty @scope")
         if normalized_name.startswith("@") or "/" in normalized_name:
             raise PackageIdentityError("npm name must be an unqualified leaf name")

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_identity.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_identity.py
@@ -1,0 +1,137 @@
+"""Canonical identities for supply-chain package records and targets."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_LOWERCASE_ECOSYSTEMS = frozenset({"npm", "packagist", "pypi"})
+
+
+class PackageIdentityError(ValueError):
+    """Raised when package identity fields cannot form one canonical key."""
+
+
+@dataclass(frozen=True, order=True, slots=True)
+class CanonicalPackageIdentity:
+    """A collision-free ecosystem, namespace, leaf-name, and version key."""
+
+    ecosystem: str
+    namespace: str | None
+    name: str
+    version: str
+
+    @property
+    def qualified_name(self) -> str:
+        return f"{self.namespace}/{self.name}" if self.namespace is not None else self.name
+
+    @property
+    def display(self) -> str:
+        return f"{self.ecosystem}:{self.qualified_name}@{self.version}"
+
+
+def normalize_ecosystem(ecosystem: str) -> str:
+    """Normalize the ecosystem identifier, which is an enum-like field."""
+
+    normalized = ecosystem.strip().lower()
+    if not normalized:
+        raise PackageIdentityError("Package ecosystem cannot be empty")
+    return normalized
+
+
+def normalize_package_component(ecosystem: str, value: str) -> str:
+    """Normalize one name component according to its ecosystem's rules."""
+
+    normalized_ecosystem = normalize_ecosystem(ecosystem)
+    normalized = value.strip()
+    if not normalized:
+        raise PackageIdentityError("Package name components cannot be empty")
+    if normalized_ecosystem in _LOWERCASE_ECOSYSTEMS:
+        normalized = normalized.lower()
+    if normalized_ecosystem == "pypi":
+        normalized = re.sub(r"[-_.]+", "-", normalized)
+    return normalized
+
+
+def canonical_package_identity(
+    *,
+    ecosystem: str,
+    namespace: str | None,
+    name: str,
+    version: str,
+) -> CanonicalPackageIdentity:
+    """Build a canonical key from already structured bundle fields."""
+
+    normalized_ecosystem = normalize_ecosystem(ecosystem)
+    normalized_version = version.strip()
+    if not normalized_version:
+        raise PackageIdentityError("Package version cannot be empty")
+    normalized_namespace = (
+        normalize_package_component(normalized_ecosystem, namespace) if namespace is not None else None
+    )
+    normalized_name = normalize_package_component(normalized_ecosystem, name)
+    if normalized_ecosystem == "npm":
+        if normalized_namespace is not None and (
+            not normalized_namespace.startswith("@") or normalized_namespace == "@" or "/" in normalized_namespace
+        ):
+            raise PackageIdentityError("npm namespace must be one non-empty @scope")
+        if normalized_name.startswith("@") or "/" in normalized_name:
+            raise PackageIdentityError("npm name must be an unqualified leaf name")
+    elif normalized_ecosystem == "pypi":
+        if normalized_namespace is not None or "/" in normalized_name:
+            raise PackageIdentityError("PyPI package identities cannot contain a namespace")
+    elif normalized_ecosystem == "packagist":
+        if normalized_namespace is None or "/" in normalized_namespace or "/" in normalized_name:
+            raise PackageIdentityError("Packagist identity must contain vendor and package components")
+    return CanonicalPackageIdentity(
+        ecosystem=normalized_ecosystem,
+        namespace=normalized_namespace,
+        name=normalized_name,
+        version=normalized_version,
+    )
+
+
+def parse_package_identity(*, ecosystem: str, package_name: str, version: str) -> CanonicalPackageIdentity:
+    """Parse one target name using only the selected ecosystem's syntax."""
+
+    normalized_ecosystem = normalize_ecosystem(ecosystem)
+    value = package_name.strip()
+    if not value:
+        raise PackageIdentityError("Package name cannot be empty")
+    namespace: str | None = None
+    name = value
+    if normalized_ecosystem == "npm":
+        if value.startswith("@"):
+            if value.count("/") != 1:
+                raise PackageIdentityError("Scoped npm name must be exactly @scope/name")
+            namespace, name = value.split("/", 1)
+        elif "/" in value:
+            raise PackageIdentityError("Unscoped npm name cannot contain a slash")
+    elif normalized_ecosystem == "packagist":
+        if value.count("/") != 1:
+            raise PackageIdentityError("Packagist name must be exactly vendor/package")
+        namespace, name = value.split("/", 1)
+    return canonical_package_identity(
+        ecosystem=normalized_ecosystem,
+        namespace=namespace,
+        name=name,
+        version=version,
+    )
+
+
+def normalize_qualified_package_name(ecosystem: str, package_name: str) -> str:
+    """Return a versionless qualified name without erasing scope boundaries."""
+
+    identity = parse_package_identity(ecosystem=ecosystem, package_name=package_name, version="*")
+    return identity.qualified_name
+
+
+__all__ = [
+    "CanonicalPackageIdentity",
+    "PackageIdentityError",
+    "canonical_package_identity",
+    "normalize_ecosystem",
+    "normalize_package_component",
+    "normalize_qualified_package_name",
+    "parse_package_identity",
+]

--- a/tests/test_guard_js_supply_chain_phase11.py
+++ b/tests/test_guard_js_supply_chain_phase11.py
@@ -876,6 +876,12 @@ def test_malformed_result_identities_remain_opaque_and_collision_free() -> None:
     assert direct_identity != transitive_identity
     assert direct_identity != explicit_unknown_identity
 
+    direct_evidence = supply_chain_package_eval_module._evidence_id("same-intent", direct)
+    transitive_evidence = supply_chain_package_eval_module._evidence_id("same-intent", transitive)
+    explicit_unknown_evidence = supply_chain_package_eval_module._evidence_id("same-intent", explicit_unknown)
+
+    assert len({direct_evidence, transitive_evidence, explicit_unknown_evidence}) == 3
+
 
 def test_scoped_recommended_fix_does_not_use_unscoped_record(
     tmp_path: Path,

--- a/tests/test_guard_js_supply_chain_phase11.py
+++ b/tests/test_guard_js_supply_chain_phase11.py
@@ -830,9 +830,7 @@ def test_transitive_scoped_and_unscoped_packages_keep_distinct_bundle_actions(
 
     artifact = _artifact_from_command("npm audit fix --package-lock-only", workspace=workspace_dir)
     result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
-    decisions = {
-        (package["namespace"], package["name"]): package["decision"] for package in result.packages
-    }
+    decisions = {(package["namespace"], package["name"]): package["decision"] for package in result.packages}
 
     assert decisions[(None, "pkg")] == "warn"
     assert decisions[("@scope", "pkg")] == "block"
@@ -849,20 +847,34 @@ def test_scoped_package_evidence_ids_are_collision_free() -> None:
         "resolvedVersion": "1.2.3",
         "dependencyPath": None,
     }
-    unscoped = supply_chain_package_eval_module._evidence_id(
-        "same-intent", {**common, "namespace": None}
-    )
-    scoped = supply_chain_package_eval_module._evidence_id(
-        "same-intent", {**common, "namespace": "@scope"}
-    )
-    other_scope = supply_chain_package_eval_module._evidence_id(
-        "same-intent", {**common, "namespace": "@other"}
-    )
+    unscoped = supply_chain_package_eval_module._evidence_id("same-intent", {**common, "namespace": None})
+    scoped = supply_chain_package_eval_module._evidence_id("same-intent", {**common, "namespace": "@scope"})
+    other_scope = supply_chain_package_eval_module._evidence_id("same-intent", {**common, "namespace": "@other"})
     other_ecosystem = supply_chain_package_eval_module._evidence_id(
         "same-intent", {**common, "ecosystem": "go", "namespace": None}
     )
 
     assert len({unscoped, scoped, other_scope, other_ecosystem}) == 4
+
+
+def test_malformed_result_identities_remain_opaque_and_collision_free() -> None:
+    direct = {
+        "name": "pkg",
+        "resolvedVersion": "1.2.3",
+        "decision": "block",
+        "dependencyPath": "direct",
+    }
+    transitive = {**direct, "dependencyPath": "root > pkg"}
+    explicit_unknown = {**direct, "ecosystem": "unknown"}
+
+    direct_identity = supply_chain_package_eval_module._result_package_identity(direct)
+    transitive_identity = supply_chain_package_eval_module._result_package_identity(transitive)
+    explicit_unknown_identity = supply_chain_package_eval_module._result_package_identity(explicit_unknown)
+
+    assert direct_identity[0] == "opaque"
+    assert transitive_identity[0] == "opaque"
+    assert direct_identity != transitive_identity
+    assert direct_identity != explicit_unknown_identity
 
 
 def test_scoped_recommended_fix_does_not_use_unscoped_record(

--- a/tests/test_guard_js_supply_chain_phase11.py
+++ b/tests/test_guard_js_supply_chain_phase11.py
@@ -783,3 +783,123 @@ def test_evaluate_package_request_artifact_avoids_scoped_package_name_collisions
 
     assert result.decision == "ask"
     assert result.packages[0]["reasons"][0]["code"] == "no_cached_match"
+
+
+@pytest.mark.parametrize("reverse_bundle_order", [False, True])
+def test_transitive_scoped_and_unscoped_packages_keep_distinct_bundle_actions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    reverse_bundle_order: bool,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    _write_text(
+        workspace_dir / "package-lock.json",
+        json.dumps(
+            {
+                "lockfileVersion": 3,
+                "packages": {
+                    "": {"name": "demo"},
+                    "node_modules/pkg": {"name": "pkg", "version": "1.2.3"},
+                    "node_modules/@scope/pkg": {"name": "@scope/pkg", "version": "1.2.3"},
+                },
+            }
+        ),
+    )
+    packages = [
+        _package(name="pkg", version="1.2.3", default_action="warn", recommended_fix_version=None),
+        _package(
+            name="pkg",
+            namespace="@scope",
+            version="1.2.3",
+            default_action="block",
+            recommended_fix_version=None,
+        ),
+    ]
+    if reverse_bundle_order:
+        packages.reverse()
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(packages=packages),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command("npm audit fix --package-lock-only", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+    decisions = {
+        (package["namespace"], package["name"]): package["decision"] for package in result.packages
+    }
+
+    assert decisions[(None, "pkg")] == "warn"
+    assert decisions[("@scope", "pkg")] == "block"
+    scoped = next(package for package in result.packages if package["namespace"] == "@scope")
+    assert "@scope/pkg@1.2.3" in scoped["reasons"][0]["message"]
+
+
+def test_scoped_package_evidence_ids_are_collision_free() -> None:
+    common = {
+        "decision": "block",
+        "ecosystem": "npm",
+        "name": "pkg",
+        "requestedVersion": "1.2.3",
+        "resolvedVersion": "1.2.3",
+        "dependencyPath": None,
+    }
+    unscoped = supply_chain_package_eval_module._evidence_id(
+        "same-intent", {**common, "namespace": None}
+    )
+    scoped = supply_chain_package_eval_module._evidence_id(
+        "same-intent", {**common, "namespace": "@scope"}
+    )
+    other_scope = supply_chain_package_eval_module._evidence_id(
+        "same-intent", {**common, "namespace": "@other"}
+    )
+    other_ecosystem = supply_chain_package_eval_module._evidence_id(
+        "same-intent", {**common, "ecosystem": "go", "namespace": None}
+    )
+
+    assert len({unscoped, scoped, other_scope, other_ecosystem}) == 4
+
+
+def test_scoped_recommended_fix_does_not_use_unscoped_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(
+            packages=[
+                _package(
+                    name="pkg",
+                    version="1.2.3",
+                    default_action="block",
+                    recommended_fix_version="9.9.9",
+                ),
+                _package(
+                    name="pkg",
+                    namespace="@scope",
+                    version="1.2.3",
+                    default_action="block",
+                    recommended_fix_version="1.2.4",
+                ),
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command("npm install @scope/pkg@1.2.4", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "allow"
+    assert result.packages[0]["namespace"] == "@scope"
+    assert result.packages[0]["name"] == "pkg"

--- a/tests/test_guard_supply_chain_bundle.py
+++ b/tests/test_guard_supply_chain_bundle.py
@@ -446,6 +446,9 @@ def test_supply_chain_bundle_uses_ecosystem_specific_case_normalization() -> Non
     pypi = evaluate_cached_supply_chain_bundle(
         response, package_name="foo-bar", package_version="1.2.3", ecosystem="pypi"
     )
+    uppercase_npm = evaluate_cached_supply_chain_bundle(
+        response, package_name="@scope/pkg", package_version="1.2.3", ecosystem="NPM"
+    )
     exact_go = evaluate_cached_supply_chain_bundle(
         response, package_name="Example.com/Org/Repo", package_version="1.2.3", ecosystem="go"
     )
@@ -455,6 +458,7 @@ def test_supply_chain_bundle_uses_ecosystem_specific_case_normalization() -> Non
 
     assert npm.action == "block"
     assert pypi.action == "block"
+    assert uppercase_npm.action == "block"
     assert exact_go.action == "block"
     assert wrong_case_go.reason == "no_cached_match"
 
@@ -570,7 +574,7 @@ def test_supply_chain_bundle_offline_evaluation_enforces_emergency_deny_without_
         response,
         package_name="minimist",
         package_version="1.2.8",
-        ecosystem="npm",
+        ecosystem="NPM",
         now=response.bundle.generated_at_timestamp + 60,
     )
 

--- a/tests/test_guard_supply_chain_bundle.py
+++ b/tests/test_guard_supply_chain_bundle.py
@@ -120,6 +120,29 @@ def _bundle_dict(
     }
 
 
+def _package_record(
+    *,
+    ecosystem: str = "npm",
+    name: str,
+    namespace: str | None,
+    version: str = "1.2.3",
+    default_action: str = "block",
+) -> dict[str, object]:
+    record = dict(_bundle_dict()["packages"][0])  # type: ignore[index]
+    qualified_name = f"{namespace}/{name}" if namespace is not None else name
+    record.update(
+        {
+            "defaultAction": default_action,
+            "ecosystem": ecosystem,
+            "name": name,
+            "namespace": namespace,
+            "purl": f"pkg:{ecosystem}/{qualified_name}@{version}",
+            "version": version,
+        }
+    )
+    return record
+
+
 def _sign_bundle_response(
     bundle: dict[str, object],
     *,
@@ -327,6 +350,138 @@ def test_supply_chain_bundle_rejects_expired_and_malformed_payloads() -> None:
 
     with pytest.raises(SupplyChainBundleMalformedError):
         load_supply_chain_bundle_response(json.dumps(malformed_payload))
+
+
+def test_supply_chain_bundle_deduplicates_identical_canonical_package_records() -> None:
+    private_key, _public_key = _generate_key_pair()
+    bundle = _bundle_dict()
+    package = _package_record(name="pkg", namespace="@scope")
+    bundle["packages"] = [package, dict(package)]
+
+    response = load_supply_chain_bundle_response(json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key)))
+
+    assert response.bundle.packages == (response.bundle.packages[0],)
+    assert response.bundle.packages[0].namespace == "@scope"
+
+
+def test_supply_chain_bundle_normalizes_legacy_qualified_packagist_name() -> None:
+    private_key, _public_key = _generate_key_pair()
+    bundle = _bundle_dict()
+    bundle["packages"] = [
+        _package_record(
+            ecosystem="packagist",
+            name="Laravel/Framework",
+            namespace=None,
+            version="11.1.0",
+        )
+    ]
+
+    response = load_supply_chain_bundle_response(json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key)))
+
+    package = response.bundle.packages[0]
+    assert package.ecosystem == "packagist"
+    assert package.namespace == "laravel"
+    assert package.name == "framework"
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [
+        (
+            _package_record(name="pkg", namespace="@scope", default_action="block"),
+            _package_record(name="pkg", namespace="@scope", default_action="warn"),
+        ),
+        (
+            _package_record(name="Pkg", namespace="@Scope", default_action="block"),
+            _package_record(name="pkg", namespace="@scope", default_action="warn"),
+        ),
+    ],
+)
+def test_supply_chain_bundle_rejects_conflicting_canonical_package_records(
+    first: dict[str, object],
+    second: dict[str, object],
+) -> None:
+    private_key, _public_key = _generate_key_pair()
+    bundle = _bundle_dict()
+    bundle["packages"] = [first, second]
+
+    with pytest.raises(SupplyChainBundleMalformedError, match=r"Conflicting package records.*npm:@scope/pkg@1\.2\.3"):
+        load_supply_chain_bundle_response(json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key)))
+
+
+@pytest.mark.parametrize(
+    "package",
+    [
+        _package_record(name="pkg", namespace="scope"),
+        _package_record(name="@scope/pkg", namespace=None),
+        _package_record(ecosystem="pypi", name="org/pkg", namespace=None),
+        _package_record(ecosystem="packagist", name="pkg", namespace=None),
+    ],
+)
+def test_supply_chain_bundle_rejects_malformed_ecosystem_identity_fields(
+    package: dict[str, object],
+) -> None:
+    private_key, _public_key = _generate_key_pair()
+    bundle = _bundle_dict()
+    bundle["packages"] = [package]
+
+    with pytest.raises(SupplyChainBundleMalformedError, match="Invalid package identity"):
+        load_supply_chain_bundle_response(json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key)))
+
+
+def test_supply_chain_bundle_uses_ecosystem_specific_case_normalization() -> None:
+    private_key, _public_key = _generate_key_pair()
+    bundle = _bundle_dict()
+    bundle["packages"] = [
+        _package_record(name="Pkg", namespace="@Scope"),
+        _package_record(ecosystem="pypi", name="Foo_Bar", namespace=None),
+        _package_record(ecosystem="go", name="Example.com/Org/Repo", namespace=None),
+    ]
+    response = load_supply_chain_bundle_response(json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key)))
+
+    npm = evaluate_cached_supply_chain_bundle(
+        response, package_name="@scope/pkg", package_version="1.2.3", ecosystem="npm"
+    )
+    pypi = evaluate_cached_supply_chain_bundle(
+        response, package_name="foo-bar", package_version="1.2.3", ecosystem="pypi"
+    )
+    exact_go = evaluate_cached_supply_chain_bundle(
+        response, package_name="Example.com/Org/Repo", package_version="1.2.3", ecosystem="go"
+    )
+    wrong_case_go = evaluate_cached_supply_chain_bundle(
+        response, package_name="example.com/org/repo", package_version="1.2.3", ecosystem="go"
+    )
+
+    assert npm.action == "block"
+    assert pypi.action == "block"
+    assert exact_go.action == "block"
+    assert wrong_case_go.reason == "no_cached_match"
+
+
+def test_supply_chain_bundle_keeps_multiple_scopes_and_unscoped_leaf_distinct() -> None:
+    private_key, _public_key = _generate_key_pair()
+    bundle = _bundle_dict()
+    bundle["packages"] = [
+        _package_record(name="pkg", namespace=None, default_action="monitor"),
+        _package_record(name="pkg", namespace="@one", default_action="block"),
+        _package_record(name="pkg", namespace="@two", default_action="warn"),
+    ]
+    response = load_supply_chain_bundle_response(json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key)))
+    now = response.bundle.generated_at_timestamp + 1
+
+    unscoped = evaluate_cached_supply_chain_bundle(
+        response, package_name="pkg", package_version="1.2.3", ecosystem="npm", now=now
+    )
+    first_scope = evaluate_cached_supply_chain_bundle(
+        response, package_name="@one/pkg", package_version="1.2.3", ecosystem="npm", now=now
+    )
+    second_scope = evaluate_cached_supply_chain_bundle(
+        response, package_name="@two/pkg", package_version="1.2.3", ecosystem="npm", now=now
+    )
+
+    assert unscoped.action == "monitor"
+    assert first_scope.action == "block"
+    assert second_scope.action == "warn"
 
 
 def test_supply_chain_bundle_offline_evaluation_blocks_high_confidence_and_monitors_stale_low_risk() -> None:

--- a/tests/test_guard_supply_chain_bundle.py
+++ b/tests/test_guard_supply_chain_bundle.py
@@ -413,6 +413,7 @@ def test_supply_chain_bundle_rejects_conflicting_canonical_package_records(
     "package",
     [
         _package_record(name="pkg", namespace="scope"),
+        _package_record(name="pkg", namespace="@scope@"),
         _package_record(name="@scope/pkg", namespace=None),
         _package_record(ecosystem="pypi", name="org/pkg", namespace=None),
         _package_record(ecosystem="packagist", name="pkg", namespace=None),


### PR DESCRIPTION
## Summary

- introduce a canonical package identity containing normalized ecosystem, ecosystem-aware namespace, normalized leaf name, and version
- preserve npm `@scope/name` boundaries and Packagist `vendor/package` parsing without treating arbitrary slashes as namespaces in other ecosystems
- apply lowercase normalization only to npm, Packagist, and PyPI; retain exact case in case-sensitive ecosystems such as Go
- build the transitive bundle index with one canonical key per record, removing the scoped package's unsafe bare-name alias
- deterministically deduplicate identical canonical records and reject conflicting or malformed identities as an invalid bundle before evaluation
- use the same identity rules in direct matching, recommended-fix lookup, transitive lockfile results, direct/transitive deduplication, qualified messages, and evidence IDs

## Regression coverage

- unscoped `pkg@1.2.3` and scoped `@scope/pkg@1.2.3` receive distinct transitive actions in both bundle orders
- multiple npm scopes sharing one leaf remain distinct from each other and from the unscoped package
- identical duplicates deduplicate; conflicting exact or case-normalized duplicates fail explicitly
- malformed npm, PyPI, and Packagist namespace/name combinations fail during bundle parsing
- npm and PyPI case normalization matches their ecosystem rules while a differently cased Go module does not match
- scoped recommended fixes cannot resolve through an unscoped record
- evidence identities remain distinct across unscoped, multiple scopes, and ecosystems
- messages include the complete qualified package identity and version

## Validation

- `207 passed` — supply-chain evaluator, JavaScript phase 11, signed bundle, package-shim, transitive, recommended-fix, and cache-related selection
- `19 passed, 37 deselected` — final canonical identity/scoped/case/duplicate/transitive/recommended-fix regression selection
- Ruff lint passed for all changed files
- Basedpyright reports `0 errors` in all changed production modules
- `uv build` produced the release-head sdist and wheel successfully
- changed supporting modules remain under the repository's 500-line limit

## Attribution and target

- target branch: `release/2.1`
- direct parent: `f6b7d2d7699a420cbc9cd6b5b6d69aff3e4417fd`
- commit author/committer: `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>`
