### PR TITLE
fix(codex): inventory every hook before activation

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 import hashlib
 import importlib
 import json
-import re
 import shlex
 import sys
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlencode
 
 from ...version import __version__
@@ -21,7 +20,7 @@ from ..aibom_detection import (
     extend_detection_with_workspace_aibom,
 )
 from ..codex_config import dump_toml, read_toml_payload, write_toml_payload
-from ..codex_hook_file_integrity import split_hook_command, validate_regular_file
+from ..codex_hook_file_integrity import validate_regular_file
 from ..codex_hook_integrity import (
     atomic_write_text,
     hook_manifest_path,
@@ -32,8 +31,14 @@ from ..codex_hook_integrity import (
     snapshot_regular_file,
     write_hook_manifest,
 )
-from ..codex_hook_manifest import (
-    MANAGED_CODEX_HOOK_EVENTS as _MANAGED_HOOK_EVENTS,
+from ..codex_hook_inventory import (
+    CODEX_HOOK_INVENTORY_SOURCE_CHANGED,
+    CODEX_HOOK_INVENTORY_SOURCE_DUPLICATE,
+    CODEX_HOOK_INVENTORY_SOURCE_MALFORMED,
+    CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE,
+    CODEX_HOOK_INVENTORY_UNMANAGED_EXECUTABLE,
+    CodexHookInventory,
+    enumerate_codex_hooks,
 )
 from ..codex_hook_manifest import (
     CodexHookManifestSpec,
@@ -203,16 +208,6 @@ _SHELL_GUARD_BEGIN = "# >>> HOL Guard Codex shell guard >>>"
 _SHELL_GUARD_END = "# <<< HOL Guard Codex shell guard <<<"
 _AUTHORITATIVE_ENFORCEMENT_BOUNDARY = "codex-native-hooks"
 _AUTHORITATIVE_HOOK_UNAVAILABLE_REASON = "codex_authoritative_hook_unavailable"
-_DAEMON_BRIDGE_PATH_SUFFIX = (
-    "codex_plugin_scanner",
-    "guard",
-    "adapters",
-    "codex_daemon_hook_bridge.py",
-)
-_GUARD_INSTALL_PATH_SEGMENTS = (
-    ("uv", "tools", "hol-guard"),
-    ("pipx", "venvs", "hol-guard"),
-)
 
 
 def _json_object(path: Path) -> dict[str, object]:
@@ -226,17 +221,104 @@ def _json_object(path: Path) -> dict[str, object]:
 
 
 def _strict_json_object(path: Path, *, label: str) -> dict[str, object]:
-    if path.exists() and not path.is_file():
-        raise RuntimeError(f"Guard refused to overwrite non-file {label} at {path}")
+    if path.is_symlink() or (path.exists() and not path.is_file()):
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE}: Guard refused to overwrite non-file {label} at {path}. "
+            "Replace it with a readable regular file before retrying install."
+        )
     if not path.is_file():
         return {}
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"Guard refused to overwrite unreadable {label} at {path}") from exc
+        payload = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=_unique_json_object)
+    except _DuplicateJsonKeyError as exc:
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_DUPLICATE}: Guard found duplicate key {exc.key!r} in {label} at "
+            f"{path}. Remove the duplicate before retrying install."
+        ) from exc
+    except OSError as exc:
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE}: Guard could not read {label} at {path}. Repair file "
+            "permissions before retrying install."
+        ) from exc
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_MALFORMED}: Guard refused to overwrite unreadable {label} at {path} "
+            "because its JSON is malformed. Repair the JSON before retrying install."
+        ) from exc
     if not isinstance(payload, dict):
-        raise RuntimeError(f"Guard refused to overwrite non-object {label} at {path}")
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_MALFORMED}: Guard refused to overwrite non-object {label} at {path}. "
+            "Replace it with a JSON object before retrying install."
+        )
     return payload
+
+
+class _DuplicateJsonKeyError(ValueError):
+    key: str
+
+    def __init__(self, key: str) -> None:
+        super().__init__(key)
+        self.key = key
+
+
+def _unique_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    payload: dict[str, object] = {}
+    for key, value in pairs:
+        if key in payload:
+            raise _DuplicateJsonKeyError(key)
+        payload[key] = value
+    return payload
+
+
+def _strict_toml_object(path: Path, *, label: str) -> dict[str, object]:
+    if path.is_symlink() or (path.exists() and not path.is_file()):
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE}: Guard refused to overwrite non-file {label} at {path}. "
+            "Replace it with a readable regular file before retrying install."
+        )
+    if not path.is_file():
+        return {}
+    try:
+        with path.open("rb") as handle:
+            payload = tomllib.load(handle)
+    except OSError as exc:
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE}: Guard could not read {label} at {path}. Repair file "
+            "permissions before retrying install."
+        ) from exc
+    except tomllib.TOMLDecodeError as exc:
+        reason = (
+            CODEX_HOOK_INVENTORY_SOURCE_DUPLICATE
+            if "overwrite" in str(exc).lower()
+            else CODEX_HOOK_INVENTORY_SOURCE_MALFORMED
+        )
+        raise RuntimeError(
+            f"{reason}: Guard could not parse {label} at {path}. Repair the TOML before retrying install."
+        ) from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_MALFORMED}: Guard refused to overwrite non-object {label} at {path}."
+        )
+    return payload
+
+
+def _require_hook_inventory_sources_unchanged(
+    *,
+    config_payloads: Mapping[Path, dict[str, object]],
+    hook_payloads: Mapping[Path, dict[str, object]],
+) -> None:
+    for path, expected in config_payloads.items():
+        if _strict_toml_object(path, label="Codex config file") != expected:
+            raise RuntimeError(
+                f"{CODEX_HOOK_INVENTORY_SOURCE_CHANGED}: Codex config changed after pre-activation inventory at "
+                f"{path}. Retry install after configuration writes have stopped."
+            )
+    for path, expected in hook_payloads.items():
+        if _strict_json_object(path, label="Codex hooks file") != expected:
+            raise RuntimeError(
+                f"{CODEX_HOOK_INVENTORY_SOURCE_CHANGED}: Codex hooks changed after pre-activation inventory at "
+                f"{path}. Retry install after configuration writes have stopped."
+            )
 
 
 def _local_hook_command_parts_for_home_mode(
@@ -488,295 +570,6 @@ def _current_install_legacy_bindings(context: HarnessContext, hooks: dict[str, o
     )
 
 
-def _tokens_are_managed_hook_command(tokens: list[str]) -> bool:
-    if tokens and Path(tokens[0]).name == "hol-guard-codex-hook.sh":
-        return True
-    if len(tokens) < 2:
-        return False
-    executable = Path(tokens[0]).name.lower()
-    if not executable.startswith("python"):
-        return False
-    if _is_daemon_bridge_hook_command(tokens):
-        return True
-    if len(tokens) < 3:
-        return False
-    if _argv_is_direct_codex_hook(tokens):
-        return True
-    return bool(_argv_is_inline_codex_hook(tokens))
-
-
-def _is_managed_hook_command(command: object) -> bool:
-    tokens = split_hook_command(command)
-    if tokens is None:
-        return False
-    return _tokens_are_managed_hook_command(tokens)
-
-
-def _python_script_and_args(tokens: list[str]) -> tuple[str, list[str]] | None:
-    """Return (script_path, remaining_args) after a python executable and its flags."""
-    if not tokens or not Path(tokens[0]).name.lower().startswith("python"):
-        return None
-    index = 1
-    while index < len(tokens):
-        token = tokens[index]
-        if token in {"-c", "-m"}:
-            return None
-        if token.startswith("-"):
-            # Flags that consume a following argument (e.g. -W error, -X faulthandler).
-            if token in {"-W", "-X", "-Q"} and index + 1 < len(tokens):
-                index += 2
-                continue
-            index += 1
-            continue
-        return token, tokens[index + 1 :]
-    return None
-
-
-def _is_daemon_bridge_hook_command(tokens: list[str]) -> bool:
-    script_and_args = _python_script_and_args(tokens)
-    if script_and_args is None:
-        return False
-    script_path, remaining = script_and_args
-    managed_bridge_path = Path(__file__).with_name("codex_daemon_hook_bridge.py").resolve()
-    try:
-        if Path(script_path).resolve() == managed_bridge_path:
-            return True
-    except OSError:
-        pass
-    bridge_path = Path(script_path)
-    return (
-        len(remaining) >= 1
-        and bridge_path.parts[-len(_DAEMON_BRIDGE_PATH_SUFFIX) :] == _DAEMON_BRIDGE_PATH_SUFFIX
-        and _bridge_config_targets_codex(remaining[0])
-    )
-
-
-def _tokens_are_unambiguously_managed_hook_command(tokens: list[str]) -> bool:
-    """Return True for hook commands that only Guard installs.
-
-    Direct ``python -m codex_plugin_scanner.cli guard hook`` entries are ambiguous:
-    a user can hand-author the same command. Bridge paths and the shell wrapper are
-    unique to Guard installs and can be reclaimed without a statusMessage marker.
-    """
-    if tokens and Path(tokens[0]).name == "hol-guard-codex-hook.sh":
-        return True
-    if len(tokens) < 2:
-        return False
-    executable = Path(tokens[0]).name.lower()
-    if not executable.startswith("python"):
-        return False
-    return _is_daemon_bridge_hook_command(tokens)
-
-
-def _is_unambiguously_managed_hook_command(command: object) -> bool:
-    tokens = split_hook_command(command)
-    if tokens is None:
-        return False
-    return _tokens_are_unambiguously_managed_hook_command(tokens)
-
-
-def _bridge_config_targets_codex(config_text: str) -> bool:
-    try:
-        config_value: object = json.loads(config_text)
-    except json.JSONDecodeError:
-        return False
-    if not isinstance(config_value, dict):
-        return False
-    config = {key: value for key, value in config_value.items() if isinstance(key, str)}
-    fallback_value = config.get("fallback_command")
-    if not isinstance(fallback_value, list) or not all(isinstance(token, str) for token in fallback_value):
-        return False
-    fallback_command = [token for token in fallback_value if isinstance(token, str)]
-    return _argv_is_direct_codex_hook(fallback_command)
-
-
-def _argv_is_direct_codex_hook(tokens: list[str]) -> bool:
-    if not tokens or not Path(tokens[0]).name.lower().startswith("python"):
-        return False
-    for index, token in enumerate(tokens[1:], start=1):
-        if token == "-c":
-            return False
-        if token != "-m":
-            continue
-        if index + 3 >= len(tokens):
-            return False
-        return (
-            tokens[index + 1] == "codex_plugin_scanner.cli"
-            and tokens[index + 2] == "guard"
-            and tokens[index + 3] == "hook"
-            and _argv_targets_codex(tokens[index + 4 :])
-        )
-    return False
-
-
-def _argv_is_inline_codex_hook(tokens: list[str]) -> bool:
-    if not tokens or not Path(tokens[0]).name.lower().startswith("python"):
-        return False
-    for index, token in enumerate(tokens[1:], start=1):
-        if token == "-m":
-            return False
-        if token != "-c":
-            continue
-        if index + 1 >= len(tokens):
-            return False
-        code = tokens[index + 1]
-        has_guard_call = (
-            re.search(r"['\"]guard['\"]", code) is not None
-            and re.search(r"['\"]hook['\"]", code) is not None
-            and re.search(r"['\"]--harness['\"]", code) is not None
-            and re.search(r"['\"]codex['\"]", code) is not None
-        )
-        return "codex_plugin_scanner.cli" in code and "main([" in code and has_guard_call
-    return False
-
-
-def _python_executable_is_guard_install(executable: str) -> bool:
-    """True when the interpreter path is a Guard pipx/uv install, not a substring lookalike."""
-    parts = tuple(part.lower() for part in Path(executable).parts)
-    return any(
-        any(parts[index : index + len(segment)] == segment for index in range(len(parts) - len(segment) + 1))
-        for segment in _GUARD_INSTALL_PATH_SEGMENTS
-    )
-
-
-def _argv_targets_codex(argv: list[str]) -> bool:
-    for index, token in enumerate(argv):
-        if token == "--harness" and index + 1 < len(argv) and argv[index + 1] == "codex":
-            return True
-        if token.startswith("--harness=") and token.split("=", 1)[1] == "codex":
-            return True
-    return False
-
-
-def _is_managed_hook_group(group: object) -> bool:
-    if not isinstance(group, dict):
-        return False
-    hooks = group.get("hooks")
-    if not isinstance(hooks, list):
-        return False
-    return any(_is_managed_hook_entry(entry) for entry in hooks)
-
-
-def _hook_command_matches_current_boundary(command: object, context: HarnessContext) -> bool:
-    tokens = split_hook_command(command)
-    if tokens is None or len(tokens) != 3:
-        return False
-    try:
-        if Path(tokens[0]).resolve() != Path(sys.executable).resolve():
-            return False
-        if Path(tokens[1]).resolve() != Path(__file__).with_name("codex_daemon_hook_bridge.py").resolve():
-            return False
-    except OSError:
-        return False
-    home_is_current = not context.home_override_explicit and context.home_dir.resolve() == Path.home().resolve()
-    expected_tokens = _hook_command_parts_for_home_mode(
-        context,
-        home_is_current=home_is_current,
-        python_executable=tokens[0],
-    )
-    return tuple(tokens) == expected_tokens
-
-
-def _is_current_managed_hook_group(
-    group: object,
-    expected: Mapping[str, object],
-    context: HarnessContext,
-) -> bool:
-    """Require an intact Guard-owned group used by the launch security boundary."""
-
-    if not isinstance(group, dict):
-        return False
-    group_payload = cast(dict[str, object], group)
-    actual_hooks = group_payload.get("hooks")
-    expected_hooks = expected.get("hooks")
-    if not isinstance(actual_hooks, list):
-        return False
-    if not isinstance(expected_hooks, list):
-        return False
-    actual_hook_entries = cast(list[object], actual_hooks)
-    expected_hook_entries = cast(list[object], expected_hooks)
-    if len(actual_hook_entries) != 1 or len(expected_hook_entries) != 1:
-        return False
-    actual_entry_value = actual_hook_entries[0]
-    expected_entry_value = expected_hook_entries[0]
-    if not isinstance(actual_entry_value, dict) or not isinstance(expected_entry_value, dict):
-        return False
-    actual_entry = cast(dict[str, object], actual_entry_value)
-    expected_entry = cast(dict[str, object], expected_entry_value)
-    if not _hook_command_matches_current_boundary(actual_entry.get("command"), context):
-        return False
-    comparison_entry = dict(expected_entry)
-    comparison_entry["command"] = actual_entry.get("command")
-    comparison = {**expected, "hooks": [comparison_entry]}
-    return group_payload == comparison
-
-
-def _is_managed_hook_entry(entry: object) -> bool:
-    if not isinstance(entry, dict):
-        return False
-    if entry.get("type") != "command":
-        return False
-    tokens = split_hook_command(entry.get("command"))
-    if tokens is None or not _tokens_are_managed_hook_command(tokens):
-        return False
-    # Bridge/wrapper commands are uniquely Guard-owned.
-    if _tokens_are_unambiguously_managed_hook_command(tokens):
-        return True
-    status_message = entry.get("statusMessage")
-    if isinstance(status_message, str) and status_message in _LEGACY_MANAGED_HOOK_STATUS_MESSAGES:
-        return True
-    # Intentional: direct Guard CLI hooks under pipx/uv hol-guard installs are reclaimed even
-    # without statusMessage. Stale PostToolUse installs often drop the marker while keeping the
-    # same python -m codex_plugin_scanner.cli path; leaving them breaks Codex JSON parsing.
-    # Hand-authored hooks that intentionally use that same Guard interpreter are treated as
-    # managed so repair can replace them with the daemon bridge.
-    return _python_executable_is_guard_install(tokens[0])
-
-
-def _remove_managed_hook_entries(group: object) -> object | None:
-    if not isinstance(group, dict):
-        return group
-    hooks = group.get("hooks")
-    if not isinstance(hooks, list):
-        return group
-    remaining_hooks = [entry for entry in hooks if not _is_managed_hook_entry(entry)]
-    if len(remaining_hooks) == len(hooks):
-        return group
-    if not remaining_hooks:
-        return None
-    updated_group = dict(group)
-    updated_group["hooks"] = remaining_hooks
-    return updated_group
-
-
-def _remove_hook_groups(groups: object) -> list[object]:
-    if not isinstance(groups, list):
-        return []
-    remaining: list[object] = []
-    for group in groups:
-        cleaned_group = _remove_managed_hook_entries(group)
-        if cleaned_group is not None:
-            remaining.append(cleaned_group)
-    return remaining
-
-
-def _remove_managed_hook_events(hooks: dict[str, object]) -> tuple[dict[str, object], bool]:
-    updated_hooks = dict(hooks)
-    changed = False
-    for event_name in ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse"):
-        original_groups = deepcopy(updated_hooks.get(event_name))
-        remaining = _remove_hook_groups(original_groups)
-        managed_removed = isinstance(original_groups, list) and remaining != original_groups
-        if not managed_removed:
-            continue
-        changed = True
-        if remaining:
-            updated_hooks[event_name] = remaining
-        else:
-            updated_hooks.pop(event_name, None)
-    return updated_hooks, changed
-
-
 def _append_unique_hook_groups(existing_groups: object, incoming_groups: object) -> list[object]:
     merged = list(existing_groups) if isinstance(existing_groups, list) else []
     if not isinstance(incoming_groups, list):
@@ -814,22 +607,41 @@ def _migrate_hooks_json_into_config(
     return changed
 
 
-def _hooks_payload_has_unmanaged_entries(
-    hooks_payload: dict[str, object],
+def _codex_hook_inventory(
+    payload: dict[str, object],
     *,
+    source_path: Path,
+    source_scope: str,
+    source_format: str,
+    source_hooks_enabled: bool,
     context: HarnessContext,
-    owned_bindings: Sequence[Mapping[str, object]] = (),
-) -> bool:
-    hooks = hooks_payload.get("hooks")
-    if not isinstance(hooks, dict):
-        return False
-    cleaned_hooks, _ = _remove_manifest_bound_hook_events(hooks, owned_bindings)
-    legacy_bindings = _current_install_legacy_bindings(context, cleaned_hooks)
-    cleaned_hooks, _ = _remove_manifest_bound_hook_events(cleaned_hooks, legacy_bindings)
-    return any(
-        isinstance(cleaned_hooks.get(event_name), list) and bool(cleaned_hooks.get(event_name))
-        for event_name in ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse")
+    authenticated_bindings: Sequence[Mapping[str, object]] = (),
+) -> CodexHookInventory:
+    hooks = payload.get("hooks")
+    legacy_bindings = _current_install_legacy_bindings(context, hooks if isinstance(hooks, dict) else {})
+    return enumerate_codex_hooks(
+        payload,
+        source_path=source_path,
+        source_scope=source_scope,
+        source_format="json" if source_format == "json" else "toml",
+        source_hooks_enabled=source_hooks_enabled,
+        authenticated_bindings=authenticated_bindings,
+        legacy_bindings=legacy_bindings,
     )
+
+
+def _require_complete_preactivation_inventory(inventory: CodexHookInventory) -> None:
+    if inventory.issues:
+        issue = inventory.issues[0]
+        raise RuntimeError(f"{issue.reason_code}: {issue.coordinate} in {issue.source_path}. {issue.message}")
+    unmanaged = inventory.unmanaged_active_executables
+    if inventory.records and not inventory.records[0].source_hooks_enabled and unmanaged:
+        coordinates = ", ".join(record.coordinate for record in unmanaged)
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_UNMANAGED_EXECUTABLE}: Guard refused to enable existing Codex hook entries "
+            f"without explicit approval; unmanaged executable hooks are present at {coordinates} in "
+            f"{inventory.source_path}. Review or remove those hooks before running install."
+        )
 
 
 def _payload_has_hooks_feature_enabled(config_payload: dict[str, object]) -> bool:
@@ -892,9 +704,7 @@ def _remove_managed_shell_guard_blocks(content: bytes) -> bytes:
 def _hooks_have_registered_entries(hooks: object) -> bool:
     if not isinstance(hooks, dict):
         return False
-    return any(
-        isinstance(hooks.get(event_name), list) and bool(hooks[event_name]) for event_name in _MANAGED_HOOK_EVENTS
-    )
+    return any(isinstance(groups, list) and bool(groups) for groups in hooks.values())
 
 
 def _verify_live_hook_manifest(
@@ -938,13 +748,8 @@ def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
         "config_present": config_path.is_file(),
         "hooks_path": str(hooks_path),
         "hooks_present": hooks_path.is_file(),
-        "toml_hooks_present": isinstance(toml_hooks, dict)
-        and any(
-            bool(toml_hooks.get(event_name))
-            for event_name in ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse")
-        ),
-        "json_hooks_present": isinstance(json_hooks, dict)
-        and any(bool(json_hooks.get(event_name)) for event_name in _MANAGED_HOOK_EVENTS),
+        "toml_hooks_present": _hooks_have_registered_entries(toml_hooks),
+        "json_hooks_present": _hooks_have_registered_entries(json_hooks),
         "hooks_enabled": hooks_feature_enabled,
         "codex_hooks_enabled": hooks_feature_enabled,
         "legacy_codex_hooks_enabled": legacy_codex_hooks_enabled,
@@ -1199,29 +1004,48 @@ class CodexHarnessAdapter(HarnessAdapter):
         previous_manifest = load_hook_manifest_baseline(_hook_manifest_spec(context))
         owned_bindings = _manifest_bindings(previous_manifest)
         hook_payloads = self._load_hook_payloads(context)
+        config_payloads = {
+            config_path: _strict_toml_object(config_path, label="Codex config file")
+            for config_path, _hooks_path in self._config_hook_pairs(context)
+        }
+        inventory_hook_payloads = deepcopy(hook_payloads)
+        inventory_config_payloads = deepcopy(config_payloads)
         original_text = target_config_path.read_text(encoding="utf-8") if target_config_path.is_file() else None
-        payload = read_toml_payload(target_config_path)
-        hook_payload = payload if hook_config_path == target_config_path else read_toml_payload(hook_config_path)
+        payload = config_payloads[target_config_path]
+        hook_payload = payload if hook_config_path == target_config_path else config_payloads[hook_config_path]
         for config_path, hooks_path in self._config_hook_pairs(context):
             json_hook_payload = hook_payloads.get(hooks_path, {})
-            if not json_hook_payload:
-                continue
             if config_path == target_config_path:
                 hook_config_payload = payload
             elif config_path == hook_config_path:
                 hook_config_payload = hook_payload
             else:
-                hook_config_payload = read_toml_payload(config_path)
-            config_owned_bindings = owned_bindings if config_path == hook_config_path else ()
-            if not _payload_has_hooks_feature_enabled(hook_config_payload) and _hooks_payload_has_unmanaged_entries(
-                json_hook_payload,
+                hook_config_payload = config_payloads[config_path]
+            hooks_feature_enabled = _payload_has_hooks_feature_enabled(hook_config_payload)
+            source_scope = self._scope_for(context, config_path)
+            config_inventory = _codex_hook_inventory(
+                hook_config_payload,
+                source_path=config_path,
+                source_scope=source_scope,
+                source_format="toml",
+                source_hooks_enabled=hooks_feature_enabled,
                 context=context,
-                owned_bindings=config_owned_bindings,
-            ):
-                raise RuntimeError(
-                    "Guard refused to enable existing Codex hook entries without explicit approval. "
-                    f"Review or remove unmanaged hooks in {hooks_path} before running install."
-                )
+                authenticated_bindings=owned_bindings if config_path == hook_config_path else (),
+            )
+            json_inventory = _codex_hook_inventory(
+                json_hook_payload,
+                source_path=hooks_path,
+                source_scope=source_scope,
+                source_format="json",
+                source_hooks_enabled=hooks_feature_enabled,
+                context=context,
+            )
+            _require_complete_preactivation_inventory(config_inventory)
+            _require_complete_preactivation_inventory(json_inventory)
+        _require_hook_inventory_sources_unchanged(
+            config_payloads=inventory_config_payloads,
+            hook_payloads=inventory_hook_payloads,
+        )
         target_hooks_path = self._hooks_path(context)
         target_hook_payload = hook_payloads.get(target_hooks_path, {})
         target_hooks_migrated = _migrate_hooks_json_into_config(
@@ -1277,6 +1101,7 @@ class CodexHarnessAdapter(HarnessAdapter):
         self._migrate_alternate_hook_configs(
             context,
             payloads=hook_payloads,
+            config_payloads=config_payloads,
             skip_config_path=hook_config_path,
             owned_bindings=(),
         )
@@ -1434,6 +1259,7 @@ class CodexHarnessAdapter(HarnessAdapter):
         context: HarnessContext,
         *,
         payloads: dict[Path, dict[str, object]],
+        config_payloads: dict[Path, dict[str, object]],
         skip_config_path: Path,
         owned_bindings: Sequence[Mapping[str, object]] = (),
     ) -> None:
@@ -1443,7 +1269,7 @@ class CodexHarnessAdapter(HarnessAdapter):
             hooks_payload = payloads.get(hooks_path, {})
             if not hooks_payload:
                 continue
-            config_payload = read_toml_payload(config_path)
+            config_payload = config_payloads[config_path]
             if (
                 _migrate_hooks_json_into_config(
                     config_payload,

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -32,10 +32,6 @@ from ..codex_hook_integrity import (
     write_hook_manifest,
 )
 from ..codex_hook_inventory import (
-    CODEX_HOOK_INVENTORY_SOURCE_CHANGED,
-    CODEX_HOOK_INVENTORY_SOURCE_DUPLICATE,
-    CODEX_HOOK_INVENTORY_SOURCE_MALFORMED,
-    CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE,
     CODEX_HOOK_INVENTORY_UNMANAGED_EXECUTABLE,
     CodexHookInventory,
     enumerate_codex_hooks,
@@ -58,6 +54,11 @@ from ..codex_hook_registration import (
 from ..codex_hook_registration import (
     remove_manifest_bound_hook_events as _remove_manifest_bound_hook_events,
 )
+from ..codex_hook_sources import (
+    require_hook_inventory_sources_unchanged as _require_hook_inventory_sources_unchanged,
+)
+from ..codex_hook_sources import strict_json_object as _strict_json_object
+from ..codex_hook_sources import strict_toml_object as _strict_toml_object
 from ..config import MAX_APPROVAL_WAIT_TIMEOUT_SECONDS, load_guard_config, resolve_guard_home
 from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
@@ -218,107 +219,6 @@ def _json_object(path: Path) -> dict[str, object]:
     except (OSError, json.JSONDecodeError):
         return {}
     return payload if isinstance(payload, dict) else {}
-
-
-def _strict_json_object(path: Path, *, label: str) -> dict[str, object]:
-    if path.is_symlink() or (path.exists() and not path.is_file()):
-        raise RuntimeError(
-            f"{CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE}: Guard refused to overwrite non-file {label} at {path}. "
-            "Replace it with a readable regular file before retrying install."
-        )
-    if not path.is_file():
-        return {}
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=_unique_json_object)
-    except _DuplicateJsonKeyError as exc:
-        raise RuntimeError(
-            f"{CODEX_HOOK_INVENTORY_SOURCE_DUPLICATE}: Guard found duplicate key {exc.key!r} in {label} at "
-            f"{path}. Remove the duplicate before retrying install."
-        ) from exc
-    except OSError as exc:
-        raise RuntimeError(
-            f"{CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE}: Guard could not read {label} at {path}. Repair file "
-            "permissions before retrying install."
-        ) from exc
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise RuntimeError(
-            f"{CODEX_HOOK_INVENTORY_SOURCE_MALFORMED}: Guard refused to overwrite unreadable {label} at {path} "
-            "because its JSON is malformed. Repair the JSON before retrying install."
-        ) from exc
-    if not isinstance(payload, dict):
-        raise RuntimeError(
-            f"{CODEX_HOOK_INVENTORY_SOURCE_MALFORMED}: Guard refused to overwrite non-object {label} at {path}. "
-            "Replace it with a JSON object before retrying install."
-        )
-    return payload
-
-
-class _DuplicateJsonKeyError(ValueError):
-    key: str
-
-    def __init__(self, key: str) -> None:
-        super().__init__(key)
-        self.key = key
-
-
-def _unique_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
-    payload: dict[str, object] = {}
-    for key, value in pairs:
-        if key in payload:
-            raise _DuplicateJsonKeyError(key)
-        payload[key] = value
-    return payload
-
-
-def _strict_toml_object(path: Path, *, label: str) -> dict[str, object]:
-    if path.is_symlink() or (path.exists() and not path.is_file()):
-        raise RuntimeError(
-            f"{CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE}: Guard refused to overwrite non-file {label} at {path}. "
-            "Replace it with a readable regular file before retrying install."
-        )
-    if not path.is_file():
-        return {}
-    try:
-        with path.open("rb") as handle:
-            payload = tomllib.load(handle)
-    except OSError as exc:
-        raise RuntimeError(
-            f"{CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE}: Guard could not read {label} at {path}. Repair file "
-            "permissions before retrying install."
-        ) from exc
-    except tomllib.TOMLDecodeError as exc:
-        reason = (
-            CODEX_HOOK_INVENTORY_SOURCE_DUPLICATE
-            if "overwrite" in str(exc).lower()
-            else CODEX_HOOK_INVENTORY_SOURCE_MALFORMED
-        )
-        raise RuntimeError(
-            f"{reason}: Guard could not parse {label} at {path}. Repair the TOML before retrying install."
-        ) from exc
-    if not isinstance(payload, dict):
-        raise RuntimeError(
-            f"{CODEX_HOOK_INVENTORY_SOURCE_MALFORMED}: Guard refused to overwrite non-object {label} at {path}."
-        )
-    return payload
-
-
-def _require_hook_inventory_sources_unchanged(
-    *,
-    config_payloads: Mapping[Path, dict[str, object]],
-    hook_payloads: Mapping[Path, dict[str, object]],
-) -> None:
-    for path, expected in config_payloads.items():
-        if _strict_toml_object(path, label="Codex config file") != expected:
-            raise RuntimeError(
-                f"{CODEX_HOOK_INVENTORY_SOURCE_CHANGED}: Codex config changed after pre-activation inventory at "
-                f"{path}. Retry install after configuration writes have stopped."
-            )
-    for path, expected in hook_payloads.items():
-        if _strict_json_object(path, label="Codex hooks file") != expected:
-            raise RuntimeError(
-                f"{CODEX_HOOK_INVENTORY_SOURCE_CHANGED}: Codex hooks changed after pre-activation inventory at "
-                f"{path}. Retry install after configuration writes have stopped."
-            )
 
 
 def _local_hook_command_parts_for_home_mode(

--- a/src/codex_plugin_scanner/guard/codex_hook_inventory.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_inventory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -335,7 +336,7 @@ def _activation_fields_are_valid(entry: Mapping[str, object]) -> bool:
 def _timeout(value: object) -> int | float | None:
     if isinstance(value, bool) or not isinstance(value, int | float):
         return None
-    if value < 0 or value != value or value in {float("inf"), float("-inf")}:
+    if value < 0 or not math.isfinite(value):
         return None
     return value
 
@@ -348,7 +349,7 @@ def _environment_keys(handler: Mapping[str, object]) -> tuple[tuple[str, ...], b
         isinstance(key, str) and isinstance(value, str) for key, value in raw_environment.items()
     ):
         return (), False
-    return tuple(sorted(str(key) for key in raw_environment)), True
+    return tuple(sorted(raw_environment)), True
 
 
 def _ownership(

--- a/src/codex_plugin_scanner/guard/codex_hook_inventory.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_inventory.py
@@ -1,0 +1,401 @@
+"""Complete typed inventory for executable Codex hook configuration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+CODEX_HOOK_INVENTORY_UNMANAGED_EXECUTABLE = "codex_hook_inventory_unmanaged_executable"
+CODEX_HOOK_INVENTORY_UNSUPPORTED_EVENT = "codex_hook_inventory_unsupported_event_shape"
+CODEX_HOOK_INVENTORY_MALFORMED_GROUP = "codex_hook_inventory_malformed_group"
+CODEX_HOOK_INVENTORY_MALFORMED_HANDLER = "codex_hook_inventory_malformed_handler"
+CODEX_HOOK_INVENTORY_UNKNOWN_HANDLER = "codex_hook_inventory_unknown_handler_type"
+CODEX_HOOK_INVENTORY_SOURCE_DUPLICATE = "codex_hook_inventory_source_duplicate_key"
+CODEX_HOOK_INVENTORY_SOURCE_MALFORMED = "codex_hook_inventory_source_malformed"
+CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE = "codex_hook_inventory_source_unreadable"
+CODEX_HOOK_INVENTORY_SOURCE_CHANGED = "codex_hook_inventory_source_changed"
+
+HookSourceFormat = Literal["json", "toml"]
+HookOwnership = Literal["authenticated_manifest", "exact_legacy_adoption", "unmanaged"]
+
+
+@dataclass(frozen=True, slots=True)
+class CodexHookInventoryRecord:
+    """One handler with exact source coordinates and execution-affecting fields."""
+
+    source_path: str
+    source_scope: str
+    source_format: HookSourceFormat
+    source_hooks_enabled: bool
+    event_name: str
+    group_index: int
+    matcher: object
+    handler_index: int
+    handler_type: str | None
+    command: str | None
+    timeout: int | float | None
+    environment_keys: tuple[str, ...]
+    active: bool
+    executable: bool
+    ownership: HookOwnership
+
+    @property
+    def coordinate(self) -> str:
+        return f"{self.event_name}/group[{self.group_index}]/handler[{self.handler_index}]"
+
+
+@dataclass(frozen=True, slots=True)
+class CodexHookInventoryIssue:
+    """Stable fail-closed reason tied to one source coordinate."""
+
+    reason_code: str
+    message: str
+    source_path: str
+    event_name: str | None = None
+    group_index: int | None = None
+    handler_index: int | None = None
+
+    @property
+    def coordinate(self) -> str:
+        if self.event_name is None:
+            return self.source_path
+        coordinate = self.event_name
+        if self.group_index is not None:
+            coordinate += f"/group[{self.group_index}]"
+        if self.handler_index is not None:
+            coordinate += f"/handler[{self.handler_index}]"
+        return coordinate
+
+
+@dataclass(frozen=True, slots=True)
+class CodexHookInventory:
+    """Complete inventory result for one JSON or TOML source."""
+
+    source_path: str
+    records: tuple[CodexHookInventoryRecord, ...]
+    issues: tuple[CodexHookInventoryIssue, ...]
+
+    @property
+    def complete(self) -> bool:
+        return not self.issues
+
+    @property
+    def unmanaged_active_executables(self) -> tuple[CodexHookInventoryRecord, ...]:
+        return tuple(
+            record for record in self.records if record.active and record.executable and record.ownership == "unmanaged"
+        )
+
+
+def enumerate_codex_hooks(
+    payload: Mapping[str, object],
+    *,
+    source_path: Path,
+    source_scope: str,
+    source_format: HookSourceFormat,
+    source_hooks_enabled: bool,
+    authenticated_bindings: Sequence[Mapping[str, object]] = (),
+    legacy_bindings: Sequence[Mapping[str, object]] = (),
+) -> CodexHookInventory:
+    """Walk every event, group, and handler accepted by the Codex hook shape."""
+
+    hooks = payload.get("hooks")
+    if hooks is None:
+        return CodexHookInventory(str(source_path), (), ())
+    if not isinstance(hooks, Mapping):
+        issue = CodexHookInventoryIssue(
+            CODEX_HOOK_INVENTORY_UNSUPPORTED_EVENT,
+            "Codex hooks must be an event table. Repair the hook configuration before retrying install.",
+            str(source_path),
+        )
+        return CodexHookInventory(str(source_path), (), (issue,))
+
+    records: list[CodexHookInventoryRecord] = []
+    issues: list[CodexHookInventoryIssue] = []
+    for event_name, groups in hooks.items():
+        if not isinstance(event_name, str) or not isinstance(groups, list):
+            issues.append(
+                CodexHookInventoryIssue(
+                    CODEX_HOOK_INVENTORY_UNSUPPORTED_EVENT,
+                    "Each Codex hook event must contain a list of matcher groups. Repair the event shape before "
+                    "retrying install.",
+                    str(source_path),
+                    event_name if isinstance(event_name, str) else None,
+                )
+            )
+            continue
+        for group_index, group in enumerate(groups):
+            if not isinstance(group, Mapping):
+                issues.append(
+                    CodexHookInventoryIssue(
+                        CODEX_HOOK_INVENTORY_MALFORMED_GROUP,
+                        "Each Codex hook matcher group must be an object. Repair the group before retrying install.",
+                        str(source_path),
+                        event_name,
+                        group_index,
+                    )
+                )
+                continue
+            if not _activation_fields_are_valid(group) or not isinstance(group.get("matcher"), (str, type(None))):
+                issues.append(
+                    CodexHookInventoryIssue(
+                        CODEX_HOOK_INVENTORY_MALFORMED_GROUP,
+                        "A Codex hook matcher and activation fields must use supported scalar types. Repair the "
+                        "group before retrying install.",
+                        str(source_path),
+                        event_name,
+                        group_index,
+                    )
+                )
+            handlers = group.get("hooks")
+            if handlers is None:
+                continue
+            if not isinstance(handlers, list):
+                issues.append(
+                    CodexHookInventoryIssue(
+                        CODEX_HOOK_INVENTORY_MALFORMED_GROUP,
+                        "A Codex hook group's handlers must be a list. Repair the group before retrying install.",
+                        str(source_path),
+                        event_name,
+                        group_index,
+                    )
+                )
+                continue
+            group_active = _entry_is_active(group)
+            for handler_index, handler in enumerate(handlers):
+                record, handler_issues = _handler_record(
+                    handler,
+                    source_path=source_path,
+                    source_scope=source_scope,
+                    source_format=source_format,
+                    source_hooks_enabled=source_hooks_enabled,
+                    event_name=event_name,
+                    group_index=group_index,
+                    matcher=group.get("matcher"),
+                    handler_index=handler_index,
+                    group_active=group_active,
+                    authenticated_bindings=authenticated_bindings,
+                    legacy_bindings=legacy_bindings,
+                    group=group,
+                )
+                if record is not None:
+                    records.append(record)
+                issues.extend(handler_issues)
+    return CodexHookInventory(str(source_path), tuple(records), tuple(issues))
+
+
+def _handler_record(
+    handler: object,
+    *,
+    source_path: Path,
+    source_scope: str,
+    source_format: HookSourceFormat,
+    source_hooks_enabled: bool,
+    event_name: str,
+    group_index: int,
+    matcher: object,
+    handler_index: int,
+    group_active: bool,
+    authenticated_bindings: Sequence[Mapping[str, object]],
+    legacy_bindings: Sequence[Mapping[str, object]],
+    group: Mapping[str, object],
+) -> tuple[CodexHookInventoryRecord | None, tuple[CodexHookInventoryIssue, ...]]:
+    if not isinstance(handler, Mapping):
+        return None, (
+            _handler_issue(
+                CODEX_HOOK_INVENTORY_MALFORMED_HANDLER,
+                "Each Codex hook handler must be an object. Repair the handler before retrying install.",
+                source_path,
+                event_name,
+                group_index,
+                handler_index,
+            ),
+        )
+    raw_type = handler.get("type")
+    handler_type = raw_type if isinstance(raw_type, str) and raw_type.strip() else None
+    raw_command = handler.get("command")
+    command = raw_command if isinstance(raw_command, str) and raw_command.strip() else None
+    executable = raw_command is not None or handler_type == "command"
+    issues: list[CodexHookInventoryIssue] = []
+    if not _activation_fields_are_valid(handler):
+        issues.append(
+            _handler_issue(
+                CODEX_HOOK_INVENTORY_MALFORMED_HANDLER,
+                "Codex hook activation fields must be booleans. Repair the handler before retrying install.",
+                source_path,
+                event_name,
+                group_index,
+                handler_index,
+            )
+        )
+    if executable and command is None:
+        issues.append(
+            _handler_issue(
+                CODEX_HOOK_INVENTORY_MALFORMED_HANDLER,
+                "An executable Codex command hook must contain a non-empty string command. Repair the handler "
+                "before retrying install.",
+                source_path,
+                event_name,
+                group_index,
+                handler_index,
+            )
+        )
+    if handler_type not in {None, "command"}:
+        issues.append(
+            _handler_issue(
+                CODEX_HOOK_INVENTORY_UNKNOWN_HANDLER,
+                "Guard found an executable Codex hook type it cannot model. Remove or convert the handler to a "
+                "supported command hook before retrying install.",
+                source_path,
+                event_name,
+                group_index,
+                handler_index,
+            )
+        )
+    timeout = _timeout(handler.get("timeout"))
+    if handler.get("timeout") is not None and timeout is None and executable:
+        issues.append(
+            _handler_issue(
+                CODEX_HOOK_INVENTORY_MALFORMED_HANDLER,
+                "An executable Codex hook timeout must be a finite non-negative number. Repair the handler before "
+                "retrying install.",
+                source_path,
+                event_name,
+                group_index,
+                handler_index,
+            )
+        )
+    environment_keys, environment_valid = _environment_keys(handler)
+    if not environment_valid and executable:
+        issues.append(
+            _handler_issue(
+                CODEX_HOOK_INVENTORY_MALFORMED_HANDLER,
+                "An executable Codex hook environment must be a string-keyed object. Repair the handler before "
+                "retrying install.",
+                source_path,
+                event_name,
+                group_index,
+                handler_index,
+            )
+        )
+    ownership = _ownership(
+        event_name,
+        group,
+        handler,
+        authenticated_bindings=authenticated_bindings,
+        legacy_bindings=legacy_bindings,
+    )
+    record = CodexHookInventoryRecord(
+        source_path=str(source_path),
+        source_scope=source_scope,
+        source_format=source_format,
+        source_hooks_enabled=source_hooks_enabled,
+        event_name=event_name,
+        group_index=group_index,
+        matcher=matcher,
+        handler_index=handler_index,
+        handler_type=handler_type,
+        command=command,
+        timeout=timeout,
+        environment_keys=environment_keys,
+        active=group_active and _entry_is_active(handler),
+        executable=executable,
+        ownership=ownership,
+    )
+    return record, tuple(issues)
+
+
+def _handler_issue(
+    reason_code: str,
+    message: str,
+    source_path: Path,
+    event_name: str,
+    group_index: int,
+    handler_index: int,
+) -> CodexHookInventoryIssue:
+    return CodexHookInventoryIssue(
+        reason_code,
+        message,
+        str(source_path),
+        event_name,
+        group_index,
+        handler_index,
+    )
+
+
+def _entry_is_active(entry: Mapping[str, object]) -> bool:
+    return entry.get("enabled") is not False and entry.get("disabled") is not True
+
+
+def _activation_fields_are_valid(entry: Mapping[str, object]) -> bool:
+    return all(key not in entry or isinstance(entry[key], bool) for key in ("enabled", "disabled"))
+
+
+def _timeout(value: object) -> int | float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    if value < 0 or value != value or value in {float("inf"), float("-inf")}:
+        return None
+    return value
+
+
+def _environment_keys(handler: Mapping[str, object]) -> tuple[tuple[str, ...], bool]:
+    raw_environment = handler.get("env", handler.get("environment"))
+    if raw_environment is None:
+        return (), True
+    if not isinstance(raw_environment, Mapping) or not all(
+        isinstance(key, str) and isinstance(value, str) for key, value in raw_environment.items()
+    ):
+        return (), False
+    return tuple(sorted(str(key) for key in raw_environment)), True
+
+
+def _ownership(
+    event_name: str,
+    group: Mapping[str, object],
+    handler: Mapping[str, object],
+    *,
+    authenticated_bindings: Sequence[Mapping[str, object]],
+    legacy_bindings: Sequence[Mapping[str, object]],
+) -> HookOwnership:
+    if _bindings_contain_handler(authenticated_bindings, event_name, group, handler):
+        return "authenticated_manifest"
+    if _bindings_contain_handler(legacy_bindings, event_name, group, handler):
+        return "exact_legacy_adoption"
+    return "unmanaged"
+
+
+def _bindings_contain_handler(
+    bindings: Sequence[Mapping[str, object]],
+    event_name: str,
+    group: Mapping[str, object],
+    handler: Mapping[str, object],
+) -> bool:
+    for binding in bindings:
+        expected_group = binding.get("group")
+        if (
+            binding.get("event") == event_name
+            and isinstance(expected_group, Mapping)
+            and expected_group.get("matcher") == group.get("matcher")
+            and binding.get("handler") == handler
+        ):
+            return True
+    return False
+
+
+__all__ = [
+    "CODEX_HOOK_INVENTORY_MALFORMED_GROUP",
+    "CODEX_HOOK_INVENTORY_MALFORMED_HANDLER",
+    "CODEX_HOOK_INVENTORY_SOURCE_CHANGED",
+    "CODEX_HOOK_INVENTORY_SOURCE_DUPLICATE",
+    "CODEX_HOOK_INVENTORY_SOURCE_MALFORMED",
+    "CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE",
+    "CODEX_HOOK_INVENTORY_UNKNOWN_HANDLER",
+    "CODEX_HOOK_INVENTORY_UNMANAGED_EXECUTABLE",
+    "CODEX_HOOK_INVENTORY_UNSUPPORTED_EVENT",
+    "CodexHookInventory",
+    "CodexHookInventoryIssue",
+    "CodexHookInventoryRecord",
+    "enumerate_codex_hooks",
+]

--- a/src/codex_plugin_scanner/guard/codex_hook_sources.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_sources.py
@@ -1,0 +1,124 @@
+"""Strict source loading for Codex hook inventory and activation."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from .codex_hook_inventory import (
+    CODEX_HOOK_INVENTORY_SOURCE_CHANGED,
+    CODEX_HOOK_INVENTORY_SOURCE_DUPLICATE,
+    CODEX_HOOK_INVENTORY_SOURCE_MALFORMED,
+    CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE,
+)
+
+tomllib: Any
+if sys.version_info >= (3, 11):
+    import tomllib as tomllib  # pyright: ignore[reportMissingImports]
+else:  # pragma: no cover - Python 3.10 runtime compatibility
+    tomllib = importlib.import_module("tomli")
+
+
+class _DuplicateJsonKeyError(ValueError):
+    key: str
+
+    def __init__(self, key: str) -> None:
+        super().__init__(key)
+        self.key = key
+
+
+def _unique_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    payload: dict[str, object] = {}
+    for key, value in pairs:
+        if key in payload:
+            raise _DuplicateJsonKeyError(key)
+        payload[key] = value
+    return payload
+
+
+def strict_json_object(path: Path, *, label: str) -> dict[str, object]:
+    if path.is_symlink() or (path.exists() and not path.is_file()):
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE}: Guard refused to overwrite non-file {label} at {path}. "
+            "Replace it with a readable regular file before retrying install."
+        )
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=_unique_json_object)
+    except _DuplicateJsonKeyError as exc:
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_DUPLICATE}: Guard found duplicate key {exc.key!r} in {label} at "
+            f"{path}. Remove the duplicate before retrying install."
+        ) from exc
+    except OSError as exc:
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE}: Guard could not read {label} at {path}. Repair file "
+            "permissions before retrying install."
+        ) from exc
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_MALFORMED}: Guard refused to overwrite unreadable {label} at {path} "
+            "because its JSON is malformed. Repair the JSON before retrying install."
+        ) from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_MALFORMED}: Guard refused to overwrite non-object {label} at {path}. "
+            "Replace it with a JSON object before retrying install."
+        )
+    return payload
+
+
+def strict_toml_object(path: Path, *, label: str) -> dict[str, object]:
+    if path.is_symlink() or (path.exists() and not path.is_file()):
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE}: Guard refused to overwrite non-file {label} at {path}. "
+            "Replace it with a readable regular file before retrying install."
+        )
+    if not path.is_file():
+        return {}
+    try:
+        with path.open("rb") as handle:
+            payload = tomllib.load(handle)
+    except OSError as exc:
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE}: Guard could not read {label} at {path}. Repair file "
+            "permissions before retrying install."
+        ) from exc
+    except tomllib.TOMLDecodeError as exc:
+        reason = (
+            CODEX_HOOK_INVENTORY_SOURCE_DUPLICATE
+            if "overwrite" in str(exc).lower()
+            else CODEX_HOOK_INVENTORY_SOURCE_MALFORMED
+        )
+        raise RuntimeError(
+            f"{reason}: Guard could not parse {label} at {path}. Repair the TOML before retrying install."
+        ) from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(
+            f"{CODEX_HOOK_INVENTORY_SOURCE_MALFORMED}: Guard refused to overwrite non-object {label} at {path}."
+        )
+    return payload
+
+
+def require_hook_inventory_sources_unchanged(
+    *,
+    config_payloads: Mapping[Path, dict[str, object]],
+    hook_payloads: Mapping[Path, dict[str, object]],
+) -> None:
+    for path, expected in config_payloads.items():
+        if strict_toml_object(path, label="Codex config file") != expected:
+            raise RuntimeError(
+                f"{CODEX_HOOK_INVENTORY_SOURCE_CHANGED}: Codex config changed after pre-activation inventory at "
+                f"{path}. Retry install after configuration writes have stopped."
+            )
+    for path, expected in hook_payloads.items():
+        if strict_json_object(path, label="Codex hooks file") != expected:
+            raise RuntimeError(
+                f"{CODEX_HOOK_INVENTORY_SOURCE_CHANGED}: Codex hooks changed after pre-activation inventory at "
+                f"{path}. Retry install after configuration writes have stopped."
+            )

--- a/tests/test_codex_hook_inventory.py
+++ b/tests/test_codex_hook_inventory.py
@@ -1,0 +1,410 @@
+"""P22 regressions for complete Codex hook pre-activation inventory."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.adapters import codex as codex_adapter
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.codex_config import dump_toml
+from codex_plugin_scanner.guard.codex_hook_inventory import (
+    CODEX_HOOK_INVENTORY_MALFORMED_GROUP,
+    CODEX_HOOK_INVENTORY_UNKNOWN_HANDLER,
+    CODEX_HOOK_INVENTORY_UNMANAGED_EXECUTABLE,
+    enumerate_codex_hooks,
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _install_args(home_dir: Path, workspace_dir: Path) -> list[str]:
+    return [
+        "guard",
+        "install",
+        "codex",
+        "--home",
+        str(home_dir),
+        "--workspace",
+        str(workspace_dir),
+        "--json",
+    ]
+
+
+def _command_group(command: str = "python3 harmless-marker.py", **handler_fields: object) -> dict[str, object]:
+    return {
+        "matcher": "fixture",
+        "hooks": [{"type": "command", "command": command, **handler_fields}],
+    }
+
+
+@pytest.mark.parametrize(
+    "event_name",
+    (
+        "PreToolUse",
+        "PermissionRequest",
+        "UserPromptSubmit",
+        "PostToolUse",
+        "SessionStart",
+        "Stop",
+        "FutureAgentEvent",
+    ),
+)
+def test_every_known_and_future_executable_event_blocks_preactivation(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    event_name: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    config_path = workspace_dir / ".codex" / "config.toml"
+    hooks_path = workspace_dir / ".codex" / "hooks.json"
+    original_config = 'approval_policy = "never"\n'
+    original_hooks = json.dumps({"hooks": {event_name: [_command_group()]}}, indent=2) + "\n"
+    _write(config_path, original_config)
+    _write(hooks_path, original_hooks)
+
+    rc = main(_install_args(home_dir, workspace_dir))
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert CODEX_HOOK_INVENTORY_UNMANAGED_EXECUTABLE in captured.err
+    assert f"{event_name}/group[0]/handler[0]" in captured.err
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert hooks_path.read_text(encoding="utf-8") == original_hooks
+
+
+@pytest.mark.parametrize("scope", ("global", "project"))
+@pytest.mark.parametrize("source_format", ("json", "toml"))
+def test_global_and_workspace_json_and_toml_sources_are_checked_before_any_write(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    scope: str,
+    source_format: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    source_root = home_dir if scope == "global" else workspace_dir
+    config_path = source_root / ".codex" / "config.toml"
+    hooks_path = source_root / ".codex" / "hooks.json"
+    payload: dict[str, object] = {"hooks": {"FutureAgentEvent": [_command_group()]}}
+    if source_format == "json":
+        _write(config_path, "[features]\nhooks = false\n")
+        _write(hooks_path, json.dumps(payload, indent=2) + "\n")
+        source_path = hooks_path
+    else:
+        payload["features"] = {"hooks": False}
+        _write(config_path, dump_toml(payload))
+        source_path = config_path
+    original = source_path.read_bytes()
+
+    rc = main(_install_args(home_dir, workspace_dir))
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert CODEX_HOOK_INVENTORY_UNMANAGED_EXECUTABLE in captured.err
+    assert str(source_path) in captured.err
+    assert source_path.read_bytes() == original
+    assert (home_dir / ".codex" / "config.toml").exists() is (scope == "global")
+
+
+def test_inventory_preserves_handler_coordinates_and_execution_fields(tmp_path: Path) -> None:
+    payload = {
+        "hooks": {
+            "FutureAgentEvent": [
+                {
+                    "matcher": "agent|resume",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "python3 fixture.py",
+                            "timeout": 12,
+                            "env": {"TOKEN": "redacted", "MODE": "safe"},
+                            "enabled": False,
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+
+    inventory = enumerate_codex_hooks(
+        payload,
+        source_path=tmp_path / "hooks.json",
+        source_scope="project",
+        source_format="json",
+        source_hooks_enabled=False,
+    )
+
+    assert inventory.complete is True
+    assert len(inventory.records) == 1
+    record = inventory.records[0]
+    assert record.coordinate == "FutureAgentEvent/group[0]/handler[0]"
+    assert record.matcher == "agent|resume"
+    assert record.handler_type == "command"
+    assert record.command == "python3 fixture.py"
+    assert record.timeout == 12
+    assert record.environment_keys == ("MODE", "TOKEN")
+    assert record.active is False
+    assert record.source_hooks_enabled is False
+    assert record.ownership == "unmanaged"
+
+
+@pytest.mark.parametrize(
+    "handler",
+    (
+        {
+            "type": "command",
+            "command": "python /untrusted/codex_daemon_hook_bridge.py '{}'",
+            "statusMessage": "HOL Guard checking tool action",
+        },
+        {
+            "type": "command",
+            "command": (
+                "/home/user/.local/pipx/venvs/hol-guard/bin/python -m codex_plugin_scanner.cli guard hook "
+                "--harness codex"
+            ),
+        },
+    ),
+)
+def test_managed_looking_paths_commands_and_status_are_unmanaged_without_identity(
+    tmp_path: Path,
+    handler: dict[str, object],
+) -> None:
+    inventory = enumerate_codex_hooks(
+        {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [handler]}]}},
+        source_path=tmp_path / "config.toml",
+        source_scope="global",
+        source_format="toml",
+        source_hooks_enabled=False,
+    )
+
+    assert inventory.complete is True
+    assert inventory.records[0].ownership == "unmanaged"
+    assert inventory.unmanaged_active_executables == inventory.records
+
+
+def test_authenticated_manifest_binding_is_the_managed_ownership_authority(tmp_path: Path) -> None:
+    handler = {"type": "command", "command": "python3 exact-guard-hook.py"}
+    group = {"matcher": "Bash", "hooks": [handler]}
+    binding = {"event": "PreToolUse", "group": group, "handler": handler}
+
+    inventory = enumerate_codex_hooks(
+        {"hooks": {"PreToolUse": [group]}},
+        source_path=tmp_path / "config.toml",
+        source_scope="global",
+        source_format="toml",
+        source_hooks_enabled=False,
+        authenticated_bindings=(binding,),
+    )
+
+    assert inventory.complete is True
+    assert inventory.records[0].ownership == "authenticated_manifest"
+    assert inventory.unmanaged_active_executables == ()
+
+
+def test_mixed_exact_legacy_and_unmanaged_handlers_block_only_the_unmanaged_handler(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    context = HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir)
+    managed_group = codex_adapter._managed_hook_groups(context)["PreToolUse"]
+    handlers = managed_group["hooks"]
+    assert isinstance(handlers, list)
+    mixed_group = {**managed_group, "hooks": [*handlers, {"type": "command", "command": "python3 custom.py"}]}
+    hooks_path = workspace_dir / ".codex" / "hooks.json"
+    _write(workspace_dir / ".codex" / "config.toml", "[features]\nhooks = false\n")
+    _write(hooks_path, json.dumps({"hooks": {"PreToolUse": [mixed_group]}}, indent=2) + "\n")
+
+    rc = main(_install_args(home_dir, workspace_dir))
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert CODEX_HOOK_INVENTORY_UNMANAGED_EXECUTABLE in captured.err
+    assert "PreToolUse/group[0]/handler[1]" in captured.err
+
+
+def test_disabled_unmanaged_entry_and_metadata_only_event_are_preserved_without_review(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    hooks_path = home_dir / ".codex" / "hooks.json"
+    _write(
+        hooks_path,
+        json.dumps(
+            {
+                "hooks": {
+                    "FutureAgentEvent": [
+                        {**_command_group(), "enabled": False},
+                        {"matcher": "metadata", "description": "retained metadata"},
+                    ]
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+
+    codex_adapter.CodexHarnessAdapter().install(
+        HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir)
+    )
+
+    installed = codex_adapter.tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    assert hooks_path.exists() is False
+    assert installed["hooks"]["FutureAgentEvent"] == [
+        {**_command_group(), "enabled": False},
+        {"matcher": "metadata", "description": "retained metadata"},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("payload", "reason_code"),
+    (
+        ({"hooks": {"Stop": ["not-a-group"]}}, CODEX_HOOK_INVENTORY_MALFORMED_GROUP),
+        (
+            {"hooks": {"Stop": [{"hooks": [{"type": "future-exec", "command": "python3 fixture.py"}]}]}},
+            CODEX_HOOK_INVENTORY_UNKNOWN_HANDLER,
+        ),
+        (
+            {"hooks": {"Stop": [{"hooks": [{"type": "future-exec", "argv": ["python3", "fixture.py"]}]}]}},
+            CODEX_HOOK_INVENTORY_UNKNOWN_HANDLER,
+        ),
+    ),
+)
+def test_incomplete_inventory_fails_closed_even_when_hooks_are_already_enabled(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    payload: dict[str, object],
+    reason_code: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    config_path = workspace_dir / ".codex" / "config.toml"
+    payload["features"] = {"hooks": True}
+    original = dump_toml(payload)
+    _write(config_path, original)
+
+    rc = main(_install_args(home_dir, workspace_dir))
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert reason_code in captured.err
+    assert config_path.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.parametrize(
+    ("path_name", "content", "reason_code"),
+    (
+        (
+            "hooks.json",
+            '{"hooks":{"Stop":[]},"hooks":{"FutureAgentEvent":[]}}\n',
+            "codex_hook_inventory_source_duplicate_key",
+        ),
+        (
+            "config.toml",
+            "[features]\nhooks = false\n[hooks]\nStop = []\nStop = []\n",
+            "codex_hook_inventory_source_duplicate_key",
+        ),
+        ("hooks.json", '{"hooks":', "codex_hook_inventory_source_malformed"),
+        ("config.toml", "[hooks\n", "codex_hook_inventory_source_malformed"),
+    ),
+)
+def test_duplicate_or_malformed_sources_fail_before_writes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    path_name: str,
+    content: str,
+    reason_code: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    source_path = workspace_dir / ".codex" / path_name
+    _write(source_path, content)
+
+    rc = main(_install_args(home_dir, workspace_dir))
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert reason_code in captured.err
+    assert source_path.read_text(encoding="utf-8") == content
+    assert (home_dir / ".codex" / "config.toml").exists() is False
+
+
+def test_non_file_config_source_fails_closed_before_writes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    (workspace_dir / ".codex" / "config.toml").mkdir(parents=True)
+
+    rc = main(_install_args(home_dir, workspace_dir))
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "codex_hook_inventory_source_unreadable" in captured.err
+    assert (home_dir / ".codex" / "config.toml").exists() is False
+
+
+@pytest.mark.parametrize("source_name", ("config.toml", "hooks.json"))
+def test_symlink_config_source_fails_closed_before_writes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    source_name: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    external_path = tmp_path / f"external-{source_name}"
+    external_content = "" if source_name.endswith(".toml") else "{}\n"
+    _write(external_path, external_content)
+    source_path = workspace_dir / ".codex" / source_name
+    source_path.parent.mkdir(parents=True)
+    source_path.symlink_to(external_path)
+
+    rc = main(_install_args(home_dir, workspace_dir))
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "codex_hook_inventory_source_unreadable" in captured.err
+    assert external_path.read_text(encoding="utf-8") == external_content
+    assert (home_dir / ".codex" / "config.toml").exists() is False
+
+
+def test_source_change_after_inventory_stops_before_activation_write(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    hooks_path = workspace_dir / ".codex" / "hooks.json"
+    original_payload = {"hooks": {"FutureAgentEvent": [{**_command_group("python3 first.py"), "enabled": False}]}}
+    changed_payload = {"hooks": {"FutureAgentEvent": [{**_command_group("python3 changed.py"), "enabled": False}]}}
+    _write(hooks_path, json.dumps(original_payload, indent=2) + "\n")
+    original_verify = codex_adapter._require_hook_inventory_sources_unchanged
+
+    def mutate_then_verify(
+        *,
+        config_payloads: Mapping[Path, dict[str, object]],
+        hook_payloads: Mapping[Path, dict[str, object]],
+    ) -> None:
+        _write(hooks_path, json.dumps(changed_payload, indent=2) + "\n")
+        original_verify(config_payloads=config_payloads, hook_payloads=hook_payloads)
+
+    monkeypatch.setattr(codex_adapter, "_require_hook_inventory_sources_unchanged", mutate_then_verify)
+
+    rc = main(_install_args(home_dir, workspace_dir))
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "codex_hook_inventory_source_changed" in captured.err
+    assert (home_dir / ".codex" / "config.toml").exists() is False
+    assert json.loads(hooks_path.read_text(encoding="utf-8")) == changed_payload

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4354,7 +4354,6 @@ args = ["workspace-skill.js", "--changed"]
         before = codex_adapter_module.codex_native_hook_state(context)
 
         assert install_rc == 0
-        assert codex_adapter_module._is_managed_hook_entry(managed_handler) is True
         assert before["protection_active"] is False
         assert before["integrity_reason"] == "codex_hook_registration_mismatch"
 
@@ -4576,7 +4575,7 @@ args = ["workspace-skill.js", "--changed"]
         assert hooks_payload["PreToolUse"]
         assert (workspace_dir / ".codex" / "config.toml").exists() is False
 
-    def test_guard_update_repairs_malformed_codex_config(self, tmp_path, monkeypatch, capsys):
+    def test_guard_update_fails_closed_on_malformed_codex_config(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
         _write_text(home_dir / ".codex" / "config.toml", "[broken\n")
         GuardStore(home_dir).set_managed_install(
@@ -4608,8 +4607,9 @@ args = ["workspace-skill.js", "--changed"]
 
         assert rc == 0
         assert output["status"] == "current"
-        assert output["managed_install"]["harness"] == "codex"
-        assert output["managed_install"]["active"] is True
+        assert "managed_install" not in output
+        assert any("codex_hook_inventory_source_malformed" in note for note in output["notes"])
+        assert (home_dir / ".codex" / "config.toml").read_text(encoding="utf-8") == "[broken\n"
 
     def test_guard_update_does_not_adopt_unmanaged_codex_config(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_codex_authoritative_hook_boundary.py
+++ b/tests/test_guard_codex_authoritative_hook_boundary.py
@@ -204,7 +204,6 @@ def test_codex_launch_rejects_hook_bound_to_opposite_home_mode(
         python_executable=sys.executable,
     )
     entry["command"] = shlex.join(opposite_home_command)
-    assert codex_adapter._hook_command_matches_current_boundary(entry["command"], context) is False
     config_path.write_text(dump_toml(payload), encoding="utf-8")
 
     with pytest.raises(RuntimeError, match="codex_authoritative_hook_unavailable"):

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -737,120 +737,6 @@ def test_guard_codex_launch_uses_remote_control_for_dashboard_continuation(tmp_p
     assert environment["CODEX_HOME"] == str(home_dir / ".codex")
 
 
-def test_guard_codex_does_not_claim_untrusted_bridge_lookalike() -> None:
-    command = "python /untrusted/codex_daemon_hook_bridge.py '{}'"
-
-    assert codex_adapter._is_managed_hook_command(command) is False
-
-
-def test_guard_codex_preserves_user_owned_direct_hook_without_status_message() -> None:
-    command = shlex.join(
-        [
-            sys.executable,
-            "-m",
-            "codex_plugin_scanner.cli",
-            "guard",
-            "hook",
-            "--harness",
-            "codex",
-        ]
-    )
-    entry = {"type": "command", "command": command}
-
-    assert codex_adapter._is_managed_hook_command(command) is True
-    assert codex_adapter._is_unambiguously_managed_hook_command(command) is False
-    assert codex_adapter._is_managed_hook_entry(entry) is False
-
-
-def test_guard_codex_claims_stale_pipx_direct_hook_without_status_message() -> None:
-    command = shlex.join(
-        [
-            "/home/user/.local/pipx/venvs/hol-guard/bin/python",
-            "-m",
-            "codex_plugin_scanner.cli",
-            "guard",
-            "hook",
-            "--harness",
-            "codex",
-        ]
-    )
-    entry = {"type": "command", "command": command}
-
-    assert codex_adapter._is_managed_hook_entry(entry) is True
-
-
-def test_guard_codex_does_not_claim_guard_install_path_lookalike() -> None:
-    lookalike_python = "/home/user/.local/uv/tools/hol-guard-extra/bin/python"
-    command = shlex.join(
-        [
-            lookalike_python,
-            "-m",
-            "codex_plugin_scanner.cli",
-            "guard",
-            "hook",
-            "--harness",
-            "codex",
-        ]
-    )
-    entry = {"type": "command", "command": command}
-
-    assert codex_adapter._python_executable_is_guard_install(lookalike_python) is False
-    assert codex_adapter._is_managed_hook_entry(entry) is False
-
-
-def test_guard_codex_detects_direct_hook_with_python_runtime_flags() -> None:
-    command_tokens = [
-        "python3",
-        "-P",
-        "-m",
-        "codex_plugin_scanner.cli",
-        "guard",
-        "hook",
-        "--harness",
-        "codex",
-    ]
-    command = shlex.join(command_tokens)
-    entry = {
-        "type": "command",
-        "command": command,
-        "statusMessage": "HOL Guard checking tool result",
-    }
-
-    assert codex_adapter._argv_is_direct_codex_hook(command_tokens) is True
-    assert codex_adapter._is_managed_hook_command(command) is True
-    assert codex_adapter._is_managed_hook_entry(entry) is True
-
-
-def test_guard_codex_detects_bridge_hook_with_python_runtime_flags(tmp_path: Path) -> None:
-    bridge_path = (
-        tmp_path / "site-packages" / "codex_plugin_scanner" / "guard" / "adapters" / "codex_daemon_hook_bridge.py"
-    )
-    bridge_path.parent.mkdir(parents=True, exist_ok=True)
-    bridge_path.write_text("# bridge\n", encoding="utf-8")
-    config = json.dumps(
-        {
-            "fallback_command": [
-                sys.executable,
-                "-m",
-                "codex_plugin_scanner.cli",
-                "guard",
-                "hook",
-                "--harness",
-                "codex",
-            ]
-        },
-        separators=(",", ":"),
-    )
-    command_tokens = ["python3", "-I", str(bridge_path), config]
-    command = shlex.join(command_tokens)
-    entry = {"type": "command", "command": command}
-
-    assert codex_adapter._is_daemon_bridge_hook_command(command_tokens) is True
-    assert codex_adapter._is_managed_hook_command(command) is True
-    assert codex_adapter._is_unambiguously_managed_hook_command(command) is True
-    assert codex_adapter._is_managed_hook_entry(entry) is True
-
-
 def test_guard_install_and_repair_codex_preserve_ambiguous_legacy_post_tool_hooks(
     tmp_path,
     capsys,
@@ -1568,6 +1454,50 @@ def test_guard_install_codex_refuses_unmanaged_existing_hook_entries(tmp_path, c
     assert (workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8") == original_hooks
 
 
+def test_guard_install_codex_refuses_unmanaged_future_event_before_enabling_hooks(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    original_config = 'approval_policy = "never"\n'
+    original_hooks = (
+        json.dumps(
+            {
+                "hooks": {
+                    "FutureAgentEvent": [
+                        {
+                            "matcher": "agent",
+                            "hooks": [{"type": "command", "command": "python3 harmless-marker.py"}],
+                        }
+                    ]
+                }
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    _write_text(workspace_dir / ".codex" / "config.toml", original_config)
+    _write_text(workspace_dir / ".codex" / "hooks.json", original_hooks)
+
+    rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "codex_hook_inventory_unmanaged_executable" in captured.err
+    assert "FutureAgentEvent/group[0]/handler[0]" in captured.err
+    assert (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8") == original_config
+    assert (workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8") == original_hooks
+
+
 def test_guard_install_codex_allows_unmanaged_hooks_when_hooks_already_enabled(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
@@ -1626,7 +1556,10 @@ hooks = true
 def test_guard_install_codex_migrates_global_and_workspace_hooks_to_toml(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
-    _write_text(home_dir / ".codex" / "config.toml", 'model = "gpt-5.3-codex"\n')
+    _write_text(
+        home_dir / ".codex" / "config.toml",
+        'model = "gpt-5.3-codex"\n\n[features]\nhooks = true\n',
+    )
     _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
     context = HarnessContext(home_dir=home_dir, guard_home=home_dir, workspace_dir=workspace_dir)
     legacy_group = codex_adapter._managed_hook_groups(context)["PreToolUse"]


### PR DESCRIPTION
## Summary

- add one typed Codex hook inventory that dynamically walks every event, matcher group, and handler in global/workspace JSON and TOML sources
- preserve exact source coordinates and execution fields, and classify ownership only through authenticated manifest bindings or exact legacy adoption—not basenames, status text, paths, or command substrings
- fail closed before the first write on unmanaged executable activation, malformed/unknown shapes, duplicate keys, unreadable/non-regular/symlink sources, or a source that changes after inventory
- use the same strict-read canonical payloads for inventory and migration while preserving disabled hooks and metadata-only events

## Security invariant

Guard cannot set `features.hooks = true` until every executable hook Codex could load has been inventoried completely. Incomplete inventory leaves all source files unchanged.

## Regression proof

The pre-fix reproduction `test_guard_install_codex_refuses_unmanaged_future_event_before_enabling_hooks` failed because install returned success for an unmanaged `FutureAgentEvent`. It now stops before activation with `codex_hook_inventory_unmanaged_executable` and the exact `FutureAgentEvent/group[0]/handler[0]` coordinate.

The event matrix exercises `PreToolUse`, `PermissionRequest`, `UserPromptSubmit`, `PostToolUse`, `SessionStart`, `Stop`, and `FutureAgentEvent`, across global/project JSON and TOML. It also covers multiple handlers, disabled/metadata entries, authenticated ownership, duplicate/malformed sources, unknown handler types, non-files, symlinks, and source-change detection.

## Verification

- 115 focused Codex inventory/install/repair/authoritative-boundary tests passed on the default Python
- 92 inventory/install tests passed on Python 3.10
- Ruff format and lint passed
- basedpyright reported 0 errors
- sdist and wheel builds passed on Python 3.10 and the default Python
- exact commit author and committer: `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>`

Stable reasons include `codex_hook_inventory_unmanaged_executable`, `codex_hook_inventory_unsupported_event_shape`, `codex_hook_inventory_malformed_group`, `codex_hook_inventory_malformed_handler`, `codex_hook_inventory_unknown_handler_type`, `codex_hook_inventory_source_duplicate_key`, `codex_hook_inventory_source_malformed`, `codex_hook_inventory_source_unreadable`, and `codex_hook_inventory_source_changed`.
