### PR TITLE
fix(mdm): avoid health lock during cloud delivery

### DIFF
--- a/src/codex_plugin_scanner/guard/mdm/user_health.py
+++ b/src/codex_plugin_scanner/guard/mdm/user_health.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import hashlib
 import json
 import os
@@ -186,16 +187,15 @@ def _validate_state(state: UserHealthState) -> None:
     try:
         private_key = serialization.load_pem_private_key(state.private_key_pem.encode(), password=None)
         public_der = base64.b64decode(state.public_key_spki, validate=True)
-    except (TypeError, UnsupportedAlgorithm, ValueError) as exc:
+        key_digest = base64.b64decode(f"{state.key_id}=", altchars=b"-_", validate=True)
+    except (binascii.Error, TypeError, UnsupportedAlgorithm, ValueError) as exc:
         raise ValueError("user_health_state_invalid") from exc
     if not isinstance(private_key, ec.EllipticCurvePrivateKey) or not isinstance(private_key.curve, ec.SECP256R1):
         raise ValueError("user_health_state_invalid")
     expected_der = private_key.public_key().public_bytes(
         serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
     )
-    if expected_der != public_der or hashlib.sha256(public_der).digest() != base64.urlsafe_b64decode(
-        f"{state.key_id}="
-    ):
+    if expected_der != public_der or hashlib.sha256(public_der).digest() != key_digest:
         raise ValueError("user_health_state_invalid")
 
 
@@ -423,39 +423,55 @@ def run_user_health_cadence(
                 updated_at=resolved_now.isoformat(),
             )
             _write_state(guard_home, state)
-        resolved_transport = transport or GuardCloudMachineHealthTransport(guard_home)
-        if state.sequence == 0:
-            resolved_transport.register_key(_registration(state, resolved_now))
-        ack = resolved_transport.deliver_lease(outbox)
-        claims = outbox.lease.claims
-        expected = (
-            state.workspace_id,
-            state.device_id,
-            state.machine_installation_id,
-            state.installation_generation,
-            claims.sequence,
-            outbox.lease.digest,
+    resolved_transport = transport or GuardCloudMachineHealthTransport(guard_home)
+    if state.sequence == 0:
+        resolved_transport.register_key(_registration(state, resolved_now))
+    ack = resolved_transport.deliver_lease(outbox)
+    claims = outbox.lease.claims
+    expected = (
+        state.workspace_id,
+        state.device_id,
+        state.machine_installation_id,
+        state.installation_generation,
+        claims.sequence,
+        outbox.lease.digest,
+    )
+    actual = (
+        ack.workspace_id,
+        ack.device_id,
+        ack.machine_installation_id,
+        ack.installation_generation,
+        ack.sequence,
+        ack.lease_digest,
+    )
+    if actual != expected:
+        raise OSError("health_lease_ack_conflict")
+    with _state_lock(guard_home):
+        current = _read_state(guard_home)
+        if current is None:
+            raise OSError("health_lease_state_conflict")
+        already_committed = (
+            current.pending_outbox is None
+            and current.sequence == claims.sequence
+            and current.last_lease_digest == outbox.lease.digest
         )
-        actual = (
-            ack.workspace_id,
-            ack.device_id,
-            ack.machine_installation_id,
-            ack.installation_generation,
-            ack.sequence,
-            ack.lease_digest,
-        )
-        if actual != expected:
-            raise OSError("health_lease_ack_conflict")
-        _write_state(
-            guard_home,
-            replace(
-                state,
-                sequence=claims.sequence,
-                last_lease_digest=outbox.lease.digest,
-                pending_outbox=None,
-                updated_at=ack.received_datetime.isoformat(),
-            ),
-        )
+        if not already_committed:
+            if (
+                current.pending_outbox != encoded_outbox
+                or current.sequence != state.sequence
+                or current.last_lease_digest != state.last_lease_digest
+            ):
+                raise OSError("health_lease_state_conflict")
+            _write_state(
+                guard_home,
+                replace(
+                    current,
+                    sequence=claims.sequence,
+                    last_lease_digest=outbox.lease.digest,
+                    pending_outbox=None,
+                    updated_at=ack.received_datetime.isoformat(),
+                ),
+            )
     return {
         "schemaVersion": "hol-guard-user-health-report.v1",
         "delivered": True,

--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
+from ..mdm.user_health import run_user_health_cadence, user_health_report_due
 from ..review_contracts import (
     GuardReviewContractError,
     GuardReviewOAuthMetadata,
@@ -706,8 +707,6 @@ def _cloud_sync_sync_loop(
         try:
             auth_context = _resolve_live_request_sync_auth_context(store)
             result = sync_live_requests_once(store, auth_context)
-            from ..mdm.user_health import run_user_health_cadence, user_health_report_due
-
             with suppress(OSError, PermissionError, RuntimeError, ValueError):
                 if user_health_report_due(store.guard_home):
                     run_user_health_cadence(store.guard_home)

--- a/tests/test_guard_mdm_user_health.py
+++ b/tests/test_guard_mdm_user_health.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
@@ -48,6 +49,27 @@ class FailingTransport(Transport):
     def deliver_lease(self, outbox: HealthLeaseOutbox) -> HealthLeaseAck:
         self.outboxes.append(outbox)
         raise ConnectionError("offline")
+
+
+class ConcurrentTransport(Transport):
+    def __init__(self) -> None:
+        super().__init__()
+        self.barrier = threading.Barrier(2)
+
+    def deliver_lease(self, outbox: HealthLeaseOutbox) -> HealthLeaseAck:
+        self.outboxes.append(outbox)
+        self.barrier.wait(timeout=5)
+        claims = outbox.lease.claims
+        return HealthLeaseAck(
+            "accepted",
+            claims.workspace_id,
+            claims.device_id,
+            claims.machine_installation_id,
+            claims.installation_generation,
+            claims.sequence,
+            outbox.lease.digest,
+            "2026-07-19T14:00:01.000Z",
+        )
 
 
 @pytest.fixture
@@ -110,7 +132,7 @@ def test_user_health_registers_and_delivers_signed_monotonic_leases(guard_home: 
 
 def test_user_health_serializes_concurrent_cadence_runs(guard_home: Path) -> None:
     user_health.configure_user_health_leases(guard_home, enabled=True, now=NOW)
-    transport = Transport()
+    transport = ConcurrentTransport()
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         reports = list(
@@ -124,9 +146,9 @@ def test_user_health_serializes_concurrent_cadence_runs(guard_home: Path) -> Non
             )
         )
 
-    assert {report["sequence"] for report in reports} == {1, 2}
-    ordered = sorted(transport.outboxes, key=lambda outbox: outbox.lease.claims.sequence)
-    assert ordered[1].lease.claims.previous_lease_digest == ordered[0].lease.digest
+    assert {report["sequence"] for report in reports} == {1}
+    assert len({outbox.lease.digest for outbox in transport.outboxes}) == 1
+    assert user_health.user_health_status(guard_home)["sequence"] == 1
 
 
 def test_user_health_disable_preserves_continuity_but_stops_delivery(guard_home: Path) -> None:


### PR DESCRIPTION
## Summary
- keep user health state locks scoped to local state transitions instead of Cloud round trips
- reconcile concurrent idempotent acknowledgements without forking lease continuity
- validate key identifiers defensively and avoid repeated imports in the live sync loop

## Testing
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/runtime/live_request_sync.py src/codex_plugin_scanner/guard/mdm/user_health.py tests/test_guard_mdm_user_health.py`
- `uv run --no-sync pytest -q tests/test_guard_mdm_user_health.py tests/test_guard_live_request_sync.py` (37 passed)
