### PR TITLE
fix(update): allow prereleases when installing alpha pins

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -1367,6 +1367,15 @@ def _hol_guard_package_spec(target_version: str | None = None) -> str:
     return "hol-guard"
 
 
+def _target_version_is_prerelease(target_version: str | None) -> bool:
+    if not isinstance(target_version, str) or not target_version.strip():
+        return False
+    try:
+        return Version(target_version.strip()).is_prerelease
+    except InvalidVersion:
+        return False
+
+
 def _installer_output_text(stdout: object, stderr: object) -> str:
     return "\n".join(part.strip() for part in (str(stdout or "").strip(), str(stderr or "").strip()) if part.strip())
 
@@ -1402,12 +1411,24 @@ def _update_command(
             return ["pipx", "install", "--force", wheel]
         return [sys.executable, "-m", "pip", "install", "--force-reinstall", wheel]
     package = _hol_guard_package_spec(target_version)
+    allow_prerelease = _target_version_is_prerelease(target_version)
     if use_pypi:
         if installer == "uv":
-            return ["uv", "tool", "install", "--force", package]
+            command = ["uv", "tool", "install", "--force"]
+            if allow_prerelease:
+                command.append("--prerelease=allow")
+            command.append(package)
+            return command
         if installer == "pipx":
-            return ["pipx", "install", "--force", package]
-        return [sys.executable, "-m", "pip", "install", "--upgrade", "--force-reinstall", package]
+            command = ["pipx", "install", "--force", package]
+            if allow_prerelease:
+                command.extend(["--pip-args", "--pre"])
+            return command
+        command = [sys.executable, "-m", "pip", "install", "--upgrade", "--force-reinstall"]
+        if allow_prerelease:
+            command.append("--pre")
+        command.append(package)
+        return command
     if installer == "uv":
         return ["uv", "tool", "upgrade", "hol-guard"]
     if installer == "pipx":

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -91,10 +91,40 @@ def test_update_alpha_pins_latest_alpha_in_installed_major(monkeypatch: pytest.M
     payload, exit_code = update_commands.run_guard_update(dry_run=True, include_alpha=True)
 
     assert exit_code == 0
-    assert payload["command"] == ["pipx", "install", "--force", "hol-guard==2.1.0a35"]
+    assert payload["command"] == [
+        "pipx",
+        "install",
+        "--force",
+        "hol-guard==2.1.0a35",
+        "--pip-args",
+        "--pre",
+    ]
     assert payload["retry_command"] == "hol-guard update --alpha"
     assert payload["release_channel"] == "alpha"
     assert payload["version_check"]["release_channel"] == "alpha"
+
+
+def test_update_command_allows_prerelease_for_alpha_pins() -> None:
+    assert update_commands._update_command(
+        "uv",
+        use_pypi=True,
+        target_version="2.1.0a51",
+    ) == ["uv", "tool", "install", "--force", "--prerelease=allow", "hol-guard==2.1.0a51"]
+    assert update_commands._update_command(
+        "pipx",
+        use_pypi=True,
+        target_version="2.1.0a51",
+    ) == ["pipx", "install", "--force", "hol-guard==2.1.0a51", "--pip-args", "--pre"]
+    assert update_commands._update_command(
+        "pip",
+        use_pypi=True,
+        target_version="2.1.0a51",
+    )[-2:] == ["--pre", "hol-guard==2.1.0a51"]
+    assert update_commands._update_command(
+        "uv",
+        use_pypi=True,
+        target_version="2.0.1127",
+    ) == ["uv", "tool", "install", "--force", "hol-guard==2.0.1127"]
 
 
 def test_latest_alpha_version_stays_in_current_major_and_skips_yanked(


### PR DESCRIPTION
## Summary
- When `hol-guard update --alpha` pins a prerelease such as `2.1.0a51`, installer commands now allow prereleases so uv/pip can resolve the exact alpha version.
- Stable version pins remain unchanged (no prerelease flags).

## Testing
- `python3 -m pytest -q tests/test_guard_phase03_remainder.py -k 'alpha or prerelease' --tb=short`
- Manual: `uv tool install --force --prerelease=allow hol-guard==2.1.0a51` succeeds where the unflagged command reported no version.

## Notes
- Root cause: uv reports "there is no version of hol-guard==2.1.0a51" unless prereleases are allowed, even for exact pins.
