### PR TITLE
fix(codex): canonicalize hook migration identity

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -588,7 +588,7 @@ def _canonical_hook_semantics(
     hooks = payload.get("hooks")
     if not isinstance(hooks, Mapping):
         return {}
-    source_hooks_enabled = _payload_has_hooks_feature_enabled(dict(payload))
+    source_hooks_enabled = _payload_has_hooks_feature_enabled(payload)
     semantics: dict[str, tuple[str, ...]] = {}
     for event_name, groups in hooks.items():
         if not isinstance(event_name, str) or not isinstance(groups, list):
@@ -628,6 +628,7 @@ def _migration_group_identities(
     payload: Mapping[str, object],
     *,
     source_scope: str,
+    source_hooks_enabled: bool,
 ) -> set[str]:
     hooks = payload.get("hooks")
     if not isinstance(hooks, Mapping):
@@ -635,7 +636,7 @@ def _migration_group_identities(
     return {
         canonical_codex_hook_group_identity(
             source_scope=source_scope,
-            source_hooks_enabled=True,
+            source_hooks_enabled=source_hooks_enabled,
             event_name=event_name,
             group=group,
         )
@@ -775,9 +776,9 @@ def _codex_hook_artifacts(
     return tuple(artifacts)
 
 
-def _payload_has_hooks_feature_enabled(config_payload: dict[str, object]) -> bool:
+def _payload_has_hooks_feature_enabled(config_payload: Mapping[str, object]) -> bool:
     features = config_payload.get("features")
-    if not isinstance(features, dict):
+    if not isinstance(features, Mapping):
         return False
     return features.get("hooks") is True or features.get("codex_hooks") is True
 
@@ -1539,11 +1540,20 @@ class CodexHarnessAdapter(HarnessAdapter):
                 context=context,
                 owned_bindings=owned_bindings if config_path == hook_config_path else (),
             )
-            expected = _migration_group_identities(expected_payload, source_scope=source_scope)
+            written_payload = _strict_toml_object(config_path, label="migrated Codex config file")
+            source_hooks_enabled = _payload_has_hooks_feature_enabled(written_payload)
+            expected = _migration_group_identities(
+                expected_payload,
+                source_scope=source_scope,
+                source_hooks_enabled=source_hooks_enabled,
+            )
             if not expected:
                 continue
-            written_payload = _strict_toml_object(config_path, label="migrated Codex config file")
-            actual = _migration_group_identities(written_payload, source_scope=source_scope)
+            actual = _migration_group_identities(
+                written_payload,
+                source_scope=source_scope,
+                source_hooks_enabled=source_hooks_enabled,
+            )
             if not expected.issubset(actual):
                 raise RuntimeError(
                     f"{_CODEX_HOOK_MIGRATION_READBACK_MISMATCH}: {config_path} does not contain every canonical "

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -726,6 +726,8 @@ def _codex_hook_artifacts(
 ) -> tuple[GuardArtifact, ...]:
     by_identity: dict[str, list[CodexHookInventoryRecord]] = {}
     for record in records:
+        if record.ownership != "unmanaged":
+            continue
         by_identity.setdefault(record.canonical_identity, []).append(record)
     artifacts: list[GuardArtifact] = []
     for identity, matching_records in sorted(by_identity.items()):
@@ -746,7 +748,7 @@ def _codex_hook_artifacts(
             "codex_hook_identity_schema": CODEX_HOOK_IDENTITY_SCHEMA,
             "codex_hook_identity": identity,
             "event": primary.event_name,
-            "matcher": primary.matcher,
+            "matcher": primary.matcher if isinstance(primary.matcher, str | type(None)) else None,
             "handler_type": primary.handler_type,
             "timeout": primary.timeout,
             "env_keys": list(primary.environment_keys),
@@ -1007,6 +1009,9 @@ class CodexHarnessAdapter(HarnessAdapter):
         hook_records: list[CodexHookInventoryRecord] = []
         warnings: list[str] = []
         config_payloads: dict[Path, dict[str, object]] = {}
+        authenticated_manifest = load_hook_manifest_baseline(_hook_manifest_spec(context))
+        authenticated_bindings = _manifest_bindings(authenticated_manifest)
+        hook_config_path = self._hook_config_path(context)
         for config_path, _hooks_path in self._config_hook_pairs(context):
             payload = _read_toml(config_path)
             config_payloads[config_path] = payload
@@ -1021,6 +1026,7 @@ class CodexHarnessAdapter(HarnessAdapter):
                 source_format="toml",
                 source_hooks_enabled=_payload_has_hooks_feature_enabled(payload),
                 context=context,
+                authenticated_bindings=authenticated_bindings if config_path == hook_config_path else (),
             )
             hook_records.extend(inventory.records)
             warnings.extend(

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -32,8 +32,12 @@ from ..codex_hook_integrity import (
     write_hook_manifest,
 )
 from ..codex_hook_inventory import (
+    CODEX_HOOK_IDENTITY_SCHEMA,
     CODEX_HOOK_INVENTORY_UNMANAGED_EXECUTABLE,
     CodexHookInventory,
+    CodexHookInventoryRecord,
+    canonical_codex_hook_conflict_keys,
+    canonical_codex_hook_group_identity,
     enumerate_codex_hooks,
 )
 from ..codex_hook_manifest import (
@@ -470,13 +474,72 @@ def _current_install_legacy_bindings(context: HarnessContext, hooks: dict[str, o
     )
 
 
-def _append_unique_hook_groups(existing_groups: object, incoming_groups: object) -> list[object]:
+_CODEX_HOOK_MIGRATION_CONFLICT = "codex_hook_migration_conflict"
+_CODEX_HOOK_MIGRATION_READBACK_MISMATCH = "codex_hook_migration_readback_mismatch"
+
+
+def _append_unique_hook_groups(
+    existing_groups: object,
+    incoming_groups: object,
+    *,
+    event_name: str,
+    source_scope: str,
+    source_hooks_enabled: bool,
+) -> list[object]:
     merged = list(existing_groups) if isinstance(existing_groups, list) else []
     if not isinstance(incoming_groups, list):
         return merged
+    identities = {
+        canonical_codex_hook_group_identity(
+            source_scope=source_scope,
+            source_hooks_enabled=source_hooks_enabled,
+            event_name=event_name,
+            group=group,
+        )
+        for group in merged
+        if isinstance(group, Mapping)
+    }
+    conflict_keys = {
+        key
+        for group in merged
+        if isinstance(group, Mapping)
+        for key in canonical_codex_hook_conflict_keys(
+            source_scope=source_scope,
+            source_hooks_enabled=source_hooks_enabled,
+            event_name=event_name,
+            group=group,
+        )
+    }
     for group in incoming_groups:
-        if group not in merged:
-            merged.append(group)
+        if not isinstance(group, Mapping):
+            if group not in merged:
+                merged.append(group)
+            continue
+        identity = canonical_codex_hook_group_identity(
+            source_scope=source_scope,
+            source_hooks_enabled=source_hooks_enabled,
+            event_name=event_name,
+            group=group,
+        )
+        if identity in identities:
+            continue
+        incoming_conflicts = set(
+            canonical_codex_hook_conflict_keys(
+                source_scope=source_scope,
+                source_hooks_enabled=source_hooks_enabled,
+                event_name=event_name,
+                group=group,
+            )
+        )
+        if incoming_conflicts & conflict_keys:
+            raise RuntimeError(
+                f"{_CODEX_HOOK_MIGRATION_CONFLICT}: Codex hook sources define the same {event_name!r} "
+                "matcher and command with different execution-affecting fields. Reconcile the definitions before "
+                "retrying migration."
+            )
+        merged.append(deepcopy(group))
+        identities.add(identity)
+        conflict_keys.update(incoming_conflicts)
     return merged
 
 
@@ -485,6 +548,7 @@ def _migrate_hooks_json_into_config(
     hooks_payload: dict[str, object],
     *,
     context: HarnessContext,
+    source_scope: str,
     owned_bindings: Sequence[Mapping[str, object]] = (),
 ) -> bool:
     json_hooks = hooks_payload.get("hooks")
@@ -496,15 +560,126 @@ def _migrate_hooks_json_into_config(
     cleaned_json_hooks, _ = _remove_manifest_bound_hook_events(json_hooks, owned_bindings)
     legacy_bindings = _current_install_legacy_bindings(context, cleaned_json_hooks)
     cleaned_json_hooks, _ = _remove_manifest_bound_hook_events(cleaned_json_hooks, legacy_bindings)
+    source_hooks_enabled = _payload_has_hooks_feature_enabled(config_payload)
     changed = False
     for event_name, groups in cleaned_json_hooks.items():
-        merged_groups = _append_unique_hook_groups(config_hooks.get(event_name), groups)
+        if not isinstance(event_name, str):
+            continue
+        merged_groups = _append_unique_hook_groups(
+            config_hooks.get(event_name),
+            groups,
+            event_name=event_name,
+            source_scope=source_scope,
+            source_hooks_enabled=source_hooks_enabled,
+        )
         if merged_groups != config_hooks.get(event_name):
             changed = True
         config_hooks[event_name] = merged_groups
     if config_hooks:
         config_payload["hooks"] = config_hooks
     return changed
+
+
+def _canonical_hook_semantics(
+    payload: Mapping[str, object],
+    *,
+    source_scope: str,
+) -> dict[str, tuple[str, ...]]:
+    hooks = payload.get("hooks")
+    if not isinstance(hooks, Mapping):
+        return {}
+    source_hooks_enabled = _payload_has_hooks_feature_enabled(dict(payload))
+    semantics: dict[str, tuple[str, ...]] = {}
+    for event_name, groups in hooks.items():
+        if not isinstance(event_name, str) or not isinstance(groups, list):
+            continue
+        semantics[event_name] = tuple(
+            canonical_codex_hook_group_identity(
+                source_scope=source_scope,
+                source_hooks_enabled=source_hooks_enabled,
+                event_name=event_name,
+                group=group,
+            )
+            for group in groups
+            if isinstance(group, Mapping)
+        )
+    return semantics
+
+
+def _require_hook_semantics_readback(
+    expected: Mapping[str, object],
+    actual: Mapping[str, object],
+    *,
+    source_scope: str,
+    source_path: Path,
+) -> None:
+    if _canonical_hook_semantics(expected, source_scope=source_scope) != _canonical_hook_semantics(
+        actual,
+        source_scope=source_scope,
+    ):
+        raise RuntimeError(
+            f"{_CODEX_HOOK_MIGRATION_READBACK_MISMATCH}: Rendered Codex hooks at {source_path} did not preserve "
+            "their canonical event, matcher, handler, environment, timeout, status, and command semantics. The "
+            "legacy source was retained; repair the config and retry migration."
+        )
+
+
+def _migration_group_identities(
+    payload: Mapping[str, object],
+    *,
+    source_scope: str,
+) -> set[str]:
+    hooks = payload.get("hooks")
+    if not isinstance(hooks, Mapping):
+        return set()
+    return {
+        canonical_codex_hook_group_identity(
+            source_scope=source_scope,
+            source_hooks_enabled=True,
+            event_name=event_name,
+            group=group,
+        )
+        for event_name, groups in hooks.items()
+        if isinstance(event_name, str) and isinstance(groups, list)
+        for group in groups
+        if isinstance(group, Mapping)
+    }
+
+
+def _unmanaged_migration_payload(
+    hooks_payload: Mapping[str, object],
+    *,
+    context: HarnessContext,
+    owned_bindings: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    hooks = hooks_payload.get("hooks")
+    if not isinstance(hooks, dict):
+        return {}
+    cleaned_hooks, _ = _remove_manifest_bound_hook_events(hooks, owned_bindings)
+    legacy_bindings = _current_install_legacy_bindings(context, cleaned_hooks)
+    cleaned_hooks, _ = _remove_manifest_bound_hook_events(cleaned_hooks, legacy_bindings)
+    return {"hooks": cleaned_hooks} if cleaned_hooks else {}
+
+
+def _write_hook_migration_backup(
+    context: HarnessContext,
+    *,
+    config_path: Path,
+) -> Path:
+    resolved_path = str(config_path.resolve())
+    digest = hashlib.sha256(resolved_path.encode("utf-8")).hexdigest()[:16]
+    backup_path = context.guard_home / "managed" / "codex" / "migration-backups" / f"{digest}.json"
+    if backup_path.exists():
+        return backup_path
+    content = config_path.read_text(encoding="utf-8") if config_path.is_file() else ""
+    backup_payload = {
+        "schema": "codex-hook-migration-backup-v1",
+        "config_path": resolved_path,
+        "existed": config_path.is_file(),
+        "content": content,
+    }
+    atomic_write_text(backup_path, json.dumps(backup_payload, sort_keys=True, indent=2) + "\n", mode=0o600)
+    return backup_path
 
 
 def _codex_hook_inventory(
@@ -542,6 +717,60 @@ def _require_complete_preactivation_inventory(inventory: CodexHookInventory) -> 
             f"without explicit approval; unmanaged executable hooks are present at {coordinates} in "
             f"{inventory.source_path}. Review or remove those hooks before running install."
         )
+
+
+def _codex_hook_artifacts(
+    records: Sequence[CodexHookInventoryRecord],
+    *,
+    harness: str,
+) -> tuple[GuardArtifact, ...]:
+    by_identity: dict[str, list[CodexHookInventoryRecord]] = {}
+    for record in records:
+        by_identity.setdefault(record.canonical_identity, []).append(record)
+    artifacts: list[GuardArtifact] = []
+    for identity, matching_records in sorted(by_identity.items()):
+        ordered = sorted(
+            matching_records,
+            key=lambda record: (record.source_path, record.source_format, record.coordinate),
+        )
+        primary = ordered[0]
+        provenance = [
+            {
+                "path": record.source_path,
+                "format": record.source_format,
+                "coordinate": record.coordinate,
+            }
+            for record in ordered
+        ]
+        metadata: dict[str, object] = {
+            "codex_hook_identity_schema": CODEX_HOOK_IDENTITY_SCHEMA,
+            "codex_hook_identity": identity,
+            "event": primary.event_name,
+            "matcher": primary.matcher,
+            "handler_type": primary.handler_type,
+            "timeout": primary.timeout,
+            "env_keys": list(primary.environment_keys),
+            "command_argv": list(primary.command_argv) if primary.command_argv is not None else None,
+            "active": primary.active and primary.source_hooks_enabled,
+            "executable": primary.executable,
+            "ownership": sorted({record.ownership for record in ordered}),
+            "source_provenance": provenance,
+            "source_formats": sorted({record.source_format for record in ordered}),
+            "source_paths": sorted({record.source_path for record in ordered}),
+        }
+        artifacts.append(
+            GuardArtifact(
+                artifact_id=f"codex:{primary.source_scope}:hook:{identity}",
+                name=primary.event_name,
+                harness=harness,
+                artifact_type="hook",
+                source_scope=primary.source_scope,
+                config_path=primary.source_path,
+                command=primary.command,
+                metadata=metadata,
+            )
+        )
+    return tuple(artifacts)
 
 
 def _payload_has_hooks_feature_enabled(config_payload: dict[str, object]) -> bool:
@@ -773,17 +1002,31 @@ class CodexHarnessAdapter(HarnessAdapter):
         return tuple(pairs)
 
     def detect(self, context: HarnessContext) -> HarnessDetection:
-        config_paths = [context.home_dir / ".codex" / "config.toml"]
-        if context.workspace_dir is not None:
-            config_paths.append(context.workspace_dir / ".codex" / "config.toml")
         artifacts: list[GuardArtifact] = []
         found_paths: list[str] = []
-        for config_path in config_paths:
+        hook_records: list[CodexHookInventoryRecord] = []
+        warnings: list[str] = []
+        config_payloads: dict[Path, dict[str, object]] = {}
+        for config_path, _hooks_path in self._config_hook_pairs(context):
             payload = _read_toml(config_path)
+            config_payloads[config_path] = payload
             if not payload:
                 continue
             found_paths.append(str(config_path))
             scope = self._scope_for(context, config_path)
+            inventory = _codex_hook_inventory(
+                payload,
+                source_path=config_path,
+                source_scope=scope,
+                source_format="toml",
+                source_hooks_enabled=_payload_has_hooks_feature_enabled(payload),
+                context=context,
+            )
+            hook_records.extend(inventory.records)
+            warnings.extend(
+                f"{issue.reason_code}: {issue.coordinate} in {issue.source_path}. {issue.message}"
+                for issue in inventory.issues
+            )
             mcp_servers = payload.get("mcp_servers")
             if isinstance(mcp_servers, dict):
                 for name, server_config in mcp_servers.items():
@@ -842,47 +1085,34 @@ class CodexHarnessAdapter(HarnessAdapter):
                             metadata=mcp_metadata,
                         )
                     )
-        hooks_paths = [context.home_dir / ".codex" / "hooks.json"]
-        if context.workspace_dir is not None:
-            hooks_paths.append(context.workspace_dir / ".codex" / "hooks.json")
-        for hooks_path in hooks_paths:
+        for config_path, hooks_path in self._config_hook_pairs(context):
             hooks_payload = _json_object(hooks_path)
-            hooks = hooks_payload.get("hooks")
-            if not isinstance(hooks, dict):
+            if not hooks_path.is_file():
                 continue
             found_paths.append(str(hooks_path))
             scope = self._scope_for(context, hooks_path)
-            hook_groups = hooks.get("PreToolUse")
-            if not isinstance(hook_groups, list):
-                continue
-            for group_index, group in enumerate(hook_groups):
-                if not isinstance(group, dict):
-                    continue
-                handlers = group.get("hooks")
-                if not isinstance(handlers, list):
-                    continue
-                for handler_index, handler in enumerate(handlers):
-                    if not isinstance(handler, dict):
-                        continue
-                    command = handler.get("command")
-                    artifacts.append(
-                        GuardArtifact(
-                            artifact_id=f"codex:{scope}:pretooluse:{group_index}:{handler_index}",
-                            name="PreToolUse",
-                            harness=self.harness,
-                            artifact_type="hook",
-                            source_scope=scope,
-                            config_path=str(hooks_path),
-                            command=command if isinstance(command, str) else None,
-                        )
-                    )
+            config_payload = config_payloads.get(config_path, {})
+            inventory = _codex_hook_inventory(
+                hooks_payload,
+                source_path=hooks_path,
+                source_scope=scope,
+                source_format="json",
+                source_hooks_enabled=_payload_has_hooks_feature_enabled(config_payload),
+                context=context,
+            )
+            hook_records.extend(inventory.records)
+            warnings.extend(
+                f"{issue.reason_code}: {issue.coordinate} in {issue.source_path}. {issue.message}"
+                for issue in inventory.issues
+            )
+        artifacts.extend(_codex_hook_artifacts(hook_records, harness=self.harness))
         detection = HarnessDetection(
             harness=self.harness,
             installed=bool(found_paths) or _command_available(self.executable),
             command_available=_command_available(self.executable),
             config_paths=tuple(found_paths),
             artifacts=tuple(artifacts),
-            warnings=(),
+            warnings=tuple(warnings),
         )
         extended = extend_detection_with_workspace_aibom(
             detection,
@@ -952,8 +1182,11 @@ class CodexHarnessAdapter(HarnessAdapter):
             hook_payload,
             target_hook_payload,
             context=context,
+            source_scope=self._scope_for(context, hook_config_path),
             owned_bindings=owned_bindings,
         )
+        if target_hooks_migrated:
+            _write_hook_migration_backup(context, config_path=hook_config_path)
         backup_path = self._backup_path(context)
         if not backup_path.exists():
             backup_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1010,6 +1243,11 @@ class CodexHarnessAdapter(HarnessAdapter):
             context,
             managed_servers=managed_servers,
             skip_config_path=target_config_path,
+        )
+        self._verify_json_hook_migrations(
+            context,
+            payloads=hook_payloads,
+            owned_bindings=owned_bindings,
         )
         hooks_path = self._remove_json_hook_files(context, payloads=hook_payloads)
         self._uninstall_shell_guard(context)
@@ -1175,11 +1413,28 @@ class CodexHarnessAdapter(HarnessAdapter):
                     config_payload,
                     hooks_payload,
                     context=context,
+                    source_scope=self._scope_for(context, config_path),
                     owned_bindings=owned_bindings,
                 )
                 and config_payload
             ):
-                atomic_write_text(config_path, dump_toml(config_payload), mode=0o600)
+                _write_hook_migration_backup(context, config_path=config_path)
+                original_text = config_path.read_text(encoding="utf-8") if config_path.is_file() else None
+                try:
+                    atomic_write_text(config_path, dump_toml(config_payload), mode=0o600)
+                    written_payload = _strict_toml_object(config_path, label="rendered Codex config file")
+                    _require_hook_semantics_readback(
+                        config_payload,
+                        written_payload,
+                        source_scope=self._scope_for(context, config_path),
+                        source_path=config_path,
+                    )
+                except BaseException:
+                    if original_text is None:
+                        config_path.unlink(missing_ok=True)
+                    else:
+                        atomic_write_text(config_path, original_text, mode=0o600)
+                    raise
 
     def _remove_managed_hooks_from_alternate_configs(
         self,
@@ -1260,6 +1515,36 @@ class CodexHarnessAdapter(HarnessAdapter):
                 config_payload.pop("mcp_servers", None)
             write_toml_payload(config_path, config_payload)
 
+    def _verify_json_hook_migrations(
+        self,
+        context: HarnessContext,
+        *,
+        payloads: Mapping[Path, Mapping[str, object]],
+        owned_bindings: Sequence[Mapping[str, object]],
+    ) -> None:
+        hook_config_path = self._hook_config_path(context)
+        for config_path, hooks_path in self._config_hook_pairs(context):
+            hooks_payload = payloads.get(hooks_path)
+            if not hooks_payload:
+                continue
+            source_scope = self._scope_for(context, config_path)
+            expected_payload = _unmanaged_migration_payload(
+                hooks_payload,
+                context=context,
+                owned_bindings=owned_bindings if config_path == hook_config_path else (),
+            )
+            expected = _migration_group_identities(expected_payload, source_scope=source_scope)
+            if not expected:
+                continue
+            written_payload = _strict_toml_object(config_path, label="migrated Codex config file")
+            actual = _migration_group_identities(written_payload, source_scope=source_scope)
+            if not expected.issubset(actual):
+                raise RuntimeError(
+                    f"{_CODEX_HOOK_MIGRATION_READBACK_MISMATCH}: {config_path} does not contain every canonical "
+                    f"hook migrated from {hooks_path}. The legacy JSON source was retained; repair the config and "
+                    "retry migration."
+                )
+
     def _remove_json_hook_files(
         self,
         context: HarnessContext,
@@ -1267,9 +1552,18 @@ class CodexHarnessAdapter(HarnessAdapter):
         payloads: dict[Path, dict[str, object]],
     ) -> Path:
         target_hooks_path = self._hooks_path(context)
-        for hooks_path in self._all_hook_paths(context):
-            if hooks_path in payloads and hooks_path.is_file():
+        snapshots = {
+            hooks_path: snapshot_regular_file(hooks_path)
+            for hooks_path in self._all_hook_paths(context)
+            if hooks_path in payloads and hooks_path.is_file()
+        }
+        try:
+            for hooks_path in snapshots:
                 hooks_path.unlink()
+        except BaseException:
+            for hooks_path, snapshot in snapshots.items():
+                restore_private_file(hooks_path, snapshot)
+            raise
         return target_hooks_path
 
     def _install_hooks(self, context: HarnessContext, *, payloads: dict[Path, dict[str, object]] | None = None) -> Path:
@@ -1342,6 +1636,13 @@ class CodexHarnessAdapter(HarnessAdapter):
             _assert_package_reauthentication_is_safe(previous_manifest, manifest)
             write_hook_manifest(context.guard_home, config_path, manifest)
             atomic_write_text(config_path, dump_toml(payload), mode=0o600)
+            written_payload = _strict_toml_object(config_path, label="rendered Codex config file")
+            _require_hook_semantics_readback(
+                payload,
+                written_payload,
+                source_scope=CodexHarnessAdapter._scope_for(context, config_path),
+                source_path=config_path,
+            )
             state = codex_native_hook_state(context)
             if not bool(state.get("protection_active")):
                 reason = str(state.get("integrity_reason") or "codex_hook_integrity_readback_failed")

--- a/src/codex_plugin_scanner/guard/codex_hook_identity.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_identity.py
@@ -1,0 +1,177 @@
+"""Canonical, serialization-independent identities for Codex hooks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import shlex
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime, time
+from typing import Any
+
+CODEX_HOOK_IDENTITY_SCHEMA = "codex-hook-identity-v1"
+
+_SHELL_SENSITIVE_COMMAND_RE = re.compile(r"[\\'\"`$|&;<>(){}\[\]*?!~#\r\n]")
+
+
+def canonical_codex_hook_identity(
+    *,
+    source_scope: str,
+    source_hooks_enabled: bool,
+    event_name: str,
+    group: Mapping[str, object],
+    handler: Mapping[str, object],
+) -> str:
+    """Return one format- and coordinate-independent handler identity."""
+
+    payload = {
+        "schema": CODEX_HOOK_IDENTITY_SCHEMA,
+        "source_scope": source_scope,
+        "source_hooks_enabled": source_hooks_enabled,
+        "event": event_name,
+        "matcher": _canonical_value(group.get("matcher")),
+        "group": _canonical_mapping(group, excluded_keys=frozenset({"hooks", "matcher"})),
+        "handler": _canonical_handler(handler),
+    }
+    return _canonical_digest(payload)
+
+
+def canonical_codex_hook_group_identity(
+    *,
+    source_scope: str,
+    source_hooks_enabled: bool,
+    event_name: str,
+    group: Mapping[str, object],
+) -> str:
+    """Return a canonical identity for one complete matcher group."""
+
+    raw_handlers = group.get("hooks")
+    if isinstance(raw_handlers, list):
+        canonical_handlers: list[object] = []
+        for handler in raw_handlers:
+            if isinstance(handler, Mapping):
+                canonical_handlers.append(_canonical_handler(handler))
+            else:
+                canonical_handlers.append(_canonical_value(handler))
+        handlers: object = canonical_handlers
+    else:
+        handlers = _canonical_value(raw_handlers)
+    payload = {
+        "schema": f"{CODEX_HOOK_IDENTITY_SCHEMA}:group",
+        "source_scope": source_scope,
+        "source_hooks_enabled": source_hooks_enabled,
+        "event": event_name,
+        "matcher": _canonical_value(group.get("matcher")),
+        "group": _canonical_mapping(group, excluded_keys=frozenset({"hooks", "matcher"})),
+        "handlers": handlers,
+    }
+    return _canonical_digest(payload)
+
+
+def canonical_codex_hook_conflict_keys(
+    *,
+    source_scope: str,
+    source_hooks_enabled: bool,
+    event_name: str,
+    group: Mapping[str, object],
+) -> tuple[str, ...]:
+    """Identify handler slots whose differing definitions must not be collapsed."""
+
+    raw_handlers = group.get("hooks")
+    if not isinstance(raw_handlers, list):
+        return ()
+    keys: list[str] = []
+    for handler in raw_handlers:
+        if not isinstance(handler, Mapping):
+            continue
+        raw_command = handler.get("command")
+        if isinstance(raw_command, str):  # noqa: SIM108 - keep identity branches explicit
+            command = _canonical_command(raw_command)
+        else:
+            command = _canonical_value(raw_command)
+        payload = {
+            "schema": f"{CODEX_HOOK_IDENTITY_SCHEMA}:conflict",
+            "source_scope": source_scope,
+            "source_hooks_enabled": source_hooks_enabled,
+            "event": event_name,
+            "matcher": _canonical_value(group.get("matcher")),
+            "handler_type": _canonical_value(handler.get("type")),
+            "command": command,
+        }
+        keys.append(_canonical_digest(payload))
+    return tuple(keys)
+
+
+def canonical_codex_command_argv(command: str | None) -> tuple[str, ...] | None:
+    """Normalize only commands whose shell tokenization is provably uncomplicated."""
+
+    if command is None or _SHELL_SENSITIVE_COMMAND_RE.search(command):
+        return None
+    try:
+        argv = tuple(shlex.split(command, posix=True))
+    except ValueError:
+        return None
+    return argv or None
+
+
+def _canonical_handler(handler: Mapping[str, object]) -> dict[str, object]:
+    values = _canonical_mapping(handler, excluded_keys=frozenset({"command"}))
+    raw_command = handler.get("command")
+    if isinstance(raw_command, str):
+        values["command"] = _canonical_command(raw_command)
+    else:
+        values["command"] = _canonical_value(raw_command)
+    return values
+
+
+def _canonical_command(command: str) -> dict[str, object]:
+    argv = canonical_codex_command_argv(command)
+    if argv is not None:
+        return {"mode": "argv", "argv": list(argv)}
+    return {"mode": "shell", "text": command}
+
+
+def _canonical_mapping(
+    value: Mapping[Any, Any],
+    *,
+    excluded_keys: frozenset[str] = frozenset(),
+) -> dict[str, object]:
+    items: list[tuple[str, object]] = []
+    for key, item in value.items():
+        if isinstance(key, str) and key in excluded_keys:
+            continue
+        canonical_key = key if isinstance(key, str) else f"<{type(key).__name__}>:{key!r}"
+        items.append((canonical_key, _canonical_value(item)))
+    return {key: item for key, item in sorted(items, key=lambda pair: pair[0])}
+
+
+def _canonical_value(value: object) -> object:
+    if value is None or isinstance(value, str | bool | int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return {"type": "float", "value": repr(value)}
+        return int(value) if value.is_integer() else value
+    if isinstance(value, Mapping):
+        return _canonical_mapping(value)
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_canonical_value(item) for item in value]
+    if isinstance(value, datetime | date | time):
+        return {"type": type(value).__name__, "value": value.isoformat()}
+    return {"type": type(value).__name__, "value": repr(value)}
+
+
+def _canonical_digest(payload: object) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+__all__ = [
+    "CODEX_HOOK_IDENTITY_SCHEMA",
+    "canonical_codex_command_argv",
+    "canonical_codex_hook_conflict_keys",
+    "canonical_codex_hook_group_identity",
+    "canonical_codex_hook_identity",
+]

--- a/src/codex_plugin_scanner/guard/codex_hook_inventory.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_inventory.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import math
+import re
+import shlex
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from datetime import date, datetime, time
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 CODEX_HOOK_INVENTORY_UNMANAGED_EXECUTABLE = "codex_hook_inventory_unmanaged_executable"
 CODEX_HOOK_INVENTORY_UNSUPPORTED_EVENT = "codex_hook_inventory_unsupported_event_shape"
@@ -17,6 +22,9 @@ CODEX_HOOK_INVENTORY_SOURCE_DUPLICATE = "codex_hook_inventory_source_duplicate_k
 CODEX_HOOK_INVENTORY_SOURCE_MALFORMED = "codex_hook_inventory_source_malformed"
 CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE = "codex_hook_inventory_source_unreadable"
 CODEX_HOOK_INVENTORY_SOURCE_CHANGED = "codex_hook_inventory_source_changed"
+CODEX_HOOK_IDENTITY_SCHEMA = "codex-hook-identity-v1"
+
+_SHELL_SENSITIVE_COMMAND_RE = re.compile(r"[\\'\"`$|&;<>(){}\[\]*?!~#\r\n]")
 
 HookSourceFormat = Literal["json", "toml"]
 HookOwnership = Literal["authenticated_manifest", "exact_legacy_adoption", "unmanaged"]
@@ -36,11 +44,13 @@ class CodexHookInventoryRecord:
     handler_index: int
     handler_type: str | None
     command: str | None
+    command_argv: tuple[str, ...] | None
     timeout: int | float | None
     environment_keys: tuple[str, ...]
     active: bool
     executable: bool
     ownership: HookOwnership
+    canonical_identity: str
 
     @property
     def coordinate(self) -> str:
@@ -186,6 +196,155 @@ def enumerate_codex_hooks(
     return CodexHookInventory(str(source_path), tuple(records), tuple(issues))
 
 
+def canonical_codex_hook_identity(
+    *,
+    source_scope: str,
+    source_hooks_enabled: bool,
+    event_name: str,
+    group: Mapping[str, object],
+    handler: Mapping[str, object],
+) -> str:
+    """Return one format- and coordinate-independent handler identity."""
+
+    payload = {
+        "schema": CODEX_HOOK_IDENTITY_SCHEMA,
+        "source_scope": source_scope,
+        "source_hooks_enabled": source_hooks_enabled,
+        "event": event_name,
+        "matcher": _canonical_value(group.get("matcher")),
+        "group": _canonical_mapping(group, excluded_keys=frozenset({"hooks", "matcher"})),
+        "handler": _canonical_handler(handler),
+    }
+    return _canonical_digest(payload)
+
+
+def canonical_codex_hook_group_identity(
+    *,
+    source_scope: str,
+    source_hooks_enabled: bool,
+    event_name: str,
+    group: Mapping[str, object],
+) -> str:
+    """Return a canonical identity for one complete matcher group."""
+
+    raw_handlers = group.get("hooks")
+    handlers = (
+        [
+            _canonical_handler(handler) if isinstance(handler, Mapping) else _canonical_value(handler)
+            for handler in raw_handlers
+        ]
+        if isinstance(raw_handlers, list)
+        else _canonical_value(raw_handlers)
+    )
+    payload = {
+        "schema": f"{CODEX_HOOK_IDENTITY_SCHEMA}:group",
+        "source_scope": source_scope,
+        "source_hooks_enabled": source_hooks_enabled,
+        "event": event_name,
+        "matcher": _canonical_value(group.get("matcher")),
+        "group": _canonical_mapping(group, excluded_keys=frozenset({"hooks", "matcher"})),
+        "handlers": handlers,
+    }
+    return _canonical_digest(payload)
+
+
+def canonical_codex_hook_conflict_keys(
+    *,
+    source_scope: str,
+    source_hooks_enabled: bool,
+    event_name: str,
+    group: Mapping[str, object],
+) -> tuple[str, ...]:
+    """Identify handler slots whose differing definitions must not be collapsed."""
+
+    raw_handlers = group.get("hooks")
+    if not isinstance(raw_handlers, list):
+        return ()
+    keys: list[str] = []
+    for handler in raw_handlers:
+        if not isinstance(handler, Mapping):
+            continue
+        raw_command = handler.get("command")
+        payload = {
+            "schema": f"{CODEX_HOOK_IDENTITY_SCHEMA}:conflict",
+            "source_scope": source_scope,
+            "source_hooks_enabled": source_hooks_enabled,
+            "event": event_name,
+            "matcher": _canonical_value(group.get("matcher")),
+            "handler_type": _canonical_value(handler.get("type")),
+            "command": _canonical_command(raw_command)
+            if isinstance(raw_command, str)
+            else _canonical_value(raw_command),
+        }
+        keys.append(_canonical_digest(payload))
+    return tuple(keys)
+
+
+def canonical_codex_command_argv(command: str | None) -> tuple[str, ...] | None:
+    """Normalize only commands whose shell tokenization is provably uncomplicated."""
+
+    if command is None or _SHELL_SENSITIVE_COMMAND_RE.search(command):
+        return None
+    try:
+        argv = tuple(shlex.split(command, posix=True))
+    except ValueError:
+        return None
+    return argv or None
+
+
+def _canonical_handler(handler: Mapping[str, object]) -> object:
+    values = _canonical_mapping(handler, excluded_keys=frozenset({"command"}))
+    if not isinstance(values, dict):  # pragma: no cover - Mapping always canonicalizes to a dict
+        return values
+    raw_command = handler.get("command")
+    values["command"] = (
+        _canonical_command(raw_command) if isinstance(raw_command, str) else _canonical_value(raw_command)
+    )
+    return values
+
+
+def _canonical_command(command: str) -> dict[str, object]:
+    argv = canonical_codex_command_argv(command)
+    if argv is not None:
+        return {"mode": "argv", "argv": list(argv)}
+    return {"mode": "shell", "text": command}
+
+
+def _canonical_mapping(
+    value: Mapping[Any, Any],
+    *,
+    excluded_keys: frozenset[str] = frozenset(),
+) -> dict[str, object]:
+    items: list[tuple[str, object]] = []
+    for key, item in value.items():
+        if isinstance(key, str) and key in excluded_keys:
+            continue
+        canonical_key = key if isinstance(key, str) else f"<{type(key).__name__}>:{key!r}"
+        items.append((canonical_key, _canonical_value(item)))
+    return {key: item for key, item in sorted(items, key=lambda pair: pair[0])}
+
+
+def _canonical_value(value: object) -> object:
+    if value is None or isinstance(value, str | bool | int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return {"type": "float", "value": repr(value)}
+        return int(value) if value.is_integer() else value
+    if isinstance(value, Mapping):
+        return _canonical_mapping(value)
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_canonical_value(item) for item in value]
+    if isinstance(value, datetime | date | time):
+        return {"type": type(value).__name__, "value": value.isoformat()}
+    return {"type": type(value).__name__, "value": repr(value)}
+
+
+def _canonical_digest(payload: object) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
 def _handler_record(
     handler: object,
     *,
@@ -287,6 +446,14 @@ def _handler_record(
         authenticated_bindings=authenticated_bindings,
         legacy_bindings=legacy_bindings,
     )
+    command_argv = canonical_codex_command_argv(command)
+    canonical_identity = canonical_codex_hook_identity(
+        source_scope=source_scope,
+        source_hooks_enabled=source_hooks_enabled,
+        event_name=event_name,
+        group=group,
+        handler=handler,
+    )
     record = CodexHookInventoryRecord(
         source_path=str(source_path),
         source_scope=source_scope,
@@ -298,11 +465,13 @@ def _handler_record(
         handler_index=handler_index,
         handler_type=handler_type,
         command=command,
+        command_argv=command_argv,
         timeout=timeout,
         environment_keys=environment_keys,
         active=group_active and _entry_is_active(handler),
         executable=executable,
         ownership=ownership,
+        canonical_identity=canonical_identity,
     )
     return record, tuple(issues)
 
@@ -386,6 +555,7 @@ def _bindings_contain_handler(
 
 
 __all__ = [
+    "CODEX_HOOK_IDENTITY_SCHEMA",
     "CODEX_HOOK_INVENTORY_MALFORMED_GROUP",
     "CODEX_HOOK_INVENTORY_MALFORMED_HANDLER",
     "CODEX_HOOK_INVENTORY_SOURCE_CHANGED",
@@ -398,5 +568,9 @@ __all__ = [
     "CodexHookInventory",
     "CodexHookInventoryIssue",
     "CodexHookInventoryRecord",
+    "canonical_codex_command_argv",
+    "canonical_codex_hook_conflict_keys",
+    "canonical_codex_hook_group_identity",
+    "canonical_codex_hook_identity",
     "enumerate_codex_hooks",
 ]

--- a/src/codex_plugin_scanner/guard/codex_hook_inventory.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_inventory.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 import math
-import re
-import shlex
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from datetime import date, datetime, time
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
+
+from .codex_hook_identity import (
+    CODEX_HOOK_IDENTITY_SCHEMA,
+    canonical_codex_command_argv,
+    canonical_codex_hook_conflict_keys,
+    canonical_codex_hook_group_identity,
+    canonical_codex_hook_identity,
+)
 
 CODEX_HOOK_INVENTORY_UNMANAGED_EXECUTABLE = "codex_hook_inventory_unmanaged_executable"
 CODEX_HOOK_INVENTORY_UNSUPPORTED_EVENT = "codex_hook_inventory_unsupported_event_shape"
@@ -22,10 +25,6 @@ CODEX_HOOK_INVENTORY_SOURCE_DUPLICATE = "codex_hook_inventory_source_duplicate_k
 CODEX_HOOK_INVENTORY_SOURCE_MALFORMED = "codex_hook_inventory_source_malformed"
 CODEX_HOOK_INVENTORY_SOURCE_UNREADABLE = "codex_hook_inventory_source_unreadable"
 CODEX_HOOK_INVENTORY_SOURCE_CHANGED = "codex_hook_inventory_source_changed"
-CODEX_HOOK_IDENTITY_SCHEMA = "codex-hook-identity-v1"
-
-_SHELL_SENSITIVE_COMMAND_RE = re.compile(r"[\\'\"`$|&;<>(){}\[\]*?!~#\r\n]")
-
 HookSourceFormat = Literal["json", "toml"]
 HookOwnership = Literal["authenticated_manifest", "exact_legacy_adoption", "unmanaged"]
 
@@ -194,155 +193,6 @@ def enumerate_codex_hooks(
                     records.append(record)
                 issues.extend(handler_issues)
     return CodexHookInventory(str(source_path), tuple(records), tuple(issues))
-
-
-def canonical_codex_hook_identity(
-    *,
-    source_scope: str,
-    source_hooks_enabled: bool,
-    event_name: str,
-    group: Mapping[str, object],
-    handler: Mapping[str, object],
-) -> str:
-    """Return one format- and coordinate-independent handler identity."""
-
-    payload = {
-        "schema": CODEX_HOOK_IDENTITY_SCHEMA,
-        "source_scope": source_scope,
-        "source_hooks_enabled": source_hooks_enabled,
-        "event": event_name,
-        "matcher": _canonical_value(group.get("matcher")),
-        "group": _canonical_mapping(group, excluded_keys=frozenset({"hooks", "matcher"})),
-        "handler": _canonical_handler(handler),
-    }
-    return _canonical_digest(payload)
-
-
-def canonical_codex_hook_group_identity(
-    *,
-    source_scope: str,
-    source_hooks_enabled: bool,
-    event_name: str,
-    group: Mapping[str, object],
-) -> str:
-    """Return a canonical identity for one complete matcher group."""
-
-    raw_handlers = group.get("hooks")
-    handlers = (
-        [
-            _canonical_handler(handler) if isinstance(handler, Mapping) else _canonical_value(handler)
-            for handler in raw_handlers
-        ]
-        if isinstance(raw_handlers, list)
-        else _canonical_value(raw_handlers)
-    )
-    payload = {
-        "schema": f"{CODEX_HOOK_IDENTITY_SCHEMA}:group",
-        "source_scope": source_scope,
-        "source_hooks_enabled": source_hooks_enabled,
-        "event": event_name,
-        "matcher": _canonical_value(group.get("matcher")),
-        "group": _canonical_mapping(group, excluded_keys=frozenset({"hooks", "matcher"})),
-        "handlers": handlers,
-    }
-    return _canonical_digest(payload)
-
-
-def canonical_codex_hook_conflict_keys(
-    *,
-    source_scope: str,
-    source_hooks_enabled: bool,
-    event_name: str,
-    group: Mapping[str, object],
-) -> tuple[str, ...]:
-    """Identify handler slots whose differing definitions must not be collapsed."""
-
-    raw_handlers = group.get("hooks")
-    if not isinstance(raw_handlers, list):
-        return ()
-    keys: list[str] = []
-    for handler in raw_handlers:
-        if not isinstance(handler, Mapping):
-            continue
-        raw_command = handler.get("command")
-        payload = {
-            "schema": f"{CODEX_HOOK_IDENTITY_SCHEMA}:conflict",
-            "source_scope": source_scope,
-            "source_hooks_enabled": source_hooks_enabled,
-            "event": event_name,
-            "matcher": _canonical_value(group.get("matcher")),
-            "handler_type": _canonical_value(handler.get("type")),
-            "command": _canonical_command(raw_command)
-            if isinstance(raw_command, str)
-            else _canonical_value(raw_command),
-        }
-        keys.append(_canonical_digest(payload))
-    return tuple(keys)
-
-
-def canonical_codex_command_argv(command: str | None) -> tuple[str, ...] | None:
-    """Normalize only commands whose shell tokenization is provably uncomplicated."""
-
-    if command is None or _SHELL_SENSITIVE_COMMAND_RE.search(command):
-        return None
-    try:
-        argv = tuple(shlex.split(command, posix=True))
-    except ValueError:
-        return None
-    return argv or None
-
-
-def _canonical_handler(handler: Mapping[str, object]) -> object:
-    values = _canonical_mapping(handler, excluded_keys=frozenset({"command"}))
-    if not isinstance(values, dict):  # pragma: no cover - Mapping always canonicalizes to a dict
-        return values
-    raw_command = handler.get("command")
-    values["command"] = (
-        _canonical_command(raw_command) if isinstance(raw_command, str) else _canonical_value(raw_command)
-    )
-    return values
-
-
-def _canonical_command(command: str) -> dict[str, object]:
-    argv = canonical_codex_command_argv(command)
-    if argv is not None:
-        return {"mode": "argv", "argv": list(argv)}
-    return {"mode": "shell", "text": command}
-
-
-def _canonical_mapping(
-    value: Mapping[Any, Any],
-    *,
-    excluded_keys: frozenset[str] = frozenset(),
-) -> dict[str, object]:
-    items: list[tuple[str, object]] = []
-    for key, item in value.items():
-        if isinstance(key, str) and key in excluded_keys:
-            continue
-        canonical_key = key if isinstance(key, str) else f"<{type(key).__name__}>:{key!r}"
-        items.append((canonical_key, _canonical_value(item)))
-    return {key: item for key, item in sorted(items, key=lambda pair: pair[0])}
-
-
-def _canonical_value(value: object) -> object:
-    if value is None or isinstance(value, str | bool | int):
-        return value
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            return {"type": "float", "value": repr(value)}
-        return int(value) if value.is_integer() else value
-    if isinstance(value, Mapping):
-        return _canonical_mapping(value)
-    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
-        return [_canonical_value(item) for item in value]
-    if isinstance(value, datetime | date | time):
-        return {"type": type(value).__name__, "value": value.isoformat()}
-    return {"type": type(value).__name__, "value": repr(value)}
-
-
-def _canonical_digest(payload: object) -> str:
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
 
 
 def _handler_record(

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -120,7 +120,33 @@ def _serialize_artifact(artifact: GuardArtifact) -> dict[str, object]:
     return payload
 
 
+def _codex_hook_identity(artifact: GuardArtifact) -> str | None:
+    if artifact.harness != "codex" or artifact.artifact_type != "hook":
+        return None
+    identity = artifact.metadata.get("codex_hook_identity")
+    return identity if isinstance(identity, str) and identity else None
+
+
+def _snapshot_codex_hook_identity(snapshot: Mapping[str, object]) -> str | None:
+    if snapshot.get("harness") != "codex" or snapshot.get("artifact_type") != "hook":
+        return None
+    metadata = snapshot.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return None
+    identity = metadata.get("codex_hook_identity")
+    return identity if isinstance(identity, str) and identity else None
+
+
 def _hash_payload(artifact: GuardArtifact) -> dict[str, object]:
+    codex_hook_identity = _codex_hook_identity(artifact)
+    if codex_hook_identity is not None:
+        return {
+            "schema": "codex-hook-artifact-hash-v1",
+            "harness": artifact.harness,
+            "artifact_type": artifact.artifact_type,
+            "source_scope": artifact.source_scope,
+            "codex_hook_identity": codex_hook_identity,
+        }
     payload = artifact.to_dict()
     metadata = artifact.metadata
     if (
@@ -170,6 +196,19 @@ def diff_artifact(previous: dict[str, object] | None, current: GuardArtifact) ->
             "current_snapshot": current_payload,
         }
     previous_payload = dict(previous)
+    previous_codex_hook_identity = _snapshot_codex_hook_identity(previous_payload)
+    current_codex_hook_identity = _codex_hook_identity(current)
+    if current_codex_hook_identity is not None and previous_codex_hook_identity == current_codex_hook_identity:
+        previous_hash = previous.get("artifact_hash")
+        previous_hash_value = previous_hash if isinstance(previous_hash, str) else None
+        hash_changed = previous_hash_value is not None and previous_hash_value != current_hash
+        return {
+            "changed": hash_changed,
+            "changed_fields": ["metadata"] if hash_changed else [],
+            "previous_hash": previous_hash_value,
+            "current_hash": current_hash,
+            "current_snapshot": current_payload,
+        }
     if "env_keys" not in previous_payload:
         previous_payload["env_keys"] = []
     changed_fields = [key for key, value in current_payload.items() if previous_payload.get(key) != value]
@@ -496,6 +535,12 @@ def _consumer_execution_identity(
 
 
 def _consumer_context_metadata(artifact: GuardArtifact) -> dict[str, object]:
+    codex_hook_identity = _codex_hook_identity(artifact)
+    if codex_hook_identity is not None:
+        return {
+            "codex_hook_identity_schema": artifact.metadata.get("codex_hook_identity_schema"),
+            "codex_hook_identity": codex_hook_identity,
+        }
     if artifact.artifact_type != "prompt_request":
         return dict(artifact.metadata)
     return {
@@ -587,8 +632,29 @@ def _consumer_approval_context_token(
     effective_cwd = _consumer_effective_cwd(config)
     normalized_cwd = _normalized_consumer_path(effective_cwd)
     normalized_workspace = _normalized_consumer_path(config.workspace) if config.workspace is not None else None
-    return build_approval_context_token(
-        identity={
+    codex_hook_identity = _codex_hook_identity(artifact)
+    if codex_hook_identity is not None:
+        identity_payload: dict[str, object] = {
+            "artifact_id": artifact.artifact_id,
+            "artifact_name": artifact.name,
+            "artifact_type": artifact.artifact_type,
+            "codex_hook_identity": codex_hook_identity,
+            "config_path": f"codex-hook://{artifact.source_scope}",
+            "cwd": normalized_cwd,
+            "detection_harness": detection.harness,
+            "executable": {"codex_hook_identity": codex_hook_identity},
+            "harness": artifact.harness,
+            "publisher": artifact.publisher,
+            "source_scope": artifact.source_scope,
+            "workspace": normalized_workspace,
+        }
+        content_payload: dict[str, object] = {
+            "artifact_hash": content_hash,
+            "codex_hook_identity": codex_hook_identity,
+            "metadata": _consumer_context_metadata(artifact),
+        }
+    else:
+        identity_payload = {
             "artifact_id": artifact.artifact_id,
             "artifact_name": artifact.name,
             "artifact_type": artifact.artifact_type,
@@ -605,14 +671,17 @@ def _consumer_approval_context_token(
             "publisher": artifact.publisher,
             "source_scope": artifact.source_scope,
             "workspace": normalized_workspace,
-        },
-        content={
+        }
+        content_payload = {
             "args": list(artifact.args),
             "artifact_hash": content_hash,
             "command": artifact.command,
             "metadata": _consumer_context_metadata(artifact),
             "url": artifact.url,
-        },
+        }
+    return build_approval_context_token(
+        identity=identity_payload,
+        content=content_payload,
         capabilities={
             "artifact_capabilities": dict(capability_snapshot),
             "command_available": detection.command_available,

--- a/tests/test_codex_hook_identity.py
+++ b/tests/test_codex_hook_identity.py
@@ -146,6 +146,25 @@ def test_event_name_is_part_of_canonical_identity(tmp_path: Path) -> None:
     )
 
 
+def test_migration_identity_uses_the_written_hook_activation_state() -> None:
+    payload: dict[str, object] = {"hooks": {"PreToolUse": [_group()]}}
+
+    disabled = codex_adapter._migration_group_identities(
+        payload,
+        source_scope="global",
+        source_hooks_enabled=False,
+    )
+    enabled = codex_adapter._migration_group_identities(
+        payload,
+        source_scope="global",
+        source_hooks_enabled=True,
+    )
+
+    assert len(disabled) == 1
+    assert len(enabled) == 1
+    assert disabled != enabled
+
+
 def test_detect_inventories_every_toml_event_and_deduplicates_mixed_sources(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     config_path = home_dir / ".codex" / "config.toml"

--- a/tests/test_codex_hook_identity.py
+++ b/tests/test_codex_hook_identity.py
@@ -1,0 +1,318 @@
+"""P23 regressions for format-independent Codex hook identity and migration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import codex as codex_adapter
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.codex_config import dump_toml
+from codex_plugin_scanner.guard.codex_hook_inventory import enumerate_codex_hooks
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.consumer.service import (
+    _consumer_approval_context_token,
+    artifact_hash,
+    diff_artifact,
+)
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+from codex_plugin_scanner.guard.types import ProvenanceBundle
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _group(
+    command: str = "python3 hook.py",
+    *,
+    matcher: str = "Bash",
+    handler_type: str = "command",
+    **handler_fields: object,
+) -> dict[str, object]:
+    return {
+        "matcher": matcher,
+        "hooks": [{"type": handler_type, "command": command, **handler_fields}],
+    }
+
+
+def _record_identity(
+    group: dict[str, object],
+    *,
+    event: str = "PreToolUse",
+    source_format: str = "json",
+    tmp_path: Path,
+) -> str:
+    inventory = enumerate_codex_hooks(
+        {"hooks": {event: [group]}},
+        source_path=tmp_path / ("hooks.json" if source_format == "json" else "config.toml"),
+        source_scope="global",
+        source_format="json" if source_format == "json" else "toml",
+        source_hooks_enabled=True,
+    )
+    assert len(inventory.records) == 1
+    return inventory.records[0].canonical_identity
+
+
+def _hook_artifact(detection: HarnessDetection, event: str) -> GuardArtifact:
+    return next(
+        artifact for artifact in detection.artifacts if artifact.artifact_type == "hook" and artifact.name == event
+    )
+
+
+def _approval_token(
+    detection: HarnessDetection,
+    artifact: GuardArtifact,
+    *,
+    tmp_path: Path,
+) -> str:
+    return _consumer_approval_context_token(
+        detection=detection,
+        artifact=artifact,
+        content_hash=artifact_hash(artifact),
+        capability_snapshot={},
+        structured_signals=(),
+        provenance=ProvenanceBundle(),
+        config=GuardConfig(guard_home=tmp_path / "guard-home", workspace=None),
+        configured_action=None,
+        effective_default_action=None,
+        current_action="review",
+        runtime_detector_context=None,
+    )
+
+
+def test_json_and_toml_inventory_share_identity_for_plain_argv_and_mapping_order(tmp_path: Path) -> None:
+    json_group = {
+        "matcher": "Bash",
+        "description": "fixture",
+        "hooks": [
+            {
+                "type": "command",
+                "command": "python3   hook.py --mode safe",
+                "env": {"SECOND": "2", "FIRST": "1"},
+                "timeout": 12,
+            }
+        ],
+    }
+    toml_group = {
+        "hooks": [
+            {
+                "timeout": 12.0,
+                "env": {"FIRST": "1", "SECOND": "2"},
+                "command": "python3 hook.py --mode safe",
+                "type": "command",
+            }
+        ],
+        "description": "fixture",
+        "matcher": "Bash",
+    }
+
+    assert _record_identity(json_group, tmp_path=tmp_path) == _record_identity(
+        toml_group,
+        source_format="toml",
+        tmp_path=tmp_path,
+    )
+
+
+@pytest.mark.parametrize(
+    "changed_group",
+    (
+        _group(env={"MODE": "changed"}),
+        _group(timeout=13),
+        _group(matcher="Read"),
+        _group(command="python3 'hook.py'"),
+        _group(handler_type="future-command"),
+        _group(statusMessage="changed status"),
+    ),
+)
+def test_execution_affecting_hook_fields_have_distinct_identities(
+    tmp_path: Path,
+    changed_group: dict[str, object],
+) -> None:
+    assert _record_identity(_group(), tmp_path=tmp_path) != _record_identity(changed_group, tmp_path=tmp_path)
+
+
+def test_event_name_is_part_of_canonical_identity(tmp_path: Path) -> None:
+    group = _group()
+
+    assert _record_identity(group, event="PreToolUse", tmp_path=tmp_path) != _record_identity(
+        group,
+        event="FutureAgentEvent",
+        tmp_path=tmp_path,
+    )
+
+
+def test_detect_inventories_every_toml_event_and_deduplicates_mixed_sources(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    config_path = home_dir / ".codex" / "config.toml"
+    hooks_path = home_dir / ".codex" / "hooks.json"
+    shared_toml_group = _group("python3 hook.py")
+    shared_json_group = _group("python3   hook.py")
+    _write(
+        config_path,
+        dump_toml(
+            {
+                "features": {"hooks": True},
+                "hooks": {
+                    "FutureAgentEvent": [shared_toml_group],
+                    "Stop": [_group("python3 stop.py", matcher="stop")],
+                },
+            }
+        ),
+    )
+    _write(hooks_path, json.dumps({"hooks": {"FutureAgentEvent": [shared_json_group]}}) + "\n")
+
+    detection = codex_adapter.CodexHarnessAdapter().detect(
+        HarnessContext(home_dir=home_dir, workspace_dir=None, guard_home=tmp_path / "guard-home")
+    )
+    hook_artifacts = [artifact for artifact in detection.artifacts if artifact.artifact_type == "hook"]
+    future = _hook_artifact(detection, "FutureAgentEvent")
+
+    assert {artifact.name for artifact in hook_artifacts} == {"FutureAgentEvent", "Stop"}
+    assert len(hook_artifacts) == 2
+    assert future.metadata["source_formats"] == ["json", "toml"]
+    assert future.metadata["source_paths"] == sorted([str(config_path), str(hooks_path)])
+
+
+def test_hash_diff_and_approval_identity_survive_json_to_toml_format_change(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    config_path = home_dir / ".codex" / "config.toml"
+    hooks_path = home_dir / ".codex" / "hooks.json"
+    _write(config_path, dump_toml({"features": {"hooks": True}}))
+    _write(hooks_path, json.dumps({"hooks": {"FutureAgentEvent": [_group()]}}) + "\n")
+    adapter = codex_adapter.CodexHarnessAdapter()
+    context = HarnessContext(home_dir=home_dir, workspace_dir=None, guard_home=tmp_path / "guard-home")
+    json_detection = adapter.detect(context)
+    json_artifact = _hook_artifact(json_detection, "FutureAgentEvent")
+
+    hooks_path.unlink()
+    _write(
+        config_path,
+        dump_toml({"features": {"hooks": True}, "hooks": {"FutureAgentEvent": [_group()]}}),
+    )
+    toml_detection = adapter.detect(context)
+    toml_artifact = _hook_artifact(toml_detection, "FutureAgentEvent")
+    previous = {**json_artifact.to_dict(), "artifact_hash": artifact_hash(json_artifact)}
+
+    assert json_artifact.artifact_id == toml_artifact.artifact_id
+    assert artifact_hash(json_artifact) == artifact_hash(toml_artifact)
+    assert diff_artifact(previous, toml_artifact)["changed"] is False
+    assert _approval_token(json_detection, json_artifact, tmp_path=tmp_path) == _approval_token(
+        toml_detection,
+        toml_artifact,
+        tmp_path=tmp_path,
+    )
+
+    tampered_previous = {**previous, "artifact_hash": "0" * 64}
+    tampered_diff = diff_artifact(tampered_previous, toml_artifact)
+    assert tampered_diff["changed"] is True
+    assert tampered_diff["changed_fields"] == ["metadata"]
+
+
+def test_migration_deduplicates_only_canonical_equivalents_and_surfaces_conflicts(tmp_path: Path) -> None:
+    context = HarnessContext(home_dir=tmp_path / "home", workspace_dir=None, guard_home=tmp_path / "guard")
+    config_payload: dict[str, object] = {
+        "features": {"hooks": True},
+        "hooks": {"PreToolUse": [_group("python3 hook.py", timeout=12)]},
+    }
+    equivalent = {"hooks": {"PreToolUse": [_group("python3   hook.py", timeout=12.0)]}}
+
+    changed = codex_adapter._migrate_hooks_json_into_config(
+        config_payload,
+        equivalent,
+        context=context,
+        source_scope="global",
+    )
+
+    assert changed is False
+    assert len(config_payload["hooks"]["PreToolUse"]) == 1  # type: ignore[index]
+
+    conflicting = {"hooks": {"PreToolUse": [_group("python3 hook.py", timeout=13)]}}
+    with pytest.raises(RuntimeError, match="codex_hook_migration_conflict"):
+        codex_adapter._migrate_hooks_json_into_config(
+            config_payload,
+            conflicting,
+            context=context,
+            source_scope="global",
+        )
+
+
+def test_readback_failure_preserves_original_toml_and_legacy_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    guard_home = tmp_path / "guard-home"
+    config_path = home_dir / ".codex" / "config.toml"
+    hooks_path = home_dir / ".codex" / "hooks.json"
+    original_config = '[features]\nhooks = true\nmodel = "fixture"\n'
+    original_hooks = json.dumps({"hooks": {"FutureAgentEvent": [_group()]}}) + "\n"
+    _write(config_path, original_config)
+    _write(hooks_path, original_hooks)
+
+    def _fail_readback(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("injected canonical readback failure")
+
+    monkeypatch.setattr(codex_adapter, "_require_hook_semantics_readback", _fail_readback)
+
+    with pytest.raises(RuntimeError, match="injected canonical readback failure"):
+        codex_adapter.CodexHarnessAdapter().install(
+            HarnessContext(home_dir=home_dir, workspace_dir=None, guard_home=guard_home)
+        )
+
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert hooks_path.read_text(encoding="utf-8") == original_hooks
+    backups = list((guard_home / "managed" / "codex" / "migration-backups").glob("*.json"))
+    assert len(backups) == 1
+    assert json.loads(backups[0].read_text(encoding="utf-8"))["content"] == original_config
+
+
+def test_partial_unlink_failure_restores_every_legacy_source_and_keeps_toml_backups(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    home_config = home_dir / ".codex" / "config.toml"
+    workspace_config = workspace_dir / ".codex" / "config.toml"
+    home_hooks = home_dir / ".codex" / "hooks.json"
+    workspace_hooks = workspace_dir / ".codex" / "hooks.json"
+    original_home_config = '[features]\nhooks = true\nmodel = "fixture"\n'
+    original_workspace_config = '[features]\nhooks = true\napproval_policy = "never"\n'
+    original_home_hooks = json.dumps({"hooks": {"FutureGlobalEvent": [_group("python3 global.py")]}}) + "\n"
+    original_workspace_hooks = json.dumps({"hooks": {"FutureProjectEvent": [_group("python3 project.py")]}}) + "\n"
+    _write(home_config, original_home_config)
+    _write(workspace_config, original_workspace_config)
+    _write(home_hooks, original_home_hooks)
+    _write(workspace_hooks, original_workspace_hooks)
+    original_unlink = Path.unlink
+    failed = False
+
+    def _unlink(path: Path, missing_ok: bool = False) -> None:
+        nonlocal failed
+        if path == workspace_hooks and not failed:
+            failed = True
+            raise OSError("injected legacy unlink failure")
+        original_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", _unlink)
+
+    with pytest.raises(OSError, match="injected legacy unlink failure"):
+        codex_adapter.CodexHarnessAdapter().install(
+            HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=guard_home)
+        )
+
+    assert home_hooks.read_text(encoding="utf-8") == original_home_hooks
+    assert workspace_hooks.read_text(encoding="utf-8") == original_workspace_hooks
+    backup_payloads = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in (guard_home / "managed" / "codex" / "migration-backups").glob("*.json")
+    ]
+    assert {payload["content"] for payload in backup_payloads} == {
+        original_home_config,
+        original_workspace_config,
+    }

--- a/tests/test_codex_hook_identity.py
+++ b/tests/test_codex_hook_identity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
@@ -40,7 +41,7 @@ def _group(
 
 
 def _record_identity(
-    group: dict[str, object],
+    group: Mapping[str, object],
     *,
     event: str = "PreToolUse",
     source_format: str = "json",
@@ -218,7 +219,7 @@ def test_migration_deduplicates_only_canonical_equivalents_and_surfaces_conflict
         "features": {"hooks": True},
         "hooks": {"PreToolUse": [_group("python3 hook.py", timeout=12)]},
     }
-    equivalent = {"hooks": {"PreToolUse": [_group("python3   hook.py", timeout=12.0)]}}
+    equivalent: dict[str, object] = {"hooks": {"PreToolUse": [_group("python3   hook.py", timeout=12.0)]}}
 
     changed = codex_adapter._migrate_hooks_json_into_config(
         config_payload,
@@ -228,9 +229,13 @@ def test_migration_deduplicates_only_canonical_equivalents_and_surfaces_conflict
     )
 
     assert changed is False
-    assert len(config_payload["hooks"]["PreToolUse"]) == 1  # type: ignore[index]
+    config_hooks = config_payload["hooks"]
+    assert isinstance(config_hooks, dict)
+    pre_tool_use = config_hooks["PreToolUse"]
+    assert isinstance(pre_tool_use, list)
+    assert len(pre_tool_use) == 1
 
-    conflicting = {"hooks": {"PreToolUse": [_group("python3 hook.py", timeout=13)]}}
+    conflicting: dict[str, object] = {"hooks": {"PreToolUse": [_group("python3 hook.py", timeout=13)]}}
     with pytest.raises(RuntimeError, match="codex_hook_migration_conflict"):
         codex_adapter._migrate_hooks_json_into_config(
             config_payload,

--- a/tests/test_codex_hook_identity.py
+++ b/tests/test_codex_hook_identity.py
@@ -178,6 +178,17 @@ def test_detect_inventories_every_toml_event_and_deduplicates_mixed_sources(tmp_
     assert future.metadata["source_paths"] == sorted([str(config_path), str(hooks_path)])
 
 
+def test_authenticated_guard_hooks_do_not_become_consumer_artifacts(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    context = HarnessContext(home_dir=home_dir, workspace_dir=None, guard_home=tmp_path / "guard-home")
+    adapter = codex_adapter.CodexHarnessAdapter()
+
+    adapter.install(context)
+    detection = adapter.detect(context)
+
+    assert not [artifact for artifact in detection.artifacts if artifact.artifact_type == "hook"]
+
+
 def test_hash_diff_and_approval_identity_survive_json_to_toml_format_change(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     config_path = home_dir / ".codex" / "config.toml"


### PR DESCRIPTION
## Summary

- introduce one canonical Codex hook identity shared by JSON/TOML inventory and migration
- inventory TOML hooks and every event, deduplicating format-equivalent handlers while retaining source provenance
- bind event, matcher, handler type, command semantics, environment, timeout, activation/status fields, scope, and unknown execution fields into the canonical hash
- keep shell-sensitive command text verbatim and normalize only uncomplicated command argv
- make migration reject conflicting duplicate definitions, verify rendered TOML semantics before deleting JSON, retain private pre-migration TOML backups, and restore every legacy JSON source after a partial unlink failure
- keep artifact hashes, snapshot diffs, and approval context stable across a JSON-to-TOML-only format move while still detecting changed fields and stored-hash tampering

## Canonical inventory comparison

Before migration, a legacy JSON `FutureAgentEvent` handler and its TOML equivalent now produce the same `codex-hook-identity-v1` digest and the same `codex:<scope>:hook:<digest>` artifact ID. While both sources exist, detection returns one artifact with `source_formats = ["json", "toml"]`; after JSON removal, the artifact ID, artifact hash, and approval token remain unchanged and only the retained source provenance becomes TOML-only.

Changing environment values, timeout, matcher, event, handler type, status behavior, or quoting-sensitive command text produces a different canonical digest. A dependency or mapping-order-only change does not.

## Validation

- Python 3.10: 127 Codex identity/inventory/install/boundary tests passed
- final affected Python 3.13 matrix: 671 tests passed
- basedpyright: 0 errors on changed implementation and regression files (Python 3.10 and 3.13)
- Ruff check/format: passed
- full Python 3.13 suite: 9,617 passed, 26 skipped, 5 deselected; the initial run exposed seven managed-hook artifact regressions, all fixed and replayed green in `3b0a4467`
- the five remaining failed nodes reproduce identically on clean `origin/release/2.1` (`2c2ff509`): three inherited Bun/supply-chain cases, one Vitest approval-output case, and the host OS credential-store case
- `python -m build`: built `hol_guard-2.0.1113.tar.gz` and `hol_guard-2.0.1113-py3-none-any.whl`

Base: `release/2.1`
