### PR TITLE
fix(dashboard): restore queue command previews

### DIFF
--- a/dashboard/src/approval-center-mobile.test.ts
+++ b/dashboard/src/approval-center-mobile.test.ts
@@ -3,6 +3,7 @@ import {
   sortQueue,
   buildProgressCopy,
 } from "./queue-state";
+import { queueItemPreview } from "./review-queue-item";
 import type { GuardApprovalRequest } from "./guard-types";
 
 function assert(condition: boolean, message: string): void {
@@ -60,6 +61,21 @@ const THIRD_REQUEST: GuardApprovalRequest = {
 };
 
 const multipleRequests = [BASE_REQUEST, SECOND_REQUEST, THIRD_REQUEST];
+
+assert(
+  queueItemPreview(BASE_REQUEST) === "git status",
+  "Queue rows prefer the command launch target over the artifact category",
+);
+
+assert(
+  queueItemPreview({
+    ...BASE_REQUEST,
+    launch_target: null,
+    launch_summary: "Pi wants to run `scp report.txt host:/srv/report.txt`",
+    artifact_name: "compound bash SCP overwrite command",
+  }) === "scp report.txt host:/srv/report.txt",
+  "Queue rows recover a command prefix from the launch summary before the artifact category",
+);
 
 assert(
   multipleRequests.length >= 2,

--- a/dashboard/src/review-queue-item.tsx
+++ b/dashboard/src/review-queue-item.tsx
@@ -20,7 +20,7 @@ import {
   HiMiniServerStack,
   HiMiniShieldCheck,
 } from "react-icons/hi2";
-import { displayArtifactName, harnessDisplayName } from "./approval-center-utils";
+import { harnessDisplayName, resolveStoppedCommandText } from "./approval-center-utils";
 import type { GuardApprovalRequest } from "./guard-types";
 import {
   formatQueueRequestDate,
@@ -144,7 +144,7 @@ export function QueueItemRow({ item, active, readState, index, onOpenRequest, se
               {preview}
             </p>
             <p className="truncate text-[11px] text-muted-foreground">
-              {harnessDisplayName(item.harness)} · {category.shortLabel} · {formatQueueRequestDate(item)}
+              {harnessDisplayName(item.harness)} · {formatQueueRequestDate(item)}
             </p>
           </div>
           <span
@@ -234,7 +234,7 @@ function iconForQueueCategory(categoryId: QueueCategoryId) {
   }
 }
 
-function queueItemPreview(item: GuardApprovalRequest): string {
+export function queueItemPreview(item: GuardApprovalRequest): string {
   const envelope = item.action_envelope_json;
   return (
     envelope?.command ??
@@ -242,6 +242,6 @@ function queueItemPreview(item: GuardApprovalRequest): string {
     envelope?.mcp_tool ??
     (envelope?.prompt_text ?? envelope?.prompt_excerpt) ??
     envelope?.package_name ??
-    displayArtifactName(item)
+    resolveStoppedCommandText(item)
   );
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -28201,8 +28201,6 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                 /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "truncate text-[11px] text-muted-foreground", children: [
                   harnessDisplayName(item.harness),
                   " · ",
-                  category.shortLabel,
-                  " · ",
                   formatQueueRequestDate(item)
                 ] })
               ] }),
@@ -28297,7 +28295,7 @@ function iconForQueueCategory(categoryId) {
 }
 function queueItemPreview(item) {
   const envelope = item.action_envelope_json;
-  return envelope?.command ?? item.raw_command_text ?? envelope?.mcp_tool ?? (envelope?.prompt_text ?? envelope?.prompt_excerpt) ?? envelope?.package_name ?? displayArtifactName(item);
+  return envelope?.command ?? item.raw_command_text ?? envelope?.mcp_tool ?? (envelope?.prompt_text ?? envelope?.prompt_excerpt) ?? envelope?.package_name ?? resolveStoppedCommandText(item);
 }
 const QUEUE_PAGE_SIZE$1 = 10;
 function ReviewHeader({


### PR DESCRIPTION
## Summary
- restore command previews in Inbox queue rows when commands are stored in launch metadata
- keep command categories in the existing accessible icon tooltip instead of repeating them as row text
- rebuild the bundled dashboard asset

## Testing
- `bun src/approval-center-mobile.test.ts`
- `bun run build`

## Notes
- The authenticated browser replay was blocked by Guard because it required passing the local dashboard session to a headless process.
