### PR TITLE
fix(macos): bound passive keychain reads

### DIFF
--- a/src/codex_plugin_scanner/guard/store_base.py
+++ b/src/codex_plugin_scanner/guard/store_base.py
@@ -802,7 +802,8 @@ class SystemKeyringSecretStore:
         if sys.platform == "darwin":
             if (
                 self._test_keyring_module() is not None
-                and getattr(type(self)._get_secret_without_macos_ui, "__name__", "") == "_get_secret_without_macos_ui"
+                and getattr(type(self)._get_macos_secret_in_isolated_process, "__name__", "")
+                == "_get_macos_secret_in_isolated_process"
             ):
                 return self.get_secret(secret_id)
             if self._supports_native_macos_security_reads():

--- a/src/codex_plugin_scanner/guard/store_base.py
+++ b/src/codex_plugin_scanner/guard/store_base.py
@@ -749,8 +749,54 @@ class SystemKeyringSecretStore:
             return None
         return None  # unknown non-zero status
 
+    def _get_macos_secret_in_isolated_process(
+        self,
+        secret_id: str,
+        *,
+        timeout_seconds: float,
+    ) -> str | None:
+        """Read one Keychain item behind a killable process boundary.
+
+        Some macOS Keychain configurations can block inside
+        ``SecItemCopyMatching`` even with the query-local no-UI flag. A thread
+        timeout cannot recover from that native call, so passive Guard reads
+        run in a disposable interpreter and fail closed when the deadline
+        expires.
+        """
+
+        worker = (
+            "import json,sys;"
+            "from codex_plugin_scanner.guard.store_base import SystemKeyringSecretStore;"
+            "value=SystemKeyringSecretStore(service_name=sys.argv[1])."
+            "_get_secret_without_macos_ui(sys.argv[2]);"
+            "sys.stdout.write(json.dumps({'value':value},separators=(',',':')))"
+        )
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key in {"HOME", "LANG", "LC_ALL", "LOGNAME", "PATH", "TMPDIR", "USER"} or key.startswith("LC_")
+        }
+        try:
+            completed = subprocess.run(
+                [sys.executable, "-I", "-c", worker, self.service_name, secret_id],
+                check=False,
+                capture_output=True,
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                timeout=max(timeout_seconds, 0.1),
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        if completed.returncode != 0:
+            return None
+        try:
+            payload = json.loads(completed.stdout.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return None
+        value = payload.get("value") if isinstance(payload, dict) else None
+        return value if isinstance(value, str) and value else None
+
     def get_secret_with_timeout(self, secret_id: str, *, timeout_seconds: float = 0.0) -> str | None:
-        _ = timeout_seconds
         if sys.platform != "darwin" and self._test_keyring_module() is not None:
             return self.get_secret(secret_id)
         if sys.platform == "darwin":
@@ -760,7 +806,10 @@ class SystemKeyringSecretStore:
             ):
                 return self.get_secret(secret_id)
             if self._supports_native_macos_security_reads():
-                return self._get_secret_without_macos_ui(secret_id)
+                return self._get_macos_secret_in_isolated_process(
+                    secret_id,
+                    timeout_seconds=timeout_seconds,
+                )
             if self._test_keyring_module() is not None:
                 return self.get_secret(secret_id)
             if self.service_name == _POLICY_INTEGRITY_SERVICE_NAME:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -155,8 +155,8 @@ def _enable_macos_native_policy_integrity(
     )
     monkeypatch.setattr(
         SystemKeyringSecretStore,
-        "_get_secret_without_macos_ui",
-        lambda self, secret_id: fake_keyring.get_password(self.service_name, secret_id),
+        "_get_macos_secret_in_isolated_process",
+        lambda self, secret_id, *, timeout_seconds: fake_keyring.get_password(self.service_name, secret_id),
     )
     return fake_keyring
 

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -297,7 +297,11 @@ def test_system_keyring_timeout_keeps_non_policy_integrity_macos_services(
         "_supports_native_macos_security_reads",
         classmethod(lambda cls: True),
     )
-    monkeypatch.setattr(secret_store, "_get_secret_without_macos_ui", lambda _secret_id: "oauth-secret")
+    monkeypatch.setattr(
+        secret_store,
+        "_get_macos_secret_in_isolated_process",
+        lambda _secret_id, *, timeout_seconds: "oauth-secret",
+    )
 
     assert secret_store.get_secret_with_timeout("oauth-token", timeout_seconds=1.0) == "oauth-secret"
 
@@ -330,7 +334,7 @@ def test_system_keyring_native_macos_read_uses_cfstr_decoder(
     )
     monkeypatch.setattr(secret_store, "_load_macos_keyring_api_module", lambda: fake_api)
 
-    assert secret_store.get_secret_with_timeout("policy-key", timeout_seconds=1.0) == "native-secret"
+    assert secret_store._get_secret_without_macos_ui("policy-key") == "native-secret"
 
 
 def test_system_keyring_native_macos_read_does_not_disable_keychain_interaction_globally(
@@ -372,8 +376,68 @@ def test_system_keyring_native_macos_read_does_not_disable_keychain_interaction_
     )
     monkeypatch.setattr(secret_store, "_load_macos_keyring_api_module", lambda: fake_api)
 
-    assert secret_store.get_secret_with_timeout("policy-key", timeout_seconds=1.0) == "native-secret"
+    assert secret_store._get_secret_without_macos_ui("policy-key") == "native-secret"
     assert interaction_enabled is True
+
+
+def test_system_keyring_macos_read_runs_behind_killable_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret_store = SystemKeyringSecretStore(service_name="hol-guard.policy-integrity")
+    captured: dict[str, object] = {}
+
+    def run_worker(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        captured["command"] = command
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(command, 0, b'{"value":"native-secret"}', b"")
+
+    monkeypatch.setattr(guard_store_module.subprocess, "run", run_worker)
+
+    assert secret_store._get_macos_secret_in_isolated_process("policy-key", timeout_seconds=0.75) == "native-secret"
+    command = captured["command"]
+    assert isinstance(command, list)
+    assert command[:3] == [sys.executable, "-I", "-c"]
+    assert command[-2:] == ["hol-guard.policy-integrity", "policy-key"]
+    assert captured["timeout"] == 0.75
+    assert captured["stdin"] is subprocess.DEVNULL
+
+
+def test_system_keyring_macos_read_fails_closed_on_native_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret_store = SystemKeyringSecretStore(service_name="hol-guard.policy-integrity")
+
+    def time_out(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        raise subprocess.TimeoutExpired(command, timeout=0.1)
+
+    monkeypatch.setattr(guard_store_module.subprocess, "run", time_out)
+
+    assert secret_store._get_macos_secret_in_isolated_process("policy-key", timeout_seconds=0.1) is None
+
+
+def test_system_keyring_timeout_routes_native_macos_reads_to_isolated_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    secret_store = SystemKeyringSecretStore(service_name="hol-guard.policy-integrity")
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_supports_native_macos_security_reads",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(secret_store, "_test_keyring_module", lambda: None)
+    monkeypatch.setattr(
+        secret_store,
+        "_get_secret_without_macos_ui",
+        lambda _secret_id: (_ for _ in ()).throw(AssertionError("native read must be isolated")),
+    )
+    monkeypatch.setattr(
+        secret_store,
+        "_get_macos_secret_in_isolated_process",
+        lambda secret_id, *, timeout_seconds: f"{secret_id}:{timeout_seconds}",
+    )
+
+    assert secret_store.get_secret_with_timeout("policy-key", timeout_seconds=0.75) == "policy-key:0.75"
 
 
 def test_system_keyring_supports_native_macos_reads_with_nonstandard_keyring_module(
@@ -408,8 +472,8 @@ def test_policy_integrity_timeout_uses_native_no_ui_path_with_nonstandard_keyrin
     secret_store = SystemKeyringSecretStore(service_name="hol-guard.policy-integrity")
     monkeypatch.setattr(
         secret_store,
-        "_get_secret_without_macos_ui",
-        lambda _secret_id: module.get_password("hol-guard.policy-integrity", _secret_id),
+        "_get_macos_secret_in_isolated_process",
+        lambda _secret_id, *, timeout_seconds: module.get_password("hol-guard.policy-integrity", _secret_id),
     )
     monkeypatch.setattr(
         secret_store,


### PR DESCRIPTION
## Summary
- isolate passive macOS Keychain reads in a disposable interpreter
- enforce the existing read deadline by terminating native calls that do not return
- fail closed without blocking Guard installation or hook recovery

## Root cause
On some macOS Keychain configurations, `SecItemCopyMatching` can block even when the query uses `kSecUseAuthenticationUIFail`. Because the call ran in the main process, the configured timeout could not interrupt it.

## Verification
- `uv run pytest -q tests/test_guard_store_migrations.py tests/test_guard_codex_install.py` (135 passed)
- targeted Ruff and basedpyright checks
- live isolated native read returned within its deadline

Follow-up to #1850.