### PR TITLE
fix(guard): attest exact Python interpreter identity

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -522,6 +522,7 @@ def _runtime_hook_approval_context_token(
         content={
             "artifact_content_hash": content_hash,
             "command_security_identity": metadata.get("command_security_identity"),
+            "interpreter_executable_identities": metadata.get("interpreter_executable_identities"),
             "shell_execution_context_hash": metadata.get("shell_execution_context_hash"),
             "shell_execution_context_hashes": metadata.get("shell_execution_context_hashes"),
             "shell_execution_context_reason_code": metadata.get("shell_execution_context_reason_code"),

--- a/src/codex_plugin_scanner/guard/runtime/approval_context.py
+++ b/src/codex_plugin_scanner/guard/runtime/approval_context.py
@@ -13,6 +13,7 @@ import base64
 import hashlib
 import hmac
 import json
+import ntpath
 import os
 import re
 import secrets
@@ -203,6 +204,7 @@ def build_runtime_executable_identity(
     *,
     search_path: str | None = None,
     cwd: Path | None = None,
+    require_executable: bool = True,
 ) -> dict[str, object]:
     """Resolve and content-bind an executable without launching it.
 
@@ -228,7 +230,10 @@ def build_runtime_executable_identity(
     if not isinstance(command, str) or not command.strip():
         return with_launch_cwd(_unreusable_executable_identity(command, status="invalid_command"))
     candidate = Path(command).expanduser()
-    has_explicit_path = os.sep in command or (os.altsep is not None and os.altsep in command)
+    has_windows_path = "\\" in command or bool(ntpath.splitdrive(command)[0]) or command.startswith("//")
+    if has_windows_path and os.name != "nt":
+        return with_launch_cwd(_unreusable_executable_identity(command, status="foreign_platform_path", path=candidate))
+    has_explicit_path = os.sep in command or (os.altsep is not None and os.altsep in command) or has_windows_path
     if candidate.is_absolute():
         resolved = candidate
     elif has_explicit_path:
@@ -250,14 +255,26 @@ def build_runtime_executable_identity(
             return with_launch_cwd(_unreusable_executable_identity(command, status="unresolved"))
         resolved = Path(located)
     try:
-        canonical = resolved.resolve(strict=True)
+        launch_path = Path(os.path.abspath(os.fspath(resolved)))
+    except (OSError, TypeError, ValueError):
+        return with_launch_cwd(_unreusable_executable_identity(command, status="invalid_path", path=resolved))
+    initial_path_chain = _executable_path_chain_snapshot(launch_path)
+    if initial_path_chain is None:
+        return with_launch_cwd(_unreusable_executable_identity(command, status="unreadable", path=launch_path))
+    try:
+        canonical = launch_path.resolve(strict=True)
         metadata = canonical.stat()
     except (OSError, RuntimeError):
-        return with_launch_cwd(_unreusable_executable_identity(command, status="unreadable", path=resolved))
+        return with_launch_cwd(_unreusable_executable_identity(command, status="unreadable", path=launch_path))
     if not stat.S_ISREG(metadata.st_mode):
         return with_launch_cwd(_unreusable_executable_identity(command, status="not_regular", path=canonical))
+    if require_executable and os.name != "nt" and metadata.st_mode & 0o111 == 0:
+        return with_launch_cwd(_unreusable_executable_identity(command, status="not_executable", path=canonical))
     stat_key = _executable_stat_key(metadata)
     digest, hash_status, shebang, shebang_status = _cached_executable_hash(str(canonical), stat_key)
+    final_path_chain = _executable_path_chain_snapshot(launch_path)
+    if final_path_chain is None or final_path_chain != initial_path_chain:
+        return with_launch_cwd(_unreusable_executable_identity(command, status="path_changed", path=launch_path))
     if shebang_status == "verified":
         file_format = "script"
     elif shebang_status == "not_script":
@@ -266,9 +283,15 @@ def build_runtime_executable_identity(
         file_format = "unverified"
     identity: dict[str, object] = {
         "command": command,
+        "launch_path": str(launch_path),
         "file_format": file_format,
         "path": str(canonical),
+        "path_chain": [dict(item) for item in initial_path_chain],
         "shebang_status": shebang_status,
+        "device": metadata.st_dev,
+        "inode": metadata.st_ino,
+        "modified_time_ns": metadata.st_mtime_ns,
+        "change_time_ns": metadata.st_ctime_ns,
         "size": metadata.st_size,
         "mode": stat.S_IMODE(metadata.st_mode),
         "status": hash_status,
@@ -280,6 +303,58 @@ def build_runtime_executable_identity(
     if shebang is not None:
         identity["shebang_sha256"] = hashlib.sha256(shebang.encode("utf-8")).hexdigest()
     return with_launch_cwd(identity)
+
+
+def _executable_path_chain_snapshot(path: Path) -> tuple[tuple[tuple[str, object], ...], ...] | None:
+    """Snapshot every lexical symlink hop used to reach an executable.
+
+    The canonical target hash alone does not bind a PATH entry or explicit
+    symlink.  Capturing stable lstat identity before and after content hashing
+    detects ordinary path swaps during evaluation and makes later approval
+    checks sensitive to changes in any symlink hop.
+    """
+
+    try:
+        canonical = path.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+    snapshots: list[tuple[tuple[str, object], ...]] = []
+    seen_paths: set[str] = set()
+    for endpoint in (path, canonical):
+        parts = endpoint.parts
+        if not parts:
+            return None
+        current = Path(parts[0])
+        for index, part in enumerate(parts[1:], start=1):
+            current /= part
+            try:
+                metadata = current.lstat()
+            except OSError:
+                return None
+            is_endpoint = index == len(parts) - 1
+            if not is_endpoint and not stat.S_ISLNK(metadata.st_mode):
+                continue
+            current_text = str(current)
+            if current_text in seen_paths:
+                continue
+            seen_paths.add(current_text)
+            target: str | None = None
+            if stat.S_ISLNK(metadata.st_mode):
+                try:
+                    target = os.readlink(current)
+                except OSError:
+                    return None
+            snapshot = {
+                "change_time_ns": metadata.st_ctime_ns,
+                "device": metadata.st_dev,
+                "inode": metadata.st_ino,
+                "mode": stat.S_IMODE(metadata.st_mode),
+                "modified_time_ns": metadata.st_mtime_ns,
+                "path": current_text,
+                "target_sha256": hashlib.sha256(target.encode("utf-8")).hexdigest() if target is not None else None,
+            }
+            snapshots.append(tuple(sorted(snapshot.items())))
+    return tuple(snapshots) if snapshots else None
 
 
 _PYTHON_LAUNCHER_PATTERN = re.compile(
@@ -1401,7 +1476,12 @@ def _file_runtime_entrypoint(*, kind: str, argument: str, launch_cwd: Path) -> d
     candidate = Path(argument).expanduser()
     if not candidate.is_absolute():
         candidate = launch_cwd / candidate
-    identity = build_runtime_executable_identity(str(candidate), search_path=None, cwd=launch_cwd)
+    identity = build_runtime_executable_identity(
+        str(candidate),
+        search_path=None,
+        cwd=launch_cwd,
+        require_executable=False,
+    )
     identity["argument_sha256"] = hashlib.sha256(argument.encode("utf-8")).hexdigest()
     identity["kind"] = kind
     return identity

--- a/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
@@ -36,6 +36,7 @@ COMMAND_ACTION_RISK_CLASSES: dict[str, tuple[str, ...]] = {
     "sensitive local file write": ("destructive_shell", "local_secret_read"),
     "destructive shell command": ("destructive_shell",),
     "pytest repository-code execution": ("execution",),
+    "untrusted python interpreter": ("execution",),
     "guard approval self-authorization command": ("policy_bypass",),
     "github pr body shell substitution": ("execution",),
     "github remote mutation command": ("destructive_shell", "network_egress"),

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -10,13 +10,16 @@ import hashlib
 import json
 import os
 import re
+import secrets
 import shlex
 import stat
+import sys
 from dataclasses import dataclass, replace
 from pathlib import Path
 
 from ..models import GuardArtifact
 from .actions import GuardActionEnvelope, apply_patch_target_paths
+from .approval_context import build_runtime_executable_identity
 from .command_evaluation import evaluate_command
 from .command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from .command_model import CanonicalCommand, parse_shell_command
@@ -53,7 +56,7 @@ from .self_approval import (
     SELF_APPROVAL_REASON,
     is_guard_approval_mutation_command,
 )
-from .shell_command_wrappers import normalize_transparent_shell_command
+from .shell_command_wrappers import is_trusted_absolute_command_path, normalize_transparent_shell_command
 from .shell_execution_context import (
     ShellExecutionContext,
     model_shell_execution_context,
@@ -226,6 +229,12 @@ _DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
     "sk-",
 )
 _SAFE_PYTHON_MODULE_COMMANDS = frozenset({"pytest", "ruff"})
+_TRUSTED_INTERPRETER_INSTALL_ROOTS = (
+    Path("/home/linuxbrew/.linuxbrew"),
+    Path("/opt/homebrew"),
+    Path("/opt/hostedtoolcache/Python"),
+    Path("/usr/local"),
+)
 _SAFE_PYTHON_MODULE_SHADOW_PATHS = {
     "pytest": (
         "pytest.py",
@@ -454,7 +463,7 @@ _SHELL_NEWLINE_SEPARATOR = ";"
 _HEREDOC_PATTERN = re.compile(r"<<-?\s*(['\"]?)([^\s'\";|&<>]+)\1")
 _SAFE_INTERPRETER_SETUP_SEGMENT_PATTERN = r"(?:cd\b[^\n;&|<>$`]*)"
 _SINGLE_INTERPRETER_HEREDOC_PATTERN = re.compile(
-    rf"^\s*(?:(?:{_SAFE_INTERPRETER_SETUP_SEGMENT_PATTERN})\s*&&\s*)*(?P<interpreter>[^\s;&|<>$`]*(?:perl|python(?:\d+(?:\.\d+)*)?|ruby))\b(?P<args>[^\n;&|]*)<<-?\s*(?P<quote>['\"]?)(?P<tag>[^\s'\";|&<>]+)(?P=quote)\s*\n(?P<body>.*)\n(?P=tag)\s*$",
+    rf"^\s*(?:(?:{_SAFE_INTERPRETER_SETUP_SEGMENT_PATTERN})\s*&&\s*)*(?P<interpreter>[^\s;&|<>$`]*(?:perl|pythonw?(?:\d+(?:\.\d+)*)?(?:\.exe)?|ruby))\b(?P<args>[^\n;&|]*)<<-?\s*(?P<quote>['\"]?)(?P<tag>[^\s'\";|&<>]+)(?P=quote)\s*\n(?P<body>.*)\n(?P=tag)\s*$",
     re.IGNORECASE | re.DOTALL,
 )
 _SINGLE_NODE_HEREDOC_PATTERN = re.compile(
@@ -714,6 +723,7 @@ class ToolActionRequestMatch:
     pytest_config_identity_sha256: str | None = None
     pytest_config_sources: tuple[str, ...] = ()
     pytest_config_reason_codes: tuple[str, ...] = ()
+    interpreter_executable_identities: tuple[dict[str, object], ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -1157,6 +1167,13 @@ def is_explicitly_benign_tool_action_request(
         return False
     found_benign_candidate = False
     for command_text in _candidate_command_texts(arguments):
+        interpreter_evidence = _python_interpreter_executable_identities(
+            command_text,
+            cwd=cwd,
+            home_dir=home_dir,
+        )
+        if any(evidence.get("trust") not in {"trusted_guard", "trusted_system"} for evidence in interpreter_evidence):
+            return False
         if normalized_tool_name in _SHELL_TOOL_NAMES:
             command_text = normalize_transparent_shell_command(
                 command_text, cwd=cwd, home_dir=home_dir
@@ -1254,6 +1271,16 @@ def _destructive_shell_tool_action_request(
         else PytestConfigAssessment((), True, False, (), None)
     )
     pytest_config_sources = tuple(result.source_path for result in pytest_config_assessment.results)
+    interpreter_executable_identities = _python_interpreter_executable_identities(
+        raw_command_text or detection_command_text,
+        cwd=cwd,
+        home_dir=home_dir,
+        execution_context=(
+            raw_execution_context
+            if raw_command_text is not None and raw_command_text != detection_command_text
+            else execution_context
+        ),
+    )
     if is_guard_approval_mutation_command(detection_command_text):
         return ToolActionRequestMatch(
             tool_name=tool_name,
@@ -1274,6 +1301,7 @@ def _destructive_shell_tool_action_request(
                 "payloads in-process without executing them during evaluation."
             ),
             canonical_command=canonical_command,
+            interpreter_executable_identities=interpreter_executable_identities,
         )
     if _contains_shell_credential_exfiltration(detection_command_text, cwd=cwd, home_dir=home_dir):
         return ToolActionRequestMatch(
@@ -1286,6 +1314,7 @@ def _destructive_shell_tool_action_request(
                 "sensitive because they can exfiltrate local secrets before the user confirms the action."
             ),
             canonical_command=canonical_command,
+            interpreter_executable_identities=interpreter_executable_identities,
         )
     if _contains_shell_network_file_upload(detection_command_text, cwd=cwd, home_dir=home_dir):
         return ToolActionRequestMatch(
@@ -1298,6 +1327,7 @@ def _destructive_shell_tool_action_request(
                 "contents to a network endpoint before the user confirms the action."
             ),
             canonical_command=canonical_command,
+            interpreter_executable_identities=interpreter_executable_identities,
         )
     if _gh_pr_create_body_has_shell_command_substitution(detection_command_text) or (
         raw_command_text is not None
@@ -1315,6 +1345,7 @@ def _destructive_shell_tool_action_request(
                 "`--body-file` for PR descriptions."
             ),
             canonical_command=canonical_command,
+            interpreter_executable_identities=interpreter_executable_identities,
         )
     for _extension, rule, _evidence in BUILT_IN_COMMAND_EXTENSION_REGISTRY.matching_rules(canonical_command):
         if not rule.action_classes or rule.action_classes[0] != "GitHub Actions administrative command":
@@ -1326,6 +1357,7 @@ def _destructive_shell_tool_action_request(
             action_class=rule.action_classes[0],
             reason=rule.description,
             canonical_command=canonical_command,
+            interpreter_executable_identities=interpreter_executable_identities,
         )
     execution_context_reason = _shell_execution_context_validation_reason(execution_context)
     if execution_context.directory_change_present and execution_context_reason is not None:
@@ -1349,6 +1381,7 @@ def _destructive_shell_tool_action_request(
             pytest_config_identity_sha256=pytest_config_assessment.identity_sha256,
             pytest_config_sources=pytest_config_sources,
             pytest_config_reason_codes=pytest_config_assessment.reason_codes,
+            interpreter_executable_identities=interpreter_executable_identities,
         )
     detection_command_is_destructive = _looks_destructive_shell_command(
         detection_command_text,
@@ -1401,6 +1434,7 @@ def _destructive_shell_tool_action_request(
             pytest_config_identity_sha256=pytest_config_assessment.identity_sha256,
             pytest_config_sources=pytest_config_sources,
             pytest_config_reason_codes=pytest_config_assessment.reason_codes,
+            interpreter_executable_identities=interpreter_executable_identities,
         )
     if pytest_execution_requested:
         return ToolActionRequestMatch(
@@ -1421,6 +1455,7 @@ def _destructive_shell_tool_action_request(
             pytest_config_identity_sha256=pytest_config_assessment.identity_sha256,
             pytest_config_sources=pytest_config_sources,
             pytest_config_reason_codes=pytest_config_assessment.reason_codes,
+            interpreter_executable_identities=interpreter_executable_identities,
         )
     github_assessment = _github_shell_capability_assessment(
         detection_command_text,
@@ -1445,6 +1480,7 @@ def _destructive_shell_tool_action_request(
                 )
             ),
             canonical_command=canonical_command,
+            interpreter_executable_identities=interpreter_executable_identities,
         )
     for _extension, rule, _evidence in BUILT_IN_COMMAND_EXTENSION_REGISTRY.matching_rules(canonical_command):
         if not rule.action_classes:
@@ -1456,6 +1492,30 @@ def _destructive_shell_tool_action_request(
             action_class=rule.action_classes[0],
             reason=rule.description,
             canonical_command=canonical_command,
+            interpreter_executable_identities=interpreter_executable_identities,
+        )
+    untrusted_interpreters = tuple(
+        evidence
+        for evidence in interpreter_executable_identities
+        if evidence.get("trust") not in {"trusted_guard", "trusted_system"}
+    )
+    if untrusted_interpreters:
+        trust_reasons = ", ".join(
+            sorted({str(evidence.get("trust") or "unknown") for evidence in untrusted_interpreters})
+        )
+        return ToolActionRequestMatch(
+            tool_name=tool_name,
+            normalized_tool_name=normalized_tool_name,
+            command_text=command_text,
+            action_class="untrusted Python interpreter",
+            reason=(
+                "Guard requires review because the Python command resolves through an interpreter path that is "
+                f"not an attested Guard or system runtime ({trust_reasons}). The decision is bound to the raw "
+                "interpreter token, launch path, symlink chain, executable mode, file identity, and content hash."
+            ),
+            canonical_command=canonical_command,
+            reason_code="interpreter_identity_untrusted",
+            interpreter_executable_identities=interpreter_executable_identities,
         )
     return None
 
@@ -4058,6 +4118,7 @@ def build_tool_action_request_artifact(
         "command_text": request.command_text,
         "action_class": request.action_class,
         "shell_execution_context_hash": request.shell_execution_context_hash,
+        "interpreter_executable_identities": request.interpreter_executable_identities,
     }
     if request.restricted_profile_version is not None:
         fingerprint_payload["restricted_profile_version"] = request.restricted_profile_version
@@ -4110,6 +4171,9 @@ def build_tool_action_request_artifact(
             "risk_classes": list(evaluation.risk_classes),
             "command_parse_confidence": evaluation.command.confidence,
             "command_uncertainty_reason": evaluation.command.uncertainty_reason,
+            "interpreter_executable_identities": [
+                dict(identity) for identity in request.interpreter_executable_identities
+            ],
             **execution_context_metadata,
             **(
                 {"guard_default_action": request.guard_default_action}
@@ -4171,6 +4235,7 @@ def _request_with_wrapper_context(
         pytest_config_identity_sha256=request.pytest_config_identity_sha256,
         pytest_config_sources=request.pytest_config_sources,
         pytest_config_reason_codes=request.pytest_config_reason_codes,
+        interpreter_executable_identities=request.interpreter_executable_identities,
     )
 
 
@@ -8112,7 +8177,409 @@ def _is_unmodeled_inline_interpreter_command(command_name: str) -> bool:
 
 
 def _is_python_interpreter_command(command_name: str) -> bool:
-    return re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", command_name) is not None
+    normalized_name = _normalized_shell_command_name(command_name)
+    return re.fullmatch(r"pythonw?(?:\d+(?:\.\d+)*)?(?:\.exe)?", normalized_name) is not None
+
+
+@dataclass(frozen=True, slots=True)
+class _ShellLaunchCandidate:
+    tokens: tuple[str, ...]
+    command_index: int
+    effective_cwd: Path
+    environment: dict[str, str]
+    resolution_reason: str | None = None
+
+
+def _python_interpreter_executable_identities(
+    command_text: str,
+    *,
+    cwd: Path | None,
+    home_dir: Path | None,
+    environment: dict[str, str] | None = None,
+    workspace_root: Path | None = None,
+    execution_context: ShellExecutionContext | None = None,
+    depth: int = 0,
+) -> tuple[dict[str, object], ...]:
+    """Resolve exact Python tokens without executing candidate interpreters."""
+
+    initial_cwd = _normalized_interpreter_cwd(cwd)
+    root = _normalized_interpreter_cwd(workspace_root or cwd)
+    inherited_environment = dict(os.environ if environment is None else environment)
+    if depth > 8:
+        return _ambiguous_python_evidence_from_tokens(
+            _split_shell_parts(command_text),
+            cwd=initial_cwd,
+            environment=inherited_environment,
+            workspace_root=root,
+            home_dir=home_dir,
+            reason="nested_shell_depth_exceeded",
+        )
+
+    execution_context = execution_context or model_shell_execution_context(
+        command_text,
+        cwd=initial_cwd,
+        workspace_root=root,
+    )
+    evidence: list[dict[str, object]] = []
+    for context_segment in execution_context.segments:
+        if context_segment.directory_operation is not None:
+            continue
+        segment_cwd, context_reason = validate_shell_execution_segment(execution_context, context_segment)
+        if segment_cwd is None or context_reason is not None:
+            evidence.extend(
+                _ambiguous_python_evidence_from_tokens(
+                    list(context_segment.tokens),
+                    cwd=initial_cwd,
+                    environment=inherited_environment,
+                    workspace_root=root,
+                    home_dir=home_dir,
+                    reason=context_reason or "interpreter_cwd_unresolved",
+                )
+            )
+            continue
+        candidate = _shell_launch_candidate(
+            list(context_segment.tokens),
+            cwd=segment_cwd,
+            environment=inherited_environment,
+        )
+        if candidate is None:
+            evidence.extend(
+                _ambiguous_python_evidence_from_tokens(
+                    list(context_segment.tokens),
+                    cwd=segment_cwd,
+                    environment=inherited_environment,
+                    workspace_root=root,
+                    home_dir=home_dir,
+                    reason="interpreter_wrapper_unresolved",
+                )
+            )
+            continue
+        raw_token = _shell_command_token_without_attached_redirection(candidate.tokens[candidate.command_index]).strip()
+        if _is_python_interpreter_command(raw_token):
+            evidence.append(
+                _python_interpreter_executable_identity(
+                    raw_token,
+                    cwd=candidate.effective_cwd,
+                    environment=candidate.environment,
+                    workspace_root=root,
+                    home_dir=home_dir,
+                    resolution_reason=candidate.resolution_reason,
+                )
+            )
+        command_name = _normalized_shell_command_name(raw_token)
+        if command_name in _SHELL_COMMAND_STRING_INTERPRETERS:
+            payload = _shell_interpreter_command_payload(
+                list(candidate.tokens),
+                candidate.command_index,
+            )
+            if payload is not None:
+                evidence.extend(
+                    _python_interpreter_executable_identities(
+                        payload.script_text,
+                        cwd=candidate.effective_cwd,
+                        home_dir=home_dir,
+                        environment=candidate.environment,
+                        workspace_root=root,
+                        depth=depth + 1,
+                    )
+                )
+    for payload in _shell_command_substitution_payloads(command_text):
+        evidence.extend(
+            _python_interpreter_executable_identities(
+                payload,
+                cwd=initial_cwd,
+                home_dir=home_dir,
+                environment=inherited_environment,
+                workspace_root=root,
+                depth=depth + 1,
+            )
+        )
+    unique: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for item in evidence:
+        stable_item = _without_interpreter_reuse_nonces(item)
+        key = json.dumps(stable_item, sort_keys=True, separators=(",", ":"), default=str)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(item)
+    return tuple(unique)
+
+
+def _normalized_interpreter_cwd(cwd: Path | None) -> Path:
+    candidate = cwd or Path.cwd()
+    try:
+        return candidate.expanduser().resolve(strict=False)
+    except (OSError, RuntimeError):
+        return candidate.expanduser().absolute()
+
+
+def _shell_launch_candidate(
+    tokens: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    depth: int = 0,
+    resolution_reason: str | None = None,
+) -> _ShellLaunchCandidate | None:
+    if depth > 8:
+        return None
+    working = list(tokens)
+    effective_environment = dict(environment)
+    effective_cwd = cwd
+    index = 0
+    while index < len(working):
+        redirected = _leading_shell_redirection_tokens_consumed(working, index)
+        if redirected:
+            index += redirected
+            continue
+        token = _shell_command_token_without_attached_redirection(working[index]).strip()
+        if _SHELL_ASSIGNMENT_PATTERN.match(token):
+            name, _, value = token.partition("=")
+            if name.endswith("+"):
+                name = name[:-1]
+                value = f"{effective_environment.get(name, '')}{value}"
+            effective_environment[name] = value
+            index += 1
+            continue
+        command_name = _normalized_shell_command_name(token)
+        if command_name == "env":
+            parsed = parse_env_wrapper(
+                working[index + 1 :],
+                inherited_environment=effective_environment,
+                cwd=effective_cwd,
+            )
+            if not parsed.complete or not parsed.executable_argv:
+                return None
+            parsed_environment = parsed.environment_dict()
+            if parsed_environment is None or parsed.effective_cwd is None:
+                return None
+            path_value = parsed_environment.get("PATH")
+            env_reason = resolution_reason
+            if path_value is not None and ("$" in path_value or "`" in path_value):
+                env_reason = "path_expression_unresolved"
+            return _shell_launch_candidate(
+                list(parsed.executable_argv),
+                cwd=parsed.effective_cwd,
+                environment=parsed_environment,
+                depth=depth + 1,
+                resolution_reason=env_reason,
+            )
+        if command_name not in _SHELL_COMMAND_WRAPPERS:
+            path_value = effective_environment.get("PATH")
+            final_reason = resolution_reason
+            if path_value is not None and ("$" in path_value or "`" in path_value):
+                final_reason = "path_expression_unresolved"
+            return _ShellLaunchCandidate(
+                tokens=tuple(working),
+                command_index=index,
+                effective_cwd=effective_cwd,
+                environment=effective_environment,
+                resolution_reason=final_reason,
+            )
+        if command_name == "sudo":
+            index, effective_cwd, sudo_reason = _consume_sudo_wrapper_for_interpreter(
+                working,
+                index + 1,
+                cwd=effective_cwd,
+            )
+            resolution_reason = resolution_reason or sudo_reason
+            continue
+        index += 1
+        while index < len(working) and working[index].startswith("-"):
+            wrapper_token = working[index]
+            if command_name == "command" and "p" in wrapper_token.lstrip("-"):
+                effective_environment["PATH"] = os.defpath
+            index += _wrapper_option_tokens_consumed(command_name, wrapper_token)
+    return None
+
+
+def _consume_sudo_wrapper_for_interpreter(
+    tokens: list[str],
+    index: int,
+    *,
+    cwd: Path,
+) -> tuple[int, Path, str | None]:
+    chdir_value: str | None = None
+    reason: str | None = "sudo_path_resolution_unproven"
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            return index + 1, cwd, reason
+        if not token.startswith("-"):
+            break
+        if token in {"-R", "--chroot"} or token.startswith(("-R", "--chroot=")):
+            reason = "sudo_chroot_unresolved"
+        if token in {"-D", "--chdir"}:
+            if index + 1 >= len(tokens):
+                return len(tokens), cwd, "sudo_chdir_missing"
+            chdir_value = tokens[index + 1]
+        elif token.startswith("--chdir="):
+            chdir_value = token.split("=", 1)[1]
+        elif token.startswith("-D") and token != "-D":
+            chdir_value = token[2:]
+        index += _wrapper_option_tokens_consumed("sudo", token)
+    if chdir_value is not None:
+        if not chdir_value or any(marker in chdir_value for marker in ("$", "`", "\x00")):
+            return index, cwd, "sudo_chdir_unresolved"
+        candidate = Path(chdir_value).expanduser()
+        if not candidate.is_absolute():
+            candidate = cwd / candidate
+        try:
+            resolved_cwd = candidate.resolve(strict=True)
+        except (OSError, RuntimeError):
+            return index, cwd, "sudo_chdir_unresolved"
+        if not resolved_cwd.is_dir():
+            return index, cwd, "sudo_chdir_unresolved"
+        cwd = resolved_cwd
+    return index, cwd, reason
+
+
+def _ambiguous_python_evidence_from_tokens(
+    tokens: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    workspace_root: Path,
+    home_dir: Path | None,
+    reason: str,
+) -> tuple[dict[str, object], ...]:
+    evidence: list[dict[str, object]] = []
+    for token in tokens:
+        raw_token = _shell_command_token_without_attached_redirection(token).strip()
+        if not _is_python_interpreter_command(raw_token):
+            continue
+        evidence.append(
+            _python_interpreter_executable_identity(
+                raw_token,
+                cwd=cwd,
+                environment=environment,
+                workspace_root=workspace_root,
+                home_dir=home_dir,
+                resolution_reason=reason,
+            )
+        )
+    return tuple(evidence)
+
+
+def _python_interpreter_executable_identity(
+    raw_token: str,
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    workspace_root: Path,
+    home_dir: Path | None,
+    resolution_reason: str | None,
+) -> dict[str, object]:
+    search_path = environment.get("PATH")
+    identity = build_runtime_executable_identity(raw_token, search_path=search_path, cwd=cwd)
+    if resolution_reason is not None and not _interpreter_token_has_path(raw_token):
+        identity = {**identity, "resolution_reason": resolution_reason, "reuse_nonce": secrets.token_hex(16)}
+    trust = _python_interpreter_trust(
+        raw_token,
+        identity=identity,
+        workspace_root=workspace_root,
+        home_dir=home_dir,
+        resolution_reason=resolution_reason,
+    )
+    return {
+        "effective_cwd": str(cwd),
+        "executable": identity,
+        "normalized_name": _normalized_shell_command_name(raw_token),
+        "raw_token": raw_token,
+        "search_path_sha256": hashlib.sha256((search_path or "").encode("utf-8")).hexdigest(),
+        "trust": trust,
+    }
+
+
+def _python_interpreter_trust(
+    raw_token: str,
+    *,
+    identity: dict[str, object],
+    workspace_root: Path,
+    home_dir: Path | None,
+    resolution_reason: str | None,
+) -> str:
+    status = str(identity.get("status") or "unknown")
+    if resolution_reason is not None and not _interpreter_token_has_path(raw_token):
+        return "ambiguous"
+    if status in {"unresolved", "unreadable", "path_unreadable"}:
+        return "missing"
+    if status == "not_executable":
+        return "non_executable"
+    if status != "verified":
+        return "ambiguous" if status in {"foreign_platform_path", "invalid_path", "path_changed"} else "unknown"
+    raw_launch_path = identity.get("launch_path")
+    canonical_path = identity.get("path")
+    if not isinstance(raw_launch_path, str) or not isinstance(canonical_path, str):
+        return "unknown"
+    launch_path = Path(raw_launch_path)
+    canonical = Path(canonical_path)
+    if _interpreter_path_is_within(launch_path, workspace_root):
+        return "workspace_local"
+    try:
+        guard_launch = Path(sys.executable).expanduser().absolute()
+        guard_canonical = guard_launch.resolve(strict=True)
+    except (OSError, RuntimeError):
+        guard_launch = Path(sys.executable).expanduser().absolute()
+        guard_canonical = guard_launch
+    if canonical == guard_canonical and launch_path in {guard_launch, guard_canonical}:
+        return "trusted_guard"
+    if home_dir is not None and _interpreter_path_is_within(launch_path, home_dir):
+        return "user_controlled"
+    if os.name == "nt":
+        return "user_controlled"
+    if any(
+        _interpreter_path_is_within(launch_path, trusted_root) for trusted_root in _TRUSTED_INTERPRETER_INSTALL_ROOTS
+    ) and _interpreter_identity_path_chain_is_stable(identity):
+        return "trusted_system"
+    try:
+        if is_trusted_absolute_command_path(launch_path, cwd=workspace_root, home_dir=home_dir):
+            return "trusted_system"
+    except (OSError, RuntimeError):
+        pass
+    return "user_controlled"
+
+
+def _interpreter_identity_path_chain_is_stable(identity: dict[str, object]) -> bool:
+    path_chain = identity.get("path_chain")
+    if not isinstance(path_chain, list) or not path_chain:
+        return False
+    for item in path_chain:
+        if not isinstance(item, dict):
+            return False
+        mode = item.get("mode")
+        if not isinstance(mode, int) or mode & 0o022:
+            return False
+    return True
+
+
+def _interpreter_token_has_path(raw_token: str) -> bool:
+    normalized = raw_token.strip()
+    return (
+        "/" in normalized
+        or "\\" in normalized
+        or bool(re.match(r"^[A-Za-z]:", normalized))
+        or normalized.startswith("//")
+    )
+
+
+def _interpreter_path_is_within(path: Path, root: Path) -> bool:
+    try:
+        path.absolute().relative_to(root.absolute())
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return True
+
+
+def _without_interpreter_reuse_nonces(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            str(key): _without_interpreter_reuse_nonces(item) for key, item in value.items() if key != "reuse_nonce"
+        }
+    if isinstance(value, (list, tuple)):
+        return [_without_interpreter_reuse_nonces(item) for item in value]
+    return value
 
 
 def _is_pytest_python_interpreter_command(command_name: str) -> bool:
@@ -8177,7 +8644,7 @@ def _single_interpreter_heredoc_interpreter(command_text: str) -> str | None:
     match = _SINGLE_INTERPRETER_HEREDOC_PATTERN.fullmatch(command_text.strip())
     if match is None:
         return None
-    interpreter = _normalized_shell_command_name(match.group("interpreter").strip())
+    interpreter = match.group("interpreter").strip()
     return interpreter or None
 
 

--- a/src/codex_plugin_scanner/guard/runtime/shell_command_wrappers.py
+++ b/src/codex_plugin_scanner/guard/runtime/shell_command_wrappers.py
@@ -329,12 +329,18 @@ def _command_name(
     command_path = Path(token)
     if not command_path.is_absolute():
         return ""
-    if not _trusted_absolute_command_path(command_path, cwd=cwd, home_dir=home_dir):
+    if not is_trusted_absolute_command_path(command_path, cwd=cwd, home_dir=home_dir):
         return ""
     return command_path.name.lower()
 
 
-def _trusted_absolute_command_path(command_path: Path, *, cwd: Path | None, home_dir: Path | None) -> bool:
+def is_trusted_absolute_command_path(command_path: Path, *, cwd: Path | None, home_dir: Path | None) -> bool:
+    """Return whether a resolved launch path is outside user-controlled roots.
+
+    This is shared by transparent-wrapper and interpreter classification so
+    basename normalization never silently changes the trust decision.
+    """
+
     try:
         if _path_is_under(command_path, cwd) or not _stable_non_writable_path(command_path):
             return False
@@ -413,4 +419,8 @@ def _join_shell_tokens(tokens: list[str]) -> str:
     return " ".join(rendered).strip()
 
 
-__all__ = ["ShellCommandNormalization", "normalize_transparent_shell_command"]
+__all__ = [
+    "ShellCommandNormalization",
+    "is_trusted_absolute_command_path",
+    "normalize_transparent_shell_command",
+]

--- a/tests/test_guard_copilot_benign_policy_hint.py
+++ b/tests/test_guard_copilot_benign_policy_hint.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import shlex
+import sys
 from pathlib import Path
 from typing import cast
 
@@ -18,7 +20,7 @@ from codex_plugin_scanner.guard.store import GuardStore
 
 _IGNORED_BENIGN_HINT_REASON = "untrusted_hook_payload_hint_ignored_guard_verified_benign"
 _BENIGN_COMMAND = (
-    "cd /tmp/hol-guard-fixtures/hashgraph-online && python - <<'PY'\n"
+    f"cd /tmp && {shlex.quote(sys.executable)} - <<'PY'\n"
     "from pathlib import Path\n"
     "text = Path('bounty_submissions.txt').read_text()\n"
     "print('bytes', len(text))\n"

--- a/tests/test_guard_interpreter_identity.py
+++ b/tests/test_guard_interpreter_identity.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.consumer.service import artifact_hash
+from codex_plugin_scanner.guard.runtime.approval_context import (
+    approval_context_validation_reason,
+    build_approval_context_token,
+    build_runtime_executable_identity,
+)
+from codex_plugin_scanner.guard.runtime.secret_file_requests import (
+    build_tool_action_request_artifact,
+    extract_sensitive_tool_action_request,
+    is_explicitly_benign_tool_action_request,
+)
+
+
+def _write_interpreter(path: Path, body: bytes = b"#!/bin/sh\nexit 0\n", *, executable: bool = True) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(body)
+    path.chmod(0o755 if executable else 0o644)
+
+
+def _request(command: str, *, cwd: Path):
+    return extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=cwd, home_dir=Path.home())
+
+
+def _interpreter_evidence(command: str, *, cwd: Path) -> dict[str, object]:
+    request = _request(command, cwd=cwd)
+    assert request is not None
+    assert request.interpreter_executable_identities
+    return request.interpreter_executable_identities[0]
+
+
+@pytest.mark.parametrize(
+    "command_builder",
+    (
+        lambda token: f"{token} -c \"print('fixture')\"",
+        lambda token: f"{token} <<'PY'\nprint('fixture')\nPY",
+    ),
+)
+def test_project_local_interpreter_never_inherits_python_basename_trust(
+    tmp_path: Path,
+    command_builder,
+) -> None:
+    workspace = tmp_path / "workspace"
+    interpreter = workspace / "python"
+    _write_interpreter(interpreter)
+    command = command_builder("./python")
+
+    request = _request(command, cwd=workspace)
+
+    assert request is not None
+    assert request.action_class == "untrusted Python interpreter"
+    assert request.reason_code == "interpreter_identity_untrusted"
+    evidence = request.interpreter_executable_identities[0]
+    assert evidence["raw_token"] == "./python"
+    assert evidence["normalized_name"] == "python"
+    assert evidence["trust"] == "workspace_local"
+    executable = evidence["executable"]
+    assert isinstance(executable, dict)
+    assert executable["launch_path"] == str(interpreter.absolute())
+    assert executable["path"] == str(interpreter.resolve())
+    assert executable["status"] == "verified"
+    assert executable["mode"] == 0o755
+    assert isinstance(executable["sha256"], str)
+    assert executable["path_chain"]
+    assert not is_explicitly_benign_tool_action_request(
+        "Bash",
+        {"command": command},
+        cwd=workspace,
+        home_dir=Path.home(),
+    )
+
+
+@pytest.mark.parametrize(
+    "relative_token",
+    ("./python", "subdir/python", "space ☃/python"),
+)
+def test_relative_and_unicode_interpreter_paths_bind_effective_cwd(
+    tmp_path: Path,
+    relative_token: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    interpreter = workspace / relative_token
+    _write_interpreter(interpreter)
+    token = shlex.quote(relative_token)
+
+    evidence = _interpreter_evidence(f"{token} -c \"print('fixture')\"", cwd=workspace)
+
+    assert evidence["raw_token"] == relative_token
+    assert evidence["effective_cwd"] == str(workspace.resolve())
+    assert evidence["trust"] == "workspace_local"
+
+
+def test_cd_and_env_chdir_resolve_interpreter_from_segment_cwd(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    nested = workspace / "nested"
+    _write_interpreter(nested / "python")
+
+    cd_evidence = _interpreter_evidence("cd nested && ./python -c 'print(1)'", cwd=workspace)
+    env_evidence = _interpreter_evidence("env -C nested ./python -c 'print(1)'", cwd=workspace)
+
+    assert cd_evidence["effective_cwd"] == str(nested.resolve())
+    assert env_evidence["effective_cwd"] == str(nested.resolve())
+    assert cd_evidence["executable"]["path"] == env_evidence["executable"]["path"]
+
+
+def test_env_path_and_sudo_wrappers_preserve_bare_interpreter_resolution(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    bin_dir = workspace / "bin"
+    _write_interpreter(bin_dir / "python")
+    path_value = os.pathsep.join((str(bin_dir), os.defpath))
+
+    env_evidence = _interpreter_evidence(
+        f"env PATH={shlex.quote(path_value)} python -c 'print(1)'",
+        cwd=workspace,
+    )
+    sudo_evidence = _interpreter_evidence(
+        f"PATH={shlex.quote(path_value)} sudo -n python -c 'print(1)'",
+        cwd=workspace,
+    )
+
+    assert env_evidence["raw_token"] == "python"
+    assert env_evidence["trust"] == "workspace_local"
+    assert env_evidence["executable"]["launch_path"] == str((bin_dir / "python").absolute())
+    assert sudo_evidence["raw_token"] == "python"
+    assert sudo_evidence["trust"] == "ambiguous"
+    assert sudo_evidence["executable"]["resolution_reason"] == "sudo_path_resolution_unproven"
+
+
+def test_shell_command_string_preserves_nested_interpreter_token(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    _write_interpreter(workspace / "python")
+    nested = "./python -c \"print('fixture')\""
+
+    evidence = _interpreter_evidence(f"/bin/sh -c {shlex.quote(nested)}", cwd=workspace)
+
+    assert evidence["raw_token"] == "./python"
+    assert evidence["trust"] == "workspace_local"
+
+
+def test_exact_guard_interpreter_keeps_read_only_commands_prompt_free(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    token = shlex.quote(sys.executable)
+    commands = (
+        f"{token} -c \"print('fixture')\"",
+        f"{token} <<'PY'\nprint('fixture')\nPY",
+    )
+
+    for command in commands:
+        assert _request(command, cwd=workspace) is None
+        assert is_explicitly_benign_tool_action_request(
+            "Bash",
+            {"command": command},
+            cwd=workspace,
+            home_dir=Path.home(),
+        )
+
+
+@pytest.mark.skipif(not Path("/usr/bin/python3").is_file(), reason="trusted system Python is unavailable")
+def test_verified_system_interpreter_keeps_normal_read_only_path_prompt_free(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    command = "/usr/bin/python3 -c \"print('fixture')\""
+
+    assert _request(command, cwd=workspace) is None
+
+
+@pytest.mark.skipif(not Path("/usr/bin/python3").is_file(), reason="trusted system Python is unavailable")
+def test_bare_interpreter_uses_effective_path_and_keeps_trusted_resolution_prompt_free(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    command = f"PATH=/usr/bin{os.pathsep}/bin python3 -c \"print('fixture')\""
+
+    assert _request(command, cwd=workspace) is None
+    assert is_explicitly_benign_tool_action_request(
+        "Bash",
+        {"command": command},
+        cwd=workspace,
+        home_dir=Path.home(),
+    )
+
+
+@pytest.mark.parametrize(
+    "foreign_token",
+    (
+        r"C:\workspace\python.EXE",
+        r"\\server\share\python3.exe",
+    ),
+)
+def test_foreign_windows_paths_are_not_reduced_to_a_trusted_basename(
+    tmp_path: Path,
+    foreign_token: str,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("foreign-path behavior is exercised from POSIX")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    evidence = _interpreter_evidence(
+        f"{shlex.quote(foreign_token)} -c \"print('fixture')\"",
+        cwd=workspace,
+    )
+
+    assert evidence["raw_token"] == foreign_token
+    assert evidence["normalized_name"] in {"python.exe", "python3.exe"}
+    assert evidence["trust"] == "ambiguous"
+    assert evidence["executable"]["status"] == "foreign_platform_path"
+
+
+def test_missing_and_non_executable_interpreters_fail_closed(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_interpreter(workspace / "python", executable=False)
+
+    non_executable = _interpreter_evidence("./python -c 'print(1)'", cwd=workspace)
+    missing = _interpreter_evidence("./missing/python -c 'print(1)'", cwd=workspace)
+
+    assert non_executable["trust"] == "non_executable"
+    assert non_executable["executable"]["status"] == "not_executable"
+    assert missing["trust"] == "missing"
+    assert missing["executable"]["status"] in {"path_unreadable", "unreadable"}
+    assert "reuse_nonce" in missing["executable"]
+
+
+def test_symlink_swap_changes_bound_interpreter_and_artifact_identity(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    first_target = workspace / "runtimes" / "python-v1"
+    second_target = workspace / "runtimes" / "python-v2"
+    _write_interpreter(first_target, b"#!/bin/sh\necho first\n")
+    _write_interpreter(second_target, b"#!/bin/sh\necho other\n")
+    link = workspace / "python"
+    link.symlink_to(first_target.relative_to(workspace))
+    command = "./python -c 'print(1)'"
+
+    first_request = _request(command, cwd=workspace)
+    assert first_request is not None
+    first_evidence = first_request.interpreter_executable_identities[0]
+    first_artifact = build_tool_action_request_artifact(
+        "codex",
+        first_request,
+        config_path="hooks.json",
+        source_scope="project",
+    )
+
+    link.unlink()
+    link.symlink_to(second_target.relative_to(workspace))
+    second_request = _request(command, cwd=workspace)
+    assert second_request is not None
+    second_evidence = second_request.interpreter_executable_identities[0]
+    second_artifact = build_tool_action_request_artifact(
+        "codex",
+        second_request,
+        config_path="hooks.json",
+        source_scope="project",
+    )
+
+    assert first_evidence["raw_token"] == second_evidence["raw_token"] == "./python"
+    assert first_evidence["executable"]["launch_path"] == second_evidence["executable"]["launch_path"]
+    assert first_evidence["executable"]["path"] != second_evidence["executable"]["path"]
+    assert first_evidence["executable"]["sha256"] != second_evidence["executable"]["sha256"]
+    assert first_evidence["executable"]["path_chain"] != second_evidence["executable"]["path_chain"]
+    assert first_artifact.artifact_id != second_artifact.artifact_id
+    assert artifact_hash(first_artifact) != artifact_hash(second_artifact)
+
+
+def test_same_python_basename_at_different_paths_cannot_collide(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    first = workspace / "first" / "python"
+    second = workspace / "second" / "python"
+    _write_interpreter(first, b"#!/bin/sh\necho first\n")
+    _write_interpreter(second, b"#!/bin/sh\necho other\n")
+
+    first_evidence = _interpreter_evidence("first/python -c 'print(1)'", cwd=workspace)
+    second_evidence = _interpreter_evidence("second/python -c 'print(1)'", cwd=workspace)
+
+    assert first_evidence["normalized_name"] == second_evidence["normalized_name"] == "python"
+    assert first_evidence["raw_token"] != second_evidence["raw_token"]
+    assert first_evidence["executable"]["path"] != second_evidence["executable"]["path"]
+    assert first_evidence["executable"]["sha256"] != second_evidence["executable"]["sha256"]
+
+
+def test_local_interpreter_cannot_reuse_trusted_interpreter_approval(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    local_interpreter = workspace / "python"
+    _write_interpreter(local_interpreter)
+    trusted_identity = build_runtime_executable_identity(sys.executable, cwd=workspace)
+    local_identity = build_runtime_executable_identity("./python", cwd=workspace)
+    shared_context = {
+        "content": "same-inline-script",
+        "capabilities": ["read-only-observer"],
+        "policy": {"action": "review"},
+        "sandbox": {"mode": "host"},
+    }
+    approved = build_approval_context_token(
+        identity={"interpreter": trusted_identity},
+        **shared_context,
+    )
+
+    reason = approval_context_validation_reason(
+        approved,
+        identity={"interpreter": local_identity},
+        **shared_context,
+    )
+
+    assert trusted_identity["path"] != local_identity["path"]
+    assert reason == "approval_reuse_identity_changed"
+
+
+def test_same_path_same_bytes_replacement_changes_file_identity(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    interpreter = workspace / "python"
+    content = b"#!/bin/sh\nexit 0\n"
+    _write_interpreter(interpreter, content)
+    first = build_runtime_executable_identity("./python", cwd=workspace)
+    replacement = workspace / "replacement"
+    _write_interpreter(replacement, content)
+
+    os.replace(replacement, interpreter)
+    second = build_runtime_executable_identity("./python", cwd=workspace)
+
+    assert first["sha256"] == second["sha256"]
+    assert (first["device"], first["inode"]) != (second["device"], second["inode"])
+    assert first["path_chain"] != second["path_chain"]
+    assert first != second

--- a/tests/test_guard_restricted_pytest.py
+++ b/tests/test_guard_restricted_pytest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import socket
 import sys
 import tempfile
@@ -68,7 +69,7 @@ def test_uncontained_pytest_is_repository_execution_requiring_sandbox(tmp_path: 
 def test_pytest_text_in_nonexecuted_inline_literal_is_not_classified(tmp_path: Path) -> None:
     match = extract_sensitive_tool_action_request(
         "Bash",
-        {"command": "python -c 'print(\"pytest.main()\")'"},
+        {"command": f"{shlex.quote(sys.executable)} -c 'print(\"pytest.main()\")'"},
         cwd=tmp_path,
     )
 

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
 import shlex
+import sys
 from pathlib import Path
 
 import pytest
@@ -62,6 +64,14 @@ from codex_plugin_scanner.guard.store import GuardStore
 def _write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def _prefer_guard_interpreter_on_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    current_path = os.environ.get("PATH", "")
+    monkeypatch.setenv(
+        "PATH",
+        os.pathsep.join(part for part in (str(Path(sys.executable).parent), current_path) if part),
+    )
 
 
 def _symlink_or_skip(link_path: Path, target: Path) -> None:
@@ -1047,12 +1057,13 @@ def test_tool_action_request_classifier_blocks_mutating_python_module_invocation
     assert request.action_class == "destructive shell command"
 
 
-def test_tool_action_request_classifier_allows_safe_ruff_fix_invocations(tmp_path):
+def test_tool_action_request_classifier_allows_safe_ruff_fix_invocations(tmp_path, monkeypatch):
+    _prefer_guard_interpreter_on_path(monkeypatch)
     (tmp_path / "repo").mkdir()
     for command in (
         "python -m ruff check --fix .",
         "python -m ruff check --fix-only .",
-        "cd repo && python3 -m ruff check --fix src/foo.py",
+        f"cd repo && {shlex.quote(sys.executable)} -m ruff check --fix src/foo.py",
     ):
         request = extract_sensitive_tool_action_request("bash", {"command": command}, cwd=tmp_path)
 
@@ -2634,7 +2645,8 @@ def test_tool_action_request_classifier_allows_read_only_python_heredoc_debuggin
     assert request is None
 
 
-def test_tool_action_request_classifier_allows_read_only_python_heredoc_debugging_after_cd(tmp_path):
+def test_tool_action_request_classifier_allows_read_only_python_heredoc_debugging_after_cd(tmp_path, monkeypatch):
+    _prefer_guard_interpreter_on_path(monkeypatch)
     fixture_dir = tmp_path / "hashgraph-online"
     fixture_dir.mkdir()
     (fixture_dir / "bounty_submissions.txt").write_text("fixture row\n", encoding="utf-8")
@@ -2656,12 +2668,13 @@ def test_tool_action_request_classifier_allows_read_only_python_heredoc_debuggin
     assert request is None
 
 
-def test_tool_action_request_classifier_allows_versioned_python_pdf_text_extraction_heredoc():
+def test_tool_action_request_classifier_allows_guard_python_pdf_text_extraction_heredoc(tmp_path):
+    interpreter = shlex.quote(sys.executable)
     request = extract_sensitive_tool_action_request(
         "bash",
         {
             "command": (
-                "/opt/codex-runtime/dependencies/python/bin/python3.12 - <<'PY'\n"
+                f"{interpreter} - <<'PY'\n"
                 "from pathlib import Path\n"
                 "pdf = Path('/tmp/HOL Coordination Layer-compressed.pdf')\n"
                 "mods = []\n"
@@ -2683,6 +2696,7 @@ def test_tool_action_request_classifier_allows_versioned_python_pdf_text_extract
                 "PY"
             )
         },
+        cwd=tmp_path,
     )
 
     assert request is None
@@ -2720,18 +2734,20 @@ def test_tool_action_request_classifier_detects_versioned_python_inline_file_wri
     assert request.action_class == "destructive shell command"
 
 
-def test_tool_action_request_classifier_allows_patch_versioned_python_pdf_text_extraction_heredoc():
+def test_tool_action_request_classifier_allows_guard_python_pdf_text_extraction_heredoc_with_short_body(tmp_path):
+    interpreter = shlex.quote(sys.executable)
     request = extract_sensitive_tool_action_request(
         "bash",
         {
             "command": (
-                "/opt/codex-runtime/dependencies/python/bin/python3.12.1 - <<'PY'\n"
+                f"{interpreter} - <<'PY'\n"
                 "from pathlib import Path\n"
                 "pdf = Path('/tmp/HOL Coordination Layer-compressed.pdf')\n"
                 "print(pdf.name)\n"
                 "PY"
             )
         },
+        cwd=tmp_path,
     )
 
     assert request is None
@@ -3165,8 +3181,13 @@ def test_tool_action_request_classifier_allows_python_time_sleep_one_liner():
     assert request is None
 
 
-def test_tool_action_request_classifier_allows_python_c_argument_named_like_module_flag():
-    request = extract_sensitive_tool_action_request("bash", {"command": "python -c 'print(1)' -m"})
+def test_tool_action_request_classifier_allows_python_c_argument_named_like_module_flag(tmp_path, monkeypatch):
+    _prefer_guard_interpreter_on_path(monkeypatch)
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "python -c 'print(1)' -m"},
+        cwd=tmp_path,
+    )
 
     assert request is None
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -6881,7 +6881,7 @@ def test_guard_hook_emits_copilot_native_allow_response_for_benign_python_heredo
         "toolName": "bash",
         "toolArgs": {
             "command": (
-                f"cd {shlex.quote(str(fixture_dir))} && python - <<'PY'\n"
+                f"cd {shlex.quote(str(fixture_dir))} && {shlex.quote(sys.executable)} - <<'PY'\n"
                 "from pathlib import Path\n"
                 "text = Path('bounty_submissions.txt').read_text()\n"
                 "print('bytes', len(text))\n"

--- a/tests/test_guard_shell_execution_context.py
+++ b/tests/test_guard_shell_execution_context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shlex
+import sys
 from pathlib import Path
 
 import pytest
@@ -441,16 +442,17 @@ def test_heredoc_does_not_make_an_earlier_project_use_the_last_effective_cwd(tmp
 def test_literal_pushd_and_ruff_remain_prompt_free_in_the_effective_project(tmp_path: Path) -> None:
     project = tmp_path / "services" / "auth"
     project.mkdir(parents=True)
+    command = f"pushd services/auth && {shlex.quote(sys.executable)} -m ruff check ."
 
     safe_request = extract_sensitive_tool_action_request(
         "Bash",
-        {"command": "pushd services/auth && python -m ruff check ."},
+        {"command": command},
         cwd=tmp_path,
     )
     _write(project / "ruff.py", "raise SystemExit('shadowed ruff')\n")
     unsafe_request = extract_sensitive_tool_action_request(
         "Bash",
-        {"command": "pushd services/auth && python -m ruff check ."},
+        {"command": command},
         cwd=tmp_path,
     )
 


### PR DESCRIPTION
## Summary

- preserve and resolve the exact raw Python interpreter token across direct, heredoc, inline, wrapper, effective-cwd, and nested shell-command forms
- attest launch path, canonical path, executable mode, device/inode/timestamps, symlink path chain, and content hash before binding runtime artifacts and approval context
- require review for workspace-local, user-controlled, missing, non-executable, ambiguous, foreign-platform, or changed interpreter identities while retaining existing stronger action classes and pytest containment
- keep verified Guard/system interpreters on the normal prompt-free path

## Security evidence

- Before the fix, `/tmp/fake/python <<'PY' ... PY`, `./python -c ...`, and equivalent path-qualified commands were reduced to a trusted-looking Python basename and remained prompt-free.
- After the fix, the raw token is retained and those paths produce `interpreter_identity_untrusted` with exact executable evidence. Missing and non-executable paths fail closed and receive non-reusable identity evidence.
- Regression coverage proves that identical `python` basenames at different paths cannot collide, symlink swaps alter both evidence and artifact identity, same-byte inode replacement changes identity, and a project interpreter cannot reuse approval from a trusted interpreter.
- Verified `sys.executable`, trusted absolute system Python, and a trusted bare-PATH resolution remain prompt-free for read-only commands.

## Validation

- `673 passed` across interpreter identity, approval context, interpreted entrypoint, hook executable, shell wrapper, Copilot policy, risk, and effective-cwd suites on default Python.
- Python 3.10 affected-suite result: `1328 passed`; two macOS restricted-pytest launcher failures reproduce unchanged on exact base commit `50020e2a` in the same external environment.
- Default full suite: `9824 passed, 25 skipped, 5 deselected`; all code-related failures reproduce on the exact base. One Cisco dependency-order case passes when isolated on both base and head.
- Python 3.10 full suite: `9821 passed, 27 skipped, 5 deselected`; all failures either reproduce on the exact base or are the two external-venv restricted-pytest cases noted above.
- Changed files pass Ruff lint/format and `git diff --check`; basedpyright reports `0 errors` (repository-configured warnings remain).
- Wheel and sdist builds succeed on default Python and Python 3.10.

## Base

This PR targets `release/2.1`.
