### PR TITLE
fix(release): publish 2.1 alphas automatically

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ on:
         required: true
         type: string
   push:
-    branches: [main]
+    branches: [main, release/2.1]
   pull_request:
     branches: [main, release/2.1]
     types: [opened, synchronize, reopened, labeled]
@@ -80,7 +80,7 @@ jobs:
     name: Build + Verify
     if: >-
       (github.event_name != 'workflow_dispatch' || github.run_attempt == 1) &&
-      (github.event_name != 'push' || github.run_attempt == 1) &&
+      (github.event_name != 'push' || github.run_attempt == 1 || github.ref == 'refs/heads/release/2.1') &&
       (github.event.action != 'labeled' || github.event.label.name == 'run-testpypi-canary')
     needs: authorize-release
     runs-on: ubuntu-latest
@@ -117,6 +117,7 @@ jobs:
         id: version
         env:
           GITHUB_REF: ${{ github.ref }}
+          GITHUB_SHA: ${{ github.sha }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
@@ -198,6 +199,61 @@ jobs:
           print(f"{os.environ['BASE_VERSION']}.dev{pair(pair(int(os.environ['PR_NUMBER']), int(os.environ['GITHUB_RUN_NUMBER'])), int(os.environ['GITHUB_RUN_ATTEMPT']))}")
           PY
             )
+          elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/release/2.1" ]]; then
+            if [[ "$RELEASE_PUBLISHING_ENABLED" != "true" ]]; then
+              echo "Release publishing is disabled until protected environments are verified" >&2
+              exit 1
+            fi
+            if [[ "$SOURCE_SHA" != "$GITHUB_SHA" ]]; then
+              echo "Checked-out source does not match the immutable push source" >&2
+              exit 1
+            fi
+            CHANNEL="alpha"
+            TRAIN="2.1"
+            TRAIN_REF="refs/heads/release/${TRAIN}"
+            PYPI_VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \
+              list-versions --registry pypi)
+            TESTPYPI_VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \
+              list-versions --registry testpypi)
+            TAG_VERSIONS=$(git tag --list 'alpha/v*' | sed 's#^alpha/v##' | jq -R -s 'split("\n") | map(select(length > 0))')
+            EXISTING_VERSIONS=$(jq -n \
+              --argjson pypi "$PYPI_VERSIONS" \
+              --argjson testpypi "$TESTPYPI_VERSIONS" \
+              --argjson tags "$TAG_VERSIONS" \
+              '$pypi + $testpypi + $tags | unique')
+            mapfile -t SOURCE_ALPHA_TAGS < <(
+              git tag --points-at "$SOURCE_SHA" --list "alpha/v${TRAIN}.0a*" | sed 's#^alpha/v##'
+            )
+            if [[ "${#SOURCE_ALPHA_TAGS[@]}" -gt 1 ]]; then
+              echo "Source commit has multiple reserved alpha versions" >&2
+              exit 1
+            fi
+            if [[ "${#SOURCE_ALPHA_TAGS[@]}" -eq 1 ]]; then
+              RELEASE_VERSION="${SOURCE_ALPHA_TAGS[0]}"
+              REUSING_RESERVED_ALPHA=true
+              uv run --no-sync python scripts/compute_alpha_release_version.py \
+                --release-train "$TRAIN" --validate-phase-only <<< "$EXISTING_VERSIONS"
+            else
+              RELEASE_VERSION=$(uv run --no-sync python scripts/compute_alpha_release_version.py \
+                --release-train "$TRAIN" <<< "$EXISTING_VERSIONS")
+              REUSING_RESERVED_ALPHA=false
+            fi
+            EXISTING_VERSIONS_ARRAY=()
+            if [[ "$REUSING_RESERVED_ALPHA" != "true" ]]; then
+              mapfile -t EXISTING_VERSIONS_ARRAY < <(jq -r '.[]' <<< "$EXISTING_VERSIONS")
+            fi
+            VALIDATOR_ARGS=(
+              --channel "$CHANNEL"
+              --version "$RELEASE_VERSION"
+              --git-ref "$TRAIN_REF"
+              --actual-ref "$GITHUB_REF"
+              --github-sha "$SOURCE_SHA"
+              --expected-sha "$SOURCE_SHA"
+            )
+            for existing_version in "${EXISTING_VERSIONS_ARRAY[@]}"; do
+              VALIDATOR_ARGS+=(--existing-version "$existing_version")
+            done
+            VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py "${VALIDATOR_ARGS[@]}")
           elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
             CHANNEL="stable"
             PYPI_VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \
@@ -544,16 +600,73 @@ jobs:
           if-no-files-found: error
           include-hidden-files: true
 
+  reserve-alpha-tag:
+    name: Reserve alpha version
+    if: >-
+      always() &&
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      needs.build.result == 'success' &&
+      needs.build.outputs.channel == 'alpha' &&
+      (
+        (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/release/2.1')
+      )
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.build.outputs.source_sha }}
+      - name: Reserve exact alpha tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          tag="alpha/v${VERSION}"
+          for attempt in 1 2 3; do
+            remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
+            if [[ -n "$remote_tag_sha" ]]; then
+              break
+            fi
+            if gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/${tag}" \
+              -f sha="$SOURCE_SHA" >/dev/null; then
+              remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
+              if [[ -n "$remote_tag_sha" ]]; then
+                break
+              fi
+            fi
+            if [[ "$attempt" != "3" ]]; then
+              sleep $((attempt * 5))
+            fi
+          done
+          if [[ -z "$remote_tag_sha" ]]; then
+            git tag "$tag" "$SOURCE_SHA"
+            git push origin "refs/tags/${tag}" || true
+            remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
+          fi
+          if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
+            echo "Alpha tag reservation does not target the published source" >&2
+            exit 1
+          fi
+
   publish-alpha-testpypi:
     name: Verify alpha artifact on TestPyPI
     if: >-
       always() &&
       vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      github.event_name == 'workflow_dispatch' &&
-      github.run_attempt == 1 &&
-      github.event.inputs.release_channel == 'alpha' &&
-      needs.build.result == 'success'
-    needs: [build]
+      needs.build.result == 'success' &&
+      needs.reserve-alpha-tag.result == 'success' &&
+      needs.build.outputs.channel == 'alpha' &&
+      (
+        (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/release/2.1')
+      )
+    needs: [build, reserve-alpha-tag]
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -583,14 +696,8 @@ jobs:
           TRAIN: ${{ needs.build.outputs.release_train }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          train_ref="refs/heads/release/${TRAIN}"
-          remote_train_sha=$(git ls-remote --exit-code origin "$train_ref" | awk '{print $1}')
-          if [[ "$remote_train_sha" != "$SOURCE_SHA" ]]; then
-            echo "Alpha publication source is no longer the release train head" >&2
-            exit 1
-          fi
-          remote_alpha_tag_sha=$(git ls-remote origin "refs/tags/alpha/v${VERSION}" | awk '{print $1}')
-          if [[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]; then
+          remote_alpha_tag_sha=$(git ls-remote --exit-code origin "refs/tags/alpha/v${VERSION}" | awk '{print $1}')
+          if [[ "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]; then
             echo "Alpha tag targets a different source" >&2
             exit 1
           fi
@@ -645,11 +752,13 @@ jobs:
     if: >-
       always() &&
       vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      github.event_name == 'workflow_dispatch' &&
-      github.run_attempt == 1 &&
-      github.event.inputs.release_channel == 'alpha' &&
       needs.build.result == 'success' &&
-      needs.publish-alpha-testpypi.result == 'success'
+      needs.publish-alpha-testpypi.result == 'success' &&
+      needs.build.outputs.channel == 'alpha' &&
+      (
+        (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/release/2.1')
+      )
     needs: [build, publish-alpha-testpypi]
     runs-on: ubuntu-latest
     environment: pypi
@@ -694,28 +803,17 @@ jobs:
       - name: Revalidate alpha publication authorization
         env:
           ACTUAL_REF: ${{ github.ref }}
-          EXPECTED_SHA: ${{ github.event.inputs.expected_sha }}
+          EXPECTED_SHA: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.expected_sha || needs.build.outputs.source_sha }}
           SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
           TRAIN: ${{ needs.build.outputs.release_train }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           train_ref="refs/heads/release/${TRAIN}"
-          remote_train_sha=$(git ls-remote --exit-code origin "$train_ref" | awk '{print $1}')
-          if [[ "$remote_train_sha" != "$SOURCE_SHA" ]]; then
-            echo "Alpha publication source is no longer the release train head" >&2
-            exit 1
-          fi
-          remote_alpha_tag_sha=$(git ls-remote origin "refs/tags/alpha/v${VERSION}" | awk '{print $1}')
-          if [[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]; then
+          remote_alpha_tag_sha=$(git ls-remote --exit-code origin "refs/tags/alpha/v${VERSION}" | awk '{print $1}')
+          if [[ "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]; then
             echo "Alpha tag targets a different source" >&2
             exit 1
           fi
-          versions=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-            list-versions --registry pypi)
-          mapfile -t existing_versions < <(jq -r --arg version "$VERSION" '.[] | select(. != $version)' <<< "$versions")
-          mapfile -t alpha_tags < <(
-            git tag --list 'alpha/v*' | sed 's#^alpha/v##' | awk -v candidate="$VERSION" '$0 != candidate'
-          )
           validator_args=(
             --channel alpha
             --version "$VERSION"
@@ -724,9 +822,6 @@ jobs:
             --github-sha "$SOURCE_SHA"
             --expected-sha "$EXPECTED_SHA"
           )
-          for existing_version in "${existing_versions[@]}" "${alpha_tags[@]}"; do
-            [[ -z "$existing_version" ]] || validator_args+=(--existing-version "$existing_version")
-          done
           uv run --with packaging==25.0 python scripts/validate_alpha_release.py "${validator_args[@]}"
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         if: steps.pypi.outputs.upload == 'true'
@@ -1074,9 +1169,11 @@ jobs:
     name: Create alpha GitHub prerelease
     if: >-
       vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      github.event_name == 'workflow_dispatch' &&
-      github.run_attempt == 1 &&
-      needs.build.outputs.channel == 'alpha'
+      needs.build.outputs.channel == 'alpha' &&
+      (
+        (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/release/2.1')
+      )
     needs: [build, publish-alpha-pypi]
     runs-on: ubuntu-latest
     permissions:
@@ -1120,13 +1217,7 @@ jobs:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           tag="alpha/v${VERSION}"
-          remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
-          if [[ -z "$remote_tag_sha" ]]; then
-            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
-              -f ref="refs/tags/${tag}" \
-              -f sha="$SOURCE_SHA" >/dev/null
-            remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/${tag}" | awk '{print $1}')
-          fi
+          remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/${tag}" | awk '{print $1}')
           if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
             echo "Alpha tag does not target the published source" >&2
             exit 1
@@ -1182,8 +1273,8 @@ jobs:
       needs.build.result == 'success' &&
       (
         (
-          github.event_name == 'workflow_dispatch' &&
-          github.run_attempt == 1 &&
+          ((github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
+           (github.event_name == 'push' && github.ref == 'refs/heads/release/2.1')) &&
           needs.build.outputs.channel == 'alpha' &&
           needs.publish-alpha-pypi.result == 'success' &&
           needs.release-alpha.result == 'success'
@@ -1204,6 +1295,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ needs.build.outputs.source_sha }}
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
@@ -1221,6 +1314,7 @@ jobs:
       - name: Prepare image tags
         id: tags
         env:
+          CHANNEL: ${{ needs.build.outputs.channel }}
           IMAGE_NAME: ghcr.io/${{ github.repository }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
@@ -1238,7 +1332,36 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Inspect existing immutable image
+        id: image
+        env:
+          CHANNEL: ${{ needs.build.outputs.channel }}
+          IMAGE_NAME: ghcr.io/${{ github.repository }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          if [[ "$CHANNEL" != "alpha" ]]; then
+            echo "push=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          image="${IMAGE_NAME}:${VERSION}"
+          pull_output=$(mktemp)
+          if docker pull "$image" >"$pull_output" 2>&1; then
+            revision=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$image")
+            if [[ "$revision" != "$SOURCE_SHA" ]]; then
+              echo "Existing image tag targets a different source" >&2
+              exit 1
+            fi
+            echo "push=false" >> "$GITHUB_OUTPUT"
+          elif rg -qi 'manifest unknown' "$pull_output"; then
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          else
+            cat "$pull_output" >&2
+            echo "Unable to determine whether the image tag already exists" >&2
+            exit 1
+          fi
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        if: steps.image.outputs.push == 'true'
         with:
           context: .
           file: ./Dockerfile
@@ -1247,4 +1370,4 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.build.outputs.version }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ needs.build.outputs.source_sha }}

--- a/scripts/compute_alpha_release_version.py
+++ b/scripts/compute_alpha_release_version.py
@@ -51,9 +51,10 @@ def validate_alpha_phase_open(release_train: str, existing_versions: Iterable[st
 
 def compute_alpha_release_version(release_train: str, existing_versions: Iterable[str]) -> str:
     alpha_numbers = _alpha_versions(release_train, existing_versions)
+    version_prefix = ".".join(str(part) for part in SUPPORTED_TRAINS[release_train])
 
     next_alpha = max(alpha_numbers, default=0) + 1
-    return f"{release_train}.0a{next_alpha}"
+    return f"{version_prefix}a{next_alpha}"
 
 
 def main() -> int:
@@ -69,7 +70,7 @@ def main() -> int:
         items = cast(list[object], payload)
         if not all(isinstance(item, str) for item in items):
             raise ValueError("Registry versions must be a JSON array of strings")
-        existing_versions = [item for item in items if isinstance(item, str)]
+        existing_versions = cast(list[str], items)
         release_train = cast(str, args.release_train)
         validate_phase_only = cast(bool, args.validate_phase_only)
         if validate_phase_only:

--- a/scripts/compute_alpha_release_version.py
+++ b/scripts/compute_alpha_release_version.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Compute the next alpha version for an authorized release train."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable
+from typing import cast
+
+from packaging.version import InvalidVersion, Version
+
+SUPPORTED_TRAINS = {"2.1": (2, 1, 0)}
+
+
+def _alpha_versions(release_train: str, existing_versions: Iterable[str]) -> list[int]:
+    release = SUPPORTED_TRAINS.get(release_train)
+    if release is None:
+        raise ValueError(f"Unsupported alpha release train: {release_train}")
+
+    alpha_numbers: list[int] = []
+    for version_text in existing_versions:
+        try:
+            version = Version(version_text)
+        except InvalidVersion as exc:
+            raise ValueError(f"Existing version is invalid: {version_text!r}") from exc
+        if version_text != str(version) or version.local is not None:
+            raise ValueError(f"Existing version is not canonical: {version_text!r}")
+        if version.release != release:
+            continue
+        if version.post is not None:
+            raise ValueError(f"Existing post release {version} closes the alpha phase for train {release_train}")
+        if version.pre is None and version.dev is None and version.post is None:
+            raise ValueError(f"Existing stable release {version} closes release train {release_train}")
+        if version.pre is not None and version.pre[0] != "a":
+            raise ValueError(
+                f"Existing non-alpha prerelease {version} closes the alpha phase for train {release_train}"
+            )
+        if version.pre is not None and version.pre[0] == "a" and version.dev is not None:
+            raise ValueError(f"Existing alpha development release {version} is not a public alpha reservation")
+        if version.pre is not None and version.pre[0] == "a":
+            alpha_numbers.append(version.pre[1])
+
+    return alpha_numbers
+
+
+def validate_alpha_phase_open(release_train: str, existing_versions: Iterable[str]) -> None:
+    _ = _alpha_versions(release_train, existing_versions)
+
+
+def compute_alpha_release_version(release_train: str, existing_versions: Iterable[str]) -> str:
+    alpha_numbers = _alpha_versions(release_train, existing_versions)
+
+    next_alpha = max(alpha_numbers, default=0) + 1
+    return f"{release_train}.0a{next_alpha}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    _ = parser.add_argument("--release-train", required=True)
+    _ = parser.add_argument("--validate-phase-only", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        payload = cast(object, json.load(sys.stdin))
+        if not isinstance(payload, list):
+            raise ValueError("Registry versions must be a JSON array of strings")
+        items = cast(list[object], payload)
+        if not all(isinstance(item, str) for item in items):
+            raise ValueError("Registry versions must be a JSON array of strings")
+        existing_versions = [item for item in items if isinstance(item, str)]
+        release_train = cast(str, args.release_train)
+        validate_phase_only = cast(bool, args.validate_phase_only)
+        if validate_phase_only:
+            validate_alpha_phase_open(release_train, existing_versions)
+        else:
+            print(compute_alpha_release_version(release_train, existing_versions))
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_alpha_container_workflow.py
+++ b/tests/test_alpha_container_workflow.py
@@ -1,0 +1,24 @@
+"""Contracts for immutable alpha container publication."""
+
+from pathlib import Path
+
+import yaml
+
+PUBLISH_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "publish.yml"
+
+
+def test_container_refuses_to_mutate_an_existing_alpha_image() -> None:
+    workflow = yaml.safe_load(PUBLISH_WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["publish-container"]["steps"]
+    inspect_step = next(step for step in steps if step.get("name") == "Inspect existing immutable image")
+    publish_step = next(step for step in steps if str(step.get("uses", "")).startswith("docker/build-push-action@"))
+
+    assert inspect_step["env"]["CHANNEL"] == "${{ needs.build.outputs.channel }}"
+    assert 'docker pull "$image"' in inspect_step["run"]
+    assert '"$CHANNEL" != "alpha"' in inspect_step["run"]
+    assert "org.opencontainers.image.revision" in inspect_step["run"]
+    assert '"$revision" != "$SOURCE_SHA"' in inspect_step["run"]
+    assert 'echo "push=false"' in inspect_step["run"]
+    assert "manifest unknown" in inspect_step["run"]
+    assert "Unable to determine whether the image tag already exists" in inspect_step["run"]
+    assert publish_step["if"] == "steps.image.outputs.push == 'true'"

--- a/tests/test_compute_alpha_release_version.py
+++ b/tests/test_compute_alpha_release_version.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+import pytest
+
+from scripts.compute_alpha_release_version import compute_alpha_release_version, main, validate_alpha_phase_open
+
+
+@pytest.mark.parametrize(
+    ("existing", "expected"),
+    [
+        ([], "2.1.0a1"),
+        (["2.1.0a1"], "2.1.0a2"),
+        (["2.1.0a1", "2.1.0a7", "2.1.0a3"], "2.1.0a8"),
+        (["2.0.1117", "2.2.0a9", "3.1.0a12"], "2.1.0a1"),
+    ],
+)
+def test_computes_the_next_alpha_across_all_registry_sources(existing: list[str], expected: str) -> None:
+    assert compute_alpha_release_version("2.1", existing) == expected
+
+
+@pytest.mark.parametrize("release_train", ["2", "2.1.0", "3.1", "not-a-train"])
+def test_rejects_unsupported_or_noncanonical_release_train(release_train: str) -> None:
+    with pytest.raises(ValueError, match="release train"):
+        _ = compute_alpha_release_version(release_train, [])
+
+
+@pytest.mark.parametrize("existing", [["2.1.0a01"], ["v2.1.0a1"], ["not-a-version"]])
+def test_rejects_noncanonical_or_malformed_existing_versions(existing: list[str]) -> None:
+    with pytest.raises(ValueError, match="Existing version"):
+        _ = compute_alpha_release_version("2.1", existing)
+
+
+def test_same_train_stable_release_blocks_an_alpha() -> None:
+    with pytest.raises(ValueError, match="stable release"):
+        _ = compute_alpha_release_version("2.1", ["2.1.0"])
+
+
+@pytest.mark.parametrize("version", ["2.1.0b1", "2.1.0rc1"])
+def test_same_train_beta_or_release_candidate_blocks_an_alpha(version: str) -> None:
+    with pytest.raises(ValueError, match="non-alpha prerelease"):
+        _ = compute_alpha_release_version("2.1", [version])
+
+
+@pytest.mark.parametrize("version", ["2.1.0.post1", "2.1.0a2.post1"])
+def test_same_train_post_release_blocks_an_alpha(version: str) -> None:
+    with pytest.raises(ValueError, match="post release"):
+        _ = compute_alpha_release_version("2.1", [version])
+
+
+def test_same_train_alpha_development_release_fails_closed() -> None:
+    with pytest.raises(ValueError, match="alpha development release"):
+        _ = compute_alpha_release_version("2.1", ["2.1.0a2.dev1"])
+
+
+def test_phase_only_validation_allows_newer_public_alphas_but_not_later_phases() -> None:
+    validate_alpha_phase_open("2.1", ["2.1.0a2", "2.1.0a3"])
+    with pytest.raises(ValueError, match="non-alpha prerelease"):
+        validate_alpha_phase_open("2.1", ["2.1.0rc1"])
+
+
+def test_cli_reads_combined_versions_from_stdin(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["compute_alpha_release_version.py", "--release-train", "2.1"])
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(["2.1.0a1", "2.1.0a2"])))
+
+    assert main() == 0
+    assert capsys.readouterr().out == "2.1.0a3\n"
+
+
+def test_cli_fails_closed_for_invalid_registry_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["compute_alpha_release_version.py", "--release-train", "2.1"])
+    monkeypatch.setattr(sys, "stdin", io.StringIO('{"version":"2.1.0a1"}'))
+
+    assert main() == 1
+    assert "JSON array of strings" in capsys.readouterr().err

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -10,7 +10,8 @@ ROOT = Path(__file__).resolve().parents[1]
 PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "publish.yml"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 CODEOWNERS = ROOT / ".github" / "CODEOWNERS"
-PUSH_BRANCHES = ["main"]
+CI_PUSH_BRANCHES = ["main"]
+PUBLISH_PUSH_BRANCHES = ["main", "release/2.1"]
 PR_BRANCHES = ["main", "release/2.1"]
 RELEASE_MAINTAINERS = {"@kantorcodes", "@deep-purple-boots"}
 
@@ -33,24 +34,31 @@ def test_release_branches_run_ci_and_pr_canaries() -> None:
     ci = _workflow(CI_WORKFLOW)
     publish = _workflow(PUBLISH_WORKFLOW)
 
-    assert ci[True]["push"]["branches"] == PUSH_BRANCHES
+    assert ci[True]["push"]["branches"] == CI_PUSH_BRANCHES
     assert ci[True]["pull_request"]["branches"] == PR_BRANCHES
-    assert publish[True]["push"]["branches"] == PUSH_BRANCHES
+    assert publish[True]["push"]["branches"] == PUBLISH_PUSH_BRANCHES
     assert publish[True]["pull_request"]["branches"] == PR_BRANCHES
     assert "tags" not in publish[True]["push"]
+    assert publish["concurrency"]["group"] == "hol-guard-publish-${{ github.ref }}"
+    assert publish["concurrency"]["cancel-in-progress"] is False
 
 
-def test_main_pushes_publish_stable_while_tag_pushes_cannot_publish() -> None:
+def test_branch_pushes_publish_their_channel_while_tag_pushes_cannot_publish() -> None:
     workflow = _workflow(PUBLISH_WORKFLOW)
     jobs = workflow["jobs"]
 
     for job_name in (
         "publish-alpha-testpypi",
         "publish-alpha-pypi",
+        "reserve-alpha-tag",
         "release-alpha",
         "publish-container",
     ):
-        assert "github.event_name == 'workflow_dispatch'" in jobs[job_name]["if"]
+        condition = jobs[job_name]["if"]
+        assert "github.event_name == 'workflow_dispatch'" in condition
+        assert "github.event_name == 'push'" in condition
+        assert "github.ref == 'refs/heads/release/2.1'" in condition
+        assert "needs.build.outputs.channel == 'alpha'" in condition
     for job_name in ("publish-main-testpypi", "publish-main-pypi", "release-main"):
         condition = jobs[job_name]["if"]
         assert "github.event_name == 'push'" in condition
@@ -89,6 +97,52 @@ def test_main_push_build_computes_a_registry_derived_stable_version() -> None:
     condition = '[[ "$CURRENT_VERSION" == "$VERSION" ]]'
     assert stamp_run.index("--check") < stamp_run.index(condition)
     assert stamp_run.index(condition) < stamp_run.index("--version")
+
+
+def test_release_21_push_computes_a_deterministic_source_bound_alpha() -> None:
+    workflow = _workflow(PUBLISH_WORKFLOW)
+    build_steps = workflow["jobs"]["build"]["steps"]
+    checkout = next(step for step in build_steps if str(step.get("uses", "")).startswith("actions/checkout@"))
+    compute_run = next(step["run"] for step in build_steps if step.get("name") == "Compute publish version")
+
+    assert _mapping(checkout["with"])["ref"] == (
+        "${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
+    )
+    assert 'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/release/2.1" ]]' in compute_run
+    assert 'CHANNEL="alpha"' in compute_run
+    assert 'TRAIN="2.1"' in compute_run
+    assert "compute_alpha_release_version.py" in compute_run
+    assert '--release-train "$TRAIN"' in compute_run
+    assert "SOURCE_SHA=$(git rev-parse 'HEAD^{commit}')" in compute_run
+    assert '"$SOURCE_SHA" != "$GITHUB_SHA"' in compute_run
+
+    auto_alpha_block = compute_run[
+        compute_run.index(
+            'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/release/2.1" ]]'
+        ) : compute_run.index('elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]')
+    ]
+    assert "list-versions --registry pypi" in auto_alpha_block
+    assert "list-versions --registry testpypi" in auto_alpha_block
+    assert "git tag --list 'alpha/v*'" in auto_alpha_block
+    assert "compute_alpha_release_version.py" in auto_alpha_block
+    assert 'awk -v candidate="$RELEASE_VERSION"' not in auto_alpha_block
+    assert "$0 != candidate" not in auto_alpha_block
+    assert 'git tag --points-at "$SOURCE_SHA" --list "alpha/v${TRAIN}.0a*"' in auto_alpha_block
+    assert '"${#SOURCE_ALPHA_TAGS[@]}" -gt 1' in auto_alpha_block
+    assert '"${#SOURCE_ALPHA_TAGS[@]}" -eq 1' in auto_alpha_block
+    assert 'RELEASE_VERSION="${SOURCE_ALPHA_TAGS[0]}"' in auto_alpha_block
+    assert "select(. != $candidate)" not in auto_alpha_block
+    assert "REUSING_RESERVED_ALPHA=true" in auto_alpha_block
+    assert "--validate-phase-only" in auto_alpha_block
+    assert 'if [[ "$REUSING_RESERVED_ALPHA" != "true" ]]' in auto_alpha_block
+    assert auto_alpha_block.index('"${#SOURCE_ALPHA_TAGS[@]}" -eq 1') < auto_alpha_block.index(
+        'if [[ "$REUSING_RESERVED_ALPHA" != "true" ]]'
+    )
+
+
+def _mapping(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    return value
 
 
 def test_alpha_only_dispatch_and_pr_version_stamping_contracts() -> None:
@@ -138,16 +192,22 @@ def test_release_dispatch_binds_channel_train_version_and_sha() -> None:
     assert jobs["build"]["needs"] == "authorize-release"
     build_condition = jobs["build"]["if"]
     assert "github.event_name != 'workflow_dispatch' || github.run_attempt == 1" in build_condition
-    assert "github.event_name != 'push' || github.run_attempt == 1" in build_condition
+    assert (
+        "github.event_name != 'push' || github.run_attempt == 1 || github.ref == 'refs/heads/release/2.1'"
+        in build_condition
+    )
     assert jobs["alpha-cross-platform"]["needs"] == "build"
     for job_name in (
         "alpha-cross-platform",
         "publish-alpha-testpypi",
         "publish-alpha-pypi",
+        "reserve-alpha-tag",
         "release-alpha",
         "publish-container",
     ):
         assert "github.run_attempt == 1" in jobs[job_name]["if"]
+        if job_name != "alpha-cross-platform":
+            assert "(github.event_name == 'push' && github.ref == 'refs/heads/release/2.1')" in jobs[job_name]["if"]
     compute_run = next(step["run"] for step in build_steps if step.get("name") == "Compute publish version")
     assert 'if [[ "$CHANNEL" != "alpha" ]]' in compute_run
     assert 'if [[ "$TRAIN" != "2.1" ]]' in compute_run
@@ -185,15 +245,53 @@ def test_alpha_release_test_paths_exist() -> None:
 def test_alpha_publication_is_independent_of_cross_platform_tests() -> None:
     jobs = _workflow(PUBLISH_WORKFLOW)["jobs"]
 
-    assert jobs["publish-alpha-testpypi"]["needs"] == ["build"]
+    assert jobs["reserve-alpha-tag"]["needs"] == ["build"]
+    assert jobs["publish-alpha-testpypi"]["needs"] == ["build", "reserve-alpha-tag"]
     assert jobs["publish-alpha-pypi"]["needs"] == [
         "build",
         "publish-alpha-testpypi",
     ]
-    for job_name in ("publish-alpha-testpypi", "publish-alpha-pypi"):
+    for job_name in ("reserve-alpha-tag", "publish-alpha-testpypi", "publish-alpha-pypi"):
         assert "alpha-cross-platform" not in jobs[job_name]["needs"]
         assert "needs.alpha-cross-platform" not in jobs[job_name]["if"]
     assert jobs["release-alpha"]["needs"] == ["build", "publish-alpha-pypi"]
+
+
+def test_alpha_tag_is_reserved_atomically_before_testpypi() -> None:
+    jobs = _workflow(PUBLISH_WORKFLOW)["jobs"]
+    reserve = jobs["reserve-alpha-tag"]
+
+    assert reserve["permissions"] == {"contents": "write"}
+    checkout = next(step for step in reserve["steps"] if str(step.get("uses", "")).startswith("actions/checkout@"))
+    assert _mapping(checkout["with"])["ref"] == "${{ needs.build.outputs.source_sha }}"
+    reserve_run = next(step["run"] for step in reserve["steps"] if step.get("name") == "Reserve exact alpha tag")
+    assert 'gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs"' in reserve_run
+    assert '-f ref="refs/tags/${tag}"' in reserve_run
+    assert '-f sha="$SOURCE_SHA"' in reserve_run
+    assert 'remote_tag_sha" != "$SOURCE_SHA"' in reserve_run
+
+
+def test_alpha_publication_uses_the_push_sha_without_branch_head_drift_gates() -> None:
+    jobs = _workflow(PUBLISH_WORKFLOW)["jobs"]
+
+    for job_name in (
+        "reserve-alpha-tag",
+        "publish-alpha-testpypi",
+        "publish-alpha-pypi",
+        "release-alpha",
+        "publish-container",
+    ):
+        checkout = next(
+            step for step in jobs[job_name]["steps"] if str(step.get("uses", "")).startswith("actions/checkout@")
+        )
+        assert _mapping(checkout["with"])["ref"] == "${{ needs.build.outputs.source_sha }}"
+
+    for job_name in ("publish-alpha-testpypi", "publish-alpha-pypi"):
+        commands = "\n".join(str(step.get("run", "")) for step in jobs[job_name]["steps"])
+        assert "remote_train_sha=$(git ls-remote" not in commands
+        assert '"$remote_train_sha" != "$SOURCE_SHA"' not in commands
+        assert "refs/tags/alpha/v${VERSION}" in commands
+        assert '"$remote_alpha_tag_sha" != "$SOURCE_SHA"' in commands
 
 
 def test_release_publication_reuses_one_hashed_build_artifact() -> None:
@@ -290,11 +388,11 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
         for step in jobs["publish-alpha-pypi"]["steps"]
         if step.get("name") == "Revalidate alpha publication authorization"
     )
-    assert "list-versions --registry pypi" in alpha_run
-    assert "git ls-remote --exit-code origin" in alpha_run
+    assert "list-versions --registry pypi" not in alpha_run
+    assert 'git ls-remote --exit-code origin "refs/tags/alpha/v${VERSION}"' in alpha_run
     assert "validate_alpha_release.py" in alpha_run
     assert "refs/tags/alpha/v${VERSION}" in alpha_run
-    assert 'awk -v candidate="$VERSION"' in alpha_run
+    assert 'awk -v candidate="$VERSION"' not in alpha_run
 
     workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
     assert 'for registry in ("pypi.org", "test.pypi.org")' not in workflow_text
@@ -326,32 +424,33 @@ def test_release_tags_are_bound_to_the_exact_published_source() -> None:
         for step in jobs["publish-alpha-testpypi"]["steps"]
         if step.get("name") == "Revalidate alpha source before TestPyPI"
     )
-    assert 'git ls-remote --exit-code origin "$train_ref"' in alpha_test_run
+    assert 'git ls-remote --exit-code origin "$train_ref"' not in alpha_test_run
     assert "refs/tags/alpha/v${VERSION}" in alpha_test_run
-    assert '[[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]' in alpha_test_run
+    assert '[[ "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]' in alpha_test_run
 
     alpha_pypi_run = next(
         step["run"]
         for step in jobs["publish-alpha-pypi"]["steps"]
         if step.get("name") == "Revalidate alpha publication authorization"
     )
-    assert '[[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]' in alpha_pypi_run
+    assert '[[ "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]' in alpha_pypi_run
 
     release_run = next(
         step["run"]
         for step in jobs["release-alpha"]["steps"]
         if step.get("name") == "Create discoverable alpha prerelease"
     )
-    assert 'gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs"' in release_run
-    assert '-f ref="refs/tags/${tag}"' in release_run
     assert 'remote_tag_sha" != "$SOURCE_SHA"' in release_run
+    assert 'gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs"' not in release_run
     assert 'gh release view "$tag" --json isDraft,isPrerelease' in release_run
     assert 'gh release download "$tag"' in release_run
     assert 'cmp --silent "$local_file"' in release_run
     assert "mapfile -d '' local_files" in release_run
     assert 'gh attestation verify "$remote_file"' in release_run
     assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in release_run
+    assert '--target "$SOURCE_SHA"' in release_run
     assert "--verify-tag" in release_run
+    assert 'git ls-remote --exit-code origin "refs/tags/${tag}"' in release_run
 
     main_release_run = next(
         step["run"] for step in jobs["release-main"]["steps"] if step.get("name") == "Create discoverable main release"


### PR DESCRIPTION
## Summary
- publish a sequential 2.1 alpha automatically when the release branch advances
- reserve and verify the exact source tag before package publication, with idempotent recovery
- prevent alpha container tags from being overwritten on reruns

## Testing
- `uv run --no-sync pytest -q tests/test_compute_alpha_release_version.py tests/test_release_train_workflow.py tests/test_alpha_container_workflow.py tests/test_pr_testpypi_canary_workflow.py tests/test_validate_alpha_release.py tests/test_guard_github_workflow_privacy.py tests/test_guard_workflow_capabilities.py --tb=short`
- `uv run --no-sync ruff check scripts/compute_alpha_release_version.py tests/test_compute_alpha_release_version.py tests/test_release_train_workflow.py tests/test_alpha_container_workflow.py`
- `uv run --no-sync ruff format --check scripts/compute_alpha_release_version.py tests/test_compute_alpha_release_version.py tests/test_release_train_workflow.py tests/test_alpha_container_workflow.py`
- `uv run --no-sync basedpyright scripts/compute_alpha_release_version.py tests/test_compute_alpha_release_version.py`
- `actionlint .github/workflows/publish.yml`
- `git diff --check`
