### PR TITLE
fix(guard): migrate command shadow evaluator schema

### DIFF
--- a/src/codex_plugin_scanner/guard/store_command_shadow_schema.py
+++ b/src/codex_plugin_scanner/guard/store_command_shadow_schema.py
@@ -9,7 +9,8 @@ import sqlite3
 from typing import Final, cast
 
 COMMAND_SHADOW_LEGACY_MIGRATION_VERSION: Final = 15
-COMMAND_SHADOW_MIGRATION_VERSION: Final = 17
+COMMAND_SHADOW_PREVIOUS_MIGRATION_VERSION: Final = 17
+COMMAND_SHADOW_MIGRATION_VERSION: Final = 18
 
 _ACTIONS: Final = "'allow', 'warn', 'review', 'require-reapproval', 'sandbox-required', 'block'"
 _DISPOSITIONS: Final = (
@@ -46,7 +47,7 @@ _SCHEMA_STATEMENTS: Final = (
         and proposal_version glob '[a-z]*'
         and proposal_version not glob '*[^a-z0-9.-]*'
       ),
-      evaluator_schema_version text not null check (evaluator_schema_version = '1.0.0'),
+      evaluator_schema_version text not null check (evaluator_schema_version in ('1.0.0', '1.1.0')),
       control_generation integer not null check (control_generation = 1),
       sample_basis_points integer not null check (sample_basis_points between 1 and 10000),
       schema_version text not null check (schema_version = 'guard.command-shadow.v1'),
@@ -184,26 +185,41 @@ _LEGACY_SCHEMA_STATEMENTS: Final = (
     end""",
 )
 
+_PREVIOUS_SCHEMA_STATEMENTS: Final = (
+    _SCHEMA_STATEMENTS[0].replace(
+        "evaluator_schema_version in ('1.0.0', '1.1.0')",
+        "evaluator_schema_version = '1.0.0'",
+    ),
+    *_SCHEMA_STATEMENTS[1:],
+)
+
 
 def ensure_command_shadow_schema(connection: sqlite3.Connection, *, applied_at: str) -> None:
-    """Apply the current schema atomically, upgrading the exact legacy v15 shape."""
+    """Apply the current schema atomically, upgrading either supported legacy shape."""
 
-    connection.execute("savepoint command_shadow_schema_v17")
+    connection.execute("savepoint command_shadow_schema_v18")
     try:
         current = _expected_schema(_SCHEMA_STATEMENTS)
         legacy = _expected_schema(_LEGACY_SCHEMA_STATEMENTS)
-        actual = _read_schema(connection, frozenset(current) | frozenset(legacy))
+        previous = _expected_schema(_PREVIOUS_SCHEMA_STATEMENTS)
+        actual = _read_schema(connection, frozenset(current) | frozenset(legacy) | frozenset(previous))
         _reject_external_foreign_keys(connection)
-        _reject_external_sql_dependencies(connection, (current, legacy))
+        _reject_external_sql_dependencies(connection, (current, legacy, previous))
         if actual == legacy:
-            _upgrade_legacy_schema(connection)
+            _upgrade_legacy_schema(connection, _LEGACY_SCHEMA_STATEMENTS)
+        elif actual == previous:
+            _upgrade_legacy_schema(connection, _PREVIOUS_SCHEMA_STATEMENTS)
         elif actual and actual != current:
             raise RuntimeError("incompatible command shadow schema objects")
         elif not actual:
             for statement in _SCHEMA_STATEMENTS:
                 connection.execute(statement)
         _validate_schema(connection)
-        for version in (COMMAND_SHADOW_LEGACY_MIGRATION_VERSION, COMMAND_SHADOW_MIGRATION_VERSION):
+        for version in (
+            COMMAND_SHADOW_LEGACY_MIGRATION_VERSION,
+            COMMAND_SHADOW_PREVIOUS_MIGRATION_VERSION,
+            COMMAND_SHADOW_MIGRATION_VERSION,
+        ):
             connection.execute(
                 "insert or ignore into schema_migrations (version, applied_at) values (?, ?)",
                 (version, applied_at),
@@ -215,14 +231,17 @@ def ensure_command_shadow_schema(connection: sqlite3.Connection, *, applied_at: 
         if row is None or not str(row[0]):
             raise RuntimeError("command_shadow_migration_not_recorded")
     except BaseException:
-        connection.execute("rollback to command_shadow_schema_v17")
-        connection.execute("release command_shadow_schema_v17")
+        connection.execute("rollback to command_shadow_schema_v18")
+        connection.execute("release command_shadow_schema_v18")
         raise
-    connection.execute("release command_shadow_schema_v17")
+    connection.execute("release command_shadow_schema_v18")
 
 
-def _upgrade_legacy_schema(connection: sqlite3.Connection) -> None:
-    for object_type, name in _schema_object_identities(_LEGACY_SCHEMA_STATEMENTS):
+def _upgrade_legacy_schema(
+    connection: sqlite3.Connection,
+    source_statements: tuple[str, ...],
+) -> None:
+    for object_type, name in _schema_object_identities(source_statements):
         if object_type != "table":
             connection.execute(f"drop {object_type} {name}")
     connection.execute("alter table command_activity_shadow_cohorts rename to command_activity_shadow_cohorts_v15")

--- a/tests/test_guard_command_shadow_persistence.py
+++ b/tests/test_guard_command_shadow_persistence.py
@@ -80,12 +80,18 @@ def _record_in_process(guard_home: str) -> bool:
     return store.record_command_activity(evidence, shadow=shadow)
 
 
-def _legacy_shadow_database(path: Path, *, proposal_version: str = "proposal.multi.v1") -> sqlite3.Connection:
+def _legacy_shadow_database(
+    path: Path,
+    *,
+    proposal_version: str = "proposal.multi.v1",
+    statements: tuple[str, ...] = shadow_schema._LEGACY_SCHEMA_STATEMENTS,
+    migration_version: int = shadow_schema.COMMAND_SHADOW_LEGACY_MIGRATION_VERSION,
+) -> sqlite3.Connection:
     connection = sqlite3.connect(path)
     connection.row_factory = sqlite3.Row
     connection.execute("create table schema_migrations (version integer primary key, applied_at text not null)")
     connection.execute("create table command_activity (activity_id text primary key, occurred_at text not null) strict")
-    for statement in shadow_schema._LEGACY_SCHEMA_STATEMENTS:
+    for statement in statements:
         connection.execute(statement)
     occurred_at = _OCCURRED_AT.isoformat()
     connection.execute("insert into command_activity values (?, ?)", ("activity:legacy", occurred_at))
@@ -101,7 +107,7 @@ def _legacy_shadow_database(path: Path, *, proposal_version: str = "proposal.mul
     connection.execute("insert into command_activity_shadow_cohorts values (?, 0, 'baseline')", ("activity:legacy",))
     connection.execute(
         "insert into schema_migrations values (?, ?)",
-        (shadow_schema.COMMAND_SHADOW_LEGACY_MIGRATION_VERSION, occurred_at),
+        (migration_version, occurred_at),
     )
     connection.commit()
     return connection
@@ -128,9 +134,10 @@ def test_migration_upgrades_exact_legacy_schema_and_preserves_rows(tmp_path: Pat
 
         shadow_schema._validate_schema(connection)
         versions = connection.execute(
-            "select version from schema_migrations where version in (?, ?) order by version",
+            "select version from schema_migrations where version in (?, ?, ?) order by version",
             (
                 shadow_schema.COMMAND_SHADOW_LEGACY_MIGRATION_VERSION,
+                shadow_schema.COMMAND_SHADOW_PREVIOUS_MIGRATION_VERSION,
                 shadow_schema.COMMAND_SHADOW_MIGRATION_VERSION,
             ),
         ).fetchall()
@@ -147,6 +154,7 @@ def test_migration_upgrades_exact_legacy_schema_and_preserves_rows(tmp_path: Pat
 
     assert [tuple(row) for row in versions] == [
         (shadow_schema.COMMAND_SHADOW_LEGACY_MIGRATION_VERSION,),
+        (shadow_schema.COMMAND_SHADOW_PREVIOUS_MIGRATION_VERSION,),
         (shadow_schema.COMMAND_SHADOW_MIGRATION_VERSION,),
     ]
     assert tuple(evaluation) == ("activity:legacy", "proposal.multi.v1")
@@ -171,6 +179,33 @@ def test_migration_rolls_back_exact_legacy_schema_when_a_row_is_invalid(tmp_path
     assert actual == expected_legacy
     assert [tuple(version) for version in versions] == [(shadow_schema.COMMAND_SHADOW_LEGACY_MIGRATION_VERSION,)]
     assert tuple(row) == ("activity:legacy", "INVALID!")
+
+
+def test_migration_upgrades_previous_constrained_schema(tmp_path: Path) -> None:
+    with _legacy_shadow_database(
+        tmp_path / "previous.db",
+        statements=shadow_schema._PREVIOUS_SCHEMA_STATEMENTS,
+        migration_version=shadow_schema.COMMAND_SHADOW_PREVIOUS_MIGRATION_VERSION,
+    ) as connection:
+        shadow_schema.ensure_command_shadow_schema(connection, applied_at=_OCCURRED_AT.isoformat())
+
+        shadow_schema._validate_schema(connection)
+        evaluation = connection.execute(
+            "select activity_id, evaluator_schema_version from command_activity_shadow_evaluations"
+        ).fetchone()
+        versions = connection.execute(
+            "select version from schema_migrations where version in (?, ?) order by version",
+            (
+                shadow_schema.COMMAND_SHADOW_PREVIOUS_MIGRATION_VERSION,
+                shadow_schema.COMMAND_SHADOW_MIGRATION_VERSION,
+            ),
+        ).fetchall()
+
+    assert tuple(evaluation) == ("activity:legacy", "1.0.0")
+    assert [tuple(row) for row in versions] == [
+        (shadow_schema.COMMAND_SHADOW_PREVIOUS_MIGRATION_VERSION,),
+        (shadow_schema.COMMAND_SHADOW_MIGRATION_VERSION,),
+    ]
 
 
 def test_migration_rejects_unknown_near_legacy_schema_without_changes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- accept the 1.1 effect-decision schema in command-shadow persistence
- migrate both legacy unconstrained and prior 1.0-constrained SQLite schemas atomically
- preserve evaluation/cohort rows and reject near-legacy schemas

## Verification
- `uv run pytest -q tests/test_guard_command_shadow_persistence.py tests/test_guard_command_activity_hook_integration.py --tb=short` (34 passed)
- `uv run ruff check src/codex_plugin_scanner/guard/store_command_shadow_schema.py tests/test_guard_command_shadow_persistence.py`

No deployment or release actions.