### PR TITLE
fix(runtime): parse pytest configuration semantically

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/pytest_config.py
+++ b/src/codex_plugin_scanner/guard/runtime/pytest_config.py
@@ -417,8 +417,13 @@ def _read_config_bytes(workspace_root: Path, relative_path: str) -> _ConfigRead:
             descriptor = None
             content = handle.read(MAX_PYTEST_CONFIG_FILE_BYTES + 1)
             opened_after_read = os.fstat(handle.fileno())
-        if len(content) > MAX_PYTEST_CONFIG_FILE_BYTES:
+            handle.seek(0)
+            verified_content = handle.read(MAX_PYTEST_CONFIG_FILE_BYTES + 1)
+            opened_after_verify = os.fstat(handle.fileno())
+        if len(content) > MAX_PYTEST_CONFIG_FILE_BYTES or len(verified_content) > MAX_PYTEST_CONFIG_FILE_BYTES:
             return _ConfigRead(True, None, PYTEST_CONFIG_OVERSIZE)
+        if verified_content != content:
+            return _ConfigRead(True, None, PYTEST_CONFIG_FILE_CHANGED)
         opened_identity = (
             opened.st_dev,
             opened.st_ino,
@@ -432,6 +437,14 @@ def _read_config_bytes(workspace_root: Path, relative_path: str) -> _ConfigRead:
             opened_after_read.st_size,
             opened_after_read.st_mtime_ns,
             opened_after_read.st_ctime_ns,
+        ) != opened_identity:
+            return _ConfigRead(True, None, PYTEST_CONFIG_FILE_CHANGED)
+        if (
+            opened_after_verify.st_dev,
+            opened_after_verify.st_ino,
+            opened_after_verify.st_size,
+            opened_after_verify.st_mtime_ns,
+            opened_after_verify.st_ctime_ns,
         ) != opened_identity:
             return _ConfigRead(True, None, PYTEST_CONFIG_FILE_CHANGED)
         after = resolved.stat()

--- a/src/codex_plugin_scanner/guard/runtime/pytest_config.py
+++ b/src/codex_plugin_scanner/guard/runtime/pytest_config.py
@@ -1,0 +1,470 @@
+"""Semantic, fail-closed parsing for pytest configuration files."""
+
+from __future__ import annotations
+
+import configparser
+import hashlib
+import importlib
+import json
+import os
+import shlex
+import stat
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING or sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised by the Python 3.10 validation job
+    tomllib = importlib.import_module("tomli")
+
+MAX_PYTEST_CONFIG_FILE_BYTES = 1_000_000
+PYTEST_CONFIG_PATH_INVALID = "pytest_config_path_invalid"
+PYTEST_CONFIG_SYMLINK = "pytest_config_symlink"
+PYTEST_CONFIG_NOT_REGULAR = "pytest_config_not_regular"
+PYTEST_CONFIG_OVERSIZE = "pytest_config_oversize"
+PYTEST_CONFIG_DECODE_ERROR = "pytest_config_decode_error"
+PYTEST_CONFIG_DUPLICATE_KEY = "pytest_config_duplicate_key"
+PYTEST_CONFIG_SYNTAX_ERROR = "pytest_config_syntax_error"
+PYTEST_CONFIG_VALUE_TYPE_INVALID = "pytest_config_value_type_invalid"
+PYTEST_CONFIG_IO_ERROR = "pytest_config_io_error"
+PYTEST_CONFIG_FILE_CHANGED = "pytest_config_file_changed"
+PYTEST_CONFIG_MISSING = "pytest_config_missing"
+
+_UNSAFE_ADDOPTS_MARKERS = (
+    "--basetemp",
+    "--cache-clear",
+    "--config-file",
+    "--debug",
+    "--junit-xml",
+    "--junitxml",
+    "--log-file",
+    "--confcutdir",
+    "--override-ini",
+    "--rootdir",
+    "-c",
+    "-o",
+)
+_UNSAFE_VALUE_KEYS = frozenset({"log_file", "pythonpath", "required_plugins"})
+
+
+@dataclass(frozen=True, slots=True)
+class PytestConfigValue:
+    """Execution-affecting values resolved by the containing config grammar."""
+
+    addopts: tuple[str, ...] = ()
+    log_file: str | None = None
+    execution_options: tuple[tuple[str, str], ...] = ()
+    unsafe: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class PytestConfigParseResult:
+    """One config parse with an explicit completeness and evidence identity."""
+
+    source_path: str
+    present: bool
+    value: PytestConfigValue | None
+    complete: bool
+    reason_code: str | None
+    content_sha256: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class PytestConfigAssessment:
+    """Deterministic aggregate used by policy and approval identity."""
+
+    results: tuple[PytestConfigParseResult, ...]
+    complete: bool
+    unsafe: bool
+    reason_codes: tuple[str, ...]
+    identity_sha256: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _ConfigRead:
+    present: bool
+    content: bytes | None
+    reason_code: str | None
+
+
+def parse_pytest_config(workspace_root: Path, relative_path: str) -> PytestConfigParseResult:
+    """Parse one supported config without following a symlink or partial file."""
+
+    normalized_path = Path(relative_path).as_posix()
+    read = _read_config_bytes(workspace_root, relative_path)
+    if not read.present:
+        return PytestConfigParseResult(normalized_path, False, None, read.reason_code is None, read.reason_code, None)
+    if read.content is None:
+        return PytestConfigParseResult(normalized_path, True, None, False, read.reason_code, None)
+    content_hash = hashlib.sha256(read.content).hexdigest()
+    try:
+        text = read.content.decode("utf-8")
+    except UnicodeDecodeError:
+        return PytestConfigParseResult(
+            normalized_path,
+            True,
+            None,
+            False,
+            PYTEST_CONFIG_DECODE_ERROR,
+            content_hash,
+        )
+    try:
+        if Path(relative_path).suffix.lower() == ".toml":
+            value = _parse_toml(text, filename=Path(relative_path).name)
+        else:
+            value = _parse_ini(text, filename=Path(relative_path).name)
+    except (configparser.DuplicateOptionError, configparser.DuplicateSectionError):
+        return _parse_failure(normalized_path, content_hash, PYTEST_CONFIG_DUPLICATE_KEY)
+    except tomllib.TOMLDecodeError as error:
+        reason = PYTEST_CONFIG_DUPLICATE_KEY if "overwrite" in str(error).lower() else PYTEST_CONFIG_SYNTAX_ERROR
+        return _parse_failure(normalized_path, content_hash, reason)
+    except (configparser.Error, ValueError):
+        return _parse_failure(normalized_path, content_hash, PYTEST_CONFIG_SYNTAX_ERROR)
+    except TypeError:
+        return _parse_failure(normalized_path, content_hash, PYTEST_CONFIG_VALUE_TYPE_INVALID)
+    return PytestConfigParseResult(normalized_path, True, value, True, None, content_hash)
+
+
+def assess_pytest_configs(
+    workspace_root: Path,
+    relative_paths: Iterable[str],
+    *,
+    require_present: bool = False,
+) -> PytestConfigAssessment:
+    """Parse existing candidates and produce one collision-resistant identity."""
+
+    parsed_results = tuple(parse_pytest_config(workspace_root, path) for path in dict.fromkeys(relative_paths))
+    results = tuple(
+        PytestConfigParseResult(
+            source_path=result.source_path,
+            present=False,
+            value=None,
+            complete=False,
+            reason_code=PYTEST_CONFIG_MISSING,
+            content_sha256=None,
+        )
+        if require_present and not result.present and result.complete
+        else result
+        for result in parsed_results
+    )
+    relevant = tuple(result for result in results if result.present or not result.complete)
+    if not relevant:
+        return PytestConfigAssessment((), True, False, (), None)
+    reason_codes = tuple(dict.fromkeys(result.reason_code for result in relevant if result.reason_code is not None))
+    complete = all(result.complete for result in relevant)
+    unsafe = not complete or any(result.value is not None and result.value.unsafe for result in relevant)
+    identity_payload = [
+        {
+            "complete": result.complete,
+            "content_sha256": result.content_sha256,
+            "reason_code": result.reason_code,
+            "source_path": result.source_path,
+        }
+        for result in relevant
+    ]
+    identity = hashlib.sha256(
+        json.dumps(identity_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return PytestConfigAssessment(relevant, complete, unsafe, reason_codes, identity)
+
+
+def assess_selected_pytest_config(
+    workspace_root: Path,
+    relative_paths: Iterable[str],
+) -> PytestConfigAssessment:
+    """Apply pytest's first-applicable-config precedence to bounded candidates."""
+
+    fallback_pyproject: PytestConfigParseResult | None = None
+    for relative_path in dict.fromkeys(relative_paths):
+        result = parse_pytest_config(workspace_root, relative_path)
+        if not result.present:
+            continue
+        if not result.complete:
+            return _assessment_from_results((result,))
+        if result.value is not None:
+            return _assessment_from_results((result,))
+        if Path(relative_path).name == "pyproject.toml" and fallback_pyproject is None:
+            fallback_pyproject = result
+    if fallback_pyproject is not None:
+        return _assessment_from_results((fallback_pyproject,))
+    return PytestConfigAssessment((), True, False, (), None)
+
+
+def combine_pytest_config_assessments(
+    assessments: Iterable[PytestConfigAssessment],
+) -> PytestConfigAssessment:
+    """Combine per-segment assessments without dropping incomplete evidence."""
+
+    selected = tuple(
+        assessment
+        for assessment in assessments
+        if assessment.results
+        or not assessment.complete
+        or assessment.unsafe
+        or assessment.reason_codes
+        or assessment.identity_sha256 is not None
+    )
+    if not selected:
+        return PytestConfigAssessment((), True, False, (), None)
+    results = tuple(result for assessment in selected for result in assessment.results)
+    reason_codes = tuple(
+        dict.fromkeys(reason_code for assessment in selected for reason_code in assessment.reason_codes)
+    )
+    identity = hashlib.sha256(
+        json.dumps(
+            [assessment.identity_sha256 for assessment in selected],
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return PytestConfigAssessment(
+        results=results,
+        complete=all(assessment.complete for assessment in selected),
+        unsafe=any(assessment.unsafe for assessment in selected),
+        reason_codes=reason_codes,
+        identity_sha256=identity,
+    )
+
+
+def _parse_failure(source_path: str, content_hash: str, reason_code: str) -> PytestConfigParseResult:
+    return PytestConfigParseResult(source_path, True, None, False, reason_code, content_hash)
+
+
+def _assessment_from_results(results: tuple[PytestConfigParseResult, ...]) -> PytestConfigAssessment:
+    reason_codes = tuple(dict.fromkeys(result.reason_code for result in results if result.reason_code is not None))
+    complete = all(result.complete for result in results)
+    unsafe = not complete or any(result.value is not None and result.value.unsafe for result in results)
+    identity_payload = [
+        {
+            "complete": result.complete,
+            "content_sha256": result.content_sha256,
+            "reason_code": result.reason_code,
+            "source_path": result.source_path,
+        }
+        for result in results
+    ]
+    identity = hashlib.sha256(
+        json.dumps(identity_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return PytestConfigAssessment(results, complete, unsafe, reason_codes, identity)
+
+
+def _parse_toml(text: str, *, filename: str) -> PytestConfigValue | None:
+    payload = tomllib.loads(text)
+    if filename in {"pytest.toml", ".pytest.toml"}:
+        pytest_payload = payload.get("pytest")
+        if pytest_payload is None:
+            return PytestConfigValue()
+        if not isinstance(pytest_payload, dict):
+            raise TypeError("pytest must be a table")
+        return _config_value({str(key): value for key, value in pytest_payload.items()})
+    tool = payload.get("tool")
+    if tool is None:
+        return None
+    if not isinstance(tool, dict):
+        raise TypeError("tool must be a table")
+    pytest_payload = tool.get("pytest")
+    if pytest_payload is None:
+        return None
+    if not isinstance(pytest_payload, dict):
+        raise TypeError("tool.pytest must be a table")
+    ini_options = pytest_payload.get("ini_options")
+    native_options = {str(key): value for key, value in pytest_payload.items() if key != "ini_options"}
+    if native_options and ini_options is not None:
+        raise ValueError("tool.pytest and tool.pytest.ini_options cannot both define options")
+    if native_options:
+        return _config_value(native_options)
+    if ini_options is None:
+        return None
+    if not isinstance(ini_options, dict):
+        raise TypeError("tool.pytest.ini_options must be a table")
+    raw_addopts = ini_options.get("addopts")
+    if raw_addopts is not None and not (
+        isinstance(raw_addopts, str)
+        or (isinstance(raw_addopts, list) and all(isinstance(item, str) for item in raw_addopts))
+    ):
+        raise TypeError("tool.pytest.ini_options.addopts must be a string or string list")
+    ini_compatible: dict[str, object] = {
+        str(key): value if isinstance(value, list) else str(value) for key, value in ini_options.items()
+    }
+    return _config_value(ini_compatible)
+
+
+def _parse_ini(text: str, *, filename: str) -> PytestConfigValue | None:
+    parser = configparser.ConfigParser(interpolation=None, strict=True, empty_lines_in_values=True)
+    parser.optionxform = lambda optionstr: optionstr.lower()
+    parser.read_string(text)
+    section = "tool:pytest" if filename == "setup.cfg" else "pytest"
+    if not parser.has_section(section):
+        return PytestConfigValue() if filename in {"pytest.ini", ".pytest.ini"} else None
+    return _config_value(dict(parser.items(section, raw=True)))
+
+
+def _config_value(options: dict[str, object]) -> PytestConfigValue:
+    addopts = _addopts_tokens(options.get("addopts"))
+    log_file = _optional_config_string(options.get("log_file"), key="log_file")
+    execution_options: list[tuple[str, str]] = []
+    for key, raw_value in sorted(options.items()):
+        if key == "addopts":
+            execution_options.append((key, " ".join(addopts)))
+            continue
+        execution_options.append((key, _execution_option_text(raw_value)))
+    unsafe = _addopts_are_unsafe(addopts) or any(
+        key in _UNSAFE_VALUE_KEYS and bool(value.strip()) for key, value in execution_options
+    )
+    return PytestConfigValue(
+        addopts=addopts,
+        log_file=log_file,
+        execution_options=tuple(execution_options),
+        unsafe=unsafe,
+    )
+
+
+def _execution_option_text(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "\n".join(_execution_option_text(item) for item in value)
+    if isinstance(value, dict):
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    if isinstance(value, bool | int | float) or value is None:
+        return json.dumps(value, separators=(",", ":"))
+    return str(value)
+
+
+def _addopts_tokens(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, list):
+        if not all(isinstance(item, str) for item in value):
+            raise TypeError("addopts list values must be strings")
+        return tuple(value)
+    if not isinstance(value, str):
+        raise TypeError("addopts must be a string or string list")
+    try:
+        return tuple(shlex.split(value, comments=True, posix=True))
+    except ValueError as error:
+        raise ValueError("addopts is not valid shell-style option text") from error
+
+
+def _optional_config_string(value: object, *, key: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(f"{key} must be a string")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _addopts_are_unsafe(tokens: tuple[str, ...]) -> bool:
+    for token in tokens:
+        if token == "-p" or (token.startswith("-p") and not token.startswith("--")):
+            return True
+        if token in _UNSAFE_ADDOPTS_MARKERS:
+            return True
+        if any(token.startswith(f"{marker}=") for marker in _UNSAFE_ADDOPTS_MARKERS if marker != "-c"):
+            return True
+        if token.startswith("-c") and token != "-c":
+            return True
+        if token.startswith("-o") and token != "-o":
+            return True
+    return False
+
+
+def _read_config_bytes(workspace_root: Path, relative_path: str) -> _ConfigRead:
+    relative = Path(relative_path)
+    if not relative_path or relative.is_absolute() or ".." in relative.parts:
+        return _ConfigRead(False, None, PYTEST_CONFIG_PATH_INVALID)
+    try:
+        root = workspace_root.expanduser().resolve(strict=True)
+    except OSError:
+        return _ConfigRead(False, None, PYTEST_CONFIG_IO_ERROR)
+    candidate = root / relative
+    try:
+        current = root
+        for part in relative.parts:
+            current = current / part
+            metadata = current.lstat()
+            if stat.S_ISLNK(metadata.st_mode):
+                return _ConfigRead(True, None, PYTEST_CONFIG_SYMLINK)
+    except FileNotFoundError:
+        return _ConfigRead(False, None, None)
+    except OSError:
+        return _ConfigRead(True, None, PYTEST_CONFIG_IO_ERROR)
+    try:
+        resolved = candidate.resolve(strict=True)
+        _ = resolved.relative_to(root)
+        before = resolved.stat()
+    except (OSError, ValueError):
+        return _ConfigRead(True, None, PYTEST_CONFIG_PATH_INVALID)
+    if not stat.S_ISREG(before.st_mode):
+        return _ConfigRead(True, None, PYTEST_CONFIG_NOT_REGULAR)
+    if before.st_size > MAX_PYTEST_CONFIG_FILE_BYTES:
+        return _ConfigRead(True, None, PYTEST_CONFIG_OVERSIZE)
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(resolved, flags)
+        opened = os.fstat(descriptor)
+        if (opened.st_dev, opened.st_ino, opened.st_size) != (before.st_dev, before.st_ino, before.st_size):
+            return _ConfigRead(True, None, PYTEST_CONFIG_FILE_CHANGED)
+        with os.fdopen(descriptor, "rb", closefd=True) as handle:
+            descriptor = None
+            content = handle.read(MAX_PYTEST_CONFIG_FILE_BYTES + 1)
+            opened_after_read = os.fstat(handle.fileno())
+        if len(content) > MAX_PYTEST_CONFIG_FILE_BYTES:
+            return _ConfigRead(True, None, PYTEST_CONFIG_OVERSIZE)
+        opened_identity = (
+            opened.st_dev,
+            opened.st_ino,
+            opened.st_size,
+            opened.st_mtime_ns,
+            opened.st_ctime_ns,
+        )
+        if (
+            opened_after_read.st_dev,
+            opened_after_read.st_ino,
+            opened_after_read.st_size,
+            opened_after_read.st_mtime_ns,
+            opened_after_read.st_ctime_ns,
+        ) != opened_identity:
+            return _ConfigRead(True, None, PYTEST_CONFIG_FILE_CHANGED)
+        after = resolved.stat()
+        if (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_ctime_ns) != opened_identity:
+            return _ConfigRead(True, None, PYTEST_CONFIG_FILE_CHANGED)
+        return _ConfigRead(True, content, None)
+    except FileNotFoundError:
+        return _ConfigRead(True, None, PYTEST_CONFIG_FILE_CHANGED)
+    except OSError:
+        return _ConfigRead(True, None, PYTEST_CONFIG_IO_ERROR)
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+__all__ = [
+    "MAX_PYTEST_CONFIG_FILE_BYTES",
+    "PYTEST_CONFIG_DECODE_ERROR",
+    "PYTEST_CONFIG_DUPLICATE_KEY",
+    "PYTEST_CONFIG_FILE_CHANGED",
+    "PYTEST_CONFIG_IO_ERROR",
+    "PYTEST_CONFIG_MISSING",
+    "PYTEST_CONFIG_NOT_REGULAR",
+    "PYTEST_CONFIG_OVERSIZE",
+    "PYTEST_CONFIG_PATH_INVALID",
+    "PYTEST_CONFIG_SYMLINK",
+    "PYTEST_CONFIG_SYNTAX_ERROR",
+    "PYTEST_CONFIG_VALUE_TYPE_INVALID",
+    "PytestConfigAssessment",
+    "PytestConfigParseResult",
+    "PytestConfigValue",
+    "assess_pytest_configs",
+    "assess_selected_pytest_config",
+    "combine_pytest_config_assessments",
+    "parse_pytest_config",
+]

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -7210,17 +7210,23 @@ def _segment_targets_pytest(
 
 
 def _argument_sequence_targets_pytest(args: list[str]) -> bool:
+    return _pytest_args_from_argument_sequence(args) is not None
+
+
+def _pytest_args_from_argument_sequence(args: list[str]) -> list[str] | None:
     for index, token in enumerate(args):
         command_token = token.rsplit(":", 1)[-1]
         command_name = _normalized_shell_command_name(command_token)
         if command_name in _PYTEST_COMMAND_NAMES:
-            return True
-        if _is_pytest_python_interpreter_command(command_name) and (
-            _python_segment_targets_module(args[index + 1 :], "pytest")
-            or _python_inline_script_runs_pytest(args[index + 1 :])
-        ):
-            return True
-    return False
+            return args[index + 1 :]
+        if not _is_pytest_python_interpreter_command(command_name):
+            continue
+        python_args = _pytest_args_from_python(args[index + 1 :])
+        if python_args is not None:
+            return python_args
+        if _python_inline_script_runs_pytest(args[index + 1 :]):
+            return []
+    return None
 
 
 def _python_inline_script_runs_pytest(args: list[str]) -> bool:
@@ -7963,31 +7969,58 @@ def _pytest_config_assessment_for_command(
                 PytestConfigAssessment((), False, True, (reason_code or PYTEST_CONFIG_PATH_INVALID,), None)
             )
             continue
-        assessments.append(_pytest_config_assessment(segment_cwd, _pytest_args_from_segment(segment, command_index)))
+        pytest_args = _pytest_args_from_segment(segment, command_index)
+        assessments.append(
+            _pytest_config_assessment(segment_cwd, pytest_args)
+            if pytest_args is not None
+            else PytestConfigAssessment((), False, True, (PYTEST_CONFIG_PATH_INVALID,), None)
+        )
     if not assessments and _shell_command_targets_pytest(command_text):
         assessments.append(_pytest_config_assessment(cwd, []))
     return combine_pytest_config_assessments(assessments)
 
 
-def _pytest_args_from_segment(segment: list[str], command_index: int) -> list[str]:
+def _pytest_args_from_segment(segment: list[str], command_index: int) -> list[str] | None:
     command_name = _normalized_shell_command_name(segment[command_index])
     command_args = segment[command_index + 1 :]
-    if command_name == "pytest":
+    if command_name in _PYTEST_COMMAND_NAMES:
         return command_args
-    if not _is_pytest_python_interpreter_command(command_name):
-        return []
+    if _is_pytest_python_interpreter_command(command_name):
+        return _pytest_args_from_python(command_args)
+    if command_name == "uvx" or command_name in _PYTEST_EXECUTOR_COMMANDS:
+        return _pytest_args_from_argument_sequence(command_args)
+    runner_subcommands = _PYTEST_COMMAND_RUNNER_SUBCOMMANDS.get(command_name)
+    if runner_subcommands is not None:
+        for index, token in enumerate(command_args):
+            if token in runner_subcommands:
+                return _pytest_args_from_argument_sequence(command_args[index + 1 :])
+        return None
+    if command_name == "find":
+        for index, token in enumerate(command_args):
+            if token in _FIND_EXEC_ACTION_FLAGS:
+                return _pytest_args_from_argument_sequence(command_args[index + 1 :])
+        return None
+    if command_name == "fd":
+        for index, token in enumerate(command_args):
+            if fd_arg_requests_exec(token):
+                return _pytest_args_from_argument_sequence(command_args[index + 1 :])
+        return None
+    return None
+
+
+def _pytest_args_from_python(command_args: list[str]) -> list[str] | None:
     index = 0
     while index < len(command_args):
         token = command_args[index]
         if token == "-m" and index + 1 < len(command_args):
-            return command_args[index + 2 :] if command_args[index + 1].split(".", 1)[0] == "pytest" else []
+            return command_args[index + 2 :] if command_args[index + 1].split(".", 1)[0] == "pytest" else None
         if token.startswith("-m") and len(token) > 2:
-            return command_args[index + 1 :] if token[2:].split(".", 1)[0] == "pytest" else []
+            return command_args[index + 1 :] if token[2:].split(".", 1)[0] == "pytest" else None
         if token in _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES:
             index += 2
             continue
         index += 1
-    return []
+    return None
 
 
 def _pytest_config_search_dirs(module_args: list[str], *, cwd: Path) -> tuple[str, ...] | None:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -36,6 +36,13 @@ from .false_positive_rules import (
 from .github_command_capabilities import GitHubCommandAssessment, classify_github_cli
 from .interpreter_options import shell_interpreter_command_payload as _shell_interpreter_command_payload
 from .kubernetes_commands import kubernetes_secret_read_source
+from .pytest_config import (
+    PYTEST_CONFIG_PATH_INVALID,
+    PytestConfigAssessment,
+    assess_pytest_configs,
+    assess_selected_pytest_config,
+    combine_pytest_config_assessments,
+)
 from .restricted_pytest import PYTEST_RESTRICTED_PROFILE_VERSION
 from .secret_sensitivity import SecretPathMatch as SensitivePathMatch
 from .secret_sensitivity import classify_secret_path
@@ -236,19 +243,17 @@ _SAFE_PYTHON_MODULE_SHADOW_PATHS = {
         "ruff/__main__.pyc",
     ),
 }
-_PYTEST_OPTION_CONFIG_PATHS = ("pytest.ini", "tox.ini", "setup.cfg", "pyproject.toml")
-_PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS = (
-    "--basetemp",
-    "--cache-clear",
-    "--debug",
-    "--junitxml",
-    "--junit-xml",
-    "--log-file",
-    "-p",
+_PYTEST_OPTION_CONFIG_PATHS = (
+    "pytest.toml",
+    ".pytest.toml",
+    "pytest.ini",
+    ".pytest.ini",
+    "pyproject.toml",
+    "tox.ini",
+    "setup.cfg",
 )
 _PYTEST_UNSAFE_ENV_KEYS = frozenset({"PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTHONHOME", "PYTHONPATH", "PYTHONUSERBASE"})
 _SHELL_STARTUP_ENV_KEYS = frozenset({"BASH_ENV", "ENV", "ZDOTDIR"})
-_MAX_PYTEST_CONFIG_FILE_BYTES = 1_000_000
 _PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-k", "-m", "--maxfail", "--tb"})
 _PYTEST_SAFE_FLAGS = frozenset({"-q", "-s", "-v", "-x", "--disable-warnings", "--quiet", "--verbose"})
 _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES = frozenset({"--check-hash-based-pycs", "-W", "-X"})
@@ -679,6 +684,9 @@ class ToolActionRequestMatch:
     guard_default_action: str | None = None
     reason_code: str | None = None
     restricted_profile_version: str | None = None
+    pytest_config_identity_sha256: str | None = None
+    pytest_config_sources: tuple[str, ...] = ()
+    pytest_config_reason_codes: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -1209,6 +1217,16 @@ def _destructive_shell_tool_action_request(
     )
     detection_command_text = command_text
     pytest_execution_requested = _shell_command_targets_pytest(detection_command_text)
+    pytest_config_assessment = (
+        _pytest_config_assessment_for_command(
+            detection_command_text,
+            cwd=cwd,
+            execution_context=execution_context,
+        )
+        if pytest_execution_requested
+        else PytestConfigAssessment((), True, False, (), None)
+    )
+    pytest_config_sources = tuple(result.source_path for result in pytest_config_assessment.results)
     if is_guard_approval_mutation_command(detection_command_text):
         return ToolActionRequestMatch(
             tool_name=tool_name,
@@ -1301,6 +1319,9 @@ def _destructive_shell_tool_action_request(
             guard_default_action="sandbox-required" if pytest_execution_requested else None,
             reason_code="pytest_restricted_profile_required" if pytest_execution_requested else None,
             restricted_profile_version=PYTEST_RESTRICTED_PROFILE_VERSION if pytest_execution_requested else None,
+            pytest_config_identity_sha256=pytest_config_assessment.identity_sha256,
+            pytest_config_sources=pytest_config_sources,
+            pytest_config_reason_codes=pytest_config_assessment.reason_codes,
         )
     detection_command_is_destructive = _looks_destructive_shell_command(
         detection_command_text,
@@ -1321,15 +1342,22 @@ def _destructive_shell_tool_action_request(
     if detection_command_is_destructive or raw_command_is_destructive:
         matched_execution_context = raw_execution_context if raw_command_is_destructive else execution_context
         matched_execution_context = matched_execution_context or execution_context
+        destructive_reason = (
+            "Guard found execution-affecting pytest configuration or could not inspect the selected pytest "
+            "configuration completely. Keep plugin/output/config overrides inside the restricted pytest profile; "
+            "repair or remove malformed, missing, unreadable, oversized, or unsafe config inputs before retrying."
+            if pytest_execution_requested and pytest_config_assessment.unsafe
+            else (
+                "Guard treats destructive shell writes and delete operations as sensitive because they can mutate "
+                "the local machine before the user confirms the action."
+            )
+        )
         return ToolActionRequestMatch(
             tool_name=tool_name,
             normalized_tool_name=normalized_tool_name,
             command_text=command_text,
             action_class="destructive shell command",
-            reason=(
-                "Guard treats destructive shell writes and delete operations as sensitive because they can mutate "
-                "the local machine before the user confirms the action."
-            ),
+            reason=destructive_reason,
             canonical_command=canonical_command,
             shell_execution_context_hash=(
                 matched_execution_context.context_hash if matched_execution_context.directory_change_present else None
@@ -1343,6 +1371,9 @@ def _destructive_shell_tool_action_request(
             guard_default_action="sandbox-required" if pytest_execution_requested else None,
             reason_code="pytest_restricted_profile_required" if pytest_execution_requested else None,
             restricted_profile_version=PYTEST_RESTRICTED_PROFILE_VERSION if pytest_execution_requested else None,
+            pytest_config_identity_sha256=pytest_config_assessment.identity_sha256,
+            pytest_config_sources=pytest_config_sources,
+            pytest_config_reason_codes=pytest_config_assessment.reason_codes,
         )
     if pytest_execution_requested:
         return ToolActionRequestMatch(
@@ -1360,6 +1391,9 @@ def _destructive_shell_tool_action_request(
             guard_default_action="sandbox-required",
             reason_code="pytest_restricted_profile_required",
             restricted_profile_version=PYTEST_RESTRICTED_PROFILE_VERSION,
+            pytest_config_identity_sha256=pytest_config_assessment.identity_sha256,
+            pytest_config_sources=pytest_config_sources,
+            pytest_config_reason_codes=pytest_config_assessment.reason_codes,
         )
     github_assessment = _github_shell_capability_assessment(
         detection_command_text,
@@ -4045,6 +4079,8 @@ def build_tool_action_request_artifact(
     }
     if request.restricted_profile_version is not None:
         fingerprint_payload["restricted_profile_version"] = request.restricted_profile_version
+    if request.pytest_config_identity_sha256 is not None:
+        fingerprint_payload["pytest_config_identity_sha256"] = request.pytest_config_identity_sha256
     fingerprint = hashlib.sha256(json.dumps(fingerprint_payload, sort_keys=True).encode("utf-8")).hexdigest()
     request_summary = f"Requested `{request.tool_name}` action `{request.command_text}` ({request.action_class})."
     if wrapper_chain:
@@ -4101,6 +4137,16 @@ def build_tool_action_request_artifact(
             **({"reason_code": request.reason_code} if request.reason_code is not None else {}),
             **(
                 {
+                    "pytest_config_identity_sha256": request.pytest_config_identity_sha256,
+                    "pytest_config_sources": list(request.pytest_config_sources),
+                    "pytest_config_complete": not request.pytest_config_reason_codes,
+                    "pytest_config_reason_codes": list(request.pytest_config_reason_codes),
+                }
+                if request.pytest_config_identity_sha256 is not None
+                else {}
+            ),
+            **(
+                {
                     "restricted_profile_version": request.restricted_profile_version,
                     "restricted_capabilities": {
                         "workspace": "read-write",
@@ -4140,6 +4186,9 @@ def _request_with_wrapper_context(
         guard_default_action=request.guard_default_action,
         reason_code=request.reason_code,
         restricted_profile_version=request.restricted_profile_version,
+        pytest_config_identity_sha256=request.pytest_config_identity_sha256,
+        pytest_config_sources=request.pytest_config_sources,
+        pytest_config_reason_codes=request.pytest_config_reason_codes,
     )
 
 
@@ -7840,32 +7889,122 @@ def _pytest_local_entry_point_metadata_exists(cwd: Path) -> bool:
 def _pytest_config_may_add_unsafe_options(cwd: Path | None, module_args: list[str]) -> bool:
     if cwd is None:
         return True
+    return _pytest_config_assessment(cwd, module_args).unsafe
+
+
+def _pytest_config_assessment(cwd: Path, module_args: list[str]) -> PytestConfigAssessment:
+    explicit_config_paths = _pytest_explicit_config_paths(module_args, cwd=cwd)
+    if explicit_config_paths is None:
+        return assess_pytest_configs(cwd, ("../invalid-pytest-config-search",))
+    if explicit_config_paths:
+        return assess_pytest_configs(cwd, explicit_config_paths, require_present=True)
     config_dirs = _pytest_config_search_dirs(module_args, cwd=cwd)
     if config_dirs is None:
-        return True
-    for config_dir in config_dirs:
-        for config_path in _PYTEST_OPTION_CONFIG_PATHS:
-            if _pytest_config_file_has_unsafe_addopts(cwd, config_dir, config_path):
-                return True
-    return False
+        return assess_pytest_configs(cwd, ("../invalid-pytest-config-search",))
+    candidates = tuple(
+        (Path(config_dir) / config_path).as_posix()
+        for config_dir in config_dirs
+        for config_path in _PYTEST_OPTION_CONFIG_PATHS
+    )
+    return assess_selected_pytest_config(cwd, candidates)
+
+
+def _pytest_explicit_config_paths(module_args: list[str], *, cwd: Path) -> tuple[str, ...] | None:
+    paths: list[str] = []
+    index = 0
+    while index < len(module_args):
+        token = module_args[index]
+        path_text: str | None = None
+        if token in {"-c", "--config-file"}:
+            if index + 1 >= len(module_args):
+                return None
+            path_text = module_args[index + 1]
+            index += 2
+        elif token.startswith("--config-file="):
+            path_text = token.split("=", 1)[1]
+            index += 1
+        elif token.startswith("-c="):
+            path_text = token[3:]
+            index += 1
+        elif token.startswith("-c") and len(token) > 2:
+            path_text = token[2:]
+            index += 1
+        else:
+            index += 1
+            continue
+        selected_path = _pytest_selected_relative_path(path_text, cwd=cwd)
+        if selected_path is None or not selected_path:
+            return None
+        paths.append(selected_path)
+    return (paths[-1],) if paths else ()
+
+
+def _pytest_config_assessment_for_command(
+    command_text: str,
+    *,
+    cwd: Path | None,
+    execution_context: ShellExecutionContext,
+) -> PytestConfigAssessment:
+    if cwd is None:
+        return PytestConfigAssessment((), False, True, (PYTEST_CONFIG_PATH_INVALID,), None)
+    assessments: list[PytestConfigAssessment] = []
+    for context_segment in execution_context.segments:
+        if context_segment.directory_operation is not None:
+            continue
+        segment = list(context_segment.tokens)
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name is None or command_index is None:
+            continue
+        if not _segment_targets_pytest(segment, command_name, command_index):
+            continue
+        segment_cwd, reason_code = validate_shell_execution_segment(execution_context, context_segment)
+        if segment_cwd is None or reason_code is not None:
+            assessments.append(
+                PytestConfigAssessment((), False, True, (reason_code or PYTEST_CONFIG_PATH_INVALID,), None)
+            )
+            continue
+        assessments.append(_pytest_config_assessment(segment_cwd, _pytest_args_from_segment(segment, command_index)))
+    if not assessments and _shell_command_targets_pytest(command_text):
+        assessments.append(_pytest_config_assessment(cwd, []))
+    return combine_pytest_config_assessments(assessments)
+
+
+def _pytest_args_from_segment(segment: list[str], command_index: int) -> list[str]:
+    command_name = _normalized_shell_command_name(segment[command_index])
+    command_args = segment[command_index + 1 :]
+    if command_name == "pytest":
+        return command_args
+    if not _is_pytest_python_interpreter_command(command_name):
+        return []
+    index = 0
+    while index < len(command_args):
+        token = command_args[index]
+        if token == "-m" and index + 1 < len(command_args):
+            return command_args[index + 2 :] if command_args[index + 1].split(".", 1)[0] == "pytest" else []
+        if token.startswith("-m") and len(token) > 2:
+            return command_args[index + 1 :] if token[2:].split(".", 1)[0] == "pytest" else []
+        if token in _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
+        index += 1
+    return []
 
 
 def _pytest_config_search_dirs(module_args: list[str], *, cwd: Path) -> tuple[str, ...] | None:
-    config_dirs: list[str] = [""]
-    for module_arg in _pytest_positional_args(module_args):
+    positional_args = _pytest_positional_args(module_args)
+    config_dirs: list[str] = []
+    if not positional_args:
+        return ("",)
+    for module_arg in positional_args:
         selected_path = _pytest_selected_relative_path(module_arg, cwd=cwd)
         if selected_path is None:
             return None
         if selected_path == "":
             continue
         selected_root = Path(selected_path)
-        roots = [selected_root]
-        if selected_root.suffix != "":
-            roots.append(selected_root.parent)
-        for root in roots:
-            for candidate in _pytest_config_ancestor_dirs(root):
-                if candidate not in config_dirs:
-                    config_dirs.append(candidate)
+        for candidate in _pytest_config_ancestor_dirs(selected_root):
+            if candidate not in config_dirs:
+                config_dirs.append(candidate)
     return tuple(config_dirs)
 
 
@@ -7900,6 +8039,7 @@ def _pytest_config_ancestor_dirs(root: Path) -> tuple[str, ...]:
     while str(current) not in {"", "."}:
         dirs.append(current.as_posix())
         current = current.parent
+    dirs.append("")
     return tuple(dirs)
 
 
@@ -7916,6 +8056,9 @@ def _pytest_positional_args(module_args: list[str]) -> tuple[str, ...]:
         if arg in _PYTEST_SAFE_FLAGS_WITH_VALUES:
             index += 2
             continue
+        if arg in {"-c", "--config-file"}:
+            index += 2
+            continue
         if any(arg.startswith(f"{flag}=") for flag in _PYTEST_SAFE_FLAGS_WITH_VALUES):
             index += 1
             continue
@@ -7923,74 +8066,6 @@ def _pytest_positional_args(module_args: list[str]) -> tuple[str, ...]:
             positional_args.append(arg)
         index += 1
     return tuple(positional_args)
-
-
-def _pytest_config_file_has_unsafe_addopts(cwd: Path, config_dir: str, config_path: str) -> bool:
-    if Path(config_dir).is_absolute() or ".." in Path(config_dir).parts:
-        return True
-    dir_fd: int | None = None
-    file_handle: int | None = None
-    try:
-        # codeql[py/path-injection] config_dir is relative-only and config_path is from a fixed allowlist.
-        dir_fd = os.open(cwd / config_dir, os.O_RDONLY)
-        file_stat = os.stat(config_path, dir_fd=dir_fd)
-        if not stat.S_ISREG(file_stat.st_mode):
-            return False
-        if file_stat.st_size > _MAX_PYTEST_CONFIG_FILE_BYTES:
-            return True
-        file_handle = os.open(config_path, os.O_RDONLY, dir_fd=dir_fd)
-        with os.fdopen(file_handle, encoding="utf-8", errors="ignore") as config_file:
-            file_handle = None
-            config_text = config_file.read().lower()
-        if "addopts" not in config_text and "log_file" not in config_text:
-            return False
-        return _pytest_config_text_has_unsafe_addopts(config_text)
-    except (FileNotFoundError, NotADirectoryError):
-        return False
-    except OSError:
-        return True
-    finally:
-        if file_handle is not None:
-            os.close(file_handle)
-        if dir_fd is not None:
-            os.close(dir_fd)
-
-
-def _pytest_config_text_has_unsafe_addopts(config_text: str) -> bool:
-    in_addopts = False
-    for raw_line in config_text.splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith(("#", ";")):
-            continue
-        if re.match(r"^log_file\s*=", line):
-            return True
-        addopts_match = re.match(r"^addopts\s*=(.*)$", line)
-        if addopts_match is not None:
-            in_addopts = True
-            if _pytest_addopts_text_has_unsafe_marker(addopts_match.group(1)):
-                return True
-            continue
-        if in_addopts and (line.startswith("[") or re.match(r"^[a-z0-9_.-]+\s*=", line)):
-            in_addopts = False
-        if in_addopts and _pytest_addopts_text_has_unsafe_marker(line):
-            return True
-    return False
-
-
-def _pytest_addopts_text_has_unsafe_marker(addopts_text: str) -> bool:
-    try:
-        tokens = shlex.split(addopts_text, comments=True, posix=True)
-    except ValueError:
-        tokens = addopts_text.split()
-    for raw_token in tokens:
-        token = raw_token.strip("[],")
-        if token in _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS:
-            return True
-        if any(marker != "-p" and token.startswith(f"{marker}=") for marker in _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS):
-            return True
-        if token.startswith("-p") and not token.startswith("--"):
-            return True
-    return False
 
 
 def _pytest_module_args_are_safe(module_args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -417,6 +417,33 @@ _PYTEST_COMMAND_RUNNER_SUBCOMMANDS = {
     "rye": frozenset({"run"}),
     "uv": frozenset({"run"}),
 }
+_PYTEST_RUNNER_OPTIONS_WITH_VALUES = {
+    "conda": frozenset({"--cwd", "--name", "--prefix"}),
+    "hatch": frozenset({"--env", "--project"}),
+    "mise": frozenset({"--cwd", "--env", "--jobs"}),
+    "pdm": frozenset({"--config", "--project", "--site-packages"}),
+    "pipenv": frozenset({"--categories", "--extra-pip-args", "--python"}),
+    "pipx": frozenset({"--index-url", "--pip-args", "--suffix", "--with"}),
+    "pixi": frozenset({"--environment", "--manifest-path"}),
+    "poetry": frozenset({"--directory", "--project"}),
+    "rye": frozenset({"--pyproject"}),
+    "uv": frozenset(
+        {
+            "--cache-dir",
+            "--config-file",
+            "--directory",
+            "--env-file",
+            "--index",
+            "--index-url",
+            "--project",
+            "--python",
+            "--with",
+            "--with-editable",
+            "--with-requirements",
+        }
+    ),
+}
+_PYTEST_RUNNER_POSITIONAL_PREFIX_COUNTS = {"direnv": 1}
 _PYTEST_EXECUTOR_COMMANDS = frozenset({"parallel", "watch", "xargs"})
 _BROAD_CREDENTIAL_EXFILTRATION_SKIP_COMMANDS = frozenset({"cat", "curl", "echo", "printf", "sed", "tr", "wget"})
 _SHELL_NETWORK_SINK_COMMANDS = frozenset({"curl", "wget", "nc", "ncat", "netcat", "scp", "rsync", "ssh"})
@@ -7189,7 +7216,8 @@ def _segment_targets_pytest(
     runner_subcommands = _PYTEST_COMMAND_RUNNER_SUBCOMMANDS.get(command_name)
     if runner_subcommands is not None:
         return any(
-            token in runner_subcommands and _argument_sequence_targets_pytest(command_args[index + 1 :])
+            token in runner_subcommands
+            and _pytest_args_from_runner_argument_sequence(command_name, command_args[index + 1 :]) is not None
             for index, token in enumerate(command_args)
         )
     if command_name in _PYTEST_EXECUTOR_COMMANDS:
@@ -7214,18 +7242,63 @@ def _argument_sequence_targets_pytest(args: list[str]) -> bool:
 
 
 def _pytest_args_from_argument_sequence(args: list[str]) -> list[str] | None:
-    for index, token in enumerate(args):
-        command_token = token.rsplit(":", 1)[-1]
-        command_name = _normalized_shell_command_name(command_token)
-        if command_name in _PYTEST_COMMAND_NAMES:
-            return args[index + 1 :]
-        if not _is_pytest_python_interpreter_command(command_name):
+    return _pytest_args_from_argument_sequence_ignoring(args, ignored_indices=frozenset())
+
+
+def _pytest_args_from_runner_argument_sequence(command_name: str, args: list[str]) -> list[str] | None:
+    value_options = _PYTEST_RUNNER_OPTIONS_WITH_VALUES.get(command_name, frozenset())
+    ignored_indices: set[int] = set()
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token == "--":
+            break
+        if token in value_options:
+            if index + 1 >= len(args):
+                return None
+            ignored_indices.add(index + 1)
+            index += 2
             continue
-        python_args = _pytest_args_from_python(args[index + 1 :])
-        if python_args is not None:
-            return python_args
-        if _python_inline_script_runs_pytest(args[index + 1 :]):
-            return []
+        index += 1
+    positional_prefix_count = _PYTEST_RUNNER_POSITIONAL_PREFIX_COUNTS.get(command_name, 0)
+    for index, token in enumerate(args):
+        if index in ignored_indices or token == "--" or token.startswith("-"):
+            continue
+        if _SHELL_ASSIGNMENT_PATTERN.match(token):
+            continue
+        if positional_prefix_count:
+            positional_prefix_count -= 1
+            continue
+        return _pytest_args_from_command_position(args, index)
+    return None
+
+
+def _pytest_args_from_argument_sequence_ignoring(
+    args: list[str],
+    *,
+    ignored_indices: frozenset[int],
+) -> list[str] | None:
+    for index in range(len(args)):
+        if index in ignored_indices:
+            continue
+        pytest_args = _pytest_args_from_command_position(args, index)
+        if pytest_args is not None:
+            return pytest_args
+    return None
+
+
+def _pytest_args_from_command_position(args: list[str], index: int) -> list[str] | None:
+    command_token = args[index].rsplit(":", 1)[-1]
+    command_name = _normalized_shell_command_name(command_token)
+    if command_name in _PYTEST_COMMAND_NAMES:
+        return args[index + 1 :]
+    if not _is_pytest_python_interpreter_command(command_name):
+        return None
+    python_args = _pytest_args_from_python(args[index + 1 :])
+    if python_args is not None:
+        return python_args
+    if _python_inline_script_runs_pytest(args[index + 1 :]):
+        return []
     return None
 
 
@@ -7993,7 +8066,7 @@ def _pytest_args_from_segment(segment: list[str], command_index: int) -> list[st
     if runner_subcommands is not None:
         for index, token in enumerate(command_args):
             if token in runner_subcommands:
-                return _pytest_args_from_argument_sequence(command_args[index + 1 :])
+                return _pytest_args_from_runner_argument_sequence(command_name, command_args[index + 1 :])
         return None
     if command_name == "find":
         for index, token in enumerate(command_args):

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -8001,7 +8001,10 @@ def _pytest_config_search_dirs(module_args: list[str], *, cwd: Path) -> tuple[st
             return None
         if selected_path == "":
             continue
-        selected_paths.append(selected_path)
+        config_root = Path(selected_path)
+        if not (cwd / config_root).is_dir():
+            config_root = config_root.parent
+        selected_paths.append("" if str(config_root) == "." else config_root.as_posix())
     if not selected_paths:
         return ("",)
     try:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -7992,20 +7992,23 @@ def _pytest_args_from_segment(segment: list[str], command_index: int) -> list[st
 
 def _pytest_config_search_dirs(module_args: list[str], *, cwd: Path) -> tuple[str, ...] | None:
     positional_args = _pytest_positional_args(module_args)
-    config_dirs: list[str] = []
     if not positional_args:
         return ("",)
+    selected_paths: list[str] = []
     for module_arg in positional_args:
         selected_path = _pytest_selected_relative_path(module_arg, cwd=cwd)
         if selected_path is None:
             return None
         if selected_path == "":
             continue
-        selected_root = Path(selected_path)
-        for candidate in _pytest_config_ancestor_dirs(selected_root):
-            if candidate not in config_dirs:
-                config_dirs.append(candidate)
-    return tuple(config_dirs)
+        selected_paths.append(selected_path)
+    if not selected_paths:
+        return ("",)
+    try:
+        selected_root = Path(os.path.commonpath(selected_paths))
+    except ValueError:
+        return None
+    return _pytest_config_ancestor_dirs(selected_root)
 
 
 def _pytest_selected_relative_path(module_arg: str, *, cwd: Path) -> str | None:

--- a/tests/test_pytest_config_semantics.py
+++ b/tests/test_pytest_config_semantics.py
@@ -1,0 +1,355 @@
+"""P24 regressions for semantic, fail-closed pytest configuration parsing."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime import pytest_config as pytest_config_module
+from codex_plugin_scanner.guard.runtime.pytest_config import (
+    MAX_PYTEST_CONFIG_FILE_BYTES,
+    PYTEST_CONFIG_DECODE_ERROR,
+    PYTEST_CONFIG_DUPLICATE_KEY,
+    PYTEST_CONFIG_FILE_CHANGED,
+    PYTEST_CONFIG_IO_ERROR,
+    PYTEST_CONFIG_MISSING,
+    PYTEST_CONFIG_NOT_REGULAR,
+    PYTEST_CONFIG_OVERSIZE,
+    PYTEST_CONFIG_SYMLINK,
+    PYTEST_CONFIG_SYNTAX_ERROR,
+    PYTEST_CONFIG_VALUE_TYPE_INVALID,
+    parse_pytest_config,
+)
+from codex_plugin_scanner.guard.runtime.secret_file_requests import (
+    build_tool_action_request_artifact,
+    extract_sensitive_tool_action_request,
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("path", "content"),
+    (
+        ("pyproject.toml", '[tool.pytest.ini_options]\naddopts = "-p evil"\n'),
+        ("pyproject.toml", '[tool.pytest.ini_options]\n"addopts" = "-p evil"\n'),
+        ("pyproject.toml", 'tool.pytest.ini_options.addopts = "-p evil"\n'),
+        ("pyproject.toml", '[tool.pytest]\naddopts = ["-p", "evil"]\n'),
+        ("pytest.toml", '[pytest]\naddopts = ["-p", "evil"]\n'),
+        (".pytest.toml", '[pytest]\naddopts = ["-p", "evil"]\n'),
+        (".pytest.ini", "[pytest]\naddopts = -p evil\n"),
+        ("setup.cfg", "[tool:pytest]\naddopts = -p evil\n"),
+        ("tox.ini", "[pytest]\naddopts = -p evil\n"),
+    ),
+)
+def test_semantic_pytest_config_blocks_plugin_loading(tmp_path: Path, path: str, content: str) -> None:
+    _write(tmp_path / path, content)
+
+    match = extract_sensitive_tool_action_request("Bash", {"command": "pytest -q"}, cwd=tmp_path)
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
+def test_setup_cfg_ignores_addopts_outside_tool_pytest_section(tmp_path: Path) -> None:
+    _write(tmp_path / "setup.cfg", "[metadata]\naddopts = -p unrelated\n[tool:pytest]\naddopts = -q\n")
+
+    match = extract_sensitive_tool_action_request("Bash", {"command": "pytest -q"}, cwd=tmp_path)
+
+    assert match is not None
+    assert match.action_class == "pytest repository-code execution"
+
+
+def test_malformed_pytest_config_fails_closed(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", "[tool.pytest.ini_options\naddopts = '-q'\n")
+
+    match = extract_sensitive_tool_action_request("Bash", {"command": "pytest -q"}, cwd=tmp_path)
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+    assert match.pytest_config_reason_codes == (PYTEST_CONFIG_SYNTAX_ERROR,)
+
+
+@pytest.mark.parametrize(
+    ("path", "content"),
+    (
+        ("pytest.ini", "[pytest]\naddopts =\n  -q\n  -p evil\n"),
+        ("tox.ini", "[pytest]\naddopts = -pno:cacheprovider\n"),
+        ("pytest.ini", "[pytest]\naddopts = --override-ini log_file=pytest.log\n"),
+        ("pytest.ini", "[pytest]\naddopts = -o pythonpath=../outside\n"),
+        ("pytest.ini", "[pytest]\naddopts = --rootdir ../outside\n"),
+        ("pytest.ini", "[pytest]\naddopts = --confcutdir ../outside\n"),
+        ("setup.cfg", "[tool:pytest]\nlog_file = pytest.log\n"),
+        (
+            "pyproject.toml",
+            '[tool."pytest".ini_options]\naddopts = """\n-q\n-p evil\n"""\n',
+        ),
+        (
+            "pyproject.toml",
+            "[tool.pytest.ini_options]\naddopts = '''\n-q\n-p evil\n'''\n",
+        ),
+        ("pyproject.toml", '[tool.pytest.ini_options]\naddopts = ["-q", "-c", "other.ini"]\n'),
+    ),
+)
+def test_parser_handles_format_specific_multiline_and_option_forms(
+    tmp_path: Path,
+    path: str,
+    content: str,
+) -> None:
+    _write(tmp_path / path, content)
+
+    result = parse_pytest_config(tmp_path, path)
+
+    assert result.complete is True
+    assert result.value is not None
+    assert result.value.unsafe is True
+    assert result.content_sha256 is not None
+
+
+@pytest.mark.parametrize(
+    ("path", "content"),
+    (
+        ("pytest.ini", "[pytest]\naddopts = -q\naddopts = -v\n"),
+        ("setup.cfg", "[tool:pytest]\naddopts = -q\n[tool:pytest]\naddopts = -v\n"),
+        ("pyproject.toml", '[tool.pytest.ini_options]\naddopts = "-q"\naddopts = "-v"\n'),
+    ),
+)
+def test_duplicate_config_keys_fail_closed(tmp_path: Path, path: str, content: str) -> None:
+    _write(tmp_path / path, content)
+
+    result = parse_pytest_config(tmp_path, path)
+
+    assert result.complete is False
+    assert result.reason_code == PYTEST_CONFIG_DUPLICATE_KEY
+
+
+def test_wrong_pyproject_value_type_fails_closed(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", "[tool.pytest.ini_options]\naddopts = 7\n")
+
+    result = parse_pytest_config(tmp_path, "pyproject.toml")
+
+    assert result.complete is False
+    assert result.reason_code == PYTEST_CONFIG_VALUE_TYPE_INVALID
+
+
+def test_toml_option_names_remain_case_sensitive(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", '[tool.pytest.ini_options]\n"ADDOPTS" = "-p evil"\n')
+
+    result = parse_pytest_config(tmp_path, "pyproject.toml")
+
+    assert result.complete is True
+    assert result.value is not None
+    assert result.value.unsafe is False
+
+
+def test_native_toml_scalar_options_do_not_make_inventory_incomplete(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", "[tool.pytest]\nxfail_strict = true\nverbosity_test_cases = 2\n")
+
+    result = parse_pytest_config(tmp_path, "pyproject.toml")
+
+    assert result.complete is True
+    assert result.value is not None
+    assert result.value.unsafe is False
+
+
+def test_first_applicable_config_wins_without_inspecting_lower_precedence_files(tmp_path: Path) -> None:
+    _write(tmp_path / "pytest.ini", "[pytest]\naddopts = -q\n")
+    _write(tmp_path / "tox.ini", "[pytest\naddopts = -p ignored\n")
+
+    match = extract_sensitive_tool_action_request("Bash", {"command": "pytest -q"}, cwd=tmp_path)
+
+    assert match is not None
+    assert match.action_class == "pytest repository-code execution"
+    assert match.pytest_config_sources == ("pytest.ini",)
+
+
+def test_selected_test_root_config_precedes_invocation_directory_config(tmp_path: Path) -> None:
+    _write(tmp_path / "pytest.ini", "[pytest]\naddopts = -q\n")
+    _write(tmp_path / "sub" / "pytest.ini", "[pytest]\naddopts = -p evil\n")
+
+    match = extract_sensitive_tool_action_request("Bash", {"command": "pytest sub -q"}, cwd=tmp_path)
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+    assert match.pytest_config_sources == ("sub/pytest.ini",)
+
+
+def test_non_applicable_pyproject_does_not_hide_later_tox_config(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", '[build-system]\nrequires = ["fixture"]\n')
+    _write(tmp_path / "tox.ini", "[pytest]\naddopts = -p evil\n")
+
+    match = extract_sensitive_tool_action_request("Bash", {"command": "pytest -q"}, cwd=tmp_path)
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+    assert match.pytest_config_sources == ("tox.ini",)
+
+
+def test_oversized_pytest_config_fails_closed_without_partial_parse(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "pytest.ini",
+        "[pytest]\naddopts = -q\n" + ("# padding\n" * (MAX_PYTEST_CONFIG_FILE_BYTES // 5)),
+    )
+
+    result = parse_pytest_config(tmp_path, "pytest.ini")
+
+    assert result.complete is False
+    assert result.reason_code == PYTEST_CONFIG_OVERSIZE
+    assert result.content_sha256 is None
+
+
+def test_pytest_config_symlink_is_rejected(tmp_path: Path) -> None:
+    target = tmp_path / "real.ini"
+    _write(target, "[pytest]\naddopts = -q\n")
+    (tmp_path / "pytest.ini").symlink_to(target)
+
+    result = parse_pytest_config(tmp_path, "pytest.ini")
+
+    assert result.complete is False
+    assert result.reason_code == PYTEST_CONFIG_SYMLINK
+
+
+def test_pytest_config_directory_is_not_treated_as_missing(tmp_path: Path) -> None:
+    (tmp_path / "pytest.ini").mkdir()
+
+    result = parse_pytest_config(tmp_path, "pytest.ini")
+
+    assert result.complete is False
+    assert result.reason_code == PYTEST_CONFIG_NOT_REGULAR
+
+
+def test_unreadable_pytest_config_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_path = tmp_path / "pytest.ini"
+    _write(config_path, "[pytest]\naddopts = -q\n")
+
+    def denied_open(_path: object, _flags: int) -> int:
+        raise PermissionError("fixture denies the config read")
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.runtime.pytest_config.os.open", denied_open)
+
+    result = parse_pytest_config(tmp_path, "pytest.ini")
+
+    assert result.complete is False
+    assert result.reason_code == PYTEST_CONFIG_IO_ERROR
+
+
+def test_non_utf8_pytest_config_fails_closed(tmp_path: Path) -> None:
+    (tmp_path / "pytest.ini").write_bytes(b"[pytest]\naddopts = \xff\n")
+
+    result = parse_pytest_config(tmp_path, "pytest.ini")
+
+    assert result.complete is False
+    assert result.reason_code == PYTEST_CONFIG_DECODE_ERROR
+
+
+def test_pytest_config_changed_during_read_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "pytest.ini"
+    _write(config_path, "[pytest]\naddopts = -q\n")
+    original_fstat = pytest_config_module.os.fstat
+    calls = 0
+
+    def racing_fstat(descriptor: int) -> os.stat_result:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            _write(config_path, "[pytest]\naddopts = -v\n")
+        return original_fstat(descriptor)
+
+    monkeypatch.setattr(pytest_config_module.os, "fstat", racing_fstat)
+
+    result = parse_pytest_config(tmp_path, "pytest.ini")
+
+    assert result.complete is False
+    assert result.reason_code == PYTEST_CONFIG_FILE_CHANGED
+
+
+def test_config_content_hash_changes_pytest_approval_identity(tmp_path: Path) -> None:
+    config_path = tmp_path / "pyproject.toml"
+    _write(config_path, '[tool.pytest.ini_options]\naddopts = "-q"\n')
+    first_match = extract_sensitive_tool_action_request("Bash", {"command": "pytest tests -q"}, cwd=tmp_path)
+    assert first_match is not None
+    first_artifact = build_tool_action_request_artifact(
+        "codex",
+        first_match,
+        config_path=str(config_path),
+        source_scope="project",
+    )
+
+    _write(config_path, '[tool.pytest.ini_options]\naddopts = "-v"\n')
+    second_match = extract_sensitive_tool_action_request("Bash", {"command": "pytest tests -q"}, cwd=tmp_path)
+    assert second_match is not None
+    second_artifact = build_tool_action_request_artifact(
+        "codex",
+        second_match,
+        config_path=str(config_path),
+        source_scope="project",
+    )
+
+    assert first_match.action_class == "pytest repository-code execution"
+    assert second_match.action_class == "pytest repository-code execution"
+    assert first_match.pytest_config_identity_sha256 != second_match.pytest_config_identity_sha256
+    assert first_artifact.artifact_id != second_artifact.artifact_id
+    assert first_artifact.metadata["pytest_config_sources"] == ["pyproject.toml"]
+
+
+@pytest.mark.parametrize(
+    ("path", "content"),
+    (
+        ("pytest.ini", "[pytest]\naddopts = -q\n"),
+        ("tox.ini", "[pytest]\naddopts = -q\n"),
+        ("setup.cfg", "[tool:pytest]\naddopts = -q\n"),
+        ("pyproject.toml", '[tool.pytest.ini_options]\naddopts = "-q"\n'),
+    ),
+)
+def test_safe_config_remains_in_prompt_free_restricted_profile(tmp_path: Path, path: str, content: str) -> None:
+    _write(tmp_path / path, content)
+
+    match = extract_sensitive_tool_action_request("Bash", {"command": "pytest -q"}, cwd=tmp_path)
+
+    assert match is not None
+    assert match.action_class == "pytest repository-code execution"
+    assert match.guard_default_action == "sandbox-required"
+    assert match.pytest_config_reason_codes == ()
+
+
+@pytest.mark.parametrize(
+    "config_flag",
+    ("-c selected.ini", "-cselected.ini", "--config-file=selected.ini", "-c selected.toml"),
+)
+def test_explicit_config_is_parsed_and_bound_to_identity(tmp_path: Path, config_flag: str) -> None:
+    _write(tmp_path / "selected.ini", "[pytest]\naddopts = -p evil\n")
+    _write(tmp_path / "selected.toml", '[tool.pytest.ini_options]\n"addopts" = "-p evil"\n')
+
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": f"python -m pytest {config_flag} -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+    expected_source = "selected.toml" if "selected.toml" in config_flag else "selected.ini"
+    assert match.pytest_config_sources == (expected_source,)
+    assert match.pytest_config_identity_sha256 is not None
+
+
+def test_missing_explicit_config_fails_closed_with_stable_reason(tmp_path: Path) -> None:
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pytest -c missing.ini -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+    assert match.pytest_config_sources == ("missing.ini",)
+    assert match.pytest_config_reason_codes == (PYTEST_CONFIG_MISSING,)
+    assert "repair or remove malformed" in match.reason

--- a/tests/test_pytest_config_semantics.py
+++ b/tests/test_pytest_config_semantics.py
@@ -23,6 +23,7 @@ from codex_plugin_scanner.guard.runtime.pytest_config import (
     parse_pytest_config,
 )
 from codex_plugin_scanner.guard.runtime.secret_file_requests import (
+    _pytest_args_from_segment,
     build_tool_action_request_artifact,
     extract_sensitive_tool_action_request,
 )
@@ -247,6 +248,33 @@ def test_pytest_runner_preserves_explicit_config_arguments(tmp_path: Path, comma
     assert match.action_class == "pytest repository-code execution"
     assert match.pytest_config_sources == ("selected.ini",)
     assert match.pytest_config_identity_sha256 == direct_match.pytest_config_identity_sha256
+
+
+def test_pytest_runner_skips_option_values_before_wrapped_command(tmp_path: Path) -> None:
+    _write(tmp_path / "tests" / "pytest.ini", "[pytest]\npythonpath = helper_path\n")
+
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "uv run --with pytest pytest tests -q"},
+        cwd=tmp_path,
+    )
+    direct_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pytest tests -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert direct_match is not None
+    assert match.pytest_config_sources == ("tests/pytest.ini",)
+    assert match.pytest_config_identity_sha256 == direct_match.pytest_config_identity_sha256
+
+
+def test_pytest_runner_does_not_treat_dependency_or_payload_argument_as_executable() -> None:
+    assert _pytest_args_from_segment(
+        ["uv", "run", "--with", "pytest", "echo", "pytest", "tests"],
+        0,
+    ) is None
 
 
 def test_non_applicable_pyproject_does_not_hide_later_tox_config(tmp_path: Path) -> None:

--- a/tests/test_pytest_config_semantics.py
+++ b/tests/test_pytest_config_semantics.py
@@ -179,6 +179,22 @@ def test_selected_test_root_config_precedes_invocation_directory_config(tmp_path
     assert match.pytest_config_sources == ("sub/pytest.ini",)
 
 
+def test_multiple_test_roots_search_from_their_common_ancestor(tmp_path: Path) -> None:
+    _write(tmp_path / "tests" / "pytest.ini", "[pytest]\naddopts = -p evil\n")
+    _write(tmp_path / "tests" / "a" / "pytest.ini", "[pytest]\naddopts = -q\n")
+    (tmp_path / "tests" / "b").mkdir(parents=True)
+
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pytest tests/a tests/b -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+    assert match.pytest_config_sources == ("tests/pytest.ini",)
+
+
 def test_non_applicable_pyproject_does_not_hide_later_tox_config(tmp_path: Path) -> None:
     _write(tmp_path / "pyproject.toml", '[build-system]\nrequires = ["fixture"]\n')
     _write(tmp_path / "tox.ini", "[pytest]\naddopts = -p evil\n")

--- a/tests/test_pytest_config_semantics.py
+++ b/tests/test_pytest_config_semantics.py
@@ -195,6 +195,35 @@ def test_multiple_test_roots_search_from_their_common_ancestor(tmp_path: Path) -
     assert match.pytest_config_sources == ("tests/pytest.ini",)
 
 
+def test_selected_test_file_searches_for_config_from_parent_directory(tmp_path: Path) -> None:
+    _write(tmp_path / "tests" / "test_sample.py", "def test_sample():\n    pass\n")
+    _write(tmp_path / "tests" / "pytest.ini", "[pytest]\naddopts = -p evil\n")
+
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pytest tests/test_sample.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+    assert match.pytest_config_sources == ("tests/pytest.ini",)
+
+
+def test_selected_test_file_without_config_does_not_fail_as_not_a_directory(tmp_path: Path) -> None:
+    _write(tmp_path / "tests" / "test_sample.py", "def test_sample():\n    pass\n")
+
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pytest tests/test_sample.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "pytest repository-code execution"
+    assert match.pytest_config_sources == ()
+
+
 def test_non_applicable_pyproject_does_not_hide_later_tox_config(tmp_path: Path) -> None:
     _write(tmp_path / "pyproject.toml", '[build-system]\nrequires = ["fixture"]\n')
     _write(tmp_path / "tox.ini", "[pytest]\naddopts = -p evil\n")

--- a/tests/test_pytest_config_semantics.py
+++ b/tests/test_pytest_config_semantics.py
@@ -224,6 +224,31 @@ def test_selected_test_file_without_config_does_not_fail_as_not_a_directory(tmp_
     assert match.pytest_config_sources == ()
 
 
+@pytest.mark.parametrize(
+    "command",
+    (
+        "uv run pytest -c selected.ini -q",
+        "poetry run pytest --config-file=selected.ini -q",
+    ),
+)
+def test_pytest_runner_preserves_explicit_config_arguments(tmp_path: Path, command: str) -> None:
+    _write(tmp_path / "pytest.ini", "[pytest]\naddopts = -q\n")
+    _write(tmp_path / "selected.ini", "[pytest]\naddopts = -p evil\n")
+
+    match = extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=tmp_path)
+    direct_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pytest -c selected.ini -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert direct_match is not None
+    assert match.action_class == "pytest repository-code execution"
+    assert match.pytest_config_sources == ("selected.ini",)
+    assert match.pytest_config_identity_sha256 == direct_match.pytest_config_identity_sha256
+
+
 def test_non_applicable_pyproject_does_not_hide_later_tox_config(tmp_path: Path) -> None:
     _write(tmp_path / "pyproject.toml", '[build-system]\nrequires = ["fixture"]\n')
     _write(tmp_path / "tox.ini", "[pytest]\naddopts = -p evil\n")


### PR DESCRIPTION
## Summary

- replace substring-based pytest safety checks with semantic parsing of pytest TOML/INI configuration;
- model pytest's exact config discovery precedence (`pytest.toml`, `.pytest.toml`, `pytest.ini`, `.pytest.ini`, `pyproject.toml`, `tox.ini`, `setup.cfg`) from the effective command root;
- support native `[pytest]`, `[tool.pytest]`, and compatibility `[tool.pytest.ini_options]` TOML tables;
- read only bounded, regular, contained configuration files and fail closed on malformed, unreadable, raced, oversized, non-UTF-8, symlinked, or escaping sources;
- preserve typed evidence hashes and stable configuration identity for approval decisions.

## Validation

- 46 semantic pytest-configuration tests on Python 3.12
- 46 semantic pytest-configuration tests on Python 3.10
- 12 existing runtime pytest-configuration tests
- 45 restricted/shell pytest tests
- Ruff passed
- basedpyright passed with 0 errors
- package build passed
- full local suite reached 9,590 passed, 26 skipped, and 5 deselected; two unrelated credential-store environment tests failed because the local macOS keyring was unavailable. One of those two passes independently, and the other is explicitly configured to exercise the host credential backend rather than the test keyring. GitHub's clean CI matrix is the authoritative full-suite result.

## Attribution and base

- Base: `release/2.1`
- Author and committer: `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>`
