### PR TITLE
fix(pi): avoid stale daemon hook timeouts

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from ...version import __version__
 from .pi_extension_approval_source import APPROVAL_RESUME_HELPERS_SOURCE
 from .pi_extension_content_source import CONTENT_REVIEW_HELPERS_SOURCE
 
 GUARD_HOOK_TIMEOUT_MS = 8_000
-GUARD_DAEMON_HOOK_TIMEOUT_MS = 2_500
-GUARD_CLI_HOOK_TIMEOUT_MS = 4_500
+GUARD_DAEMON_HOOK_TIMEOUT_MS = 7_000
+GUARD_CLI_HOOK_TIMEOUT_MS = 7_000
 GUARD_HOOK_TEXT_LIMIT_CHARS = 12_000
 GUARD_HOOK_CONTENT_ITEM_LIMIT = 24
 GUARD_HOOK_OBJECT_KEY_LIMIT = 24
@@ -19,7 +20,7 @@ GUARD_HOOK_MAX_SERIALIZED_PAYLOAD_CHARS = 24_000
 
 
 def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path: Path) -> str:
-    guard_args = ["hook", "--guard-home", str(guard_home), "--harness", "pi"]
+    guard_args = ["hook", "--json", "--guard-home", str(guard_home), "--harness", "pi"]
     if home_dir.resolve() != Path.home().resolve():
         guard_args.extend(["--home", str(home_dir)])
     guard_args_json = json.dumps(guard_args)
@@ -27,6 +28,7 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
     home_dir_json = json.dumps(str(home_dir))
     home_dir_is_default_json = "true" if home_dir.resolve() == Path.home().resolve() else "false"
     config_path_json = json.dumps(str(settings_path))
+    package_version_json = json.dumps(__version__)
     return (
         'import { spawn, spawnSync } from "node:child_process";\n'
         'import { createCipheriv, createHash, randomBytes } from "node:crypto";\n'
@@ -41,6 +43,7 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         f"const GUARD_HOME_DIR = {home_dir_json};\n"
         f"const GUARD_HOME_DIR_IS_DEFAULT = {home_dir_is_default_json};\n"
         f"const GUARD_CONFIG_PATH = {config_path_json};\n"
+        f"const GUARD_PACKAGE_VERSION = {package_version_json};\n"
         f"const GUARD_TIMEOUT_MS = {GUARD_HOOK_TIMEOUT_MS};\n"
         f"const GUARD_DAEMON_TIMEOUT_MS = {GUARD_DAEMON_HOOK_TIMEOUT_MS};\n"
         f"const GUARD_CLI_TIMEOUT_MS = {GUARD_CLI_HOOK_TIMEOUT_MS};\n"
@@ -76,7 +79,8 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "  try {\n"
         "    const daemonState = JSON.parse(\n"
         "      readFileSync(join(GUARD_HOME, 'daemon-state.json'), 'utf8'),\n"
-        "    ) as { port?: unknown };\n"
+        "    ) as { package_version?: unknown; port?: unknown };\n"
+        "    if (daemonState.package_version !== GUARD_PACKAGE_VERSION) return null;\n"
         "    port = typeof daemonState.port === 'number' ? daemonState.port : 0;\n"
         "    authToken = readFileSync(join(GUARD_HOME, 'daemon-auth-token'), 'utf8').trim();\n"
         "  } catch {\n"
@@ -114,7 +118,14 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "    if (!raw) return {};\n"
         "    const parsed = JSON.parse(raw) as GuardResponse;\n"
         "    return parsed && typeof parsed === 'object' ? parsed : null;\n"
-        "  } catch {\n"
+        "  } catch (error) {\n"
+        "    if (error instanceof Error && error.name === 'AbortError') {\n"
+        "      return {\n"
+        '        decision: "deny",\n'
+        "        reason: `HOL Guard Pi hook timed out after "
+        + "${GUARD_DAEMON_TIMEOUT_MS}ms while reviewing this action.`,\n"
+        "      };\n"
+        "    }\n"
         "    return null;\n"
         "  } finally {\n"
         "    clearTimeout(timeoutHandle);\n"

--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
@@ -10,6 +10,7 @@ from .pi_extension_approval_source import APPROVAL_RESUME_HELPERS_SOURCE
 from .pi_extension_content_source import CONTENT_REVIEW_HELPERS_SOURCE
 
 GUARD_HOOK_TIMEOUT_MS = 8_000
+GUARD_HOOK_DEADLINE_RESERVE_MS = 250
 GUARD_DAEMON_HOOK_TIMEOUT_MS = 7_000
 GUARD_CLI_HOOK_TIMEOUT_MS = 7_000
 GUARD_HOOK_TEXT_LIMIT_CHARS = 12_000
@@ -45,6 +46,7 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         f"const GUARD_CONFIG_PATH = {config_path_json};\n"
         f"const GUARD_PACKAGE_VERSION = {package_version_json};\n"
         f"const GUARD_TIMEOUT_MS = {GUARD_HOOK_TIMEOUT_MS};\n"
+        f"const GUARD_DEADLINE_RESERVE_MS = {GUARD_HOOK_DEADLINE_RESERVE_MS};\n"
         f"const GUARD_DAEMON_TIMEOUT_MS = {GUARD_DAEMON_HOOK_TIMEOUT_MS};\n"
         f"const GUARD_CLI_TIMEOUT_MS = {GUARD_CLI_HOOK_TIMEOUT_MS};\n"
         f"const GUARD_TEXT_LIMIT_CHARS = {GUARD_HOOK_TEXT_LIMIT_CHARS};\n"
@@ -137,6 +139,7 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "  cwd?: string,\n"
         "  options?: { enforceSizeCap?: boolean },\n"
         "): Promise<GuardResponse> {\n"
+        "  const deadlineAt = Date.now() + GUARD_TIMEOUT_MS - GUARD_DEADLINE_RESERVE_MS;\n"
         "  const args = [...GUARD_ARGS];\n"
         '  const workspace = typeof cwd === "string" && cwd ? cwd : process.cwd();\n'
         '  if (workspace) args.push("--workspace", workspace);\n'
@@ -189,11 +192,12 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "    return daemonResponse;\n"
         "  }\n"
         "  let result: ReturnType<typeof spawnSync<string>> | null = null;\n"
+        "  const cliTimeoutMs = Math.min(GUARD_CLI_TIMEOUT_MS, Math.max(deadlineAt - Date.now(), 1));\n"
         "  for (const command of GUARD_COMMAND_CANDIDATES) {\n"
         "    result = spawnSync(command, args, {\n"
         "      input: `${serializedPayload}\\n`,\n"
         '      encoding: "utf-8",\n'
-        "      timeout: GUARD_CLI_TIMEOUT_MS,\n"
+        "      timeout: cliTimeoutMs,\n"
         "    });\n"
         "    const resultError = result.error as (Error & { code?: unknown }) | undefined;\n"
         "    if (!(result.error && resultError?.code === 'ENOENT')) break;\n"
@@ -212,7 +216,7 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "    return {\n"
         '      decision: "deny",\n'
         "      reason: errorCode === 'ETIMEDOUT' || result.error?.name === 'TimeoutError'\n"
-        "        ? `HOL Guard Pi hook timed out after ${GUARD_CLI_TIMEOUT_MS}ms while reviewing this action.`\n"
+        "        ? `HOL Guard Pi hook timed out while reviewing this action.`\n"
         "        : `HOL Guard Pi hook failed before completing review: ${errorMessage}`,\n"
         "    };\n"
         "  }\n"

--- a/tests/test_pi_adapter.py
+++ b/tests/test_pi_adapter.py
@@ -280,9 +280,10 @@ class TestPiInstall:
         assert "guardPayload.tool_response = event.content" in text
         assert "const GUARD_CONFIG_PATH =" in text
         assert "config_path: GUARD_CONFIG_PATH" in text
-        assert '"hook", "--guard-home"' in text
+        assert '"hook", "--json", "--guard-home"' in text
         assert '"guard", "hook"' not in text
         assert '"--harness", "pi"' in text
+        assert '"hook", "--json"' in text
         assert '"--home"' in text
         assert "ctx.cwd" in text
         assert "timeout: GUARD_CLI_TIMEOUT_MS" in text

--- a/tests/test_pi_adapter.py
+++ b/tests/test_pi_adapter.py
@@ -286,7 +286,7 @@ class TestPiInstall:
         assert '"hook", "--json"' in text
         assert '"--home"' in text
         assert "ctx.cwd" in text
-        assert "timeout: GUARD_CLI_TIMEOUT_MS" in text
+        assert "timeout: cliTimeoutMs" in text
         assert str(extension_path) in json.loads(settings_path.read_text(encoding="utf-8"))["extensions"]
         assert omp_extension_path.is_file()
         assert str(omp_extension_path) in json.loads(omp_settings_path.read_text(encoding="utf-8"))["extensions"]

--- a/tests/test_pi_hook_latency.py
+++ b/tests/test_pi_hook_latency.py
@@ -85,11 +85,13 @@ def test_pi_extension_keeps_fallbacks_inside_outer_hook_deadline(tmp_path: Path)
     )
 
     assert "const GUARD_TIMEOUT_MS = 8000;" in source
+    assert "const GUARD_DEADLINE_RESERVE_MS = 250;" in source
     assert "const GUARD_DAEMON_TIMEOUT_MS = 7000;" in source
     assert "const GUARD_CLI_TIMEOUT_MS = 7000;" in source
     assert 'const GUARD_ARGS = ["hook", "--json"' in source
     assert "daemonState.package_version !== GUARD_PACKAGE_VERSION" in source
     assert "error.name === 'AbortError'" in source
     assert source.index("error.name === 'AbortError'") > source.index("await fetch")
-    assert "timeout: GUARD_CLI_TIMEOUT_MS" in source
-    assert "timed out after ${GUARD_CLI_TIMEOUT_MS}ms" in source
+    assert "const deadlineAt = Date.now() + GUARD_TIMEOUT_MS - GUARD_DEADLINE_RESERVE_MS" in source
+    assert "Math.max(deadlineAt - Date.now(), 1)" in source
+    assert "timeout: cliTimeoutMs" in source

--- a/tests/test_pi_hook_latency.py
+++ b/tests/test_pi_hook_latency.py
@@ -85,7 +85,11 @@ def test_pi_extension_keeps_fallbacks_inside_outer_hook_deadline(tmp_path: Path)
     )
 
     assert "const GUARD_TIMEOUT_MS = 8000;" in source
-    assert "const GUARD_DAEMON_TIMEOUT_MS = 2500;" in source
-    assert "const GUARD_CLI_TIMEOUT_MS = 4500;" in source
+    assert "const GUARD_DAEMON_TIMEOUT_MS = 7000;" in source
+    assert "const GUARD_CLI_TIMEOUT_MS = 7000;" in source
+    assert 'const GUARD_ARGS = ["hook", "--json"' in source
+    assert "daemonState.package_version !== GUARD_PACKAGE_VERSION" in source
+    assert "error.name === 'AbortError'" in source
+    assert source.index("error.name === 'AbortError'") > source.index("await fetch")
     assert "timeout: GUARD_CLI_TIMEOUT_MS" in source
     assert "timed out after ${GUARD_CLI_TIMEOUT_MS}ms" in source


### PR DESCRIPTION
## Summary
- prevent Pi hooks from using a daemon running a different Guard package version
- make CLI fallback return approval results without synchronous waiting
- keep real daemon and CLI stalls fail-closed with an accurate bounded timeout

## Testing
- `uv run --no-sync pytest -q tests/test_pi_hook_latency.py tests/test_pi_adapter.py tests/test_pi_tool_call_id_adapter.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/adapters/pi_extension_source.py tests/test_pi_hook_latency.py tests/test_pi_adapter.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/adapters/pi_extension_source.py tests/test_pi_hook_latency.py tests/test_pi_adapter.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/adapters/pi_extension_source.py tests/test_pi_hook_latency.py`
- `git diff --check`
