### PR TITLE
fix(guard): tolerate removed install workspace

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_workspace.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_workspace.py
@@ -435,11 +435,14 @@ def _resolve_default_install_workspace(
 ) -> Path | None:
     """Pick a project workspace for install/uninstall when --workspace is omitted."""
 
-    cwd = Path.cwd().resolve()
     harness = _requested_install_harness(args)
     cursor_project_dir = _workspace_from_cursor_project_dir()
     if cursor_project_dir is not None and (harness is None or harness == "cursor"):
         return cursor_project_dir
+    try:
+        cwd = Path.cwd().resolve()
+    except OSError:
+        return None
 
     if _workspace_has_project_markers(cwd):
         return cwd

--- a/src/codex_plugin_scanner/guard/launcher.py
+++ b/src/codex_plugin_scanner/guard/launcher.py
@@ -36,7 +36,22 @@ def merge_guard_launcher_env(env: Mapping[str, str] | None = None, *, pin_packag
 
 
 def _normalize_launcher_pythonpath(value: str | None) -> str:
-    return _merge_path_entries("", value or "", relative_base=Path.cwd())
+    try:
+        relative_base = Path.cwd()
+    except OSError:
+        return _absolute_path_entries(value or "")
+    return _merge_path_entries("", value or "", relative_base=relative_base)
+
+
+def _absolute_path_entries(value: str) -> str:
+    entries: list[str] = []
+    for entry in value.split(os.pathsep):
+        path = Path(entry.strip()).expanduser()
+        if path.is_absolute():
+            normalized = str(path)
+            if normalized not in entries:
+                entries.append(normalized)
+    return os.pathsep.join(entries)
 
 
 def _merge_path_entries(left: str, right: str, relative_base: Path | None = None) -> str:

--- a/tests/test_guard_install_workspace.py
+++ b/tests/test_guard_install_workspace.py
@@ -17,6 +17,7 @@ from codex_plugin_scanner.guard.cli.commands import (
     _resolve_guard_workspace,
 )
 from codex_plugin_scanner.guard.config import resolve_guard_home
+from codex_plugin_scanner.guard.launcher import merge_guard_launcher_env
 
 
 def _install_args(*, harness: str = "cursor", workspace: str | None = None) -> argparse.Namespace:
@@ -68,6 +69,49 @@ def test_resolve_default_install_workspace_uses_cursor_project_dir(
     guard_home = resolve_guard_home(None)
     resolved = _resolve_default_install_workspace(_install_args(), guard_home=guard_home)
     assert resolved == project.resolve()
+
+
+def test_install_and_uninstall_omp_survive_unavailable_current_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+
+    def unavailable_cwd() -> Path:
+        raise FileNotFoundError("current directory was removed")
+
+    monkeypatch.setattr(Path, "cwd", staticmethod(unavailable_cwd))
+
+    install_rc = main(["guard", "install", "omp", "--home", str(home_dir), "--json"])
+    install_capture = capsys.readouterr()
+    assert install_rc == 0, install_capture.err
+    install_output = json.loads(install_capture.out)
+    uninstall_rc = main(["guard", "uninstall", "omp", "--home", str(home_dir), "--json"])
+    uninstall_capture = capsys.readouterr()
+    assert uninstall_rc == 0, uninstall_capture.err
+    uninstall_output = json.loads(uninstall_capture.out)
+
+    assert install_output["managed_install"]["harness"] == "pi"
+    assert install_output["managed_install"]["workspace"] is None
+    assert uninstall_output["managed_install"]["harness"] == "pi"
+    assert uninstall_output["managed_install"]["workspace"] is None
+
+
+def test_launcher_drops_relative_pythonpath_when_current_directory_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    absolute_entry = tmp_path / "trusted"
+    monkeypatch.setenv("PYTHONPATH", os.pathsep.join(("relative-package", str(absolute_entry))))
+
+    def unavailable_cwd() -> Path:
+        raise FileNotFoundError("current directory was removed")
+
+    monkeypatch.setattr(Path, "cwd", staticmethod(unavailable_cwd))
+
+    assert merge_guard_launcher_env() == {"PYTHONPATH": str(absolute_entry)}
 
 
 def test_resolve_guard_workspace_explicit_flag_wins(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- let install and uninstall continue with global harness setup when the invoking working directory is unavailable
- retain only absolute launcher import paths when relative paths cannot be resolved safely
- cover the OMP alias lifecycle under an unavailable working directory

## Testing
- `uv run --no-sync pytest -q tests/test_guard_install_workspace.py tests/test_pi_adapter.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/commands_support_workspace.py src/codex_plugin_scanner/guard/launcher.py tests/test_guard_install_workspace.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/cli/commands_support_workspace.py src/codex_plugin_scanner/guard/launcher.py tests/test_guard_install_workspace.py`
- `uv build --wheel --out-dir dist-omp-fix`
- `uv tool run --from 'dist-omp-fix/hol_guard-2.1.0-py3-none-any.whl' hol-guard --version`
- `git diff --check`
