### PR TITLE
fix(guard): recover command evidence health

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -13,6 +13,7 @@ import mimetypes
 import os
 import platform
 import secrets
+import sqlite3
 import tempfile
 import threading
 import time
@@ -4171,7 +4172,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                             repaired_check_ids.append(containment_check_id)
                         else:
                             failed_check_ids.append(containment_check_id)
-                except (OSError, RuntimeError, TypeError, ValueError):
+                except (OSError, RuntimeError, TypeError, ValueError, sqlite3.Error):
                     failed_check_ids.extend(["decision_plane_compatibility", "containment_compatibility", "sandbox"])
                 try:
                     config = load_guard_config(store.guard_home)
@@ -4229,7 +4230,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     detail_retain_days=config.evidence_retain_days,
                 )
                 health = store.get_command_activity_persistence_health()
-            except (OSError, RuntimeError, TypeError, ValueError):
+            except (OSError, RuntimeError, TypeError, ValueError, sqlite3.Error):
                 self._write_json(
                     {
                         "error": "protection_repair_failed",

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -149,6 +149,15 @@ from ..review_contracts import (
     validated_remote_approval_envelope,
 )
 from ..runtime.approval_attention import ApprovalAttentionCoordinator
+from ..runtime.command_activity_contract import ActivityApprovalReuseStatus, ActivityDecisionReason
+from ..runtime.command_activity_lifecycle import CommandActivityDecisionFacts, build_pre_hook_evidence
+from ..runtime.command_evaluation import evaluate_command
+from ..runtime.command_shadow_evaluation import (
+    CommandShadowCohort,
+    CommandShadowControl,
+    baseline_command_shadow_proposal,
+    build_command_shadow_observation,
+)
 from ..runtime.containment_health import containment_health_signals
 from ..runtime.live_request_sync import LiveRequestSyncWorker, start_cloud_sync_sync_worker, stop_cloud_sync_sync_worker
 from ..runtime.protection_health import ProtectionCheckStatus
@@ -1404,6 +1413,43 @@ def _finalize_daemon_guard_connect_payload(
     except (GuardSyncNotConfiguredError, GuardSyncNotAvailableError, RuntimeError) as error:
         payload["supply_chain_error"] = str(error)
     return payload
+
+
+def _repair_command_activity_persistence_health(store: GuardStore) -> None:
+    shadow_evaluation = evaluate_command("git push origin release/2.1 --force")
+    shadow_proposal = baseline_command_shadow_proposal(shadow_evaluation)
+    occurred_at = datetime.now(timezone.utc)
+    evidence = build_pre_hook_evidence(
+        shadow_evaluation,
+        CommandActivityDecisionFacts(
+            policy_action="allow",
+            decision_reason_code=ActivityDecisionReason.EXTENSION_MATCH,
+            prompted=False,
+            approval_reuse_status=ActivityApprovalReuseStatus.NOT_APPLICABLE,
+            receipt_id=None,
+        ),
+        activity_id="activity:protection-repair-probe",
+        occurred_at=occurred_at,
+        harness="codex",
+        request_correlation=None,
+    )
+    shadow = build_command_shadow_observation(
+        shadow_evaluation,
+        authoritative_action="allow",
+        proposal=shadow_proposal,
+        activity_id="activity:protection-repair-probe",
+        occurred_at=occurred_at,
+        control=CommandShadowControl(
+            enabled=True,
+            kill_switch=False,
+            release_cohorts=frozenset({CommandShadowCohort.BASELINE}),
+            disabled_cohorts=frozenset(),
+            sample_basis_points=10_000,
+        ),
+    )
+    if shadow is None:
+        raise RuntimeError("command shadow repair probe was not selected")
+    store.probe_command_activity_persistence(evidence, shadow=shadow)
 
 
 class _GuardDaemonHandler(BaseHTTPRequestHandler):
@@ -4129,6 +4175,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     failed_check_ids.extend(["decision_plane_compatibility", "containment_compatibility", "sandbox"])
                 try:
                     config = load_guard_config(store.guard_home)
+                    _repair_command_activity_persistence_health(store)
                     store.maintain_command_activity(
                         now=datetime.now(timezone.utc),
                         detail_retain_days=config.evidence_retain_days,
@@ -4176,6 +4223,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if check_id == "decision_stream":
             try:
                 config = load_guard_config(store.guard_home)
+                _repair_command_activity_persistence_health(store)
                 store.maintain_command_activity(
                     now=datetime.now(timezone.utc),
                     detail_retain_days=config.evidence_retain_days,

--- a/src/codex_plugin_scanner/guard/store_command_activity.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity.py
@@ -39,15 +39,7 @@ class StoreCommandActivityMixin:
     ) -> bool:
         """Persist one logical command and its rule hits; return false for an exact replay."""
 
-        if not isinstance(cast(object, evidence), CommandActivityEvidence):
-            raise ValueError("evidence must be a CommandActivityEvidence")
-        if shadow is not None:
-            if not isinstance(cast(object, shadow), CommandShadowObservation):
-                raise ValueError("shadow must be a CommandShadowObservation")
-            if shadow.activity_id != evidence.activity.activity_id:
-                raise ValueError("shadow activity_id must match command evidence")
-            if shadow.occurred_at != evidence.activity.occurred_at:
-                raise ValueError("shadow occurred_at must match command evidence")
+        _validate_command_activity_write(evidence, shadow)
         with self._connect() as connection:
             connection.execute("begin immediate")
             existing = cast(
@@ -78,57 +70,47 @@ class StoreCommandActivityMixin:
                 is not None
             ):
                 return False
-            connection.execute(
-                """
-                insert into command_activity (
-                  activity_id, occurred_at, harness, hook_phase, execution_status,
-                  proof_level, policy_action, decision_reason_code, controlling_rule_id,
-                  parse_confidence, uncertainty_class, match_count, prompted,
-                  approval_reuse_status, receipt_link_status, receipt_id,
-                  evaluation_latency_bucket, persistence_latency_bucket, schema_version
-                ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                _activity_values(evidence.activity),
+            _record_new_command_activity(
+                connection,
+                evidence,
+                shadow=shadow,
+                shadow_evaluation_succeeded=shadow_evaluation_succeeded,
             )
-            connection.executemany(
-                """
-                insert into command_activity_matches (
-                  activity_id, ordinal, extension_id, extension_version, rule_id,
-                  rule_version, match_class, severity, default_floor,
-                  safe_variant_id, schema_version
-                ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                tuple(_match_values(item) for item in evidence.matches),
-            )
-            connection.executemany(
-                """
-                insert into command_activity_match_effects (
-                  activity_id, ordinal, effect_class
-                ) values (?, ?, ?)
-                """,
-                _effect_values(evidence),
-            )
-            connection.executemany(
-                """
-                insert into command_activity_correlations (
-                  activity_id, kind, harness, key_id, digest
-                ) values (?, ?, ?, ?, ?)
-                """,
-                _correlation_values(evidence.activity),
-            )
-            if shadow is not None:
-                record_command_shadow_observation(connection, shadow)
-            record_command_activity_rollups(connection, evidence)
+            return True
+
+    def probe_command_activity_persistence(
+        self: _ConnectionOwner,
+        evidence: CommandActivityEvidence,
+        *,
+        shadow: CommandShadowObservation,
+    ) -> None:
+        """Exercise and roll back the real command and shadow write path."""
+
+        _validate_command_activity_write(evidence, shadow)
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            connection.execute("savepoint command_activity_repair_probe")
+            try:
+                _record_new_command_activity(
+                    connection,
+                    evidence,
+                    shadow=shadow,
+                    shadow_evaluation_succeeded=True,
+                )
+            except BaseException:
+                connection.execute("rollback to command_activity_repair_probe")
+                connection.execute("release command_activity_repair_probe")
+                raise
+            connection.execute("rollback to command_activity_repair_probe")
+            connection.execute("release command_activity_repair_probe")
             recover_command_activity_persistence(
                 connection,
                 error_domain=COMMAND_PERSISTENCE_ERROR_DOMAIN,
             )
-            if shadow is not None or shadow_evaluation_succeeded:
-                recover_command_activity_persistence(
-                    connection,
-                    error_domain=SHADOW_PERSISTENCE_ERROR_DOMAIN,
-                )
-            return True
+            recover_command_activity_persistence(
+                connection,
+                error_domain=SHADOW_PERSISTENCE_ERROR_DOMAIN,
+            )
 
     def count_command_activities(self: _ConnectionOwner) -> int:
         with self._connect() as connection:
@@ -154,6 +136,81 @@ class StoreCommandActivityMixin:
                     ).fetchone(),
                 )
         return int(row[0]) if row is not None else 0
+
+
+def _validate_command_activity_write(
+    evidence: CommandActivityEvidence,
+    shadow: CommandShadowObservation | None,
+) -> None:
+    if not isinstance(cast(object, evidence), CommandActivityEvidence):
+        raise ValueError("evidence must be a CommandActivityEvidence")
+    if shadow is None:
+        return
+    if not isinstance(cast(object, shadow), CommandShadowObservation):
+        raise ValueError("shadow must be a CommandShadowObservation")
+    if shadow.activity_id != evidence.activity.activity_id:
+        raise ValueError("shadow activity_id must match command evidence")
+    if shadow.occurred_at != evidence.activity.occurred_at:
+        raise ValueError("shadow occurred_at must match command evidence")
+
+
+def _record_new_command_activity(
+    connection: sqlite3.Connection,
+    evidence: CommandActivityEvidence,
+    *,
+    shadow: CommandShadowObservation | None,
+    shadow_evaluation_succeeded: bool,
+) -> None:
+    connection.execute(
+        """
+        insert into command_activity (
+          activity_id, occurred_at, harness, hook_phase, execution_status,
+          proof_level, policy_action, decision_reason_code, controlling_rule_id,
+          parse_confidence, uncertainty_class, match_count, prompted,
+          approval_reuse_status, receipt_link_status, receipt_id,
+          evaluation_latency_bucket, persistence_latency_bucket, schema_version
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        _activity_values(evidence.activity),
+    )
+    connection.executemany(
+        """
+        insert into command_activity_matches (
+          activity_id, ordinal, extension_id, extension_version, rule_id,
+          rule_version, match_class, severity, default_floor,
+          safe_variant_id, schema_version
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        tuple(_match_values(item) for item in evidence.matches),
+    )
+    connection.executemany(
+        """
+        insert into command_activity_match_effects (
+          activity_id, ordinal, effect_class
+        ) values (?, ?, ?)
+        """,
+        _effect_values(evidence),
+    )
+    connection.executemany(
+        """
+        insert into command_activity_correlations (
+          activity_id, kind, harness, key_id, digest
+        ) values (?, ?, ?, ?, ?)
+        """,
+        _correlation_values(evidence.activity),
+    )
+    if shadow is not None:
+        record_command_shadow_observation(connection, shadow)
+    record_command_activity_rollups(connection, evidence)
+    recover_command_activity_persistence(
+        connection,
+        error_domain=COMMAND_PERSISTENCE_ERROR_DOMAIN,
+    )
+    if shadow is not None or shadow_evaluation_succeeded:
+        recover_command_activity_persistence(
+            connection,
+            error_domain=SHADOW_PERSISTENCE_ERROR_DOMAIN,
+        )
 
 
 def _require_exact_replay(

--- a/tests/test_guard_command_activity_health_recovery.py
+++ b/tests/test_guard_command_activity_health_recovery.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import cast
@@ -121,3 +122,43 @@ def test_successful_disabled_shadow_evaluation_recovers_shadow_health(tmp_path: 
     store.record_command_activity(activity_evidence, shadow_evaluation_succeeded=True)
 
     assert _health(store)["status"] == "healthy"
+
+
+def test_repair_probe_recovers_active_store_errors_without_resetting_history(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    store.record_command_activity_persistence_failure(error_code="post_record_failed", occurred_at=_NOW)
+    store.record_command_activity_persistence_failure(error_code="shadow_evaluation_failed", occurred_at=_NOW)
+
+    activity_evidence, shadow = _shadow_evidence("activity:repair-probe")
+    store.probe_command_activity_persistence(activity_evidence, shadow=shadow)
+
+    recovered = _health(store)
+    assert recovered["status"] == "healthy"
+    assert recovered["dropped_events"] == recovered["persistence_errors"] == 2
+    assert recovered["last_error_class"] == "shadow_evaluation_failed"
+
+
+def test_repair_probe_preserves_errors_when_real_command_write_fails(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    store.record_command_activity_persistence_failure(error_code="post_record_failed", occurred_at=_NOW)
+    store.record_command_activity_persistence_failure(error_code="shadow_evaluation_failed", occurred_at=_NOW)
+    with store._connect() as connection:
+        connection.execute(
+            """
+            create trigger reject_command_activity_repair_probe
+            before insert on command_activity
+            begin
+              select raise(abort, 'simulated command write failure');
+            end
+            """
+        )
+    activity_evidence, shadow = _shadow_evidence("activity:rejected-repair-probe")
+
+    try:
+        store.probe_command_activity_persistence(activity_evidence, shadow=shadow)
+    except sqlite3.IntegrityError as error:
+        assert "simulated command write failure" in str(error)
+    else:
+        raise AssertionError("repair probe unexpectedly accepted a failing command write")
+
+    assert _health(store)["status"] == "degraded"

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import sqlite3
 import time
 import urllib.error
 import urllib.parse
@@ -231,6 +232,39 @@ class TestGuardSurfaceServer:
         request = urllib.request.Request(
             f"http://127.0.0.1:{daemon.port}/v1/protection/repair",
             data=json.dumps({"check_id": "all"}).encode("utf-8"),
+            headers={"Content-Type": "application/json", "X-Guard-Token": daemon._server.auth_token},
+            method="POST",
+        )
+        try:
+            with pytest.raises(urllib.error.HTTPError) as error:
+                urllib.request.urlopen(request, timeout=5)
+            payload = json.loads(error.value.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert error.value.code == 409
+        assert payload["error"] == "protection_repair_failed"
+
+    def test_protection_repair_converts_command_store_errors_to_inline_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+
+        def fail_probe(_store: GuardStore) -> None:
+            raise sqlite3.OperationalError("write failed")
+
+        monkeypatch.setattr(
+            daemon_server_module,
+            "_repair_command_activity_persistence_health",
+            fail_probe,
+        )
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/protection/repair",
+            data=json.dumps({"check_id": "decision_stream"}).encode("utf-8"),
             headers={"Content-Type": "application/json", "X-Guard-Token": daemon._server.auth_token},
             method="POST",
         )


### PR DESCRIPTION
## Summary
- recover active command evidence errors only after the real command, match, correlation, shadow, and rollup write path succeeds inside a rolled-back transaction
- force a deterministic shadow observation before clearing its active error while preserving historical error counters
- let the single Protect repair action converge when no later command event is available to prove recovery

## Testing
- `uv run --no-sync pytest -q tests/test_guard_command_activity_health_recovery.py tests/test_guard_protection_health.py tests/test_guard_surface_server.py tests/test_guard_protect_workspace_asset.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/store_command_activity.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_command_activity_health_recovery.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/store_command_activity.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_command_activity_health_recovery.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/store_command_activity.py tests/test_guard_command_activity_health_recovery.py`
- `git diff --check`
