### PR TITLE
feat(guard): add command decision shadow evaluation

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
@@ -26,7 +26,13 @@ from ..runtime.command_activity_lifecycle import (
     build_pre_hook_evidence,
     build_unpaired_post_evidence,
 )
-from ..runtime.command_evaluation import evaluate_command
+from ..runtime.command_evaluation import CompositeCommandEvaluation, evaluate_command
+from ..runtime.command_shadow_evaluation import (
+    CommandShadowObservation,
+    baseline_command_shadow_proposal,
+    build_command_shadow_observation,
+    load_command_shadow_control,
+)
 from ..runtime.secret_file_requests import extract_sensitive_tool_action_request
 from ..store import GuardStore
 
@@ -71,6 +77,8 @@ def record_pre_hook_command_activity_best_effort(
             payload=payload,
             key=key,
         )
+        activity_id = _activity_id()
+        occurred_at = _utc_now()
         evidence = build_pre_hook_evidence(
             evaluation,
             CommandActivityDecisionFacts(
@@ -84,19 +92,28 @@ def record_pre_hook_command_activity_best_effort(
                 approval_reuse_status=approval_reuse_status,
                 receipt_id=receipt_id,
             ),
-            activity_id=_activity_id(),
-            occurred_at=_utc_now(),
+            activity_id=activity_id,
+            occurred_at=occurred_at,
             harness=harness,
             request_correlation=correlation,
         )
         if correlation is not None and store.is_exact_command_activity_pre_replay(evidence):
             return False
+        shadow, shadow_failed = _build_shadow_best_effort(
+            evaluation=evaluation,
+            policy_action=policy_action,
+            activity_id=activity_id,
+            occurred_at=occurred_at,
+        )
         try:
-            return store.record_command_activity(evidence)
+            recorded = store.record_command_activity(evidence, shadow=shadow)
         except Exception:
             if correlation is not None and store.is_exact_command_activity_pre_replay(evidence):
                 return False
             raise
+        if shadow_failed:
+            _record_persistence_failure(store, "shadow_evaluation_failed")
+        return recorded
     except Exception:
         _record_persistence_failure(store, "pre_record_failed")
         return False
@@ -190,6 +207,30 @@ def record_command_activity_failure_best_effort(store: GuardStore, error_code: s
     """Count an analytics-boundary failure without affecting hook enforcement."""
 
     _record_persistence_failure(store, error_code)
+
+
+def _build_shadow_best_effort(
+    *,
+    evaluation: CompositeCommandEvaluation,
+    policy_action: GuardAction,
+    activity_id: str,
+    occurred_at: datetime,
+) -> tuple[CommandShadowObservation | None, bool]:
+    try:
+        proposal = baseline_command_shadow_proposal(evaluation)
+        return (
+            build_command_shadow_observation(
+                evaluation,
+                authoritative_action=policy_action,
+                proposal=proposal,
+                activity_id=activity_id,
+                occurred_at=occurred_at,
+                control=load_command_shadow_control(),
+            ),
+            False,
+        )
+    except Exception:
+        return None, True
 
 
 def _evaluate_payload_command(

--- a/src/codex_plugin_scanner/guard/runtime/command_shadow_evaluation.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_shadow_evaluation.py
@@ -78,7 +78,7 @@ class CommandShadowControl:
     ) -> tuple[CommandShadowCohort, ...]:
         if not self.enabled or self.kill_switch or self.sample_basis_points == 0:
             return ()
-        selected = proposal_cohorts & self.release_cohorts - self.disabled_cohorts
+        selected = proposal_cohorts & (self.release_cohorts - self.disabled_cohorts)
         return tuple(
             cohort
             for cohort in sorted(selected, key=lambda item: item.value)

--- a/src/codex_plugin_scanner/guard/runtime/command_shadow_evaluation.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_shadow_evaluation.py
@@ -1,0 +1,316 @@
+"""Privacy-safe shadow comparison for the central command decision plane."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Final, cast
+
+from codex_plugin_scanner.guard.action_lattice import guard_action_severity, is_guard_action
+from codex_plugin_scanner.guard.models import GuardAction
+
+from .command_evaluation import CompositeCommandEvaluation
+from .effect_decision import EFFECT_DECISION_SCHEMA_VERSION, EffectDecision, FinalDisposition
+
+COMMAND_SHADOW_SCHEMA_VERSION: Final = "guard.command-shadow.v1"
+COMMAND_SHADOW_CONTROL_SCHEMA_VERSION: Final = "guard.command-shadow-control.v1"
+COMMAND_SHADOW_BASELINE_PROPOSAL_VERSION: Final = "guard.command-shadow-proposal.baseline.v1"
+COMMAND_SHADOW_CONTROL_GENERATION: Final = 1
+COMMAND_SHADOW_ENABLED_ENV: Final = "HOL_GUARD_DECISION_SHADOW_ENABLED"
+COMMAND_SHADOW_KILL_SWITCH_ENV: Final = "HOL_GUARD_DECISION_SHADOW_KILL_SWITCH"
+COMMAND_SHADOW_DISABLED_COHORTS_ENV: Final = "HOL_GUARD_DECISION_SHADOW_DISABLED_COHORTS"
+COMMAND_SHADOW_SAMPLE_BASIS_POINTS_ENV: Final = "HOL_GUARD_DECISION_SHADOW_SAMPLE_BASIS_POINTS"
+
+_ACTIVITY_ID: Final = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,255}")
+_PROPOSAL_VERSION: Final = re.compile(r"[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*")
+_BASIS_POINTS_MAX: Final = 10_000
+
+
+class CommandShadowCohort(str, Enum):
+    BASELINE = "baseline"
+    VERIFIED_READS = "cdx-060-verified-reads"
+    CONTAINED_CHECKS = "cdx-061-contained-checks"
+    CONTAINED_WRITES = "cdx-062-contained-writes"
+    TASK_CAPABILITIES = "cdx-063-task-capabilities"
+    REMOTE_MUTATION_FLOORS = "cdx-064-remote-mutation-floors"
+    PACKAGE_PROVENANCE_FLOORS = "cdx-065-package-provenance-floors"
+    CRITICAL_BLOCK_FLOORS = "cdx-066-critical-block-floors"
+
+
+class CommandShadowComparison(str, Enum):
+    LOWERED = "lowered"
+    UNCHANGED = "unchanged"
+    STRENGTHENED = "strengthened"
+
+
+@dataclass(frozen=True, slots=True)
+class CommandShadowControl:
+    enabled: bool
+    kill_switch: bool
+    release_cohorts: frozenset[CommandShadowCohort]
+    disabled_cohorts: frozenset[CommandShadowCohort]
+    sample_basis_points: int
+    generation: int = COMMAND_SHADOW_CONTROL_GENERATION
+    schema_version: str = COMMAND_SHADOW_CONTROL_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if type(self.enabled) is not bool or type(self.kill_switch) is not bool:
+            raise ValueError("shadow enable and kill-switch controls must be booleans")
+        _require_cohorts(self.release_cohorts, "release_cohorts")
+        _require_cohorts(self.disabled_cohorts, "disabled_cohorts")
+        if type(self.sample_basis_points) is not int or not 0 <= self.sample_basis_points <= _BASIS_POINTS_MAX:
+            raise ValueError("sample_basis_points must be between 0 and 10000")
+        if self.generation != COMMAND_SHADOW_CONTROL_GENERATION:
+            raise ValueError("unsupported shadow control generation")
+        if self.schema_version != COMMAND_SHADOW_CONTROL_SCHEMA_VERSION:
+            raise ValueError("unsupported shadow control schema version")
+
+    def selected_cohorts(
+        self,
+        *,
+        proposal_cohorts: frozenset[CommandShadowCohort],
+        activity_id: str,
+    ) -> tuple[CommandShadowCohort, ...]:
+        if not self.enabled or self.kill_switch or self.sample_basis_points == 0:
+            return ()
+        selected = proposal_cohorts & self.release_cohorts - self.disabled_cohorts
+        return tuple(
+            cohort
+            for cohort in sorted(selected, key=lambda item: item.value)
+            if _sample_bucket(cohort, activity_id) < self.sample_basis_points
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CommandShadowProposal:
+    decision: EffectDecision
+    cohorts: frozenset[CommandShadowCohort]
+    version: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(cast(object, self.decision), EffectDecision):
+            raise ValueError("decision must be an EffectDecision")
+        _require_cohorts(self.cohorts, "cohorts")
+        if not self.cohorts:
+            raise ValueError("a shadow proposal must name at least one release cohort")
+        if (
+            not isinstance(cast(object, self.version), str)
+            or len(self.version) > 128
+            or _PROPOSAL_VERSION.fullmatch(self.version) is None
+        ):
+            raise ValueError("proposal version must be a stable identifier")
+
+
+@dataclass(frozen=True, slots=True)
+class CommandShadowObservation:
+    activity_id: str
+    occurred_at: datetime
+    cohorts: tuple[CommandShadowCohort, ...]
+    authoritative_action: GuardAction
+    current_action: GuardAction
+    current_disposition: FinalDisposition
+    proposed_action: GuardAction
+    proposed_disposition: FinalDisposition
+    comparison: CommandShadowComparison
+    proposal_version: str
+    evaluator_schema_version: str
+    control_generation: int
+    sample_basis_points: int
+    schema_version: str = COMMAND_SHADOW_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if not isinstance(cast(object, self.activity_id), str) or _ACTIVITY_ID.fullmatch(self.activity_id) is None:
+            raise ValueError("activity_id must be an opaque identifier")
+        if not isinstance(cast(object, self.occurred_at), datetime) or self.occurred_at.tzinfo is None:
+            raise ValueError("occurred_at must be timezone-aware")
+        if self.occurred_at.utcoffset() != timezone.utc.utcoffset(self.occurred_at):
+            raise ValueError("occurred_at must be UTC")
+        if not isinstance(cast(object, self.cohorts), tuple) or not self.cohorts:
+            raise ValueError("cohorts must be a non-empty tuple")
+        if tuple(sorted(set(self.cohorts), key=lambda item: item.value)) != self.cohorts:
+            raise ValueError("cohorts must be unique and canonically ordered")
+        if any(not isinstance(item, CommandShadowCohort) for item in cast(tuple[object, ...], self.cohorts)):
+            raise ValueError("cohorts must contain exact CommandShadowCohort values")
+        if not is_guard_action(self.authoritative_action):
+            raise ValueError("authoritative_action must be a canonical GuardAction")
+        if not is_guard_action(self.current_action) or not is_guard_action(self.proposed_action):
+            raise ValueError("shadow actions must be canonical GuardAction values")
+        if not isinstance(cast(object, self.current_disposition), FinalDisposition):
+            raise ValueError("current_disposition must be a FinalDisposition")
+        if not isinstance(cast(object, self.proposed_disposition), FinalDisposition):
+            raise ValueError("proposed_disposition must be a FinalDisposition")
+        if not isinstance(cast(object, self.comparison), CommandShadowComparison):
+            raise ValueError("comparison must be a CommandShadowComparison")
+        if not _disposition_matches(self.current_action, self.current_disposition):
+            raise ValueError("current disposition does not match current action")
+        if not _disposition_matches(self.proposed_action, self.proposed_disposition):
+            raise ValueError("proposed disposition does not match proposed action")
+        if self.comparison is not _comparison(self.current_action, self.proposed_action):
+            raise ValueError("comparison does not match the action lattice")
+        if (
+            not isinstance(cast(object, self.proposal_version), str)
+            or len(self.proposal_version) > 128
+            or _PROPOSAL_VERSION.fullmatch(self.proposal_version) is None
+        ):
+            raise ValueError("proposal_version must be a stable identifier")
+        if self.evaluator_schema_version != EFFECT_DECISION_SCHEMA_VERSION:
+            raise ValueError("unsupported evaluator schema version")
+        if self.control_generation != COMMAND_SHADOW_CONTROL_GENERATION:
+            raise ValueError("unsupported shadow control generation")
+        if type(self.sample_basis_points) is not int or not 1 <= self.sample_basis_points <= _BASIS_POINTS_MAX:
+            raise ValueError("recorded sample_basis_points must be between 1 and 10000")
+        if self.schema_version != COMMAND_SHADOW_SCHEMA_VERSION:
+            raise ValueError("unsupported command shadow schema version")
+
+
+def load_command_shadow_control(environ: Mapping[str, str] | None = None) -> CommandShadowControl:
+    """Load strict observation-only rollout controls; malformed input disables recording."""
+
+    source = os.environ if environ is None else environ
+    enabled = _strict_flag(source.get(COMMAND_SHADOW_ENABLED_ENV), default=True, invalid=False)
+    kill_switch = _strict_flag(source.get(COMMAND_SHADOW_KILL_SWITCH_ENV), default=False, invalid=True)
+    disabled_cohorts = _cohort_set(source.get(COMMAND_SHADOW_DISABLED_COHORTS_ENV), default=frozenset())
+    sample_basis_points = _sample_basis_points(source.get(COMMAND_SHADOW_SAMPLE_BASIS_POINTS_ENV))
+    return CommandShadowControl(
+        enabled=enabled,
+        kill_switch=kill_switch,
+        release_cohorts=frozenset({CommandShadowCohort.BASELINE}),
+        disabled_cohorts=disabled_cohorts,
+        sample_basis_points=sample_basis_points,
+    )
+
+
+def build_command_shadow_observation(
+    evaluation: CompositeCommandEvaluation,
+    *,
+    authoritative_action: GuardAction,
+    proposal: CommandShadowProposal,
+    activity_id: str,
+    occurred_at: datetime,
+    control: CommandShadowControl,
+) -> CommandShadowObservation | None:
+    """Build a comparison record while binding enforcement to the current action."""
+
+    if not isinstance(cast(object, evaluation), CompositeCommandEvaluation):
+        raise ValueError("evaluation must be a CompositeCommandEvaluation")
+    if not is_guard_action(authoritative_action):
+        raise ValueError("authoritative_action must be a canonical GuardAction")
+    if not isinstance(cast(object, proposal), CommandShadowProposal):
+        raise ValueError("proposal must be a CommandShadowProposal")
+    if not isinstance(cast(object, control), CommandShadowControl):
+        raise ValueError("control must be a CommandShadowControl")
+    selected_cohorts = control.selected_cohorts(proposal_cohorts=proposal.cohorts, activity_id=activity_id)
+    if not evaluation.matches or not selected_cohorts:
+        return None
+    current = evaluation.decision_plane
+    proposed = proposal.decision
+    return CommandShadowObservation(
+        activity_id=activity_id,
+        occurred_at=occurred_at,
+        cohorts=selected_cohorts,
+        authoritative_action=authoritative_action,
+        current_action=current.action,
+        current_disposition=current.disposition,
+        proposed_action=proposed.action,
+        proposed_disposition=proposed.disposition,
+        comparison=_comparison(current.action, proposed.action),
+        proposal_version=proposal.version,
+        evaluator_schema_version=proposed.schema_version,
+        control_generation=control.generation,
+        sample_basis_points=control.sample_basis_points,
+    )
+
+
+def baseline_command_shadow_proposal(evaluation: CompositeCommandEvaluation) -> CommandShadowProposal:
+    """Return the release baseline proposal without changing the current evaluator."""
+
+    if not isinstance(cast(object, evaluation), CompositeCommandEvaluation):
+        raise ValueError("evaluation must be a CompositeCommandEvaluation")
+    return CommandShadowProposal(
+        decision=evaluation.decision_plane,
+        cohorts=frozenset({CommandShadowCohort.BASELINE}),
+        version=COMMAND_SHADOW_BASELINE_PROPOSAL_VERSION,
+    )
+
+
+def _comparison(current: GuardAction, proposed: GuardAction) -> CommandShadowComparison:
+    current_rank = guard_action_severity(current)
+    proposed_rank = guard_action_severity(proposed)
+    if proposed_rank < current_rank:
+        return CommandShadowComparison.LOWERED
+    if proposed_rank > current_rank:
+        return CommandShadowComparison.STRENGTHENED
+    return CommandShadowComparison.UNCHANGED
+
+
+def _disposition_matches(action: GuardAction, disposition: FinalDisposition) -> bool:
+    if action == "allow":
+        return disposition in {
+            FinalDisposition.SILENT_VERIFIED,
+            FinalDisposition.SILENT_CONTAINED,
+            FinalDisposition.WORKFLOW_AUTHORIZED,
+        }
+    return disposition.value == action
+
+
+def _sample_bucket(cohort: CommandShadowCohort, activity_id: str) -> int:
+    if not isinstance(cast(object, activity_id), str) or _ACTIVITY_ID.fullmatch(activity_id) is None:
+        raise ValueError("activity_id must be an opaque identifier")
+    framed = f"{len(cohort.value)}:{cohort.value}{len(activity_id)}:{activity_id}".encode("ascii")
+    return int.from_bytes(hashlib.sha256(framed).digest(), "big") % _BASIS_POINTS_MAX
+
+
+def _strict_flag(raw: str | None, *, default: bool, invalid: bool) -> bool:
+    if raw is None:
+        return default
+    if raw == "1":
+        return True
+    if raw == "0":
+        return False
+    return invalid
+
+
+def _cohort_set(raw: str | None, *, default: frozenset[CommandShadowCohort]) -> frozenset[CommandShadowCohort]:
+    if raw is None:
+        return default
+    values = raw.split(",") if raw else []
+    try:
+        return frozenset(CommandShadowCohort(value) for value in values)
+    except ValueError:
+        return frozenset(CommandShadowCohort)
+
+
+def _sample_basis_points(raw: str | None) -> int:
+    if raw is None:
+        return _BASIS_POINTS_MAX
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return 0
+    return parsed if 0 <= parsed <= _BASIS_POINTS_MAX else 0
+
+
+def _require_cohorts(value: object, field_name: str) -> None:
+    if not isinstance(value, frozenset) or any(not isinstance(item, CommandShadowCohort) for item in value):
+        raise ValueError(f"{field_name} must contain exact CommandShadowCohort values")
+
+
+__all__ = (
+    "COMMAND_SHADOW_BASELINE_PROPOSAL_VERSION",
+    "COMMAND_SHADOW_CONTROL_GENERATION",
+    "COMMAND_SHADOW_CONTROL_SCHEMA_VERSION",
+    "COMMAND_SHADOW_SCHEMA_VERSION",
+    "CommandShadowCohort",
+    "CommandShadowComparison",
+    "CommandShadowControl",
+    "CommandShadowObservation",
+    "CommandShadowProposal",
+    "baseline_command_shadow_proposal",
+    "build_command_shadow_observation",
+    "load_command_shadow_control",
+)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -17,6 +17,7 @@ from .store_command_activity_api import StoreCommandActivityApiMixin
 from .store_command_activity_lifecycle import StoreCommandActivityLifecycleMixin
 from .store_command_activity_maintenance import StoreCommandActivityMaintenanceMixin
 from .store_command_activity_privacy import StoreCommandActivityPrivacyMixin
+from .store_command_shadow import StoreCommandShadowMixin
 from .store_connection_schema import StoreConnectionSchemaMixin
 from .store_event_receipts import StoreEventReceiptsMixin
 from .store_evidence_facade import StoreEvidenceMixin
@@ -48,6 +49,7 @@ class GuardStore(
     StoreCommandActivityLifecycleMixin,
     StoreCommandActivityMaintenanceMixin,
     StoreCommandActivityPrivacyMixin,
+    StoreCommandShadowMixin,
     StoreInventoryMixin,
     StorePolicyMixin,
     StorePolicyIntegrityAdminMixin,

--- a/src/codex_plugin_scanner/guard/store_command_activity.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity.py
@@ -15,7 +15,9 @@ from .runtime.command_activity_contract import (
     CommandActivityMatch,
     CorrelationHandle,
 )
+from .runtime.command_shadow_evaluation import CommandShadowObservation
 from .store_command_activity_rollups import record_command_activity_rollups
+from .store_command_shadow import record_command_shadow_observation
 
 
 class _ConnectionOwner(Protocol):
@@ -23,11 +25,23 @@ class _ConnectionOwner(Protocol):
 
 
 class StoreCommandActivityMixin:
-    def record_command_activity(self: _ConnectionOwner, evidence: CommandActivityEvidence) -> bool:
+    def record_command_activity(
+        self: _ConnectionOwner,
+        evidence: CommandActivityEvidence,
+        *,
+        shadow: CommandShadowObservation | None = None,
+    ) -> bool:
         """Persist one logical command and its rule hits; return false for an exact replay."""
 
         if not isinstance(cast(object, evidence), CommandActivityEvidence):
             raise ValueError("evidence must be a CommandActivityEvidence")
+        if shadow is not None:
+            if not isinstance(cast(object, shadow), CommandShadowObservation):
+                raise ValueError("shadow must be a CommandShadowObservation")
+            if shadow.activity_id != evidence.activity.activity_id:
+                raise ValueError("shadow activity_id must match command evidence")
+            if shadow.occurred_at != evidence.activity.occurred_at:
+                raise ValueError("shadow occurred_at must match command evidence")
         with self._connect() as connection:
             connection.execute("begin immediate")
             existing = cast(
@@ -39,6 +53,16 @@ class StoreCommandActivityMixin:
             )
             if existing is not None:
                 _require_exact_replay(connection, evidence, existing)
+                if shadow is not None:
+                    if (
+                        connection.execute(
+                            "select 1 from command_activity_shadow_evaluations where activity_id = ?",
+                            (shadow.activity_id,),
+                        ).fetchone()
+                        is None
+                    ):
+                        raise ValueError("command shadow replay is missing persisted evidence")
+                    record_command_shadow_observation(connection, shadow)
                 return False
             if (
                 connection.execute(
@@ -86,6 +110,8 @@ class StoreCommandActivityMixin:
                 """,
                 _correlation_values(evidence.activity),
             )
+            if shadow is not None:
+                record_command_shadow_observation(connection, shadow)
             record_command_activity_rollups(connection, evidence)
             return True
 

--- a/src/codex_plugin_scanner/guard/store_command_activity_maintenance.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_maintenance.py
@@ -155,6 +155,14 @@ def _delete_retained_detail_batch(
         activity_ids,
     ).fetchone()
     correlations = int(correlation_row[0]) if correlation_row is not None else 0
+    connection.execute(
+        f"delete from command_activity_shadow_cohorts where activity_id in ({placeholders})",
+        activity_ids,
+    )
+    connection.execute(
+        f"delete from command_activity_shadow_evaluations where activity_id in ({placeholders})",
+        activity_ids,
+    )
     result = connection.execute(
         f"delete from command_activity where activity_id in ({placeholders})",
         activity_ids,

--- a/src/codex_plugin_scanner/guard/store_command_activity_privacy.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_privacy.py
@@ -15,6 +15,7 @@ from .runtime.command_activity_contract import (
     CommandProofLevel,
 )
 from .runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+from .runtime.command_shadow_evaluation import COMMAND_SHADOW_SCHEMA_VERSION
 from .store_command_activity_health_schema import COMMAND_ACTIVITY_HEALTH_SCHEMA_VERSION
 from .store_command_activity_maintenance_schema import COMMAND_ACTIVITY_MAINTENANCE_SCHEMA_VERSION
 
@@ -32,6 +33,7 @@ _ALLOWED_ERROR_CLASSES: Final = frozenset(
         "maintenance_failed",
         "post_record_failed",
         "pre_record_failed",
+        "shadow_evaluation_failed",
     }
 )
 _COUNT_TABLES: Final = (
@@ -45,8 +47,12 @@ _COUNT_TABLES: Final = (
     ("rollup_pending", "command_activity_rollup_pending"),
     ("feedback", "command_activity_feedback"),
     ("invalidations", "command_activity_invalidations"),
+    ("shadow_evaluations", "command_activity_shadow_evaluations"),
+    ("shadow_cohorts", "command_activity_shadow_cohorts"),
 )
 _DELETE_TABLES: Final = (
+    "command_activity_shadow_cohorts",
+    "command_activity_shadow_evaluations",
     "command_activity_feedback",
     "command_activity",
     "command_activity_match_effects",
@@ -163,6 +169,7 @@ class StoreCommandActivityPrivacyMixin:
                 "api": COMMAND_ACTIVITY_API_SCHEMA_VERSION,
                 "health": COMMAND_ACTIVITY_HEALTH_SCHEMA_VERSION,
                 "maintenance": COMMAND_ACTIVITY_MAINTENANCE_SCHEMA_VERSION,
+                "shadow": COMMAND_SHADOW_SCHEMA_VERSION,
             },
             "counts": counts,
             "proof_coverage": [

--- a/src/codex_plugin_scanner/guard/store_command_shadow.py
+++ b/src/codex_plugin_scanner/guard/store_command_shadow.py
@@ -1,0 +1,150 @@
+"""Atomic persistence and bounded reads for command shadow evidence."""
+
+# pyright: reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Sequence
+from contextlib import AbstractContextManager
+from datetime import datetime
+from typing import Protocol, cast
+
+from .models import GuardAction
+from .runtime.command_shadow_evaluation import (
+    CommandShadowCohort,
+    CommandShadowComparison,
+    CommandShadowObservation,
+)
+from .runtime.effect_decision import FinalDisposition
+
+
+class _ConnectionOwner(Protocol):
+    def _connect(self) -> AbstractContextManager[sqlite3.Connection]: ...
+
+
+class StoreCommandShadowMixin:
+    def count_command_shadow_observations(self: _ConnectionOwner) -> int:
+        with self._connect() as connection:
+            row = connection.execute("select count(*) from command_activity_shadow_evaluations").fetchone()
+        return int(row[0]) if row is not None else 0
+
+    def list_command_shadow_observations(
+        self: _ConnectionOwner,
+        *,
+        limit: int = 10_000,
+    ) -> tuple[CommandShadowObservation, ...]:
+        if type(limit) is not int or not 1 <= limit <= 10_000:
+            raise ValueError("limit must be between 1 and 10000")
+        with self._connect() as connection:
+            connection.execute("begin")
+            rows = cast(
+                list[sqlite3.Row],
+                connection.execute(
+                    """
+                    select * from command_activity_shadow_evaluations
+                    order by occurred_at, activity_id limit ?
+                    """,
+                    (limit,),
+                ).fetchall(),
+            )
+            return tuple(_observation_from_row(connection, row) for row in rows)
+
+
+def record_command_shadow_observation(
+    connection: sqlite3.Connection,
+    observation: CommandShadowObservation,
+) -> bool:
+    if not isinstance(cast(object, observation), CommandShadowObservation):
+        raise ValueError("observation must be a CommandShadowObservation")
+    existing = cast(
+        sqlite3.Row | None,
+        connection.execute(
+            "select * from command_activity_shadow_evaluations where activity_id = ?",
+            (observation.activity_id,),
+        ).fetchone(),
+    )
+    values = _observation_values(observation)
+    if existing is not None:
+        if _row_values(existing) != values or _cohort_values(connection, observation.activity_id) != tuple(
+            (observation.activity_id, ordinal, cohort.value) for ordinal, cohort in enumerate(observation.cohorts)
+        ):
+            raise ValueError("command shadow replay conflicts with persisted evidence")
+        return False
+    connection.execute(
+        """
+        insert into command_activity_shadow_evaluations (
+          activity_id, occurred_at, authoritative_action, current_action, current_disposition,
+          proposed_action, proposed_disposition, comparison, proposal_version,
+          evaluator_schema_version, control_generation, sample_basis_points, schema_version
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        values,
+    )
+    connection.executemany(
+        """
+        insert into command_activity_shadow_cohorts (activity_id, ordinal, cohort)
+        values (?, ?, ?)
+        """,
+        tuple((observation.activity_id, ordinal, cohort.value) for ordinal, cohort in enumerate(observation.cohorts)),
+    )
+    return True
+
+
+def _observation_values(observation: CommandShadowObservation) -> tuple[object, ...]:
+    return (
+        observation.activity_id,
+        observation.occurred_at.isoformat(),
+        observation.authoritative_action,
+        observation.current_action,
+        observation.current_disposition.value,
+        observation.proposed_action,
+        observation.proposed_disposition.value,
+        observation.comparison.value,
+        observation.proposal_version,
+        observation.evaluator_schema_version,
+        observation.control_generation,
+        observation.sample_basis_points,
+        observation.schema_version,
+    )
+
+
+def _row_values(row: sqlite3.Row) -> tuple[object, ...]:
+    return tuple(cast(Sequence[object], row))
+
+
+def _cohort_values(connection: sqlite3.Connection, activity_id: str) -> tuple[tuple[object, ...], ...]:
+    rows = cast(
+        list[sqlite3.Row],
+        connection.execute(
+            "select * from command_activity_shadow_cohorts where activity_id = ? order by ordinal",
+            (activity_id,),
+        ).fetchall(),
+    )
+    return tuple(_row_values(row) for row in rows)
+
+
+def _observation_from_row(connection: sqlite3.Connection, row: sqlite3.Row) -> CommandShadowObservation:
+    cohort_rows = _cohort_values(connection, str(row["activity_id"]))
+    return CommandShadowObservation(
+        activity_id=str(row["activity_id"]),
+        occurred_at=datetime.fromisoformat(str(row["occurred_at"])),
+        cohorts=tuple(CommandShadowCohort(str(item[2])) for item in cohort_rows),
+        authoritative_action=cast(GuardAction, row["authoritative_action"]),
+        current_action=cast(GuardAction, row["current_action"]),
+        current_disposition=FinalDisposition(str(row["current_disposition"])),
+        proposed_action=cast(GuardAction, row["proposed_action"]),
+        proposed_disposition=FinalDisposition(str(row["proposed_disposition"])),
+        comparison=CommandShadowComparison(str(row["comparison"])),
+        proposal_version=str(row["proposal_version"]),
+        evaluator_schema_version=str(row["evaluator_schema_version"]),
+        control_generation=int(row["control_generation"]),
+        sample_basis_points=int(row["sample_basis_points"]),
+        schema_version=str(row["schema_version"]),
+    )
+
+
+__all__: Sequence[str] = (
+    "StoreCommandShadowMixin",
+    "record_command_shadow_observation",
+)

--- a/src/codex_plugin_scanner/guard/store_command_shadow_schema.py
+++ b/src/codex_plugin_scanner/guard/store_command_shadow_schema.py
@@ -1,0 +1,204 @@
+"""Crash-safe schema for privacy-safe command decision shadow evidence."""
+
+# pyright: reportAny=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from typing import Final, cast
+
+COMMAND_SHADOW_MIGRATION_VERSION: Final = 15
+
+_ACTIONS: Final = "'allow', 'warn', 'review', 'require-reapproval', 'sandbox-required', 'block'"
+_DISPOSITIONS: Final = (
+    "'silent-verified', 'silent-contained', 'workflow-authorized', 'warn', 'review', "
+    "'require-reapproval', 'sandbox-required', 'block'"
+)
+_COHORTS: Final = (
+    "'baseline', 'cdx-060-verified-reads', 'cdx-061-contained-checks', "
+    "'cdx-062-contained-writes', 'cdx-063-task-capabilities', "
+    "'cdx-064-remote-mutation-floors', 'cdx-065-package-provenance-floors', "
+    "'cdx-066-critical-block-floors'"
+)
+
+_SCHEMA_STATEMENTS: Final = (
+    f"""create table if not exists command_activity_shadow_evaluations (
+      activity_id text primary key references command_activity(activity_id) on delete cascade,
+      occurred_at text not null,
+      authoritative_action text not null check (authoritative_action in ({_ACTIONS})),
+      current_action text not null check (current_action in ({_ACTIONS})),
+      current_disposition text not null check (current_disposition in ({_DISPOSITIONS})),
+      proposed_action text not null check (proposed_action in ({_ACTIONS})),
+      proposed_disposition text not null check (proposed_disposition in ({_DISPOSITIONS})),
+      comparison text not null check (comparison in ('lowered', 'unchanged', 'strengthened')),
+      proposal_version text not null check (
+        length(proposal_version) between 1 and 128
+        and proposal_version glob '[a-z]*'
+        and proposal_version not glob '*[^a-z0-9.-]*'
+      ),
+      evaluator_schema_version text not null check (evaluator_schema_version = '1.0.0'),
+      control_generation integer not null check (control_generation = 1),
+      sample_basis_points integer not null check (sample_basis_points between 1 and 10000),
+      schema_version text not null check (schema_version = 'guard.command-shadow.v1'),
+      check (
+        (current_action = 'allow' and current_disposition in (
+          'silent-verified', 'silent-contained', 'workflow-authorized'
+        )) or (current_action != 'allow' and current_disposition = current_action)
+      ),
+      check (
+        (proposed_action = 'allow' and proposed_disposition in (
+          'silent-verified', 'silent-contained', 'workflow-authorized'
+        )) or (proposed_action != 'allow' and proposed_disposition = proposed_action)
+      )
+    ) strict""",
+    f"""create table if not exists command_activity_shadow_cohorts (
+      activity_id text not null references command_activity_shadow_evaluations(activity_id) on delete cascade,
+      ordinal integer not null check (ordinal >= 0),
+      cohort text not null check (cohort in ({_COHORTS})),
+      primary key (activity_id, ordinal),
+      unique (activity_id, cohort)
+    ) strict""",
+    """create index if not exists idx_command_activity_shadow_comparison
+    on command_activity_shadow_evaluations (comparison, occurred_at desc, activity_id desc)""",
+    """create index if not exists idx_command_activity_shadow_cohort
+    on command_activity_shadow_cohorts (cohort, activity_id)""",
+    """create trigger if not exists trg_command_activity_shadow_evaluations_immutable
+    before update on command_activity_shadow_evaluations
+    begin select raise(abort, 'command_activity_shadow_evaluations_immutable'); end""",
+    """create trigger if not exists trg_command_activity_shadow_cohorts_immutable
+    before update on command_activity_shadow_cohorts
+    begin select raise(abort, 'command_activity_shadow_cohorts_immutable'); end""",
+    """create trigger if not exists trg_command_activity_shadow_require_activity
+    before insert on command_activity_shadow_evaluations
+    begin
+      select case when not exists (
+        select 1 from command_activity
+        where activity_id = new.activity_id and occurred_at = new.occurred_at
+      ) then raise(abort, 'command_activity_shadow_activity_missing') end;
+    end""",
+    """create trigger if not exists trg_command_activity_shadow_require_evaluation
+    before insert on command_activity_shadow_cohorts
+    begin
+      select case when not exists (
+        select 1 from command_activity_shadow_evaluations where activity_id = new.activity_id
+      ) then raise(abort, 'command_activity_shadow_evaluation_missing') end;
+      select case when new.ordinal != (
+        select count(*) from command_activity_shadow_cohorts where activity_id = new.activity_id
+      ) then raise(abort, 'command_activity_shadow_cohort_ordinal_invalid') end;
+    end""",
+    """create trigger if not exists trg_command_activity_shadow_require_comparison
+    before insert on command_activity_shadow_evaluations
+    begin
+      select case when new.comparison != case
+        when (
+          case new.proposed_action
+            when 'allow' then 0 when 'warn' then 1 when 'review' then 2
+            when 'require-reapproval' then 3 when 'sandbox-required' then 4 else 5 end
+        ) < (
+          case new.current_action
+            when 'allow' then 0 when 'warn' then 1 when 'review' then 2
+            when 'require-reapproval' then 3 when 'sandbox-required' then 4 else 5 end
+        ) then 'lowered'
+        when new.proposed_action = new.current_action then 'unchanged'
+        else 'strengthened'
+      end then raise(abort, 'command_activity_shadow_comparison_invalid') end;
+    end""",
+    """create trigger if not exists trg_command_activity_shadow_delete_cohorts
+    after delete on command_activity_shadow_evaluations
+    begin
+      delete from command_activity_shadow_cohorts where activity_id = old.activity_id;
+    end""",
+    """create trigger if not exists trg_command_activity_shadow_delete_evaluation
+    after delete on command_activity
+    begin
+      delete from command_activity_shadow_evaluations where activity_id = old.activity_id;
+    end""",
+)
+
+
+def ensure_command_shadow_schema(connection: sqlite3.Connection, *, applied_at: str) -> None:
+    """Apply migration 15 atomically and validate every owned object."""
+
+    connection.execute("savepoint command_shadow_schema_v15")
+    try:
+        for statement in _SCHEMA_STATEMENTS:
+            connection.execute(statement)
+        _validate_schema(connection)
+        connection.execute(
+            "insert or ignore into schema_migrations (version, applied_at) values (?, ?)",
+            (COMMAND_SHADOW_MIGRATION_VERSION, applied_at),
+        )
+        row = connection.execute(
+            "select applied_at from schema_migrations where version = ?",
+            (COMMAND_SHADOW_MIGRATION_VERSION,),
+        ).fetchone()
+        if row is None or not str(row[0]):
+            raise RuntimeError("command_shadow_migration_not_recorded")
+    except BaseException:
+        connection.execute("rollback to command_shadow_schema_v15")
+        connection.execute("release command_shadow_schema_v15")
+        raise
+    connection.execute("release command_shadow_schema_v15")
+
+
+def _validate_schema(connection: sqlite3.Connection) -> None:
+    expected: dict[str, str] = {}
+    for statement in _SCHEMA_STATEMENTS:
+        canonical = _canonical_sql(statement)
+        match = re.match(r"create (?:table|index|trigger) if not exists ([a-z0-9_]+)", canonical)
+        if match is None:
+            raise RuntimeError("unrecognized command shadow schema statement")
+        expected[match.group(1)] = canonical.replace(" if not exists", "", 1)
+    placeholders = ", ".join("?" for _ in expected)
+    rows = cast(
+        list[sqlite3.Row],
+        connection.execute(
+            f"select name, sql from sqlite_schema where name in ({placeholders})",
+            tuple(expected),
+        ).fetchall(),
+    )
+    actual = {str(row["name"]): _canonical_sql(str(row["sql"])) for row in rows}
+    if actual != expected:
+        raise RuntimeError("incompatible command shadow schema objects")
+    expected_columns = {
+        "command_activity_shadow_evaluations": (
+            "activity_id",
+            "occurred_at",
+            "authoritative_action",
+            "current_action",
+            "current_disposition",
+            "proposed_action",
+            "proposed_disposition",
+            "comparison",
+            "proposal_version",
+            "evaluator_schema_version",
+            "control_generation",
+            "sample_basis_points",
+            "schema_version",
+        ),
+        "command_activity_shadow_cohorts": ("activity_id", "ordinal", "cohort"),
+    }
+    expected_primary_keys = {
+        "command_activity_shadow_evaluations": ("activity_id",),
+        "command_activity_shadow_cohorts": ("activity_id", "ordinal"),
+    }
+    for table, names in expected_columns.items():
+        columns = cast(list[sqlite3.Row], connection.execute(f"pragma table_info({table})").fetchall())
+        if tuple(str(row["name"]) for row in columns) != names:
+            raise RuntimeError("incompatible command shadow schema columns")
+        primary_key = tuple(
+            str(row["name"]) for row in sorted(columns, key=lambda item: int(item["pk"])) if int(row["pk"]) > 0
+        )
+        if primary_key != expected_primary_keys[table]:
+            raise RuntimeError("incompatible command shadow primary key")
+
+
+def _canonical_sql(value: str) -> str:
+    return " ".join(value.strip().lower().split())
+
+
+__all__ = (
+    "COMMAND_SHADOW_MIGRATION_VERSION",
+    "ensure_command_shadow_schema",
+)

--- a/src/codex_plugin_scanner/guard/store_command_shadow_schema.py
+++ b/src/codex_plugin_scanner/guard/store_command_shadow_schema.py
@@ -154,7 +154,7 @@ def _validate_schema(connection: sqlite3.Connection) -> None:
     rows = cast(
         list[sqlite3.Row],
         connection.execute(
-            f"select name, sql from sqlite_schema where name in ({placeholders})",
+            f"select name, sql from sqlite_master where name in ({placeholders})",
             tuple(expected),
         ).fetchall(),
     )

--- a/src/codex_plugin_scanner/guard/store_command_shadow_schema.py
+++ b/src/codex_plugin_scanner/guard/store_command_shadow_schema.py
@@ -187,9 +187,11 @@ def _validate_schema(connection: sqlite3.Connection) -> None:
         columns = cast(list[sqlite3.Row], connection.execute(f"pragma table_info({table})").fetchall())
         if tuple(str(row["name"]) for row in columns) != names:
             raise RuntimeError("incompatible command shadow schema columns")
-        primary_key = tuple(
-            str(row["name"]) for row in sorted(columns, key=lambda item: int(item["pk"])) if int(row["pk"]) > 0
+        primary_key_columns = sorted(
+            (column for column in columns if int(column["pk"]) > 0),
+            key=lambda column: int(column["pk"]),
         )
+        primary_key = tuple(str(column["name"]) for column in primary_key_columns)
         if primary_key != expected_primary_keys[table]:
             raise RuntimeError("incompatible command shadow primary key")
 

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -12,6 +12,7 @@ from .store_command_activity_api_schema import ensure_command_activity_api_schem
 from .store_command_activity_health_schema import ensure_command_activity_health_schema
 from .store_command_activity_maintenance_schema import ensure_command_activity_maintenance_schema
 from .store_command_activity_schema import ensure_command_activity_schema
+from .store_command_shadow_schema import ensure_command_shadow_schema
 from .store_live_request_outbox import ensure_live_request_outbox_schema, seed_live_request_outbox
 from .store_secret_policy_integrity import _POLICY_INTEGRITY_LOOKUP_UNSET
 from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
@@ -636,6 +637,7 @@ class StoreConnectionSchemaMixin:
             ensure_command_activity_api_schema(connection, applied_at=_now())
             ensure_evidence_schema(connection)
             ensure_workflow_capability_schema(connection, applied_at=_now())
+            ensure_command_shadow_schema(connection, applied_at=_now())
             if not self._schema_version_applied(connection, version=4):
                 self._record_schema_version(connection, version=4)
             for idx_stmt in supply_chain_index_statements():

--- a/tests/test_guard_command_activity_deletion_privacy.py
+++ b/tests/test_guard_command_activity_deletion_privacy.py
@@ -27,6 +27,7 @@ from codex_plugin_scanner.guard.runtime.command_activity_contract import (
     COMMAND_ACTIVITY_SCHEMA_VERSION,
     CommandProofLevel,
 )
+from codex_plugin_scanner.guard.runtime.command_shadow_evaluation import COMMAND_SHADOW_SCHEMA_VERSION
 from codex_plugin_scanner.guard.store import GuardStore
 from codex_plugin_scanner.guard.store_command_activity_health_schema import (
     COMMAND_ACTIVITY_HEALTH_SCHEMA_VERSION,
@@ -51,6 +52,8 @@ _COMMAND_TABLES = (
     "command_activity_rollup_pending",
     "command_activity_feedback",
     "command_activity_invalidations",
+    "command_activity_shadow_evaluations",
+    "command_activity_shadow_cohorts",
 )
 
 
@@ -93,6 +96,25 @@ def _seed_clear_state(store: GuardStore) -> None:
         occurred_at=datetime(2026, 7, 18, 22, 1, tzinfo=timezone.utc),
     )
     with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            """
+            insert into command_activity_shadow_evaluations (
+              activity_id, occurred_at, authoritative_action, current_action, current_disposition,
+              proposed_action, proposed_disposition, comparison, proposal_version,
+              evaluator_schema_version, control_generation, sample_basis_points, schema_version
+            ) values (
+              'activity:01', '2026-07-18T20:00:00+00:00', 'allow', 'review', 'review',
+              'review', 'review', 'unchanged', 'proposal.test.v1',
+              '1.0.0', 1, 10000, 'guard.command-shadow.v1'
+            )
+            """
+        )
+        connection.execute(
+            """
+            insert into command_activity_shadow_cohorts (activity_id, ordinal, cohort)
+            values ('activity:01', 0, 'baseline')
+            """
+        )
         connection.execute(
             """
             insert into command_activity_correlations (activity_id, kind, harness, key_id, digest)
@@ -157,6 +179,7 @@ def test_diagnostics_has_an_exact_bounded_allowlist(tmp_path: Path) -> None:
         "api": COMMAND_ACTIVITY_API_SCHEMA_VERSION,
         "health": COMMAND_ACTIVITY_HEALTH_SCHEMA_VERSION,
         "maintenance": COMMAND_ACTIVITY_MAINTENANCE_SCHEMA_VERSION,
+        "shadow": COMMAND_SHADOW_SCHEMA_VERSION,
     }
     assert diagnostics["counts"] == {
         "activities": 3,
@@ -169,6 +192,8 @@ def test_diagnostics_has_an_exact_bounded_allowlist(tmp_path: Path) -> None:
         "rollup_pending": 0,
         "feedback": 0,
         "invalidations": 3,
+        "shadow_evaluations": 0,
+        "shadow_cohorts": 0,
         "dropped_events": 1,
         "persistence_errors": 1,
     }

--- a/tests/test_guard_command_shadow_evaluation.py
+++ b/tests/test_guard_command_shadow_evaluation.py
@@ -1,0 +1,159 @@
+"""Deterministic command shadow evaluation and rollout-control tests."""
+
+# pyright: reportMissingImports=false, reportUnknownMemberType=false, reportUntypedFunctionDecorator=false
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+
+import pytest
+
+from codex_plugin_scanner.guard.models import GuardAction
+from codex_plugin_scanner.guard.runtime.command_evaluation import evaluate_command
+from codex_plugin_scanner.guard.runtime.command_shadow_evaluation import (
+    COMMAND_SHADOW_BASELINE_PROPOSAL_VERSION,
+    COMMAND_SHADOW_DISABLED_COHORTS_ENV,
+    COMMAND_SHADOW_ENABLED_ENV,
+    COMMAND_SHADOW_KILL_SWITCH_ENV,
+    COMMAND_SHADOW_SAMPLE_BASIS_POINTS_ENV,
+    CommandShadowCohort,
+    CommandShadowComparison,
+    CommandShadowProposal,
+    baseline_command_shadow_proposal,
+    build_command_shadow_observation,
+    load_command_shadow_control,
+)
+from codex_plugin_scanner.guard.runtime.effect_decision import FinalDisposition
+
+_OCCURRED_AT = datetime(2026, 7, 19, 12, 0, tzinfo=timezone.utc)
+
+
+def _evaluation():
+    evaluation = evaluate_command("git push origin release/2.2 --force")
+    assert evaluation.matches
+    return evaluation
+
+
+def test_baseline_records_distinct_authoritative_current_and_proposed_facts() -> None:
+    evaluation = _evaluation()
+    observation = build_command_shadow_observation(
+        evaluation,
+        authoritative_action="allow",
+        proposal=baseline_command_shadow_proposal(evaluation),
+        activity_id="activity:baseline",
+        occurred_at=_OCCURRED_AT,
+        control=load_command_shadow_control({}),
+    )
+
+    assert observation is not None
+    assert observation.authoritative_action == "allow"
+    assert observation.current_action == evaluation.decision_plane.action
+    assert observation.proposed_action == evaluation.decision_plane.action
+    assert observation.comparison is CommandShadowComparison.UNCHANGED
+    assert observation.proposal_version == COMMAND_SHADOW_BASELINE_PROPOSAL_VERSION
+    assert observation.cohorts == (CommandShadowCohort.BASELINE,)
+
+
+@pytest.mark.parametrize(
+    ("action", "disposition", "comparison"),
+    [
+        ("allow", FinalDisposition.SILENT_VERIFIED, CommandShadowComparison.LOWERED),
+        ("block", FinalDisposition.BLOCK, CommandShadowComparison.STRENGTHENED),
+    ],
+)
+def test_comparison_uses_canonical_action_lattice(
+    action: GuardAction,
+    disposition: FinalDisposition,
+    comparison: CommandShadowComparison,
+) -> None:
+    evaluation = _evaluation()
+    proposal = CommandShadowProposal(
+        decision=replace(evaluation.decision_plane, action=action, disposition=disposition),
+        cohorts=frozenset({CommandShadowCohort.BASELINE}),
+        version="proposal.test.v1",
+    )
+
+    observation = build_command_shadow_observation(
+        evaluation,
+        authoritative_action="review",
+        proposal=proposal,
+        activity_id=f"activity:{comparison.value}",
+        occurred_at=_OCCURRED_AT,
+        control=load_command_shadow_control({}),
+    )
+
+    assert observation is not None
+    assert observation.comparison is comparison
+    assert observation.authoritative_action == "review"
+
+
+@pytest.mark.parametrize(
+    "environment",
+    [
+        {COMMAND_SHADOW_ENABLED_ENV: "0"},
+        {COMMAND_SHADOW_ENABLED_ENV: "invalid"},
+        {COMMAND_SHADOW_KILL_SWITCH_ENV: "1"},
+        {COMMAND_SHADOW_KILL_SWITCH_ENV: "invalid"},
+        {COMMAND_SHADOW_SAMPLE_BASIS_POINTS_ENV: "0"},
+        {COMMAND_SHADOW_SAMPLE_BASIS_POINTS_ENV: "10001"},
+        {COMMAND_SHADOW_DISABLED_COHORTS_ENV: "baseline"},
+        {COMMAND_SHADOW_DISABLED_COHORTS_ENV: "unknown-cohort"},
+    ],
+)
+def test_disable_controls_and_malformed_values_fail_closed(environment: dict[str, str]) -> None:
+    evaluation = _evaluation()
+
+    assert (
+        build_command_shadow_observation(
+            evaluation,
+            authoritative_action="review",
+            proposal=baseline_command_shadow_proposal(evaluation),
+            activity_id="activity:disabled",
+            occurred_at=_OCCURRED_AT,
+            control=load_command_shadow_control(environment),
+        )
+        is None
+    )
+
+
+def test_local_controls_cannot_enable_unreleased_cohorts() -> None:
+    evaluation = _evaluation()
+    proposal = CommandShadowProposal(
+        decision=evaluation.decision_plane,
+        cohorts=frozenset({CommandShadowCohort.VERIFIED_READS}),
+        version="proposal.unreleased.v1",
+    )
+
+    assert (
+        build_command_shadow_observation(
+            evaluation,
+            authoritative_action="review",
+            proposal=proposal,
+            activity_id="activity:unreleased",
+            occurred_at=_OCCURRED_AT,
+            control=load_command_shadow_control({}),
+        )
+        is None
+    )
+
+
+def test_sampling_is_deterministic_and_bounded() -> None:
+    control = load_command_shadow_control({COMMAND_SHADOW_SAMPLE_BASIS_POINTS_ENV: "5000"})
+    cohorts = frozenset({CommandShadowCohort.BASELINE})
+
+    first = control.selected_cohorts(proposal_cohorts=cohorts, activity_id="activity:sample")
+    assert first == control.selected_cohorts(proposal_cohorts=cohorts, activity_id="activity:sample")
+    assert first in {(), (CommandShadowCohort.BASELINE,)}
+
+
+def test_proposal_version_is_bounded_and_canonical() -> None:
+    evaluation = _evaluation()
+
+    for version in ("a" * 129, "proposal..v1"):
+        with pytest.raises(ValueError, match="stable identifier"):
+            _ = CommandShadowProposal(
+                decision=evaluation.decision_plane,
+                cohorts=frozenset({CommandShadowCohort.BASELINE}),
+                version=version,
+            )

--- a/tests/test_guard_command_shadow_persistence.py
+++ b/tests/test_guard_command_shadow_persistence.py
@@ -1,0 +1,322 @@
+"""Atomic storage, replay, migration, and privacy tests for command shadow evidence."""
+
+# pyright: reportAny=false, reportMissingImports=false, reportPrivateUsage=false
+# pyright: reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from dataclasses import replace
+from datetime import datetime, timezone
+from multiprocessing import get_context
+from pathlib import Path
+from threading import Event
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard import store_command_shadow as shadow_store
+from codex_plugin_scanner.guard import store_command_shadow_schema as shadow_schema
+from codex_plugin_scanner.guard.cli import commands_support_command_activity as activity_support
+from codex_plugin_scanner.guard.cli.commands_support_command_activity import (
+    record_pre_hook_command_activity_best_effort,
+)
+from codex_plugin_scanner.guard.runtime.command_activity_contract import (
+    ActivityApprovalReuseStatus,
+    ActivityDecisionReason,
+)
+from codex_plugin_scanner.guard.runtime.command_activity_lifecycle import (
+    CommandActivityDecisionFacts,
+    build_pre_hook_evidence,
+)
+from codex_plugin_scanner.guard.runtime.command_evaluation import evaluate_command
+from codex_plugin_scanner.guard.runtime.command_shadow_evaluation import (
+    COMMAND_SHADOW_SCHEMA_VERSION,
+    CommandShadowCohort,
+    CommandShadowControl,
+    CommandShadowProposal,
+    build_command_shadow_observation,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+_OCCURRED_AT = datetime(2026, 7, 19, 12, 0, tzinfo=timezone.utc)
+
+
+def _evidence_and_shadow(*, activity_id: str = "activity:shadow"):
+    evaluation = evaluate_command("git push origin release/2.2 --force")
+    evidence = build_pre_hook_evidence(
+        evaluation,
+        CommandActivityDecisionFacts(
+            policy_action="allow",
+            decision_reason_code=ActivityDecisionReason.EXTENSION_MATCH,
+            prompted=False,
+            approval_reuse_status=ActivityApprovalReuseStatus.NOT_APPLICABLE,
+            receipt_id=None,
+        ),
+        activity_id=activity_id,
+        occurred_at=_OCCURRED_AT,
+        harness="codex",
+        request_correlation=None,
+    )
+    cohorts = frozenset({CommandShadowCohort.BASELINE, CommandShadowCohort.REMOTE_MUTATION_FLOORS})
+    proposal = CommandShadowProposal(evaluation.decision_plane, cohorts, "proposal.multi.v1")
+    control = CommandShadowControl(True, False, cohorts, frozenset(), 10_000)
+    shadow = build_command_shadow_observation(
+        evaluation,
+        authoritative_action="allow",
+        proposal=proposal,
+        activity_id=activity_id,
+        occurred_at=_OCCURRED_AT,
+        control=control,
+    )
+    assert shadow is not None
+    return evidence, shadow
+
+
+def _record_in_process(guard_home: str) -> bool:
+    store = GuardStore(Path(guard_home), prime_policy_integrity=False)
+    evidence, shadow = _evidence_and_shadow()
+    return store.record_command_activity(evidence, shadow=shadow)
+
+
+def test_migration_creates_validated_normalized_schema(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+
+    with sqlite3.connect(store.path) as connection:
+        tables = {str(row[0]) for row in connection.execute("select name from sqlite_schema").fetchall()}
+        version = connection.execute(
+            "select version from schema_migrations where version = ?",
+            (shadow_schema.COMMAND_SHADOW_MIGRATION_VERSION,),
+        ).fetchone()
+
+    assert "command_activity_shadow_evaluations" in tables
+    assert "command_activity_shadow_cohorts" in tables
+    assert version == (shadow_schema.COMMAND_SHADOW_MIGRATION_VERSION,)
+
+
+def test_migration_rolls_back_objects_and_version_on_validation_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "migration.db"
+    with sqlite3.connect(path) as connection:
+        connection.row_factory = sqlite3.Row
+        connection.execute("create table schema_migrations (version integer primary key, applied_at text not null)")
+        connection.execute("create table command_activity (activity_id text primary key) strict")
+        statements = shadow_schema._SCHEMA_STATEMENTS
+        monkeypatch.setattr(shadow_schema, "_SCHEMA_STATEMENTS", (*statements, "create table"))
+        with pytest.raises(sqlite3.OperationalError):
+            shadow_schema.ensure_command_shadow_schema(connection, applied_at=_OCCURRED_AT.isoformat())
+        tables = {str(row[0]) for row in connection.execute("select name from sqlite_schema").fetchall()}
+        version = connection.execute(
+            "select version from schema_migrations where version = ?",
+            (shadow_schema.COMMAND_SHADOW_MIGRATION_VERSION,),
+        ).fetchone()
+
+    assert "command_activity_shadow_evaluations" not in tables
+    assert "command_activity_shadow_cohorts" not in tables
+    assert version is None
+
+
+def test_activity_and_multi_cohort_shadow_are_atomic_and_replay_exactly(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    evidence, shadow = _evidence_and_shadow()
+
+    assert store.record_command_activity(evidence, shadow=shadow)
+    assert not store.record_command_activity(evidence, shadow=shadow)
+    assert store.count_command_activities() == 1
+    assert store.count_command_shadow_observations() == 1
+    assert store.list_command_shadow_observations() == (shadow,)
+
+    with pytest.raises(ValueError, match="shadow replay conflicts"):
+        store.record_command_activity(evidence, shadow=replace(shadow, proposal_version="proposal.changed.v1"))
+
+
+def test_shadow_cannot_be_added_after_parent_replay(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    evidence, shadow = _evidence_and_shadow()
+    store.record_command_activity(evidence)
+
+    with pytest.raises(ValueError, match="missing persisted evidence"):
+        store.record_command_activity(evidence, shadow=shadow)
+
+
+def test_concurrent_exact_shadow_replay_persists_once(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    GuardStore(guard_home, prime_policy_integrity=False)
+
+    with ProcessPoolExecutor(max_workers=2, mp_context=get_context("spawn")) as executor:
+        results = tuple(executor.map(_record_in_process, (str(guard_home), str(guard_home))))
+
+    store = GuardStore(guard_home, prime_policy_integrity=False)
+    assert sorted(results) == [False, True]
+    assert store.count_command_activities() == 1
+    assert store.count_command_shadow_observations() == 1
+
+
+def test_list_uses_consistent_snapshot_during_concurrent_delete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    evidence, shadow = _evidence_and_shadow()
+    store.record_command_activity(evidence, shadow=shadow)
+    with sqlite3.connect(store.path) as connection:
+        assert connection.execute("pragma journal_mode=wal").fetchone() == ("wal",)
+    parent_read = Event()
+    continue_read = Event()
+    original = shadow_store._observation_from_row
+
+    def pause_after_parent(connection: sqlite3.Connection, row: sqlite3.Row):
+        parent_read.set()
+        assert continue_read.wait(timeout=5)
+        return original(connection, row)
+
+    monkeypatch.setattr(shadow_store, "_observation_from_row", pause_after_parent)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(store.list_command_shadow_observations)
+        assert parent_read.wait(timeout=5)
+        store.clear_command_activity_evidence()
+        continue_read.set()
+        assert future.result(timeout=5) == (shadow,)
+
+    assert store.count_command_shadow_observations() == 0
+
+
+def test_schema_rejects_orphans_and_direct_parent_delete_cascades(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    evidence, shadow = _evidence_and_shadow()
+    store.record_command_activity(evidence, shadow=shadow)
+
+    with sqlite3.connect(store.path) as connection:
+        with pytest.raises(sqlite3.IntegrityError, match="activity_missing"):
+            connection.execute(
+                """
+                insert into command_activity_shadow_evaluations
+                select 'activity:orphan', occurred_at, authoritative_action, current_action,
+                  current_disposition, proposed_action, proposed_disposition, comparison,
+                  proposal_version, evaluator_schema_version, control_generation,
+                  sample_basis_points, schema_version
+                from command_activity_shadow_evaluations where activity_id = ?
+                """,
+                (evidence.activity.activity_id,),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="evaluation_missing"):
+            connection.execute("insert into command_activity_shadow_cohorts values ('activity:orphan', 0, 'baseline')")
+        connection.execute(
+            """
+            insert into command_activity
+            select 'activity:comparison', occurred_at, harness, hook_phase, execution_status,
+              proof_level, policy_action, decision_reason_code, controlling_rule_id,
+              parse_confidence, uncertainty_class, match_count, prompted,
+              approval_reuse_status, receipt_link_status, receipt_id,
+              evaluation_latency_bucket, persistence_latency_bucket, schema_version
+            from command_activity where activity_id = ?
+            """,
+            (evidence.activity.activity_id,),
+        )
+        with pytest.raises(sqlite3.IntegrityError, match="comparison_invalid"):
+            connection.execute(
+                """
+                insert into command_activity_shadow_evaluations
+                select 'activity:comparison', occurred_at, authoritative_action, current_action,
+                  current_disposition, proposed_action, proposed_disposition, 'lowered',
+                  proposal_version, evaluator_schema_version, control_generation,
+                  sample_basis_points, schema_version
+                from command_activity_shadow_evaluations where activity_id = ?
+                """,
+                (evidence.activity.activity_id,),
+            )
+        connection.execute("delete from command_activity where activity_id = ?", (evidence.activity.activity_id,))
+        evaluation_count = connection.execute("select count(*) from command_activity_shadow_evaluations").fetchone()
+        cohort_count = connection.execute("select count(*) from command_activity_shadow_cohorts").fetchone()
+
+    assert evaluation_count == (0,)
+    assert cohort_count == (0,)
+
+
+def test_shadow_failure_rolls_back_parent_activity(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    evidence, shadow = _evidence_and_shadow()
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("drop table command_activity_shadow_cohorts")
+
+    with pytest.raises(sqlite3.OperationalError):
+        store.record_command_activity(evidence, shadow=shadow)
+    assert store.count_command_activities() == 0
+
+
+def test_parent_deletion_cascades_and_privacy_clear_counts_shadow_rows(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    evidence, shadow = _evidence_and_shadow()
+    store.record_command_activity(evidence, shadow=shadow)
+
+    diagnostics = store.command_activity_diagnostics()
+    schemas = cast(dict[str, str], diagnostics["schemas"])
+    counts = cast(dict[str, int], diagnostics["counts"])
+    assert schemas["shadow"] == COMMAND_SHADOW_SCHEMA_VERSION
+    assert counts["shadow_evaluations"] == 1
+    assert counts["shadow_cohorts"] == 2
+    deleted = cast(dict[str, int], store.clear_command_activity_evidence()["deleted"])
+    assert deleted["shadow_evaluations"] == 1
+    assert deleted["shadow_cohorts"] == 2
+    assert store.count_command_shadow_observations() == 0
+
+
+def test_retention_deletes_shadow_with_expired_parent(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    evidence, shadow = _evidence_and_shadow()
+    store.record_command_activity(evidence, shadow=shadow)
+
+    result = store.maintain_command_activity(
+        now=datetime(2026, 8, 19, 12, 0, tzinfo=timezone.utc),
+        detail_retain_days=1,
+    )
+
+    assert result.detail_rows_deleted == 1
+    assert store.count_command_shadow_observations() == 0
+
+
+def test_proposal_failure_records_activity_without_changing_hook_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home, prime_policy_integrity=False)
+
+    def fail_proposal(_evaluation: object) -> None:
+        raise RuntimeError("injected proposal failure")
+
+    monkeypatch.setattr(activity_support, "baseline_command_shadow_proposal", fail_proposal)
+    result = record_pre_hook_command_activity_best_effort(
+        store=store,
+        guard_home=guard_home,
+        harness="codex",
+        event="PreToolUse",
+        payload={
+            "tool_name": "Shell",
+            "tool_input": {"command": "git push origin release/2.2 --force"},
+            "tool_call_id": "toolcall_shadow_failure_abcdef1234567890",
+        },
+        policy_action="allow",
+        receipt_id=None,
+        prompted=False,
+    )
+
+    health = store.get_command_activity_persistence_health()
+    assert (
+        result,
+        store.count_command_activities(),
+        health.persistence_error_count,
+        health.last_error_code,
+    ) == (
+        True,
+        1,
+        1,
+        "shadow_evaluation_failed",
+    )
+    assert store.count_command_activities() == 1
+    assert store.count_command_shadow_observations() == 0
+    assert health.persistence_error_count == 1
+    assert health.last_error_code == "shadow_evaluation_failed"

--- a/tests/test_guard_command_shadow_persistence.py
+++ b/tests/test_guard_command_shadow_persistence.py
@@ -84,7 +84,7 @@ def test_migration_creates_validated_normalized_schema(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
 
     with sqlite3.connect(store.path) as connection:
-        tables = {str(row[0]) for row in connection.execute("select name from sqlite_schema").fetchall()}
+        tables = {str(row[0]) for row in connection.execute("select name from sqlite_master").fetchall()}
         version = connection.execute(
             "select version from schema_migrations where version = ?",
             (shadow_schema.COMMAND_SHADOW_MIGRATION_VERSION,),
@@ -108,7 +108,7 @@ def test_migration_rolls_back_objects_and_version_on_validation_failure(
         monkeypatch.setattr(shadow_schema, "_SCHEMA_STATEMENTS", (*statements, "create table"))
         with pytest.raises(sqlite3.OperationalError):
             shadow_schema.ensure_command_shadow_schema(connection, applied_at=_OCCURRED_AT.isoformat())
-        tables = {str(row[0]) for row in connection.execute("select name from sqlite_schema").fetchall()}
+        tables = {str(row[0]) for row in connection.execute("select name from sqlite_master").fetchall()}
         version = connection.execute(
             "select version from schema_migrations where version = ?",
             (shadow_schema.COMMAND_SHADOW_MIGRATION_VERSION,),


### PR DESCRIPTION
## Summary
- record observation-only comparisons between the authoritative hook action, current command decision, and a separately supplied proposal
- add release-bounded cohort controls, fail-closed kill switches, and canonical action-lattice classifications
- persist privacy-safe shadow evidence atomically with exact replay, retention, deletion, diagnostics, and consistent snapshot reads

## Testing
- `uv run --no-sync pytest -q tests/test_guard_command_activity_*.py tests/test_guard_command_shadow_*.py --tb=short`
- `uv run --no-sync ruff check <changed Python files>`
- `uv run --no-sync ruff format --check <changed Python files>`
- `uv run --no-sync basedpyright <new shadow modules and tests>`
- `uv build`
