### PR TITLE
fix(dashboard): restore queue command previews

### DIFF
--- a/dashboard/src/approval-center-mobile.test.ts
+++ b/dashboard/src/approval-center-mobile.test.ts
@@ -78,6 +78,16 @@ assert(
 );
 
 assert(
+  queueItemPreview({
+    ...BASE_REQUEST,
+    launch_target: "Compound command findings: review required",
+    queue_preview: "git status && bun test",
+    queue_command_category: "command.git",
+  }) === "git status && bun test",
+  "Paginated queue rows prefer the lightweight command preview over the compound category summary",
+);
+
+assert(
   multipleRequests.length >= 2,
   "L114: Queue drawer renders multiple requests on mobile (375px) — at least 2 requests exist"
 );

--- a/dashboard/src/approval-center-mobile.test.ts
+++ b/dashboard/src/approval-center-mobile.test.ts
@@ -82,6 +82,7 @@ assert(
     ...BASE_REQUEST,
     launch_target: "Compound command findings: review required",
     queue_preview: "git status && bun test",
+    raw_command_text: "opaque-wrapper action",
     queue_command_category: "command.git",
   }) === "git status && bun test",
   "Paginated queue rows prefer the lightweight command preview over the compound category summary",

--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -387,6 +387,16 @@ assert(
 );
 
 const parsedShell = parseActionEnvelope({ ...BASE_ENVELOPE, action_type: "shell_command", command: "git diff HEAD~1 -- src/" });
+const parsedCategorizedShell = parseActionEnvelope({
+  ...BASE_ENVELOPE,
+  action_type: "shell_command",
+  command: "opaque-wrapper action",
+  command_category: "command.github",
+});
+assert(
+  parsedCategorizedShell?.command_category === "command.github",
+  "T070: command category survives action-envelope normalization",
+);
 assert(parsedShell !== null && parsedShell.action_type === "shell_command", "T070: valid shell_command envelope parses correctly");
 
 const parsedPrompt = parseActionEnvelope({

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -1119,6 +1119,7 @@ export function parseActionEnvelope(raw: unknown): GuardActionEnvelope | null {
   const mcpTool = raw["mcp_tool"];
   const packageManager = raw["package_manager"];
   const packageName = raw["package_name"];
+  const commandCategory = raw["command_category"];
   const packageIntentKind = raw["package_intent_kind"];
   const packageTargets = raw["package_targets"];
   const preExecutionResult = aliasedPreExecutionResult.value;
@@ -1145,6 +1146,7 @@ export function parseActionEnvelope(raw: unknown): GuardActionEnvelope | null {
     !isStringOrNull(mcpTool) ||
     !isStringOrNull(packageManager) ||
     !isStringOrNull(packageName) ||
+    (commandCategory !== undefined && !isStringOrNull(commandCategory)) ||
     (packageIntentKind !== undefined && !isStringOrNull(packageIntentKind)) ||
     (preExecutionResult !== undefined && preExecutionResult !== null && !isGuardAction(preExecutionResult)) ||
     (policyAction !== undefined && policyAction !== null && !isGuardAction(policyAction)) ||
@@ -1180,6 +1182,7 @@ export function parseActionEnvelope(raw: unknown): GuardActionEnvelope | null {
     mcp_tool: mcpTool,
     package_manager: packageManager,
     package_name: packageName,
+    command_category: isStringOrNull(commandCategory) ? commandCategory : null,
     package_intent_kind: isStringOrNull(packageIntentKind) ? packageIntentKind : null,
     package_targets: isStringArray(packageTargets) ? packageTargets : [],
     pre_execution_result: isGuardAction(preExecutionResult) ? preExecutionResult : null,

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -206,6 +206,8 @@ export type GuardApprovalRequest = {
   decision_contract_error?: string;
   fallback_cli_command?: string | null;
   raw_command_text?: string | null;
+  queue_preview?: string | null;
+  queue_command_category?: string | null;
   action_identity?: string | null;
   queue_group_id?: string | null;
   dedupe_count?: number;

--- a/dashboard/src/queue-state.test.ts
+++ b/dashboard/src/queue-state.test.ts
@@ -408,6 +408,20 @@ assert(
   "T-QS-31c: first-class GitHub metadata drives the queue category"
 );
 
+const paginatedGitHubItem: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  request_id: "req-paginated-github",
+  launch_target: "Compound command findings: review required",
+  queue_preview: "opaque-wrapper action",
+  queue_command_category: "command.github",
+  action_envelope_json: null,
+};
+
+assert(
+  resolveQueueCategory(paginatedGitHubItem).label === "GitHub command",
+  "T-QS-31d: lightweight queue metadata preserves the command category"
+);
+
 const persistenceItem: GuardApprovalRequest = {
   ...BASE_REQUEST,
   request_id: "req-persistence",

--- a/dashboard/src/queue-state.ts
+++ b/dashboard/src/queue-state.ts
@@ -649,7 +649,7 @@ export function queueCategoriesForItems(items: GuardApprovalRequest[]): QueueCat
 function resolveQueueCategoryId(item: GuardApprovalRequest): QueueCategoryId {
   const envelope = item.action_envelope_json;
   const decisionCategories = item.decision_v2_json?.signals.map((signal) => signal.category) ?? [];
-  const command = envelope?.command ?? item.launch_target ?? "";
+  const command = envelope?.command ?? item.queue_preview ?? item.launch_target ?? "";
   const text = queueCategoryText(item);
   const isPromptReview = envelope?.action_type === "prompt" || decisionCategories.includes("prompt");
   const isWriteReview = envelope?.action_type === "file_write" || commandLooksLikeFileEdit(command);
@@ -694,7 +694,9 @@ function resolveQueueCategoryId(item: GuardApprovalRequest): QueueCategoryId {
     return "destructive_shell";
   }
 
-  const commandCategory = categoryFromCommandExtension(envelope?.command_category);
+  const commandCategory = categoryFromCommandExtension(
+    envelope?.command_category ?? item.queue_command_category,
+  );
   if (commandCategory !== null) {
     return commandCategory;
   }
@@ -783,6 +785,7 @@ function queueCategoryText(item: GuardApprovalRequest): string {
     item.launch_summary ?? "",
     item.why_now ?? "",
     item.launch_target ?? "",
+    item.queue_preview ?? "",
     envelope?.action_type ?? "",
     envelope?.command ?? "",
     envelope?.tool_name ?? "",
@@ -1163,6 +1166,7 @@ export function searchQueue(items: GuardApprovalRequest[], term: string): GuardA
       item.launch_summary ?? "",
       item.why_now ?? "",
       envelope?.command ?? "",
+      item.queue_preview ?? "",
       item.raw_command_text ?? "",
       item.fallback_cli_command ?? "",
       item.review_command ?? "",

--- a/dashboard/src/review-queue-item.tsx
+++ b/dashboard/src/review-queue-item.tsx
@@ -243,8 +243,8 @@ export function queueItemPreview(item: GuardApprovalRequest): string {
   const envelope = item.action_envelope_json;
   return (
     envelope?.command ??
-    item.raw_command_text ??
     item.queue_preview ??
+    item.raw_command_text ??
     envelope?.mcp_tool ??
     (envelope?.prompt_text ?? envelope?.prompt_excerpt) ??
     envelope?.package_name ??

--- a/dashboard/src/review-queue-item.tsx
+++ b/dashboard/src/review-queue-item.tsx
@@ -244,6 +244,7 @@ export function queueItemPreview(item: GuardApprovalRequest): string {
   return (
     envelope?.command ??
     item.raw_command_text ??
+    item.queue_preview ??
     envelope?.mcp_tool ??
     (envelope?.prompt_text ?? envelope?.prompt_excerpt) ??
     envelope?.package_name ??

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -28335,7 +28335,7 @@ function iconForQueueCategory(categoryId) {
 }
 function queueItemPreview(item) {
   const envelope = item.action_envelope_json;
-  return envelope?.command ?? item.raw_command_text ?? item.queue_preview ?? envelope?.mcp_tool ?? (envelope?.prompt_text ?? envelope?.prompt_excerpt) ?? envelope?.package_name ?? resolveStoppedCommandText(item);
+  return envelope?.command ?? item.queue_preview ?? item.raw_command_text ?? envelope?.mcp_tool ?? (envelope?.prompt_text ?? envelope?.prompt_excerpt) ?? envelope?.package_name ?? resolveStoppedCommandText(item);
 }
 const QUEUE_PAGE_SIZE$1 = 10;
 function ReviewHeader({

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13736,7 +13736,7 @@ function queueCategoriesForItems(items) {
 function resolveQueueCategoryId(item) {
   const envelope = item.action_envelope_json;
   const decisionCategories = item.decision_v2_json?.signals.map((signal) => signal.category) ?? [];
-  const command = envelope?.command ?? item.launch_target ?? "";
+  const command = envelope?.command ?? item.queue_preview ?? item.launch_target ?? "";
   const text = queueCategoryText(item);
   const isPromptReview = envelope?.action_type === "prompt" || decisionCategories.includes("prompt");
   const isWriteReview = envelope?.action_type === "file_write" || commandLooksLikeFileEdit(command);
@@ -13770,7 +13770,9 @@ function resolveQueueCategoryId(item) {
   if (textIncludesAny(text, ["destructive shell command", " rm -", "rm -rf", "delete files", "wipe", "force-clean", "git clean -fd", "truncate"])) {
     return "destructive_shell";
   }
-  const commandCategory = categoryFromCommandExtension(envelope?.command_category);
+  const commandCategory = categoryFromCommandExtension(
+    envelope?.command_category ?? item.queue_command_category
+  );
   if (commandCategory !== null) {
     return commandCategory;
   }
@@ -13844,6 +13846,7 @@ function queueCategoryText(item) {
     item.launch_summary ?? "",
     item.why_now ?? "",
     item.launch_target ?? "",
+    item.queue_preview ?? "",
     envelope?.action_type ?? "",
     envelope?.command ?? "",
     envelope?.tool_name ?? "",
@@ -14124,6 +14127,7 @@ function searchQueue(items, term) {
       item.launch_summary ?? "",
       item.why_now ?? "",
       envelope?.command ?? "",
+      item.queue_preview ?? "",
       item.raw_command_text ?? "",
       item.fallback_cli_command ?? "",
       item.review_command ?? "",
@@ -16418,6 +16422,7 @@ function parseActionEnvelope(raw) {
   const mcpTool = raw["mcp_tool"];
   const packageManager = raw["package_manager"];
   const packageName = raw["package_name"];
+  const commandCategory = raw["command_category"];
   const packageIntentKind = raw["package_intent_kind"];
   const packageTargets = raw["package_targets"];
   const preExecutionResult = aliasedPreExecutionResult.value;
@@ -16427,7 +16432,7 @@ function parseActionEnvelope(raw) {
   if (typeof schemaVersion !== "number" || typeof actionId !== "string" || typeof harness !== "string" || typeof eventName !== "string" || !isGuardActionType(actionType)) {
     return null;
   }
-  if (!isStringOrNull(workspace) || !isStringOrNull(workspaceHash) || !isStringOrNull(toolName) || !isStringOrNull(command) || !isStringOrNull(promptExcerpt) || promptText !== void 0 && !isStringOrNull(promptText) || !isStringOrNull(mcpServer) || !isStringOrNull(mcpTool) || !isStringOrNull(packageManager) || !isStringOrNull(packageName) || packageIntentKind !== void 0 && !isStringOrNull(packageIntentKind) || preExecutionResult !== void 0 && preExecutionResult !== null && !isGuardAction(preExecutionResult) || policyAction !== void 0 && policyAction !== null && !isGuardAction(policyAction) || !isStringOrNull(scriptName)) {
+  if (!isStringOrNull(workspace) || !isStringOrNull(workspaceHash) || !isStringOrNull(toolName) || !isStringOrNull(command) || !isStringOrNull(promptExcerpt) || promptText !== void 0 && !isStringOrNull(promptText) || !isStringOrNull(mcpServer) || !isStringOrNull(mcpTool) || !isStringOrNull(packageManager) || !isStringOrNull(packageName) || commandCategory !== void 0 && !isStringOrNull(commandCategory) || packageIntentKind !== void 0 && !isStringOrNull(packageIntentKind) || preExecutionResult !== void 0 && preExecutionResult !== null && !isGuardAction(preExecutionResult) || policyAction !== void 0 && policyAction !== null && !isGuardAction(policyAction) || !isStringOrNull(scriptName)) {
     return null;
   }
   if (!isStringArray(targetPaths) || !isStringArray(networkHosts) || packageTargets !== void 0 && !isStringArray(packageTargets)) {
@@ -16454,6 +16459,7 @@ function parseActionEnvelope(raw) {
     mcp_tool: mcpTool,
     package_manager: packageManager,
     package_name: packageName,
+    command_category: isStringOrNull(commandCategory) ? commandCategory : null,
     package_intent_kind: isStringOrNull(packageIntentKind) ? packageIntentKind : null,
     package_targets: isStringArray(packageTargets) ? packageTargets : [],
     pre_execution_result: isGuardAction(preExecutionResult) ? preExecutionResult : null,
@@ -28329,7 +28335,7 @@ function iconForQueueCategory(categoryId) {
 }
 function queueItemPreview(item) {
   const envelope = item.action_envelope_json;
-  return envelope?.command ?? item.raw_command_text ?? envelope?.mcp_tool ?? (envelope?.prompt_text ?? envelope?.prompt_excerpt) ?? envelope?.package_name ?? resolveStoppedCommandText(item);
+  return envelope?.command ?? item.raw_command_text ?? item.queue_preview ?? envelope?.mcp_tool ?? (envelope?.prompt_text ?? envelope?.prompt_excerpt) ?? envelope?.package_name ?? resolveStoppedCommandText(item);
 }
 const QUEUE_PAGE_SIZE$1 = 10;
 function ReviewHeader({

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -16,6 +16,7 @@ from .runtime.action_identity import normalize_command_identity
 from .runtime.browser_mcp_intent import _classify_operation
 
 MAX_APPROVAL_PAGE_LIMIT = 200
+APPROVAL_QUEUE_PREVIEW_MAX_LENGTH = 512
 APPROVAL_QUEUE_BACKFILL_BATCH_SIZE = 500
 _APPROVAL_RESOLUTION_BATCH_SIZE = 500
 _QUEUE_IDENTITY_VERSION = "v1"
@@ -88,6 +89,25 @@ def _browser_risk_signals_for_display(signals: list[object], target: str | None)
     if target is None:
         return signals
     return [signal.replace("unknown target", target) if isinstance(signal, str) else signal for signal in signals]
+
+
+def _approval_queue_preview(
+    action_envelope: dict[str, object] | None,
+    launch_target: object,
+) -> str | None:
+    command = action_envelope.get("command") if action_envelope is not None else None
+    candidate = command if isinstance(command, str) and command.strip() else launch_target
+    if not isinstance(candidate, str) or not candidate.strip():
+        return None
+    normalized = candidate.strip()
+    if len(normalized) <= APPROVAL_QUEUE_PREVIEW_MAX_LENGTH:
+        return normalized
+    return f"{normalized[: APPROVAL_QUEUE_PREVIEW_MAX_LENGTH - 1]}…"
+
+
+def _approval_queue_command_category(action_envelope: dict[str, object] | None) -> str | None:
+    value = action_envelope.get("command_category") if action_envelope is not None else None
+    return value if isinstance(value, str) and value.startswith("command.") else None
 
 
 def _begin_immediate(connection: sqlite3.Connection) -> None:
@@ -848,6 +868,7 @@ def _row_to_approval_summary(row: sqlite3.Row) -> dict[str, object]:
         reject_contradiction=False,
     )
     launch_target, _browser_target = _browser_launch_target_for_display(row["launch_target"])
+    action_envelope = canonical_decision.action_envelope_json
     payload: dict[str, object] = {
         "request_id": str(row["request_id"]),
         "harness": str(row["harness"]),
@@ -860,6 +881,8 @@ def _row_to_approval_summary(row: sqlite3.Row) -> dict[str, object]:
         "config_path": str(row["config_path"]),
         "workspace": row["workspace"],
         "launch_target": launch_target,
+        "queue_preview": _approval_queue_preview(action_envelope, launch_target),
+        "queue_command_category": _approval_queue_command_category(action_envelope),
         "risk_summary": row["risk_summary"],
         "risk_headline": row["risk_headline"],
         "raw_command_text": row["raw_command_text"],

--- a/tests/test_guard_queue_contract.py
+++ b/tests/test_guard_queue_contract.py
@@ -386,6 +386,35 @@ def test_pending_summary_pagination_uses_stable_cursor() -> None:
     assert second_page["next_cursor"] is None
 
 
+def test_pending_summary_preserves_bounded_command_preview_and_category() -> None:
+    connection = _connection()
+    request = _request("req-compound", command="git status && bun test")
+    envelope = dict(request.action_envelope_json or {})
+    envelope["command_category"] = "command.git"
+    request = replace(
+        request,
+        launch_target="Compound command findings: review required",
+        action_envelope_json=envelope,
+    )
+    add_approval_request(connection, request, "2026-05-08T10:00:00+00:00")
+    long_command = "x" * 600
+    add_approval_request(
+        connection,
+        _request("req-long", command=long_command),
+        "2026-05-08T10:01:00+00:00",
+    )
+
+    items = list_pending_approval_summaries(connection, limit=2)["items"]
+    item = next(value for value in items if value["request_id"] == "req-compound")
+    long_item = next(value for value in items if value["request_id"] == "req-long")
+
+    assert item["queue_preview"] == "git status && bun test"
+    assert item["queue_command_category"] == "command.git"
+    assert "action_envelope_json" not in item
+    assert len(long_item["queue_preview"]) == 512
+    assert long_item["queue_preview"].endswith("…")
+
+
 def test_pending_summary_rejects_invalid_cursor() -> None:
     connection = _connection()
     add_approval_request(connection, _request("req-only"), "2026-05-08T10:00:00+00:00")


### PR DESCRIPTION
## Summary
- restore actual command previews in lightweight Inbox queue pages
- preserve command category icons and tooltips without returning full action envelopes
- cap queue previews to keep large queues responsive

## Testing
- `uv run pytest -q tests/test_guard_queue_contract.py -k 'pending_summary'`
- `uv run pytest -q tests/test_guard_approval_store_scale.py -k 'listing_first_queue_page_with_100k_rows_stays_under_100ms or listing_queue_page_without_totals_stays_under_50ms_with_100k_rows'`
- `bun dashboard/src/guard-api.test.ts`
- `bun dashboard/src/queue-state.test.ts`
- `bun dashboard/src/approval-center-mobile.test.ts`
- `cd dashboard && bun run build`

## Notes
- Repository-wide TypeScript checking remains blocked by pre-existing errors outside this change.
