### PR TITLE
fix(settings): honor connected cloud entitlement

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_prompts.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_prompts.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 
 from ..action_lattice import coerce_guard_action
+from ..package_firewall_entitlement import resolve_package_firewall_entitlement
 from ._commands_shared import *
 from .commands_parser_helpers import *
 
@@ -149,7 +150,13 @@ def _update_guard_cli_settings(*, args: argparse.Namespace, config: GuardConfig,
     )
 
     def persist_settings(payload: dict[str, object]) -> GuardConfig:
-        return update_guard_settings(guard_home, payload, approval_gate_grant=approval_gate_grant)
+        entitlement = resolve_package_firewall_entitlement(GuardStore(guard_home))
+        return update_guard_settings(
+            guard_home,
+            payload,
+            approval_gate_grant=approval_gate_grant,
+            cloud_sync_entitled=bool(entitlement.get("allowed")),
+        )
 
     if settings_command == "security-level":
         payload: dict[str, object] = {"security_level": args.security_level}

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -516,6 +516,7 @@ def update_guard_settings(
     payload: dict[str, object],
     *,
     approval_gate_grant: ApprovalGateGrant | None = None,
+    cloud_sync_entitled: bool = False,
 ) -> GuardConfig:
     """Persist safe local Guard settings to config.toml and return the updated config."""
 
@@ -545,7 +546,8 @@ def update_guard_settings(
         ]
         if weakened:
             raise ValueError(f"Managed policy locks prevent weakening: {', '.join(sorted(weakened))}")
-    if next_payload.get("sync") is True and next_payload.get("billing") is not True:
+    enabling_cloud_sync = next_payload.get("sync") is True and not current_config.sync
+    if enabling_cloud_sync and not cloud_sync_entitled:
         raise ValueError("Cloud sync requires a paid team plan.")
     _write_guard_config(guard_home / "config.toml", next_payload)
     return load_guard_config(guard_home)

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -546,8 +546,7 @@ def update_guard_settings(
         ]
         if weakened:
             raise ValueError(f"Managed policy locks prevent weakening: {', '.join(sorted(weakened))}")
-    enabling_cloud_sync = next_payload.get("sync") is True and not current_config.sync
-    if enabling_cloud_sync and not cloud_sync_entitled:
+    if next_payload.get("sync") is True and not cloud_sync_entitled:
         raise ValueError("Cloud sync requires a paid team plan.")
     _write_guard_config(guard_home / "config.toml", next_payload)
     return load_guard_config(guard_home)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -4101,7 +4101,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     approval_gate_grant=approval_gate_grant,
                 )
             config_settings = {key: value for key, value in settings.items() if key != "approval_gate"}
-            config = update_guard_settings(guard_home, config_settings, approval_gate_grant=approval_gate_grant)
+            entitlement = resolve_package_firewall_entitlement(self.server.store)  # type: ignore[attr-defined]
+            config = update_guard_settings(
+                guard_home,
+                config_settings,
+                approval_gate_grant=approval_gate_grant,
+                cloud_sync_entitled=bool(entitlement.get("allowed")),
+            )
             if isinstance(gate_payload, dict):
                 update_approval_gate_settings(
                     guard_home,
@@ -4146,7 +4152,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     approval_gate_grant=approval_gate_grant,
                 )
             config_settings = {key: value for key, value in settings.items() if key != "approval_gate"}
-            config = update_guard_settings(guard_home, config_settings, approval_gate_grant=approval_gate_grant)
+            entitlement = resolve_package_firewall_entitlement(self.server.store)  # type: ignore[attr-defined]
+            config = update_guard_settings(
+                guard_home,
+                config_settings,
+                approval_gate_grant=approval_gate_grant,
+                cloud_sync_entitled=bool(entitlement.get("allowed")),
+            )
             if isinstance(gate_payload, dict):
                 update_approval_gate_settings(
                     guard_home,

--- a/tests/test_guard_settings_api.py
+++ b/tests/test_guard_settings_api.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from codex_plugin_scanner.guard.config import load_guard_config, resolve_risk_action, update_guard_settings
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.models import PolicyDecision
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -84,7 +85,12 @@ def test_relaxed_security_level_persists_granular_risk_settings(tmp_path: Path) 
     assert settings["harness_risk_actions"]["codex"]["local_secret_read"] == "block"
 
 
-def test_settings_export_import_and_reset_round_trip(tmp_path: Path) -> None:
+def test_settings_export_import_and_reset_round_trip(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        daemon_server_module,
+        "resolve_package_firewall_entitlement",
+        lambda _store: {"allowed": True, "reason": "paid_entitlement_active", "tier": "team"},
+    )
     _store, daemon = _with_daemon(tmp_path / "guard-home")
     try:
         update_status, _update_payload = _json_request(
@@ -131,7 +137,7 @@ def test_settings_export_import_and_reset_round_trip(tmp_path: Path) -> None:
     assert import_payload["settings"]["sync"] is True
 
 
-def test_cloud_sync_requires_paid_team_gate(tmp_path: Path) -> None:
+def test_cloud_sync_requires_trusted_paid_team_entitlement(tmp_path: Path, monkeypatch) -> None:
     _store, daemon = _with_daemon(tmp_path / "guard-home")
     try:
         blocked_status, blocked_payload = _json_request(
@@ -141,20 +147,34 @@ def test_cloud_sync_requires_paid_team_gate(tmp_path: Path) -> None:
             method="POST",
             payload={"settings": {"sync": True}},
         )
-        allowed_status, allowed_payload = _json_request(
+        asserted_billing_status, asserted_billing_payload = _json_request(
             daemon.port,
             daemon._server.auth_token,
             "/v1/settings",
             method="POST",
             payload={"settings": {"billing": True, "sync": True}},
         )
+        monkeypatch.setattr(
+            daemon_server_module,
+            "resolve_package_firewall_entitlement",
+            lambda _store: {"allowed": True, "reason": "paid_entitlement_active", "tier": "team"},
+        )
+        allowed_status, allowed_payload = _json_request(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/settings",
+            method="POST",
+            payload={"settings": {"billing": False, "sync": True}},
+        )
     finally:
         daemon.stop()
 
     assert blocked_status == 400
     assert blocked_payload["message"] == "Cloud sync requires a paid team plan."
+    assert asserted_billing_status == 400
+    assert asserted_billing_payload["message"] == "Cloud sync requires a paid team plan."
     assert allowed_status == 200
-    assert allowed_payload["settings"]["billing"] is True
+    assert allowed_payload["settings"]["billing"] is False
     assert allowed_payload["settings"]["sync"] is True
 
 

--- a/tests/test_guard_settings_api.py
+++ b/tests/test_guard_settings_api.py
@@ -166,6 +166,18 @@ def test_cloud_sync_requires_trusted_paid_team_entitlement(tmp_path: Path, monke
             method="POST",
             payload={"settings": {"billing": False, "sync": True}},
         )
+        monkeypatch.setattr(
+            daemon_server_module,
+            "resolve_package_firewall_entitlement",
+            lambda _store: {"allowed": False, "reason": "paid_guard_cloud_required", "tier": "free"},
+        )
+        expired_status, expired_payload = _json_request(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/settings",
+            method="POST",
+            payload={"settings": {"mode": "enforce", "sync": True}},
+        )
     finally:
         daemon.stop()
 
@@ -176,6 +188,8 @@ def test_cloud_sync_requires_trusted_paid_team_entitlement(tmp_path: Path, monke
     assert allowed_status == 200
     assert allowed_payload["settings"]["billing"] is False
     assert allowed_payload["settings"]["sync"] is True
+    assert expired_status == 400
+    assert expired_payload["message"] == "Cloud sync requires a paid team plan."
 
 
 def test_risk_settings_drive_runtime_policy_resolution(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- validate cloud sync against the trusted connected-plan entitlement instead of the local billing preference
- prevent clients from self-asserting billing access while allowing eligible connected accounts to enable sync
- apply the same entitlement behavior to dashboard updates, settings imports, and CLI settings changes

## Testing
- `uv run --no-sync pytest -q tests/test_guard_settings_api.py tests/test_guard_config_paths.py tests/test_guard_approval_attention.py --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_command_decision_diff.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/config.py src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/cli/commands_support_prompts.py tests/test_guard_settings_api.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/config.py src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/cli/commands_support_prompts.py tests/test_guard_settings_api.py`
- `git diff --check`
