### PR TITLE
fix(codex): isolate authenticated hook fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,13 @@ jobs:
           tests/test_guard_aibom_detection.py
           tests/test_guard_aibom_content_upload_batches.py
           tests/test_guard_aibom_skill_directory_identity.py
+          --tb=short
+      - name: Run Windows Codex hook process-tree regressions
+        if: runner.os == 'Windows'
+        run: >-
+          uv run --no-sync pytest
           tests/test_codex_hook_fallback_isolation.py
+          -k "isolated_process_timeout_kills_descendants or isolated_process_closes_descendant_held_pipes_after_parent_exit"
           --tb=short
 
   windows-updater:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
           tests/test_guard_aibom_detection.py
           tests/test_guard_aibom_content_upload_batches.py
           tests/test_guard_aibom_skill_directory_identity.py
+          tests/test_codex_hook_fallback_isolation.py
           --tb=short
 
   windows-updater:

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -442,6 +442,7 @@ def _hook_packaged_file_paths() -> tuple[tuple[str, Path], ...]:
         ("daemon_manager", daemon_root / "manager.py"),
         ("launch_runtime", guard_root / "codex_hook_launch_runtime.py"),
         ("runtime_trust", guard_root / "codex_hook_runtime_trust.py"),
+        ("windows_job", guard_root / "codex_hook_windows_job.py"),
     )
 
 

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -232,6 +232,7 @@ def _local_hook_command_parts_for_home_mode(
     home_is_current: bool,
     python_executable: str,
 ) -> tuple[str, ...]:
+    runtime_guard_home = (resolve_guard_home() if home_is_current else context.guard_home).resolve(strict=False)
     guard_args = [
         "guard",
         "hook",
@@ -240,8 +241,8 @@ def _local_hook_command_parts_for_home_mode(
     ]
     if not home_is_current:
         guard_args.extend(["--home", str(context.home_dir)])
-        if context.guard_home.resolve() != context.home_dir.resolve():
-            guard_args.extend(["--guard-home", str(context.guard_home)])
+        if runtime_guard_home != context.home_dir.resolve():
+            guard_args.extend(["--guard-home", str(runtime_guard_home)])
     if context.workspace_dir is not None:
         guard_args.extend(["--workspace", str(context.workspace_dir)])
     package_root = Path(__file__).resolve().parents[3]
@@ -259,7 +260,8 @@ def _home_is_current(context: HarnessContext) -> bool:
 
 
 def _runtime_guard_home(context: HarnessContext) -> Path:
-    return resolve_guard_home() if _home_is_current(context) else context.guard_home
+    guard_home = resolve_guard_home() if _home_is_current(context) else context.guard_home
+    return guard_home.resolve(strict=False)
 
 
 def _local_hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
@@ -281,7 +283,7 @@ def _hook_command_parts_for_home_mode(
     home_is_current: bool,
     python_executable: str,
 ) -> tuple[str, ...]:
-    guard_home = resolve_guard_home() if home_is_current else context.guard_home
+    guard_home = (resolve_guard_home() if home_is_current else context.guard_home).resolve(strict=False)
     query = {"guard-home": str(guard_home)}
     if not home_is_current:
         query["home"] = str(context.home_dir)

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -40,6 +40,7 @@ from ..codex_hook_inventory import (
     canonical_codex_hook_group_identity,
     enumerate_codex_hooks,
 )
+from ..codex_hook_launch_runtime import isolated_daemon_start_command, isolated_guard_cli_command
 from ..codex_hook_manifest import (
     CodexHookManifestSpec,
     build_authenticated_hook_manifest,
@@ -243,7 +244,8 @@ def _local_hook_command_parts_for_home_mode(
             guard_args.extend(["--guard-home", str(context.guard_home)])
     if context.workspace_dir is not None:
         guard_args.extend(["--workspace", str(context.workspace_dir)])
-    return (python_executable, "-m", "codex_plugin_scanner.cli", *guard_args)
+    package_root = Path(__file__).resolve().parents[3]
+    return isolated_guard_cli_command(python_executable, package_root, guard_args)
 
 
 def _guard_python_executable() -> str:
@@ -270,14 +272,7 @@ def _local_hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
 
 def _daemon_start_command(guard_home: Path, *, python_executable: str = sys.executable) -> tuple[str, ...]:
     package_root = Path(__file__).resolve().parents[3]
-    code = (
-        "import sys;"
-        f"sys.path.insert(0, {str(package_root)!r});"
-        "from pathlib import Path;"
-        "from codex_plugin_scanner.guard.daemon import ensure_guard_daemon;"
-        f"ensure_guard_daemon(Path({str(guard_home)!r}))"
-    )
-    return (python_executable, "-c", code)
+    return isolated_daemon_start_command(python_executable, package_root, guard_home)
 
 
 def _hook_command_parts_for_home_mode(
@@ -295,6 +290,12 @@ def _hook_command_parts_for_home_mode(
     long_timeout = _post_tool_hook_timeout_seconds(context)
     config = {
         "state_path": str(guard_home / "daemon-state.json"),
+        "manifest_path": str(
+            hook_manifest_path(
+                guard_home,
+                CodexHarnessAdapter._hook_config_path(context),
+            )
+        ),
         "fallback_command": list(
             _local_hook_command_parts_for_home_mode(
                 context,
@@ -312,7 +313,7 @@ def _hook_command_parts_for_home_mode(
         },
     }
     bridge_path = Path(__file__).with_name("codex_daemon_hook_bridge.py").resolve()
-    return (python_executable, str(bridge_path), json.dumps(config, separators=(",", ":")))
+    return (python_executable, "-I", str(bridge_path), json.dumps(config, separators=(",", ":")))
 
 
 def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
@@ -429,12 +430,16 @@ def _manifest_event_bindings(context: HarnessContext) -> list[dict[str, object]]
 
 def _hook_packaged_file_paths() -> tuple[tuple[str, Path], ...]:
     scanner_root = Path(__file__).resolve().parents[2]
+    guard_root = Path(__file__).resolve().parents[1]
     daemon_root = Path(__file__).resolve().parents[1] / "daemon"
     return (
         ("bridge", Path(__file__).with_name("codex_daemon_hook_bridge.py").resolve()),
+        ("bridge_runtime", guard_root / "codex_hook_bridge_runtime.py"),
         ("fallback_entrypoint", scanner_root / "cli.py"),
         ("daemon_entrypoint", daemon_root / "__init__.py"),
         ("daemon_manager", daemon_root / "manager.py"),
+        ("launch_runtime", guard_root / "codex_hook_launch_runtime.py"),
+        ("runtime_trust", guard_root / "codex_hook_runtime_trust.py"),
     )
 
 

--- a/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
@@ -15,8 +15,33 @@ import time
 import urllib.error
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import TypedDict
 from urllib.parse import urlparse
+
+if __package__:
+    from ..codex_hook_bridge_runtime import BridgeConfig
+    from ..codex_hook_bridge_runtime import TrustedHookLaunch as _TrustedHookLaunch
+    from ..codex_hook_bridge_runtime import bounded_hook_input as _hook_input
+    from ..codex_hook_bridge_runtime import bridge_config_from_argv as _parse_bridge_config
+    from ..codex_hook_bridge_runtime import trusted_hook_launch as _trusted_hook_launch
+else:  # pragma: no cover - exercised by subprocess integration tests
+    _package_root = str(Path(__file__).resolve().parents[3])
+    if _package_root not in sys.path:
+        sys.path.insert(0, _package_root)
+    from codex_plugin_scanner.guard.codex_hook_bridge_runtime import (
+        BridgeConfig,
+    )
+    from codex_plugin_scanner.guard.codex_hook_bridge_runtime import (
+        TrustedHookLaunch as _TrustedHookLaunch,
+    )
+    from codex_plugin_scanner.guard.codex_hook_bridge_runtime import (
+        bounded_hook_input as _hook_input,
+    )
+    from codex_plugin_scanner.guard.codex_hook_bridge_runtime import (
+        bridge_config_from_argv as _parse_bridge_config,
+    )
+    from codex_plugin_scanner.guard.codex_hook_bridge_runtime import (
+        trusted_hook_launch as _trusted_hook_launch,
+    )
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 _HOOK_TIMEOUT_GRACE_SECONDS = 2
@@ -24,15 +49,11 @@ _DAEMON_START_TIMEOUT_SECONDS = 8
 _DISCOVERY_PROTOCOL_VERSION = 1
 _DISCOVERY_CHALLENGE_TTL_SECONDS = 5
 _MAX_DAEMON_RESPONSE_BYTES = 1_000_000
+_MAX_HOOK_INPUT_BYTES = 1_000_000
 _FAIL_CLOSED_REASON = "HOL Guard could not authenticate the local daemon. Run `hol-guard daemon repair`, then retry."
-
-
-class BridgeConfig(TypedDict):
-    state_path: str
-    fallback_command: tuple[str, ...]
-    start_command: tuple[str, ...]
-    query: str
-    hook_timeouts: dict[str, int]
+_LAUNCH_INTEGRITY_REASON = (
+    "HOL Guard could not authenticate its managed Codex hook launcher. Run `hol-guard install codex`, then retry."
+)
 
 
 def _assert_loopback_http_url(url: str) -> None:
@@ -376,13 +397,20 @@ def main(
     start_command: Sequence[str],
     query: str,
     hook_timeouts: Mapping[str, int],
+    manifest_path: str | Path | None = None,
+    config_json: str | None = None,
 ) -> int:
     """Review one Codex hook through the resident daemon or a fail-safe fallback."""
 
-    data = sys.stdin.read().strip() or "{}"
+    data = _hook_input(_MAX_HOOK_INPUT_BYTES)
+    if data is None:
+        sys.stdout.write(json.dumps(_fail_closed("PreToolUse"), separators=(",", ":")))
+        return 0
     event_name = _event_name(data)
     timeout_seconds = _request_timeout(event_name, hook_timeouts)
     response: dict[str, object] | None = None
+    trusted_launch: _TrustedHookLaunch | None = None
+    launch_integrity_failed = False
     try:
         response = _daemon_response(
             state_path=state_path,
@@ -391,7 +419,28 @@ def main(
             timeout_seconds=timeout_seconds,
         )
     except (OSError, ValueError, http.client.HTTPException, urllib.error.URLError):
-        if _run_daemon_start(start_command, timeout_seconds=timeout_seconds):
+        if manifest_path is not None or config_json is not None:
+            try:
+                if manifest_path is None or config_json is None:
+                    raise ValueError("managed Codex hook launch identity is incomplete")
+                trusted_launch = _trusted_hook_launch(
+                    manifest_path=manifest_path,
+                    state_path=state_path,
+                    fallback_command=fallback_command,
+                    start_command=start_command,
+                    config_json=config_json,
+                )
+            except (ImportError, OSError, RuntimeError, ValueError):
+                launch_integrity_failed = True
+        start_succeeded = (
+            trusted_launch.run_start(
+                start_command,
+                timeout_seconds=min(timeout_seconds, _DAEMON_START_TIMEOUT_SECONDS),
+            )
+            if trusted_launch is not None
+            else not launch_integrity_failed and _run_daemon_start(start_command, timeout_seconds=timeout_seconds)
+        )
+        if start_succeeded:
             try:
                 response = _daemon_response(
                     state_path=state_path,
@@ -402,55 +451,29 @@ def main(
             except (OSError, ValueError, http.client.HTTPException, urllib.error.URLError):
                 response = None
     if response is None:
-        response = _run_local_fallback(
-            fallback_command,
-            data=data,
-            timeout_seconds=timeout_seconds,
-        )
+        if trusted_launch is not None:
+            fallback_stdout = trusted_launch.run_fallback(
+                fallback_command,
+                data=data,
+                timeout_seconds=timeout_seconds,
+            )
+            if fallback_stdout is not None:
+                response = _json_object(fallback_stdout.strip()) if fallback_stdout.strip() else {}
+        elif not launch_integrity_failed:
+            response = _run_local_fallback(
+                fallback_command,
+                data=data,
+                timeout_seconds=timeout_seconds,
+            )
     if response is None:
-        response = _fail_closed(event_name)
+        failure_reason = _LAUNCH_INTEGRITY_REASON if launch_integrity_failed else _FAIL_CLOSED_REASON
+        response = _fail_closed(event_name, failure_reason)
     sys.stdout.write(json.dumps(response, separators=(",", ":")))
     return 0
 
 
-def _string_sequence(value: object, *, label: str) -> tuple[str, ...]:
-    if not isinstance(value, list) or not value or not all(isinstance(item, str) for item in value):
-        raise SystemExit(f"codex_daemon_hook_bridge config missing {label}")
-    return tuple(value)
-
-
-def _hook_timeout_mapping(value: object) -> dict[str, int]:
-    if not isinstance(value, dict):
-        raise SystemExit("codex_daemon_hook_bridge config missing hook_timeouts")
-    timeouts = {
-        str(key): timeout
-        for key, timeout in value.items()
-        if isinstance(key, str) and isinstance(timeout, int) and timeout > _HOOK_TIMEOUT_GRACE_SECONDS
-    }
-    if not timeouts:
-        raise SystemExit("codex_daemon_hook_bridge config has no valid hook_timeouts")
-    return timeouts
-
-
 def _bridge_config_from_argv(argv: Sequence[str]) -> BridgeConfig:
-    if len(argv) != 2:
-        raise SystemExit("codex_daemon_hook_bridge expects one JSON config argument")
-    payload = _json_object(argv[1])
-    if payload is None:
-        raise SystemExit("codex_daemon_hook_bridge config must be a JSON object")
-    state_path = payload.get("state_path")
-    query = payload.get("query")
-    if not isinstance(state_path, str):
-        raise SystemExit("codex_daemon_hook_bridge config missing state_path")
-    if not isinstance(query, str):
-        raise SystemExit("codex_daemon_hook_bridge config missing query")
-    return BridgeConfig(
-        state_path=state_path,
-        fallback_command=_string_sequence(payload.get("fallback_command"), label="fallback_command"),
-        start_command=_string_sequence(payload.get("start_command"), label="start_command"),
-        query=query,
-        hook_timeouts=_hook_timeout_mapping(payload.get("hook_timeouts")),
-    )
+    return _parse_bridge_config(argv, timeout_grace_seconds=_HOOK_TIMEOUT_GRACE_SECONDS)
 
 
 if __name__ == "__main__":
@@ -458,9 +481,11 @@ if __name__ == "__main__":
     raise SystemExit(
         main(
             state_path=_config["state_path"],
+            manifest_path=_config["manifest_path"],
             fallback_command=_config["fallback_command"],
             start_command=_config["start_command"],
             query=_config["query"],
             hook_timeouts=_config["hook_timeouts"],
+            config_json=_config["config_json"],
         )
     )

--- a/src/codex_plugin_scanner/guard/codex_hook_bridge_runtime.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_bridge_runtime.py
@@ -1,0 +1,121 @@
+"""Small dependency-light runtime boundary for the Codex daemon bridge."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Protocol, TypedDict
+
+
+class BridgeConfig(TypedDict):
+    state_path: str
+    manifest_path: str
+    fallback_command: tuple[str, ...]
+    start_command: tuple[str, ...]
+    query: str
+    hook_timeouts: dict[str, int]
+    config_json: str
+
+
+class TrustedHookLaunch(Protocol):
+    def run_start(self, command: Sequence[str], *, timeout_seconds: float) -> bool: ...
+
+    def run_fallback(
+        self,
+        command: Sequence[str],
+        *,
+        data: str,
+        timeout_seconds: float,
+    ) -> str | None: ...
+
+
+def bounded_hook_input(limit: int) -> str | None:
+    data = sys.stdin.read(limit + 1)
+    try:
+        encoded_size = len(data.encode("utf-8"))
+    except UnicodeError:
+        return None
+    if encoded_size > limit:
+        return None
+    return data if data.strip() else "{}"
+
+
+def trusted_hook_launch(
+    *,
+    manifest_path: str | Path,
+    state_path: str | Path,
+    fallback_command: Sequence[str],
+    start_command: Sequence[str],
+    config_json: str,
+) -> TrustedHookLaunch:
+    from .codex_hook_runtime_trust import validate_codex_hook_launch
+
+    return validate_codex_hook_launch(
+        manifest_path=manifest_path,
+        state_path=state_path,
+        fallback_command=fallback_command,
+        start_command=start_command,
+        config_json=config_json,
+    )
+
+
+def bridge_config_from_argv(argv: Sequence[str], *, timeout_grace_seconds: int) -> BridgeConfig:
+    if len(argv) != 2:
+        raise SystemExit("codex_daemon_hook_bridge expects one JSON config argument")
+    try:
+        payload = json.loads(argv[1])
+    except json.JSONDecodeError as exc:
+        raise SystemExit("codex_daemon_hook_bridge config must be a JSON object") from exc
+    if not isinstance(payload, dict):
+        raise SystemExit("codex_daemon_hook_bridge config must be a JSON object")
+    state_path = payload.get("state_path")
+    manifest_path = payload.get("manifest_path")
+    query = payload.get("query")
+    if not isinstance(state_path, str):
+        raise SystemExit("codex_daemon_hook_bridge config missing state_path")
+    if not isinstance(manifest_path, str) or not manifest_path:
+        raise SystemExit("codex_daemon_hook_bridge config missing manifest_path")
+    if not isinstance(query, str):
+        raise SystemExit("codex_daemon_hook_bridge config missing query")
+    return BridgeConfig(
+        state_path=state_path,
+        manifest_path=manifest_path,
+        fallback_command=_string_sequence(payload.get("fallback_command"), label="fallback_command"),
+        start_command=_string_sequence(payload.get("start_command"), label="start_command"),
+        query=query,
+        hook_timeouts=_hook_timeout_mapping(
+            payload.get("hook_timeouts"),
+            timeout_grace_seconds=timeout_grace_seconds,
+        ),
+        config_json=argv[1],
+    )
+
+
+def _string_sequence(value: object, *, label: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value or not all(isinstance(item, str) for item in value):
+        raise SystemExit(f"codex_daemon_hook_bridge config missing {label}")
+    return tuple(value)
+
+
+def _hook_timeout_mapping(value: object, *, timeout_grace_seconds: int) -> dict[str, int]:
+    if not isinstance(value, dict):
+        raise SystemExit("codex_daemon_hook_bridge config missing hook_timeouts")
+    timeouts = {
+        str(key): timeout
+        for key, timeout in value.items()
+        if isinstance(key, str) and isinstance(timeout, int) and timeout > timeout_grace_seconds
+    }
+    if not timeouts:
+        raise SystemExit("codex_daemon_hook_bridge config has no valid hook_timeouts")
+    return timeouts
+
+
+__all__ = [
+    "BridgeConfig",
+    "TrustedHookLaunch",
+    "bounded_hook_input",
+    "bridge_config_from_argv",
+    "trusted_hook_launch",
+]

--- a/src/codex_plugin_scanner/guard/codex_hook_integrity.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_integrity.py
@@ -29,7 +29,7 @@ from .local_authority_integrity import (
     verify_local_authority_payload,
 )
 
-HOOK_MANIFEST_SCHEMA_VERSION = 1
+HOOK_MANIFEST_SCHEMA_VERSION = 2
 HOOK_MANIFEST_MAC_ALGORITHM = LOCAL_AUTHORITY_INTEGRITY_MAC_ALGORITHM
 _HOOK_SECRET_SCHEMA_VERSION = 1
 _HOOK_KEY_BYTES = 32
@@ -142,7 +142,15 @@ def load_authenticated_hook_manifest(
     guard_home: Path,
     config_path: Path,
 ) -> dict[str, object]:
-    path = hook_manifest_path(guard_home, config_path)
+    return load_authenticated_hook_manifest_path(guard_home, hook_manifest_path(guard_home, config_path))
+
+
+def load_authenticated_hook_manifest_path(
+    guard_home: Path,
+    path: Path,
+) -> dict[str, object]:
+    """Authenticate an explicit private manifest path without creating state."""
+
     if not path.exists() and not path.is_symlink():
         raise CodexHookIntegrityError(
             "codex_hook_manifest_missing",
@@ -416,6 +424,7 @@ __all__ = [
     "hook_manifest_path",
     "hook_secret_path",
     "load_authenticated_hook_manifest",
+    "load_authenticated_hook_manifest_path",
     "load_or_create_hook_secret",
     "remove_hook_manifest",
     "remove_hook_secret_if_unused",

--- a/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
@@ -13,6 +13,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO
 
+from .codex_hook_windows_job import (
+    WindowsHookJob,
+    close_windows_hook_job,
+    spawn_windows_hook_process,
+)
+
 _HOOK_SUBPROCESS_OUTPUT_LIMIT = 1_000_000
 _HOOK_ENVIRONMENT_KEYS = frozenset(
     {
@@ -120,16 +126,13 @@ def run_isolated_hook_process(
 ) -> BoundedHookProcessResult:
     """Run one child with bounded input lifetime and combined output bytes."""
 
+    windows_job: WindowsHookJob | None = None
     try:
         if os.name == "nt":
-            process = subprocess.Popen(
+            process, windows_job = spawn_windows_hook_process(
                 list(command),
                 cwd=cwd,
-                env=dict(environment),
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                creationflags=getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0),
+                environment=dict(environment),
             )
         else:
             process = subprocess.Popen(
@@ -185,52 +188,61 @@ def run_isolated_hook_process(
     timed_out = False
     while process.poll() is None:
         if output_limit_exceeded.is_set():
-            _kill_hook_process(process)
+            _kill_hook_process(process, windows_job)
             break
         if time.monotonic() >= deadline:
             timed_out = True
-            _kill_hook_process(process)
+            _kill_hook_process(process, windows_job)
             break
         time.sleep(0.01)
     try:
         returncode = process.wait(timeout=1)
     except subprocess.TimeoutExpired:
-        _kill_hook_process(process)
+        _kill_hook_process(process, windows_job)
         returncode = process.wait()
+    job_cleanup_failed = False
+    if windows_job is not None:
+        try:
+            close_windows_hook_job(windows_job)
+        except OSError:
+            job_cleanup_failed = True
+            _kill_hook_process(process, windows_job)
     writer.join(timeout=1)
     for thread in readers:
         thread.join(timeout=0.05)
     if any(thread.is_alive() for thread in readers):
-        _kill_hook_process_group(process)
+        _kill_hook_process(process, windows_job)
         for thread in readers:
             thread.join(timeout=1)
     with output_lock:
         stdout_decoded = stdout_bytes.decode("utf-8", errors="replace")
     return BoundedHookProcessResult(
-        returncode=returncode,
+        returncode=None if job_cleanup_failed else returncode,
         stdout=stdout_decoded,
         output_limit_exceeded=output_limit_exceeded.is_set(),
         timed_out=timed_out,
     )
 
 
-def _kill_hook_process(process: subprocess.Popen[bytes]) -> None:
+def _kill_hook_process(process: subprocess.Popen[bytes], windows_job: WindowsHookJob | None) -> None:
+    if windows_job is not None:
+        try:
+            windows_job.terminate()
+            return
+        except OSError:
+            pass
+    if os.name != "nt":
+        _kill_hook_process_group(process)
+        return
     if process.poll() is not None:
         return
     try:
-        if os.name != "nt":
-            _kill_hook_process_group(process)
-        else:
-            process.kill()
+        process.kill()
     except (OSError, ProcessLookupError):
         process.kill()
 
 
 def _kill_hook_process_group(process: subprocess.Popen[bytes]) -> None:
-    if os.name == "nt":
-        if process.poll() is None:
-            process.kill()
-        return
     try:
         os.killpg(process.pid, signal.SIGKILL)
     except (OSError, ProcessLookupError):

--- a/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
@@ -199,10 +199,16 @@ def run_isolated_hook_process(
         returncode = process.wait()
     writer.join(timeout=1)
     for thread in readers:
-        thread.join(timeout=1)
+        thread.join(timeout=0.05)
+    if any(thread.is_alive() for thread in readers):
+        _kill_hook_process_group(process)
+        for thread in readers:
+            thread.join(timeout=1)
+    with output_lock:
+        stdout_decoded = stdout_bytes.decode("utf-8", errors="replace")
     return BoundedHookProcessResult(
         returncode=returncode,
-        stdout=stdout_bytes.decode("utf-8", errors="replace"),
+        stdout=stdout_decoded,
         output_limit_exceeded=output_limit_exceeded.is_set(),
         timed_out=timed_out,
     )
@@ -213,11 +219,23 @@ def _kill_hook_process(process: subprocess.Popen[bytes]) -> None:
         return
     try:
         if os.name != "nt":
-            os.killpg(process.pid, signal.SIGKILL)
+            _kill_hook_process_group(process)
         else:
             process.kill()
     except (OSError, ProcessLookupError):
         process.kill()
+
+
+def _kill_hook_process_group(process: subprocess.Popen[bytes]) -> None:
+    if os.name == "nt":
+        if process.poll() is None:
+            process.kill()
+        return
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except (OSError, ProcessLookupError):
+        if process.poll() is None:
+            process.kill()
 
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
@@ -1,0 +1,230 @@
+"""Isolated, resource-bounded subprocesses for managed Codex hooks."""
+
+from __future__ import annotations
+
+import os
+import signal
+import stat
+import subprocess
+import threading
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+
+_HOOK_SUBPROCESS_OUTPUT_LIMIT = 1_000_000
+_HOOK_ENVIRONMENT_KEYS = frozenset(
+    {
+        "CODEX_HOME",
+        "COMSPEC",
+        "HOME",
+        "LANG",
+        "PATH",
+        "PATHEXT",
+        "SYSTEMROOT",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "USERPROFILE",
+        "WINDIR",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class BoundedHookProcessResult:
+    """One bounded child result without inherited process context."""
+
+    returncode: int | None
+    stdout: str
+    output_limit_exceeded: bool
+    timed_out: bool
+
+
+def isolated_guard_cli_command(
+    python_executable: str,
+    package_root: Path,
+    guard_args: Sequence[str],
+) -> tuple[str, ...]:
+    """Build the exact isolated fallback contract pinned to one package root."""
+
+    bootstrap = (
+        "import sys;"
+        f"sys.path.insert(0, {str(package_root.resolve())!r});"
+        "from codex_plugin_scanner.cli import main;"
+        "raise SystemExit(main(sys.argv[1:]))"
+    )
+    return (python_executable, "-I", "-c", bootstrap, *guard_args)
+
+
+def isolated_daemon_start_command(
+    python_executable: str,
+    package_root: Path,
+    guard_home: Path,
+) -> tuple[str, ...]:
+    """Build the exact isolated daemon-start contract."""
+
+    bootstrap = (
+        "import sys;"
+        f"sys.path.insert(0, {str(package_root.resolve())!r});"
+        "from pathlib import Path;"
+        "from codex_plugin_scanner.guard.daemon import ensure_guard_daemon;"
+        f"ensure_guard_daemon(Path({str(guard_home)!r}))"
+    )
+    return (python_executable, "-I", "-c", bootstrap)
+
+
+def isolated_hook_environment(environment: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Keep only OS, user-home, locale, temp, PATH, and Codex state."""
+
+    source = os.environ if environment is None else environment
+    return {
+        name: value
+        for name, value in source.items()
+        if name.upper() in _HOOK_ENVIRONMENT_KEYS or name.upper().startswith("LC_")
+    }
+
+
+def private_hook_runtime_cwd(manifest_path: Path) -> Path:
+    """Return the authenticated manifest's private Guard-owned directory."""
+
+    parent = manifest_path.parent
+    try:
+        parent_metadata = parent.lstat()
+        resolved = parent.resolve(strict=True)
+        resolved_metadata = resolved.lstat()
+    except (OSError, RuntimeError) as exc:
+        raise ValueError("managed Codex hook runtime directory is unavailable") from exc
+    if stat.S_ISLNK(parent_metadata.st_mode) or not stat.S_ISDIR(parent_metadata.st_mode):
+        raise ValueError("managed Codex hook runtime directory is not a regular directory")
+    if (parent_metadata.st_dev, parent_metadata.st_ino) != (resolved_metadata.st_dev, resolved_metadata.st_ino):
+        raise ValueError("managed Codex hook runtime directory changed during validation")
+    if os.name != "nt":
+        current_uid = os.getuid() if hasattr(os, "getuid") else None
+        if current_uid is not None and parent_metadata.st_uid != current_uid:
+            raise ValueError("managed Codex hook runtime directory has an unexpected owner")
+        if stat.S_IMODE(parent_metadata.st_mode) & 0o077:
+            raise ValueError("managed Codex hook runtime directory is not owner-only")
+    return resolved
+
+
+def run_isolated_hook_process(
+    command: Sequence[str],
+    *,
+    input_text: str,
+    cwd: Path,
+    environment: Mapping[str, str],
+    timeout_seconds: float,
+    output_limit: int = _HOOK_SUBPROCESS_OUTPUT_LIMIT,
+) -> BoundedHookProcessResult:
+    """Run one child with bounded input lifetime and combined output bytes."""
+
+    try:
+        if os.name == "nt":
+            process = subprocess.Popen(
+                list(command),
+                cwd=cwd,
+                env=dict(environment),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                creationflags=getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0),
+            )
+        else:
+            process = subprocess.Popen(
+                list(command),
+                cwd=cwd,
+                env=dict(environment),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                start_new_session=True,
+            )
+    except OSError:
+        return BoundedHookProcessResult(None, "", False, False)
+
+    stdout_bytes = bytearray()
+    output_bytes = 0
+    output_lock = threading.Lock()
+    output_limit_exceeded = threading.Event()
+
+    def drain(stream: BinaryIO, *, capture: bool) -> None:
+        nonlocal output_bytes
+        while chunk := stream.read(64 * 1024):
+            with output_lock:
+                remaining = max(0, output_limit - output_bytes)
+                accepted = chunk[:remaining]
+                output_bytes += len(chunk)
+                if capture and accepted:
+                    stdout_bytes.extend(accepted)
+                if output_bytes > output_limit:
+                    output_limit_exceeded.set()
+
+    def write_input() -> None:
+        if process.stdin is None:
+            return
+        try:
+            process.stdin.write(input_text.encode("utf-8"))
+            process.stdin.flush()
+        except (BrokenPipeError, OSError):
+            pass
+        finally:
+            process.stdin.close()
+
+    readers = [
+        threading.Thread(target=drain, args=(process.stdout,), kwargs={"capture": True}, daemon=True),
+        threading.Thread(target=drain, args=(process.stderr,), kwargs={"capture": False}, daemon=True),
+    ]
+    writer = threading.Thread(target=write_input, daemon=True)
+    for thread in readers:
+        thread.start()
+    writer.start()
+
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    timed_out = False
+    while process.poll() is None:
+        if output_limit_exceeded.is_set():
+            _kill_hook_process(process)
+            break
+        if time.monotonic() >= deadline:
+            timed_out = True
+            _kill_hook_process(process)
+            break
+        time.sleep(0.01)
+    try:
+        returncode = process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        _kill_hook_process(process)
+        returncode = process.wait()
+    writer.join(timeout=1)
+    for thread in readers:
+        thread.join(timeout=1)
+    return BoundedHookProcessResult(
+        returncode=returncode,
+        stdout=stdout_bytes.decode("utf-8", errors="replace"),
+        output_limit_exceeded=output_limit_exceeded.is_set(),
+        timed_out=timed_out,
+    )
+
+
+def _kill_hook_process(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        if os.name != "nt":
+            os.killpg(process.pid, signal.SIGKILL)
+        else:
+            process.kill()
+    except (OSError, ProcessLookupError):
+        process.kill()
+
+
+__all__ = [
+    "BoundedHookProcessResult",
+    "isolated_daemon_start_command",
+    "isolated_guard_cli_command",
+    "isolated_hook_environment",
+    "private_hook_runtime_cwd",
+    "run_isolated_hook_process",
+]

--- a/src/codex_plugin_scanner/guard/codex_hook_manifest.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_manifest.py
@@ -62,7 +62,16 @@ def build_authenticated_hook_manifest(spec: CodexHookManifestSpec) -> dict[str, 
         identity.get("role"): identity for identity in packaged_files if isinstance(identity.get("role"), str)
     }
     bridge = packaged_by_role.get("bridge")
-    if not isinstance(bridge, dict) or len(packaged_by_role) != len(spec.packaged_file_paths):
+    bridge_runtime = packaged_by_role.get("bridge_runtime")
+    launch_runtime = packaged_by_role.get("launch_runtime")
+    runtime_trust = packaged_by_role.get("runtime_trust")
+    if (
+        not isinstance(bridge, dict)
+        or not isinstance(bridge_runtime, dict)
+        or not isinstance(launch_runtime, dict)
+        or not isinstance(runtime_trust, dict)
+        or len(packaged_by_role) != len(spec.packaged_file_paths)
+    ):
         raise CodexHookIntegrityError(
             "codex_hook_manifest_packaged_files_invalid",
             "Guard cannot authenticate an incomplete Codex hook package identity.",
@@ -89,7 +98,13 @@ def build_authenticated_hook_manifest(spec: CodexHookManifestSpec) -> dict[str, 
         "package_version": spec.package_version,
         "packaged_files": packaged_files,
         "schema_version": HOOK_MANIFEST_SCHEMA_VERSION,
-        "transport": {"bridge": bridge, "wrapper": None},
+        "transport": {
+            "bridge": bridge,
+            "bridge_runtime": bridge_runtime,
+            "launch_runtime": launch_runtime,
+            "runtime_trust": runtime_trust,
+            "wrapper": None,
+        },
     }
     return sign_hook_manifest(unsigned_manifest, secret)
 
@@ -357,6 +372,9 @@ def _verify_launch_identities(
         not isinstance(transport, dict)
         or transport.get("wrapper") is not None
         or transport.get("bridge") != packaged_by_role.get("bridge")
+        or transport.get("bridge_runtime") != packaged_by_role.get("bridge_runtime")
+        or transport.get("launch_runtime") != packaged_by_role.get("launch_runtime")
+        or transport.get("runtime_trust") != packaged_by_role.get("runtime_trust")
     ):
         _raise_manifest_failure(
             "codex_hook_manifest_transport_invalid",

--- a/src/codex_plugin_scanner/guard/codex_hook_manifest.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_manifest.py
@@ -65,11 +65,13 @@ def build_authenticated_hook_manifest(spec: CodexHookManifestSpec) -> dict[str, 
     bridge_runtime = packaged_by_role.get("bridge_runtime")
     launch_runtime = packaged_by_role.get("launch_runtime")
     runtime_trust = packaged_by_role.get("runtime_trust")
+    windows_job = packaged_by_role.get("windows_job")
     if (
         not isinstance(bridge, dict)
         or not isinstance(bridge_runtime, dict)
         or not isinstance(launch_runtime, dict)
         or not isinstance(runtime_trust, dict)
+        or not isinstance(windows_job, dict)
         or len(packaged_by_role) != len(spec.packaged_file_paths)
     ):
         raise CodexHookIntegrityError(
@@ -103,6 +105,7 @@ def build_authenticated_hook_manifest(spec: CodexHookManifestSpec) -> dict[str, 
             "bridge_runtime": bridge_runtime,
             "launch_runtime": launch_runtime,
             "runtime_trust": runtime_trust,
+            "windows_job": windows_job,
             "wrapper": None,
         },
     }
@@ -375,6 +378,7 @@ def _verify_launch_identities(
         or transport.get("bridge_runtime") != packaged_by_role.get("bridge_runtime")
         or transport.get("launch_runtime") != packaged_by_role.get("launch_runtime")
         or transport.get("runtime_trust") != packaged_by_role.get("runtime_trust")
+        or transport.get("windows_job") != packaged_by_role.get("windows_job")
     ):
         _raise_manifest_failure(
             "codex_hook_manifest_transport_invalid",

--- a/src/codex_plugin_scanner/guard/codex_hook_runtime_trust.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_runtime_trust.py
@@ -106,7 +106,7 @@ def validate_codex_hook_launch(
         manifest,
         interpreter=interpreter,
         packaged_by_role=packaged_by_role,
-        runtime_guard_home=state.parent,
+        runtime_guard_home=guard_home,
         fallback_command=fallback_command,
         start_command=start_command,
     )

--- a/src/codex_plugin_scanner/guard/codex_hook_runtime_trust.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_runtime_trust.py
@@ -1,0 +1,266 @@
+"""Runtime enforcement for authenticated managed Codex hook launchers."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from .codex_hook_file_integrity import (
+    canonical_path,
+    verify_executable_file_identity,
+    verify_regular_file_identity,
+)
+from .codex_hook_integrity import (
+    HOOK_MANIFEST_SCHEMA_VERSION,
+    hook_manifest_path,
+    load_authenticated_hook_manifest_path,
+)
+from .codex_hook_launch_runtime import (
+    isolated_daemon_start_command,
+    isolated_guard_cli_command,
+    isolated_hook_environment,
+    private_hook_runtime_cwd,
+    run_isolated_hook_process,
+)
+
+_REQUIRED_PACKAGE_ROLES = frozenset(
+    {
+        "bridge",
+        "bridge_runtime",
+        "daemon_entrypoint",
+        "daemon_manager",
+        "fallback_entrypoint",
+        "launch_runtime",
+        "runtime_trust",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedCodexHookLaunch:
+    """A live authenticated launch context safe for child execution."""
+
+    cwd: Path
+    environment: Mapping[str, str]
+
+    def run_start(self, command: Sequence[str], *, timeout_seconds: float) -> bool:
+        result = run_isolated_hook_process(
+            command,
+            input_text="",
+            cwd=self.cwd,
+            environment=self.environment,
+            timeout_seconds=timeout_seconds,
+        )
+        return result.returncode == 0 and not result.output_limit_exceeded and not result.timed_out
+
+    def run_fallback(
+        self,
+        command: Sequence[str],
+        *,
+        data: str,
+        timeout_seconds: float,
+    ) -> str | None:
+        result = run_isolated_hook_process(
+            command,
+            input_text=data,
+            cwd=self.cwd,
+            environment=self.environment,
+            timeout_seconds=timeout_seconds,
+        )
+        if result.returncode != 0 or result.output_limit_exceeded or result.timed_out:
+            return None
+        return result.stdout
+
+
+def validate_codex_hook_launch(
+    *,
+    manifest_path: str | Path,
+    state_path: str | Path,
+    fallback_command: Sequence[str],
+    start_command: Sequence[str],
+    config_json: str,
+) -> TrustedCodexHookLaunch:
+    """Authenticate the complete current bridge config and child identities."""
+
+    state = Path(state_path)
+    configured_manifest = Path(manifest_path)
+    if not state.is_absolute() or not configured_manifest.is_absolute():
+        raise ValueError("managed Codex hook paths must be absolute")
+    guard_home = state.parent.resolve(strict=False)
+    expected_managed_directory = (guard_home / "managed" / "codex").resolve(strict=False)
+    manifest_directory = configured_manifest.parent.resolve(strict=False)
+    if state.name != "daemon-state.json" or manifest_directory != expected_managed_directory:
+        raise ValueError("managed Codex hook paths do not belong to this Guard home")
+    if not configured_manifest.name.startswith("hooks-") or not configured_manifest.name.endswith(".manifest.json"):
+        raise ValueError("managed Codex hook manifest path is invalid")
+
+    manifest = load_authenticated_hook_manifest_path(guard_home, configured_manifest)
+    _verify_manifest_context(manifest, guard_home=guard_home, manifest_path=configured_manifest)
+    interpreter = _mapping(manifest.get("interpreter"), label="interpreter")
+    verify_executable_file_identity(interpreter)
+    packaged_by_role = _verified_packaged_files(manifest)
+    _verify_transport(packaged_by_role, manifest)
+    _verify_launch_contracts(
+        manifest,
+        interpreter=interpreter,
+        packaged_by_role=packaged_by_role,
+        runtime_guard_home=state.parent,
+        fallback_command=fallback_command,
+        start_command=start_command,
+    )
+    _verify_registered_bridge_argv(
+        manifest,
+        interpreter=interpreter,
+        bridge=packaged_by_role["bridge"],
+        config_json=config_json,
+    )
+    return TrustedCodexHookLaunch(
+        cwd=private_hook_runtime_cwd(configured_manifest),
+        environment=isolated_hook_environment(),
+    )
+
+
+def _verify_manifest_context(manifest: Mapping[str, object], *, guard_home: Path, manifest_path: Path) -> None:
+    if manifest.get("schema_version") != HOOK_MANIFEST_SCHEMA_VERSION or manifest.get("harness") != "codex":
+        raise ValueError("managed Codex hook manifest schema is unsupported")
+    context = _mapping(manifest.get("context"), label="context")
+    if context.get("runtime_guard_home") != canonical_path(guard_home):
+        raise ValueError("managed Codex hook manifest belongs to another Guard home")
+    config = _mapping(manifest.get("config"), label="config")
+    config_target = config.get("target")
+    if not isinstance(config_target, str) or not Path(config_target).is_absolute():
+        raise ValueError("managed Codex hook config target is invalid")
+    expected_manifest = hook_manifest_path(guard_home, Path(config_target)).resolve(strict=False)
+    if expected_manifest != manifest_path.resolve(strict=False):
+        raise ValueError("managed Codex hook manifest target binding is invalid")
+
+
+def _verified_packaged_files(manifest: Mapping[str, object]) -> dict[str, dict[str, object]]:
+    packaged_files = manifest.get("packaged_files")
+    if not isinstance(packaged_files, list):
+        raise ValueError("managed Codex hook packaged-file identity is invalid")
+    packaged_by_role: dict[str, dict[str, object]] = {}
+    for value in packaged_files:
+        identity = _mapping(value, label="packaged file")
+        role = identity.get("role")
+        if not isinstance(role, str) or role in packaged_by_role:
+            raise ValueError("managed Codex hook packaged-file roles are invalid")
+        verify_regular_file_identity(identity)
+        packaged_by_role[role] = identity
+    if set(packaged_by_role) != _REQUIRED_PACKAGE_ROLES:
+        raise ValueError("managed Codex hook package identity is incomplete")
+    return packaged_by_role
+
+
+def _verify_transport(
+    packaged_by_role: Mapping[str, dict[str, object]],
+    manifest: Mapping[str, object],
+) -> None:
+    bridge_path = Path(__file__).with_name("adapters").joinpath("codex_daemon_hook_bridge.py").resolve()
+    bridge_runtime_path = Path(__file__).with_name("codex_hook_bridge_runtime.py").resolve()
+    launch_runtime_path = Path(__file__).with_name("codex_hook_launch_runtime.py").resolve()
+    runtime_trust_path = Path(__file__).resolve()
+    if packaged_by_role["bridge"].get("path") != str(bridge_path):
+        raise ValueError("managed Codex hook bridge path is invalid")
+    if packaged_by_role["bridge_runtime"].get("path") != str(bridge_runtime_path):
+        raise ValueError("managed Codex hook bridge runtime path is invalid")
+    if packaged_by_role["launch_runtime"].get("path") != str(launch_runtime_path):
+        raise ValueError("managed Codex hook launch runtime path is invalid")
+    if packaged_by_role["runtime_trust"].get("path") != str(runtime_trust_path):
+        raise ValueError("managed Codex hook runtime trust path is invalid")
+    transport = _mapping(manifest.get("transport"), label="transport")
+    if (
+        transport.get("bridge") != packaged_by_role["bridge"]
+        or transport.get("bridge_runtime") != packaged_by_role["bridge_runtime"]
+        or transport.get("launch_runtime") != packaged_by_role["launch_runtime"]
+        or transport.get("runtime_trust") != packaged_by_role["runtime_trust"]
+        or transport.get("wrapper") is not None
+    ):
+        raise ValueError("managed Codex hook transport identity is invalid")
+
+
+def _verify_launch_contracts(
+    manifest: Mapping[str, object],
+    *,
+    interpreter: Mapping[str, object],
+    packaged_by_role: Mapping[str, dict[str, object]],
+    runtime_guard_home: Path,
+    fallback_command: Sequence[str],
+    start_command: Sequence[str],
+) -> None:
+    interpreter_path = interpreter.get("invocation_path")
+    fallback_entrypoint = packaged_by_role["fallback_entrypoint"].get("path")
+    if not isinstance(interpreter_path, str) or not isinstance(fallback_entrypoint, str):
+        raise ValueError("managed Codex hook launch identity is invalid")
+    fallback_path = Path(fallback_entrypoint)
+    if fallback_path.name != "cli.py" or fallback_path.parent.name != "codex_plugin_scanner":
+        raise ValueError("managed Codex hook fallback entrypoint is invalid")
+    package_root = fallback_path.parent.parent
+    fallback = _mapping(manifest.get("fallback"), label="fallback")
+    fallback_argv = tuple(_string_list(fallback.get("argv"), label="fallback argv"))
+    if (
+        fallback_argv != tuple(fallback_command)
+        or fallback.get("interpreter") != interpreter
+        or fallback.get("package_roles") != ["fallback_entrypoint"]
+        or fallback_argv[4:8] != ("guard", "hook", "--harness", "codex")
+        or isolated_guard_cli_command(interpreter_path, package_root, fallback_argv[4:]) != fallback_argv
+    ):
+        raise ValueError("managed Codex hook fallback contract is invalid")
+
+    daemon_start = _mapping(manifest.get("daemon_start"), label="daemon start")
+    daemon_argv = tuple(_string_list(daemon_start.get("argv"), label="daemon start argv"))
+    context = _mapping(manifest.get("context"), label="context")
+    authenticated_guard_home = context.get("runtime_guard_home")
+    if (
+        not isinstance(authenticated_guard_home, str)
+        or canonical_path(runtime_guard_home) != authenticated_guard_home
+        or daemon_argv != tuple(start_command)
+        or daemon_start.get("interpreter") != interpreter
+        or daemon_start.get("package_roles") != ["daemon_entrypoint", "daemon_manager"]
+        or isolated_daemon_start_command(interpreter_path, package_root, runtime_guard_home) != daemon_argv
+    ):
+        raise ValueError("managed Codex hook daemon-start contract is invalid")
+
+
+def _verify_registered_bridge_argv(
+    manifest: Mapping[str, object],
+    *,
+    interpreter: Mapping[str, object],
+    bridge: Mapping[str, object],
+    config_json: str,
+) -> None:
+    try:
+        config_payload = json.loads(config_json)
+    except json.JSONDecodeError as exc:
+        raise ValueError("managed Codex hook bridge config is malformed") from exc
+    if not isinstance(config_payload, dict):
+        raise ValueError("managed Codex hook bridge config is malformed")
+    interpreter_path = interpreter.get("invocation_path")
+    bridge_path = bridge.get("path")
+    if not isinstance(interpreter_path, str) or not isinstance(bridge_path, str):
+        raise ValueError("managed Codex hook bridge identity is invalid")
+    expected_argv = [interpreter_path, "-I", bridge_path, config_json]
+    events = manifest.get("events")
+    if not isinstance(events, list) or not events:
+        raise ValueError("managed Codex hook event identity is invalid")
+    for event in events:
+        binding = _mapping(event, label="event")
+        if binding.get("argv") != expected_argv:
+            raise ValueError("managed Codex hook bridge config changed after authentication")
+
+
+def _mapping(value: object, *, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"managed Codex hook {label} identity is invalid")
+    return {str(key): item for key, item in value.items() if isinstance(key, str)}
+
+
+def _string_list(value: object, *, label: str) -> list[str]:
+    if not isinstance(value, list) or not value or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"managed Codex hook {label} is invalid")
+    return [item for item in value if isinstance(item, str)]
+
+
+__all__ = ["TrustedCodexHookLaunch", "validate_codex_hook_launch"]

--- a/src/codex_plugin_scanner/guard/codex_hook_runtime_trust.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_runtime_trust.py
@@ -34,6 +34,7 @@ _REQUIRED_PACKAGE_ROLES = frozenset(
         "fallback_entrypoint",
         "launch_runtime",
         "runtime_trust",
+        "windows_job",
     }
 )
 
@@ -162,6 +163,7 @@ def _verify_transport(
     bridge_runtime_path = Path(__file__).with_name("codex_hook_bridge_runtime.py").resolve()
     launch_runtime_path = Path(__file__).with_name("codex_hook_launch_runtime.py").resolve()
     runtime_trust_path = Path(__file__).resolve()
+    windows_job_path = Path(__file__).with_name("codex_hook_windows_job.py").resolve()
     if packaged_by_role["bridge"].get("path") != str(bridge_path):
         raise ValueError("managed Codex hook bridge path is invalid")
     if packaged_by_role["bridge_runtime"].get("path") != str(bridge_runtime_path):
@@ -170,12 +172,15 @@ def _verify_transport(
         raise ValueError("managed Codex hook launch runtime path is invalid")
     if packaged_by_role["runtime_trust"].get("path") != str(runtime_trust_path):
         raise ValueError("managed Codex hook runtime trust path is invalid")
+    if packaged_by_role["windows_job"].get("path") != str(windows_job_path):
+        raise ValueError("managed Codex hook Windows job path is invalid")
     transport = _mapping(manifest.get("transport"), label="transport")
     if (
         transport.get("bridge") != packaged_by_role["bridge"]
         or transport.get("bridge_runtime") != packaged_by_role["bridge_runtime"]
         or transport.get("launch_runtime") != packaged_by_role["launch_runtime"]
         or transport.get("runtime_trust") != packaged_by_role["runtime_trust"]
+        or transport.get("windows_job") != packaged_by_role["windows_job"]
         or transport.get("wrapper") is not None
     ):
         raise ValueError("managed Codex hook transport identity is invalid")

--- a/src/codex_plugin_scanner/guard/codex_hook_windows_job.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_windows_job.py
@@ -1,0 +1,291 @@
+"""Windows Job Object process-tree boundary for isolated Codex hooks."""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import subprocess
+from ctypes import wintypes
+from dataclasses import dataclass
+from pathlib import Path
+
+_CREATE_SUSPENDED = 0x00000004
+_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+_JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS = 9
+_TH32CS_SNAPTHREAD = 0x00000004
+_THREAD_SUSPEND_RESUME = 0x0002
+_RESUME_THREAD_FAILED = 0xFFFFFFFF
+_ERROR_NO_MORE_FILES = 18
+
+
+class _BasicLimitInformation(ctypes.Structure):
+    _fields_ = [
+        ("per_process_user_time_limit", ctypes.c_longlong),
+        ("per_job_user_time_limit", ctypes.c_longlong),
+        ("limit_flags", wintypes.DWORD),
+        ("minimum_working_set_size", ctypes.c_size_t),
+        ("maximum_working_set_size", ctypes.c_size_t),
+        ("active_process_limit", wintypes.DWORD),
+        ("affinity", ctypes.c_size_t),
+        ("priority_class", wintypes.DWORD),
+        ("scheduling_class", wintypes.DWORD),
+    ]
+
+
+class _IoCounters(ctypes.Structure):
+    _fields_ = [
+        ("read_operation_count", ctypes.c_ulonglong),
+        ("write_operation_count", ctypes.c_ulonglong),
+        ("other_operation_count", ctypes.c_ulonglong),
+        ("read_transfer_count", ctypes.c_ulonglong),
+        ("write_transfer_count", ctypes.c_ulonglong),
+        ("other_transfer_count", ctypes.c_ulonglong),
+    ]
+
+
+class _ExtendedLimitInformation(ctypes.Structure):
+    _fields_ = [
+        ("basic_limit_information", _BasicLimitInformation),
+        ("io_info", _IoCounters),
+        ("process_memory_limit", ctypes.c_size_t),
+        ("job_memory_limit", ctypes.c_size_t),
+        ("peak_process_memory_used", ctypes.c_size_t),
+        ("peak_job_memory_used", ctypes.c_size_t),
+    ]
+
+
+class _ThreadEntry32(ctypes.Structure):
+    _fields_ = [
+        ("dwSize", wintypes.DWORD),
+        ("cntUsage", wintypes.DWORD),
+        ("th32ThreadID", wintypes.DWORD),
+        ("th32OwnerProcessID", wintypes.DWORD),
+        ("tpBasePri", wintypes.LONG),
+        ("tpDeltaPri", wintypes.LONG),
+        ("dwFlags", wintypes.DWORD),
+    ]
+
+
+@dataclass(slots=True)
+class WindowsHookJob:
+    """One kill-on-close Windows Job Object handle."""
+
+    handle: int
+    closed: bool = False
+
+    def terminate(self) -> None:
+        if self.closed:
+            return
+        kernel32 = _kernel32()
+        terminate_job = kernel32.TerminateJobObject
+        terminate_job.argtypes = [wintypes.HANDLE, wintypes.UINT]
+        terminate_job.restype = wintypes.BOOL
+        if not terminate_job(wintypes.HANDLE(self.handle), 1):
+            raise OSError(ctypes.get_last_error(), "TerminateJobObject failed")
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        kernel32 = _kernel32()
+        close_handle = kernel32.CloseHandle
+        close_handle.argtypes = [wintypes.HANDLE]
+        close_handle.restype = wintypes.BOOL
+        if not close_handle(wintypes.HANDLE(self.handle)):
+            raise OSError(ctypes.get_last_error(), "CloseHandle failed")
+        self.closed = True
+
+
+def spawn_windows_hook_process(
+    command: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+) -> tuple[subprocess.Popen[bytes], WindowsHookJob]:
+    """Start suspended, assign to a kill-on-close job, then resume."""
+
+    job = _create_job()
+    process: subprocess.Popen[bytes] | None = None
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=environment,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            creationflags=getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) | _CREATE_SUSPENDED,
+        )
+        _assign_and_resume(process, job)
+        return process, job
+    except BaseException:
+        _cleanup_failed_spawn(process, job)
+        raise
+
+
+def close_windows_hook_job(job: WindowsHookJob) -> None:
+    """Close the job, deterministically terminating any remaining descendants."""
+
+    try:
+        job.close()
+    except OSError:
+        with contextlib.suppress(OSError):
+            job.terminate()
+        job.close()
+
+
+def _kernel32():  # type: ignore[no-untyped-def]
+    win_dll = getattr(ctypes, "WinDLL", None)
+    if win_dll is None:
+        raise OSError("windows_job_api_unavailable")
+    return win_dll("kernel32", use_last_error=True)
+
+
+def _create_job() -> WindowsHookJob:
+    kernel32 = _kernel32()
+    create_job = kernel32.CreateJobObjectW
+    create_job.argtypes = [ctypes.c_void_p, wintypes.LPCWSTR]
+    create_job.restype = wintypes.HANDLE
+    set_information = kernel32.SetInformationJobObject
+    set_information.argtypes = [wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD]
+    set_information.restype = wintypes.BOOL
+    raw_handle = create_job(None, None)
+    if raw_handle is None:
+        raise OSError(ctypes.get_last_error(), "CreateJobObjectW failed")
+    job = WindowsHookJob(handle=int(raw_handle))
+    try:
+        limits = _ExtendedLimitInformation()
+        limits.basic_limit_information.limit_flags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        if not set_information(
+            wintypes.HANDLE(job.handle),
+            _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS,
+            ctypes.byref(limits),
+            ctypes.sizeof(limits),
+        ):
+            raise OSError(ctypes.get_last_error(), "SetInformationJobObject failed")
+        return job
+    except BaseException:
+        with contextlib.suppress(OSError):
+            job.close()
+        raise
+
+
+def _assign_and_resume(process: subprocess.Popen[bytes], job: WindowsHookJob) -> None:
+    kernel32 = _kernel32()
+    assign_process = kernel32.AssignProcessToJobObject
+    assign_process.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+    assign_process.restype = wintypes.BOOL
+    is_process_in_job = kernel32.IsProcessInJob
+    is_process_in_job.argtypes = [wintypes.HANDLE, wintypes.HANDLE, ctypes.POINTER(wintypes.BOOL)]
+    is_process_in_job.restype = wintypes.BOOL
+    process_handle = _process_handle(process)
+    if not assign_process(wintypes.HANDLE(job.handle), wintypes.HANDLE(process_handle)):
+        raise OSError(ctypes.get_last_error(), "AssignProcessToJobObject failed")
+    assigned = wintypes.BOOL()
+    if (
+        not is_process_in_job(
+            wintypes.HANDLE(process_handle),
+            wintypes.HANDLE(job.handle),
+            ctypes.byref(assigned),
+        )
+        or not assigned.value
+    ):
+        raise OSError(ctypes.get_last_error(), "IsProcessInJob failed")
+    _resume_primary_thread(process.pid)
+
+
+def _process_handle(process: subprocess.Popen[bytes]) -> int:
+    raw_handle = getattr(process, "_handle", None)
+    if not isinstance(raw_handle, int) or raw_handle <= 0:
+        raise OSError("Windows process handle is unavailable")
+    return raw_handle
+
+
+def _resume_primary_thread(process_id: int) -> None:
+    kernel32 = _kernel32()
+    create_snapshot = kernel32.CreateToolhelp32Snapshot
+    create_snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
+    create_snapshot.restype = wintypes.HANDLE
+    thread_first = kernel32.Thread32First
+    thread_first.argtypes = [wintypes.HANDLE, ctypes.POINTER(_ThreadEntry32)]
+    thread_first.restype = wintypes.BOOL
+    thread_next = kernel32.Thread32Next
+    thread_next.argtypes = [wintypes.HANDLE, ctypes.POINTER(_ThreadEntry32)]
+    thread_next.restype = wintypes.BOOL
+    open_thread = kernel32.OpenThread
+    open_thread.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    open_thread.restype = wintypes.HANDLE
+    resume_thread = kernel32.ResumeThread
+    resume_thread.argtypes = [wintypes.HANDLE]
+    resume_thread.restype = wintypes.DWORD
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+
+    snapshot = create_snapshot(_TH32CS_SNAPTHREAD, 0)
+    invalid_handle = ctypes.c_void_p(-1).value
+    if snapshot in {None, invalid_handle}:
+        raise OSError(ctypes.get_last_error(), "CreateToolhelp32Snapshot failed")
+    thread_ids: list[int] = []
+    enumeration_error = 0
+    try:
+        entry = _ThreadEntry32()
+        entry.dwSize = ctypes.sizeof(entry)
+        ctypes.set_last_error(0)
+        has_entry = bool(thread_first(snapshot, ctypes.byref(entry)))
+        first_error = 0 if has_entry else ctypes.get_last_error()
+        while has_entry:
+            if int(entry.th32OwnerProcessID) == process_id:
+                thread_ids.append(int(entry.th32ThreadID))
+            entry.dwSize = ctypes.sizeof(entry)
+            ctypes.set_last_error(0)
+            has_entry = bool(thread_next(snapshot, ctypes.byref(entry)))
+            if not has_entry:
+                enumeration_error = ctypes.get_last_error()
+    finally:
+        _ = close_handle(snapshot)
+    if first_error:
+        raise OSError(first_error, "Thread32First failed")
+    if enumeration_error != _ERROR_NO_MORE_FILES:
+        raise OSError(enumeration_error, "Thread32Next failed")
+    if len(thread_ids) != 1:
+        raise OSError("suspended Windows hook process primary thread is ambiguous")
+
+    thread_handle = open_thread(_THREAD_SUSPEND_RESUME, False, thread_ids[0])
+    if not thread_handle:
+        raise OSError(ctypes.get_last_error(), "OpenThread failed")
+    try:
+        previous_suspend_count = int(resume_thread(thread_handle))
+    finally:
+        _ = close_handle(thread_handle)
+    if previous_suspend_count == _RESUME_THREAD_FAILED:
+        raise OSError(ctypes.get_last_error(), "ResumeThread failed")
+    if previous_suspend_count != 1:
+        raise OSError("suspended Windows hook process had an unexpected suspend count")
+
+
+def _cleanup_failed_spawn(process: subprocess.Popen[bytes] | None, job: WindowsHookJob) -> None:
+    with contextlib.suppress(OSError):
+        job.terminate()
+    if process is not None:
+        if process.poll() is None:
+            with contextlib.suppress(OSError):
+                process.kill()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            process.wait(timeout=1)
+        _close_process_streams(process)
+    with contextlib.suppress(OSError):
+        close_windows_hook_job(job)
+
+
+def _close_process_streams(process: subprocess.Popen[bytes]) -> None:
+    for stream in (process.stdin, process.stdout, process.stderr):
+        if stream is not None:
+            with contextlib.suppress(OSError):
+                stream.close()
+
+
+__all__ = [
+    "WindowsHookJob",
+    "close_windows_hook_job",
+    "spawn_windows_hook_process",
+]

--- a/tests/test_codex_daemon_hook_bridge.py
+++ b/tests/test_codex_daemon_hook_bridge.py
@@ -144,6 +144,7 @@ def _write_authenticated_daemon_files(guard_home: Path, port: int) -> None:
     _DaemonHandler.captured_challenge_guard_token = None
     _DaemonHandler.captured_guard_token = None
     _DaemonHandler.captured_hook_body = None
+    _DaemonHandler.response_body = b"{}"
     _DaemonHandler.challenge_mode = "valid"
     _DaemonHandler.challenge_count = 0
 
@@ -604,7 +605,8 @@ def test_bridge_script_cold_start_stays_below_hook_budget(tmp_path: Path) -> Non
     port = daemon.server_address[1]
     _write_authenticated_daemon_files(guard_home, port)
     config = _bridge_config(guard_home, port)
-    command = [sys.executable, str(Path(bridge.__file__).resolve()), json.dumps(config)]
+    config["manifest_path"] = str(guard_home / "managed" / "codex" / "hooks-fixture.manifest.json")
+    command = [sys.executable, "-I", str(Path(bridge.__file__).resolve()), json.dumps(config)]
     payload = json.dumps({"hook_event_name": "PreToolUse"})
 
     try:

--- a/tests/test_codex_hook_fallback_isolation.py
+++ b/tests/test_codex_hook_fallback_isolation.py
@@ -1,0 +1,267 @@
+"""Security regressions for the authenticated, isolated Codex hook fallback."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import codex as codex_adapter
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
+from codex_plugin_scanner.guard.codex_hook_file_integrity import CodexHookIntegrityError
+from codex_plugin_scanner.guard.codex_hook_launch_runtime import (
+    isolated_hook_environment,
+    run_isolated_hook_process,
+)
+from codex_plugin_scanner.guard.codex_hook_runtime_trust import validate_codex_hook_launch
+
+
+def _installed_launch(tmp_path: Path) -> tuple[HarnessContext, tuple[str, ...], dict[str, object]]:
+    workspace = tmp_path / "workspace with spaces"
+    workspace.mkdir(parents=True)
+    context = HarnessContext(
+        home_dir=tmp_path / "home with spaces",
+        workspace_dir=workspace,
+        guard_home=tmp_path / "Guard home with spaces",
+        home_override_explicit=True,
+    )
+    CodexHarnessAdapter().install(context)
+    bridge_command = codex_adapter._hook_command_parts(context)
+    config = json.loads(bridge_command[3])
+    assert isinstance(config, dict)
+    return context, bridge_command, config
+
+
+def _trusted_launch(bridge_command: tuple[str, ...], config: dict[str, object]):
+    return validate_codex_hook_launch(
+        manifest_path=str(config["manifest_path"]),
+        state_path=str(config["state_path"]),
+        fallback_command=_config_command(config, "fallback_command"),
+        start_command=_config_command(config, "start_command"),
+        config_json=bridge_command[3],
+    )
+
+
+def _config_command(config: dict[str, object], name: str) -> list[str]:
+    value = config[name]
+    assert isinstance(value, list)
+    assert value and all(isinstance(token, str) for token in value)
+    return [token for token in value if isinstance(token, str)]
+
+
+def test_fallback_environment_drops_import_virtualenv_project_and_loader_controls(
+    tmp_path: Path,
+) -> None:
+    hostile = {
+        "PATH": str(tmp_path / "bin"),
+        "HOME": str(tmp_path / "home"),
+        "CODEX_HOME": str(tmp_path / "codex"),
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "C",
+        "PYTHONPATH": str(tmp_path / "python-path"),
+        "PYTHONHOME": str(tmp_path / "python-home"),
+        "PYTHONSTARTUP": str(tmp_path / "startup.py"),
+        "PYTHONINSPECT": "1",
+        "PYTHONWARNINGS": "error",
+        "PYTHONBREAKPOINT": "attacker.breakpoint",
+        "VIRTUAL_ENV": str(tmp_path / ".venv"),
+        "UV_PROJECT_ENVIRONMENT": str(tmp_path / "uv-project"),
+        "UV_PYTHON": str(tmp_path / "uv-python"),
+        "CONDA_PREFIX": str(tmp_path / "conda"),
+        "PIP_CONFIG_FILE": str(tmp_path / "pip.conf"),
+        "LD_PRELOAD": str(tmp_path / "preload.so"),
+        "DYLD_INSERT_LIBRARIES": str(tmp_path / "inject.dylib"),
+    }
+
+    environment = isolated_hook_environment(hostile)
+
+    assert environment == {
+        "PATH": hostile["PATH"],
+        "HOME": hostile["HOME"],
+        "CODEX_HOME": hostile["CODEX_HOME"],
+        "LANG": hostile["LANG"],
+        "LC_ALL": hostile["LC_ALL"],
+    }
+
+
+def test_verified_fallback_ignores_workspace_and_ambient_python_imports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context, bridge_command, config = _installed_launch(tmp_path)
+    workspace = context.workspace_dir
+    assert workspace is not None
+    marker = tmp_path / "attacker-imported.marker"
+    marker_write = f"from pathlib import Path\nPath({str(marker)!r}).write_text('executed')\n"
+    (workspace / "sitecustomize.py").write_text(marker_write, encoding="utf-8")
+    (workspace / "codex_plugin_scanner.py").write_text(marker_write, encoding="utf-8")
+    fake_package = workspace / "codex_plugin_scanner"
+    fake_package.mkdir()
+    (fake_package / "__init__.py").write_text(marker_write, encoding="utf-8")
+    monkeypatch.chdir(workspace)
+    monkeypatch.setenv("PYTHONPATH", str(workspace))
+    monkeypatch.setenv("PYTHONSTARTUP", str(workspace / "sitecustomize.py"))
+    monkeypatch.setenv("VIRTUAL_ENV", str(workspace / ".venv"))
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", str(workspace))
+
+    trusted = _trusted_launch(bridge_command, config)
+    fallback_command = _config_command(config, "fallback_command")
+    payload = json.dumps(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "printf 'payload survives'"},
+        },
+        separators=(",", ":"),
+    )
+    fallback_stdout = trusted.run_fallback(fallback_command, data=payload, timeout_seconds=20)
+
+    assert fallback_stdout == ""
+    assert trusted.cwd == Path(str(config["manifest_path"])).parent.resolve(strict=True)
+    assert trusted.cwd != workspace.resolve()
+    assert {"PYTHONPATH", "PYTHONSTARTUP", "VIRTUAL_ENV", "UV_PROJECT_ENVIRONMENT"}.isdisjoint(trusted.environment)
+    workspace_index = fallback_command.index("--workspace")
+    assert fallback_command[workspace_index + 1] == str(workspace)
+    assert fallback_command[:3] == [str(Path(sys.executable).absolute()), "-I", "-c"]
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize("mutation", ["extra-argv", "altered-entrypoint"])
+def test_tampered_bridge_launch_contract_fails_closed_without_executing_project_code(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    context, bridge_command, config = _installed_launch(tmp_path)
+    workspace = context.workspace_dir
+    assert workspace is not None
+    marker = tmp_path / "sitecustomize-executed.marker"
+    (workspace / "sitecustomize.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('executed')\n",
+        encoding="utf-8",
+    )
+    fallback_command = _config_command(config, "fallback_command")
+    if mutation == "extra-argv":
+        fallback_command.append("--attacker-argument")
+    else:
+        fallback_command[3] = f"from pathlib import Path;Path({str(marker)!r}).write_text('executed')"
+    config["fallback_command"] = fallback_command
+    tampered_json = json.dumps(config, separators=(",", ":"))
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(workspace)
+    result = subprocess.run(
+        [*bridge_command[:3], tampered_json],
+        input=json.dumps({"hook_event_name": "PreToolUse"}),
+        capture_output=True,
+        text=True,
+        cwd=workspace,
+        env=environment,
+        timeout=10,
+        check=False,
+    )
+
+    response = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert response["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "hol-guard install codex" in result.stdout
+    assert result.stderr == ""
+    assert not marker.exists()
+
+
+def test_runtime_rejects_a_manifest_changed_after_install(tmp_path: Path) -> None:
+    _context, bridge_command, config = _installed_launch(tmp_path)
+    manifest_path = Path(str(config["manifest_path"]))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["package_version"] = "attacker-replacement"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(CodexHookIntegrityError, match="authentication failed"):
+        _trusted_launch(bridge_command, config)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink replacement semantics differ on Windows")
+def test_runtime_rejects_interpreter_symlink_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    interpreter_link = tmp_path / "guard-python"
+    interpreter_link.symlink_to(Path(sys.executable).resolve(strict=True))
+    replacement = tmp_path / "replacement-python"
+    replacement.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    replacement.chmod(0o755)
+    monkeypatch.setattr(codex_adapter.sys, "executable", str(interpreter_link))
+    _context, bridge_command, config = _installed_launch(tmp_path)
+    interpreter_link.unlink()
+    interpreter_link.symlink_to(replacement)
+
+    with pytest.raises(CodexHookIntegrityError, match="symlink target changed"):
+        _trusted_launch(bridge_command, config)
+
+
+def test_isolated_process_preserves_exact_input_and_bounds_combined_output(tmp_path: Path) -> None:
+    cwd = tmp_path / "neutral"
+    cwd.mkdir(mode=0o700)
+    payload = "exact input with spaces, unicode: \N{SNOWMAN}\n"
+    echo_result = run_isolated_hook_process(
+        [sys.executable, "-I", "-c", "import sys;sys.stdout.buffer.write(sys.stdin.buffer.read())"],
+        input_text=payload,
+        cwd=cwd,
+        environment=isolated_hook_environment(),
+        timeout_seconds=5,
+        output_limit=1024,
+    )
+    overflow_result = run_isolated_hook_process(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            "import sys;sys.stdout.write('o'*800);sys.stderr.write('e'*800);sys.stdout.flush();sys.stderr.flush()",
+        ],
+        input_text="",
+        cwd=cwd,
+        environment=isolated_hook_environment(),
+        timeout_seconds=5,
+        output_limit=1024,
+    )
+
+    assert echo_result.returncode == 0
+    assert echo_result.stdout == payload
+    assert echo_result.output_limit_exceeded is False
+    assert overflow_result.output_limit_exceeded is True
+    assert len(overflow_result.stdout.encode("utf-8")) <= 1024
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group lifetime assertion")
+def test_isolated_process_timeout_kills_descendants(tmp_path: Path) -> None:
+    cwd = tmp_path / "neutral"
+    cwd.mkdir(mode=0o700)
+    marker = tmp_path / "escaped-child.marker"
+    child = f"import time;from pathlib import Path;time.sleep(0.5);Path({str(marker)!r}).write_text('escaped')"
+    parent = f"import subprocess,sys,time;subprocess.Popen([sys.executable,'-I','-c',{child!r}]);time.sleep(10)"
+
+    result = run_isolated_hook_process(
+        [sys.executable, "-I", "-c", parent],
+        input_text="",
+        cwd=cwd,
+        environment=isolated_hook_environment(),
+        timeout_seconds=0.1,
+    )
+    time.sleep(0.6)
+
+    assert result.timed_out is True
+    assert not marker.exists()
+
+
+@pytest.fixture(autouse=True)
+def _restore_current_directory() -> Iterator[None]:
+    original = Path.cwd()
+    try:
+        yield
+    finally:
+        os.chdir(original)

--- a/tests/test_codex_hook_fallback_isolation.py
+++ b/tests/test_codex_hook_fallback_isolation.py
@@ -263,7 +263,6 @@ def test_isolated_process_preserves_exact_input_and_bounds_combined_output(tmp_p
     assert len(overflow_result.stdout.encode("utf-8")) <= 1024
 
 
-@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group lifetime assertion")
 def test_isolated_process_timeout_kills_descendants(tmp_path: Path) -> None:
     cwd = tmp_path / "neutral"
     cwd.mkdir(mode=0o700)
@@ -284,7 +283,6 @@ def test_isolated_process_timeout_kills_descendants(tmp_path: Path) -> None:
     assert not marker.exists()
 
 
-@pytest.mark.skipif(os.name == "nt", reason="POSIX descendant-held pipe assertion")
 def test_isolated_process_closes_descendant_held_pipes_after_parent_exit(tmp_path: Path) -> None:
     cwd = tmp_path / "neutral"
     cwd.mkdir(mode=0o700)

--- a/tests/test_codex_hook_fallback_isolation.py
+++ b/tests/test_codex_hook_fallback_isolation.py
@@ -186,6 +186,32 @@ def test_runtime_rejects_a_manifest_changed_after_install(tmp_path: Path) -> Non
 
 
 @pytest.mark.skipif(os.name == "nt", reason="symlink replacement semantics differ on Windows")
+def test_signed_runtime_guard_home_is_canonical_across_directory_aliases(tmp_path: Path) -> None:
+    real_root = tmp_path / "real"
+    real_root.mkdir()
+    alias_root = tmp_path / "alias"
+    alias_root.symlink_to(real_root, target_is_directory=True)
+    workspace = alias_root / "workspace"
+    workspace.mkdir()
+    context = HarnessContext(
+        home_dir=alias_root / "home",
+        workspace_dir=workspace,
+        guard_home=alias_root / "guard-home",
+        home_override_explicit=True,
+    )
+
+    CodexHarnessAdapter().install(context)
+    bridge_command = codex_adapter._hook_command_parts(context)
+    config = json.loads(bridge_command[3])
+    trusted = _trusted_launch(bridge_command, config)
+    canonical_guard_home = context.guard_home.resolve(strict=True)
+
+    assert Path(str(config["state_path"])).parent == canonical_guard_home
+    assert str(canonical_guard_home) in _config_command(config, "start_command")[3]
+    assert trusted.cwd == canonical_guard_home / "managed" / "codex"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink replacement semantics differ on Windows")
 def test_runtime_rejects_interpreter_symlink_swap(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -255,6 +281,30 @@ def test_isolated_process_timeout_kills_descendants(tmp_path: Path) -> None:
     time.sleep(0.6)
 
     assert result.timed_out is True
+    assert not marker.exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX descendant-held pipe assertion")
+def test_isolated_process_closes_descendant_held_pipes_after_parent_exit(tmp_path: Path) -> None:
+    cwd = tmp_path / "neutral"
+    cwd.mkdir(mode=0o700)
+    marker = tmp_path / "escaped-after-parent-exit.marker"
+    child = f"import time;from pathlib import Path;time.sleep(0.5);Path({str(marker)!r}).write_text('escaped')"
+    parent = f"import subprocess,sys;subprocess.Popen([sys.executable,'-I','-c',{child!r}])"
+
+    started_at = time.monotonic()
+    result = run_isolated_hook_process(
+        [sys.executable, "-I", "-c", parent],
+        input_text="",
+        cwd=cwd,
+        environment=isolated_hook_environment(),
+        timeout_seconds=2,
+    )
+    elapsed = time.monotonic() - started_at
+    time.sleep(0.6)
+
+    assert result.returncode == 0
+    assert elapsed < 1
     assert not marker.exists()
 
 

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -166,17 +166,20 @@ def test_guard_codex_hook_command_uses_lightweight_authenticated_daemon_bridge(t
         )
     )
     tokens = shlex.split(command)
-    bridge_config = json.loads(tokens[2])
+    bridge_config = json.loads(tokens[3])
 
-    assert Path(tokens[1]).name == "codex_daemon_hook_bridge.py"
+    assert tokens[1] == "-I"
+    assert Path(tokens[2]).name == "codex_daemon_hook_bridge.py"
     assert bridge_config["state_path"] == str(guard_home / "daemon-state.json")
+    assert bridge_config["manifest_path"].startswith(str(guard_home / "managed" / "codex"))
     assert bridge_config["query"].startswith("guard-home=")
     assert bridge_config["fallback_command"][:3] == [
         str(Path(sys.executable).absolute()),
-        "-m",
-        "codex_plugin_scanner.cli",
+        "-I",
+        "-c",
     ]
-    assert bridge_config["start_command"][0] == str(Path(sys.executable).absolute())
+    assert bridge_config["fallback_command"][4:8] == ["guard", "hook", "--harness", "codex"]
+    assert bridge_config["start_command"][:3] == [str(Path(sys.executable).absolute()), "-I", "-c"]
     assert bridge_config["hook_timeouts"]["PreToolUse"] > bridge_config["hook_timeouts"]["UserPromptSubmit"]
 
 
@@ -922,7 +925,7 @@ def test_guard_install_and_repair_codex_preserve_ambiguous_legacy_post_tool_hook
     command_tokens = [shlex.split(command) for command in commands]
     current_bridge_path = Path(codex_adapter.__file__).with_name("codex_daemon_hook_bridge.py").resolve()
     authenticated_bridge_commands = [
-        tokens for tokens in command_tokens if len(tokens) > 1 and Path(tokens[1]).resolve() == current_bridge_path
+        tokens for tokens in command_tokens if len(tokens) > 2 and Path(tokens[2]).resolve() == current_bridge_path
     ]
     final_state = codex_adapter.codex_native_hook_state(
         HarnessContext(


### PR DESCRIPTION
## Summary

- isolate the Codex daemon-start and local fallback interpreter with `-I`, an attested absolute interpreter, and a bootstrap pinned to the authenticated package root
- authenticate the complete bridge config, manifest, packaged runtime files, fallback argv, daemon-start argv, event bindings, and interpreter immediately before any recovery child runs
- run recovery children from the private Guard-managed manifest directory with Python, virtualenv, project, package-manager, and dynamic-loader controls removed
- bound hook input, combined child output, timeout, and descendant process lifetime; fail closed with `hol-guard install codex` repair guidance on any identity failure
- contain Windows recovery descendants in an authenticated kill-on-close Job Object, assigning the suspended child before any hook code can run

## Testing

- `uv run --no-sync python -m ruff check src/`
- `uv run --no-sync basedpyright --level error`
- `uv run --no-sync pytest -q tests/test_codex_hook_fallback_isolation.py tests/test_codex_daemon_hook_bridge.py tests/test_guard_codex_install.py` — 97 passed on final-head Python 3.12
- `uv run --isolated --frozen --extra dev --python 3.10 pytest -q tests/test_codex_hook_fallback_isolation.py tests/test_codex_daemon_hook_bridge.py tests/test_guard_codex_install.py` — 97 passed on final head
- `uv run --no-sync pytest --tb=short -q` — 9,748 passed, 26 skipped, 5 deselected on the pre-review head; the final review patch adds two passing focused regressions
- `uv build --python 3.12` and `uv build --python 3.10` — both sdists and wheels passed

## Notes

Security evidence:

- neutral cwd: the resolved, owner-only `Guard home/managed/codex` manifest directory, never the agent workspace
- scrubbed controls include `PYTHONPATH`, `PYTHONHOME`, `PYTHONSTARTUP`, `PYTHONINSPECT`, `VIRTUAL_ENV`, `UV_PROJECT_ENVIRONMENT`, `UV_PYTHON`, `CONDA_PREFIX`, `PIP_CONFIG_FILE`, `LD_PRELOAD`, and `DYLD_INSERT_LIBRARIES`
- authenticated package roles: bridge, bridge runtime, launch runtime, runtime trust, fallback entrypoint, daemon entrypoint, and daemon manager
- Windows Job Object implementation is a separately authenticated package role; timeout and parent-exit descendant tests run in the Windows cross-platform CI job
- marker-file tests prove fake `codex_plugin_scanner` modules/packages and `sitecustomize.py` in cwd/PYTHONPATH never execute
- tampered argv/bootstrap, manifest MAC changes, interpreter symlink swaps, output overflow, timeout, and descendant escape attempts all fail closed

Full-run failures are the 11 failures reproduced on `release/2.1` (7 hook-inventory and 4 Bun/Vitest fixtures), plus one local macOS OS-credential-store availability failure. The final P26 head adds 12 passing tests.

Base: `release/2.1`. Feature commit author and committer: `deep-purple-boots <301892678+deep-purple-boots@users.noreply.github.com>`.
