### PR TITLE
fix(release): align alpha trusted publisher environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -468,7 +468,7 @@ jobs:
       (needs.alpha-cross-platform.result == 'success' || needs.alpha-cross-platform.result == 'skipped')
     needs: [build, alpha-cross-platform, publish-alpha-testpypi]
     runs-on: ubuntu-latest
-    environment: pypi-alpha
+    environment: pypi
     permissions:
       contents: read
       id-token: write

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -198,7 +198,7 @@ def test_publish_jobs_use_registered_protected_environments() -> None:
 
     assert jobs["publish-testpypi"]["environment"] == "testpypi"
     assert jobs["publish-alpha-testpypi"]["environment"] == "testpypi"
-    assert jobs["publish-alpha-pypi"]["environment"] == "pypi-alpha"
+    assert jobs["publish-alpha-pypi"]["environment"] == "pypi"
     assert jobs["publish-main-testpypi"]["environment"] == "testpypi"
     assert jobs["publish-main-pypi"]["environment"] == "pypi"
     assert jobs["publish-testpypi"]["permissions"] == {"id-token": "write"}


### PR DESCRIPTION
## Summary
- align alpha publishing with the PyPI trusted publisher's `pypi` environment
- keep the workflow contract test synchronized with the registered publisher identity

## Testing
- `actionlint .github/workflows/publish.yml`
- `uv run --no-sync pytest -q tests/test_release_train_workflow.py tests/test_pr_testpypi_canary_workflow.py tests/test_privileged_workflow_policy.py` (20 passed)
