### PR TITLE
fix(macos): bind cached trust to live daemon

### DIFF
--- a/src/codex_plugin_scanner/guard/local_trust_controller.py
+++ b/src/codex_plugin_scanner/guard/local_trust_controller.py
@@ -6,6 +6,7 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from .daemon.manager import load_guard_daemon_url
 from .local_trust_contract import (
     POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT,
     POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE,
@@ -84,9 +85,8 @@ class _MacOSNativeTrustBackend:
                 reason=POLICY_INTEGRITY_REASON_KEY_UNAVAILABLE,
                 setup_available=True,
             )
-        if not daemon_runtime_is_current(
-            self._store.get_runtime_state(),
-            now=datetime.now(timezone.utc),
+        if load_guard_daemon_url(self._store.guard_home) is None or not daemon_runtime_is_current(
+            self._store.get_runtime_state(), now=datetime.now(timezone.utc)
         ):
             return _degraded_safe_status(
                 backend=self.name,

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -19,6 +19,7 @@ import pytest
 
 from codex_plugin_scanner.cli import _resolve_legacy_args, main
 from codex_plugin_scanner.guard import local_trust_contract as local_trust_contract_module
+from codex_plugin_scanner.guard import local_trust_controller as local_trust_controller_module
 from codex_plugin_scanner.guard import policy_integrity as policy_integrity_module
 from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard import store_policy_integrity_runtime as policy_integrity_runtime_module
@@ -3339,6 +3340,11 @@ def test_trust_cli_explain_reports_protected_local_rule(
         started_at="2026-06-19T12:00:00Z",
         last_heartbeat_at=datetime.now(timezone.utc).isoformat(),
     )
+    monkeypatch.setattr(
+        local_trust_controller_module,
+        "load_guard_daemon_url",
+        lambda guard_home: "http://127.0.0.1:5474",
+    )
     store.upsert_policy(_decision(artifact_id="codex:project:local-rule"), "2026-06-19T12:01:00Z")
     decision_id = int(_policy_row(home_dir, artifact_id="codex:project:local-rule")["decision_id"])
 
@@ -3370,6 +3376,11 @@ def test_trust_cli_explain_human_output_uses_trust_renderer(
         daemon_port=5474,
         started_at="2026-06-19T12:00:00Z",
         last_heartbeat_at=datetime.now(timezone.utc).isoformat(),
+    )
+    monkeypatch.setattr(
+        local_trust_controller_module,
+        "load_guard_daemon_url",
+        lambda guard_home: "http://127.0.0.1:5474",
     )
     store.upsert_policy(_decision(artifact_id="codex:project:local-rule-human"), "2026-06-19T12:01:00Z")
     decision_id = int(_policy_row(home_dir, artifact_id="codex:project:local-rule-human")["decision_id"])

--- a/tests/test_guard_trust_cli_passive_backend.py
+++ b/tests/test_guard_trust_cli_passive_backend.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard import local_trust_controller as trust_controller_module
 from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.cli import commands_dispatch_trust as trust_dispatch_module
 from codex_plugin_scanner.guard.local_trust_contract import TrustStatus
@@ -155,6 +156,11 @@ def test_trust_cli_macos_native_status_uses_daemon_authored_cached_state_without
             "last_heartbeat_at": datetime.now(timezone.utc).isoformat(),
         },
     )
+    monkeypatch.setattr(
+        trust_controller_module,
+        "load_guard_daemon_url",
+        lambda guard_home: "http://127.0.0.1:5474",
+    )
 
     rc = main(
         [
@@ -233,6 +239,11 @@ def test_trust_cli_rejects_protected_cache_with_stale_daemon_heartbeat(
         "get_runtime_state",
         lambda self: {"last_heartbeat_at": stale_heartbeat},
     )
+    monkeypatch.setattr(
+        trust_controller_module,
+        "load_guard_daemon_url",
+        lambda guard_home: "http://127.0.0.1:5474",
+    )
 
     rc = main(
         [
@@ -250,6 +261,46 @@ def test_trust_cli_rejects_protected_cache_with_stale_daemon_heartbeat(
 
     assert rc == 0
     assert payload["runtime_protection"] == "degraded"
+    assert payload["degraded_reasons"] == ["trust_backend_unavailable"]
+
+
+def test_trust_cli_rejects_protected_cache_when_daemon_process_is_not_live(
+    tmp_path: Path,
+    capsys,
+    monkeypatch: pytest.MonkeyPatch,
+    install_fake_system_keyring,
+) -> None:
+    _enable_macos_native_policy_integrity(monkeypatch, install_fake_system_keyring)
+    home_dir = tmp_path / "home"
+    monkeypatch.setattr(
+        GuardStore,
+        "get_cached_policy_integrity_state",
+        lambda self: {"backend": "system-keyring", "degraded_reasons": [], "mode": "protected"},
+    )
+    monkeypatch.setattr(
+        GuardStore,
+        "get_runtime_state",
+        lambda self: {"last_heartbeat_at": datetime.now(timezone.utc).isoformat()},
+    )
+    monkeypatch.setattr(trust_controller_module, "load_guard_daemon_url", lambda guard_home: None)
+
+    rc = main(
+        [
+            "guard",
+            "trust",
+            "status",
+            "--backend",
+            "macos-native",
+            "--home",
+            str(home_dir),
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["runtime_protection"] == "degraded"
+    assert payload["remembered_rules"] == "disabled_degraded"
     assert payload["degraded_reasons"] == ["trust_backend_unavailable"]
 
 


### PR DESCRIPTION
## Summary
- require authenticated live-daemon discovery before accepting cached macOS trust state
- keep heartbeat freshness as an additional protection against orphaned trust caches
- cover live, stopped, missing, malformed, and stale daemon states

## Testing
- `uv run --no-sync pytest -q tests/test_guard_trust_cli_passive_backend.py tests/test_guard_policy_integrity.py tests/test_guard_protection_health.py --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_command_decision_diff.py tests/test_guard_command_corpus.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/local_trust_controller.py tests/test_guard_trust_cli_passive_backend.py tests/test_guard_policy_integrity.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/local_trust_controller.py tests/test_guard_trust_cli_passive_backend.py`
