### PR TITLE
feat(guard): persist extension control authority

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extensions.py
@@ -397,9 +397,15 @@ def _validate_registry_relationships(
                     f"Command safety extension {extension.extension_id} has unknown dependency {dependency}"
                 )
         for conflict in extension.conflicts:
+            if conflict == extension.extension_id:
+                raise ValueError(f"Command safety extension {extension.extension_id} conflicts with itself")
             if conflict not in by_id:
                 raise ValueError(f"Command safety extension {extension.extension_id} has unknown conflict {conflict}")
-            raise ValueError(f"Command safety extension {extension.extension_id} conflicts with {conflict}")
+            conflicting_extension = by_id[conflict]
+            if extension.extension_id not in conflicting_extension.conflicts:
+                raise ValueError(
+                    f"Command safety extension {extension.extension_id} has non-reciprocal conflict {conflict}"
+                )
 
     visiting: set[str] = set()
     visited: set[str] = set()

--- a/src/codex_plugin_scanner/guard/runtime/command_permission_catalog.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_permission_catalog.py
@@ -109,7 +109,7 @@ class CommandPermissionCatalog:
             if permission.permission_id in by_id:
                 raise ValueError(f"duplicate permission ID: {permission.permission_id}")
             by_id[permission.permission_id] = permission
-            _index_unique(by_rule_id, permission.rule_ids, permission, "rule")
+            _index_unique(by_rule_id, permission.rule_ids, permission, "rule", normalize=True)
             _index_unique(
                 by_action_class,
                 permission.action_classes,
@@ -117,7 +117,13 @@ class CommandPermissionCatalog:
                 "action class",
                 normalize=True,
             )
-            _index_unique(by_capability, permission.typed_capabilities, permission, "typed capability")
+            _index_unique(
+                by_capability,
+                permission.typed_capabilities,
+                permission,
+                "typed capability",
+                normalize=True,
+            )
         _validate_references(ordered, by_id)
         _validate_dependency_cycles(ordered, by_id)
         self._permissions = ordered
@@ -143,16 +149,16 @@ class CommandPermissionCatalog:
         }
 
     def get(self, permission_id: str) -> CommandPermissionSpec | None:
-        return self._by_id.get(permission_id)
+        return self._by_id.get(permission_id.strip().lower())
 
     def for_rule_id(self, rule_id: str) -> CommandPermissionSpec | None:
-        return self._by_rule_id.get(rule_id)
+        return self._by_rule_id.get(rule_id.strip().lower())
 
     def for_action_class(self, action_class: str) -> CommandPermissionSpec | None:
         return self._by_action_class.get(action_class.strip().lower())
 
     def for_typed_capability(self, capability: str) -> CommandPermissionSpec | None:
-        return self._by_capability.get(capability)
+        return self._by_capability.get(capability.strip().lower())
 
 
 def permission_for_rule(

--- a/src/codex_plugin_scanner/guard/runtime/effect_decision.py
+++ b/src/codex_plugin_scanner/guard/runtime/effect_decision.py
@@ -24,7 +24,7 @@ from .effect_contract import (
 )
 from .extension_evidence import ExtensionEvidenceBatch
 
-EFFECT_DECISION_SCHEMA_VERSION: Final = "1.0.0"
+EFFECT_DECISION_SCHEMA_VERSION: Final = "1.1.0"
 _REASON_CODE: Final = re.compile(r"[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*")
 _REFERENCE: Final = re.compile(r"[a-z][a-z0-9_-]*:[a-z0-9][a-z0-9._/-]*")
 _SHA256: Final = re.compile(r"[0-9a-f]{64}")
@@ -36,6 +36,8 @@ class DecisionFactorSource(str, Enum):
     POLICY = "policy"
     CONTAINMENT = "containment"
     AUTHORIZATION = "authorization"
+
+    CONTROL = "control"
 
 
 class FinalDisposition(str, Enum):

--- a/src/codex_plugin_scanner/guard/runtime/extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/runtime/extension_control_authority.py
@@ -55,7 +55,10 @@ class ExtensionControlAuthorityView:
     def layers_for(self, surface: ControlSurface) -> tuple[ExtensionControlLayer, ...]:
         if self.health is AuthorityHealth.PROTECTED:
             return self.layers
-        if surface in {ControlSurface.TRUSTED_LOCAL_RECOVERY, ControlSurface.TRUSTED_LOCAL_PROOF}:
+        if type(surface) is ControlSurface and surface in {
+            ControlSurface.TRUSTED_LOCAL_RECOVERY,
+            ControlSurface.TRUSTED_LOCAL_PROOF,
+        }:
             return ()
         return (
             ExtensionControlLayer(

--- a/src/codex_plugin_scanner/guard/runtime/extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/runtime/extension_control_authority.py
@@ -1,0 +1,250 @@
+"""Authenticated records for the command-extension control authority."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from enum import Enum
+from typing import Final, cast
+
+from .extension_control_contract import (
+    CONTROL_SCHEMA_VERSION,
+    ControlLayerKind,
+    ControlState,
+    ControlSurface,
+    ControlTarget,
+    ControlTargetKind,
+    ExtensionControl,
+    ExtensionControlLayer,
+)
+
+AUTHORITY_SCHEMA_VERSION: Final = 1
+SNAPSHOT_PURPOSE: Final = "extension-control.snapshot"
+TRANSITION_PURPOSE: Final = "extension-control.transition"
+ANCHOR_PURPOSE: Final = "extension-control.anchor"
+_AUTH_DOMAIN: Final = b"hol-guard.extension-control-authority.v1\0"
+
+
+class ExtensionControlAuthorityError(RuntimeError):
+    """An extension-control authority invariant could not be satisfied."""
+
+
+class AuthorityPhase(str, Enum):
+    PREPARED = "prepared"
+    ANCHORED = "anchored"
+    COMMITTED = "committed"
+
+
+class AuthorityHealth(str, Enum):
+    PROTECTED = "protected"
+    DEGRADED_UNACKNOWLEDGED = "degraded-unacknowledged"
+    DEGRADED_ACKNOWLEDGED = "degraded-acknowledged"
+    TAMPERED = "tampered"
+    RECOVERY_REQUIRED = "recovery-required"
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionControlAuthorityView:
+    health: AuthorityHealth
+    revision: int
+    catalog_digest: str
+    layers: tuple[ExtensionControlLayer, ...]
+
+    def layers_for(self, surface: ControlSurface) -> tuple[ExtensionControlLayer, ...]:
+        if self.health is AuthorityHealth.PROTECTED:
+            return self.layers
+        if surface in {ControlSurface.TRUSTED_LOCAL_RECOVERY, ControlSurface.TRUSTED_LOCAL_PROOF}:
+            return ()
+        return (
+            ExtensionControlLayer(
+                schema_version=CONTROL_SCHEMA_VERSION,
+                kind=ControlLayerKind.LOCAL_ADMIN,
+                catalog_digest=self.catalog_digest,
+                global_lockdown=True,
+                controls=(),
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityAnchor:
+    revision: int
+    snapshot_digest: str
+    phase: AuthorityPhase
+
+
+def layers_to_json(layers: tuple[ExtensionControlLayer, ...]) -> str:
+    return _canonical_json([_layer_to_value(layer) for layer in layers])
+
+
+def layers_from_json(value: str) -> tuple[ExtensionControlLayer, ...]:
+    try:
+        raw = cast(object, json.loads(value))
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ExtensionControlAuthorityError("invalid extension control layers") from exc
+    if not isinstance(raw, list):
+        raise ExtensionControlAuthorityError("invalid extension control layers")
+    return tuple(_layer_from_value(item) for item in cast(list[object], raw))
+
+
+def authenticated_record(
+    payload: dict[str, object],
+    *,
+    key: bytes,
+    purpose: str,
+) -> tuple[str, str, str]:
+    framed = {"authority_schema_version": AUTHORITY_SCHEMA_VERSION, "purpose": purpose, **payload}
+    encoded = _canonical_json(framed)
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+    mac = hmac.new(_purpose_key(key, purpose), encoded.encode("utf-8"), hashlib.sha256).hexdigest()
+    return encoded, digest, mac
+
+
+def verify_authenticated_record(
+    encoded: str,
+    *,
+    expected_digest: str,
+    expected_mac: str,
+    key: bytes,
+    purpose: str,
+) -> dict[str, object]:
+    try:
+        raw = cast(object, json.loads(encoded))
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ExtensionControlAuthorityError("invalid authenticated authority record") from exc
+    if not isinstance(raw, dict):
+        raise ExtensionControlAuthorityError("invalid authenticated authority record")
+    mapping = cast(dict[object, object], raw)
+    if any(not isinstance(name, str) for name in mapping):
+        raise ExtensionControlAuthorityError("invalid authenticated authority record")
+    payload = cast(dict[str, object], mapping)
+    if payload.get("authority_schema_version") != AUTHORITY_SCHEMA_VERSION:
+        raise ExtensionControlAuthorityError("unsupported authority schema")
+    if payload.get("purpose") != purpose:
+        raise ExtensionControlAuthorityError("authority record purpose mismatch")
+    canonical = _canonical_json(payload)
+    actual_digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    actual_mac = hmac.new(_purpose_key(key, purpose), canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(actual_digest, expected_digest) or not hmac.compare_digest(actual_mac, expected_mac):
+        raise ExtensionControlAuthorityError("authority record authentication failed")
+    return payload
+
+
+def anchor_to_json(anchor: AuthorityAnchor, *, key: bytes) -> str:
+    encoded, digest, mac = authenticated_record(
+        {
+            "revision": anchor.revision,
+            "snapshot_digest": anchor.snapshot_digest,
+            "phase": anchor.phase.value,
+        },
+        key=key,
+        purpose=ANCHOR_PURPOSE,
+    )
+    return _canonical_json({"record": encoded, "digest": digest, "mac": mac})
+
+
+def anchor_from_json(value: str, *, key: bytes) -> AuthorityAnchor:
+    try:
+        raw_envelope = cast(object, json.loads(value))
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ExtensionControlAuthorityError("invalid authority anchor") from exc
+    if not isinstance(raw_envelope, dict):
+        raise ExtensionControlAuthorityError("invalid authority anchor")
+    envelope = cast(dict[object, object], raw_envelope)
+    record = envelope.get("record")
+    digest = envelope.get("digest")
+    mac = envelope.get("mac")
+    if not all(isinstance(item, str) for item in (record, digest, mac)):
+        raise ExtensionControlAuthorityError("invalid authority anchor")
+    payload = verify_authenticated_record(
+        cast(str, record),
+        expected_digest=cast(str, digest),
+        expected_mac=cast(str, mac),
+        key=key,
+        purpose=ANCHOR_PURPOSE,
+    )
+    revision = payload.get("revision")
+    snapshot_digest = payload.get("snapshot_digest")
+    phase = payload.get("phase")
+    if type(revision) is not int or revision < 0:
+        raise ExtensionControlAuthorityError("invalid authority anchor revision")
+    if not isinstance(snapshot_digest, str) or len(snapshot_digest) != 64:
+        raise ExtensionControlAuthorityError("invalid authority anchor digest")
+    if not isinstance(phase, str):
+        raise ExtensionControlAuthorityError("invalid authority anchor phase")
+    try:
+        parsed_phase = AuthorityPhase(phase)
+    except ValueError as exc:
+        raise ExtensionControlAuthorityError("invalid authority anchor phase") from exc
+    return AuthorityAnchor(revision, snapshot_digest, parsed_phase)
+
+
+def _layer_to_value(layer: ExtensionControlLayer) -> dict[str, object]:
+    return {
+        "schema_version": layer.schema_version,
+        "kind": layer.kind.value,
+        "catalog_digest": layer.catalog_digest,
+        "global_lockdown": layer.global_lockdown,
+        "controls": [
+            {
+                "target_kind": control.target.kind.value,
+                "target_id": control.target.target_id,
+                "state": control.state.value,
+            }
+            for control in layer.controls
+        ],
+    }
+
+
+def _layer_from_value(raw: object) -> ExtensionControlLayer:
+    if not isinstance(raw, dict):
+        raise ExtensionControlAuthorityError("invalid extension control layer")
+    mapping = cast(dict[object, object], raw)
+    if any(not isinstance(name, str) for name in mapping):
+        raise ExtensionControlAuthorityError("invalid extension control layer")
+    value = cast(dict[str, object], mapping)
+    controls_raw = value.get("controls")
+    if not isinstance(controls_raw, list):
+        raise ExtensionControlAuthorityError("invalid extension controls")
+    controls: list[ExtensionControl] = []
+    try:
+        for item_raw in cast(list[object], controls_raw):
+            if not isinstance(item_raw, dict):
+                raise ExtensionControlAuthorityError("invalid extension control")
+            item = cast(dict[str, object], item_raw)
+            target_kind = ControlTargetKind(item.get("target_kind"))
+            target_id = item.get("target_id")
+            if not isinstance(target_id, str):
+                raise ExtensionControlAuthorityError("invalid extension control target")
+            controls.append(
+                ExtensionControl(
+                    ControlTarget(target_kind, target_id),
+                    ControlState(item.get("state")),
+                )
+            )
+        schema_version = value.get("schema_version")
+        catalog_digest = value.get("catalog_digest")
+        lockdown = value.get("global_lockdown")
+        if not isinstance(schema_version, str) or not isinstance(catalog_digest, str):
+            raise ExtensionControlAuthorityError("invalid extension control layer metadata")
+        if type(lockdown) is not bool:
+            raise ExtensionControlAuthorityError("invalid extension control lockdown")
+        return ExtensionControlLayer(
+            schema_version=schema_version,
+            kind=ControlLayerKind(value.get("kind")),
+            catalog_digest=catalog_digest,
+            global_lockdown=lockdown,
+            controls=tuple(controls),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ExtensionControlAuthorityError("invalid extension control layer") from exc
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _purpose_key(key: bytes, purpose: str) -> bytes:
+    return hmac.new(key, _AUTH_DOMAIN + purpose.encode("utf-8"), hashlib.sha256).digest()

--- a/src/codex_plugin_scanner/guard/runtime/extension_control_contract.py
+++ b/src/codex_plugin_scanner/guard/runtime/extension_control_contract.py
@@ -1,0 +1,134 @@
+"""Immutable, versioned inputs and outputs for command-extension controls."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Final, cast
+
+from .effect_decision import DecisionFactor
+
+CONTROL_SCHEMA_VERSION: Final = "1.0.0"
+_SHA256: Final = re.compile(r"[0-9a-f]{64}")
+_TARGET_ID: Final = re.compile(r"command\.[a-z0-9]+(?:[.-][a-z0-9]+)*")
+
+
+class ControlLayerKind(str, Enum):
+    LOCAL_ADMIN = "local-admin"
+    SIGNED_CLOUD = "signed-cloud"
+
+
+class ControlTargetKind(str, Enum):
+    EXTENSION = "extension"
+    PERMISSION = "permission"
+
+
+class ControlState(str, Enum):
+    ENABLED = "enabled"
+    DISABLED = "disabled"
+
+
+class ControlSurface(str, Enum):
+    COMMAND_EVALUATION = "command-evaluation"
+    TRUSTED_LOCAL_RECOVERY = "trusted-local-recovery"
+    TRUSTED_LOCAL_PROOF = "trusted-local-proof"
+
+
+class ResolverFailureCode(str, Enum):
+    UNSUPPORTED_CONTROL_SCHEMA = "unsupported-control-schema"
+    DUPLICATE_LAYER_KIND = "duplicate-layer-kind"
+    DUPLICATE_TARGET_IN_LAYER = "duplicate-target-in-layer"
+    CATALOG_DIGEST_MISMATCH = "catalog-digest-mismatch"
+    UNKNOWN_EXTENSION_TARGET = "unknown-extension-target"
+    UNKNOWN_PERMISSION_TARGET = "unknown-permission-target"
+    INVALID_CONTROL_SURFACE = "invalid-control-surface"
+    INVALID_OBSERVATION_BINDING = "invalid-observation-binding"
+    CATALOG_UNAVAILABLE = "catalog-unavailable"
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class ControlTarget:
+    kind: ControlTargetKind
+    target_id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(cast(object, self.kind), ControlTargetKind):
+            raise ValueError("kind must be an exact ControlTargetKind")
+        if _TARGET_ID.fullmatch(self.target_id) is None:
+            raise ValueError("target_id must be a canonical command catalog ID")
+        if self.kind is ControlTargetKind.PERMISSION and ".permission." not in self.target_id:
+            raise ValueError("permission targets must contain a permission segment")
+        if self.kind is ControlTargetKind.EXTENSION and ".permission." in self.target_id:
+            raise ValueError("extension targets cannot contain a permission segment")
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionControl:
+    target: ControlTarget
+    state: ControlState
+
+    def __post_init__(self) -> None:
+        if not isinstance(cast(object, self.target), ControlTarget):
+            raise ValueError("target must be a ControlTarget")
+        if not isinstance(cast(object, self.state), ControlState):
+            raise ValueError("state must be an exact ControlState")
+
+
+@dataclass(frozen=True, slots=True)
+class ExtensionControlLayer:
+    schema_version: str
+    kind: ControlLayerKind
+    catalog_digest: str
+    global_lockdown: bool
+    controls: tuple[ExtensionControl, ...]
+
+    def __post_init__(self) -> None:
+        if self.schema_version != CONTROL_SCHEMA_VERSION:
+            raise ValueError("unsupported control schema version")
+        if not isinstance(cast(object, self.kind), ControlLayerKind):
+            raise ValueError("kind must be an exact ControlLayerKind")
+        if _SHA256.fullmatch(self.catalog_digest) is None:
+            raise ValueError("catalog_digest must be a lowercase SHA-256 digest")
+        if type(self.global_lockdown) is not bool:
+            raise ValueError("global_lockdown must be a boolean")
+        controls = cast(object, self.controls)
+        if not isinstance(controls, tuple):
+            raise ValueError("controls must contain exact ExtensionControl values")
+        if any(not isinstance(item, ExtensionControl) for item in cast(tuple[object, ...], controls)):
+            raise ValueError("controls must contain exact ExtensionControl values")
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class ControlResolverFailure:
+    code: ResolverFailureCode
+    layer_kind: ControlLayerKind | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(cast(object, self.code), ResolverFailureCode):
+            raise ValueError("code must be an exact ResolverFailureCode")
+        if self.layer_kind is not None and not isinstance(cast(object, self.layer_kind), ControlLayerKind):
+            raise ValueError("layer_kind must be an exact ControlLayerKind")
+
+
+@dataclass(frozen=True, slots=True)
+class ComposedExtensionControls:
+    global_lockdown: bool
+    controls: tuple[ExtensionControl, ...]
+    failures: tuple[ControlResolverFailure, ...] = ()
+
+    def state_for(self, kind: ControlTargetKind, target_id: str) -> ControlState:
+        target = ControlTarget(kind, target_id)
+        return next(
+            (control.state for control in self.controls if control.target == target),
+            ControlState.ENABLED,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ControlResolution:
+    composed: ComposedExtensionControls
+    blocked: bool
+    factors: tuple[DecisionFactor, ...]
+    failures: tuple[ControlResolverFailure, ...]
+    observations: tuple[str, ...]

--- a/src/codex_plugin_scanner/guard/runtime/extension_control_contract.py
+++ b/src/codex_plugin_scanner/guard/runtime/extension_control_contract.py
@@ -45,6 +45,8 @@ class ResolverFailureCode(str, Enum):
     INVALID_CONTROL_SURFACE = "invalid-control-surface"
     INVALID_OBSERVATION_BINDING = "invalid-observation-binding"
     CATALOG_UNAVAILABLE = "catalog-unavailable"
+    INPUT_LIMIT_EXCEEDED = "input-limit-exceeded"
+    NON_CANONICAL_TARGET = "non-canonical-target"
 
 
 @dataclass(frozen=True, slots=True, order=True)

--- a/src/codex_plugin_scanner/guard/runtime/extension_control_resolver.py
+++ b/src/codex_plugin_scanner/guard/runtime/extension_control_resolver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from itertools import islice
 from typing import cast
 
 from .command_extensions import CommandSafetyExtensionRegistry
@@ -24,6 +25,11 @@ from .extension_control_contract import (
 
 _FAILURE_REASON = "control.resolver-failure"
 _TRUSTED_LOCKDOWN_SURFACES = frozenset({ControlSurface.TRUSTED_LOCAL_RECOVERY, ControlSurface.TRUSTED_LOCAL_PROOF})
+_MAX_LAYERS = len(ControlLayerKind)
+_MAX_CONTROLS_PER_LAYER = 512
+_MAX_RESOLUTION_IDS = 1024
+_MAX_OBSERVATIONS = 2048
+_MAX_INPUT_TEXT_LENGTH = 256
 
 
 def compose_control_layers(layers: Iterable[ExtensionControlLayer]) -> ComposedExtensionControls:
@@ -62,10 +68,24 @@ def resolve_extension_controls(
     observations: tuple[str, ...] = (),
 ) -> ControlResolution:
     """Resolve controls for classified catalog identities without suppressing observations."""
-    layer_values = tuple(layers)
+    layer_values = tuple(islice(layers, _MAX_LAYERS + 1))
     composed = compose_control_layers(layer_values)
     failures = set(composed.failures)
-    if not isinstance(cast(object, surface), ControlSurface):
+    if (
+        len(layer_values) > _MAX_LAYERS
+        or any(len(layer.controls) > _MAX_CONTROLS_PER_LAYER for layer in layer_values)
+        or len(extension_ids) > _MAX_RESOLUTION_IDS
+        or len(permission_ids) > _MAX_RESOLUTION_IDS
+        or len(observations) > _MAX_OBSERVATIONS
+        or any(
+            len(value) > _MAX_INPUT_TEXT_LENGTH
+            for values in (extension_ids, permission_ids, observations)
+            for value in values
+        )
+    ):
+        failures.add(ControlResolverFailure(ResolverFailureCode.INPUT_LIMIT_EXCEEDED))
+        return _resolution(composed, failures, observations[:_MAX_OBSERVATIONS], reason=None)
+    if type(surface) is not ControlSurface:
         failures.add(ControlResolverFailure(ResolverFailureCode.INVALID_CONTROL_SURFACE))
     if not isinstance(cast(object, registry), CommandSafetyExtensionRegistry):
         failures.add(ControlResolverFailure(ResolverFailureCode.CATALOG_UNAVAILABLE))
@@ -107,8 +127,11 @@ def _validate_layer_targets(
 ) -> None:
     for control in layer.controls:
         if control.target.kind is ControlTargetKind.EXTENSION:
-            if registry.get(control.target.target_id) is None:
+            extension = registry.get(control.target.target_id)
+            if extension is None:
                 failures.add(ControlResolverFailure(ResolverFailureCode.UNKNOWN_EXTENSION_TARGET, layer.kind))
+            elif extension.extension_id != control.target.target_id:
+                failures.add(ControlResolverFailure(ResolverFailureCode.NON_CANONICAL_TARGET, layer.kind))
         elif registry.permission(control.target.target_id) is None:
             failures.add(ControlResolverFailure(ResolverFailureCode.UNKNOWN_PERMISSION_TARGET, layer.kind))
 

--- a/src/codex_plugin_scanner/guard/runtime/extension_control_resolver.py
+++ b/src/codex_plugin_scanner/guard/runtime/extension_control_resolver.py
@@ -1,0 +1,174 @@
+"""Fail-closed composition and resolution of command-extension controls."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import cast
+
+from .command_extensions import CommandSafetyExtensionRegistry
+from .effect_contract import DecisionBasis
+from .effect_decision import DecisionFactor, DecisionFactorSource
+from .extension_control_contract import (
+    ComposedExtensionControls,
+    ControlLayerKind,
+    ControlResolution,
+    ControlResolverFailure,
+    ControlState,
+    ControlSurface,
+    ControlTarget,
+    ControlTargetKind,
+    ExtensionControl,
+    ExtensionControlLayer,
+    ResolverFailureCode,
+)
+
+_FAILURE_REASON = "control.resolver-failure"
+_TRUSTED_LOCKDOWN_SURFACES = frozenset({ControlSurface.TRUSTED_LOCAL_RECOVERY, ControlSurface.TRUSTED_LOCAL_PROOF})
+
+
+def compose_control_layers(layers: Iterable[ExtensionControlLayer]) -> ComposedExtensionControls:
+    """Compose local and cloud layers with disable dominance and deterministic output."""
+    states: dict[ControlTarget, ControlState] = {}
+    seen_layer_kinds: set[ControlLayerKind] = set()
+    failures: set[ControlResolverFailure] = set()
+    lockdown = False
+    for layer in layers:
+        if layer.kind in seen_layer_kinds:
+            failures.add(ControlResolverFailure(ResolverFailureCode.DUPLICATE_LAYER_KIND, layer.kind))
+        seen_layer_kinds.add(layer.kind)
+        lockdown = lockdown or layer.global_lockdown
+        seen_targets: set[ControlTarget] = set()
+        for control in layer.controls:
+            if control.target in seen_targets:
+                failures.add(ControlResolverFailure(ResolverFailureCode.DUPLICATE_TARGET_IN_LAYER, layer.kind))
+                continue
+            seen_targets.add(control.target)
+            previous = states.get(control.target)
+            if previous is ControlState.DISABLED or control.state is ControlState.DISABLED:
+                states[control.target] = ControlState.DISABLED
+            else:
+                states[control.target] = ControlState.ENABLED
+    controls = tuple(ExtensionControl(target, states[target]) for target in sorted(states))
+    return ComposedExtensionControls(lockdown, controls, tuple(sorted(failures)))
+
+
+def resolve_extension_controls(
+    layers: Iterable[ExtensionControlLayer],
+    registry: CommandSafetyExtensionRegistry,
+    *,
+    extension_ids: tuple[str, ...],
+    permission_ids: tuple[str, ...],
+    surface: ControlSurface,
+    observations: tuple[str, ...] = (),
+) -> ControlResolution:
+    """Resolve controls for classified catalog identities without suppressing observations."""
+    layer_values = tuple(layers)
+    composed = compose_control_layers(layer_values)
+    failures = set(composed.failures)
+    if not isinstance(cast(object, surface), ControlSurface):
+        failures.add(ControlResolverFailure(ResolverFailureCode.INVALID_CONTROL_SURFACE))
+    if not isinstance(cast(object, registry), CommandSafetyExtensionRegistry):
+        failures.add(ControlResolverFailure(ResolverFailureCode.CATALOG_UNAVAILABLE))
+        return _resolution(composed, failures, observations, reason=None)
+
+    for layer in layer_values:
+        if layer.catalog_digest != registry.catalog_digest:
+            failures.add(ControlResolverFailure(ResolverFailureCode.CATALOG_DIGEST_MISMATCH, layer.kind))
+        _validate_layer_targets(layer, registry, failures)
+
+    expanded_extensions = _extension_closure(registry, extension_ids, failures)
+    expanded_permissions = _permission_closure(registry, permission_ids, failures)
+    for permission_id in tuple(expanded_permissions):
+        permission = registry.permission(permission_id)
+        if permission is not None:
+            expanded_extensions.update(_extension_closure(registry, (permission.extension_id,), failures))
+
+    if failures:
+        return _resolution(composed, failures, observations, reason=None)
+    if composed.global_lockdown and surface not in _TRUSTED_LOCKDOWN_SURFACES:
+        return _resolution(composed, failures, observations, reason="control.global-lockdown")
+    if any(
+        composed.state_for(ControlTargetKind.EXTENSION, extension_id) is ControlState.DISABLED
+        for extension_id in expanded_extensions
+    ):
+        return _resolution(composed, failures, observations, reason="control.disabled-extension")
+    if any(
+        composed.state_for(ControlTargetKind.PERMISSION, permission_id) is ControlState.DISABLED
+        for permission_id in expanded_permissions
+    ):
+        return _resolution(composed, failures, observations, reason="control.disabled-permission")
+    return ControlResolution(composed, False, (), (), observations)
+
+
+def _validate_layer_targets(
+    layer: ExtensionControlLayer,
+    registry: CommandSafetyExtensionRegistry,
+    failures: set[ControlResolverFailure],
+) -> None:
+    for control in layer.controls:
+        if control.target.kind is ControlTargetKind.EXTENSION:
+            if registry.get(control.target.target_id) is None:
+                failures.add(ControlResolverFailure(ResolverFailureCode.UNKNOWN_EXTENSION_TARGET, layer.kind))
+        elif registry.permission(control.target.target_id) is None:
+            failures.add(ControlResolverFailure(ResolverFailureCode.UNKNOWN_PERMISSION_TARGET, layer.kind))
+
+
+def _extension_closure(
+    registry: CommandSafetyExtensionRegistry,
+    extension_ids: tuple[str, ...],
+    failures: set[ControlResolverFailure],
+) -> set[str]:
+    resolved: set[str] = set()
+    pending = list(extension_ids)
+    while pending:
+        extension_id = pending.pop()
+        extension = registry.get(extension_id)
+        if extension is None:
+            failures.add(ControlResolverFailure(ResolverFailureCode.UNKNOWN_EXTENSION_TARGET))
+            continue
+        if extension.extension_id in resolved:
+            continue
+        resolved.add(extension.extension_id)
+        pending.extend(extension.dependencies)
+    return resolved
+
+
+def _permission_closure(
+    registry: CommandSafetyExtensionRegistry,
+    permission_ids: tuple[str, ...],
+    failures: set[ControlResolverFailure],
+) -> set[str]:
+    resolved: set[str] = set()
+    pending = list(permission_ids)
+    while pending:
+        permission_id = pending.pop()
+        permission = registry.permission(permission_id)
+        if permission is None:
+            failures.add(ControlResolverFailure(ResolverFailureCode.UNKNOWN_PERMISSION_TARGET))
+            continue
+        if permission.permission_id in resolved:
+            continue
+        resolved.add(permission.permission_id)
+        pending.extend(permission.dependencies)
+        pending.extend(permission.implied_permissions)
+    return resolved
+
+
+def _resolution(
+    composed: ComposedExtensionControls,
+    failures: set[ControlResolverFailure],
+    observations: tuple[str, ...],
+    *,
+    reason: str | None,
+) -> ControlResolution:
+    ordered_failures = tuple(sorted(failures))
+    reason_code = _FAILURE_REASON if ordered_failures else reason
+    if reason_code is None:
+        return ControlResolution(composed, False, (), ordered_failures, observations)
+    factor = DecisionFactor(
+        source=DecisionFactorSource.CONTROL,
+        reason_code=reason_code,
+        basis=DecisionBasis("block", None),
+        producer_ref="control:resolver",
+    )
+    return ControlResolution(composed, True, (factor,), ordered_failures, observations)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -20,6 +20,7 @@ from .store_command_activity_privacy import StoreCommandActivityPrivacyMixin
 from .store_command_shadow import StoreCommandShadowMixin
 from .store_connection_schema import StoreConnectionSchemaMixin
 from .store_event_receipts import StoreEventReceiptsMixin
+from .store_extension_control_authority import StoreExtensionControlAuthorityMixin
 from .store_evidence_facade import StoreEvidenceMixin
 from .store_inventory import StoreInventoryMixin
 from .store_live_request_outbox import StoreLiveRequestOutboxMixin
@@ -44,6 +45,7 @@ class GuardStore(
     StoreSecretPolicyIntegrityMixin,
     StoreWorkflowCapabilitySecretControlMixin,
     StoreConnectionSchemaMixin,
+    StoreExtensionControlAuthorityMixin,
     StoreCommandActivityMixin,
     StoreCommandActivityApiMixin,
     StoreCommandActivityLifecycleMixin,

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -13,6 +13,7 @@ from .store_command_activity_health_schema import ensure_command_activity_health
 from .store_command_activity_maintenance_schema import ensure_command_activity_maintenance_schema
 from .store_command_activity_schema import ensure_command_activity_schema
 from .store_command_shadow_schema import ensure_command_shadow_schema
+from .store_extension_control_authority_schema import ensure_extension_control_authority_schema
 from .store_live_request_outbox import ensure_live_request_outbox_schema, seed_live_request_outbox
 from .store_secret_policy_integrity import _POLICY_INTEGRITY_LOOKUP_UNSET
 from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
@@ -646,6 +647,7 @@ class StoreConnectionSchemaMixin:
             ensure_command_activity_maintenance_schema(connection, applied_at=_now())
             ensure_command_activity_api_schema(connection, applied_at=_now())
             ensure_evidence_schema(connection)
+            ensure_extension_control_authority_schema(connection)
             ensure_workflow_capability_schema(connection, applied_at=_now())
             ensure_command_shadow_schema(connection, applied_at=_now())
             if not self._schema_version_applied(connection, version=4):

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -5,14 +5,7 @@
 from __future__ import annotations
 
 import base64
-import hashlib
 import secrets
-import sqlite3
-from collections.abc import Generator
-from contextlib import contextmanager
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import cast
 
 from .runtime.extension_control_authority import (
     SNAPSHOT_PURPOSE,
@@ -22,26 +15,24 @@ from .runtime.extension_control_authority import (
     AuthorityPhase,
     ExtensionControlAuthorityError,
     ExtensionControlAuthorityView,
-    anchor_from_json,
-    anchor_to_json,
     authenticated_record,
     layers_from_json,
     layers_to_json,
     verify_authenticated_record,
 )
-from .runtime.extension_control_contract import (
-    ControlLayerKind,
-    ExtensionControlLayer,
-)
-from .runtime.extension_control_resolver import compose_control_layers
-from .store_base import SecretStore, SystemKeyringSecretStore
+from .runtime.extension_control_contract import ExtensionControlLayer
+from .store_base import SecretStore
 from .store_extension_control_authority_schema import ensure_extension_control_authority_schema
+from .store_extension_control_authority_support import (
+    _now,
+    _private_hash,
+    _row_int,
+    _row_str,
+)
+from .store_extension_control_authority_transitions import _ExtensionControlAuthorityTransitionMixin
 
-_KEY_REF_SUFFIX = ":authentication-key"
-_ANCHOR_REF_SUFFIX = ":anchor"
 
-
-class StoreExtensionControlAuthorityMixin:
+class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMixin):
     """GuardStore mixin for the local extension-control authority."""
 
     _extension_control_authority_secret_store: SecretStore | None = None
@@ -76,21 +67,40 @@ class StoreExtensionControlAuthorityMixin:
             idempotency_key=idempotency_key,
             nonce=nonce,
         )
+        layers_json = layers_to_json(layers)
+        self._validate_serialized_layers(layers_json)
         with self._extension_control_authority_lock():
             current = self._read_extension_control_authority_locked(catalog_digest, bootstrap=True)
-            if current.health is not AuthorityHealth.PROTECTED:
-                raise ExtensionControlAuthorityError("extension control authority unavailable")
             key = self._authority_key(required=True)
             assert key is not None
-            idempotency_hash = _private_hash(idempotency_key)
-            nonce_hash = _private_hash(nonce)
+            actor_hash = _private_hash(actor_id, key=key, purpose="actor")
+            idempotency_hash = _private_hash(idempotency_key, key=key, purpose="idempotency")
+            nonce_hash = _private_hash(nonce, key=key, purpose="nonce")
             with self._connect() as connection:
                 replay = connection.execute(
-                    "select revision from extension_control_authority_transition where idempotency_key_hash = ?",
+                    "select * from extension_control_authority_transition where idempotency_key_hash = ?",
                     (idempotency_hash,),
                 ).fetchone()
                 if replay is not None:
-                    return current
+                    resumed = self._resume_idempotent_transition(
+                        connection,
+                        replay,
+                        current=current,
+                        catalog_digest=catalog_digest,
+                        layers_json=layers_json,
+                        actor_hash=actor_hash,
+                        idempotency_hash=idempotency_hash,
+                        nonce_hash=nonce_hash,
+                        expected_revision=expected_revision,
+                        key=key,
+                    )
+                    if resumed is not None:
+                        return resumed
+                    connection.commit()
+                    current = self._read_extension_control_authority_locked(catalog_digest, bootstrap=False)
+            if current.health is not AuthorityHealth.PROTECTED:
+                raise ExtensionControlAuthorityError("extension control authority unavailable")
+            with self._connect() as connection:
                 if current.revision != expected_revision:
                     raise ExtensionControlAuthorityError("extension control authority revision conflict")
                 if (
@@ -110,7 +120,6 @@ class StoreExtensionControlAuthorityMixin:
 
             revision = current.revision + 1
             created_at = _now()
-            layers_json = layers_to_json(layers)
             snapshot_json, snapshot_digest, snapshot_mac = authenticated_record(
                 {
                     "revision": revision,
@@ -129,7 +138,7 @@ class StoreExtensionControlAuthorityMixin:
                     "previous_digest": previous_digest,
                     "snapshot_digest": snapshot_digest,
                     "catalog_digest": catalog_digest,
-                    "actor_id_hash": _private_hash(actor_id),
+                    "actor_id_hash": actor_hash,
                     "idempotency_key_hash": idempotency_hash,
                     "nonce_hash": nonce_hash,
                     "created_at": created_at,
@@ -152,7 +161,7 @@ class StoreExtensionControlAuthorityMixin:
                         revision,
                         current.revision,
                         AuthorityPhase.PREPARED.value,
-                        _private_hash(actor_id),
+                        actor_hash,
                         idempotency_hash,
                         nonce_hash,
                         catalog_digest,
@@ -224,35 +233,52 @@ class StoreExtensionControlAuthorityMixin:
                 ).fetchone()
                 if snapshot is None or anchor is None:
                     return self._tampered_view(catalog_digest)
-                current_revision = int(snapshot["revision"])
-                current_digest = str(snapshot["snapshot_digest"])
+                current_revision = _row_int(snapshot, "revision")
+                current_digest = _row_str(snapshot, "snapshot_digest")
                 pending = connection.execute(
-                    "select * from extension_control_authority_transition where revision = ?",
-                    (current_revision + 1,),
+                    """
+                    select * from extension_control_authority_transition
+                    where (revision = ? and phase != ?) or revision = ?
+                    order by revision
+                    limit 1
+                    """,
+                    (
+                        current_revision,
+                        AuthorityPhase.COMMITTED.value,
+                        current_revision + 1,
+                    ),
                 ).fetchone()
-                if anchor.revision == current_revision and anchor.snapshot_digest == current_digest:
-                    if pending is not None and str(pending["phase"]) == AuthorityPhase.PREPARED.value:
-                        connection.execute(
-                            "delete from extension_control_authority_transition where revision = ?",
-                            (current_revision + 1,),
-                        )
-                    if anchor.phase is not AuthorityPhase.COMMITTED:
-                        self._write_and_verify_anchor(
-                            AuthorityAnchor(current_revision, current_digest, AuthorityPhase.COMMITTED),
-                            key=key,
-                        )
-                    return self._read_extension_control_authority_locked(catalog_digest, bootstrap=False)
-                if (
-                    pending is not None
-                    and anchor.phase is AuthorityPhase.ANCHORED
-                    and anchor.revision == current_revision + 1
-                    and anchor.snapshot_digest == str(pending["snapshot_digest"])
-                ):
-                    self._commit_pending_transition(connection, pending)
-                    self._write_and_verify_anchor(
-                        AuthorityAnchor(anchor.revision, anchor.snapshot_digest, AuthorityPhase.COMMITTED),
+                if pending is not None:
+                    resumed = self._resume_idempotent_transition(
+                        connection,
+                        pending,
+                        current=ExtensionControlAuthorityView(
+                            AuthorityHealth.RECOVERY_REQUIRED,
+                            current_revision,
+                            catalog_digest,
+                            (),
+                        ),
+                        catalog_digest=_row_str(pending, "catalog_digest"),
+                        layers_json=_row_str(pending, "layers_json"),
+                        actor_hash=_row_str(pending, "actor_id_hash"),
+                        idempotency_hash=_row_str(pending, "idempotency_key_hash"),
+                        nonce_hash=_row_str(pending, "nonce_hash"),
+                        expected_revision=_row_int(pending, "previous_revision"),
                         key=key,
                     )
+                    if resumed is not None:
+                        return resumed
+                    connection.commit()
+                if anchor.revision == current_revision and anchor.snapshot_digest == current_digest:
+                    if anchor.phase is not AuthorityPhase.COMMITTED:
+                        self._write_and_verify_anchor(
+                            AuthorityAnchor(
+                                current_revision,
+                                current_digest,
+                                AuthorityPhase.COMMITTED,
+                            ),
+                            key=key,
+                        )
                     return self._read_extension_control_authority_locked(catalog_digest, bootstrap=False)
             return self._tampered_view(catalog_digest)
 
@@ -273,8 +299,8 @@ class StoreExtensionControlAuthorityMixin:
             anchor = self._read_anchor(key=key) if key is not None else None
         except Exception:
             return self._degraded_view(catalog_digest)
-        if row is None and anchor is None and bootstrap:
-            return self._bootstrap_extension_control_authority(catalog_digest, key=key)
+        if row is None and anchor is None and key is None and bootstrap:
+            return self._bootstrap_extension_control_authority(catalog_digest, key=None)
         if row is None or key is None or anchor is None:
             return self._tampered_view(catalog_digest)
         try:
@@ -297,6 +323,7 @@ class StoreExtensionControlAuthorityMixin:
             }
             if any(payload.get(name) != value for name, value in expected.items()):
                 raise ExtensionControlAuthorityError("extension control snapshot field mismatch")
+            self._validate_serialized_layers(str(row["layers_json"]))
             layers = layers_from_json(str(row["layers_json"]))
             self._validate_layers(layers, catalog_digest)
             if anchor.revision != revision or anchor.snapshot_digest != str(row["snapshot_digest"]):
@@ -309,9 +336,20 @@ class StoreExtensionControlAuthorityMixin:
                 ):
                     raise ExtensionControlAuthorityError("extension control authority rollback detected")
                 return ExtensionControlAuthorityView(AuthorityHealth.RECOVERY_REQUIRED, revision, catalog_digest, ())
+            if self._pending_transition(revision + 1) is not None:
+                return ExtensionControlAuthorityView(
+                    AuthorityHealth.RECOVERY_REQUIRED,
+                    revision,
+                    catalog_digest,
+                    (),
+                )
             if anchor.phase is not AuthorityPhase.COMMITTED:
                 return ExtensionControlAuthorityView(AuthorityHealth.RECOVERY_REQUIRED, revision, catalog_digest, ())
-            self._validate_transition_chain(revision, key=key)
+            self._validate_transition_chain(
+                revision,
+                current_snapshot_digest=_row_str(row, "snapshot_digest"),
+                key=key,
+            )
             return ExtensionControlAuthorityView(AuthorityHealth.PROTECTED, revision, catalog_digest, layers)
         except ExtensionControlAuthorityError:
             return self._tampered_view(catalog_digest)
@@ -352,186 +390,3 @@ class StoreExtensionControlAuthorityMixin:
             )
         self._write_and_verify_anchor(AuthorityAnchor(0, digest, AuthorityPhase.COMMITTED), key=key)
         return ExtensionControlAuthorityView(AuthorityHealth.PROTECTED, 0, catalog_digest, ())
-
-    def _validate_transition_chain(self, revision: int, *, key: bytes) -> None:
-        with self._connect() as connection:
-            rows = connection.execute(
-                "select * from extension_control_authority_transition order by revision"
-            ).fetchall()
-        committed = [row for row in rows if str(row["phase"]) == AuthorityPhase.COMMITTED.value]
-        if [int(row["revision"]) for row in committed] != list(range(1, revision + 1)):
-            raise ExtensionControlAuthorityError("extension control transition gap")
-        for row in committed:
-            payload = verify_authenticated_record(
-                str(row["transition_json"]),
-                expected_digest=str(row["transition_digest"]),
-                expected_mac=str(row["transition_mac"]),
-                key=key,
-                purpose=TRANSITION_PURPOSE,
-            )
-            expected = {
-                "revision": int(row["revision"]),
-                "previous_revision": int(row["previous_revision"]),
-                "snapshot_digest": str(row["snapshot_digest"]),
-                "catalog_digest": str(row["catalog_digest"]),
-                "actor_id_hash": str(row["actor_id_hash"]),
-                "idempotency_key_hash": str(row["idempotency_key_hash"]),
-                "nonce_hash": str(row["nonce_hash"]),
-                "created_at": str(row["created_at"]),
-                "phase": AuthorityPhase.PREPARED.value,
-            }
-            if any(payload.get(name) != value for name, value in expected.items()):
-                raise ExtensionControlAuthorityError("extension control transition field mismatch")
-
-    def _commit_pending_transition(self, connection: sqlite3.Connection, row: sqlite3.Row) -> None:
-        _ = connection.execute(
-            """
-            update extension_control_authority_snapshot
-            set revision = ?, catalog_digest = ?, layers_json = ?, previous_digest = snapshot_digest,
-                snapshot_json = ?, snapshot_digest = ?, snapshot_mac = ?, committed_at = ?
-            where singleton = 1 and revision = ?
-            """,
-            (
-                _row_int(row, "revision"),
-                _row_str(row, "catalog_digest"),
-                _row_str(row, "layers_json"),
-                _row_str(row, "snapshot_json"),
-                _row_str(row, "snapshot_digest"),
-                _row_str(row, "snapshot_mac"),
-                _row_str(row, "created_at"),
-                _row_int(row, "previous_revision"),
-            ),
-        )
-        _ = connection.execute(
-            "update extension_control_authority_transition set phase = ?, committed_at = ? where revision = ?",
-            (AuthorityPhase.COMMITTED.value, _now(), _row_int(row, "revision")),
-        )
-
-    def _pending_transition(self, revision: int) -> sqlite3.Row | None:
-        with self._connect() as connection:
-            return connection.execute(
-                "select * from extension_control_authority_transition where revision = ?",
-                (revision,),
-            ).fetchone()
-
-    def _authority_key(self, *, required: bool) -> bytes | None:
-        try:
-            value = self._secret_store().get_secret(self._key_ref())
-        except Exception as exc:
-            if required:
-                raise ExtensionControlAuthorityError("extension control credential store unavailable") from exc
-            raise
-        if value is None:
-            if required:
-                raise ExtensionControlAuthorityError("extension control authentication key missing")
-            return None
-        try:
-            key = base64.urlsafe_b64decode(value.encode("ascii"))
-        except (ValueError, UnicodeEncodeError) as exc:
-            raise ExtensionControlAuthorityError("invalid extension control authentication key") from exc
-        if len(key) != 32:
-            raise ExtensionControlAuthorityError("invalid extension control authentication key")
-        return key
-
-    def _read_anchor(self, *, key: bytes) -> AuthorityAnchor | None:
-        value = self._secret_store().get_secret(self._anchor_ref())
-        return None if value is None else anchor_from_json(value, key=key)
-
-    def _write_and_verify_anchor(self, anchor: AuthorityAnchor, *, key: bytes) -> None:
-        encoded = anchor_to_json(anchor, key=key)
-        self._secret_store().set_secret(self._anchor_ref(), encoded)
-        observed = self._secret_store().get_secret(self._anchor_ref())
-        if observed != encoded:
-            raise ExtensionControlAuthorityError("extension control anchor read-back mismatch")
-
-    def _secret_store(self) -> SecretStore:
-        current = self._extension_control_authority_secret_store
-        if current is None:
-            current = SystemKeyringSecretStore(service_name="hol-guard.extension-control-authority")
-            self._extension_control_authority_secret_store = current
-        if isinstance(current, SystemKeyringSecretStore) and not current._is_available():
-            raise RuntimeError("extension control credential store unavailable")
-        return current
-
-    def _authority_ref_prefix(self) -> str:
-        home = str(cast(Path, self.guard_home).resolve())
-        return "extension-control:" + hashlib.sha256(home.encode("utf-8")).hexdigest()[:20]
-
-    def _key_ref(self) -> str:
-        return self._authority_ref_prefix() + _KEY_REF_SUFFIX
-
-    def _anchor_ref(self) -> str:
-        return self._authority_ref_prefix() + _ANCHOR_REF_SUFFIX
-
-    @contextmanager
-    def _extension_control_authority_lock(self) -> Generator[None, None, None]:
-        with self._hold_advisory_file_lock(
-            path=cast(Path, self.guard_home) / "extension-control-authority.lock",
-            timeout_seconds=30.0,
-            poll_seconds=0.05,
-            timeout_message="Timed out waiting for the extension control authority lock.",
-        ):
-            yield
-
-    @staticmethod
-    def _validate_layers(layers: tuple[ExtensionControlLayer, ...], catalog_digest: str) -> None:
-        if any(layer.catalog_digest != catalog_digest for layer in layers):
-            raise ExtensionControlAuthorityError("extension control catalog digest mismatch")
-        composed = compose_control_layers(layers)
-        if composed.failures:
-            raise ExtensionControlAuthorityError("invalid extension control layers")
-        if len({layer.kind for layer in layers}) != len(layers):
-            raise ExtensionControlAuthorityError("duplicate extension control layer")
-        if any(layer.kind not in {ControlLayerKind.LOCAL_ADMIN, ControlLayerKind.SIGNED_CLOUD} for layer in layers):
-            raise ExtensionControlAuthorityError("invalid extension control layer kind")
-
-    @classmethod
-    def _validate_commit_input(
-        cls,
-        layers: tuple[ExtensionControlLayer, ...],
-        *,
-        catalog_digest: str,
-        actor_id: str,
-        expected_revision: int,
-        idempotency_key: str,
-        nonce: str,
-    ) -> None:
-        cls._validate_layers(layers, catalog_digest)
-        if type(expected_revision) is not int or expected_revision < 0:
-            raise ExtensionControlAuthorityError("invalid expected authority revision")
-        if not actor_id.strip() or not idempotency_key.strip() or not nonce.strip():
-            raise ExtensionControlAuthorityError("invalid extension control transition identity")
-
-    def _degraded_view(self, catalog_digest: str) -> ExtensionControlAuthorityView:
-        health = (
-            AuthorityHealth.DEGRADED_ACKNOWLEDGED
-            if self._extension_control_degraded_acknowledged
-            else AuthorityHealth.DEGRADED_UNACKNOWLEDGED
-        )
-        return ExtensionControlAuthorityView(health, 0, catalog_digest, ())
-
-    @staticmethod
-    def _tampered_view(catalog_digest: str) -> ExtensionControlAuthorityView:
-        return ExtensionControlAuthorityView(AuthorityHealth.TAMPERED, 0, catalog_digest, ())
-
-
-def _row_str(row: sqlite3.Row, name: str) -> str:
-    value = cast(object, row[name])
-    if not isinstance(value, str):
-        raise ExtensionControlAuthorityError("invalid extension control authority row")
-    return value
-
-
-def _row_int(row: sqlite3.Row, name: str) -> int:
-    value = cast(object, row[name])
-    if type(value) is not int:
-        raise ExtensionControlAuthorityError("invalid extension control authority row")
-    return value
-
-
-def _private_hash(value: str) -> str:
-    return hashlib.sha256(value.encode("utf-8")).hexdigest()
-
-
-def _now() -> str:
-    return datetime.now(timezone.utc).isoformat()

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -1,0 +1,537 @@
+"""Crash-safe, externally anchored extension-control authority persistence."""
+
+# pyright: reportAttributeAccessIssue=false, reportPrivateUsage=false, reportUnknownArgumentType=false, reportUnknownMemberType=false, reportUnknownVariableType=false
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+import sqlite3
+from collections.abc import Generator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+
+from .runtime.extension_control_authority import (
+    SNAPSHOT_PURPOSE,
+    TRANSITION_PURPOSE,
+    AuthorityAnchor,
+    AuthorityHealth,
+    AuthorityPhase,
+    ExtensionControlAuthorityError,
+    ExtensionControlAuthorityView,
+    anchor_from_json,
+    anchor_to_json,
+    authenticated_record,
+    layers_from_json,
+    layers_to_json,
+    verify_authenticated_record,
+)
+from .runtime.extension_control_contract import (
+    ControlLayerKind,
+    ExtensionControlLayer,
+)
+from .runtime.extension_control_resolver import compose_control_layers
+from .store_base import SecretStore, SystemKeyringSecretStore
+from .store_extension_control_authority_schema import ensure_extension_control_authority_schema
+
+_KEY_REF_SUFFIX = ":authentication-key"
+_ANCHOR_REF_SUFFIX = ":anchor"
+
+
+class StoreExtensionControlAuthorityMixin:
+    """GuardStore mixin for the local extension-control authority."""
+
+    _extension_control_authority_secret_store: SecretStore | None = None
+    _extension_control_degraded_acknowledged: bool = False
+    _extension_control_last_catalog_digest: str = "0" * 64
+
+    def read_extension_control_authority(self, *, catalog_digest: str) -> ExtensionControlAuthorityView:
+        self._extension_control_last_catalog_digest = catalog_digest
+        try:
+            with self._extension_control_authority_lock():
+                return self._read_extension_control_authority_locked(catalog_digest, bootstrap=True)
+        except ExtensionControlAuthorityError:
+            raise
+        except Exception:
+            return self._degraded_view(catalog_digest)
+
+    def commit_extension_control_layers(
+        self,
+        layers: tuple[ExtensionControlLayer, ...],
+        *,
+        catalog_digest: str,
+        actor_id: str,
+        expected_revision: int,
+        idempotency_key: str,
+        nonce: str,
+    ) -> ExtensionControlAuthorityView:
+        self._validate_commit_input(
+            layers,
+            catalog_digest=catalog_digest,
+            actor_id=actor_id,
+            expected_revision=expected_revision,
+            idempotency_key=idempotency_key,
+            nonce=nonce,
+        )
+        with self._extension_control_authority_lock():
+            current = self._read_extension_control_authority_locked(catalog_digest, bootstrap=True)
+            if current.health is not AuthorityHealth.PROTECTED:
+                raise ExtensionControlAuthorityError("extension control authority unavailable")
+            key = self._authority_key(required=True)
+            assert key is not None
+            idempotency_hash = _private_hash(idempotency_key)
+            nonce_hash = _private_hash(nonce)
+            with self._connect() as connection:
+                replay = connection.execute(
+                    "select revision from extension_control_authority_transition where idempotency_key_hash = ?",
+                    (idempotency_hash,),
+                ).fetchone()
+                if replay is not None:
+                    return current
+                if current.revision != expected_revision:
+                    raise ExtensionControlAuthorityError("extension control authority revision conflict")
+                if (
+                    connection.execute(
+                        "select 1 from extension_control_authority_transition where nonce_hash = ?",
+                        (nonce_hash,),
+                    ).fetchone()
+                    is not None
+                ):
+                    raise ExtensionControlAuthorityError("extension control authority nonce replay")
+                snapshot_row = connection.execute(
+                    "select snapshot_digest from extension_control_authority_snapshot where singleton = 1"
+                ).fetchone()
+                if snapshot_row is None:
+                    raise ExtensionControlAuthorityError("extension control authority snapshot missing")
+                previous_digest = str(snapshot_row["snapshot_digest"])
+
+            revision = current.revision + 1
+            created_at = _now()
+            layers_json = layers_to_json(layers)
+            snapshot_json, snapshot_digest, snapshot_mac = authenticated_record(
+                {
+                    "revision": revision,
+                    "catalog_digest": catalog_digest,
+                    "layers_json": layers_json,
+                    "previous_digest": previous_digest,
+                    "committed_at": created_at,
+                },
+                key=key,
+                purpose=SNAPSHOT_PURPOSE,
+            )
+            transition_json, transition_digest, transition_mac = authenticated_record(
+                {
+                    "revision": revision,
+                    "previous_revision": current.revision,
+                    "previous_digest": previous_digest,
+                    "snapshot_digest": snapshot_digest,
+                    "catalog_digest": catalog_digest,
+                    "actor_id_hash": _private_hash(actor_id),
+                    "idempotency_key_hash": idempotency_hash,
+                    "nonce_hash": nonce_hash,
+                    "created_at": created_at,
+                    "phase": AuthorityPhase.PREPARED.value,
+                },
+                key=key,
+                purpose=TRANSITION_PURPOSE,
+            )
+            with self._connect() as connection:
+                ensure_extension_control_authority_schema(connection)
+                connection.execute(
+                    """
+                    insert into extension_control_authority_transition (
+                        revision, previous_revision, phase, actor_id_hash, idempotency_key_hash,
+                        nonce_hash, catalog_digest, layers_json, snapshot_json, snapshot_digest,
+                        snapshot_mac, transition_json, transition_digest, transition_mac, created_at
+                    ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        revision,
+                        current.revision,
+                        AuthorityPhase.PREPARED.value,
+                        _private_hash(actor_id),
+                        idempotency_hash,
+                        nonce_hash,
+                        catalog_digest,
+                        layers_json,
+                        snapshot_json,
+                        snapshot_digest,
+                        snapshot_mac,
+                        transition_json,
+                        transition_digest,
+                        transition_mac,
+                        created_at,
+                    ),
+                )
+            anchored = AuthorityAnchor(revision, snapshot_digest, AuthorityPhase.ANCHORED)
+            try:
+                self._write_and_verify_anchor(anchored, key=key)
+            except Exception as exc:
+                raise ExtensionControlAuthorityError("extension control authority anchor unavailable") from exc
+            with self._connect() as connection:
+                connection.execute(
+                    "update extension_control_authority_transition set phase = ? where revision = ?",
+                    (AuthorityPhase.ANCHORED.value, revision),
+                )
+                connection.execute(
+                    """
+                    update extension_control_authority_snapshot
+                    set revision = ?, catalog_digest = ?, layers_json = ?, previous_digest = ?,
+                        snapshot_json = ?, snapshot_digest = ?, snapshot_mac = ?, committed_at = ?
+                    where singleton = 1 and revision = ? and snapshot_digest = ?
+                    """,
+                    (
+                        revision,
+                        catalog_digest,
+                        layers_json,
+                        previous_digest,
+                        snapshot_json,
+                        snapshot_digest,
+                        snapshot_mac,
+                        created_at,
+                        current.revision,
+                        previous_digest,
+                    ),
+                )
+                if connection.execute("select changes()").fetchone()[0] != 1:
+                    raise ExtensionControlAuthorityError("extension control authority concurrent update")
+                connection.execute(
+                    "update extension_control_authority_transition set phase = ?, committed_at = ? where revision = ?",
+                    (AuthorityPhase.COMMITTED.value, created_at, revision),
+                )
+            try:
+                self._write_and_verify_anchor(
+                    AuthorityAnchor(revision, snapshot_digest, AuthorityPhase.COMMITTED),
+                    key=key,
+                )
+            except Exception as exc:
+                raise ExtensionControlAuthorityError("extension control authority final anchor unavailable") from exc
+            return self._read_extension_control_authority_locked(catalog_digest, bootstrap=False)
+
+    def recover_extension_control_authority(self, *, catalog_digest: str) -> ExtensionControlAuthorityView:
+        with self._extension_control_authority_lock():
+            key = self._authority_key(required=True)
+            if key is None:
+                return self._degraded_view(catalog_digest)
+            anchor = self._read_anchor(key=key)
+            with self._connect() as connection:
+                ensure_extension_control_authority_schema(connection)
+                snapshot = connection.execute(
+                    "select revision, snapshot_digest from extension_control_authority_snapshot where singleton = 1"
+                ).fetchone()
+                if snapshot is None or anchor is None:
+                    return self._tampered_view(catalog_digest)
+                current_revision = int(snapshot["revision"])
+                current_digest = str(snapshot["snapshot_digest"])
+                pending = connection.execute(
+                    "select * from extension_control_authority_transition where revision = ?",
+                    (current_revision + 1,),
+                ).fetchone()
+                if anchor.revision == current_revision and anchor.snapshot_digest == current_digest:
+                    if pending is not None and str(pending["phase"]) == AuthorityPhase.PREPARED.value:
+                        connection.execute(
+                            "delete from extension_control_authority_transition where revision = ?",
+                            (current_revision + 1,),
+                        )
+                    if anchor.phase is not AuthorityPhase.COMMITTED:
+                        self._write_and_verify_anchor(
+                            AuthorityAnchor(current_revision, current_digest, AuthorityPhase.COMMITTED),
+                            key=key,
+                        )
+                    return self._read_extension_control_authority_locked(catalog_digest, bootstrap=False)
+                if (
+                    pending is not None
+                    and anchor.phase is AuthorityPhase.ANCHORED
+                    and anchor.revision == current_revision + 1
+                    and anchor.snapshot_digest == str(pending["snapshot_digest"])
+                ):
+                    self._commit_pending_transition(connection, pending)
+                    self._write_and_verify_anchor(
+                        AuthorityAnchor(anchor.revision, anchor.snapshot_digest, AuthorityPhase.COMMITTED),
+                        key=key,
+                    )
+                    return self._read_extension_control_authority_locked(catalog_digest, bootstrap=False)
+            return self._tampered_view(catalog_digest)
+
+    def acknowledge_extension_control_degraded_mode(self) -> ExtensionControlAuthorityView:
+        self._extension_control_degraded_acknowledged = True
+        return self._degraded_view(self._extension_control_last_catalog_digest)
+
+    def _read_extension_control_authority_locked(
+        self, catalog_digest: str, *, bootstrap: bool
+    ) -> ExtensionControlAuthorityView:
+        with self._connect() as connection:
+            ensure_extension_control_authority_schema(connection)
+            row = connection.execute(
+                "select * from extension_control_authority_snapshot where singleton = 1"
+            ).fetchone()
+        try:
+            key = self._authority_key(required=False)
+            anchor = self._read_anchor(key=key) if key is not None else None
+        except Exception:
+            return self._degraded_view(catalog_digest)
+        if row is None and anchor is None and bootstrap:
+            return self._bootstrap_extension_control_authority(catalog_digest, key=key)
+        if row is None or key is None or anchor is None:
+            return self._tampered_view(catalog_digest)
+        try:
+            revision = int(row["revision"])
+            if str(row["catalog_digest"]) != catalog_digest:
+                raise ExtensionControlAuthorityError("extension control catalog digest mismatch")
+            payload = verify_authenticated_record(
+                str(row["snapshot_json"]),
+                expected_digest=str(row["snapshot_digest"]),
+                expected_mac=str(row["snapshot_mac"]),
+                key=key,
+                purpose=SNAPSHOT_PURPOSE,
+            )
+            expected = {
+                "revision": revision,
+                "catalog_digest": str(row["catalog_digest"]),
+                "layers_json": str(row["layers_json"]),
+                "previous_digest": row["previous_digest"],
+                "committed_at": str(row["committed_at"]),
+            }
+            if any(payload.get(name) != value for name, value in expected.items()):
+                raise ExtensionControlAuthorityError("extension control snapshot field mismatch")
+            layers = layers_from_json(str(row["layers_json"]))
+            self._validate_layers(layers, catalog_digest)
+            if anchor.revision != revision or anchor.snapshot_digest != str(row["snapshot_digest"]):
+                pending = self._pending_transition(revision + 1)
+                if not (
+                    pending is not None
+                    and anchor.phase is AuthorityPhase.ANCHORED
+                    and anchor.revision == revision + 1
+                    and anchor.snapshot_digest == _row_str(pending, "snapshot_digest")
+                ):
+                    raise ExtensionControlAuthorityError("extension control authority rollback detected")
+                return ExtensionControlAuthorityView(AuthorityHealth.RECOVERY_REQUIRED, revision, catalog_digest, ())
+            if anchor.phase is not AuthorityPhase.COMMITTED:
+                return ExtensionControlAuthorityView(AuthorityHealth.RECOVERY_REQUIRED, revision, catalog_digest, ())
+            self._validate_transition_chain(revision, key=key)
+            return ExtensionControlAuthorityView(AuthorityHealth.PROTECTED, revision, catalog_digest, layers)
+        except ExtensionControlAuthorityError:
+            return self._tampered_view(catalog_digest)
+
+    def _bootstrap_extension_control_authority(
+        self, catalog_digest: str, *, key: bytes | None
+    ) -> ExtensionControlAuthorityView:
+        if key is None:
+            key = secrets.token_bytes(32)
+            self._secret_store().set_secret(self._key_ref(), base64.urlsafe_b64encode(key).decode())
+        committed_at = _now()
+        layers_json = layers_to_json(())
+        snapshot_json, digest, mac = authenticated_record(
+            {
+                "revision": 0,
+                "catalog_digest": catalog_digest,
+                "layers_json": layers_json,
+                "previous_digest": None,
+                "committed_at": committed_at,
+            },
+            key=key,
+            purpose=SNAPSHOT_PURPOSE,
+        )
+        with self._connect() as connection:
+            existing = connection.execute(
+                "select 1 from extension_control_authority_snapshot where singleton = 1"
+            ).fetchone()
+            if existing is not None:
+                raise ExtensionControlAuthorityError("extension control authority already exists")
+            connection.execute(
+                """
+                insert into extension_control_authority_snapshot (
+                    singleton, revision, catalog_digest, layers_json, previous_digest,
+                    snapshot_json, snapshot_digest, snapshot_mac, committed_at
+                ) values (1, 0, ?, ?, null, ?, ?, ?, ?)
+                """,
+                (catalog_digest, layers_json, snapshot_json, digest, mac, committed_at),
+            )
+        self._write_and_verify_anchor(AuthorityAnchor(0, digest, AuthorityPhase.COMMITTED), key=key)
+        return ExtensionControlAuthorityView(AuthorityHealth.PROTECTED, 0, catalog_digest, ())
+
+    def _validate_transition_chain(self, revision: int, *, key: bytes) -> None:
+        with self._connect() as connection:
+            rows = connection.execute(
+                "select * from extension_control_authority_transition order by revision"
+            ).fetchall()
+        committed = [row for row in rows if str(row["phase"]) == AuthorityPhase.COMMITTED.value]
+        if [int(row["revision"]) for row in committed] != list(range(1, revision + 1)):
+            raise ExtensionControlAuthorityError("extension control transition gap")
+        for row in committed:
+            payload = verify_authenticated_record(
+                str(row["transition_json"]),
+                expected_digest=str(row["transition_digest"]),
+                expected_mac=str(row["transition_mac"]),
+                key=key,
+                purpose=TRANSITION_PURPOSE,
+            )
+            expected = {
+                "revision": int(row["revision"]),
+                "previous_revision": int(row["previous_revision"]),
+                "snapshot_digest": str(row["snapshot_digest"]),
+                "catalog_digest": str(row["catalog_digest"]),
+                "actor_id_hash": str(row["actor_id_hash"]),
+                "idempotency_key_hash": str(row["idempotency_key_hash"]),
+                "nonce_hash": str(row["nonce_hash"]),
+                "created_at": str(row["created_at"]),
+                "phase": AuthorityPhase.PREPARED.value,
+            }
+            if any(payload.get(name) != value for name, value in expected.items()):
+                raise ExtensionControlAuthorityError("extension control transition field mismatch")
+
+    def _commit_pending_transition(self, connection: sqlite3.Connection, row: sqlite3.Row) -> None:
+        _ = connection.execute(
+            """
+            update extension_control_authority_snapshot
+            set revision = ?, catalog_digest = ?, layers_json = ?, previous_digest = snapshot_digest,
+                snapshot_json = ?, snapshot_digest = ?, snapshot_mac = ?, committed_at = ?
+            where singleton = 1 and revision = ?
+            """,
+            (
+                _row_int(row, "revision"),
+                _row_str(row, "catalog_digest"),
+                _row_str(row, "layers_json"),
+                _row_str(row, "snapshot_json"),
+                _row_str(row, "snapshot_digest"),
+                _row_str(row, "snapshot_mac"),
+                _row_str(row, "created_at"),
+                _row_int(row, "previous_revision"),
+            ),
+        )
+        _ = connection.execute(
+            "update extension_control_authority_transition set phase = ?, committed_at = ? where revision = ?",
+            (AuthorityPhase.COMMITTED.value, _now(), _row_int(row, "revision")),
+        )
+
+    def _pending_transition(self, revision: int) -> sqlite3.Row | None:
+        with self._connect() as connection:
+            return connection.execute(
+                "select * from extension_control_authority_transition where revision = ?",
+                (revision,),
+            ).fetchone()
+
+    def _authority_key(self, *, required: bool) -> bytes | None:
+        try:
+            value = self._secret_store().get_secret(self._key_ref())
+        except Exception as exc:
+            if required:
+                raise ExtensionControlAuthorityError("extension control credential store unavailable") from exc
+            raise
+        if value is None:
+            if required:
+                raise ExtensionControlAuthorityError("extension control authentication key missing")
+            return None
+        try:
+            key = base64.urlsafe_b64decode(value.encode("ascii"))
+        except (ValueError, UnicodeEncodeError) as exc:
+            raise ExtensionControlAuthorityError("invalid extension control authentication key") from exc
+        if len(key) != 32:
+            raise ExtensionControlAuthorityError("invalid extension control authentication key")
+        return key
+
+    def _read_anchor(self, *, key: bytes) -> AuthorityAnchor | None:
+        value = self._secret_store().get_secret(self._anchor_ref())
+        return None if value is None else anchor_from_json(value, key=key)
+
+    def _write_and_verify_anchor(self, anchor: AuthorityAnchor, *, key: bytes) -> None:
+        encoded = anchor_to_json(anchor, key=key)
+        self._secret_store().set_secret(self._anchor_ref(), encoded)
+        observed = self._secret_store().get_secret(self._anchor_ref())
+        if observed != encoded:
+            raise ExtensionControlAuthorityError("extension control anchor read-back mismatch")
+
+    def _secret_store(self) -> SecretStore:
+        current = self._extension_control_authority_secret_store
+        if current is None:
+            current = SystemKeyringSecretStore(service_name="hol-guard.extension-control-authority")
+            self._extension_control_authority_secret_store = current
+        if isinstance(current, SystemKeyringSecretStore) and not current._is_available():
+            raise RuntimeError("extension control credential store unavailable")
+        return current
+
+    def _authority_ref_prefix(self) -> str:
+        home = str(cast(Path, self.guard_home).resolve())
+        return "extension-control:" + hashlib.sha256(home.encode("utf-8")).hexdigest()[:20]
+
+    def _key_ref(self) -> str:
+        return self._authority_ref_prefix() + _KEY_REF_SUFFIX
+
+    def _anchor_ref(self) -> str:
+        return self._authority_ref_prefix() + _ANCHOR_REF_SUFFIX
+
+    @contextmanager
+    def _extension_control_authority_lock(self) -> Generator[None, None, None]:
+        with self._hold_advisory_file_lock(
+            path=cast(Path, self.guard_home) / "extension-control-authority.lock",
+            timeout_seconds=30.0,
+            poll_seconds=0.05,
+            timeout_message="Timed out waiting for the extension control authority lock.",
+        ):
+            yield
+
+    @staticmethod
+    def _validate_layers(layers: tuple[ExtensionControlLayer, ...], catalog_digest: str) -> None:
+        if any(layer.catalog_digest != catalog_digest for layer in layers):
+            raise ExtensionControlAuthorityError("extension control catalog digest mismatch")
+        composed = compose_control_layers(layers)
+        if composed.failures:
+            raise ExtensionControlAuthorityError("invalid extension control layers")
+        if len({layer.kind for layer in layers}) != len(layers):
+            raise ExtensionControlAuthorityError("duplicate extension control layer")
+        if any(layer.kind not in {ControlLayerKind.LOCAL_ADMIN, ControlLayerKind.SIGNED_CLOUD} for layer in layers):
+            raise ExtensionControlAuthorityError("invalid extension control layer kind")
+
+    @classmethod
+    def _validate_commit_input(
+        cls,
+        layers: tuple[ExtensionControlLayer, ...],
+        *,
+        catalog_digest: str,
+        actor_id: str,
+        expected_revision: int,
+        idempotency_key: str,
+        nonce: str,
+    ) -> None:
+        cls._validate_layers(layers, catalog_digest)
+        if type(expected_revision) is not int or expected_revision < 0:
+            raise ExtensionControlAuthorityError("invalid expected authority revision")
+        if not actor_id.strip() or not idempotency_key.strip() or not nonce.strip():
+            raise ExtensionControlAuthorityError("invalid extension control transition identity")
+
+    def _degraded_view(self, catalog_digest: str) -> ExtensionControlAuthorityView:
+        health = (
+            AuthorityHealth.DEGRADED_ACKNOWLEDGED
+            if self._extension_control_degraded_acknowledged
+            else AuthorityHealth.DEGRADED_UNACKNOWLEDGED
+        )
+        return ExtensionControlAuthorityView(health, 0, catalog_digest, ())
+
+    @staticmethod
+    def _tampered_view(catalog_digest: str) -> ExtensionControlAuthorityView:
+        return ExtensionControlAuthorityView(AuthorityHealth.TAMPERED, 0, catalog_digest, ())
+
+
+def _row_str(row: sqlite3.Row, name: str) -> str:
+    value = cast(object, row[name])
+    if not isinstance(value, str):
+        raise ExtensionControlAuthorityError("invalid extension control authority row")
+    return value
+
+
+def _row_int(row: sqlite3.Row, name: str) -> int:
+    value = cast(object, row[name])
+    if type(value) is not int:
+        raise ExtensionControlAuthorityError("invalid extension control authority row")
+    return value
+
+
+def _private_hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority_schema.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority_schema.py
@@ -1,0 +1,90 @@
+"""Forward-only SQLite schema for extension-control authority records."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from typing import Final, cast
+
+from .runtime.extension_control_authority import ExtensionControlAuthorityError
+
+EXTENSION_CONTROL_SCHEMA_VERSION: Final = 1
+_SCHEMA_CHECKSUM: Final = hashlib.sha256(b"hol-guard.extension-control-authority.schema.v1").hexdigest()
+
+
+def ensure_extension_control_authority_schema(connection: sqlite3.Connection) -> None:
+    _ = connection.execute(
+        """
+        create table if not exists extension_control_schema_migration (
+            singleton integer primary key check (singleton = 1),
+            version integer not null,
+            checksum text not null
+        )
+        """
+    )
+    row = cast(
+        object,
+        connection.execute(
+            "select version, checksum from extension_control_schema_migration where singleton = 1"
+        ).fetchone(),
+    )
+    if row is None:
+        _ = connection.execute(
+            "insert into extension_control_schema_migration (singleton, version, checksum) values (1, ?, ?)",
+            (EXTENSION_CONTROL_SCHEMA_VERSION, _SCHEMA_CHECKSUM),
+        )
+    else:
+        if isinstance(row, sqlite3.Row):
+            version_raw = cast(object, row["version"])
+            checksum_raw = cast(object, row["checksum"])
+        elif isinstance(row, tuple):
+            row_values = cast(tuple[object, ...], row)
+            if len(row_values) != 2:
+                raise ExtensionControlAuthorityError("invalid extension control schema marker")
+            version_raw, checksum_raw = row_values
+        else:
+            raise ExtensionControlAuthorityError("invalid extension control schema marker")
+        if type(version_raw) is not int or not isinstance(checksum_raw, str):
+            raise ExtensionControlAuthorityError("invalid extension control schema marker")
+        version = version_raw
+        checksum = checksum_raw
+        if version != EXTENSION_CONTROL_SCHEMA_VERSION or checksum != _SCHEMA_CHECKSUM:
+            raise ExtensionControlAuthorityError("unsupported or invalid extension control schema")
+
+    _ = connection.execute(
+        """
+        create table if not exists extension_control_authority_snapshot (
+            singleton integer primary key check (singleton = 1),
+            revision integer not null check (revision >= 0),
+            catalog_digest text not null,
+            layers_json text not null,
+            previous_digest text,
+            snapshot_json text not null,
+            snapshot_digest text not null,
+            snapshot_mac text not null,
+            committed_at text not null
+        )
+        """
+    )
+    _ = connection.execute(
+        """
+        create table if not exists extension_control_authority_transition (
+            revision integer primary key check (revision > 0),
+            previous_revision integer not null check (previous_revision >= 0),
+            phase text not null check (phase in ('prepared', 'anchored', 'committed')),
+            actor_id_hash text not null,
+            idempotency_key_hash text not null unique,
+            nonce_hash text not null unique,
+            catalog_digest text not null,
+            layers_json text not null,
+            snapshot_json text not null,
+            snapshot_digest text not null,
+            snapshot_mac text not null,
+            transition_json text not null,
+            transition_digest text not null,
+            transition_mac text not null,
+            created_at text not null,
+            committed_at text
+        )
+        """
+    )

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority_support.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority_support.py
@@ -1,0 +1,175 @@
+"""Shared validation, credential, and row helpers for extension-control authority."""
+
+# pyright: reportAttributeAccessIssue=false, reportPrivateUsage=false, reportUnknownMemberType=false, reportUninitializedInstanceVariable=false
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import sqlite3
+from collections.abc import Generator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+
+from .runtime.extension_control_authority import (
+    AuthorityAnchor,
+    AuthorityHealth,
+    ExtensionControlAuthorityError,
+    ExtensionControlAuthorityView,
+    anchor_from_json,
+    anchor_to_json,
+)
+from .runtime.extension_control_contract import ControlLayerKind, ExtensionControlLayer
+from .runtime.extension_control_resolver import compose_control_layers
+from .store_base import SecretStore, SystemKeyringSecretStore
+
+_KEY_REF_SUFFIX = ":authentication-key"
+_ANCHOR_REF_SUFFIX = ":anchor"
+_MAX_TRANSITION_ID_LENGTH = 256
+_MAX_CONTROLS_PER_LAYER = 512
+_MAX_SERIALIZED_LAYERS_BYTES = 256 * 1024
+
+
+class _ExtensionControlAuthoritySupportMixin:
+    def _authority_key(self, *, required: bool) -> bytes | None:
+        try:
+            value = self._secret_store().get_secret(self._key_ref())
+        except Exception as exc:
+            if required:
+                raise ExtensionControlAuthorityError("extension control credential store unavailable") from exc
+            raise
+        if value is None:
+            if required:
+                raise ExtensionControlAuthorityError("extension control authentication key missing")
+            return None
+        try:
+            key = base64.urlsafe_b64decode(value.encode("ascii"))
+        except (ValueError, UnicodeEncodeError) as exc:
+            raise ExtensionControlAuthorityError("invalid extension control authentication key") from exc
+        if len(key) != 32:
+            raise ExtensionControlAuthorityError("invalid extension control authentication key")
+        return key
+
+    def _read_anchor(self, *, key: bytes) -> AuthorityAnchor | None:
+        value = self._secret_store().get_secret(self._anchor_ref())
+        return None if value is None else anchor_from_json(value, key=key)
+
+    def _write_and_verify_anchor(self, anchor: AuthorityAnchor, *, key: bytes) -> None:
+        encoded = anchor_to_json(anchor, key=key)
+        self._secret_store().set_secret(self._anchor_ref(), encoded)
+        observed = self._secret_store().get_secret(self._anchor_ref())
+        if observed != encoded:
+            raise ExtensionControlAuthorityError("extension control anchor read-back mismatch")
+
+    def _secret_store(self) -> SecretStore:
+        current = self._extension_control_authority_secret_store
+        if current is None:
+            current = SystemKeyringSecretStore(service_name="hol-guard.extension-control-authority")
+            self._extension_control_authority_secret_store = current
+        if isinstance(current, SystemKeyringSecretStore) and not current._is_available():
+            raise RuntimeError("extension control credential store unavailable")
+        return current
+
+    def _authority_ref_prefix(self) -> str:
+        home = str(cast(Path, self.guard_home).resolve())
+        return "extension-control:" + hashlib.sha256(home.encode("utf-8")).hexdigest()[:20]
+
+    def _key_ref(self) -> str:
+        return self._authority_ref_prefix() + _KEY_REF_SUFFIX
+
+    def _anchor_ref(self) -> str:
+        return self._authority_ref_prefix() + _ANCHOR_REF_SUFFIX
+
+    @contextmanager
+    def _extension_control_authority_lock(self) -> Generator[None, None, None]:
+        with self._hold_advisory_file_lock(
+            path=cast(Path, self.guard_home) / "extension-control-authority.lock",
+            timeout_seconds=30.0,
+            poll_seconds=0.05,
+            timeout_message="Timed out waiting for the extension control authority lock.",
+        ):
+            yield
+
+    @staticmethod
+    def _validate_layers(layers: tuple[ExtensionControlLayer, ...], catalog_digest: str) -> None:
+        if len(layers) > len(ControlLayerKind):
+            raise ExtensionControlAuthorityError("too many extension control layers")
+        if any(len(layer.controls) > _MAX_CONTROLS_PER_LAYER for layer in layers):
+            raise ExtensionControlAuthorityError("too many extension controls in layer")
+        if any(layer.catalog_digest != catalog_digest for layer in layers):
+            raise ExtensionControlAuthorityError("extension control catalog digest mismatch")
+        composed = compose_control_layers(layers)
+        if composed.failures:
+            raise ExtensionControlAuthorityError("invalid extension control layers")
+        if len({layer.kind for layer in layers}) != len(layers):
+            raise ExtensionControlAuthorityError("duplicate extension control layer")
+        if any(layer.kind not in {ControlLayerKind.LOCAL_ADMIN, ControlLayerKind.SIGNED_CLOUD} for layer in layers):
+            raise ExtensionControlAuthorityError("invalid extension control layer kind")
+
+    @classmethod
+    def _validate_commit_input(
+        cls,
+        layers: tuple[ExtensionControlLayer, ...],
+        *,
+        catalog_digest: str,
+        actor_id: str,
+        expected_revision: int,
+        idempotency_key: str,
+        nonce: str,
+    ) -> None:
+        cls._validate_layers(layers, catalog_digest)
+        if type(expected_revision) is not int or expected_revision < 0:
+            raise ExtensionControlAuthorityError("invalid expected authority revision")
+        identities = (actor_id, idempotency_key, nonce)
+        if any(not value.strip() or len(value) > _MAX_TRANSITION_ID_LENGTH for value in identities):
+            raise ExtensionControlAuthorityError("invalid extension control transition identity")
+
+    @staticmethod
+    def _validate_serialized_layers(layers_json: str) -> None:
+        if len(layers_json.encode("utf-8")) > _MAX_SERIALIZED_LAYERS_BYTES:
+            raise ExtensionControlAuthorityError("extension control layers exceed storage limit")
+
+    def _degraded_view(self, catalog_digest: str) -> ExtensionControlAuthorityView:
+        health = (
+            AuthorityHealth.DEGRADED_ACKNOWLEDGED
+            if self._extension_control_degraded_acknowledged
+            else AuthorityHealth.DEGRADED_UNACKNOWLEDGED
+        )
+        return ExtensionControlAuthorityView(health, 0, catalog_digest, ())
+
+    @staticmethod
+    def _tampered_view(catalog_digest: str) -> ExtensionControlAuthorityView:
+        return ExtensionControlAuthorityView(AuthorityHealth.TAMPERED, 0, catalog_digest, ())
+
+
+def _row_str(row: sqlite3.Row, name: str) -> str:
+    value = cast(object, row[name])
+    if not isinstance(value, str):
+        raise ExtensionControlAuthorityError("invalid extension control authority row")
+    return value
+
+
+def _row_optional_str(row: sqlite3.Row, name: str) -> str | None:
+    value = cast(object, row[name])
+    if value is not None and not isinstance(value, str):
+        raise ExtensionControlAuthorityError("invalid extension control authority row")
+    return value
+
+
+def _row_int(row: sqlite3.Row, name: str) -> int:
+    value = cast(object, row[name])
+    if type(value) is not int:
+        raise ExtensionControlAuthorityError("invalid extension control authority row")
+    return value
+
+
+def _private_hash(value: str, *, key: bytes, purpose: str) -> str:
+    framed = b"hol-guard.extension-control.private-ref.v1\x00" + purpose.encode("ascii")
+    return hmac.new(key, framed + b"\x00" + value.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority_transitions.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority_transitions.py
@@ -1,0 +1,248 @@
+"""Authenticated extension-control transition validation and recovery helpers."""
+
+# pyright: reportAttributeAccessIssue=false, reportPrivateUsage=false, reportUnknownArgumentType=false, reportUnknownMemberType=false, reportUnknownVariableType=false
+
+from __future__ import annotations
+
+import sqlite3
+from typing import cast
+
+from .runtime.extension_control_authority import (
+    SNAPSHOT_PURPOSE,
+    TRANSITION_PURPOSE,
+    AuthorityAnchor,
+    AuthorityHealth,
+    AuthorityPhase,
+    ExtensionControlAuthorityError,
+    ExtensionControlAuthorityView,
+    layers_from_json,
+    verify_authenticated_record,
+)
+from .store_extension_control_authority_support import (
+    _ExtensionControlAuthoritySupportMixin,
+    _now,
+    _row_int,
+    _row_optional_str,
+    _row_str,
+)
+
+
+class _ExtensionControlAuthorityTransitionMixin(_ExtensionControlAuthoritySupportMixin):
+    def _resume_idempotent_transition(
+        self,
+        connection: sqlite3.Connection,
+        row: sqlite3.Row,
+        *,
+        current: ExtensionControlAuthorityView,
+        catalog_digest: str,
+        layers_json: str,
+        actor_hash: str,
+        idempotency_hash: str,
+        nonce_hash: str,
+        expected_revision: int,
+        key: bytes,
+    ) -> ExtensionControlAuthorityView | None:
+        self._validate_serialized_layers(layers_json)
+        if (
+            _row_int(row, "previous_revision") != expected_revision
+            or _row_str(row, "catalog_digest") != catalog_digest
+            or _row_str(row, "layers_json") != layers_json
+            or _row_str(row, "actor_id_hash") != actor_hash
+            or _row_str(row, "idempotency_key_hash") != idempotency_hash
+            or _row_str(row, "nonce_hash") != nonce_hash
+        ):
+            raise ExtensionControlAuthorityError("idempotency key request mismatch")
+        snapshot = connection.execute(
+            "select * from extension_control_authority_snapshot where singleton = 1"
+        ).fetchone()
+        if snapshot is None:
+            raise ExtensionControlAuthorityError("extension control authority snapshot missing")
+        previous_revision = _row_int(row, "previous_revision")
+        revision = _row_int(row, "revision")
+        snapshot_revision = _row_int(snapshot, "revision")
+        if snapshot_revision == previous_revision:
+            previous_digest = _row_str(snapshot, "snapshot_digest")
+        elif snapshot_revision == revision:
+            previous_digest = _row_optional_str(snapshot, "previous_digest")
+            if previous_digest is None:
+                raise ExtensionControlAuthorityError("idempotent transition chain mismatch")
+        else:
+            raise ExtensionControlAuthorityError("idempotent transition revision mismatch")
+        transition_payload = verify_authenticated_record(
+            _row_str(row, "transition_json"),
+            expected_digest=_row_str(row, "transition_digest"),
+            expected_mac=_row_str(row, "transition_mac"),
+            key=key,
+            purpose=TRANSITION_PURPOSE,
+        )
+        transition_expected: dict[str, object] = {
+            "revision": revision,
+            "previous_revision": previous_revision,
+            "previous_digest": previous_digest,
+            "snapshot_digest": _row_str(row, "snapshot_digest"),
+            "catalog_digest": catalog_digest,
+            "actor_id_hash": actor_hash,
+            "idempotency_key_hash": idempotency_hash,
+            "nonce_hash": nonce_hash,
+            "created_at": _row_str(row, "created_at"),
+            "phase": AuthorityPhase.PREPARED.value,
+        }
+        if any(transition_payload.get(name) != value for name, value in transition_expected.items()):
+            raise ExtensionControlAuthorityError("idempotent transition authentication mismatch")
+        snapshot_payload = verify_authenticated_record(
+            _row_str(row, "snapshot_json"),
+            expected_digest=_row_str(row, "snapshot_digest"),
+            expected_mac=_row_str(row, "snapshot_mac"),
+            key=key,
+            purpose=SNAPSHOT_PURPOSE,
+        )
+        snapshot_expected: dict[str, object] = {
+            "revision": revision,
+            "catalog_digest": catalog_digest,
+            "layers_json": layers_json,
+            "previous_digest": previous_digest,
+            "committed_at": _row_str(row, "created_at"),
+        }
+        if any(snapshot_payload.get(name) != value for name, value in snapshot_expected.items()):
+            raise ExtensionControlAuthorityError("idempotent snapshot authentication mismatch")
+        anchor = self._read_anchor(key=key)
+        if anchor is None:
+            raise ExtensionControlAuthorityError("extension control authority anchor missing")
+        if (
+            snapshot_revision == previous_revision
+            and anchor.revision == previous_revision
+            and anchor.snapshot_digest == previous_digest
+            and anchor.phase is AuthorityPhase.COMMITTED
+            and _row_str(row, "phase") == AuthorityPhase.PREPARED.value
+        ):
+            _ = connection.execute(
+                "delete from extension_control_authority_transition where revision = ?",
+                (revision,),
+            )
+            return None
+        if (
+            anchor.revision == revision
+            and anchor.snapshot_digest == _row_str(row, "snapshot_digest")
+            and anchor.phase in {AuthorityPhase.ANCHORED, AuthorityPhase.COMMITTED}
+        ):
+            if snapshot_revision == previous_revision:
+                self._commit_pending_transition(connection, row)
+            elif _row_str(row, "phase") != AuthorityPhase.COMMITTED.value:
+                _ = connection.execute(
+                    "update extension_control_authority_transition set phase = ?, committed_at = ? where revision = ?",
+                    (AuthorityPhase.COMMITTED.value, _now(), revision),
+                )
+            connection.commit()
+            self._write_and_verify_anchor(
+                AuthorityAnchor(revision, _row_str(row, "snapshot_digest"), AuthorityPhase.COMMITTED),
+                key=key,
+            )
+            resumed = self._read_extension_control_authority_locked(catalog_digest, bootstrap=False)
+            if resumed.health is not AuthorityHealth.PROTECTED or resumed.revision != revision:
+                raise ExtensionControlAuthorityError("idempotent transition recovery failed")
+            return resumed
+        if current.health is AuthorityHealth.PROTECTED and current.revision == revision:
+            return current
+        raise ExtensionControlAuthorityError("idempotent transition state mismatch")
+
+    def _validate_transition_chain(
+        self,
+        revision: int,
+        *,
+        current_snapshot_digest: str,
+        key: bytes,
+    ) -> None:
+        with self._connect() as connection:
+            rows = cast(
+                list[sqlite3.Row],
+                connection.execute("select * from extension_control_authority_transition order by revision").fetchall(),
+            )
+        committed = [row for row in rows if _row_str(row, "phase") == AuthorityPhase.COMMITTED.value]
+        if [_row_int(row, "revision") for row in committed] != list(range(1, revision + 1)):
+            raise ExtensionControlAuthorityError("extension control transition gap")
+        prior_snapshot_digest: str | None = None
+        for row in committed:
+            row_revision = _row_int(row, "revision")
+            previous_revision = _row_int(row, "previous_revision")
+            if previous_revision != row_revision - 1:
+                raise ExtensionControlAuthorityError("extension control transition chain mismatch")
+            layers_json = _row_str(row, "layers_json")
+            self._validate_serialized_layers(layers_json)
+            snapshot_payload = verify_authenticated_record(
+                _row_str(row, "snapshot_json"),
+                expected_digest=_row_str(row, "snapshot_digest"),
+                expected_mac=_row_str(row, "snapshot_mac"),
+                key=key,
+                purpose=SNAPSHOT_PURPOSE,
+            )
+            previous_digest = snapshot_payload.get("previous_digest")
+            if not isinstance(previous_digest, str):
+                raise ExtensionControlAuthorityError("extension control transition chain mismatch")
+            if prior_snapshot_digest is not None and previous_digest != prior_snapshot_digest:
+                raise ExtensionControlAuthorityError("extension control transition chain mismatch")
+            snapshot_expected: dict[str, object] = {
+                "revision": row_revision,
+                "catalog_digest": _row_str(row, "catalog_digest"),
+                "layers_json": layers_json,
+                "previous_digest": previous_digest,
+                "committed_at": _row_str(row, "created_at"),
+            }
+            if any(snapshot_payload.get(name) != value for name, value in snapshot_expected.items()):
+                raise ExtensionControlAuthorityError("extension control transition snapshot mismatch")
+            self._validate_layers(layers_from_json(layers_json), _row_str(row, "catalog_digest"))
+            transition_payload = verify_authenticated_record(
+                _row_str(row, "transition_json"),
+                expected_digest=_row_str(row, "transition_digest"),
+                expected_mac=_row_str(row, "transition_mac"),
+                key=key,
+                purpose=TRANSITION_PURPOSE,
+            )
+            transition_expected: dict[str, object] = {
+                "revision": row_revision,
+                "previous_revision": previous_revision,
+                "previous_digest": previous_digest,
+                "snapshot_digest": _row_str(row, "snapshot_digest"),
+                "catalog_digest": _row_str(row, "catalog_digest"),
+                "actor_id_hash": _row_str(row, "actor_id_hash"),
+                "idempotency_key_hash": _row_str(row, "idempotency_key_hash"),
+                "nonce_hash": _row_str(row, "nonce_hash"),
+                "created_at": _row_str(row, "created_at"),
+                "phase": AuthorityPhase.PREPARED.value,
+            }
+            if any(transition_payload.get(name) != value for name, value in transition_expected.items()):
+                raise ExtensionControlAuthorityError("extension control transition field mismatch")
+            prior_snapshot_digest = _row_str(row, "snapshot_digest")
+        if prior_snapshot_digest is not None and prior_snapshot_digest != current_snapshot_digest:
+            raise ExtensionControlAuthorityError("extension control transition head mismatch")
+
+    def _commit_pending_transition(self, connection: sqlite3.Connection, row: sqlite3.Row) -> None:
+        self._validate_serialized_layers(_row_str(row, "layers_json"))
+        _ = connection.execute(
+            """
+            update extension_control_authority_snapshot
+            set revision = ?, catalog_digest = ?, layers_json = ?, previous_digest = snapshot_digest,
+                snapshot_json = ?, snapshot_digest = ?, snapshot_mac = ?, committed_at = ?
+            where singleton = 1 and revision = ?
+            """,
+            (
+                _row_int(row, "revision"),
+                _row_str(row, "catalog_digest"),
+                _row_str(row, "layers_json"),
+                _row_str(row, "snapshot_json"),
+                _row_str(row, "snapshot_digest"),
+                _row_str(row, "snapshot_mac"),
+                _row_str(row, "created_at"),
+                _row_int(row, "previous_revision"),
+            ),
+        )
+        _ = connection.execute(
+            "update extension_control_authority_transition set phase = ?, committed_at = ? where revision = ?",
+            (AuthorityPhase.COMMITTED.value, _now(), _row_int(row, "revision")),
+        )
+
+    def _pending_transition(self, revision: int) -> sqlite3.Row | None:
+        with self._connect() as connection:
+            return connection.execute(
+                "select * from extension_control_authority_transition where revision = ?",
+                (revision,),
+            ).fetchone()

--- a/tests/test_guard_command_extension_registry.py
+++ b/tests/test_guard_command_extension_registry.py
@@ -93,13 +93,33 @@ def test_command_extension_registry_validates_relationships_and_aliases() -> Non
     with pytest.raises(ValueError, match="unknown dependency"):
         CommandSafetyExtensionRegistry((unknown_dependency,))
 
-    conflict = _test_extension(
+    one_way_conflict = _test_extension(
         "command.conflict",
         rule=_test_rule("command.conflict.rule", executable="conflict-tool"),
         conflicts=("command.base",),
     )
-    with pytest.raises(ValueError, match="conflicts with"):
-        CommandSafetyExtensionRegistry((base, conflict))
+    with pytest.raises(ValueError, match="non-reciprocal conflict"):
+        CommandSafetyExtensionRegistry((base, one_way_conflict))
+    symmetric_base = _test_extension(
+        "command.symmetric-base",
+        rule=_test_rule("command.symmetric-base.rule", executable="symmetric-base-tool"),
+        conflicts=("command.symmetric-peer",),
+    )
+    symmetric_peer = _test_extension(
+        "command.symmetric-peer",
+        rule=_test_rule("command.symmetric-peer.rule", executable="symmetric-peer-tool"),
+        conflicts=("command.symmetric-base",),
+    )
+    symmetric_registry = CommandSafetyExtensionRegistry((symmetric_peer, symmetric_base))
+    assert symmetric_registry.get("command.symmetric-base") is symmetric_base
+    assert symmetric_registry.get("command.symmetric-peer") is symmetric_peer
+    self_conflict = _test_extension(
+        "command.self-conflict",
+        rule=_test_rule("command.self-conflict.rule", executable="self-conflict-tool"),
+        conflicts=("command.self-conflict",),
+    )
+    with pytest.raises(ValueError, match="conflicts with itself"):
+        CommandSafetyExtensionRegistry((self_conflict,))
     unknown_conflict = _test_extension(
         "command.unknown-conflict",
         rule=_test_rule("command.unknown-conflict.rule", executable="unknown-conflict-tool"),

--- a/tests/test_guard_command_permission_catalog.py
+++ b/tests/test_guard_command_permission_catalog.py
@@ -97,6 +97,13 @@ def test_github_permission_catalog_is_exhaustive_and_admin_merge_is_distinct() -
     assert admin.rule_ids == ("command.github.admin-merge",)
     assert admin.action_classes == ("GitHub administrator pull-request merge command",)
     assert registry.permission_for_action_class("  github ADMINISTRATOR pull-request MERGE command  ") is admin
+    assert registry.permission_for_rule_id("COMMAND.GITHUB.ADMIN-MERGE") is admin
+    assert registry.permission_for_typed_capability(" ADMIN_MERGE_REMOTE ") is admin
+    catalog = CommandPermissionCatalog(registry.permissions)
+    assert catalog.get(" COMMAND.GITHUB.PERMISSION.MERGE-ADMIN ") is admin
+    assert catalog.for_rule_id(" COMMAND.GITHUB.ADMIN-MERGE ") is admin
+    assert catalog.for_action_class(" github administrator pull-request merge command ") is admin
+    assert catalog.for_typed_capability(" ADMIN_MERGE_REMOTE ") is admin
     assert admin.baseline_floor == "require-reapproval"
     assert ordinary.permission_id == "command.github.permission.merge-remote"
     assert ordinary.rule_ids == ("command.github.merge",)
@@ -182,6 +189,32 @@ def test_permission_catalog_rejects_duplicate_mappings_cycles_and_invalid_refere
                     typed_capabilities=("test_normalized_collision",),
                     action_classes=(" TEST BASE ACTION ",),
                     rule_ids=("command.test.normalized-collision",),
+                ),
+            )
+        )
+    with pytest.raises(ValueError, match=r"rule .* mapped by multiple permissions"):
+        CommandPermissionCatalog(
+            (
+                base,
+                replace(
+                    base,
+                    permission_id="command.test.permission.rule-collision",
+                    typed_capabilities=("test_rule_collision",),
+                    action_classes=("test rule collision action",),
+                    rule_ids=(" COMMAND.TEST.BASE ",),
+                ),
+            )
+        )
+    with pytest.raises(ValueError, match=r"typed capability .* mapped by multiple permissions"):
+        CommandPermissionCatalog(
+            (
+                base,
+                replace(
+                    base,
+                    permission_id="command.test.permission.capability-collision",
+                    typed_capabilities=(" TEST_BASE ",),
+                    action_classes=("test capability collision action",),
+                    rule_ids=("command.test.capability-collision",),
                 ),
             )
         )

--- a/tests/test_guard_extension_control_authority.py
+++ b/tests/test_guard_extension_control_authority.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+from codex_plugin_scanner.guard.runtime.extension_control_authority import (
+    AuthorityHealth,
+    AuthorityPhase,
+    ExtensionControlAuthorityError,
+)
+from codex_plugin_scanner.guard.runtime.extension_control_contract import (
+    CONTROL_SCHEMA_VERSION,
+    ControlLayerKind,
+    ControlState,
+    ControlSurface,
+    ControlTarget,
+    ControlTargetKind,
+    ExtensionControl,
+    ExtensionControlLayer,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_base import SystemKeyringSecretStore
+
+
+class MemorySecretStore:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+        self.available = True
+        self.anchor_set_count = 0
+        self.fail_anchor_set_number: int | None = None
+
+    def set_secret(self, secret_id: str, value: str) -> None:
+        if not self.available:
+            raise RuntimeError("credential store unavailable")
+        if secret_id.endswith(":anchor"):
+            self.anchor_set_count += 1
+            if self.fail_anchor_set_number == self.anchor_set_count:
+                raise RuntimeError("injected anchor failure")
+        self.values[secret_id] = value
+
+    def get_secret(self, secret_id: str) -> str | None:
+        if not self.available:
+            raise RuntimeError("credential store unavailable")
+        return self.values.get(secret_id)
+
+    def delete_secret(self, secret_id: str) -> None:
+        if not self.available:
+            raise RuntimeError("credential store unavailable")
+        self.values.pop(secret_id, None)
+
+
+def _store(tmp_path: Path, secrets: MemorySecretStore) -> GuardStore:
+    store = GuardStore(tmp_path, prime_policy_integrity=False)
+    store._extension_control_authority_secret_store = secrets
+    return store
+
+
+def _disabled_layer() -> ExtensionControlLayer:
+    extension = BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions[0]
+    return ExtensionControlLayer(
+        schema_version=CONTROL_SCHEMA_VERSION,
+        kind=ControlLayerKind.LOCAL_ADMIN,
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
+        global_lockdown=False,
+        controls=(
+            ExtensionControl(
+                ControlTarget(ControlTargetKind.EXTENSION, extension.extension_id),
+                ControlState.DISABLED,
+            ),
+        ),
+    )
+
+
+def _commit(store: GuardStore, *, revision: int = 0, key: str = "change-1") -> None:
+    store.commit_extension_control_layers(
+        (_disabled_layer(),),
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
+        actor_id="local-admin",
+        expected_revision=revision,
+        idempotency_key=key,
+        nonce=f"nonce-{key}",
+    )
+
+
+def test_bootstrap_occurs_only_when_database_and_anchor_are_both_absent(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+
+    initial = store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    assert initial.health is AuthorityHealth.PROTECTED
+    assert initial.revision == 0
+    assert initial.layers == ()
+
+    with store._connect() as connection:
+        connection.execute("delete from extension_control_authority_snapshot")
+    missing_database = store.read_extension_control_authority(
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+    )
+    assert missing_database.health is AuthorityHealth.TAMPERED
+    assert missing_database.layers_for(ControlSurface.COMMAND_EVALUATION)[0].global_lockdown is True
+
+
+def test_authenticated_snapshot_transition_and_anchor_detect_sqlite_tamper(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    _commit(store)
+
+    with store._connect() as connection:
+        connection.execute(
+            "update extension_control_authority_snapshot set layers_json = ? where singleton = 1",
+            ("[]",),
+        )
+    view = store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    assert view.health is AuthorityHealth.TAMPERED
+    assert view.layers == ()
+
+
+def test_database_rollback_against_monotonic_anchor_fails_closed(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    with store._connect() as connection:
+        original = dict(connection.execute("select * from extension_control_authority_snapshot").fetchone())
+    _commit(store)
+    with store._connect() as connection:
+        connection.execute(
+            """
+            update extension_control_authority_snapshot
+            set revision = ?, catalog_digest = ?, layers_json = ?, previous_digest = ?,
+                snapshot_json = ?, snapshot_digest = ?, snapshot_mac = ?, committed_at = ?
+            where singleton = 1
+            """,
+            (
+                original["revision"],
+                original["catalog_digest"],
+                original["layers_json"],
+                original["previous_digest"],
+                original["snapshot_json"],
+                original["snapshot_digest"],
+                original["snapshot_mac"],
+                original["committed_at"],
+            ),
+        )
+
+    view = store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    assert view.health is AuthorityHealth.TAMPERED
+
+
+def test_credential_store_failure_requires_explicit_degraded_acknowledgement(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    secrets.available = False
+
+    degraded = store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    assert degraded.health is AuthorityHealth.DEGRADED_UNACKNOWLEDGED
+    assert degraded.layers_for(ControlSurface.COMMAND_EVALUATION)[0].global_lockdown is True
+    assert degraded.layers_for(ControlSurface.TRUSTED_LOCAL_RECOVERY) == ()
+
+    acknowledged = store.acknowledge_extension_control_degraded_mode()
+    assert acknowledged.health is AuthorityHealth.DEGRADED_ACKNOWLEDGED
+    with pytest.raises(ExtensionControlAuthorityError, match="unavailable"):
+        _commit(store)
+
+
+def test_unavailable_system_keyring_never_silently_falls_back(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_is_available",
+        classmethod(lambda cls: False),
+    )
+    store = GuardStore(tmp_path, prime_policy_integrity=False)
+
+    view = store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+
+    assert view.health is AuthorityHealth.DEGRADED_UNACKNOWLEDGED
+    assert view.layers_for(ControlSurface.COMMAND_EVALUATION)[0].global_lockdown is True
+
+
+def test_failed_anchor_write_leaves_recoverable_prepared_transition(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    secrets.fail_anchor_set_number = secrets.anchor_set_count + 1
+    with pytest.raises(ExtensionControlAuthorityError, match="anchor"):
+        _commit(store)
+
+    with store._connect() as connection:
+        row = connection.execute(
+            "select phase from extension_control_authority_transition order by revision desc limit 1"
+        ).fetchone()
+    assert row["phase"] == AuthorityPhase.PREPARED.value
+    recovered = store.recover_extension_control_authority(
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+    )
+    assert recovered.health is AuthorityHealth.PROTECTED
+    assert recovered.revision == 0
+
+
+def test_recovery_finalizes_database_commit_when_final_anchor_write_failed(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    secrets.fail_anchor_set_number = secrets.anchor_set_count + 2
+    with pytest.raises(ExtensionControlAuthorityError, match="final anchor"):
+        _commit(store)
+
+    interrupted = store.read_extension_control_authority(
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+    )
+    assert interrupted.health is AuthorityHealth.RECOVERY_REQUIRED
+    recovered = store.recover_extension_control_authority(
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+    )
+    assert recovered.health is AuthorityHealth.PROTECTED
+    assert recovered.revision == 1
+    assert recovered.layers == (_disabled_layer(),)
+
+
+def test_transition_records_are_purpose_separated_and_replay_safe(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    _commit(store)
+    replay = store.commit_extension_control_layers(
+        (_disabled_layer(),),
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
+        actor_id="local-admin",
+        expected_revision=0,
+        idempotency_key="change-1",
+        nonce="nonce-change-1",
+    )
+    assert replay.revision == 1
+
+    with store._connect() as connection:
+        row = connection.execute(
+            "select transition_json, transition_mac from extension_control_authority_transition where revision = 1"
+        ).fetchone()
+        payload = json.loads(row["transition_json"])
+        payload["purpose"] = "extension-control.snapshot"
+        connection.execute(
+            "update extension_control_authority_transition set transition_json = ? where revision = 1",
+            (json.dumps(payload, sort_keys=True, separators=(",", ":")),),
+        )
+    tampered = store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    assert tampered.health is AuthorityHealth.TAMPERED
+
+
+def test_extension_control_schema_rejects_future_or_gapped_versions(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    with store._connect() as connection:
+        connection.execute("update extension_control_schema_migration set version = 99 where singleton = 1")
+    with pytest.raises(ExtensionControlAuthorityError, match="schema"):
+        store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)

--- a/tests/test_guard_extension_control_authority.py
+++ b/tests/test_guard_extension_control_authority.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -10,6 +11,7 @@ from codex_plugin_scanner.guard.runtime.extension_control_authority import (
     AuthorityHealth,
     AuthorityPhase,
     ExtensionControlAuthorityError,
+    ExtensionControlAuthorityView,
 )
 from codex_plugin_scanner.guard.runtime.extension_control_contract import (
     CONTROL_SCHEMA_VERSION,
@@ -74,11 +76,17 @@ def _disabled_layer() -> ExtensionControlLayer:
     )
 
 
-def _commit(store: GuardStore, *, revision: int = 0, key: str = "change-1") -> None:
+def _commit(
+    store: GuardStore,
+    *,
+    revision: int = 0,
+    key: str = "change-1",
+    actor_id: str = "local-admin",
+) -> None:
     store.commit_extension_control_layers(
         (_disabled_layer(),),
         catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
-        actor_id="local-admin",
+        actor_id=actor_id,
         expected_revision=revision,
         idempotency_key=key,
         nonce=f"nonce-{key}",
@@ -102,6 +110,19 @@ def test_bootstrap_occurs_only_when_database_and_anchor_are_both_absent(tmp_path
     assert missing_database.health is AuthorityHealth.TAMPERED
     assert missing_database.layers_for(ControlSurface.COMMAND_EVALUATION)[0].global_lockdown is True
 
+    second_secrets = MemorySecretStore()
+    second_store = _store(tmp_path / "both-missing", second_secrets)
+    second_store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    anchor_ref = next(secret_id for secret_id in second_secrets.values if secret_id.endswith(":anchor"))
+    del second_secrets.values[anchor_ref]
+    with second_store._connect() as connection:
+        connection.execute("delete from extension_control_authority_snapshot")
+    missing_both_with_existing_key = second_store.read_extension_control_authority(
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+    )
+    assert missing_both_with_existing_key.health is AuthorityHealth.TAMPERED
+    assert anchor_ref not in second_secrets.values
+
 
 def test_authenticated_snapshot_transition_and_anchor_detect_sqlite_tamper(tmp_path: Path) -> None:
     secrets = MemorySecretStore()
@@ -117,6 +138,30 @@ def test_authenticated_snapshot_transition_and_anchor_detect_sqlite_tamper(tmp_p
     view = store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
     assert view.health is AuthorityHealth.TAMPERED
     assert view.layers == ()
+
+
+def test_authenticated_historical_transition_fields_detect_tamper(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    _commit(store)
+    store.commit_extension_control_layers(
+        (),
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
+        actor_id="local-admin",
+        expected_revision=1,
+        idempotency_key="change-2",
+        nonce="nonce-change-2",
+    )
+    with store._connect() as connection:
+        connection.execute(
+            "update extension_control_authority_transition set layers_json = ? where revision = 1",
+            ("[]",),
+        )
+
+    view = store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+
+    assert view.health is AuthorityHealth.TAMPERED
 
 
 def test_database_rollback_against_monotonic_anchor_fails_closed(tmp_path: Path) -> None:
@@ -201,6 +246,30 @@ def test_failed_anchor_write_leaves_recoverable_prepared_transition(tmp_path: Pa
     assert recovered.revision == 0
 
 
+def test_idempotent_retry_after_prepared_transition_commits_once(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    secrets.fail_anchor_set_number = secrets.anchor_set_count + 1
+    with pytest.raises(ExtensionControlAuthorityError, match="anchor"):
+        _commit(store)
+
+    retried = store.commit_extension_control_layers(
+        (_disabled_layer(),),
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
+        actor_id="local-admin",
+        expected_revision=0,
+        idempotency_key="change-1",
+        nonce="nonce-change-1",
+    )
+
+    assert retried.health is AuthorityHealth.PROTECTED
+    assert retried.revision == 1
+    with store._connect() as connection:
+        count = connection.execute("select count(*) from extension_control_authority_transition").fetchone()[0]
+    assert count == 1
+
+
 def test_recovery_finalizes_database_commit_when_final_anchor_write_failed(tmp_path: Path) -> None:
     secrets = MemorySecretStore()
     store = _store(tmp_path, secrets)
@@ -257,3 +326,66 @@ def test_extension_control_schema_rejects_future_or_gapped_versions(tmp_path: Pa
         connection.execute("update extension_control_schema_migration set version = 99 where singleton = 1")
     with pytest.raises(ExtensionControlAuthorityError, match="schema"):
         store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+
+
+def test_non_protected_authority_requires_exact_trusted_surface_enum() -> None:
+    digest = BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+    view = ExtensionControlAuthorityView(AuthorityHealth.TAMPERED, 0, digest, ())
+
+    raw = view.layers_for(cast(ControlSurface, "trusted-local-proof"))
+    trusted = view.layers_for(ControlSurface.TRUSTED_LOCAL_PROOF)
+
+    assert len(raw) == 1
+    assert raw[0].kind is ControlLayerKind.LOCAL_ADMIN
+    assert raw[0].global_lockdown is True
+    assert trusted == ()
+
+
+def test_transition_private_values_and_authority_secrets_never_enter_sqlite(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    _commit(store, actor_id="private-actor")
+
+    with store._connect() as connection:
+        rows = [
+            *connection.execute("select * from extension_control_authority_snapshot").fetchall(),
+            *connection.execute("select * from extension_control_authority_transition").fetchall(),
+        ]
+    database_dump = repr([tuple(row) for row in rows])
+
+    for private_value in ("private-actor", "change-1", "nonce-change-1", *secrets.values.values()):
+        assert private_value not in database_dump
+
+
+def test_idempotency_key_cannot_replay_different_transition(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    _commit(store)
+
+    with pytest.raises(ExtensionControlAuthorityError, match="idempotency key request mismatch"):
+        store.commit_extension_control_layers(
+            (),
+            catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
+            actor_id="different-actor",
+            expected_revision=0,
+            idempotency_key="change-1",
+            nonce="different-nonce",
+        )
+
+
+def test_oversized_persisted_layers_fail_closed_without_deserialization(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    oversized = "x" * (256 * 1024 + 1)
+    with store._connect() as connection:
+        connection.execute(
+            "update extension_control_authority_snapshot set layers_json = ? where singleton = 1",
+            (oversized,),
+        )
+
+    view = store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+
+    assert view.health is AuthorityHealth.TAMPERED

--- a/tests/test_guard_extension_control_resolver.py
+++ b/tests/test_guard_extension_control_resolver.py
@@ -274,3 +274,57 @@ def test_duplicate_layers_targets_and_invalid_surface_fail_closed() -> None:
     )
     assert invalid.blocked is True
     assert invalid.failures[0].code is ResolverFailureCode.INVALID_CONTROL_SURFACE
+
+
+def test_resolver_rejects_alias_targets_instead_of_missing_disabled_control() -> None:
+    canonical = BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions[0]
+    alias = "command.legacy-control-alias"
+    aliased = replace(canonical, aliases=(*canonical.aliases, alias))
+    registry = CommandSafetyExtensionRegistry(
+        tuple(
+            aliased if item.extension_id == canonical.extension_id else item
+            for item in BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions
+        )
+    )
+    layer = _layer(
+        ControlLayerKind.LOCAL_ADMIN,
+        _control(ControlTargetKind.EXTENSION, alias, ControlState.DISABLED),
+        digest=registry.catalog_digest,
+    )
+
+    resolution = resolve_extension_controls(
+        (layer,),
+        registry=registry,
+        extension_ids=(canonical.extension_id,),
+        permission_ids=(),
+        observations=("classified",),
+        surface=ControlSurface.COMMAND_EVALUATION,
+    )
+
+    assert resolution.blocked is True
+    assert resolution.failures[0].code is ResolverFailureCode.NON_CANONICAL_TARGET
+    assert evaluate_effect_decision(EffectDecisionRequest(resolution.factors)).action == "block"
+
+
+def test_resolver_input_limits_fail_closed_at_boundary() -> None:
+    extension_id, _ = _catalog_subjects()
+    accepted = resolve_extension_controls(
+        (),
+        registry=BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+        extension_ids=(extension_id,),
+        permission_ids=(),
+        observations=tuple("observed" for _ in range(2048)),
+        surface=ControlSurface.COMMAND_EVALUATION,
+    )
+    rejected = resolve_extension_controls(
+        (),
+        registry=BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+        extension_ids=(extension_id,),
+        permission_ids=(),
+        observations=tuple("observed" for _ in range(2049)),
+        surface=ControlSurface.COMMAND_EVALUATION,
+    )
+
+    assert accepted.blocked is False
+    assert rejected.blocked is True
+    assert rejected.failures[0].code is ResolverFailureCode.INPUT_LIMIT_EXCEEDED

--- a/tests/test_guard_extension_control_resolver.py
+++ b/tests/test_guard_extension_control_resolver.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import itertools
+from dataclasses import FrozenInstanceError, replace
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.command_extensions import (
+    BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+    CommandSafetyExtensionRegistry,
+)
+from codex_plugin_scanner.guard.runtime.effect_decision import EffectDecisionRequest, evaluate_effect_decision
+from codex_plugin_scanner.guard.runtime.extension_control_contract import (
+    CONTROL_SCHEMA_VERSION,
+    ControlLayerKind,
+    ControlState,
+    ControlSurface,
+    ControlTarget,
+    ControlTargetKind,
+    ExtensionControl,
+    ExtensionControlLayer,
+    ResolverFailureCode,
+)
+from codex_plugin_scanner.guard.runtime.extension_control_resolver import (
+    compose_control_layers,
+    resolve_extension_controls,
+)
+
+
+def _catalog_subjects() -> tuple[str, str]:
+    extension = BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions[0]
+    return extension.extension_id, extension.permissions[0].permission_id
+
+
+def _layer(
+    kind: ControlLayerKind,
+    *controls: ExtensionControl,
+    lockdown: bool = False,
+    digest: str | None = None,
+) -> ExtensionControlLayer:
+    return ExtensionControlLayer(
+        schema_version=CONTROL_SCHEMA_VERSION,
+        kind=kind,
+        catalog_digest=digest or BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
+        global_lockdown=lockdown,
+        controls=controls,
+    )
+
+
+def _control(kind: ControlTargetKind, target_id: str, state: ControlState) -> ExtensionControl:
+    return ExtensionControl(ControlTarget(kind, target_id), state)
+
+
+def test_control_contract_is_versioned_immutable_and_exactly_typed() -> None:
+    extension_id, _ = _catalog_subjects()
+    control = _control(ControlTargetKind.EXTENSION, extension_id, ControlState.DISABLED)
+    layer = _layer(ControlLayerKind.LOCAL_ADMIN, control)
+
+    assert layer.schema_version == "1.0.0"
+    assert layer.controls == (control,)
+    with pytest.raises(FrozenInstanceError):
+        layer.__setattr__("global_lockdown", False)
+    with pytest.raises(ValueError, match="schema version"):
+        replace(layer, schema_version="2.0.0")
+    with pytest.raises(ValueError, match="exact ControlState"):
+        ExtensionControl(control.target, cast(ControlState, "disabled"))
+
+
+def test_composition_is_permutation_independent_and_disable_dominates_enable() -> None:
+    extension_id, permission_id = _catalog_subjects()
+    local = _layer(
+        ControlLayerKind.LOCAL_ADMIN,
+        _control(ControlTargetKind.EXTENSION, extension_id, ControlState.ENABLED),
+        _control(ControlTargetKind.PERMISSION, permission_id, ControlState.DISABLED),
+    )
+    cloud = _layer(
+        ControlLayerKind.SIGNED_CLOUD,
+        _control(ControlTargetKind.EXTENSION, extension_id, ControlState.DISABLED),
+        _control(ControlTargetKind.PERMISSION, permission_id, ControlState.ENABLED),
+    )
+
+    compositions = {compose_control_layers(order) for order in itertools.permutations((local, cloud))}
+    assert len(compositions) == 1
+    composed = compositions.pop()
+    assert composed.global_lockdown is False
+    assert composed.state_for(ControlTargetKind.EXTENSION, extension_id) is ControlState.DISABLED
+    assert composed.state_for(ControlTargetKind.PERMISSION, permission_id) is ControlState.DISABLED
+
+
+def test_adding_restrictions_never_reduces_the_resolved_action() -> None:
+    extension_id, permission_id = _catalog_subjects()
+    targets = (
+        (ControlTargetKind.EXTENSION, extension_id),
+        (ControlTargetKind.PERMISSION, permission_id),
+    )
+    actions: dict[frozenset[int], str] = {}
+    for count in range(len(targets) + 1):
+        for indexes in itertools.combinations(range(len(targets)), count):
+            disabled = frozenset(indexes)
+            controls = tuple(
+                _control(kind, target_id, ControlState.DISABLED)
+                for index, (kind, target_id) in enumerate(targets)
+                if index in disabled
+            )
+            resolution = resolve_extension_controls(
+                (_layer(ControlLayerKind.LOCAL_ADMIN, *controls),),
+                BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+                extension_ids=(extension_id,),
+                permission_ids=(permission_id,),
+                surface=ControlSurface.COMMAND_EVALUATION,
+            )
+            actions[disabled] = evaluate_effect_decision(EffectDecisionRequest(resolution.factors)).action
+
+    assert actions[frozenset()] != "block"
+    assert all(action == "block" for disabled, action in actions.items() if disabled)
+
+
+def test_global_lockdown_preserves_observations_and_allows_only_typed_local_recovery() -> None:
+    extension_id, permission_id = _catalog_subjects()
+    layer = _layer(ControlLayerKind.LOCAL_ADMIN, lockdown=True)
+    observations = ("classification:package-manager", "classification:remote-mutation")
+
+    command = resolve_extension_controls(
+        (layer,),
+        BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+        extension_ids=(extension_id,),
+        permission_ids=(permission_id,),
+        surface=ControlSurface.COMMAND_EVALUATION,
+        observations=observations,
+    )
+    recovery = resolve_extension_controls(
+        (layer,),
+        BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+        extension_ids=(),
+        permission_ids=(),
+        surface=ControlSurface.TRUSTED_LOCAL_RECOVERY,
+        observations=observations,
+    )
+
+    assert command.blocked is True
+    assert command.observations == observations
+    assert command.factors[0].reason_code == "control.global-lockdown"
+    assert recovery.blocked is False
+    assert recovery.factors == ()
+    assert recovery.observations == observations
+
+
+def test_disabled_extension_permission_dependency_and_implied_permission_each_block() -> None:
+    owner = next(
+        extension for extension in BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions if len(extension.permissions) >= 2
+    )
+    dependency = next(
+        extension
+        for extension in BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions
+        if extension.extension_id != owner.extension_id and extension.permissions
+    )
+    dependency_permission = owner.permissions[1]
+    owner_permission = replace(
+        owner.permissions[0],
+        dependencies=(dependency_permission.permission_id,),
+        implied_permissions=(),
+    )
+    owner = replace(
+        owner,
+        dependencies=(dependency.extension_id,),
+        permissions=(owner_permission, *owner.permissions[1:]),
+    )
+    registry = CommandSafetyExtensionRegistry((owner, dependency))
+    scenarios = (
+        (
+            (owner.extension_id,),
+            (),
+            _control(ControlTargetKind.EXTENSION, owner.extension_id, ControlState.DISABLED),
+        ),
+        (
+            (),
+            (owner_permission.permission_id,),
+            _control(ControlTargetKind.PERMISSION, owner_permission.permission_id, ControlState.DISABLED),
+        ),
+        (
+            (owner.extension_id,),
+            (),
+            _control(ControlTargetKind.EXTENSION, dependency.extension_id, ControlState.DISABLED),
+        ),
+        (
+            (),
+            (owner_permission.permission_id,),
+            _control(
+                ControlTargetKind.PERMISSION,
+                dependency_permission.permission_id,
+                ControlState.DISABLED,
+            ),
+        ),
+    )
+
+    for extension_ids, permission_ids, control in scenarios:
+        layer = ExtensionControlLayer(
+            schema_version=CONTROL_SCHEMA_VERSION,
+            kind=ControlLayerKind.LOCAL_ADMIN,
+            catalog_digest=registry.catalog_digest,
+            global_lockdown=False,
+            controls=(control,),
+        )
+        resolution = resolve_extension_controls(
+            (layer,),
+            registry,
+            extension_ids=extension_ids,
+            permission_ids=permission_ids,
+            surface=ControlSurface.COMMAND_EVALUATION,
+        )
+        assert resolution.blocked is True
+        assert evaluate_effect_decision(EffectDecisionRequest(resolution.factors)).action == "block"
+
+
+def test_resolver_failures_are_typed_privacy_safe_and_fail_closed() -> None:
+    extension_id, _ = _catalog_subjects()
+    cases = (
+        (
+            (_layer(ControlLayerKind.LOCAL_ADMIN, digest="0" * 64),),
+            (extension_id,),
+            ResolverFailureCode.CATALOG_DIGEST_MISMATCH,
+        ),
+        (
+            (_layer(ControlLayerKind.LOCAL_ADMIN),),
+            ("command.private-unknown-input",),
+            ResolverFailureCode.UNKNOWN_EXTENSION_TARGET,
+        ),
+    )
+    for layers, extension_ids, expected_code in cases:
+        resolution = resolve_extension_controls(
+            layers,
+            BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+            extension_ids=extension_ids,
+            permission_ids=(),
+            surface=ControlSurface.COMMAND_EVALUATION,
+        )
+        assert resolution.blocked is True
+        assert resolution.failures[0].code is expected_code
+        assert evaluate_effect_decision(EffectDecisionRequest(resolution.factors)).action == "block"
+        serialized = repr(resolution.factors)
+        assert "private-unknown-input" not in serialized
+
+
+def test_duplicate_layers_targets_and_invalid_surface_fail_closed() -> None:
+    extension_id, _ = _catalog_subjects()
+    control = _control(ControlTargetKind.EXTENSION, extension_id, ControlState.DISABLED)
+    duplicate_target = _layer(ControlLayerKind.LOCAL_ADMIN, control, control)
+    duplicate_kind = (
+        _layer(ControlLayerKind.LOCAL_ADMIN),
+        _layer(ControlLayerKind.LOCAL_ADMIN),
+    )
+
+    for layers, expected in (
+        ((duplicate_target,), ResolverFailureCode.DUPLICATE_TARGET_IN_LAYER),
+        (duplicate_kind, ResolverFailureCode.DUPLICATE_LAYER_KIND),
+    ):
+        resolution = resolve_extension_controls(
+            layers,
+            BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+            extension_ids=(extension_id,),
+            permission_ids=(),
+            surface=ControlSurface.COMMAND_EVALUATION,
+        )
+        assert resolution.blocked is True
+        assert resolution.failures[0].code is expected
+
+    invalid = resolve_extension_controls(
+        (),
+        BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+        extension_ids=(extension_id,),
+        permission_ids=(),
+        surface=cast(ControlSurface, "recovery/by-path"),
+    )
+    assert invalid.blocked is True
+    assert invalid.failures[0].code is ResolverFailureCode.INVALID_CONTROL_SURFACE


### PR DESCRIPTION
## Summary
- add immutable extension/permission control contracts and a disable-dominant resolver
- emit privacy-safe block-only factors through the central effect decision plane
- persist authenticated snapshots and transitions with an OS credential-store anchor, fail-closed health, and crash recovery
- normalize catalog indexes and validate symmetric extension conflicts

## Verification
- `uv run pytest -q tests/test_guard_extension_control_authority.py tests/test_guard_extension_control_resolver.py tests/test_guard_command_extension_registry.py tests/test_guard_command_permission_catalog.py tests/test_guard_effect_decision.py tests/test_guard_store_migrations.py tests/test_guard_policy_integrity.py --tb=short` (217 passed)
- focused Ruff checks passed
- focused basedpyright checks passed

No release, publish, or deploy actions are included.