### PR TITLE
feat(mdm): add portable conformance lab

### DIFF
--- a/.github/workflows/mdm-local-lab.yml
+++ b/.github/workflows/mdm-local-lab.yml
@@ -18,17 +18,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-2022]
+        include:
+          - os: ubuntu-24.04
+            suites: ""
+          - os: macos-14
+            suites: ""
+          - os: windows-2022
+            suites: "--suite adapter-contract --suite enterprise-network"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
-          version: "0.9.26"
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
           enable-cache: true
-      - run: uv sync --extra dev --frozen
-      - run: uv run --no-sync python scripts/mdm/run-local-lab.py --json --output mdm-local-conformance.json
-      - uses: actions/upload-artifact@v7
+      - run: uv sync --python 3.12 --extra dev --frozen
+      - run: uv run --python 3.12 --no-sync python scripts/mdm/run-local-lab.py --json --output mdm-local-conformance.json ${{ matrix.suites }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: mdm-local-conformance-${{ matrix.os }}
           path: mdm-local-conformance.json

--- a/.github/workflows/mdm-local-lab.yml
+++ b/.github/workflows/mdm-local-lab.yml
@@ -1,0 +1,36 @@
+name: MDM local conformance lab
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/mdm-local-lab.yml"
+      - "scripts/mdm/**"
+      - "src/codex_plugin_scanner/guard/mdm/**"
+      - "tests/test_guard_mdm_*.py"
+      - "tests/test_guard_self_protection_schemas.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-14, windows-2022]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --extra dev --frozen
+      - run: uv run --no-sync python scripts/mdm/run-local-lab.py --json --output mdm-local-conformance.json
+      - uses: actions/upload-artifact@v7
+        with:
+          name: mdm-local-conformance-${{ matrix.os }}
+          path: mdm-local-conformance.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/guard/mdm-local-testing.md
+++ b/docs/guard/mdm-local-testing.md
@@ -12,9 +12,11 @@ Use `--suite <name>` to run one or more focused suites. The report contains comm
 summaries, output digests, covered capabilities, and an explicit native-certification section.
 Portable results never claim Apple or Windows certification.
 
-The `MDM local conformance lab` workflow runs the same evidence generator on free public-repository
-Ubuntu, macOS, and Windows GitHub runners and retains each JSON report. `--output <path>` writes the
-canonical report for any attached self-hosted native runner.
+The `MDM local conformance lab` workflow runs the complete evidence generator on free
+public-repository Ubuntu and macOS runners. Windows runs the portable signed-adapter and enterprise
+network suites; Windows-native lifecycle behavior remains a certification gate until an attached
+runner is available. Every job retains its JSON report. `--output <path>` writes the canonical
+report for any attached self-hosted native runner.
 
 The lab intentionally leaves these gates unevaluated until a native host is attached: Apple APNs
 enrollment and supervision, signing/notarization, Windows CSP enrollment and SYSTEM context,

--- a/docs/guard/mdm-local-testing.md
+++ b/docs/guard/mdm-local-testing.md
@@ -1,0 +1,28 @@
+# Local MDM testing
+
+HOL Guard provides a portable, vendor-neutral MDM conformance lab. It runs the real lifecycle,
+integrity, health lease, managed-policy, enterprise-network, observer, and remediation test suites
+inside any Python or Docker environment and emits canonical JSON evidence.
+
+```bash
+uv run --extra dev --frozen python scripts/mdm/run-local-lab.py --json
+```
+
+Use `--suite <name>` to run one or more focused suites. The report contains commands, bounded
+summaries, output digests, covered capabilities, and an explicit native-certification section.
+Portable results never claim Apple or Windows certification.
+
+The `MDM local conformance lab` workflow runs the same evidence generator on free public-repository
+Ubuntu, macOS, and Windows GitHub runners and retains each JSON report. `--output <path>` writes the
+canonical report for any attached self-hosted native runner.
+
+The lab intentionally leaves these gates unevaluated until a native host is attached: Apple APNs
+enrollment and supervision, signing/notarization, Windows CSP enrollment and SYSTEM context,
+Authenticode/WDAC, and real-vendor command delivery. A macOS host and a Windows evaluation VM can
+run the same command for fast native feedback. Final certification still requires retained evidence
+from the supported MDM product.
+
+For an optional open-source Apple control plane, NanoMDM can deliver protocol commands after APNs
+and device enrollment are configured. Self-hosted Fleet can also act as a control plane, but some
+MDM capabilities require a commercial license and Windows enrollment can require Microsoft Entra.
+Neither dependency is required for the portable lab.

--- a/scripts/mdm/Dockerfile.local-lab
+++ b/scripts/mdm/Dockerfile.local-lab
@@ -8,6 +8,10 @@ COPY scripts/mdm ./scripts/mdm
 
 RUN uv sync --extra dev --frozen
 
+RUN useradd --create-home --uid 10001 guard && chown -R guard:guard /hol-guard
+
 ENV PATH="/hol-guard/.venv/bin:${PATH}"
+
+USER 10001:10001
 
 ENTRYPOINT ["python", "scripts/mdm/run-local-lab.py", "--json"]

--- a/scripts/mdm/Dockerfile.local-lab
+++ b/scripts/mdm/Dockerfile.local-lab
@@ -3,7 +3,9 @@ FROM ghcr.io/astral-sh/uv:0.9.26-python3.12-bookworm-slim
 WORKDIR /hol-guard
 
 COPY pyproject.toml uv.lock README.md ./
+COPY docs ./docs
 COPY src ./src
+COPY tests ./tests
 COPY scripts/mdm ./scripts/mdm
 
 RUN uv sync --extra dev --frozen

--- a/scripts/mdm/Dockerfile.local-lab
+++ b/scripts/mdm/Dockerfile.local-lab
@@ -1,0 +1,13 @@
+FROM ghcr.io/astral-sh/uv:0.9.26-python3.12-bookworm-slim
+
+WORKDIR /hol-guard
+
+COPY pyproject.toml uv.lock README.md ./
+COPY src ./src
+COPY scripts/mdm ./scripts/mdm
+
+RUN uv sync --extra dev --frozen
+
+ENV PATH="/hol-guard/.venv/bin:${PATH}"
+
+ENTRYPOINT ["python", "scripts/mdm/run-local-lab.py", "--json"]

--- a/scripts/mdm/Dockerfile.local-lab.dockerignore
+++ b/scripts/mdm/Dockerfile.local-lab.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.pytest_cache
+.ruff_cache
+.venv
+dashboard
+dist
+action
+**/__pycache__
+**/*.pyc

--- a/scripts/mdm/run-local-lab.py
+++ b/scripts/mdm/run-local-lab.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Run the portable HOL Guard MDM conformance lab and emit bounded evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True, slots=True)
+class Suite:
+    name: str
+    capabilities: tuple[str, ...]
+    paths: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class Result:
+    name: str
+    capabilities: tuple[str, ...]
+    command: tuple[str, ...]
+    duration_seconds: float
+    outcome: str
+    output_digest: str
+    summary: str
+
+
+SUITES = (
+    Suite(
+        "adapter-contract",
+        ("observer", "remediation", "signature", "replay", "mapping"),
+        ("tests/test_guard_mdm_adapter_conformance.py", "tests/test_guard_self_protection_schemas.py"),
+    ),
+    Suite(
+        "machine-integrity",
+        ("acl", "continuity", "device-key", "manifest", "tamper"),
+        (
+            "tests/test_guard_mdm_acl.py",
+            "tests/test_guard_mdm_continuity.py",
+            "tests/test_guard_mdm_device_key.py",
+            "tests/test_guard_mdm_device_key_signing.py",
+            "tests/test_guard_mdm_integrity.py",
+            "tests/test_guard_mdm_integrity_detection.py",
+            "tests/test_guard_mdm_manifest.py",
+        ),
+    ),
+    Suite(
+        "user-lifecycle",
+        ("activate", "repair", "deactivate", "multi-user", "harness-coverage"),
+        (
+            "tests/test_guard_mdm_lifecycle.py",
+            "tests/test_guard_mdm_native.py",
+            "tests/test_guard_mdm_harness_coverage.py",
+            "tests/test_guard_mdm_harness_coverage_lifecycle.py",
+            "tests/test_guard_mdm_supervisor.py",
+            "tests/test_guard_mdm_user_health.py",
+        ),
+    ),
+    Suite(
+        "health-lease",
+        ("health", "lease", "key-rotation", "acknowledgement", "offline-outbox"),
+        tuple(str(path.relative_to(ROOT)) for path in sorted((ROOT / "tests").glob("test_guard_mdm_health*.py"))),
+    ),
+    Suite(
+        "enterprise-network",
+        ("managed-policy", "proxy", "private-ca", "tls", "offline"),
+        ("tests/test_guard_mdm_network.py", "tests/test_guard_mdm_policy.py"),
+    ),
+)
+
+NATIVE_GATES = (
+    "apple-apns-enrollment",
+    "apple-supervision",
+    "apple-signing-notarization",
+    "windows-csp-enrollment",
+    "windows-system-context",
+    "windows-authenticode-wdac",
+    "real-vendor-command-delivery",
+)
+
+
+def _summary(output: str) -> str:
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    matches = [line for line in lines if " passed" in line or " failed" in line or " error" in line]
+    return (matches[-1] if matches else (lines[-1] if lines else "no output"))[:240]
+
+
+def run_suite(suite: Suite) -> Result:
+    command = ("pytest", "-p", "no:cacheprovider", "--tb=short", "-q", *suite.paths)
+    started = time.monotonic()
+    completed = subprocess.run(command, cwd=ROOT, capture_output=True, text=True, check=False)
+    output = f"{completed.stdout}\n{completed.stderr}"
+    return Result(
+        name=suite.name,
+        capabilities=suite.capabilities,
+        command=command,
+        duration_seconds=round(time.monotonic() - started, 3),
+        outcome="passed" if completed.returncode == 0 else "failed",
+        output_digest=hashlib.sha256(output.encode()).hexdigest(),
+        summary=_summary(output),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit canonical JSON only")
+    parser.add_argument("--output", type=Path, help="write the canonical report to this path")
+    parser.add_argument("--suite", action="append", choices=[suite.name for suite in SUITES])
+    args = parser.parse_args()
+    selected = [suite for suite in SUITES if not args.suite or suite.name in args.suite]
+    results = [run_suite(suite) for suite in selected]
+    report = {
+        "schemaVersion": "hol-guard-mdm-local-lab.v1",
+        "mode": "portable-contract",
+        "executionPlatform": platform.system().casefold(),
+        "healthy": all(result.outcome == "passed" for result in results),
+        "results": [
+            {
+                **asdict(result),
+                "durationSeconds": result.duration_seconds,
+                "outputDigest": result.output_digest,
+            }
+            for result in results
+        ],
+        "nativeCertification": {
+            "outcome": "not-evaluated",
+            "requiredGates": NATIVE_GATES,
+            "reason": "native_platform_or_vendor_required",
+        },
+    }
+    for result in report["results"]:
+        result.pop("duration_seconds")
+        result.pop("output_digest")
+    encoded = json.dumps(report, sort_keys=True, separators=(",", ":"))
+    if args.output is not None:
+        args.output.write_text(f"{encoded}\n", encoding="utf-8")
+    print(encoded if args.json else json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["healthy"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_guard_mdm_acl.py
+++ b/tests/test_guard_mdm_acl.py
@@ -192,13 +192,14 @@ def test_macos_acl_verification_detects_final_same_type_swap(tmp_path: Path, mon
 
     def swap_before_final(path: Path) -> os.stat_result:
         nonlocal target_calls
+        metadata = real_lstat(path)
         if path == target:
             target_calls += 1
             if target_calls == 4:
-                target.unlink()
-                target.write_text("replacement")
-                target.chmod(0o644)
-        return real_lstat(path)
+                values = list(metadata)
+                values[1] += 1
+                return os.stat_result(values)
+        return metadata
 
     monkeypatch.setattr(Path, "lstat", swap_before_final)
     monkeypatch.setattr(acl, "_macos_acl_is_mutable", lambda _path: False)

--- a/tests/test_guard_mdm_local_lab.py
+++ b/tests/test_guard_mdm_local_lab.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _module() -> ModuleType:
+    path = Path(__file__).parents[1] / "scripts" / "mdm" / "run-local-lab.py"
+    spec = importlib.util.spec_from_file_location("guard_mdm_local_lab", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_local_lab_covers_portable_contract_and_keeps_native_gates_explicit() -> None:
+    module = _module()
+    suite_names = {suite.name for suite in module.SUITES}
+    capabilities = {capability for suite in module.SUITES for capability in suite.capabilities}
+
+    assert suite_names == {
+        "adapter-contract",
+        "enterprise-network",
+        "health-lease",
+        "machine-integrity",
+        "user-lifecycle",
+    }
+    assert {"observer", "remediation", "tamper", "multi-user", "offline", "proxy"} <= capabilities
+    assert "apple-apns-enrollment" in module.NATIVE_GATES
+    assert "windows-system-context" in module.NATIVE_GATES
+
+
+def test_summary_is_bounded_and_prefers_pytest_result() -> None:
+    module = _module()
+    summary = module._summary("noise\n12 passed, 2 skipped in 1.20s\n")
+    assert summary == "12 passed, 2 skipped in 1.20s"
+    assert len(module._summary("x" * 500)) == 240
+
+
+def test_suite_commands_disable_cache_writes(monkeypatch) -> None:
+    module = _module()
+    recorded = {}
+
+    class Completed:
+        returncode = 0
+        stdout = "1 passed in 0.01s"
+        stderr = ""
+
+    def fake_run(command, **kwargs):
+        recorded["command"] = command
+        recorded["kwargs"] = kwargs
+        return Completed()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    result = module.run_suite(module.SUITES[0])
+
+    assert result.outcome == "passed"
+    assert result.command[:5] == ("pytest", "-p", "no:cacheprovider", "--tb=short", "-q")
+    assert recorded["kwargs"]["cwd"] == module.ROOT


### PR DESCRIPTION
## Summary
- add a portable MDM conformance runner with canonical JSON evidence and explicit native certification gates
- run the locked matrix in a network-isolated container and on Linux, macOS, and Windows CI runners
- make the ACL swap regression deterministic across filesystems

## Testing
- `uv run --no-sync python scripts/mdm/run-local-lab.py --json`
- `uv run --no-sync pytest tests/test_guard_mdm_local_lab.py tests/test_guard_mdm_acl.py::test_macos_acl_verification_detects_final_same_type_swap -q`
- `uv run --no-sync ruff check scripts/mdm/run-local-lab.py tests/test_guard_mdm_local_lab.py tests/test_guard_mdm_acl.py`
- `actionlint .github/workflows/mdm-local-lab.yml`
