### PR TITLE
fix(release): use portable container absence check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1353,7 +1353,7 @@ jobs:
               exit 1
             fi
             echo "push=false" >> "$GITHUB_OUTPUT"
-          elif rg -qi 'manifest unknown' "$pull_output"; then
+          elif grep -Eqi 'manifest unknown' "$pull_output"; then
             echo "push=true" >> "$GITHUB_OUTPUT"
           else
             cat "$pull_output" >&2

--- a/tests/test_alpha_container_workflow.py
+++ b/tests/test_alpha_container_workflow.py
@@ -19,6 +19,7 @@ def test_container_refuses_to_mutate_an_existing_alpha_image() -> None:
     assert "org.opencontainers.image.revision" in inspect_step["run"]
     assert '"$revision" != "$SOURCE_SHA"' in inspect_step["run"]
     assert 'echo "push=false"' in inspect_step["run"]
-    assert "manifest unknown" in inspect_step["run"]
+    assert "grep -Eqi 'manifest unknown'" in inspect_step["run"]
+    assert "rg -qi" not in inspect_step["run"]
     assert "Unable to determine whether the image tag already exists" in inspect_step["run"]
     assert publish_step["if"] == "steps.image.outputs.push == 'true'"


### PR DESCRIPTION
## Summary
- use the hosted runner's portable text matcher for the container absence check
- retain fail-closed handling for authentication, network, and unexpected registry errors

## Testing
- `uv run --no-sync pytest -q tests/test_alpha_container_workflow.py tests/test_release_train_workflow.py --tb=short`
- `uv run --no-sync ruff check tests/test_alpha_container_workflow.py`
- `uv run --no-sync ruff format --check tests/test_alpha_container_workflow.py`
- `actionlint .github/workflows/publish.yml`
- `git diff --check`
