### PR TITLE
fix(evidence): recover command activity health

### DIFF
--- a/src/codex_plugin_scanner/guard/store_command_activity.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity.py
@@ -16,6 +16,11 @@ from .runtime.command_activity_contract import (
     CorrelationHandle,
 )
 from .runtime.command_shadow_evaluation import CommandShadowObservation
+from .store_command_activity_lifecycle import (
+    COMMAND_PERSISTENCE_ERROR_DOMAIN,
+    SHADOW_PERSISTENCE_ERROR_DOMAIN,
+    recover_command_activity_persistence,
+)
 from .store_command_activity_rollups import record_command_activity_rollups
 from .store_command_shadow import record_command_shadow_observation
 
@@ -113,6 +118,15 @@ class StoreCommandActivityMixin:
             if shadow is not None:
                 record_command_shadow_observation(connection, shadow)
             record_command_activity_rollups(connection, evidence)
+            recover_command_activity_persistence(
+                connection,
+                error_domain=COMMAND_PERSISTENCE_ERROR_DOMAIN,
+            )
+            if shadow is not None:
+                recover_command_activity_persistence(
+                    connection,
+                    error_domain=SHADOW_PERSISTENCE_ERROR_DOMAIN,
+                )
             return True
 
     def count_command_activities(self: _ConnectionOwner) -> int:

--- a/src/codex_plugin_scanner/guard/store_command_activity_api.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_api.py
@@ -424,12 +424,29 @@ def _health_payload(connection: sqlite3.Connection) -> dict[str, object]:
     )
     if row is None:
         return {"status": "degraded", "dropped_events": 0, "persistence_errors": 0}
+    active = cast(
+        sqlite3.Row | None,
+        connection.execute("select * from command_activity_health_active where singleton = 1").fetchone(),
+    )
+    last_error_at = str(row["last_error_at"]) if row["last_error_at"] is not None else None
     return {
-        "status": ("degraded" if int(row["dropped_event_count"]) or int(row["persistence_error_count"]) else "healthy"),
+        "status": (
+            "degraded"
+            if active is None
+            or any(
+                int(active[column])
+                for column in (
+                    "command_error_active",
+                    "shadow_error_active",
+                    "maintenance_error_active",
+                )
+            )
+            else "healthy"
+        ),
         "dropped_events": int(row["dropped_event_count"]),
         "persistence_errors": int(row["persistence_error_count"]),
         "last_error_class": str(row["last_error_code"]) if row["last_error_code"] is not None else None,
-        "last_error_at": str(row["last_error_at"]) if row["last_error_at"] is not None else None,
+        "last_error_at": last_error_at,
     }
 
 

--- a/src/codex_plugin_scanner/guard/store_command_activity_health_schema.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_health_schema.py
@@ -9,6 +9,7 @@ import sqlite3
 from typing import Final, cast
 
 COMMAND_ACTIVITY_HEALTH_MIGRATION_VERSION: Final = 11
+COMMAND_ACTIVITY_HEALTH_ACTIVE_MIGRATION_VERSION: Final = 19
 COMMAND_ACTIVITY_HEALTH_SCHEMA_VERSION: Final = "1.0.0"
 _HEALTH_TABLE_SQL: Final = """
 create table if not exists command_activity_health (
@@ -18,6 +19,15 @@ create table if not exists command_activity_health (
   last_error_code text check (last_error_code is null or length(last_error_code) between 1 and 64),
   last_error_at text,
   schema_version text not null
+)
+"""
+_HEALTH_ACTIVE_TABLE_SQL: Final = """
+create table if not exists command_activity_health_active (
+  singleton integer primary key check (singleton = 1),
+  command_error_active integer not null check (command_error_active in (0, 1)),
+  shadow_error_active integer not null check (shadow_error_active in (0, 1)),
+  maintenance_error_active integer not null check (maintenance_error_active in (0, 1)),
+  foreign key (singleton) references command_activity_health(singleton) on delete cascade
 )
 """
 
@@ -39,9 +49,30 @@ def ensure_command_activity_health_schema(connection: sqlite3.Connection, *, app
             (COMMAND_ACTIVITY_HEALTH_SCHEMA_VERSION,),
         )
         _validate_health_row(connection)
+        connection.execute(_HEALTH_ACTIVE_TABLE_SQL)
+        _validate_health_active_schema(connection)
+        connection.execute(
+            """
+            insert or ignore into command_activity_health_active (
+              singleton, command_error_active, shadow_error_active, maintenance_error_active
+            )
+            select singleton,
+              case when last_error_code is not null
+                     and last_error_code not in ('shadow_evaluation_failed', 'maintenance_failed')
+                   then 1 else 0 end,
+              case when last_error_code = 'shadow_evaluation_failed' then 1 else 0 end,
+              case when last_error_code = 'maintenance_failed' then 1 else 0 end
+            from command_activity_health where singleton = 1
+            """
+        )
+        _validate_health_active_row(connection)
         connection.execute(
             "insert or ignore into schema_migrations (version, applied_at) values (?, ?)",
             (COMMAND_ACTIVITY_HEALTH_MIGRATION_VERSION, applied_at),
+        )
+        connection.execute(
+            "insert or ignore into schema_migrations (version, applied_at) values (?, ?)",
+            (COMMAND_ACTIVITY_HEALTH_ACTIVE_MIGRATION_VERSION, applied_at),
         )
     except BaseException:
         connection.execute("rollback to command_activity_health_schema_v1")
@@ -86,6 +117,42 @@ def _validate_health_row(connection: sqlite3.Connection) -> None:
     )
     if row is None or row[5] != COMMAND_ACTIVITY_HEALTH_SCHEMA_VERSION:
         raise RuntimeError("incompatible command_activity_health singleton")
+
+
+def _validate_health_active_schema(connection: sqlite3.Connection) -> None:
+    rows = cast(
+        list[tuple[int, str, str, int, object | None, int]],
+        connection.execute("pragma table_info(command_activity_health_active)").fetchall(),
+    )
+    expected_columns = {
+        "singleton",
+        "command_error_active",
+        "shadow_error_active",
+        "maintenance_error_active",
+    }
+    if {str(row[1]) for row in rows} != expected_columns:
+        raise RuntimeError("incompatible command_activity_health_active schema")
+    primary_key = tuple(str(row[1]) for row in rows if int(row[5]) > 0)
+    if primary_key != ("singleton",):
+        raise RuntimeError("incompatible command_activity_health_active primary key")
+    row = cast(
+        tuple[str] | None,
+        connection.execute(
+            "select sql from sqlite_schema where type = 'table' and name = 'command_activity_health_active'"
+        ).fetchone(),
+    )
+    expected_sql = _canonical_sql(_HEALTH_ACTIVE_TABLE_SQL).replace(" if not exists", "", 1)
+    if row is None or _canonical_sql(row[0]) != expected_sql:
+        raise RuntimeError("incompatible command_activity_health_active schema object")
+
+
+def _validate_health_active_row(connection: sqlite3.Connection) -> None:
+    row = cast(
+        tuple[int, int, int, int] | None,
+        connection.execute("select * from command_activity_health_active where singleton = 1").fetchone(),
+    )
+    if row is None:
+        raise RuntimeError("incompatible command_activity_health_active singleton")
 
 
 def _canonical_sql(value: str) -> str:

--- a/src/codex_plugin_scanner/guard/store_command_activity_health_schema.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_health_schema.py
@@ -56,7 +56,11 @@ def ensure_command_activity_health_schema(connection: sqlite3.Connection, *, app
             insert or ignore into command_activity_health_active (
               singleton, command_error_active, shadow_error_active, maintenance_error_active
             )
-            select singleton, 0, 0, 0 from command_activity_health where singleton = 1
+            select singleton,
+              case when last_error_code is null then 0 else 1 end,
+              case when last_error_code is null then 0 else 1 end,
+              case when last_error_code is null then 0 else 1 end
+            from command_activity_health where singleton = 1
             """
         )
         _validate_health_active_row(connection)

--- a/src/codex_plugin_scanner/guard/store_command_activity_health_schema.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_health_schema.py
@@ -56,13 +56,7 @@ def ensure_command_activity_health_schema(connection: sqlite3.Connection, *, app
             insert or ignore into command_activity_health_active (
               singleton, command_error_active, shadow_error_active, maintenance_error_active
             )
-            select singleton,
-              case when last_error_code is not null
-                     and last_error_code not in ('shadow_evaluation_failed', 'maintenance_failed')
-                   then 1 else 0 end,
-              case when last_error_code = 'shadow_evaluation_failed' then 1 else 0 end,
-              case when last_error_code = 'maintenance_failed' then 1 else 0 end
-            from command_activity_health where singleton = 1
+            select singleton, 0, 0, 0 from command_activity_health where singleton = 1
             """
         )
         _validate_health_active_row(connection)

--- a/src/codex_plugin_scanner/guard/store_command_activity_lifecycle.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_lifecycle.py
@@ -35,6 +35,16 @@ from .store_command_activity_rollups import transition_command_activity_rollups
 
 _MAX_COUNTER: Final = 9_223_372_036_854_775_807
 _ERROR_CODE: Final = re.compile(r"[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*")
+COMMAND_PERSISTENCE_ERROR_DOMAIN: Final = "command"
+SHADOW_PERSISTENCE_ERROR_DOMAIN: Final = "shadow"
+MAINTENANCE_ERROR_DOMAIN: Final = "maintenance"
+_PERSISTENCE_ERROR_DOMAINS: Final = frozenset(
+    {
+        COMMAND_PERSISTENCE_ERROR_DOMAIN,
+        SHADOW_PERSISTENCE_ERROR_DOMAIN,
+        MAINTENANCE_ERROR_DOMAIN,
+    }
+)
 _EnumT = TypeVar("_EnumT", bound=Enum)
 
 
@@ -157,6 +167,10 @@ class StoreCommandActivityLifecycleMixin:
             if result.rowcount != 1:
                 raise RuntimeError("command activity changed during lifecycle transition")
             transition_command_activity_rollups(connection, previous, current)
+            recover_command_activity_persistence(
+                connection,
+                error_domain=COMMAND_PERSISTENCE_ERROR_DOMAIN,
+            )
             return True
 
     def record_command_activity_persistence_failure(
@@ -181,6 +195,14 @@ class StoreCommandActivityLifecycleMixin:
                 """,
                 (_MAX_COUNTER, _MAX_COUNTER, error_code, occurred_at.isoformat()),
             )
+            error_domain = _persistence_error_domain(error_code)
+            connection.execute(
+                f"""
+                update command_activity_health_active
+                set {error_domain}_error_active = 1
+                where singleton = 1
+                """
+            )
 
     def get_command_activity_persistence_health(
         self: _ConnectionOwner,
@@ -200,6 +222,32 @@ class StoreCommandActivityLifecycleMixin:
             last_error_at=datetime.fromisoformat(last_error_at) if last_error_at is not None else None,
             schema_version=str(row["schema_version"]),
         )
+
+
+def recover_command_activity_persistence(
+    connection: sqlite3.Connection,
+    *,
+    error_domain: str,
+) -> None:
+    """Clear only the active error class recovered by this successful operation."""
+
+    if error_domain not in _PERSISTENCE_ERROR_DOMAINS:
+        raise ValueError("invalid persistence error domain")
+    connection.execute(
+        f"""
+        update command_activity_health_active
+        set {error_domain}_error_active = 0
+        where singleton = 1
+        """
+    )
+
+
+def _persistence_error_domain(error_code: str) -> str:
+    if error_code == "maintenance_failed":
+        return MAINTENANCE_ERROR_DOMAIN
+    if error_code == "shadow_evaluation_failed":
+        return SHADOW_PERSISTENCE_ERROR_DOMAIN
+    return COMMAND_PERSISTENCE_ERROR_DOMAIN
 
 
 def _select_by_request_correlation(

--- a/src/codex_plugin_scanner/guard/store_command_activity_maintenance.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_maintenance.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from typing import Final, Protocol, cast
 
+from .store_command_activity_lifecycle import MAINTENANCE_ERROR_DOMAIN, recover_command_activity_persistence
 from .store_command_activity_rollups import (
     CommandActivityRollupBackfillResult,
     backfill_command_activity_rollups_batch,
@@ -58,6 +59,7 @@ class StoreCommandActivityMaintenanceMixin:
             last_completed_day = str(state["last_completed_day"]) if state["last_completed_day"] is not None else None
             pending = connection.execute("select 1 from command_activity_rollup_pending limit 1").fetchone()
             if last_completed_day == today and pending is None:
+                recover_command_activity_persistence(connection, error_domain=MAINTENANCE_ERROR_DOMAIN)
                 return CommandActivityMaintenanceResult(False, True, 0, 0, 0, 0)
 
             backfill = _backfill_batch(connection, state=state, batch_size=batch_size, now=now)
@@ -102,6 +104,7 @@ class StoreCommandActivityMaintenanceMixin:
                     backfill.cursor_complete,
                 ),
             )
+            recover_command_activity_persistence(connection, error_domain=MAINTENANCE_ERROR_DOMAIN)
             return CommandActivityMaintenanceResult(
                 True,
                 completed,

--- a/src/codex_plugin_scanner/guard/store_command_activity_privacy.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_privacy.py
@@ -92,6 +92,15 @@ class StoreCommandActivityPrivacyMixin:
             )
             connection.execute(
                 """
+                update command_activity_health_active
+                set command_error_active = 0,
+                    shadow_error_active = 0,
+                    maintenance_error_active = 0
+                where singleton = 1
+                """
+            )
+            connection.execute(
+                """
                 update command_activity_maintenance
                 set last_completed_day = null,
                     last_run_at = null,

--- a/tests/test_guard_command_activity_health_recovery.py
+++ b/tests/test_guard_command_activity_health_recovery.py
@@ -1,0 +1,113 @@
+"""Recovery semantics for current command-activity persistence health."""
+
+# pyright: reportAny=false, reportIndexIssue=false, reportPrivateUsage=false, reportUnusedCallResult=false
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import cast
+
+from codex_plugin_scanner.guard.runtime.command_activity_api_contract import CommandActivityAnalyticsQuery
+from codex_plugin_scanner.guard.runtime.command_activity_contract import (
+    ActivityApprovalReuseStatus,
+    ActivityDecisionReason,
+)
+from codex_plugin_scanner.guard.runtime.command_activity_lifecycle import (
+    CommandActivityDecisionFacts,
+    build_pre_hook_evidence,
+)
+from codex_plugin_scanner.guard.runtime.command_evaluation import evaluate_command
+from codex_plugin_scanner.guard.runtime.command_shadow_evaluation import (
+    CommandShadowCohort,
+    CommandShadowControl,
+    CommandShadowProposal,
+    build_command_shadow_observation,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+from tests.guard_command_activity_api_support import evidence, seed
+
+_NOW = datetime(2026, 7, 18, 20, 4, tzinfo=timezone.utc)
+
+
+def _health(store: GuardStore) -> dict[str, object]:
+    payload = store.command_activity_analytics(
+        CommandActivityAnalyticsQuery(days=7),
+        as_of=date(2026, 7, 18),
+    )
+    return cast(dict[str, object], payload["health"])
+
+
+def _shadow_evidence(activity_id: str):
+    evaluation = evaluate_command("git push origin release/2.1 --force")
+    activity_evidence = build_pre_hook_evidence(
+        evaluation,
+        CommandActivityDecisionFacts(
+            policy_action="allow",
+            decision_reason_code=ActivityDecisionReason.EXTENSION_MATCH,
+            prompted=False,
+            approval_reuse_status=ActivityApprovalReuseStatus.NOT_APPLICABLE,
+            receipt_id=None,
+        ),
+        activity_id=activity_id,
+        occurred_at=_NOW,
+        harness="codex",
+        request_correlation=None,
+    )
+    cohorts = frozenset({CommandShadowCohort.BASELINE})
+    shadow = build_command_shadow_observation(
+        evaluation,
+        authoritative_action="allow",
+        proposal=CommandShadowProposal(evaluation.decision_plane, cohorts, "proposal.recovery.v1"),
+        activity_id=activity_id,
+        occurred_at=_NOW,
+        control=CommandShadowControl(True, False, cohorts, frozenset(), 10_000),
+    )
+    assert shadow is not None
+    return activity_evidence, shadow
+
+
+def test_command_health_recovers_by_write_order_without_resetting_counters(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    seed(store)
+    store.record_command_activity(evidence("activity:future-event", minute=10))
+    store.record_command_activity_persistence_failure(error_code="post_record_failed", occurred_at=_NOW)
+    assert _health(store)["status"] == "degraded"
+
+    store.record_command_activity(evidence("activity:delayed-event", minute=3))
+    recovered = _health(store)
+    assert recovered["status"] == "healthy"
+    assert recovered["dropped_events"] == recovered["persistence_errors"] == 1
+    assert recovered["last_error_class"] == "post_record_failed"
+
+
+def test_interleaved_failure_domains_recover_independently(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    store.record_command_activity_persistence_failure(error_code="maintenance_failed", occurred_at=_NOW)
+    store.record_command_activity_persistence_failure(error_code="post_record_failed", occurred_at=_NOW)
+    store.record_command_activity(evidence("activity:command-recovered", minute=5))
+    assert _health(store)["status"] == "degraded"
+
+    store.maintain_command_activity(now=_NOW, detail_retain_days=30)
+    recovered = _health(store)
+    assert recovered["status"] == "healthy"
+    assert recovered["dropped_events"] == recovered["persistence_errors"] == 2
+
+
+def test_command_write_does_not_mask_maintenance_failure(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    store.record_command_activity_persistence_failure(error_code="maintenance_failed", occurred_at=_NOW)
+    store.record_command_activity(evidence("activity:command-success", minute=5))
+    assert _health(store)["status"] == "degraded"
+
+
+def test_shadow_failure_requires_successful_shadow_persistence_to_recover(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    store.record_command_activity_persistence_failure(error_code="shadow_evaluation_failed", occurred_at=_NOW)
+    activity_evidence, _shadow = _shadow_evidence("activity:shadow-not-run")
+    store.record_command_activity(activity_evidence)
+    assert _health(store)["status"] == "degraded"
+
+    recovered_evidence, recovered_shadow = _shadow_evidence("activity:shadow-recovered")
+    store.record_command_activity(recovered_evidence, shadow=recovered_shadow)
+    assert _health(store)["status"] == "healthy"

--- a/tests/test_guard_command_activity_lifecycle_store.py
+++ b/tests/test_guard_command_activity_lifecycle_store.py
@@ -104,7 +104,7 @@ def test_health_migration_is_v11_atomic_and_reopens(tmp_path: Path) -> None:
     assert initial.schema_version == health_schema.COMMAND_ACTIVITY_HEALTH_SCHEMA_VERSION
 
 
-def test_health_active_domain_migration_starts_new_observation_without_resetting_counts(tmp_path: Path) -> None:
+def test_health_active_domain_migration_requires_each_pipeline_to_prove_recovery(tmp_path: Path) -> None:
     path = tmp_path / "legacy-health.db"
     with sqlite3.connect(path) as connection:
         connection.execute("pragma foreign_keys = on")
@@ -127,7 +127,7 @@ def test_health_active_domain_migration_starts_new_observation_without_resetting
         ).fetchone()
 
     assert health == (1, 337, 337, "post_record_failed", "2026-07-18T20:00:00+00:00", "1.0.0")
-    assert active == (1, 0, 0, 0)
+    assert active == (1, 1, 1, 1)
     assert migration == (19,)
 
 

--- a/tests/test_guard_command_activity_lifecycle_store.py
+++ b/tests/test_guard_command_activity_lifecycle_store.py
@@ -1,6 +1,7 @@
 """Transactional lifecycle and health tests for command activity persistence."""
 
-# pyright: reportAny=false, reportPrivateUsage=false, reportUnusedCallResult=false
+# pyright: reportAny=false, reportMissingImports=false, reportPrivateUsage=false
+# pyright: reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnusedCallResult=false
 
 from __future__ import annotations
 
@@ -101,6 +102,33 @@ def test_health_migration_is_v11_atomic_and_reopens(tmp_path: Path) -> None:
     assert initial == reopened.get_command_activity_persistence_health()
     assert initial.dropped_event_count == 0
     assert initial.schema_version == health_schema.COMMAND_ACTIVITY_HEALTH_SCHEMA_VERSION
+
+
+def test_health_active_domain_migration_maps_existing_error_without_resetting_counts(tmp_path: Path) -> None:
+    path = tmp_path / "legacy-health.db"
+    with sqlite3.connect(path) as connection:
+        connection.execute("pragma foreign_keys = on")
+        connection.execute("create table schema_migrations (version integer primary key, applied_at text not null)")
+        connection.execute(health_schema._HEALTH_TABLE_SQL)
+        connection.execute(
+            """
+            insert into command_activity_health values (
+              1, 337, 337, 'post_record_failed', '2026-07-18T20:00:00+00:00', '1.0.0'
+            )
+            """
+        )
+
+        health_schema.ensure_command_activity_health_schema(connection, applied_at=_NOW.isoformat())
+        health = connection.execute("select * from command_activity_health where singleton = 1").fetchone()
+        active = connection.execute("select * from command_activity_health_active where singleton = 1").fetchone()
+        migration = connection.execute(
+            "select version from schema_migrations where version = ?",
+            (health_schema.COMMAND_ACTIVITY_HEALTH_ACTIVE_MIGRATION_VERSION,),
+        ).fetchone()
+
+    assert health == (1, 337, 337, "post_record_failed", "2026-07-18T20:00:00+00:00", "1.0.0")
+    assert active == (1, 1, 0, 0)
+    assert migration == (19,)
 
 
 def test_health_migration_failure_rolls_back_table_and_version(

--- a/tests/test_guard_command_activity_lifecycle_store.py
+++ b/tests/test_guard_command_activity_lifecycle_store.py
@@ -104,7 +104,7 @@ def test_health_migration_is_v11_atomic_and_reopens(tmp_path: Path) -> None:
     assert initial.schema_version == health_schema.COMMAND_ACTIVITY_HEALTH_SCHEMA_VERSION
 
 
-def test_health_active_domain_migration_maps_existing_error_without_resetting_counts(tmp_path: Path) -> None:
+def test_health_active_domain_migration_starts_new_observation_without_resetting_counts(tmp_path: Path) -> None:
     path = tmp_path / "legacy-health.db"
     with sqlite3.connect(path) as connection:
         connection.execute("pragma foreign_keys = on")
@@ -127,7 +127,7 @@ def test_health_active_domain_migration_maps_existing_error_without_resetting_co
         ).fetchone()
 
     assert health == (1, 337, 337, "post_record_failed", "2026-07-18T20:00:00+00:00", "1.0.0")
-    assert active == (1, 1, 0, 0)
+    assert active == (1, 0, 0, 0)
     assert migration == (19,)
 
 


### PR DESCRIPTION
## Summary
- recover current command-activity health after successful persistence without resetting cumulative failure counters
- track command, shadow, and maintenance failures independently across existing and new local databases
- add regression coverage for delayed timestamps, interleaved failures, maintenance isolation, shadow recovery, and legacy state migration

## Testing
- `uv run --no-sync pytest -q tests/test_guard_command_activity_*.py tests/test_guard_command_shadow_persistence.py --tb=short`
- `uv run --no-sync ruff check <changed Python files>`
- `uv run --no-sync ruff format --check <changed Python files>`
- `uv run --no-sync basedpyright <changed Python files>`
- `uv build`
- `git diff --check`
