### PR TITLE
fix(guard): harden daemon hook resilience

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -1,0 +1,224 @@
+"""Bounded subprocess bridge for harnesses without a daemon-native hook."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import cast
+
+from ..codex_hook_launch_runtime import (
+    isolated_guard_cli_command,
+    isolated_hook_environment,
+    run_isolated_hook_process,
+)
+
+_MAX_HOOK_INPUT_BYTES = 1_000_000
+_FAILURE_REASON = "HOL Guard could not complete this review before the hook deadline. Retry the action."
+
+
+def bounded_cli_hook_command(
+    *,
+    python_executable: str,
+    package_root: Path,
+    guard_home: Path,
+    cli_args: Sequence[str],
+    harness: str,
+    timeout_seconds: float,
+) -> tuple[str, ...]:
+    """Build a shell-free hook command backed by a process-tree deadline."""
+
+    config = {
+        "python_executable": python_executable,
+        "package_root": str(package_root.resolve()),
+        "guard_home": str(guard_home.resolve(strict=False)),
+        "cli_args": list(cli_args),
+        "harness": harness,
+        "timeout_seconds": timeout_seconds,
+    }
+    bootstrap = (
+        "import sys;"
+        f"sys.path.insert(0,{str(package_root.resolve())!r});"
+        "from codex_plugin_scanner.guard.adapters.bounded_cli_hook_bridge import main_from_argv;"
+        "raise SystemExit(main_from_argv(sys.argv[1:]))"
+    )
+    return (
+        python_executable,
+        "-I",
+        "-c",
+        bootstrap,
+        json.dumps(config, ensure_ascii=True, separators=(",", ":")),
+    )
+
+
+def _bounded_stdin() -> str | None:
+    raw = sys.stdin.buffer.read(_MAX_HOOK_INPUT_BYTES + 1)
+    if len(raw) > _MAX_HOOK_INPUT_BYTES:
+        return None
+    return raw.decode("utf-8", errors="replace")
+
+
+def _json_object(text: str) -> dict[str, object] | None:
+    try:
+        raw = cast(object, json.loads(text))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    payload: dict[str, object] = {}
+    for key, value in cast(dict[object, object], raw).items():
+        if isinstance(key, str):
+            payload[key] = value
+    return payload
+
+
+def _event_name(input_text: str) -> str:
+    payload = _json_object(input_text or "{}")
+    if payload is None:
+        return "PreToolUse"
+    for key in ("hook_event_name", "hookEventName", "event", "eventName", "hook_name", "hookName"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            normalized = value.replace("_", "").replace("-", "").lower()
+            return {
+                "permissionrequest": "PermissionRequest",
+                "pretooluse": "PreToolUse",
+                "userpromptsubmit": "UserPromptSubmit",
+                "posttooluse": "PostToolUse",
+                "sessionstart": "SessionStart",
+                "notification": "Notification",
+                "stop": "Stop",
+            }.get(normalized, value.strip())
+    return "PreToolUse"
+
+
+def _has_json_object_line(output: str) -> bool:
+    for line in reversed(output.splitlines()):
+        if not line.strip():
+            continue
+        return _json_object(line.strip()) is not None
+    return False
+
+
+def _failure_payload(*, harness: str, event_name: str, reason: str) -> tuple[dict[str, object], int]:
+    if harness == "copilot":
+        if event_name == "PermissionRequest":
+            return {
+                "behavior": "deny",
+                "message": reason,
+                "interrupt": True,
+            }, 0
+        return {
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }, 0
+    if harness in {"grok", "hermes", "openclaw"}:
+        return {"decision": "deny", "reason": reason}, 0
+    if event_name == "UserPromptSubmit":
+        return {
+            "decision": "block",
+            "reason": reason,
+            "hookSpecificOutput": {
+                "hookEventName": event_name,
+                "additionalContext": reason,
+            },
+        }, 2
+    if event_name == "PreToolUse":
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": event_name,
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        }, 2
+    return {
+        "continue": False,
+        "stopReason": reason,
+        "systemMessage": reason,
+    }, 0
+
+
+def _emit_failure(*, harness: str, input_text: str, reason: str = _FAILURE_REASON) -> int:
+    payload, returncode = _failure_payload(
+        harness=harness,
+        event_name=_event_name(input_text),
+        reason=reason,
+    )
+    _ = sys.stdout.write(json.dumps(payload, ensure_ascii=True, separators=(",", ":")) + "\n")
+    return returncode
+
+
+def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> int:
+    """Run one isolated CLI hook and preserve its native stdout contract."""
+
+    python_executable = config.get("python_executable")
+    package_root_value = config.get("package_root")
+    guard_home_value = config.get("guard_home")
+    cli_args_value = config.get("cli_args")
+    harness = config.get("harness")
+    timeout_seconds = config.get("timeout_seconds")
+    if (
+        not isinstance(python_executable, str)
+        or not isinstance(package_root_value, str)
+        or not isinstance(guard_home_value, str)
+        or not isinstance(cli_args_value, list)
+        or not isinstance(harness, str)
+        or not isinstance(timeout_seconds, (int, float))
+        or timeout_seconds <= 0
+    ):
+        return _emit_failure(harness=str(harness or "unknown"), input_text=input_text)
+    raw_cli_args = cast(list[object], cli_args_value)
+    cli_args = [item for item in raw_cli_args if isinstance(item, str)]
+    if len(cli_args) != len(raw_cli_args):
+        return _emit_failure(harness=harness, input_text=input_text)
+    package_root = Path(package_root_value)
+    guard_home = Path(guard_home_value)
+    command = isolated_guard_cli_command(
+        python_executable,
+        package_root,
+        cli_args,
+    )
+    result = run_isolated_hook_process(
+        command,
+        input_text=input_text,
+        cwd=guard_home,
+        environment=isolated_hook_environment(),
+        timeout_seconds=float(timeout_seconds),
+    )
+    if result.timed_out:
+        return _emit_failure(harness=harness, input_text=input_text)
+    if result.output_limit_exceeded:
+        return _emit_failure(
+            harness=harness,
+            input_text=input_text,
+            reason="HOL Guard blocked this action because hook output exceeded the safe size limit.",
+        )
+    if result.returncode is None:
+        return _emit_failure(harness=harness, input_text=input_text)
+    if not _has_json_object_line(result.stdout):
+        return _emit_failure(harness=harness, input_text=input_text)
+    if result.stdout:
+        _ = sys.stdout.write(result.stdout)
+    return result.returncode
+
+
+def main_from_argv(argv: Sequence[str]) -> int:
+    """Parse the authenticated install-time hook config and run it."""
+
+    input_text = _bounded_stdin()
+    if input_text is None:
+        return _emit_failure(
+            harness="unknown",
+            input_text="{}",
+            reason="HOL Guard blocked this action because hook input exceeded the safe size limit.",
+        )
+    if len(argv) != 1:
+        return _emit_failure(harness="unknown", input_text=input_text)
+    config = _json_object(argv[0])
+    if config is None:
+        return _emit_failure(harness="unknown", input_text=input_text)
+    return run_bounded_cli_hook(config, input_text=input_text)
+
+
+__all__ = ["bounded_cli_hook_command", "main_from_argv", "run_bounded_cli_hook"]

--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -4,16 +4,20 @@ from __future__ import annotations
 
 import json
 import queue
-import subprocess
 import sys
 import threading
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any, Protocol
 from urllib.parse import parse_qs, urljoin, urlparse
 
-from ..codex_hook_launch_runtime import isolated_daemon_start_command
+from ..codex_hook_launch_runtime import (
+    isolated_daemon_start_command,
+    isolated_hook_environment,
+    run_isolated_hook_process,
+)
 from ..daemon.manager import load_guard_daemon_auth_token
 from .claude_code import CLAUDE_GUARD_DAEMON_HOOK_MARKER
 
@@ -39,10 +43,15 @@ _DAEMON_IO_TIMEOUT_SECONDS = 2
 _RECOVERY_TIMEOUT_SECONDS = 3
 _FALLBACK_TIMEOUT_SECONDS = 2
 _MAX_DAEMON_RESPONSE_BYTES = 1_000_000
+_MAX_HOOK_INPUT_BYTES = 1_000_000
+_HOOK_DEADLINE_SECONDS = 8
+_MINIMUM_OPERATION_SECONDS = 0.01
 
 
 class _ResponseReader(Protocol):
     def read(self, size: int = -1, /) -> bytes: ...
+
+    def close(self) -> None: ...
 
 
 class _DaemonHTTPError(RuntimeError):
@@ -62,19 +71,24 @@ def main(
     """Proxy Claude hook stdin to the Guard daemon, falling back to the Python hook."""
 
     _ = CLAUDE_GUARD_DAEMON_HOOK_MARKER
-    body = sys.stdin.read()
+    deadline = time.monotonic() + _HOOK_DEADLINE_SECONDS
+    body = sys.stdin.read(_MAX_HOOK_INPUT_BYTES + 1)
+    if len(body.encode("utf-8", errors="replace")) > _MAX_HOOK_INPUT_BYTES:
+        sys.stdout.write(_degraded("hook input exceeded the safe size limit", "{}"))
+        return 0
     data = body.strip() or "{}"
     recovery_command = _recovery_command(state_path, query)
     try:
         endpoint = urljoin(_daemon_url(state_path, fallback_daemon_url), f"/v1/hooks/claude-code?{query}")
         _assert_loopback_http_url(endpoint)
         response_body = _valid_hook_json_or_degraded(
-            _post_to_loopback_daemon(endpoint, data, state_path=state_path),
+            _post_to_loopback_daemon(endpoint, data, state_path=state_path, deadline=deadline),
             reason="daemon returned malformed hook JSON",
             data=data,
         )
     except Exception as error:
         reason = _daemon_failure_reason(error)
+        failure_kind = _daemon_failure_kind(error)
         if _daemon_failure_is_recoverable(error):
             response_body = _recover_retry_or_fallback(
                 reason,
@@ -84,9 +98,11 @@ def main(
                 fallback_command=fallback_command,
                 recovery_command=recovery_command,
                 query=query,
+                deadline=deadline,
+                failure_kind=failure_kind,
             )
         else:
-            response_body = _run_local_fallback(reason, data, fallback_command)
+            response_body = _run_local_fallback(reason, data, fallback_command, deadline=deadline)
         sys.stdout.write(response_body)
         return 0
     if _should_suppress_output(data, response_body):
@@ -119,21 +135,47 @@ def _assert_loopback_http_url(url: str) -> None:
         raise ValueError("daemon URL must include an explicit port")
 
 
-def _post_to_loopback_daemon(endpoint: str, data: str, *, state_path: str | Path) -> str:
+def _remaining_seconds(deadline: float | None, *, cap: float) -> float:
+    if deadline is None:
+        return cap
+    return min(cap, max(0.0, deadline - time.monotonic()))
+
+
+def _post_to_loopback_daemon(
+    endpoint: str,
+    data: str,
+    *,
+    state_path: str | Path,
+    deadline: float | None = None,
+) -> str:
     result_queue: queue.Queue[tuple[str | None, Exception | None]] = queue.Queue(maxsize=1)
+    timeout_seconds = _remaining_seconds(deadline, cap=_DAEMON_IO_TIMEOUT_SECONDS)
+    if timeout_seconds < _MINIMUM_OPERATION_SECONDS:
+        raise TimeoutError("Guard daemon hook request exhausted its absolute deadline")
 
     def request_once() -> None:
+        request_deadline = time.monotonic() + timeout_seconds
         try:
-            result_queue.put((_blocking_post_to_loopback_daemon(endpoint, data, state_path=state_path), None))
+            result_queue.put(
+                (
+                    _blocking_post_to_loopback_daemon(
+                        endpoint,
+                        data,
+                        state_path=state_path,
+                        timeout_seconds=timeout_seconds,
+                    ),
+                    None,
+                )
+            )
         except urllib.error.HTTPError as error:
-            detail = _read_bounded_response(error).strip()
+            detail = _read_bounded_response(error, deadline=request_deadline).strip()
             result_queue.put((None, _DaemonHTTPError(error.code, detail)))
         except Exception as error:
             result_queue.put((None, error))
 
     threading.Thread(target=request_once, daemon=True, name="hol-guard-claude-hook-request").start()
     try:
-        response_body, error = result_queue.get(timeout=_DAEMON_IO_TIMEOUT_SECONDS)
+        response_body, error = result_queue.get(timeout=timeout_seconds)
     except queue.Empty as error:
         raise TimeoutError("Guard daemon hook request exceeded its absolute deadline") from error
     if error is not None:
@@ -143,7 +185,13 @@ def _post_to_loopback_daemon(endpoint: str, data: str, *, state_path: str | Path
     return response_body
 
 
-def _blocking_post_to_loopback_daemon(endpoint: str, data: str, *, state_path: str | Path) -> str:
+def _blocking_post_to_loopback_daemon(
+    endpoint: str,
+    data: str,
+    *,
+    state_path: str | Path,
+    timeout_seconds: float,
+) -> str:
     auth_token = load_guard_daemon_auth_token(Path(state_path).parent)
     headers = {"Content-Type": "application/json"}
     if isinstance(auth_token, str) and auth_token.strip():
@@ -155,15 +203,27 @@ def _blocking_post_to_loopback_daemon(endpoint: str, data: str, *, state_path: s
         method="POST",
     )
     opener = _build_loopback_opener()
-    with opener.open(request, timeout=_DAEMON_IO_TIMEOUT_SECONDS) as response:
+    with opener.open(request, timeout=timeout_seconds) as response:
         final_url = response.geturl()
         if final_url:
             _assert_loopback_http_url(final_url)
-        return _read_bounded_response(response)
+        return _read_bounded_response(response, deadline=time.monotonic() + timeout_seconds)
 
 
-def _read_bounded_response(response: _ResponseReader) -> str:
-    body = response.read(_MAX_DAEMON_RESPONSE_BYTES + 1)
+def _read_bounded_response(response: _ResponseReader, *, deadline: float | None = None) -> str:
+    timer: threading.Timer | None = None
+    if deadline is not None:
+        remaining = max(0.0, deadline - time.monotonic())
+        if remaining < _MINIMUM_OPERATION_SECONDS:
+            raise TimeoutError("Guard daemon response exhausted its absolute deadline")
+        timer = threading.Timer(remaining, response.close)
+        timer.daemon = True
+        timer.start()
+    try:
+        body = response.read(_MAX_DAEMON_RESPONSE_BYTES + 1)
+    finally:
+        if timer is not None:
+            timer.cancel()
     if len(body) > _MAX_DAEMON_RESPONSE_BYTES:
         raise ValueError("Guard daemon hook response exceeded the safe size limit")
     return body.decode("utf-8", errors="replace")
@@ -265,20 +325,24 @@ def _valid_hook_json_or_degraded(output: str, *, reason: str, data: str) -> str:
     return trimmed
 
 
-def _run_local_fallback(reason: str, data: str, fallback_command: tuple[str, ...]) -> str:
-    try:
-        result = subprocess.run(
-            list(fallback_command),
-            input=data,
-            capture_output=True,
-            text=True,
-            errors="replace",
-            timeout=_FALLBACK_TIMEOUT_SECONDS,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired) as error:
-        return _degraded(f"{reason}; fallback failed: {error}", data)
-    if result.returncode == 0:
+def _run_local_fallback(
+    reason: str,
+    data: str,
+    fallback_command: tuple[str, ...],
+    *,
+    deadline: float | None = None,
+) -> str:
+    timeout_seconds = _remaining_seconds(deadline, cap=_FALLBACK_TIMEOUT_SECONDS)
+    if timeout_seconds < _MINIMUM_OPERATION_SECONDS:
+        return _degraded(f"{reason}; fallback exhausted the hook deadline", data)
+    result = run_isolated_hook_process(
+        fallback_command,
+        input_text=data,
+        cwd=Path.home(),
+        environment=isolated_hook_environment(),
+        timeout_seconds=timeout_seconds,
+    )
+    if result.returncode == 0 and not result.timed_out and not result.output_limit_exceeded:
         stdout = (result.stdout or "").strip()
         if _should_suppress_output(data, stdout):
             return ""
@@ -287,10 +351,9 @@ def _run_local_fallback(reason: str, data: str, fallback_command: tuple[str, ...
             reason=f"{reason}; fallback returned malformed hook JSON",
             data=data,
         )
-    detail = (result.stderr or result.stdout or "").strip()
-    suffix = f"; fallback exited {result.returncode}"
-    if detail:
-        suffix = f"{suffix}: {detail}"
+    suffix = "; fallback timed out" if result.timed_out else f"; fallback exited {result.returncode}"
+    if result.output_limit_exceeded:
+        suffix = "; fallback exceeded its output limit"
     return _degraded(f"{reason}{suffix}", data)
 
 
@@ -309,6 +372,8 @@ def _daemon_failure_is_recoverable(error: Exception) -> bool:
     if isinstance(error, ValueError):
         return False
     if isinstance(error, (urllib.error.HTTPError, _DaemonHTTPError)):
+        if _daemon_failure_is_authenticated_overload(error):
+            return False
         return error.code in {401, 403, 408, 500, 502, 503, 504}
     return True
 
@@ -322,34 +387,66 @@ def _recover_retry_or_fallback(
     fallback_command: tuple[str, ...],
     recovery_command: tuple[str, ...],
     query: str,
+    deadline: float | None = None,
+    failure_kind: str = "transport-failure",
 ) -> str:
-    if recovery_command and _run_recovery_command(recovery_command):
+    if recovery_command and _run_recovery_command(
+        recovery_command,
+        deadline=deadline,
+        failure_kind=failure_kind,
+    ):
         try:
             endpoint = urljoin(_daemon_url(state_path, fallback_daemon_url), f"/v1/hooks/claude-code?{query}")
             _assert_loopback_http_url(endpoint)
             return _valid_hook_json_or_degraded(
-                _post_to_loopback_daemon(endpoint, data, state_path=state_path),
+                _post_to_loopback_daemon(endpoint, data, state_path=state_path, deadline=deadline),
                 reason=f"{reason}; recovered daemon returned malformed hook JSON",
                 data=data,
             )
         except Exception as retry_error:
             reason = f"{reason}; daemon recovery retry failed: {retry_error}"
-    return _run_local_fallback(reason, data, fallback_command)
+    return _run_local_fallback(reason, data, fallback_command, deadline=deadline)
 
 
-def _run_recovery_command(recovery_command: tuple[str, ...]) -> bool:
-    try:
-        result = subprocess.run(
-            list(recovery_command),
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            timeout=_RECOVERY_TIMEOUT_SECONDS,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
+def _run_recovery_command(
+    recovery_command: tuple[str, ...],
+    *,
+    deadline: float | None = None,
+    failure_kind: str = "transport-failure",
+) -> bool:
+    timeout_seconds = _remaining_seconds(deadline, cap=_RECOVERY_TIMEOUT_SECONDS)
+    if timeout_seconds < _MINIMUM_OPERATION_SECONDS:
         return False
-    return result.returncode == 0
+    environment = isolated_hook_environment()
+    environment["HOL_GUARD_HOOK_FAILURE_KIND"] = failure_kind
+    result = run_isolated_hook_process(
+        recovery_command,
+        input_text="",
+        cwd=Path.home(),
+        environment=environment,
+        timeout_seconds=timeout_seconds,
+        allow_windows_breakaway=True,
+    )
+    return result.returncode == 0 and not result.timed_out and not result.output_limit_exceeded
+
+
+def _daemon_failure_is_authenticated_overload(error: urllib.error.HTTPError | _DaemonHTTPError) -> bool:
+    detail = error.detail.lower() if isinstance(error, _DaemonHTTPError) else ""
+    return error.code == 429 or any(
+        marker in detail for marker in ("capacity", "overload", "too_many", "too many", "busy")
+    )
+
+
+def _daemon_failure_kind(error: Exception) -> str:
+    if isinstance(error, (urllib.error.HTTPError, _DaemonHTTPError)):
+        if _daemon_failure_is_authenticated_overload(error):
+            return "overload"
+        if error.code in {401, 403}:
+            return "authenticated-control-plane-failure"
+        return "transport-failure"
+    if isinstance(error, ValueError):
+        return "authenticated-control-plane-failure"
+    return "transport-failure"
 
 
 def _recovery_command(state_path: str | Path, query: str) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
@@ -9,7 +9,6 @@ import json
 import os
 import secrets
 import stat
-import subprocess
 import sys
 import time
 import urllib.error
@@ -23,6 +22,8 @@ if __package__:
     from ..codex_hook_bridge_runtime import bounded_hook_input as _hook_input
     from ..codex_hook_bridge_runtime import bridge_config_from_argv as _parse_bridge_config
     from ..codex_hook_bridge_runtime import trusted_hook_launch as _trusted_hook_launch
+    from ..codex_hook_launch_runtime import isolated_hook_environment as _isolated_hook_environment
+    from ..codex_hook_launch_runtime import run_isolated_hook_process as _run_isolated_hook_process
 else:  # pragma: no cover - exercised by subprocess integration tests
     _package_root = str(Path(__file__).resolve().parents[3])
     if _package_root not in sys.path:
@@ -42,6 +43,12 @@ else:  # pragma: no cover - exercised by subprocess integration tests
     from codex_plugin_scanner.guard.codex_hook_bridge_runtime import (
         trusted_hook_launch as _trusted_hook_launch,
     )
+    from codex_plugin_scanner.guard.codex_hook_launch_runtime import (
+        isolated_hook_environment as _isolated_hook_environment,
+    )
+    from codex_plugin_scanner.guard.codex_hook_launch_runtime import (
+        run_isolated_hook_process as _run_isolated_hook_process,
+    )
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 _HOOK_TIMEOUT_GRACE_SECONDS = 2
@@ -54,6 +61,15 @@ _FAIL_CLOSED_REASON = "HOL Guard could not authenticate the local daemon. Run `h
 _LAUNCH_INTEGRITY_REASON = (
     "HOL Guard could not authenticate its managed Codex hook launcher. Run `hol-guard install codex`, then retry."
 )
+_MINIMUM_OPERATION_SECONDS = 0.01
+
+
+class _DaemonResponseError(ValueError):
+    def __init__(self, status: int, detail: str, *, authenticated: bool) -> None:
+        super().__init__(f"daemon returned HTTP {status}")
+        self.status = status
+        self.detail = detail
+        self.authenticated = authenticated
 
 
 def _assert_loopback_http_url(url: str) -> None:
@@ -188,13 +204,34 @@ def _daemon_auth_token(state_path: str | Path, state: Mapping[str, object]) -> s
     return token
 
 
-def _http_json_response(response: http.client.HTTPResponse, *, label: str) -> dict[str, object]:
-    body = response.read(_MAX_DAEMON_RESPONSE_BYTES + 1)
+def _http_json_response(
+    response: http.client.HTTPResponse,
+    *,
+    label: str,
+    connection: http.client.HTTPConnection,
+    deadline: float,
+    authenticated: bool,
+) -> dict[str, object]:
+    body = bytearray()
+    while len(body) <= _MAX_DAEMON_RESPONSE_BYTES:
+        remaining = _remaining_seconds(deadline)
+        if remaining < _MINIMUM_OPERATION_SECONDS:
+            raise TimeoutError(f"{label} exceeded the hook deadline")
+        if connection.sock is not None:
+            connection.sock.settimeout(remaining)
+        chunk = response.read1(min(64 * 1024, _MAX_DAEMON_RESPONSE_BYTES + 1 - len(body)))
+        if not chunk:
+            break
+        body.extend(chunk)
     if len(body) > _MAX_DAEMON_RESPONSE_BYTES:
         raise ValueError(f"{label} response is too large")
     if response.status != 200:
-        raise ValueError(f"{label} returned HTTP {response.status}")
-    payload = _json_object(body.decode("utf-8", errors="replace").strip())
+        raise _DaemonResponseError(
+            response.status,
+            body.decode("utf-8", errors="replace").strip(),
+            authenticated=authenticated,
+        )
+    payload = _json_object(bytes(body).decode("utf-8", errors="replace").strip())
     if payload is None:
         raise ValueError(f"{label} returned malformed JSON")
     return payload
@@ -253,6 +290,11 @@ def _request_timeout(event_name: str, hook_timeouts: Mapping[str, int]) -> float
     return float(max(1, timeout - _HOOK_TIMEOUT_GRACE_SECONDS))
 
 
+def _remaining_seconds(deadline: float, *, cap: float | None = None) -> float:
+    remaining = max(0.0, deadline - time.monotonic())
+    return remaining if cap is None else min(remaining, cap)
+
+
 def _fail_closed(event_name: str, reason: str = _FAIL_CLOSED_REASON) -> dict[str, object]:
     if event_name == "PermissionRequest":
         return {
@@ -285,19 +327,26 @@ def _fail_closed(event_name: str, reason: str = _FAIL_CLOSED_REASON) -> dict[str
     }
 
 
-def _run_daemon_start(start_command: Sequence[str], *, timeout_seconds: float) -> bool:
-    try:
-        result = subprocess.run(
-            list(start_command),
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            timeout=min(timeout_seconds, _DAEMON_START_TIMEOUT_SECONDS),
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
+def _run_daemon_start(
+    start_command: Sequence[str],
+    *,
+    timeout_seconds: float,
+    failure_kind: str = "transport-failure",
+) -> bool:
+    timeout = min(timeout_seconds, _DAEMON_START_TIMEOUT_SECONDS)
+    if timeout < _MINIMUM_OPERATION_SECONDS:
         return False
-    return result.returncode == 0
+    environment = _isolated_hook_environment()
+    environment["HOL_GUARD_HOOK_FAILURE_KIND"] = failure_kind
+    result = _run_isolated_hook_process(
+        start_command,
+        input_text="",
+        cwd=Path.home(),
+        environment=environment,
+        timeout_seconds=timeout,
+        allow_windows_breakaway=True,
+    )
+    return result.returncode == 0 and not result.timed_out and not result.output_limit_exceeded
 
 
 def _run_local_fallback(
@@ -306,19 +355,16 @@ def _run_local_fallback(
     data: str,
     timeout_seconds: float,
 ) -> dict[str, object] | None:
-    try:
-        result = subprocess.run(
-            list(fallback_command),
-            input=data,
-            capture_output=True,
-            text=True,
-            errors="replace",
-            timeout=timeout_seconds,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
+    if timeout_seconds < _MINIMUM_OPERATION_SECONDS:
         return None
-    if result.returncode != 0:
+    result = _run_isolated_hook_process(
+        fallback_command,
+        input_text=data,
+        cwd=Path.home(),
+        environment=_isolated_hook_environment(),
+        timeout_seconds=timeout_seconds,
+    )
+    if result.returncode != 0 or result.timed_out or result.output_limit_exceeded:
         return None
     if not result.stdout.strip():
         return {}
@@ -332,6 +378,7 @@ def _daemon_response(
     data: str,
     timeout_seconds: float,
 ) -> dict[str, object] | None:
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
     state, discovery_key = _authenticated_state(state_path)
     host = str(state["host"])
     port_value = state["port"]
@@ -360,7 +407,13 @@ def _daemon_response(
             body=challenge_body.encode("utf-8"),
             headers={"Content-Type": "application/json", "Connection": "keep-alive"},
         )
-        challenge = _http_json_response(connection.getresponse(), label="daemon identity challenge")
+        challenge = _http_json_response(
+            connection.getresponse(),
+            label="daemon identity challenge",
+            connection=connection,
+            deadline=deadline,
+            authenticated=False,
+        )
         proof = _verify_challenge_response(
             challenge,
             state=state,
@@ -372,6 +425,12 @@ def _daemon_response(
         if current_state != state or not secrets.compare_digest(current_key, discovery_key):
             raise ValueError("daemon state changed during identity verification")
         auth_token = _daemon_auth_token(state_path, state)
+        remaining = _remaining_seconds(deadline)
+        if remaining < _MINIMUM_OPERATION_SECONDS:
+            raise TimeoutError("daemon identity challenge exhausted the hook deadline")
+        connection.timeout = remaining
+        if connection.sock is not None:
+            connection.sock.settimeout(remaining)
         hook_path = f"/v1/hooks/codex?{query}"
         connection.request(
             "POST",
@@ -385,7 +444,13 @@ def _daemon_response(
                 "X-Guard-Daemon-Proof": proof,
             },
         )
-        return _http_json_response(connection.getresponse(), label="daemon hook")
+        return _http_json_response(
+            connection.getresponse(),
+            label="daemon hook",
+            connection=connection,
+            deadline=deadline,
+            authenticated=True,
+        )
     finally:
         connection.close()
 
@@ -408,17 +473,22 @@ def main(
         return 0
     event_name = _event_name(data)
     timeout_seconds = _request_timeout(event_name, hook_timeouts)
+    deadline = time.monotonic() + timeout_seconds
     response: dict[str, object] | None = None
     trusted_launch: _TrustedHookLaunch | None = None
     launch_integrity_failed = False
+    daemon_overloaded = False
+    failure_kind = "transport-failure"
     try:
         response = _daemon_response(
             state_path=state_path,
             query=query,
             data=data,
-            timeout_seconds=timeout_seconds,
+            timeout_seconds=_remaining_seconds(deadline),
         )
-    except (OSError, ValueError, http.client.HTTPException, urllib.error.URLError):
+    except (OSError, ValueError, http.client.HTTPException, urllib.error.URLError) as error:
+        daemon_overloaded = _authenticated_daemon_overload(error)
+        failure_kind = _daemon_failure_kind(error)
         if manifest_path is not None or config_json is not None:
             try:
                 if manifest_path is None or config_json is None:
@@ -433,12 +503,22 @@ def main(
             except (ImportError, OSError, RuntimeError, ValueError):
                 launch_integrity_failed = True
         start_succeeded = (
-            trusted_launch.run_start(
-                start_command,
-                timeout_seconds=min(timeout_seconds, _DAEMON_START_TIMEOUT_SECONDS),
+            False
+            if daemon_overloaded
+            else (
+                trusted_launch.run_start(
+                    start_command,
+                    timeout_seconds=_remaining_seconds(deadline, cap=_DAEMON_START_TIMEOUT_SECONDS),
+                    failure_kind=failure_kind,
+                )
+                if trusted_launch is not None
+                else not launch_integrity_failed
+                and _run_daemon_start(
+                    start_command,
+                    timeout_seconds=_remaining_seconds(deadline, cap=_DAEMON_START_TIMEOUT_SECONDS),
+                    failure_kind=failure_kind,
+                )
             )
-            if trusted_launch is not None
-            else not launch_integrity_failed and _run_daemon_start(start_command, timeout_seconds=timeout_seconds)
         )
         if start_succeeded:
             try:
@@ -446,7 +526,7 @@ def main(
                     state_path=state_path,
                     query=query,
                     data=data,
-                    timeout_seconds=timeout_seconds,
+                    timeout_seconds=_remaining_seconds(deadline),
                 )
             except (OSError, ValueError, http.client.HTTPException, urllib.error.URLError):
                 response = None
@@ -455,7 +535,7 @@ def main(
             fallback_stdout = trusted_launch.run_fallback(
                 fallback_command,
                 data=data,
-                timeout_seconds=timeout_seconds,
+                timeout_seconds=_remaining_seconds(deadline),
             )
             if fallback_stdout is not None:
                 response = _json_object(fallback_stdout.strip()) if fallback_stdout.strip() else {}
@@ -463,13 +543,34 @@ def main(
             response = _run_local_fallback(
                 fallback_command,
                 data=data,
-                timeout_seconds=timeout_seconds,
+                timeout_seconds=_remaining_seconds(deadline),
             )
     if response is None:
         failure_reason = _LAUNCH_INTEGRITY_REASON if launch_integrity_failed else _FAIL_CLOSED_REASON
         response = _fail_closed(event_name, failure_reason)
     sys.stdout.write(json.dumps(response, separators=(",", ":")))
     return 0
+
+
+def _authenticated_daemon_overload(error: BaseException) -> bool:
+    if not isinstance(error, _DaemonResponseError) or not error.authenticated:
+        return False
+    detail = error.detail.lower()
+    return error.status == 429 or any(
+        marker in detail for marker in ("capacity", "overload", "too_many", "too many", "busy")
+    )
+
+
+def _daemon_failure_kind(error: BaseException) -> str:
+    if _authenticated_daemon_overload(error):
+        return "overload"
+    if isinstance(error, _DaemonResponseError):
+        if error.authenticated and error.status in {401, 403}:
+            return "authenticated-control-plane-failure"
+        return "transport-failure"
+    if isinstance(error, ValueError):
+        return "authenticated-control-plane-failure"
+    return "transport-failure"
 
 
 def _bridge_config_from_argv(argv: Sequence[str]) -> BridgeConfig:
@@ -488,4 +589,10 @@ if __name__ == "__main__":
             hook_timeouts=_config["hook_timeouts"],
             config_json=_config["config_json"],
         )
+    )
+    from codex_plugin_scanner.guard.codex_hook_launch_runtime import (
+        isolated_hook_environment as _isolated_hook_environment,
+    )
+    from codex_plugin_scanner.guard.codex_hook_launch_runtime import (
+        run_isolated_hook_process as _run_isolated_hook_process,
     )

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -294,7 +294,7 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
         resume_support=False,
         known_blind_spots=(
             "Tool output post-processing and inline edits applied without a tool call are not visible to Guard. "
-            "Hooks run in parallel and fail open on crash or timeout."
+            "Hooks run in parallel, so separate requests may be reviewed concurrently."
         ),
         smoke_command="hol-guard install kimi --dry-run",
     ),
@@ -311,8 +311,8 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
         browser_fallback=True,
         resume_support=False,
         known_blind_spots=(
-            "Grok hooks fail open on crash or timeout. --always-approve and bypassPermissions weaken "
-            "prompt policy but PreToolUse hooks still run when installed."
+            "--always-approve and bypassPermissions weaken prompt policy, but the bounded Guard hook still "
+            "returns a native deny when its local review cannot finish."
         ),
         smoke_command="hol-guard install grok --dry-run",
     ),

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import ast
-import importlib.util
 import json
-import os
 import re
 import shlex
 import subprocess
@@ -19,6 +17,7 @@ from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _json_payload, _run_command_probe
+from .bounded_cli_hook_bridge import bounded_cli_hook_command
 from .mcp_servers import (
     ManagedMcpServer,
     is_guard_proxy_command,
@@ -39,6 +38,7 @@ _DETECTABLE_HOOK_EVENTS = (
     "errorOccurred",
 )
 _MANAGED_HOOK_FILENAME = "hol-guard-copilot.json"
+_GUARD_HOOK_INTERNAL_TIMEOUT_SECONDS = 25
 _LEGACY_MANAGED_HOOK_PATTERNS = (
     re.compile(r'(^|["\s])-m["\s]+codex_plugin_scanner\.cli(["\s]|$)'),
     re.compile(r'(^|["\s])guard(["\s]|$)'),
@@ -94,15 +94,14 @@ def _hook_command_parts(context: HarnessContext, *, include_workspace: bool) -> 
         guard_args.extend(["--home", str(context.home_dir)])
     if include_workspace and context.workspace_dir is not None:
         guard_args.extend(["--workspace", str(context.workspace_dir)])
-    trusted_path_entries = _trusted_pythonpath_entries()
-    guard_args_json = json.dumps(guard_args)
-    code = (
-        "import json,sys;"
-        f"sys.path[:0]={trusted_path_entries!r};"
-        "from codex_plugin_scanner.cli import main;"
-        f"raise SystemExit(main(json.loads({guard_args_json!r})))"
+    return bounded_cli_hook_command(
+        python_executable=sys.executable,
+        package_root=Path(__file__).resolve().parents[3],
+        guard_home=context.guard_home,
+        cli_args=guard_args,
+        harness="copilot",
+        timeout_seconds=_GUARD_HOOK_INTERNAL_TIMEOUT_SECONDS,
     )
-    return (sys.executable, "-c", code)
 
 
 def _hook_shell_commands(context: HarnessContext, *, include_workspace: bool) -> tuple[str, str]:
@@ -139,32 +138,23 @@ def _is_managed_hook_command(command: str) -> bool:
     if not executable.startswith("python") or tokens[1] != "-c":
         return False
     inline_code = tokens[2]
+    if "bounded_cli_hook_bridge" in inline_code and len(tokens) == 4:
+        try:
+            raw_config: object = json.loads(tokens[3])
+        except json.JSONDecodeError:
+            return False
+        if not isinstance(raw_config, dict):
+            return False
+        config: dict[str, object] = {key: value for key, value in raw_config.items() if isinstance(key, str)}
+        if config.get("harness") != "copilot":
+            return False
+        cli_args = config.get("cli_args")
+        if not isinstance(cli_args, list):
+            return False
+        normalized_args = tuple(item.lower() for item in cli_args if isinstance(item, str))
+        return len(normalized_args) == len(cli_args) and _argv_targets_copilot(normalized_args)
     inline_args = _inline_guard_args(inline_code)
     return "codex_plugin_scanner.cli" in inline_code and _argv_targets_copilot(inline_args)
-
-
-def _trusted_pythonpath_entries() -> list[str]:
-    launcher_env = merge_guard_launcher_env()
-    path_entries = [entry for entry in launcher_env.get("PYTHONPATH", "").split(os.pathsep) if entry.strip()]
-    package_root = _trusted_package_root()
-    cli_entrypoint = package_root / "codex_plugin_scanner" / "cli.py"
-    if not cli_entrypoint.is_file():
-        raise RuntimeError(f"Guard could not locate the trusted CLI entrypoint at {cli_entrypoint}")
-    package_root_str = str(package_root)
-    if package_root_str not in path_entries:
-        path_entries.insert(0, package_root_str)
-    return path_entries
-
-
-def _trusted_package_root() -> Path:
-    spec = importlib.util.find_spec("codex_plugin_scanner")
-    if spec is None:
-        raise RuntimeError("Guard could not locate the codex_plugin_scanner package")
-    if spec.submodule_search_locations:
-        return Path(next(iter(spec.submodule_search_locations))).resolve().parent
-    if spec.origin is None:
-        raise RuntimeError("Guard could not determine the codex_plugin_scanner package root")
-    return Path(spec.origin).resolve().parent.parent
 
 
 def _inline_guard_args(inline_code: str) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_head.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_head.py
@@ -13,18 +13,35 @@ import os
 import shlex
 import subprocess
 import sys
+import threading
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Mapping
 from pathlib import Path
 
+from codex_plugin_scanner.guard.codex_hook_launch_runtime import run_isolated_hook_process
+
 GUARD_HOME = __GUARD_HOME__
 GUARD_CLI = __GUARD_CLI__
+GUARD_RECOVERY_COMMAND = __GUARD_RECOVERY_COMMAND__
 GUARD_HOOK_ARGV = __GUARD_HOOK_ARGV__
 GUARD_INHERIT_ENV_KEYS = __GUARD_INHERIT_ENV_KEYS__
 GUARD_HOOK_TIMEOUT_SECONDS = __GUARD_HOOK_TIMEOUT_SECONDS__
 GUARD_ACTIONS = frozenset({"allow", "warn", "review", "require-reapproval", "sandbox-required", "block"})
+_FALLBACK_LOCK = threading.Lock()
+
+
+def _remaining_seconds(deadline_monotonic: float) -> float:
+    return max(deadline_monotonic - time.monotonic(), 0.0)
+
+
+def _request_timeout(deadline_monotonic: float, preferred_seconds: float) -> float | None:
+    remaining = _remaining_seconds(deadline_monotonic)
+    if remaining <= 0:
+        return None
+    return min(preferred_seconds, remaining)
 
 
 def _hook_process_env() -> dict[str, str]:
@@ -82,52 +99,56 @@ def _daemon_hook_env_overlay(guard_env: Mapping[str, str]) -> dict[str, str]:
 def _daemon_hook_result(
     payload_json: str,
     *,
+    deadline_monotonic: float,
     workspace: str | None,
     hook_env_overlay: Mapping[str, str] | None = None,
-) -> tuple[int, str, str] | None:
+) -> tuple[tuple[int, str, str] | None, str | None]:
     state_path = Path(GUARD_HOME) / "daemon-state.json"
     token_path = Path(GUARD_HOME) / "daemon-auth-token"
     try:
         state = json.loads(state_path.read_text(encoding="utf-8"))
         auth_token = token_path.read_text(encoding="utf-8").strip()
     except (OSError, ValueError):
-        return None
+        return (None, None)
     if not isinstance(state, dict):
-        return None
+        return (None, None)
     port = state.get("port")
     if not isinstance(port, int) or port <= 0 or not auth_token:
-        return None
+        return (None, None)
     # Validate the recorded PID is still alive before trusting the state file.
     # A stale state file after a crash could point at an attacker-controlled listener.
     pid = state.get("pid")
     if not isinstance(pid, int) or pid <= 0:
-        return None
+        return (None, None)
     try:
         os.kill(pid, 0)
     except OSError:
-        return None
+        return (None, "transport-failure")
     # Probe /healthz before sending the hook payload and auth token.
     # Ensures the listener is actually the Guard daemon, not a spoofed process.
     # Validate the response body — not just HTTP 200 — so an attacker listener
     # that returns 200 but doesn't know the daemon's compatibility version is rejected.
     opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
     try:
+        timeout = _request_timeout(deadline_monotonic, 2)
+        if timeout is None:
+            return (None, "transport-failure")
         health_req = urllib.request.Request(f"http://127.0.0.1:{port}/healthz", method="GET")
-        with opener.open(health_req, timeout=2) as health_response:
+        with opener.open(health_req, timeout=timeout) as health_response:
             if health_response.status != 200:
-                return None
+                return (None, None)
             health_body = health_response.read().decode("utf-8", errors="replace")
     except (OSError, urllib.error.URLError):
-        return None
+        return (None, "transport-failure")
     try:
         health_json = json.loads(health_body)
     except ValueError:
-        return None
+        return (None, None)
     if not isinstance(health_json, dict) or health_json.get("ok") is not True:
-        return None
+        return (None, None)
     state_compat = state.get("compatibility_version")
     if isinstance(state_compat, str) and health_json.get("compatibility_version") != state_compat:
-        return None
+        return (None, None)
     # Challenge-response: prove the listener knows the auth_token before sending it.
     # A spoofed listener can return public healthz values but cannot forge the HMAC.
     # The proof is bound to the daemon's listening port so a relay attacker cannot
@@ -137,29 +158,34 @@ def _daemon_hook_result(
     nonce = os.urandom(16).hex()
     proof_message = f"{port}:{nonce}"
     try:
+        timeout = _request_timeout(deadline_monotonic, 2)
+        if timeout is None:
+            return (None, "transport-failure")
         verify_req = urllib.request.Request(
             f"http://127.0.0.1:{port}/v1/healthz/verify",
             data=json.dumps({"nonce": nonce}).encode("utf-8"),
             headers={"Content-Type": "application/json"},
             method="POST",
         )
-        with opener.open(verify_req, timeout=2) as verify_response:
+        with opener.open(verify_req, timeout=timeout) as verify_response:
             verify_body = verify_response.read().decode("utf-8", errors="replace")
             try:
                 verify_json = json.loads(verify_body)
             except ValueError:
-                return None
+                return (None, "authenticated-control-plane-failure")
             if not isinstance(verify_json, dict) or not isinstance(verify_json.get("proof"), str):
-                return None
+                return (None, "authenticated-control-plane-failure")
             expected_proof = hmac.new(
                 auth_token.encode("utf-8"),
                 proof_message.encode("utf-8"),
                 hashlib.sha256,
             ).hexdigest()
             if not hmac.compare_digest(verify_json["proof"], expected_proof):
-                return None
-    except (urllib.error.HTTPError, OSError, urllib.error.URLError):
-        return None
+                return (None, None)
+    except urllib.error.HTTPError:
+        return (None, "authenticated-control-plane-failure")
+    except (OSError, urllib.error.URLError):
+        return (None, "transport-failure")
     params = [("guard-home", GUARD_HOME)]
     if workspace:
         params.append(("workspace", workspace))
@@ -169,9 +195,9 @@ def _daemon_hook_result(
     try:
         request_payload = json.loads(payload_json)
     except ValueError:
-        return None
+        return (None, "authenticated-control-plane-failure")
     if not isinstance(request_payload, dict):
-        return None
+        return (None, "authenticated-control-plane-failure")
     if hook_env_overlay:
         request_payload["hook_env"] = dict(hook_env_overlay)
     query = urllib.parse.urlencode(params)
@@ -185,27 +211,98 @@ def _daemon_hook_result(
         method="POST",
     )
     try:
-        with opener.open(request, timeout=max(GUARD_HOOK_TIMEOUT_SECONDS - 2, 1)) as response:
+        timeout = _request_timeout(deadline_monotonic, GUARD_HOOK_TIMEOUT_SECONDS)
+        if timeout is None:
+            return (None, "transport-failure")
+        with opener.open(request, timeout=timeout) as response:
             body = response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as error:
+        try:
+            detail = error.read().decode("utf-8", errors="replace").lower()
+        except OSError:
+            detail = ""
+        if error.code in {429, 503} or any(
+            marker in detail for marker in ("capacity", "overload", "too_many", "too many", "busy")
+        ):
+            return (None, "overload")
+        return (None, "authenticated-control-plane-failure")
     except (OSError, urllib.error.URLError):
-        return None
+        return (None, "transport-failure")
     # Reject empty or non-dict responses — they default policy_action to "allow".
     # Fall through to the CLI subprocess path instead of trusting a malformed response.
     body_stripped = body.strip()
     if not body_stripped:
-        return None
+        return (None, "authenticated-control-plane-failure")
     try:
         parsed_body = json.loads(body_stripped)
     except ValueError:
-        return None
+        return (None, "authenticated-control-plane-failure")
     if not isinstance(parsed_body, dict):
-        return None
+        return (None, "authenticated-control-plane-failure")
     raw_event_name = _raw_hook_event_name(request_payload)
     if raw_event_name not in {"aftershellexecution", "aftermcpexecution"}:
         policy_action = parsed_body.get("policy_action")
         if not isinstance(policy_action, str) or policy_action not in GUARD_ACTIONS:
-            return None
-    return (0, body_stripped, "")
+            return (None, "authenticated-control-plane-failure")
+    return ((0, body_stripped, ""), None)
+
+
+def _run_guard_fallback(
+    guard_argv: list[str],
+    *,
+    payload_json: str,
+    guard_env: Mapping[str, str],
+    deadline_monotonic: float,
+) -> subprocess.CompletedProcess[str]:
+    if not _FALLBACK_LOCK.acquire(blocking=False):
+        raise RuntimeError("HOL Guard fallback review is already in progress")
+    try:
+        remaining = _remaining_seconds(deadline_monotonic)
+        if remaining <= 0:
+            raise subprocess.TimeoutExpired([*GUARD_CLI, *guard_argv], GUARD_HOOK_TIMEOUT_SECONDS)
+        result = run_isolated_hook_process(
+            [*GUARD_CLI, *guard_argv],
+            cwd=GUARD_HOME,
+            environment=dict(guard_env),
+            input_text=payload_json,
+            timeout_seconds=remaining,
+        )
+        if result.timed_out:
+            raise subprocess.TimeoutExpired([*GUARD_CLI, *guard_argv], remaining)
+        return subprocess.CompletedProcess(
+            [*GUARD_CLI, *guard_argv],
+            result.returncode if result.returncode is not None else 1,
+            stdout=result.stdout,
+            stderr="",
+        )
+    finally:
+        _FALLBACK_LOCK.release()
+
+
+def _run_guard_recovery(
+    failure_kind: str,
+    *,
+    guard_env: Mapping[str, str],
+    deadline_monotonic: float,
+) -> None:
+    if failure_kind == "overload" or not _FALLBACK_LOCK.acquire(blocking=False):
+        return
+    try:
+        remaining = min(_remaining_seconds(deadline_monotonic), 5.0)
+        if remaining <= 0:
+            return
+        _ = run_isolated_hook_process(
+            [*GUARD_RECOVERY_COMMAND, failure_kind],
+            cwd=GUARD_HOME,
+            environment=dict(guard_env),
+            input_text="",
+            timeout_seconds=remaining,
+            allow_windows_breakaway=True,
+        )
+    except (OSError, ValueError):
+        return
+    finally:
+        _FALLBACK_LOCK.release()
 
 
 def _validated_hol_guard_src_path(path_str: str) -> str | None:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
@@ -245,11 +245,25 @@ def main() -> int:
         if proof:
             guard_env["HOL_GUARD_CURSOR_AFTER_SHELL_PROOF"] = proof
     payload_json = json.dumps(prepared)
-    daemon_result = _daemon_hook_result(
+    deadline_monotonic = time.monotonic() + GUARD_HOOK_TIMEOUT_SECONDS
+    daemon_result, daemon_failure_kind = _daemon_hook_result(
         payload_json,
+        deadline_monotonic=deadline_monotonic,
         workspace=workspace,
         hook_env_overlay=_daemon_hook_env_overlay(guard_env),
     )
+    if daemon_result is None and daemon_failure_kind not in {None, "overload"}:
+        _run_guard_recovery(
+            daemon_failure_kind,
+            guard_env=guard_env,
+            deadline_monotonic=deadline_monotonic,
+        )
+        daemon_result, _retry_failure_kind = _daemon_hook_result(
+            payload_json,
+            deadline_monotonic=deadline_monotonic,
+            workspace=workspace,
+            hook_env_overlay=_daemon_hook_env_overlay(guard_env),
+        )
     try:
         if daemon_result is not None:
             proc = subprocess.CompletedProcess(
@@ -259,14 +273,11 @@ def main() -> int:
                 stderr=daemon_result[2],
             )
         else:
-            proc = subprocess.run(
-                [*GUARD_CLI, *guard_argv],
-                input=payload_json,
-                capture_output=True,
-                text=True,
-                cwd=GUARD_HOME,
-                env=guard_env,
-                timeout=GUARD_HOOK_TIMEOUT_SECONDS,
+            proc = _run_guard_fallback(
+                guard_argv,
+                payload_json=payload_json,
+                guard_env=guard_env,
+                deadline_monotonic=deadline_monotonic,
             )
     except subprocess.TimeoutExpired:
         print(

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -38,6 +38,7 @@ from .cursor_hook_script_template_head import HOOK_SCRIPT_TEMPLATE_HEAD
 from .cursor_hook_script_template_tail import HOOK_SCRIPT_TEMPLATE_TAIL
 from .cursor_native_approval import ensure_cursor_hook_attestation_secret
 from .guard_cli_attestation import resolve_attested_guard_cli
+from .hook_python import HookPythonAttestation
 
 _HOOK_SCRIPT_TEMPLATE = HOOK_SCRIPT_TEMPLATE_HEAD + HOOK_SCRIPT_TEMPLATE_TAIL
 _INHERIT_ENV_KEYS = (
@@ -89,7 +90,11 @@ def install_cursor_hooks(context: HarnessContext) -> dict[str, object]:
     script_path = cursor_hook_script_path(context)
     managed_script_path = managed_hook_script_path(context)
     managed_script_path.parent.mkdir(parents=True, exist_ok=True)
-    script_source = cursor_hook_script_source(context, guard_cli=list(guard_cli.command))
+    script_source = cursor_hook_script_source(
+        context,
+        guard_cli=list(guard_cli.command),
+        recovery_command=_cursor_recovery_command(context, guard_cli.python),
+    )
     managed_script_path.write_text(script_source, encoding="utf-8")
     _make_executable(managed_script_path)
     script_path.parent.mkdir(parents=True, exist_ok=True)
@@ -349,18 +354,47 @@ def _embedded_guard_hook_argv(context: HarnessContext) -> list[str]:
     return guard_argv
 
 
+def _cursor_recovery_command(
+    context: HarnessContext,
+    attestation: HookPythonAttestation,
+) -> list[str]:
+    trusted_roots = [str(root) for root in attestation.import_roots]
+    bootstrap = (
+        "import json,sys;"
+        f"sys.path[:0]={json.dumps(trusted_roots)};"
+        "from pathlib import Path;"
+        "from codex_plugin_scanner.guard.daemon import recover_guard_daemon_after_hook_failure;"
+        f"recover_guard_daemon_after_hook_failure(Path({str(context.guard_home.resolve())!r}),"
+        f"home_dir=Path({str(context.home_dir.resolve())!r}),failure_kind=sys.argv[1])"
+    )
+    return [
+        str(attestation.identity.target_path),
+        "-I",
+        "-S",
+        "-s",
+        "-c",
+        bootstrap,
+    ]
+
+
 def cursor_hook_script_source(
     context: HarnessContext,
     *,
     guard_cli: list[str] | None = None,
+    recovery_command: list[str] | None = None,
 ) -> str:
-    guard_cli = list(guard_cli) if guard_cli is not None else _resolve_guard_cli_command(context)
+    if guard_cli is None:
+        guard_cli = _resolve_guard_cli_command(context)
+    if recovery_command is None:
+        recovery_command = _cursor_recovery_command(context, resolve_attested_guard_cli(context).python)
+    guard_cli = list(guard_cli)
     guard_argv = _embedded_guard_hook_argv(context)
     if not _uses_top_level_hook_command(guard_cli):
         guard_argv = ["guard", *guard_argv]
     return (
         _HOOK_SCRIPT_TEMPLATE.replace("__GUARD_HOME__", json.dumps(str(context.guard_home.resolve())))
         .replace("__GUARD_CLI__", json.dumps(guard_cli))
+        .replace("__GUARD_RECOVERY_COMMAND__", json.dumps(recovery_command))
         .replace(
             "__GUARD_HOOK_ARGV__",
             json.dumps(guard_argv),

--- a/src/codex_plugin_scanner/guard/adapters/grok.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok.py
@@ -22,6 +22,7 @@ from .base import (
     _run_command_probe,
     _shell_command,
 )
+from .bounded_cli_hook_bridge import bounded_cli_hook_command
 from .grok_config import (
     GROK_CONFIG_FILE,
     GROK_DIR,
@@ -56,6 +57,7 @@ except ModuleNotFoundError:
     tomllib = importlib.import_module("tomli")
 
 _GROK_HOME_ENV_VAR = "GROK_HOME"
+_GUARD_HOOK_INTERNAL_TIMEOUT_SECONDS = 25
 
 
 class GrokHarnessAdapter(HarnessAdapter):
@@ -360,14 +362,14 @@ class GrokHarnessAdapter(HarnessAdapter):
             guard_args.extend(["--home", str(context.home_dir)])
         if context.workspace_dir is not None:
             guard_args.extend(["--workspace", str(context.workspace_dir)])
-        package_root = Path(__file__).resolve().parents[3]
-        code = (
-            "import sys;"
-            f"sys.path.insert(0, {str(package_root)!r});"
-            "from codex_plugin_scanner.cli import main;"
-            f"raise SystemExit(main({guard_args!r}))"
+        return bounded_cli_hook_command(
+            python_executable=sys.executable,
+            package_root=Path(__file__).resolve().parents[3],
+            guard_home=context.guard_home,
+            cli_args=guard_args,
+            harness="grok",
+            timeout_seconds=_GUARD_HOOK_INTERNAL_TIMEOUT_SECONDS,
         )
-        return (sys.executable, "-c", code)
 
     def install(self, context: HarnessContext) -> dict[str, object]:
         shim_manifest = install_guard_shim(

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -25,6 +25,7 @@ from ..skill_directory_identity import (
     skill_directory_identity_metadata,
 )
 from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload, _run_command_probe
+from .bounded_cli_hook_bridge import bounded_cli_hook_command
 from .cloud_identity import cloud_agent_identity_environment, cloud_agent_identity_hints
 from .hermes_file_inspection import (
     HermesConfigInspection,
@@ -61,6 +62,8 @@ _SCANNABLE_NAMES = {".env", "Makefile", "Dockerfile", "Procfile"}
 
 _HERMES_MANAGED_APPROVAL_TIER = "native-or-center"
 _HERMES_MANAGED_PROMPT_CHANNEL = "native"
+_GUARD_PRETOOL_INTERNAL_TIMEOUT_SECONDS = 3
+_GUARD_PRETOOL_HOST_TIMEOUT_SECONDS = 5
 
 
 def _hermes_home(context: HarnessContext) -> Path:
@@ -1117,10 +1120,7 @@ def _mcp_proxy_command(*, context: HarnessContext, server_key: str) -> list[str]
 
 
 def _pretool_payload(*, context: HarnessContext) -> dict[str, object]:
-    command = [
-        str(Path(sys.executable)),
-        "-m",
-        "codex_plugin_scanner.cli",
+    cli_args = [
         "hermes",
         "pretool",
         "--guard-home",
@@ -1128,12 +1128,23 @@ def _pretool_payload(*, context: HarnessContext) -> dict[str, object]:
         "--json",
     ]
     if context.home_dir.resolve() != Path.home().resolve():
-        command.extend(["--home", str(context.home_dir)])
+        cli_args.extend(["--home", str(context.home_dir)])
     if context.workspace_dir is not None:
-        command.extend(["--workspace", str(context.workspace_dir)])
+        cli_args.extend(["--workspace", str(context.workspace_dir)])
     return {
-        "command": command,
+        "command": list(
+            bounded_cli_hook_command(
+                python_executable=sys.executable,
+                package_root=Path(__file__).resolve().parents[3],
+                guard_home=context.guard_home,
+                cli_args=cli_args,
+                harness="hermes",
+                timeout_seconds=_GUARD_PRETOOL_INTERNAL_TIMEOUT_SECONDS,
+            )
+        ),
         "harness": "hermes",
+        "timeout_seconds": _GUARD_PRETOOL_HOST_TIMEOUT_SECONDS,
+        "fail_open": False,
     }
 
 
@@ -1344,9 +1355,9 @@ def _write_guard_to_hermes_config_yaml(
     existing[_GUARD_CONFIG_KEY] = {
         "enabled": True,
         "base_url": _resolve_guard_consumer_base_url(context),
-        "timeout_seconds": 5,
+        "timeout_seconds": _GUARD_PRETOOL_HOST_TIMEOUT_SECONDS,
         "cache_ttl_seconds": 60,
-        "fail_open": True,
+        "fail_open": False,
         "token_env_var": "HERMES_GUARD_TOKEN",
         "enforce_mcp_tools": True,
         "pain_signals_enabled": True,

--- a/src/codex_plugin_scanner/guard/adapters/kimi.py
+++ b/src/codex_plugin_scanner/guard/adapters/kimi.py
@@ -20,6 +20,7 @@ from .base import (
     _json_payload,
     _shell_command,
 )
+from .bounded_cli_hook_bridge import bounded_cli_hook_command
 
 tomllib: Any
 try:
@@ -32,6 +33,7 @@ _KIMI_HOME_ENV_VAR = "KIMI_CODE_HOME"
 _KIMI_DIR = ".kimi-code"
 _KIMI_CONFIG_FILE = "config.toml"
 _KIMI_MCP_FILE = "mcp.json"
+_GUARD_HOOK_INTERNAL_TIMEOUT_SECONDS = 25
 
 
 _GUARD_MANAGED_BEGIN = "# BEGIN HOL GUARD MANAGED HOOKS"
@@ -225,14 +227,14 @@ class KimiHarnessAdapter(HarnessAdapter):
             guard_args.extend(["--home", str(context.home_dir)])
         if context.workspace_dir is not None:
             guard_args.extend(["--workspace", str(context.workspace_dir)])
-        package_root = Path(__file__).resolve().parents[3]
-        code = (
-            "import sys;"
-            f"sys.path.insert(0, {str(package_root)!r});"
-            "from codex_plugin_scanner.cli import main;"
-            f"raise SystemExit(main({guard_args!r}))"
+        return bounded_cli_hook_command(
+            python_executable=sys.executable,
+            package_root=Path(__file__).resolve().parents[3],
+            guard_home=context.guard_home,
+            cli_args=guard_args,
+            harness="kimi",
+            timeout_seconds=_GUARD_HOOK_INTERNAL_TIMEOUT_SECONDS,
         )
-        return (sys.executable, "-c", code)
 
     def install(self, context: HarnessContext) -> dict[str, object]:
         shim_manifest = install_guard_shim(

--- a/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from ..models import GuardArtifact, HarnessDetection
 from .base import HarnessContext
+from .bounded_cli_hook_bridge import bounded_cli_hook_command
 from .openclaw_mcp_inventory import (
     OpenClawMcpInventory,
     OpenClawMcpServer,
@@ -20,6 +21,8 @@ _MAX_FILE_READ = 64 * 1024
 _SKILL_SUBDIRS = ("references", "templates", "scripts", "assets")
 _SCANNABLE_EXTENSIONS = {".md", ".txt", ".py", ".sh", ".bash", ".js", ".ts", ".yaml", ".yml", ".json", ".toml"}
 _SCANNABLE_NAMES = {".env", "Dockerfile", "Makefile", "Procfile"}
+_GUARD_PRETOOL_INTERNAL_TIMEOUT_SECONDS = 3
+_GUARD_PRETOOL_HOST_TIMEOUT_SECONDS = 5
 
 
 def config_path(context: HarnessContext) -> Path:
@@ -67,10 +70,7 @@ def overlay_payload(detection: HarnessDetection) -> dict[str, object]:
 
 
 def pretool_payload(*, context: HarnessContext) -> dict[str, object]:
-    command = [
-        str(Path(sys.executable)),
-        "-m",
-        "codex_plugin_scanner.cli",
+    cli_args = [
         "hook",
         "--harness",
         "openclaw",
@@ -81,8 +81,21 @@ def pretool_payload(*, context: HarnessContext) -> dict[str, object]:
         "--json",
     ]
     if context.workspace_dir is not None:
-        command.extend(["--workspace", str(context.workspace_dir)])
-    return {"command": command, "harness": "openclaw"}
+        cli_args.extend(["--workspace", str(context.workspace_dir)])
+    command = bounded_cli_hook_command(
+        python_executable=sys.executable,
+        package_root=Path(__file__).resolve().parents[3],
+        guard_home=context.guard_home,
+        cli_args=cli_args,
+        harness="openclaw",
+        timeout_seconds=_GUARD_PRETOOL_INTERNAL_TIMEOUT_SECONDS,
+    )
+    return {
+        "command": list(command),
+        "harness": "openclaw",
+        "timeout_seconds": _GUARD_PRETOOL_HOST_TIMEOUT_SECONDS,
+        "fail_open": False,
+    }
 
 
 def install_state(

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -28,6 +28,8 @@ const GUARD_HOOK_LAUNCHER = __GUARD_HOOK_LAUNCHER__;
 const GUARD_HOOK_ENV = __GUARD_HOOK_ENV__;
 const GUARD_INHERIT_ENV_KEYS = __GUARD_INHERIT_ENV_KEYS__;
 const INTERCEPT_TOOLS = new Set(__INTERCEPT_TOOLS__);
+const GUARD_HOOK_TIMEOUT_MS = 30_000;
+let fallbackInFlight = false;
 
 type GuardFileMetadata = {
   device: string;
@@ -114,24 +116,150 @@ function normalizeCommand(command: unknown): string | null {
   return null;
 }
 
-async function spawnGuardProcess(options: {
+function waitForGuardProcessExit(
+  proc: ReturnType<typeof nodeSpawn>,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (proc.exitCode !== null || proc.signalCode !== null) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (exited: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(watchdog);
+      resolve(exited);
+    };
+    const watchdog = setTimeout(
+      () => finish(proc.exitCode !== null || proc.signalCode !== null),
+      timeoutMs,
+    );
+    proc.once("exit", () => finish(true));
+  });
+}
+
+async function terminateGuardProcessGroup(proc: ReturnType<typeof nodeSpawn>): Promise<boolean> {
+  const processGroupId = proc.pid;
+  if (process.platform === "win32" && (proc.exitCode !== null || proc.signalCode !== null)) {
+    return false;
+  }
+  if (process.platform === "win32" && typeof processGroupId === "number") {
+    const systemRoot = process.env.SystemRoot ?? process.env.SYSTEMROOT;
+    if (systemRoot) {
+      const treeKilled = await new Promise<boolean>((resolve) => {
+        const taskkill = nodeSpawn(
+          `${systemRoot}\\System32\\taskkill.exe`,
+          ["/PID", String(processGroupId), "/T", "/F"],
+          { stdio: "ignore", windowsHide: true },
+        );
+        const watchdog = setTimeout(() => {
+          taskkill.kill("SIGKILL");
+          resolve(false);
+        }, 200);
+        taskkill.once("error", () => {
+          clearTimeout(watchdog);
+          resolve(false);
+        });
+        taskkill.once("close", (status) => {
+          clearTimeout(watchdog);
+          resolve(status === 0);
+        });
+      });
+      if (!treeKilled) {
+        proc.kill("SIGKILL");
+        await waitForGuardProcessExit(proc, 200);
+        return false;
+      }
+      return waitForGuardProcessExit(proc, 200);
+    }
+    proc.kill("SIGKILL");
+    await waitForGuardProcessExit(proc, 200);
+    return false;
+  }
+  let groupSignaled = false;
+  try {
+    if (process.platform === "win32") {
+      proc.kill("SIGTERM");
+    } else if (typeof processGroupId === "number") {
+      process.kill(-processGroupId, "SIGTERM");
+      groupSignaled = true;
+    }
+  } catch {}
+  await waitForGuardProcessExit(proc, 100);
+  try {
+    if (process.platform === "win32") {
+      proc.kill("SIGKILL");
+    } else if (typeof processGroupId === "number") {
+      // The direct parent may have exited while descendants still hold hook pipes.
+      process.kill(-processGroupId, "SIGKILL");
+      groupSignaled = true;
+    }
+  } catch (error) {
+    if (!(error instanceof Error) || !("code" in error) || error.code !== "ESRCH") {
+      groupSignaled = false;
+    }
+  }
+  const parentExited = await waitForGuardProcessExit(proc, 200);
+  return parentExited && (process.platform === "win32" || groupSignaled);
+}
+
+export async function spawnGuardProcess(options: {
   args: string[];
   cwd: string;
+  deadlineMs: number;
   env: Record<string, string>;
   stdin: string;
 }): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
+    if (fallbackInFlight) {
+      reject(new Error("HOL Guard fallback review is already in progress"));
+      return;
+    }
+    const remainingMs = options.deadlineMs - Date.now();
+    if (remainingMs <= 0) {
+      reject(new Error("HOL Guard fallback review deadline expired"));
+      return;
+    }
+    fallbackInFlight = true;
+    let settled = false;
+    let timedOut = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const finish = (
+      outcome:
+        | { kind: "resolve"; value: { exitCode: number; stdout: string; stderr: string } }
+        | { kind: "reject"; error: unknown },
+    ) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+      fallbackInFlight = false;
+      if (outcome.kind === "resolve") {
+        resolve(outcome.value);
+      } else {
+        reject(outcome.error);
+      }
+    };
     try {
       verifyGuardPythonIdentity();
     } catch (error) {
-      reject(error);
+      finish({ kind: "reject", error });
       return;
     }
-    const proc = nodeSpawn(GUARD_PYTHON.targetPath, options.args, {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+    let proc: ReturnType<typeof nodeSpawn>;
+    try {
+      proc = nodeSpawn(GUARD_PYTHON.targetPath, options.args, {
+        cwd: options.cwd,
+        detached: process.platform !== "win32",
+        env: options.env,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (error) {
+      finish({ kind: "reject", error });
+      return;
+    }
     let stdout = "";
     let stderr = "";
     proc.stdout?.setEncoding("utf8");
@@ -142,16 +270,38 @@ async function spawnGuardProcess(options: {
     proc.stderr?.on("data", (chunk: string) => {
       stderr += chunk;
     });
-    proc.on("error", reject);
-    proc.on("close", (code: number | null) => {
-      resolve({ exitCode: code ?? 1, stdout, stderr });
+    proc.on("error", (error) => {
+      if (timedOut) return;
+      finish({ kind: "reject", error });
     });
+    proc.on("close", (code: number | null) => {
+      if (timedOut) return;
+      finish({ kind: "resolve", value: { exitCode: code ?? 1, stdout, stderr } });
+    });
+    timer = setTimeout(() => {
+      timedOut = true;
+      void terminateGuardProcessGroup(proc).then((terminated) => {
+        if (!terminated) {
+          if (settled) return;
+          settled = true;
+          if (timer !== undefined) clearTimeout(timer);
+          reject(new Error("HOL Guard fallback containment could not be confirmed"));
+          return;
+        }
+        finish({ kind: "reject", error: new Error("HOL Guard fallback review timed out") });
+      });
+    }, remainingMs);
+    timer.unref();
     proc.stdin?.on("error", () => {});
     proc.stdin?.end(options.stdin);
   });
 }
 
-async function runGuardHook(directory: string, payload: Record<string, unknown>) {
+async function runGuardHook(
+  directory: string,
+  payload: Record<string, unknown>,
+  deadlineMs: number,
+) {
   const workspace = directory?.trim() || process.cwd();
   const guardArgv = [
     "guard",
@@ -167,6 +317,7 @@ async function runGuardHook(directory: string, payload: Record<string, unknown>)
   return spawnGuardProcess({
     args: ["-I", "-S", "-s", "-c", GUARD_HOOK_LAUNCHER],
     cwd: GUARD_HOME,
+    deadlineMs,
     env: hookProcessEnv(guardArgv),
     stdin: JSON.stringify(payload),
   });
@@ -278,16 +429,21 @@ export const HolGuardPretoolPlugin = async ({
         return;
       }
       const workspace = directory?.trim() || process.cwd();
+      const deadlineMs = Date.now() + GUARD_HOOK_TIMEOUT_MS;
       let result;
       try {
-        result = await runGuardHook(directory, {
-          hook_event_name: "PreToolUse",
-          event: "PreToolUse",
-          tool_name: input.tool,
-          tool_input: { command },
-          cwd: workspace,
-          source_scope: directory?.trim() ? "project" : "global",
-        });
+        result = await runGuardHook(
+          directory,
+          {
+            hook_event_name: "PreToolUse",
+            event: "PreToolUse",
+            tool_name: input.tool,
+            tool_input: { command },
+            cwd: workspace,
+            source_scope: directory?.trim() ? "project" : "global",
+          },
+          deadlineMs,
+        );
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
         throw new Error(
@@ -328,8 +484,16 @@ def _pretool_hook_launcher_code(
         "import json,os,sys;"
         f"trusted={json.dumps(trusted_entries)};"
         "sys.path[:0]=trusted;"
-        "from codex_plugin_scanner.cli import main;"
-        f"raise SystemExit(main(json.loads(os.environ[{_HOOK_ARGV_ENV!r}])))"
+        "from pathlib import Path;"
+        "import codex_plugin_scanner;"
+        "from codex_plugin_scanner.guard.adapters.bounded_cli_hook_bridge import run_bounded_cli_hook;"
+        f"argv=json.loads(os.environ[{_HOOK_ARGV_ENV!r}]);"
+        "guard_index=argv.index('--guard-home');"
+        "guard_home=argv[guard_index+1];"
+        "package_root=Path(codex_plugin_scanner.__file__).resolve().parent.parent;"
+        "config={'python_executable':sys.executable,'package_root':str(package_root),"
+        "'guard_home':guard_home,'cli_args':argv,'harness':'opencode','timeout_seconds':25};"
+        "raise SystemExit(run_bounded_cli_hook(config,input_text=sys.stdin.read(1000001)))"
     )
 
 

--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_cli_runtime_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_cli_runtime_source.py
@@ -1,0 +1,180 @@
+"""Generated Pi CLI fallback and daemon recovery runtime source."""
+
+from __future__ import annotations
+
+CLI_RUNTIME_HELPERS_SOURCE = r"""
+type GuardCliResult = {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error & { code?: unknown };
+};
+let guardCliEvaluationInFlight = false;
+let guardCliContainmentFailed = false;
+let guardDaemonRecoveryInFlight: Promise<boolean> | null = null;
+
+function waitForGuardCliChildExit(
+  child: ReturnType<typeof spawn>,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (exited: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(watchdog);
+      resolve(exited);
+    };
+    const watchdog = setTimeout(
+      () => finish(child.exitCode !== null || child.signalCode !== null),
+      timeoutMs,
+    );
+    child.once('exit', () => finish(true));
+  });
+}
+
+async function signalGuardCliChild(
+  child: ReturnType<typeof spawn>,
+  signal: NodeJS.Signals,
+): Promise<boolean> {
+  if (process.platform === 'win32' && typeof child.pid === 'number') {
+    const systemRoot = process.env.SystemRoot ?? process.env.SYSTEMROOT;
+    if (systemRoot) {
+      const treeKilled = await new Promise<boolean>((resolve) => {
+        const taskkill = spawn(
+          `${systemRoot}\\System32\\taskkill.exe`,
+          ['/PID', String(child.pid), '/T', '/F'],
+          { stdio: 'ignore', windowsHide: true },
+        );
+        const watchdog = setTimeout(() => {
+          taskkill.kill('SIGKILL');
+          resolve(false);
+        }, 200);
+        taskkill.once('error', () => {
+          clearTimeout(watchdog);
+          resolve(false);
+        });
+        taskkill.once('close', (status) => {
+          clearTimeout(watchdog);
+          resolve(status === 0);
+        });
+      });
+      if (!treeKilled) child.kill('SIGKILL');
+      return waitForGuardCliChildExit(child, 200);
+    }
+  }
+  if (process.platform !== 'win32' && typeof child.pid === 'number') {
+    try {
+      process.kill(-child.pid, signal);
+      return waitForGuardCliChildExit(child, 200);
+    } catch {}
+  }
+  child.kill(signal);
+  return waitForGuardCliChildExit(child, 200);
+}
+
+function runGuardCliCommand(
+  command: string,
+  args: string[],
+  serializedPayload: string,
+  timeoutMs: number,
+): Promise<GuardCliResult> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timedOut = false;
+    let stdout = '';
+    let stderr = '';
+    let escalationHandle: ReturnType<typeof setTimeout> | undefined;
+    let forcedSettleHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeoutError = () => Object.assign(
+      new Error('Guard child process timed out.'),
+      { code: 'ETIMEDOUT' },
+    );
+    const settle = (result: GuardCliResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutHandle);
+      if (escalationHandle !== undefined) clearTimeout(escalationHandle);
+      if (forcedSettleHandle !== undefined) clearTimeout(forcedSettleHandle);
+      resolve(result);
+    };
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(command, args, {
+        detached: process.platform !== 'win32',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (error) {
+      resolve({ status: null, stdout, stderr, error: error as Error });
+      return;
+    }
+    const timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      void signalGuardCliChild(child, 'SIGTERM').then(() => {
+        escalationHandle = setTimeout(() => {
+          void signalGuardCliChild(child, 'SIGKILL').then((killed) => {
+            if (!killed) {
+              guardCliContainmentFailed = true;
+              settle({
+                status: null,
+                stdout,
+                stderr,
+                error: Object.assign(
+                  new Error('Guard child process containment could not be confirmed.'),
+                  { code: 'ECONTAINMENT' },
+                ),
+              });
+              return;
+            }
+            forcedSettleHandle = setTimeout(
+              () => settle({ status: null, stdout, stderr, error: timeoutError() }),
+              100,
+            );
+          });
+        }, 100);
+      });
+    }, timeoutMs);
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
+      stdout = (stdout + chunk).slice(-GUARD_TEXT_LIMIT_CHARS);
+    });
+    child.stderr?.on('data', (chunk: string) => {
+      stderr = (stderr + chunk).slice(-GUARD_TEXT_LIMIT_CHARS);
+    });
+    child.once('error', (error) => {
+      if (!timedOut) settle({ status: null, stdout, stderr, error });
+    });
+    child.once('close', (status) => {
+      if (!timedOut) settle({ status, stdout, stderr });
+    });
+    child.stdin?.once('error', () => {});
+    child.stdin?.end(serializedPayload ? `${serializedPayload}\n` : '');
+  });
+}
+
+type GuardDaemonRecoveryKind = "authenticated-control-plane-failure" | "transport-failure";
+
+async function recoverGuardDaemon(
+  timeoutMs: number,
+  failureKind: GuardDaemonRecoveryKind,
+): Promise<boolean> {
+  if (guardCliContainmentFailed) return false;
+  if (guardDaemonRecoveryInFlight !== null) return guardDaemonRecoveryInFlight;
+  guardDaemonRecoveryInFlight = (async () => {
+    const result = await runGuardCliCommand(
+      GUARD_DAEMON_RECOVERY_COMMAND,
+      [...GUARD_DAEMON_RECOVERY_ARGS, failureKind],
+      '',
+      timeoutMs,
+    );
+    return result.error === undefined && result.status === 0;
+  })();
+  try {
+    return await guardDaemonRecoveryInFlight;
+  } finally {
+    guardDaemonRecoveryInFlight = null;
+  }
+}
+"""

--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
@@ -3,18 +3,22 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 from ..daemon.manager import GUARD_DAEMON_COMPATIBILITY_VERSION
 from .pi_extension_approval_source import APPROVAL_RESUME_HELPERS_SOURCE
+from .pi_extension_cli_runtime_source import CLI_RUNTIME_HELPERS_SOURCE
 from .pi_extension_content_source import CONTENT_REVIEW_HELPERS_SOURCE
 
 # Pi terminates extension hooks at roughly 4.5 seconds. Keep Guard's daemon and
-# CLI fallback path below that host deadline so its fail-open result can return.
+# recovery/fallback paths below that host deadline so a fail-safe result returns.
 GUARD_HOOK_TIMEOUT_MS = 4_000
 GUARD_HOOK_DEADLINE_RESERVE_MS = 250
-GUARD_DAEMON_HOOK_TIMEOUT_MS = 1_250
-GUARD_CLI_HOOK_TIMEOUT_MS = 2_250
+GUARD_DAEMON_HOOK_TIMEOUT_MS = 1_600
+GUARD_DAEMON_RECOVERY_TIMEOUT_MS = 600
+GUARD_DAEMON_RETRY_TIMEOUT_MS = 500
+GUARD_CLI_HOOK_TIMEOUT_MS = 1_000
 GUARD_HOOK_TEXT_LIMIT_CHARS = 12_000
 GUARD_HOOK_CONTENT_ITEM_LIMIT = 24
 GUARD_HOOK_OBJECT_KEY_LIMIT = 24
@@ -32,15 +36,43 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
     home_dir_is_default_json = "true" if home_dir.resolve() == Path.home().resolve() else "false"
     config_path_json = json.dumps(str(settings_path))
     compatibility_version_json = json.dumps(GUARD_DAEMON_COMPATIBILITY_VERSION)
+    package_root = Path(__file__).resolve().parents[3]
+    cli_wrapper_bootstrap = (
+        "import json,sys;"
+        f"sys.path.insert(0,{str(package_root)!r});"
+        "from pathlib import Path;"
+        "from codex_plugin_scanner.guard.adapters.bounded_cli_hook_bridge import run_bounded_cli_hook;"
+        "argv=json.loads(sys.argv[1]);"
+        "config={'python_executable':sys.executable,"
+        f"'package_root':{str(package_root)!r},"
+        f"'guard_home':{str(guard_home)!r},"
+        "'cli_args':argv,'harness':'pi','timeout_seconds':0.75};"
+        "raise SystemExit(run_bounded_cli_hook(config,input_text=sys.stdin.read(1000001)))"
+    )
+    cli_wrapper_command_json = json.dumps(str(Path(sys.executable).expanduser().absolute()))
+    cli_wrapper_args_json = json.dumps(["-I", "-c", cli_wrapper_bootstrap])
+    recovery_bootstrap = (
+        "import sys;"
+        f"sys.path.insert(0,{str(package_root)!r});"
+        "from pathlib import Path;"
+        "from codex_plugin_scanner.guard.daemon.manager import recover_guard_daemon_after_hook_failure;"
+        f"recover_guard_daemon_after_hook_failure(Path({str(guard_home)!r}),"
+        f"home_dir=Path({str(home_dir)!r}),failure_kind=sys.argv[1])"
+    )
+    recovery_command_json = json.dumps(str(Path(sys.executable).expanduser().absolute()))
+    recovery_args_json = json.dumps(["-I", "-c", recovery_bootstrap])
     return (
-        'import { spawn, spawnSync } from "node:child_process";\n'
-        'import { createCipheriv, createHash, randomBytes } from "node:crypto";\n'
+        'import { spawn } from "node:child_process";\n'
+        + 'import { createCipheriv, createHash, randomBytes } from "node:crypto";\n'  # pyright: ignore[reportImplicitStringConcatenation]
         'import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";\n'
         'import { tmpdir } from "node:os";\n'
         'import { join } from "node:path";\n'
         'import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";\n'
         "\n"
-        'const GUARD_COMMAND_CANDIDATES = ["plugin-guard", "hol-guard"] as const;\n'
+        f"const GUARD_CLI_WRAPPER_COMMAND = {cli_wrapper_command_json};\n"
+        f"const GUARD_CLI_WRAPPER_ARGS = {cli_wrapper_args_json};\n"
+        f"const GUARD_DAEMON_RECOVERY_COMMAND = {recovery_command_json};\n"
+        f"const GUARD_DAEMON_RECOVERY_ARGS = {recovery_args_json};\n"
         f"const GUARD_ARGS = {guard_args_json};\n"
         f"const GUARD_HOME = {guard_home_json};\n"
         f"const GUARD_HOME_DIR = {home_dir_json};\n"
@@ -50,6 +82,8 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         f"const GUARD_TIMEOUT_MS = {GUARD_HOOK_TIMEOUT_MS};\n"
         f"const GUARD_DEADLINE_RESERVE_MS = {GUARD_HOOK_DEADLINE_RESERVE_MS};\n"
         f"const GUARD_DAEMON_TIMEOUT_MS = {GUARD_DAEMON_HOOK_TIMEOUT_MS};\n"
+        f"const GUARD_DAEMON_RECOVERY_TIMEOUT_MS = {GUARD_DAEMON_RECOVERY_TIMEOUT_MS};\n"
+        f"const GUARD_DAEMON_RETRY_TIMEOUT_MS = {GUARD_DAEMON_RETRY_TIMEOUT_MS};\n"
         f"const GUARD_CLI_TIMEOUT_MS = {GUARD_CLI_HOOK_TIMEOUT_MS};\n"
         f"const GUARD_TEXT_LIMIT_CHARS = {GUARD_HOOK_TEXT_LIMIT_CHARS};\n"
         f"const GUARD_CONTENT_ITEM_LIMIT = {GUARD_HOOK_CONTENT_ITEM_LIMIT};\n"
@@ -75,7 +109,14 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "  reviewed_output_sha256?: string;\n"
         '  notice?: "none" | "excerpt" | "warning";\n'
         "  reason_code?: string;\n"
-        "};\n" + CONTENT_REVIEW_HELPERS_SOURCE + "type GuardDaemonConnection = { port: number; authToken: string };\n"
+        "};\n"
+        + CLI_RUNTIME_HELPERS_SOURCE
+        + CONTENT_REVIEW_HELPERS_SOURCE
+        + "type GuardDaemonConnection = { port: number; authToken: string };\n"
+        + "type GuardDaemonAttempt = {\n"  # pyright: ignore[reportImplicitStringConcatenation]
+        "  response: GuardResponse | null;\n"
+        "  recoveryKind: GuardDaemonRecoveryKind | null;\n"
+        "};\n"
         "\n"
         "function loadGuardDaemonConnection(): GuardDaemonConnection | null {\n"
         "  let port = 0;\n"
@@ -99,16 +140,19 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "async function daemonGuardResponse(\n"
         "  serializedPayload: string,\n"
         "  cwd?: string,\n"
-        "): Promise<GuardResponse | null> {\n"
-        "  if (typeof fetch !== 'function') return null;\n"
+        "  timeoutMs: number = GUARD_DAEMON_TIMEOUT_MS,\n"
+        "): Promise<GuardDaemonAttempt> {\n"
+        '  if (typeof fetch !== "function") {\n'
+        '    return { response: null, recoveryKind: "transport-failure" };\n'
+        "  }\n"
         "  const connection = loadGuardDaemonConnection();\n"
-        "  if (!connection) return null;\n"
+        '  if (!connection) return { response: null, recoveryKind: "transport-failure" };\n'
         '  const workspace = typeof cwd === "string" && cwd ? cwd : process.cwd();\n'
         "  const params = new URLSearchParams({ 'guard-home': GUARD_HOME });\n"
         "  if (workspace) params.set('workspace', workspace);\n"
         "  if (!GUARD_HOME_DIR_IS_DEFAULT && GUARD_HOME_DIR) params.set('home', GUARD_HOME_DIR);\n"
         "  const controller = typeof AbortController === 'function' ? new AbortController() : undefined;\n"
-        "  const timeoutHandle = setTimeout(() => controller?.abort(), GUARD_DAEMON_TIMEOUT_MS);\n"
+        "  const timeoutHandle = setTimeout(() => controller?.abort(), timeoutMs);\n"
         "  try {\n"
         "    const response = await fetch(`http://127.0.0.1:${connection.port}/v1/hooks/pi?${params.toString()}`, {\n"
         "      method: 'POST',\n"
@@ -119,18 +163,53 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "      body: serializedPayload,\n"
         "      signal: controller?.signal,\n"
         "    });\n"
-        "    if (!response.ok) return null;\n"
+        "    if (!response.ok) {\n"
+        "      let reasonCode = `daemon_http_${response.status}`;\n"
+        "      try {\n"
+        "        const errorPayload = JSON.parse((await response.text()).slice(0, GUARD_TEXT_LIMIT_CHARS)) as {\n"
+        "          error?: unknown;\n"
+        "        };\n"
+        "        if (typeof errorPayload.error === 'string' && errorPayload.error) {\n"
+        "          reasonCode = errorPayload.error;\n"
+        "        }\n"
+        "      } catch {}\n"
+        "      if (response.status === 401 || response.status === 403) {\n"
+        "        return {\n"
+        "          response: null,\n"
+        '          recoveryKind: "authenticated-control-plane-failure",\n'
+        "        };\n"
+        "      }\n"
+        "      return {\n"
+        "        response: {\n"
+        '          decision: "deny",\n'
+        "          reason: `HOL Guard could not safely review this action (${reasonCode}).`,\n"
+        "          reason_code: reasonCode,\n"
+        "        },\n"
+        "        recoveryKind: null,\n"
+        "      };\n"
+        "    }\n"
         "    const raw = (await response.text()).trim();\n"
-        "    if (!raw) return {};\n"
-        "    const parsed = JSON.parse(raw) as GuardResponse;\n"
-        "    return parsed && typeof parsed === 'object' ? parsed : null;\n"
+        "    if (!raw) return { response: {}, recoveryKind: null };\n"
+        "    try {\n"
+        "      const parsed = JSON.parse(raw) as GuardResponse;\n"
+        "      if (parsed && typeof parsed === 'object') {\n"
+        "        return { response: parsed, recoveryKind: null };\n"
+        "      }\n"
+        "    } catch {}\n"
+        "    return {\n"
+        "      response: {\n"
+        '        decision: "deny",\n'
+        '        reason: "HOL Guard received an invalid response from the authenticated local daemon.",\n'
+        '        reason_code: "daemon_invalid_response",\n'
+        "      },\n"
+        "      recoveryKind: null,\n"
+        "    };\n"
         "  } catch (error) {\n"
         "    if (error instanceof Error && error.name === 'AbortError') {\n"
-        "      // The daemon is only a fast path. Fall through to the bounded local CLI so\n"
-        "      // an unresponsive daemon cannot stall or bypass Guard enforcement.\n"
-        "      return null;\n"
+        "      // Classified transport recovery preserves a live overloaded daemon.\n"
+        '      return { response: null, recoveryKind: "transport-failure" };\n'
         "    }\n"
-        "    return null;\n"
+        '    return { response: null, recoveryKind: "transport-failure" };\n'
         "  } finally {\n"
         "    clearTimeout(timeoutHandle);\n"
         "  }\n"
@@ -188,21 +267,57 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         '        + "the safe size limit.",\n'
         "    };\n"
         "  }\n"
-        "  const daemonResponse = await daemonGuardResponse(serializedPayload, cwd);\n"
-        "  if (daemonResponse) {\n"
+        "  let daemonAttempt = await daemonGuardResponse(serializedPayload, cwd);\n"
+        "  if (daemonAttempt.response) {\n"
         "    cleanupPayloadReference();\n"
-        "    return daemonResponse;\n"
+        "    return daemonAttempt.response;\n"
         "  }\n"
-        "  let result: ReturnType<typeof spawnSync<string>> | null = null;\n"
+        "  if (daemonAttempt.recoveryKind !== null) {\n"
+        "    const recoveryTimeoutMs = Math.min(\n"
+        "      GUARD_DAEMON_RECOVERY_TIMEOUT_MS,\n"
+        "      Math.max(deadlineAt - Date.now(), 1),\n"
+        "    );\n"
+        "    if (await recoverGuardDaemon(recoveryTimeoutMs, daemonAttempt.recoveryKind)) {\n"
+        "      daemonAttempt = await daemonGuardResponse(\n"
+        "        serializedPayload,\n"
+        "        cwd,\n"
+        "        Math.min(GUARD_DAEMON_RETRY_TIMEOUT_MS, Math.max(deadlineAt - Date.now(), 1)),\n"
+        "      );\n"
+        "      if (daemonAttempt.response) {\n"
+        "        cleanupPayloadReference();\n"
+        "        return daemonAttempt.response;\n"
+        "      }\n"
+        "    }\n"
+        "  }\n"
+        "  if (guardCliContainmentFailed) {\n"
+        "    cleanupPayloadReference();\n"
+        "    return {\n"
+        '      decision: "deny",\n'
+        '      reason: "HOL Guard cannot safely start another fallback because prior child cleanup "\n'
+        '        + "was not confirmed.",\n'
+        '      reason_code: "guard_cli_containment_failed",\n'
+        "    };\n"
+        "  }\n"
+        "  if (guardCliEvaluationInFlight) {\n"
+        "    cleanupPayloadReference();\n"
+        "    return {\n"
+        '      decision: "deny",\n'
+        '      reason: "HOL Guard recovery is already reviewing another action. Retry after it completes.",\n'
+        '      reason_code: "guard_cli_recovery_busy",\n'
+        "    };\n"
+        "  }\n"
+        "  guardCliEvaluationInFlight = true;\n"
+        "  let result: GuardCliResult | null = null;\n"
         "  const cliTimeoutMs = Math.min(GUARD_CLI_TIMEOUT_MS, Math.max(deadlineAt - Date.now(), 1));\n"
-        "  for (const command of GUARD_COMMAND_CANDIDATES) {\n"
-        "    result = spawnSync(command, args, {\n"
-        "      input: `${serializedPayload}\\n`,\n"
-        '      encoding: "utf-8",\n'
-        "      timeout: cliTimeoutMs,\n"
-        "    });\n"
-        "    const resultError = result.error as (Error & { code?: unknown }) | undefined;\n"
-        "    if (!(result.error && resultError?.code === 'ENOENT')) break;\n"
+        "  try {\n"
+        "    result = await runGuardCliCommand(\n"
+        "      GUARD_CLI_WRAPPER_COMMAND,\n"
+        "      [...GUARD_CLI_WRAPPER_ARGS, JSON.stringify(args)],\n"
+        "      serializedPayload,\n"
+        "      cliTimeoutMs,\n"
+        "    );\n"
+        "  } finally {\n"
+        "    guardCliEvaluationInFlight = false;\n"
         "  }\n"
         "  cleanupPayloadReference();\n"
         "  if (result === null) {\n"
@@ -212,15 +327,13 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "    };\n"
         "  }\n"
         "  if (result.error) {\n"
-        "    const resultError = result.error as (Error & { code?: unknown }) | undefined;\n"
-        "    const errorMessage = resultError instanceof Error ? resultError.message : String(result.error);\n"
-        "    const errorCode = typeof resultError?.code === 'string' ? resultError.code : '';\n"
-        "    if (errorCode === 'ETIMEDOUT' || result.error?.name === 'TimeoutError') {\n"
+        "    const errorMessage = result.error.message;\n"
+        "    const errorCode = typeof result.error.code === 'string' ? result.error.code : '';\n"
+        "    if (errorCode === 'ETIMEDOUT') {\n"
         "      return {\n"
-        '        decision: "allow",\n'
-        '        notice: "warning",\n'
-        "        reason: `HOL Guard Pi hook timed out while reviewing this action; `\n"
-        "          + `continuing without a completed review.`,\n"
+        '        decision: "deny",\n'
+        '        reason: "HOL Guard could not complete fallback review before the Pi deadline. Retry the action.",\n'
+        '        reason_code: "guard_cli_recovery_timeout",\n'
         "      };\n"
         "    }\n"
         "    return {\n"
@@ -277,7 +390,7 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "  if (isError) result.isError = true;\n"
         "  return result;\n"
         "}\n"
-        "\n" + APPROVAL_RESUME_HELPERS_SOURCE + "export default function (pi: ExtensionAPI) {\n"
+        "\n" + APPROVAL_RESUME_HELPERS_SOURCE + "export default function (pi: ExtensionAPI) {\n"  # pyright: ignore[reportImplicitStringConcatenation]
         "  const blockedToolResults = new Map<string, string>();\n"
         "  const pendingApprovalResumes = new Set<string>();\n"
         "  const openedApprovalCenters = new Set<string>();\n"

--- a/src/codex_plugin_scanner/guard/adapters/zcode.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode.py
@@ -31,6 +31,7 @@ from .base import (
     _json_payload,
     _shell_command,
 )
+from .bounded_cli_hook_bridge import bounded_cli_hook_command
 from .zcode_config import (
     GUARD_MANAGED_MARKER,
     ZCODE_BUNDLE_IDENTIFIER,
@@ -54,6 +55,7 @@ from .zcode_config import (
 _ZCODE_HOME_ENV_VAR = "ZCODE_HOME"
 _ZCODE_PRETOOL_TIMEOUT_SECONDS = 30
 _ZCODE_PROMPT_TIMEOUT_SECONDS = 30
+_GUARD_HOOK_INTERNAL_TIMEOUT_SECONDS = 25
 
 
 class ZCodeHarnessAdapter(HarnessAdapter):
@@ -252,14 +254,14 @@ class ZCodeHarnessAdapter(HarnessAdapter):
             guard_args.extend(["--home", str(context.home_dir)])
         if context.workspace_dir is not None:
             guard_args.extend(["--workspace", str(context.workspace_dir)])
-        package_root = Path(__file__).resolve().parents[3]
-        code = (
-            "import sys;"
-            f"sys.path.insert(0, {str(package_root)!r});"
-            "from codex_plugin_scanner.cli import main;"
-            f"raise SystemExit(main({guard_args!r}))"
+        return bounded_cli_hook_command(
+            python_executable=sys.executable,
+            package_root=Path(__file__).resolve().parents[3],
+            guard_home=context.guard_home,
+            cli_args=guard_args,
+            harness="zcode",
+            timeout_seconds=_GUARD_HOOK_INTERNAL_TIMEOUT_SECONDS,
         )
-        return (sys.executable, "-c", code)
 
     @staticmethod
     def _managed_command_wrapper(hook_command: str) -> str:

--- a/src/codex_plugin_scanner/guard/cli/commands_hook.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook.py
@@ -155,6 +155,15 @@ def _run_guard_hook_command(
         return 0
     if args.harness == "copilot":
         runtime_workspace = _resolve_copilot_workspace_root(runtime_workspace)
+    post_tool_result = _try_resident_post_tool_review(
+        args,
+        context=context,
+        payload=payload,
+        runtime_workspace=runtime_workspace,
+        store=store,
+    )
+    if post_tool_result is not None:
+        return post_tool_result
     # Fast path: if the payload contains guard_source_ref, try the hook
     # review engine before the full runtime artifact path. This avoids
     # CLI command layering cost for safe source-file reads.
@@ -436,6 +445,32 @@ def _run_guard_hook_command(
         store=store,
         post_claim_revalidator=revalidate_generic_after_claim,
     )
+
+
+def _try_resident_post_tool_review(
+    args: argparse.Namespace,
+    *,
+    context: HarnessContext,
+    payload: dict[str, object],
+    runtime_workspace: Path | None,
+    store: GuardStore,
+) -> int | None:
+    """Use the deterministic review engine for every completed tool action."""
+
+    if _hook_event_name(payload) != "PostToolUse":
+        return None
+    from ..daemon.hook_worker import HookWorker
+
+    result = HookWorker(store=store).review_http_payload(
+        payload=payload,
+        params={"runtime-harness": [args.harness]},
+        default_harness=args.harness,
+        home_dir=context.home_dir,
+        guard_home=context.guard_home,
+        workspace=runtime_workspace,
+    )
+    _emit("hook", result, getattr(args, "json", False))
+    return 0
 
 
 def _try_source_ref_fast_path(

--- a/src/codex_plugin_scanner/guard/codex_hook_bridge_runtime.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_bridge_runtime.py
@@ -20,7 +20,13 @@ class BridgeConfig(TypedDict):
 
 
 class TrustedHookLaunch(Protocol):
-    def run_start(self, command: Sequence[str], *, timeout_seconds: float) -> bool: ...
+    def run_start(
+        self,
+        command: Sequence[str],
+        *,
+        timeout_seconds: float,
+        failure_kind: str = "transport-failure",
+    ) -> bool: ...
 
     def run_fallback(
         self,

--- a/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
@@ -25,6 +25,7 @@ _HOOK_ENVIRONMENT_KEYS = frozenset(
         "CODEX_HOME",
         "COMSPEC",
         "HOME",
+        "HOL_GUARD_HOOK_FAILURE_KIND",
         "LANG",
         "PATH",
         "PATHEXT",
@@ -79,11 +80,16 @@ def isolated_daemon_start_command(
     resolved_home_dir = Path.home() if home_dir is None else home_dir
 
     bootstrap = (
-        "import sys;"
+        "import os,sys;"
         f"sys.path.insert(0, {str(package_root.resolve())!r});"
         "from pathlib import Path;"
         "from codex_plugin_scanner.guard.daemon import recover_guard_daemon_after_hook_failure;"
-        f"recover_guard_daemon_after_hook_failure(Path({str(guard_home)!r}),home_dir=Path({str(resolved_home_dir)!r}))"
+        "failure_kind=os.environ.get('HOL_GUARD_HOOK_FAILURE_KIND','transport-failure');"
+        "failure_kind=failure_kind if failure_kind in"
+        " {'overload','transport-failure','authenticated-control-plane-failure'}"
+        " else 'transport-failure';"
+        f"recover_guard_daemon_after_hook_failure(Path({str(guard_home)!r}),"
+        f"home_dir=Path({str(resolved_home_dir)!r}),failure_kind=failure_kind)"
     )
     return (python_executable, "-I", "-c", bootstrap)
 
@@ -130,6 +136,7 @@ def run_isolated_hook_process(
     environment: Mapping[str, str],
     timeout_seconds: float,
     output_limit: int = _HOOK_SUBPROCESS_OUTPUT_LIMIT,
+    allow_windows_breakaway: bool = False,
 ) -> BoundedHookProcessResult:
     """Run one child with bounded input lifetime and combined output bytes."""
 
@@ -140,6 +147,7 @@ def run_isolated_hook_process(
                 list(command),
                 cwd=cwd,
                 environment=dict(environment),
+                allow_breakaway=allow_windows_breakaway,
             )
         else:
             process = subprocess.Popen(

--- a/src/codex_plugin_scanner/guard/codex_hook_runtime_trust.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_runtime_trust.py
@@ -46,13 +46,28 @@ class TrustedCodexHookLaunch:
     cwd: Path
     environment: Mapping[str, str]
 
-    def run_start(self, command: Sequence[str], *, timeout_seconds: float) -> bool:
+    def run_start(
+        self,
+        command: Sequence[str],
+        *,
+        timeout_seconds: float,
+        failure_kind: str = "transport-failure",
+    ) -> bool:
+        if failure_kind not in {
+            "authenticated-control-plane-failure",
+            "overload",
+            "transport-failure",
+        }:
+            failure_kind = "transport-failure"
+        environment = dict(self.environment)
+        environment["HOL_GUARD_HOOK_FAILURE_KIND"] = failure_kind
         result = run_isolated_hook_process(
             command,
             input_text="",
             cwd=self.cwd,
-            environment=self.environment,
+            environment=environment,
             timeout_seconds=timeout_seconds,
+            allow_windows_breakaway=True,
         )
         return result.returncode == 0 and not result.output_limit_exceeded and not result.timed_out
 

--- a/src/codex_plugin_scanner/guard/codex_hook_windows_job.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_windows_job.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 _CREATE_SUSPENDED = 0x00000004
+_JOB_OBJECT_LIMIT_BREAKAWAY_OK = 0x00000800
 _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
 _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS = 9
 _TH32CS_SNAPTHREAD = 0x00000004
@@ -100,10 +101,11 @@ def spawn_windows_hook_process(
     *,
     cwd: Path,
     environment: dict[str, str],
+    allow_breakaway: bool = False,
 ) -> tuple[subprocess.Popen[bytes], WindowsHookJob]:
     """Start suspended, assign to a kill-on-close job, then resume."""
 
-    job = _create_job()
+    job = _create_job(allow_breakaway=allow_breakaway)
     process: subprocess.Popen[bytes] | None = None
     try:
         process = subprocess.Popen(
@@ -140,7 +142,7 @@ def _kernel32():  # type: ignore[no-untyped-def]
     return win_dll("kernel32", use_last_error=True)
 
 
-def _create_job() -> WindowsHookJob:
+def _create_job(*, allow_breakaway: bool = False) -> WindowsHookJob:
     kernel32 = _kernel32()
     create_job = kernel32.CreateJobObjectW
     create_job.argtypes = [ctypes.c_void_p, wintypes.LPCWSTR]
@@ -154,7 +156,7 @@ def _create_job() -> WindowsHookJob:
     job = WindowsHookJob(handle=int(raw_handle))
     try:
         limits = _ExtendedLimitInformation()
-        limits.basic_limit_information.limit_flags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        limits.basic_limit_information.limit_flags = _job_limit_flags(allow_breakaway=allow_breakaway)
         if not set_information(
             wintypes.HANDLE(job.handle),
             _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS,
@@ -167,6 +169,13 @@ def _create_job() -> WindowsHookJob:
         with contextlib.suppress(OSError):
             job.close()
         raise
+
+
+def _job_limit_flags(*, allow_breakaway: bool) -> int:
+    flags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    if allow_breakaway:
+        flags |= _JOB_OBJECT_LIMIT_BREAKAWAY_OK
+    return flags
 
 
 def _assign_and_resume(process: subprocess.Popen[bytes], job: WindowsHookJob) -> None:

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_protocol.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_protocol.py
@@ -1,0 +1,85 @@
+"""Content-safe protocol helpers for isolated hook workers."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+from collections.abc import Callable, Generator, Mapping
+from contextlib import contextmanager, redirect_stdout
+from typing import TextIO, TypeGuard, cast
+
+_HOOK_PROCESS_OUTPUT_LIMIT = 1_000_000
+HOOK_ENV_ALLOWLIST = frozenset(
+    {
+        "HOL_GUARD_MANAGED_CURSOR_HOOK",
+        "HOL_GUARD_CURSOR_APPROVAL_BINDING",
+        "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF",
+        "CURSOR_PROJECT_DIR",
+        "CURSOR_VERSION",
+        "CURSOR_TRACE_ID",
+        "CURSOR_SESSION_ID",
+        "CURSOR_TRANSCRIPT_PATH",
+    }
+)
+
+
+def capture_hook_command(run: Callable[[TextIO], int]) -> dict[str, object]:
+    output = io.StringIO()
+    with redirect_stdout(output):
+        exit_code = run(output)
+    raw_response = output.getvalue()
+    if len(raw_response.encode("utf-8")) > _HOOK_PROCESS_OUTPUT_LIMIT:
+        return {"payload": None, "reason_code": "daemon_hook_process_output_limit"}
+    if not raw_response.strip():
+        return {
+            "payload": {} if exit_code == 0 else None,
+            "reason_code": None if exit_code == 0 else "daemon_hook_process_failed",
+        }
+    try:
+        parsed = cast(object, json.loads(raw_response))
+    except json.JSONDecodeError:
+        return {"payload": None, "reason_code": "daemon_hook_process_invalid_json"}
+    typed_payload = as_string_object_dict(parsed)
+    if typed_payload is None:
+        return {"payload": None, "reason_code": "daemon_hook_process_invalid_json"}
+    return {"payload": typed_payload, "reason_code": None}
+
+
+def as_string_object_dict(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    raw = cast(dict[object, object], value)
+    if not all(isinstance(key, str) for key in raw):
+        return None
+    return {key: item for key, item in raw.items() if isinstance(key, str)}
+
+
+def is_pair(value: object) -> TypeGuard[tuple[object, object]]:
+    return isinstance(value, tuple) and len(cast(tuple[object, ...], value)) == 2
+
+
+@contextmanager
+def applied_hook_environment(request: Mapping[str, object]) -> Generator[None, None, None]:
+    raw_overlay = request.get("hook_env")
+    overlay = as_string_object_dict(raw_overlay) or {}
+    applied = {key: value for key, value in overlay.items() if key in HOOK_ENV_ALLOWLIST and isinstance(value, str)}
+    original_env = {key: os.environ.get(key) for key in applied}
+    try:
+        os.environ.update(applied)
+        yield
+    finally:
+        for key, original in original_env.items():
+            if original is None:
+                _ = os.environ.pop(key, None)
+            else:
+                os.environ[key] = original
+
+
+__all__ = [
+    "HOOK_ENV_ALLOWLIST",
+    "applied_hook_environment",
+    "as_string_object_dict",
+    "capture_hook_command",
+    "is_pair",
+]

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
@@ -1,0 +1,485 @@
+"""Prewarmed, killable process isolation for daemon hook evaluation."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import multiprocessing
+import os
+import queue
+import signal
+import threading
+import time
+from collections.abc import Mapping
+from contextlib import suppress
+from multiprocessing.connection import Connection
+from pathlib import Path
+from typing import TYPE_CHECKING, cast, final
+
+from .hook_process_protocol import (
+    HOOK_ENV_ALLOWLIST as _HOOK_ENV_ALLOWLIST,
+)
+from .hook_process_protocol import (
+    applied_hook_environment as _applied_hook_environment,
+)
+from .hook_process_protocol import (
+    as_string_object_dict as _as_string_object_dict,
+)
+from .hook_process_protocol import (
+    capture_hook_command as _capture_hook_command,
+)
+from .hook_process_protocol import (
+    is_pair as _is_pair,
+)
+from .hook_process_worker import HookProcessReview, HookWorkerSlot, terminate_worker_tree
+
+if TYPE_CHECKING:
+    from ..store import GuardStore
+
+_HOOK_PROCESS_LIMIT = 4
+_HOOK_PROCESS_TIMEOUT_SECONDS = 1.45
+_HOOK_PROCESS_READY_TIMEOUT_SECONDS = 5.0
+_HOOK_PROCESS_RETRY_MAX_SECONDS = 5.0
+_HOOK_SQLITE_TIMEOUT_ENV = "HOL_GUARD_INTERNAL_HOOK_SQLITE_TIMEOUT_MS"
+_TERMINATE_SIGNAL = getattr(signal, "SIGTERM", 15)
+_KILL_SIGNAL = getattr(signal, "SIGKILL", 9)
+
+
+@final
+class HookProcessRunner:
+    """Run hook policy in prewarmed workers outside the HTTP supervisor."""
+
+    def __init__(
+        self,
+        *,
+        guard_home: Path | None = None,
+        process_limit: int = _HOOK_PROCESS_LIMIT,
+        timeout_seconds: float = _HOOK_PROCESS_TIMEOUT_SECONDS,
+    ):
+        if process_limit < 1:
+            raise ValueError("process_limit must be positive")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._guard_home: Path | None = guard_home.resolve(strict=False) if guard_home is not None else None
+        self._process_limit: int = process_limit
+        self._timeout_seconds: float = timeout_seconds
+        self._slots: queue.Queue[HookWorkerSlot] = queue.Queue(maxsize=process_limit)
+        self._all_slots: dict[int, HookWorkerSlot] = {}
+        self._recovery_event: threading.Event = threading.Event()
+        self._spawn_thread: threading.Thread | None = None
+        self._supervisor_thread: threading.Thread | None = None
+        self._state_lock: threading.Lock = threading.Lock()
+        self._metrics_lock: threading.Lock = threading.Lock()
+        self._generation: int = 0
+        self._closed: bool = False
+        self._started: bool = False
+        self._timeouts: int = 0
+        self._failures: int = 0
+        self._restarts: int = 0
+
+    def start(self) -> None:
+        """Prewarm the fixed worker set before the daemon accepts hooks."""
+
+        with self._state_lock:
+            if self._started and not self._closed:
+                return
+            if self._closed:
+                self._slots = queue.Queue(maxsize=self._process_limit)
+            self._recovery_event.clear()
+            self._generation += 1
+            generation = self._generation
+            self._closed = False
+            self._started = True
+            supervisor = threading.Thread(
+                target=lambda: self._supervise_capacity(generation),
+                name="hol-guard-hook-worker-supervisor",
+                daemon=True,
+            )
+            self._supervisor_thread = supervisor
+        supervisor.start()
+        deadline = time.monotonic() + _HOOK_PROCESS_READY_TIMEOUT_SECONDS
+        while self._slots.qsize() < self._process_limit and time.monotonic() < deadline:
+            _ = self._recovery_event.wait(timeout=min(0.02, max(0.0, deadline - time.monotonic())))
+
+    def review(
+        self,
+        *,
+        payload: Mapping[str, object],
+        harness: str,
+        home_dir: Path,
+        guard_home: Path,
+        workspace: Path | None,
+        hook_env: Mapping[str, str],
+    ) -> HookProcessReview:
+        """Return parsed hook JSON or a stable fail-safe reason."""
+
+        if self._closed:
+            return HookProcessReview(None, "daemon_hook_process_closed")
+        if not self._started:
+            return HookProcessReview(None, "daemon_hook_process_not_ready")
+        try:
+            slot = self._slots.get_nowait()
+        except queue.Empty:
+            return HookProcessReview(None, "daemon_hook_process_overloaded")
+
+        request = {
+            "payload": dict(payload),
+            "harness": harness,
+            "home_dir": str(home_dir),
+            "guard_home": str(guard_home),
+            "workspace": str(workspace) if workspace is not None else None,
+            "hook_env": {key: value for key, value in hook_env.items() if key in _HOOK_ENV_ALLOWLIST},
+        }
+        try:
+            slot.connection.send(("review", request))
+            if not slot.connection.poll(self._timeout_seconds):
+                self._increment_metric("timeouts")
+                self._replace_slot_async(slot)
+                return HookProcessReview(None, "daemon_hook_process_timeout")
+            raw_message = slot.connection.recv()
+        except (BrokenPipeError, EOFError, OSError):
+            self._increment_metric("failures")
+            self._replace_slot_async(slot)
+            return HookProcessReview(None, "daemon_hook_process_failed")
+
+        if not _is_pair(raw_message):
+            self._increment_metric("failures")
+            self._replace_slot_async(slot)
+            return HookProcessReview(None, "daemon_hook_process_invalid_json")
+        message_type, result = raw_message
+        if message_type != "result":
+            self._increment_metric("failures")
+            self._replace_slot_async(slot)
+            return HookProcessReview(None, "daemon_hook_process_invalid_json")
+        if slot.process.is_alive() and not self._closed:
+            self._slots.put_nowait(slot)
+        else:
+            self._replace_slot_async(slot)
+        typed_result = _as_string_object_dict(result)
+        if typed_result is None:
+            return HookProcessReview(None, "daemon_hook_process_invalid_json")
+        reason_code = typed_result.get("reason_code")
+        response = typed_result.get("payload")
+        if response is None:
+            return HookProcessReview(
+                None,
+                reason_code if isinstance(reason_code, str) else "daemon_hook_process_failed",
+            )
+        typed_response = _as_string_object_dict(response)
+        if typed_response is None:
+            return HookProcessReview(None, "daemon_hook_process_invalid_json")
+        return HookProcessReview(typed_response, None)
+
+    def stats(self) -> dict[str, int]:
+        """Return content-free worker health counters."""
+
+        with self._state_lock:
+            worker_count = len(self._all_slots)
+        with self._metrics_lock:
+            return {
+                "configured": self._process_limit,
+                "workers": worker_count,
+                "ready": self._slots.qsize(),
+                "timeouts": self._timeouts,
+                "failures": self._failures,
+                "restarts": self._restarts,
+            }
+
+    def close(self) -> None:
+        """Stop every worker without waiting on hook code."""
+
+        with self._state_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._started = False
+            self._generation += 1
+            slots = list(self._all_slots.values())
+            self._all_slots.clear()
+            supervisor = self._supervisor_thread
+            spawn_thread = self._spawn_thread
+            self._recovery_event.set()
+        for slot in slots:
+            self._retire_slot(slot, graceful=True)
+        if supervisor is not None:
+            supervisor.join(timeout=1.0)
+        if spawn_thread is not None:
+            spawn_thread.join(timeout=0.2)
+        with self._state_lock:
+            if supervisor is not None and not supervisor.is_alive():
+                self._supervisor_thread = None
+            if spawn_thread is not None and not spawn_thread.is_alive():
+                self._spawn_thread = None
+
+    def _start_slot(self, *, generation: int) -> HookWorkerSlot:
+        context = multiprocessing.get_context("spawn")
+        parent_connection, child_connection = context.Pipe(duplex=True)
+        process = context.Process(
+            target=_hook_worker_main,
+            args=(child_connection, str(self._guard_home) if self._guard_home is not None else None),
+            name="hol-guard-hook-worker",
+            daemon=True,
+        )
+        try:
+            process.start()
+        except BaseException:
+            parent_connection.close()
+            child_connection.close()
+            raise
+        child_connection.close()
+        slot = HookWorkerSlot(process=process, connection=parent_connection)
+        with self._state_lock:
+            stale = self._closed or generation != self._generation
+            if not stale:
+                self._all_slots[process.pid or id(slot)] = slot
+        if stale:
+            self._retire_slot(slot)
+        return slot
+
+    @staticmethod
+    def _slot_became_ready(slot: HookWorkerSlot, timeout: float) -> bool:
+        if timeout <= 0:
+            return False
+        try:
+            return slot.connection.poll(timeout) and slot.connection.recv() == ("ready", None)
+        except (EOFError, OSError):
+            return False
+
+    def _supervise_capacity(self, generation: int) -> None:
+        """Reconcile desired worker capacity with bounded spawn pressure."""
+
+        retry_delay = 0.05
+        while True:
+            with self._state_lock:
+                closed = self._closed or generation != self._generation
+                should_wait = len(self._all_slots) >= self._process_limit
+            if closed:
+                return
+            if should_wait:
+                _ = self._recovery_event.wait()
+                self._recovery_event.clear()
+                retry_delay = 0.05
+                continue
+            self._recovery_event.clear()
+            replacement = self._start_slot_interruptibly(generation)
+            if replacement is None:
+                with self._state_lock:
+                    closed = self._closed or generation != self._generation
+                if closed:
+                    return
+                _ = self._recovery_event.wait(timeout=retry_delay)
+                retry_delay = min(retry_delay * 2, _HOOK_PROCESS_RETRY_MAX_SECONDS)
+                continue
+            if not self._slot_became_ready(replacement, _HOOK_PROCESS_READY_TIMEOUT_SECONDS):
+                self._increment_metric("failures")
+                self._retire_slot(replacement)
+                _ = self._recovery_event.wait(timeout=retry_delay)
+                retry_delay = min(retry_delay * 2, _HOOK_PROCESS_RETRY_MAX_SECONDS)
+                continue
+            try:
+                self._slots.put_nowait(replacement)
+            except queue.Full:
+                self._retire_slot(replacement)
+            retry_delay = 0.05
+
+    def _start_slot_interruptibly(self, generation: int) -> HookWorkerSlot | None:
+        outcomes: queue.Queue[HookWorkerSlot | BaseException] = queue.Queue(maxsize=1)
+
+        def attempt() -> None:
+            try:
+                outcomes.put(self._start_slot(generation=generation))
+            except BaseException as error:
+                outcomes.put(error)
+            finally:
+                with self._state_lock:
+                    if self._spawn_thread is threading.current_thread():
+                        self._spawn_thread = None
+
+        thread = threading.Thread(target=attempt, name="hol-guard-hook-worker-spawn", daemon=True)
+        with self._state_lock:
+            if self._closed or generation != self._generation:
+                return None
+            self._spawn_thread = thread
+        thread.start()
+        while thread.is_alive():
+            _ = self._recovery_event.wait(timeout=0.05)
+            with self._state_lock:
+                if self._closed or generation != self._generation:
+                    return None
+        outcome = outcomes.get_nowait()
+        if isinstance(outcome, BaseException):
+            self._increment_metric("failures")
+            return None
+        return outcome
+
+    def _replace_slot_async(self, slot: HookWorkerSlot) -> None:
+        self._retire_slot(slot)
+        self._increment_metric("restarts")
+        self._recovery_event.set()
+
+    def _increment_metric(self, metric: str) -> None:
+        with self._metrics_lock:
+            if metric == "timeouts":
+                self._timeouts += 1
+            elif metric == "failures":
+                self._failures += 1
+            elif metric == "restarts":
+                self._restarts += 1
+
+    def _retire_slot(self, slot: HookWorkerSlot, *, graceful: bool = False) -> None:
+        with slot.retire_lock:
+            if slot.retired:
+                return
+            slot.retired = True
+        with self._state_lock:
+            _ = self._all_slots.pop(slot.process.pid or id(slot), None)
+        if graceful and slot.process.is_alive():
+            with suppress(BrokenPipeError, OSError):
+                slot.connection.send(("stop", None))
+            slot.process.join(timeout=0.2)
+        if slot.process.is_alive():
+            terminate_worker_tree(slot.process, _TERMINATE_SIGNAL)
+            slot.process.join(timeout=0.5)
+        if slot.process.is_alive():
+            terminate_worker_tree(slot.process, _KILL_SIGNAL)
+            slot.process.join(timeout=0.5)
+        slot.connection.close()
+
+
+def _hook_worker_main(connection: Connection, configured_guard_home: str | None) -> None:
+    if os.name != "nt":
+        with suppress(OSError):
+            os.setsid()
+    os.environ[_HOOK_SQLITE_TIMEOUT_ENV] = "250"
+    for module_name in (
+        "codex_plugin_scanner.guard.cli.commands_hook",
+        "codex_plugin_scanner.guard.cli.commands_support_connect",
+        "codex_plugin_scanner.guard.config",
+    ):
+        _ = importlib.import_module(module_name)
+    from ..store import GuardStore
+
+    stores: dict[str, GuardStore] = {}
+    if configured_guard_home is not None:
+        with suppress(Exception):
+            stores[configured_guard_home] = GuardStore(Path(configured_guard_home))
+        with suppress(Exception):
+            _ = _run_resident_hook_request(
+                {
+                    "payload": {
+                        "hook_event_name": "PreToolUse",
+                        "tool_name": "Bash",
+                        "tool_input": {"command": "true"},
+                    },
+                    "hook_env": {},
+                    "harness": "pi",
+                    "home_dir": str(Path.home()),
+                    "guard_home": configured_guard_home,
+                    "workspace": None,
+                },
+                stores=stores,
+                configured_guard_home=configured_guard_home,
+            )
+    connection.send(("ready", None))
+    while True:
+        try:
+            raw_message = cast(object, connection.recv())
+        except EOFError:
+            return
+        if not _is_pair(raw_message):
+            connection.send(("result", {"payload": None, "reason_code": "daemon_hook_process_invalid_request"}))
+            continue
+        message_type, raw_request = raw_message
+        if message_type == "stop":
+            return
+        typed_request = _as_string_object_dict(raw_request)
+        if message_type != "review" or typed_request is None:
+            connection.send(("result", {"payload": None, "reason_code": "daemon_hook_process_invalid_request"}))
+            continue
+        try:
+            response = _run_resident_hook_request(
+                typed_request,
+                stores=stores,
+                configured_guard_home=configured_guard_home,
+            )
+        except BaseException:
+            response = {"payload": None, "reason_code": "daemon_hook_process_failed"}
+        connection.send(("result", response))
+
+
+def _run_resident_hook_request(
+    request: dict[str, object],
+    *,
+    stores: dict[str, GuardStore],
+    configured_guard_home: str | None,
+) -> dict[str, object]:
+    from ..adapters.base import HarnessContext
+    from ..cli.commands_hook import _run_guard_hook_command
+    from ..cli.commands_support_connect import _synced_policy_payload
+    from ..config import load_guard_config, overlay_synced_guard_policy
+    from ..store import GuardStore
+
+    payload = request.get("payload")
+    harness = request.get("harness")
+    home_value = request.get("home_dir")
+    guard_home_value = request.get("guard_home")
+    workspace_value = request.get("workspace")
+    if (
+        not isinstance(payload, dict)
+        or not isinstance(harness, str)
+        or not isinstance(home_value, str)
+        or not isinstance(guard_home_value, str)
+        or (workspace_value is not None and not isinstance(workspace_value, str))
+    ):
+        return {"payload": None, "reason_code": "daemon_hook_process_invalid_request"}
+    guard_home = Path(guard_home_value).resolve(strict=False)
+    if configured_guard_home is not None and guard_home != Path(configured_guard_home):
+        return {"payload": None, "reason_code": "daemon_hook_process_guard_home_mismatch"}
+    store_key = str(guard_home)
+    store = stores.get(store_key)
+    if store is None:
+        store = GuardStore(guard_home)
+        stores[store_key] = store
+    home_dir = Path(home_value)
+    workspace = Path(workspace_value) if isinstance(workspace_value, str) else None
+    context = HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace,
+        guard_home=guard_home,
+        home_override_explicit=True,
+        workspace_override_explicit=workspace is not None,
+    )
+    with _applied_hook_environment(request):
+        config = overlay_synced_guard_policy(
+            load_guard_config(guard_home, workspace=workspace),
+            _synced_policy_payload(store),
+        )
+        args = argparse.Namespace(
+            guard_command="hook",
+            home=str(home_dir),
+            guard_home=str(guard_home),
+            workspace=str(workspace) if workspace is not None else None,
+            runtime_harness=harness,
+            harness=harness,
+            artifact_id=None,
+            artifact_name=None,
+            policy_action=None,
+            event_file=None,
+            json=True,
+        )
+        return _capture_hook_command(
+            lambda output: _run_guard_hook_command(
+                args,
+                guard_home=guard_home,
+                workspace=workspace,
+                context=context,
+                store=store,
+                config=config,
+                input_text=json.dumps(payload, separators=(",", ":")),
+                output_stream=output,
+            )
+        )
+
+
+__all__ = ["HookProcessReview", "HookProcessRunner"]

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_worker.py
@@ -1,0 +1,87 @@
+"""Process primitives shared by the isolated hook worker pool."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import threading
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+class WorkerProcess(Protocol):
+    @property
+    def pid(self) -> int | None: ...
+
+    def is_alive(self) -> bool: ...
+    def join(self, timeout: float | None = None) -> None: ...
+    def terminate(self) -> None: ...
+    def kill(self) -> None: ...
+
+
+class WorkerConnection(Protocol):
+    def send(self, obj: object) -> None: ...
+    def recv(self) -> object: ...
+    def poll(self, timeout: float = 0.0) -> bool: ...
+    def close(self) -> None: ...
+
+
+@dataclass(slots=True)
+class HookWorkerSlot:
+    process: WorkerProcess
+    connection: WorkerConnection
+    retire_lock: threading.Lock = field(default_factory=threading.Lock)
+    retired: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class HookProcessReview:
+    """One isolated hook evaluation result."""
+
+    payload: dict[str, object] | None
+    reason_code: str | None
+
+
+def terminate_worker_tree(process: WorkerProcess, signal_number: int) -> None:
+    """Signal one isolated worker and its descendants."""
+
+    if os.name == "nt" and process.pid is not None:
+        system_root = os.environ.get("SYSTEMROOT")
+        taskkill = os.path.join(system_root, "System32", "taskkill.exe") if system_root else "taskkill.exe"
+        try:
+            result = subprocess.run(
+                [taskkill, "/PID", str(process.pid), "/T", "/F"],
+                check=False,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=1,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+            if result.returncode == 0:
+                return
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    if os.name != "nt" and process.pid is not None:
+        try:
+            os.killpg(process.pid, signal_number)
+            return
+        except (OSError, ProcessLookupError):
+            pass
+    if signal_number == getattr(signal, "SIGKILL", 9):
+        with suppress(OSError):
+            process.kill()
+    else:
+        with suppress(OSError):
+            process.terminate()
+
+
+__all__ = [
+    "HookProcessReview",
+    "HookWorkerSlot",
+    "WorkerConnection",
+    "WorkerProcess",
+    "terminate_worker_tree",
+]

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -24,7 +24,7 @@ import urllib.request
 from contextlib import contextmanager, suppress
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import BinaryIO, TypedDict
+from typing import BinaryIO, Literal, TypedDict
 
 from ...version import __version__
 from ..windows_paths import (
@@ -51,7 +51,7 @@ GUARD_DAEMON_COMPATIBILITY_VERSION = 2
 GUARD_DAEMON_START_TIMEOUT_SECONDS = 5.0
 GUARD_DAEMON_POST_UPDATE_START_TIMEOUT_SECONDS = 30.0
 GUARD_DAEMON_POLL_INTERVAL_SECONDS = 0.1
-GUARD_DAEMON_HOOK_RECOVERY_COOLDOWN_SECONDS = 5.0
+GUARD_DAEMON_HOOK_RECOVERY_COOLDOWN_SECONDS = 30.0
 _EPHEMERAL_GUARD_DAEMON_REAP_INTERVAL_SECONDS = 30.0
 _EPHEMERAL_GUARD_DAEMON_STALE_SECONDS = 30.0
 _EPHEMERAL_GUARD_DAEMON_MAX_STATES = 512
@@ -60,6 +60,7 @@ _GUARD_DAEMON_PRIVATE_DIR_MODE = 0o700
 _APPROVAL_CENTER_LOCATOR_FILE = "approval-center-locator.json"
 _GUARD_DAEMON_PENDING_LAUNCH_FILE = "daemon-launch-pending.json"
 _GUARD_DAEMON_OWNER_LOCK_FILE = "daemon-owner.lock"
+_GUARD_DAEMON_RECOVERY_LOCK_FILE = "daemon-recovery.lock"
 _GUARD_DAEMON_STATE_MAX_BYTES = 64 * 1024
 _GUARD_DAEMON_PENDING_LAUNCH_MAX_BYTES = 4096
 _GUARD_DAEMON_PROCESS_QUERY_TIMEOUT_SECONDS = 5.0
@@ -113,10 +114,18 @@ _GUARD_DAEMON_ENV_KEYS = frozenset(
 
 _START_LOCKS: dict[str, threading.Lock] = {}
 _START_LOCKS_GUARD = threading.Lock()
+_RECOVERY_LOCKS: dict[str, threading.Lock] = {}
+_RECOVERY_LOCKS_GUARD = threading.Lock()
 _STATE_WRITE_LOCKS: dict[str, threading.Lock] = {}
 _STATE_WRITE_LOCKS_GUARD = threading.Lock()
 _LAST_EPHEMERAL_REAP_AT = 0.0
 _runtime_fingerprint_cache: str | None = None
+
+GuardDaemonHookFailureKind = Literal[
+    "authenticated-control-plane-failure",
+    "overload",
+    "transport-failure",
+]
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -150,7 +159,11 @@ def _trusted_daemon_home(home_dir: Path | None) -> Path:
     return resolved
 
 
-def _daemon_launcher_env(*, home_dir: Path | None = None) -> dict[str, str]:
+def _daemon_launcher_env(
+    *,
+    home_dir: Path | None = None,
+    guard_home: Path | None = None,
+) -> dict[str, str]:
     """Build a minimal detached-daemon environment without Python startup hooks."""
 
     env = {key: value for key, value in os.environ.items() if key.upper() in _GUARD_DAEMON_ENV_KEYS}
@@ -164,6 +177,8 @@ def _daemon_launcher_env(*, home_dir: Path | None = None) -> dict[str, str]:
     )
     if os.name == "nt":
         env["USERPROFILE"] = str(trusted_home)
+    if guard_home is not None and not _guard_home_is_ephemeral(guard_home):
+        env["GUARD_DAEMON_IDLE_TIMEOUT_SECONDS"] = "0"
     return env
 
 
@@ -360,7 +375,7 @@ def ensure_guard_daemon(
                     stdin=subprocess.PIPE,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
-                    env=_daemon_launcher_env(home_dir=home_dir),
+                    env=_daemon_launcher_env(home_dir=home_dir, guard_home=guard_home),
                     creationflags=_windows_daemon_creation_flags(
                         allow_job_breakaway=allow_windows_job_breakaway,
                     ),
@@ -371,7 +386,7 @@ def ensure_guard_daemon(
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
-                    env=_daemon_launcher_env(home_dir=home_dir),
+                    env=_daemon_launcher_env(home_dir=home_dir, guard_home=guard_home),
                     start_new_session=True,
                 )
             pending_creation_time: int | None = None
@@ -441,24 +456,69 @@ def recover_guard_daemon_after_hook_failure(
     guard_home: Path,
     *,
     home_dir: Path | None = None,
+    failure_kind: GuardDaemonHookFailureKind = "authenticated-control-plane-failure",
 ) -> str:
-    """Restart an older daemon after its authenticated hook endpoint fails.
+    """Recover daemon service after a classified hook endpoint failure.
 
-    The normal health endpoint can remain responsive while hook workers or the
-    identity challenge are wedged. The managed bridge invokes this only after
-    an authenticated hook request fails. A short generation cooldown prevents
-    concurrent failed hooks from repeatedly retiring the replacement daemon.
+    Recovery is single-flight across threads and processes for one Guard home.
+    Capacity rejection preserves an authenticated current process even when
+    its health endpoint is saturated. Transport and authenticated control-plane
+    failures replace a process only when health cannot prove it responsive,
+    while the cooldown preserves a replacement long enough for concurrent and
+    immediately repeated callers to converge.
     """
 
-    with _guard_daemon_start_lock(guard_home):
-        state = load_authenticated_daemon_state(guard_home)
-        current_url = load_guard_daemon_url(guard_home)
-        if current_url is not None and _daemon_generation_is_recent(state):
-            return current_url
-        retire_all_guard_daemons_for_home(guard_home)
-        if not guard_daemon_retirement_is_complete(guard_home):
-            raise RuntimeError("Unresponsive Guard daemon could not be retired safely.")
-    return ensure_guard_daemon(guard_home, home_dir=home_dir)
+    if failure_kind not in {
+        "authenticated-control-plane-failure",
+        "overload",
+        "transport-failure",
+    }:
+        raise ValueError(f"Unsupported Guard daemon hook failure kind: {failure_kind}")
+
+    with _guard_daemon_recovery_lock(guard_home):
+        with _guard_daemon_start_lock(guard_home):
+            state = load_authenticated_daemon_state(guard_home)
+            current_url = load_guard_daemon_url(guard_home)
+            live_process_url = _authenticated_live_current_daemon_url(guard_home, state)
+            if current_url is not None:
+                if failure_kind != "authenticated-control-plane-failure" or _daemon_generation_is_recent(state):
+                    return current_url
+            elif live_process_url is not None and failure_kind == "overload":
+                return live_process_url
+            live_generation_url = current_url or live_process_url
+            if live_generation_url is not None:
+                retire_all_guard_daemons_for_home(guard_home)
+                if not guard_daemon_retirement_is_complete(guard_home):
+                    raise RuntimeError("Unresponsive Guard daemon could not be retired safely.")
+        if os.name == "nt":
+            return ensure_guard_daemon(
+                guard_home,
+                home_dir=home_dir,
+                allow_windows_job_breakaway=True,
+            )
+        return ensure_guard_daemon(guard_home, home_dir=home_dir)
+
+
+def _authenticated_live_current_daemon_url(
+    guard_home: Path,
+    state: dict[str, object] | None,
+) -> str | None:
+    """Locate an authenticated current process for overload preservation."""
+
+    if not isinstance(state, dict) or not _guard_daemon_state_matches_current_runtime(state):
+        return None
+    pid = state.get("pid")
+    port = state.get("port")
+    if (
+        not isinstance(pid, int)
+        or pid <= 0
+        or not isinstance(port, int)
+        or not 1 <= port <= 65_535
+        or not _guard_daemon_pid_is_running(pid)
+        or not _guard_daemon_pid_matches_command(pid, expected_guard_home=guard_home)
+    ):
+        return None
+    return f"http://127.0.0.1:{port}"
 
 
 def _daemon_generation_is_recent(state: dict[str, object] | None) -> bool:
@@ -1970,7 +2030,9 @@ def _guard_daemon_process_inventory_for_guard_home(guard_home: Path) -> list[tup
         parts = _split_process_command(command_line)
         if parts is None:
             lowered = command_line.lower()
-            if "codex_plugin_scanner" in lowered or "guard" in lowered:
+            if ("codex_plugin_scanner" in lowered or "guard" in lowered) and _malformed_command_may_launch_guard(
+                command_line
+            ):
                 return None
             continue
         if not _guard_daemon_command_parts_match(parts):
@@ -1986,6 +2048,20 @@ def _guard_daemon_process_inventory_for_guard_home(guard_home: Path) -> list[tup
         if matches_home:
             processes.append((pid, port))
     return sorted(processes, key=lambda item: item[1])
+
+
+def _malformed_command_may_launch_guard(command_line: str) -> bool:
+    first_token = command_line.lstrip().split(maxsplit=1)[0].strip("\"'")
+    launcher = ntpath.basename(first_token).lower()
+    return launcher.startswith("python") or launcher in {
+        "env",
+        "hol-guard",
+        "hol-guard.exe",
+        "plugin-guard",
+        "plugin-guard.exe",
+        "uv",
+        "uv.exe",
+    }
 
 
 def _running_guard_daemon_processes_for_guard_home(guard_home: Path) -> list[tuple[int, int]]:
@@ -2242,6 +2318,24 @@ def _guard_daemon_start_lock(guard_home: Path):
         thread_lock = _START_LOCKS.setdefault(lock_key, threading.Lock())
     with thread_lock:
         lock_path = guard_home / "daemon-start.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a+b") as handle:
+            _lock_daemon_start_file(handle)
+            try:
+                yield
+            finally:
+                _unlock_daemon_start_file(handle)
+
+
+@contextmanager
+def _guard_daemon_recovery_lock(guard_home: Path):
+    """Serialize a complete daemon recovery transaction for one Guard home."""
+
+    lock_key = str(guard_home.resolve())
+    with _RECOVERY_LOCKS_GUARD:
+        thread_lock = _RECOVERY_LOCKS.setdefault(lock_key, threading.Lock())
+    with thread_lock:
+        lock_path = guard_home / _GUARD_DAEMON_RECOVERY_LOCK_FILE
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         with lock_path.open("a+b") as handle:
             _lock_daemon_start_file(handle)

--- a/src/codex_plugin_scanner/guard/daemon/runtime_heartbeat.py
+++ b/src/codex_plugin_scanner/guard/daemon/runtime_heartbeat.py
@@ -1,0 +1,94 @@
+"""Coalesced storage-independent daemon heartbeat persistence."""
+
+from __future__ import annotations
+
+import threading
+from typing import Protocol, final
+
+
+class RuntimeHeartbeatStore(Protocol):
+    def try_touch_runtime_state(
+        self,
+        *,
+        session_id: str,
+        last_heartbeat_at: str,
+        timeout_seconds: float,
+    ) -> bool: ...
+
+
+@final
+class RuntimeHeartbeatWriter:
+    """Persist only the newest heartbeat outside request-handling threads."""
+
+    def __init__(
+        self,
+        *,
+        store: RuntimeHeartbeatStore,
+        session_id: str,
+        write_timeout_seconds: float = 0.05,
+        retry_interval_seconds: float = 0.05,
+    ) -> None:
+        self._store = store
+        self._session_id = session_id
+        self._write_timeout_seconds = max(write_timeout_seconds, 0.0)
+        self._retry_interval_seconds = max(retry_interval_seconds, 0.001)
+        self._condition = threading.Condition()
+        self._pending_heartbeat: str | None = None
+        self._stopping = False
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        with self._condition:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stopping = False
+            self._thread = threading.Thread(
+                target=self._run,
+                daemon=True,
+                name="guard-runtime-heartbeat-writer",
+            )
+            self._thread.start()
+
+    def touch(self, last_heartbeat_at: str) -> None:
+        with self._condition:
+            if self._stopping:
+                return
+            self._pending_heartbeat = last_heartbeat_at
+            self._condition.notify()
+
+    def stop(self, *, timeout_seconds: float = 1.0) -> None:
+        with self._condition:
+            self._stopping = True
+            self._condition.notify_all()
+            thread = self._thread
+        if thread is not None:
+            thread.join(timeout=max(timeout_seconds, 0.0))
+        with self._condition:
+            if self._thread is thread and (thread is None or not thread.is_alive()):
+                self._thread = None
+
+    def _run(self) -> None:
+        while True:
+            with self._condition:
+                while self._pending_heartbeat is None and not self._stopping:
+                    _ = self._condition.wait()
+                if self._stopping:
+                    return
+                heartbeat = self._pending_heartbeat
+            assert heartbeat is not None
+            succeeded = False
+            try:
+                succeeded = self._store.try_touch_runtime_state(
+                    session_id=self._session_id,
+                    last_heartbeat_at=heartbeat,
+                    timeout_seconds=self._write_timeout_seconds,
+                )
+            except Exception:
+                succeeded = False
+            with self._condition:
+                if succeeded and self._pending_heartbeat == heartbeat:
+                    self._pending_heartbeat = None
+                if self._stopping:
+                    return
+                if not succeeded:
+                    _ = self._condition.wait(timeout=self._retry_interval_seconds)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2,25 +2,24 @@
 
 from __future__ import annotations
 
-import argparse
 import base64
 import hashlib
 import hmac
 import inspect
-import io
 import json
 import mimetypes
 import os
 import platform
 import secrets
+import socket
 import sqlite3
 import tempfile
 import threading
 import time
 import uuid
 import webbrowser
-from collections.abc import Iterator, Mapping
-from contextlib import contextmanager, suppress
+from collections.abc import Mapping
+from contextlib import suppress
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -227,6 +226,7 @@ from .discovery import (
     load_authenticated_daemon_state,
     load_daemon_discovery_key,
 )
+from .hook_process_runner import HookProcessRunner
 from .manager import (
     GUARD_DAEMON_COMPATIBILITY_VERSION,
     acquire_guard_daemon_owner_lock,
@@ -237,6 +237,7 @@ from .manager import (
     repair_approval_center_locator,
     write_guard_daemon_state,
 )
+from .runtime_heartbeat import RuntimeHeartbeatWriter
 
 _HEADLESS_CLOUD_SYNC_STATE_LOCK = threading.Lock()
 _HEADLESS_CLOUD_SYNC_IN_FLIGHT: set[str] = set()
@@ -306,6 +307,32 @@ class _CursorReceiptContext(TypedDict):
     summary: dict[str, object]
 
 
+_MAX_CONCURRENT_DAEMON_REQUESTS = 64
+_MAX_CONCURRENT_DAEMON_CONTROL_REQUESTS = 8
+_MAX_CONCURRENT_DAEMON_CRITICAL_REQUESTS = 4
+_MAX_CONCURRENT_DAEMON_CONNECTIONS = (
+    _MAX_CONCURRENT_DAEMON_REQUESTS + _MAX_CONCURRENT_DAEMON_CONTROL_REQUESTS + _MAX_CONCURRENT_DAEMON_CRITICAL_REQUESTS
+)
+_MAX_CONCURRENT_RUNTIME_HOOKS = 32
+_MAX_CONCURRENT_RUNTIME_HOOKS_PER_HARNESS = 24
+_DAEMON_REQUEST_READ_TIMEOUT_SECONDS = 0.25
+_DAEMON_CONNECTION_ADMISSION_WAIT_SECONDS = 0.05
+_DAEMON_UNCLASSIFIED_WATCHDOG_POLL_SECONDS = 0.025
+_DAEMON_CONTROL_PATHS = frozenset(
+    {
+        "/v1/healthz/details",
+        "/v1/healthz/verify",
+    }
+)
+_DAEMON_CRITICAL_PATHS = frozenset(
+    {
+        "/healthz",
+        "/v1/daemon/identity-challenge",
+    }
+)
+_PEER_DISCONNECT_ERRORS = (BrokenPipeError, ConnectionResetError, ConnectionAbortedError)
+
+
 class _GuardDaemonHttpServer(ThreadingHTTPServer):
     store: GuardStore
     runtime: GuardSurfaceRuntime
@@ -335,6 +362,41 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
     containment_health_cache: dict[str, object] | None
     containment_health_cache_monotonic: float
     containment_health_cache_lock: threading.Lock
+    hook_capacity: threading.BoundedSemaphore
+    hook_capacity_limit: int
+    active_hook_requests: int
+    rejected_hook_requests: int
+    hook_harness_capacity: dict[str, threading.BoundedSemaphore]
+    hook_harness_active: dict[str, int]
+    hook_harness_rejected: dict[str, int]
+    hook_capacity_lock: threading.Lock
+    request_capacity: threading.BoundedSemaphore
+    request_capacity_limit: int
+    connection_capacity: threading.BoundedSemaphore
+    connection_capacity_limit: int
+    control_request_capacity: threading.BoundedSemaphore
+    control_request_capacity_limit: int
+    critical_request_capacity: threading.BoundedSemaphore
+    critical_request_capacity_limit: int
+    active_requests: int
+    rejected_requests: int
+    request_capacity_kinds: dict[int, str]
+    request_capacity_lock: threading.Lock
+    unclassified_connections: dict[int, tuple[socket.socket, float]]
+    unclassified_connections_lock: threading.Lock
+    unclassified_watchdog_stop: threading.Event
+    unclassified_watchdog_thread: threading.Thread | None
+    hook_process_runner: HookProcessRunner
+    runtime_heartbeat: RuntimeHeartbeatWriter
+
+    def handle_error(self, request: socket.socket, client_address: tuple[str, int]) -> None:
+        """Suppress expected peer disconnects without hiding server defects."""
+
+        import sys
+
+        if isinstance(sys.exc_info()[1], _PEER_DISCONNECT_ERRORS):
+            return
+        super().handle_error(request, client_address)
 
     def __init__(
         self,
@@ -377,6 +439,37 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
         self.containment_health_cache = None
         self.containment_health_cache_monotonic = 0.0
         self.containment_health_cache_lock = threading.Lock()
+        self.hook_capacity_limit = _MAX_CONCURRENT_RUNTIME_HOOKS
+        self.hook_capacity = threading.BoundedSemaphore(self.hook_capacity_limit)
+        self.active_hook_requests = 0
+        self.rejected_hook_requests = 0
+        self.hook_harness_capacity = {}
+        self.hook_harness_active = {}
+        self.hook_harness_rejected = {}
+        self.hook_capacity_lock = threading.Lock()
+        self.request_capacity_limit = _MAX_CONCURRENT_DAEMON_REQUESTS
+        self.request_capacity = threading.BoundedSemaphore(self.request_capacity_limit)
+        self.connection_capacity_limit = _MAX_CONCURRENT_DAEMON_CONNECTIONS
+        self.connection_capacity = threading.BoundedSemaphore(self.connection_capacity_limit)
+        self.control_request_capacity_limit = _MAX_CONCURRENT_DAEMON_CONTROL_REQUESTS
+        self.control_request_capacity = threading.BoundedSemaphore(self.control_request_capacity_limit)
+        self.critical_request_capacity_limit = _MAX_CONCURRENT_DAEMON_CRITICAL_REQUESTS
+        self.critical_request_capacity = threading.BoundedSemaphore(self.critical_request_capacity_limit)
+        self.active_requests = 0
+        self.rejected_requests = 0
+        self.request_capacity_kinds = {}
+        self.request_capacity_lock = threading.Lock()
+        self.unclassified_connections = {}
+        self.unclassified_connections_lock = threading.Lock()
+        self.unclassified_watchdog_stop = threading.Event()
+        self.unclassified_watchdog_thread = None
+        self.hook_process_runner = HookProcessRunner(guard_home=store.guard_home)
+        self.runtime_heartbeat = RuntimeHeartbeatWriter(
+            store=store,
+            session_id=runtime_session_id,
+            write_timeout_seconds=0.05,
+            retry_interval_seconds=0.05,
+        )
         self.store.set_policy_integrity_state_listener(self.publish_trust_state)
         from .hook_worker import HookWorker
 
@@ -386,6 +479,136 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
             runtime=self.runtime,
             opener=webbrowser.open,
         )
+
+    def process_request(self, request: socket.socket, client_address: tuple[str, int]) -> None:
+        admitted = self.connection_capacity.acquire(blocking=False)
+        if not admitted:
+            self._evict_oldest_unclassified_connection()
+            admitted = self.connection_capacity.acquire(
+                blocking=True,
+                timeout=_DAEMON_CONNECTION_ADMISSION_WAIT_SECONDS,
+            )
+        if not admitted:
+            with self.request_capacity_lock:
+                self.rejected_requests += 1
+            self.shutdown_request(request)
+            return
+        with suppress(OSError):
+            request.settimeout(_DAEMON_REQUEST_READ_TIMEOUT_SECONDS)
+        self._register_unclassified_connection(request)
+        with self.request_capacity_lock:
+            self.active_requests += 1
+        try:
+            super().process_request(request, client_address)
+        except BaseException:
+            self._release_request_capacity(request)
+            raise
+
+    def process_request_thread(self, request: socket.socket, client_address: tuple[str, int]) -> None:
+        try:
+            super().process_request_thread(request, client_address)
+        finally:
+            self._release_request_capacity(request)
+
+    def _release_request_capacity(self, request: socket.socket) -> None:
+        self.classify_connection(request)
+        with self.request_capacity_lock:
+            self.active_requests -= 1
+            capacity_kind = self.request_capacity_kinds.pop(id(request), None)
+        if capacity_kind is not None:
+            self._request_capacity_for_kind(capacity_kind).release()
+        self.connection_capacity.release()
+
+    def _register_unclassified_connection(self, request: socket.socket) -> None:
+        deadline = time.monotonic() + _DAEMON_REQUEST_READ_TIMEOUT_SECONDS
+        with self.unclassified_connections_lock:
+            self.unclassified_connections[id(request)] = (request, deadline)
+
+    def classify_connection(self, request: socket.socket) -> None:
+        with self.unclassified_connections_lock:
+            self.unclassified_connections.pop(id(request), None)
+
+    def _evict_oldest_unclassified_connection(self) -> None:
+        with self.unclassified_connections_lock:
+            oldest = next(iter(self.unclassified_connections.values()), None)
+        if oldest is not None:
+            self._close_unclassified_socket(oldest[0])
+
+    @staticmethod
+    def _close_unclassified_socket(request: socket.socket) -> None:
+        with suppress(OSError):
+            request.shutdown(socket.SHUT_RDWR)
+        with suppress(OSError):
+            request.close()
+
+    def start_unclassified_watchdog(self) -> None:
+        if self.unclassified_watchdog_thread is not None and self.unclassified_watchdog_thread.is_alive():
+            return
+        self.unclassified_watchdog_stop.clear()
+        self.unclassified_watchdog_thread = threading.Thread(
+            target=self._watch_unclassified_connections,
+            daemon=True,
+            name="guard-unclassified-connection-watchdog",
+        )
+        self.unclassified_watchdog_thread.start()
+
+    def stop_unclassified_watchdog(self) -> None:
+        self.unclassified_watchdog_stop.set()
+        thread = self.unclassified_watchdog_thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+        self.unclassified_watchdog_thread = None
+
+    def _watch_unclassified_connections(self) -> None:
+        while not self.unclassified_watchdog_stop.wait(_DAEMON_UNCLASSIFIED_WATCHDOG_POLL_SECONDS):
+            now = time.monotonic()
+            with self.unclassified_connections_lock:
+                expired = [request for request, deadline in self.unclassified_connections.values() if deadline <= now]
+            for request in expired:
+                self._close_unclassified_socket(request)
+
+    def claim_request_capacity(self, request: socket.socket, path: str) -> bool:
+        capacity_kind = self._request_capacity_kind(path)
+        capacity = self._request_capacity_for_kind(capacity_kind)
+        if not capacity.acquire(blocking=False):
+            with self.request_capacity_lock:
+                self.rejected_requests += 1
+            return False
+        with self.request_capacity_lock:
+            self.request_capacity_kinds[id(request)] = capacity_kind
+        return True
+
+    def _request_capacity_for_kind(self, capacity_kind: str) -> threading.BoundedSemaphore:
+        if capacity_kind == "critical":
+            return self.critical_request_capacity
+        if capacity_kind == "control":
+            return self.control_request_capacity
+        return self.request_capacity
+
+    @staticmethod
+    def _request_capacity_kind(path: str) -> str:
+        path = path.split("?", 1)[0]
+        if path in _DAEMON_CRITICAL_PATHS:
+            return "critical"
+        if path in _DAEMON_CONTROL_PATHS:
+            return "control"
+        return "general"
+
+    def hook_harness_semaphore(self, harness: str) -> threading.BoundedSemaphore:
+        capacity_harness = self.canonical_hook_capacity_harness(harness)
+        with self.hook_capacity_lock:
+            capacity = self.hook_harness_capacity.get(capacity_harness)
+            if capacity is None:
+                capacity = threading.BoundedSemaphore(_MAX_CONCURRENT_RUNTIME_HOOKS_PER_HARNESS)
+                self.hook_harness_capacity[capacity_harness] = capacity
+            return capacity
+
+    @staticmethod
+    def canonical_hook_capacity_harness(harness: str) -> str:
+        try:
+            return get_adapter(harness).harness
+        except ValueError:
+            return "other"
 
     def daemon_host(self) -> str:
         return str(self.server_address[0])
@@ -430,48 +653,6 @@ _ROOT_STATIC_FILES = {
 }
 
 
-class _RuntimeHookExecutionGate:
-    """Allow concurrent hooks unless one temporarily mutates process environment."""
-
-    def __init__(self) -> None:
-        self._condition = threading.Condition()
-        self._readers = 0
-        self._writer = False
-        self._waiting_writers = 0
-
-    @contextmanager
-    def shared(self) -> Iterator[None]:
-        with self._condition:
-            while self._writer or self._waiting_writers > 0:
-                self._condition.wait()
-            self._readers += 1
-        try:
-            yield
-        finally:
-            with self._condition:
-                self._readers -= 1
-                if self._readers == 0:
-                    self._condition.notify_all()
-
-    @contextmanager
-    def exclusive(self) -> Iterator[None]:
-        with self._condition:
-            self._waiting_writers += 1
-            try:
-                while self._writer or self._readers > 0:
-                    self._condition.wait()
-            finally:
-                self._waiting_writers -= 1
-            self._writer = True
-        try:
-            yield
-        finally:
-            with self._condition:
-                self._writer = False
-                self._condition.notify_all()
-
-
-_RUNTIME_HOOK_EXECUTION_GATE = _RuntimeHookExecutionGate()
 _RUNTIME_HOOK_ENV_ALLOWLIST = frozenset(
     {
         "HOL_GUARD_MANAGED_CURSOR_HOOK",
@@ -1471,6 +1652,16 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     _MAX_BODY_BYTES = 1_000_000
     server: _GuardDaemonHttpServer  # pyright: ignore[reportIncompatibleVariableOverride]
 
+    def parse_request(self) -> bool:
+        parsed = super().parse_request()
+        self._daemon_server().classify_connection(self.request)
+        if not parsed:
+            return False
+        if self._daemon_server().claim_request_capacity(self.request, self.path):
+            return True
+        self.send_error(503, "Guard daemon request capacity reached")
+        return False
+
     def do_OPTIONS(self) -> None:
         origin = self._normalize_origin(self.headers.get("Origin"))
         if origin is None:
@@ -1914,7 +2105,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         payload, body_error = self._load_request_body()
         if body_error is not None:
-            self._write_json({"error": body_error}, status=400)
+            status = {
+                "request_body_timeout": 408,
+                "request_body_too_large": 413,
+            }.get(body_error, 400)
+            self._write_json({"error": body_error}, status=status)
             return
         if parsed.path == "/v1/healthz/verify":
             nonce = self._optional_string(payload.get("nonce")) if payload else None
@@ -2406,22 +2601,59 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         return _build_local_url(host, port, "/#/inbox")
 
     def _load_request_body(self) -> tuple[dict[str, object], str | None]:
-        length = int(self.headers.get("Content-Length", "0"))
-        if length <= 0 or length > self._MAX_BODY_BYTES:
-            return {}, None
+        if self.headers.get("Transfer-Encoding") is not None:
+            return {}, "unsupported_transfer_encoding"
+        content_lengths = self.headers.get_all("Content-Length", [])
+        if len(content_lengths) > 1:
+            return {}, "invalid_content_length"
         try:
-            raw_body = self.rfile.read(length).decode("utf-8")
+            length = int(content_lengths[0]) if content_lengths else 0
+        except ValueError:
+            return {}, "invalid_content_length"
+        if length < 0:
+            return {}, "invalid_content_length"
+        if length == 0:
+            return {}, None
+        if length > self._MAX_BODY_BYTES:
+            return {}, "request_body_too_large"
+        raw_body, body_error = self._read_request_body(length)
+        if body_error is not None:
+            return {}, body_error
+        try:
+            decoded_body = raw_body.decode("utf-8")
         except UnicodeDecodeError:
             return {}, "invalid_request_body"
         content_type = self.headers.get("Content-Type", "")
         if "application/json" in content_type:
             try:
-                payload = json.loads(raw_body)
+                payload = json.loads(decoded_body)
             except json.JSONDecodeError:
                 return {}, "invalid_request_body"
             return (payload if isinstance(payload, dict) else {}), None
-        form_payload = parse_qs(raw_body)
+        form_payload = parse_qs(decoded_body)
         return {key: values[-1] for key, values in form_payload.items() if values}, None
+
+    def _read_request_body(self, length: int) -> tuple[bytes, str | None]:
+        deadline = time.monotonic() + _DAEMON_REQUEST_READ_TIMEOUT_SECONDS
+        chunks: list[bytes] = []
+        remaining = length
+        while remaining > 0:
+            timeout = deadline - time.monotonic()
+            if timeout <= 0:
+                return b"", "request_body_timeout"
+            with suppress(OSError):
+                self.connection.settimeout(timeout)
+            try:
+                chunk = self.rfile.read1(min(remaining, 64 * 1024))
+            except TimeoutError:
+                return b"", "request_body_timeout"
+            except OSError:
+                return b"", "incomplete_request_body"
+            if not chunk:
+                return b"", "incomplete_request_body"
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks), None
 
     def _handle_capabilities(self) -> None:
         context = self._harness_context({})
@@ -4831,21 +5063,139 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": error.code}, status=400)
             return
 
-        # Fast path: use the resident hook worker for supported hooks.
-        if self._hook_fast_path_enabled():
-            result = self._handle_runtime_hook_fast(
+        daemon_server = self._daemon_server()
+        runtime_harness = self._optional_string(params.get("runtime-harness", [None])[-1])
+        capacity_harness = daemon_server.canonical_hook_capacity_harness(
+            (runtime_harness or default_harness).strip().lower().replace("_", "-")
+        )
+        harness_capacity = daemon_server.hook_harness_semaphore(capacity_harness)
+        if not harness_capacity.acquire(blocking=False):
+            self._record_hook_capacity_rejection(daemon_server, capacity_harness)
+            self._write_json(
+                self._runtime_hook_capacity_response(
+                    payload,
+                    params,
+                    default_harness=default_harness,
+                )
+            )
+            return
+        if not daemon_server.hook_capacity.acquire(blocking=False):
+            harness_capacity.release()
+            self._record_hook_capacity_rejection(daemon_server, capacity_harness)
+            self._write_json(
+                self._runtime_hook_capacity_response(
+                    payload,
+                    params,
+                    default_harness=default_harness,
+                )
+            )
+            return
+        with daemon_server.hook_capacity_lock:
+            daemon_server.active_hook_requests += 1
+            daemon_server.hook_harness_active[capacity_harness] = (
+                daemon_server.hook_harness_active.get(capacity_harness, 0) + 1
+            )
+        try:
+            self._execute_runtime_hook(
                 payload,
                 params,
+                hook_env=hook_env,
                 default_harness=default_harness,
                 home_dir=home_dir,
                 guard_home=guard_home,
                 workspace=workspace,
             )
-            if result is not None:
-                self._write_json(result)
-                return
+        finally:
+            with daemon_server.hook_capacity_lock:
+                daemon_server.active_hook_requests -= 1
+                daemon_server.hook_harness_active[capacity_harness] -= 1
+            daemon_server.hook_capacity.release()
+            harness_capacity.release()
 
-        # Legacy CLI path.
+    @staticmethod
+    def _record_hook_capacity_rejection(
+        daemon_server: _GuardDaemonHttpServer,
+        capacity_harness: str,
+    ) -> None:
+        with daemon_server.hook_capacity_lock:
+            daemon_server.rejected_hook_requests += 1
+            daemon_server.hook_harness_rejected[capacity_harness] = (
+                daemon_server.hook_harness_rejected.get(capacity_harness, 0) + 1
+            )
+
+    def _runtime_hook_capacity_response(
+        self,
+        payload: Mapping[str, object],
+        params: Mapping[str, list[str]],
+        *,
+        default_harness: str,
+    ) -> dict[str, object]:
+        return self._runtime_hook_fail_safe_response(
+            payload,
+            params,
+            default_harness=default_harness,
+            reason="HOL Guard is at local review capacity. Retry this action after the active reviews complete.",
+            reason_code="daemon_hook_capacity",
+        )
+
+    def _runtime_hook_fail_safe_response(
+        self,
+        payload: Mapping[str, object],
+        params: Mapping[str, list[str]],
+        *,
+        default_harness: str,
+        reason: str,
+        reason_code: str,
+    ) -> dict[str, object]:
+        runtime_harness = self._optional_string(params.get("runtime-harness", [None])[-1])
+        harness = (runtime_harness or default_harness).strip().lower().replace("_", "-")
+        event = self._optional_string(payload.get("hook_event_name", payload.get("event"))) or "PreToolUse"
+        if harness == "pi":
+            return {
+                "decision": "deny",
+                "reason": reason,
+                "model_output_action": "block",
+                "notice": "warning",
+                "reason_code": reason_code,
+            }
+        if event == "PermissionRequest":
+            return {
+                "reason_code": reason_code,
+                "hookSpecificOutput": {
+                    "hookEventName": event,
+                    "decision": {
+                        "behavior": "deny",
+                        "message": reason,
+                    },
+                },
+            }
+        if event == "PreToolUse":
+            return {
+                "reason_code": reason_code,
+                "hookSpecificOutput": {
+                    "hookEventName": event,
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                },
+            }
+        return {
+            "continue": False,
+            "stopReason": reason,
+            "systemMessage": reason,
+            "reason_code": reason_code,
+        }
+
+    def _execute_runtime_hook(
+        self,
+        payload: dict[str, object],
+        params: Mapping[str, list[str]],
+        *,
+        hook_env: dict[str, str],
+        default_harness: str,
+        home_dir: str | None,
+        guard_home: str | None,
+        workspace: str | None,
+    ) -> None:
         self._handle_runtime_hook_legacy_cli(
             payload,
             params,
@@ -4930,52 +5280,27 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     ) -> None:
         runtime_harness = self._optional_string(params.get("runtime-harness", [None])[-1])
         harness = runtime_harness or default_harness
-        args = argparse.Namespace(
-            guard_command="hook",
-            home=home_dir,
-            guard_home=guard_home,
-            workspace=workspace,
-            runtime_harness=runtime_harness,
+        review = self._daemon_server().hook_process_runner.review(
+            payload=payload,
             harness=harness,
-            artifact_id=None,
-            artifact_name=None,
-            policy_action=None,
-            event_file=None,
-            json=True,
+            home_dir=Path(home_dir) if home_dir is not None else Path.home(),
+            guard_home=(Path(guard_home) if guard_home is not None else self._daemon_server().store.guard_home),
+            workspace=Path(workspace) if workspace is not None else None,
+            hook_env=hook_env,
         )
-        buffer = io.StringIO()
-        execution_guard = (
-            _RUNTIME_HOOK_EXECUTION_GATE.exclusive() if hook_env else _RUNTIME_HOOK_EXECUTION_GATE.shared()
-        )
-        with execution_guard:
-            from ..cli.commands import run_guard_command
-
-            original_env: dict[str, str | None] = {key: os.environ.get(key) for key in hook_env}
-            try:
-                os.environ.update(hook_env)
-                exit_code = run_guard_command(args, input_text=json.dumps(payload), output_stream=buffer)
-            finally:
-                for key, original in original_env.items():
-                    if original is None:
-                        os.environ.pop(key, None)
-                    else:
-                        os.environ[key] = original
-        raw_response = buffer.getvalue().strip()
-        if not raw_response:
-            if exit_code == 0:
-                self._write_json({})
-                return
-            self._write_json({"error": "empty_hook_response", "exit_code": exit_code}, status=502)
+        if review.payload is not None:
+            self._write_json(review.payload)
             return
-        try:
-            hook_payload = json.loads(raw_response)
-        except json.JSONDecodeError:
-            self._write_json(
-                {"error": "invalid_hook_response", "raw": raw_response, "exit_code": exit_code},
-                status=502,
+        reason_code = review.reason_code or "daemon_hook_process_failed"
+        self._write_json(
+            self._runtime_hook_fail_safe_response(
+                payload,
+                params,
+                default_harness=default_harness,
+                reason="HOL Guard could not complete isolated local hook review safely.",
+                reason_code=reason_code,
             )
-            return
-        self._write_json(hook_payload)
+        )
 
     def _query_has_guard_token(self, query: str) -> bool:
         return any(key == "token" for key, _value in parse_qsl(query, keep_blank_values=True))
@@ -5662,10 +5987,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if path != "/healthz" and not path.startswith("/v1/"):
             return
         self.server.last_activity_monotonic = time.monotonic()  # type: ignore[attr-defined]
-        self.server.store.touch_runtime_state(  # type: ignore[attr-defined]
-            session_id=self.server.runtime_session_id,  # type: ignore[attr-defined]
-            last_heartbeat_at=_now(),
-        )
+        self._daemon_server().runtime_heartbeat.touch(_now())
 
     def _increment_active_stream_clients(self) -> None:
         with self.server.active_stream_clients_lock:  # type: ignore[attr-defined]
@@ -5836,9 +6158,27 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
 
     def _detailed_healthz_payload(self) -> dict[str, object]:
         uptime = round(time.monotonic() - self.server.start_monotonic, 1)  # type: ignore[attr-defined]
-        store = self.server.store  # type: ignore[attr-defined]
+        daemon_server = self._daemon_server()
+        store = daemon_server.store
         pending_approvals = store.count_approval_requests()
         activity_health = store.get_command_activity_persistence_health()
+        with daemon_server.hook_capacity_lock:
+            hook_capacity = {
+                "active": daemon_server.active_hook_requests,
+                "limit": daemon_server.hook_capacity_limit,
+                "per_harness_active": dict(daemon_server.hook_harness_active),
+                "per_harness_rejected": dict(daemon_server.hook_harness_rejected),
+                "rejected": daemon_server.rejected_hook_requests,
+            }
+        with daemon_server.request_capacity_lock:
+            request_capacity = {
+                "active": daemon_server.active_requests,
+                "connection_limit": daemon_server.connection_capacity_limit,
+                "control_limit": daemon_server.control_request_capacity_limit,
+                "critical_limit": daemon_server.critical_request_capacity_limit,
+                "limit": daemon_server.request_capacity_limit,
+                "rejected": daemon_server.rejected_requests,
+            }
         return {
             "ok": True,
             "receipts": len(store.list_receipts(limit=500)),
@@ -5861,6 +6201,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 ),
                 "schema_version": activity_health.schema_version,
             },
+            "hook_capacity": hook_capacity,
+            "hook_workers": daemon_server.hook_process_runner.stats(),
+            "request_capacity": request_capacity,
         }
 
     @staticmethod
@@ -6241,13 +6584,16 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         cors_headers = self._cors_headers_for_request(allow_methods="GET, POST, OPTIONS")
         if cors_headers is not None:
             headers = {**cors_headers, **headers}
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        for key, value in self._validated_headers(headers).items():
-            self.send_header(key, value)
-        self.end_headers()
-        self.wfile.write(body)
+        try:
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            for key, value in self._validated_headers(headers).items():
+                self.send_header(key, value)
+            self.end_headers()
+            self.wfile.write(body)
+        except _PEER_DISCONNECT_ERRORS:
+            self.close_connection = True
 
     def _write_empty(
         self,
@@ -6255,10 +6601,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         status: int,
         extra_headers: dict[str, str] | None = None,
     ) -> None:
-        self.send_response(status)
-        for key, value in self._validated_headers(extra_headers).items():
-            self.send_header(key, value)
-        self.end_headers()
+        try:
+            self.send_response(status)
+            for key, value in self._validated_headers(extra_headers).items():
+                self.send_header(key, value)
+            self.end_headers()
+        except _PEER_DISCONNECT_ERRORS:
+            self.close_connection = True
 
     @staticmethod
     def _validated_headers(extra_headers: dict[str, str] | None) -> dict[str, str]:
@@ -6452,6 +6801,7 @@ class GuardDaemonServer:
             self._aibom_refresh_thread = None
         self._require_command_activity_maintenance_stopped()
         self._shutdown_started.clear()
+        self._server.hook_process_runner.start()
         self._maintain_command_activity_best_effort()
         self._persist_aibom_inventory_context()
         self._server.last_activity_monotonic = time.monotonic()
@@ -6463,6 +6813,8 @@ class GuardDaemonServer:
             started_at=self._server.runtime_started_at,
             last_heartbeat_at=_now(),
         )
+        self._server.start_unclassified_watchdog()
+        self._server.runtime_heartbeat.start()
         approval_attention = getattr(self._server, "approval_attention", None)
         if approval_attention is not None:
             approval_attention.start()
@@ -6554,11 +6906,14 @@ class GuardDaemonServer:
     def _finish_service(self) -> None:
         try:
             self._shutdown_started.set()
+            self._server.stop_unclassified_watchdog()
             approval_attention = getattr(self._server, "approval_attention", None)
             if approval_attention is not None:
                 approval_attention.stop()
             self._command_queue_worker = stop_command_queue_worker(self._command_queue_worker)
             self._live_request_sync_worker = stop_cloud_sync_sync_worker(self._live_request_sync_worker)
+            self._server.runtime_heartbeat.stop(timeout_seconds=1.0)
+            self._server.hook_process_runner.close()
             clear_guard_daemon_state_if_current(self._server.store.guard_home, pid=os.getpid(), port=self.port)
             self._server.store.clear_runtime_state(session_id=self._server.runtime_session_id)
         finally:

--- a/src/codex_plugin_scanner/guard/sqlite_tuning.py
+++ b/src/codex_plugin_scanner/guard/sqlite_tuning.py
@@ -2,6 +2,28 @@
 
 from __future__ import annotations
 
-SQLITE_CONNECT_TIMEOUT_SECONDS = 30.0
+import os
+from collections.abc import Mapping
+
+_DEFAULT_SQLITE_CONNECT_TIMEOUT_SECONDS = 30.0
+_INTERNAL_HOOK_SQLITE_TIMEOUT_ENV = "HOL_GUARD_INTERNAL_HOOK_SQLITE_TIMEOUT_MS"
+_MAX_INTERNAL_HOOK_SQLITE_TIMEOUT_MS = 250
+
+
+def sqlite_connect_timeout_seconds(environment: Mapping[str, str] | None = None) -> float:
+    source = os.environ if environment is None else environment
+    raw_timeout = source.get(_INTERNAL_HOOK_SQLITE_TIMEOUT_ENV)
+    if not isinstance(raw_timeout, str):
+        return _DEFAULT_SQLITE_CONNECT_TIMEOUT_SECONDS
+    try:
+        timeout_ms = int(raw_timeout)
+    except ValueError:
+        return _DEFAULT_SQLITE_CONNECT_TIMEOUT_SECONDS
+    if timeout_ms <= 0:
+        return _DEFAULT_SQLITE_CONNECT_TIMEOUT_SECONDS
+    return min(timeout_ms, _MAX_INTERNAL_HOOK_SQLITE_TIMEOUT_MS) / 1000
+
+
+SQLITE_CONNECT_TIMEOUT_SECONDS = sqlite_connect_timeout_seconds()
 SQLITE_BUSY_TIMEOUT_MS = int(SQLITE_CONNECT_TIMEOUT_SECONDS * 1000)
 SQLITE_WAL_BUSY_TIMEOUT_MS = 1000

--- a/src/codex_plugin_scanner/guard/store_base.py
+++ b/src/codex_plugin_scanner/guard/store_base.py
@@ -58,7 +58,7 @@ from .runtime.actions import GuardActionEnvelope
 from .runtime.approval_context import parse_approval_context_token
 from .runtime.scanner_cache import scanner_cache_key
 from .schemas.guard_event_v1 import GuardEventV1
-from .sqlite_tuning import SQLITE_BUSY_TIMEOUT_MS, SQLITE_CONNECT_TIMEOUT_SECONDS, SQLITE_WAL_BUSY_TIMEOUT_MS
+from .sqlite_tuning import SQLITE_WAL_BUSY_TIMEOUT_MS, sqlite_connect_timeout_seconds
 from .store_approvals import (
     _json_object,
     _json_object_list,

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -139,12 +139,13 @@ class StoreConnectionSchemaMixin:
 
     @contextmanager
     def _connect(self) -> Iterator[sqlite3.Connection]:
-        connection = sqlite3.connect(self.path, timeout=SQLITE_CONNECT_TIMEOUT_SECONDS)
+        connect_timeout_seconds = sqlite_connect_timeout_seconds()
+        connection = sqlite3.connect(self.path, timeout=connect_timeout_seconds)
         connection.row_factory = sqlite3.Row
         start = time.monotonic()
         notification: dict[str, object] | None = None
         try:
-            connection.execute(f"pragma busy_timeout={SQLITE_BUSY_TIMEOUT_MS}")
+            connection.execute(f"pragma busy_timeout={int(connect_timeout_seconds * 1000)}")
             yield connection
             connection.commit()
             notification = self._take_policy_integrity_state_notification(connection)

--- a/src/codex_plugin_scanner/guard/store_receipts.py
+++ b/src/codex_plugin_scanner/guard/store_receipts.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from contextlib import closing
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 
@@ -771,6 +772,33 @@ class StoreReceiptsRuntimeMixin:
                 """,
                 (last_heartbeat_at, session_id),
             )
+
+    def try_touch_runtime_state(
+        self,
+        *,
+        session_id: str,
+        last_heartbeat_at: str,
+        timeout_seconds: float,
+    ) -> bool:
+        """Persist a heartbeat without inheriting the store's long busy timeout."""
+
+        bounded_timeout = min(max(timeout_seconds, 0.0), 1.0)
+        try:
+            with closing(sqlite3.connect(self.path, timeout=bounded_timeout)) as connection:
+                connection.execute(f"pragma busy_timeout={int(bounded_timeout * 1000)}")
+                connection.execute(
+                    """
+                    update guard_runtime_state
+                    set last_heartbeat_at = ?
+                    where state_key = 'runtime'
+                      and session_id = ?
+                    """,
+                    (last_heartbeat_at, session_id),
+                )
+                connection.commit()
+        except (OSError, sqlite3.Error):
+            return False
+        return True
 
     def get_runtime_state(self) -> dict[str, object] | None:
         with self._connect() as connection:

--- a/src/codex_plugin_scanner/guard/store_secret_policy_integrity.py
+++ b/src/codex_plugin_scanner/guard/store_secret_policy_integrity.py
@@ -1078,10 +1078,11 @@ class StoreSecretPolicyIntegrityMixin:
             return
 
         def compute_prepared_state(base_state: dict[str, object]) -> dict[str, object]:
-            connection = sqlite3.connect(self.path, timeout=SQLITE_CONNECT_TIMEOUT_SECONDS)
+            connect_timeout_seconds = sqlite_connect_timeout_seconds()
+            connection = sqlite3.connect(self.path, timeout=connect_timeout_seconds)
             connection.row_factory = sqlite3.Row
             try:
-                connection.execute(f"pragma busy_timeout={SQLITE_BUSY_TIMEOUT_MS}")
+                connection.execute(f"pragma busy_timeout={int(connect_timeout_seconds * 1000)}")
                 return self._prepared_startup_policy_integrity_state(
                     connection,
                     key=raw_key,
@@ -1094,10 +1095,11 @@ class StoreSecretPolicyIntegrityMixin:
         prepared_state = compute_prepared_state(trusted_state)
         current_trusted_state = self._load_policy_integrity_control_state(create=False)
         if current_trusted_state is None:
-            connection = sqlite3.connect(self.path, timeout=SQLITE_CONNECT_TIMEOUT_SECONDS)
+            connect_timeout_seconds = sqlite_connect_timeout_seconds()
+            connection = sqlite3.connect(self.path, timeout=connect_timeout_seconds)
             connection.row_factory = sqlite3.Row
             try:
-                connection.execute(f"pragma busy_timeout={SQLITE_BUSY_TIMEOUT_MS}")
+                connection.execute(f"pragma busy_timeout={int(connect_timeout_seconds * 1000)}")
                 still_matches = self._prefetched_startup_state_still_matches_local_rows(
                     connection,
                     key=raw_key,

--- a/tests/test_bounded_cli_hook_bridge.py
+++ b/tests/test_bounded_cli_hook_bridge.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import io
+import json
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import bounded_cli_hook_bridge
+from codex_plugin_scanner.guard.codex_hook_launch_runtime import BoundedHookProcessResult
+
+
+def _runner_result(result: BoundedHookProcessResult) -> Callable[..., BoundedHookProcessResult]:
+    def run(
+        command: Sequence[str],
+        *,
+        input_text: str,
+        cwd: Path,
+        environment: Mapping[str, str],
+        timeout_seconds: float,
+        output_limit: int = 1_000_000,
+    ) -> BoundedHookProcessResult:
+        del command, input_text, cwd, environment, timeout_seconds, output_limit
+        return result
+
+    return run
+
+
+def _json_object(text: str) -> dict[str, object]:
+    payload = cast(object, json.loads(text))
+    assert isinstance(payload, dict)
+    return {str(key): value for key, value in cast(dict[object, object], payload).items()}
+
+
+def _config(tmp_path: Path, *, harness: str) -> dict[str, object]:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    return {
+        "python_executable": "python",
+        "package_root": str(tmp_path),
+        "guard_home": str(guard_home),
+        "cli_args": ["guard", "hook", "--harness", harness],
+        "harness": harness,
+        "timeout_seconds": 3,
+    }
+
+
+@pytest.mark.parametrize(
+    ("harness", "expected"),
+    [
+        ("copilot", {"permissionDecision": "deny"}),
+        ("grok", {"decision": "deny"}),
+        ("hermes", {"decision": "deny"}),
+        ("openclaw", {"decision": "deny"}),
+    ],
+)
+def test_timeout_emits_successful_native_deny(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    harness: str,
+    expected: dict[str, str],
+) -> None:
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "run_isolated_hook_process",
+        _runner_result(BoundedHookProcessResult(None, "", False, True)),
+    )
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(
+            _config(tmp_path, harness=harness),
+            input_text=json.dumps({"hook_event_name": "PreToolUse"}),
+        )
+
+    payload = _json_object(output.getvalue())
+    assert returncode == 0
+    for key, value in expected.items():
+        assert payload[key] == value
+
+
+@pytest.mark.parametrize("harness", ["kimi", "zcode"])
+def test_claude_shaped_timeout_emits_deny_and_block_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    harness: str,
+) -> None:
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "run_isolated_hook_process",
+        _runner_result(BoundedHookProcessResult(None, "", False, True)),
+    )
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(
+            _config(tmp_path, harness=harness),
+            input_text=json.dumps({"hookEventName": "PreToolUse"}),
+        )
+
+    payload = _json_object(output.getvalue())
+    assert returncode == 2
+    hook_output = payload["hookSpecificOutput"]
+    assert isinstance(hook_output, dict)
+    assert hook_output["permissionDecision"] == "deny"
+
+
+def test_success_preserves_child_stdout_and_returncode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "run_isolated_hook_process",
+        _runner_result(BoundedHookProcessResult(2, '{"decision":"deny"}\n', False, False)),
+    )
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(
+            _config(tmp_path, harness="grok"),
+            input_text="{}",
+        )
+
+    assert returncode == 2
+    assert output.getvalue() == '{"decision":"deny"}\n'
+
+
+def test_empty_failed_child_is_converted_to_native_deny(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "run_isolated_hook_process",
+        _runner_result(BoundedHookProcessResult(1, "", False, False)),
+    )
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(
+            _config(tmp_path, harness="copilot"),
+            input_text="{}",
+        )
+
+    assert returncode == 0
+    assert _json_object(output.getvalue())["permissionDecision"] == "deny"
+
+
+def test_malformed_success_is_converted_to_native_deny(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "run_isolated_hook_process",
+        _runner_result(BoundedHookProcessResult(0, "not-json\n", False, False)),
+    )
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(
+            _config(tmp_path, harness="grok"),
+            input_text="{}",
+        )
+
+    assert returncode == 0
+    assert _json_object(output.getvalue())["decision"] == "deny"
+
+
+def test_copilot_permission_timeout_uses_permission_request_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "run_isolated_hook_process",
+        _runner_result(BoundedHookProcessResult(None, "", False, True)),
+    )
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(
+            _config(tmp_path, harness="copilot"),
+            input_text=json.dumps({"hookEventName": "PermissionRequest"}),
+        )
+
+    assert returncode == 0
+    assert _json_object(output.getvalue())["behavior"] == "deny"

--- a/tests/test_claude_daemon_hook_bridge.py
+++ b/tests/test_claude_daemon_hook_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import sys
 import threading
 import time
 import urllib.request
@@ -252,6 +253,24 @@ def test_daemon_response_body_is_size_bounded() -> None:
         bridge._read_bounded_response(OversizedResponse())
 
 
+def test_oversized_hook_input_fails_safe_without_daemon_contact(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr("sys.stdin", io.StringIO("x" * (bridge._MAX_HOOK_INPUT_BYTES + 1)))
+
+    result = bridge.main(
+        state_path="/missing/state.json",
+        fallback_daemon_url="http://127.0.0.1:5474",
+        fallback_command=(sys.executable, "-c", "raise SystemExit(99)"),
+        query="",
+    )
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+
+
 def test_bridge_timeouts_stay_under_harness_budget() -> None:
     assert bridge._HARNESS_TIMEOUT_BUDGET_SECONDS == 10
     assert (
@@ -267,8 +286,14 @@ def test_main_recovers_missing_daemon_and_retries_hook(
     attempts = 0
     recovery_commands: list[tuple[str, ...]] = []
 
-    def fake_post(endpoint: str, data: str, *, state_path: str | Path) -> str:
-        del endpoint, data, state_path
+    def fake_post(
+        endpoint: str,
+        data: str,
+        *,
+        state_path: str | Path,
+        deadline: float | None = None,
+    ) -> str:
+        del endpoint, data, state_path, deadline
         nonlocal attempts
         attempts += 1
         if attempts == 1:
@@ -282,7 +307,14 @@ def test_main_recovers_missing_daemon_and_retries_hook(
             }
         )
 
-    def fake_recover(command: tuple[str, ...]) -> bool:
+    def fake_recover(
+        command: tuple[str, ...],
+        *,
+        deadline: float | None = None,
+        failure_kind: str,
+    ) -> bool:
+        del deadline
+        assert failure_kind == "transport-failure"
         recovery_commands.append(command)
         return True
 
@@ -317,6 +349,32 @@ def test_recovery_only_restarts_for_transport_auth_and_server_failures() -> None
     bounded_http_error = bridge._DaemonHTTPError(503, "worker-captured detail")
     assert bridge._daemon_failure_is_recoverable(bounded_http_error)
     assert bridge._daemon_failure_reason(bounded_http_error).endswith("worker-captured detail")
+    assert not bridge._daemon_failure_is_recoverable(
+        bridge._DaemonHTTPError(429, '{"error":"hook_capacity_exhausted"}')
+    )
+    assert not bridge._daemon_failure_is_recoverable(bridge._DaemonHTTPError(503, '{"error":"daemon_overloaded"}'))
+    assert bridge._daemon_failure_kind(bridge._DaemonHTTPError(429, "busy")) == "overload"
+    assert bridge._daemon_failure_kind(TimeoutError("deadline")) == "transport-failure"
+    assert bridge._daemon_failure_kind(ValueError("bad state")) == "authenticated-control-plane-failure"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group assertion")
+def test_fallback_timeout_kills_descendants(tmp_path: Path) -> None:
+    marker = tmp_path / "escaped-child.marker"
+    child = f"import time;from pathlib import Path;time.sleep(.3);Path({str(marker)!r}).write_text('escaped')"
+    parent = f"import subprocess,sys,time;subprocess.Popen([sys.executable,'-c',{child!r}]);time.sleep(10)"
+    data = json.dumps({"hook_event_name": "PreToolUse"})
+
+    response = bridge._run_local_fallback(
+        "daemon unavailable",
+        data,
+        (sys.executable, "-c", parent),
+        deadline=time.monotonic() + 0.05,
+    )
+    time.sleep(0.4)
+
+    assert json.loads(response)["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert not marker.exists()
 
 
 def test_recovery_command_preserves_custom_home_and_guard_home(tmp_path: Path) -> None:

--- a/tests/test_cli_only_hook_resilience.py
+++ b/tests/test_cli_only_hook_resilience.py
@@ -1,0 +1,95 @@
+"""Bounded execution contracts for managed CLI-only harness hooks."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.copilot import (
+    _hook_command_parts as copilot_hook_command_parts,  # pyright: ignore[reportPrivateUsage]
+)
+from codex_plugin_scanner.guard.adapters.grok import GrokHarnessAdapter
+from codex_plugin_scanner.guard.adapters.hermes import (
+    _pretool_payload as hermes_pretool_payload,  # pyright: ignore[reportPrivateUsage]
+)
+from codex_plugin_scanner.guard.adapters.kimi import KimiHarnessAdapter
+from codex_plugin_scanner.guard.adapters.openclaw_support import pretool_payload as openclaw_pretool_payload
+from codex_plugin_scanner.guard.adapters.zcode import ZCodeHarnessAdapter
+
+CommandFactory = Callable[[HarnessContext], tuple[str, ...]]
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    home_dir.mkdir()
+    workspace_dir.mkdir()
+    guard_home.mkdir()
+    return HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=guard_home,
+    )
+
+
+def _copilot_command(context: HarnessContext) -> tuple[str, ...]:
+    return copilot_hook_command_parts(context, include_workspace=True)
+
+
+@pytest.mark.parametrize(
+    ("harness", "factory", "timeout_seconds"),
+    [
+        ("copilot", _copilot_command, 25),
+        ("grok", GrokHarnessAdapter._hook_command_parts, 25),  # pyright: ignore[reportPrivateUsage]
+        ("kimi", KimiHarnessAdapter._hook_command_parts, 25),  # pyright: ignore[reportPrivateUsage]
+        ("zcode", ZCodeHarnessAdapter._hook_command_parts, 25),  # pyright: ignore[reportPrivateUsage]
+    ],
+)
+def test_managed_cli_hooks_use_bounded_process_bridge(
+    tmp_path: Path,
+    harness: str,
+    factory: CommandFactory,
+    timeout_seconds: int,
+) -> None:
+    command = factory(_context(tmp_path))
+
+    assert command[1:3] == ("-I", "-c")
+    assert "bounded_cli_hook_bridge" in command[3]
+    config = cast(dict[str, object], json.loads(command[-1]))
+    assert config["harness"] == harness
+    assert config["timeout_seconds"] == timeout_seconds
+    assert config["guard_home"] == str(tmp_path / "guard-home")
+
+
+@pytest.mark.parametrize(
+    ("harness", "factory"),
+    [
+        ("hermes", hermes_pretool_payload),
+        ("openclaw", openclaw_pretool_payload),
+    ],
+)
+def test_proxy_hook_contracts_bound_children_and_fail_closed(
+    tmp_path: Path,
+    harness: str,
+    factory: Callable[..., dict[str, object]],
+) -> None:
+    payload = factory(context=_context(tmp_path))
+    command = payload["command"]
+
+    assert payload["timeout_seconds"] == 5
+    assert payload["fail_open"] is False
+    assert isinstance(command, list)
+    command_items = cast(list[object], command)
+    assert all(isinstance(item, str) for item in command_items)
+    command_parts = cast(list[str], command_items)
+    assert command_parts[1:3] == ["-I", "-c"]
+    assert "bounded_cli_hook_bridge" in command_parts[3]
+    config = cast(dict[str, object], json.loads(command_parts[-1]))
+    assert config["harness"] == harness
+    assert config["timeout_seconds"] == 3

--- a/tests/test_codex_daemon_hook_bridge.py
+++ b/tests/test_codex_daemon_hook_bridge.py
@@ -579,9 +579,15 @@ def test_main_starts_daemon_once_then_retries_hook(
             raise urllib.error.URLError("daemon cold")
         return {}
 
-    def start_daemon(command: tuple[str, ...], *, timeout_seconds: float) -> bool:
+    def start_daemon(
+        command: tuple[str, ...],
+        *,
+        timeout_seconds: float,
+        failure_kind: str,
+    ) -> bool:
         starts.append(tuple(command))
-        assert timeout_seconds == 8
+        assert 7.9 < timeout_seconds <= 8
+        assert failure_kind == "transport-failure"
         return True
 
     config = _bridge_config(guard_home, 1)
@@ -595,6 +601,69 @@ def test_main_starts_daemon_once_then_retries_hook(
     assert len(responses) == 2
     assert starts == [tuple(config["start_command"])]
     assert json.loads(capsys.readouterr().out) == {}
+
+
+def test_authenticated_overload_uses_fallback_without_restarting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    starts: list[tuple[str, ...]] = []
+
+    def overloaded_daemon(**kwargs: object) -> dict[str, object]:
+        del kwargs
+        raise bridge._DaemonResponseError(429, '{"error":"hook_capacity_exhausted"}', authenticated=True)
+
+    def start_daemon(
+        command: tuple[str, ...],
+        *,
+        timeout_seconds: float,
+        failure_kind: str,
+    ) -> bool:
+        del timeout_seconds, failure_kind
+        starts.append(command)
+        return True
+
+    config = _bridge_config(guard_home, 1)
+    monkeypatch.setattr(bridge, "_daemon_response", overloaded_daemon)
+    monkeypatch.setattr(bridge, "_run_daemon_start", start_daemon)
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "PreToolUse"})))
+
+    assert bridge.main(**config) == 0
+    assert starts == []
+    assert json.loads(capsys.readouterr().out) == {}
+
+
+def test_daemon_failure_kind_separates_overload_transport_and_control_plane() -> None:
+    assert (
+        bridge._daemon_failure_kind(
+            bridge._DaemonResponseError(429, '{"error":"hook_capacity_exhausted"}', authenticated=True)
+        )
+        == "overload"
+    )
+    assert bridge._daemon_failure_kind(TimeoutError("deadline")) == "transport-failure"
+    assert bridge._daemon_failure_kind(ValueError("state authentication failed")) == (
+        "authenticated-control-plane-failure"
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group assertion")
+def test_untrusted_fallback_timeout_kills_descendants(tmp_path: Path) -> None:
+    marker = tmp_path / "escaped-child.marker"
+    child = f"import time;from pathlib import Path;time.sleep(.3);Path({str(marker)!r}).write_text('escaped')"
+    parent = f"import subprocess,sys,time;subprocess.Popen([sys.executable,'-c',{child!r}]);time.sleep(10)"
+
+    response = bridge._run_local_fallback(
+        (sys.executable, "-c", parent),
+        data="{}",
+        timeout_seconds=0.05,
+    )
+    time.sleep(0.4)
+
+    assert response is None
+    assert not marker.exists()
 
 
 def test_bridge_script_cold_start_stays_below_hook_budget(tmp_path: Path) -> None:

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import os
 import sqlite3
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -227,6 +230,325 @@ def test_cursor_hook_script_source_includes_daemon_fast_path(tmp_path: Path) -> 
     assert "/v1/hooks/cursor?" in source
     assert '"hook_env"' in source
     assert "subprocess.CompletedProcess(" in source
+
+
+def test_cursor_hook_script_uses_one_deadline_and_isolated_process_tree(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
+
+    context = HarnessContext(home_dir=tmp_path / "home", guard_home=tmp_path / "guard", workspace_dir=tmp_path)
+    source = cursor_hook_script_source(context)
+
+    assert "deadline_monotonic = time.monotonic() + GUARD_HOOK_TIMEOUT_SECONDS" in source
+    assert "timeout = _request_timeout(deadline_monotonic" in source
+    assert "run_isolated_hook_process(" in source
+    assert "allow_windows_breakaway=True" in source
+    assert "_FALLBACK_LOCK.acquire(blocking=False)" in source
+    assert 'daemon_failure_kind not in {None, "overload"}' in source
+    assert "[*GUARD_RECOVERY_COMMAND, failure_kind]" in source
+
+
+def test_cursor_hook_recovers_dead_daemon_once_then_retries(
+    tmp_path: Path,
+) -> None:
+    import http.server
+    import threading
+
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
+
+    home_dir = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    workspace_dir = tmp_path / "workspace"
+    recovery_marker = tmp_path / "recovery-kind"
+    fallback_marker = tmp_path / "fallback-ran"
+    token = "cursor-recovery-token"
+    guard_home.mkdir()
+    workspace_dir.mkdir()
+
+    class _RecoveredDaemonHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"ok": True, "compatibility_version": "v1"}).encode())
+
+        def do_POST(self) -> None:
+            if self.path == "/v1/healthz/verify":
+                body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+                proof = hmac.new(
+                    token.encode(),
+                    f"{self.server.server_address[1]}:{body['nonce']}".encode(),
+                    hashlib.sha256,
+                ).hexdigest()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"proof": proof}).encode())
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"policy_action": "allow"}).encode())
+
+        def log_message(self, *_args: object) -> None:
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _RecoveredDaemonHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.server_address[1]
+    recovery = tmp_path / "recover.py"
+    recovery.write_text(
+        "import json,sys\n"
+        "from pathlib import Path\n"
+        f"Path({str(recovery_marker)!r}).write_text(sys.argv[1], encoding='utf-8')\n"
+        f"Path({str(guard_home / 'daemon-state.json')!r}).write_text("
+        f"json.dumps({{'port': {port}, 'pid': {os.getpid()}, 'compatibility_version': 'v1'}}), encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    fallback = tmp_path / "fallback.py"
+    fallback.write_text(
+        f"from pathlib import Path;Path({str(fallback_marker)!r}).write_text('ran');"
+        'print(\'{"policy_action":"block"}\')\n',
+        encoding="utf-8",
+    )
+    (guard_home / "daemon-state.json").write_text(
+        json.dumps({"port": 59999, "pid": 999999, "compatibility_version": "v1"}),
+        encoding="utf-8",
+    )
+    (guard_home / "daemon-auth-token").write_text(token, encoding="utf-8")
+    context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=workspace_dir)
+    script_path = tmp_path / "cursor-hook.py"
+    script_path.write_text(
+        cursor_hook_script_source(
+            context,
+            guard_cli=[sys.executable, str(fallback)],
+            recovery_command=[sys.executable, str(recovery)],
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(script_path)],
+            input=json.dumps(
+                {
+                    "hook_event_name": "beforeShellExecution",
+                    "tool_name": "Bash",
+                    "command": "echo hi",
+                    "cwd": str(workspace_dir),
+                }
+            ),
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    finally:
+        server.shutdown()
+
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(proc.stdout) == {"permission": "allow"}
+    assert recovery_marker.read_text(encoding="utf-8") == "transport-failure"
+    assert not fallback_marker.exists()
+
+
+def test_cursor_hook_authenticated_overload_skips_recovery(
+    tmp_path: Path,
+) -> None:
+    import http.server
+    import threading
+
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
+
+    home_dir = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    workspace_dir = tmp_path / "workspace"
+    recovery_marker = tmp_path / "recovery-ran"
+    token = "cursor-overload-token"
+    guard_home.mkdir()
+    workspace_dir.mkdir()
+
+    class _OverloadedDaemonHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"ok": True, "compatibility_version": "v1"}).encode())
+
+        def do_POST(self) -> None:
+            if self.path == "/v1/healthz/verify":
+                body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+                proof = hmac.new(
+                    token.encode(),
+                    f"{self.server.server_address[1]}:{body['nonce']}".encode(),
+                    hashlib.sha256,
+                ).hexdigest()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"proof": proof}).encode())
+                return
+            self.send_response(503)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": "daemon_hook_capacity_exceeded"}).encode())
+
+        def log_message(self, *_args: object) -> None:
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _OverloadedDaemonHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.server_address[1]
+    recovery = tmp_path / "recover.py"
+    recovery.write_text(
+        f"from pathlib import Path;Path({str(recovery_marker)!r}).write_text('ran')\n",
+        encoding="utf-8",
+    )
+    fallback = tmp_path / "fallback.py"
+    fallback.write_text('print(\'{"policy_action":"block"}\')\n', encoding="utf-8")
+    (guard_home / "daemon-state.json").write_text(
+        json.dumps({"port": port, "pid": os.getpid(), "compatibility_version": "v1"}),
+        encoding="utf-8",
+    )
+    (guard_home / "daemon-auth-token").write_text(token, encoding="utf-8")
+    context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=workspace_dir)
+    script_path = tmp_path / "cursor-hook.py"
+    script_path.write_text(
+        cursor_hook_script_source(
+            context,
+            guard_cli=[sys.executable, str(fallback)],
+            recovery_command=[sys.executable, str(recovery)],
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(script_path)],
+            input=json.dumps(
+                {
+                    "hook_event_name": "beforeShellExecution",
+                    "tool_name": "Bash",
+                    "command": "echo hi",
+                    "cwd": str(workspace_dir),
+                }
+            ),
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    finally:
+        server.shutdown()
+
+    assert proc.returncode == 2
+    assert json.loads(proc.stdout)["permission"] == "deny"
+    assert not recovery_marker.exists()
+
+
+def test_cursor_hook_recovery_honors_total_deadline(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
+
+    home_dir = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    workspace_dir = tmp_path / "workspace"
+    guard_home.mkdir()
+    workspace_dir.mkdir()
+    recovery = tmp_path / "slow-recovery.py"
+    recovery.write_text("import time;time.sleep(10)\n", encoding="utf-8")
+    fallback = tmp_path / "fallback.py"
+    fallback.write_text('print(\'{"policy_action":"allow"}\')\n', encoding="utf-8")
+    (guard_home / "daemon-state.json").write_text(
+        json.dumps({"port": 59999, "pid": 999999, "compatibility_version": "v1"}),
+        encoding="utf-8",
+    )
+    (guard_home / "daemon-auth-token").write_text("stale-token", encoding="utf-8")
+    context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=workspace_dir)
+    source = cursor_hook_script_source(
+        context,
+        guard_cli=[sys.executable, str(fallback)],
+        recovery_command=[sys.executable, str(recovery)],
+    ).replace(
+        f"GUARD_HOOK_TIMEOUT_SECONDS = {_MANAGED_HOOK_TIMEOUT_SECONDS - 3}",
+        "GUARD_HOOK_TIMEOUT_SECONDS = 0.2",
+        1,
+    )
+    script_path = tmp_path / "cursor-hook.py"
+    script_path.write_text(source, encoding="utf-8")
+    started = time.monotonic()
+
+    proc = subprocess.run(
+        [sys.executable, str(script_path)],
+        input=json.dumps(
+            {
+                "hook_event_name": "beforeShellExecution",
+                "tool_name": "Bash",
+                "command": "echo hi",
+                "cwd": str(workspace_dir),
+            }
+        ),
+        capture_output=True,
+        text=True,
+        timeout=3,
+    )
+
+    assert time.monotonic() - started < 1
+    assert proc.returncode == 2
+    assert json.loads(proc.stdout)["permission"] == "deny"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process-group descendant assertion requires POSIX")
+def test_cursor_hook_timeout_kills_fallback_descendants(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
+
+    home_dir = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    workspace_dir = tmp_path / "workspace"
+    marker = tmp_path / "descendant-ran"
+    guard_home.mkdir()
+    workspace_dir.mkdir()
+    fake_guard = tmp_path / "slow-guard.py"
+    descendant = f"import time;time.sleep(0.8);open({str(marker)!r},'w',encoding='utf-8').write('ran')"
+    fake_guard.write_text(
+        f"import subprocess,sys,time\nsubprocess.Popen([sys.executable, '-c', {descendant!r}])\ntime.sleep(10)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
+        lambda _context: [sys.executable, str(fake_guard)],
+    )
+    context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=workspace_dir)
+    source = cursor_hook_script_source(context)
+    source = source.replace(
+        f"GUARD_HOOK_TIMEOUT_SECONDS = {_MANAGED_HOOK_TIMEOUT_SECONDS - 3}",
+        "GUARD_HOOK_TIMEOUT_SECONDS = 0.2",
+        1,
+    )
+    script_path = tmp_path / "cursor-hook.py"
+    script_path.write_text(source, encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, str(script_path)],
+        input=json.dumps(
+            {
+                "hook_event_name": "beforeShellExecution",
+                "tool_name": "Bash",
+                "command": "echo hi",
+                "cwd": str(workspace_dir),
+            }
+        ),
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CURSOR_PROJECT_DIR": str(workspace_dir)},
+        timeout=3,
+    )
+    time.sleep(1)
+
+    assert proc.returncode == 2
+    assert json.loads(proc.stdout)["permission"] == "deny"
+    assert not marker.exists()
 
 
 def test_cursor_hook_script_uses_daemon_fast_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -224,13 +224,13 @@ def test_copilot_install_and_uninstall_manage_inline_config_hooks_idempotently(t
         assert managed_hooks["preToolUse"][0]["cwd"] == str(context.guard_home)
         assert managed_hooks["preToolUse"][0]["timeoutSec"] == 30
         assert managed_hooks["preToolUse"][0]["env"]["PYTHONPATH"] == original_pythonpath
-        assert "from codex_plugin_scanner.cli import main" in managed_hooks["preToolUse"][0]["bash"]
+        assert "bounded_cli_hook_bridge" in managed_hooks["preToolUse"][0]["bash"]
         assert "copilot" in managed_hooks["preToolUse"][0]["bash"]
         assert "--workspace" not in managed_hooks["preToolUse"][0]["bash"]
-        assert "from codex_plugin_scanner.cli import main" in managed_hooks["preToolUse"][0]["powershell"]
-        assert "from codex_plugin_scanner.cli import main" in managed_hooks["userPromptSubmitted"][0]["bash"]
+        assert "bounded_cli_hook_bridge" in managed_hooks["preToolUse"][0]["powershell"]
+        assert "bounded_cli_hook_bridge" in managed_hooks["userPromptSubmitted"][0]["bash"]
         assert managed_hooks["postToolUse"][0]["type"] == "command"
-        assert "from codex_plugin_scanner.cli import main" in managed_hooks["postToolUse"][0]["bash"]
+        assert "bounded_cli_hook_bridge" in managed_hooks["postToolUse"][0]["bash"]
         assert len(managed_workspace_hooks["userPromptSubmitted"]) == 1
         assert len(managed_workspace_hooks["preToolUse"]) == 1
         assert len(managed_workspace_hooks["postToolUse"]) == 1

--- a/tests/test_guard_daemon_adversarial_transport.py
+++ b/tests/test_guard_daemon_adversarial_transport.py
@@ -1,0 +1,372 @@
+# pyright: reportAny=false, reportImplicitStringConcatenation=false, reportPrivateUsage=false
+# pyright: reportUnknownArgumentType=false, reportUnknownLambdaType=false
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+import urllib.parse
+import urllib.request
+from collections.abc import Generator
+from contextlib import contextmanager, suppress
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon import manager as daemon_manager
+from codex_plugin_scanner.guard.daemon import server as daemon_server
+from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+@contextmanager
+def _running_daemon(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[GuardDaemonServer]:
+    monkeypatch.setattr(
+        daemon_manager,
+        "_guard_daemon_process_inventory_for_guard_home",
+        lambda _guard_home: [],
+    )
+    daemon = GuardDaemonServer(
+        GuardStore(tmp_path / "guard-home"),
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=0,
+    )
+    daemon.start()
+    try:
+        yield daemon
+    finally:
+        daemon.stop()
+
+
+def _raw_request(port: int, request: bytes) -> bytes:
+    client = socket.create_connection(("127.0.0.1", port), timeout=1)
+    client.settimeout(2)
+    try:
+        client.sendall(request)
+        client.shutdown(socket.SHUT_WR)
+        return _recv_all(client)
+    finally:
+        client.close()
+
+
+def _recv_all(client: socket.socket) -> bytes:
+    chunks: list[bytes] = []
+    while True:
+        chunk = client.recv(4096)
+        if not chunk:
+            return b"".join(chunks)
+        chunks.append(chunk)
+
+
+def _status_code(response: bytes) -> int:
+    status_line = response.split(b"\r\n", 1)[0]
+    return int(status_line.split()[1])
+
+
+@pytest.mark.parametrize(
+    ("headers", "body", "expected_status"),
+    [
+        (b"Content-Length: nope\r\n", b"{}", 400),
+        (b"Content-Length: -1\r\n", b"", 400),
+        (b"Content-Length: 1000001\r\n", b"", 413),
+        (b"Content-Length: 2\r\nContent-Length: 2\r\n", b"{}", 400),
+        (b"Transfer-Encoding: chunked\r\n", b"2\r\n{}\r\n0\r\n\r\n", 400),
+        (b"Content-Type: application/json\r\nContent-Length: 1\r\n", b"\xff", 400),
+        (b"Content-Type: application/json\r\nContent-Length: 1\r\n", b"{", 400),
+    ],
+)
+def test_malformed_request_framing_returns_bounded_error_without_handler_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    headers: bytes,
+    body: bytes,
+    expected_status: int,
+) -> None:
+    with _running_daemon(tmp_path, monkeypatch) as daemon:
+        handler_errors: list[object] = []
+        monkeypatch.setattr(
+            daemon._server,
+            "handle_error",
+            lambda _request, address: handler_errors.append(address),
+        )
+        request = (
+            b"POST /v1/hooks/pi HTTP/1.1\r\n"
+            b"Host: 127.0.0.1\r\n"
+            + headers
+            + f"X-Guard-Token: {daemon._server.auth_token}\r\n".encode()
+            + b"\r\n"
+            + body
+        )
+
+        response = _raw_request(daemon.port, request)
+
+    assert _status_code(response) == expected_status
+    assert handler_errors == []
+
+
+def test_truncated_request_body_returns_400_without_handler_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _running_daemon(tmp_path, monkeypatch) as daemon:
+        handler_errors: list[object] = []
+        monkeypatch.setattr(
+            daemon._server,
+            "handle_error",
+            lambda _request, address: handler_errors.append(address),
+        )
+        response = _raw_request(
+            daemon.port,
+            (
+                b"POST /v1/hooks/pi HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: 10\r\n" + f"X-Guard-Token: {daemon._server.auth_token}\r\n".encode() + b"\r\n{}"
+            ),
+        )
+
+    assert _status_code(response) == 400
+    assert b"incomplete_request_body" in response
+    assert handler_errors == []
+
+
+def test_slow_request_body_expires_and_releases_handler_capacity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(daemon_server, "_DAEMON_REQUEST_READ_TIMEOUT_SECONDS", 0.05)
+    with _running_daemon(tmp_path, monkeypatch) as daemon:
+        client = socket.create_connection(("127.0.0.1", daemon.port), timeout=1)
+        client.settimeout(1)
+        try:
+            client.sendall(
+                b"POST /v1/hooks/pi HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: 10\r\n" + f"X-Guard-Token: {daemon._server.auth_token}\r\n".encode() + b"\r\n{"
+            )
+            response = _recv_all(client)
+        finally:
+            client.close()
+        deadline = time.monotonic() + 1
+        while daemon._server.active_requests and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        assert _status_code(response) == 408
+        assert b"request_body_timeout" in response
+        assert daemon._server.active_requests == 0
+
+
+def test_disconnected_slow_clients_do_not_emit_handler_exception_storm(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(daemon_server, "_DAEMON_REQUEST_READ_TIMEOUT_SECONDS", 0.05)
+    with _running_daemon(tmp_path, monkeypatch) as daemon:
+        handler_errors: list[object] = []
+        monkeypatch.setattr(
+            daemon._server,
+            "handle_error",
+            lambda _request, address: handler_errors.append(address),
+        )
+        clients: list[socket.socket] = []
+        for _ in range(64):
+            client = socket.create_connection(("127.0.0.1", daemon.port), timeout=1)
+            client.sendall(
+                b"POST /v1/hooks/pi HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: 9999\r\n" + f"X-Guard-Token: {daemon._server.auth_token}\r\n".encode() + b"\r\n{"
+            )
+            clients.append(client)
+        for client in clients:
+            client.close()
+        deadline = time.monotonic() + 2
+        while daemon._server.active_requests and time.monotonic() < deadline:
+            time.sleep(0.01)
+        with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/healthz", timeout=0.5) as response:
+            assert json.loads(response.read())["ok"] is True
+
+    assert handler_errors == []
+    assert daemon._server.active_requests == 0
+
+
+def test_partial_connections_are_bounded_before_handler_threads_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(daemon_server, "_DAEMON_REQUEST_READ_TIMEOUT_SECONDS", 1.0)
+    with _running_daemon(tmp_path, monkeypatch) as daemon:
+        daemon._server.connection_capacity_limit = 2
+        daemon._server.connection_capacity = threading.BoundedSemaphore(2)
+        clients = [socket.create_connection(("127.0.0.1", daemon.port), timeout=1) for _ in range(3)]
+        try:
+            deadline = time.monotonic() + 0.2
+            while time.monotonic() < deadline:
+                with daemon._server.request_capacity_lock:
+                    if daemon._server.active_requests == 2:
+                        break
+                time.sleep(0.01)
+            with daemon._server.request_capacity_lock:
+                assert daemon._server.active_requests == 2
+            with daemon._server.unclassified_connections_lock:
+                assert len(daemon._server.unclassified_connections) == 2
+            clients[0].settimeout(0.2)
+            with suppress(ConnectionResetError):
+                assert clients[0].recv(1) == b""
+        finally:
+            for client in clients:
+                client.close()
+
+
+def test_absolute_header_deadline_closes_trickle_client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _running_daemon(tmp_path, monkeypatch) as daemon:
+        client = socket.create_connection(("127.0.0.1", daemon.port), timeout=1)
+        client.settimeout(1)
+        started = time.monotonic()
+        try:
+            for byte in b"GET /healthz HTTP/1.1\r\n":
+                try:
+                    client.sendall(bytes((byte,)))
+                except OSError:
+                    break
+                time.sleep(0.04)
+            with suppress(ConnectionResetError):
+                assert client.recv(1) == b""
+        finally:
+            client.close()
+        elapsed = time.monotonic() - started
+        deadline = time.monotonic() + 1
+        while daemon._server.active_requests and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+    assert elapsed < 0.6
+    assert daemon._server.active_requests == 0
+
+
+def test_liveness_progresses_during_continuous_slow_client_replenishment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _running_daemon(tmp_path, monkeypatch) as daemon:
+        daemon._server.connection_capacity_limit = 4
+        daemon._server.connection_capacity = threading.BoundedSemaphore(4)
+        slow_clients = [socket.create_connection(("127.0.0.1", daemon.port), timeout=1) for _ in range(4)]
+        health_latencies: list[float] = []
+        try:
+            for _ in range(12):
+                started = time.monotonic()
+                with urllib.request.urlopen(
+                    f"http://127.0.0.1:{daemon.port}/healthz",
+                    timeout=0.5,
+                ) as response:
+                    assert json.loads(response.read())["ok"] is True
+                health_latencies.append(time.monotonic() - started)
+                slow_clients.append(socket.create_connection(("127.0.0.1", daemon.port), timeout=1))
+        finally:
+            for client in slow_clients:
+                client.close()
+
+    assert max(health_latencies) < 0.25
+
+
+def test_liveness_uses_reserved_capacity_when_general_requests_are_saturated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with _running_daemon(tmp_path, monkeypatch) as daemon:
+        acquired = [
+            daemon._server.request_capacity.acquire(blocking=False)
+            for _ in range(daemon._server.request_capacity_limit)
+        ]
+        try:
+            started = time.monotonic()
+            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/healthz", timeout=1) as response:
+                health = json.loads(response.read())
+            elapsed = time.monotonic() - started
+        finally:
+            for held in acquired:
+                if held:
+                    daemon._server.request_capacity.release()
+
+    assert health["ok"] is True
+    assert elapsed < 0.5
+
+
+@pytest.mark.parametrize(
+    ("path", "payload", "assertion"),
+    [
+        (
+            "/v1/hooks/pi",
+            {"hook_event_name": "PreToolUse", "tool_name": "read", "tool_input": {}},
+            ("decision", "deny"),
+        ),
+        (
+            "/v1/hooks/claude-code",
+            {"hook_event_name": "PreToolUse", "tool_name": "Read", "tool_input": {}},
+            ("permissionDecision", "deny"),
+        ),
+        (
+            "/v1/hooks/claude-code",
+            {"hook_event_name": "PermissionRequest", "tool_name": "Read", "tool_input": {}},
+            ("behavior", "deny"),
+        ),
+    ],
+)
+def test_hook_overload_returns_native_fail_safe_response(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+    payload: dict[str, object],
+    assertion: tuple[str, str],
+) -> None:
+    monkeypatch.setattr(daemon_server, "_MAX_CONCURRENT_RUNTIME_HOOKS_PER_HARNESS", 1)
+    with _running_daemon(tmp_path, monkeypatch) as daemon:
+        harness = "pi" if path.endswith("/pi") else "claude-code"
+        harness_capacity = daemon._server.hook_harness_semaphore(harness)
+        assert harness_capacity.acquire(blocking=False)
+        query = urllib.parse.urlencode(
+            {
+                "guard-home": str(daemon._server.store.guard_home),
+                "workspace": str(tmp_path),
+            }
+        )
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}{path}?{query}",
+            data=json.dumps(payload).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "X-Guard-Token": daemon._server.auth_token,
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=1) as response:
+                result = json.loads(response.read())
+        finally:
+            harness_capacity.release()
+
+    assert result["reason_code"] == "daemon_hook_capacity"
+    if assertion[0] == "decision":
+        assert result["decision"] == assertion[1]
+    elif assertion[0] == "permissionDecision":
+        assert result["hookSpecificOutput"]["permissionDecision"] == assertion[1]
+    else:
+        assert result["hookSpecificOutput"]["decision"]["behavior"] == assertion[1]
+
+
+def test_unknown_harnesses_share_one_bounded_capacity_bucket(tmp_path: Path) -> None:
+    daemon = GuardDaemonServer(GuardStore(tmp_path / "guard-home"), host="127.0.0.1", port=0)
+    try:
+        capacities = {id(daemon._server.hook_harness_semaphore(f"unknown-{index}")) for index in range(1_000)}
+    finally:
+        daemon._server.server_close()
+
+    assert len(capacities) == 1
+    assert set(daemon._server.hook_harness_capacity) == {"other"}

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -2417,6 +2417,30 @@ def test_windows_daemon_inventory_is_bounded_strict_and_guard_home_scoped(tmp_pa
     assert "ConvertTo-Json" in query_commands[0][-1]
 
 
+def test_daemon_inventory_ignores_malformed_unrelated_process_with_guard_text(tmp_path, monkeypatch) -> None:
+    command_line = '/Applications/Host UI.app/Contents/MacOS/Host turn-ended {"prompt":"guard daemon --serve'
+    monkeypatch.setattr(daemon_manager_module, "_trusted_posix_ps_path", lambda: "/bin/ps")
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_bounded_process_query_stdout",
+        lambda _command: f"123 {command_line}\n",
+    )
+
+    assert daemon_manager_module._guard_daemon_process_inventory_for_guard_home(tmp_path) == []
+
+
+def test_daemon_inventory_fails_closed_for_malformed_python_guard_process(tmp_path, monkeypatch) -> None:
+    command_line = '/usr/bin/python3 -m codex_plugin_scanner.cli guard daemon --serve "'
+    monkeypatch.setattr(daemon_manager_module, "_trusted_posix_ps_path", lambda: "/bin/ps")
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_bounded_process_query_stdout",
+        lambda _command: f"123 {command_line}\n",
+    )
+
+    assert daemon_manager_module._guard_daemon_process_inventory_for_guard_home(tmp_path) is None
+
+
 def test_inventoried_windows_daemon_termination_is_bound_to_sampled_creation_time(tmp_path, monkeypatch) -> None:
     guard_home = tmp_path / "guard-home"
     creation_time = 8_765_432

--- a/tests/test_guard_daemon_recovery_resilience.py
+++ b/tests/test_guard_daemon_recovery_resilience.py
@@ -1,0 +1,325 @@
+"""Adversarial daemon recovery coordination tests."""
+
+# pyright: reportPrivateUsage=false, reportUnknownArgumentType=false, reportUnknownLambdaType=false
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+import time
+from contextlib import nullcontext
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon import manager as daemon_manager_module
+
+
+def _old_generation() -> dict[str, object]:
+    return {"started_at": (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()}
+
+
+def _recent_generation() -> dict[str, object]:
+    return {"started_at": datetime.now(timezone.utc).isoformat()}
+
+
+@pytest.mark.parametrize("failure_kind", ["overload", "transport-failure"])
+def test_recovery_preserves_live_daemon_for_non_control_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: daemon_manager_module.GuardDaemonHookFailureKind,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    monkeypatch.setattr(daemon_manager_module, "load_authenticated_daemon_state", lambda _home: _old_generation())
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "load_guard_daemon_url",
+        lambda _home: "http://127.0.0.1:4781",
+    )
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "retire_all_guard_daemons_for_home",
+        lambda _home: pytest.fail("load shedding and transient transport failures must not retire a live daemon"),
+    )
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "ensure_guard_daemon",
+        lambda _home, *, home_dir=None: pytest.fail("a live daemon must be reused"),
+    )
+
+    recovered = daemon_manager_module.recover_guard_daemon_after_hook_failure(
+        guard_home,
+        failure_kind=failure_kind,
+    )
+
+    assert recovered == "http://127.0.0.1:4781"
+
+
+def test_recovery_starts_when_overloaded_state_has_no_live_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    retired: list[Path] = []
+    monkeypatch.setattr(daemon_manager_module, "load_authenticated_daemon_state", lambda _home: _old_generation())
+    monkeypatch.setattr(daemon_manager_module, "load_guard_daemon_url", lambda _home: None)
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "retire_all_guard_daemons_for_home",
+        lambda home: retired.append(home) or [],
+    )
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "ensure_guard_daemon",
+        lambda _home, *, home_dir=None: "http://127.0.0.1:4782",
+    )
+
+    recovered = daemon_manager_module.recover_guard_daemon_after_hook_failure(
+        guard_home,
+        failure_kind="overload",
+    )
+
+    assert recovered == "http://127.0.0.1:4782"
+    assert retired == []
+
+
+def test_recovery_preserves_authenticated_live_process_when_health_probe_misses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    state = {
+        "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+        "source_root": daemon_manager_module._current_guard_daemon_source_root(),
+        "runtime_fingerprint": daemon_manager_module._current_guard_daemon_runtime_fingerprint(),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "pid": 4321,
+        "port": 4781,
+    }
+    monkeypatch.setattr(daemon_manager_module, "load_authenticated_daemon_state", lambda _home: state)
+    monkeypatch.setattr(daemon_manager_module, "load_guard_daemon_url", lambda _home: None)
+    monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_running", lambda _pid: True)
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_guard_daemon_pid_matches_command",
+        lambda _pid, expected_guard_home=None: expected_guard_home == guard_home,
+    )
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "ensure_guard_daemon",
+        lambda _home, *, home_dir=None: pytest.fail("a proven live generation must not be replaced"),
+    )
+
+    recovered = daemon_manager_module.recover_guard_daemon_after_hook_failure(
+        guard_home,
+        failure_kind="overload",
+    )
+
+    assert recovered == "http://127.0.0.1:4781"
+
+
+def test_transport_recovery_replaces_authenticated_process_when_health_probe_misses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    state = {
+        "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+        "source_root": daemon_manager_module._current_guard_daemon_source_root(),
+        "runtime_fingerprint": daemon_manager_module._current_guard_daemon_runtime_fingerprint(),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "pid": 4321,
+        "port": 4781,
+    }
+    retired: list[Path] = []
+    monkeypatch.setattr(daemon_manager_module, "load_authenticated_daemon_state", lambda _home: state)
+    monkeypatch.setattr(daemon_manager_module, "load_guard_daemon_url", lambda _home: None)
+    monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_running", lambda _pid: True)
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_guard_daemon_pid_matches_command",
+        lambda _pid, expected_guard_home=None: expected_guard_home == guard_home,
+    )
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "retire_all_guard_daemons_for_home",
+        lambda home: retired.append(home) or [],
+    )
+    monkeypatch.setattr(daemon_manager_module, "guard_daemon_retirement_is_complete", lambda _home: True)
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "ensure_guard_daemon",
+        lambda _home, *, home_dir=None: "http://127.0.0.1:4782",
+    )
+
+    recovered = daemon_manager_module.recover_guard_daemon_after_hook_failure(
+        guard_home,
+        failure_kind="transport-failure",
+    )
+
+    assert recovered == "http://127.0.0.1:4782"
+    assert retired == [guard_home]
+
+
+def test_recovery_does_not_reuse_recent_stale_runtime_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    stale_state: dict[str, object] = {
+        "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+        "source_root": daemon_manager_module._current_guard_daemon_source_root(),
+        "runtime_fingerprint": "stale-runtime-fingerprint",
+        "started_at": datetime.now(timezone.utc).isoformat(),
+    }
+    start_count = 0
+
+    def ensure(_home: Path, *, home_dir: Path | None = None) -> str:
+        nonlocal start_count
+        del home_dir
+        start_count += 1
+        return "http://127.0.0.1:4782"
+
+    assert not daemon_manager_module._guard_daemon_state_matches_current_runtime(stale_state)
+    monkeypatch.setattr(daemon_manager_module, "load_authenticated_daemon_state", lambda _home: stale_state)
+    monkeypatch.setattr(daemon_manager_module, "load_guard_daemon_url", lambda _home: None)
+    monkeypatch.setattr(daemon_manager_module, "ensure_guard_daemon", ensure)
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "retire_all_guard_daemons_for_home",
+        lambda _home: pytest.fail("ensure_guard_daemon owns stale runtime retirement"),
+    )
+
+    recovered = daemon_manager_module.recover_guard_daemon_after_hook_failure(
+        guard_home,
+        failure_kind="overload",
+    )
+
+    assert recovered == "http://127.0.0.1:4782"
+    assert start_count == 1
+
+
+def test_recovery_retires_one_old_generation_for_concurrent_control_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    generation_lock = threading.Lock()
+    generation_state = _old_generation()
+    generation_url: str | None = "http://127.0.0.1:4781"
+    retirement_started = threading.Event()
+    allow_retirement = threading.Event()
+    retire_count = 0
+    start_count = 0
+
+    def load_state(_home: Path) -> dict[str, object]:
+        with generation_lock:
+            return generation_state
+
+    def load_url(_home: Path) -> str | None:
+        with generation_lock:
+            return generation_url
+
+    def retire(_home: Path) -> list[int]:
+        nonlocal generation_url, retire_count
+        retire_count += 1
+        retirement_started.set()
+        assert allow_retirement.wait(timeout=2)
+        with generation_lock:
+            generation_url = None
+        return []
+
+    def ensure(_home: Path, *, home_dir: Path | None = None) -> str:
+        nonlocal generation_state, generation_url, start_count
+        del home_dir
+        start_count += 1
+        with generation_lock:
+            generation_state = _recent_generation()
+            generation_url = "http://127.0.0.1:4782"
+        return "http://127.0.0.1:4782"
+
+    monkeypatch.setattr(daemon_manager_module, "_guard_daemon_start_lock", lambda _home: nullcontext())
+    monkeypatch.setattr(daemon_manager_module, "load_authenticated_daemon_state", load_state)
+    monkeypatch.setattr(daemon_manager_module, "load_guard_daemon_url", load_url)
+    monkeypatch.setattr(daemon_manager_module, "retire_all_guard_daemons_for_home", retire)
+    monkeypatch.setattr(daemon_manager_module, "guard_daemon_retirement_is_complete", lambda _home: True)
+    monkeypatch.setattr(daemon_manager_module, "ensure_guard_daemon", ensure)
+    results: list[str] = []
+
+    first = threading.Thread(
+        target=lambda: results.append(daemon_manager_module.recover_guard_daemon_after_hook_failure(guard_home))
+    )
+    second = threading.Thread(
+        target=lambda: results.append(daemon_manager_module.recover_guard_daemon_after_hook_failure(guard_home))
+    )
+    first.start()
+    assert retirement_started.wait(timeout=1)
+    second.start()
+    time.sleep(0.05)
+    assert second.is_alive()
+    allow_retirement.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert retire_count == 1
+    assert start_count == 1
+    assert results == ["http://127.0.0.1:4782"] * 2
+
+
+def test_recovery_lock_serializes_separate_processes(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    with daemon_manager_module._guard_daemon_recovery_lock(guard_home):
+        script = (
+            "from pathlib import Path;"
+            "from codex_plugin_scanner.guard.daemon.manager import _guard_daemon_recovery_lock;"
+            f"home=Path({str(guard_home)!r});"
+            "lock=_guard_daemon_recovery_lock(home);"
+            "lock.__enter__();"
+            "print('acquired', flush=True);"
+            "lock.__exit__(None,None,None)"
+        )
+        process = subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        time.sleep(0.2)
+        assert process.poll() is None
+
+    stdout, stderr = process.communicate(timeout=5)
+
+    assert process.returncode == 0, stderr
+    assert stdout.strip() == "acquired"
+
+
+def test_managed_daemon_launch_disables_idle_shutdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(daemon_manager_module, "_guard_home_is_ephemeral", lambda _home: False)
+
+    child_env = daemon_manager_module._daemon_launcher_env(
+        home_dir=tmp_path,
+        guard_home=tmp_path / "guard-home",
+    )
+
+    assert child_env["GUARD_DAEMON_IDLE_TIMEOUT_SECONDS"] == "0"
+
+
+def test_ephemeral_daemon_launch_retains_server_idle_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(daemon_manager_module, "_guard_home_is_ephemeral", lambda _home: True)
+
+    child_env = daemon_manager_module._daemon_launcher_env(
+        home_dir=tmp_path,
+        guard_home=tmp_path / "guard-home",
+    )
+
+    assert "GUARD_DAEMON_IDLE_TIMEOUT_SECONDS" not in child_env

--- a/tests/test_guard_daemon_storage_liveness.py
+++ b/tests/test_guard_daemon_storage_liveness.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from http.client import HTTPResponse
+from pathlib import Path
+from typing import TypeGuard, cast, final
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon import manager as daemon_manager_module
+from codex_plugin_scanner.guard.daemon.discovery import (
+    DAEMON_DISCOVERY_PROTOCOL_VERSION,
+    load_authenticated_daemon_state,
+)
+from codex_plugin_scanner.guard.daemon.runtime_heartbeat import RuntimeHeartbeatWriter
+from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.sqlite_tuning import sqlite_connect_timeout_seconds
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _is_string_object_dict(value: object) -> TypeGuard[dict[str, object]]:
+    return isinstance(value, dict) and all(isinstance(key, str) for key in cast(dict[object, object], value))
+
+
+def _open_json(
+    request: str | urllib.request.Request,
+    *,
+    timeout_seconds: float = 1,
+) -> tuple[dict[str, object], float]:
+    started = time.monotonic()
+    with cast(HTTPResponse, urllib.request.urlopen(request, timeout=timeout_seconds)) as response:
+        raw_payload = cast(object, json.loads(response.read().decode("utf-8")))
+    assert _is_string_object_dict(raw_payload)
+    return raw_payload, time.monotonic() - started
+
+
+def test_critical_daemon_liveness_does_not_wait_for_locked_storage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def empty_inventory(_home: Path) -> list[tuple[int, int]]:
+        return []
+
+    monkeypatch.setattr(daemon_manager_module, "_guard_daemon_process_inventory_for_guard_home", empty_inventory)
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    blocker = sqlite3.connect(store.path, timeout=0.1, isolation_level=None)
+
+    try:
+        initial_runtime = store.get_runtime_state()
+        assert initial_runtime is not None
+        initial_heartbeat = str(initial_runtime["last_heartbeat_at"])
+        state = load_authenticated_daemon_state(store.guard_home)
+        assert state is not None
+        _ = blocker.execute("begin exclusive")
+
+        health, health_elapsed = _open_json(f"http://127.0.0.1:{daemon.port}/healthz")
+        identity_request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/daemon/identity-challenge",
+            data=json.dumps(
+                {
+                    "nonce": "a" * 64,
+                    "hook_event": "PreToolUse",
+                    "state_id": state["state_id"],
+                    "protocol_version": DAEMON_DISCOVERY_PROTOCOL_VERSION,
+                }
+            ).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        identity, identity_elapsed = _open_json(identity_request)
+
+        assert health["ok"] is True
+        assert isinstance(identity.get("proof"), str)
+        assert health_elapsed < 0.25
+        assert identity_elapsed < 0.25
+
+        _ = blocker.execute("rollback")
+        deadline = time.monotonic() + 2
+        persisted_heartbeat = initial_heartbeat
+        while time.monotonic() < deadline:
+            runtime = store.get_runtime_state()
+            assert runtime is not None
+            persisted_heartbeat = str(runtime["last_heartbeat_at"])
+            if datetime.fromisoformat(persisted_heartbeat) > datetime.fromisoformat(initial_heartbeat):
+                break
+            time.sleep(0.02)
+        assert datetime.fromisoformat(persisted_heartbeat) > datetime.fromisoformat(initial_heartbeat)
+    finally:
+        if blocker.in_transaction:
+            blocker.rollback()
+        blocker.close()
+        daemon.stop()
+
+
+def test_locked_storage_hook_burst_fails_safe_without_stranding_daemon(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def empty_inventory(_home: Path) -> list[tuple[int, int]]:
+        return []
+
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_guard_daemon_process_inventory_for_guard_home",
+        empty_inventory,
+    )
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    blocker = sqlite3.connect(store.path, timeout=0.1, isolation_level=None)
+    _ = blocker.execute("begin exclusive")
+    endpoint = (
+        f"http://127.0.0.1:{daemon.port}/v1/hooks/pi?guard-home={store.guard_home}&home={tmp_path}&workspace={tmp_path}"
+    )
+
+    def review(index: int) -> tuple[dict[str, object], float]:
+        request = urllib.request.Request(
+            endpoint,
+            data=json.dumps(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Bash",
+                    "tool_input": {"command": f"echo bounded-{index}"},
+                }
+            ).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "X-Guard-Token": daemon._server.auth_token,  # pyright: ignore[reportPrivateUsage]
+            },
+            method="POST",
+        )
+        return _open_json(request, timeout_seconds=1.75)
+
+    try:
+        with ThreadPoolExecutor(max_workers=24) as executor:
+            futures = [executor.submit(review, index) for index in range(24)]
+            health, health_elapsed = _open_json(f"http://127.0.0.1:{daemon.port}/healthz")
+            results = [future.result(timeout=2) for future in futures]
+        assert health["ok"] is True
+        assert health_elapsed < 0.25
+        assert max(elapsed for _payload, elapsed in results) < 1.6
+        assert all(payload.get("decision") == "deny" for payload, _elapsed in results)
+        assert daemon._server.active_hook_requests == 0  # pyright: ignore[reportPrivateUsage]
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+    try:
+        worker_stats = daemon._server.hook_process_runner.stats()  # pyright: ignore[reportPrivateUsage]
+        resumed_payload, resumed_elapsed = review(100)
+        assert worker_stats["timeouts"] == 0
+        assert worker_stats["ready"] == worker_stats["configured"]
+        assert resumed_payload.get("policy_action") in {"allow", "warn"}
+        assert resumed_elapsed < 1.0
+    finally:
+        daemon.stop()
+
+
+def test_runtime_heartbeat_writer_coalesces_pending_updates() -> None:
+    @final
+    class DelayedStore:
+        def __init__(self) -> None:
+            self.attempts: list[str] = []
+            self.allow_write: bool = False
+
+        def try_touch_runtime_state(
+            self,
+            *,
+            session_id: str,
+            last_heartbeat_at: str,
+            timeout_seconds: float,
+        ) -> bool:
+            assert session_id == "session"
+            assert timeout_seconds == 0.01
+            self.attempts.append(last_heartbeat_at)
+            return self.allow_write
+
+    store = DelayedStore()
+    writer = RuntimeHeartbeatWriter(
+        store=store,
+        session_id="session",
+        write_timeout_seconds=0.01,
+        retry_interval_seconds=0.01,
+    )
+    writer.start()
+    try:
+        for index in range(100):
+            writer.touch(f"heartbeat-{index}")
+        deadline = time.monotonic() + 1
+        while not store.attempts and time.monotonic() < deadline:
+            time.sleep(0.005)
+        store.allow_write = True
+        writer.touch("heartbeat-final")
+        deadline = time.monotonic() + 1
+        while (not store.attempts or store.attempts[-1] != "heartbeat-final") and time.monotonic() < deadline:
+            time.sleep(0.005)
+    finally:
+        writer.stop()
+
+    assert store.attempts[-1] == "heartbeat-final"
+    assert len(store.attempts) < 20
+
+
+def test_bounded_runtime_heartbeat_connection_closes_after_write_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    closed = False
+
+    @final
+    class FailingConnection:
+        def execute(
+            self,
+            _statement: str,
+            _parameters: tuple[object, ...] = (),
+        ) -> None:
+            raise sqlite3.OperationalError("database is locked")
+
+        def close(self) -> None:
+            nonlocal closed
+            closed = True
+
+    def failing_connect(*_args: object, **_kwargs: object) -> FailingConnection:
+        return FailingConnection()
+
+    monkeypatch.setattr(sqlite3, "connect", failing_connect)
+
+    assert not store.try_touch_runtime_state(
+        session_id="session",
+        last_heartbeat_at="2026-07-25T00:00:00+00:00",
+        timeout_seconds=0.01,
+    )
+    assert closed
+
+
+def test_internal_hook_sqlite_timeout_is_bounded_without_changing_default() -> None:
+    assert sqlite_connect_timeout_seconds({}) == 30.0
+    assert sqlite_connect_timeout_seconds({"HOL_GUARD_INTERNAL_HOOK_SQLITE_TIMEOUT_MS": "125"}) == 0.125
+    assert sqlite_connect_timeout_seconds({"HOL_GUARD_INTERNAL_HOOK_SQLITE_TIMEOUT_MS": "10000"}) == 0.25
+    assert sqlite_connect_timeout_seconds({"HOL_GUARD_INTERNAL_HOOK_SQLITE_TIMEOUT_MS": "invalid"}) == 30.0
+    assert sqlite_connect_timeout_seconds({"HOL_GUARD_INTERNAL_HOOK_SQLITE_TIMEOUT_MS": "0"}) == 30.0

--- a/tests/test_guard_hook_process_runner.py
+++ b/tests/test_guard_hook_process_runner.py
@@ -1,0 +1,430 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import threading
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TextIO, final
+
+import pytest
+
+from codex_plugin_scanner.guard.codex_hook_launch_runtime import (
+    BoundedHookProcessResult,
+    isolated_daemon_start_command,
+    isolated_hook_environment,
+)
+from codex_plugin_scanner.guard.codex_hook_runtime_trust import TrustedCodexHookLaunch
+from codex_plugin_scanner.guard.codex_hook_windows_job import (
+    _JOB_OBJECT_LIMIT_BREAKAWAY_OK,  # pyright: ignore[reportPrivateUsage]
+    _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,  # pyright: ignore[reportPrivateUsage]
+    _job_limit_flags,  # pyright: ignore[reportPrivateUsage]
+)
+from codex_plugin_scanner.guard.daemon import hook_process_runner as hook_runner_module
+from codex_plugin_scanner.guard.daemon import hook_process_worker as hook_worker_module
+from codex_plugin_scanner.guard.daemon.hook_process_protocol import capture_hook_command
+from codex_plugin_scanner.guard.daemon.hook_process_runner import HookProcessRunner
+from codex_plugin_scanner.guard.daemon.hook_process_worker import HookWorkerSlot
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def test_windows_worker_timeout_terminates_entire_process_tree(monkeypatch: pytest.MonkeyPatch) -> None:
+    commands: list[list[str]] = []
+
+    @final
+    class FakeProcess:
+        pid: int = 4321
+
+        def is_alive(self) -> bool:
+            return True
+
+        def join(self, timeout: float | None = None) -> None:
+            del timeout
+
+        def terminate(self) -> None:
+            pytest.fail("taskkill must terminate the Windows worker tree")
+
+        def kill(self) -> None:
+            pytest.fail("taskkill must terminate the Windows worker tree")
+
+    monkeypatch.setattr(
+        hook_worker_module,
+        "os",
+        SimpleNamespace(
+            name="nt",
+            environ={"SYSTEMROOT": r"C:\Windows"},
+            path=os.path,
+        ),
+    )
+
+    def fake_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    hook_worker_module.terminate_worker_tree(FakeProcess(), 15)
+
+    assert commands == [[r"C:\Windows/System32/taskkill.exe", "/PID", "4321", "/T", "/F"]]
+
+
+def test_windows_hook_job_breakaway_is_recovery_only() -> None:
+    assert _job_limit_flags(allow_breakaway=False) == _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    assert _job_limit_flags(allow_breakaway=True) == (
+        _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | _JOB_OBJECT_LIMIT_BREAKAWAY_OK
+    )
+
+
+def test_windows_worker_taskkill_failure_falls_back_to_direct_termination(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    terminated = False
+
+    @final
+    class FakeProcess:
+        pid: int = 4321
+
+        def is_alive(self) -> bool:
+            return True
+
+        def join(self, timeout: float | None = None) -> None:
+            del timeout
+
+        def terminate(self) -> None:
+            nonlocal terminated
+            terminated = True
+
+        def kill(self) -> None:
+            pytest.fail("SIGTERM fallback should terminate the direct worker")
+
+    monkeypatch.setattr(
+        hook_worker_module,
+        "os",
+        SimpleNamespace(
+            name="nt",
+            environ={"SYSTEMROOT": r"C:\Windows"},
+            path=os.path,
+        ),
+    )
+
+    def failed_taskkill(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.CompletedProcess([], 1, b"", b"")
+
+    monkeypatch.setattr(subprocess, "run", failed_taskkill)
+
+    hook_worker_module.terminate_worker_tree(FakeProcess(), 15)
+
+    assert terminated
+
+
+def test_worker_request_returns_parsed_hook_json() -> None:
+    def run(output_stream: TextIO) -> int:
+        _ = output_stream.write('{"decision":"deny"}')
+        return 0
+
+    result = capture_hook_command(run)
+
+    assert result == {"payload": {"decision": "deny"}, "reason_code": None}
+
+
+def test_worker_request_fails_safe_on_invalid_json() -> None:
+    def run(output_stream: TextIO) -> int:
+        _ = output_stream.write("not-json")
+        return 0
+
+    result = capture_hook_command(run)
+
+    assert result == {"payload": None, "reason_code": "daemon_hook_process_invalid_json"}
+
+
+def test_prewarmed_runner_handles_real_hook_and_closes(tmp_path: Path) -> None:
+    runner = HookProcessRunner(process_limit=1, timeout_seconds=2)
+    try:
+        runner.start()
+        result = runner.review(
+            payload={"hook_event_name": "SessionStart"},
+            harness="pi",
+            home_dir=tmp_path,
+            guard_home=tmp_path,
+            workspace=tmp_path,
+            hook_env={},
+        )
+    finally:
+        runner.close()
+        runner.close()
+
+    assert result.reason_code is None
+    assert result.payload is not None
+
+
+def test_worker_prewarm_does_not_create_approval_request(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path)
+    runner = HookProcessRunner(guard_home=tmp_path, process_limit=1)
+    try:
+        runner.start()
+    finally:
+        runner.close()
+
+    assert store.count_approval_requests() == 0
+
+
+def test_transient_initial_worker_failure_replenishes_capacity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = HookProcessRunner(guard_home=tmp_path, process_limit=1)
+    original_ready = runner._slot_became_ready  # pyright: ignore[reportPrivateUsage]
+    attempts = 0
+
+    def transient_ready(slot: HookWorkerSlot, timeout: float) -> bool:
+        nonlocal attempts
+        attempts += 1
+        return attempts > 1 and original_ready(slot, timeout)
+
+    monkeypatch.setattr(runner, "_slot_became_ready", transient_ready)
+    ready_workers = 0
+    review_payload: dict[str, object] | None = None
+    try:
+        runner.start()
+        deadline = time.monotonic() + 3
+        while runner.stats()["ready"] != 1 and time.monotonic() < deadline:
+            time.sleep(0.02)
+        ready_workers = runner.stats()["ready"]
+        review_payload = runner.review(
+            payload={"hook_event_name": "SessionStart"},
+            harness="pi",
+            home_dir=tmp_path,
+            guard_home=tmp_path,
+            workspace=tmp_path,
+            hook_env={},
+        ).payload
+    finally:
+        runner.close()
+
+    assert attempts >= 2
+    assert ready_workers == 1
+    assert review_payload is not None
+    assert runner.stats()["workers"] == 0
+
+
+def test_transient_worker_spawn_failure_replenishes_capacity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = HookProcessRunner(guard_home=tmp_path, process_limit=1)
+    original_start = runner._start_slot  # pyright: ignore[reportPrivateUsage]
+    attempts = 0
+
+    def transient_start(*, generation: int) -> HookWorkerSlot:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise MemoryError("temporary process exhaustion")
+        return original_start(generation=generation)
+
+    monkeypatch.setattr(runner, "_start_slot", transient_start)
+    try:
+        runner.start()
+        assert runner.stats()["ready"] == 1
+        result = runner.review(
+            payload={"hook_event_name": "SessionStart"},
+            harness="pi",
+            home_dir=tmp_path,
+            guard_home=tmp_path,
+            workspace=tmp_path,
+            hook_env={},
+        )
+    finally:
+        runner.close()
+
+    assert attempts == 3
+    assert result.payload is not None
+
+
+def test_persistent_spawn_failure_uses_one_bounded_backoff_supervisor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = HookProcessRunner(guard_home=tmp_path, process_limit=4)
+    attempts = 0
+
+    def unavailable_start(*, generation: int) -> HookWorkerSlot:
+        del generation
+        nonlocal attempts
+        attempts += 1
+        raise OSError("process table exhausted")
+
+    monkeypatch.setattr(hook_runner_module, "_HOOK_PROCESS_READY_TIMEOUT_SECONDS", 0.3)
+    monkeypatch.setattr(runner, "_start_slot", unavailable_start)
+    runner.start()
+    try:
+        assert attempts <= 4
+        assert runner.stats()["workers"] == 0
+        assert runner.stats()["failures"] == attempts
+    finally:
+        runner.close()
+
+
+def test_blocked_worker_spawn_does_not_block_supervisor_shutdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = HookProcessRunner(guard_home=tmp_path, process_limit=1)
+    original_start = runner._start_slot  # pyright: ignore[reportPrivateUsage]
+    spawn_started = threading.Event()
+    release_spawn = threading.Event()
+    attempts = 0
+
+    def controlled_start(*, generation: int) -> HookWorkerSlot:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            spawn_started.set()
+            assert release_spawn.wait(timeout=5)
+        return original_start(generation=generation)
+
+    monkeypatch.setattr(hook_runner_module, "_HOOK_PROCESS_READY_TIMEOUT_SECONDS", 0.1)
+    monkeypatch.setattr(runner, "_start_slot", controlled_start)
+    runner.start()
+    assert spawn_started.wait(timeout=1)
+    supervisor = runner._supervisor_thread  # pyright: ignore[reportPrivateUsage]
+    spawn_thread = runner._spawn_thread  # pyright: ignore[reportPrivateUsage]
+
+    started = time.monotonic()
+    runner.close()
+    elapsed = time.monotonic() - started
+
+    assert supervisor is not None and not supervisor.is_alive()
+    assert spawn_thread is not None and spawn_thread.is_alive()
+    assert elapsed < 0.5
+    monkeypatch.setattr(hook_runner_module, "_HOOK_PROCESS_READY_TIMEOUT_SECONDS", 5.0)
+    runner.start()
+    deadline = time.monotonic() + 3
+    while runner.stats()["ready"] != 1 and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert runner.stats()["ready"] == 1
+    release_spawn.set()
+    spawn_thread.join(timeout=2)
+    deadline = time.monotonic() + 1
+    while runner.stats()["workers"] != 1 and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert not spawn_thread.is_alive()
+    assert runner.stats()["workers"] == 1
+    runner.close()
+
+
+def test_crashed_worker_is_replaced_and_reviews_resume(tmp_path: Path) -> None:
+    runner = HookProcessRunner(guard_home=tmp_path, process_limit=1, timeout_seconds=0.5)
+    runner.start()
+    try:
+        slot = runner._slots.get_nowait()  # pyright: ignore[reportPrivateUsage]
+        slot.process.kill()
+        slot.process.join(timeout=1)
+        runner._slots.put_nowait(slot)  # pyright: ignore[reportPrivateUsage]
+
+        failed = runner.review(
+            payload={"hook_event_name": "SessionStart"},
+            harness="pi",
+            home_dir=tmp_path,
+            guard_home=tmp_path,
+            workspace=tmp_path,
+            hook_env={},
+        )
+        deadline = time.monotonic() + 2
+        while runner.stats()["ready"] != 1 and time.monotonic() < deadline:
+            time.sleep(0.02)
+        recovered = runner.review(
+            payload={"hook_event_name": "SessionStart"},
+            harness="pi",
+            home_dir=tmp_path,
+            guard_home=tmp_path,
+            workspace=tmp_path,
+            hook_env={},
+        )
+    finally:
+        runner.close()
+
+    assert failed.payload is None
+    assert runner.stats()["restarts"] == 1
+    assert recovered.payload is not None
+
+
+def test_close_joins_in_flight_worker_recovery(tmp_path: Path) -> None:
+    runner = HookProcessRunner(guard_home=tmp_path, process_limit=1, timeout_seconds=0.5)
+    runner.start()
+    slot = runner._slots.get_nowait()  # pyright: ignore[reportPrivateUsage]
+    slot.process.kill()
+    slot.process.join(timeout=1)
+    runner._slots.put_nowait(slot)  # pyright: ignore[reportPrivateUsage]
+
+    _ = runner.review(
+        payload={"hook_event_name": "SessionStart"},
+        harness="pi",
+        home_dir=tmp_path,
+        guard_home=tmp_path,
+        workspace=tmp_path,
+        hook_env={},
+    )
+    supervisor = runner._supervisor_thread  # pyright: ignore[reportPrivateUsage]
+    runner.close()
+
+    assert runner.stats()["workers"] == 0
+    assert supervisor is None or not supervisor.is_alive()
+
+
+def test_runner_rejects_invalid_limits() -> None:
+    with pytest.raises(ValueError, match="process_limit"):
+        _ = HookProcessRunner(process_limit=0)
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        _ = HookProcessRunner(timeout_seconds=0)
+
+
+def test_recovery_failure_kind_is_tightly_allowlisted(tmp_path: Path) -> None:
+    environment = isolated_hook_environment(
+        {
+            "HOL_GUARD_HOOK_FAILURE_KIND": "overload",
+            "HOL_GUARD_UNTRUSTED_FAILURE_KIND": "authenticated-control-plane-failure",
+        }
+    )
+    command = isolated_daemon_start_command("python", tmp_path, tmp_path / "guard")
+
+    assert environment == {"HOL_GUARD_HOOK_FAILURE_KIND": "overload"}
+    assert "'transport-failure'" in command[3]
+    assert "'overload'" in command[3]
+    assert "HOL_GUARD_UNTRUSTED_FAILURE_KIND" not in command[3]
+
+
+def test_trusted_recovery_overlays_only_valid_failure_kind(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    environments: list[dict[str, str]] = []
+
+    def capture_process(
+        command: Sequence[str],
+        *,
+        input_text: str,
+        cwd: Path,
+        environment: Mapping[str, str],
+        timeout_seconds: float,
+        output_limit: int = 1_000_000,
+        allow_windows_breakaway: bool = False,
+    ) -> BoundedHookProcessResult:
+        del command, input_text, cwd, timeout_seconds, output_limit
+        assert allow_windows_breakaway
+        environments.append(dict(environment))
+        return BoundedHookProcessResult(0, "", False, False)
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.codex_hook_runtime_trust.run_isolated_hook_process",
+        capture_process,
+    )
+    launch = TrustedCodexHookLaunch(cwd=tmp_path, environment={"HOME": str(tmp_path)})
+
+    assert launch.run_start(("python",), timeout_seconds=1, failure_kind="overload")
+    assert launch.run_start(("python",), timeout_seconds=1, failure_kind="invalid")
+
+    assert environments[0]["HOL_GUARD_HOOK_FAILURE_KIND"] == "overload"
+    assert environments[1]["HOL_GUARD_HOOK_FAILURE_KIND"] == "transport-failure"

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -961,18 +961,19 @@ class TestGuardSurfaceServer:
         workspace_dir.mkdir(parents=True, exist_ok=True)
         captured: dict[str, str | None] = {}
 
-        def fake_run_guard_command(args, *, input_text, output_stream):
-            del input_text
-            captured["binding"] = os.environ.get("HOL_GUARD_CURSOR_APPROVAL_BINDING")
-            captured["proof"] = os.environ.get("HOL_GUARD_CURSOR_AFTER_SHELL_PROOF")
-            captured["managed"] = os.environ.get("HOL_GUARD_MANAGED_CURSOR_HOOK")
-            captured["session"] = os.environ.get("CURSOR_SESSION_ID")
-            output_stream.write("{}")
-            return 0
+        def fake_review(**kwargs):
+            hook_env = kwargs["hook_env"]
+            captured["binding"] = hook_env.get("HOL_GUARD_CURSOR_APPROVAL_BINDING")
+            captured["proof"] = hook_env.get("HOL_GUARD_CURSOR_AFTER_SHELL_PROOF")
+            captured["managed"] = hook_env.get("HOL_GUARD_MANAGED_CURSOR_HOOK")
+            captured["session"] = hook_env.get("CURSOR_SESSION_ID")
+            from codex_plugin_scanner.guard.daemon.hook_process_runner import HookProcessReview
 
-        monkeypatch.setattr(guard_commands_module, "run_guard_command", fake_run_guard_command)
+            return HookProcessReview({}, None)
+
         daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
         daemon.start()
+        monkeypatch.setattr(daemon._server.hook_process_runner, "review", fake_review)
 
         try:
             request = urllib.request.Request(
@@ -1175,15 +1176,15 @@ class TestGuardSurfaceServer:
         workspace_dir.mkdir(parents=True, exist_ok=True)
         captured: dict[str, str | None] = {}
 
-        def fake_run_guard_command(args, *, input_text, output_stream):
-            del input_text
-            captured["workspace"] = args.workspace
-            output_stream.write("{}")
-            return 0
+        def fake_review(**kwargs):
+            captured["workspace"] = str(kwargs["workspace"])
+            from codex_plugin_scanner.guard.daemon.hook_process_runner import HookProcessReview
 
-        monkeypatch.setattr(guard_commands_module, "run_guard_command", fake_run_guard_command)
+            return HookProcessReview({}, None)
+
         daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
         daemon.start()
+        monkeypatch.setattr(daemon._server.hook_process_runner, "review", fake_review)
 
         try:
             trailing_none = workspace_dir / "None"
@@ -3593,11 +3594,14 @@ class TestGuardDaemonFastHookPath:
         daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
         daemon.start()
 
-        def broken_review_http_payload(**kwargs):
-            raise RuntimeError("boom")
-
         try:
-            monkeypatch.setattr(daemon._server.hook_worker, "review_http_payload", broken_review_http_payload)
+            from codex_plugin_scanner.guard.daemon.hook_process_runner import HookProcessReview
+
+            monkeypatch.setattr(
+                daemon._server.hook_process_runner,
+                "review",
+                lambda **_kwargs: HookProcessReview(None, "daemon_worker_exception"),
+            )
             payload = {
                 "hook_event_name": "PostToolUse",
                 "tool_name": "Read",

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -78,10 +78,16 @@ def test_install_generates_guard_managed_overlay_and_pretool_files(tmp_path: Pat
     overlay_path = Path(str(manifest["mcp_overlay_path"]))
     pretool_path = Path(str(manifest["pretool_hook_path"]))
     overlay_payload = json.loads(overlay_path.read_text(encoding="utf-8"))
+    pretool_payload = json.loads(pretool_path.read_text(encoding="utf-8"))
 
     assert manifest["install_state"] == "installed"
     assert overlay_path.exists() is True
     assert pretool_path.exists() is True
+    bridge_config = json.loads(pretool_payload["command"][-1])
+    assert bridge_config["harness"] == "hermes"
+    assert bridge_config["timeout_seconds"] == 3
+    assert pretool_payload["timeout_seconds"] == 5
+    assert pretool_payload["fail_open"] is False
     assert overlay_payload["github"]["command"] == str(Path(sys.executable))
     assert overlay_payload["github"]["args"][-3:] == ["--server", "yaml:github", "--stdio"]
     assert overlay_payload["remote-docs"]["command"] == str(Path(sys.executable))
@@ -134,6 +140,7 @@ def test_install_writes_guard_section_to_config_yaml(tmp_path: Path):
 
     assert "guard" in config
     assert config["guard"]["enabled"] is True
+    assert config["guard"]["fail_open"] is False
     assert config["guard"]["token_env_var"] == "HERMES_GUARD_TOKEN"
     assert config["guard"]["enforce_mcp_tools"] is True
 

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -392,7 +392,11 @@ def test_install_exports_guard_managed_openclaw_overlay(tmp_path: Path) -> None:
     assert manifest["install_state"] == "installed"
     assert overlay_path.exists() is True
     assert pretool_path.exists() is True
-    assert pretool["command"][pretool["command"].index("--home") + 1] == str(context.home_dir)
+    bridge_config = json.loads(pretool["command"][-1])
+    assert bridge_config["cli_args"][bridge_config["cli_args"].index("--home") + 1] == str(context.home_dir)
+    assert bridge_config["timeout_seconds"] == 3
+    assert pretool["timeout_seconds"] == 5
+    assert pretool["fail_open"] is False
     assert env["OPENCLAW_GUARD_OVERLAY_PATH"] == str(overlay_path)
     assert env["OPENCLAW_GUARD_PRETOOL_PATH"] == str(pretool_path)
     assert env["OPENCLAW_GUARD_CHANNEL_POSTURE"] == "enabled"

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -29,6 +29,19 @@ from codex_plugin_scanner.guard.adapters.opencode_pretool import (
 from codex_plugin_scanner.guard.cli import install_commands as install_commands_module
 
 
+def _bun_executable() -> str | None:
+    path_without_guard_shims = os.pathsep.join(
+        entry for entry in os.environ.get("PATH", "").split(os.pathsep) if "package-shims" not in entry
+    )
+    unwrapped = shutil.which("bun", path=path_without_guard_shims)
+    if unwrapped is not None:
+        return unwrapped
+    user_install = Path.home() / ".bun" / "bin" / "bun"
+    if user_install.is_file():
+        return str(user_install)
+    return shutil.which("bun")
+
+
 def _ctx(tmp_path: Path, *, workspace: bool = False) -> HarnessContext:
     home = tmp_path / "home"
     workspace_dir = tmp_path / "workspace" if workspace else None
@@ -42,7 +55,7 @@ def _ctx(tmp_path: Path, *, workspace: bool = False) -> HarnessContext:
 
 
 def _run_generated_guard_block_message(tmp_path: Path, *, stdout: str, stderr: str = "") -> str:
-    bun = shutil.which("bun")
+    bun = _bun_executable()
     if bun is None:
         pytest.skip("bun not installed")
     source = pretool_plugin_source(_ctx(tmp_path))
@@ -66,6 +79,26 @@ def _run_generated_guard_block_message(tmp_path: Path, *, stdout: str, stderr: s
     )
     assert completed.returncode == 0, completed.stderr
     return completed.stdout.strip()
+
+
+def _run_generated_spawn_script(tmp_path: Path, body: str) -> subprocess.CompletedProcess[str]:
+    bun = _bun_executable()
+    if bun is None:
+        pytest.skip("bun not installed")
+    plugin_path = tmp_path / "guard-spawn-plugin.ts"
+    plugin_path.write_text(pretool_plugin_source(_ctx(tmp_path)), encoding="utf-8")
+    script_path = tmp_path / "guard-spawn-runner.ts"
+    script_path.write_text(
+        "import { spawnGuardProcess } from './guard-spawn-plugin';\n" + body,
+        encoding="utf-8",
+    )
+    return subprocess.run(
+        [bun, str(script_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
 
 
 def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
@@ -163,6 +196,8 @@ def test_pretool_hook_launcher_ignores_workspace_package_hijack(
     guard_python = resolve_guard_hook_python(ctx)
     package_root = package_root_from_python(guard_python, ctx)
     launcher = _pretool_hook_launcher_code(package_root=package_root)
+    assert "run_bounded_cli_hook" in launcher
+    assert "'timeout_seconds':25" in launcher
     inherit_env = {key: os.environ[key] for key in ("PATH", "HOME") if key in os.environ}
     env = {**inherit_env, **_pretool_hook_env(package_root=package_root), _HOOK_ARGV_ENV: '["guard","hook","--json"]'}
     completed = subprocess.run(
@@ -215,6 +250,83 @@ def test_pretool_plugin_source_includes_node_spawn_fallback(tmp_path: Path) -> N
     assert 'proc.stdout?.setEncoding("utf8")' in spawn_block
     assert 'proc.stdin?.on("error", () => {})' in spawn_block
     assert "proc.stdin?.end(options.stdin)" in spawn_block
+
+
+def test_pretool_plugin_source_bounds_and_serializes_fallback(tmp_path: Path) -> None:
+    source = pretool_plugin_source(_ctx(tmp_path))
+
+    assert "const GUARD_HOOK_TIMEOUT_MS = 30_000;" in source
+    assert "const deadlineMs = Date.now() + GUARD_HOOK_TIMEOUT_MS;" in source
+    assert "const remainingMs = options.deadlineMs - Date.now();" in source
+    assert "if (fallbackInFlight)" in source
+    assert 'detached: process.platform !== "win32"' in source
+    assert 'process.kill(-processGroupId, "SIGTERM")' in source
+    assert 'process.kill(-processGroupId, "SIGKILL")' in source
+    assert 'taskkill.once("close", (status) => {' in source
+    assert "resolve(status === 0)" in source
+    assert 'taskkill.kill("SIGKILL")' in source
+    assert "void terminateGuardProcessGroup(proc).then((terminated) => {" in source
+    assert "if (!terminated)" in source
+    assert "fallback containment could not be confirmed" in source
+    assert 'process.kill(-processGroupId, "SIGKILL")' in source
+    assert "return false;" in source
+
+
+def test_pretool_plugin_rejects_overlapping_fallback_in_process(tmp_path: Path) -> None:
+    completed = _run_generated_spawn_script(
+        tmp_path,
+        """
+const options = {
+  args: ["-c", "import time;time.sleep(0.3)"],
+  cwd: process.cwd(),
+  deadlineMs: Date.now() + 2_000,
+  env: {},
+  stdin: "",
+};
+const first = spawnGuardProcess(options);
+let overlap = "";
+try {
+  await spawnGuardProcess(options);
+} catch (error) {
+  overlap = error instanceof Error ? error.message : String(error);
+}
+await first;
+console.log(overlap);
+""",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "HOL Guard fallback review is already in progress"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process-group descendant assertion requires POSIX")
+def test_pretool_plugin_timeout_kills_fallback_descendants(tmp_path: Path) -> None:
+    marker = tmp_path / "opencode-descendant-ran"
+    descendant = f"import time;time.sleep(0.8);open({str(marker)!r},'w',encoding='utf-8').write('ran')"
+    parent = f"import subprocess,sys,time;subprocess.Popen([sys.executable,'-c',{descendant!r}]);time.sleep(10)"
+    completed = _run_generated_spawn_script(
+        tmp_path,
+        f"""
+let message = "";
+try {{
+  await spawnGuardProcess({{
+    args: ["-c", {json.dumps(parent)}],
+    cwd: process.cwd(),
+    deadlineMs: Date.now() + 100,
+    env: {{}},
+    stdin: "",
+  }});
+}} catch (error) {{
+  message = error instanceof Error ? error.message : String(error);
+}}
+await new Promise((resolve) => setTimeout(resolve, 1_000));
+console.log(message);
+""",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "HOL Guard fallback review timed out"
+    assert not marker.exists()
 
 
 def test_pretool_plugin_source_has_no_bun_identifier(tmp_path: Path) -> None:

--- a/tests/test_pi_adapter.py
+++ b/tests/test_pi_adapter.py
@@ -256,7 +256,8 @@ class TestPiInstall:
         assert 'pi.on("input"' in text
         assert 'hook_event_name: "PostToolUse"' in text
         assert "    return undefined;\n  });\n}" in text
-        assert 'const GUARD_COMMAND_CANDIDATES = ["plugin-guard", "hol-guard"]' in text
+        assert "const GUARD_CLI_WRAPPER_COMMAND =" in text
+        assert "const GUARD_CLI_WRAPPER_ARGS =" in text
         assert "const GUARD_HOME =" in text
         assert "daemon-state.json" in text
         assert "daemon-auth-token" in text
@@ -286,7 +287,24 @@ class TestPiInstall:
         assert '"hook", "--json"' in text
         assert '"--home"' in text
         assert "ctx.cwd" in text
-        assert "timeout: cliTimeoutMs" in text
+        assert "const timeoutHandle = setTimeout(() => {" in text
+        assert "}, timeoutMs);" in text
+        assert "taskkill.exe" in text
+        assert "['/PID', String(child.pid), '/T', '/F']" in text
+        assert "taskkill.once('close', (status) => {" in text
+        assert "resolve(status === 0)" in text
+        assert "taskkill.kill('SIGKILL')" in text
+        assert "return waitForGuardCliChildExit(child, 200)" in text
+        assert "guardCliContainmentFailed = true" in text
+        assert 'reason_code: "guard_cli_containment_failed"' in text
+        assert "{ code: 'ECONTAINMENT' }" in text
+        recovery_block = text.split("async function recoverGuardDaemon(", 1)[1].split(
+            "async function daemonGuardResponse(",
+            1,
+        )[0]
+        assert recovery_block.index("if (guardCliContainmentFailed) return false;") < recovery_block.index(
+            "runGuardCliCommand("
+        )
         assert str(extension_path) in json.loads(settings_path.read_text(encoding="utf-8"))["extensions"]
         assert omp_extension_path.is_file()
         assert str(omp_extension_path) in json.loads(omp_settings_path.read_text(encoding="utf-8"))["extensions"]
@@ -303,20 +321,17 @@ class TestPiInstall:
         text = Path(str(manifest["config_path"])).read_text(encoding="utf-8")
         assert "serializedPayload = JSON.stringify(payloadToSend);" in text
         assert "serializedPayload.length > GUARD_MAX_SERIALIZED_PAYLOAD_CHARS" in text
-        assert "for (const command of GUARD_COMMAND_CANDIDATES)" in text
-        assert "resultError?.code === 'ENOENT'" in text
+        assert "[...GUARD_CLI_WRAPPER_ARGS, JSON.stringify(args)]" in text
         assert "async function daemonGuardResponse(" in text
         assert "await fetch(`http://127.0.0.1:${connection.port}/v1/hooks/pi?" in text
-        assert "const daemonResponse = await daemonGuardResponse(serializedPayload, cwd);" in text
+        assert "let daemonAttempt = await daemonGuardResponse(serializedPayload, cwd);" in text
         assert "const response = await runGuard(" in text
         assert "if (result.error) {" in text
-        assert "const resultError =" in text
+        assert "const errorMessage = result.error.message;" in text
         assert "const errorCode =" in text
-        assert 'decision: "allow"' in text
-        assert 'notice: "warning"' in text
+        assert 'decision: "deny"' in text
         assert "errorCode === 'ETIMEDOUT'" in text
-        assert "HOL Guard Pi hook timed out" in text
-        assert "continuing without a completed review" in text
+        assert "could not complete fallback review before the Pi deadline" in text
         assert "HOL Guard Pi hook failed before completing review" in text
         assert "GUARD_COMPATIBILITY_VERSION" in text
         assert "compatibility_version !== GUARD_COMPATIBILITY_VERSION" in text

--- a/tests/test_pi_hook_latency.py
+++ b/tests/test_pi_hook_latency.py
@@ -1,18 +1,56 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
+import sys
 import threading
+import time
 import urllib.parse
 import urllib.request
-from argparse import Namespace
+from http.client import HTTPResponse
 from pathlib import Path
-from typing import TextIO
+from typing import Protocol, cast
 
 import pytest
 
-from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.daemon.hook_process_runner import HookProcessReview
+from codex_plugin_scanner.guard.daemon.manager import GUARD_DAEMON_COMPATIBILITY_VERSION
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.store import GuardStore
+
+
+class _DaemonInternals(Protocol):
+    auth_token: str
+    hook_process_runner: object
+
+
+def _daemon_internals(daemon: GuardDaemonServer) -> _DaemonInternals:
+    return cast(_DaemonInternals, vars(daemon)["_server"])
+
+
+def _decode_json_object(payload: str | bytes) -> dict[str, object]:
+    loaded = cast(object, json.loads(payload))
+    assert isinstance(loaded, dict)
+    return cast(dict[str, object], loaded)
+
+
+def _read_json_object(response: HTTPResponse) -> dict[str, object]:
+    return _decode_json_object(response.read())
+
+
+def _bun_executable() -> str | None:
+    path_without_guard_shims = os.pathsep.join(
+        entry for entry in os.environ.get("PATH", "").split(os.pathsep) if "package-shims" not in entry
+    )
+    unwrapped = shutil.which("bun", path=path_without_guard_shims)
+    if unwrapped is not None:
+        return unwrapped
+    user_install = Path.home() / ".bun" / "bin" / "bun"
+    if user_install.is_file():
+        return str(user_install)
+    return shutil.which("bun")
 
 
 def _pi_hook_request(*, daemon: GuardDaemonServer, guard_home: str, call_id: str) -> urllib.request.Request:
@@ -27,9 +65,50 @@ def _pi_hook_request(*, daemon: GuardDaemonServer, guard_home: str, call_id: str
                 "tool_input": {"path": "README.md"},
             }
         ).encode(),
-        headers={"Content-Type": "application/json", "X-Guard-Token": daemon._server.auth_token},
+        headers={"Content-Type": "application/json", "X-Guard-Token": _daemon_internals(daemon).auth_token},
         method="POST",
     )
+
+
+def test_review_required_pi_hook_returns_before_worker_deadline(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    (guard_home / "config.toml").write_text(
+        'security_level = "custom"\n[risk_actions]\ndestructive_shell = "review"\n',
+        encoding="utf-8",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    query = urllib.parse.urlencode(
+        {
+            "guard-home": str(guard_home),
+            "home": str(tmp_path),
+            "workspace": str(tmp_path),
+        }
+    )
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{daemon.port}/v1/hooks/pi?{query}",
+        data=json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf build"},
+            }
+        ).encode(),
+        headers={"Content-Type": "application/json", "X-Guard-Token": _daemon_internals(daemon).auth_token},
+        method="POST",
+    )
+    try:
+        started = time.monotonic()
+        with urllib.request.urlopen(request, timeout=2) as response:
+            result = _read_json_object(response)
+        elapsed = time.monotonic() - started
+    finally:
+        daemon.stop()
+
+    assert result["decision"] == "deny"
+    assert store.count_pending_requests(harness="pi") == 1
+    assert elapsed < 1.45
 
 
 def test_pi_hook_is_not_queued_behind_unrelated_overlay_free_review(
@@ -39,33 +118,32 @@ def test_pi_hook_is_not_queued_behind_unrelated_overlay_free_review(
     first_started = threading.Event()
     release_first = threading.Event()
 
-    def fake_run_guard_command(args: Namespace, *, input_text: str, output_stream: TextIO) -> int:
-        del args
-        payload = json.loads(input_text)
+    def fake_review(**kwargs: object) -> HookProcessReview:
+        payload = kwargs["payload"]
+        assert isinstance(payload, dict)
         if payload["tool_call_id"] == "first":
             first_started.set()
             assert release_first.wait(timeout=2)
-        output_stream.write('{"decision":"allow"}')
-        return 0
+        return HookProcessReview({"decision": "allow"}, None)
 
-    monkeypatch.setattr(guard_commands_module, "run_guard_command", fake_run_guard_command)
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    monkeypatch.setattr(_daemon_internals(daemon).hook_process_runner, "review", fake_review)
     daemon.start()
     first_result: list[dict[str, object]] = []
 
     def run_first() -> None:
         request = _pi_hook_request(daemon=daemon, guard_home=str(store.guard_home), call_id="first")
-        with urllib.request.urlopen(request, timeout=3) as response:
-            first_result.append(json.loads(response.read()))
+        with cast(HTTPResponse, urllib.request.urlopen(request, timeout=3)) as response:
+            first_result.append(_read_json_object(response))
 
     first_thread = threading.Thread(target=run_first)
     first_thread.start()
     try:
         assert first_started.wait(timeout=1)
         request = _pi_hook_request(daemon=daemon, guard_home=str(store.guard_home), call_id="second")
-        with urllib.request.urlopen(request, timeout=1) as response:
-            second_result = json.loads(response.read())
+        with cast(HTTPResponse, urllib.request.urlopen(request, timeout=1)) as response:
+            second_result = _read_json_object(response)
     finally:
         release_first.set()
         first_thread.join(timeout=3)
@@ -86,18 +164,32 @@ def test_pi_extension_keeps_fallbacks_inside_outer_hook_deadline(tmp_path: Path)
 
     assert "const GUARD_TIMEOUT_MS = 4000;" in source
     assert "const GUARD_DEADLINE_RESERVE_MS = 250;" in source
-    assert "const GUARD_DAEMON_TIMEOUT_MS = 1250;" in source
-    assert "const GUARD_CLI_TIMEOUT_MS = 2250;" in source
+    assert "const GUARD_DAEMON_TIMEOUT_MS = 1600;" in source
+    assert "const GUARD_DAEMON_RECOVERY_TIMEOUT_MS = 600;" in source
+    assert "const GUARD_DAEMON_RETRY_TIMEOUT_MS = 500;" in source
+    assert "const GUARD_CLI_TIMEOUT_MS = 1000;" in source
     assert 'const GUARD_ARGS = ["hook", "--json"' in source
     assert "compatibility_version !== GUARD_COMPATIBILITY_VERSION" in source
     assert "error.name === 'AbortError'" in source
     assert source.index("error.name === 'AbortError'") > source.index("await fetch")
-    assert "an unresponsive daemon cannot stall or bypass Guard enforcement" in source
     timeout_branch = source[source.index("error.name === 'AbortError'") :]
-    assert "return null;" in timeout_branch
+    assert 'recoveryKind: "transport-failure"' in timeout_branch
+    assert "response.status === 401 || response.status === 403" in source
+    assert 'recoveryKind: "authenticated-control-plane-failure"' in source
+    assert "failure_kind=sys.argv[1]" in source
+    assert "recover_guard_daemon_after_hook_failure" in source
+    assert "if (!response.ok) {" in source
+    assert "reason_code: reasonCode" in source
     assert "const deadlineAt = Date.now() + GUARD_TIMEOUT_MS - GUARD_DEADLINE_RESERVE_MS" in source
     assert "Math.max(deadlineAt - Date.now(), 1)" in source
-    assert "timeout: cliTimeoutMs" in source
+    assert "spawnSync" not in source
+    assert "guardCliEvaluationInFlight" in source
+    assert "guardDaemonRecoveryInFlight" in source
+    assert "result = await runGuardCliCommand(" in source
+    assert "GUARD_CLI_WRAPPER_COMMAND" in source
+    assert "[...GUARD_CLI_WRAPPER_ARGS, JSON.stringify(args)]" in source
+    assert 'reason_code: "guard_cli_recovery_busy"' in source
+    assert 'reason_code: "guard_cli_recovery_timeout"' in source
 
 
 def test_pi_hook_deadline_stays_inside_host_timeout() -> None:
@@ -106,12 +198,212 @@ def test_pi_hook_deadline_stays_inside_host_timeout() -> None:
     from codex_plugin_scanner.guard.adapters.pi_extension_source import (
         GUARD_CLI_HOOK_TIMEOUT_MS,
         GUARD_DAEMON_HOOK_TIMEOUT_MS,
+        GUARD_DAEMON_RECOVERY_TIMEOUT_MS,
+        GUARD_DAEMON_RETRY_TIMEOUT_MS,
         GUARD_HOOK_DEADLINE_RESERVE_MS,
         GUARD_HOOK_TIMEOUT_MS,
     )
 
     assert pi_hook_host_timeout_ms > GUARD_HOOK_TIMEOUT_MS
     assert (
-        GUARD_DAEMON_HOOK_TIMEOUT_MS + GUARD_CLI_HOOK_TIMEOUT_MS + GUARD_HOOK_DEADLINE_RESERVE_MS
+        GUARD_DAEMON_HOOK_TIMEOUT_MS
+        + GUARD_DAEMON_RECOVERY_TIMEOUT_MS
+        + GUARD_DAEMON_RETRY_TIMEOUT_MS
+        + GUARD_CLI_HOOK_TIMEOUT_MS
+        + GUARD_HOOK_DEADLINE_RESERVE_MS
         < GUARD_HOOK_TIMEOUT_MS
     )
+
+
+@pytest.mark.skipif(_bun_executable() is None, reason="Bun is required to execute the managed Pi extension")
+def test_pi_extension_treats_authenticated_daemon_overload_as_terminal(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.pi_extension_source import managed_extension_source
+
+    bun = _bun_executable()
+    assert bun is not None
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    _ = (guard_home / "daemon-state.json").write_text(
+        json.dumps({"compatibility_version": GUARD_DAEMON_COMPATIBILITY_VERSION, "port": 1}),
+        encoding="utf-8",
+    )
+    _ = (guard_home / "daemon-auth-token").write_text("test-token", encoding="utf-8")
+    extension_path = tmp_path / "hol-guard.ts"
+    compiled_path = tmp_path / "hol-guard.mjs"
+    harness_path = tmp_path / "load.mjs"
+    _ = extension_path.write_text(
+        managed_extension_source(
+            guard_home=guard_home,
+            home_dir=tmp_path,
+            settings_path=tmp_path / "settings.json",
+        ),
+        encoding="utf-8",
+    )
+    _ = subprocess.run(
+        [
+            bun,
+            "build",
+            str(extension_path),
+            "--target=bun",
+            "--format=esm",
+            f"--outfile={compiled_path}",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    _ = harness_path.write_text(
+        f"""
+import installGuard from {json.dumps(str(compiled_path))};
+let fetchCount = 0;
+globalThis.fetch = async () => {{
+  fetchCount += 1;
+  return new Response(
+    JSON.stringify({{ error: "daemon_hook_capacity" }}),
+    {{ status: 503, headers: {{ "Content-Type": "application/json" }} }},
+  );
+}};
+const handlers = new Map();
+installGuard({{ on: (event, handler) => handlers.set(event, handler), sendMessage: () => {{}} }});
+const handler = handlers.get("tool_call");
+const notices = [];
+const results = await Promise.all(Array.from({{ length: 20 }}, (_, index) => handler(
+  {{ toolCallId: `call-${{index}}`, toolName: "read", input: {{ path: "README.md" }} }},
+  {{ cwd: {json.dumps(str(tmp_path))}, ui: {{ notify: (reason) => notices.push(reason) }} }},
+)));
+console.log(JSON.stringify({{
+  fetchCount,
+  blocked: results.filter((result) => result?.block === true).length,
+  overloadReasons: notices.filter((reason) => reason.includes("daemon_hook_capacity")).length,
+}}));
+""",
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        [bun, str(harness_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    payload = _decode_json_object(completed.stdout)
+
+    assert payload == {"fetchCount": 20, "blocked": 20, "overloadReasons": 20}
+
+
+@pytest.mark.skipif(
+    _bun_executable() is None or os.name != "posix",
+    reason="Bun and POSIX process groups are required for fallback termination testing",
+)
+def test_pi_extension_allows_only_one_cli_fallback_during_daemon_outage(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.pi_extension_source import managed_extension_source
+
+    bun = _bun_executable()
+    assert bun is not None
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    _ = (guard_home / "daemon-state.json").write_text(
+        json.dumps({"compatibility_version": GUARD_DAEMON_COMPATIBILITY_VERSION, "port": 1}),
+        encoding="utf-8",
+    )
+    _ = (guard_home / "daemon-auth-token").write_text("test-token", encoding="utf-8")
+    extension_path = tmp_path / "hol-guard.ts"
+    compiled_path = tmp_path / "hol-guard.mjs"
+    harness_path = tmp_path / "load.mjs"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fallback_count_path = tmp_path / "fallback-count"
+    fake_cli = fake_bin / "plugin-guard"
+    _ = fake_cli.write_text(
+        (
+            '#!/bin/sh\ntrap "" TERM\nprintf "1\\n" >> "$FALLBACK_COUNT_PATH"\n'
+            'sleep 5\nprintf \'{"decision":"allow"}\\n\'\n'
+        ),
+        encoding="utf-8",
+    )
+    _ = fake_cli.chmod(0o755)
+    source = managed_extension_source(
+        guard_home=guard_home,
+        home_dir=tmp_path,
+        settings_path=tmp_path / "settings.json",
+    )
+    recovery_command = f"const GUARD_DAEMON_RECOVERY_COMMAND = {json.dumps(str(Path(sys.executable).absolute()))};"
+    source = source.replace(
+        recovery_command,
+        'const GUARD_DAEMON_RECOVERY_COMMAND = "missing-guard-recovery-command";',
+    )
+    source = source.replace(
+        f"const GUARD_CLI_WRAPPER_COMMAND = {json.dumps(str(Path(sys.executable).absolute()))};",
+        f"const GUARD_CLI_WRAPPER_COMMAND = {json.dumps(str(fake_cli))};",
+    )
+    source = source.replace(
+        source[
+            source.index("const GUARD_CLI_WRAPPER_ARGS = ") : source.index(
+                ";\n", source.index("const GUARD_CLI_WRAPPER_ARGS = ")
+            )
+            + 2
+        ],
+        "const GUARD_CLI_WRAPPER_ARGS = [];\n",
+    )
+    assert "missing-guard-recovery-command" in source
+    _ = extension_path.write_text(source, encoding="utf-8")
+    _ = subprocess.run(
+        [
+            bun,
+            "build",
+            str(extension_path),
+            "--target=bun",
+            "--format=esm",
+            f"--outfile={compiled_path}",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    _ = harness_path.write_text(
+        f"""
+import installGuard from {json.dumps(str(compiled_path))};
+globalThis.fetch = async () => {{ throw new Error("daemon unavailable"); }};
+const handlers = new Map();
+installGuard({{ on: (event, handler) => handlers.set(event, handler), sendMessage: () => {{}} }});
+const handler = handlers.get("tool_call");
+const notices = [];
+const startedAt = performance.now();
+const results = await Promise.all(Array.from({{ length: 20 }}, (_, index) => handler(
+  {{ toolCallId: `call-${{index}}`, toolName: "read", input: {{ path: "README.md" }} }},
+  {{ cwd: {json.dumps(str(tmp_path))}, ui: {{ notify: (reason) => notices.push(reason) }} }},
+)));
+console.log(JSON.stringify({{
+  elapsedMs: performance.now() - startedAt,
+  allowed: results.filter((result) => result === undefined).length,
+  blocked: results.filter((result) => result?.block === true).length,
+  recoveryBusy: notices.filter((reason) => reason.includes("recovery is already reviewing")).length,
+  recoveryTimeout: notices.filter((reason) => reason.includes("could not complete fallback review")).length,
+}}));
+""",
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        [bun, str(harness_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        env={
+            **os.environ,
+            "FALLBACK_COUNT_PATH": str(fallback_count_path),
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+        },
+    )
+    payload = _decode_json_object(completed.stdout)
+
+    assert fallback_count_path.read_text(encoding="utf-8").splitlines() == ["1"]
+    assert payload["allowed"] == 0
+    assert payload["blocked"] == 20
+    assert payload["recoveryBusy"] == 19
+    assert payload["recoveryTimeout"] == 1
+    elapsed_ms = payload["elapsedMs"]
+    assert isinstance(elapsed_ms, (int, float))
+    assert elapsed_ms < 2_000


### PR DESCRIPTION
## Summary

- bound daemon admission, request framing, and per-harness work so slow or malformed clients cannot starve liveness
- isolate hook evaluation in a supervised worker pool that survives storage stalls, crashes, and process exhaustion
- coordinate recovery and child cleanup across supported hooks while preserving fail-safe native responses

## Testing

- `uv run --no-sync pytest -q tests/test_guard_daemon_adversarial_transport.py --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_daemon_storage_liveness.py tests/test_guard_daemon_recovery_resilience.py --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_hook_process_runner.py --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_surface_server.py --tb=short`
- focused adapter suites for Claude, Codex, Copilot, Cursor, Hermes, OpenClaw, OpenCode, and Pi
- `uv run --no-sync ruff check <changed Python files>`
- `uv run --no-sync basedpyright <new Python files>`
- `uv build`
- installed-wheel stress: 128 partial clients and 100 concurrent Pi hooks with all workers remaining ready
