### PR TITLE
fix(pi): bound hook fallback deadline

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
@@ -11,11 +11,10 @@ from .pi_extension_content_source import CONTENT_REVIEW_HELPERS_SOURCE
 
 # Pi terminates extension hooks at roughly 4.5 seconds. Keep Guard's daemon and
 # CLI fallback path below that host deadline so its fail-open result can return.
-PI_HOOK_HOST_TIMEOUT_MS = 4_500
 GUARD_HOOK_TIMEOUT_MS = 4_000
 GUARD_HOOK_DEADLINE_RESERVE_MS = 250
 GUARD_DAEMON_HOOK_TIMEOUT_MS = 1_250
-GUARD_CLI_HOOK_TIMEOUT_MS = 2_500
+GUARD_CLI_HOOK_TIMEOUT_MS = 2_250
 GUARD_HOOK_TEXT_LIMIT_CHARS = 12_000
 GUARD_HOOK_CONTENT_ITEM_LIMIT = 24
 GUARD_HOOK_OBJECT_KEY_LIMIT = 24

--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
@@ -9,12 +9,13 @@ from ..daemon.manager import GUARD_DAEMON_COMPATIBILITY_VERSION
 from .pi_extension_approval_source import APPROVAL_RESUME_HELPERS_SOURCE
 from .pi_extension_content_source import CONTENT_REVIEW_HELPERS_SOURCE
 
-# Keep the end-to-end budget short enough for interactive Pi, but prefer the
-# resident daemon and never hard-block tool calls solely because review timed out.
-GUARD_HOOK_TIMEOUT_MS = 12_000
+# Pi terminates extension hooks at roughly 4.5 seconds. Keep Guard's daemon and
+# CLI fallback path below that host deadline so its fail-open result can return.
+PI_HOOK_HOST_TIMEOUT_MS = 4_500
+GUARD_HOOK_TIMEOUT_MS = 4_000
 GUARD_HOOK_DEADLINE_RESERVE_MS = 250
-GUARD_DAEMON_HOOK_TIMEOUT_MS = 2_000
-GUARD_CLI_HOOK_TIMEOUT_MS = 10_000
+GUARD_DAEMON_HOOK_TIMEOUT_MS = 1_250
+GUARD_CLI_HOOK_TIMEOUT_MS = 2_500
 GUARD_HOOK_TEXT_LIMIT_CHARS = 12_000
 GUARD_HOOK_CONTENT_ITEM_LIMIT = 24
 GUARD_HOOK_OBJECT_KEY_LIMIT = 24

--- a/tests/test_pi_hook_latency.py
+++ b/tests/test_pi_hook_latency.py
@@ -84,10 +84,10 @@ def test_pi_extension_keeps_fallbacks_inside_outer_hook_deadline(tmp_path: Path)
         settings_path=tmp_path / "settings.json",
     )
 
-    assert "const GUARD_TIMEOUT_MS = 12000;" in source
+    assert "const GUARD_TIMEOUT_MS = 4000;" in source
     assert "const GUARD_DEADLINE_RESERVE_MS = 250;" in source
-    assert "const GUARD_DAEMON_TIMEOUT_MS = 2000;" in source
-    assert "const GUARD_CLI_TIMEOUT_MS = 10000;" in source
+    assert "const GUARD_DAEMON_TIMEOUT_MS = 1250;" in source
+    assert "const GUARD_CLI_TIMEOUT_MS = 2500;" in source
     assert 'const GUARD_ARGS = ["hook", "--json"' in source
     assert "compatibility_version !== GUARD_COMPATIBILITY_VERSION" in source
     assert "error.name === 'AbortError'" in source
@@ -98,3 +98,19 @@ def test_pi_extension_keeps_fallbacks_inside_outer_hook_deadline(tmp_path: Path)
     assert "const deadlineAt = Date.now() + GUARD_TIMEOUT_MS - GUARD_DEADLINE_RESERVE_MS" in source
     assert "Math.max(deadlineAt - Date.now(), 1)" in source
     assert "timeout: cliTimeoutMs" in source
+
+
+def test_pi_hook_deadline_stays_inside_host_timeout() -> None:
+    from codex_plugin_scanner.guard.adapters.pi_extension_source import (
+        GUARD_CLI_HOOK_TIMEOUT_MS,
+        GUARD_DAEMON_HOOK_TIMEOUT_MS,
+        GUARD_HOOK_DEADLINE_RESERVE_MS,
+        GUARD_HOOK_TIMEOUT_MS,
+        PI_HOOK_HOST_TIMEOUT_MS,
+    )
+
+    assert GUARD_HOOK_TIMEOUT_MS < PI_HOOK_HOST_TIMEOUT_MS
+    assert (
+        GUARD_DAEMON_HOOK_TIMEOUT_MS + GUARD_CLI_HOOK_TIMEOUT_MS + GUARD_HOOK_DEADLINE_RESERVE_MS
+        <= GUARD_HOOK_TIMEOUT_MS
+    )

--- a/tests/test_pi_hook_latency.py
+++ b/tests/test_pi_hook_latency.py
@@ -87,7 +87,7 @@ def test_pi_extension_keeps_fallbacks_inside_outer_hook_deadline(tmp_path: Path)
     assert "const GUARD_TIMEOUT_MS = 4000;" in source
     assert "const GUARD_DEADLINE_RESERVE_MS = 250;" in source
     assert "const GUARD_DAEMON_TIMEOUT_MS = 1250;" in source
-    assert "const GUARD_CLI_TIMEOUT_MS = 2500;" in source
+    assert "const GUARD_CLI_TIMEOUT_MS = 2250;" in source
     assert 'const GUARD_ARGS = ["hook", "--json"' in source
     assert "compatibility_version !== GUARD_COMPATIBILITY_VERSION" in source
     assert "error.name === 'AbortError'" in source
@@ -101,16 +101,17 @@ def test_pi_extension_keeps_fallbacks_inside_outer_hook_deadline(tmp_path: Path)
 
 
 def test_pi_hook_deadline_stays_inside_host_timeout() -> None:
+    pi_hook_host_timeout_ms = 4_500
+
     from codex_plugin_scanner.guard.adapters.pi_extension_source import (
         GUARD_CLI_HOOK_TIMEOUT_MS,
         GUARD_DAEMON_HOOK_TIMEOUT_MS,
         GUARD_HOOK_DEADLINE_RESERVE_MS,
         GUARD_HOOK_TIMEOUT_MS,
-        PI_HOOK_HOST_TIMEOUT_MS,
     )
 
-    assert GUARD_HOOK_TIMEOUT_MS < PI_HOOK_HOST_TIMEOUT_MS
+    assert pi_hook_host_timeout_ms > GUARD_HOOK_TIMEOUT_MS
     assert (
         GUARD_DAEMON_HOOK_TIMEOUT_MS + GUARD_CLI_HOOK_TIMEOUT_MS + GUARD_HOOK_DEADLINE_RESERVE_MS
-        <= GUARD_HOOK_TIMEOUT_MS
+        < GUARD_HOOK_TIMEOUT_MS
     )


### PR DESCRIPTION
## Summary
- keep Pi Guard review fallbacks inside the host hook deadline
- preserve daemon-first review with a bounded local CLI fallback
- add a regression ratchet for the complete timeout budget

## Testing
- `uv run --no-sync pytest -q tests/test_pi_hook_latency.py tests/test_pi_adapter.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/adapters/pi_extension_source.py tests/test_pi_hook_latency.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/adapters/pi_extension_source.py tests/test_pi_hook_latency.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/adapters/pi_extension_source.py tests/test_pi_hook_latency.py`
- `uv build`
