### PR TITLE
fix(guard): preserve Codex hook state metadata

### DIFF
--- a/src/codex_plugin_scanner/guard/codex_hook_inventory.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_inventory.py
@@ -124,6 +124,8 @@ def enumerate_codex_hooks(
     records: list[CodexHookInventoryRecord] = []
     issues: list[CodexHookInventoryIssue] = []
     for event_name, groups in hooks.items():
+        if _is_codex_hook_state_metadata(event_name, groups, source_format):
+            continue
         if not isinstance(event_name, str) or not isinstance(groups, list):
             issues.append(
                 CodexHookInventoryIssue(
@@ -193,6 +195,36 @@ def enumerate_codex_hooks(
                     records.append(record)
                 issues.extend(handler_issues)
     return CodexHookInventory(str(source_path), tuple(records), tuple(issues))
+
+
+def _is_codex_hook_state_metadata(
+    event_name: object,
+    value: object,
+    source_format: HookSourceFormat,
+) -> bool:
+    """Recognize Codex's reserved TOML hook-state metadata table."""
+
+    return (
+        source_format == "toml"
+        and event_name == "state"
+        and isinstance(value, Mapping)
+        and all(
+            isinstance(coordinate, str)
+            and isinstance(state_entry, Mapping)
+            and set(state_entry) == {"trusted_hash"}
+            and _is_trusted_hook_hash(state_entry.get("trusted_hash"))
+            for coordinate, state_entry in value.items()
+        )
+    )
+
+
+def _is_trusted_hook_hash(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and value.startswith("sha256:")
+        and len(value) == 71
+        and all(character in "0123456789abcdef" for character in value[7:])
+    )
 
 
 def _handler_record(

--- a/src/codex_plugin_scanner/guard/codex_hook_inventory.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_inventory.py
@@ -211,7 +211,8 @@ def _is_codex_hook_state_metadata(
         and all(
             isinstance(coordinate, str)
             and isinstance(state_entry, Mapping)
-            and set(state_entry) == {"trusted_hash"}
+            and len(state_entry) == 1
+            and "trusted_hash" in state_entry
             and _is_trusted_hook_hash(state_entry.get("trusted_hash"))
             for coordinate, state_entry in value.items()
         )
@@ -223,7 +224,7 @@ def _is_trusted_hook_hash(value: object) -> bool:
         isinstance(value, str)
         and value.startswith("sha256:")
         and len(value) == 71
-        and all(character in "0123456789abcdef" for character in value[7:])
+        and all(character in "0123456789abcdefABCDEF" for character in value[7:])
     )
 
 

--- a/tests/test_guard_codex_hook_state_metadata.py
+++ b/tests/test_guard_codex_hook_state_metadata.py
@@ -54,6 +54,18 @@ def test_guard_install_codex_preserves_codex_hook_state_metadata(
     assert isinstance(installed["hooks"]["PreToolUse"], list)
 
 
+def test_uppercase_codex_hook_state_hash_is_recognized(tmp_path: Path) -> None:
+    inventory = enumerate_codex_hooks(
+        {"hooks": {"state": {"fixture": {"trusted_hash": f"sha256:{'A' * 64}"}}}},
+        source_path=tmp_path / "config.toml",
+        source_scope="global",
+        source_format="toml",
+        source_hooks_enabled=False,
+    )
+
+    assert inventory.complete is True
+
+
 @pytest.mark.parametrize(
     "state",
     (

--- a/tests/test_guard_codex_hook_state_metadata.py
+++ b/tests/test_guard_codex_hook_state_metadata.py
@@ -1,0 +1,74 @@
+"""Regression coverage for Codex-owned TOML hook-state metadata."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import tomllib
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.codex_config import dump_toml
+from codex_plugin_scanner.guard.codex_hook_inventory import (
+    CODEX_HOOK_INVENTORY_UNSUPPORTED_EVENT,
+    enumerate_codex_hooks,
+)
+
+
+def _install_args(home_dir: Path, workspace_dir: Path) -> list[str]:
+    return [
+        "guard",
+        "install",
+        "codex",
+        "--home",
+        str(home_dir),
+        "--workspace",
+        str(workspace_dir),
+        "--json",
+    ]
+
+
+def test_guard_install_codex_preserves_codex_hook_state_metadata(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    state = {
+        "fixture:pre_tool_use:0:0": {
+            "trusted_hash": f"sha256:{'a' * 64}",
+        }
+    }
+    config_path = home_dir / ".codex" / "config.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(dump_toml({"hooks": {"state": state}}), encoding="utf-8")
+
+    rc = main(_install_args(home_dir, workspace_dir))
+    output = json.loads(capsys.readouterr().out)
+    installed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+
+    assert rc == 0
+    assert output["managed_install"]["active"] is True
+    assert installed["hooks"]["state"] == state
+    assert isinstance(installed["hooks"]["PreToolUse"], list)
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "not-a-metadata-table",
+        {"fixture": {"trusted_hash": "not-a-sha256-hash"}},
+    ),
+)
+def test_malformed_codex_hook_state_metadata_remains_fail_closed(tmp_path: Path, state: object) -> None:
+    inventory = enumerate_codex_hooks(
+        {"hooks": {"state": state}},
+        source_path=tmp_path / "config.toml",
+        source_scope="global",
+        source_format="toml",
+        source_hooks_enabled=False,
+    )
+
+    assert inventory.complete is False
+    assert inventory.issues[0].reason_code == CODEX_HOOK_INVENTORY_UNSUPPORTED_EVENT


### PR DESCRIPTION
## Summary
- Recognize validated Codex hook-state metadata as non-executable inventory data.
- Preserve trusted hook state when Guard installs native hooks.

## Testing
- `uv run --no-sync pytest -q tests/test_guard_codex_hook_state_metadata.py tests/test_codex_hook_inventory.py --tb=short`
- `uv build`
