### PR TITLE
fix(evidence): recover command activity health

### DIFF
--- a/dashboard/src/command-activity/command-activity-presenters.test.ts
+++ b/dashboard/src/command-activity/command-activity-presenters.test.ts
@@ -114,5 +114,8 @@ assert(
 );
 assert(homeCommandActivityModel({ ...analytics, commands_checked: 0 }) === null, "home card stays absent without activity");
 assert(homeCommandActivityModel(analytics)?.health?.includes("incomplete") === true, "home model carries degraded health");
-assert(commandHealthCopy(analytics)?.includes("incomplete") === true, "degraded health is explicit");
+assert(
+  commandHealthCopy(analytics)?.includes("Guard retries automatically") === true,
+  "degraded health explains automatic recovery",
+);
 assert(!Object.values(commandMetricSummary(analytics)).some((value) => Number.isNaN(value)), "zero denominators are unnecessary");

--- a/dashboard/src/command-activity/command-activity-presenters.ts
+++ b/dashboard/src/command-activity/command-activity-presenters.ts
@@ -176,7 +176,7 @@ export function homeCommandActivityModel(analytics: CommandActivityAnalytics): {
 
 export function commandHealthCopy(analytics: CommandActivityAnalytics): string | null {
   if (analytics.health.status === "healthy") return null;
-  return "Command activity evidence is degraded. Counts may be incomplete.";
+  return "Guard could not record some recent command activity. Counts may be incomplete. Guard retries automatically; check again after the next command.";
 }
 
 export function commandWindowLabel(analytics: CommandActivityAnalytics): string {

--- a/dashboard/src/command-activity/command-activity-summary.tsx
+++ b/dashboard/src/command-activity/command-activity-summary.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
+import { FiRefreshCw } from "react-icons/fi";
 
-import { SectionLabel } from "../approval-center-primitives";
+import { ActionButton, SectionLabel } from "../approval-center-primitives";
 import type { CommandActivityLoadState } from "./command-activity-state";
 import {
   commandBreakdownsAreGlobalOnly,
@@ -81,6 +82,7 @@ function FrequencyList(props: { title: string; buckets: CommandCountBucket[] }) 
 export function CommandActivitySummary(props: {
   state: CommandActivityLoadState<CommandActivityAnalytics>;
   outsideTableFilters: boolean;
+  onRetry: () => void;
 }) {
   if (props.state.kind === "idle" || (props.state.kind === "loading" && props.state.previous === null)) {
     return <div className="guard-skeleton h-52 w-full" aria-label="Loading command activity summary" />;
@@ -109,8 +111,12 @@ export function CommandActivitySummary(props: {
         </div>
       ) : null}
       {healthCopy ? (
-        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900" role="status">
-          {healthCopy}
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900" role="status">
+          <p>{healthCopy}</p>
+          <ActionButton variant="outline" onClick={props.onRetry}>
+            <FiRefreshCw aria-hidden="true" />
+            Check again
+          </ActionButton>
         </div>
       ) : null}
       {props.state.kind === "error" ? (

--- a/dashboard/src/command-activity/command-activity-ui-contract.test.ts
+++ b/dashboard/src/command-activity/command-activity-ui-contract.test.ts
@@ -27,6 +27,7 @@ assert(appModes.includes('role="tab"') && appModes.includes("aria-selected"), "a
 assert(appModes.includes("ArrowLeft") && appModes.includes("ArrowRight"), "app activity modes support arrow navigation");
 assert(workspace.includes("commandExecutionEvidenceCopy(props.harness ?? null"), "execution-proof disclosure is harness aware");
 assert(workspace.includes("Showing the last loaded command activity page"), "refresh failures retain prior valid page data");
+assert(workspace.includes("onRetry={activity.retry}"), "degraded command evidence exposes a retry action");
 assert(workspace.includes('activity.page.kind === "empty"'), "empty command pages render an explicit state");
 assert(filters.includes("preserveActiveOption"), "deep-linked stable filters remain represented outside aggregate options");
 assert(filters.includes('<option value="attempted">Attempt recorded</option>'), "all valid execution states remain selectable");
@@ -37,6 +38,7 @@ assert(
 );
 assert(summary.includes("Command checks by day: ${accessibleSummary}"), "trend values are included in the chart accessible name");
 assert(summary.includes("point.count === 0 ? 0"), "zero-count trend days do not render a visible bar");
+assert(summary.includes("Check again") && summary.includes("props.onRetry"), "degraded health offers a recovery action");
 assert(detail.includes('label="Containment evidence"'), "detail separates containment evidence");
 assert(detail.includes('label="Workflow capability"'), "detail separates workflow capability evidence");
 assert(detail.includes("FEEDBACK_LABELS.should_not_have_interrupted"), "detail exposes bounded interruption feedback");

--- a/dashboard/src/command-activity/command-activity-workspace.tsx
+++ b/dashboard/src/command-activity/command-activity-workspace.tsx
@@ -47,6 +47,7 @@ export function CommandActivityWorkspace(props: { harness?: string | null }) {
       <CommandActivitySummary
         state={activity.analytics}
         outsideTableFilters={commandSummaryIsOutsideTableFilters(activity.filters)}
+        onRetry={activity.retry}
       />
       <p className="rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600">
         {commandExecutionEvidenceCopy(props.harness ?? null, hasPostProof)}

--- a/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
@@ -161,7 +161,7 @@ def record_post_hook_command_activity_best_effort(
                 if previous.execution_status is expected_status:
                     return False
                 if previous.execution_status is not CommandExecutionStatus.ALLOWED_UNCONFIRMED:
-                    raise ValueError("post-hook proof conflicts with persisted command lifecycle")
+                    return False
                 current = build_correlated_post_activity(
                     previous,
                     request_correlation=correlation,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
@@ -161,6 +161,7 @@ def record_post_hook_command_activity_best_effort(
                 if previous.execution_status is expected_status:
                     return False
                 if previous.execution_status is not CommandExecutionStatus.ALLOWED_UNCONFIRMED:
+                    store.record_command_activity_observation_conflict(occurred_at=_utc_now())
                     return False
                 current = build_correlated_post_activity(
                     previous,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14468,6 +14468,11 @@ function infinitiveVerb(type) {
       return "run";
   }
 }
+function isShellCommandRequest(request) {
+  const artifactType = (request.artifact_type ?? "").toLowerCase();
+  const actionType = (request.action_envelope_json?.action_type ?? "").toLowerCase();
+  return actionType === "shell_command" || artifactType.includes("shell") || artifactType.includes("command");
+}
 function plainEnglishRequestTitle(request) {
   const category = detectCategory({
     ...request,
@@ -14491,6 +14496,9 @@ function plainEnglishRequestTitle(request) {
     case "tool-call":
       return `${app} wants to use a tool`;
     default:
+      if (isShellCommandRequest(request)) {
+        return `${app} wants to run a shell command`;
+      }
       return `${app} wants to do something with ${name}`;
   }
 }
@@ -14515,6 +14523,9 @@ function whyPaused(request) {
     case "tool-call":
       return "This uses an outside tool. Guard stops new tools by default.";
     default:
+      if (isShellCommandRequest(request)) {
+        return "This shell command has parts Guard could not fully inspect. Guard pauses these so you can review before running.";
+      }
       return "Guard paused this so you can review it first.";
   }
 }
@@ -14765,6 +14776,10 @@ function resolveSecondaryRiskSummary(item) {
     return null;
   }
   if (duplicatesStoppedActionText(item, summary)) {
+    return null;
+  }
+  const dashboardDetail = resolveDecisionV2Detail(item);
+  if (dashboardDetail && normalizeDuplicateReviewText(summary) === normalizeDuplicateReviewText(dashboardDetail)) {
     return null;
   }
   return summary;
@@ -22195,6 +22210,9 @@ function openPackageFirewallAuthorizeFallback(authorizeUrl, browserOpened) {
 function FiShare2(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 24 24", "fill": "none", "stroke": "currentColor", "strokeWidth": "2", "strokeLinecap": "round", "strokeLinejoin": "round" }, "child": [{ "tag": "circle", "attr": { "cx": "18", "cy": "5", "r": "3" }, "child": [] }, { "tag": "circle", "attr": { "cx": "6", "cy": "12", "r": "3" }, "child": [] }, { "tag": "circle", "attr": { "cx": "18", "cy": "19", "r": "3" }, "child": [] }, { "tag": "line", "attr": { "x1": "8.59", "y1": "13.51", "x2": "15.42", "y2": "17.49" }, "child": [] }, { "tag": "line", "attr": { "x1": "15.41", "y1": "6.51", "x2": "8.59", "y2": "10.49" }, "child": [] }] })(props);
 }
+function FiRefreshCw(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 24 24", "fill": "none", "stroke": "currentColor", "strokeWidth": "2", "strokeLinecap": "round", "strokeLinejoin": "round" }, "child": [{ "tag": "polyline", "attr": { "points": "23 4 23 10 17 10" }, "child": [] }, { "tag": "polyline", "attr": { "points": "1 20 1 14 7 14" }, "child": [] }, { "tag": "path", "attr": { "d": "M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" }, "child": [] }] })(props);
+}
 function FiCopy(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 24 24", "fill": "none", "stroke": "currentColor", "strokeWidth": "2", "strokeLinecap": "round", "strokeLinejoin": "round" }, "child": [{ "tag": "rect", "attr": { "x": "9", "y": "9", "width": "13", "height": "13", "rx": "2", "ry": "2" }, "child": [] }, { "tag": "path", "attr": { "d": "M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" }, "child": [] }] })(props);
 }
@@ -24075,7 +24093,7 @@ function homeCommandActivityModel(analytics) {
 }
 function commandHealthCopy(analytics) {
   if (analytics.health.status === "healthy") return null;
-  return "Command activity evidence is degraded. Counts may be incomplete.";
+  return "Guard could not record some recent command activity. Counts may be incomplete. Guard retries automatically; check again after the next command.";
 }
 function commandWindowLabel(analytics) {
   return `${analytics.window.days}-day window ending ${analytics.window.through}`;
@@ -24584,7 +24602,13 @@ function CommandActivitySummary(props) {
   const healthCopy = commandHealthCopy(analytics);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "min-w-0 max-w-full space-y-5", "aria-label": "Command activity summary", children: [
     props.outsideTableFilters ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700", role: "status", children: "Summary and trend totals do not include every active filter below." }) : null,
-    healthCopy ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900", role: "status", children: healthCopy }) : null,
+    healthCopy ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900", role: "status", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: healthCopy }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "outline", onClick: props.onRetry, children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(FiRefreshCw, { "aria-hidden": "true" }),
+        "Check again"
+      ] })
+    ] }) : null,
     props.state.kind === "error" ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900", role: "status", children: "Refresh failed. Showing the last loaded command activity summary." }) : null,
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 sm:grid-cols-2 xl:grid-cols-4", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(Metric, { label: "Commands checked", value: metrics.commandsChecked, detail: "One per recorded activity" }),
@@ -25493,7 +25517,8 @@ function CommandActivityWorkspace(props) {
       CommandActivitySummary,
       {
         state: activity.analytics,
-        outsideTableFilters: commandSummaryIsOutsideTableFilters(activity.filters)
+        outsideTableFilters: commandSummaryIsOutsideTableFilters(activity.filters),
+        onRetry: activity.retry
       }
     ),
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600", children: commandExecutionEvidenceCopy(props.harness ?? null, hasPostProof) }),

--- a/src/codex_plugin_scanner/guard/store_command_activity_lifecycle.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity_lifecycle.py
@@ -204,6 +204,26 @@ class StoreCommandActivityLifecycleMixin:
                 """
             )
 
+    def record_command_activity_observation_conflict(
+        self: _ConnectionOwner,
+        *,
+        occurred_at: datetime,
+    ) -> None:
+        """Retain one conflicting terminal observation without claiming a persistence outage."""
+
+        _require_utc_datetime(occurred_at)
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            connection.execute(
+                """
+                update command_activity_health
+                set dropped_event_count = min(dropped_event_count + 1, ?),
+                    last_error_code = 'post_result_conflict', last_error_at = ?
+                where singleton = 1
+                """,
+                (_MAX_COUNTER, occurred_at.isoformat()),
+            )
+
     def get_command_activity_persistence_health(
         self: _ConnectionOwner,
     ) -> CommandActivityPersistenceHealth:

--- a/tests/test_guard_command_activity_hook_integration.py
+++ b/tests/test_guard_command_activity_hook_integration.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import sqlite3
+from datetime import date
 from pathlib import Path
 from typing import cast
 
@@ -15,6 +16,7 @@ from codex_plugin_scanner.guard.cli.commands_support_command_activity import (
     record_post_hook_command_activity_best_effort,
     record_pre_hook_command_activity_best_effort,
 )
+from codex_plugin_scanner.guard.runtime.command_activity_api_contract import CommandActivityAnalyticsQuery
 from codex_plugin_scanner.guard.runtime.command_activity_contract import (
     COMMAND_ACTIVITY_HARNESSES,
     ActivityDecisionReason,
@@ -281,7 +283,7 @@ def test_strong_post_pairs_without_repeated_command_content(tmp_path: Path) -> N
     assert store.count_command_activities() == 1
 
 
-def test_conflicting_terminal_post_is_ignored_without_degrading_evidence_health(tmp_path: Path) -> None:
+def test_conflicting_terminal_post_is_diagnosed_without_degrading_persistence_health(tmp_path: Path) -> None:
     guard_home = tmp_path / "guard-home"
     store = _store(guard_home)
     payload = _command_payload()
@@ -313,8 +315,11 @@ def test_conflicting_terminal_post_is_ignored_without_degrading_evidence_health(
     )
     assert store.count_command_activities() == 1
     health = store.get_command_activity_persistence_health()
-    assert health.dropped_event_count == 0
-    assert health.last_error_code is None
+    assert health.dropped_event_count == 1
+    assert health.persistence_error_count == 0
+    assert health.last_error_code == "post_result_conflict"
+    analytics = store.command_activity_analytics(CommandActivityAnalyticsQuery(days=7), as_of=date.today())
+    assert cast(dict[str, object], analytics["health"])["status"] == "healthy"
 
 
 def test_prevented_command_post_result_does_not_degrade_evidence_health(tmp_path: Path) -> None:

--- a/tests/test_guard_command_activity_hook_integration.py
+++ b/tests/test_guard_command_activity_hook_integration.py
@@ -281,7 +281,7 @@ def test_strong_post_pairs_without_repeated_command_content(tmp_path: Path) -> N
     assert store.count_command_activities() == 1
 
 
-def test_conflicting_terminal_post_is_counted_without_creating_unpaired_evidence(tmp_path: Path) -> None:
+def test_conflicting_terminal_post_is_ignored_without_degrading_evidence_health(tmp_path: Path) -> None:
     guard_home = tmp_path / "guard-home"
     store = _store(guard_home)
     payload = _command_payload()
@@ -313,8 +313,8 @@ def test_conflicting_terminal_post_is_counted_without_creating_unpaired_evidence
     )
     assert store.count_command_activities() == 1
     health = store.get_command_activity_persistence_health()
-    assert health.dropped_event_count == 1
-    assert health.last_error_code == "post_record_failed"
+    assert health.dropped_event_count == 0
+    assert health.last_error_code is None
 
 
 def test_prevented_command_post_result_does_not_degrade_evidence_health(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- ignore late terminal command lifecycle replays without marking command evidence persistence as degraded
- make degraded command evidence guidance actionable with automatic-recovery context and a retry control

## Testing
- `uv run --no-sync pytest -q tests/test_guard_command_activity_hook_integration.py tests/test_guard_command_activity_health_recovery.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py tests/test_guard_command_activity_hook_integration.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py tests/test_guard_command_activity_hook_integration.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py tests/test_guard_command_activity_hook_integration.py`
- `uv run --no-sync python tests/guard_command_decision_diff.py --check`
- `bun run test`
- `bun run build`

## Notes
- The packaged command-analytics lab cannot run its Linux-only containment probe on macOS; it stopped before container startup and teardown confirmed zero resources.
