### PR TITLE
fix(cisco): contain preflight scans to approved roots

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -206,7 +206,7 @@ def _runtime_cisco_scanner_evidence(
         workspaces.append(runtime_workspace)
 
     primary_workspace = runtime_workspace or next((item for item in workspaces if item is not None), None)
-    approved_scan_roots = tuple(item for item in workspaces if item is not None and item != primary_workspace)
+    approved_scan_roots = tuple(item for item in workspaces if item is not None)
     evidence: list[GuardRiskSignalV3] = []
     for workspace in workspaces:
         for signal in scan_action_for_cisco_evidence(

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -205,9 +205,15 @@ def _runtime_cisco_scanner_evidence(
     if not workspaces:
         workspaces.append(runtime_workspace)
 
+    primary_workspace = runtime_workspace or next((item for item in workspaces if item is not None), None)
+    approved_scan_roots = tuple(item for item in workspaces if item is not None and item != primary_workspace)
     evidence: list[GuardRiskSignalV3] = []
     for workspace in workspaces:
-        for signal in scan_action_for_cisco_evidence(action_envelope, workspace=workspace):
+        for signal in scan_action_for_cisco_evidence(
+            action_envelope,
+            workspace=workspace or primary_workspace,
+            approved_scan_roots=approved_scan_roots,
+        ):
             if signal not in evidence:
                 evidence.append(signal)
     return tuple(evidence)

--- a/src/codex_plugin_scanner/guard/runtime/_shell_execution_context_support.py
+++ b/src/codex_plugin_scanner/guard/runtime/_shell_execution_context_support.py
@@ -49,14 +49,17 @@ class ShellPathIdentity:
     inode: int
     mode: int
     change_time_ns: int
+    creation_time_ns: int
 
     @classmethod
     def from_stat(cls, value: os.stat_result) -> ShellPathIdentity:
+        birth_time = getattr(value, "st_birthtime", None)
         return cls(
             device=value.st_dev,
             inode=value.st_ino,
             mode=stat.S_IFMT(value.st_mode),
             change_time_ns=value.st_ctime_ns,
+            creation_time_ns=int(birth_time * 1_000_000_000) if isinstance(birth_time, int | float) else 0,
         )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
+++ b/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import os
+import stat
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 from codex_plugin_scanner.guard.action_lattice import most_restrictive_guard_action
@@ -11,6 +14,7 @@ from codex_plugin_scanner.guard.models import GuardAction
 from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
 from codex_plugin_scanner.guard.runtime.cisco_evidence import cisco_finding_to_risk_signal
 from codex_plugin_scanner.guard.runtime.signals import GuardRiskSignalV3, RiskSignalV2
+from codex_plugin_scanner.guard.stable_digest import stable_digest_hex
 from codex_plugin_scanner.integrations import cisco_mcp_scanner, cisco_skill_scanner
 from codex_plugin_scanner.integrations.cisco_skill_scanner import CiscoIntegrationStatus
 from codex_plugin_scanner.models import Finding
@@ -26,6 +30,28 @@ _SOURCE_RISK_CLASS: dict[str, str] = {
 
 
 _CISCO_DETECTOR_MIN_BUDGET_SECONDS = 0.5
+_OUTSIDE_APPROVED_WORKSPACE = "outside_approved_workspace"
+
+
+@dataclass(frozen=True, slots=True)
+class _ApprovedScanRoot:
+    path: Path
+    label: str
+
+
+@dataclass(frozen=True, slots=True)
+class _ValidatedScanTarget:
+    path: Path | None
+    scan_root: Path
+    approved_root: _ApprovedScanRoot
+    kind: str
+
+
+class _CiscoPathContainmentError(RuntimeError):
+    def __init__(self, reason: str, *, approved_root_label: str = "selected-workspace") -> None:
+        super().__init__(reason)
+        self.reason: str = reason
+        self.approved_root_label: str = approved_root_label
 
 
 class CiscoSkillPreflightDetector:
@@ -42,7 +68,11 @@ class CiscoSkillPreflightDetector:
         if budget_seconds < _CISCO_DETECTOR_MIN_BUDGET_SECONDS:
             return ()
         signals = scan_action_for_cisco_evidence(
-            action, workspace=workspace, sources=("skill",), timeout_seconds=budget_seconds
+            action,
+            workspace=workspace,
+            approved_scan_roots=getattr(context, "approved_scan_roots", ()),
+            sources=("skill",),
+            timeout_seconds=budget_seconds,
         )
         return tuple(cisco_risk_signal_v3_to_v2(signal) for signal in signals)
 
@@ -61,7 +91,11 @@ class CiscoMcpPreflightDetector:
         if budget_seconds < _CISCO_DETECTOR_MIN_BUDGET_SECONDS:
             return ()
         signals = scan_action_for_cisco_evidence(
-            action, workspace=workspace, sources=("mcp",), timeout_seconds=budget_seconds
+            action,
+            workspace=workspace,
+            approved_scan_roots=getattr(context, "approved_scan_roots", ()),
+            sources=("mcp",),
+            timeout_seconds=budget_seconds,
         )
         return tuple(cisco_risk_signal_v3_to_v2(signal) for signal in signals)
 
@@ -75,6 +109,7 @@ def scan_action_for_cisco_evidence(
     action: GuardActionEnvelope,
     *,
     workspace: Path | str | None,
+    approved_scan_roots: Iterable[Path | str] = (),
     mode: str = "auto",
     sources: Iterable[str] = ("skill", "mcp"),
     timeout_seconds: float = _DEFAULT_SCANNER_TIMEOUT_SECONDS,
@@ -83,66 +118,94 @@ def scan_action_for_cisco_evidence(
 
     if action.action_type not in {"file_write", "config_change"}:
         return ()
-    workspace_path = Path(workspace).expanduser().resolve() if workspace is not None else Path.cwd().resolve()
     requested_sources = frozenset(sources)
     signals: list[GuardRiskSignalV3] = []
+    try:
+        approved_roots = _canonical_approved_scan_roots(workspace, approved_scan_roots)
+    except _CiscoPathContainmentError as exc:
+        return (_cisco_path_containment_signal("approved-root", exc),)
+    primary_root = approved_roots[0]
     scanned_skill_roots: set[Path] = set()
     scanned_mcp_roots: set[Path] = set()
-    skill_via_path = False
-    mcp_via_path = False
+    redacted_skill_target = False
+    redacted_mcp_target = False
     for target_str in action.target_paths:
-        target_path = _resolve_target_path(target_str, workspace_path)
-        if target_path is None:
+        target_kind = _cisco_target_kind(target_str, requested_sources)
+        if target_kind is None:
             continue
-        if "skill" in requested_sources and _is_skill_file(target_path):
-            if _is_redacted_path(target_str):
-                skill_via_path = True
-            else:
-                skill_via_path = True
-                skill_root = _skill_scan_root_for_file(target_path, workspace_path)
-                if skill_root not in scanned_skill_roots:
-                    scanned_skill_roots.add(skill_root)
-                    signals.extend(
-                        _skill_findings_to_signals(
-                            cisco_skill_scanner.run_cisco_skill_scan(
-                                skill_root,
-                                mode=mode,
-                                timeout_seconds=timeout_seconds,
-                            )
+        if _is_redacted_path(target_str):
+            redacted_skill_target = redacted_skill_target or target_kind == "skill"
+            redacted_mcp_target = redacted_mcp_target or target_kind == "mcp"
+            continue
+        try:
+            validated = _validated_scan_target(
+                target_str,
+                kind=target_kind,
+                resolution_root=primary_root.path,
+                approved_roots=approved_roots,
+            )
+            _revalidate_scan_target(validated)
+        except _CiscoPathContainmentError as exc:
+            _append_unique_signal(signals, _cisco_path_containment_signal(target_kind, exc))
+            continue
+        if target_kind == "skill" and validated.scan_root not in scanned_skill_roots:
+            scanned_skill_roots.add(validated.scan_root)
+            signals.extend(
+                _skill_findings_to_signals(
+                    cisco_skill_scanner.run_cisco_skill_scan(
+                        validated.scan_root,
+                        mode=mode,
+                        timeout_seconds=timeout_seconds,
+                    )
+                )
+            )
+        if target_kind == "mcp" and validated.scan_root not in scanned_mcp_roots:
+            scanned_mcp_roots.add(validated.scan_root)
+            signals.extend(
+                _mcp_findings_to_signals(
+                    cisco_mcp_scanner.run_cisco_mcp_scan(
+                        validated.scan_root,
+                        mode=mode,
+                        timeout_seconds=timeout_seconds,
+                    )
+                )
+            )
+    if redacted_skill_target:
+        try:
+            validated = _validated_redacted_scan_target("skill", primary_root)
+            _revalidate_scan_target(validated)
+        except _CiscoPathContainmentError as exc:
+            _append_unique_signal(signals, _cisco_path_containment_signal("skill", exc))
+        else:
+            if validated.scan_root not in scanned_skill_roots:
+                scanned_skill_roots.add(validated.scan_root)
+                signals.extend(
+                    _skill_findings_to_signals(
+                        cisco_skill_scanner.run_cisco_skill_scan(
+                            validated.scan_root,
+                            mode=mode,
+                            timeout_seconds=timeout_seconds,
                         )
                     )
-        if "mcp" in requested_sources and target_path.name == ".mcp.json":
-            if _is_redacted_path(target_str):
-                mcp_via_path = True
-            else:
-                mcp_via_path = True
-                mcp_root = target_path.parent
-                if mcp_root not in scanned_mcp_roots:
-                    scanned_mcp_roots.add(mcp_root)
-                    signals.extend(
-                        _mcp_findings_to_signals(
-                            cisco_mcp_scanner.run_cisco_mcp_scan(
-                                mcp_root,
-                                mode=mode,
-                                timeout_seconds=timeout_seconds,
-                            )
+                )
+    if redacted_mcp_target:
+        try:
+            validated = _validated_redacted_scan_target("mcp", primary_root)
+            _revalidate_scan_target(validated)
+        except _CiscoPathContainmentError as exc:
+            _append_unique_signal(signals, _cisco_path_containment_signal("mcp", exc))
+        else:
+            if validated.scan_root not in scanned_mcp_roots:
+                scanned_mcp_roots.add(validated.scan_root)
+                signals.extend(
+                    _mcp_findings_to_signals(
+                        cisco_mcp_scanner.run_cisco_mcp_scan(
+                            validated.scan_root,
+                            mode=mode,
+                            timeout_seconds=timeout_seconds,
                         )
                     )
-    if "skill" in requested_sources and skill_via_path and not scanned_skill_roots:
-        skill_root = _skill_scan_root_for_workspace(workspace_path)
-        scanned_skill_roots.add(skill_root)
-        signals.extend(
-            _skill_findings_to_signals(
-                cisco_skill_scanner.run_cisco_skill_scan(skill_root, mode=mode, timeout_seconds=timeout_seconds)
-            )
-        )
-    if "mcp" in requested_sources and mcp_via_path and not scanned_mcp_roots:
-        scanned_mcp_roots.add(workspace_path)
-        signals.extend(
-            _mcp_findings_to_signals(
-                cisco_mcp_scanner.run_cisco_mcp_scan(workspace_path, mode=mode, timeout_seconds=timeout_seconds)
-            )
-        )
+                )
     return tuple(signals)
 
 
@@ -239,15 +302,208 @@ def policy_action_for_cisco_signals(
     return action
 
 
-def _resolve_target_path(target: str, workspace: Path) -> Path | None:
+def _canonical_approved_scan_roots(
+    workspace: Path | str | None,
+    approved_scan_roots: Iterable[Path | str],
+) -> tuple[_ApprovedScanRoot, ...]:
+    primary_value = workspace if workspace is not None else Path.cwd()
+    primary_path = _canonical_readable_directory(primary_value, label="selected-workspace")
+    roots = [_ApprovedScanRoot(primary_path, "selected-workspace")]
+    for index, root_value in enumerate(approved_scan_roots, start=1):
+        label = f"explicit-root-{index}"
+        canonical = _canonical_readable_directory(root_value, label=label)
+        if canonical not in {root.path for root in roots}:
+            roots.append(_ApprovedScanRoot(canonical, label))
+    return tuple(roots)
+
+
+def _canonical_readable_directory(value: Path | str, *, label: str) -> Path:
+    try:
+        canonical = Path(value).expanduser().resolve(strict=True)
+        metadata = canonical.stat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise _CiscoPathContainmentError("approved_root_unresolved", approved_root_label=label) from exc
+    readable_bits = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+    searchable_bits = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or not metadata.st_mode & readable_bits
+        or not metadata.st_mode & searchable_bits
+        or not os.access(canonical, os.R_OK | os.X_OK)
+    ):
+        raise _CiscoPathContainmentError("approved_root_unreadable", approved_root_label=label)
+    return canonical
+
+
+def _cisco_target_kind(target: str, requested_sources: frozenset[str]) -> str | None:
+    target_name = Path(target).name
+    if "skill" in requested_sources and target_name == "SKILL.md":
+        return "skill"
+    if "mcp" in requested_sources and target_name == ".mcp.json":
+        return "mcp"
+    return None
+
+
+def _validated_scan_target(
+    target: str,
+    *,
+    kind: str,
+    resolution_root: Path,
+    approved_roots: tuple[_ApprovedScanRoot, ...],
+) -> _ValidatedScanTarget:
     candidate = Path(target).expanduser()
-    if candidate.is_absolute():
-        return candidate.resolve()
-    return (workspace / candidate).resolve()
+    if not candidate.is_absolute():
+        candidate = resolution_root / candidate
+    try:
+        target_path = candidate.resolve(strict=True)
+        target_metadata = target_path.stat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise _CiscoPathContainmentError("target_unresolved") from exc
+    approved_root = _most_specific_approved_root(target_path, approved_roots)
+    if approved_root is None:
+        raise _CiscoPathContainmentError("target_outside_approved_roots")
+    if not stat.S_ISREG(target_metadata.st_mode) or not target_metadata.st_mode & (
+        stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+    ):
+        raise _CiscoPathContainmentError(
+            "target_not_readable_regular_file",
+            approved_root_label=approved_root.label,
+        )
+    if not os.access(target_path, os.R_OK):
+        raise _CiscoPathContainmentError("target_unreadable", approved_root_label=approved_root.label)
+    scan_root = _derived_scan_root(target_path, kind=kind, approved_root=approved_root)
+    return _ValidatedScanTarget(target_path, scan_root, approved_root, kind)
 
 
-def _is_skill_file(path: Path) -> bool:
-    return path.name == "SKILL.md"
+def _validated_redacted_scan_target(kind: str, primary_root: _ApprovedScanRoot) -> _ValidatedScanTarget:
+    scan_root = _skill_scan_root_for_workspace(primary_root.path) if kind == "skill" else primary_root.path
+    canonical_scan_root = _canonical_scan_root(scan_root, approved_root=primary_root)
+    return _ValidatedScanTarget(None, canonical_scan_root, primary_root, kind)
+
+
+def _derived_scan_root(
+    target_path: Path,
+    *,
+    kind: str,
+    approved_root: _ApprovedScanRoot,
+) -> Path:
+    candidate = _skill_scan_root_for_file(target_path, approved_root.path) if kind == "skill" else target_path.parent
+    return _canonical_scan_root(candidate, approved_root=approved_root)
+
+
+def _canonical_scan_root(candidate: Path, *, approved_root: _ApprovedScanRoot) -> Path:
+    try:
+        canonical = candidate.resolve(strict=True)
+        metadata = canonical.stat()
+        _ = canonical.relative_to(approved_root.path)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise _CiscoPathContainmentError(
+            "derived_scan_root_outside_approved_root",
+            approved_root_label=approved_root.label,
+        ) from exc
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or not metadata.st_mode & (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+        or not metadata.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        or not os.access(canonical, os.R_OK | os.X_OK)
+    ):
+        raise _CiscoPathContainmentError(
+            "derived_scan_root_unreadable",
+            approved_root_label=approved_root.label,
+        )
+    return canonical
+
+
+def _most_specific_approved_root(
+    target: Path,
+    approved_roots: tuple[_ApprovedScanRoot, ...],
+) -> _ApprovedScanRoot | None:
+    for root in sorted(approved_roots, key=lambda item: len(item.path.parts), reverse=True):
+        try:
+            _ = target.relative_to(root.path)
+        except ValueError:
+            continue
+        return root
+    return None
+
+
+def _revalidate_scan_target(target: _ValidatedScanTarget) -> None:
+    approved_root = _canonical_readable_directory(target.approved_root.path, label=target.approved_root.label)
+    if approved_root != target.approved_root.path:
+        raise _CiscoPathContainmentError(
+            "approved_root_changed",
+            approved_root_label=target.approved_root.label,
+        )
+    if target.path is not None:
+        try:
+            resolved_target = target.path.resolve(strict=True)
+            target_metadata = resolved_target.stat()
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise _CiscoPathContainmentError(
+                "target_changed",
+                approved_root_label=target.approved_root.label,
+            ) from exc
+        if (
+            resolved_target != target.path
+            or not stat.S_ISREG(target_metadata.st_mode)
+            or not target_metadata.st_mode & (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+            or not os.access(resolved_target, os.R_OK)
+        ):
+            raise _CiscoPathContainmentError(
+                "target_changed",
+                approved_root_label=target.approved_root.label,
+            )
+        derived_root = _derived_scan_root(
+            resolved_target,
+            kind=target.kind,
+            approved_root=target.approved_root,
+        )
+        if derived_root != target.scan_root:
+            raise _CiscoPathContainmentError(
+                "derived_scan_root_changed",
+                approved_root_label=target.approved_root.label,
+            )
+    revalidated_scan_root = _canonical_scan_root(target.scan_root, approved_root=target.approved_root)
+    if revalidated_scan_root != target.scan_root:
+        raise _CiscoPathContainmentError(
+            "derived_scan_root_changed",
+            approved_root_label=target.approved_root.label,
+        )
+
+
+def _cisco_path_containment_signal(kind: str, error: _CiscoPathContainmentError) -> GuardRiskSignalV3:
+    signal_suffix = stable_digest_hex(f"{kind}|{error.reason}|{error.approved_root_label}".encode(), length=12)
+    return GuardRiskSignalV3(
+        signal_id=f"cisco-preflight:{_OUTSIDE_APPROVED_WORKSPACE}:{signal_suffix}",
+        source="runtime_detector",
+        source_version="1",
+        category="filesystem",
+        severity="high",
+        confidence="strong",
+        title="Cisco preflight target is outside the approved workspace",
+        plain_language_summary=(
+            "Guard did not run the Cisco scanner because the target or derived scan root could not be proven "
+            "to remain inside the selected workspace or another explicitly approved folder."
+        ),
+        technical_detail=f"{_OUTSIDE_APPROVED_WORKSPACE}: {error.reason}",
+        evidence_ref=f"approved-root:{error.approved_root_label}",
+        scanner_name="Cisco preflight containment",
+        scanner_status="failed",
+        scanner_rule_id=_OUTSIDE_APPROVED_WORKSPACE,
+        redaction_level="redacted",
+        source_path=None,
+        source_line=None,
+        data_source=None,
+        data_sink=None,
+        recommended_action=(
+            "Move the target into the selected workspace or explicitly approve its containing folder, then retry."
+        ),
+    )
+
+
+def _append_unique_signal(signals: list[GuardRiskSignalV3], signal: GuardRiskSignalV3) -> None:
+    if signal not in signals:
+        signals.append(signal)
 
 
 def _skill_scan_root_for_file(path: Path, workspace: Path) -> Path:

--- a/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
+++ b/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import os
-import stat
 from collections.abc import Iterable
-from dataclasses import dataclass
 from pathlib import Path
 
 from codex_plugin_scanner.guard.action_lattice import most_restrictive_guard_action
@@ -13,6 +10,27 @@ from codex_plugin_scanner.guard.config import GuardConfig, resolve_risk_action
 from codex_plugin_scanner.guard.models import GuardAction
 from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
 from codex_plugin_scanner.guard.runtime.cisco_evidence import cisco_finding_to_risk_signal
+from codex_plugin_scanner.guard.runtime.cisco_scan_containment import (
+    CiscoPathContainmentError as _CiscoPathContainmentError,
+)
+from codex_plugin_scanner.guard.runtime.cisco_scan_containment import (
+    canonical_approved_scan_roots as _canonical_approved_scan_roots,
+)
+from codex_plugin_scanner.guard.runtime.cisco_scan_containment import (
+    cisco_target_kind as _cisco_target_kind,
+)
+from codex_plugin_scanner.guard.runtime.cisco_scan_containment import (
+    revalidate_scan_target as _revalidate_scan_target,
+)
+from codex_plugin_scanner.guard.runtime.cisco_scan_containment import (
+    skill_scan_root_for_workspace as _skill_scan_root_for_workspace,
+)
+from codex_plugin_scanner.guard.runtime.cisco_scan_containment import (
+    validated_redacted_scan_target as _validated_redacted_scan_target,
+)
+from codex_plugin_scanner.guard.runtime.cisco_scan_containment import (
+    validated_scan_target as _validated_scan_target,
+)
 from codex_plugin_scanner.guard.runtime.signals import GuardRiskSignalV3, RiskSignalV2
 from codex_plugin_scanner.guard.stable_digest import stable_digest_hex
 from codex_plugin_scanner.integrations import cisco_mcp_scanner, cisco_skill_scanner
@@ -31,27 +49,6 @@ _SOURCE_RISK_CLASS: dict[str, str] = {
 
 _CISCO_DETECTOR_MIN_BUDGET_SECONDS = 0.5
 _OUTSIDE_APPROVED_WORKSPACE = "outside_approved_workspace"
-
-
-@dataclass(frozen=True, slots=True)
-class _ApprovedScanRoot:
-    path: Path
-    label: str
-
-
-@dataclass(frozen=True, slots=True)
-class _ValidatedScanTarget:
-    path: Path | None
-    scan_root: Path
-    approved_root: _ApprovedScanRoot
-    kind: str
-
-
-class _CiscoPathContainmentError(RuntimeError):
-    def __init__(self, reason: str, *, approved_root_label: str = "selected-workspace") -> None:
-        super().__init__(reason)
-        self.reason: str = reason
-        self.approved_root_label: str = approved_root_label
 
 
 class CiscoSkillPreflightDetector:
@@ -302,175 +299,6 @@ def policy_action_for_cisco_signals(
     return action
 
 
-def _canonical_approved_scan_roots(
-    workspace: Path | str | None,
-    approved_scan_roots: Iterable[Path | str],
-) -> tuple[_ApprovedScanRoot, ...]:
-    primary_value = workspace if workspace is not None else Path.cwd()
-    primary_path = _canonical_readable_directory(primary_value, label="selected-workspace")
-    roots = [_ApprovedScanRoot(primary_path, "selected-workspace")]
-    for index, root_value in enumerate(approved_scan_roots, start=1):
-        label = f"explicit-root-{index}"
-        canonical = _canonical_readable_directory(root_value, label=label)
-        if canonical not in {root.path for root in roots}:
-            roots.append(_ApprovedScanRoot(canonical, label))
-    return tuple(roots)
-
-
-def _canonical_readable_directory(value: Path | str, *, label: str) -> Path:
-    try:
-        canonical = Path(value).expanduser().resolve(strict=True)
-        metadata = canonical.stat()
-    except (OSError, RuntimeError, ValueError) as exc:
-        raise _CiscoPathContainmentError("approved_root_unresolved", approved_root_label=label) from exc
-    readable_bits = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
-    searchable_bits = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-    if (
-        not stat.S_ISDIR(metadata.st_mode)
-        or not metadata.st_mode & readable_bits
-        or not metadata.st_mode & searchable_bits
-        or not os.access(canonical, os.R_OK | os.X_OK)
-    ):
-        raise _CiscoPathContainmentError("approved_root_unreadable", approved_root_label=label)
-    return canonical
-
-
-def _cisco_target_kind(target: str, requested_sources: frozenset[str]) -> str | None:
-    target_name = Path(target).name
-    if "skill" in requested_sources and target_name == "SKILL.md":
-        return "skill"
-    if "mcp" in requested_sources and target_name == ".mcp.json":
-        return "mcp"
-    return None
-
-
-def _validated_scan_target(
-    target: str,
-    *,
-    kind: str,
-    resolution_root: Path,
-    approved_roots: tuple[_ApprovedScanRoot, ...],
-) -> _ValidatedScanTarget:
-    candidate = Path(target).expanduser()
-    if not candidate.is_absolute():
-        candidate = resolution_root / candidate
-    try:
-        target_path = candidate.resolve(strict=True)
-        target_metadata = target_path.stat()
-    except (OSError, RuntimeError, ValueError) as exc:
-        raise _CiscoPathContainmentError("target_unresolved") from exc
-    approved_root = _most_specific_approved_root(target_path, approved_roots)
-    if approved_root is None:
-        raise _CiscoPathContainmentError("target_outside_approved_roots")
-    if not stat.S_ISREG(target_metadata.st_mode) or not target_metadata.st_mode & (
-        stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
-    ):
-        raise _CiscoPathContainmentError(
-            "target_not_readable_regular_file",
-            approved_root_label=approved_root.label,
-        )
-    if not os.access(target_path, os.R_OK):
-        raise _CiscoPathContainmentError("target_unreadable", approved_root_label=approved_root.label)
-    scan_root = _derived_scan_root(target_path, kind=kind, approved_root=approved_root)
-    return _ValidatedScanTarget(target_path, scan_root, approved_root, kind)
-
-
-def _validated_redacted_scan_target(kind: str, primary_root: _ApprovedScanRoot) -> _ValidatedScanTarget:
-    scan_root = _skill_scan_root_for_workspace(primary_root.path) if kind == "skill" else primary_root.path
-    canonical_scan_root = _canonical_scan_root(scan_root, approved_root=primary_root)
-    return _ValidatedScanTarget(None, canonical_scan_root, primary_root, kind)
-
-
-def _derived_scan_root(
-    target_path: Path,
-    *,
-    kind: str,
-    approved_root: _ApprovedScanRoot,
-) -> Path:
-    candidate = _skill_scan_root_for_file(target_path, approved_root.path) if kind == "skill" else target_path.parent
-    return _canonical_scan_root(candidate, approved_root=approved_root)
-
-
-def _canonical_scan_root(candidate: Path, *, approved_root: _ApprovedScanRoot) -> Path:
-    try:
-        canonical = candidate.resolve(strict=True)
-        metadata = canonical.stat()
-        _ = canonical.relative_to(approved_root.path)
-    except (OSError, RuntimeError, ValueError) as exc:
-        raise _CiscoPathContainmentError(
-            "derived_scan_root_outside_approved_root",
-            approved_root_label=approved_root.label,
-        ) from exc
-    if (
-        not stat.S_ISDIR(metadata.st_mode)
-        or not metadata.st_mode & (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
-        or not metadata.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-        or not os.access(canonical, os.R_OK | os.X_OK)
-    ):
-        raise _CiscoPathContainmentError(
-            "derived_scan_root_unreadable",
-            approved_root_label=approved_root.label,
-        )
-    return canonical
-
-
-def _most_specific_approved_root(
-    target: Path,
-    approved_roots: tuple[_ApprovedScanRoot, ...],
-) -> _ApprovedScanRoot | None:
-    for root in sorted(approved_roots, key=lambda item: len(item.path.parts), reverse=True):
-        try:
-            _ = target.relative_to(root.path)
-        except ValueError:
-            continue
-        return root
-    return None
-
-
-def _revalidate_scan_target(target: _ValidatedScanTarget) -> None:
-    approved_root = _canonical_readable_directory(target.approved_root.path, label=target.approved_root.label)
-    if approved_root != target.approved_root.path:
-        raise _CiscoPathContainmentError(
-            "approved_root_changed",
-            approved_root_label=target.approved_root.label,
-        )
-    if target.path is not None:
-        try:
-            resolved_target = target.path.resolve(strict=True)
-            target_metadata = resolved_target.stat()
-        except (OSError, RuntimeError, ValueError) as exc:
-            raise _CiscoPathContainmentError(
-                "target_changed",
-                approved_root_label=target.approved_root.label,
-            ) from exc
-        if (
-            resolved_target != target.path
-            or not stat.S_ISREG(target_metadata.st_mode)
-            or not target_metadata.st_mode & (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
-            or not os.access(resolved_target, os.R_OK)
-        ):
-            raise _CiscoPathContainmentError(
-                "target_changed",
-                approved_root_label=target.approved_root.label,
-            )
-        derived_root = _derived_scan_root(
-            resolved_target,
-            kind=target.kind,
-            approved_root=target.approved_root,
-        )
-        if derived_root != target.scan_root:
-            raise _CiscoPathContainmentError(
-                "derived_scan_root_changed",
-                approved_root_label=target.approved_root.label,
-            )
-    revalidated_scan_root = _canonical_scan_root(target.scan_root, approved_root=target.approved_root)
-    if revalidated_scan_root != target.scan_root:
-        raise _CiscoPathContainmentError(
-            "derived_scan_root_changed",
-            approved_root_label=target.approved_root.label,
-        )
-
-
 def _cisco_path_containment_signal(kind: str, error: _CiscoPathContainmentError) -> GuardRiskSignalV3:
     signal_suffix = stable_digest_hex(f"{kind}|{error.reason}|{error.approved_root_label}".encode(), length=12)
     return GuardRiskSignalV3(
@@ -504,25 +332,6 @@ def _cisco_path_containment_signal(kind: str, error: _CiscoPathContainmentError)
 def _append_unique_signal(signals: list[GuardRiskSignalV3], signal: GuardRiskSignalV3) -> None:
     if signal not in signals:
         signals.append(signal)
-
-
-def _skill_scan_root_for_file(path: Path, workspace: Path) -> Path:
-    parent = path.parent
-    if parent.parent.name == "skills":
-        return parent.parent
-    if parent.name == "skills":
-        return parent
-    if parent == workspace:
-        return parent
-    # Default: scan from the containing directory; callers should verify the result is meaningful.
-    return parent
-
-
-def _skill_scan_root_for_workspace(target: Path) -> Path:
-    skills_dir = target / "skills"
-    if skills_dir.is_dir():
-        return skills_dir
-    return target
 
 
 def _skill_findings_to_signals(summary: object) -> tuple[GuardRiskSignalV3, ...]:

--- a/src/codex_plugin_scanner/guard/runtime/cisco_scan_containment.py
+++ b/src/codex_plugin_scanner/guard/runtime/cisco_scan_containment.py
@@ -1,0 +1,217 @@
+"""Filesystem containment and revalidation for Cisco preflight scans."""
+
+from __future__ import annotations
+
+import os
+import stat
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovedScanRoot:
+    path: Path
+    label: str
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedScanTarget:
+    path: Path | None
+    scan_root: Path
+    approved_root: ApprovedScanRoot
+    kind: str
+
+
+class CiscoPathContainmentError(RuntimeError):
+    def __init__(self, reason: str, *, approved_root_label: str = "selected-workspace") -> None:
+        super().__init__(reason)
+        self.reason: str = reason
+        self.approved_root_label: str = approved_root_label
+
+
+def canonical_approved_scan_roots(
+    workspace: Path | str | None,
+    approved_scan_roots: Iterable[Path | str],
+) -> tuple[ApprovedScanRoot, ...]:
+    primary_value = workspace if workspace is not None else Path.cwd()
+    primary_path = _canonical_readable_directory(primary_value, label="selected-workspace")
+    roots = [ApprovedScanRoot(primary_path, "selected-workspace")]
+    for index, root_value in enumerate(approved_scan_roots, start=1):
+        label = f"explicit-root-{index}"
+        canonical = _canonical_readable_directory(root_value, label=label)
+        if canonical not in {root.path for root in roots}:
+            roots.append(ApprovedScanRoot(canonical, label))
+    return tuple(roots)
+
+
+def _canonical_readable_directory(value: Path | str, *, label: str) -> Path:
+    try:
+        canonical = Path(value).expanduser().resolve(strict=True)
+        metadata = canonical.stat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CiscoPathContainmentError("approved_root_unresolved", approved_root_label=label) from exc
+    readable_bits = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+    searchable_bits = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or not metadata.st_mode & readable_bits
+        or not metadata.st_mode & searchable_bits
+        or not os.access(canonical, os.R_OK | os.X_OK)
+    ):
+        raise CiscoPathContainmentError("approved_root_unreadable", approved_root_label=label)
+    return canonical
+
+
+def cisco_target_kind(target: str, requested_sources: frozenset[str]) -> str | None:
+    target_name = Path(target).name
+    if "skill" in requested_sources and target_name == "SKILL.md":
+        return "skill"
+    if "mcp" in requested_sources and target_name == ".mcp.json":
+        return "mcp"
+    return None
+
+
+def validated_scan_target(
+    target: str,
+    *,
+    kind: str,
+    resolution_root: Path,
+    approved_roots: tuple[ApprovedScanRoot, ...],
+) -> ValidatedScanTarget:
+    candidate = Path(target).expanduser()
+    if not candidate.is_absolute():
+        candidate = resolution_root / candidate
+    try:
+        target_path = candidate.resolve(strict=True)
+        target_metadata = target_path.stat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CiscoPathContainmentError("target_unresolved") from exc
+    approved_root = _most_specific_approved_root(target_path, approved_roots)
+    if approved_root is None:
+        raise CiscoPathContainmentError("target_outside_approved_roots")
+    if not stat.S_ISREG(target_metadata.st_mode) or not target_metadata.st_mode & (
+        stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+    ):
+        raise CiscoPathContainmentError(
+            "target_not_readable_regular_file",
+            approved_root_label=approved_root.label,
+        )
+    if not os.access(target_path, os.R_OK):
+        raise CiscoPathContainmentError("target_unreadable", approved_root_label=approved_root.label)
+    scan_root = _derived_scan_root(target_path, kind=kind, approved_root=approved_root)
+    return ValidatedScanTarget(target_path, scan_root, approved_root, kind)
+
+
+def validated_redacted_scan_target(kind: str, primary_root: ApprovedScanRoot) -> ValidatedScanTarget:
+    scan_root = skill_scan_root_for_workspace(primary_root.path) if kind == "skill" else primary_root.path
+    canonical_scan_root = _canonical_scan_root(scan_root, approved_root=primary_root)
+    return ValidatedScanTarget(None, canonical_scan_root, primary_root, kind)
+
+
+def _derived_scan_root(
+    target_path: Path,
+    *,
+    kind: str,
+    approved_root: ApprovedScanRoot,
+) -> Path:
+    candidate = _skill_scan_root_for_file(target_path, approved_root.path) if kind == "skill" else target_path.parent
+    return _canonical_scan_root(candidate, approved_root=approved_root)
+
+
+def _canonical_scan_root(candidate: Path, *, approved_root: ApprovedScanRoot) -> Path:
+    try:
+        canonical = candidate.resolve(strict=True)
+        metadata = canonical.stat()
+        _ = canonical.relative_to(approved_root.path)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CiscoPathContainmentError(
+            "derived_scan_root_outside_approved_root",
+            approved_root_label=approved_root.label,
+        ) from exc
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or not metadata.st_mode & (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+        or not metadata.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        or not os.access(canonical, os.R_OK | os.X_OK)
+    ):
+        raise CiscoPathContainmentError(
+            "derived_scan_root_unreadable",
+            approved_root_label=approved_root.label,
+        )
+    return canonical
+
+
+def _most_specific_approved_root(
+    target: Path,
+    approved_roots: tuple[ApprovedScanRoot, ...],
+) -> ApprovedScanRoot | None:
+    for root in sorted(approved_roots, key=lambda item: len(item.path.parts), reverse=True):
+        try:
+            _ = target.relative_to(root.path)
+        except ValueError:
+            continue
+        return root
+    return None
+
+
+def revalidate_scan_target(target: ValidatedScanTarget) -> None:
+    approved_root = _canonical_readable_directory(target.approved_root.path, label=target.approved_root.label)
+    if approved_root != target.approved_root.path:
+        raise CiscoPathContainmentError(
+            "approved_root_changed",
+            approved_root_label=target.approved_root.label,
+        )
+    if target.path is not None:
+        try:
+            resolved_target = target.path.resolve(strict=True)
+            target_metadata = resolved_target.stat()
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise CiscoPathContainmentError(
+                "target_changed",
+                approved_root_label=target.approved_root.label,
+            ) from exc
+        if (
+            resolved_target != target.path
+            or not stat.S_ISREG(target_metadata.st_mode)
+            or not target_metadata.st_mode & (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+            or not os.access(resolved_target, os.R_OK)
+        ):
+            raise CiscoPathContainmentError(
+                "target_changed",
+                approved_root_label=target.approved_root.label,
+            )
+        derived_root = _derived_scan_root(
+            resolved_target,
+            kind=target.kind,
+            approved_root=target.approved_root,
+        )
+        if derived_root != target.scan_root:
+            raise CiscoPathContainmentError(
+                "derived_scan_root_changed",
+                approved_root_label=target.approved_root.label,
+            )
+    revalidated_scan_root = _canonical_scan_root(target.scan_root, approved_root=target.approved_root)
+    if revalidated_scan_root != target.scan_root:
+        raise CiscoPathContainmentError(
+            "derived_scan_root_changed",
+            approved_root_label=target.approved_root.label,
+        )
+
+
+def _skill_scan_root_for_file(path: Path, workspace: Path) -> Path:
+    parent = path.parent
+    if parent.parent.name == "skills":
+        return parent.parent
+    if parent.name == "skills":
+        return parent
+    if parent == workspace:
+        return parent
+    return parent
+
+
+def skill_scan_root_for_workspace(target: Path) -> Path:
+    skills_dir = target / "skills"
+    if skills_dir.is_dir():
+        return skills_dir
+    return target

--- a/src/codex_plugin_scanner/guard/runtime/detectors.py
+++ b/src/codex_plugin_scanner/guard/runtime/detectors.py
@@ -72,6 +72,7 @@ class DetectorContext:
     prior_decisions: Mapping[str, object]
     threat_intel: Mapping[str, object]
     redaction_settings: Mapping[str, object]
+    approved_scan_roots: tuple[Path, ...] = ()
 
 
 class GuardDetector(Protocol):

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -1273,6 +1273,7 @@ def _shell_path_identity_payload(identity: ShellPathIdentity | None) -> dict[str
         return None
     return {
         "change_time_ns": identity.change_time_ns,
+        "creation_time_ns": identity.creation_time_ns,
         "device": identity.device,
         "inode": identity.inode,
         "mode": identity.mode,

--- a/src/codex_plugin_scanner/guard/runtime/shell_execution_context.py
+++ b/src/codex_plugin_scanner/guard/runtime/shell_execution_context.py
@@ -418,6 +418,7 @@ def _identity_payload(identity: ShellPathIdentity | None) -> dict[str, int] | No
         return None
     return {
         "change_time_ns": identity.change_time_ns,
+        "creation_time_ns": identity.creation_time_ns,
         "device": identity.device,
         "inode": identity.inode,
         "mode": identity.mode,

--- a/tests/test_guard_cisco_runtime_cli.py
+++ b/tests/test_guard_cisco_runtime_cli.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import builtins
 import json
+import os
 from pathlib import Path
 
 import pytest
 
+import codex_plugin_scanner.guard.runtime.cisco_preflight as cisco_preflight_module
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
@@ -290,7 +292,7 @@ def test_cisco_preflight_changed_skill_file_produces_normalized_signal(
     assert signals[0].scanner_rule_id == "CISCO-SKILL-EXFIL"
 
 
-def test_cisco_preflight_scans_skill_targets_that_resolve_outside_workspace_via_symlink(
+def test_cisco_preflight_rejects_skill_targets_that_resolve_outside_workspace_via_symlink(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -318,11 +320,12 @@ def test_cisco_preflight_scans_skill_targets_that_resolve_outside_workspace_via_
         workspace=tmp_path,
     )
 
-    assert [signal.source for signal in signals] == ["cisco_skill"]
-    assert called == [external_skill.parent]
+    assert [signal.scanner_rule_id for signal in signals] == ["outside_approved_workspace"]
+    assert called == []
+    assert str(external_root) not in json.dumps(signals[0].to_dict())
 
 
-def test_cisco_preflight_scans_explicit_absolute_skill_targets_outside_workspace(
+def test_cisco_preflight_rejects_absolute_skill_targets_outside_workspace(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -341,11 +344,11 @@ def test_cisco_preflight_scans_explicit_absolute_skill_targets_outside_workspace
 
     signals = scan_action_for_cisco_evidence(_absolute_file_write_action(external_skill), workspace=tmp_path)
 
-    assert [signal.source for signal in signals] == ["cisco_skill"]
-    assert called == [external_skill.parent]
+    assert [signal.scanner_rule_id for signal in signals] == ["outside_approved_workspace"]
+    assert called == []
 
 
-def test_cisco_preflight_scans_explicit_relative_traversal_skill_targets(
+def test_cisco_preflight_rejects_relative_traversal_skill_targets(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -367,11 +370,11 @@ def test_cisco_preflight_scans_explicit_relative_traversal_skill_targets(
         workspace=tmp_path,
     )
 
-    assert [signal.source for signal in signals] == ["cisco_skill"]
-    assert called == [external_skill.parent]
+    assert [signal.scanner_rule_id for signal in signals] == ["outside_approved_workspace"]
+    assert called == []
 
 
-def test_cisco_preflight_scans_explicit_relative_traversal_mcp_targets(
+def test_cisco_preflight_rejects_relative_traversal_mcp_targets(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -393,11 +396,11 @@ def test_cisco_preflight_scans_explicit_relative_traversal_mcp_targets(
         workspace=tmp_path,
     )
 
-    assert [signal.source for signal in signals] == ["cisco_mcp"]
-    assert called == [external_mcp.parent]
+    assert [signal.scanner_rule_id for signal in signals] == ["outside_approved_workspace"]
+    assert called == []
 
 
-def test_cisco_preflight_scans_mcp_targets_that_resolve_outside_workspace_via_symlink(
+def test_cisco_preflight_rejects_mcp_targets_that_resolve_outside_workspace_via_symlink(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -422,8 +425,8 @@ def test_cisco_preflight_scans_mcp_targets_that_resolve_outside_workspace_via_sy
 
     signals = scan_action_for_cisco_evidence(_file_write_action(workspace_mcp, tmp_path), workspace=tmp_path)
 
-    assert [signal.source for signal in signals] == ["cisco_mcp"]
-    assert called == [external_root]
+    assert [signal.scanner_rule_id for signal in signals] == ["outside_approved_workspace"]
+    assert called == []
 
 
 def test_cisco_preflight_changed_mcp_config_produces_normalized_signal(
@@ -444,6 +447,205 @@ def test_cisco_preflight_changed_mcp_config_produces_normalized_signal(
 
     assert [signal.source for signal in signals] == ["cisco_mcp"]
     assert signals[0].scanner_rule_id == "CISCO-MCP-POISON"
+
+
+def test_cisco_preflight_scans_absolute_target_inside_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    mcp_path = tmp_path / "nested" / ".mcp.json"
+    mcp_path.parent.mkdir()
+    mcp_path.write_text("{}", encoding="utf-8")
+    called: list[Path] = []
+
+    def fake_scan(path: Path, mode: str = "auto", timeout_seconds: float | None = None):
+        called.append(path)
+        return _mcp_summary(CiscoIntegrationStatus.ENABLED, (_mcp_finding(),))
+
+    monkeypatch.setattr(cisco_mcp_scanner, "run_cisco_mcp_scan", fake_scan)
+
+    signals = cisco_preflight_module.scan_action_for_cisco_evidence(
+        _absolute_file_write_action(mcp_path),
+        workspace=tmp_path,
+    )
+
+    assert [signal.source for signal in signals] == ["cisco_mcp"]
+    assert called == [mcp_path.parent]
+
+
+def test_cisco_preflight_scans_external_target_only_when_root_is_explicitly_approved(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    external_root = tmp_path.parent / f"{tmp_path.name}-approved"
+    external_skill = external_root / "skills" / "demo" / "SKILL.md"
+    external_skill.parent.mkdir(parents=True)
+    external_skill.write_text("# Approved\n", encoding="utf-8")
+    called: list[Path] = []
+
+    def fake_scan(path: Path, mode: str = "auto", timeout_seconds: float | None = None):
+        called.append(path)
+        return _skill_summary(CiscoIntegrationStatus.ENABLED, (_skill_finding(),))
+
+    monkeypatch.setattr(cisco_skill_scanner, "run_cisco_skill_scan", fake_scan)
+
+    signals = cisco_preflight_module.scan_action_for_cisco_evidence(
+        _absolute_file_write_action(external_skill),
+        workspace=tmp_path,
+        approved_scan_roots=(external_root,),
+    )
+
+    assert [signal.source for signal in signals] == ["cisco_skill"]
+    assert called == [external_root / "skills"]
+
+
+def test_cisco_preflight_rejects_derived_skill_root_broader_than_explicit_approval(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    external_skill_root = tmp_path.parent / f"{tmp_path.name}-narrow" / "skills" / "demo"
+    external_skill_root.mkdir(parents=True)
+    external_skill = external_skill_root / "SKILL.md"
+    external_skill.write_text("# Narrow\n", encoding="utf-8")
+    called: list[Path] = []
+    monkeypatch.setattr(
+        cisco_skill_scanner,
+        "run_cisco_skill_scan",
+        lambda path, **kwargs: called.append(path),
+    )
+
+    signals = cisco_preflight_module.scan_action_for_cisco_evidence(
+        _absolute_file_write_action(external_skill),
+        workspace=tmp_path,
+        approved_scan_roots=(external_skill_root,),
+    )
+
+    assert [signal.scanner_rule_id for signal in signals] == ["outside_approved_workspace"]
+    assert signals[0].technical_detail == "outside_approved_workspace: derived_scan_root_outside_approved_root"
+    assert called == []
+
+
+def test_cisco_preflight_redacted_skill_target_falls_back_only_to_selected_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    skills_root = tmp_path / "skills"
+    (skills_root / "demo").mkdir(parents=True)
+    (skills_root / "demo" / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    called: list[Path] = []
+
+    def fake_scan(path: Path, mode: str = "auto", timeout_seconds: float | None = None):
+        called.append(path)
+        return _skill_summary(CiscoIntegrationStatus.ENABLED, (_skill_finding(),))
+
+    monkeypatch.setattr(cisco_skill_scanner, "run_cisco_skill_scan", fake_scan)
+
+    signals = cisco_preflight_module.scan_action_for_cisco_evidence(
+        _relative_target_write_action(".../SKILL.md"),
+        workspace=tmp_path,
+        approved_scan_roots=(tmp_path.parent,),
+    )
+
+    assert [signal.source for signal in signals] == ["cisco_skill"]
+    assert called == [skills_root]
+
+
+@pytest.mark.parametrize("target_kind", ["missing", "unreadable", "special"])
+def test_cisco_preflight_rejects_ambiguous_or_non_regular_targets_without_scanning(
+    target_kind: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    skill_path = tmp_path / "skills" / "demo" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    if target_kind == "unreadable":
+        skill_path.write_text("# Unreadable\n", encoding="utf-8")
+        skill_path.chmod(0)
+    elif target_kind == "special":
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("FIFOs are unavailable on this platform")
+        os.mkfifo(skill_path)
+    called: list[Path] = []
+    monkeypatch.setattr(
+        cisco_skill_scanner,
+        "run_cisco_skill_scan",
+        lambda path, **kwargs: called.append(path),
+    )
+
+    try:
+        signals = cisco_preflight_module.scan_action_for_cisco_evidence(
+            _relative_target_write_action("skills/demo/SKILL.md"),
+            workspace=tmp_path,
+        )
+    finally:
+        if target_kind == "unreadable":
+            skill_path.chmod(0o600)
+
+    assert [signal.scanner_rule_id for signal in signals] == ["outside_approved_workspace"]
+    assert called == []
+
+
+def test_cisco_preflight_accepts_canonical_workspace_selected_through_symlink(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    real_workspace = tmp_path / "real-workspace"
+    skill_path = real_workspace / "skills" / "demo" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("# Demo\n", encoding="utf-8")
+    workspace_link = tmp_path / "workspace-link"
+    try:
+        workspace_link.symlink_to(real_workspace, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are not supported in this environment")
+    called: list[Path] = []
+
+    def fake_scan(path: Path, mode: str = "auto", timeout_seconds: float | None = None):
+        called.append(path)
+        return _skill_summary(CiscoIntegrationStatus.ENABLED, (_skill_finding(),))
+
+    monkeypatch.setattr(cisco_skill_scanner, "run_cisco_skill_scan", fake_scan)
+
+    signals = cisco_preflight_module.scan_action_for_cisco_evidence(
+        _relative_target_write_action("skills/demo/SKILL.md"),
+        workspace=workspace_link,
+    )
+
+    assert [signal.source for signal in signals] == ["cisco_skill"]
+    assert called == [real_workspace / "skills"]
+
+
+def test_cisco_preflight_revalidation_catches_target_symlink_race_before_scanner_call(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    skill_path = tmp_path / "skills" / "demo" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("# Before\n", encoding="utf-8")
+    outside = tmp_path.parent / f"{tmp_path.name}-race-target.md"
+    outside.write_text("# Outside\n", encoding="utf-8")
+    called: list[Path] = []
+    real_revalidate = cisco_preflight_module._revalidate_scan_target
+
+    def swap_then_revalidate(target: object) -> None:
+        skill_path.unlink()
+        skill_path.symlink_to(outside)
+        real_revalidate(target)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(cisco_preflight_module, "_revalidate_scan_target", swap_then_revalidate)
+    monkeypatch.setattr(
+        cisco_skill_scanner,
+        "run_cisco_skill_scan",
+        lambda path, **kwargs: called.append(path),
+    )
+
+    signals = cisco_preflight_module.scan_action_for_cisco_evidence(
+        _relative_target_write_action("skills/demo/SKILL.md"),
+        workspace=tmp_path,
+    )
+
+    assert [signal.scanner_rule_id for signal in signals] == ["outside_approved_workspace"]
+    assert called == []
 
 
 def test_cisco_policy_blocks_critical_balanced_but_not_low_confidence_info(tmp_path: Path) -> None:

--- a/tests/test_guard_shell_execution_context.py
+++ b/tests/test_guard_shell_execution_context.py
@@ -643,7 +643,7 @@ def test_cisco_preflight_scans_every_distinct_effective_project(
 
     evidence = runtime_eval_module._runtime_cisco_scanner_evidence(
         action,
-        runtime_workspace=tmp_path,
+        runtime_workspace=project_a,
         raw_shell_cwds=[str(project_a), str(project_b), str(project_a), ""],
     )
 

--- a/tests/test_guard_shell_execution_context.py
+++ b/tests/test_guard_shell_execution_context.py
@@ -581,7 +581,7 @@ def test_cisco_preflight_scans_every_distinct_effective_project(
     project_b = tmp_path / "project-b"
     project_a.mkdir()
     project_b.mkdir()
-    calls: list[Path | None] = []
+    calls: list[tuple[Path | None, tuple[Path, ...]]] = []
     signal = GuardRiskSignalV3(
         signal_id="cisco:test",
         source="cisco_skill",
@@ -629,8 +629,14 @@ def test_cisco_preflight_scans_every_distinct_effective_project(
         _action: GuardActionEnvelope,
         *,
         workspace: Path | str | None,
+        approved_scan_roots: tuple[Path, ...],
     ) -> tuple[GuardRiskSignalV3, ...]:
-        calls.append(Path(workspace) if workspace is not None else None)
+        calls.append(
+            (
+                Path(workspace) if workspace is not None else None,
+                approved_scan_roots,
+            )
+        )
         return (signal,)
 
     monkeypatch.setattr(runtime_eval_module, "scan_action_for_cisco_evidence", fake_scan)
@@ -641,7 +647,10 @@ def test_cisco_preflight_scans_every_distinct_effective_project(
         raw_shell_cwds=[str(project_a), str(project_b), str(project_a), ""],
     )
 
-    assert calls == [project_a.resolve(), project_b.resolve()]
+    assert calls == [
+        (project_a.resolve(), (project_a.resolve(), project_b.resolve())),
+        (project_b.resolve(), (project_a.resolve(), project_b.resolve())),
+    ]
     assert evidence == (signal,)
 
 


### PR DESCRIPTION
## Summary

- canonicalize the selected workspace and only caller-supplied explicit scan roots before Cisco preflight;
- resolve candidate files strictly, require readable regular files, enforce post-symlink containment, and reject missing, unreadable, special, traversing, or escaping paths;
- derive skill/MCP scan roots only after target containment and reject any derived root broader than its matched approval;
- revalidate the approved root, target, and derived scan root immediately before invoking Cisco to catch path replacement races;
- restrict redacted target fallback to the selected workspace rather than neighboring or broad external roots;
- emit a stable high-severity `outside_approved_workspace` signal with a safe approved-root label and no arbitrary outside path, ensuring “not scanned” cannot be mistaken for “safe”;
- carry explicit approved roots through detector context and multi-project shell execution context.

## Approved-root and scanner-call evidence

- the canonical selected workspace is always root label `selected-workspace`;
- external folders are accepted only through `approved_scan_roots` and receive non-path labels such as `explicit-root-1`;
- contained relative/absolute skill and MCP targets call scanner mocks with canonical roots inside the matching approval;
- an explicitly approved external folder scans normally;
- traversal, absolute outside targets, file/parent symlink escapes, missing/unreadable/FIFO targets, a too-broad derived skill root, and a target replacement race all produce `outside_approved_workspace` while scanner call lists remain empty;
- receipt-ready signal serialization contains only the safe root label and excludes the rejected outside path.

## Validation

- Python 3.12: 94 focused Cisco runtime, evidence, inventory, detector, and shell-context tests passed
- Python 3.10: the same 94 tests passed
- Ruff passed
- basedpyright on changed source modules: 0 errors
- package sdist/wheel build with Cisco extras passed

## Attribution and base

- Base: `release/2.1`
- Author and committer: `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>`
