### PR TITLE
fix(daemon): restart after installed runtime updates

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -642,6 +642,13 @@ def _daemon_healthz_details_match_guard_home(url: str, guard_home: Path, *, auth
     return _healthz_payload_matches_guard_home(json.dumps(payload), guard_home)
 
 
+def _daemon_healthz_details_match_current_runtime(payload: dict[str, object]) -> bool:
+    return (
+        payload.get("package_version") == __version__
+        and payload.get("runtime_fingerprint") == _current_guard_daemon_runtime_fingerprint()
+    )
+
+
 def _guard_daemon_url_port(url: str) -> int | None:
     try:
         parsed = urllib.parse.urlparse(url)
@@ -708,7 +715,11 @@ def _initialize_existing_guard_daemon(guard_home: Path, port: int) -> _ExistingG
     if not isinstance(auth_token, str) or not auth_token.strip():
         return None
     details_payload = _daemon_healthz_details_payload(url, auth_token)
-    if details_payload is None or not _healthz_payload_matches_guard_home(json.dumps(details_payload), guard_home):
+    if (
+        details_payload is None
+        or not _healthz_payload_matches_guard_home(json.dumps(details_payload), guard_home)
+        or not _daemon_healthz_details_match_current_runtime(details_payload)
+    ):
         return None
     pid = details_payload.get("pid")
     if not isinstance(pid, int) or pid <= 0:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5639,6 +5639,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "tables": store.list_table_names(),
             "compatibility_version": GUARD_DAEMON_COMPATIBILITY_VERSION,
             "package_version": __version__,
+            "runtime_fingerprint": current_guard_daemon_runtime_fingerprint(),
             "guard_home": str(store.guard_home.resolve()),
             "command_activity_evidence": {
                 "state": "degraded" if activity_health.persistence_error_count else "healthy",

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -572,6 +572,71 @@ def test_ensure_guard_daemon_adopts_running_guard_daemon_before_respawning(tmp_p
     assert state_payload["pid"] == 111
 
 
+@pytest.mark.parametrize(
+    ("package_version", "runtime_fingerprint", "expected"),
+    [
+        (
+            daemon_manager_module.__version__,
+            daemon_manager_module._current_guard_daemon_runtime_fingerprint(),
+            True,
+        ),
+        ("older-release", daemon_manager_module._current_guard_daemon_runtime_fingerprint(), False),
+        (daemon_manager_module.__version__, "older-runtime", False),
+        (None, None, False),
+    ],
+)
+def test_daemon_adoption_requires_exact_installed_runtime(
+    package_version: object,
+    runtime_fingerprint: object,
+    expected: bool,
+) -> None:
+    assert (
+        daemon_manager_module._daemon_healthz_details_match_current_runtime(
+            {
+                "package_version": package_version,
+                "runtime_fingerprint": runtime_fingerprint,
+            }
+        )
+        is expected
+    )
+
+
+def test_initialize_existing_guard_daemon_rejects_stale_runtime(tmp_path, monkeypatch) -> None:
+    guard_home = tmp_path / "guard-home"
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "ok": True,
+                    "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+                }
+            ).encode("utf-8")
+
+    monkeypatch.setattr(daemon_manager_module.urllib.request, "urlopen", lambda *_args, **_kwargs: FakeResponse())
+    monkeypatch.setattr(daemon_manager_module, "load_guard_daemon_auth_token", lambda _guard_home: "secret-token")
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_daemon_healthz_details_payload",
+        lambda _url, _token: {
+            "guard_home": str(guard_home.resolve()),
+            "package_version": daemon_manager_module.__version__,
+            "runtime_fingerprint": "older-runtime",
+            "pid": 111,
+        },
+    )
+
+    assert daemon_manager_module._initialize_existing_guard_daemon(guard_home, 5474) is None
+
+
 def test_adopt_existing_guard_daemon_skips_scan_on_windows(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -48,6 +48,7 @@ from codex_plugin_scanner.guard.codex_config import read_toml_payload
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config, overlay_synced_guard_policy
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.daemon.manager import current_guard_daemon_runtime_fingerprint
 from codex_plugin_scanner.guard.models import (
     GuardAction,
     GuardApprovalRequest,
@@ -19933,6 +19934,8 @@ def test_guard_daemon_serves_health_and_receipt_state(tmp_path):
     assert "receipts" not in health_payload
     assert detailed_health_payload["ok"] is True
     assert detailed_health_payload["receipts"] == 1
+    assert detailed_health_payload["package_version"]
+    assert detailed_health_payload["runtime_fingerprint"] == current_guard_daemon_runtime_fingerprint()
     assert runtime_error is not None
     assert runtime_error.code == 404
 


### PR DESCRIPTION
## Summary

- expose the authenticated daemon runtime fingerprint in detailed health state
- adopt an existing daemon only when its package version and runtime fingerprint exactly match the installed runtime
- reject stale or legacy daemon processes so a package update starts the newly installed code

## Why

A daemon from an older installation could be adopted after an upgrade because adoption checked only protocol compatibility and Guard home identity. That left the old process serving stale behavior even though the CLI package had been updated.

## Verification

- `uv run pytest -q tests/test_guard_daemon_manager.py`
- focused daemon adoption and detailed health tests
- `uv run ruff check` on changed files
- `uv run basedpyright` on changed source files