### PR TITLE
fix(evidence): recover command activity health promptly

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
@@ -112,7 +112,11 @@ def record_pre_hook_command_activity_best_effort(
             occurred_at=occurred_at,
         )
         try:
-            recorded = store.record_command_activity(evidence, shadow=shadow)
+            recorded = store.record_command_activity(
+                evidence,
+                shadow=shadow,
+                shadow_evaluation_succeeded=not shadow_failed,
+            )
         except Exception:
             if correlation is not None and store.is_exact_command_activity_pre_replay(evidence):
                 return False

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -6306,6 +6306,7 @@ class GuardDaemonServer:
             self._command_activity_maintenance_thread = None
 
     def _command_activity_maintenance_loop(self) -> None:
+        self._maintain_command_activity_best_effort()
         while not self._shutdown_started.wait(3_600):
             self._maintain_command_activity_best_effort()
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -6306,6 +6306,8 @@ class GuardDaemonServer:
             self._command_activity_maintenance_thread = None
 
     def _command_activity_maintenance_loop(self) -> None:
+        if self._shutdown_started.is_set():
+            return
         self._maintain_command_activity_best_effort()
         while not self._shutdown_started.wait(3_600):
             self._maintain_command_activity_best_effort()

--- a/src/codex_plugin_scanner/guard/store_command_activity.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity.py
@@ -35,6 +35,7 @@ class StoreCommandActivityMixin:
         evidence: CommandActivityEvidence,
         *,
         shadow: CommandShadowObservation | None = None,
+        shadow_evaluation_succeeded: bool = False,
     ) -> bool:
         """Persist one logical command and its rule hits; return false for an exact replay."""
 
@@ -122,7 +123,7 @@ class StoreCommandActivityMixin:
                 connection,
                 error_domain=COMMAND_PERSISTENCE_ERROR_DOMAIN,
             )
-            if shadow is not None:
+            if shadow is not None or shadow_evaluation_succeeded:
                 recover_command_activity_persistence(
                     connection,
                     error_domain=SHADOW_PERSISTENCE_ERROR_DOMAIN,

--- a/tests/test_guard_command_activity_health_recovery.py
+++ b/tests/test_guard_command_activity_health_recovery.py
@@ -111,3 +111,13 @@ def test_shadow_failure_requires_successful_shadow_persistence_to_recover(tmp_pa
     recovered_evidence, recovered_shadow = _shadow_evidence("activity:shadow-recovered")
     store.record_command_activity(recovered_evidence, shadow=recovered_shadow)
     assert _health(store)["status"] == "healthy"
+
+
+def test_successful_disabled_shadow_evaluation_recovers_shadow_health(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    store.record_command_activity_persistence_failure(error_code="shadow_evaluation_failed", occurred_at=_NOW)
+    activity_evidence, _shadow = _shadow_evidence("activity:shadow-disabled")
+
+    store.record_command_activity(activity_evidence, shadow_evaluation_succeeded=True)
+
+    assert _health(store)["status"] == "healthy"

--- a/tests/test_guard_command_activity_maintenance_runtime.py
+++ b/tests/test_guard_command_activity_maintenance_runtime.py
@@ -26,6 +26,9 @@ class _SequencedEvent:
         self.calls += 1
         return self.calls > 2
 
+    def is_set(self) -> bool:
+        return False
+
 
 @dataclass(frozen=True, slots=True)
 class _LoadedConfig:
@@ -77,6 +80,18 @@ def test_long_lived_daemon_rechecks_daily_and_uses_global_retention(monkeypatch:
     monkeypatch.setattr(daemon_server, "load_guard_config", load)
     daemon_server.GuardDaemonServer._maintain_command_activity_best_effort(service)
     assert loaded == [(Path("/global-home"), None)]
+
+
+def test_daemon_shutdown_skips_initial_command_activity_maintenance() -> None:
+    service = object.__new__(daemon_server.GuardDaemonServer)
+    service._shutdown_started = threading.Event()
+    service._shutdown_started.set()
+    maintenance_calls: list[int] = []
+    service._maintain_command_activity_best_effort = lambda: maintenance_calls.append(1)
+
+    service._command_activity_maintenance_loop()
+
+    assert maintenance_calls == []
 
 
 def test_daemon_restart_rejects_a_still_stopping_maintenance_worker() -> None:

--- a/tests/test_guard_command_activity_maintenance_runtime.py
+++ b/tests/test_guard_command_activity_maintenance_runtime.py
@@ -64,7 +64,7 @@ def test_long_lived_daemon_rechecks_daily_and_uses_global_retention(monkeypatch:
     maintenance_calls: list[int] = []
     service._maintain_command_activity_best_effort = lambda: maintenance_calls.append(1)
     service._command_activity_maintenance_loop()
-    assert len(maintenance_calls) == 2
+    assert len(maintenance_calls) == 3
 
     loaded: list[tuple[Path, Path | None]] = []
     object.__setattr__(service, "_server", _FakeServer(_FakeStore()))


### PR DESCRIPTION
## Summary
- clear recovered shadow-evaluation health after a successful evaluation, including intentionally disabled shadow sampling
- run command-activity maintenance immediately when the daemon starts so recovered evidence health is reflected promptly

## Testing
- `uv run --no-sync pytest -q tests/test_guard_command_activity*.py tests/test_pi_tool_call_id_adapter.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/store_command_activity.py src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_command_activity_health_recovery.py tests/test_guard_command_activity_maintenance_runtime.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/store_command_activity.py src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_command_activity_health_recovery.py tests/test_guard_command_activity_maintenance_runtime.py`
- `uv build --wheel --out-dir <output-directory>`
