### PR TITLE
fix(runtime): recover cross-workspace inspections

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
@@ -239,7 +239,7 @@ def _unmodeled_shell_runtime_artifact(
     execution_context = model_shell_execution_context(command_text, cwd=workspace, workspace_root=workspace)
     if canonical_command.confidence == "exact" and execution_context.complete:
         return None
-    if canonical_command.confidence == "exact" and workspace is None:
+    if canonical_command.confidence == "exact" and not execution_context.complete:
         home_execution_context = low_risk_compound_developer_execution_context(
             command_text,
             home_dir=home_dir,

--- a/src/codex_plugin_scanner/guard/runtime/compound_git_inspection.py
+++ b/src/codex_plugin_scanner/guard/runtime/compound_git_inspection.py
@@ -8,7 +8,7 @@ from typing import Final
 from .shell_execution_context import ShellExecutionContext, ShellExecutionSegment
 
 _REF: Final = re.compile(r"[A-Za-z0-9][A-Za-z0-9._/-]{0,255}")
-_REPOSITORY_DIR: Final = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}")
+_REPOSITORY_PATH_COMPONENT: Final = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}")
 _BOUND: Final = 1000
 
 
@@ -58,7 +58,7 @@ def is_low_risk_git_inspection_segment(segment: ShellExecutionSegment) -> bool:
         return False
     operation_index = 1
     if tokens[1] == "-C":
-        if len(tokens) < 4 or _REPOSITORY_DIR.fullmatch(tokens[2]) is None:
+        if len(tokens) < 4 or not _safe_repository_path(tokens[2]):
             return False
         operation_index = 3
     operation = tokens[operation_index]
@@ -83,6 +83,20 @@ def is_low_risk_git_inspection_segment(segment: ShellExecutionSegment) -> bool:
             arg in {"--stat", "--oneline", "--name-only", "--name-status", "HEAD"} or _safe_ref(arg) for arg in args
         )
     return False
+
+
+def _safe_repository_path(value: str) -> bool:
+    if value == ".":
+        return True
+    if not value or len(value) > 512 or value.startswith(("/", "~")) or _dynamic(value):
+        return False
+    components = value.split("/")
+    if components[:1] == ["."]:
+        components = components[1:]
+    return bool(components) and all(
+        component not in {"", ".", ".."} and _REPOSITORY_PATH_COMPONENT.fullmatch(component) is not None
+        for component in components
+    )
 
 
 def _without_stderr_merge(tokens: tuple[str, ...]) -> tuple[str, ...] | None:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -1564,7 +1564,7 @@ def _destructive_shell_tool_action_request(
             canonical_command=canonical_command,
             interpreter_executable_identities=interpreter_executable_identities,
         )
-    if not execution_context.complete and cwd is None and home_dir is not None:
+    if not execution_context.complete and home_dir is not None:
         developer_execution_context = low_risk_compound_developer_execution_context(
             detection_command_text,
             home_dir=home_dir,

--- a/tests/fixtures/guard-command-corpus/decision-diff-report.json
+++ b/tests/fixtures/guard-command-corpus/decision-diff-report.json
@@ -12,8 +12,8 @@
     },
     "sources_sha256": {
       "source-0181b7136f7bc07d3738def8": "198f5e851641f0efc2187c46877c61d6049d9aac53943f205febbcf8ef29c45a",
-      "source-01febcca4015bcd1b7aeebc7": "d8ba562f931fb94cc5fb70cee874f36a26bc5607fd775994c4619ccf1d644c84",
-      "source-02aeab3ad023a11ada3b7743": "263ab3c2a24a7b87317fbbb7b7dcd609f4331a3382288ab2c8b84b12c8df369a",
+      "source-01febcca4015bcd1b7aeebc7": "de5d071acd98ddee81c7dbc9baeb89dd83bddbabf6a85364a304a2ada5c9ff39",
+      "source-02aeab3ad023a11ada3b7743": "c414d599148bd756f4bc8c03712af3433302cc4ece488d1d11e573ed0a2a29fb",
       "source-02c7cfdf8b65ef460436b48e": "afddde6b40115d0f834186b04bc3006c5fab25eb4085105c99cb901be33afdef",
       "source-05328ef847b0e979fa3bd03c": "64858338b8722344a1a30da5fbeda1cd6325e790d83979e4701229deeb68eda5",
       "source-0568fda2efc7a8044a58a4de": "4584361a7c51cb79073f2c5361a544623c082fffdf303ccbe73b05d843d41dc9",

--- a/tests/test_guard_compound_developer_inspection.py
+++ b/tests/test_guard_compound_developer_inspection.py
@@ -8,7 +8,13 @@ from codex_plugin_scanner.guard.cli.commands_support_runtime_artifacts import _h
 from codex_plugin_scanner.guard.models import GuardArtifact
 
 
-def _artifact(command: str, *, home: Path, harness: str = "pi") -> GuardArtifact | None:
+def _artifact(
+    command: str,
+    *,
+    home: Path,
+    harness: str = "pi",
+    workspace: Path | None = None,
+) -> GuardArtifact | None:
     return _hook_runtime_artifact(
         harness=harness,
         payload={
@@ -19,7 +25,7 @@ def _artifact(command: str, *, home: Path, harness: str = "pi") -> GuardArtifact
         action_envelope=None,
         home_dir=home,
         guard_home=home / ".guard",
-        workspace=None,
+        workspace=workspace,
     )
 
 
@@ -39,6 +45,52 @@ def test_harnesses_evaluate_compound_source_inspection_as_one_unit(
     )
 
     assert artifact is None
+
+
+@pytest.mark.parametrize("harness", ("pi", "codex", "claude-code", "gemini", "cursor"))
+def test_harnesses_recover_safe_inspection_after_cross_workspace_cd(
+    tmp_path: Path,
+    harness: str,
+) -> None:
+    home = tmp_path / "home"
+    active_workspace = home / "projects" / "active"
+    inspected_workspace = home / "projects" / "inspected"
+    active_workspace.mkdir(parents=True)
+    (inspected_workspace / "src").mkdir(parents=True)
+
+    artifact = _artifact(
+        f"cd {inspected_workspace} && grep -n TODO src/example.ts | head -20",
+        home=home,
+        harness=harness,
+        workspace=active_workspace,
+    )
+
+    assert artifact is None
+
+
+def test_cross_workspace_recovery_preserves_mutating_command_review(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    active_workspace = home / "projects" / "active"
+    inspected_workspace = home / "projects" / "inspected"
+    active_workspace.mkdir(parents=True)
+    inspected_workspace.mkdir(parents=True)
+
+    assert (
+        _artifact(
+            f"cd {inspected_workspace} && git push origin main",
+            home=home,
+            workspace=active_workspace,
+        )
+        is not None
+    )
+    assert (
+        _artifact(
+            f"cd {inspected_workspace} && vitest run src/example.test.ts --maxWorkers=1",
+            home=home,
+            workspace=active_workspace,
+        )
+        is not None
+    )
 
 
 def test_compound_git_and_filesystem_inspection_is_one_unit(tmp_path: Path) -> None:

--- a/tests/test_guard_compound_git_inspection.py
+++ b/tests/test_guard_compound_git_inspection.py
@@ -38,6 +38,18 @@ def test_compound_git_refresh_and_inspection_is_evaluated_as_one_unit(tmp_path: 
     assert artifact is None
 
 
+@pytest.mark.parametrize("repository", ("projects/repository", "./projects/repository", "."))
+def test_compound_git_inspection_accepts_bounded_relative_repository_paths(
+    tmp_path: Path,
+    repository: str,
+) -> None:
+    home = tmp_path / "home"
+    workspace = home / "workspace"
+    (workspace / "projects" / "repository").mkdir(parents=True)
+
+    assert _artifact(f"cd {workspace} && git -C {repository} status --short | head -20", home=home) is None
+
+
 @pytest.mark.parametrize(
     "suffix",
     (
@@ -45,6 +57,10 @@ def test_compound_git_refresh_and_inspection_is_evaluated_as_one_unit(tmp_path: 
         "git -C repository reset --hard origin/main",
         "git -C repository fetch origin main:refs/heads/main",
         "git -C ../outside fetch origin main",
+        "git -C projects/../../outside status --short",
+        "git -C /outside status --short",
+        "git -C ~/outside status --short",
+        "git -C projects/$TARGET status --short",
         "git -C repository status --short | sh",
         "git -C repository status --short > report.txt",
     ),


### PR DESCRIPTION
## Summary
- recover bounded read-only inspection after a deterministic cross-workspace directory change
- accept nested relative repository paths for constrained Git inspection
- preserve review for traversal, dynamic paths, test runners, and mutating Git operations

## Testing
- `uv run --no-sync pytest tests/test_guard_compound_git_inspection.py tests/test_guard_compound_developer_inspection.py tests/test_guard_shell_execution_context.py tests/test_guard_command_extensions.py tests/test_guard_package_intent.py tests/test_guard_approval_attention.py tests/test_pi_adapter.py tests/test_pi_hook_latency.py tests/test_pi_tool_call_id_adapter.py -q --tb=short`
- `uv run --no-sync pytest tests/test_guard_command_decision_diff.py -q --tb=short`
- `uv run --no-sync basedpyright --level error src/codex_plugin_scanner/guard/runtime/compound_git_inspection.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py`
- installed-wheel verification in an isolated Python container
