### PR TITLE
fix(guard): recover equivalent Codex hook package installs

### DIFF
--- a/src/codex_plugin_scanner/guard/codex_hook_manifest.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_manifest.py
@@ -31,6 +31,7 @@ from .codex_hook_integrity import (
     load_or_create_hook_secret,
     sign_hook_manifest,
 )
+from .codex_hook_package_identity import assert_package_reauthentication_is_safe
 
 MANAGED_CODEX_HOOK_EVENTS = ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse")
 
@@ -145,28 +146,6 @@ def authenticated_manifest_for_ownership(spec: CodexHookManifestSpec) -> dict[st
     except (CodexHookIntegrityError, OSError):
         return None
     return manifest if _manifest_has_owned_installation_context(manifest, spec) else None
-
-
-def assert_package_reauthentication_is_safe(
-    previous_manifest: dict[str, object] | None,
-    replacement_manifest: dict[str, object],
-) -> None:
-    """Refuse to bless changed executable identities at the same package version."""
-
-    if previous_manifest is None:
-        return
-    if previous_manifest.get("schema_version") != HOOK_MANIFEST_SCHEMA_VERSION:
-        return
-    if previous_manifest.get("package_version") != replacement_manifest.get("package_version"):
-        return
-    if previous_manifest.get("interpreter") != replacement_manifest.get("interpreter") or previous_manifest.get(
-        "packaged_files"
-    ) != replacement_manifest.get("packaged_files"):
-        raise CodexHookIntegrityError(
-            "codex_hook_package_reauthentication_refused",
-            "Guard refused to authenticate changed same-version hook code or interpreter bytes. "
-            "Reinstall hol-guard from a trusted package, then run `hol-guard install codex` again.",
-        )
 
 
 def manifest_bindings(manifest: object) -> list[dict[str, object]]:

--- a/src/codex_plugin_scanner/guard/codex_hook_package_identity.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_package_identity.py
@@ -1,0 +1,61 @@
+"""Same-version package identity checks for authenticated Codex hook updates."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from .codex_hook_file_integrity import CodexHookIntegrityError
+from .codex_hook_integrity import HOOK_MANIFEST_SCHEMA_VERSION
+
+
+def assert_package_reauthentication_is_safe(
+    previous_manifest: Mapping[str, object] | None,
+    replacement_manifest: Mapping[str, object],
+) -> None:
+    """Allow interpreter relocation only when the managed package bytes match."""
+
+    if previous_manifest is None or previous_manifest.get("schema_version") != HOOK_MANIFEST_SCHEMA_VERSION:
+        return
+    if previous_manifest.get("package_version") != replacement_manifest.get("package_version"):
+        return
+    previous_identity = _package_content_identity(previous_manifest)
+    replacement_identity = _package_content_identity(replacement_manifest)
+    if previous_identity is not None and previous_identity == replacement_identity:
+        return
+    raise CodexHookIntegrityError(
+        "codex_hook_package_reauthentication_refused",
+        "Guard refused to authenticate changed same-version hook code or interpreter bytes. "
+        "Reinstall hol-guard from a trusted package, then run `hol-guard install codex` again.",
+    )
+
+
+def _package_content_identity(manifest: Mapping[str, object]) -> tuple[tuple[str, str, int, int, bool], ...] | None:
+    packaged_files = manifest.get("packaged_files")
+    if not isinstance(packaged_files, list) or not packaged_files:
+        return None
+    identities: list[tuple[str, str, int, int, bool]] = []
+    for file_identity in packaged_files:
+        if not isinstance(file_identity, Mapping):
+            return None
+        role = file_identity.get("role")
+        digest = file_identity.get("sha256")
+        size = file_identity.get("size")
+        mode = file_identity.get("mode")
+        executable_required = file_identity.get("executable_required")
+        if (
+            not isinstance(role, str)
+            or not isinstance(digest, str)
+            or not isinstance(size, int)
+            or isinstance(size, bool)
+            or not isinstance(mode, int)
+            or isinstance(mode, bool)
+            or not isinstance(executable_required, bool)
+        ):
+            return None
+        identities.append((role, digest, size, mode, executable_required))
+    if len({identity[0] for identity in identities}) != len(identities):
+        return None
+    return tuple(sorted(identities))
+
+
+__all__ = ["assert_package_reauthentication_is_safe"]

--- a/tests/test_guard_codex_interpreter_migration.py
+++ b/tests/test_guard_codex_interpreter_migration.py
@@ -1,0 +1,54 @@
+"""Codex managed-hook reinstallation coverage for interpreter relocation."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import codex as codex_adapter
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
+from codex_plugin_scanner.guard.codex_hook_file_integrity import CodexHookIntegrityError
+from codex_plugin_scanner.guard.codex_hook_integrity import HOOK_MANIFEST_SCHEMA_VERSION
+from codex_plugin_scanner.guard.codex_hook_package_identity import assert_package_reauthentication_is_safe
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX executable fixtures are required")
+def test_guard_install_codex_adopts_equivalent_package_with_relocated_interpreter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+    first_interpreter = tmp_path / "first-python"
+    second_interpreter = tmp_path / "second-python"
+    for interpreter in (first_interpreter, second_interpreter):
+        interpreter.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        interpreter.chmod(0o755)
+
+    monkeypatch.setattr(codex_adapter.sys, "executable", str(first_interpreter))
+    adapter = CodexHarnessAdapter()
+    adapter.install(context)
+
+    monkeypatch.setattr(codex_adapter.sys, "executable", str(second_interpreter))
+    installed = adapter.install(context)
+    state = codex_adapter.codex_native_hook_state(context)
+
+    assert installed["active"] is True
+    assert state["protection_active"] is True
+
+
+def test_reauthentication_rejects_incomplete_package_identity() -> None:
+    manifest = {
+        "schema_version": HOOK_MANIFEST_SCHEMA_VERSION,
+        "package_version": "2.1.0a6",
+        "packaged_files": [],
+    }
+
+    with pytest.raises(CodexHookIntegrityError, match="changed same-version hook code"):
+        assert_package_reauthentication_is_safe(manifest, manifest)


### PR DESCRIPTION
## Summary
- Allow Codex hook reinstallation when the same-version managed package identity matches exactly.
- Keep changed managed package bytes on the fail-closed path.

## Testing
- `uv run --no-sync pytest -q tests/test_guard_codex_install.py tests/test_guard_codex_interpreter_migration.py --tb=short`
- `uv build`
