### PR TITLE
feat(controls): sync privacy-safe authority events

### DIFF
--- a/src/codex_plugin_scanner/guard/extension_control_events.py
+++ b/src/codex_plugin_scanner/guard/extension_control_events.py
@@ -1,0 +1,37 @@
+"""Privacy-safe extension-control authority event payloads."""
+
+from __future__ import annotations
+
+from .runtime.extension_control_contract import ControlState, ControlTargetKind, ExtensionControlLayer
+
+
+def extension_control_change_payload(
+    *,
+    revision: int,
+    previous_revision: int,
+    catalog_digest: str,
+    snapshot_digest: str,
+    layers: tuple[ExtensionControlLayer, ...],
+) -> dict[str, object]:
+    """Summarize a control change without actor, proof, nonce, or command data."""
+
+    controls = tuple(control for layer in layers for control in layer.controls)
+    return {
+        "schema": "guard.extension-control-authority-change.v1",
+        "action": "authority.changed",
+        "revision": revision,
+        "previousRevision": previous_revision,
+        "catalogDigest": catalog_digest,
+        "snapshotDigest": snapshot_digest,
+        "layerKinds": [layer.kind.value for layer in layers],
+        "globalLockdown": any(layer.global_lockdown for layer in layers),
+        "disabledExtensionCount": sum(
+            control.state is ControlState.DISABLED and control.target.kind is ControlTargetKind.EXTENSION
+            for control in controls
+        ),
+        "disabledPermissionCount": sum(
+            control.state is ControlState.DISABLED and control.target.kind is ControlTargetKind.PERMISSION
+            for control in controls
+        ),
+        "blockSource": "extension-control-authority",
+    }

--- a/src/codex_plugin_scanner/guard/extension_control_events.py
+++ b/src/codex_plugin_scanner/guard/extension_control_events.py
@@ -4,33 +4,31 @@ from __future__ import annotations
 
 from .runtime.extension_control_contract import ControlState, ControlTargetKind, ExtensionControlLayer
 
+EXTENSION_CONTROL_CHANGE_SCHEMA = "guard.extension-control-authority-change.v1"
+
 
 def extension_control_change_payload(
     *,
     revision: int,
     previous_revision: int,
-    catalog_digest: str,
-    snapshot_digest: str,
     layers: tuple[ExtensionControlLayer, ...],
 ) -> dict[str, object]:
     """Summarize a control change without actor, proof, nonce, or command data."""
 
     controls = tuple(control for layer in layers for control in layer.controls)
     return {
-        "schema": "guard.extension-control-authority-change.v1",
+        "schema": EXTENSION_CONTROL_CHANGE_SCHEMA,
         "action": "authority.changed",
         "revision": revision,
         "previousRevision": previous_revision,
-        "catalogDigest": catalog_digest,
-        "snapshotDigest": snapshot_digest,
         "layerKinds": [layer.kind.value for layer in layers],
         "globalLockdown": any(layer.global_lockdown for layer in layers),
         "disabledExtensionCount": sum(
-            control.state is ControlState.DISABLED and control.target.kind is ControlTargetKind.EXTENSION
+            control.state == ControlState.DISABLED and control.target.kind == ControlTargetKind.EXTENSION
             for control in controls
         ),
         "disabledPermissionCount": sum(
-            control.state is ControlState.DISABLED and control.target.kind is ControlTargetKind.PERMISSION
+            control.state == ControlState.DISABLED and control.target.kind == ControlTargetKind.PERMISSION
             for control in controls
         ),
         "blockSource": "extension-control-authority",

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -334,6 +334,15 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                     "update extension_control_authority_transition set phase = ?, committed_at = ? where revision = ?",
                     (AuthorityPhase.COMMITTED.value, created_at, revision),
                 )
+                self._queue_extension_control_change_event(
+                    connection,
+                    revision=revision,
+                    previous_revision=current.revision,
+                    catalog_digest=catalog_digest,
+                    snapshot_digest=snapshot_digest,
+                    layers_json=layers_json,
+                    occurred_at=created_at,
+                )
             try:
                 self._write_and_verify_anchor(
                     AuthorityAnchor(revision, snapshot_digest, AuthorityPhase.COMMITTED),

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -334,15 +334,6 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                     "update extension_control_authority_transition set phase = ?, committed_at = ? where revision = ?",
                     (AuthorityPhase.COMMITTED.value, created_at, revision),
                 )
-                self._queue_extension_control_change_event(
-                    connection,
-                    revision=revision,
-                    previous_revision=current.revision,
-                    catalog_digest=catalog_digest,
-                    snapshot_digest=snapshot_digest,
-                    layers_json=layers_json,
-                    occurred_at=created_at,
-                )
             try:
                 self._write_and_verify_anchor(
                     AuthorityAnchor(revision, snapshot_digest, AuthorityPhase.COMMITTED),
@@ -350,6 +341,14 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                 )
             except Exception as exc:
                 raise ExtensionControlAuthorityError("extension control authority final anchor unavailable") from exc
+            with self._connect() as connection:
+                self._queue_extension_control_change_event(
+                    connection,
+                    revision=revision,
+                    previous_revision=current.revision,
+                    layers_json=layers_json,
+                    occurred_at=created_at,
+                )
             return self._read_extension_control_authority_locked(catalog_digest)
 
     def recover_extension_control_authority(self, *, catalog_digest: str) -> ExtensionControlAuthorityView:
@@ -410,6 +409,21 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                                 AuthorityPhase.COMMITTED,
                             ),
                             key=key,
+                        )
+                    if current_revision > 0:
+                        committed = connection.execute(
+                            """select previous_revision, layers_json, created_at
+                               from extension_control_authority_transition where revision = ? and phase = ?""",
+                            (current_revision, AuthorityPhase.COMMITTED.value),
+                        ).fetchone()
+                        if committed is None:
+                            return self._tampered_view(catalog_digest)
+                        self._queue_extension_control_change_event(
+                            connection,
+                            revision=current_revision,
+                            previous_revision=_row_int(committed, "previous_revision"),
+                            layers_json=_row_str(committed, "layers_json"),
+                            occurred_at=_row_str(committed, "created_at"),
                         )
                     return self._read_extension_control_authority_locked(catalog_digest)
             return self._tampered_view(catalog_digest)

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority_support.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority_support.py
@@ -14,6 +14,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import cast
 
+from .edge_events import build_policy_event
+from .extension_control_events import extension_control_change_payload
 from .runtime.extension_control_authority import (
     AuthorityAnchor,
     AuthorityHealth,
@@ -21,6 +23,7 @@ from .runtime.extension_control_authority import (
     ExtensionControlAuthorityView,
     anchor_from_json,
     anchor_to_json,
+    layers_from_json,
 )
 from .runtime.extension_control_contract import ControlLayerKind, ExtensionControlLayer
 from .runtime.extension_control_resolver import compose_control_layers
@@ -131,6 +134,35 @@ class _ExtensionControlAuthoritySupportMixin:
     def _validate_serialized_layers(layers_json: str) -> None:
         if len(layers_json.encode("utf-8")) > _MAX_SERIALIZED_LAYERS_BYTES:
             raise ExtensionControlAuthorityError("extension control layers exceed storage limit")
+
+    def _queue_extension_control_change_event(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        revision: int,
+        previous_revision: int,
+        catalog_digest: str,
+        snapshot_digest: str,
+        layers_json: str,
+        occurred_at: str,
+    ) -> None:
+        layers = layers_from_json(layers_json)
+        self._add_guard_event_v1(
+            connection,
+            build_policy_event(
+                policy_key=f"extension-controls:{revision}",
+                occurred_at=occurred_at,
+                device_id=None,
+                workspace_id=self._cloud_workspace_id_from_connection(connection),
+                payload=extension_control_change_payload(
+                    revision=revision,
+                    previous_revision=previous_revision,
+                    catalog_digest=catalog_digest,
+                    snapshot_digest=snapshot_digest,
+                    layers=layers,
+                ),
+            ),
+        )
 
     def _degraded_view(self, catalog_digest: str) -> ExtensionControlAuthorityView:
         health = (

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority_support.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority_support.py
@@ -141,8 +141,6 @@ class _ExtensionControlAuthoritySupportMixin:
         *,
         revision: int,
         previous_revision: int,
-        catalog_digest: str,
-        snapshot_digest: str,
         layers_json: str,
         occurred_at: str,
     ) -> None:
@@ -157,8 +155,6 @@ class _ExtensionControlAuthoritySupportMixin:
                 payload=extension_control_change_payload(
                     revision=revision,
                     previous_revision=previous_revision,
-                    catalog_digest=catalog_digest,
-                    snapshot_digest=snapshot_digest,
                     layers=layers,
                 ),
             ),

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority_transitions.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority_transitions.py
@@ -132,25 +132,32 @@ class _ExtensionControlAuthorityTransitionMixin(_ExtensionControlAuthoritySuppor
                     "update extension_control_authority_transition set phase = ?, committed_at = ? where revision = ?",
                     (AuthorityPhase.COMMITTED.value, _now(), revision),
                 )
-            self._queue_extension_control_change_event(
-                connection,
-                revision=revision,
-                previous_revision=previous_revision,
-                catalog_digest=catalog_digest,
-                snapshot_digest=_row_str(row, "snapshot_digest"),
-                layers_json=layers_json,
-                occurred_at=_row_str(row, "created_at"),
-            )
             connection.commit()
             self._write_and_verify_anchor(
                 AuthorityAnchor(revision, _row_str(row, "snapshot_digest"), AuthorityPhase.COMMITTED),
                 key=key,
             )
+            self._queue_extension_control_change_event(
+                connection,
+                revision=revision,
+                previous_revision=previous_revision,
+                layers_json=layers_json,
+                occurred_at=_row_str(row, "created_at"),
+            )
+            connection.commit()
             resumed = self._read_extension_control_authority_locked(catalog_digest)
             if resumed.health is not AuthorityHealth.PROTECTED or resumed.revision != revision:
                 raise ExtensionControlAuthorityError("idempotent transition recovery failed")
             return resumed
         if current.health is AuthorityHealth.PROTECTED and current.revision == revision:
+            self._queue_extension_control_change_event(
+                connection,
+                revision=revision,
+                previous_revision=previous_revision,
+                layers_json=layers_json,
+                occurred_at=_row_str(row, "created_at"),
+            )
+            connection.commit()
             return current
         raise ExtensionControlAuthorityError("idempotent transition state mismatch")
 

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority_transitions.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority_transitions.py
@@ -132,6 +132,15 @@ class _ExtensionControlAuthorityTransitionMixin(_ExtensionControlAuthoritySuppor
                     "update extension_control_authority_transition set phase = ?, committed_at = ? where revision = ?",
                     (AuthorityPhase.COMMITTED.value, _now(), revision),
                 )
+            self._queue_extension_control_change_event(
+                connection,
+                revision=revision,
+                previous_revision=previous_revision,
+                catalog_digest=catalog_digest,
+                snapshot_digest=_row_str(row, "snapshot_digest"),
+                layers_json=layers_json,
+                occurred_at=_row_str(row, "created_at"),
+            )
             connection.commit()
             self._write_and_verify_anchor(
                 AuthorityAnchor(revision, _row_str(row, "snapshot_digest"), AuthorityPhase.COMMITTED),

--- a/tests/test_guard_extension_control_authority.py
+++ b/tests/test_guard_extension_control_authority.py
@@ -700,3 +700,28 @@ def test_prepared_transition_retries_with_same_reserved_proof(tmp_path: Path) ->
         proof=proof,
     )
     assert committed.revision == 1
+
+
+def test_control_change_queues_privacy_safe_append_only_cloud_event(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+
+    _commit(store, actor_id="private-admin-identity")
+
+    with store._connect() as connection:
+        rows = connection.execute(
+            "select event_type, payload_json from guard_cloud_events where event_type = 'policy.changed'"
+        ).fetchall()
+    assert len(rows) == 1
+    envelope = json.loads(str(rows[0]["payload_json"]))
+    assert envelope["source"] == "policy"
+    payload = envelope["payload"]
+    assert payload["schema"] == "guard.extension-control-authority-change.v1"
+    assert payload["revision"] == 1
+    assert payload["previousRevision"] == 0
+    assert payload["disabledExtensionCount"] == 1
+    assert payload["blockSource"] == "extension-control-authority"
+    serialized = json.dumps(envelope)
+    assert "private-admin-identity" not in serialized
+    assert "nonce-change-1" not in serialized
+    assert _PASSWORD not in serialized

--- a/tests/test_guard_extension_control_authority.py
+++ b/tests/test_guard_extension_control_authority.py
@@ -8,6 +8,7 @@ from typing import cast
 import pytest
 
 from codex_plugin_scanner.guard.approval_gate import ApprovalGateInput, update_settings
+from codex_plugin_scanner.guard.extension_control_events import extension_control_change_payload
 from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from codex_plugin_scanner.guard.runtime.extension_control_authority import (
     AuthorityHealth,
@@ -391,6 +392,10 @@ def test_idempotent_retry_after_prepared_transition_commits_once(tmp_path: Path)
     assert retried.revision == 1
     with store._connect() as connection:
         count = connection.execute("select count(*) from extension_control_authority_transition").fetchone()[0]
+        event_count = connection.execute(
+            "select count(*) from guard_cloud_events where event_type = 'policy.changed'"
+        ).fetchone()[0]
+    assert event_count == 1
     assert count == 1
 
 
@@ -401,6 +406,11 @@ def test_recovery_finalizes_database_commit_when_final_anchor_write_failed(tmp_p
     secrets.fail_anchor_set_number = secrets.anchor_set_count + 2
     with pytest.raises(ExtensionControlAuthorityError, match="final anchor"):
         _commit(store)
+    with store._connect() as connection:
+        premature_events = connection.execute(
+            "select count(*) from guard_cloud_events where event_type = 'policy.changed'"
+        ).fetchone()[0]
+    assert premature_events == 0
 
     interrupted = store.read_extension_control_authority(
         catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
@@ -412,6 +422,11 @@ def test_recovery_finalizes_database_commit_when_final_anchor_write_failed(tmp_p
     assert recovered.health is AuthorityHealth.PROTECTED
     assert recovered.revision == 1
     assert recovered.layers == (_disabled_layer(),)
+    with store._connect() as connection:
+        recovered_events = connection.execute(
+            "select count(*) from guard_cloud_events where event_type = 'policy.changed'"
+        ).fetchone()[0]
+    assert recovered_events == 1
 
 
 def test_transition_records_are_purpose_separated_and_replay_safe(tmp_path: Path) -> None:
@@ -725,3 +740,33 @@ def test_control_change_queues_privacy_safe_append_only_cloud_event(tmp_path: Pa
     assert "private-admin-identity" not in serialized
     assert "nonce-change-1" not in serialized
     assert _PASSWORD not in serialized
+
+
+def test_control_change_payload_counts_extension_and_permission_blocks() -> None:
+    extension = BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions[0]
+    permission = extension.permissions[0]
+    layer = ExtensionControlLayer(
+        schema_version=CONTROL_SCHEMA_VERSION,
+        kind=ControlLayerKind.LOCAL_ADMIN,
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
+        global_lockdown=False,
+        controls=(
+            ExtensionControl(
+                ControlTarget(ControlTargetKind.EXTENSION, extension.extension_id),
+                ControlState.DISABLED,
+            ),
+            ExtensionControl(
+                ControlTarget(ControlTargetKind.PERMISSION, permission.permission_id),
+                ControlState.DISABLED,
+            ),
+        ),
+    )
+
+    payload = extension_control_change_payload(
+        revision=2,
+        previous_revision=1,
+        layers=(layer,),
+    )
+
+    assert payload["disabledExtensionCount"] == 1
+    assert payload["disabledPermissionCount"] == 1

--- a/tests/test_guard_extension_control_resolver.py
+++ b/tests/test_guard_extension_control_resolver.py
@@ -173,16 +173,19 @@ def test_disabled_extension_permission_dependency_and_implied_permission_each_bl
             (owner.extension_id,),
             (),
             _control(ControlTargetKind.EXTENSION, owner.extension_id, ControlState.DISABLED),
+            "control.disabled-extension",
         ),
         (
             (),
             (owner_permission.permission_id,),
             _control(ControlTargetKind.PERMISSION, owner_permission.permission_id, ControlState.DISABLED),
+            "control.disabled-permission",
         ),
         (
             (owner.extension_id,),
             (),
             _control(ControlTargetKind.EXTENSION, dependency.extension_id, ControlState.DISABLED),
+            "control.disabled-extension",
         ),
         (
             (),
@@ -192,10 +195,11 @@ def test_disabled_extension_permission_dependency_and_implied_permission_each_bl
                 dependency_permission.permission_id,
                 ControlState.DISABLED,
             ),
+            "control.disabled-permission",
         ),
     )
 
-    for extension_ids, permission_ids, control in scenarios:
+    for extension_ids, permission_ids, control, expected_reason in scenarios:
         layer = ExtensionControlLayer(
             schema_version=CONTROL_SCHEMA_VERSION,
             kind=ControlLayerKind.LOCAL_ADMIN,
@@ -212,6 +216,7 @@ def test_disabled_extension_permission_dependency_and_implied_permission_each_bl
         )
         assert resolution.blocked is True
         assert evaluate_effect_decision(EffectDecisionRequest(resolution.factors)).action == "block"
+        assert resolution.factors[0].reason_code == expected_reason
 
 
 def test_resolver_failures_are_typed_privacy_safe_and_fail_closed() -> None:


### PR DESCRIPTION
## Summary
- append an idempotent `policy.changed` outbox event in the authority commit transaction
- retain audit event creation during interrupted-transition recovery
- sync only bounded authority provenance and aggregate control counts
- exclude actor identity, proof material, nonce, password, and command data

## Verification
- `uv run pytest -q tests/test_guard_extension_control_authority.py` (20 passed)
- Ruff passed for changed files
- basedpyright reported zero errors for changed modules

Targets `release/3.1`.