### PR TITLE
fix(supply-chain): fail closed on incomplete lockfiles

### DIFF
--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -49,6 +49,7 @@ from .runtime.approval_reuse import (
     ApprovalReuseValidationFailure,
     evaluate_approval_reuse,
 )
+from .runtime.lockfile_parse_result import LOCKFILE_PARSER_VERSION
 from .runtime.package_execution_policy import is_execution_permitted
 from .runtime.package_intent_common import (
     PackageIntent,
@@ -2752,6 +2753,7 @@ def _package_request_artifact_hash(
         },
         content={
             **content_material,
+            "lockfile_parser_version": LOCKFILE_PARSER_VERSION,
             "manifests_and_lockfiles": component_digests.get("manifests_and_lockfiles"),
             "workspace_configuration": component_digests.get("workspace_configuration"),
         },

--- a/src/codex_plugin_scanner/guard/runtime/jsonc.py
+++ b/src/codex_plugin_scanner/guard/runtime/jsonc.py
@@ -1,0 +1,107 @@
+"""Small, bounded JSON-with-comments decoder used by Bun lockfiles."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import cast
+
+
+def loads_jsonc(
+    text: str,
+    *,
+    object_pairs_hook: Callable[[list[tuple[str, object]]], object] | None = None,
+    deadline_check: Callable[[], None] | None = None,
+) -> object:
+    """Decode JSONC while preserving JSON's duplicate-key hook semantics."""
+
+    without_comments = _strip_comments(text, deadline_check=deadline_check)
+    normalized = _strip_trailing_commas(without_comments, deadline_check=deadline_check)
+    return cast(object, json.loads(normalized, object_pairs_hook=object_pairs_hook))
+
+
+def _strip_comments(text: str, *, deadline_check: Callable[[], None] | None) -> str:
+    output = list(text)
+    in_string = False
+    escaped = False
+    index = 0
+    while index < len(text):
+        if deadline_check is not None and index % 4096 == 0:
+            deadline_check()
+        character = text[index]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            index += 1
+            continue
+        if character == '"':
+            in_string = True
+            index += 1
+            continue
+        if character != "/" or index + 1 >= len(text):
+            index += 1
+            continue
+        marker = text[index + 1]
+        if marker == "/":
+            output[index] = " "
+            output[index + 1] = " "
+            index += 2
+            while index < len(text) and text[index] not in "\r\n":
+                output[index] = " "
+                index += 1
+            continue
+        if marker != "*":
+            index += 1
+            continue
+        comment_start = index
+        output[index] = " "
+        output[index + 1] = " "
+        index += 2
+        while index + 1 < len(text) and text[index : index + 2] != "*/":
+            if deadline_check is not None and index % 4096 == 0:
+                deadline_check()
+            if text[index] not in "\r\n":
+                output[index] = " "
+            index += 1
+        if index + 1 >= len(text):
+            raise json.JSONDecodeError("Unterminated block comment", text, comment_start)
+        output[index] = " "
+        output[index + 1] = " "
+        index += 2
+    if deadline_check is not None:
+        deadline_check()
+    return "".join(output)
+
+
+def _strip_trailing_commas(text: str, *, deadline_check: Callable[[], None] | None) -> str:
+    output = list(text)
+    in_string = False
+    escaped = False
+    for index, character in enumerate(text):
+        if deadline_check is not None and index % 4096 == 0:
+            deadline_check()
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+            continue
+        if character != ",":
+            continue
+        next_index = index + 1
+        while next_index < len(text) and text[next_index].isspace():
+            next_index += 1
+        if next_index < len(text) and text[next_index] in "}]":
+            output[index] = " "
+    if deadline_check is not None:
+        deadline_check()
+    return "".join(output)

--- a/src/codex_plugin_scanner/guard/runtime/lockfile_evaluation_support.py
+++ b/src/codex_plugin_scanner/guard/runtime/lockfile_evaluation_support.py
@@ -1,0 +1,152 @@
+"""Evaluator-neutral lockfile collection and incomplete-result helpers."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Protocol, cast
+
+from .lockfile_parse_result import (
+    DependencyMapParser,
+    LockfileParseResult,
+    PackageLockParser,
+    incomplete_lockfile_result,
+    parse_lockfile_text,
+)
+from .workspace_path_guard import read_bytes_within_workspace, resolve_path_within_workspace
+
+
+class LockfileTextParser(Protocol):
+    def __call__(self, path: str, text: str) -> LockfileParseResult: ...
+
+
+def collect_lockfile_parse_results(
+    workspace_dir: Path | None,
+    lockfile_paths: object,
+    *,
+    budget_ms: float,
+    parse_text_result: LockfileTextParser,
+) -> tuple[LockfileParseResult, ...]:
+    """Parse every supported workspace lockfile without returning partial data."""
+
+    if workspace_dir is None or not isinstance(lockfile_paths, list):
+        return ()
+    results: list[LockfileParseResult] = []
+    for relative_path_value in cast("list[object]", lockfile_paths):
+        relative_path = str(relative_path_value)
+        lockfile_path = resolve_path_within_workspace(workspace_dir, relative_path)
+        if lockfile_path is None:
+            results.append(
+                incomplete_lockfile_result(
+                    relative_path,
+                    b"",
+                    error_reason="traversal_error",
+                    budget_ms=budget_ms,
+                )
+            )
+            continue
+        if not lockfile_path.exists() or lockfile_path.name.lower() == "bun.lockb":
+            continue
+        lockfile_bytes = read_bytes_within_workspace(workspace_dir, relative_path)
+        if lockfile_bytes is None:
+            results.append(
+                incomplete_lockfile_result(
+                    lockfile_path.name,
+                    b"",
+                    error_reason="read_error",
+                    budget_ms=budget_ms,
+                )
+            )
+            continue
+        try:
+            lockfile_text = lockfile_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            results.append(
+                incomplete_lockfile_result(
+                    lockfile_path.name,
+                    lockfile_bytes,
+                    error_reason="decode_error",
+                    budget_ms=budget_ms,
+                )
+            )
+            continue
+        results.append(
+            parse_text_result(lockfile_path.name, lockfile_text)
+        )
+    return tuple(results)
+
+
+def parse_lockfile_with_budget(
+    path: str,
+    text: str,
+    *,
+    budget_seconds: float,
+    dependency_parser: DependencyMapParser,
+    package_lock_parser: PackageLockParser,
+) -> LockfileParseResult:
+    budget_ms = budget_seconds * 1000
+    return parse_lockfile_text(
+        path,
+        text,
+        deadline=time.monotonic() + budget_seconds,
+        budget_ms=budget_ms,
+        dependency_parser=dependency_parser,
+        package_lock_parser=package_lock_parser,
+    )
+
+
+def incomplete_lockfile_metadata(parse_result: LockfileParseResult) -> dict[str, object]:
+    return {
+        "lockfileHash": parse_result.source_hash,
+        "lockfileParserVersion": parse_result.parser_version,
+        "lockfileFormat": parse_result.format,
+        "lockfileParseComplete": False,
+        "lockfileParseError": parse_result.error_reason or "parse_error",
+        "lockfileParseElapsedMs": round(parse_result.elapsed_ms, 3),
+        "lockfileParseBudgetMs": parse_result.budget_ms,
+        "lockfileParseWarnings": list(parse_result.warnings),
+    }
+
+
+def incomplete_lockfile_fallback_target(parse_result: LockfileParseResult) -> dict[str, object]:
+    ecosystem = {
+        "bundler-lock": "rubygems",
+        "cargo-lock": "cargo",
+        "composer-lock": "composer",
+        "pipenv-lock": "pypi",
+        "poetry-lock": "pypi",
+        "uv-lock": "pypi",
+    }.get(parse_result.format, "npm")
+    package_manager = {
+        "bundler-lock": "bundler",
+        "cargo-lock": "cargo",
+        "composer-lock": "composer",
+        "pipenv-lock": "pipenv",
+        "poetry-lock": "poetry",
+        "uv-lock": "uv",
+    }.get(parse_result.format, "npm")
+    return {
+        "ecosystem": ecosystem,
+        "name": "unresolved-lockfile",
+        "namespace": None,
+        "package_manager": package_manager,
+        "range": None,
+        "version": None,
+        "redacted_command": None,
+        "alias": None,
+    }
+
+
+def package_has_incomplete_lockfile(package: Mapping[str, object]) -> bool:
+    if package.get("lockfileParseComplete") is False:
+        return True
+    reasons = package.get("reasons")
+    if not isinstance(reasons, (list, tuple)):
+        return False
+    for reason in cast("list[object] | tuple[object, ...]", reasons):
+        if isinstance(reason, Mapping) and cast("Mapping[object, object]", reason).get("code") == (
+            "lockfile_parse_incomplete"
+        ):
+            return True
+    return False

--- a/src/codex_plugin_scanner/guard/runtime/lockfile_evaluation_support.py
+++ b/src/codex_plugin_scanner/guard/runtime/lockfile_evaluation_support.py
@@ -71,9 +71,7 @@ def collect_lockfile_parse_results(
                 )
             )
             continue
-        results.append(
-            parse_text_result(lockfile_path.name, lockfile_text)
-        )
+        results.append(parse_text_result(lockfile_path.name, lockfile_text))
     return tuple(results)
 
 
@@ -119,12 +117,15 @@ def incomplete_lockfile_fallback_target(parse_result: LockfileParseResult) -> di
         "uv-lock": "pypi",
     }.get(parse_result.format, "npm")
     package_manager = {
+        "bun-lock": "bun",
         "bundler-lock": "bundler",
         "cargo-lock": "cargo",
         "composer-lock": "composer",
         "pipenv-lock": "pipenv",
+        "pnpm-lock": "pnpm",
         "poetry-lock": "poetry",
         "uv-lock": "uv",
+        "yarn-lock": "yarn",
     }.get(parse_result.format, "npm")
     return {
         "ecosystem": ecosystem,

--- a/src/codex_plugin_scanner/guard/runtime/lockfile_evaluation_support.py
+++ b/src/codex_plugin_scanner/guard/runtime/lockfile_evaluation_support.py
@@ -111,7 +111,7 @@ def incomplete_lockfile_fallback_target(parse_result: LockfileParseResult) -> di
     ecosystem = {
         "bundler-lock": "rubygems",
         "cargo-lock": "cargo",
-        "composer-lock": "composer",
+        "composer-lock": "packagist",
         "pipenv-lock": "pypi",
         "poetry-lock": "pypi",
         "uv-lock": "pypi",

--- a/src/codex_plugin_scanner/guard/runtime/lockfile_parse_result.py
+++ b/src/codex_plugin_scanner/guard/runtime/lockfile_parse_result.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
 from ..stable_digest import stable_digest_hex
+from .jsonc import loads_jsonc
 from .package_manifest_diff import _DeadlineExceededError
 
 if TYPE_CHECKING or sys.version_info >= (3, 11):
@@ -24,8 +25,21 @@ LOCKFILE_MAX_NODES = 250_000
 LOCKFILE_MAX_DEPTH = 128
 
 _JSON_LOCKFILES = {"package-lock.json", "composer.lock", "pipfile.lock"}
-_TOML_LOCKFILES = {"bun.lock", "cargo.lock", "poetry.lock", "uv.lock"}
+_JSONC_LOCKFILES = {"bun.lock"}
+_TOML_LOCKFILES = {"cargo.lock", "poetry.lock", "uv.lock"}
 _TEXT_LOCKFILES = {"gemfile.lock", "pnpm-lock.yaml", "yarn.lock"}
+_LOCKFILE_FORMAT_MAP = {
+    "package-lock.json": "npm-package-lock",
+    "pnpm-lock.yaml": "pnpm-lock",
+    "yarn.lock": "yarn-lock",
+    "bun.lock": "bun-lock",
+    "cargo.lock": "cargo-lock",
+    "composer.lock": "composer-lock",
+    "gemfile.lock": "bundler-lock",
+    "poetry.lock": "poetry-lock",
+    "uv.lock": "uv-lock",
+    "pipfile.lock": "pipenv-lock",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -109,7 +123,7 @@ def parse_lockfile_text(
         if len(source) > LOCKFILE_MAX_BYTES:
             raise _LockfileValidationError("byte_limit_exceeded")
         lower_name = path.rsplit("/", 1)[-1].lower()
-        if lower_name not in _JSON_LOCKFILES | _TOML_LOCKFILES | _TEXT_LOCKFILES:
+        if lower_name not in _JSON_LOCKFILES | _JSONC_LOCKFILES | _TOML_LOCKFILES | _TEXT_LOCKFILES:
             raise _LockfileValidationError("unsupported_format")
         _validate_lockfile_structure(lower_name, text, deadline=deadline)
         if lower_name == "package-lock.json":
@@ -147,6 +161,9 @@ def parse_lockfile_text(
         error_reason = "resource_limit_exceeded"
     except (TypeError, UnicodeError, ValueError):
         error_reason = "parse_error"
+    except Exception:
+        # Dependency parsers are pluggable; any unexpected parser failure must fail closed.
+        error_reason = "parse_error"
     return incomplete_lockfile_result(
         path,
         source,
@@ -158,27 +175,7 @@ def parse_lockfile_text(
 
 def _lockfile_format(path: str) -> str:
     name = path.rsplit("/", 1)[-1].lower()
-    if name == "package-lock.json":
-        return "npm-package-lock"
-    if name == "pnpm-lock.yaml":
-        return "pnpm-lock"
-    if name == "yarn.lock":
-        return "yarn-lock"
-    if name == "bun.lock":
-        return "bun-lock"
-    if name == "cargo.lock":
-        return "cargo-lock"
-    if name == "composer.lock":
-        return "composer-lock"
-    if name == "gemfile.lock":
-        return "bundler-lock"
-    if name == "poetry.lock":
-        return "poetry-lock"
-    if name == "uv.lock":
-        return "uv-lock"
-    if name == "pipfile.lock":
-        return "pipenv-lock"
-    return "unknown"
+    return _LOCKFILE_FORMAT_MAP.get(name, "unknown")
 
 
 def _ensure_within_deadline(deadline: float) -> None:
@@ -198,6 +195,17 @@ def _validate_lockfile_structure(name: str, text: str, *, deadline: float) -> No
             _validate_optional_lists(payload, ("packages", "packages-dev"))
         else:
             _validate_optional_mappings(payload, ("default", "develop"))
+        return
+    if name in _JSONC_LOCKFILES:
+        payload = loads_jsonc(
+            text or "{}",
+            object_pairs_hook=_unique_object,
+            deadline_check=lambda: _ensure_within_deadline(deadline),
+        )
+        _validate_object_bounds(payload, deadline=deadline)
+        if not isinstance(payload, dict):
+            raise _LockfileValidationError("unsupported_shape")
+        _validate_bun_lock(payload)
         return
     if name in _TOML_LOCKFILES:
         payload = tomllib.loads(text or "")
@@ -231,10 +239,11 @@ def _validate_object_bounds(payload: object, *, deadline: float) -> None:
             raise _LockfileValidationError("node_limit_exceeded")
         if depth > LOCKFILE_MAX_DEPTH:
             raise _LockfileValidationError("depth_limit_exceeded")
+        next_depth = depth + 1
         if isinstance(value, dict):
-            stack.extend((item, depth + 1) for item in value.values())
+            stack.extend([(item, next_depth) for item in value.values()])
         elif isinstance(value, list):
-            stack.extend((item, depth + 1) for item in value)
+            stack.extend([(item, next_depth) for item in value])
 
 
 def _validate_package_lock(payload: dict[str, object]) -> None:
@@ -242,6 +251,13 @@ def _validate_package_lock(payload: dict[str, object]) -> None:
     if version is not None and (isinstance(version, bool) or version not in {1, 2, 3}):
         raise _LockfileValidationError("unsupported_version")
     _validate_optional_mappings(payload, ("packages", "dependencies"))
+
+
+def _validate_bun_lock(payload: dict[str, object]) -> None:
+    version = payload.get("lockfileVersion")
+    if version is not None and (isinstance(version, bool) or version not in {0, 1, 2}):
+        raise _LockfileValidationError("unsupported_version")
+    _validate_optional_mappings(payload, ("workspaces", "packages"))
 
 
 def _validate_optional_mappings(payload: dict[str, object], keys: tuple[str, ...]) -> None:
@@ -265,8 +281,8 @@ def _validate_text_lockfile(name: str, text: str, *, deadline: float) -> None:
         stripped = raw_line.strip()
         if not stripped or stripped.startswith("#"):
             continue
-        bracket_depth += sum(raw_line.count(char) for char in "[{")
-        bracket_depth -= sum(raw_line.count(char) for char in "]}")
+        bracket_depth += raw_line.count("[") + raw_line.count("{")
+        bracket_depth -= raw_line.count("]") + raw_line.count("}")
         if bracket_depth < 0:
             raise _LockfileValidationError("syntax_error")
         if name == "pnpm-lock.yaml" and ":" not in stripped and not stripped.startswith("-"):

--- a/src/codex_plugin_scanner/guard/runtime/lockfile_parse_result.py
+++ b/src/codex_plugin_scanner/guard/runtime/lockfile_parse_result.py
@@ -1,0 +1,277 @@
+"""Complete-or-fail lockfile parsing contract and resource bounds."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+from ..stable_digest import stable_digest_hex
+from .package_manifest_diff import _DeadlineExceededError
+
+if TYPE_CHECKING or sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - Python 3.10 runtime compatibility
+    tomllib = importlib.import_module("tomli")
+
+LOCKFILE_PARSER_VERSION = "complete-v1"
+LOCKFILE_MAX_BYTES = 8 * 1024 * 1024
+LOCKFILE_MAX_ENTRIES = 100_000
+LOCKFILE_MAX_NODES = 250_000
+LOCKFILE_MAX_DEPTH = 128
+
+_JSON_LOCKFILES = {"package-lock.json", "composer.lock", "pipfile.lock"}
+_TOML_LOCKFILES = {"bun.lock", "cargo.lock", "poetry.lock", "uv.lock"}
+_TEXT_LOCKFILES = {"gemfile.lock", "pnpm-lock.yaml", "yarn.lock"}
+
+
+@dataclass(frozen=True, slots=True)
+class LockfileDependencyEntry:
+    dependency_path: str
+    package_name: str
+    version: str
+    direct: bool
+
+
+@dataclass(frozen=True, slots=True)
+class LockfileParseResult:
+    entries: tuple[LockfileDependencyEntry, ...]
+    complete: bool
+    format: str
+    source_hash: str
+    elapsed_ms: float
+    budget_ms: float
+    warnings: tuple[str, ...] = ()
+    error_reason: str | None = None
+    parser_version: str = LOCKFILE_PARSER_VERSION
+
+    def dependency_map(self) -> dict[str, str]:
+        if not self.complete:
+            return {}
+        return {entry.dependency_path: entry.version for entry in self.entries}
+
+
+class DependencyMapParser(Protocol):
+    def __call__(self, path: str, text: str, *, deadline: float) -> dict[str, str]: ...
+
+
+class PackageLockParser(Protocol):
+    def __call__(
+        self,
+        text: str,
+        *,
+        deadline: float | None = None,
+    ) -> list[tuple[str, str, str, bool]]: ...
+
+
+class _LockfileValidationError(ValueError):
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def incomplete_lockfile_result(
+    path: str,
+    source: bytes,
+    *,
+    error_reason: str,
+    budget_ms: float,
+    elapsed_ms: float = 0.0,
+) -> LockfileParseResult:
+    return LockfileParseResult(
+        entries=(),
+        complete=False,
+        format=_lockfile_format(path),
+        source_hash=stable_digest_hex(source),
+        elapsed_ms=elapsed_ms,
+        budget_ms=budget_ms,
+        error_reason=error_reason,
+    )
+
+
+def parse_lockfile_text(
+    path: str,
+    text: str,
+    *,
+    deadline: float,
+    budget_ms: float,
+    dependency_parser: DependencyMapParser,
+    package_lock_parser: PackageLockParser,
+) -> LockfileParseResult:
+    started = time.monotonic()
+    source = text.encode("utf-8")
+    lockfile_format = _lockfile_format(path)
+    try:
+        _ensure_within_deadline(deadline)
+        if len(source) > LOCKFILE_MAX_BYTES:
+            raise _LockfileValidationError("byte_limit_exceeded")
+        lower_name = path.rsplit("/", 1)[-1].lower()
+        if lower_name not in _JSON_LOCKFILES | _TOML_LOCKFILES | _TEXT_LOCKFILES:
+            raise _LockfileValidationError("unsupported_format")
+        _validate_lockfile_structure(lower_name, text, deadline=deadline)
+        if lower_name == "package-lock.json":
+            raw_entries = package_lock_parser(text, deadline=deadline)
+            entries = tuple(LockfileDependencyEntry(*entry) for entry in raw_entries)
+        else:
+            dependency_map = dependency_parser(path, text, deadline=deadline)
+            entries = tuple(
+                LockfileDependencyEntry(
+                    dependency_path=package_name,
+                    package_name=package_name,
+                    version=version,
+                    direct=False,
+                )
+                for package_name, version in dependency_map.items()
+            )
+        _ensure_within_deadline(deadline)
+        if len(entries) > LOCKFILE_MAX_ENTRIES:
+            raise _LockfileValidationError("entry_limit_exceeded")
+        return LockfileParseResult(
+            entries=entries,
+            complete=True,
+            format=lockfile_format,
+            source_hash=stable_digest_hex(source),
+            elapsed_ms=(time.monotonic() - started) * 1000,
+            budget_ms=budget_ms,
+        )
+    except _DeadlineExceededError:
+        error_reason = "deadline_exceeded"
+    except _LockfileValidationError as exc:
+        error_reason = exc.reason
+    except (json.JSONDecodeError, tomllib.TOMLDecodeError):
+        error_reason = "syntax_error"
+    except (MemoryError, RecursionError):
+        error_reason = "resource_limit_exceeded"
+    except (TypeError, UnicodeError, ValueError):
+        error_reason = "parse_error"
+    return incomplete_lockfile_result(
+        path,
+        source,
+        error_reason=error_reason,
+        budget_ms=budget_ms,
+        elapsed_ms=(time.monotonic() - started) * 1000,
+    )
+
+
+def _lockfile_format(path: str) -> str:
+    name = path.rsplit("/", 1)[-1].lower()
+    if name == "package-lock.json":
+        return "npm-package-lock"
+    if name == "pnpm-lock.yaml":
+        return "pnpm-lock"
+    if name == "yarn.lock":
+        return "yarn-lock"
+    if name == "bun.lock":
+        return "bun-lock"
+    if name == "cargo.lock":
+        return "cargo-lock"
+    if name == "composer.lock":
+        return "composer-lock"
+    if name == "gemfile.lock":
+        return "bundler-lock"
+    if name == "poetry.lock":
+        return "poetry-lock"
+    if name == "uv.lock":
+        return "uv-lock"
+    if name == "pipfile.lock":
+        return "pipenv-lock"
+    return "unknown"
+
+
+def _ensure_within_deadline(deadline: float) -> None:
+    if time.monotonic() > deadline:
+        raise _DeadlineExceededError("deadline_exceeded")
+
+
+def _validate_lockfile_structure(name: str, text: str, *, deadline: float) -> None:
+    if name in _JSON_LOCKFILES:
+        payload = json.loads(text or "{}", object_pairs_hook=_unique_object)
+        _validate_object_bounds(payload, deadline=deadline)
+        if not isinstance(payload, dict):
+            raise _LockfileValidationError("unsupported_shape")
+        if name == "package-lock.json":
+            _validate_package_lock(payload)
+        elif name == "composer.lock":
+            _validate_optional_lists(payload, ("packages", "packages-dev"))
+        else:
+            _validate_optional_mappings(payload, ("default", "develop"))
+        return
+    if name in _TOML_LOCKFILES:
+        payload = tomllib.loads(text or "")
+        _validate_object_bounds(payload, deadline=deadline)
+        if not isinstance(payload, dict):
+            raise _LockfileValidationError("unsupported_shape")
+        packages = payload.get("package")
+        if packages is not None and not isinstance(packages, list):
+            raise _LockfileValidationError("unsupported_shape")
+        return
+    _validate_text_lockfile(name, text, deadline=deadline)
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    payload: dict[str, object] = {}
+    for key, value in pairs:
+        if key in payload:
+            raise _LockfileValidationError("duplicate_key")
+        payload[key] = value
+    return payload
+
+
+def _validate_object_bounds(payload: object, *, deadline: float) -> None:
+    stack: list[tuple[object, int]] = [(payload, 0)]
+    visited = 0
+    while stack:
+        _ensure_within_deadline(deadline)
+        value, depth = stack.pop()
+        visited += 1
+        if visited > LOCKFILE_MAX_NODES:
+            raise _LockfileValidationError("node_limit_exceeded")
+        if depth > LOCKFILE_MAX_DEPTH:
+            raise _LockfileValidationError("depth_limit_exceeded")
+        if isinstance(value, dict):
+            stack.extend((item, depth + 1) for item in value.values())
+        elif isinstance(value, list):
+            stack.extend((item, depth + 1) for item in value)
+
+
+def _validate_package_lock(payload: dict[str, object]) -> None:
+    version = payload.get("lockfileVersion")
+    if version is not None and (isinstance(version, bool) or version not in {1, 2, 3}):
+        raise _LockfileValidationError("unsupported_version")
+    _validate_optional_mappings(payload, ("packages", "dependencies"))
+
+
+def _validate_optional_mappings(payload: dict[str, object], keys: tuple[str, ...]) -> None:
+    for key in keys:
+        if key in payload and not isinstance(payload[key], dict):
+            raise _LockfileValidationError("unsupported_shape")
+
+
+def _validate_optional_lists(payload: dict[str, object], keys: tuple[str, ...]) -> None:
+    for key in keys:
+        if key in payload and not isinstance(payload[key], list):
+            raise _LockfileValidationError("unsupported_shape")
+
+
+def _validate_text_lockfile(name: str, text: str, *, deadline: float) -> None:
+    bracket_depth = 0
+    for raw_line in text.splitlines():
+        _ensure_within_deadline(deadline)
+        if "\x00" in raw_line or ("\t" in raw_line and name == "pnpm-lock.yaml"):
+            raise _LockfileValidationError("syntax_error")
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        bracket_depth += sum(raw_line.count(char) for char in "[{")
+        bracket_depth -= sum(raw_line.count(char) for char in "]}")
+        if bracket_depth < 0:
+            raise _LockfileValidationError("syntax_error")
+        if name == "pnpm-lock.yaml" and ":" not in stripped and not stripped.startswith("-"):
+            raise _LockfileValidationError("syntax_error")
+        if name == "yarn.lock" and not raw_line.startswith((" ", "\t")) and not stripped.endswith(":"):
+            raise _LockfileValidationError("syntax_error")
+    if bracket_depth != 0:
+        raise _LockfileValidationError("syntax_error")

--- a/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING or sys.version_info >= (3, 11):
 else:
     tomllib = importlib.import_module("tomli")
 
+from .jsonc import loads_jsonc
 from .package_intent_common import (
     ManifestDependencyChange,
     ManifestParseResult,
@@ -278,31 +279,56 @@ def _yarn_selector_name(selector: str) -> str | None:
 
 
 def _bun_lock_dependency_map(text: str, deadline: float) -> dict[str, str]:
-    _ensure_within_deadline(deadline)
-    payload = tomllib.loads(text or "")
-    packages = payload.get("package")
+    versions_by_name = _bun_lock_package_versions(text, deadline)
     dependencies: dict[str, str] = {}
-    if not isinstance(packages, list):
-        return dependencies
-    for package in packages:
-        _ensure_within_deadline(deadline)
-        if not isinstance(package, dict):
-            continue
-        name = package.get("name")
-        version = package.get("version")
-        if isinstance(name, str) and isinstance(version, str):
-            dependencies[name] = version
-        nested_dependencies = package.get("dependencies")
-        if not isinstance(nested_dependencies, list):
-            continue
-        for dependency in nested_dependencies:
-            if not isinstance(dependency, dict):
-                continue
-            dependency_name = dependency.get("name")
-            exact_version = _exact_dependency_version(dependency.get("version"))
-            if isinstance(dependency_name, str) and exact_version is not None:
-                dependencies.setdefault(dependency_name, exact_version)
+    for package_name, versions in versions_by_name.items():
+        if versions:
+            dependencies[package_name] = versions[0]
     return dependencies
+
+
+def _bun_lock_package_versions(text: str, deadline: float) -> dict[str, list[str]]:
+    _ensure_within_deadline(deadline)
+    payload = loads_jsonc(text or "{}", deadline_check=lambda: _ensure_within_deadline(deadline))
+    if not isinstance(payload, dict):
+        raise ValueError("unsupported Bun lockfile shape")
+    packages = payload.get("packages", {})
+    if not isinstance(packages, dict):
+        raise ValueError("unsupported Bun packages shape")
+    versions_by_name: dict[str, list[str]] = {}
+    for package in packages.values():
+        _ensure_within_deadline(deadline)
+        if not isinstance(package, list) or not package or not isinstance(package[0], str):
+            raise ValueError("unsupported Bun package entry")
+        identity = _bun_resolution_identity(package[0])
+        if identity is None:
+            continue
+        package_name, version = identity
+        versions = versions_by_name.setdefault(package_name, [])
+        if version not in versions:
+            versions.append(version)
+    return versions_by_name
+
+
+def _bun_resolution_identity(resolution: str) -> tuple[str, str] | None:
+    if resolution.startswith("@"):
+        scope_separator = resolution.find("/")
+        version_separator = resolution.find("@", scope_separator + 1)
+    else:
+        version_separator = resolution.find("@")
+    if version_separator <= 0:
+        return None
+    package_name = resolution[:version_separator]
+    version = resolution[version_separator + 1 :]
+    if version.startswith("npm:"):
+        version = version.removeprefix("npm:")
+    if (
+        not package_name
+        or not version
+        or version.startswith(("workspace:", "root:", "file:", "link:", "git:", "git+", "http:", "https:"))
+    ):
+        return None
+    return package_name, version
 
 
 def _exact_dependency_version(value: object) -> str | None:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -32,12 +32,14 @@ from ..store import GuardStore
 from ..store_evidence import EvidenceRecord
 from ..text import ensure_terminal_punctuation as _ensure_terminal_punctuation
 from .js_semver import highest_js_version_for_selector, version_matches_js_selector
-from .lockfile_parse_result import (
-    LOCKFILE_PARSER_VERSION,
-    LockfileParseResult,
-    incomplete_lockfile_result,
-    parse_lockfile_text,
+from .lockfile_evaluation_support import (
+    collect_lockfile_parse_results,
+    incomplete_lockfile_fallback_target,
+    incomplete_lockfile_metadata,
+    package_has_incomplete_lockfile,
+    parse_lockfile_with_budget,
 )
+from .lockfile_parse_result import LOCKFILE_PARSER_VERSION, LockfileParseResult, parse_lockfile_text
 from .manifest_dependency_targets import evaluation_targets as _manifest_evaluation_targets
 from .npm_policy_range import (
     bind_resolved_npm_policy_result,
@@ -315,7 +317,7 @@ def evaluate_package_request_artifact(
         return _finalize_incomplete_lockfile_evaluation(
             artifact=artifact,
             store=store,
-            target=targets[0] if targets else _incomplete_lockfile_fallback_target(incomplete_lockfile),
+            target=targets[0] if targets else incomplete_lockfile_fallback_target(incomplete_lockfile),
             workspace_dir=workspace_dir,
             parse_result=incomplete_lockfile,
             package_intent_hash=package_intent_hash,
@@ -1563,7 +1565,7 @@ def _evaluate_with_bundle(
             workspace_dir=workspace_dir,
             now_timestamp=now_timestamp,
         )
-        if _is_incomplete_lockfile_package(package) or _result_package_identity(package) not in direct_identities
+        if package_has_incomplete_lockfile(package) or _result_package_identity(package) not in direct_identities
     )
     if not packages:
         return None
@@ -2006,65 +2008,19 @@ def _lockfile_parse_results(
     workspace_dir: Path | None,
     artifact: GuardArtifact,
 ) -> tuple[LockfileParseResult, ...]:
-    if workspace_dir is None:
-        return ()
-    lockfile_paths = artifact.metadata.get("lockfile_paths")
-    if not isinstance(lockfile_paths, list):
-        return ()
-    budget_ms = _LOCKFILE_PARSE_BUDGET_SECONDS * 1000
-    results: list[LockfileParseResult] = []
-    for relative_path_value in lockfile_paths:
-        relative_path = str(relative_path_value)
-        lockfile_path = resolve_path_within_workspace(workspace_dir, relative_path)
-        if lockfile_path is None:
-            results.append(
-                incomplete_lockfile_result(
-                    relative_path,
-                    b"",
-                    error_reason="traversal_error",
-                    budget_ms=budget_ms,
-                )
-            )
-            continue
-        if not lockfile_path.exists():
-            continue
-        if lockfile_path.name.lower() == "bun.lockb":
-            # Bun's binary lockfile has its own explicit review-only fallback.
-            continue
-        lockfile_bytes = read_bytes_within_workspace(workspace_dir, relative_path)
-        if lockfile_bytes is None:
-            results.append(
-                incomplete_lockfile_result(
-                    lockfile_path.name,
-                    b"",
-                    error_reason="read_error",
-                    budget_ms=budget_ms,
-                )
-            )
-            continue
-        try:
-            lockfile_text = lockfile_bytes.decode("utf-8")
-        except UnicodeDecodeError:
-            results.append(
-                incomplete_lockfile_result(
-                    lockfile_path.name,
-                    lockfile_bytes,
-                    error_reason="decode_error",
-                    budget_ms=budget_ms,
-                )
-            )
-            continue
-        results.append(_parse_lockfile_text_result(lockfile_path.name, lockfile_text))
-    return tuple(results)
+    return collect_lockfile_parse_results(
+        workspace_dir,
+        artifact.metadata.get("lockfile_paths"),
+        budget_ms=_LOCKFILE_PARSE_BUDGET_SECONDS * 1000,
+        parse_text_result=_parse_lockfile_text_result,
+    )
 
 
 def _parse_lockfile_text_result(path: str, text: str) -> LockfileParseResult:
-    budget_ms = _LOCKFILE_PARSE_BUDGET_SECONDS * 1000
-    return parse_lockfile_text(
+    return parse_lockfile_with_budget(
         path,
         text,
-        deadline=time.monotonic() + _LOCKFILE_PARSE_BUDGET_SECONDS,
-        budget_ms=budget_ms,
+        budget_seconds=_LOCKFILE_PARSE_BUDGET_SECONDS,
         dependency_parser=_dependency_map_for_path,
         package_lock_parser=_package_lock_entries,
     )
@@ -2140,50 +2096,12 @@ def _incomplete_lockfile_package_result(
         ),
         severity="high",
     )
-    metadata: dict[str, object] = {
-        "lockfileHash": parse_result.source_hash,
-        "lockfileParserVersion": parse_result.parser_version,
-        "lockfileFormat": parse_result.format,
-        "lockfileParseComplete": False,
-        "lockfileParseError": error_reason,
-        "lockfileParseElapsedMs": round(parse_result.elapsed_ms, 3),
-        "lockfileParseBudgetMs": parse_result.budget_ms,
-        "lockfileParseWarnings": list(parse_result.warnings),
-    }
+    metadata = incomplete_lockfile_metadata(parse_result)
     package.update(metadata)
     first_reason = _first_dict_item(package.get("reasons"))
     if first_reason is not None:
         package["reasons"] = ({**first_reason, **metadata},)
     return package
-
-
-def _incomplete_lockfile_fallback_target(parse_result: LockfileParseResult) -> dict[str, object]:
-    ecosystem = {
-        "bundler-lock": "rubygems",
-        "cargo-lock": "cargo",
-        "composer-lock": "composer",
-        "pipenv-lock": "pypi",
-        "poetry-lock": "pypi",
-        "uv-lock": "pypi",
-    }.get(parse_result.format, "npm")
-    package_manager = {
-        "bundler-lock": "bundler",
-        "cargo-lock": "cargo",
-        "composer-lock": "composer",
-        "pipenv-lock": "pipenv",
-        "poetry-lock": "poetry",
-        "uv-lock": "uv",
-    }.get(parse_result.format, "npm")
-    return {
-        "ecosystem": ecosystem,
-        "name": "unresolved-lockfile",
-        "namespace": None,
-        "package_manager": package_manager,
-        "range": None,
-        "version": None,
-        "redacted_command": None,
-        "alias": None,
-    }
 
 
 def _workspace_fingerprint(
@@ -2325,7 +2243,7 @@ def _transitive_lockfile_results(
             results.append(
                 _incomplete_lockfile_package_result(
                     target=(
-                        direct_targets[0] if direct_targets else _incomplete_lockfile_fallback_target(parse_result)
+                        direct_targets[0] if direct_targets else incomplete_lockfile_fallback_target(parse_result)
                     ),
                     parse_result=parse_result,
                 )
@@ -4670,12 +4588,6 @@ def _result_package_identity(package: dict[str, object]) -> tuple[str, str, str,
         json.dumps(package, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
     )
     return ("opaque", ecosystem or "", namespace or "", name, version or "", opaque_sha256)
-
-
-def _is_incomplete_lockfile_package(package: dict[str, object]) -> bool:
-    if package.get("lockfileParseComplete") is False:
-        return True
-    return any(reason.get("code") == "lockfile_parse_incomplete" for reason in _dict_items(package.get("reasons")))
 
 
 def _with_additional_reason(

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1563,7 +1563,7 @@ def _evaluate_with_bundle(
             workspace_dir=workspace_dir,
             now_timestamp=now_timestamp,
         )
-        if _result_package_identity(package) not in direct_identities
+        if _is_incomplete_lockfile_package(package) or _result_package_identity(package) not in direct_identities
     )
     if not packages:
         return None
@@ -3440,7 +3440,7 @@ def _lockfile_dependency_versions(
             versions.update(_yarn_lock_target_versions(lockfile_text, targets))
             continue
         if lockfile_path.name == "bun.lock":
-            versions.update(_bun_lock_target_versions(lockfile_text, targets))
+            versions.update(_bun_lock_target_versions(parse_result, targets))
             continue
         if lockfile_path.name == "Cargo.lock":
             versions.update(_cargo_lock_target_versions(lockfile_text, targets))
@@ -3801,25 +3801,14 @@ def _expected_yarn_selectors(target: dict[str, object]) -> tuple[str, ...]:
 
 
 def _bun_lock_target_versions(
-    text: str,
+    parse_result: LockfileParseResult,
     targets: tuple[dict[str, object], ...],
 ) -> dict[tuple[str, str | None], str]:
-    try:
-        payload = tomllib.loads(text or "")
-    except tomllib.TOMLDecodeError:
-        return {}
-    packages = payload.get("package")
-    if not isinstance(packages, list):
-        return {}
     versions_by_name: dict[str, list[str]] = {}
-    for entry in packages:
-        if not isinstance(entry, dict):
-            continue
-        name = _optional_string(entry.get("name"))
-        version = _optional_string(entry.get("version"))
-        if name is None or version is None:
-            continue
-        versions_by_name.setdefault(name, []).append(version)
+    for entry in parse_result.entries:
+        candidate_versions = versions_by_name.setdefault(entry.package_name, [])
+        if entry.version not in candidate_versions:
+            candidate_versions.append(entry.version)
     versions: dict[tuple[str, str | None], str] = {}
     for target in targets:
         target_key = _lockfile_target_key(target)
@@ -4651,6 +4640,12 @@ def _result_package_identity(package: dict[str, object]) -> tuple[str, str, str,
         json.dumps(package, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
     )
     return ("opaque", ecosystem or "", namespace or "", name, version or "", opaque_sha256)
+
+
+def _is_incomplete_lockfile_package(package: dict[str, object]) -> bool:
+    if package.get("lockfileParseComplete") is False:
+        return True
+    return any(reason.get("code") == "lockfile_parse_incomplete" for reason in _dict_items(package.get("reasons")))
 
 
 def _with_additional_reason(

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -2242,9 +2242,7 @@ def _transitive_lockfile_results(
         if not parse_result.complete:
             results.append(
                 _incomplete_lockfile_package_result(
-                    target=(
-                        direct_targets[0] if direct_targets else incomplete_lockfile_fallback_target(parse_result)
-                    ),
+                    target=(direct_targets[0] if direct_targets else incomplete_lockfile_fallback_target(parse_result)),
                     parse_result=parse_result,
                 )
             )

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -311,11 +311,11 @@ def evaluate_package_request_artifact(
         if (source_url := _optional_string(target.get("source_url"))) is not None
     )
     incomplete_lockfile = _first_incomplete_lockfile_result(workspace_dir, artifact)
-    if incomplete_lockfile is not None and targets:
+    if incomplete_lockfile is not None:
         return _finalize_incomplete_lockfile_evaluation(
             artifact=artifact,
             store=store,
-            target=targets[0],
+            target=targets[0] if targets else _incomplete_lockfile_fallback_target(incomplete_lockfile),
             workspace_dir=workspace_dir,
             parse_result=incomplete_lockfile,
             package_intent_hash=package_intent_hash,
@@ -2157,6 +2157,35 @@ def _incomplete_lockfile_package_result(
     return package
 
 
+def _incomplete_lockfile_fallback_target(parse_result: LockfileParseResult) -> dict[str, object]:
+    ecosystem = {
+        "bundler-lock": "rubygems",
+        "cargo-lock": "cargo",
+        "composer-lock": "composer",
+        "pipenv-lock": "pypi",
+        "poetry-lock": "pypi",
+        "uv-lock": "pypi",
+    }.get(parse_result.format, "npm")
+    package_manager = {
+        "bundler-lock": "bundler",
+        "cargo-lock": "cargo",
+        "composer-lock": "composer",
+        "pipenv-lock": "pipenv",
+        "poetry-lock": "poetry",
+        "uv-lock": "uv",
+    }.get(parse_result.format, "npm")
+    return {
+        "ecosystem": ecosystem,
+        "name": "unresolved-lockfile",
+        "namespace": None,
+        "package_manager": package_manager,
+        "range": None,
+        "version": None,
+        "redacted_command": None,
+        "alias": None,
+    }
+
+
 def _workspace_fingerprint(
     workspace_id: str,
     *,
@@ -2293,13 +2322,14 @@ def _transitive_lockfile_results(
         dependency_entries: list[tuple[str, str, str, bool]] = []
         parse_result = _parse_lockfile_text_result(lockfile_path.name, lockfile_text)
         if not parse_result.complete:
-            if direct_targets:
-                results.append(
-                    _incomplete_lockfile_package_result(
-                        target=direct_targets[0],
-                        parse_result=parse_result,
-                    )
+            results.append(
+                _incomplete_lockfile_package_result(
+                    target=(
+                        direct_targets[0] if direct_targets else _incomplete_lockfile_fallback_target(parse_result)
+                    ),
+                    parse_result=parse_result,
                 )
+            )
             continue
         for entry in parse_result.entries:
             normalized_dependency_path = entry.dependency_path.strip("/")

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
-from xml.etree import ElementTree as ET
 
 if TYPE_CHECKING:
     import tomllib
@@ -33,6 +32,12 @@ from ..store import GuardStore
 from ..store_evidence import EvidenceRecord
 from ..text import ensure_terminal_punctuation as _ensure_terminal_punctuation
 from .js_semver import highest_js_version_for_selector, version_matches_js_selector
+from .lockfile_parse_result import (
+    LOCKFILE_PARSER_VERSION,
+    LockfileParseResult,
+    incomplete_lockfile_result,
+    parse_lockfile_text,
+)
 from .manifest_dependency_targets import evaluation_targets as _manifest_evaluation_targets
 from .npm_policy_range import (
     bind_resolved_npm_policy_result,
@@ -305,6 +310,17 @@ def evaluate_package_request_artifact(
         for target in external_archive_targets
         if (source_url := _optional_string(target.get("source_url"))) is not None
     )
+    incomplete_lockfile = _first_incomplete_lockfile_result(workspace_dir, artifact)
+    if incomplete_lockfile is not None and targets:
+        return _finalize_incomplete_lockfile_evaluation(
+            artifact=artifact,
+            store=store,
+            target=targets[0],
+            workspace_dir=workspace_dir,
+            parse_result=incomplete_lockfile,
+            package_intent_hash=package_intent_hash,
+            now=now_value,
+        )
     if external_archive_targets:
         # External archives use a deliberately local two-phase evaluation.  In
         # particular, neither cloud evaluation nor archive DNS may run before
@@ -1986,6 +2002,161 @@ def _bundle_meta(bundle_payload: dict[str, object]) -> dict[str, str]:
     }
 
 
+def _lockfile_parse_results(
+    workspace_dir: Path | None,
+    artifact: GuardArtifact,
+) -> tuple[LockfileParseResult, ...]:
+    if workspace_dir is None:
+        return ()
+    lockfile_paths = artifact.metadata.get("lockfile_paths")
+    if not isinstance(lockfile_paths, list):
+        return ()
+    budget_ms = _LOCKFILE_PARSE_BUDGET_SECONDS * 1000
+    results: list[LockfileParseResult] = []
+    for relative_path_value in lockfile_paths:
+        relative_path = str(relative_path_value)
+        lockfile_path = resolve_path_within_workspace(workspace_dir, relative_path)
+        if lockfile_path is None:
+            results.append(
+                incomplete_lockfile_result(
+                    relative_path,
+                    b"",
+                    error_reason="traversal_error",
+                    budget_ms=budget_ms,
+                )
+            )
+            continue
+        if not lockfile_path.exists():
+            continue
+        if lockfile_path.name.lower() == "bun.lockb":
+            # Bun's binary lockfile has its own explicit review-only fallback.
+            continue
+        lockfile_bytes = read_bytes_within_workspace(workspace_dir, relative_path)
+        if lockfile_bytes is None:
+            results.append(
+                incomplete_lockfile_result(
+                    lockfile_path.name,
+                    b"",
+                    error_reason="read_error",
+                    budget_ms=budget_ms,
+                )
+            )
+            continue
+        try:
+            lockfile_text = lockfile_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            results.append(
+                incomplete_lockfile_result(
+                    lockfile_path.name,
+                    lockfile_bytes,
+                    error_reason="decode_error",
+                    budget_ms=budget_ms,
+                )
+            )
+            continue
+        results.append(_parse_lockfile_text_result(lockfile_path.name, lockfile_text))
+    return tuple(results)
+
+
+def _parse_lockfile_text_result(path: str, text: str) -> LockfileParseResult:
+    budget_ms = _LOCKFILE_PARSE_BUDGET_SECONDS * 1000
+    return parse_lockfile_text(
+        path,
+        text,
+        deadline=time.monotonic() + _LOCKFILE_PARSE_BUDGET_SECONDS,
+        budget_ms=budget_ms,
+        dependency_parser=_dependency_map_for_path,
+        package_lock_parser=_package_lock_entries,
+    )
+
+
+def _first_incomplete_lockfile_result(
+    workspace_dir: Path | None,
+    artifact: GuardArtifact,
+) -> LockfileParseResult | None:
+    return next((result for result in _lockfile_parse_results(workspace_dir, artifact) if not result.complete), None)
+
+
+def _finalize_incomplete_lockfile_evaluation(
+    *,
+    artifact: GuardArtifact,
+    store: GuardStore,
+    target: dict[str, object],
+    workspace_dir: Path | None,
+    parse_result: LockfileParseResult,
+    package_intent_hash: str,
+    now: str,
+) -> PackageRequestEvaluation:
+    config = load_guard_config(store.guard_home, workspace=workspace_dir)
+    decision = "block" if config.security_level in {"strict", "paranoid"} else "ask"
+    package = _incomplete_lockfile_package_result(
+        target=target,
+        parse_result=parse_result,
+        decision=decision,
+    )
+    draft = _EvaluationDraft(
+        decision=decision,
+        enforcement="free_local",
+        entitlement_state="free",
+        cache_status="miss",
+        packages=(package,),
+        reasons=tuple(_dict_items(package.get("reasons"))),
+        matched_rule_id=None,
+        exception_id=None,
+        refresh_required=False,
+        record_monitor_evidence=False,
+        bundle_version=None,
+        policy_version="local:none",
+    )
+    fingerprint = _stable_hash(
+        {
+            "lockfile_hash": parse_result.source_hash,
+            "lockfile_parser_version": parse_result.parser_version,
+        }
+    )
+    evaluation = _finalize_evaluation(
+        draft,
+        package_intent_hash=package_intent_hash,
+        workspace_fingerprint=fingerprint,
+    )
+    _persist_evidence(store=store, artifact=artifact, evaluation=evaluation, now=now)
+    return evaluation
+
+
+def _incomplete_lockfile_package_result(
+    *,
+    target: dict[str, object],
+    parse_result: LockfileParseResult,
+    decision: str = "ask",
+) -> dict[str, object]:
+    error_reason = parse_result.error_reason or "parse_error"
+    package = _heuristic_package_result(
+        target=target,
+        decision=decision,
+        code="lockfile_parse_incomplete",
+        message=(
+            f"Guard could not completely parse the existing {parse_result.format} lockfile "
+            f"({error_reason}), so this package request is paused. Repair the lockfile, then retry."
+        ),
+        severity="high",
+    )
+    metadata: dict[str, object] = {
+        "lockfileHash": parse_result.source_hash,
+        "lockfileParserVersion": parse_result.parser_version,
+        "lockfileFormat": parse_result.format,
+        "lockfileParseComplete": False,
+        "lockfileParseError": error_reason,
+        "lockfileParseElapsedMs": round(parse_result.elapsed_ms, 3),
+        "lockfileParseBudgetMs": parse_result.budget_ms,
+        "lockfileParseWarnings": list(parse_result.warnings),
+    }
+    package.update(metadata)
+    first_reason = _first_dict_item(package.get("reasons"))
+    if first_reason is not None:
+        package["reasons"] = ({**first_reason, **metadata},)
+    return package
+
+
 def _workspace_fingerprint(
     workspace_id: str,
     *,
@@ -2001,6 +2172,7 @@ def _workspace_fingerprint(
             "workspace_name": workspace_dir.name if workspace_dir is not None else None,
             "manifest_hashes": manifest_hashes,
             "lockfile_hashes": lockfile_hashes,
+            "lockfile_parser_version": LOCKFILE_PARSER_VERSION,
             "bundle_policy_hash": bundle_meta["policy_hash"] if bundle_meta is not None else None,
         }
     )
@@ -2053,18 +2225,29 @@ def _lockfile_context(workspace_dir: Path | None, artifact: GuardArtifact) -> di
     lockfile_path = resolve_path_within_workspace(workspace_dir, str(lockfile_paths[0]))
     if lockfile_path is None or not lockfile_path.exists():
         return None
+    if lockfile_path.name.lower() == "bun.lockb":
+        return None
     lockfile_text = read_text_within_workspace(workspace_dir, str(lockfile_paths[0]))
     if lockfile_text is None:
         return None
-    dependencies = _safe_dependency_map_for_path(
-        str(lockfile_path.name), lockfile_text, deadline=time.monotonic() + _LOCKFILE_PARSE_BUDGET_SECONDS
-    )
+    parse_result = _parse_lockfile_text_result(lockfile_path.name, lockfile_text)
+    if not parse_result.complete:
+        return {
+            "dependencyCount": 0,
+            "fileName": lockfile_path.name,
+            "lockfileHash": parse_result.source_hash,
+            "lockfileParserVersion": parse_result.parser_version,
+            "parseComplete": False,
+            "parseError": parse_result.error_reason,
+        }
     manifest_hashes = _hash_paths(workspace_dir, artifact.metadata.get("manifest_paths"))
     return {
-        "dependencyCount": len(dependencies),
+        "dependencyCount": len(parse_result.entries),
         "fileName": lockfile_path.name,
-        "lockfileHash": stable_digest_hex(lockfile_text.encode("utf-8")),
+        "lockfileHash": parse_result.source_hash,
+        "lockfileParserVersion": parse_result.parser_version,
         "manifestHash": manifest_hashes[0] if manifest_hashes else None,
+        "parseComplete": True,
         "repository": workspace_dir.name,
     }
 
@@ -2096,6 +2279,8 @@ def _transitive_lockfile_results(
         lockfile_path = resolve_path_within_workspace(workspace_dir, str(relative_path))
         if lockfile_path is None or not lockfile_path.exists():
             continue
+        if lockfile_path.name.lower() == "bun.lockb":
+            continue
         lockfile_ecosystem = _lockfile_ecosystem(lockfile_path.name)
         direct_target_names = (
             direct_target_names_by_ecosystem.get(lockfile_ecosystem, all_direct_target_names)
@@ -2106,49 +2291,35 @@ def _transitive_lockfile_results(
         if lockfile_text is None:
             continue
         dependency_entries: list[tuple[str, str, str, bool]] = []
-        parse_deadline = time.monotonic() + _LOCKFILE_PARSE_BUDGET_SECONDS
-        try:
-            if lockfile_path.name == "package-lock.json":
-                dependency_entries = [
-                    (
-                        dependency_path,
-                        package_name,
-                        version,
-                        dependency_path in direct_target_names,
+        parse_result = _parse_lockfile_text_result(lockfile_path.name, lockfile_text)
+        if not parse_result.complete:
+            if direct_targets:
+                results.append(
+                    _incomplete_lockfile_package_result(
+                        target=direct_targets[0],
+                        parse_result=parse_result,
                     )
-                    for dependency_path, package_name, version, _direct in _package_lock_entries(
-                        lockfile_text, deadline=parse_deadline
-                    )
-                ]
-            else:
-                dependency_map = _safe_dependency_map_for_path(
-                    str(lockfile_path.name),
-                    lockfile_text,
-                    deadline=parse_deadline,
                 )
-                for dependency_path, version in dependency_map.items():
-                    normalized_dependency_path = dependency_path.strip("/")
-                    if not normalized_dependency_path:
-                        continue
-                    package_name = _dependency_package_name(normalized_dependency_path)
-                    if package_name is None:
-                        continue
-                    dependency_entries.append(
-                        (
-                            dependency_path,
-                            package_name,
-                            version,
-                            normalized_dependency_path in direct_target_names,
-                        )
-                    )
-        except _DeadlineExceededError:
-            timeout_warning = _transitive_lockfile_timeout_warning(
-                targets=direct_targets,
-                lockfile_name=lockfile_path.name,
-            )
-            if timeout_warning is not None:
-                results.append(timeout_warning)
             continue
+        for entry in parse_result.entries:
+            normalized_dependency_path = entry.dependency_path.strip("/")
+            if not normalized_dependency_path:
+                continue
+            package_name = (
+                entry.package_name
+                if lockfile_path.name == "package-lock.json"
+                else _dependency_package_name(normalized_dependency_path)
+            )
+            if package_name is None:
+                continue
+            dependency_entries.append(
+                (
+                    entry.dependency_path,
+                    package_name,
+                    entry.version,
+                    normalized_dependency_path in direct_target_names,
+                )
+            )
         for dependency_path, package_name, version, direct in dependency_entries:
             if direct:
                 continue
@@ -2317,25 +2488,6 @@ def _bundle_package_from_index(
     except PackageIdentityError:
         return None
     return index.get(identity)
-
-
-def _transitive_lockfile_timeout_warning(
-    *,
-    targets: tuple[dict[str, object], ...],
-    lockfile_name: str,
-) -> dict[str, object] | None:
-    if not targets:
-        return None
-    return _heuristic_package_result(
-        target=targets[0],
-        decision="warn",
-        code="transitive_lockfile_timeout",
-        message=(
-            f"Guard only partially scanned {lockfile_name} before the resolver deadline; "
-            "transitive dependency results may be incomplete."
-        ),
-        severity="unknown",
-    )
 
 
 def _parse_evaluation_timestamp(now_value: str) -> float | None:
@@ -3270,11 +3422,16 @@ def _lockfile_dependency_versions(
         lockfile_path = resolve_path_within_workspace(workspace_dir, str(relative_path))
         if lockfile_path is None or not lockfile_path.exists():
             continue
+        if lockfile_path.name.lower() == "bun.lockb":
+            continue
         lockfile_text = read_text_within_workspace(workspace_dir, str(relative_path))
         if lockfile_text is None:
             continue
+        parse_result = _parse_lockfile_text_result(lockfile_path.name, lockfile_text)
+        if not parse_result.complete:
+            continue
         if lockfile_path.name == "package-lock.json":
-            versions.update(_package_lock_target_versions(lockfile_text, targets))
+            versions.update(_package_lock_target_versions_from_entries(parse_result, targets))
             continue
         if lockfile_path.name == "pnpm-lock.yaml":
             versions.update(_pnpm_lock_target_versions(lockfile_text, targets))
@@ -3398,20 +3555,26 @@ def _package_lock_target_versions(
     text: str,
     targets: tuple[dict[str, object], ...],
 ) -> dict[tuple[str, str | None], str]:
-    try:
-        entries = _package_lock_entries(text, deadline=time.monotonic() + _LOCKFILE_PARSE_BUDGET_SECONDS)
-    except _DeadlineExceededError:
+    parse_result = _parse_lockfile_text_result("package-lock.json", text)
+    if not parse_result.complete:
         return {}
+    return _package_lock_target_versions_from_entries(parse_result, targets)
+
+
+def _package_lock_target_versions_from_entries(
+    parse_result: LockfileParseResult,
+    targets: tuple[dict[str, object], ...],
+) -> dict[tuple[str, str | None], str]:
     versions: dict[tuple[str, str | None], str] = {}
     for target in targets:
         target_key = _lockfile_target_key(target)
         candidate_paths = set(_package_lock_candidate_names(target))
         normalized_name = str(target["normalized_name"])
-        for dependency_path, package_name, version, direct in entries:
-            if not direct:
+        for entry in parse_result.entries:
+            if not entry.direct:
                 continue
-            if dependency_path in candidate_paths or package_name == normalized_name:
-                versions[target_key] = version
+            if entry.dependency_path in candidate_paths or entry.package_name == normalized_name:
+                versions[target_key] = entry.version
                 break
     return versions
 
@@ -3423,7 +3586,7 @@ def _package_lock_entries(text: str, *, deadline: float | None = None) -> list[t
     if isinstance(packages, dict):
         for package_path, value in packages.items():
             if deadline is not None and time.monotonic() > deadline:
-                break
+                raise _DeadlineExceededError("deadline_exceeded")
             if not isinstance(package_path, str) or not package_path.startswith("node_modules/"):
                 continue
             version = value.get("version") if isinstance(value, dict) else None
@@ -3455,7 +3618,7 @@ def _walk_package_lock_entries(
 ) -> None:
     for package_name, value in payload.items():
         if deadline is not None and time.monotonic() > deadline:
-            return
+            raise _DeadlineExceededError("deadline_exceeded")
         if not isinstance(package_name, str) or not isinstance(value, dict):
             continue
         version = value.get("version")
@@ -3491,32 +3654,32 @@ def _cargo_lock_target_versions(
     text: str,
     targets: tuple[dict[str, object], ...],
 ) -> dict[tuple[str, str | None], str]:
-    direct_versions, _error = _safe_dependency_map_result_for_path("Cargo.lock", text, deadline=time.monotonic() + 0.2)
-    return _target_versions_from_direct_map(targets, direct_versions)
+    parse_result = _safe_dependency_map_result_for_path("Cargo.lock", text, deadline=time.monotonic() + 0.2)
+    return _target_versions_from_direct_map(targets, parse_result.dependency_map())
 
 
 def _composer_lock_target_versions(
     text: str,
     targets: tuple[dict[str, object], ...],
 ) -> dict[tuple[str, str | None], str]:
-    direct_versions, _error = _safe_dependency_map_result_for_path(
+    parse_result = _safe_dependency_map_result_for_path(
         "composer.lock",
         text,
         deadline=time.monotonic() + 0.2,
     )
-    return _target_versions_from_direct_map(targets, direct_versions)
+    return _target_versions_from_direct_map(targets, parse_result.dependency_map())
 
 
 def _gemfile_lock_target_versions(
     text: str,
     targets: tuple[dict[str, object], ...],
 ) -> dict[tuple[str, str | None], str]:
-    direct_versions, _error = _safe_dependency_map_result_for_path(
+    parse_result = _safe_dependency_map_result_for_path(
         "Gemfile.lock",
         text,
         deadline=time.monotonic() + 0.2,
     )
-    return _target_versions_from_direct_map(targets, direct_versions)
+    return _target_versions_from_direct_map(targets, parse_result.dependency_map())
 
 
 def _pnpm_lock_target_versions(
@@ -4067,8 +4230,7 @@ def _source_url_from_raw_spec(raw_spec: str) -> str | None:
 
 
 def _safe_dependency_map_for_path(path: str, text: str, *, deadline: float) -> dict[str, str]:
-    dependency_map, _error = _safe_dependency_map_result_for_path(path, text, deadline=deadline)
-    return dependency_map
+    return _safe_dependency_map_result_for_path(path, text, deadline=deadline).dependency_map()
 
 
 def _safe_dependency_map_result_for_path(
@@ -4076,17 +4238,16 @@ def _safe_dependency_map_result_for_path(
     text: str,
     *,
     deadline: float,
-) -> tuple[dict[str, str], str | None]:
-    try:
-        return _dependency_map_for_path(path, text, deadline=deadline), None
-    except (
-        _DeadlineExceededError,
-        ET.ParseError,
-        UnicodeDecodeError,
-        ValueError,
-        json.JSONDecodeError,
-    ):
-        return {}, "parse_error"
+) -> LockfileParseResult:
+    budget_ms = max(0.0, (deadline - time.monotonic()) * 1000)
+    return parse_lockfile_text(
+        path,
+        text,
+        deadline=deadline,
+        budget_ms=budget_ms,
+        dependency_parser=_dependency_map_for_path,
+        package_lock_parser=_package_lock_entries,
+    )
 
 
 def _lockfile_parse_warning_result(
@@ -4105,28 +4266,24 @@ def _lockfile_parse_warning_result(
         lockfile_path = resolve_path_within_workspace(workspace_dir, str(relative_path))
         if lockfile_path is None or not lockfile_path.exists():
             continue
+        if lockfile_path.name.lower() == "bun.lockb":
+            continue
         lockfile_ecosystem = _lockfile_ecosystem(lockfile_path.name)
         if lockfile_ecosystem is not None and lockfile_ecosystem != target_ecosystem:
             continue
         lockfile_text = read_text_within_workspace(workspace_dir, str(relative_path))
         if lockfile_text is None:
             continue
-        _dependency_map, error = _safe_dependency_map_result_for_path(
+        parse_result = _safe_dependency_map_result_for_path(
             lockfile_path.name,
             lockfile_text,
             deadline=time.monotonic() + 0.2,
         )
-        if error is None:
+        if parse_result.complete:
             continue
-        return _heuristic_package_result(
+        return _incomplete_lockfile_package_result(
             target=target,
-            decision="ask",
-            code="lockfile_parse_error",
-            message=(
-                "Guard could not parse the existing lockfile, so this range-based package request needs review. "
-                "Repair the lockfile, then retry."
-            ),
-            severity="high",
+            parse_result=parse_result,
         )
     return None
 

--- a/tests/test_guard_approval_precedence_consumers.py
+++ b/tests/test_guard_approval_precedence_consumers.py
@@ -358,6 +358,39 @@ def test_package_policy_and_sandbox_context_changes_invalidate_review_approval(
     assert result.reasons[0]["code"] == expected_reason
 
 
+def test_package_lockfile_parser_version_changes_approval_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact = _package_artifact(workspace)
+    context = build_package_execution_context(workspace_dir=workspace, artifact=artifact, executable="npm")
+    evaluation = _package_evaluation("review")
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace)
+    store = GuardStore(tmp_path / "guard-home")
+    original_digest = package_request_policy_hash(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace,
+        evaluation=evaluation,
+        execution_context=context,
+        config=config,
+    )
+
+    monkeypatch.setattr(local_supply_chain_module, "LOCKFILE_PARSER_VERSION", "complete-v2")
+    upgraded_digest = package_request_policy_hash(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace,
+        evaluation=evaluation,
+        execution_context=context,
+        config=config,
+    )
+
+    assert original_digest != upgraded_digest
+
+
 @pytest.mark.parametrize(("saved_action", "expected"), [("allow", False), ("block", True)])
 def test_package_cache_error_probe_is_non_consuming_and_never_authorizes_saved_allow(
     tmp_path: Path,

--- a/tests/test_guard_js_lockfile_resolution_phase11.py
+++ b/tests/test_guard_js_lockfile_resolution_phase11.py
@@ -9,6 +9,9 @@ import pytest
 
 import codex_plugin_scanner.guard.runtime.lockfile_parse_result as lockfile_parse_module
 import codex_plugin_scanner.guard.runtime.supply_chain_package_eval as evaluator_module
+from codex_plugin_scanner.guard.runtime.lockfile_evaluation_support import (
+    incomplete_lockfile_fallback_target,
+)
 from codex_plugin_scanner.guard.runtime.lockfile_parse_result import LOCKFILE_MAX_BYTES
 from codex_plugin_scanner.guard.runtime.package_manifest_diff import _DeadlineExceededError
 from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
@@ -21,6 +24,32 @@ from tests.test_guard_js_supply_chain_phase11 import (
     _package,
     _write_text,
 )
+
+
+@pytest.mark.parametrize(
+    ("lockfile_name", "package_manager"),
+    (
+        ("package-lock.json", "npm"),
+        ("pnpm-lock.yaml", "pnpm"),
+        ("yarn.lock", "yarn"),
+        ("bun.lock", "bun"),
+    ),
+)
+def test_incomplete_javascript_lockfile_fallback_preserves_package_manager(
+    lockfile_name: str,
+    package_manager: str,
+) -> None:
+    parse_result = lockfile_parse_module.incomplete_lockfile_result(
+        lockfile_name,
+        b"",
+        error_reason="parse_error",
+        budget_ms=200,
+    )
+
+    target = incomplete_lockfile_fallback_target(parse_result)
+
+    assert target["ecosystem"] == "npm"
+    assert target["package_manager"] == package_manager
 
 
 def test_evaluate_package_request_artifact_preserves_direct_version_when_package_lock_contains_nested_duplicate(

--- a/tests/test_guard_js_lockfile_resolution_phase11.py
+++ b/tests/test_guard_js_lockfile_resolution_phase11.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
+import codex_plugin_scanner.guard.runtime.lockfile_parse_result as lockfile_parse_module
+import codex_plugin_scanner.guard.runtime.supply_chain_package_eval as evaluator_module
+from codex_plugin_scanner.guard.runtime.lockfile_parse_result import LOCKFILE_MAX_BYTES
+from codex_plugin_scanner.guard.runtime.package_manifest_diff import _DeadlineExceededError
 from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.stable_digest import stable_digest_hex
 from codex_plugin_scanner.guard.store import GuardStore
 from tests.test_guard_js_supply_chain_phase11 import (
     WORKSPACE_ID,
@@ -80,3 +86,158 @@ def test_evaluate_package_request_artifact_resolves_alias_range_from_package_loc
     assert result.decision == "block"
     assert result.packages[0]["resolvedVersion"] == "1.2.8"
     assert result.user_copy.next_step == "npm install guard-safe@npm:minimist@1.2.9"
+
+
+def test_recursive_package_lock_deadline_raises_instead_of_returning_partial_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ticks = iter((0.0, 1.0))
+    monkeypatch.setattr(evaluator_module.time, "monotonic", lambda: next(ticks))
+    lockfile_text = json.dumps(
+        {
+            "dependencies": {
+                "safe-first": {
+                    "version": "1.0.0",
+                    "dependencies": {"risky-last": {"version": "9.9.9"}},
+                }
+            }
+        }
+    )
+
+    with pytest.raises(_DeadlineExceededError, match="deadline_exceeded"):
+        evaluator_module._package_lock_entries(lockfile_text, deadline=0.5)
+
+
+@pytest.mark.parametrize(
+    ("lockfile_name", "lockfile_text", "error_reason"),
+    [
+        ("package-lock.json", "{broken", "syntax_error"),
+        ("package-lock.json", '{"packages":{"node_modules/a":{"version":"1.0.0"}}', "syntax_error"),
+        (
+            "package-lock.json",
+            '{"packages":{"node_modules/a":{"version":"1"},"node_modules/a":{"version":"2"}}}',
+            "duplicate_key",
+        ),
+        ("package-lock.json", '{"lockfileVersion":99,"packages":{}}', "unsupported_version"),
+        ("package-lock.json", '{"lockfileVersion":3,"packages":[]}', "unsupported_shape"),
+        ("Cargo.lock", "version = [\n", "syntax_error"),
+        ("poetry.lock", "[[package]\nname = 'demo'\n", "syntax_error"),
+        ("pnpm-lock.yaml", "packages:\n  truncated-entry\n", "syntax_error"),
+        ("yarn.lock", '"demo@1.0.0"\n  version "1.0.0"\n', "syntax_error"),
+        ("yarn.lock", "#" * (LOCKFILE_MAX_BYTES + 1), "byte_limit_exceeded"),
+    ],
+)
+def test_lockfile_parse_result_rejects_incomplete_or_unsupported_inputs(
+    lockfile_name: str,
+    lockfile_text: str,
+    error_reason: str,
+) -> None:
+    result = evaluator_module._parse_lockfile_text_result(lockfile_name, lockfile_text)
+
+    assert result.complete is False
+    assert result.entries == ()
+    assert result.error_reason == error_reason
+    assert result.source_hash == stable_digest_hex(lockfile_text.encode("utf-8"))
+    assert result.parser_version == "complete-v1"
+    assert result.budget_ms == 200
+
+
+def test_lockfile_parse_result_rejects_excessive_json_depth() -> None:
+    nested: object = "leaf"
+    for _index in range(130):
+        nested = {"next": nested}
+    lockfile_text = json.dumps({"lockfileVersion": 3, "packages": {}, "metadata": nested})
+
+    result = evaluator_module._parse_lockfile_text_result("package-lock.json", lockfile_text)
+
+    assert result.complete is False
+    assert result.error_reason == "depth_limit_exceeded"
+
+
+def test_lockfile_parse_result_rejects_dependency_count_over_bound(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(lockfile_parse_module, "LOCKFILE_MAX_ENTRIES", 1)
+    lockfile_text = json.dumps(
+        {
+            "lockfileVersion": 3,
+            "packages": {
+                "node_modules/first": {"version": "1.0.0"},
+                "node_modules/second": {"version": "2.0.0"},
+            },
+        }
+    )
+
+    result = evaluator_module._parse_lockfile_text_result("package-lock.json", lockfile_text)
+
+    assert result.complete is False
+    assert result.entries == ()
+    assert result.error_reason == "entry_limit_exceeded"
+
+
+@pytest.mark.parametrize(
+    "lockfile_name",
+    [
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+        "bun.lock",
+        "Cargo.lock",
+        "composer.lock",
+        "Gemfile.lock",
+        "poetry.lock",
+        "uv.lock",
+        "Pipfile.lock",
+    ],
+)
+def test_lockfile_parse_result_distinguishes_valid_empty_lockfile_from_failure(lockfile_name: str) -> None:
+    result = evaluator_module._parse_lockfile_text_result(lockfile_name, "")
+
+    assert result.complete is True
+    assert result.entries == ()
+    assert result.error_reason is None
+
+
+def test_incomplete_lockfile_evidence_contains_hash_and_reason_without_contents(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo","dependencies":{"minimist":"^1.2.0"}}\n')
+    malformed_lockfile = '{"lockfileVersion":3,"packages":{"node_modules/secret-fixture":'
+    _write_text(workspace_dir / "package-lock.json", malformed_lockfile)
+    store = GuardStore(home_dir)
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_from_command("npm install minimist@^1.2.0", workspace=workspace_dir),
+        store=store,
+        workspace_dir=workspace_dir,
+    )
+
+    assert result.decision == "ask"
+    assert result.policy_action == "require-reapproval"
+    package = result.packages[0]
+    assert package["lockfileParseError"] == "syntax_error"
+    assert package["lockfileHash"] == stable_digest_hex(malformed_lockfile.encode("utf-8"))
+    evidence_payload = json.dumps(store.list_evidence(), sort_keys=True)
+    assert package["lockfileHash"] in evidence_payload
+    assert "lockfile_parse_incomplete" in evidence_payload
+    assert malformed_lockfile not in evidence_payload
+
+
+def test_incomplete_lockfile_blocks_in_strict_mode(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo","dependencies":{"minimist":"^1.2.0"}}\n')
+    _write_text(workspace_dir / "package-lock.json", '{"lockfileVersion":99,"packages":{}}\n')
+    store = GuardStore(home_dir)
+    store.guard_home.mkdir(parents=True, exist_ok=True)
+    _write_text(store.guard_home / "config.toml", 'security_level = "strict"\n')
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_from_command("npm install minimist@^1.2.0", workspace=workspace_dir),
+        store=store,
+        workspace_dir=workspace_dir,
+    )
+
+    assert result.decision == "block"
+    assert result.policy_action == "block"
+    assert result.packages[0]["lockfileParseError"] == "unsupported_version"

--- a/tests/test_guard_js_lockfile_resolution_phase11.py
+++ b/tests/test_guard_js_lockfile_resolution_phase11.py
@@ -52,6 +52,20 @@ def test_incomplete_javascript_lockfile_fallback_preserves_package_manager(
     assert target["package_manager"] == package_manager
 
 
+def test_incomplete_composer_lockfile_fallback_uses_packagist_ecosystem() -> None:
+    parse_result = lockfile_parse_module.incomplete_lockfile_result(
+        "composer.lock",
+        b"",
+        error_reason="parse_error",
+        budget_ms=200,
+    )
+
+    target = incomplete_lockfile_fallback_target(parse_result)
+
+    assert target["ecosystem"] == "packagist"
+    assert target["package_manager"] == "composer"
+
+
 def test_evaluate_package_request_artifact_preserves_direct_version_when_package_lock_contains_nested_duplicate(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_js_lockfile_resolution_phase11.py
+++ b/tests/test_guard_js_lockfile_resolution_phase11.py
@@ -120,6 +120,9 @@ def test_recursive_package_lock_deadline_raises_instead_of_returning_partial_ent
         ),
         ("package-lock.json", '{"lockfileVersion":99,"packages":{}}', "unsupported_version"),
         ("package-lock.json", '{"lockfileVersion":3,"packages":[]}', "unsupported_shape"),
+        ("bun.lock", '{"lockfileVersion":99,"packages":{}}', "unsupported_version"),
+        ("bun.lock", '{"lockfileVersion":1,"packages":[]}', "unsupported_shape"),
+        ("bun.lock", '{"lockfileVersion":1,"packages":{"demo":[]}}', "parse_error"),
         ("Cargo.lock", "version = [\n", "syntax_error"),
         ("poetry.lock", "[[package]\nname = 'demo'\n", "syntax_error"),
         ("pnpm-lock.yaml", "packages:\n  truncated-entry\n", "syntax_error"),
@@ -171,6 +174,43 @@ def test_lockfile_parse_result_rejects_dependency_count_over_bound(monkeypatch: 
     assert result.complete is False
     assert result.entries == ()
     assert result.error_reason == "entry_limit_exceeded"
+
+
+def test_lockfile_parse_result_fail_closes_on_unexpected_dependency_parser_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_parser_failure(*args: object, **kwargs: object) -> dict[str, str]:
+        del args, kwargs
+        raise RuntimeError("unexpected parser failure")
+
+    monkeypatch.setattr(evaluator_module, "_dependency_map_for_path", unexpected_parser_failure)
+
+    result = evaluator_module._parse_lockfile_text_result("Cargo.lock", "")
+
+    assert result.complete is False
+    assert result.entries == ()
+    assert result.error_reason == "parse_error"
+
+
+def test_bun_jsonc_lockfile_is_parsed_completely() -> None:
+    lockfile_text = """{
+      // Bun's text lockfile supports JSONC.
+      "lockfileVersion": 1,
+      "packages": {
+        "left-pad": ["left-pad@1.3.0", "", {}, "sha512-demo",],
+        "@scope/demo": ["@scope/demo@2.4.1", "", {},],
+        "local": ["local@workspace:packages/local"],
+      },
+    }
+    """
+
+    result = evaluator_module._parse_lockfile_text_result("bun.lock", lockfile_text)
+
+    assert result.complete is True
+    assert {(entry.package_name, entry.version) for entry in result.entries} == {
+        ("@scope/demo", "2.4.1"),
+        ("left-pad", "1.3.0"),
+    }
 
 
 @pytest.mark.parametrize(
@@ -241,3 +281,57 @@ def test_incomplete_lockfile_blocks_in_strict_mode(tmp_path: Path) -> None:
     assert result.decision == "block"
     assert result.policy_action == "block"
     assert result.packages[0]["lockfileParseError"] == "unsupported_version"
+
+
+def test_late_incomplete_lockfile_result_is_not_deduplicated_against_direct_package(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    lockfile_text = json.dumps(
+        {
+            "lockfileVersion": 3,
+            "packages": {
+                "": {"dependencies": {"react": "18.0.0"}},
+                "node_modules/react": {"version": "18.0.0"},
+            },
+        }
+    )
+    _write_text(workspace_dir / "package-lock.json", lockfile_text)
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(packages=[_package(name="react", version="18.0.0", default_action="allow")]),
+        "2026-05-19T00:00:00Z",
+    )
+    real_parser = evaluator_module._parse_lockfile_text_result
+    parse_calls = 0
+
+    def changing_parser(path: str, text: str):
+        nonlocal parse_calls
+        parse_calls += 1
+        if parse_calls == 3:
+            return lockfile_parse_module.incomplete_lockfile_result(
+                path,
+                text.encode("utf-8"),
+                error_reason="parse_error",
+                budget_ms=200,
+            )
+        return real_parser(path, text)
+
+    monkeypatch.setattr(evaluator_module, "_parse_lockfile_text_result", changing_parser)
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_from_command("npm install react@18.0.0", workspace=workspace_dir),
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert parse_calls >= 3
+    assert result.decision == "ask"
+    assert any(package.get("lockfileParseComplete") is False for package in result.packages)
+    assert any(reason["code"] == "lockfile_parse_incomplete" for reason in result.reasons)

--- a/tests/test_guard_js_lockfile_resolution_phase11.py
+++ b/tests/test_guard_js_lockfile_resolution_phase11.py
@@ -262,6 +262,25 @@ def test_incomplete_lockfile_evidence_contains_hash_and_reason_without_contents(
     assert malformed_lockfile not in evidence_payload
 
 
+def test_incomplete_lockfile_without_direct_package_target_still_fails_closed(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package-lock.json", '{"lockfileVersion":3,"packages":')
+    store = GuardStore(tmp_path / "home")
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_from_command("npm install", workspace=workspace_dir),
+        store=store,
+        workspace_dir=workspace_dir,
+    )
+
+    assert result.decision == "ask"
+    assert result.policy_action == "require-reapproval"
+    assert result.packages[0]["name"] == "unresolved-lockfile"
+    assert result.packages[0]["lockfileParseComplete"] is False
+    assert any(reason["code"] == "lockfile_parse_incomplete" for reason in result.reasons)
+
+
 def test_incomplete_lockfile_blocks_in_strict_mode(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_python_supply_chain_phase12.py
+++ b/tests/test_guard_python_supply_chain_phase12.py
@@ -365,12 +365,6 @@ source = { registry = "https://pypi.org/simple" }
         bundle_response_fixture(packages=[npm_package, pypi_package]),
         "2026-05-19T00:00:00Z",
     )
-    monkeypatch.setattr(
-        supply_chain_package_eval_module,
-        "_safe_dependency_map_for_path",
-        lambda _path, _text, *, deadline: {"requests": "2.31.0"},
-    )
-
     bundle_response = load_supply_chain_bundle_response(bundle_response_fixture(packages=[npm_package, pypi_package]))
     artifact = artifact_from_command_fixture("uv add fastapi>=0.110,<0.116", workspace=workspace_dir)
     results = supply_chain_package_eval_module._transitive_lockfile_results(
@@ -405,6 +399,11 @@ version = 1
 name = "fastapi"
 version = "0.115.0"
 source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
 """.strip()
         + "\n",
     )
@@ -424,12 +423,6 @@ source = { registry = "https://pypi.org/simple" }
         ),
         "2026-05-19T00:00:00Z",
     )
-    monkeypatch.setattr(
-        supply_chain_package_eval_module,
-        "_safe_dependency_map_for_path",
-        lambda _path, _text, *, deadline: {"requests": "2.31.0"},
-    )
-
     artifact = artifact_from_command_fixture("uv add fastapi>=0.110,<0.116", workspace=workspace_dir)
     result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
 

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -1940,7 +1940,10 @@ def test_transitive_lockfile_resolution_uses_bounded_deadline(tmp_path: Path, mo
     assert captured["deadline"] == pytest.approx(100.2)
 
 
-def test_transitive_lockfile_timeout_surfaces_warn_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_transitive_lockfile_timeout_pauses_without_using_partial_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     store = GuardStore(tmp_path / "guard-home")
     monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
     response = _bundle_response(
@@ -1981,9 +1984,13 @@ def test_transitive_lockfile_timeout_surfaces_warn_result(tmp_path: Path, monkey
         now="2026-05-19T00:00:00Z",
     )
 
-    assert result.decision == "warn"
-    assert any(reason["code"] == "transitive_lockfile_timeout" for reason in result.reasons)
-    assert "package-lock.json" in result.user_copy.harness_message
+    assert result.decision == "ask"
+    assert result.policy_action == "require-reapproval"
+    assert any(reason["code"] == "lockfile_parse_incomplete" for reason in result.reasons)
+    assert result.packages[0]["lockfileParseError"] == "deadline_exceeded"
+    assert result.packages[0]["lockfileParseComplete"] is False
+    assert result.packages[0]["lockfileParserVersion"] == "complete-v1"
+    assert "npm-package-lock" in result.user_copy.harness_message
 
 
 def test_package_from_cloud_result_preserves_direct_and_dependency_path_schema() -> None:
@@ -2157,7 +2164,7 @@ def test_evaluate_package_request_artifact_handles_invalid_lockfile_bytes_withou
     assert result.policy_action == "require-reapproval"
 
 
-def test_evaluate_package_request_artifact_handles_unreadable_workspace_paths_without_crashing(
+def test_evaluate_package_request_artifact_pauses_for_unreadable_lockfile(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
@@ -2201,8 +2208,10 @@ def test_evaluate_package_request_artifact_handles_unreadable_workspace_paths_wi
         now="2026-05-19T00:00:00Z",
     )
 
-    assert result.decision == "monitor"
-    assert result.policy_action == "allow"
+    assert result.decision == "ask"
+    assert any(reason["code"] == "lockfile_parse_incomplete" for reason in result.reasons)
+    assert result.packages[0]["lockfileParseError"] == "read_error"
+    assert result.policy_action == "require-reapproval"
 
 
 def test_evaluate_package_request_artifact_handles_unreadable_transitive_lockfile_without_crashing(

--- a/tests/test_guard_tier2_supply_chain_phase13.py
+++ b/tests/test_guard_tier2_supply_chain_phase13.py
@@ -385,5 +385,6 @@ clap = "4.5"
 
     assert result.decision == "ask"
     assert result.policy_action == "require-reapproval"
-    assert any(reason["code"] == "lockfile_parse_error" for reason in result.reasons)
+    assert any(reason["code"] == "lockfile_parse_incomplete" for reason in result.reasons)
+    assert result.packages[0]["lockfileParseError"] == "syntax_error"
     assert result.packages[0]["supportLevel"] == "beta"


### PR DESCRIPTION
## Summary

- replace partial lockfile maps with a typed complete-or-fail parse result carrying entries, format, content hash, parser version, timing budget, warnings, and a stable failure reason
- propagate recursive package-lock deadlines instead of returning partial dependencies, and validate supported lockfile structures, duplicate keys, versions, depth, node, entry, byte, decode, traversal, and read failures
- stop direct/transitive evaluation on incomplete parses, ask by default or block in strict/paranoid mode, and bind the lockfile hash plus parser version into evidence and workspace/cache identity

## Security invariant

Partial lockfile data is never evaluated as if parsing completed. A deadline or malformed/bounded input produces no usable entries and pauses the package request.

## Verification

- 155 focused lockfile, JS/Python supply-chain, evaluator, tier-2, and approval-precedence tests passed on the default Python
- the same 155 focused tests passed on Python 3.10
- Ruff format and lint passed
- basedpyright reported 0 errors
- Python 3.10 sdist and wheel builds passed
- exact commit author and committer: `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>`

## Regression proof

`test_recursive_package_lock_deadline_raises_instead_of_returning_partial_entries` forces the deadline between nested entries and proves the parser raises rather than returning the earlier partial set. The incomplete-evaluation regressions prove the resulting decision is review-required (or blocked under strict policy), carries only the lockfile hash/parser metadata, and does not leak lockfile contents.
