### PR TITLE
fix(cursor): preserve global hook state from home

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -222,6 +222,8 @@ def _cleanup_legacy_project_cursor_hooks(context: HarnessContext) -> None:
         return
     hooks_path = _legacy_project_cursor_hooks_path(context.workspace_dir)
     script_path = _legacy_project_cursor_hook_script_path(context.workspace_dir)
+    if hooks_path.resolve() == cursor_hooks_path(context).resolve():
+        return
     if not hooks_path.is_file() and not script_path.is_file():
         return
     managed = False

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -400,6 +400,17 @@ def test_cursor_install_persists_only_attested_cli_identity(
     assert cursor_native_hook_state(context)["protection_active"] is True
 
 
+def test_cursor_install_from_home_does_not_remove_global_hook_state(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    context = HarnessContext(home_dir=home, guard_home=tmp_path / "guard", workspace_dir=home)
+
+    manifest = install_cursor_hooks(context)
+
+    assert Path(str(manifest["state_path"])).is_file()
+    assert cursor_native_hook_state(context)["protection_active"] is True
+
+
 def test_cursor_update_repairs_tampered_cli_binding(tmp_path: Path) -> None:
     home = tmp_path / "home"
     workspace = tmp_path / "workspace"


### PR DESCRIPTION
## Summary
- prevent legacy project-hook cleanup from treating the global Cursor hook as project-local when installation runs from the user home directory
- retain the newly written hook state so post-install integrity verification succeeds
- cover the home-directory alias case with a regression test

## Verification
- focused Cursor hook, workspace install, and CLI suites: 79 passed
- Ruff: passed
- basedpyright on the changed runtime module: 0 errors
- built and installed the wheel in an isolated environment, invoked the Cursor installer from its home directory, and confirmed hooks, state, and script proofs exist