### PR TITLE
fix(guard): defer incomplete runtime controls

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_hook.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook.py
@@ -255,7 +255,6 @@ def _run_guard_hook_command(
         data_flow_signals=data_flow_signals,
         home_dir=context.home_dir,
         guard_home=context.guard_home,
-        store=store,
         workspace=runtime_workspace,
     )
     result = _run_hook_claude_permission_request(
@@ -322,7 +321,6 @@ def _run_guard_hook_command(
                 data_flow_signals=fresh_data_flow_signals,
                 home_dir=context.home_dir,
                 guard_home=context.guard_home,
-                store=store,
                 workspace=runtime_workspace,
             )
             if fresh_runtime_artifact is None:

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_github_workflow.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_github_workflow.py
@@ -11,8 +11,6 @@ from ..config import GuardConfig
 from ..models import GuardArtifact
 from ..runtime.command_decision_adapter import effect_decision_to_dict
 from ..runtime.command_evaluation import evaluate_command
-from ..runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
-from ..runtime.extension_control_contract import ControlSurface
 from ..runtime.github_workflow_approval_record import GitHubWorkflowApprovalRecord
 from ..runtime.github_workflow_context import GitHubWorkflowDescriptor, build_github_workflow_descriptor
 from ..runtime.github_workflow_runtime import (
@@ -56,16 +54,12 @@ def prepare_github_workflow_hook_state(
     if authorization is None:
         return GitHubWorkflowHookState(artifact, descriptor, record, False, required)
     metadata = dict(artifact.metadata)
-    extension_control_layers = store.read_extension_control_authority(
-        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
-    ).layers_for(ControlSurface.COMMAND_EVALUATION)
     evaluation = evaluate_command(
         artifact.command or "",
         compatibility_action_class=_optional_string(metadata.get("action_class")),
         compatibility_reason=_optional_string(metadata.get("runtime_request_reason")),
         cwd=workspace,
         workflow_authorization=authorization,
-        extension_control_layers=extension_control_layers,
     )
     metadata["command_action_floor"] = evaluation.decision_plane.action
     metadata["command_decision_plane"] = effect_decision_to_dict(evaluation.decision_plane)

--- a/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
@@ -27,14 +27,12 @@ from ..runtime.command_activity_lifecycle import (
     build_unpaired_post_evidence,
 )
 from ..runtime.command_evaluation import CompositeCommandEvaluation, evaluate_command
-from ..runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from ..runtime.command_shadow_evaluation import (
     CommandShadowObservation,
     baseline_command_shadow_proposal,
     build_command_shadow_observation,
     load_command_shadow_control,
 )
-from ..runtime.extension_control_contract import ControlSurface, ExtensionControlLayer
 from ..runtime.secret_file_requests import extract_sensitive_tool_action_request
 from ..store import GuardStore
 
@@ -70,14 +68,10 @@ def record_pre_hook_command_activity_best_effort(
     try:
         if event not in _PRE_HOOK_EVENTS:
             return False
-        extension_control_layers = store.read_extension_control_authority(
-            catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
-        ).layers_for(ControlSurface.COMMAND_EVALUATION)
         evaluation = _evaluate_payload_command(
             payload,
             cwd=cwd,
             home_dir=home_dir,
-            extension_control_layers=extension_control_layers,
         )
         if evaluation is None:
             return False
@@ -265,7 +259,6 @@ def _evaluate_payload_command(
     *,
     cwd: Path | None,
     home_dir: Path | None,
-    extension_control_layers: tuple[ExtensionControlLayer, ...],
 ):
     arguments = payload.get("tool_input", payload.get("arguments"))
     request = extract_sensitive_tool_action_request(
@@ -281,12 +274,11 @@ def _evaluate_payload_command(
             canonical_command=(request.canonical_command if request.raw_command_text is None else None),
             compatibility_action_class=request.action_class,
             compatibility_reason=request.reason,
-            extension_control_layers=extension_control_layers,
         )
     command_text = _payload_command_text(payload)
     if command_text is None:
         return None
-    return evaluate_command(command_text, extension_control_layers=extension_control_layers)
+    return evaluate_command(command_text)
 
 
 def _payload_command_text(payload: Mapping[str, object]) -> str | None:

--- a/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
@@ -363,7 +363,6 @@ def _persist_cursor_native_permission_after_shell(
             action_envelope=action_envelope,
             home_dir=home_dir,
             guard_home=guard_home,
-            store=store,
             workspace=workspace,
         )
         if runtime_artifact is not None:

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
@@ -32,8 +32,6 @@ if TYPE_CHECKING:
     from .commands_support_runtime_resolution import _canonical_harness_name, _runtime_policy_path
 
 
-from ..runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
-from ..runtime.extension_control_contract import ControlSurface
 from ..runtime.kubernetes_commands import kubernetes_secret_read_source
 from ..runtime.shell_command_wrappers import normalize_transparent_shell_command
 from ._commands_shared import *
@@ -170,12 +168,7 @@ def _hook_runtime_artifact(
     home_dir: Path,
     guard_home: Path,
     workspace: Path | None,
-    store: GuardStore | None = None,
 ) -> GuardArtifact | None:
-    authority_store = store if store is not None else GuardStore(guard_home)
-    extension_control_layers = authority_store.read_extension_control_authority(
-        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
-    ).layers_for(ControlSurface.COMMAND_EVALUATION)
     harness = _canonical_harness_name(harness)
     event_name = _hook_event_name(payload)
     if harness in {"codex", "pi"} and event_name == "PostToolUse":
@@ -303,7 +296,6 @@ def _hook_runtime_artifact(
         request=tool_request,
         config_path=config_path,
         source_scope=source_scope,
-        extension_control_layers=extension_control_layers,
     )
 
 


### PR DESCRIPTION
## Summary
- stop loading extension-control authority in production hook, workflow, activity, and permission-reuse paths
- preserve the catalog, resolver, persistence, and proof foundations for the later complete feature rollout
- restore 2.2 runtime behavior without per-command authority-store reads or partial enforcement

## Verification
- `uv run ruff check src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py src/codex_plugin_scanner/guard/cli/commands_hook.py src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py src/codex_plugin_scanner/guard/cli/commands_hook_github_workflow.py`
- `uv run basedpyright src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py src/codex_plugin_scanner/guard/cli/commands_hook.py src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py src/codex_plugin_scanner/guard/cli/commands_hook_github_workflow.py` (0 errors)
- `uv run pytest -q tests/test_guard_command_decision_routing.py tests/test_guard_command_extensions.py tests/test_guard_command_activity_hook_integration.py tests/test_guard_github_workflow_runtime.py tests/test_guard_github_workflow_privacy.py tests/test_guard_github_workflow_retry_reuse.py tests/test_guard_github_workflow_authorization.py tests/test_guard_github_workflow_context_binding.py tests/test_guard_runtime.py -k 'hook_runtime_artifact or github_workflow or command_activity or extension_control' --tb=short` (132 passed)