### PR TITLE
fix(guard): canonicalize npm source identities

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/npm_source_spec.py
+++ b/src/codex_plugin_scanner/guard/runtime/npm_source_spec.py
@@ -47,9 +47,15 @@ def parse_npm_source_spec(value: str | None) -> NpmSourceSpec | None:
     if value is None or not (source := value.strip()):
         return None
     lowered = source.lower()
-    if lowered.startswith("npm:"):
-        nested = parse_npm_source_spec(source[4:])
-        return nested
+    alias_depth = 0
+    while lowered.startswith("npm:"):
+        alias_depth += 1
+        if alias_depth > 32:
+            return _invalid(source, "npm_source_alias_depth_exceeded")
+        source = source[4:].strip()
+        if not source:
+            return _invalid(value, "npm_source_alias_invalid")
+        lowered = source.lower()
     if lowered.startswith("file:"):
         parsed_file = urllib.parse.urlsplit(source)
         if parsed_file.netloc or parsed_file.query or parsed_file.fragment:
@@ -96,8 +102,12 @@ def _url_source(source: str) -> NpmSourceSpec:
         return _invalid(source, "npm_source_host_invalid")
     rendered_host = _host_with_port(host, scheme, port)
     git_hosted = host in set(_HOSTED.values())
-    if scheme in _GIT_SCHEMES or git_hosted:
+    if scheme in _GIT_SCHEMES:
         return _git_from_host_path(rendered_host, parsed.path, parsed.fragment)
+    if git_hosted:
+        git_source = _git_from_host_path(rendered_host, parsed.path, parsed.fragment)
+        if git_source.valid or git_source.reason != "npm_source_path_invalid":
+            return git_source
     normalized_path = _canonical_path(parsed.path, minimum_parts=1)
     if normalized_path is None:
         return _invalid(source, "npm_source_path_invalid")
@@ -184,7 +194,10 @@ def _repository_path(host: str, raw_path: str) -> tuple[str | None, str | None]:
     elif host == "gitlab.com" and "-" in parts:
         marker_index = parts.index("-")
         if marker_index + 1 < len(parts) and parts[marker_index + 1].lower() == "archive":
-            revision = parts[marker_index + 2] if marker_index + 2 < len(parts) else None
+            revision_parts = parts[marker_index + 2 :]
+            if revision_parts and _looks_like_archive_filename(revision_parts[-1]):
+                revision_parts = revision_parts[:-1]
+            revision = "/".join(revision_parts) or None
             parts = parts[:marker_index]
     elif host == "bitbucket.org" and len(parts) > 2:
         if parts[2].lower() != "get":
@@ -208,6 +221,11 @@ def _strip_archive_suffix(value: str) -> str:
         if lowered.endswith(suffix):
             return value[: -len(suffix)]
     return value
+
+
+def _looks_like_archive_filename(value: str) -> bool:
+    lowered = value.lower()
+    return lowered.endswith((".tar.gz", ".tgz", ".tar", ".zip"))
 
 
 def _canonical_path(raw_path: str, *, minimum_parts: int) -> str | None:

--- a/src/codex_plugin_scanner/guard/runtime/npm_source_spec.py
+++ b/src/codex_plugin_scanner/guard/runtime/npm_source_spec.py
@@ -1,0 +1,282 @@
+"""Canonical, credential-free npm source specification identities."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import urllib.parse
+from dataclasses import dataclass
+from typing import Literal
+
+SourceKind = Literal["git", "url", "local", "invalid"]
+RevisionKind = Literal["immutable_commit", "mutable_ref", "missing", "not_applicable"]
+
+_HOSTED = {
+    "github": "github.com",
+    "gitlab": "gitlab.com",
+    "bitbucket": "bitbucket.org",
+}
+_GIT_SCHEMES = frozenset({"git", "git+https", "git+ssh", "ssh"})
+_URL_SCHEMES = frozenset({"http", "https", *_GIT_SCHEMES})
+_DEFAULT_PORTS = {"http": 80, "https": 443, "git+https": 443, "ssh": 22, "git+ssh": 22, "git": 9418}
+_SCP_RE = re.compile(r"^(?P<user>[^@/:]+)@(?P<host>[^/:]+):(?P<path>[^#]+)(?:#(?P<fragment>.*))?$")
+_COMMIT_RE = re.compile(r"(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})")
+_ENCODED_SEPARATOR_RE = re.compile(r"%(?:00|2f|5c)", re.IGNORECASE)
+_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+
+
+@dataclass(frozen=True, slots=True)
+class NpmSourceSpec:
+    source_kind: SourceKind
+    canonical_repository: str | None
+    revision: str | None
+    revision_kind: RevisionKind
+    identity: str
+    redacted: str
+    valid: bool = True
+    reason: str | None = None
+
+    @property
+    def is_git(self) -> bool:
+        return self.source_kind == "git" and self.valid
+
+
+def parse_npm_source_spec(value: str | None) -> NpmSourceSpec | None:
+    """Return one canonical source identity, or ``None`` for registry syntax."""
+
+    if value is None or not (source := value.strip()):
+        return None
+    lowered = source.lower()
+    if lowered.startswith("npm:"):
+        nested = parse_npm_source_spec(source[4:])
+        return nested
+    if lowered.startswith("file:"):
+        parsed_file = urllib.parse.urlsplit(source)
+        if parsed_file.netloc or parsed_file.query or parsed_file.fragment:
+            return _invalid(source, "npm_source_local_url_invalid")
+        return _non_git_source("local", source, redacted="file:<local-source>")
+    for prefix, host in _HOSTED.items():
+        marker = f"{prefix}:"
+        if lowered.startswith(marker):
+            return _git_from_host_path(host, source[len(marker) :], None)
+    scp = _SCP_RE.fullmatch(source)
+    if scp is not None:
+        if scp.group("user").lower() != "git":
+            return _invalid(source, "npm_source_ambiguous_userinfo")
+        return _git_from_host_path(scp.group("host"), scp.group("path"), scp.group("fragment"))
+    if "://" in source or _SCHEME_RE.match(source) is not None:
+        return _url_source(source)
+    if source.startswith(("@", "./", "../", "/", "~", "\\")) or ":" in source:
+        return None
+    parts = source.split("#", 1)
+    path = parts[0]
+    fragment = parts[1] if len(parts) == 2 else None
+    if path.count("/") == 1 and all(part.strip() for part in path.split("/")):
+        return _git_from_host_path("github.com", path, fragment)
+    return None
+
+
+def _url_source(source: str) -> NpmSourceSpec:
+    try:
+        parsed = urllib.parse.urlsplit(source)
+        port = parsed.port
+    except ValueError:
+        return _invalid(source, "npm_source_malformed_port")
+    scheme = parsed.scheme.lower()
+    if scheme not in _URL_SCHEMES:
+        return _invalid(source, "npm_source_protocol_unsupported")
+    if parsed.hostname is None:
+        return _invalid(source, "npm_source_host_missing")
+    if parsed.password is not None or parsed.username not in {None, "git"}:
+        return _invalid(source, "npm_source_ambiguous_userinfo")
+    if parsed.username == "git" and scheme not in {"ssh", "git+ssh"}:
+        return _invalid(source, "npm_source_ambiguous_userinfo")
+    host = _canonical_host(parsed.hostname)
+    if host is None:
+        return _invalid(source, "npm_source_host_invalid")
+    rendered_host = _host_with_port(host, scheme, port)
+    git_hosted = host in set(_HOSTED.values())
+    if scheme in _GIT_SCHEMES or git_hosted:
+        return _git_from_host_path(rendered_host, parsed.path, parsed.fragment)
+    normalized_path = _canonical_path(parsed.path, minimum_parts=1)
+    if normalized_path is None:
+        return _invalid(source, "npm_source_path_invalid")
+    canonical = f"{scheme}://{rendered_host}/{normalized_path}"
+    digest = _digest(canonical)
+    return NpmSourceSpec(
+        source_kind="url",
+        canonical_repository=None,
+        revision=None,
+        revision_kind="not_applicable",
+        identity=f"url:{digest}",
+        redacted=canonical,
+    )
+
+
+def _git_from_host_path(host_value: str, path_value: str, fragment: str | None) -> NpmSourceSpec:
+    if fragment is None and "#" in path_value:
+        path_value, fragment = path_value.split("#", 1)
+    host, separator, port_text = host_value.partition(":")
+    canonical_host = _canonical_host(host)
+    if canonical_host is None:
+        return _invalid(f"{host_value}/{path_value}", "npm_source_host_invalid")
+    if separator:
+        try:
+            port = int(port_text)
+        except ValueError:
+            return _invalid(f"{host_value}/{path_value}", "npm_source_malformed_port")
+        if not 1 <= port <= 65535:
+            return _invalid(f"{host_value}/{path_value}", "npm_source_malformed_port")
+        rendered_host = f"{canonical_host}:{port}"
+    else:
+        rendered_host = canonical_host
+    if "?" in path_value or "\\" in path_value or _ENCODED_SEPARATOR_RE.search(path_value):
+        return _invalid(f"{host_value}/{path_value}", "npm_source_path_invalid")
+    path, archive_revision = _repository_path(canonical_host, path_value)
+    if path is None:
+        return _invalid(f"{host_value}/{path_value}", "npm_source_path_invalid")
+    revision = fragment.strip() if fragment is not None and fragment.strip() else archive_revision
+    if revision is not None:
+        revision = _canonical_revision(revision)
+        if revision is None:
+            return _invalid(f"{host_value}/{path_value}", "npm_source_revision_invalid")
+    revision_kind: RevisionKind
+    if revision is None:
+        revision_kind = "missing"
+        revision_identity = "missing"
+        revision_display = ""
+    elif _COMMIT_RE.fullmatch(revision):
+        revision = revision.lower()
+        revision_kind = "immutable_commit"
+        revision_identity = f"commit:{revision}"
+        revision_display = "#<immutable-commit>"
+    else:
+        revision_kind = "mutable_ref"
+        revision_identity = f"mutable:{_digest(revision)}"
+        revision_display = "#<mutable-ref>"
+    repository = f"git:{rendered_host}/{path}"
+    return NpmSourceSpec(
+        source_kind="git",
+        canonical_repository=repository,
+        revision=revision,
+        revision_kind=revision_kind,
+        identity=f"{repository}#{revision_identity}",
+        redacted=f"{repository}{revision_display}",
+    )
+
+
+def _repository_path(host: str, raw_path: str) -> tuple[str | None, str | None]:
+    minimum_parts = 2 if host in _HOSTED.values() else 1
+    normalized = _canonical_path(raw_path, minimum_parts=minimum_parts)
+    if normalized is None:
+        return None, None
+    parts = normalized.split("/")
+    revision: str | None = None
+    if host == "github.com" and len(parts) > 2:
+        marker = parts[2].lower()
+        if marker in {"archive", "tarball", "zipball"}:
+            revision = "/".join(parts[3:]) or None
+            if revision is not None:
+                revision = _strip_archive_suffix(revision)
+            parts = parts[:2]
+        else:
+            return None, None
+    elif host == "gitlab.com" and "-" in parts:
+        marker_index = parts.index("-")
+        if marker_index + 1 < len(parts) and parts[marker_index + 1].lower() == "archive":
+            revision = parts[marker_index + 2] if marker_index + 2 < len(parts) else None
+            parts = parts[:marker_index]
+    elif host == "bitbucket.org" and len(parts) > 2:
+        if parts[2].lower() != "get":
+            return None, None
+        revision = _strip_archive_suffix("/".join(parts[3:])) or None
+        parts = parts[:2]
+    if len(parts) < minimum_parts:
+        return None, None
+    if host in _HOSTED.values():
+        parts = [part.lower() for part in parts]
+    if parts[-1].lower().endswith(".git"):
+        parts[-1] = parts[-1][:-4]
+    if not parts[-1]:
+        return None, None
+    return "/".join(parts), revision
+
+
+def _strip_archive_suffix(value: str) -> str:
+    lowered = value.lower()
+    for suffix in (".tar.gz", ".tgz", ".tar", ".zip"):
+        if lowered.endswith(suffix):
+            return value[: -len(suffix)]
+    return value
+
+
+def _canonical_path(raw_path: str, *, minimum_parts: int) -> str | None:
+    if _ENCODED_SEPARATOR_RE.search(raw_path) or "\\" in raw_path:
+        return None
+    raw_parts = [part for part in raw_path.strip("/").split("/") if part]
+    if len(raw_parts) < minimum_parts:
+        return None
+    normalized: list[str] = []
+    for part in raw_parts:
+        try:
+            decoded = urllib.parse.unquote(part, errors="strict")
+        except UnicodeError:
+            return None
+        if decoded in {".", ".."} or not decoded or "/" in decoded or "\\" in decoded or "\x00" in decoded:
+            return None
+        normalized.append(urllib.parse.quote(decoded, safe="!$&'()+,;=@._~-"))
+    return "/".join(normalized)
+
+
+def _canonical_revision(raw_revision: str) -> str | None:
+    if _ENCODED_SEPARATOR_RE.search(raw_revision) or "\\" in raw_revision or "?" in raw_revision:
+        return None
+    try:
+        revision = urllib.parse.unquote(raw_revision, errors="strict").strip()
+    except UnicodeError:
+        return None
+    if not revision or "\x00" in revision or any(character.isspace() for character in revision):
+        return None
+    return revision
+
+
+def _canonical_host(host: str) -> str | None:
+    try:
+        return host.rstrip(".").encode("idna").decode("ascii").lower() or None
+    except UnicodeError:
+        return None
+
+
+def _host_with_port(host: str, scheme: str, port: int | None) -> str:
+    return host if port is None or _DEFAULT_PORTS.get(scheme) == port else f"{host}:{port}"
+
+
+def _non_git_source(kind: Literal["local"], source: str, *, redacted: str) -> NpmSourceSpec:
+    return NpmSourceSpec(
+        source_kind=kind,
+        canonical_repository=None,
+        revision=None,
+        revision_kind="not_applicable",
+        identity=f"{kind}:{_digest(source)}",
+        redacted=redacted,
+    )
+
+
+def _invalid(source: str, reason: str) -> NpmSourceSpec:
+    return NpmSourceSpec(
+        source_kind="invalid",
+        canonical_repository=None,
+        revision=None,
+        revision_kind="not_applicable",
+        identity=f"invalid:{reason}:{_digest(source)}",
+        redacted="<invalid-source>",
+        valid=False,
+        reason=reason,
+    )
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+__all__ = ["NpmSourceSpec", "parse_npm_source_spec"]

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
@@ -12,6 +12,7 @@ from typing import Literal
 
 from ..models import GuardArtifact
 from .mcp_protection import _split_package_token
+from .npm_source_spec import NpmSourceSpec, parse_npm_source_spec
 from .workspace_path_guard import existing_paths_within_workspace
 
 IntentKind = Literal["install", "execute", "sync"]
@@ -19,12 +20,7 @@ EvidenceStatus = Literal["available", "missing", "not_regular", "unreadable", "u
 _EXTRAS_RE = re.compile(r"^(?P<name>[A-Za-z0-9_.-]+)\[(?P<extras>[A-Za-z0-9_,.-]+)\]$")
 _EGG_FRAGMENT_RE = re.compile(r"(?:^|[#&])egg=([^&#]+)")
 _PYTHON_VERSION_RE = re.compile(r"(?P<name>[^<>=!~\s]+)(?P<op>===|==|~=|!=|<=|>=|<|>|=)?(?P<version>.*)")
-_JS_SOURCE_PREFIXES = ("http:", "https:", "git+", "github:", "gitlab:", "bitbucket:", "file:")
 _HTTP_SOURCE_IN_TOKEN_RE = re.compile(r"https?:", re.IGNORECASE)
-_NAMED_JS_SOURCE_SEPARATOR_RE = re.compile(
-    r"@(?=(?:https?|git\+|github|gitlab|bitbucket|file):)",
-    re.IGNORECASE,
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,6 +30,11 @@ class PackageIntentTarget:
     raw_spec: str = field(repr=False)
     requested_specifier: str | None
     source_url: str | None = field(default=None, repr=False)
+    source_kind: str | None = None
+    source_repository: str | None = None
+    source_revision_kind: str | None = None
+    source_identity: str | None = None
+    source_invalid_reason: str | None = None
     alias: str | None = None
     dependency_group: str | None = None
     extras: tuple[str, ...] = ()
@@ -52,6 +53,15 @@ class PackageIntentTarget:
         """Return exact request values for ephemeral in-process enforcement."""
 
         return asdict(self)
+
+    def to_fingerprint_dict(self) -> dict[str, object]:
+        """Return approval identity fields with canonical Git source spelling."""
+
+        payload = self.to_dict()
+        if self.source_kind == "git" and self.source_identity is not None:
+            for exact_field in ("raw_spec", "raw_spec_hash", "source_url", "source_url_hash"):
+                payload.pop(exact_field, None)
+        return payload
 
 
 @dataclass(frozen=True, slots=True)
@@ -146,8 +156,8 @@ def build_package_request_artifact(
                 "harness": harness,
                 "package_manager": intent.package_manager,
                 "intent_kind": intent.intent_kind,
-                "redacted_command": intent.redacted_command,
-                "targets": [target.to_dict() for target in intent.targets],
+                "redacted_command": _fingerprint_command_shape(intent),
+                "targets": [target.to_fingerprint_dict() for target in intent.targets],
                 "manifest_paths": list(manifest_paths),
                 "lockfile_paths": list(lockfile_paths),
                 "local_executions": [evidence.to_dict() for evidence in intent.local_executions],
@@ -280,6 +290,20 @@ def package_runtime_reason(intent: PackageIntent) -> str:
     )
 
 
+def _fingerprint_command_shape(intent: PackageIntent) -> str:
+    if not any(target.source_kind == "git" for target in intent.targets):
+        return intent.redacted_command
+    tokens = list(intent.command_tokens)
+    for target in intent.targets:
+        if target.source_kind != "git":
+            continue
+        for source_spelling in (target.raw_spec, target.source_url):
+            if not source_spelling:
+                continue
+            tokens = [token.replace(source_spelling, "<canonical-git-source>") for token in tokens]
+    return shlex.join(tokens)
+
+
 def _local_execution_runtime_metadata(intent: PackageIntent) -> dict[str, object]:
     if not intent.local_executions:
         return {}
@@ -378,34 +402,44 @@ def js_target(spec: str) -> PackageIntentTarget:
     normalized_spec = spec
     if "@npm:" in spec and not spec.startswith("@npm:"):
         alias, _, normalized_spec = spec.partition("@npm:")
-    # A complete URL can itself contain '@' in userinfo or its path.  Treat it
-    # as a source before looking for the package@source separator so an
-    # attacker cannot demote it into a schemeless/git-style request.
-    if normalized_spec.lower().startswith(_JS_SOURCE_PREFIXES):
-        return PackageIntentTarget(
-            "npm",
-            _source_url_package_name(normalized_spec),
-            spec,
-            None,
-            source_url=normalized_spec,
-            alias=alias,
-        )
+    parsed_source = parse_npm_source_spec(normalized_spec)
+    if parsed_source is not None and _is_unnamed_js_source_spec(normalized_spec):
+        return _js_source_target(spec, normalized_spec, parsed_source, alias=alias)
     named_source_package, source_url = _split_js_named_source_spec(normalized_spec)
     if source_url is not None:
-        return PackageIntentTarget("npm", named_source_package, spec, None, source_url=source_url, alias=alias)
-    if _looks_like_js_source_spec(normalized_spec):
-        return PackageIntentTarget(
-            "npm",
-            _source_url_package_name(normalized_spec),
-            spec,
-            None,
-            source_url=normalized_spec,
-            alias=alias,
-        )
+        parsed_source = parse_npm_source_spec(source_url)
+        assert parsed_source is not None
+        return _js_source_target(spec, source_url, parsed_source, package_name=named_source_package, alias=alias)
+    if parsed_source is not None:
+        return _js_source_target(spec, normalized_spec, parsed_source, alias=alias)
     package_name, requested_specifier = _split_package_token(normalized_spec)
-    if _looks_like_js_source_spec(requested_specifier):
-        return PackageIntentTarget("npm", package_name, spec, None, source_url=requested_specifier, alias=alias)
+    parsed_source = parse_npm_source_spec(requested_specifier)
+    if requested_specifier is not None and parsed_source is not None:
+        return _js_source_target(spec, requested_specifier, parsed_source, package_name=package_name, alias=alias)
     return PackageIntentTarget("npm", package_name, spec, requested_specifier, alias=alias)
+
+
+def _js_source_target(
+    raw_spec: str,
+    source_url: str,
+    source: NpmSourceSpec,
+    *,
+    package_name: str | None = None,
+    alias: str | None,
+) -> PackageIntentTarget:
+    return PackageIntentTarget(
+        "npm",
+        package_name or _source_url_package_name(source_url),
+        raw_spec,
+        None,
+        source_url=source_url,
+        source_kind=source.source_kind,
+        source_repository=source.canonical_repository,
+        source_revision_kind=source.revision_kind,
+        source_identity=source.identity,
+        source_invalid_reason=source.reason,
+        alias=alias,
+    )
 
 
 def python_target(
@@ -525,31 +559,29 @@ def _sanitize_url(value: str) -> str:
 
 
 def _split_js_named_source_spec(spec: str) -> tuple[str | None, str | None]:
-    separator = _NAMED_JS_SOURCE_SEPARATOR_RE.search(spec)
-    if separator is None:
-        return None, None
-    package_name = spec[: separator.start()]
-    source_candidate = spec[separator.end() :]
-    normalized_package_name = package_name.strip()
-    normalized_source = source_candidate.strip()
-    if not normalized_package_name or not _looks_like_js_source_spec(normalized_source):
-        return None, None
-    return normalized_package_name, normalized_source
+    for index, character in enumerate(spec):
+        if character != "@" or index == 0:
+            continue
+        package_name = spec[:index].strip()
+        source_candidate = spec[index + 1 :].strip()
+        if package_name and parse_npm_source_spec(source_candidate) is not None:
+            return package_name, source_candidate
+    return None, None
 
 
-def _looks_like_js_source_spec(value: str | None) -> bool:
-    if not value:
-        return False
-    normalized = value.strip()
-    if normalized.lower().startswith(_JS_SOURCE_PREFIXES) or "://" in normalized:
-        return True
-    if normalized.startswith("@") or normalized.startswith(("./", "../", "/")) or ":" in normalized:
-        return False
-    parts = normalized.split("/")
-    return len(parts) == 2 and all(part.strip() for part in parts)
+def _is_unnamed_js_source_spec(value: str) -> bool:
+    lowered = value.lower()
+    return (
+        re.match(r"^[A-Za-z][A-Za-z0-9+.-]*://", value) is not None
+        or lowered.startswith(("git@", "git+", "github:", "gitlab:", "bitbucket:", "file:"))
+        or "@" not in value
+    )
 
 
 def _source_url_package_name(source_url: str) -> str | None:
+    parsed_source = parse_npm_source_spec(source_url)
+    if parsed_source is not None and parsed_source.canonical_repository is not None:
+        return parsed_source.canonical_repository.rsplit("/", 1)[-1] or None
     normalized = source_url.strip()
     candidate = (
         normalized.partition(":")[2]

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
@@ -60,7 +60,7 @@ class PackageIntentTarget:
         payload = self.to_dict()
         if self.source_kind == "git" and self.source_identity is not None:
             for exact_field in ("raw_spec", "raw_spec_hash", "source_url", "source_url_hash"):
-                payload.pop(exact_field, None)
+                _ = payload.pop(exact_field, None)
         return payload
 
 
@@ -293,7 +293,7 @@ def package_runtime_reason(intent: PackageIntent) -> str:
 def _fingerprint_command_shape(intent: PackageIntent) -> str:
     if not any(target.source_kind == "git" for target in intent.targets):
         return intent.redacted_command
-    tokens = list(intent.command_tokens)
+    tokens: list[str] = list(intent.command_tokens)
     for target in intent.targets:
         if target.source_kind != "git":
             continue

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1717,6 +1717,18 @@ def _heuristic_result(
                 )
             )
             continue
+        source_invalid_reason = _optional_string(target.get("source_invalid_reason"))
+        if source_invalid_reason is not None:
+            packages.append(
+                _heuristic_package_result(
+                    target=target,
+                    decision="block",
+                    code=source_invalid_reason,
+                    message="Package source syntax is ambiguous or invalid and cannot be authenticated.",
+                    severity="high",
+                )
+            )
+            continue
         if source_url is not None and _target_is_external_https_archive(target):
             try:
                 package_result, external_archive_download = _external_tarball_dependency_result(
@@ -1770,18 +1782,6 @@ def _heuristic_result(
                 if first_reason is not None:
                     package_result = _with_package_reason(package_result, first_reason)
             packages.append(package_result)
-            continue
-        source_invalid_reason = _optional_string(target.get("source_invalid_reason"))
-        if source_invalid_reason is not None:
-            packages.append(
-                _heuristic_package_result(
-                    target=target,
-                    decision="block",
-                    code=source_invalid_reason,
-                    message="Package source syntax is ambiguous or invalid and cannot be authenticated.",
-                    severity="high",
-                )
-            )
             continue
         if target.get("manifest_unsynced") is True:
             packages.append(

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -46,6 +46,7 @@ from .npm_policy_range import (
     policy_selector_matches_target,
     target_for_resolved_npm_policy_match,
 )
+from .npm_source_spec import NpmSourceSpec, parse_npm_source_spec
 from .offline_archive_inspection import inspect_archive_offline
 from .package_intent_common import split_python_extras
 from .package_manifest_diff import (
@@ -435,6 +436,56 @@ def evaluate_package_request_artifact(
             for download in external_archive_draft.external_archive_downloads:
                 download.cleanup()
             raise
+    source_review_targets = tuple(target for target in targets if _target_requires_npm_source_review(target))
+    if source_review_targets:
+        if len(source_review_targets) != len(targets):
+            mixed_source_package = _heuristic_package_result(
+                target=source_review_targets[0],
+                decision="block",
+                code="npm_source_mixed_request_unsupported",
+                message=(
+                    "npm source dependencies must be installed separately so Guard can preserve registry "
+                    "advisory evaluation and source approval identity."
+                ),
+                severity="high",
+            )
+            source_review_draft = _EvaluationDraft(
+                decision="block",
+                enforcement="free_local",
+                entitlement_state="free",
+                cache_status="miss",
+                packages=(mixed_source_package,),
+                reasons=tuple(_dict_items(mixed_source_package.get("reasons"))),
+                matched_rule_id=None,
+                exception_id=None,
+                refresh_required=False,
+                record_monitor_evidence=False,
+                bundle_version=None,
+                policy_version="local:none",
+            )
+        else:
+            source_review_draft = _heuristic_result(
+                artifact=artifact,
+                store=store,
+                targets=targets,
+                workspace_dir=workspace_dir,
+                external_archive_network_authorized=False,
+                retain_external_archive_blob=False,
+            )
+        if source_review_draft is None:
+            raise AssertionError("npm source review target did not produce a local decision")
+        source_review_result = _finalize_evaluation(
+            source_review_draft,
+            package_intent_hash=package_intent_hash,
+            workspace_fingerprint=None,
+        )
+        _persist_evidence(
+            store=store,
+            artifact=artifact,
+            evaluation=source_review_result,
+            now=now_value,
+        )
+        return source_review_result
     workspace_id = store.get_cloud_workspace_id()
     bundle_payload = store.get_cached_supply_chain_bundle(workspace_id) if workspace_id is not None else None
     bundle_response: SupplyChainBundleResponse | None = None
@@ -1720,6 +1771,18 @@ def _heuristic_result(
                     package_result = _with_package_reason(package_result, first_reason)
             packages.append(package_result)
             continue
+        source_invalid_reason = _optional_string(target.get("source_invalid_reason"))
+        if source_invalid_reason is not None:
+            packages.append(
+                _heuristic_package_result(
+                    target=target,
+                    decision="block",
+                    code=source_invalid_reason,
+                    message="Package source syntax is ambiguous or invalid and cannot be authenticated.",
+                    severity="high",
+                )
+            )
+            continue
         if target.get("manifest_unsynced") is True:
             packages.append(
                 _heuristic_package_result(
@@ -1775,11 +1838,13 @@ def _heuristic_result(
                 severity="high",
             )
         if package_result is None and source_url is not None and _is_git_source_url(source_url):
+            repository = _optional_string(target.get("source_repository")) or "Git repository"
+            revision_kind = _optional_string(target.get("source_revision_kind")) or "missing"
             package_result = _heuristic_package_result(
                 target=target,
                 decision="ask",
                 code="git_dependency_source",
-                message="Git package source requires review before install.",
+                message=f"Git package source {repository} ({revision_kind}) requires review before install.",
                 severity="high",
             )
         if package_result is None:
@@ -1899,10 +1964,11 @@ def _targets_from_artifact(artifact: GuardArtifact) -> tuple[dict[str, object], 
         source_url = _optional_string(item.get("source_url"))
         if source_url is None:
             source_url = _source_url_from_specifier(requested)
-        if source_url is None:
+        if source_url is None and "source_kind" not in item:
             source_url = _source_url_from_raw_spec(raw_spec)
         if source_url is not None:
             requested = None
+        source_spec = _npm_source_spec(source_url, ecosystem=ecosystem)
         if requested is None and source_url is None:
             requested = _default_registry_range(ecosystem)
         exact_version = (
@@ -1919,6 +1985,12 @@ def _targets_from_artifact(artifact: GuardArtifact) -> tuple[dict[str, object], 
                 "version": exact_version,
                 "range": requested if exact_version is None else None,
                 "source_url": source_url,
+                "source_kind": source_spec.source_kind if source_spec is not None else None,
+                "source_repository": source_spec.canonical_repository if source_spec is not None else None,
+                "source_revision_kind": source_spec.revision_kind if source_spec is not None else None,
+                "source_identity": source_spec.identity if source_spec is not None else None,
+                "source_redacted": source_spec.redacted if source_spec is not None else None,
+                "source_invalid_reason": source_spec.reason if source_spec is not None else None,
                 "alias": _optional_string(item.get("alias")),
                 "dependency_group": _optional_string(item.get("dependency_group")),
                 "extras": _string_tuple(item.get("extras")),
@@ -1945,6 +2017,11 @@ def _private_package_targets_match_public(
         "dependency_group",
         "extras",
         "editable",
+        "source_kind",
+        "source_repository",
+        "source_revision_kind",
+        "source_identity",
+        "source_invalid_reason",
     )
     for private_target, public_target in zip(private_targets, public_targets, strict=True):
         if not isinstance(private_target, dict) or not isinstance(public_target, dict):
@@ -2149,7 +2226,12 @@ def _build_request_payload(
                 "ecosystem": str(target["ecosystem"]),
                 "name": str(target["name"]),
                 "namespace": target["namespace"],
-                **({"sourceUrl": str(target["source_url"])} if target.get("source_url") else {}),
+                **(
+                    {"sourceUrl": str(target.get("source_redacted") or target["source_url"])}
+                    if target.get("source_url")
+                    else {}
+                ),
+                **({"sourceIdentity": str(target["source_identity"])} if target.get("source_identity") else {}),
                 **({"version": str(target["version"])} if target.get("version") else {}),
                 **({"range": str(target["range"])} if target.get("range") else {}),
             }
@@ -2488,6 +2570,9 @@ def _bundle_package_result(
         "packageManager": _optional_string(target.get("package_manager")) or "npm",
         "redactedCommand": _optional_string(target.get("redacted_command")),
         "alias": _optional_string(target.get("alias")),
+        "sourceIdentity": _optional_string(target.get("source_identity")),
+        "sourceRepository": _optional_string(target.get("source_repository")),
+        "sourceRevisionKind": _optional_string(target.get("source_revision_kind")),
         "relatedAdvisoryIds": list(package.related_advisory_ids),
         "reasons": (
             {
@@ -2830,7 +2915,8 @@ def _local_package_manifest_path(target: dict[str, object], workspace_dir: Path 
     source_url = _optional_string(target.get("source_url"))
     if source_url is not None and source_url.startswith("file:"):
         raw_spec = source_url.partition("file:")[2]
-    if raw_spec is None or raw_spec.startswith(("http://", "https://", "git+", "github:", "gitlab:", "bitbucket:")):
+    source_spec = _npm_source_spec(raw_spec, ecosystem="npm")
+    if raw_spec is None or (source_spec is not None and source_spec.source_kind != "local"):
         return None
     if raw_spec.startswith("file:"):
         raw_spec = raw_spec.partition("file:")[2]
@@ -3061,6 +3147,9 @@ def _heuristic_package_result(
         "packageManager": _optional_string(target.get("package_manager")) or "npm",
         "redactedCommand": _optional_string(target.get("redacted_command")),
         "alias": _optional_string(target.get("alias")),
+        "sourceIdentity": _optional_string(target.get("source_identity")),
+        "sourceRepository": _optional_string(target.get("source_repository")),
+        "sourceRevisionKind": _optional_string(target.get("source_revision_kind")),
         "reasons": (
             {
                 "code": code,
@@ -3148,23 +3237,8 @@ def _go_mod_replace_map(text: str) -> dict[str, str]:
 
 
 def _is_git_source_url(source_url: str) -> bool:
-    normalized = source_url.lower()
-    if normalized.startswith(("git+", "github:", "gitlab:", "bitbucket:")):
-        return True
-    parsed = urllib.parse.urlsplit(source_url)
-    if (
-        parsed.scheme.lower() in {"http", "https"}
-        and parsed.hostname is not None
-        and parsed.hostname.lower() in {"github.com", "gitlab.com", "bitbucket.org"}
-    ):
-        path_parts = [part for part in parsed.path.split("/") if part]
-        return len(path_parts) >= 2
-    return (
-        "/" in source_url
-        and not normalized.startswith(("http://", "https://"))
-        and ":" not in source_url
-        and not source_url.startswith(("@", "./", "../", "/"))
-    )
+    source = parse_npm_source_spec(source_url)
+    return source is not None and source.is_git
 
 
 def _is_external_https_tarball_source(source_url: str) -> bool:
@@ -3174,9 +3248,19 @@ def _is_external_https_tarball_source(source_url: str) -> bool:
 def _target_is_external_https_archive(target: dict[str, object]) -> bool:
     ecosystem = (_optional_string(target.get("ecosystem")) or "").lower()
     source_url = _optional_string(target.get("source_url"))
+    source_spec = _npm_source_spec(source_url, ecosystem=ecosystem)
     return bool(
-        ecosystem in {"npm", "pypi"} and source_url is not None and _is_external_https_tarball_source(source_url)
+        ecosystem in {"npm", "pypi"}
+        and source_url is not None
+        and (source_spec is None or not source_spec.is_git)
+        and _is_external_https_tarball_source(source_url)
     )
+
+
+def _target_requires_npm_source_review(target: dict[str, object]) -> bool:
+    return (_optional_string(target.get("ecosystem")) or "").lower() == "npm" and _optional_string(
+        target.get("source_kind")
+    ) in {"git", "invalid", "local", "url"}
 
 
 def _external_tarball_dependency_result(
@@ -4145,6 +4229,8 @@ def _recommended_fix_allow_package_result(
 def _source_url_from_specifier(specifier: str | None) -> str | None:
     if specifier is None:
         return None
+    if parse_npm_source_spec(specifier) is not None:
+        return specifier
     if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*://", specifier) is not None or specifier.lower().startswith(
         ("http:", "https:", "git+", "github:", "gitlab:", "bitbucket:", "file:")
     ):
@@ -4153,14 +4239,17 @@ def _source_url_from_specifier(specifier: str | None) -> str | None:
 
 
 def _source_url_from_raw_spec(raw_spec: str) -> str | None:
-    if _source_url_from_specifier(raw_spec) is not None:
-        return raw_spec
     separator = _NAMED_SOURCE_SEPARATOR_RE.search(raw_spec)
     candidate = raw_spec[separator.end() :] if separator is not None else raw_spec
     if "://" in candidate or candidate.lower().startswith(
         ("http:", "https:", "git+", "github:", "gitlab:", "bitbucket:", "file:")
     ):
         return candidate
+    if _source_url_from_specifier(raw_spec) is not None:
+        return raw_spec
+    for index, character in enumerate(raw_spec):
+        if character == "@" and index > 0 and parse_npm_source_spec(raw_spec[index + 1 :]) is not None:
+            return raw_spec[index + 1 :]
     return None
 
 
@@ -4401,13 +4490,17 @@ def _exact_version(value: str | None) -> str | None:
     normalized = _optional_string(value)
     if normalized is None:
         return None
-    if "://" in normalized or normalized.startswith(("git+", "github:", "gitlab:", "bitbucket:", "file:")):
+    if parse_npm_source_spec(normalized) is not None:
         return None
     if normalized.startswith(("^", "~", "<", ">", "!", "*")):
         return None
     if any(token in normalized for token in ("||", " - ", ",")):
         return None
     return normalized
+
+
+def _npm_source_spec(value: str | None, *, ecosystem: str) -> NpmSourceSpec | None:
+    return parse_npm_source_spec(value) if ecosystem.lower() == "npm" else None
 
 
 def _default_registry_range(ecosystem: str) -> str | None:

--- a/tests/test_guard_external_archive_approval_boundary.py
+++ b/tests/test_guard_external_archive_approval_boundary.py
@@ -155,7 +155,7 @@ def test_npm_url_like_https_specs_are_rejected_before_approval_or_network(
     )
 
     assert result.decision == "block"
-    assert any(reason["code"] == "external_archive_destination_rejected" for reason in result.reasons)
+    assert any(reason["code"] == "npm_source_host_missing" for reason in result.reasons)
 
 
 @pytest.mark.parametrize("named", (False, True))
@@ -214,7 +214,7 @@ def test_npm_https_at_sign_is_not_mistaken_for_package_source_separator(
             workspace_dir=workspace,
         )
         assert result.decision == "block"
-        assert any(reason["code"] == "external_archive_destination_rejected" for reason in result.reasons)
+        assert any(reason["code"] == "npm_source_ambiguous_userinfo" for reason in result.reasons)
 
 
 def test_external_archive_request_caps_target_count_before_network(

--- a/tests/test_guard_js_supply_chain_phase11.py
+++ b/tests/test_guard_js_supply_chain_phase11.py
@@ -379,7 +379,7 @@ def test_invalid_npm_source_blocks_before_cloud_and_redacts_credentials(
     result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
 
     assert result.decision == "block"
-    assert result.packages[0]["reasons"][0]["code"] == "external_archive_destination_rejected"
+    assert result.packages[0]["reasons"][0]["code"] == "npm_source_ambiguous_userinfo"
     assert "VERY_SECRET" not in json.dumps(artifact.metadata)
     assert "VERY_SECRET" not in json.dumps(result.to_cache_dict())
 

--- a/tests/test_guard_js_supply_chain_phase11.py
+++ b/tests/test_guard_js_supply_chain_phase11.py
@@ -267,6 +267,123 @@ def test_evaluate_package_request_artifact_applies_js_source_heuristics(
     assert result.packages[0]["reasons"][0]["code"] == expected_code
 
 
+@pytest.mark.parametrize(
+    "source",
+    [
+        "git+https://github.com/hashgraph-online/hol-guard.git#main",
+        "git+ssh://git@github.com/hashgraph-online/hol-guard.git#main",
+        "git://github.com/hashgraph-online/hol-guard.git#main",
+        "ssh://git@github.com/hashgraph-online/hol-guard.git#main",
+        "git@github.com:hashgraph-online/hol-guard.git#main",
+        "github:hashgraph-online/hol-guard#main",
+        "gitlab:hashgraph-online/hol-guard#main",
+        "bitbucket:hashgraph-online/hol-guard#main",
+        "hashgraph-online/hol-guard#main",
+        "https://github.com/hashgraph-online/hol-guard.git#main",
+    ],
+)
+def test_every_npm_git_source_form_requires_local_review_before_registry_or_cloud(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+
+    def fail_cloud_lookup() -> str:
+        raise AssertionError("Git source must not reach registry/cloud evaluation")
+
+    monkeypatch.setattr(store, "get_cloud_workspace_id", fail_cloud_lookup)
+
+    artifact = _artifact_from_command(f"npm install {source}", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "ask"
+    assert result.packages[0]["reasons"][0]["code"] == "git_dependency_source"
+    assert result.packages[0]["sourceIdentity"].startswith("git:")
+    assert result.packages[0]["sourceRevisionKind"] == "mutable_ref"
+
+
+def test_hosted_git_archive_requires_git_review_without_archive_download(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(
+        supply_chain_package_eval_module,
+        "_scan_external_tarball",
+        lambda *_args, **_kwargs: pytest.fail("hosted Git archives must not enter generic archive download"),
+    )
+
+    artifact = _artifact_from_command(
+        "npm install https://github.com/hashgraph-online/hol-guard/archive/refs/heads/main.tar.gz?token=secret",
+        workspace=workspace_dir,
+    )
+    result = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace_dir,
+        external_archive_network_authorized=True,
+    )
+
+    assert result.decision == "ask"
+    assert result.packages[0]["reasons"][0]["code"] == "git_dependency_source"
+    assert result.packages[0]["sourceRepository"] == "git:github.com/hashgraph-online/hol-guard"
+    assert result.external_archive_downloads == ()
+
+
+def test_npm_git_source_cannot_hide_registry_targets_in_one_request(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    artifact = _artifact_from_command(
+        "npm install minimist@1.2.8 github:hashgraph-online/hol-guard#main",
+        workspace=workspace_dir,
+    )
+
+    result = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=GuardStore(tmp_path / "home"),
+        workspace_dir=workspace_dir,
+    )
+
+    assert result.decision == "block"
+    assert result.packages[0]["reasons"][0]["code"] == "npm_source_mixed_request_unsupported"
+
+
+def test_invalid_npm_source_blocks_before_cloud_and_redacts_credentials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(tmp_path / "home")
+    monkeypatch.setattr(
+        store,
+        "get_cloud_workspace_id",
+        lambda: pytest.fail("invalid source must not reach cloud evaluation"),
+    )
+
+    artifact = _artifact_from_command(
+        "npm install https://user:VERY_SECRET@github.com/hashgraph-online/hol-guard.git#main",
+        workspace=workspace_dir,
+    )
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["reasons"][0]["code"] == "external_archive_destination_rejected"
+    assert "VERY_SECRET" not in json.dumps(artifact.metadata)
+    assert "VERY_SECRET" not in json.dumps(result.to_cache_dict())
+
+
 def test_evaluate_package_request_artifact_uses_source_specific_risk_summary_for_reviewed_tarballs(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -568,7 +568,7 @@ def test_merged_all_global_installs_omit_workspace_context() -> None:
     assert artifact.metadata["lockfile_paths"] == []
 
 
-def test_evaluate_package_request_artifact_does_not_convert_npm_source_specs_to_latest(
+def test_evaluate_package_request_artifact_reviews_npm_git_sources_before_cloud(
     tmp_path: Path,
 ) -> None:
     _EvaluateHandler.captured_headers = {}
@@ -594,7 +594,7 @@ def test_evaluate_package_request_artifact_does_not_convert_npm_source_specs_to_
         workspace_dir.mkdir()
         artifact = _artifact_for_targets("git+https://github.com/org/pkg.git")
 
-        evaluate_package_request_artifact(
+        result = evaluate_package_request_artifact(
             artifact=artifact,
             store=store,
             workspace_dir=workspace_dir,
@@ -604,11 +604,10 @@ def test_evaluate_package_request_artifact_does_not_convert_npm_source_specs_to_
         server.shutdown()
         thread.join(timeout=5)
 
-    package_payload = _EvaluateHandler.captured_requests[0]["packages"][0]
-    assert package_payload["name"] == "pkg"
-    assert package_payload["sourceUrl"] == "git+https://github.com/org/pkg.git"
-    assert "range" not in package_payload
-    assert "version" not in package_payload
+    assert _EvaluateHandler.captured_requests == []
+    assert result.decision == "ask"
+    assert result.packages[0]["reasons"][0]["code"] == "git_dependency_source"
+    assert result.packages[0]["sourceIdentity"] == "git:github.com/org/pkg#missing"
 
 
 def test_evaluate_package_request_artifact_posts_open_range_for_unversioned_pypi_request(

--- a/tests/test_npm_source_spec.py
+++ b/tests/test_npm_source_spec.py
@@ -1,0 +1,202 @@
+"""Canonical npm Git/source specification tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from codex_plugin_scanner.guard.models import GuardArtifact
+from codex_plugin_scanner.guard.runtime.npm_source_spec import parse_npm_source_spec
+from codex_plugin_scanner.guard.runtime.package_intent import (
+    build_package_request_artifact,
+    parse_package_intent,
+)
+from codex_plugin_scanner.guard.runtime.package_intent_common import js_target
+
+COMMIT = "0123456789abcdef0123456789abcdef01234567"
+REPOSITORY = "git:github.com/hashgraph-online/hol-guard"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        f"github:Hashgraph-Online/hol-guard.git#{COMMIT}",
+        f"git+https://GITHUB.com:443/Hashgraph-Online/hol-guard.git#{COMMIT}",
+        f"git+ssh://git@github.com:22/hashgraph-online/hol-guard.git#{COMMIT}",
+        f"git://github.com:9418/hashgraph-online/hol-guard.git#{COMMIT}",
+        f"ssh://git@github.com/hashgraph-online/hol-guard.git#{COMMIT}",
+        f"git@github.com:hashgraph-online/hol-guard.git#{COMMIT}",
+        f"hashgraph-online/hol-guard#{COMMIT}",
+        f"https://github.com/hashgraph-online/hol-guard.git#{COMMIT}",
+        f"https://github.com/hashgraph-online/%68ol-guard.git#{COMMIT}",
+    ],
+)
+def test_equivalent_github_source_forms_share_canonical_identity(source: str) -> None:
+    parsed = parse_npm_source_spec(source)
+
+    assert parsed is not None
+    assert parsed.valid
+    assert parsed.source_kind == "git"
+    assert parsed.canonical_repository == REPOSITORY
+    assert parsed.revision == COMMIT
+    assert parsed.revision_kind == "immutable_commit"
+    assert parsed.identity == f"{REPOSITORY}#commit:{COMMIT}"
+
+
+@pytest.mark.parametrize(
+    ("fragment", "expected_kind"),
+    [
+        (None, "missing"),
+        ("main", "mutable_ref"),
+        ("v2.1.0", "mutable_ref"),
+        ("semver:^2.1.0", "mutable_ref"),
+        ("pull/1748/head", "mutable_ref"),
+        (COMMIT.upper(), "immutable_commit"),
+    ],
+)
+def test_git_revision_state_is_classified_conservatively(fragment: str | None, expected_kind: str) -> None:
+    suffix = f"#{fragment}" if fragment is not None else ""
+
+    parsed = parse_npm_source_spec(f"github:hashgraph-online/hol-guard{suffix}")
+
+    assert parsed is not None
+    assert parsed.revision_kind == expected_kind
+    if expected_kind == "immutable_commit":
+        assert parsed.revision == COMMIT
+
+
+@pytest.mark.parametrize(
+    ("source", "repository", "revision"),
+    [
+        (
+            "https://github.com/Hashgraph-Online/hol-guard/archive/refs/heads/main.tar.gz?token=secret",
+            REPOSITORY,
+            "refs/heads/main",
+        ),
+        (
+            "https://gitlab.com/Group/Subgroup/Repo/-/archive/release/repo-release.tar.gz",
+            "git:gitlab.com/group/subgroup/repo",
+            "release",
+        ),
+        (
+            "https://bitbucket.org/Owner/Repo/get/main.zip",
+            "git:bitbucket.org/owner/repo",
+            "main",
+        ),
+    ],
+)
+def test_hosted_git_archive_urls_remain_repository_sources(
+    source: str,
+    repository: str,
+    revision: str,
+) -> None:
+    parsed = parse_npm_source_spec(source)
+
+    assert parsed is not None
+    assert parsed.is_git
+    assert parsed.canonical_repository == repository
+    assert parsed.revision == revision
+    assert parsed.revision_kind == "mutable_ref"
+
+
+def test_idna_and_nondefault_ports_are_canonicalized_without_collapsing_distinct_hosts() -> None:
+    idna_source = parse_npm_source_spec("git+https://BÜCHER.example/Owner/Repo.git#main")
+    nondefault_port = parse_npm_source_spec("git+https://github.com:8443/Owner/Repo.git#main")
+    default_port = parse_npm_source_spec("github:owner/repo#main")
+
+    assert idna_source is not None
+    assert idna_source.canonical_repository == "git:xn--bcher-kva.example/Owner/Repo"
+    assert nondefault_port is not None
+    assert default_port is not None
+    assert nondefault_port.canonical_repository == "git:github.com:8443/owner/repo"
+    assert nondefault_port.identity != default_port.identity
+
+
+def test_custom_git_hosts_support_root_level_repositories() -> None:
+    parsed = parse_npm_source_spec("git+https://example.com/Guard.GIT#main")
+
+    assert parsed is not None
+    assert parsed.canonical_repository == "git:example.com/Guard"
+    assert parsed.revision_kind == "mutable_ref"
+
+
+@pytest.mark.parametrize(
+    ("source", "reason"),
+    [
+        ("https://user:password@github.com/owner/repo.git#main", "npm_source_ambiguous_userinfo"),
+        ("ssh://deploy@github.com/owner/repo.git#main", "npm_source_ambiguous_userinfo"),
+        ("deploy@github.com:owner/repo.git#main", "npm_source_ambiguous_userinfo"),
+        ("https://github.com/owner%2Frepo/project.git", "npm_source_path_invalid"),
+        ("git+https://github.com:bad/owner/repo.git", "npm_source_malformed_port"),
+        ("git+https://github.com:70000/owner/repo.git", "npm_source_malformed_port"),
+        ("git+file:///tmp/owner/repo.git", "npm_source_protocol_unsupported"),
+        ("file://server/share/owner/repo", "npm_source_local_url_invalid"),
+        ("ftp://github.com/owner/repo.git", "npm_source_protocol_unsupported"),
+        ("git+https://github.com/../owner/repo.git", "npm_source_path_invalid"),
+    ],
+)
+def test_ambiguous_or_malformed_sources_fail_with_stable_reasons(source: str, reason: str) -> None:
+    parsed = parse_npm_source_spec(source)
+
+    assert parsed is not None
+    assert not parsed.valid
+    assert parsed.source_kind == "invalid"
+    assert parsed.reason == reason
+    assert parsed.redacted == "<invalid-source>"
+    assert "password" not in parsed.identity
+
+
+def test_query_credentials_are_redacted_without_changing_git_identity() -> None:
+    plain = parse_npm_source_spec("https://github.com/owner/repo.git#main")
+    secret = parse_npm_source_spec("https://github.com/owner/repo.git?token=VERY_SECRET#main")
+
+    assert plain is not None and secret is not None
+    assert secret.identity == plain.identity
+    assert "VERY_SECRET" not in secret.redacted
+    assert secret.redacted == "git:github.com/owner/repo#<mutable-ref>"
+
+
+def test_named_and_aliased_sources_reuse_the_canonical_parser() -> None:
+    named = js_target(f"guard@github:Hashgraph-Online/hol-guard.git#{COMMIT}")
+    aliased = js_target(f"guard-alias@npm:github:hashgraph-online/hol-guard#{COMMIT}")
+
+    assert named.package_name == "guard"
+    assert aliased.package_name == "hol-guard"
+    assert aliased.alias == "guard-alias"
+    assert named.source_identity == aliased.source_identity == f"{REPOSITORY}#commit:{COMMIT}"
+    assert named.requested_specifier is None
+    assert aliased.requested_specifier is None
+
+
+def test_registry_aliases_do_not_become_ambiguous_scp_sources() -> None:
+    target = js_target("guard-safe@npm:minimist@1.2.8")
+
+    assert target.alias == "guard-safe"
+    assert target.package_name == "minimist"
+    assert target.requested_specifier == "1.2.8"
+    assert target.source_kind is None
+    assert target.source_invalid_reason is None
+
+
+def test_git_approval_fingerprint_uses_canonical_repository_and_exact_commit() -> None:
+    first = _artifact_for_source(f"github:Hashgraph-Online/hol-guard.git#{COMMIT}")
+    equivalent = _artifact_for_source(
+        f"git+https://GITHUB.com:443/hashgraph-online/hol-guard.git?token=ROTATING_SECRET#{COMMIT}"
+    )
+    different_commit = _artifact_for_source(
+        "git+https://github.com/hashgraph-online/hol-guard.git#ffffffffffffffffffffffffffffffffffffffff"
+    )
+
+    assert first.artifact_id == equivalent.artifact_id
+    assert different_commit.artifact_id != first.artifact_id
+    assert "ROTATING_SECRET" not in equivalent.artifact_id
+
+
+def _artifact_for_source(source: str) -> GuardArtifact:
+    intent = parse_package_intent(f"npm install {source}")
+    assert intent is not None
+    return build_package_request_artifact(
+        "codex",
+        intent,
+        config_path="codex.json",
+        source_scope="project",
+    )

--- a/tests/test_npm_source_spec.py
+++ b/tests/test_npm_source_spec.py
@@ -73,9 +73,9 @@ def test_git_revision_state_is_classified_conservatively(fragment: str | None, e
             "refs/heads/main",
         ),
         (
-            "https://gitlab.com/Group/Subgroup/Repo/-/archive/release/repo-release.tar.gz",
+            "https://gitlab.com/Group/Subgroup/Repo/-/archive/release/v2.1/repo-release-v2.1.tar.gz",
             "git:gitlab.com/group/subgroup/repo",
-            "release",
+            "release/v2.1",
         ),
         (
             "https://bitbucket.org/Owner/Repo/get/main.zip",
@@ -126,6 +126,7 @@ def test_custom_git_hosts_support_root_level_repositories() -> None:
         ("ssh://deploy@github.com/owner/repo.git#main", "npm_source_ambiguous_userinfo"),
         ("deploy@github.com:owner/repo.git#main", "npm_source_ambiguous_userinfo"),
         ("https://github.com/owner%2Frepo/project.git", "npm_source_path_invalid"),
+        ("https://github.com/owner/repo.git#refs%2Fheads%2Fmain", "npm_source_revision_invalid"),
         ("git+https://github.com:bad/owner/repo.git", "npm_source_malformed_port"),
         ("git+https://github.com:70000/owner/repo.git", "npm_source_malformed_port"),
         ("git+file:///tmp/owner/repo.git", "npm_source_protocol_unsupported"),
@@ -175,6 +176,14 @@ def test_registry_aliases_do_not_become_ambiguous_scp_sources() -> None:
     assert target.requested_specifier == "1.2.8"
     assert target.source_kind is None
     assert target.source_invalid_reason is None
+
+
+def test_deeply_nested_npm_aliases_fail_without_recursion() -> None:
+    parsed = parse_npm_source_spec(f"{'npm:' * 1_000}github:owner/repo")
+
+    assert parsed is not None
+    assert not parsed.valid
+    assert parsed.reason == "npm_source_alias_depth_exceeded"
 
 
 def test_git_approval_fingerprint_uses_canonical_repository_and_exact_commit() -> None:


### PR DESCRIPTION
## Summary

- add one canonical npm source-spec parser shared by intent extraction, evaluation, display redaction, cache fields, and approval fingerprints
- normalize Git schemes, hosted shorthands, SCP syntax, hosted HTTPS URLs, IDNA/default ports, repository paths, `.git`, percent encoding, and revisions
- keep Git sources out of registry/cloud allow paths, keep hosted repository archives in Git review, and preserve P28 restricted inspection for release assets and generic HTTPS archives
- bind Git approvals to canonical repository plus exact revision state while retaining exact private source data for launch-time integrity checks

## Source identity examples

| Input form | Canonical repository | Revision state |
| --- | --- | --- |
| `github:Hashgraph-Online/hol-guard.git#<sha>` | `git:github.com/hashgraph-online/hol-guard` | immutable commit |
| `git+https://GITHUB.com:443/hashgraph-online/hol-guard.git#<sha>` | `git:github.com/hashgraph-online/hol-guard` | immutable commit |
| `git+ssh://git@github.com:22/hashgraph-online/hol-guard.git#main` | `git:github.com/hashgraph-online/hol-guard` | mutable ref |
| `git@github.com:hashgraph-online/hol-guard.git` | `git:github.com/hashgraph-online/hol-guard` | missing ref |
| `https://gitlab.com/Group/Subgroup/Repo/-/archive/release/repo-release.tar.gz` | `git:gitlab.com/group/subgroup/repo` | mutable ref |

Equivalent Git spellings now produce the same approval fingerprint for the same repository and commit. A different commit produces a different fingerprint. Query tokens do not enter display or canonical identity.

## Security behavior

- full 40/64-character commit digests are immutable; branches, tags, semver selectors, PR refs, short hashes, and missing refs remain review-required
- ambiguous userinfo, encoded separators, malformed ports, remote `file://` authorities, traversal, and unsupported protocols fail closed with stable reason codes
- mixed registry/source npm requests block and must be split so source approval cannot bypass registry advisory evaluation
- GitHub/GitLab/Bitbucket repository archives require Git source review; GitHub release assets and non-Git HTTPS archives retain the existing restricted-archive flow

## Validation

- changed-file Ruff and format checks: pass
- focused BasedPyright: 0 errors
- Python 3.12 affected source/intent/evaluator/archive/URI suites: pass except the two pre-existing Bun text-lock cases
- Python 3.10 affected suite: 238 passed; the same two pre-existing Bun text-lock cases failed
- repository-wide Python 3.12 suite before the final root-level custom-host correction: 9,795 passed, 26 skipped, 5 deselected; 13 failed
- the one P32-related failure from that full run was fixed and its focused regression passes; an untouched `origin/release/2.1` replay reproduces the remaining 12 failures exactly (seven Codex hook inventory expectations, one Bun approval replay, one local credential-store availability failure, one local Vitest approval stderr expectation, and two Bun text-lock cases)
- sdist and wheel build: pass; wheel contents verified to include the new parser and integrations

## Base

This PR targets `release/2.1`.
