### PR TITLE
fix(guard): migrate initial command shadow schema

### DIFF
--- a/src/codex_plugin_scanner/guard/store_command_shadow_schema.py
+++ b/src/codex_plugin_scanner/guard/store_command_shadow_schema.py
@@ -132,12 +132,33 @@ _SCHEMA_STATEMENTS: Final = (
     end""",
 )
 
+_CURRENT_EVALUATOR_SCHEMA_CHECK: Final = "\n".join(
+    (
+        "evaluator_schema_version text not null check (",
+        f"        evaluator_schema_version in ({_EVALUATOR_SCHEMA_VERSIONS_SQL})",
+        "      )",
+    )
+)
 _PREVIOUS_SCHEMA_STATEMENTS: Final = tuple(
     statement.replace(
-        f"evaluator_schema_version text not null check (\n"
-        f"        evaluator_schema_version in ({_EVALUATOR_SCHEMA_VERSIONS_SQL})\n"
-        "      )",
+        _CURRENT_EVALUATOR_SCHEMA_CHECK,
         "evaluator_schema_version text not null check (evaluator_schema_version = '1.0.0')",
+    )
+    for statement in _SCHEMA_STATEMENTS
+)
+_INITIAL_V18_EVALUATOR_SCHEMA_VERSIONS_SQL: Final = "'1.0.0', '1.1.0'"
+_INITIAL_V18_EVALUATOR_SCHEMA_CHECK: Final = "".join(
+    (
+        "evaluator_schema_version text not null check (",
+        "evaluator_schema_version in (",
+        _INITIAL_V18_EVALUATOR_SCHEMA_VERSIONS_SQL,
+        "))",
+    )
+)
+_INITIAL_V18_SCHEMA_STATEMENTS: Final = tuple(
+    statement.replace(
+        _CURRENT_EVALUATOR_SCHEMA_CHECK,
+        _INITIAL_V18_EVALUATOR_SCHEMA_CHECK,
     )
     for statement in _SCHEMA_STATEMENTS
 )
@@ -203,20 +224,26 @@ _LEGACY_SCHEMA_STATEMENTS: Final = (
 
 
 def ensure_command_shadow_schema(connection: sqlite3.Connection, *, applied_at: str) -> None:
-    """Apply the current schema atomically, upgrading exact v15 and v17 shapes."""
+    """Apply the current schema atomically, upgrading exact historical shapes."""
 
     connection.execute("savepoint command_shadow_schema_v18")
     try:
         current = _expected_schema(_SCHEMA_STATEMENTS)
         previous = _expected_schema(_PREVIOUS_SCHEMA_STATEMENTS)
+        initial_v18 = _expected_schema(_INITIAL_V18_SCHEMA_STATEMENTS)
         legacy = _expected_schema(_LEGACY_SCHEMA_STATEMENTS)
-        actual = _read_schema(connection, frozenset(current) | frozenset(previous) | frozenset(legacy))
+        actual = _read_schema(
+            connection,
+            frozenset(current) | frozenset(previous) | frozenset(initial_v18) | frozenset(legacy),
+        )
         _reject_external_foreign_keys(connection)
-        _reject_external_sql_dependencies(connection, (current, previous, legacy))
+        _reject_external_sql_dependencies(connection, (current, previous, initial_v18, legacy))
         if actual == legacy:
             _upgrade_schema(connection, source_statements=_LEGACY_SCHEMA_STATEMENTS, suffix="v15")
         elif actual == previous:
             _upgrade_schema(connection, source_statements=_PREVIOUS_SCHEMA_STATEMENTS, suffix="v17")
+        elif actual == initial_v18:
+            _upgrade_schema(connection, source_statements=_INITIAL_V18_SCHEMA_STATEMENTS, suffix="initial_v18")
         elif actual and actual != current:
             raise RuntimeError("incompatible command shadow schema objects")
         elif not actual:

--- a/src/codex_plugin_scanner/guard/store_command_shadow_schema.py
+++ b/src/codex_plugin_scanner/guard/store_command_shadow_schema.py
@@ -9,6 +9,7 @@ import sqlite3
 from typing import Final, cast
 
 from .runtime.effect_decision import EFFECT_DECISION_SCHEMA_VERSION
+from .store_command_shadow_schema_v18 import INITIAL_V18_SCHEMA_STATEMENTS
 
 COMMAND_SHADOW_LEGACY_MIGRATION_VERSION: Final = 15
 COMMAND_SHADOW_PREVIOUS_MIGRATION_VERSION: Final = 17
@@ -132,13 +133,9 @@ _SCHEMA_STATEMENTS: Final = (
     end""",
 )
 
-_CURRENT_EVALUATOR_SCHEMA_CHECK: Final = "\n".join(
-    (
-        "evaluator_schema_version text not null check (",
-        f"        evaluator_schema_version in ({_EVALUATOR_SCHEMA_VERSIONS_SQL})",
-        "      )",
-    )
-)
+_CURRENT_EVALUATOR_SCHEMA_CHECK: Final = f"""evaluator_schema_version text not null check (
+        evaluator_schema_version in ({_EVALUATOR_SCHEMA_VERSIONS_SQL})
+      )"""
 _PREVIOUS_SCHEMA_STATEMENTS: Final = tuple(
     statement.replace(
         _CURRENT_EVALUATOR_SCHEMA_CHECK,
@@ -146,23 +143,6 @@ _PREVIOUS_SCHEMA_STATEMENTS: Final = tuple(
     )
     for statement in _SCHEMA_STATEMENTS
 )
-_INITIAL_V18_EVALUATOR_SCHEMA_VERSIONS_SQL: Final = "'1.0.0', '1.1.0'"
-_INITIAL_V18_EVALUATOR_SCHEMA_CHECK: Final = "".join(
-    (
-        "evaluator_schema_version text not null check (",
-        "evaluator_schema_version in (",
-        _INITIAL_V18_EVALUATOR_SCHEMA_VERSIONS_SQL,
-        "))",
-    )
-)
-_INITIAL_V18_SCHEMA_STATEMENTS: Final = tuple(
-    statement.replace(
-        _CURRENT_EVALUATOR_SCHEMA_CHECK,
-        _INITIAL_V18_EVALUATOR_SCHEMA_CHECK,
-    )
-    for statement in _SCHEMA_STATEMENTS
-)
-
 _LEGACY_SCHEMA_STATEMENTS: Final = (
     f"""create table command_activity_shadow_evaluations (
       activity_id text primary key references command_activity(activity_id) on delete cascade,
@@ -230,7 +210,7 @@ def ensure_command_shadow_schema(connection: sqlite3.Connection, *, applied_at: 
     try:
         current = _expected_schema(_SCHEMA_STATEMENTS)
         previous = _expected_schema(_PREVIOUS_SCHEMA_STATEMENTS)
-        initial_v18 = _expected_schema(_INITIAL_V18_SCHEMA_STATEMENTS)
+        initial_v18 = _expected_schema(INITIAL_V18_SCHEMA_STATEMENTS)
         legacy = _expected_schema(_LEGACY_SCHEMA_STATEMENTS)
         actual = _read_schema(
             connection,
@@ -243,7 +223,7 @@ def ensure_command_shadow_schema(connection: sqlite3.Connection, *, applied_at: 
         elif actual == previous:
             _upgrade_schema(connection, source_statements=_PREVIOUS_SCHEMA_STATEMENTS, suffix="v17")
         elif actual == initial_v18:
-            _upgrade_schema(connection, source_statements=_INITIAL_V18_SCHEMA_STATEMENTS, suffix="initial_v18")
+            _upgrade_schema(connection, source_statements=INITIAL_V18_SCHEMA_STATEMENTS, suffix="initial_v18")
         elif actual and actual != current:
             raise RuntimeError("incompatible command shadow schema objects")
         elif not actual:

--- a/src/codex_plugin_scanner/guard/store_command_shadow_schema_v18.py
+++ b/src/codex_plugin_scanner/guard/store_command_shadow_schema_v18.py
@@ -1,0 +1,103 @@
+"""Frozen initial-v18 command-shadow schema profile."""
+
+# ruff: noqa: E501
+
+from __future__ import annotations
+
+from typing import Final
+
+INITIAL_V18_SCHEMA_STATEMENTS: Final = (
+    """create table if not exists command_activity_shadow_evaluations (
+      activity_id text primary key references command_activity(activity_id) on delete cascade,
+      occurred_at text not null,
+      authoritative_action text not null check (authoritative_action in ('allow', 'warn', 'review', 'require-reapproval', 'sandbox-required', 'block')),
+      current_action text not null check (current_action in ('allow', 'warn', 'review', 'require-reapproval', 'sandbox-required', 'block')),
+      current_disposition text not null check (current_disposition in ('silent-verified', 'silent-contained', 'workflow-authorized', 'warn', 'review', 'require-reapproval', 'sandbox-required', 'block')),
+      proposed_action text not null check (proposed_action in ('allow', 'warn', 'review', 'require-reapproval', 'sandbox-required', 'block')),
+      proposed_disposition text not null check (proposed_disposition in ('silent-verified', 'silent-contained', 'workflow-authorized', 'warn', 'review', 'require-reapproval', 'sandbox-required', 'block')),
+      comparison text not null check (comparison in ('lowered', 'unchanged', 'strengthened')),
+      proposal_version text not null check (
+        length(proposal_version) between 1 and 128
+        and proposal_version glob '[a-z]*'
+        and proposal_version not glob '*[^a-z0-9.-]*'
+      ),
+      evaluator_schema_version text not null check (evaluator_schema_version in ('1.0.0', '1.1.0')),
+      control_generation integer not null check (control_generation = 1),
+      sample_basis_points integer not null check (sample_basis_points between 1 and 10000),
+      schema_version text not null check (schema_version = 'guard.command-shadow.v1'),
+      check (
+        (current_action = 'allow' and current_disposition in (
+          'silent-verified', 'silent-contained', 'workflow-authorized'
+        )) or (current_action != 'allow' and current_disposition = current_action)
+      ),
+      check (
+        (proposed_action = 'allow' and proposed_disposition in (
+          'silent-verified', 'silent-contained', 'workflow-authorized'
+        )) or (proposed_action != 'allow' and proposed_disposition = proposed_action)
+      )
+    ) strict""",
+    """create table if not exists command_activity_shadow_cohorts (
+      activity_id text not null references command_activity_shadow_evaluations(activity_id) on delete cascade,
+      ordinal integer not null check (ordinal >= 0),
+      cohort text not null check (cohort in ('baseline', 'cdx-060-verified-reads', 'cdx-061-contained-checks', 'cdx-062-contained-writes', 'cdx-063-task-capabilities', 'cdx-064-remote-mutation-floors', 'cdx-065-package-provenance-floors', 'cdx-066-critical-block-floors')),
+      primary key (activity_id, ordinal),
+      unique (activity_id, cohort)
+    ) strict""",
+    """create index if not exists idx_command_activity_shadow_comparison
+    on command_activity_shadow_evaluations (comparison, occurred_at desc, activity_id desc)""",
+    """create index if not exists idx_command_activity_shadow_cohort
+    on command_activity_shadow_cohorts (cohort, activity_id)""",
+    """create trigger if not exists trg_command_activity_shadow_evaluations_immutable
+    before update on command_activity_shadow_evaluations
+    begin select raise(abort, 'command_activity_shadow_evaluations_immutable'); end""",
+    """create trigger if not exists trg_command_activity_shadow_cohorts_immutable
+    before update on command_activity_shadow_cohorts
+    begin select raise(abort, 'command_activity_shadow_cohorts_immutable'); end""",
+    """create trigger if not exists trg_command_activity_shadow_require_activity
+    before insert on command_activity_shadow_evaluations
+    begin
+      select case when not exists (
+        select 1 from command_activity
+        where activity_id = new.activity_id and occurred_at = new.occurred_at
+      ) then raise(abort, 'command_activity_shadow_activity_missing') end;
+    end""",
+    """create trigger if not exists trg_command_activity_shadow_require_evaluation
+    before insert on command_activity_shadow_cohorts
+    begin
+      select case when not exists (
+        select 1 from command_activity_shadow_evaluations where activity_id = new.activity_id
+      ) then raise(abort, 'command_activity_shadow_evaluation_missing') end;
+      select case when new.ordinal != (
+        select count(*) from command_activity_shadow_cohorts where activity_id = new.activity_id
+      ) then raise(abort, 'command_activity_shadow_cohort_ordinal_invalid') end;
+    end""",
+    """create trigger if not exists trg_command_activity_shadow_require_comparison
+    before insert on command_activity_shadow_evaluations
+    begin
+      select case when new.comparison != case
+        when (
+          case new.proposed_action
+            when 'allow' then 0 when 'warn' then 1 when 'review' then 2
+            when 'require-reapproval' then 3 when 'sandbox-required' then 4 else 5 end
+        ) < (
+          case new.current_action
+            when 'allow' then 0 when 'warn' then 1 when 'review' then 2
+            when 'require-reapproval' then 3 when 'sandbox-required' then 4 else 5 end
+        ) then 'lowered'
+        when new.proposed_action = new.current_action then 'unchanged'
+        else 'strengthened'
+      end then raise(abort, 'command_activity_shadow_comparison_invalid') end;
+    end""",
+    """create trigger if not exists trg_command_activity_shadow_delete_cohorts
+    after delete on command_activity_shadow_evaluations
+    begin
+      delete from command_activity_shadow_cohorts where activity_id = old.activity_id;
+    end""",
+    """create trigger if not exists trg_command_activity_shadow_delete_evaluation
+    after delete on command_activity
+    begin
+      delete from command_activity_shadow_evaluations where activity_id = old.activity_id;
+    end""",
+)
+
+__all__ = ("INITIAL_V18_SCHEMA_STATEMENTS",)

--- a/tests/test_guard_command_shadow_schema_initial_v18.py
+++ b/tests/test_guard_command_shadow_schema_initial_v18.py
@@ -1,0 +1,73 @@
+"""Regression coverage for the initial v18 command-shadow schema."""
+
+# pyright: reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from codex_plugin_scanner.guard import store_command_shadow_schema as shadow_schema
+
+_OCCURRED_AT = datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc)
+
+
+def test_migration_upgrades_initial_v18_evaluator_schema_and_preserves_rows(tmp_path: Path) -> None:
+    with sqlite3.connect(tmp_path / "initial-v18.db") as connection:
+        connection.row_factory = sqlite3.Row
+        connection.execute("create table schema_migrations (version integer primary key, applied_at text not null)")
+        connection.execute(
+            "create table command_activity (activity_id text primary key, occurred_at text not null) strict"
+        )
+        for statement in shadow_schema._INITIAL_V18_SCHEMA_STATEMENTS:
+            connection.execute(statement)
+        occurred_at = _OCCURRED_AT.isoformat()
+        connection.execute("insert into command_activity values (?, ?)", ("activity:initial-v18", occurred_at))
+        connection.execute(
+            """
+            insert into command_activity_shadow_evaluations values (
+              ?, ?, 'allow', 'allow', 'silent-verified', 'allow', 'silent-verified',
+              'unchanged', 'proposal.initial.v18', '1.0.0', 1, 10000, 'guard.command-shadow.v1'
+            )
+            """,
+            ("activity:initial-v18", occurred_at),
+        )
+        connection.execute(
+            "insert into command_activity_shadow_cohorts values (?, 0, 'baseline')", ("activity:initial-v18",)
+        )
+        connection.execute(
+            "insert into schema_migrations values (?, ?)",
+            (shadow_schema.COMMAND_SHADOW_MIGRATION_VERSION, occurred_at),
+        )
+
+        assert shadow_schema._expected_schema(
+            shadow_schema._INITIAL_V18_SCHEMA_STATEMENTS
+        ) != shadow_schema._expected_schema(shadow_schema._SCHEMA_STATEMENTS)
+
+        shadow_schema.ensure_command_shadow_schema(connection, applied_at=occurred_at)
+
+        shadow_schema._validate_schema(connection)
+        versions = connection.execute("select version from schema_migrations order by version").fetchall()
+        evaluation = connection.execute(
+            "select activity_id, evaluator_schema_version from command_activity_shadow_evaluations"
+        ).fetchone()
+        cohort = connection.execute(
+            "select activity_id, ordinal, cohort from command_activity_shadow_cohorts"
+        ).fetchone()
+        temporary_tables = connection.execute(
+            "select count(*) from sqlite_master where name in (?, ?)",
+            (
+                "command_activity_shadow_evaluations_initial_v18",
+                "command_activity_shadow_cohorts_initial_v18",
+            ),
+        ).fetchone()
+
+    assert [tuple(row) for row in versions] == [
+        (shadow_schema.COMMAND_SHADOW_LEGACY_MIGRATION_VERSION,),
+        (shadow_schema.COMMAND_SHADOW_PREVIOUS_MIGRATION_VERSION,),
+        (shadow_schema.COMMAND_SHADOW_MIGRATION_VERSION,),
+    ]
+    assert tuple(evaluation) == ("activity:initial-v18", "1.0.0")
+    assert tuple(cohort) == ("activity:initial-v18", 0, "baseline")
+    assert tuple(temporary_tables) == (0,)

--- a/tests/test_guard_command_shadow_schema_initial_v18.py
+++ b/tests/test_guard_command_shadow_schema_initial_v18.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from codex_plugin_scanner.guard import store_command_shadow_schema as shadow_schema
+from codex_plugin_scanner.guard.store_command_shadow_schema_v18 import INITIAL_V18_SCHEMA_STATEMENTS
 
 _OCCURRED_AT = datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc)
 
@@ -20,7 +21,7 @@ def test_migration_upgrades_initial_v18_evaluator_schema_and_preserves_rows(tmp_
         connection.execute(
             "create table command_activity (activity_id text primary key, occurred_at text not null) strict"
         )
-        for statement in shadow_schema._INITIAL_V18_SCHEMA_STATEMENTS:
+        for statement in INITIAL_V18_SCHEMA_STATEMENTS:
             connection.execute(statement)
         occurred_at = _OCCURRED_AT.isoformat()
         connection.execute("insert into command_activity values (?, ?)", ("activity:initial-v18", occurred_at))
@@ -41,9 +42,9 @@ def test_migration_upgrades_initial_v18_evaluator_schema_and_preserves_rows(tmp_
             (shadow_schema.COMMAND_SHADOW_MIGRATION_VERSION, occurred_at),
         )
 
-        assert shadow_schema._expected_schema(
-            shadow_schema._INITIAL_V18_SCHEMA_STATEMENTS
-        ) != shadow_schema._expected_schema(shadow_schema._SCHEMA_STATEMENTS)
+        assert shadow_schema._expected_schema(INITIAL_V18_SCHEMA_STATEMENTS) != shadow_schema._expected_schema(
+            shadow_schema._SCHEMA_STATEMENTS
+        )
 
         shadow_schema.ensure_command_shadow_schema(connection, applied_at=occurred_at)
 


### PR DESCRIPTION
## Summary

- Restore compatibility with the initial v18 command-shadow schema profile.
- Rebuild that exact historical profile atomically into the current validated schema.
- Add a regression test that preserves historical observations and rejects migration residue.

## Testing

- `uv run --no-sync pytest -q tests/test_guard_command_shadow_persistence.py tests/test_guard_command_shadow_schema_initial_v18.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/store_command_shadow_schema.py tests/test_guard_command_shadow_persistence.py tests/test_guard_command_shadow_schema_initial_v18.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/store_command_shadow_schema.py tests/test_guard_command_shadow_persistence.py tests/test_guard_command_shadow_schema_initial_v18.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/store_command_shadow_schema.py tests/test_guard_command_shadow_persistence.py tests/test_guard_command_shadow_schema_initial_v18.py`
