### PR TITLE
feat(guard): enforce extension controls in command hooks

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_hook.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook.py
@@ -255,6 +255,7 @@ def _run_guard_hook_command(
         data_flow_signals=data_flow_signals,
         home_dir=context.home_dir,
         guard_home=context.guard_home,
+        store=store,
         workspace=runtime_workspace,
     )
     result = _run_hook_claude_permission_request(
@@ -321,6 +322,7 @@ def _run_guard_hook_command(
                 data_flow_signals=fresh_data_flow_signals,
                 home_dir=context.home_dir,
                 guard_home=context.guard_home,
+                store=store,
                 workspace=runtime_workspace,
             )
             if fresh_runtime_artifact is None:

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_github_workflow.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_github_workflow.py
@@ -11,6 +11,8 @@ from ..config import GuardConfig
 from ..models import GuardArtifact
 from ..runtime.command_decision_adapter import effect_decision_to_dict
 from ..runtime.command_evaluation import evaluate_command
+from ..runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+from ..runtime.extension_control_contract import ControlSurface
 from ..runtime.github_workflow_approval_record import GitHubWorkflowApprovalRecord
 from ..runtime.github_workflow_context import GitHubWorkflowDescriptor, build_github_workflow_descriptor
 from ..runtime.github_workflow_runtime import (
@@ -54,12 +56,16 @@ def prepare_github_workflow_hook_state(
     if authorization is None:
         return GitHubWorkflowHookState(artifact, descriptor, record, False, required)
     metadata = dict(artifact.metadata)
+    extension_control_layers = store.read_extension_control_authority(
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+    ).layers_for(ControlSurface.COMMAND_EVALUATION)
     evaluation = evaluate_command(
         artifact.command or "",
         compatibility_action_class=_optional_string(metadata.get("action_class")),
         compatibility_reason=_optional_string(metadata.get("runtime_request_reason")),
         cwd=workspace,
         workflow_authorization=authorization,
+        extension_control_layers=extension_control_layers,
     )
     metadata["command_action_floor"] = evaluation.decision_plane.action
     metadata["command_decision_plane"] = effect_decision_to_dict(evaluation.decision_plane)

--- a/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
@@ -27,12 +27,14 @@ from ..runtime.command_activity_lifecycle import (
     build_unpaired_post_evidence,
 )
 from ..runtime.command_evaluation import CompositeCommandEvaluation, evaluate_command
+from ..runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from ..runtime.command_shadow_evaluation import (
     CommandShadowObservation,
     baseline_command_shadow_proposal,
     build_command_shadow_observation,
     load_command_shadow_control,
 )
+from ..runtime.extension_control_contract import ControlSurface, ExtensionControlLayer
 from ..runtime.secret_file_requests import extract_sensitive_tool_action_request
 from ..store import GuardStore
 
@@ -68,7 +70,15 @@ def record_pre_hook_command_activity_best_effort(
     try:
         if event not in _PRE_HOOK_EVENTS:
             return False
-        evaluation = _evaluate_payload_command(payload, cwd=cwd, home_dir=home_dir)
+        extension_control_layers = store.read_extension_control_authority(
+            catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+        ).layers_for(ControlSurface.COMMAND_EVALUATION)
+        evaluation = _evaluate_payload_command(
+            payload,
+            cwd=cwd,
+            home_dir=home_dir,
+            extension_control_layers=extension_control_layers,
+        )
         if evaluation is None:
             return False
         key = load_or_create_installation_correlation_key(guard_home)
@@ -255,6 +265,7 @@ def _evaluate_payload_command(
     *,
     cwd: Path | None,
     home_dir: Path | None,
+    extension_control_layers: tuple[ExtensionControlLayer, ...],
 ):
     arguments = payload.get("tool_input", payload.get("arguments"))
     request = extract_sensitive_tool_action_request(
@@ -270,11 +281,12 @@ def _evaluate_payload_command(
             canonical_command=(request.canonical_command if request.raw_command_text is None else None),
             compatibility_action_class=request.action_class,
             compatibility_reason=request.reason,
+            extension_control_layers=extension_control_layers,
         )
     command_text = _payload_command_text(payload)
     if command_text is None:
         return None
-    return evaluate_command(command_text)
+    return evaluate_command(command_text, extension_control_layers=extension_control_layers)
 
 
 def _payload_command_text(payload: Mapping[str, object]) -> str | None:

--- a/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
@@ -363,6 +363,7 @@ def _persist_cursor_native_permission_after_shell(
             action_envelope=action_envelope,
             home_dir=home_dir,
             guard_home=guard_home,
+            store=store,
             workspace=workspace,
         )
         if runtime_artifact is not None:

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
     from .commands_support_runtime_resolution import _canonical_harness_name, _runtime_policy_path
 
 
+from ..runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+from ..runtime.extension_control_contract import ControlSurface
 from ..runtime.kubernetes_commands import kubernetes_secret_read_source
 from ..runtime.shell_command_wrappers import normalize_transparent_shell_command
 from ._commands_shared import *
@@ -168,7 +170,12 @@ def _hook_runtime_artifact(
     home_dir: Path,
     guard_home: Path,
     workspace: Path | None,
+    store: GuardStore | None = None,
 ) -> GuardArtifact | None:
+    authority_store = store if store is not None else GuardStore(guard_home)
+    extension_control_layers = authority_store.read_extension_control_authority(
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+    ).layers_for(ControlSurface.COMMAND_EVALUATION)
     harness = _canonical_harness_name(harness)
     event_name = _hook_event_name(payload)
     if harness in {"codex", "pi"} and event_name == "PostToolUse":
@@ -296,6 +303,7 @@ def _hook_runtime_artifact(
         request=tool_request,
         config_path=config_path,
         source_scope=source_scope,
+        extension_control_layers=extension_control_layers,
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/command_evaluation.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_evaluation.py
@@ -32,6 +32,8 @@ from .effect_decision import (
     EffectDecisionRequest,
     evaluate_effect_decision,
 )
+from .extension_control_contract import ControlResolution, ControlSurface, ExtensionControlLayer
+from .extension_control_resolver import resolve_extension_controls
 from .github_workflow_authorization import (
     GitHubWorkflowAuthorization,
     github_workflow_authorization_evidence,
@@ -77,6 +79,7 @@ class CompositeCommandEvaluation:
     decision_plane: EffectDecision
     baseline_factors: tuple[DecisionFactor, ...]
     baseline_uncertainties: tuple[UncertaintyKind, ...]
+    control_resolution: ControlResolution
 
     @property
     def risk_classes(self) -> tuple[str, ...]:
@@ -112,6 +115,7 @@ def evaluate_command(
     home_dir: Path | None = None,
     workflow_authorization: GitHubWorkflowAuthorization | None = None,
     registry: CommandSafetyExtensionRegistry = BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+    extension_control_layers: tuple[ExtensionControlLayer, ...] = (),
 ) -> CompositeCommandEvaluation:
     """Evaluate every built-in rule without executing or persisting the command."""
 
@@ -233,6 +237,28 @@ def evaluate_command(
             )
         )
     )
+    extension_ids = tuple(sorted({owned.extension.extension_id for owned in owned_matches}))
+    permission_ids = tuple(
+        sorted(
+            {
+                permission.permission_id
+                for owned in owned_matches
+                if (permission := registry.permission_for_rule_id(owned.match.rule.rule_id)) is not None
+            }
+        )
+    )
+    control_resolution = resolve_extension_controls(
+        extension_control_layers,
+        registry,
+        extension_ids=extension_ids,
+        permission_ids=permission_ids,
+        surface=ControlSurface.COMMAND_EVALUATION,
+        observations=tuple(
+            f"{observation.extension.extension_id}:{observation.rule.rule_id}" for observation in observations
+        ),
+    )
+    if control_resolution.blocked:
+        minimum_action = _stronger_floor(minimum_action, "block")
     decision_plane = evaluate_effect_decision(
         EffectDecisionRequest(
             factors=(
@@ -241,6 +267,7 @@ def evaluate_command(
                 *((verified_read_candidate,) if verified_read_candidate is not None else ()),
                 *workspace_write_candidates,
                 *critical_floor_factors,
+                *control_resolution.factors,
             ),
             uncertainties=decision_uncertainties,
         )
@@ -256,6 +283,7 @@ def evaluate_command(
         decision_plane=decision_plane,
         baseline_factors=baseline_factors,
         baseline_uncertainties=baseline_uncertainties,
+        control_resolution=control_resolution,
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/command_evaluation.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_evaluation.py
@@ -237,7 +237,7 @@ def evaluate_command(
             )
         )
     )
-    extension_ids = tuple(sorted({owned.extension.extension_id for owned in owned_matches}))
+    extension_ids = tuple(sorted({observation.extension.extension_id for observation in observations}))
     permission_ids = tuple(
         sorted(
             {

--- a/src/codex_plugin_scanner/guard/runtime/extension_control_resolver.py
+++ b/src/codex_plugin_scanner/guard/runtime/extension_control_resolver.py
@@ -68,6 +68,7 @@ def resolve_extension_controls(
     observations: tuple[str, ...] = (),
 ) -> ControlResolution:
     """Resolve controls for classified catalog identities without suppressing observations."""
+
     layer_values = tuple(islice(layers, _MAX_LAYERS + 1))
     composed = compose_control_layers(layer_values)
     failures = set(composed.failures)

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -25,6 +25,7 @@ from .command_extension_interaction import classify_command_extension_interactio
 from .command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from .command_model import CanonicalCommand, parse_shell_command
 from .data_flow import extract_heredocs
+from .extension_control_contract import ExtensionControlLayer
 from .false_positive_rules import (
     SOURCE_INSPECTION_BENIGN_DOTFILES,
     SOURCE_INSPECTION_EXTENSIONS,
@@ -3995,6 +3996,7 @@ def build_tool_action_request_artifact(
     *,
     config_path: str,
     source_scope: str,
+    extension_control_layers: tuple[ExtensionControlLayer, ...] = (),
 ) -> GuardArtifact:
     """Build a Guard artifact for a sensitive native tool action request."""
 
@@ -4004,6 +4006,7 @@ def build_tool_action_request_artifact(
         canonical_command=(request.canonical_command if request.raw_command_text is None else None),
         compatibility_action_class=request.action_class,
         compatibility_reason=request.reason,
+        extension_control_layers=extension_control_layers,
     )
     wrapper_chain = tuple(dict.fromkeys((*evaluation.command.wrapper_chain, *request.wrapper_chain)))
     fingerprint = hashlib.sha256(
@@ -4051,6 +4054,10 @@ def build_tool_action_request_artifact(
             "command_security_identity": evaluation.command.security_identity,
             "command_action_floor": evaluation.decision_plane.action,
             "command_decision_plane": effect_decision_to_dict(evaluation.decision_plane),
+            "extension_control_resolution": {
+                "blocked": evaluation.control_resolution.blocked,
+                "failures": [failure.code.value for failure in evaluation.control_resolution.failures],
+            },
             "command_rule_matches": [owned.to_dict() for owned in evaluation.matches],
             "risk_classes": list(evaluation.risk_classes),
             "command_parse_confidence": evaluation.command.confidence,

--- a/tests/test_guard_command_decision_routing.py
+++ b/tests/test_guard_command_decision_routing.py
@@ -175,6 +175,37 @@ def test_runtime_extension_control_disable_is_a_monotonic_blocking_factor() -> N
     assert any(reason.source is DecisionFactorSource.CONTROL for reason in evaluation.decision_plane.reasons)
 
 
+def test_disabled_extension_blocks_an_observed_safe_variant() -> None:
+    registry = _registry(
+        "review",
+        safe_variants=(CommandSafeVariant("safe", "Safe variant", _SegmentMatcher(0)),),
+    )
+    layer = ExtensionControlLayer(
+        schema_version=CONTROL_SCHEMA_VERSION,
+        kind=ControlLayerKind.LOCAL_ADMIN,
+        catalog_digest=registry.catalog_digest,
+        global_lockdown=False,
+        controls=(
+            ExtensionControl(
+                target=ControlTarget(ControlTargetKind.EXTENSION, "command.test"),
+                state=ControlState.DISABLED,
+            ),
+        ),
+    )
+
+    evaluation = evaluate_command(
+        "test-tool target",
+        registry=registry,
+        extension_control_layers=(layer,),
+    )
+
+    assert evaluation.extension_observations
+    assert evaluation.matches == ()
+    assert evaluation.minimum_action == "block"
+    assert evaluation.decision_plane.action == "block"
+    assert evaluation.control_resolution.blocked
+
+
 def test_required_extension_floors_remain_monotonic() -> None:
     high = evaluate_command("test-tool target", registry=_registry("disabled", required=True))
     critical = evaluate_command(

--- a/tests/test_guard_command_decision_routing.py
+++ b/tests/test_guard_command_decision_routing.py
@@ -37,6 +37,15 @@ from codex_plugin_scanner.guard.runtime.effect_decision import (
     EffectDecisionRequest,
     evaluate_effect_decision,
 )
+from codex_plugin_scanner.guard.runtime.extension_control_contract import (
+    CONTROL_SCHEMA_VERSION,
+    ControlLayerKind,
+    ControlState,
+    ControlTarget,
+    ControlTargetKind,
+    ExtensionControl,
+    ExtensionControlLayer,
+)
 
 
 class _FailingMatcher:
@@ -136,6 +145,34 @@ def test_legacy_floor_is_preserved_without_inventing_permissive_proof(
     evaluation = evaluate_command("test-tool target", registry=_registry(mode))
     assert evaluation.minimum_action == expected_legacy
     assert evaluation.decision_plane.action == expected_plane
+
+
+def test_runtime_extension_control_disable_is_a_monotonic_blocking_factor() -> None:
+    registry = _registry("disabled")
+    layer = ExtensionControlLayer(
+        schema_version=CONTROL_SCHEMA_VERSION,
+        kind=ControlLayerKind.LOCAL_ADMIN,
+        catalog_digest=registry.catalog_digest,
+        global_lockdown=False,
+        controls=(
+            ExtensionControl(
+                target=ControlTarget(ControlTargetKind.EXTENSION, "command.test"),
+                state=ControlState.DISABLED,
+            ),
+        ),
+    )
+
+    evaluation = evaluate_command(
+        "test-tool target",
+        registry=registry,
+        extension_control_layers=(layer,),
+    )
+
+    assert evaluation.minimum_action == "block"
+    assert evaluation.decision_plane.action == "block"
+    assert evaluation.control_resolution is not None
+    assert evaluation.control_resolution.blocked
+    assert any(reason.source is DecisionFactorSource.CONTROL for reason in evaluation.decision_plane.reasons)
 
 
 def test_required_extension_floors_remain_monotonic() -> None:

--- a/tests/test_guard_command_extensions.py
+++ b/tests/test_guard_command_extensions.py
@@ -13,6 +13,11 @@ from codex_plugin_scanner.guard.runtime.command_extensions import (
     risk_classes_for_command_action,
 )
 from codex_plugin_scanner.guard.runtime.command_inspection import command_extensions_payload, inspect_command
+from codex_plugin_scanner.guard.runtime.extension_control_contract import (
+    CONTROL_SCHEMA_VERSION,
+    ControlLayerKind,
+    ExtensionControlLayer,
+)
 from codex_plugin_scanner.guard.runtime.secret_file_requests import (
     ToolActionRequestMatch,
     build_tool_action_request_artifact,
@@ -473,6 +478,42 @@ def test_runtime_artifact_preserves_composite_rule_and_risk_evidence(tmp_path: P
         "command.encoded-execution.decode-and-execute",
     }
     assert set(artifact.metadata["risk_classes"]) == {"destructive_shell", "encoded_" + "execution"}
+
+
+def test_runtime_artifact_applies_global_extension_lockdown(tmp_path: Path) -> None:
+    command = "rm -rf ./build"
+    request = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+    layer = ExtensionControlLayer(
+        schema_version=CONTROL_SCHEMA_VERSION,
+        kind=ControlLayerKind.LOCAL_ADMIN,
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
+        global_lockdown=True,
+        controls=(),
+    )
+
+    assert request is not None
+    artifact = build_tool_action_request_artifact(
+        "codex",
+        request,
+        config_path="config.toml",
+        source_scope="project",
+        extension_control_layers=(layer,),
+    )
+
+    assert artifact.metadata["command_action_floor"] == "block"
+    assert artifact.metadata["extension_control_resolution"] == {
+        "blocked": True,
+        "failures": [],
+    }
+    decision_plane = artifact.metadata["command_decision_plane"]
+    assert isinstance(decision_plane, dict)
+    assert decision_plane["action"] == "block"
+    assert any(reason["source"] == "control" for reason in decision_plane["reasons"] if isinstance(reason, dict))
 
 
 def test_inspection_and_runtime_artifact_share_canonical_wrapper_evidence(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- apply extension, permission, and global control blocks through the central command decision plane
- load the validated control authority in hook, activity, package, and workflow evaluation paths
- expose stable control status and reason codes without recording raw commands or paths

## Verification
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/command_evaluation.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py src/codex_plugin_scanner/guard/cli/commands_hook.py src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py src/codex_plugin_scanner/guard/cli/commands_hook_github_workflow.py tests/test_guard_command_decision_routing.py tests/test_guard_command_extensions.py`
- `uv run basedpyright src/codex_plugin_scanner/guard/runtime/command_evaluation.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py src/codex_plugin_scanner/guard/runtime/extension_control_resolver.py src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py src/codex_plugin_scanner/guard/cli/commands_hook.py src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py src/codex_plugin_scanner/guard/cli/commands_hook_github_workflow.py` (0 errors)
- `uv run pytest -q tests/test_guard_extension_control_resolver.py tests/test_guard_command_decision_routing.py tests/test_guard_command_extensions.py tests/test_guard_command_activity_hook_integration.py tests/test_guard_github_workflow_runtime.py tests/test_guard_github_workflow_privacy.py tests/test_guard_github_workflow_retry_reuse.py tests/test_guard_github_workflow_authorization.py tests/test_guard_github_workflow_context_binding.py --tb=short` (233 passed)