### PR TITLE
fix(trust): preserve macOS native integrity reads

### DIFF
--- a/src/codex_plugin_scanner/guard/store_base.py
+++ b/src/codex_plugin_scanner/guard/store_base.py
@@ -703,40 +703,17 @@ class SystemKeyringSecretStore:
     def _get_secret_without_macos_ui(self, secret_id: str) -> str | None:
         if not self._supports_native_macos_security_reads():
             return None
-        set_interaction_allowed = None
-        interaction_state = None
         data = None
         try:
-            from ctypes import byref, c_ubyte
+            from ctypes import byref
 
             macos_keyring_api = self._load_macos_keyring_api_module()
             # The macOS keyring backend returns password bytes here but exposes
             # its decoder under the historical cfstr_to_str name.
             cfstr_to_str = getattr(macos_keyring_api, "cfstr_to_str", None)
             cf_release = getattr(macos_keyring_api, "CFRelease", None)
-            security_library = getattr(macos_keyring_api, "_sec", None)
-            get_interaction_allowed = (
-                getattr(security_library, "SecKeychainGetUserInteractionAllowed", None)
-                if security_library is not None
-                else None
-            )
-            set_interaction_allowed = (
-                getattr(security_library, "SecKeychainSetUserInteractionAllowed", None)
-                if security_library is not None
-                else None
-            )
-            interaction_state: c_ubyte | None = None
-            if get_interaction_allowed is not None:
-                get_interaction_allowed.restype = macos_keyring_api.OS_status
-                get_interaction_allowed.argtypes = [ctypes.POINTER(c_ubyte)]
-                interaction_state = c_ubyte(1)
-                status = get_interaction_allowed(byref(interaction_state))
-                if status != 0:
-                    interaction_state = None
-            if set_interaction_allowed is not None:
-                set_interaction_allowed.restype = macos_keyring_api.OS_status
-                set_interaction_allowed.argtypes = [c_ubyte]
-                set_interaction_allowed(0)
+            # Keep prompt suppression scoped to this query. Disabling keychain
+            # interaction process-wide makes otherwise readable items fail auth.
             query = macos_keyring_api.create_query(
                 kSecClass=macos_keyring_api.k_("kSecClassGenericPassword"),
                 kSecMatchLimit=macos_keyring_api.k_("kSecMatchLimitOne"),
@@ -749,11 +726,6 @@ class SystemKeyringSecretStore:
             status = macos_keyring_api.SecItemCopyMatching(query, byref(data))
         except Exception:
             return None
-        finally:
-            if set_interaction_allowed is not None:
-                restore_value = interaction_state.value if interaction_state is not None else 1
-                with suppress(Exception):
-                    set_interaction_allowed(restore_value)
         if status == 0:
             if not callable(cfstr_to_str):
                 return None

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -333,6 +333,49 @@ def test_system_keyring_native_macos_read_uses_cfstr_decoder(
     assert secret_store.get_secret_with_timeout("policy-key", timeout_seconds=1.0) == "native-secret"
 
 
+def test_system_keyring_native_macos_read_does_not_disable_keychain_interaction_globally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    secret_store = SystemKeyringSecretStore(service_name="hol-guard.policy-integrity")
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_supports_native_macos_security_reads",
+        classmethod(lambda cls: True),
+    )
+    interaction_enabled = True
+
+    def set_interaction_allowed(value: int) -> int:
+        nonlocal interaction_enabled
+        interaction_enabled = bool(value)
+        return 0
+
+    def copy_matching(query: dict[str, object], _data: object) -> int:
+        assert query["kSecUseAuthenticationUI"] == "kSecUseAuthenticationUIFail"
+        return 0 if interaction_enabled else -25293
+
+    fake_api = types.SimpleNamespace(
+        OS_status=guard_store_module.ctypes.c_int32,
+        _sec=types.SimpleNamespace(SecKeychainSetUserInteractionAllowed=set_interaction_allowed),
+        error=types.SimpleNamespace(
+            item_not_found=-25300,
+            keychain_denied=-128,
+            sec_auth_failed=-25293,
+            plist_missing=-67030,
+            sec_interaction_not_allowed=-25308,
+        ),
+        c_void_p=guard_store_module.ctypes.c_void_p,
+        k_=lambda name: name,
+        create_query=lambda **kwargs: kwargs,
+        SecItemCopyMatching=copy_matching,
+        cfstr_to_str=lambda _data: "native-secret",
+    )
+    monkeypatch.setattr(secret_store, "_load_macos_keyring_api_module", lambda: fake_api)
+
+    assert secret_store.get_secret_with_timeout("policy-key", timeout_seconds=1.0) == "native-secret"
+    assert interaction_enabled is True
+
+
 def test_system_keyring_supports_native_macos_reads_with_nonstandard_keyring_module(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- keep macOS no-prompt keychain reads scoped to each Security.framework query
- avoid process-global interaction changes that make valid integrity items fail authentication
- cover the regression while asserting that authentication UI remains disabled per query

## Root cause

Guard combined `kSecUseAuthenticationUIFail` with a process-global keychain interaction disable. On supported macOS keychains, the scoped query succeeds by itself, while the global disable changes the same query to an authentication failure. Integrity setup then incorrectly reports both its key and control record unavailable.

## Security

The read remains fail-closed and prompt-free through `kSecUseAuthenticationUIFail`. The change removes only the redundant process-global mutation and does not add a file fallback or weaken integrity requirements.

## Verification

- 73 store migration and passive trust CLI tests
- 5 focused macOS/keychain policy-integrity tests
- Ruff check and format validation
- isolated wheel native key/control read
- live trust setup reached protected state using the patched source
