### PR TITLE
fix(guard): canonicalize hook health identities

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -1331,6 +1331,27 @@ def _live_hook_verification(
     return verified
 
 
+def _canonical_managed_installs_for_health(
+    managed_installs: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    canonical: dict[str, tuple[bool, dict[str, object]]] = {}
+    for install in managed_installs:
+        harness = install.get("harness")
+        if not isinstance(harness, str):
+            continue
+        try:
+            canonical_harness = get_adapter(harness).harness
+        except (ImportError, RuntimeError, TypeError, ValueError):
+            canonical_harness = harness
+        candidate = dict(install)
+        candidate["harness"] = canonical_harness
+        exact = harness == canonical_harness
+        existing = canonical.get(canonical_harness)
+        if existing is None or (exact and not existing[0]):
+            canonical[canonical_harness] = (exact, candidate)
+    return [canonical[harness][1] for harness in sorted(canonical)]
+
+
 def build_runtime_snapshot(
     *,
     store: GuardStore,
@@ -1362,7 +1383,8 @@ def build_runtime_snapshot(
     )
     trust_status = store.get_cached_policy_trust_status()
     managed_installs = store.list_managed_installs()
-    hook_verification = _live_hook_verification(managed_installs, store)
+    health_managed_installs = _canonical_managed_installs_for_health(managed_installs)
+    hook_verification = _live_hook_verification(health_managed_installs, store)
     runtime_state = store.get_runtime_state()
     health_runtime_state = dict(runtime_state) if runtime_state is not None else None
     if health_runtime_state is not None and containment_health is not None:
@@ -1370,7 +1392,7 @@ def build_runtime_snapshot(
     protection_health = build_runtime_protection_health(
         store=store,
         runtime_state=health_runtime_state,
-        managed_installs=managed_installs,
+        managed_installs=health_managed_installs,
         hook_verification=hook_verification,
         trust_status=trust_status,
         now=datetime.fromisoformat(snapshot_now.replace("Z", "+00:00")),

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -1334,7 +1334,7 @@ def _live_hook_verification(
 def _canonical_managed_installs_for_health(
     managed_installs: Sequence[Mapping[str, object]],
 ) -> list[dict[str, object]]:
-    canonical: dict[str, tuple[bool, dict[str, object]]] = {}
+    canonical: dict[str, tuple[tuple[bool, bool], dict[str, object]]] = {}
     for install in managed_installs:
         harness = install.get("harness")
         if not isinstance(harness, str):
@@ -1346,9 +1346,10 @@ def _canonical_managed_installs_for_health(
         candidate = dict(install)
         candidate["harness"] = canonical_harness
         exact = harness == canonical_harness
+        priority = (install.get("active") is True, exact)
         existing = canonical.get(canonical_harness)
-        if existing is None or (exact and not existing[0]):
-            canonical[canonical_harness] = (exact, candidate)
+        if existing is None or priority > existing[0]:
+            canonical[canonical_harness] = (priority, candidate)
     return [canonical[harness][1] for harness in sorted(canonical)]
 
 

--- a/tests/test_guard_protection_health.py
+++ b/tests/test_guard_protection_health.py
@@ -174,6 +174,17 @@ def test_runtime_snapshot_reads_live_hook_verification(
     assert approvals_module._live_hook_verification(installs, store) == {}
 
 
+def test_canonical_managed_install_supersedes_legacy_alias() -> None:
+    installs = [
+        {"harness": "claude", "active": True, "manifest": {}},
+        {"harness": "claude-code", "active": True, "manifest": {"canonical": True}},
+    ]
+
+    assert approvals_module._canonical_managed_installs_for_health(installs) == [
+        {"harness": "claude-code", "active": True, "manifest": {"canonical": True}}
+    ]
+
+
 def test_historical_persistence_errors_do_not_keep_current_health_degraded() -> None:
     payload = _payload(dropped=4, errors=4, active_errors=0, activity_count=3)
     checks = cast(list[dict[str, str]], payload["checks"])

--- a/tests/test_guard_protection_health.py
+++ b/tests/test_guard_protection_health.py
@@ -184,6 +184,14 @@ def test_canonical_managed_install_supersedes_legacy_alias() -> None:
         {"harness": "claude-code", "active": True, "manifest": {"canonical": True}}
     ]
 
+    active_alias = [
+        {"harness": "claude", "active": True, "manifest": {"alias": True}},
+        {"harness": "claude-code", "active": False, "manifest": {"canonical": True}},
+    ]
+    assert approvals_module._canonical_managed_installs_for_health(active_alias) == [
+        {"harness": "claude-code", "active": True, "manifest": {"alias": True}}
+    ]
+
 
 def test_historical_persistence_errors_do_not_keep_current_health_degraded() -> None:
     payload = _payload(dropped=4, errors=4, active_errors=0, activity_count=3)


### PR DESCRIPTION
## Summary

- normalize legacy harness aliases before evaluating managed-hook health
- prefer the canonical managed-install row when both alias and canonical rows exist
- keep raw managed-install inventory unchanged outside protection health

## Verification

- `uv run --no-sync pytest -q tests/test_guard_protection_health.py --tb=short` (14 passed)
- `uv run --no-sync pytest -q tests/test_guard_command_decision_diff.py --tb=short` (4 passed)
- `uv run --no-sync ruff check ...`
- `uv run --no-sync ruff format --check ...`
- `git diff --check`
