### PR TITLE
fix(release): preserve relay half-closes

### DIFF
--- a/tests/dockerlabs/command-extension-analytics/runner.test.ts
+++ b/tests/dockerlabs/command-extension-analytics/runner.test.ts
@@ -125,7 +125,8 @@ describe("command extension analytics Dockerlabs orchestration", () => {
 
   test("installed fixture is wheel-only and exercises the required evidence paths", async () => {
     const directory = import.meta.dir;
-    const [dockerfile, dockerignore, compose, server, containmentProbe, runner, relayFetch, playwright, databasePrivacy]
+    const [dockerfile, dockerignore, compose, server, containmentProbe, runner, relay, relayFetch, playwright,
+      databasePrivacy]
       = await Promise.all([
       Bun.file(`${directory}/Dockerfile`).text(),
       Bun.file(`${directory}/Dockerfile.dockerignore`).text(),
@@ -133,6 +134,7 @@ describe("command extension analytics Dockerlabs orchestration", () => {
       Bun.file(`${directory}/installed_server.py`).text(),
       Bun.file(`${directory}/installed_containment_probe.py`).text(),
       Bun.file(`${directory}/runner.ts`).text(),
+      Bun.file(`${directory}/tcp_relay.py`).text(),
       Bun.file(`${directory}/relay-fetch.ts`).text(),
       Bun.file(`${directory}/../../../dashboard/playwright.installed.config.ts`).text(),
       Bun.file(`${directory}/database-privacy.ts`).text(),
@@ -149,6 +151,9 @@ describe("command extension analytics Dockerlabs orchestration", () => {
     expect(compose).not.toContain("SYS_ADMIN");
     expect(compose).not.toContain("seccomp:unconfined");
     expect(dockerfile).not.toContain("bubblewrap");
+    expect(relay).toContain("destination.shutdown(socket.SHUT_WR)");
+    expect(relay).toContain("active.remove(source)");
+    expect(relay).not.toContain("(), (), 30");
     for (const harness of ["codex", "claude-code", "cursor"]) {
       expect(server).toContain(`_run_installed_hook(\"${harness}\"`);
     }

--- a/tests/dockerlabs/command-extension-analytics/tcp_relay.py
+++ b/tests/dockerlabs/command-extension-analytics/tcp_relay.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import select
 import socket
 import socketserver
+from contextlib import suppress
 from typing import cast
 
 from typing_extensions import override
@@ -20,15 +21,20 @@ class _RelayHandler(socketserver.BaseRequestHandler):
         client = cast(socket.socket, self.request)
         with socket.create_connection(_TARGET_ADDRESS, timeout=5) as target:
             sockets = (client, target)
-            while True:
-                readable, _, _ = select.select(sockets, (), (), 30)
-                if not readable:
-                    return
+            active = set(sockets)
+            while active:
+                readable, _, _ = select.select(tuple(active), (), ())
                 for source in readable:
-                    payload = source.recv(_BUFFER_BYTES)
-                    if not payload:
-                        return
+                    try:
+                        payload = source.recv(_BUFFER_BYTES)
+                    except ConnectionResetError:
+                        payload = b""
                     destination = target if source is client else client
+                    if not payload:
+                        active.remove(source)
+                        with suppress(OSError):
+                            destination.shutdown(socket.SHUT_WR)
+                        continue
                     _ = destination.sendall(payload)
 
 


### PR DESCRIPTION
## Summary
- forward directional EOF as a TCP half-close instead of truncating the peer response
- continue draining the opposite direction until both sides close
- remove the relay-owned idle expiry so intentional streaming connections remain open

## Verification
- 10 Bun orchestration tests passed with 101 assertions
- relay half-close socket smoke passed
- Ruff check and format checks passed
- BasedPyright reported 0 errors and 0 warnings
- TypeScript typecheck and git diff checks passed
- independent adversarial review: SHIP