### PR TITLE
fix(runtime): parse env wrappers exactly

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_tool_output.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_tool_output.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from ..runtime.env_wrapper import parse_env_wrapper
 from ..runtime.shell_execution_context import model_shell_execution_context, validate_shell_execution_segment
 from ._commands_shared import *
 from .commands_parser_helpers import *
@@ -97,46 +98,21 @@ def _codex_strip_command_wrapper(parts: list[str]) -> list[str]:
 
 
 def _codex_strip_env_wrapper(parts: list[str]) -> list[str]:
-    index = 0
-    while index < len(parts):
-        part = parts[index]
-        if part == "--":
-            return parts[index + 1 :]
-        if part in {"-i", "-0", "--ignore-environment", "--null"}:
-            index += 1
-            continue
-        if part in {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}:
-            index += 2
-            continue
-        if part.startswith(("--unset=", "--chdir=", "--split-string=")):
-            index += 1
-            continue
-        if part.startswith("-"):
-            index += 1
-            continue
-        if "=" in part and not part.startswith("="):
-            index += 1
-            continue
-        return parts[index:]
-    return []
+    parsed = parse_env_wrapper(parts)
+    return list(parsed.executable_argv) if parsed.complete else []
 
 
 def _codex_env_args_clear_environment(parts: list[str]) -> bool:
-    saw_clear_environment = False
-    for part in parts:
-        if part == "--":
-            return False
-        if part in {"-i", "--ignore-environment"}:
-            saw_clear_environment = True
-            continue
-        if part.startswith("-"):
-            continue
-        if "=" in part and not part.startswith("="):
-            if _codex_env_assignment_uses_shell_expansion(part):
-                return False
-            continue
-        return False
-    return saw_clear_environment
+    parsed = parse_env_wrapper(parts)
+    return (
+        parsed.complete
+        and parsed.option_effects.ignore_environment
+        and not parsed.executable_argv
+        and not any(
+            _codex_env_assignment_uses_shell_expansion(f"{name}={value}")
+            for name, value in parsed.environment_delta.assignments
+        )
+    )
 
 
 def _codex_env_assignment_uses_shell_expansion(part: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/approval_context.py
+++ b/src/codex_plugin_scanner/guard/runtime/approval_context.py
@@ -25,6 +25,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Literal, TypeGuard, cast
 
+from .env_wrapper import parse_env_wrapper
+
 APPROVAL_CONTEXT_TOKEN_PREFIX = "guard-approval-context:v1:"
 
 ApprovalContextValidationFailure = Literal[
@@ -949,15 +951,10 @@ def _nested_shebang_interpreter_identity(
 
 
 def _env_shebang_command(args: tuple[str, ...]) -> tuple[str, tuple[str, ...]] | None:
-    if not args:
+    parsed = parse_env_wrapper(args)
+    if not parsed.complete or not parsed.executable_argv:
         return None
-    if args[0] in {"-S", "--split-string"}:
-        if len(args) < 2:
-            return None
-        return args[1], args[2:]
-    if args[0].startswith("-") or "=" in args[0]:
-        return None
-    return args[0], args[1:]
+    return parsed.executable_argv[0], parsed.executable_argv[1:]
 
 
 def _identity_shebang_status(identity: Mapping[str, object]) -> Literal["native", "script", "unverified"]:

--- a/src/codex_plugin_scanner/guard/runtime/command_tokens.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_tokens.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 import shlex
 
+from .env_wrapper import parse_env_wrapper
+
 _ENV_ASSIGNMENT_PATTERN = re.compile(r"^(?P<name>[A-Za-z_][A-Za-z0-9_]*)=.*$", re.DOTALL)
 _SUDO_OPTIONS_WITH_VALUES = frozenset({"-C", "-D", "-g", "-h", "-p", "-R", "-r", "-T", "-t", "-u"})
 _SUDO_LONG_OPTIONS_WITH_VALUES = frozenset(
@@ -57,8 +59,14 @@ def leading_environment(tokens: tuple[str, ...]) -> tuple[tuple[str, ...], int, 
             match = _ENV_ASSIGNMENT_PATTERN.fullmatch(tokens[index])
         executable = executable_name(tokens[index])
         if executable == "env":
+            parsed = parse_env_wrapper(tokens[index + 1 :])
+            if parsed.complete and parsed.command_index is None:
+                break
             wrappers.append("env")
-            index = _after_env_options(tokens, index + 1)
+            names.extend(name for name, _value in parsed.environment_delta.assignments)
+            if not parsed.complete or parsed.command_index is None or parsed.split_expansions:
+                return tuple(names), len(tokens), tuple(wrappers)
+            index += parsed.command_index + 1
             continue
         if executable == "sudo":
             wrappers.append("sudo")
@@ -66,23 +74,6 @@ def leading_environment(tokens: tuple[str, ...]) -> tuple[tuple[str, ...], int, 
             continue
         break
     return tuple(names), index, tuple(wrappers)
-
-
-def _after_env_options(tokens: tuple[str, ...], index: int) -> int:
-    while index < len(tokens):
-        token = tokens[index]
-        if token == "--":
-            return index + 1
-        if token in {"-u", "-C", "--unset", "--chdir"}:
-            index = min(index + 2, len(tokens))
-            continue
-        if token in {"-i", "-0", "--ignore-environment", "--null"} or token.startswith(("--unset=", "--chdir=")):
-            index += 1
-            continue
-        if _ENV_ASSIGNMENT_PATTERN.fullmatch(token) is not None:
-            return index
-        return index
-    return index
 
 
 def _after_sudo_options(tokens: tuple[str, ...], index: int) -> int:

--- a/src/codex_plugin_scanner/guard/runtime/env_wrapper.py
+++ b/src/codex_plugin_scanner/guard/runtime/env_wrapper.py
@@ -1,0 +1,322 @@
+"""Exact, side-effect-free parsing for the supported Unix ``env`` contract."""
+
+from __future__ import annotations
+
+import os
+import shlex
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+ENV_SPLIT_MAX_BYTES = 8192
+ENV_SPLIT_MAX_EXPANSIONS = 4
+ENV_TOKEN_MAX_COUNT = 256
+
+
+@dataclass(frozen=True, slots=True)
+class EnvEnvironmentDelta:
+    clear: bool
+    unset_names: tuple[str, ...]
+    assignments: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class EnvOptionEffects:
+    ignore_environment: bool
+    unset_names: tuple[str, ...]
+    chdir: str | None
+    search_path: str | None
+    verbose: bool
+
+
+@dataclass(frozen=True, slots=True)
+class EnvSplitExpansion:
+    payload: str
+    source_index: int
+    tokens: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class EnvWrapperParseResult:
+    complete: bool
+    error: str | None
+    original_tokens: tuple[str, ...]
+    expanded_tokens: tuple[str, ...]
+    option_effects: EnvOptionEffects
+    environment_delta: EnvEnvironmentDelta
+    effective_environment: tuple[tuple[str, str], ...] | None
+    effective_cwd: Path | None
+    command_index: int | None
+    executable_argv: tuple[str, ...]
+    split_expansions: tuple[EnvSplitExpansion, ...]
+
+    def environment_dict(self) -> dict[str, str] | None:
+        if self.effective_environment is None:
+            return None
+        return dict(self.effective_environment)
+
+
+@dataclass(frozen=True, slots=True)
+class _SourcedToken:
+    value: str
+    source_index: int
+
+
+def parse_env_wrapper(
+    tokens: Sequence[str],
+    *,
+    inherited_environment: Mapping[str, str] | None = None,
+    cwd: Path | None = None,
+) -> EnvWrapperParseResult:
+    """Parse argv following ``env`` with exact option-operand consumption.
+
+    Unknown implementation-specific options and malformed operands are returned
+    as incomplete so callers cannot silently model a different environment.
+    ``command_index`` refers to ``expanded_tokens`` after bounded ``-S``
+    expansion.
+    """
+
+    original_tokens = tuple(tokens)
+    working = [_SourcedToken(value, index) for index, value in enumerate(original_tokens)]
+    environment = dict(inherited_environment) if inherited_environment is not None else None
+    ignore_environment = False
+    unset_names: list[str] = []
+    assignments: list[tuple[str, str]] = []
+    chdir_operand: str | None = None
+    search_path: str | None = None
+    verbose = False
+    split_expansions: list[EnvSplitExpansion] = []
+    options = True
+    index = 0
+
+    def result(*, complete: bool, error: str | None, command_index: int | None) -> EnvWrapperParseResult:
+        effective_cwd = _effective_cwd(cwd, chdir_operand)
+        executable_argv = tuple(token.value for token in working[command_index:]) if command_index is not None else ()
+        effects = EnvOptionEffects(
+            ignore_environment=ignore_environment,
+            unset_names=tuple(unset_names),
+            chdir=chdir_operand,
+            search_path=search_path,
+            verbose=verbose,
+        )
+        delta = EnvEnvironmentDelta(
+            clear=ignore_environment,
+            unset_names=tuple(unset_names),
+            assignments=tuple(assignments),
+        )
+        return EnvWrapperParseResult(
+            complete=complete,
+            error=error,
+            original_tokens=original_tokens,
+            expanded_tokens=tuple(token.value for token in working),
+            option_effects=effects,
+            environment_delta=delta,
+            effective_environment=(tuple(sorted(environment.items())) if environment is not None else None),
+            effective_cwd=effective_cwd,
+            command_index=command_index,
+            executable_argv=executable_argv,
+            split_expansions=tuple(split_expansions),
+        )
+
+    def fail(error: str) -> EnvWrapperParseResult:
+        return result(complete=False, error=error, command_index=None)
+
+    def apply_unset(name: str) -> EnvWrapperParseResult | None:
+        if not name or "=" in name or "\x00" in name:
+            return fail("invalid_unset_operand")
+        unset_names.append(name)
+        if environment is not None:
+            _ = environment.pop(name, None)
+        return None
+
+    def apply_clear() -> None:
+        nonlocal ignore_environment
+        ignore_environment = True
+        if environment is not None:
+            environment.clear()
+
+    while index < len(working):
+        if len(working) > ENV_TOKEN_MAX_COUNT:
+            return fail("token_limit_exceeded")
+        sourced = working[index]
+        token = sourced.value
+        if "\x00" in token:
+            return fail("nul_token")
+        assignment = _env_assignment(token)
+        if not options:
+            if assignment is not None:
+                assignments.append(assignment)
+                if environment is not None:
+                    environment[assignment[0]] = assignment[1]
+                index += 1
+                continue
+            return result(complete=True, error=None, command_index=index)
+        if token == "--":
+            options = False
+            index += 1
+            continue
+        if token == "-":
+            apply_clear()
+            index += 1
+            continue
+        if not token.startswith("-"):
+            if assignment is not None:
+                options = False
+                assignments.append(assignment)
+                if environment is not None:
+                    environment[assignment[0]] = assignment[1]
+                index += 1
+                continue
+            return result(complete=True, error=None, command_index=index)
+
+        if token.startswith("--"):
+            option_name, separator, attached = token.partition("=")
+            if option_name == "--ignore-environment" and not separator:
+                apply_clear()
+                index += 1
+                continue
+            if option_name == "--debug" and not separator:
+                verbose = True
+                index += 1
+                continue
+            if option_name not in {"--unset", "--chdir", "--split-string"}:
+                return fail("unsupported_option")
+            if separator:
+                operand = attached
+                consumed = 1
+                operand_source = sourced.source_index
+            else:
+                if index + 1 >= len(working):
+                    return fail(_missing_operand_error(option_name))
+                operand = working[index + 1].value
+                consumed = 2
+                operand_source = working[index + 1].source_index
+            if option_name == "--unset":
+                invalid = apply_unset(operand)
+                if invalid is not None:
+                    return invalid
+                index += consumed
+                continue
+            if option_name == "--chdir":
+                if not operand or "\x00" in operand:
+                    return fail("invalid_chdir_operand")
+                chdir_operand = operand
+                index += consumed
+                continue
+            expansion = _split_expansion(operand, operand_source)
+            if isinstance(expansion, str):
+                return fail(expansion)
+            if len(split_expansions) >= ENV_SPLIT_MAX_EXPANSIONS:
+                return fail("split_string_limit_exceeded")
+            split_expansions.append(expansion)
+            working[index : index + consumed] = [_SourcedToken(value, operand_source) for value in expansion.tokens]
+            continue
+
+        short_index = 1
+        tokens_consumed = 1
+        replace_with_split: tuple[int, EnvSplitExpansion] | None = None
+        while short_index < len(token):
+            flag = token[short_index]
+            if flag == "i":
+                apply_clear()
+                short_index += 1
+                continue
+            if flag == "v":
+                verbose = True
+                short_index += 1
+                continue
+            if flag not in {"u", "C", "S", "P"}:
+                return fail("unsupported_option")
+            attached_operand = token[short_index + 1 :]
+            if attached_operand:
+                operand = attached_operand
+                tokens_consumed = 1
+                operand_source = sourced.source_index
+            else:
+                if index + 1 >= len(working):
+                    return fail(_missing_operand_error(f"-{flag}"))
+                operand = working[index + 1].value
+                tokens_consumed = 2
+                operand_source = working[index + 1].source_index
+            if flag == "u":
+                invalid = apply_unset(operand)
+                if invalid is not None:
+                    return invalid
+            elif flag == "C":
+                if not operand or "\x00" in operand:
+                    return fail("invalid_chdir_operand")
+                chdir_operand = operand
+            elif flag == "P":
+                if "\x00" in operand:
+                    return fail("invalid_search_path_operand")
+                search_path = operand
+            else:
+                expansion = _split_expansion(operand, operand_source)
+                if isinstance(expansion, str):
+                    return fail(expansion)
+                if len(split_expansions) >= ENV_SPLIT_MAX_EXPANSIONS:
+                    return fail("split_string_limit_exceeded")
+                split_expansions.append(expansion)
+                replace_with_split = (tokens_consumed, expansion)
+            short_index = len(token)
+        if replace_with_split is not None:
+            consumed, expansion = replace_with_split
+            working[index : index + consumed] = [
+                _SourcedToken(value, expansion.source_index) for value in expansion.tokens
+            ]
+            continue
+        index += tokens_consumed
+
+    return result(complete=True, error=None, command_index=None)
+
+
+def _env_assignment(token: str) -> tuple[str, str] | None:
+    name, separator, value = token.partition("=")
+    if separator != "=" or not name or "\x00" in name:
+        return None
+    return name, value
+
+
+def _missing_operand_error(option: str) -> str:
+    if option in {"-u", "--unset"}:
+        return "missing_unset_operand"
+    if option in {"-C", "--chdir"}:
+        return "missing_chdir_operand"
+    if option == "-P":
+        return "missing_search_path_operand"
+    return "missing_split_string_operand"
+
+
+def _split_expansion(payload: str, source_index: int) -> EnvSplitExpansion | str:
+    if len(payload.encode("utf-8")) > ENV_SPLIT_MAX_BYTES:
+        return "split_string_byte_limit_exceeded"
+    if "\x00" in payload:
+        return "split_string_nul"
+    try:
+        tokens = tuple(shlex.split(payload, posix=True, comments=False))
+    except ValueError:
+        return "split_string_syntax_error"
+    if len(tokens) > ENV_TOKEN_MAX_COUNT:
+        return "token_limit_exceeded"
+    return EnvSplitExpansion(payload=payload, source_index=source_index, tokens=tokens)
+
+
+def _effective_cwd(cwd: Path | None, operand: str | None) -> Path | None:
+    if operand is None:
+        return cwd
+    candidate = Path(operand)
+    if candidate.is_absolute() or cwd is None:
+        return Path(os.path.normpath(str(candidate)))
+    return Path(os.path.normpath(str(cwd / candidate)))
+
+
+__all__ = [
+    "ENV_SPLIT_MAX_BYTES",
+    "ENV_SPLIT_MAX_EXPANSIONS",
+    "ENV_TOKEN_MAX_COUNT",
+    "EnvEnvironmentDelta",
+    "EnvOptionEffects",
+    "EnvSplitExpansion",
+    "EnvWrapperParseResult",
+    "parse_env_wrapper",
+]

--- a/src/codex_plugin_scanner/guard/runtime/env_wrapper.py
+++ b/src/codex_plugin_scanner/guard/runtime/env_wrapper.py
@@ -27,6 +27,7 @@ class EnvOptionEffects:
     chdir: str | None
     search_path: str | None
     verbose: bool
+    null_output: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,6 +86,7 @@ def parse_env_wrapper(
     chdir_operand: str | None = None
     search_path: str | None = None
     verbose = False
+    null_output = False
     split_expansions: list[EnvSplitExpansion] = []
     options = True
     index = 0
@@ -98,6 +100,7 @@ def parse_env_wrapper(
             chdir=chdir_operand,
             search_path=search_path,
             verbose=verbose,
+            null_output=null_output,
         )
         delta = EnvEnvironmentDelta(
             clear=ignore_environment,
@@ -144,6 +147,13 @@ def parse_env_wrapper(
             return fail("nul_token")
         assignment = _env_assignment(token)
         if not options:
+            if token == "--":
+                index += 1
+                return result(
+                    complete=True,
+                    error=None,
+                    command_index=index if index < len(working) else None,
+                )
             if assignment is not None:
                 assignments.append(assignment)
                 if environment is not None:
@@ -177,6 +187,10 @@ def parse_env_wrapper(
                 continue
             if option_name == "--debug" and not separator:
                 verbose = True
+                index += 1
+                continue
+            if option_name == "--null" and not separator:
+                null_output = True
                 index += 1
                 continue
             if option_name not in {"--unset", "--chdir", "--split-string"}:
@@ -217,6 +231,10 @@ def parse_env_wrapper(
         replace_with_split: tuple[int, EnvSplitExpansion] | None = None
         while short_index < len(token):
             flag = token[short_index]
+            if flag == "0":
+                null_output = True
+                short_index += 1
+                continue
             if flag == "i":
                 apply_clear()
                 short_index += 1

--- a/src/codex_plugin_scanner/guard/runtime/kubernetes_commands.py
+++ b/src/codex_plugin_scanner/guard/runtime/kubernetes_commands.py
@@ -7,6 +7,7 @@ import shlex
 from pathlib import Path
 
 from .data_flow import extract_command_segments, extract_command_substitutions, extract_input_redirects
+from .env_wrapper import parse_env_wrapper
 from .kubernetes_command_support import (
     WRITE_ONLY_COMMANDS,
     interpreter_reads_sensitive_env,
@@ -28,7 +29,6 @@ _ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*")
 _OUTPUT_REDIRECT_TOKENS = frozenset({">", "1>", "2>", ">>", "1>>", "2>>"})
 _WRAPPER_COMMANDS = frozenset({"command", "env", "nice", "nohup", "stdbuf", "sudo", "time"})
 _WRAPPER_OPTIONS_WITH_VALUES = {
-    "env": frozenset({"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}),
     "nice": frozenset({"-n", "--adjustment"}),
     "stdbuf": frozenset({"-i", "--input", "-o", "--output", "-e", "--error"}),
     "sudo": frozenset(
@@ -193,8 +193,17 @@ def _unwrap_command_start(tokens: tuple[str, ...]) -> int:
         command_name = Path(token).name.lower()
         if command_name not in _WRAPPER_COMMANDS:
             return index
-        if command_name == "env" and not _env_looks_like_wrapper(tokens[index + 1 :]):
-            return index
+        if command_name == "env":
+            parsed = parse_env_wrapper(tokens[index + 1 :])
+            if parsed.complete and (
+                parsed.command_index is None
+                or (parsed.executable_argv and parsed.executable_argv[0] in {"&&", "||", ";", "|", "|&", "&"})
+            ):
+                return index
+            if not parsed.complete or parsed.split_expansions:
+                return len(tokens)
+            index += parsed.command_index + 1
+            continue
         index += 1
         while index < len(tokens):
             current = tokens[index]
@@ -402,25 +411,6 @@ def _remote_copy_source_reads_secret_volume(tokens: tuple[str, ...]) -> bool:
 
 def _secret_volume_source_arguments(tokens: tuple[str, ...]) -> tuple[str, ...]:
     return matching_source_arguments(tokens, is_secret_volume_path)
-
-
-def _env_looks_like_wrapper(tokens: tuple[str, ...]) -> bool:
-    index = 0
-    saw_wrapper_syntax = False
-    while index < len(tokens):
-        token = tokens[index]
-        if token == "--":
-            return saw_wrapper_syntax and index + 1 < len(tokens)
-        if _ASSIGNMENT_PATTERN.match(token):
-            saw_wrapper_syntax = True
-            index += 1
-            continue
-        if token.startswith("-"):
-            saw_wrapper_syntax = True
-            index += _option_tokens_consumed("env", token)
-            continue
-        return saw_wrapper_syntax
-    return False
 
 
 def _remote_cp_operands(tokens: tuple[str, ...]) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/runtime/kubernetes_commands.py
+++ b/src/codex_plugin_scanner/guard/runtime/kubernetes_commands.py
@@ -195,14 +195,15 @@ def _unwrap_command_start(tokens: tuple[str, ...]) -> int:
             return index
         if command_name == "env":
             parsed = parse_env_wrapper(tokens[index + 1 :])
+            command_index = parsed.command_index
             if parsed.complete and (
-                parsed.command_index is None
+                command_index is None
                 or (parsed.executable_argv and parsed.executable_argv[0] in {"&&", "||", ";", "|", "|&", "&"})
             ):
                 return index
-            if not parsed.complete or parsed.split_expansions:
+            if not parsed.complete or parsed.split_expansions or command_index is None:
                 return len(tokens)
-            index += parsed.command_index + 1
+            index += command_index + 1
             continue
         index += 1
         while index < len(tokens):

--- a/src/codex_plugin_scanner/guard/runtime/kubernetes_heredoc_support.py
+++ b/src/codex_plugin_scanner/guard/runtime/kubernetes_heredoc_support.py
@@ -12,6 +12,7 @@ from .data_flow import (
     extract_command_substitutions,
     extract_input_redirects,
 )
+from .env_wrapper import parse_env_wrapper
 from .kubernetes_command_support import (
     WRITE_ONLY_COMMANDS,
     is_output_redirect_target,
@@ -24,7 +25,6 @@ from .kubernetes_command_support import (
 _ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*")
 _HEREDOC_WRAPPER_COMMANDS = frozenset({"command", "env", "nice", "nohup", "stdbuf", "sudo", "time"})
 _HEREDOC_WRAPPER_OPTIONS_WITH_VALUES = {
-    "env": frozenset({"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}),
     "nice": frozenset({"-n", "--adjustment"}),
     "stdbuf": frozenset({"-i", "--input", "-o", "--output", "-e", "--error"}),
     "sudo": frozenset(
@@ -125,25 +125,6 @@ def kubernetes_heredoc_secret_source(command: str) -> str | None:
         if script_reads_sensitive_env(body):
             return "Kubernetes pod environment"
     return None
-
-
-def _env_looks_like_wrapper(tokens: tuple[str, ...]) -> bool:
-    index = 0
-    saw_wrapper_syntax = False
-    while index < len(tokens):
-        token = tokens[index]
-        if token == "--":
-            return saw_wrapper_syntax and index + 1 < len(tokens)
-        if _ASSIGNMENT_PATTERN.match(token):
-            saw_wrapper_syntax = True
-            index += 1
-            continue
-        if token.startswith("-"):
-            saw_wrapper_syntax = True
-            index += _wrapper_option_tokens_consumed("env", token)
-            continue
-        return saw_wrapper_syntax
-    return False
 
 
 def _interpreter_reads_stdin(args: tuple[str, ...]) -> bool:
@@ -377,8 +358,20 @@ def _unwrap_heredoc_remote_command(tokens: tuple[str, ...]) -> tuple[str | None,
         command_name = Path(token).name.lower()
         if command_name not in _HEREDOC_WRAPPER_COMMANDS:
             return command_name, tokens[index + 1 :]
-        if command_name == "env" and not _env_looks_like_wrapper(tokens[index + 1 :]):
-            return command_name, tokens[index + 1 :]
+        if command_name == "env":
+            parsed = parse_env_wrapper(tokens[index + 1 :])
+            if parsed.complete and (
+                not parsed.executable_argv or parsed.executable_argv[0] in {"&&", "||", ";", "|", "|&", "&"}
+            ):
+                return command_name, tokens[index + 1 :]
+            if not parsed.complete:
+                return None, ()
+            if parsed.split_expansions:
+                return _unwrap_heredoc_remote_command(parsed.executable_argv)
+            if parsed.command_index is None:
+                return None, ()
+            index += parsed.command_index + 1
+            continue
         index += 1
         while index < len(tokens):
             current = tokens[index]

--- a/src/codex_plugin_scanner/guard/runtime/local_request_snapshots.py
+++ b/src/codex_plugin_scanner/guard/runtime/local_request_snapshots.py
@@ -22,6 +22,7 @@ from ..review_contracts import (
 from ..store import GuardStore
 from ..synced_policy import validated_synced_policy_bundle
 from .decisions import AUTHORITATIVE_DECISION_INCONSISTENT
+from .env_wrapper import parse_env_wrapper
 
 LOCAL_REQUEST_PENDING_SNAPSHOT_LIMIT = 125
 LOCAL_REQUEST_RESOLVED_SNAPSHOT_LIMIT = 25
@@ -710,49 +711,14 @@ def _env_split_string_token_indexes(
     start: int,
     end: int,
 ) -> list[int]:
-    split_string_indexes: list[int] = []
-    value_options = frozenset({"-C", "-S", "-u", "--chdir", "--split-string", "--unset"})
-    index = start
-    while index < end:
-        value = tokens[index].value
-        if value == "--":
-            return split_string_indexes
-        clustered_split_string = _env_clustered_split_string_payload(value)
-        if clustered_split_string is not None:
-            if not clustered_split_string and index + 1 < end and _source_search_pattern_spans(tokens[index + 1].value):
-                split_string_indexes.append(index + 1)
-            index += 2 if not clustered_split_string else 1
-            continue
-        if value in value_options:
-            if (
-                value in {"-S", "--split-string"}
-                and index + 1 < end
-                and _source_search_pattern_spans(tokens[index + 1].value)
-            ):
-                split_string_indexes.append(index + 1)
-            index += 2
-            continue
-        if value.startswith("--split-string="):
-            split_string = value.removeprefix("--split-string=")
-            if _source_search_pattern_spans(split_string):
-                split_string_indexes.append(index)
-            index += 1
-            continue
-        if value.startswith(("--chdir=", "--unset=")):
-            index += 1
-            continue
-        if value.startswith("-") or _is_shell_environment_assignment(value):
-            index += 1
-            continue
-        return split_string_indexes
-    return split_string_indexes
-
-
-def _env_clustered_split_string_payload(value: str) -> str | None:
-    if not value.startswith("-") or value.startswith("--") or len(value) <= 2:
-        return None
-    split_index = value.find("S", 1)
-    return None if split_index == -1 else value[split_index + 1 :]
+    parsed = parse_env_wrapper([token.value for token in tokens[start:end]])
+    return list(
+        dict.fromkeys(
+            start + expansion.source_index
+            for expansion in parsed.split_expansions
+            if _source_search_pattern_spans(expansion.payload)
+        )
+    )
 
 
 def _source_search_command_index(
@@ -829,10 +795,6 @@ def _skip_nice_prefix_options(
         value = tokens[index].value
         if value == "--":
             return index + 1
-        clustered_split_string = _env_clustered_split_string_payload(value)
-        if clustered_split_string is not None:
-            index += 2 if not clustered_split_string else 1
-            continue
         if value in value_options:
             index += 2
             continue
@@ -905,23 +867,10 @@ def _skip_env_prefix_options(
     start: int,
     end: int,
 ) -> int:
-    value_options = frozenset({"-C", "-S", "-u", "--chdir", "--split-string", "--unset"})
-    index = start
-    while index < end:
-        value = tokens[index].value
-        if value == "--":
-            return index + 1
-        if value in value_options:
-            index += 2
-            continue
-        if value.startswith(("--chdir=", "--split-string=", "--unset=")):
-            index += 1
-            continue
-        if value.startswith("-") or _is_shell_environment_assignment(value):
-            index += 1
-            continue
-        return index
-    return index
+    parsed = parse_env_wrapper([token.value for token in tokens[start:end]])
+    if not parsed.complete or parsed.command_index is None or parsed.split_expansions:
+        return end
+    return start + parsed.command_index
 
 
 def _skip_sudo_prefix_options(

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -1433,8 +1433,11 @@ def _effective_execution_context(
         if "$" in parsed_env.option_effects.chdir or "\x00" in parsed_env.option_effects.chdir:
             cwd_source = "env_chdir_unresolved"
         elif parsed_env.effective_cwd is not None:
-            effective_cwd = parsed_env.effective_cwd.resolve()
-            cwd_source = "env_chdir"
+            try:
+                effective_cwd = parsed_env.effective_cwd.resolve()
+                cwd_source = "env_chdir"
+            except (OSError, RuntimeError):
+                cwd_source = "env_chdir_unresolved"
     return _path_for_resolution(effective_path, effective_cwd), path_source, effective_cwd, cwd_source
 
 

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from ..protect import _collect_package_specs
 from ._shell_execution_context_support import ShellPathIdentity
 from .command_model import CanonicalCommand
+from .env_wrapper import parse_env_wrapper
 from .homebrew_intent import parse_brew_intent
 from .mcp_protection import _command_name, _package_token
 from .package_intent_common import (
@@ -1402,94 +1403,38 @@ def _effective_execution_context(
     if command_name != "env":
         return _path_for_resolution(effective_path, effective_cwd), path_source, effective_cwd, cwd_source
 
-    index += 1
-    parsing_options = True
-    split_expansions = 0
-    while index < len(raw_segment):
-        token = raw_segment[index]
-        if _ENV_ASSIGNMENT_RE.match(token):
-            name, _, value = token.partition("=")
-            if name == "PATH":
-                effective_path = _expanded_path_assignment(value, effective_path)
-                path_source = "env" if effective_path is not None else "env_unresolved"
-            index += 1
-            parsing_options = False
-            continue
-        if not parsing_options:
-            break
-        if token == "--":
-            index += 1
-            parsing_options = False
-            continue
-        if token in {"-i", "--ignore-environment"}:
-            effective_path = os.defpath
-            path_source = "env_default"
-            index += 1
-            continue
-        if token in {"-u", "--unset"} and index + 1 < len(raw_segment):
-            if raw_segment[index + 1] == "PATH":
-                effective_path = os.defpath
-                path_source = "env_default"
-            index += 2
-            continue
-        if token.startswith("--unset="):
-            if token.partition("=")[2] == "PATH":
-                effective_path = os.defpath
-                path_source = "env_default"
-            index += 1
-            continue
-        if token.startswith("-u") and token != "-u":
-            if token[2:] == "PATH":
-                effective_path = os.defpath
-                path_source = "env_default"
-            index += 1
-            continue
-        if token in {"-C", "--chdir"} and index + 1 < len(raw_segment):
-            effective_cwd, cwd_source = _updated_effective_cwd(
-                effective_cwd,
-                raw_segment[index + 1],
-            )
-            index += 2
-            continue
-        if token.startswith("--chdir="):
-            effective_cwd, cwd_source = _updated_effective_cwd(
-                effective_cwd,
-                token.partition("=")[2],
-            )
-            index += 1
-            continue
-        if token.startswith("-C") and token != "-C":
-            effective_cwd, cwd_source = _updated_effective_cwd(
-                effective_cwd,
-                token[2:],
-            )
-            index += 1
-            continue
-        if token == "-P" and index + 1 < len(raw_segment):
-            effective_path = _expanded_path_assignment(raw_segment[index + 1], effective_path)
-            path_source = "env_search_path" if effective_path is not None else "env_search_path_unresolved"
-            index += 2
-            continue
-        if token.startswith("-P") and token != "-P":
-            effective_path = _expanded_path_assignment(token[2:], effective_path)
-            path_source = "env_search_path" if effective_path is not None else "env_search_path_unresolved"
-            index += 1
-            continue
-        split_value, consumed = _env_split_value(raw_segment, index)
-        if split_value is not None:
-            if split_expansions >= 4:
-                return None, "env_split_unresolved", effective_cwd, cwd_source
-            try:
-                split_tokens = shlex.split(split_value)
-            except ValueError:
-                return None, "env_split_unresolved", effective_cwd, cwd_source
-            raw_segment = [*raw_segment[:index], *split_tokens, *raw_segment[index + consumed :]]
-            split_expansions += 1
-            continue
-        if token.startswith("-"):
-            index += 1
-            continue
-        break
+    inherited_environment = dict(os.environ)
+    if effective_path is None:
+        inherited_environment.pop("PATH", None)
+    else:
+        inherited_environment["PATH"] = effective_path
+    parsed_env = parse_env_wrapper(
+        raw_segment[index + 1 :],
+        inherited_environment=inherited_environment,
+        cwd=effective_cwd,
+    )
+    if not parsed_env.complete:
+        return None, f"env_{parsed_env.error or 'unresolved'}", effective_cwd, cwd_source
+    path_was_unset = "PATH" in parsed_env.option_effects.unset_names
+    path_assignment = next(
+        (value for name, value in reversed(parsed_env.environment_delta.assignments) if name == "PATH"),
+        None,
+    )
+    if parsed_env.option_effects.search_path is not None:
+        effective_path = _expanded_path_assignment(parsed_env.option_effects.search_path, effective_path)
+        path_source = "env_search_path" if effective_path is not None else "env_search_path_unresolved"
+    elif path_assignment is not None:
+        effective_path = _expanded_path_assignment(path_assignment, effective_path)
+        path_source = "env" if effective_path is not None else "env_unresolved"
+    elif parsed_env.option_effects.ignore_environment or path_was_unset:
+        effective_path = os.defpath
+        path_source = "env_default"
+    if parsed_env.option_effects.chdir is not None:
+        if "$" in parsed_env.option_effects.chdir or "\x00" in parsed_env.option_effects.chdir:
+            cwd_source = "env_chdir_unresolved"
+        elif parsed_env.effective_cwd is not None:
+            effective_cwd = parsed_env.effective_cwd.resolve()
+            cwd_source = "env_chdir"
     return _path_for_resolution(effective_path, effective_cwd), path_source, effective_cwd, cwd_source
 
 
@@ -1714,80 +1659,20 @@ def _strip_sudo_prefix(tokens: list[str]) -> list[str]:
 
 
 def _strip_env_prefix(tokens: list[str]) -> list[str]:
-    index = 0
-    parsing_options = True
-    while index < len(tokens):
-        token = tokens[index]
-        if _ENV_ASSIGNMENT_RE.match(token):
-            index += 1
-            parsing_options = False
-            continue
-        if not parsing_options:
-            break
-        if not token.startswith("-"):
-            break
-        if token == "--":
-            index += 1
-            break
-        split_value, consumed = _env_split_value(tokens, index)
-        if split_value is not None:
-            try:
-                split_tokens = shlex.split(split_value)
-            except ValueError:
-                return tokens[index + consumed :]
-            return _strip_env_prefix([*split_tokens, *tokens[index + consumed :]])
-        if token in {"-u", "--unset", "-C", "--chdir", "-P", "-S", "--split-string"} and index + 1 < len(tokens):
-            index += 2
-            continue
-        index += 1
-    return tokens[index:]
+    parsed = parse_env_wrapper(tokens)
+    return list(parsed.executable_argv) if parsed.complete else []
 
 
 def _strip_env_prefix_for_redaction(tokens: list[str]) -> tuple[list[str], list[str]]:
-    preserved_env: list[str] = []
-    index = 0
-    parsing_options = True
-    while index < len(tokens):
-        token = tokens[index]
-        if _ENV_ASSIGNMENT_RE.match(token):
-            if _package_source_env_assignment(token):
-                preserved_env.append(token)
-            index += 1
-            parsing_options = False
-            continue
-        if not parsing_options:
-            break
-        if not token.startswith("-"):
-            break
-        if token == "--":
-            index += 1
-            break
-        split_value, consumed = _env_split_value(tokens, index)
-        if split_value is not None:
-            try:
-                split_tokens = shlex.split(split_value)
-            except ValueError:
-                return preserved_env, tokens[index + consumed :]
-            nested_preserved, nested_tokens = _strip_env_prefix_for_redaction(
-                [*split_tokens, *tokens[index + consumed :]]
-            )
-            return [*preserved_env, *nested_preserved], nested_tokens
-        if token in {"-u", "--unset", "-C", "--chdir", "-P", "-S", "--split-string"} and index + 1 < len(tokens):
-            index += 2
-            continue
-        index += 1
-    return preserved_env, tokens[index:]
-
-
-def _env_split_value(tokens: list[str], index: int) -> tuple[str | None, int]:
-    token = tokens[index]
-    if token in {"-S", "--split-string"}:
-        return (tokens[index + 1], 2) if index + 1 < len(tokens) else (None, 1)
-    if token.startswith("--split-string="):
-        return token.partition("=")[2], 1
-    if token.startswith("-S") and token != "-S":
-        return token[2:], 1
-    return None, 0
+    parsed = parse_env_wrapper(tokens)
+    if not parsed.complete:
+        return [], []
+    preserved_env = [
+        f"{name}={value}"
+        for name, value in parsed.environment_delta.assignments
+        if _package_source_env_assignment(f"{name}={value}")
+    ]
+    return preserved_env, list(parsed.executable_argv)
 
 
 def _strip_plain_wrapper_flags(tokens: list[str]) -> list[str]:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -6734,7 +6734,21 @@ def _shell_command_targets_pytest(command_text: str, *, depth: int = 0) -> bool:
 
 
 def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:
-    return _shell_command_scripts(parts)
+    scripts: list[str] = []
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name is None or command_index is None:
+            continue
+        if command_name not in _SHELL_COMMAND_STRING_INTERPRETERS and not _is_script_interpreter_command(command_name):
+            continue
+        index = command_index + 1
+        while index < len(segment):
+            flag_payload = _interpreter_flag_payload(segment, index)
+            if flag_payload is not None:
+                scripts.append(flag_payload.script_text)
+                break
+            index += 1
+    return tuple(scripts)
 
 
 def _looks_like_benign_interpreter_wait(command_text: str, parts: list[str], command_names: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -6061,11 +6061,12 @@ def _shell_segment_primary_command(segment: list[str]) -> tuple[str | None, int 
         command_name = _normalized_shell_command_name(normalized_token)
         if command_name == "env":
             parsed = parse_env_wrapper(segment[index + 1 :])
-            if parsed.complete and parsed.command_index is None:
+            command_index = parsed.command_index
+            if parsed.complete and command_index is None:
                 return command_name, index
-            if not parsed.complete or parsed.split_expansions:
+            if not parsed.complete or parsed.split_expansions or command_index is None:
                 return None, None
-            index += parsed.command_index + 1
+            index += command_index + 1
             continue
         if command_name in _SHELL_COMMAND_WRAPPERS:
             index += 1

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -21,6 +21,7 @@ from .command_evaluation import evaluate_command
 from .command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from .command_model import CanonicalCommand, parse_shell_command
 from .data_flow import extract_heredocs
+from .env_wrapper import parse_env_wrapper
 from .false_positive_rules import (
     SOURCE_INSPECTION_BENIGN_DOTFILES,
     SOURCE_INSPECTION_EXTENSIONS,
@@ -532,7 +533,6 @@ _GIT_GLOBAL_OPTIONS_WITH_VALUE = frozenset(
     }
 )
 _WRAPPER_FLAGS_WITH_VALUES = {
-    "env": frozenset({"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}),
     "exec": frozenset({"-a"}),
     "nice": frozenset({"-n", "--adjustment"}),
     "stdbuf": frozenset({"-i", "--input", "-o", "--output", "-e", "--error"}),
@@ -1579,42 +1579,15 @@ def _gh_pr_create_body_has_shell_command_substitution(command_text: str, *, dept
 
 
 def _gh_pr_env_split_string_payloads_with_substitution(segment: list[_ShellTokenWithQuoteContext]) -> tuple[str, ...]:
-    payloads: list[str] = []
     env_index = _shell_segment_env_index([token.plain for token in segment])
     if env_index is None:
         return ()
-    index = env_index + 1
-    while index < len(segment):
-        token = segment[index]
-        plain = token.plain
-        if _SHELL_ASSIGNMENT_PATTERN.match(_shell_command_token_without_attached_redirection(plain)):
-            index += 1
-            continue
-        if plain == "--":
-            break
-        if not plain.startswith("-"):
-            break
-        if plain in {"-S", "--split-string"} and index + 1 < len(segment):
-            payload_token = segment[index + 1]
-            if _shell_command_substitution_payloads(payload_token.raw):
-                payloads.append(payload_token.plain.strip())
-            index += _wrapper_option_tokens_consumed("env", plain)
-            continue
-        if plain.startswith("--split-string="):
-            if _shell_command_substitution_payloads(token.raw):
-                payloads.append(plain.split("=", 1)[1].strip())
-            index += _wrapper_option_tokens_consumed("env", plain)
-            continue
-        clustered_payload = _env_clustered_split_string_payload(plain)
-        if clustered_payload is not None:
-            if clustered_payload:
-                if _shell_command_substitution_payloads(token.raw):
-                    payloads.append(clustered_payload.strip())
-            elif index + 1 < len(segment) and _shell_command_substitution_payloads(segment[index + 1].raw):
-                payloads.append(segment[index + 1].plain.strip())
-            index += _wrapper_option_tokens_consumed("env", plain)
-            continue
-        index += _wrapper_option_tokens_consumed("env", plain)
+    parsed = parse_env_wrapper([token.plain for token in segment[env_index + 1 :]])
+    payloads: list[str] = []
+    for expansion in parsed.split_expansions:
+        source_index = env_index + 1 + expansion.source_index
+        if source_index < len(segment) and _shell_command_substitution_payloads(segment[source_index].raw):
+            payloads.append(expansion.payload.strip())
     return tuple(payload for payload in payloads if payload)
 
 
@@ -1763,28 +1736,10 @@ def _skip_shell_select_header(segment: list[_ShellTokenWithQuoteContext], index:
 
 
 def _skip_env_wrapper_options(segment: list[_ShellTokenWithQuoteContext], index: int) -> int:
-    while index < len(segment):
-        plain = segment[index].plain
-        if _SHELL_ASSIGNMENT_PATTERN.match(_shell_command_token_without_attached_redirection(plain)):
-            index += 1
-            continue
-        if plain in {"-i", "-0", "--ignore-environment", "--null"}:
-            index += 1
-            continue
-        if plain == "--":
-            index += 1
-            break
-        if plain in {"-u", "-C", "-S", "--unset", "--chdir", "--split-string"}:
-            index += 2
-            continue
-        if any(plain.startswith(f"{flag}=") for flag in {"--unset", "--chdir", "--split-string"}):
-            index += 1
-            continue
-        if plain.startswith("-"):
-            index += 1
-            continue
-        break
-    return index
+    parsed = parse_env_wrapper([token.plain for token in segment[index:]])
+    if not parsed.complete or parsed.command_index is None or parsed.split_expansions:
+        return len(segment)
+    return index + parsed.command_index
 
 
 def _skip_sudo_wrapper_options(segment: list[_ShellTokenWithQuoteContext], index: int) -> int:
@@ -4458,32 +4413,18 @@ def _docker_sensitive_reason(command_text: str, *, _inherited_sensitive_env: boo
     exported_env_context: dict[str, bool] = {}
     for segment in _iter_shell_command_segments(parts):
         if segment and _normalized_shell_command_name(segment[0]) == "env":
-            env_tokens = segment[1:]
-            env_sensitive = _inherited_sensitive_env or _docker_env_context_is_sensitive(env_tokens)
-            remaining_tokens: list[str] = []
-            split_found = False
-            for i, tok in enumerate(env_tokens):
-                split_payload = _docker_env_split_string_payload(
-                    tok,
-                    env_tokens[i + 1] if i + 1 < len(env_tokens) else None,
+            parsed_env = parse_env_wrapper(segment[1:])
+            if not parsed_env.complete:
+                return "env-wrapper-unresolved"
+            env_sensitive = False if parsed_env.option_effects.ignore_environment else _inherited_sensitive_env
+            env_sensitive = env_sensitive or _docker_env_assignments_are_sensitive(
+                parsed_env.environment_delta.assignments
+            )
+            if parsed_env.executable_argv:
+                remaining_reason = _docker_sensitive_reason(
+                    shlex.join(parsed_env.executable_argv),
+                    _inherited_sensitive_env=env_sensitive,
                 )
-                if split_payload is not None:
-                    split_found = True
-                    nested_reason = _docker_sensitive_reason(split_payload)
-                    if nested_reason is not None:
-                        return nested_reason
-                    if _docker_env_context_is_sensitive(_split_shell_parts(split_payload)):
-                        env_sensitive = True
-                    consumed = 1 if tok in {"--split-string", "-S"} else 0
-                    remaining_tokens = env_tokens[i + consumed + 1 :]
-                    break
-            if not split_found:
-                remaining_tokens = [
-                    tok for tok in env_tokens if not tok.startswith("-") and not _SHELL_ASSIGNMENT_PATTERN.match(tok)
-                ]
-            remaining_cmd = " ".join(remaining_tokens)
-            if remaining_cmd:
-                remaining_reason = _docker_sensitive_reason(remaining_cmd, _inherited_sensitive_env=env_sensitive)
                 if remaining_reason is not None:
                     return remaining_reason
             continue
@@ -4627,22 +4568,27 @@ def _docker_global_context_value_is_sensitive(flag: str, value: str) -> bool:
 
 
 def _docker_env_context_is_sensitive(prefix_tokens: list[str]) -> bool:
-    index = 0
-    while index < len(prefix_tokens):
-        token = prefix_tokens[index]
-        assignment = _docker_env_assignment(token)
-        if assignment is not None:
-            key, value = assignment
-            if _docker_env_context_value_is_sensitive(key, value):
-                return True
-        split_payload = _docker_env_split_string_payload(
-            token,
-            prefix_tokens[index + 1] if index + 1 < len(prefix_tokens) else None,
-        )
-        if split_payload is not None and _docker_env_context_is_sensitive(_split_shell_parts(split_payload)):
+    env_index = next(
+        (index for index, token in enumerate(prefix_tokens) if _normalized_shell_command_name(token) == "env"),
+        None,
+    )
+    if env_index is not None:
+        parsed = parse_env_wrapper(prefix_tokens[env_index + 1 :])
+        if not parsed.complete:
             return True
-        index += 1
-    return False
+        return _docker_env_assignments_are_sensitive(parsed.environment_delta.assignments)
+    return any(
+        assignment is not None and _docker_env_context_value_is_sensitive(*assignment)
+        for assignment in (_docker_env_assignment(token) for token in prefix_tokens)
+    )
+
+
+def _docker_env_assignments_are_sensitive(assignments: tuple[tuple[str, str], ...]) -> bool:
+    return any(
+        name.upper() in _DOCKER_SENSITIVE_CONTEXT_ENV_KEYS
+        and _docker_env_context_value_is_sensitive(name.upper(), value)
+        for name, value in assignments
+    )
 
 
 def _docker_exported_env_context_sensitivity(args: list[str]) -> dict[str, bool]:
@@ -4667,19 +4613,6 @@ def _docker_env_assignment(token: str) -> tuple[str, str] | None:
     if key not in _DOCKER_SENSITIVE_CONTEXT_ENV_KEYS:
         return None
     return key, value.strip().strip("\"'")
-
-
-def _docker_env_split_string_payload(token: str, next_token: str | None) -> str | None:
-    if token in {"--split-string", "-S"}:
-        return next_token or ""
-    if token.startswith("--split-string="):
-        return token.split("=", 1)[1]
-    if token.startswith("-S"):
-        return token[2:] or (next_token or "")
-    clustered_payload = _env_clustered_split_string_payload(token)
-    if clustered_payload is None:
-        return None
-    return clustered_payload or (next_token or "")
 
 
 def _docker_env_context_value_is_sensitive(key: str, value: str) -> bool:
@@ -6127,14 +6060,12 @@ def _shell_segment_primary_command(segment: list[str]) -> tuple[str | None, int 
             continue
         command_name = _normalized_shell_command_name(normalized_token)
         if command_name == "env":
-            index += 1
-            while index < len(segment):
-                token = segment[index]
-                if not token.startswith("-") and not _SHELL_ASSIGNMENT_PATTERN.match(token):
-                    break
-                tokens_consumed = _wrapper_option_tokens_consumed(command_name, token)
-                index += tokens_consumed
-                continue
+            parsed = parse_env_wrapper(segment[index + 1 :])
+            if parsed.complete and parsed.command_index is None:
+                return command_name, index
+            if not parsed.complete or parsed.split_expansions:
+                return None, None
+            index += parsed.command_index + 1
             continue
         if command_name in _SHELL_COMMAND_WRAPPERS:
             index += 1
@@ -6315,38 +6246,8 @@ def _env_split_string_payloads(parts: list[str]) -> tuple[str, ...]:
         env_index = _shell_segment_env_index(segment)
         if env_index is None:
             continue
-        index = env_index + 1
-        while index < len(segment):
-            token = segment[index]
-            if _SHELL_ASSIGNMENT_PATTERN.match(token):
-                index += 1
-                continue
-            if token == "--":
-                break
-            if not token.startswith("-"):
-                break
-            if token in {"-S", "--split-string"} and index + 1 < len(segment):
-                payload = segment[index + 1].strip()
-                if payload:
-                    payloads.append(payload)
-                index += _wrapper_option_tokens_consumed("env", token)
-                continue
-            if token.startswith("--split-string="):
-                payload = token.split("=", 1)[1].strip()
-                if payload:
-                    payloads.append(payload)
-                index += _wrapper_option_tokens_consumed("env", token)
-                continue
-            clustered_split_string_payload = _env_clustered_split_string_payload(token)
-            if clustered_split_string_payload is not None:
-                payload = clustered_split_string_payload.strip()
-                if not payload and index + 1 < len(segment):
-                    payload = segment[index + 1].strip()
-                if payload:
-                    payloads.append(payload)
-                index += _wrapper_option_tokens_consumed("env", token)
-                continue
-            index += _wrapper_option_tokens_consumed("env", token)
+        parsed = parse_env_wrapper(segment[env_index + 1 :])
+        payloads.extend(expansion.payload for expansion in parsed.split_expansions if expansion.payload.strip())
     return tuple(payloads)
 
 
@@ -6686,10 +6587,6 @@ def _replace_unquoted_newlines_with_separators(command_text: str) -> str:
 def _wrapper_option_tokens_consumed(command_name: str, token: str) -> int:
     if not token.startswith("-"):
         return 1
-    if command_name == "env":
-        env_short_option_tokens = _env_short_option_tokens_consumed(token)
-        if env_short_option_tokens is not None:
-            return env_short_option_tokens
     if command_name == "sudo":
         sudo_short_option_tokens = _sudo_short_option_tokens_consumed(token)
         if sudo_short_option_tokens is not None:
@@ -6699,18 +6596,6 @@ def _wrapper_option_tokens_consumed(command_name: str, token: str) -> int:
         return 2
     if _wrapper_flag_has_attached_value(command_name, token):
         return 1
-    return 1
-
-
-def _env_short_option_tokens_consumed(token: str) -> int | None:
-    if not token.startswith("-") or token.startswith("--") or len(token) <= 2:
-        return None
-    for index, flag_character in enumerate(token[1:], start=1):
-        if flag_character not in {"C", "S", "u"}:
-            continue
-        if index < len(token) - 1:
-            return 1
-        return 2
     return 1
 
 
@@ -6726,28 +6611,7 @@ def _sudo_short_option_tokens_consumed(token: str) -> int | None:
     return 1
 
 
-def _env_clustered_split_string_payload(token: str) -> str | None:
-    if not token.startswith("-") or token.startswith("--") or len(token) <= 2:
-        return None
-    split_index = token.find("S", 1)
-    if split_index == -1:
-        return None
-    if split_index + 1 >= len(token):
-        return ""
-    return token[split_index + 1 :]
-
-
 def _wrapper_flag_has_attached_value(command_name: str, token: str) -> bool:
-    if command_name == "env":
-        return any(
-            token.startswith(prefix)
-            for prefix in (
-                "--unset=",
-                "--chdir=",
-                "--split-string=",
-                "-C",
-            )
-        )
     if command_name == "nice":
         return token.startswith("--adjustment=") or (token.startswith("-n") and token != "-n")
     if command_name == "stdbuf":
@@ -6799,27 +6663,10 @@ def _is_shell_env_assignment_token(token: str) -> bool:
 
 def _shell_command_names_from_parts(parts: list[str]) -> tuple[str, ...]:
     command_names: list[str] = []
-    expect_command = True
-    for part in parts:
-        token = part.strip()
-        if not token:
-            continue
-        if token in _SHELL_COMMAND_SEPARATORS:
-            expect_command = True
-            continue
-        normalized_token = _shell_command_token_without_attached_redirection(token)
-        if not normalized_token:
-            continue
-        if not expect_command:
-            continue
-        if _is_shell_env_assignment_token(normalized_token):
-            continue
-        normalized_command = _normalized_shell_command_name(normalized_token)
-        if normalized_command in {"env", "command", "builtin", "nohup", "nice", "sudo", "time", "stdbuf"}:
-            expect_command = True
-            continue
-        command_names.append(normalized_command)
-        expect_command = False
+    for segment in _iter_shell_command_segments(parts):
+        command_name, _command_index = _shell_segment_primary_command(segment)
+        if command_name is not None:
+            command_names.append(command_name)
     return tuple(command_names)
 
 
@@ -6887,45 +6734,7 @@ def _shell_command_targets_pytest(command_text: str, *, depth: int = 0) -> bool:
 
 
 def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:
-    scripts: list[str] = []
-    current_command: str | None = None
-    expect_command = True
-    index = 0
-    while index < len(parts):
-        token = parts[index].strip()
-        if not token:
-            index += 1
-            continue
-        if token in _SHELL_COMMAND_SEPARATORS:
-            current_command = None
-            expect_command = True
-            index += 1
-            continue
-        normalized_token = token.lstrip("(").rstrip(")")
-        if not normalized_token:
-            index += 1
-            continue
-        if expect_command:
-            if _is_shell_env_assignment_token(normalized_token):
-                index += 1
-                continue
-            normalized_command = _normalized_shell_command_name(normalized_token)
-            if normalized_command in {"env", "command", "builtin", "nohup", "nice", "time", "stdbuf"}:
-                current_command = None
-                index += 1
-                continue
-            current_command = normalized_command
-            expect_command = False
-            index += 1
-            continue
-        if current_command is not None and _is_script_interpreter_command(current_command):
-            flag_payload = _interpreter_flag_payload(parts, index)
-            if flag_payload is not None:
-                scripts.append(flag_payload.script_text)
-                index += flag_payload.tokens_consumed
-                continue
-        index += 1
-    return tuple(scripts)
+    return _shell_command_scripts(parts)
 
 
 def _looks_like_benign_interpreter_wait(command_text: str, parts: list[str], command_names: list[str]) -> bool:
@@ -7516,8 +7325,46 @@ def _pytest_binary_segment_is_safe(command_token: str, module_args: list[str], *
 
 
 def _shell_segment_sets_env_key(segment: list[str], command_index: int, env_key: str) -> bool:
+    is_set, _value, complete = _shell_segment_explicit_env_value(segment, command_index, env_key)
+    return is_set or not complete
+
+
+def _shell_segment_explicit_env_value(
+    segment: list[str],
+    command_index: int,
+    env_key: str,
+) -> tuple[bool, str | None, bool]:
     normalized_env_key = env_key.upper()
-    return any(_shell_env_assignment_key(token) == normalized_env_key for token in segment[:command_index])
+    is_set = False
+    value: str | None = None
+    index = 0
+    while index < command_index:
+        token = _shell_command_token_without_attached_redirection(segment[index])
+        assignment_key = _shell_env_assignment_key(token)
+        if assignment_key == normalized_env_key:
+            is_set = True
+            value = token.split("=", 1)[1] if "=" in token else ""
+            index += 1
+            continue
+        if _normalized_shell_command_name(token) != "env":
+            index += 1
+            continue
+        parsed = parse_env_wrapper(segment[index + 1 :])
+        if not parsed.complete:
+            return is_set, value, False
+        if parsed.option_effects.ignore_environment or any(
+            name.upper() == normalized_env_key for name in parsed.option_effects.unset_names
+        ):
+            is_set = False
+            value = None
+        for name, assignment_value in parsed.environment_delta.assignments:
+            if name.upper() == normalized_env_key:
+                is_set = True
+                value = assignment_value
+        if parsed.command_index is None or parsed.split_expansions:
+            break
+        index += parsed.command_index + 1
+    return is_set, value, True
 
 
 def _shell_directory_setup_segment_is_safe(command_name: str, segment_args: list[str]) -> bool:
@@ -7599,19 +7446,12 @@ def _shell_segment_uses_env_split_string_wrapper(segment: list[str], command_ind
         if command_name != "env":
             index += 1
             continue
-        index += 1
-        while index < command_index:
-            token = segment[index]
-            if _SHELL_ASSIGNMENT_PATTERN.match(token):
-                index += 1
-                continue
-            if token in {"-S", "--split-string"} or token.startswith("--split-string="):
-                return True
-            if _env_clustered_split_string_payload(token) is not None:
-                return True
-            if not token.startswith("-"):
-                break
-            index += _wrapper_option_tokens_consumed("env", token)
+        parsed = parse_env_wrapper(segment[index + 1 :])
+        if parsed.split_expansions:
+            return True
+        if not parsed.complete or parsed.command_index is None:
+            break
+        index += parsed.command_index + 1
     return False
 
 
@@ -7623,17 +7463,12 @@ def _shell_segment_uses_env_chdir(segment: list[str], command_index: int) -> boo
         if command_name != "env":
             index += 1
             continue
-        index += 1
-        while index < command_index:
-            token = segment[index]
-            if _SHELL_ASSIGNMENT_PATTERN.match(token):
-                index += 1
-                continue
-            if token in {"-C", "--chdir"} or token.startswith(("-C", "--chdir=")):
-                return True
-            if not token.startswith("-"):
-                break
-            index += _wrapper_option_tokens_consumed("env", token)
+        parsed = parse_env_wrapper(segment[index + 1 :])
+        if parsed.option_effects.chdir is not None:
+            return True
+        if not parsed.complete or parsed.command_index is None or parsed.split_expansions:
+            break
+        index += parsed.command_index + 1
     return False
 
 
@@ -7795,16 +7630,19 @@ def _pythonpath_search_roots_from_segment(
     if cwd is None:
         return []
     search_roots: list[Path] = []
-    for token in segment[:command_index]:
-        if _shell_env_assignment_key(token) != "PYTHONPATH":
+    is_set, path_value, complete = _shell_segment_explicit_env_value(
+        segment,
+        command_index,
+        "PYTHONPATH",
+    )
+    if not complete or not is_set or path_value is None:
+        return search_roots
+    for entry in path_value.split(":"):
+        normalized_entry = entry.strip()
+        if not normalized_entry:
             continue
-        path_value = token.split("=", 1)[1] if "=" in token else ""
-        for entry in path_value.split(":"):
-            normalized_entry = entry.strip()
-            if not normalized_entry:
-                continue
-            candidate = Path(normalized_entry)
-            search_roots.append(candidate if candidate.is_absolute() else cwd / candidate)
+        candidate = Path(normalized_entry)
+        search_roots.append(candidate if candidate.is_absolute() else cwd / candidate)
     return search_roots
 
 

--- a/src/codex_plugin_scanner/guard/runtime/shell_command_wrappers.py
+++ b/src/codex_plugin_scanner/guard/runtime/shell_command_wrappers.py
@@ -7,13 +7,14 @@ import shlex
 from dataclasses import dataclass
 from pathlib import Path
 
+from .env_wrapper import parse_env_wrapper
+
 SHELL_COMMAND_NORMALIZE_MAX_BYTES = 8192
 _ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
 _SHELL_CONTROL_TOKENS = frozenset({"&&", "||", ";", "|", "|&", "&"})
 _LEAN_CTX_BINARIES = frozenset({"lean-ctx"})
 _SHELL_STRING_WRAPPERS = frozenset({"ash", "bash", "dash", "fish", "sh", "zsh"})
 _PLAIN_WRAPPERS = frozenset({"command", "nice", "nohup", "stdbuf", "time"})
-_ENV_OPTION_FLAGS_WITH_VALUES = frozenset({"-u", "-C", "--unset", "--chdir"})
 _NICE_OPTION_FLAGS_WITH_VALUES = frozenset({"-n", "--adjustment"})
 _STDBUF_VALUE_FLAGS = frozenset({"-i", "-o", "-e"})
 _TIME_OPTION_FLAGS_WITH_VALUES = frozenset({"-f", "-o", "--format", "--output"})
@@ -128,19 +129,7 @@ def _normalize_parts(
                 inner_command_text = _join_command_fragments(_join_shell_tokens(preserved_env), inner_command_text)
             return inner_command_text, tuple((*wrappers, *inner_wrappers))
         if command_name == "env":
-            next_parts, env_prefix, env_split = _strip_env_wrapper(current)
-            if env_split is not None:
-                wrappers.append("env")
-                inner_text, inner_wrappers = _normalize_command_text(
-                    env_split,
-                    depth=depth + 1,
-                    cwd=cwd,
-                    home_dir=home_dir,
-                )
-                all_env = [*preserved_env, *env_prefix]
-                if all_env:
-                    inner_text = _join_command_fragments(_join_shell_tokens(all_env), inner_text)
-                return inner_text, tuple((*wrappers, *inner_wrappers))
+            next_parts, env_prefix = _strip_env_wrapper(current, cwd=cwd)
             if next_parts is None:
                 break
             wrappers.append("env")
@@ -231,49 +220,12 @@ def _unwrap_shell_string_wrapper(parts: list[str]) -> tuple[str, list[str]] | No
     return None
 
 
-def _strip_env_wrapper(parts: list[str]) -> tuple[list[str] | None, list[str], str | None]:
-    env_prefix: list[str] = []
-    index = 1
-    while index < len(parts):
-        token = parts[index]
-        if _ENV_ASSIGNMENT_RE.fullmatch(token):
-            env_prefix.append(token)
-            index += 1
-            continue
-        if token == "--":
-            return parts[index + 1 :], env_prefix, None
-        if token in {"-S", "--split-string"}:
-            if index + 1 >= len(parts):
-                return None, env_prefix, None
-            return [], env_prefix, parts[index + 1]
-        split_string = _env_clustered_split_string_payload(token)
-        if split_string is not None:
-            if split_string:
-                return [], env_prefix, split_string
-            if index + 1 >= len(parts):
-                return None, env_prefix, None
-            return [], env_prefix, parts[index + 1]
-        short_option_tokens = _env_short_option_tokens_consumed(token)
-        if short_option_tokens is not None:
-            if index + short_option_tokens - 1 >= len(parts):
-                return None, env_prefix, None
-            index += short_option_tokens
-            continue
-        if token in _ENV_OPTION_FLAGS_WITH_VALUES:
-            if index + 1 >= len(parts):
-                return None, env_prefix, None
-            index += 2
-            continue
-        if any(token.startswith(f"{flag}=") for flag in {"--unset", "--chdir", "--split-string"}):
-            if token.startswith("--split-string="):
-                return [], env_prefix, token.partition("=")[2]
-            index += 1
-            continue
-        if token.startswith("-"):
-            index += 1
-            continue
-        return parts[index:], env_prefix, None
-    return None, env_prefix, None
+def _strip_env_wrapper(parts: list[str], *, cwd: Path | None) -> tuple[list[str] | None, list[str]]:
+    parsed = parse_env_wrapper(parts[1:], cwd=cwd)
+    if not parsed.complete or not parsed.executable_argv:
+        return None, []
+    env_prefix = [f"{name}={value}" for name, value in parsed.environment_delta.assignments]
+    return list(parsed.executable_argv), env_prefix
 
 
 def _strip_command_wrapper(parts: list[str]) -> list[str] | None:
@@ -361,29 +313,6 @@ def _strip_stdbuf_wrapper(parts: list[str]) -> list[str] | None:
             continue
         return parts[index:]
     return None
-
-
-def _env_short_option_tokens_consumed(token: str) -> int | None:
-    if not token.startswith("-") or token.startswith("--") or len(token) <= 2:
-        return None
-    for index, flag_character in enumerate(token[1:], start=1):
-        if flag_character not in {"C", "S", "u"}:
-            continue
-        if index < len(token) - 1:
-            return 1
-        return 2
-    return 1
-
-
-def _env_clustered_split_string_payload(token: str) -> str | None:
-    if not token.startswith("-") or token.startswith("--") or len(token) <= 2:
-        return None
-    split_index = token.find("S", 1)
-    if split_index == -1:
-        return None
-    if split_index + 1 >= len(token):
-        return ""
-    return token[split_index + 1 :]
 
 
 def _command_name(

--- a/tests/test_guard_command_model.py
+++ b/tests/test_guard_command_model.py
@@ -30,6 +30,14 @@ def test_parse_shell_command_tracks_env_wrapper_path_override() -> None:
     assert parsed.path_overridden is True
 
 
+def test_parse_shell_command_consumes_option_like_env_operand_once() -> None:
+    parsed = parse_shell_command("env -u -i python -m pytest -q")
+
+    assert parsed.wrapper_chain == ("env",)
+    assert parsed.segments[0].executable == "python"
+    assert parsed.segments[0].arguments == ("-m", "pytest", "-q")
+
+
 def test_parse_shell_command_tracks_sudo_and_nested_environment_wrapper() -> None:
     parsed = parse_shell_command("sudo -n env PATH=/usr/bin:/bin git -C repo push --force")
 

--- a/tests/test_guard_env_wrapper.py
+++ b/tests/test_guard_env_wrapper.py
@@ -92,6 +92,24 @@ def test_repeated_unset_and_empty_path_apply_in_order() -> None:
     assert parsed.executable_argv == ("cmd",)
 
 
+def test_post_assignment_option_terminator_is_not_the_executable() -> None:
+    parsed = parse_env_wrapper(["NAME=value", "--", "cmd", "arg"])
+
+    assert parsed.complete is True
+    assert parsed.environment_delta.assignments == (("NAME", "value"),)
+    assert parsed.command_index == 2
+    assert parsed.executable_argv == ("cmd", "arg")
+
+
+@pytest.mark.parametrize("null_option", ("-0", "--null"))
+def test_null_output_options_preserve_wrapped_command(null_option: str) -> None:
+    parsed = parse_env_wrapper([null_option, "cmd", "arg"])
+
+    assert parsed.complete is True
+    assert parsed.option_effects.null_output is True
+    assert parsed.executable_argv == ("cmd", "arg")
+
+
 def test_split_string_expands_in_place_with_suffix_and_nested_options() -> None:
     parsed = parse_env_wrapper(["-iS", "'NAME=value' command 'two words'", "tail"])
 

--- a/tests/test_guard_env_wrapper.py
+++ b/tests/test_guard_env_wrapper.py
@@ -1,0 +1,183 @@
+"""P40 regressions for the shared Unix env wrapper state machine."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.env_wrapper import parse_env_wrapper
+from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
+from codex_plugin_scanner.guard.runtime.shell_command_wrappers import normalize_transparent_shell_command
+
+
+def test_option_operand_is_consumed_exactly_once() -> None:
+    parsed = parse_env_wrapper(
+        ["-u", "-i", "python", "-c", "pass"],
+        inherited_environment={"P40_SENTINEL": "inherited", "PATH": "/bin"},
+    )
+
+    assert parsed.complete is True
+    assert parsed.option_effects.ignore_environment is False
+    assert parsed.option_effects.unset_names == ("-i",)
+    assert parsed.executable_argv == ("python", "-c", "pass")
+    assert parsed.environment_dict() == {"P40_SENTINEL": "inherited", "PATH": "/bin"}
+
+
+def test_clear_unset_and_assignments_apply_in_operating_system_order() -> None:
+    parsed = parse_env_wrapper(
+        ["-u", "OLD", "-i", "OLD=restored", "PATH=/tool/bin", "command", "arg"],
+        inherited_environment={"OLD": "before", "SECRET": "inherited"},
+    )
+
+    assert parsed.complete is True
+    assert parsed.environment_delta.clear is True
+    assert parsed.environment_delta.unset_names == ("OLD",)
+    assert parsed.environment_delta.assignments == (("OLD", "restored"), ("PATH", "/tool/bin"))
+    assert parsed.environment_dict() == {"OLD": "restored", "PATH": "/tool/bin"}
+    assert parsed.executable_argv == ("command", "arg")
+
+
+@pytest.mark.parametrize(
+    ("tokens", "ignore_environment", "unset_names", "executable"),
+    (
+        (["-iu", "NAME", "cmd"], True, ("NAME",), ("cmd",)),
+        (["-ui", "cmd"], False, ("i",), ("cmd",)),
+        (["--unset=NAME", "--ignore-environment", "cmd"], True, ("NAME",), ("cmd",)),
+        (["--unset", "-i", "cmd"], False, ("-i",), ("cmd",)),
+        (["--", "-i", "arg"], False, (), ("-i", "arg")),
+    ),
+)
+def test_short_clusters_long_forms_and_option_boundary(
+    tokens: list[str],
+    ignore_environment: bool,
+    unset_names: tuple[str, ...],
+    executable: tuple[str, ...],
+) -> None:
+    parsed = parse_env_wrapper(tokens)
+
+    assert parsed.complete is True
+    assert parsed.option_effects.ignore_environment is ignore_environment
+    assert parsed.option_effects.unset_names == unset_names
+    assert parsed.executable_argv == executable
+
+
+def test_chdir_search_path_and_repeated_options_use_last_operand(tmp_path: Path) -> None:
+    parsed = parse_env_wrapper(
+        ["-C", "first", "--chdir=second", "-P/bin", "-P", "/usr/bin", "cmd"],
+        cwd=tmp_path,
+    )
+
+    assert parsed.complete is True
+    assert parsed.option_effects.chdir == "second"
+    assert parsed.option_effects.search_path == "/usr/bin"
+    assert parsed.effective_cwd == tmp_path / "second"
+    assert parsed.executable_argv == ("cmd",)
+
+
+def test_repeated_unset_and_empty_path_apply_in_order() -> None:
+    parsed = parse_env_wrapper(
+        ["-u", "OLD", "-uOLD", "PATH=", "cmd"],
+        inherited_environment={"OLD": "value", "PATH": "/bin"},
+    )
+
+    assert parsed.complete is True
+    assert parsed.option_effects.unset_names == ("OLD", "OLD")
+    assert parsed.environment_dict() == {"PATH": ""}
+    assert parsed.executable_argv == ("cmd",)
+
+
+def test_split_string_expands_in_place_with_suffix_and_nested_options() -> None:
+    parsed = parse_env_wrapper(["-iS", "'NAME=value' command 'two words'", "tail"])
+
+    assert parsed.complete is True
+    assert parsed.option_effects.ignore_environment is True
+    assert parsed.environment_delta.assignments == (("NAME", "value"),)
+    assert parsed.executable_argv == ("command", "two words", "tail")
+    assert parsed.split_expansions[0].payload == "'NAME=value' command 'two words'"
+    assert parsed.split_expansions[0].source_index == 1
+
+
+def test_nested_split_string_env_wrappers_are_bounded_and_unwrapped() -> None:
+    normalized = normalize_transparent_shell_command(
+        "env -S 'env -u PYTHONPATH rg -n fixture src'",
+    )
+
+    assert normalized.wrapper_chain == ("env", "env")
+    assert normalized.normalized_command == "rg -n fixture src"
+
+
+@pytest.mark.parametrize(
+    ("tokens", "error"),
+    (
+        (["-u"], "missing_unset_operand"),
+        (["--chdir"], "missing_chdir_operand"),
+        (["-S"], "missing_split_string_operand"),
+        (["--unknown", "cmd"], "unsupported_option"),
+        (["-x", "cmd"], "unsupported_option"),
+        (["-S", "'unterminated"], "split_string_syntax_error"),
+        (["NAME=value\x00", "cmd"], "nul_token"),
+    ),
+)
+def test_malformed_or_unsupported_options_are_incomplete(tokens: list[str], error: str) -> None:
+    parsed = parse_env_wrapper(tokens)
+
+    assert parsed.complete is False
+    assert parsed.error == error
+    assert parsed.command_index is None
+    assert parsed.executable_argv == ()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires a POSIX env executable")
+def test_parser_matches_real_env_for_option_like_unset_operand() -> None:
+    env_executable = shutil.which("env")
+    if env_executable is None:
+        pytest.skip("env executable is unavailable")
+    inherited = {"PATH": os.environ.get("PATH", ""), "P40_SENTINEL": "still-inherited"}
+    parsed = parse_env_wrapper(
+        ["-u", "-i", sys.executable, "-c", "import os; print(os.environ.get('P40_SENTINEL', 'missing'))"],
+        inherited_environment=inherited,
+    )
+    completed = subprocess.run(
+        [
+            env_executable,
+            "-u",
+            "-i",
+            sys.executable,
+            "-c",
+            "import os; print(os.environ.get('P40_SENTINEL', 'missing'))",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=inherited,
+    )
+
+    assert parsed.environment_dict() == inherited
+    assert completed.stdout.strip() == parsed.environment_dict()["P40_SENTINEL"]
+
+
+def test_option_like_unset_operand_does_not_hide_unsafe_pythonpath(tmp_path: Path) -> None:
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "env -u -i PYTHONPATH=./malicious python3 -m pytest -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
+def test_option_like_unset_operand_does_not_hide_sensitive_docker_context(tmp_path: Path) -> None:
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "env -u -i DOCKER_CONTEXT=prod docker compose ps"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "docker-sensitive command"

--- a/tests/test_guard_env_wrapper.py
+++ b/tests/test_guard_env_wrapper.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.guard.runtime.env_wrapper import parse_env_wrapper
+from codex_plugin_scanner.guard.runtime.package_intent_parser import parse_package_intent
 from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
 from codex_plugin_scanner.guard.runtime.shell_command_wrappers import normalize_transparent_shell_command
 
@@ -181,3 +182,24 @@ def test_option_like_unset_operand_does_not_hide_sensitive_docker_context(tmp_pa
 
     assert match is not None
     assert match.action_class == "docker-sensitive command"
+
+
+def test_env_chdir_resolution_failure_is_bound_as_unresolved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    blocked = tmp_path / "blocked"
+    original_resolve = Path.resolve
+
+    def _resolve(path: Path, strict: bool = False) -> Path:
+        if path == blocked:
+            raise RuntimeError("simulated symlink loop")
+        return original_resolve(path, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", _resolve)
+
+    intent = parse_package_intent("env -C blocked npm install example", workspace=tmp_path)
+
+    assert intent is not None
+    assert intent.execution_context_cwds == (str(tmp_path),)
+    assert intent.execution_context_hashes

--- a/tests/test_guard_package_runner_identity.py
+++ b/tests/test_guard_package_runner_identity.py
@@ -142,6 +142,29 @@ def test_env_search_path_option_resolves_the_executed_manager(tmp_path: Path) ->
     assert evidence.manager.resolved_path == str(manager.resolve())
 
 
+def test_option_like_unset_operand_does_not_replace_inherited_runner_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_workspace(workspace)
+    manager = tmp_path / "manager-bin" / "npx"
+    _write_executable(manager, "manager")
+    monkeypatch.setenv("PATH", str(manager.parent))
+
+    intent = parse_package_intent(
+        "env -u -i npx --no-install vitest --help",
+        workspace=workspace,
+    )
+
+    assert intent is not None
+    evidence = intent.local_executions[0]
+    assert evidence.path_source == "inherited"
+    assert evidence.manager is not None
+    assert evidence.manager.resolved_path == str(manager.resolve())
+
+
 @pytest.mark.parametrize("option", ["-S", "--split-string"])
 def test_env_split_string_preserves_package_runner_identity(
     tmp_path: Path,


### PR DESCRIPTION
## Security invariant

Guard must model Unix `env` option operands, environment changes, working-directory changes, and the launched argv in the same order as the operating system. In particular, an option-like token consumed by `-u` must not also be interpreted as a second option.

## What changed

- Added one bounded, typed `env` state machine shared by command identity, package intent, pytest/module checks, Docker and Kubernetes inspection, approval identity, local snapshots, redaction, and Codex tool-output handling.
- Models ignore-environment, unset, assignments, `-C`/`--chdir`, `-P`, `-S`/`--split-string`, `--`, attached operands, short clusters, repeated options, effective environment/cwd, source provenance, and explicit incomplete reason codes.
- Bounds split strings to 8 KiB, four expansions, and 256 resulting tokens; malformed quoting, NULs, missing operands, and unsupported implementation-specific options stay incomplete.
- Removed the competing env token-count/split/chdir parsers from consumers while retaining thin adapters around the canonical result.
- Preserved generic Python/Perl/Ruby inline-payload parsing after the wrapper refactor; the full-suite regression cluster for benign interpreter waits, inline literals, and GitHub read pipelines is green.

## Token-consumption evidence

| argv after `env` | Parsed effect | Executable |
| --- | --- | --- |
| `-u -i python ...` | unset variable named `-i`; inherited environment remains | `python ...` |
| `-u NAME -i python ...` | unset `NAME`, then clear the environment | `python ...` |
| `-iu NAME cmd` | clear environment, then unset `NAME` | `cmd` |
| `-ui cmd` | unset variable named `i`; does not clear | `cmd` |
| `NAME=value -- cmd` | apply assignment before launch | `cmd` |
| `-- -i arg` | end option parsing | `-i arg` |

A controlled POSIX subprocess comparison sets a harmless inherited marker and executes the exact `env -u -i ...` shape. Both the real child and Guard's model retain the marker.

## Validation

- Python 3.10 focused integration: 181 passed.
- Python 3.13 affected regression matrix after the final fix: 209 passed, 1,254 deselected.
- Earlier focused groups: 108 env/command/package tests, 50 Kubernetes/approval tests, and 41 wrapper/parser tests passed.
- Full Python 3.13 suite before the final interpreter-payload correction: 9,582 passed, 25 skipped, 5 deselected, 11 failed. The nine P40-adjacent failures (eight classifier/runtime cases plus the Cursor health fixture) all pass after the correction. The two remaining failures were environment-only: the OS keyring is unavailable on this host, and the full baseline intentionally installed the Cisco MCP extra while a test expected that optional dependency to be absent.
- CI-equivalent `ruff check src/` and `ruff format --check src/` pass on Python 3.10 and 3.13.
- Repository-wide test lint remains blocked by 46 unrelated errors already on `release/2.1`; none are in this PR's diff.
- `python -m build` produced both the sdist and wheel successfully.
- `git diff --check` passes.

## Stable parser errors

`missing_unset_operand`, `missing_chdir_operand`, `missing_search_path_operand`, `missing_split_string_operand`, `unsupported_option`, `invalid_unset_operand`, `invalid_chdir_operand`, `invalid_search_path_operand`, `split_string_syntax_error`, `split_string_nul`, `split_string_byte_limit_exceeded`, `split_string_limit_exceeded`, `token_limit_exceeded`, and `nul_token`.

## Attribution and target

- Base: `release/2.1`
- Author and committer for both commits: `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>`
