### PR TITLE
fix(pi): bound hook review latency

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
@@ -201,7 +201,7 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "    return {\n"
         '      decision: "deny",\n'
         "      reason: errorCode === 'ETIMEDOUT' || result.error?.name === 'TimeoutError'\n"
-        "        ? `HOL Guard Pi hook timed out after ${GUARD_TIMEOUT_MS}ms while reviewing this action.`\n"
+        "        ? `HOL Guard Pi hook timed out after ${GUARD_CLI_TIMEOUT_MS}ms while reviewing this action.`\n"
         "        : `HOL Guard Pi hook failed before completing review: ${errorMessage}`,\n"
         "    };\n"
         "  }\n"

--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
@@ -8,7 +8,9 @@ from pathlib import Path
 from .pi_extension_approval_source import APPROVAL_RESUME_HELPERS_SOURCE
 from .pi_extension_content_source import CONTENT_REVIEW_HELPERS_SOURCE
 
-GUARD_HOOK_TIMEOUT_MS = 10_000
+GUARD_HOOK_TIMEOUT_MS = 8_000
+GUARD_DAEMON_HOOK_TIMEOUT_MS = 2_500
+GUARD_CLI_HOOK_TIMEOUT_MS = 4_500
 GUARD_HOOK_TEXT_LIMIT_CHARS = 12_000
 GUARD_HOOK_CONTENT_ITEM_LIMIT = 24
 GUARD_HOOK_OBJECT_KEY_LIMIT = 24
@@ -40,6 +42,8 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         f"const GUARD_HOME_DIR_IS_DEFAULT = {home_dir_is_default_json};\n"
         f"const GUARD_CONFIG_PATH = {config_path_json};\n"
         f"const GUARD_TIMEOUT_MS = {GUARD_HOOK_TIMEOUT_MS};\n"
+        f"const GUARD_DAEMON_TIMEOUT_MS = {GUARD_DAEMON_HOOK_TIMEOUT_MS};\n"
+        f"const GUARD_CLI_TIMEOUT_MS = {GUARD_CLI_HOOK_TIMEOUT_MS};\n"
         f"const GUARD_TEXT_LIMIT_CHARS = {GUARD_HOOK_TEXT_LIMIT_CHARS};\n"
         f"const GUARD_CONTENT_ITEM_LIMIT = {GUARD_HOOK_CONTENT_ITEM_LIMIT};\n"
         f"const GUARD_OBJECT_KEY_LIMIT = {GUARD_HOOK_OBJECT_KEY_LIMIT};\n"
@@ -94,7 +98,7 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "  if (workspace) params.set('workspace', workspace);\n"
         "  if (!GUARD_HOME_DIR_IS_DEFAULT && GUARD_HOME_DIR) params.set('home', GUARD_HOME_DIR);\n"
         "  const controller = typeof AbortController === 'function' ? new AbortController() : undefined;\n"
-        "  const timeoutHandle = setTimeout(() => controller?.abort(), Math.max(GUARD_TIMEOUT_MS - 500, 1));\n"
+        "  const timeoutHandle = setTimeout(() => controller?.abort(), GUARD_DAEMON_TIMEOUT_MS);\n"
         "  try {\n"
         "    const response = await fetch(`http://127.0.0.1:${connection.port}/v1/hooks/pi?${params.toString()}`, {\n"
         "      method: 'POST',\n"
@@ -178,7 +182,7 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "    result = spawnSync(command, args, {\n"
         "      input: `${serializedPayload}\\n`,\n"
         '      encoding: "utf-8",\n'
-        "      timeout: GUARD_TIMEOUT_MS,\n"
+        "      timeout: GUARD_CLI_TIMEOUT_MS,\n"
         "    });\n"
         "    const resultError = result.error as (Error & { code?: unknown }) | undefined;\n"
         "    if (!(result.error && resultError?.code === 'ENOENT')) break;\n"

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -18,8 +18,8 @@ import threading
 import time
 import uuid
 import webbrowser
-from collections.abc import Mapping
-from contextlib import suppress
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager, suppress
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -402,7 +402,50 @@ _ROOT_STATIC_FILES = {
     "/favicon-16x16.png",
     "/favicon-32x32.png",
 }
-_CLAUDE_HOOK_EXECUTION_LOCK = threading.Lock()
+
+
+class _RuntimeHookExecutionGate:
+    """Allow concurrent hooks unless one temporarily mutates process environment."""
+
+    def __init__(self) -> None:
+        self._condition = threading.Condition()
+        self._readers = 0
+        self._writer = False
+        self._waiting_writers = 0
+
+    @contextmanager
+    def shared(self) -> Iterator[None]:
+        with self._condition:
+            while self._writer or self._waiting_writers > 0:
+                self._condition.wait()
+            self._readers += 1
+        try:
+            yield
+        finally:
+            with self._condition:
+                self._readers -= 1
+                if self._readers == 0:
+                    self._condition.notify_all()
+
+    @contextmanager
+    def exclusive(self) -> Iterator[None]:
+        with self._condition:
+            self._waiting_writers += 1
+            try:
+                while self._writer or self._readers > 0:
+                    self._condition.wait()
+            finally:
+                self._waiting_writers -= 1
+            self._writer = True
+        try:
+            yield
+        finally:
+            with self._condition:
+                self._writer = False
+                self._condition.notify_all()
+
+
+_RUNTIME_HOOK_EXECUTION_GATE = _RuntimeHookExecutionGate()
 _RUNTIME_HOOK_ENV_ALLOWLIST = frozenset(
     {
         "HOL_GUARD_MANAGED_CURSOR_HOOK",
@@ -4690,7 +4733,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             json=True,
         )
         buffer = io.StringIO()
-        with _CLAUDE_HOOK_EXECUTION_LOCK:
+        execution_guard = (
+            _RUNTIME_HOOK_EXECUTION_GATE.exclusive() if hook_env else _RUNTIME_HOOK_EXECUTION_GATE.shared()
+        )
+        with execution_guard:
             from ..cli.commands import run_guard_command
 
             original_env: dict[str, str | None] = {key: os.environ.get(key) for key in hook_env}

--- a/tests/test_pi_adapter.py
+++ b/tests/test_pi_adapter.py
@@ -282,7 +282,7 @@ class TestPiInstall:
         assert '"--harness", "pi"' in text
         assert '"--home"' in text
         assert "ctx.cwd" in text
-        assert "timeout: GUARD_TIMEOUT_MS" in text
+        assert "timeout: GUARD_CLI_TIMEOUT_MS" in text
         assert str(extension_path) in json.loads(settings_path.read_text(encoding="utf-8"))["extensions"]
         assert omp_extension_path.is_file()
         assert str(omp_extension_path) in json.loads(omp_settings_path.read_text(encoding="utf-8"))["extensions"]

--- a/tests/test_pi_hook_latency.py
+++ b/tests/test_pi_hook_latency.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import threading
+import urllib.parse
+import urllib.request
+from argparse import Namespace
+from pathlib import Path
+from typing import TextIO
+
+import pytest
+
+from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _pi_hook_request(*, daemon: GuardDaemonServer, guard_home: str, call_id: str) -> urllib.request.Request:
+    query = urllib.parse.urlencode({"guard-home": guard_home, "home": guard_home})
+    return urllib.request.Request(
+        f"http://127.0.0.1:{daemon.port}/v1/hooks/pi?{query}",
+        data=json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_call_id": call_id,
+                "tool_name": "read",
+                "tool_input": {"path": "README.md"},
+            }
+        ).encode(),
+        headers={"Content-Type": "application/json", "X-Guard-Token": daemon._server.auth_token},
+        method="POST",
+    )
+
+
+def test_pi_hook_is_not_queued_behind_unrelated_overlay_free_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_started = threading.Event()
+    release_first = threading.Event()
+
+    def fake_run_guard_command(args: Namespace, *, input_text: str, output_stream: TextIO) -> int:
+        del args
+        payload = json.loads(input_text)
+        if payload["tool_call_id"] == "first":
+            first_started.set()
+            assert release_first.wait(timeout=2)
+        output_stream.write('{"decision":"allow"}')
+        return 0
+
+    monkeypatch.setattr(guard_commands_module, "run_guard_command", fake_run_guard_command)
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    first_result: list[dict[str, object]] = []
+
+    def run_first() -> None:
+        request = _pi_hook_request(daemon=daemon, guard_home=str(store.guard_home), call_id="first")
+        with urllib.request.urlopen(request, timeout=3) as response:
+            first_result.append(json.loads(response.read()))
+
+    first_thread = threading.Thread(target=run_first)
+    first_thread.start()
+    try:
+        assert first_started.wait(timeout=1)
+        request = _pi_hook_request(daemon=daemon, guard_home=str(store.guard_home), call_id="second")
+        with urllib.request.urlopen(request, timeout=1) as response:
+            second_result = json.loads(response.read())
+    finally:
+        release_first.set()
+        first_thread.join(timeout=3)
+        daemon.stop()
+
+    assert second_result == {"decision": "allow"}
+    assert first_result == [{"decision": "allow"}]
+
+
+def test_pi_extension_keeps_fallbacks_inside_outer_hook_deadline(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.pi_extension_source import managed_extension_source
+
+    source = managed_extension_source(
+        guard_home=tmp_path / "guard-home",
+        home_dir=tmp_path / "home",
+        settings_path=tmp_path / "settings.json",
+    )
+
+    assert "const GUARD_TIMEOUT_MS = 8000;" in source
+    assert "const GUARD_DAEMON_TIMEOUT_MS = 2500;" in source
+    assert "const GUARD_CLI_TIMEOUT_MS = 4500;" in source
+    assert "timeout: GUARD_CLI_TIMEOUT_MS" in source

--- a/tests/test_pi_hook_latency.py
+++ b/tests/test_pi_hook_latency.py
@@ -88,3 +88,4 @@ def test_pi_extension_keeps_fallbacks_inside_outer_hook_deadline(tmp_path: Path)
     assert "const GUARD_DAEMON_TIMEOUT_MS = 2500;" in source
     assert "const GUARD_CLI_TIMEOUT_MS = 4500;" in source
     assert "timeout: GUARD_CLI_TIMEOUT_MS" in source
+    assert "timed out after ${GUARD_CLI_TIMEOUT_MS}ms" in source


### PR DESCRIPTION
## Summary
- allow independent Pi hook reviews to run concurrently while keeping environment-overlay reviews exclusive
- keep daemon and CLI fallback attempts inside Pi's outer hook deadline
- cover concurrent review and generated extension timeout behavior

## Testing
- `uv run --no-sync pytest tests/test_pi_hook_latency.py tests/test_pi_adapter.py -q --tb=short`
- `uv run --no-sync pytest tests/test_guard_surface_server.py -q --tb=short -k 'daemon_pi_hook_endpoint or daemon_cursor_hook_endpoint_applies_hook_env_overlay'`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/adapters/pi_extension_source.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_pi_hook_latency.py tests/test_pi_adapter.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/adapters/pi_extension_source.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_pi_hook_latency.py`
- `uv build`
- installed-wheel Pi hook check in a disposable container
