### PR TITLE
fix(mcp): repair legacy browser request labels

### DIFF
--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -13,11 +13,24 @@ from .approval_scope_support import request_scope_contract_payload, supported_re
 from .decision_boundaries import canonical_approval_surfaces
 from .models import GuardApprovalRequest
 from .runtime.action_identity import normalize_command_identity
+from .runtime.browser_mcp_intent import _classify_operation
 
 MAX_APPROVAL_PAGE_LIMIT = 200
 APPROVAL_QUEUE_BACKFILL_BATCH_SIZE = 500
 _APPROVAL_RESOLUTION_BATCH_SIZE = 500
 _QUEUE_IDENTITY_VERSION = "v1"
+_LEGACY_BROWSER_MULTI_ELEMENT_OPERATIONS = frozenset({"drag", "drag_drop_file", "fill_form"})
+_LEGACY_BROWSER_ELEMENT_OPERATIONS = frozenset(
+    {
+        "click",
+        "fill",
+        "fill_input",
+        "focus_element",
+        "hover",
+        "select_dropdown",
+        "upload_file",
+    }
+)
 _VOLATILE_PAYLOAD_KEY_TOKENS = frozenset(
     {
         "callid",
@@ -39,6 +52,42 @@ class InvalidApprovalCursorError(ValueError):
 
 def _normalized_identity_key(launch_target: str | None) -> str:
     return normalize_command_identity(launch_target or "")
+
+
+def _browser_launch_target_for_display(value: object) -> tuple[object, str | None]:
+    """Repair legacy browser labels without changing persisted approval identity."""
+    if not isinstance(value, str):
+        return value, None
+    parts = value.split()
+    if len(parts) != 3 or parts[2] != "unknown":
+        return value, None
+    server_name, operation, _unknown = parts
+    intent = _classify_operation(operation, server_name)
+    if intent is None:
+        return value, None
+
+    operation_lower = operation.lower()
+    if "network" in operation_lower:
+        target = "network request" if operation_lower.startswith(("get_", "read_")) else "network activity"
+    elif "console" in operation_lower:
+        target = "console message" if operation_lower.startswith(("get_", "read_")) else "console messages"
+    elif operation_lower in _LEGACY_BROWSER_MULTI_ELEMENT_OPERATIONS:
+        target = "page elements"
+    elif operation_lower in _LEGACY_BROWSER_ELEMENT_OPERATIONS:
+        target = "page element"
+    elif operation_lower in {"list_pages", "browser_list_pages"}:
+        target = "open pages"
+    elif operation_lower in {"select_page", "close_page", "browser_select_page", "browser_close_page"}:
+        target = "browser page"
+    else:
+        target = "current page"
+    return f"{server_name} {operation} {target}", target
+
+
+def _browser_risk_signals_for_display(signals: list[object], target: str | None) -> list[object]:
+    if target is None:
+        return signals
+    return [signal.replace("unknown target", target) if isinstance(signal, str) else signal for signal in signals]
 
 
 def _begin_immediate(connection: sqlite3.Connection) -> None:
@@ -612,6 +661,8 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         parsed_action_envelope if parsed_action_envelope is not None else row["action_envelope_json"],
         reject_contradiction=False,
     )
+    launch_target, browser_target = _browser_launch_target_for_display(row["launch_target"])
+    risk_signals = _browser_risk_signals_for_display(_safe_json_list(row["risk_signals_json"]), browser_target)
     payload: dict[str, object] = {
         "request_id": str(row["request_id"]),
         "harness": str(row["harness"]),
@@ -627,7 +678,7 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "oauth_source": row["oauth_source"],
         "config_path": str(row["config_path"]),
         "workspace": row["workspace"],
-        "launch_target": row["launch_target"],
+        "launch_target": launch_target,
         "normalized_identity_key": row["normalized_identity_key"],
         "action_identity": row["action_identity"],
         "queue_group_id": row["queue_group_id"],
@@ -637,7 +688,7 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "resolution_intent": row["resolution_action"],
         "transport": row["transport"],
         "risk_summary": row["risk_summary"],
-        "risk_signals": _safe_json_list(row["risk_signals_json"]),
+        "risk_signals": risk_signals,
         "artifact_label": row["artifact_label"],
         "source_label": row["source_label"],
         "trigger_summary": row["trigger_summary"],
@@ -796,6 +847,7 @@ def _row_to_approval_summary(row: sqlite3.Row) -> dict[str, object]:
         parsed_action_envelope if parsed_action_envelope is not None else row["action_envelope_json"],
         reject_contradiction=False,
     )
+    launch_target, _browser_target = _browser_launch_target_for_display(row["launch_target"])
     payload: dict[str, object] = {
         "request_id": str(row["request_id"]),
         "harness": str(row["harness"]),
@@ -807,7 +859,7 @@ def _row_to_approval_summary(row: sqlite3.Row) -> dict[str, object]:
         "source_scope": str(row["source_scope"]),
         "config_path": str(row["config_path"]),
         "workspace": row["workspace"],
-        "launch_target": row["launch_target"],
+        "launch_target": launch_target,
         "risk_summary": row["risk_summary"],
         "risk_headline": row["risk_headline"],
         "raw_command_text": row["raw_command_text"],

--- a/tests/test_guard_approval_store_scale.py
+++ b/tests/test_guard_approval_store_scale.py
@@ -671,7 +671,7 @@ class TestMigrationFromOldSchema:
 
 
 class TestCorruptionRecovery:
-    def test_malformed_risk_signals_json_falls_back_gracefully(self) -> None:
+    def test_risk_signal_payloads_are_safe_and_legacy_browser_labels_are_repaired(self) -> None:
         conn = _make_conn()
         req = _make_request()
         _insert(conn, req)
@@ -682,6 +682,47 @@ class TestCorruptionRecovery:
         row = get_approval_request(conn, req.request_id)
         assert row is not None
         assert isinstance(row["risk_signals"], list)
+
+        cases = (
+            ("click", "page element", "browser interaction on"),
+            ("fill_form", "page elements", "browser interaction on"),
+            ("new_page", "current page", "browser navigation to"),
+            ("take_snapshot", "current page", "browser inspection of"),
+            ("get_network_request", "network request", "browser inspection of"),
+            ("list_console_messages", "console messages", "browser inspection of"),
+        )
+        request_ids: set[str] = set()
+        for index, (operation, target, risk_prefix) in enumerate(cases, start=1):
+            legacy = dataclasses.replace(
+                _make_request(artifact_id=f"codex:project:chrome-devtools:{operation}"),
+                artifact_name=operation,
+                artifact_type="tool_call",
+                launch_target=f"chrome-devtools {operation} unknown",
+                risk_signals=[f"{risk_prefix} unknown target"],
+            )
+            _insert(conn, legacy, now=f"2026-01-02T00:00:0{index}Z")
+            request_ids.add(legacy.request_id)
+            detail = get_approval_request(conn, legacy.request_id)
+            assert detail is not None
+            assert detail["launch_target"] == f"chrome-devtools {operation} {target}"
+            assert detail["risk_signals"] == [f"{risk_prefix} {target}"]
+            stored = conn.execute(
+                "select launch_target, risk_signals_json from approval_requests where request_id = ?",
+                (legacy.request_id,),
+            ).fetchone()
+            assert stored is not None
+            assert stored["launch_target"] == f"chrome-devtools {operation} unknown"
+            assert stored["risk_signals_json"] == f'["{risk_prefix} unknown target"]'
+
+        page = list_pending_approval_summaries(conn, limit=10)
+        summaries = page["items"]
+        assert isinstance(summaries, list)
+        repaired: set[object] = set()
+        for item in summaries:
+            assert isinstance(item, dict)
+            if item.get("request_id") in request_ids:
+                repaired.add(item.get("launch_target"))
+        assert repaired == {f"chrome-devtools {operation} {target}" for operation, target, _prefix in cases}
 
     def test_malformed_changed_fields_json_falls_back_gracefully(self) -> None:
         conn = _make_conn()


### PR DESCRIPTION
## Summary

- repair legacy browser MCP approval labels when older pending rows contain an `unknown` display target
- update matching generic browser risk copy at serialization time without mutating stored approval identity or authorization evidence
- cover Chrome DevTools interaction, form, navigation, inspection, network, and console labels

## Testing

- `uv run --no-sync pytest tests/test_guard_approval_store_scale.py tests/test_guard_queue_api_contract.py tests/test_guard_browser_mcp_intent.py --tb=short`
- `uv run --no-sync python -m ruff check src/codex_plugin_scanner/guard/store_approvals.py tests/test_guard_approval_store_scale.py`
- `uv run --no-sync basedpyright --level error src/codex_plugin_scanner/guard/store_approvals.py`
- `uv build`
- `uv tool run --from dist/hol_guard-2.1.0-py3-none-any.whl hol-guard --version`
