### PR TITLE
fix(daemon): prevent duplicate keychain access

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -1067,7 +1067,10 @@ class CodexHarnessAdapter(HarnessAdapter):
                     if not isinstance(name, str) or not isinstance(server_config, dict):
                         continue
                     command = server_config.get("command")
-                    args = tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str))
+                    raw_args = server_config.get("args")
+                    if raw_args is not None and not isinstance(raw_args, list):
+                        continue
+                    args = tuple(str(value) for value in (raw_args or []) if isinstance(value, str))
                     if is_guard_proxy_command(command if isinstance(command, str) else None, args):
                         proxy_artifact = _artifact_from_guard_proxy_args(
                             args=args,
@@ -1429,10 +1432,13 @@ class CodexHarnessAdapter(HarnessAdapter):
         current_interpreter = _guard_python_executable()
         migrated: list[str] = []
         for name, server_config in mcp_servers.items():
-            if not isinstance(name, str) or not isinstance(server_config, dict):
+            if not isinstance(server_config, dict):
                 continue
             command = server_config.get("command")
-            args = tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str))
+            raw_args = server_config.get("args")
+            if not isinstance(raw_args, list):
+                continue
+            args = tuple(str(value) for value in raw_args if isinstance(value, str))
             if not is_guard_proxy_command(command if isinstance(command, str) else None, args):
                 continue
             if command == current_interpreter:

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -1235,6 +1235,8 @@ class CodexHarnessAdapter(HarnessAdapter):
         mcp_servers = payload.get("mcp_servers")
         if not isinstance(mcp_servers, dict):
             mcp_servers = {}
+        migrated_proxy_servers = self._refresh_managed_proxy_interpreters(mcp_servers)
+        skipped_servers = tuple(name for name in skipped_servers if name not in migrated_proxy_servers)
         features = hook_payload.get("features")
         if not isinstance(features, dict):
             features = {}
@@ -1315,6 +1317,8 @@ class CodexHarnessAdapter(HarnessAdapter):
             "legacy_shell_guard_cleanup": "complete",
             "backup_path": str(backup_path),
             "managed_servers": [server.name for server in managed_servers],
+            "migrated_proxy_servers": list(migrated_proxy_servers),
+            "runtime_restart_required": bool(migrated_proxy_servers),
             "skipped_servers": list(skipped_servers),
             "source_config_paths": list(detection.config_paths),
         }
@@ -1419,6 +1423,23 @@ class CodexHarnessAdapter(HarnessAdapter):
         if env:
             entry["env"] = env
         return entry
+
+    @staticmethod
+    def _refresh_managed_proxy_interpreters(mcp_servers: dict[str, object]) -> tuple[str, ...]:
+        current_interpreter = _guard_python_executable()
+        migrated: list[str] = []
+        for name, server_config in mcp_servers.items():
+            if not isinstance(name, str) or not isinstance(server_config, dict):
+                continue
+            command = server_config.get("command")
+            args = tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str))
+            if not is_guard_proxy_command(command if isinstance(command, str) else None, args):
+                continue
+            if command == current_interpreter:
+                continue
+            server_config["command"] = current_interpreter
+            migrated.append(name)
+        return tuple(sorted(migrated))
 
     @staticmethod
     def _should_skip_workspace_override(

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -59,6 +59,7 @@ _GUARD_DAEMON_PRIVATE_FILE_MODE = 0o600
 _GUARD_DAEMON_PRIVATE_DIR_MODE = 0o700
 _APPROVAL_CENTER_LOCATOR_FILE = "approval-center-locator.json"
 _GUARD_DAEMON_PENDING_LAUNCH_FILE = "daemon-launch-pending.json"
+_GUARD_DAEMON_OWNER_LOCK_FILE = "daemon-owner.lock"
 _GUARD_DAEMON_STATE_MAX_BYTES = 64 * 1024
 _GUARD_DAEMON_PENDING_LAUNCH_MAX_BYTES = 4096
 _GUARD_DAEMON_PROCESS_QUERY_TIMEOUT_SECONDS = 5.0
@@ -2250,6 +2251,35 @@ def _guard_daemon_start_lock(guard_home: Path):
                 _unlock_daemon_start_file(handle)
 
 
+def acquire_guard_daemon_owner_lock(guard_home: Path) -> BinaryIO:
+    """Claim the single daemon slot before any background worker can read secrets."""
+
+    inventory = _guard_daemon_process_inventory_for_guard_home(guard_home)
+    if inventory is None:
+        raise RuntimeError("Guard could not verify that the daemon slot is available.")
+    if any(pid != os.getpid() for pid, _port in inventory):
+        raise RuntimeError("A Guard daemon is already active for this Guard home.")
+    lock_path = guard_home / _GUARD_DAEMON_OWNER_LOCK_FILE
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("a+b")
+    if not _try_lock_daemon_file(handle):
+        handle.close()
+        raise RuntimeError("A Guard daemon is already active for this Guard home.")
+    inventory = _guard_daemon_process_inventory_for_guard_home(guard_home)
+    if inventory is None or any(pid != os.getpid() for pid, _port in inventory):
+        _unlock_daemon_start_file(handle)
+        handle.close()
+        raise RuntimeError("A Guard daemon is already active for this Guard home.")
+    return handle
+
+
+def release_guard_daemon_owner_lock(handle: BinaryIO | None) -> None:
+    if handle is None or handle.closed:
+        return
+    _unlock_daemon_start_file(handle)
+    handle.close()
+
+
 @contextmanager
 def _guard_daemon_state_write_lock(guard_home: Path):
     """Serialize the token/state generation across threads and processes."""
@@ -2287,6 +2317,29 @@ def _lock_daemon_start_file(handle: BinaryIO) -> None:
     import fcntl
 
     fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+
+def _try_lock_daemon_file(handle: BinaryIO) -> bool:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        if os.fstat(handle.fileno()).st_size == 0:
+            handle.write(b"0")
+            handle.flush()
+        handle.seek(0)
+        try:
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        except OSError:
+            return False
+        return True
+    import fcntl
+
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        return False
+    return True
 
 
 def _unlock_daemon_start_file(handle: BinaryIO) -> None:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -24,7 +24,7 @@ from contextlib import contextmanager, suppress
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, TypedDict, TypeGuard, cast
+from typing import Any, BinaryIO, TypedDict, TypeGuard, cast
 from urllib.parse import parse_qs, parse_qsl, unquote, urlencode, urlparse, urlunparse
 
 from ...version import __version__
@@ -229,9 +229,11 @@ from .discovery import (
 )
 from .manager import (
     GUARD_DAEMON_COMPATIBILITY_VERSION,
+    acquire_guard_daemon_owner_lock,
     clear_guard_daemon_state_if_current,
     current_guard_daemon_runtime_fingerprint,
     load_guard_daemon_auth_token,
+    release_guard_daemon_owner_lock,
     repair_approval_center_locator,
     write_guard_daemon_state,
 )
@@ -6361,6 +6363,7 @@ class GuardDaemonServer:
     ) -> None:
         _validate_dashboard_bundle()
         self._shutdown_started = threading.Event()
+        self._owner_lock: BinaryIO | None = None
         self._server = _GuardDaemonHttpServer(
             (host, port),
             _GuardDaemonHandler,
@@ -6434,6 +6437,15 @@ class GuardDaemonServer:
         self._live_request_sync_worker = stop_cloud_sync_sync_worker(self._live_request_sync_worker)
 
     def _begin_service(self) -> None:
+        self._owner_lock = acquire_guard_daemon_owner_lock(self._server.store.guard_home)
+        try:
+            self._begin_owned_service()
+        except BaseException:
+            release_guard_daemon_owner_lock(self._owner_lock)
+            self._owner_lock = None
+            raise
+
+    def _begin_owned_service(self) -> None:
         if self._aibom_refresh_thread is not None:
             if self._aibom_refresh_thread.is_alive():
                 raise RuntimeError("AIBOM inventory refresh is still stopping")
@@ -6540,14 +6552,18 @@ class GuardDaemonServer:
             self._finish_service()
 
     def _finish_service(self) -> None:
-        self._shutdown_started.set()
-        approval_attention = getattr(self._server, "approval_attention", None)
-        if approval_attention is not None:
-            approval_attention.stop()
-        self._command_queue_worker = stop_command_queue_worker(self._command_queue_worker)
-        self._live_request_sync_worker = stop_cloud_sync_sync_worker(self._live_request_sync_worker)
-        clear_guard_daemon_state_if_current(self._server.store.guard_home, pid=os.getpid(), port=self.port)
-        self._server.store.clear_runtime_state(session_id=self._server.runtime_session_id)
+        try:
+            self._shutdown_started.set()
+            approval_attention = getattr(self._server, "approval_attention", None)
+            if approval_attention is not None:
+                approval_attention.stop()
+            self._command_queue_worker = stop_command_queue_worker(self._command_queue_worker)
+            self._live_request_sync_worker = stop_cloud_sync_sync_worker(self._live_request_sync_worker)
+            clear_guard_daemon_state_if_current(self._server.store.guard_home, pid=os.getpid(), port=self.port)
+            self._server.store.clear_runtime_state(session_id=self._server.runtime_session_id)
+        finally:
+            release_guard_daemon_owner_lock(self._owner_lock)
+            self._owner_lock = None
 
     def _start_watchdog(self) -> None:
         if self._watchdog_thread is not None and self._watchdog_thread.is_alive():

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -6562,7 +6562,7 @@ class GuardDaemonServer:
             clear_guard_daemon_state_if_current(self._server.store.guard_home, pid=os.getpid(), port=self.port)
             self._server.store.clear_runtime_state(session_id=self._server.runtime_session_id)
         finally:
-            release_guard_daemon_owner_lock(self._owner_lock)
+            release_guard_daemon_owner_lock(getattr(self, "_owner_lock", None))
             self._owner_lock = None
 
     def _start_watchdog(self) -> None:

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -606,17 +606,11 @@ class StoreOAuthConnectMixin:
         if cached_secret_payload is not None:
             return cached_secret_payload
         fallback_secret_json = self._load_oauth_fallback_secret_json(secret_ref)
-        skip_fallback_first = (
-            sys.platform == "darwin"
-            and isinstance(self._oauth_secret_store, FallbackSecretStore)
-            and isinstance(self._oauth_secret_store.primary, SystemKeyringSecretStore)
-        )
         fallback_secret_payload = self._load_validated_oauth_fallback_secret_payload(
             fallback_secret_json,
             secret_hash,
         )
-        prefer_primary_over_fallback = skip_fallback_first and allow_primary
-        if fallback_secret_payload is not None and not prefer_primary_over_fallback:
+        if fallback_secret_payload is not None:
             self._remember_oauth_secret_payload(secret_ref, secret_hash, fallback_secret_json)
             return fallback_secret_payload
         if not allow_primary:

--- a/tests/test_guard_codex_interpreter_migration.py
+++ b/tests/test_guard_codex_interpreter_migration.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 from pathlib import Path
 
 import pytest
-import tomllib
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    tomllib = importlib.import_module("tomli")
 
 from codex_plugin_scanner.guard.adapters import codex as codex_adapter
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
@@ -60,6 +65,27 @@ def test_guard_install_codex_adopts_equivalent_package_with_relocated_interprete
 
     assert reinstalled["migrated_proxy_servers"] == []
     assert reinstalled["runtime_restart_required"] is False
+
+
+def test_guard_install_codex_ignores_proxy_with_scalar_args(
+    tmp_path: Path,
+) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+    config_path = context.home_dir / ".codex" / "config.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        '[mcp_servers.invalid]\ncommand = "/usr/bin/python"\nargs = 1\n',
+        encoding="utf-8",
+    )
+
+    installed = CodexHarnessAdapter().install(context)
+
+    assert installed["migrated_proxy_servers"] == []
+    assert installed["runtime_restart_required"] is False
 
 
 def test_reauthentication_rejects_incomplete_package_identity() -> None:

--- a/tests/test_guard_codex_interpreter_migration.py
+++ b/tests/test_guard_codex_interpreter_migration.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 import pytest
+import tomllib
 
 from codex_plugin_scanner.guard.adapters import codex as codex_adapter
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
@@ -33,14 +34,32 @@ def test_guard_install_codex_adopts_equivalent_package_with_relocated_interprete
 
     monkeypatch.setattr(codex_adapter.sys, "executable", str(first_interpreter))
     adapter = CodexHarnessAdapter()
+    config_path = context.home_dir / ".codex" / "config.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        '[mcp_servers.browser]\ncommand = "/usr/bin/printf"\nargs = ["%s", "ready"]\n',
+        encoding="utf-8",
+    )
     adapter.install(context)
+    first_proxy = tomllib.loads(config_path.read_text(encoding="utf-8"))["mcp_servers"]["browser"]
 
     monkeypatch.setattr(codex_adapter.sys, "executable", str(second_interpreter))
     installed = adapter.install(context)
     state = codex_adapter.codex_native_hook_state(context)
+    second_proxy = tomllib.loads(config_path.read_text(encoding="utf-8"))["mcp_servers"]["browser"]
 
     assert installed["active"] is True
+    assert first_proxy["command"] == str(first_interpreter)
+    assert second_proxy["command"] == str(second_interpreter)
+    assert second_proxy["args"] == first_proxy["args"]
+    assert installed["migrated_proxy_servers"] == ["browser"]
+    assert installed["runtime_restart_required"] is True
     assert state["protection_active"] is True
+
+    reinstalled = adapter.install(context)
+
+    assert reinstalled["migrated_proxy_servers"] == []
+    assert reinstalled["runtime_restart_required"] is False
 
 
 def test_reauthentication_rejects_incomplete_package_identity() -> None:

--- a/tests/test_guard_daemon_owner_lock.py
+++ b/tests/test_guard_daemon_owner_lock.py
@@ -1,0 +1,36 @@
+"""Cross-runtime daemon ownership coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon import manager
+
+
+def test_daemon_owner_lock_rejects_second_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    guard_home = tmp_path / "guard-home"
+    monkeypatch.setattr(manager, "_guard_daemon_process_inventory_for_guard_home", lambda _home: [])
+    owner = manager.acquire_guard_daemon_owner_lock(guard_home)
+
+    with pytest.raises(RuntimeError, match="already active"):
+        manager.acquire_guard_daemon_owner_lock(guard_home)
+
+    manager.release_guard_daemon_owner_lock(owner)
+    replacement = manager.acquire_guard_daemon_owner_lock(guard_home)
+    manager.release_guard_daemon_owner_lock(replacement)
+
+
+def test_daemon_owner_lock_rejects_existing_same_home_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        manager,
+        "_guard_daemon_process_inventory_for_guard_home",
+        lambda _home: [(4242, 5474)],
+    )
+
+    with pytest.raises(RuntimeError, match="already active"):
+        manager.acquire_guard_daemon_owner_lock(tmp_path / "guard-home")

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -1916,6 +1916,38 @@ def test_get_oauth_local_credentials_uses_encrypted_fallback_on_macos_when_prima
     assert credentials["workspace_id"] == "workspace-123"
 
 
+def test_get_oauth_local_credentials_prefers_valid_fallback_over_macos_keychain(
+    tmp_path,
+    monkeypatch,
+):
+    _install_fake_system_keyring(monkeypatch)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    monkeypatch.setattr(SystemKeyringSecretStore, "_macos_default_keychain_is_usable", classmethod(lambda cls: True))
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----[REDACTED:Private key block]\\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    assert isinstance(store._oauth_secret_store, FallbackSecretStore)
+    store._clear_oauth_secret_payload_cache()
+    monkeypatch.setattr(
+        store._oauth_secret_store.primary,
+        "get_secret_with_timeout",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("Keychain read must not run")),
+    )
+
+    credentials = store.get_oauth_local_credentials(allow_primary=True)
+
+    assert credentials is not None
+    assert credentials["workspace_id"] == "workspace-123"
+
+
 def test_get_oauth_local_credential_health_avoids_primary_keychain_reads(tmp_path, monkeypatch):
     _install_fake_system_keyring(monkeypatch)
     monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)


### PR DESCRIPTION
## Summary
- refresh existing managed Codex proxy commands to the active Guard interpreter during installation
- enforce one daemon owner per Guard home before background workers access credentials
- prefer validated encrypted OAuth fallback data over passive macOS Keychain reads
- tolerate malformed managed proxy arguments and keep repeat installs idempotent

## Testing
- `uv run --no-sync pytest -q tests/test_guard_daemon_owner_lock.py tests/test_guard_daemon_wake.py tests/test_guard_daemon_worker_isolation.py tests/test_guard_store_migrations.py tests/test_guard_codex_interpreter_migration.py tests/test_guard_codex_install.py tests/test_guard_commands_router.py tests/test_guard_codex_proxy.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/adapters/codex.py src/codex_plugin_scanner/guard/daemon/manager.py src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/store_oauth.py tests/test_guard_codex_interpreter_migration.py tests/test_guard_daemon_owner_lock.py tests/test_guard_store_migrations.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/adapters/codex.py src/codex_plugin_scanner/guard/daemon/manager.py src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/store_oauth.py tests/test_guard_codex_interpreter_migration.py tests/test_guard_daemon_owner_lock.py tests/test_guard_store_migrations.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/adapters/codex.py src/codex_plugin_scanner/guard/daemon/manager.py src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/store_oauth.py tests/test_guard_codex_interpreter_migration.py tests/test_guard_daemon_owner_lock.py`
- `git diff --check`
