### PR TITLE
fix(release): run installed containment on host

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -497,9 +497,12 @@ jobs:
           cd dashboard
           bun install --frozen-lockfile --ignore-scripts
           bunx playwright install --with-deps chromium
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bubblewrap
           cd ../tests/dockerlabs/command-extension-analytics
           bun run typecheck
           HOL_GUARD_LAB_EXPECTED_VERSION="$VERSION" \
+            HOL_GUARD_LAB_PYTHON="$CANARY_PYTHON" \
             HOL_GUARD_WHEEL="$GITHUB_WORKSPACE/dist/$WHEEL_NAME" \
             bun run guard:test:command-extension-analytics \
               > "$GITHUB_WORKSPACE/installed-canary/command-extension-analytics.json"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -498,7 +498,15 @@ jobs:
           bun install --frozen-lockfile --ignore-scripts
           bunx playwright install --with-deps chromium
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends bubblewrap
+          sudo apt-get install -y --no-install-recommends apparmor bubblewrap
+          sudo tee /etc/apparmor.d/hol-guard-bwrap >/dev/null <<'EOF'
+          abi <abi/4.0>,
+          include <tunables/global>
+          /usr/bin/bwrap flags=(unconfined) {
+            userns,
+          }
+          EOF
+          sudo apparmor_parser -r /etc/apparmor.d/hol-guard-bwrap
           cd ../tests/dockerlabs/command-extension-analytics
           bun run typecheck
           HOL_GUARD_LAB_EXPECTED_VERSION="$VERSION" \

--- a/tests/dockerlabs/command-extension-analytics/Dockerfile
+++ b/tests/dockerlabs/command-extension-analytics/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends bubblewrap git \
+    && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
 ARG HOL_GUARD_LAB_WHEEL
 COPY ${HOL_GUARD_LAB_WHEEL} /opt/wheels/

--- a/tests/dockerlabs/command-extension-analytics/docker-compose.yml
+++ b/tests/dockerlabs/command-extension-analytics/docker-compose.yml
@@ -19,11 +19,8 @@ services:
       - guard-analytics
     cap_drop:
       - ALL
-    cap_add:
-      - SYS_ADMIN
     security_opt:
       - no-new-privileges:true
-      - seccomp:unconfined
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:4781/healthz', timeout=2)"]
       interval: 1s

--- a/tests/dockerlabs/command-extension-analytics/installed_containment_probe.py
+++ b/tests/dockerlabs/command-extension-analytics/installed_containment_probe.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Run the installed-wheel containment proof on the Linux host."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shlex
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+import codex_plugin_scanner
+from codex_plugin_scanner import __version__
+from codex_plugin_scanner.guard.runtime.containment_contract import (
+    ContainmentInput,
+    ContainmentPolicy,
+    ContainmentRequest,
+)
+from codex_plugin_scanner.guard.runtime.containment_executor import execute_contained, file_sha256
+
+SENTINEL = "guard-private-command-sentinel"
+
+
+@dataclass(frozen=True)
+class Arguments:
+    expected_version: str
+    repo_root: Path
+
+
+def _arguments() -> Arguments:
+    parser = argparse.ArgumentParser()
+    _ = parser.add_argument("--expected-version", required=True)
+    _ = parser.add_argument("--repo-root", required=True, type=Path)
+    namespace = parser.parse_args()
+    return Arguments(
+        expected_version=cast(str, namespace.expected_version),
+        repo_root=cast(Path, namespace.repo_root),
+    )
+
+
+def _installed_origin(repo_root: Path) -> str:
+    package_file = Path(codex_plugin_scanner.__file__ or "").resolve(strict=True)
+    if "site-packages" not in package_file.parts or package_file.is_relative_to(repo_root.resolve()):
+        raise RuntimeError("containment probe must import Guard from installed site-packages")
+    return str(package_file)
+
+
+def _probe() -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="guard-installed-containment-") as temporary:
+        workspace = Path(temporary)
+        protected = workspace / ".guard"
+        protected.mkdir()
+        secret_file = protected / "credentials.json"
+        _ = secret_file.write_text(SENTINEL, encoding="utf-8")
+        output = workspace / "output"
+        output.mkdir()
+        source = workspace / "format-input.txt"
+        _ = source.write_text("formatted\n", encoding="utf-8")
+        destination = output / "format-output.txt"
+        executable = "/bin/sh"
+        protected_path = shlex.quote(str(secret_file))
+        command = (
+            f"if secret=$(cat {protected_path} 2>/dev/null); then printf '%s' \"$secret\"; exit 91; fi; "
+            f"if printf changed 2>/dev/null > {protected_path}; then exit 92; fi; "
+            "cp format-input.txt output/format-output.txt"
+        )
+        request = ContainmentRequest(
+            argv=(executable, "-c", command),
+            cwd=str(workspace),
+            environment=(("PATH", "/usr/bin:/bin"),),
+            policy=ContainmentPolicy(str(workspace), (str(output),)),
+            inputs=(ContainmentInput(str(source), "format-input.txt", file_sha256(str(source))),),
+            launch_digest=hashlib.sha256(b"installed-command-analytics-lab").hexdigest(),
+            executable_digest=file_sha256(executable),
+            operation_id="installed.analytics.probe",
+            declared_outputs=("output/format-output.txt",),
+        )
+        result = execute_contained(request, timeout_seconds=5)
+        output_written = (
+            len(result.outputs) == 1
+            and result.outputs[0].snapshot_path == "output/format-output.txt"
+            and result.outputs[0].content == b"formatted\n"
+            and not destination.exists()
+        )
+        return {
+            "enforced": result.enforced,
+            "exit_code": result.exit_code,
+            "output_written": output_written,
+            "protected_value_unchanged": secret_file.read_text(encoding="utf-8") == SENTINEL,
+            "secret_hidden": SENTINEL not in result.stdout and SENTINEL not in result.stderr,
+        }
+
+
+def main() -> None:
+    arguments = _arguments()
+    if sys.platform != "linux":
+        raise RuntimeError("installed containment proof requires Linux")
+    if __version__ != arguments.expected_version:
+        raise RuntimeError("installed containment probe version mismatch")
+    evidence = _probe()
+    expected = {
+        "enforced": True,
+        "exit_code": 0,
+        "output_written": True,
+        "protected_value_unchanged": True,
+        "secret_hidden": True,
+    }
+    if evidence != expected:
+        raise RuntimeError("installed containment proof failed closed")
+    print(
+        json.dumps(
+            {
+                "containment": evidence,
+                "installed_origin": _installed_origin(arguments.repo_root),
+                "version": __version__,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/dockerlabs/command-extension-analytics/installed_containment_probe.py
+++ b/tests/dockerlabs/command-extension-analytics/installed_containment_probe.py
@@ -86,13 +86,22 @@ def _probe() -> dict[str, object]:
             and result.outputs[0].content == b"formatted\n"
             and not destination.exists()
         )
-        return {
+        evidence: dict[str, object] = {
             "enforced": result.enforced,
             "exit_code": result.exit_code,
             "output_written": output_written,
             "protected_value_unchanged": secret_file.read_text(encoding="utf-8") == SENTINEL,
             "secret_hidden": SENTINEL not in result.stdout and SENTINEL not in result.stderr,
         }
+        if result.exit_code != 0:
+            namespace_error = any(
+                marker in result.stderr for marker in ("No permissions", "Operation not permitted", "user namespace")
+            )
+            evidence["backend_error"] = "namespace-unavailable" if namespace_error else "command-failed"
+            evidence["failure"] = (
+                result.attestation.failure.value if result.attestation.failure is not None else "backend-command-failed"
+            )
+        return evidence
 
 
 def main() -> None:
@@ -110,7 +119,7 @@ def main() -> None:
         "secret_hidden": True,
     }
     if evidence != expected:
-        raise RuntimeError("installed containment proof failed closed")
+        raise RuntimeError(f"installed containment proof failed closed: {json.dumps(evidence, sort_keys=True)}")
     print(
         json.dumps(
             {

--- a/tests/dockerlabs/command-extension-analytics/installed_containment_probe.py
+++ b/tests/dockerlabs/command-extension-analytics/installed_containment_probe.py
@@ -61,7 +61,7 @@ def _probe() -> dict[str, object]:
         source = workspace / "format-input.txt"
         _ = source.write_text("formatted\n", encoding="utf-8")
         destination = output / "format-output.txt"
-        executable = "/bin/sh"
+        executable = str(Path("/bin/sh").resolve(strict=True))
         protected_path = shlex.quote(str(secret_file))
         command = (
             f"if secret=$(cat {protected_path} 2>/dev/null); then printf '%s' \"$secret\"; exit 91; fi; "

--- a/tests/dockerlabs/command-extension-analytics/installed_server.py
+++ b/tests/dockerlabs/command-extension-analytics/installed_server.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import signal
@@ -19,12 +18,6 @@ from codex_plugin_scanner import __version__
 from codex_plugin_scanner.guard.approval_scope_support import request_scope_contract
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.local_dashboard_session import build_local_dashboard_session_token
-from codex_plugin_scanner.guard.runtime.containment_contract import (
-    ContainmentInput,
-    ContainmentPolicy,
-    ContainmentRequest,
-)
-from codex_plugin_scanner.guard.runtime.containment_executor import execute_contained, file_sha256
 from codex_plugin_scanner.guard.store import GuardStore
 
 GUARD_HOME = Path("/guard-home")
@@ -367,40 +360,6 @@ def _assert_seeded_activity(store: GuardStore) -> None:
         raise RuntimeError(f"installed hook activity mismatch: {rows!r}")
 
 
-def _containment_probe() -> dict[str, object]:
-    protected = WORKSPACE / ".guard"
-    protected.mkdir(exist_ok=True)
-    secret_file = protected / "credentials.json"
-    _ = secret_file.write_text(SENTINEL, encoding="utf-8")
-    output = WORKSPACE / "output"
-    output.mkdir(exist_ok=True)
-    source = WORKSPACE / "format-input.txt"
-    _ = source.write_text("formatted\n", encoding="utf-8")
-    destination = output / "format-output.txt"
-    executable = "/usr/bin/cp"
-    request = ContainmentRequest(
-        argv=(executable, str(source), str(destination)),
-        cwd=str(WORKSPACE),
-        environment=(("PATH", "/usr/bin:/bin"),),
-        policy=ContainmentPolicy(str(WORKSPACE), (str(output),)),
-        inputs=(ContainmentInput(str(source), "format-input.txt", file_sha256(str(source))),),
-        launch_digest=hashlib.sha256(b"installed-command-analytics-lab").hexdigest(),
-        executable_digest=file_sha256(executable),
-        operation_id="installed.analytics.probe",
-    )
-    result = execute_contained(request, timeout_seconds=5)
-    evidence: dict[str, object] = {
-        "enforced": result.enforced,
-        "exit_code": result.exit_code,
-        "output_written": destination.exists() and destination.read_text(encoding="utf-8") == "formatted\n",
-        "protected_value_unchanged": secret_file.read_text(encoding="utf-8") == SENTINEL,
-        "secret_hidden": SENTINEL not in result.stdout and SENTINEL not in result.stderr,
-    }
-    if result.exit_code != 0:
-        evidence["failure"] = _safe_hook_diagnostic(result.stderr)
-    return evidence
-
-
 def _installed_origin() -> str:
     package_file = Path(sys.modules["codex_plugin_scanner"].__file__ or "").resolve(strict=True)
     if "site-packages" not in package_file.parts or "/workspace" in str(package_file):
@@ -447,21 +406,11 @@ def main() -> None:
             workflow_authorization = _complete_workflow_authorization(store, str(pending["request_id"]))
             prompt_free_hook_count = _invoke_real_harnesses()
         _assert_seeded_activity(store)
-        containment = _containment_probe()
-        if containment != {
-            "enforced": True,
-            "exit_code": 0,
-            "output_written": True,
-            "protected_value_unchanged": True,
-            "secret_hidden": True,
-        }:
-            raise RuntimeError(f"containment probe failed: {containment}")
         print(
             "HOL_GUARD_LAB_READY "
             + json.dumps(
                 {
                     "activity_count": store.count_command_activities(),
-                    "containment": containment,
                     "installed_origin": _installed_origin(),
                     "prompt_free_hook_count": prompt_free_hook_count,
                     "version": __version__,

--- a/tests/dockerlabs/command-extension-analytics/relay-fetch.ts
+++ b/tests/dockerlabs/command-extension-analytics/relay-fetch.ts
@@ -1,0 +1,12 @@
+export async function fetchLabGet(url: string, init?: RequestInit): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return await fetch(url, init);
+    } catch (error) {
+      lastError = error;
+      await Bun.sleep(100);
+    }
+  }
+  throw lastError;
+}

--- a/tests/dockerlabs/command-extension-analytics/runner.test.ts
+++ b/tests/dockerlabs/command-extension-analytics/runner.test.ts
@@ -146,6 +146,7 @@ describe("command extension analytics Dockerlabs orchestration", () => {
     expect(containmentProbe).toContain("not destination.exists()");
     expect(containmentProbe).toContain("cat {protected_path}");
     expect(containmentProbe).toContain("printf changed 2>/dev/null > {protected_path}");
+    expect(containmentProbe).toContain('"namespace-unavailable"');
     expect(containmentProbe).toContain('"site-packages"');
     expect(server).not.toContain("record_pre_hook_command_activity_best_effort");
     expect(server).not.toContain("record_command_activity(");

--- a/tests/dockerlabs/command-extension-analytics/runner.test.ts
+++ b/tests/dockerlabs/command-extension-analytics/runner.test.ts
@@ -168,6 +168,10 @@ describe("command extension analytics Dockerlabs orchestration", () => {
     expect(runner).toContain("approveWorkflowAuthorization(origin, pending, session)");
     expect(runner).toContain('"-I"');
     expect(runner).toContain("HOL_GUARD_LAB_PYTHON");
+    expect(runner.lastIndexOf("try {")).toBeLessThan(runner.lastIndexOf("runInstalledContainment(runner, version)"));
+    expect(runner.lastIndexOf("runInstalledContainment(runner, version)")).toBeLessThan(
+      runner.lastIndexOf('composeCommand(project, "up"'),
+    );
     expect(playwright).toContain('trace: "off"');
     expect(databasePrivacy).toContain("command_activity(?:_[a-z0-9_]+)?");
     expect(databasePrivacy).toContain("envelope_redacted_json");

--- a/tests/dockerlabs/command-extension-analytics/runner.test.ts
+++ b/tests/dockerlabs/command-extension-analytics/runner.test.ts
@@ -107,11 +107,13 @@ describe("command extension analytics Dockerlabs orchestration", () => {
 
   test("installed fixture is wheel-only and exercises the required evidence paths", async () => {
     const directory = import.meta.dir;
-    const [dockerfile, dockerignore, compose, server, runner, playwright, databasePrivacy] = await Promise.all([
+    const [dockerfile, dockerignore, compose, server, containmentProbe, runner, playwright, databasePrivacy]
+      = await Promise.all([
       Bun.file(`${directory}/Dockerfile`).text(),
       Bun.file(`${directory}/Dockerfile.dockerignore`).text(),
       Bun.file(`${directory}/docker-compose.yml`).text(),
       Bun.file(`${directory}/installed_server.py`).text(),
+      Bun.file(`${directory}/installed_containment_probe.py`).text(),
       Bun.file(`${directory}/runner.ts`).text(),
       Bun.file(`${directory}/../../../dashboard/playwright.installed.config.ts`).text(),
       Bun.file(`${directory}/database-privacy.ts`).text(),
@@ -124,6 +126,10 @@ describe("command extension analytics Dockerlabs orchestration", () => {
     expect(dockerignore).toContain("tcp_relay.py");
     expect(compose).not.toContain("../../src");
     expect(compose).toContain("internal: true");
+    expect(compose).toContain("no-new-privileges:true");
+    expect(compose).not.toContain("SYS_ADMIN");
+    expect(compose).not.toContain("seccomp:unconfined");
+    expect(dockerfile).not.toContain("bubblewrap");
     for (const harness of ["codex", "claude-code", "cursor"]) {
       expect(server).toContain(`_run_installed_hook(\"${harness}\"`);
     }
@@ -132,7 +138,15 @@ describe("command extension analytics Dockerlabs orchestration", () => {
     expect(server).toContain('"git diff --stat"');
     expect(server).toContain('"git push --delete origin stale-lab-branch"');
     expect(server).toContain('"shutdown -h now # {SENTINEL}"');
-    expect(server).toContain('executable = "/usr/bin/cp"');
+    expect(server).not.toContain("execute_contained");
+    expect(containmentProbe).toContain('executable = "/bin/sh"');
+    expect(containmentProbe).toContain("execute_contained(request");
+    expect(containmentProbe).toContain('declared_outputs=("output/format-output.txt",)');
+    expect(containmentProbe).toContain("result.outputs[0].content == b\"formatted\\n\"");
+    expect(containmentProbe).toContain("not destination.exists()");
+    expect(containmentProbe).toContain("cat {protected_path}");
+    expect(containmentProbe).toContain("printf changed 2>/dev/null > {protected_path}");
+    expect(containmentProbe).toContain('"site-packages"');
     expect(server).not.toContain("record_pre_hook_command_activity_best_effort");
     expect(server).not.toContain("record_command_activity(");
     expect(server).not.toContain("ActivityDecisionReason.CAPABILITY");
@@ -152,6 +166,8 @@ describe("command extension analytics Dockerlabs orchestration", () => {
     expect(runner).toContain('"X-Guard-Dashboard-Session": session');
     expect(runner).toContain("scope_contract_digest: pending.scope_contract_digest");
     expect(runner).toContain("approveWorkflowAuthorization(origin, pending, session)");
+    expect(runner).toContain('"-I"');
+    expect(runner).toContain("HOL_GUARD_LAB_PYTHON");
     expect(playwright).toContain('trace: "off"');
     expect(databasePrivacy).toContain("command_activity(?:_[a-z0-9_]+)?");
     expect(databasePrivacy).toContain("envelope_redacted_json");

--- a/tests/dockerlabs/command-extension-analytics/runner.test.ts
+++ b/tests/dockerlabs/command-extension-analytics/runner.test.ts
@@ -139,7 +139,7 @@ describe("command extension analytics Dockerlabs orchestration", () => {
     expect(server).toContain('"git push --delete origin stale-lab-branch"');
     expect(server).toContain('"shutdown -h now # {SENTINEL}"');
     expect(server).not.toContain("execute_contained");
-    expect(containmentProbe).toContain('executable = "/bin/sh"');
+    expect(containmentProbe).toContain('Path("/bin/sh").resolve(strict=True)');
     expect(containmentProbe).toContain("execute_contained(request");
     expect(containmentProbe).toContain('declared_outputs=("output/format-output.txt",)');
     expect(containmentProbe).toContain("result.outputs[0].content == b\"formatted\\n\"");

--- a/tests/dockerlabs/command-extension-analytics/runner.test.ts
+++ b/tests/dockerlabs/command-extension-analytics/runner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { composeCommand, safeProjectName, type CommandResult } from "./lab-process";
 import { runInstalledPlaywright } from "./installed-playwright";
+import { fetchLabGet } from "./relay-fetch";
 import { readyFromLogs } from "./runner";
 import { readDashboardSession } from "./session-handoff";
 import { teardownLab } from "./teardown";
@@ -23,6 +24,23 @@ describe("command extension analytics Dockerlabs orchestration", () => {
     expect(command.some((item) => item.endsWith("docker-compose.yml"))).toBe(true);
     expect(command).toContain("guard-command-analytics");
     expect(command.slice(-2)).toEqual(["-d", "--wait"]);
+  });
+
+  test("retries an idempotent relay GET after a transient reset", async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      if (calls === 1) throw new TypeError("connection reset");
+      return new Response("ready", { status: 200 });
+    };
+    try {
+      const response = await fetchLabGet("http://127.0.0.1:4781/healthz");
+      expect(response.status).toBe(200);
+      expect(calls).toBe(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("keeps Guard internal and publishes only the fixed-target relay", async () => {
@@ -107,7 +125,7 @@ describe("command extension analytics Dockerlabs orchestration", () => {
 
   test("installed fixture is wheel-only and exercises the required evidence paths", async () => {
     const directory = import.meta.dir;
-    const [dockerfile, dockerignore, compose, server, containmentProbe, runner, playwright, databasePrivacy]
+    const [dockerfile, dockerignore, compose, server, containmentProbe, runner, relayFetch, playwright, databasePrivacy]
       = await Promise.all([
       Bun.file(`${directory}/Dockerfile`).text(),
       Bun.file(`${directory}/Dockerfile.dockerignore`).text(),
@@ -115,6 +133,7 @@ describe("command extension analytics Dockerlabs orchestration", () => {
       Bun.file(`${directory}/installed_server.py`).text(),
       Bun.file(`${directory}/installed_containment_probe.py`).text(),
       Bun.file(`${directory}/runner.ts`).text(),
+      Bun.file(`${directory}/relay-fetch.ts`).text(),
       Bun.file(`${directory}/../../../dashboard/playwright.installed.config.ts`).text(),
       Bun.file(`${directory}/database-privacy.ts`).text(),
     ]);
@@ -169,6 +188,9 @@ describe("command extension analytics Dockerlabs orchestration", () => {
     expect(runner).toContain("approveWorkflowAuthorization(origin, pending, session)");
     expect(runner).toContain('"-I"');
     expect(runner).toContain("HOL_GUARD_LAB_PYTHON");
+    expect(relayFetch).toContain("async function fetchLabGet");
+    expect(runner).toContain("init.method === undefined");
+    expect(runner).toContain("await fetch(request, options)");
     expect(runner.lastIndexOf("try {")).toBeLessThan(runner.lastIndexOf("runInstalledContainment(runner, version)"));
     expect(runner.lastIndexOf("runInstalledContainment(runner, version)")).toBeLessThan(
       runner.lastIndexOf('composeCommand(project, "up"'),

--- a/tests/dockerlabs/command-extension-analytics/runner.ts
+++ b/tests/dockerlabs/command-extension-analytics/runner.ts
@@ -426,13 +426,13 @@ export async function runLab(runner: CommandRunner = runCommand): Promise<LabEvi
     HOL_GUARD_LAB_PORT: String(port),
     HOL_GUARD_LAB_WHEEL: wheel,
   };
-  const containment = await runInstalledContainment(runner, version);
   let cleanup: TeardownEvidence | null = null;
   try {
     const existing = await listProjectResources(project, runner);
     if (existing.containers.length || existing.volumes.length || existing.networks.length) {
       throw new Error(`Dockerlabs project is not clean before start: ${JSON.stringify(existing)}`);
     }
+    const containment = await runInstalledContainment(runner, version);
     requireSuccess(
       await runner(composeCommand(project, "up", "-d", "--build", "--wait"), { cwd: LAB_DIR, env: environment }),
       "Dockerlabs startup",

--- a/tests/dockerlabs/command-extension-analytics/runner.ts
+++ b/tests/dockerlabs/command-extension-analytics/runner.ts
@@ -16,13 +16,6 @@ import { readDashboardSession } from "./session-handoff";
 const SENTINEL = "guard-private-command-sentinel";
 interface ReadyEvidence {
   activity_count: number;
-  containment: {
-    enforced: boolean;
-    exit_code: number;
-    output_written: boolean;
-    protected_value_unchanged: boolean;
-    secret_hidden: boolean;
-  };
   installed_origin: string;
   prompt_free_hook_count: 2;
   version: string;
@@ -33,6 +26,13 @@ interface ReadyEvidence {
     drift_claimed: 0;
     request_flow: "authenticated-daemon-api";
   };
+}
+interface ContainmentEvidence {
+  enforced: boolean;
+  exit_code: number;
+  output_written: boolean;
+  protected_value_unchanged: boolean;
+  secret_hidden: boolean;
 }
 interface PendingWorkflowEvidence {
   request_id: string;
@@ -53,12 +53,17 @@ interface ApiEvidence {
 export interface LabEvidence {
   api: ApiEvidence;
   cleanup: TeardownEvidence;
-  installed: Omit<ReadyEvidence, "workflow_authorization">;
+  installed: Omit<ReadyEvidence, "workflow_authorization"> & { containment: ContainmentEvidence };
   persistence: { afterRestart: number; beforeRestart: number };
   playwright: "passed";
   privacy: { api: "clean"; database: "clean"; export: "clean"; sse: "clean" };
   status: "pass";
   workflowAuthorization: ReadyEvidence["workflow_authorization"];
+}
+interface InstalledContainmentEnvelope {
+  containment: ContainmentEvidence;
+  installed_origin: string;
+  version: string;
 }
 function packageVersion(pyproject: string): string {
   const match = pyproject.match(/^version\s*=\s*"([^"]+)"/m);
@@ -155,6 +160,33 @@ async function waitForReadyEvidence(
     await Bun.sleep(100);
   }
   throw new Error("installed daemon did not complete workflow authorization");
+}
+async function runInstalledContainment(runner: CommandRunner, version: string): Promise<ContainmentEvidence> {
+  const python = Bun.env.HOL_GUARD_LAB_PYTHON;
+  if (!python) throw new Error("HOL_GUARD_LAB_PYTHON must name the exact installed canary interpreter");
+  const result = requireSuccess(
+    await runner([
+      python, "-I", resolve(LAB_DIR, "installed_containment_probe.py"),
+      "--expected-version", version, "--repo-root", REPO_ROOT,
+    ], { cwd: LAB_DIR }),
+    "installed containment proof",
+  );
+  const envelope = JSON.parse(result) as InstalledContainmentEnvelope;
+  const expected = {
+    enforced: true,
+    exit_code: 0,
+    output_written: true,
+    protected_value_unchanged: true,
+    secret_hidden: true,
+  };
+  if (
+    envelope.version !== version
+    || !envelope.installed_origin.includes("site-packages")
+    || JSON.stringify(envelope.containment) !== JSON.stringify(expected)
+  ) {
+    throw new Error("installed containment evidence did not reconcile");
+  }
+  return envelope.containment;
 }
 async function apiJson(
   origin: string,
@@ -317,7 +349,7 @@ async function verifyCommandActivitySse(
 async function verifyApi(
   origin: string,
   session: string,
-  containment: ReadyEvidence["containment"],
+  containment: ContainmentEvidence,
   promptFreeHookCount: number,
 ): Promise<ApiEvidence> {
   const unauthenticated = await fetch(`${origin}/v1/command-activity`);
@@ -394,6 +426,7 @@ export async function runLab(runner: CommandRunner = runCommand): Promise<LabEvi
     HOL_GUARD_LAB_PORT: String(port),
     HOL_GUARD_LAB_WHEEL: wheel,
   };
+  const containment = await runInstalledContainment(runner, version);
   let cleanup: TeardownEvidence | null = null;
   try {
     const existing = await listProjectResources(project, runner);
@@ -416,7 +449,7 @@ export async function runLab(runner: CommandRunner = runCommand): Promise<LabEvi
       drift_claimed: 0,
       request_flow: "authenticated-daemon-api",
     })) throw new Error("workflow authorization evidence did not reconcile");
-    const api = await verifyApi(origin, session, first.containment, first.prompt_free_hook_count);
+    const api = await verifyApi(origin, session, containment, first.prompt_free_hook_count);
     await verifyDatabasePrivacy(project, environment, runner);
     requireSuccess(
       await runner(composeCommand(project, "restart", "guard"), { cwd: LAB_DIR, env: environment }),
@@ -428,7 +461,7 @@ export async function runLab(runner: CommandRunner = runCommand): Promise<LabEvi
     const afterRestart = await verifyApi(
       origin,
       restartedSession,
-      restarted.containment,
+      containment,
       restarted.prompt_free_hook_count,
     );
     if (afterRestart.activityCount !== api.activityCount) throw new Error("activity persistence failed across restart");
@@ -444,7 +477,7 @@ export async function runLab(runner: CommandRunner = runCommand): Promise<LabEvi
       cleanup,
       installed: {
         activity_count: first.activity_count,
-        containment: first.containment,
+        containment,
         installed_origin: first.installed_origin,
         prompt_free_hook_count: first.prompt_free_hook_count,
         version: first.version,

--- a/tests/dockerlabs/command-extension-analytics/runner.ts
+++ b/tests/dockerlabs/command-extension-analytics/runner.ts
@@ -12,6 +12,7 @@ import {
 } from "./lab-process";
 import { teardownLab, type TeardownEvidence } from "./teardown";
 import { runInstalledPlaywright } from "./installed-playwright";
+import { fetchLabGet } from "./relay-fetch";
 import { readDashboardSession } from "./session-handoff";
 const SENTINEL = "guard-private-command-sentinel";
 interface ReadyEvidence {
@@ -105,9 +106,7 @@ async function waitForReady(origin: string, timeoutMs = 60_000): Promise<void> {
   throw new Error("installed Guard daemon did not become ready");
 }
 export async function readyFromLogs(
-  project: string,
-  environment: Record<string, string>,
-  runner: CommandRunner,
+  project: string, environment: Record<string, string>, runner: CommandRunner,
 ): Promise<ReadyEvidence> {
   const logs = requireSuccess(
     await runner(composeCommand(project, "logs", "--no-color", "guard"), { cwd: LAB_DIR, env: environment }),
@@ -119,9 +118,7 @@ export async function readyFromLogs(
   return JSON.parse(payload) as ReadyEvidence;
 }
 async function pendingFromLogs(
-  project: string,
-  environment: Record<string, string>,
-  runner: CommandRunner,
+  project: string, environment: Record<string, string>, runner: CommandRunner,
 ): Promise<PendingWorkflowEvidence | null> {
   const logs = requireSuccess(
     await runner(composeCommand(project, "logs", "--no-color", "guard"), { cwd: LAB_DIR, env: environment }),
@@ -194,14 +191,18 @@ async function apiJson(
   session: string,
   init: RequestInit = {},
 ): Promise<Record<string, unknown>> {
-  const response = await fetch(`${origin}${path}`, {
+  const request = `${origin}${path}`;
+  const options = {
     ...init,
     headers: {
       "Content-Type": "application/json",
       "X-Guard-Dashboard-Session": session,
       ...init.headers,
     },
-  });
+  };
+  const response = init.method === undefined
+    ? await fetchLabGet(request, options)
+    : await fetch(request, options);
   if (!response.ok) throw new Error(`${path} returned ${response.status}: ${await response.text()}`);
   return await response.json() as Record<string, unknown>;
 }
@@ -267,7 +268,7 @@ async function verifyDiagnosticsExport(
   session: string,
   expectedActivityCount: number,
 ): Promise<number> {
-  const unauthenticated = await fetch(`${origin}/v1/command-activity/diagnostics`);
+  const unauthenticated = await fetchLabGet(`${origin}/v1/command-activity/diagnostics`);
   if (unauthenticated.status !== 401) throw new Error("command activity export did not require authentication");
   const diagnostics = await apiJson(origin, "/v1/command-activity/diagnostics", session);
   assertPrivate(diagnostics);
@@ -291,13 +292,13 @@ async function verifyCommandActivitySse(
   session: string,
   expectedActivityIds: ReadonlySet<string>,
 ): Promise<number> {
-  const unauthenticated = await fetch(`${origin}/v1/command-activity/events?cursor=0`);
+  const unauthenticated = await fetchLabGet(`${origin}/v1/command-activity/events?cursor=0`);
   if (unauthenticated.status !== 401) throw new Error("command activity SSE did not require authentication");
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 5_000);
   const seen = new Set<string>();
   try {
-    const response = await fetch(`${origin}/v1/command-activity/events?cursor=0`, {
+    const response = await fetchLabGet(`${origin}/v1/command-activity/events?cursor=0`, {
       headers: { "X-Guard-Dashboard-Session": session },
       signal: controller.signal,
     });
@@ -352,7 +353,7 @@ async function verifyApi(
   containment: ContainmentEvidence,
   promptFreeHookCount: number,
 ): Promise<ApiEvidence> {
-  const unauthenticated = await fetch(`${origin}/v1/command-activity`);
+  const unauthenticated = await fetchLabGet(`${origin}/v1/command-activity`);
   if (unauthenticated.status !== 401) throw new Error("command activity API did not require authentication");
   const [activity, analytics, cursor] = await Promise.all([
     apiJson(origin, "/v1/command-activity?limit=100", session),

--- a/tests/test_installed_canary_workflow.py
+++ b/tests/test_installed_canary_workflow.py
@@ -112,7 +112,9 @@ def test_matrix_proves_remote_bytes_install_origin_record_corpus_and_dashboard()
     assert "bun run typecheck" in workflow_text
     assert "bun run guard:test:command-extension-analytics" in workflow_text
     assert 'HOL_GUARD_LAB_PYTHON="$CANARY_PYTHON"' in workflow_text
-    assert "sudo apt-get install -y --no-install-recommends bubblewrap" in workflow_text
+    assert "sudo apt-get install -y --no-install-recommends apparmor bubblewrap" in workflow_text
+    assert "/usr/bin/bwrap flags=(unconfined)" in workflow_text
+    assert "sudo apparmor_parser -r /etc/apparmor.d/hol-guard-bwrap" in workflow_text
     assert "installed-canary/command-extension-analytics.json" in workflow_text
     assert ".artifacts/command-extension-analytics/*.png" in workflow_text
     canonical_runner_text = (ROOT / "tests/dockerlabs/command-extension-analytics/runner.ts").read_text(

--- a/tests/test_installed_canary_workflow.py
+++ b/tests/test_installed_canary_workflow.py
@@ -111,6 +111,8 @@ def test_matrix_proves_remote_bytes_install_origin_record_corpus_and_dashboard()
     assert "cd ../tests/dockerlabs/command-extension-analytics" in workflow_text
     assert "bun run typecheck" in workflow_text
     assert "bun run guard:test:command-extension-analytics" in workflow_text
+    assert 'HOL_GUARD_LAB_PYTHON="$CANARY_PYTHON"' in workflow_text
+    assert "sudo apt-get install -y --no-install-recommends bubblewrap" in workflow_text
     assert "installed-canary/command-extension-analytics.json" in workflow_text
     assert ".artifacts/command-extension-analytics/*.png" in workflow_text
     canonical_runner_text = (ROOT / "tests/dockerlabs/command-extension-analytics/runner.ts").read_text(


### PR DESCRIPTION
## Summary
- run the Linux containment proof with the exact isolated installed-canary interpreter
- keep the installed daemon non-root, capability-free, read-only, and internal-only
- grant only the Bubblewrap executable the user-namespace permission required on Ubuntu
- verify protected-path denial and captured output without promoting writes into the live workspace
- bind the containment result into the canonical installed command-activity evidence
- keep host-probe failures inside the lab cleanup boundary
- preserve TCP half-closes and retry bounded idempotent relay reads

## Verification
- 317 focused Python evidence tests passed
- 10 Bun orchestration tests passed with 100 assertions
- relay half-close socket smoke passed
- Ruff check and format checks passed
- BasedPyright reported 0 errors and 0 warnings
- TypeScript typecheck, actionlint, Compose parsing, and git diff checks passed
- independent adversarial review: SHIP