### PR TITLE
fix(pi): stop hook timeouts after Guard package drift

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from ...version import __version__
+from ..daemon.manager import GUARD_DAEMON_COMPATIBILITY_VERSION
 from .pi_extension_approval_source import APPROVAL_RESUME_HELPERS_SOURCE
 from .pi_extension_content_source import CONTENT_REVIEW_HELPERS_SOURCE
 
-GUARD_HOOK_TIMEOUT_MS = 8_000
+# Keep the end-to-end budget short enough for interactive Pi, but prefer the
+# resident daemon and never hard-block tool calls solely because review timed out.
+GUARD_HOOK_TIMEOUT_MS = 12_000
 GUARD_HOOK_DEADLINE_RESERVE_MS = 250
-GUARD_DAEMON_HOOK_TIMEOUT_MS = 7_000
-GUARD_CLI_HOOK_TIMEOUT_MS = 7_000
+GUARD_DAEMON_HOOK_TIMEOUT_MS = 10_000
+GUARD_CLI_HOOK_TIMEOUT_MS = 10_000
 GUARD_HOOK_TEXT_LIMIT_CHARS = 12_000
 GUARD_HOOK_CONTENT_ITEM_LIMIT = 24
 GUARD_HOOK_OBJECT_KEY_LIMIT = 24
@@ -29,7 +31,7 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
     home_dir_json = json.dumps(str(home_dir))
     home_dir_is_default_json = "true" if home_dir.resolve() == Path.home().resolve() else "false"
     config_path_json = json.dumps(str(settings_path))
-    package_version_json = json.dumps(__version__)
+    compatibility_version_json = json.dumps(GUARD_DAEMON_COMPATIBILITY_VERSION)
     return (
         'import { spawn, spawnSync } from "node:child_process";\n'
         'import { createCipheriv, createHash, randomBytes } from "node:crypto";\n'
@@ -44,7 +46,7 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         f"const GUARD_HOME_DIR = {home_dir_json};\n"
         f"const GUARD_HOME_DIR_IS_DEFAULT = {home_dir_is_default_json};\n"
         f"const GUARD_CONFIG_PATH = {config_path_json};\n"
-        f"const GUARD_PACKAGE_VERSION = {package_version_json};\n"
+        f"const GUARD_COMPATIBILITY_VERSION = {compatibility_version_json};\n"
         f"const GUARD_TIMEOUT_MS = {GUARD_HOOK_TIMEOUT_MS};\n"
         f"const GUARD_DEADLINE_RESERVE_MS = {GUARD_HOOK_DEADLINE_RESERVE_MS};\n"
         f"const GUARD_DAEMON_TIMEOUT_MS = {GUARD_DAEMON_HOOK_TIMEOUT_MS};\n"
@@ -81,8 +83,10 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "  try {\n"
         "    const daemonState = JSON.parse(\n"
         "      readFileSync(join(GUARD_HOME, 'daemon-state.json'), 'utf8'),\n"
-        "    ) as { package_version?: unknown; port?: unknown };\n"
-        "    if (daemonState.package_version !== GUARD_PACKAGE_VERSION) return null;\n"
+        "    ) as { compatibility_version?: unknown; package_version?: unknown; port?: unknown };\n"
+        "    // Prefer protocol compatibility over exact package version. Exact package pins\n"
+        "    // go stale after hol-guard update and force a cold CLI fallback that times out.\n"
+        "    if (daemonState.compatibility_version !== GUARD_COMPATIBILITY_VERSION) return null;\n"
         "    port = typeof daemonState.port === 'number' ? daemonState.port : 0;\n"
         "    authToken = readFileSync(join(GUARD_HOME, 'daemon-auth-token'), 'utf8').trim();\n"
         "  } catch {\n"
@@ -122,10 +126,12 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "    return parsed && typeof parsed === 'object' ? parsed : null;\n"
         "  } catch (error) {\n"
         "    if (error instanceof Error && error.name === 'AbortError') {\n"
+        "      // Infrastructure timeout: fail open so Pi remains usable; still surface a warning.\n"
         "      return {\n"
-        '        decision: "deny",\n'
+        '        decision: "allow",\n'
+        '        notice: "warning",\n'
         "        reason: `HOL Guard Pi hook timed out after "
-        + "${GUARD_DAEMON_TIMEOUT_MS}ms while reviewing this action.`,\n"
+        + "${GUARD_DAEMON_TIMEOUT_MS}ms while reviewing this action; continuing without a completed review.`,\n"
         "      };\n"
         "    }\n"
         "    return null;\n"
@@ -213,11 +219,16 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "    const resultError = result.error as (Error & { code?: unknown }) | undefined;\n"
         "    const errorMessage = resultError instanceof Error ? resultError.message : String(result.error);\n"
         "    const errorCode = typeof resultError?.code === 'string' ? resultError.code : '';\n"
+        "    if (errorCode === 'ETIMEDOUT' || result.error?.name === 'TimeoutError') {\n"
+        "      return {\n"
+        '        decision: "allow",\n'
+        '        notice: "warning",\n'
+        "        reason: `HOL Guard Pi hook timed out while reviewing this action; continuing without a completed review.`,\n"
+        "      };\n"
+        "    }\n"
         "    return {\n"
         '      decision: "deny",\n'
-        "      reason: errorCode === 'ETIMEDOUT' || result.error?.name === 'TimeoutError'\n"
-        "        ? `HOL Guard Pi hook timed out while reviewing this action.`\n"
-        "        : `HOL Guard Pi hook failed before completing review: ${errorMessage}`,\n"
+        "      reason: `HOL Guard Pi hook failed before completing review: ${errorMessage}`,\n"
         "    };\n"
         "  }\n"
         '  const lines = (result.stdout ?? "").split(/\\r?\\n/).map((line) => line.trim()).filter(Boolean);\n'
@@ -318,6 +329,9 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         '      ctx.ui.notify(reason, "warning");\n'
         '      return { action: "handled", handled: true };\n'
         "    }\n"
+        '    if (response.notice === "warning" && typeof response.reason === "string" && response.reason) {\n'
+        '      ctx.ui.notify(response.reason, "warning");\n'
+        "    }\n"
         '    return { action: "continue" };\n'
         "  });\n"
         '  pi.on("tool_call", async (event, ctx) => {\n'
@@ -341,6 +355,9 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "      scheduleApprovalResume(response, ctx, { kind: 'tool_call', toolName: event.toolName });\n"
         '      ctx.ui.notify(reason, "warning");\n'
         "      return { block: true, reason };\n"
+        "    }\n"
+        '    if (response.notice === "warning" && typeof response.reason === "string" && response.reason) {\n'
+        '      ctx.ui.notify(response.reason, "warning");\n'
         "    }\n"
         "    return undefined;\n"
         "  });\n"

--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
@@ -130,8 +130,8 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "      return {\n"
         '        decision: "allow",\n'
         '        notice: "warning",\n'
-        "        reason: `HOL Guard Pi hook timed out after "
-        + "${GUARD_DAEMON_TIMEOUT_MS}ms while reviewing this action; continuing without a completed review.`,\n"
+        "        reason: `HOL Guard Pi hook timed out after ${GUARD_DAEMON_TIMEOUT_MS}ms `\n"
+        "          + `while reviewing this action; continuing without a completed review.`,\n"
         "      };\n"
         "    }\n"
         "    return null;\n"
@@ -223,7 +223,8 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "      return {\n"
         '        decision: "allow",\n'
         '        notice: "warning",\n'
-        "        reason: `HOL Guard Pi hook timed out while reviewing this action; continuing without a completed review.`,\n"
+        "        reason: `HOL Guard Pi hook timed out while reviewing this action; `\n"
+        "          + `continuing without a completed review.`,\n"
         "      };\n"
         "    }\n"
         "    return {\n"

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -2060,10 +2060,58 @@ def _repair_supported_harnesses_in_process(
         repaired_installs.append(repaired_cursor)
     if cursor_warning is not None:
         repair_notes.append(cursor_warning)
+    repaired_pi, pi_warning = _repair_pi_install(
+        context=context,
+        store=store,
+        workspace=workspace,
+        now=now,
+    )
+    if repaired_pi is not None:
+        repaired_installs.append(repaired_pi)
+    if pi_warning is not None:
+        repair_notes.append(pi_warning)
     opencode_note = _refresh_opencode_pretool_plugin(context=context, store=store)
     if opencode_note is not None:
         repair_notes.append(opencode_note)
     return repaired_installs, repair_notes
+
+
+def _repair_pi_install(
+    *,
+    context: HarnessContext,
+    store: GuardStore,
+    workspace: str | None,
+    now: str,
+) -> tuple[dict[str, object] | None, str | None]:
+    """Rewrite the managed Pi extension after package updates.
+
+    The extension embeds timeout and daemon-compat constants. Refreshing it after
+    update keeps the fast daemon path available and avoids cold CLI timeouts.
+    """
+
+    try:
+        managed_install = store.get_managed_install("pi")
+    except (json.JSONDecodeError, sqlite3.Error):
+        return None, None
+    if managed_install is None or not bool(managed_install.get("active")):
+        return None, None
+    try:
+        repair_context, repair_workspace = _repair_context_from_managed_install(context, managed_install)
+        payload = apply_managed_install(
+            "install",
+            "pi",
+            False,
+            repair_context,
+            store,
+            repair_workspace or workspace,
+            now,
+        )
+    except (OSError, RuntimeError, json.JSONDecodeError, sqlite3.Error) as error:
+        return None, f"Could not refresh Pi protection during update: {error}"
+    repaired = payload.get("managed_install")
+    if not isinstance(repaired, dict):
+        return None, "Could not refresh Pi protection during update: managed install was not recorded"
+    return repaired, None
 
 
 def _repair_cursor_install(

--- a/tests/test_pi_adapter.py
+++ b/tests/test_pi_adapter.py
@@ -312,10 +312,14 @@ class TestPiInstall:
         assert "if (result.error) {" in text
         assert "const resultError =" in text
         assert "const errorCode =" in text
-        assert 'decision: "deny"' in text
+        assert 'decision: "allow"' in text
+        assert 'notice: "warning"' in text
         assert "errorCode === 'ETIMEDOUT'" in text
-        assert "HOL Guard Pi hook timed out after" in text
+        assert "HOL Guard Pi hook timed out" in text
+        assert "continuing without a completed review" in text
         assert "HOL Guard Pi hook failed before completing review" in text
+        assert "GUARD_COMPATIBILITY_VERSION" in text
+        assert "compatibility_version !== GUARD_COMPATIBILITY_VERSION" in text
 
     def test_install_writes_managed_extension_that_truncates_post_tool_payloads(
         self,

--- a/tests/test_pi_hook_latency.py
+++ b/tests/test_pi_hook_latency.py
@@ -84,12 +84,12 @@ def test_pi_extension_keeps_fallbacks_inside_outer_hook_deadline(tmp_path: Path)
         settings_path=tmp_path / "settings.json",
     )
 
-    assert "const GUARD_TIMEOUT_MS = 8000;" in source
+    assert "const GUARD_TIMEOUT_MS = 12000;" in source
     assert "const GUARD_DEADLINE_RESERVE_MS = 250;" in source
-    assert "const GUARD_DAEMON_TIMEOUT_MS = 7000;" in source
-    assert "const GUARD_CLI_TIMEOUT_MS = 7000;" in source
+    assert "const GUARD_DAEMON_TIMEOUT_MS = 10000;" in source
+    assert "const GUARD_CLI_TIMEOUT_MS = 10000;" in source
     assert 'const GUARD_ARGS = ["hook", "--json"' in source
-    assert "daemonState.package_version !== GUARD_PACKAGE_VERSION" in source
+    assert "compatibility_version !== GUARD_COMPATIBILITY_VERSION" in source
     assert "error.name === 'AbortError'" in source
     assert source.index("error.name === 'AbortError'") > source.index("await fetch")
     assert "const deadlineAt = Date.now() + GUARD_TIMEOUT_MS - GUARD_DEADLINE_RESERVE_MS" in source


### PR DESCRIPTION
## Summary
- Prefer daemon protocol `compatibility_version` over exact package pins so a stale Pi extension still uses the resident Guard daemon after updates.
- Fail open (allow + warning) when hook review times out so Pi tool calls are not hard-blocked by infrastructure delays.
- Refresh managed Pi installs after `hol-guard update` and raise the hook deadline budget slightly for cold CLI fallback.

## Testing
- `python3 -m pytest -q tests/test_pi_adapter.py tests/test_pi_hook_latency.py --tb=line`
- Reproduced local failure: extension embedded package `2.1.0a45` while daemon reported `2.1.0a55`, forcing CLI fallback and timeout denies.

## Notes
- Root cause was version drift: exact package match skipped the fast daemon path on every tool call.
