### PR TITLE
fix(guard): trust exact runtime interpreter aliases

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -8515,16 +8515,18 @@ def _python_interpreter_trust(
         return "unknown"
     launch_path = Path(raw_launch_path)
     canonical = Path(canonical_path)
-    if _interpreter_path_is_within(launch_path, workspace_root):
-        return "workspace_local"
     try:
         guard_launch = Path(sys.executable).expanduser().absolute()
         guard_canonical = guard_launch.resolve(strict=True)
     except (OSError, RuntimeError):
         guard_launch = Path(sys.executable).expanduser().absolute()
         guard_canonical = guard_launch
-    if canonical == guard_canonical and launch_path in {guard_launch, guard_canonical}:
+    if canonical == guard_canonical and (
+        launch_path in {guard_launch, guard_canonical} or launch_path.parent == guard_launch.parent
+    ):
         return "trusted_guard"
+    if _interpreter_path_is_within(launch_path, workspace_root):
+        return "workspace_local"
     if home_dir is not None and _interpreter_path_is_within(launch_path, home_dir):
         return "user_controlled"
     if os.name == "nt":

--- a/tests/test_guard_interpreter_identity.py
+++ b/tests/test_guard_interpreter_identity.py
@@ -164,6 +164,35 @@ def test_exact_guard_interpreter_keeps_read_only_commands_prompt_free(tmp_path: 
         )
 
 
+def test_same_directory_guard_interpreter_alias_is_trusted_but_workspace_alias_is_not(tmp_path: Path) -> None:
+    guard_canonical = Path(sys.executable).resolve(strict=True)
+    alias = next(
+        (
+            candidate
+            for candidate in Path(sys.executable).parent.glob("python*")
+            if candidate != Path(sys.executable)
+            and candidate.is_file()
+            and candidate.resolve(strict=True) == guard_canonical
+        ),
+        None,
+    )
+    if alias is None:
+        pytest.skip("the Guard interpreter directory has no sibling Python alias")
+    guard_workspace = Path(sys.executable).parent.parent
+    guard_alias_command = f"{shlex.quote(str(alias))} -c \"print('fixture')\""
+
+    assert _request(guard_alias_command, cwd=guard_workspace) is None
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    workspace_alias = workspace / "python3"
+    workspace_alias.symlink_to(guard_canonical)
+    evidence = _interpreter_evidence("./python3 -c 'print(1)'", cwd=workspace)
+
+    assert evidence["executable"]["path"] == str(guard_canonical)
+    assert evidence["trust"] == "workspace_local"
+
+
 @pytest.mark.skipif(not Path("/usr/bin/python3").is_file(), reason="trusted system Python is unavailable")
 def test_verified_system_interpreter_keeps_normal_read_only_path_prompt_free(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"


### PR DESCRIPTION
## Summary

Follow-up to #1755 after its original head was merged while the CI/review loop was still running.

- recognize `python`, `python3`, and versioned sibling launchers in the same Guard interpreter directory as `trusted_guard` only when they resolve to the exact same canonical executable as `sys.executable`
- retain fail-closed `workspace_local` classification for project-root aliases, even when they point at the same canonical interpreter
- cover both the trusted same-directory alias and untrusted project-alias cases directly

## Why this is needed

Linux CI runs the suite through `uv run`, which places the project virtual environment at the front of `PATH`. A normal `python3` token therefore resolves to a sibling launcher next to `sys.executable`. The original P36 head required the exact launcher filename and incorrectly classified this verified alias as workspace-local, causing otherwise-safe Cursor, GitHub pipeline, heredoc, Ruff, and effective-cwd workflows to require review.

The trust rule remains narrow: canonical executable equality is mandatory, and an alias outside the exact Guard interpreter directory does not inherit trust.

## Validation

- `48 passed` for every Linux CI regression and adjacent interpreter case under a `uv run`-style PATH.
- `761 passed` in the broader affected suite on default Python under the CI-style PATH.
- `761 passed` in the same affected suite on Python 3.10.
- Changed files pass Ruff lint/format and `git diff --check`.
- basedpyright reports `0 errors`.
- Wheel and sdist builds succeed on default Python and Python 3.10.

## Base

This PR targets `release/2.1` at merge commit `24c475ff`, which contains #1755.
