### PR TITLE
fix(codex): keep global hooks workspace neutral

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -1297,6 +1297,7 @@ class CodexHarnessAdapter(HarnessAdapter):
             "managed_hook_config_path": str(hook_config_path),
             "managed_hook_manifest_path": str(hook_state["manifest_path"]),
             "managed_hook_integrity": str(hook_state["integrity_status"]),
+            "hook_workspace_explicit": context.workspace_override_explicit,
             "managed_hooks_path": str(hooks_path),
             "enforcement_boundary": _AUTHORITATIVE_ENFORCEMENT_BOUNDARY,
             "legacy_shell_guard_cleanup": "complete",

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -216,6 +216,10 @@ _AUTHORITATIVE_ENFORCEMENT_BOUNDARY = "codex-native-hooks"
 _AUTHORITATIVE_HOOK_UNAVAILABLE_REASON = "codex_authoritative_hook_unavailable"
 
 
+def _hook_workspace_dir(context: HarnessContext) -> Path | None:
+    return context.workspace_dir if context.workspace_override_explicit else None
+
+
 def _json_object(path: Path) -> dict[str, object]:
     if not path.is_file():
         return {}
@@ -243,8 +247,9 @@ def _local_hook_command_parts_for_home_mode(
         guard_args.extend(["--home", str(context.home_dir)])
         if runtime_guard_home != context.home_dir.resolve():
             guard_args.extend(["--guard-home", str(runtime_guard_home)])
-    if context.workspace_dir is not None:
-        guard_args.extend(["--workspace", str(context.workspace_dir)])
+    hook_workspace = _hook_workspace_dir(context)
+    if hook_workspace is not None:
+        guard_args.extend(["--workspace", str(hook_workspace)])
     package_root = Path(__file__).resolve().parents[3]
     return isolated_guard_cli_command(python_executable, package_root, guard_args)
 
@@ -287,8 +292,9 @@ def _hook_command_parts_for_home_mode(
     query = {"guard-home": str(guard_home)}
     if not home_is_current:
         query["home"] = str(context.home_dir)
-    if context.workspace_dir is not None:
-        query["workspace"] = str(context.workspace_dir)
+    hook_workspace = _hook_workspace_dir(context)
+    if hook_workspace is not None:
+        query["workspace"] = str(hook_workspace)
     long_timeout = _post_tool_hook_timeout_seconds(context)
     config = {
         "state_path": str(guard_home / "daemon-state.json"),
@@ -376,7 +382,7 @@ def _permission_request_hook_group(context: HarnessContext) -> dict[str, object]
 def _post_tool_hook_timeout_seconds(context: HarnessContext) -> int:
     configured_wait_timeout = load_guard_config(
         context.guard_home,
-        context.workspace_dir,
+        _hook_workspace_dir(context),
     ).approval_wait_timeout_seconds
     return (
         min(
@@ -451,7 +457,7 @@ def _hook_manifest_spec(context: HarnessContext) -> CodexHookManifestSpec:
         guard_home=context.guard_home,
         home_dir=context.home_dir,
         runtime_guard_home=_runtime_guard_home(context),
-        workspace_dir=context.workspace_dir,
+        workspace_dir=_hook_workspace_dir(context),
         config_path=CodexHarnessAdapter._hook_config_path(context),
         interpreter_path=Path(_guard_python_executable()),
         package_version=__version__,

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -33,6 +33,7 @@ from ..adapters.opencode_pretool import (
     managed_plugin_path,
     pretool_plugin_source,
 )
+from ..codex_hook_integrity import CodexHookIntegrityError, load_authenticated_hook_manifest
 from ..config import resolve_guard_home
 from ..mdm.contracts import ManagedNetworkPolicy, ManagedPolicy
 from ..mdm.network import ManagedNetworkError, managed_urlopen
@@ -2131,7 +2132,11 @@ def _repair_context_from_managed_install(
         workspace_path = Path(managed_workspace).expanduser().resolve()
         manifest = managed_install.get("manifest")
         explicit_value = manifest.get("hook_workspace_explicit") if isinstance(manifest, dict) else None
-        workspace_override_explicit = explicit_value if isinstance(explicit_value, bool) else True
+        workspace_override_explicit = (
+            explicit_value
+            if isinstance(explicit_value, bool)
+            else _legacy_codex_workspace_was_explicit(context, managed_install, workspace_path)
+        )
         return (
             HarnessContext(
                 home_dir=context.home_dir,
@@ -2151,6 +2156,25 @@ def _repair_context_from_managed_install(
         ),
         None,
     )
+
+
+def _legacy_codex_workspace_was_explicit(
+    context: HarnessContext,
+    managed_install: dict[str, object],
+    workspace_path: Path,
+) -> bool:
+    if managed_install.get("harness") != "codex":
+        return True
+    try:
+        authenticated = load_authenticated_hook_manifest(
+            context.guard_home,
+            CodexHarnessAdapter._hook_config_path(context),
+        )
+    except (CodexHookIntegrityError, OSError):
+        return False
+    manifest_context = authenticated.get("context")
+    bound_workspace = manifest_context.get("workspace_dir") if isinstance(manifest_context, dict) else None
+    return isinstance(bound_workspace, str) and Path(bound_workspace).resolve() == workspace_path
 
 
 def _repair_codex_install(

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -2129,12 +2129,16 @@ def _repair_context_from_managed_install(
     managed_workspace = managed_install.get("workspace")
     if isinstance(managed_workspace, str) and managed_workspace.strip():
         workspace_path = Path(managed_workspace).expanduser().resolve()
+        manifest = managed_install.get("manifest")
+        explicit_value = manifest.get("hook_workspace_explicit") if isinstance(manifest, dict) else None
+        workspace_override_explicit = explicit_value if isinstance(explicit_value, bool) else True
         return (
             HarnessContext(
                 home_dir=context.home_dir,
                 workspace_dir=workspace_path,
                 guard_home=context.guard_home,
                 home_override_explicit=context.home_override_explicit,
+                workspace_override_explicit=workspace_override_explicit,
             ),
             str(workspace_path),
         )

--- a/tests/test_codex_hook_fallback_isolation.py
+++ b/tests/test_codex_hook_fallback_isolation.py
@@ -31,6 +31,7 @@ def _installed_launch(tmp_path: Path) -> tuple[HarnessContext, tuple[str, ...], 
         workspace_dir=workspace,
         guard_home=tmp_path / "Guard home with spaces",
         home_override_explicit=True,
+        workspace_override_explicit=True,
     )
     CodexHarnessAdapter().install(context)
     bridge_command = codex_adapter._hook_command_parts(context)

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import sqlite3
 import subprocess
 import sys
@@ -4593,6 +4594,11 @@ args = ["workspace-skill.js", "--changed"]
         assert "hooks = true" in config_text
         assert "codex_hooks" not in config_text
         assert hooks_payload["PreToolUse"]
+        hook_command = hooks_payload["PreToolUse"][0]["hooks"][0]["command"]
+        bridge_config = json.loads(shlex.split(hook_command)[3])
+        fallback_command = bridge_config["fallback_command"]
+        workspace_index = fallback_command.index("--workspace")
+        assert fallback_command[workspace_index + 1] == str(workspace_dir)
         assert (workspace_dir / ".codex" / "config.toml").exists() is False
 
     def test_guard_update_fails_closed_on_malformed_codex_config(self, tmp_path, monkeypatch, capsys):

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4555,7 +4555,9 @@ args = ["workspace-skill.js", "--changed"]
         assert "codex_hooks" not in config_text
         assert hooks_payload["PreToolUse"]
 
-    def test_guard_update_repairs_workspace_codex_install_in_recorded_workspace(self, tmp_path, monkeypatch, capsys):
+    def test_guard_update_keeps_unauthenticated_legacy_codex_workspace_record_global(
+        self, tmp_path, monkeypatch, capsys
+    ):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         GuardStore(home_dir).set_managed_install(
@@ -4596,10 +4598,31 @@ args = ["workspace-skill.js", "--changed"]
         assert hooks_payload["PreToolUse"]
         hook_command = hooks_payload["PreToolUse"][0]["hooks"][0]["command"]
         bridge_config = json.loads(shlex.split(hook_command)[3])
-        fallback_command = bridge_config["fallback_command"]
-        workspace_index = fallback_command.index("--workspace")
-        assert fallback_command[workspace_index + 1] == str(workspace_dir)
+        assert "--workspace" not in bridge_config["fallback_command"]
         assert (workspace_dir / ".codex" / "config.toml").exists() is False
+
+    def test_codex_repair_preserves_authenticated_legacy_workspace_binding(self, tmp_path, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = (tmp_path / "workspace").resolve()
+        context = HarnessContext(home_dir=home_dir, workspace_dir=None, guard_home=home_dir)
+        managed_install = {
+            "harness": "codex",
+            "workspace": str(workspace_dir),
+            "manifest": {},
+        }
+        monkeypatch.setattr(
+            guard_update_commands_module,
+            "load_authenticated_hook_manifest",
+            lambda *_args: {"context": {"workspace_dir": str(workspace_dir)}},
+        )
+
+        repair_context, repair_workspace = guard_update_commands_module._repair_context_from_managed_install(
+            context,
+            managed_install,
+        )
+
+        assert repair_context.workspace_override_explicit is True
+        assert repair_workspace == str(workspace_dir)
 
     def test_guard_update_fails_closed_on_malformed_codex_config(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -932,6 +932,7 @@ def test_guard_install_and_repair_codex_preserve_ambiguous_legacy_post_tool_hook
             workspace_dir=workspace_dir,
             guard_home=guard_home,
             home_override_explicit=True,
+            workspace_override_explicit=True,
         )
     )
 
@@ -1027,6 +1028,34 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert (home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh").exists() is False
     assert (home_dir / "managed" / "codex" / "codex-bashenv-guard.bash").exists() is False
     assert (home_dir / "managed" / "codex" / "codex-fish-guard.fish").exists() is False
+
+
+def test_guard_install_codex_does_not_bind_global_hooks_to_inferred_workspace(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(workspace_dir / "pyproject.toml", "[project]\nname = 'fixture'\nversion = '0'\n")
+    monkeypatch.chdir(workspace_dir)
+    monkeypatch.setattr(codex_adapter, "_command_available", lambda _command: True)
+
+    install_rc = main(["guard", "install", "codex", "--home", str(home_dir), "--json"])
+    install_payload = json.loads(capsys.readouterr().out)
+    doctor_rc = main(["guard", "doctor", "codex", "--home", str(home_dir), "--json"])
+    doctor_payload = json.loads(capsys.readouterr().out)
+    config_payload = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    hook_command = config_payload["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+
+    assert install_rc == 0
+    assert install_payload["managed_install"]["workspace"] == str(workspace_dir)
+    assert "--workspace" not in shlex.split(hook_command)
+    assert doctor_rc == 0
+    assert doctor_payload["setup_status"] == "active"
+    assert doctor_payload["native_hook_state"]["protection_active"] is True
+    assert not any("managed Codex hooks are missing" in warning for warning in doctor_payload["warnings"])
 
 
 def test_guard_install_codex_detects_wrapped_servers_without_rewrapping(tmp_path, capsys):
@@ -1563,7 +1592,12 @@ def test_guard_install_codex_migrates_global_and_workspace_hooks_to_toml(tmp_pat
         'model = "gpt-5.3-codex"\n\n[features]\nhooks = true\n',
     )
     _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
-    context = HarnessContext(home_dir=home_dir, guard_home=home_dir, workspace_dir=workspace_dir)
+    context = HarnessContext(
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace_dir=workspace_dir,
+        workspace_override_explicit=True,
+    )
     legacy_group = codex_adapter._managed_hook_groups(context)["PreToolUse"]
     _write_text(
         home_dir / ".codex" / "hooks.json",
@@ -1616,7 +1650,12 @@ def test_guard_install_codex_migrates_legacy_bash_only_managed_hook(tmp_path, ca
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
-    context = HarnessContext(home_dir=home_dir, guard_home=home_dir, workspace_dir=workspace_dir)
+    context = HarnessContext(
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace_dir=workspace_dir,
+        workspace_override_explicit=True,
+    )
     legacy_group = codex_adapter._managed_hook_groups(context)["PreToolUse"]
     _write_text(
         workspace_dir / ".codex" / "hooks.json",

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -78,6 +78,7 @@ def _install_codex_native_hooks(home_dir: Path, workspace_dir: Path) -> None:
         workspace_dir=workspace_dir,
         guard_home=home_dir,
         home_override_explicit=True,
+        workspace_override_explicit=True,
     )
     config_path = home_dir / ".codex" / "config.toml"
     payload = read_toml_payload(config_path)

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -148,6 +148,7 @@ def _install_codex_native_hooks(home_dir: Path, workspace_dir: Path) -> None:
         workspace_dir=workspace_dir,
         guard_home=home_dir,
         home_override_explicit=True,
+        workspace_override_explicit=True,
     )
     config_path = home_dir / ".codex" / "config.toml"
     payload = read_toml_payload(config_path)


### PR DESCRIPTION
## Summary
- keep global Codex hook identities independent of implicitly detected repositories
- preserve explicit workspace binding when `--workspace` is supplied
- keep install and doctor health results consistent after repository-local installation

## Testing
- `uv run --no-sync pytest -q tests/test_guard_codex_install.py tests/test_guard_phase03_remainder.py --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_cli.py -k 'codex and (install or doctor or update)' --tb=short`\n- `uv run --no-sync pytest -q tests/test_codex_hook_fallback_isolation.py tests/test_guard_runtime.py tests/test_guard_launch_env.py --tb=short`\n- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/adapters/codex.py tests/test_guard_codex_install.py tests/test_codex_hook_fallback_isolation.py tests/test_guard_runtime.py tests/test_guard_launch_env.py`\n- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/adapters/codex.py tests/test_guard_codex_install.py tests/test_codex_hook_fallback_isolation.py tests/test_guard_runtime.py tests/test_guard_launch_env.py`\n- `uv build`\n- packaged-wheel `install codex` followed by `doctor codex`\n