### PR TITLE
fix(guard): harden daemon worker ownership

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/hook_process_entrypoint.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_entrypoint.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import argparse
 import importlib
 import json
+import multiprocessing
 import os
+import signal
+import time
 from contextlib import suppress
 from multiprocessing.connection import Connection
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, NoReturn, cast
 
 from ..codex_hook_windows_job import assign_current_process_to_windows_hook_job
 from .hook_process_protocol import (
@@ -27,21 +30,96 @@ _HOOK_SQLITE_TIMEOUT_ENV = "HOL_GUARD_INTERNAL_HOOK_SQLITE_TIMEOUT_MS"
 
 
 def hook_worker_main(connection: Connection, configured_guard_home: str | None) -> None:
+    windows_job = None
+    if os.name == "nt":
+        windows_job = assign_current_process_to_windows_hook_job()
+        if windows_job is None:
+            connection.send(("isolation_failed", None))
+            return
+    else:
+        try:
+            os.setsid()
+        except OSError:
+            connection.send(("isolation_failed", None))
+            return
+    connection.send(
+        (
+            "isolated",
+            {
+                "process_group_id": os.getpid() if os.name != "nt" else None,
+                "windows_job_contained": windows_job is not None,
+            },
+        )
+    )
+    context = multiprocessing.get_context("spawn")
+    guardian_connection, evaluator_connection = context.Pipe(duplex=True)
+    evaluator = context.Process(
+        target=_hook_evaluator_main,
+        args=(evaluator_connection, configured_guard_home),
+        name="hol-guard-hook-evaluator",
+        daemon=True,
+    )
+    try:
+        evaluator.start()
+    except BaseException:
+        guardian_connection.close()
+        evaluator_connection.close()
+        connection.send(("worker_failed", None))
+        _hold_containment_anchor()
+    evaluator_connection.close()
+    try:
+        if not guardian_connection.poll(10.0) or guardian_connection.recv() != ("ready", None):
+            connection.send(("worker_failed", None))
+            _hold_containment_anchor()
+        connection.send(("ready", None))
+        while True:
+            try:
+                raw_message = cast(object, connection.recv())
+            except EOFError:
+                _terminate_guardian_group()
+                return
+            if is_pair(raw_message) and raw_message[0] == "stop":
+                with suppress(BrokenPipeError, OSError):
+                    guardian_connection.send(("stop", None))
+                evaluator.join(timeout=0.2)
+                _hold_containment_anchor()
+            try:
+                guardian_connection.send(raw_message)
+                response = guardian_connection.recv()
+            except (BrokenPipeError, EOFError, OSError):
+                connection.send(("worker_failed", None))
+                _hold_containment_anchor()
+            connection.send(response)
+    finally:
+        guardian_connection.close()
+        _ = windows_job
+
+
+def _hold_containment_anchor() -> NoReturn:
+    while True:
+        time.sleep(60)
+
+
+def _terminate_guardian_group() -> None:
     if os.name != "nt":
         with suppress(OSError):
-            os.setsid()
-    windows_job = assign_current_process_to_windows_hook_job() if os.name == "nt" else None
+            os.killpg(os.getpid(), getattr(signal, "SIGKILL", 9))
+
+
+def _hook_evaluator_main(connection: Connection, configured_guard_home: str | None) -> None:
     os.environ[_HOOK_SQLITE_TIMEOUT_ENV] = "250"
     for module_name in (
+        "codex_plugin_scanner.guard.adapters.base",
         "codex_plugin_scanner.guard.cli.commands_hook",
         "codex_plugin_scanner.guard.cli.commands_support_connect",
         "codex_plugin_scanner.guard.config",
+        "codex_plugin_scanner.guard.daemon.hook_worker",
+        "codex_plugin_scanner.guard.store",
     ):
         _ = importlib.import_module(module_name)
     stores: dict[str, GuardStore] = {}
     hook_workers: dict[str, HookWorker] = {}
     connection.send(("ready", None))
-    _ = windows_job
     while True:
         try:
             raw_message = cast(object, connection.recv())

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
@@ -23,6 +23,7 @@ _HOOK_PROCESS_TIMEOUT_SECONDS = 1.8
 _HOOK_PROCESS_READY_TIMEOUT_SECONDS = 10.0
 _HOOK_PROCESS_ACQUIRE_TIMEOUT_SECONDS = 0.2
 _HOOK_PROCESS_BACKFILL_DELAY_SECONDS = 2.0
+_HOOK_PROCESS_BACKFILL_MAX_DEFERRAL_SECONDS = 5.0
 _HOOK_PROCESS_RETRY_MAX_SECONDS = 5.0
 
 
@@ -45,7 +46,7 @@ class HookProcessRunner:
         self._slots: queue.Queue[HookWorkerSlot] = queue.Queue(maxsize=process_limit)
         self._all_slots: dict[int, HookWorkerSlot] = {}
         self._recovery_event: threading.Event = threading.Event()
-        self._spawn_thread: threading.Thread | None = None
+        self._spawn_threads: set[threading.Thread] = set()
         self._supervisor_thread: threading.Thread | None = None
         self._retirement_threads: set[threading.Thread] = set()
         self._state_lock: threading.Lock = threading.Lock()
@@ -53,7 +54,8 @@ class HookProcessRunner:
         self._generation: int = 0
         self._capacity_target: int = process_limit
         self._backfill_not_before: float = 0.0
-        self._active_reviews: int = 0
+        self._backfill_force_after: float = 0.0
+        self._active_reviews: dict[int, int] = {}
         self._closed: bool = False
         self._started: bool = False
         self._timeouts: int = 0
@@ -65,13 +67,15 @@ class HookProcessRunner:
             if self._started and not self._closed:
                 return
             if self._closed:
+                if self._all_slots or self._spawn_threads or self._retirement_threads or self._active_reviews:
+                    raise RuntimeError("previous hook worker generation is not contained")
                 self._slots = queue.Queue(maxsize=self._process_limit)
             self._recovery_event.clear()
             self._generation += 1
             generation = self._generation
             self._capacity_target = 1 if defer_backfill else self._process_limit
             self._backfill_not_before = 0.0
-            self._active_reviews = 0
+            self._backfill_force_after = 0.0
             self._closed = False
             self._started = True
             supervisor = threading.Thread(
@@ -89,16 +93,19 @@ class HookProcessRunner:
                 self._generation += 1
                 self._increment_metric("failures")
                 return
-        deadline = time.monotonic() + _HOOK_PROCESS_READY_TIMEOUT_SECONDS
-        while self._slots.qsize() < self._capacity_target and time.monotonic() < deadline:
-            _ = self._recovery_event.wait(timeout=min(0.02, max(0.0, deadline - time.monotonic())))
+        _ = self.wait_for_capacity(
+            minimum_workers=self._capacity_target,
+            timeout_seconds=_HOOK_PROCESS_READY_TIMEOUT_SECONDS,
+        )
 
     def enable_full_capacity(self, *, delay_seconds: float = _HOOK_PROCESS_BACKFILL_DELAY_SECONDS) -> None:
         with self._state_lock:
             if self._closed or not self._started:
                 return
+            now = time.monotonic()
             self._capacity_target = self._process_limit
-            self._backfill_not_before = time.monotonic() + max(0.0, delay_seconds)
+            self._backfill_not_before = now + max(0.0, delay_seconds)
+            self._backfill_force_after = self._backfill_not_before + _HOOK_PROCESS_BACKFILL_MAX_DEFERRAL_SECONDS
         self._recovery_event.set()
 
     def review(
@@ -116,7 +123,8 @@ class HookProcessRunner:
                 return HookProcessReview(None, "daemon_hook_process_closed")
             if not self._started:
                 return HookProcessReview(None, "daemon_hook_process_not_ready")
-            self._active_reviews += 1
+            generation = self._generation
+            self._active_reviews[generation] = self._active_reviews.get(generation, 0) + 1
         started_at = time.monotonic()
         try:
             try:
@@ -145,7 +153,11 @@ class HookProcessRunner:
                 return HookProcessReview(None, "daemon_hook_process_failed")
         finally:
             with self._state_lock:
-                self._active_reviews = max(0, self._active_reviews - 1)
+                remaining_reviews = self._active_reviews.get(generation, 0) - 1
+                if remaining_reviews > 0:
+                    self._active_reviews[generation] = remaining_reviews
+                else:
+                    _ = self._active_reviews.pop(generation, None)
             self._recovery_event.set()
 
         if not is_pair(raw_message):
@@ -158,7 +170,7 @@ class HookProcessRunner:
             self._replace_slot_async(slot)
             return HookProcessReview(None, "daemon_hook_process_invalid_json")
         with self._state_lock:
-            return_slot = slot.process.is_alive() and not self._closed
+            return_slot = slot.process.is_alive() and not self._closed and generation == self._generation
             if return_slot:
                 self._slots.put_nowait(slot)
         if not return_slot:
@@ -177,6 +189,23 @@ class HookProcessRunner:
         if typed_response is None:
             return HookProcessReview(None, "daemon_hook_process_invalid_json")
         return HookProcessReview(typed_response, None)
+
+    def wait_for_capacity(self, *, minimum_workers: int, timeout_seconds: float) -> bool:
+        if not 1 <= minimum_workers <= self._process_limit:
+            raise ValueError("minimum_workers must be within configured capacity")
+        if timeout_seconds < 0:
+            raise ValueError("timeout_seconds must not be negative")
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            with self._state_lock:
+                if self._closed or not self._started:
+                    return False
+                if self._slots.qsize() >= minimum_workers:
+                    return True
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            time.sleep(min(0.02, remaining))
 
     def stats(self) -> dict[str, int]:
         with self._state_lock:
@@ -201,7 +230,7 @@ class HookProcessRunner:
             self._generation += 1
             slots = list(self._all_slots.values())
             supervisor = self._supervisor_thread
-            spawn_thread = self._spawn_thread
+            spawn_threads = list(self._spawn_threads)
             retirement_threads = list(self._retirement_threads)
             self._recovery_event.set()
         for slot in slots:
@@ -211,15 +240,15 @@ class HookProcessRunner:
                 retirement_thread.join(timeout=3.0)
         if supervisor is not None:
             supervisor.join(timeout=1.0)
-        if spawn_thread is not None:
-            spawn_thread.join(timeout=0.2)
+        for spawn_thread in spawn_threads:
+            if spawn_thread is not threading.current_thread():
+                spawn_thread.join(timeout=0.2)
         with self._state_lock:
             if supervisor is not None and not supervisor.is_alive():
                 self._supervisor_thread = None
-            if spawn_thread is not None and not spawn_thread.is_alive():
-                self._spawn_thread = None
             contained = not self._all_slots and not self._retirement_threads
-            contained = contained and self._supervisor_thread is None and self._spawn_thread is None
+            contained = contained and not self._spawn_threads and not self._active_reviews
+            contained = contained and self._supervisor_thread is None
         return contained
 
     def _start_slot(self, *, generation: int) -> HookWorkerSlot:
@@ -229,7 +258,7 @@ class HookProcessRunner:
             target=hook_worker_main,
             args=(child_connection, str(self._guard_home) if self._guard_home is not None else None),
             name="hol-guard-hook-worker",
-            daemon=True,
+            daemon=False,
         )
         try:
             process.start()
@@ -245,22 +274,55 @@ class HookProcessRunner:
         )
         with self._state_lock:
             stale = self._closed or generation != self._generation
-            self._all_slots[process.pid or id(slot)] = slot
+            if not stale:
+                self._all_slots[process.pid or id(slot)] = slot
         if stale:
-            _ = self._retire_slot(slot)
+            _ = self._slot_became_isolated(slot, _HOOK_PROCESS_READY_TIMEOUT_SECONDS)
+            if not self._retire_slot(slot):
+                with self._state_lock:
+                    self._all_slots[process.pid or id(slot)] = slot
+                self._mark_containment_failed()
         return slot
 
     @staticmethod
-    def _slot_became_ready(slot: HookWorkerSlot, timeout: float) -> bool:
+    def _slot_became_isolated(slot: HookWorkerSlot, timeout: float) -> bool:
         if timeout <= 0:
             return False
         try:
-            ready = slot.connection.poll(timeout) and slot.connection.recv() == ("ready", None)
-            if ready:
-                slot.isolation_ready = True
-                if os.name == "nt":
-                    slot.windows_job_contained = True
-            return ready
+            if not slot.connection.poll(timeout):
+                return False
+            message = slot.connection.recv()
+            if message == ("isolation_failed", None):
+                slot.pre_isolation_contained = True
+                return False
+            if not is_pair(message) or message[0] != "isolated":
+                return False
+            proof = as_string_object_dict(message[1])
+            if proof is None:
+                return False
+            if os.name == "nt":
+                if proof.get("windows_job_contained") is not True:
+                    return False
+                slot.windows_job_contained = True
+            elif proof.get("process_group_id") != slot.process.pid:
+                return False
+            slot.isolation_ready = True
+            return True
+        except (EOFError, OSError):
+            return False
+
+    @classmethod
+    def _slot_became_ready(cls, slot: HookWorkerSlot, timeout: float) -> bool:
+        if timeout <= 0:
+            return False
+        deadline = time.monotonic() + timeout
+        if not slot.isolation_ready and not cls._slot_became_isolated(slot, timeout):
+            return False
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        try:
+            return slot.connection.poll(remaining) and slot.connection.recv() == ("ready", None)
         except (EOFError, OSError):
             return False
 
@@ -270,13 +332,17 @@ class HookProcessRunner:
             with self._state_lock:
                 closed = self._closed or generation != self._generation
                 should_wait = len(self._all_slots) >= self._capacity_target
-                active_reviews = self._active_reviews
+                active_reviews = self._active_reviews.get(generation, 0)
                 backfill_not_before = self._backfill_not_before
+                backfill_force_after = self._backfill_force_after
             if closed:
                 return
-            backfill_delay = max(0.0, backfill_not_before - time.monotonic())
-            if should_wait or active_reviews > 0 or backfill_delay > 0:
-                timeout = min(0.05, backfill_delay) if backfill_delay > 0 else None
+            now = time.monotonic()
+            backfill_delay = max(0.0, backfill_not_before - now)
+            active_review_delay = max(0.0, backfill_force_after - now) if active_reviews > 0 else 0.0
+            if should_wait or backfill_delay > 0 or active_review_delay > 0:
+                capacity_delay = max(backfill_delay, active_review_delay)
+                timeout = min(0.05, capacity_delay) if capacity_delay > 0 else None
                 _ = self._recovery_event.wait(timeout=timeout)
                 self._recovery_event.clear()
                 retry_delay = 0.05
@@ -317,19 +383,18 @@ class HookProcessRunner:
                 outcomes.put(error)
             finally:
                 with self._state_lock:
-                    if self._spawn_thread is threading.current_thread():
-                        self._spawn_thread = None
+                    self._spawn_threads.discard(threading.current_thread())
 
         thread = threading.Thread(target=attempt, name="hol-guard-hook-worker-spawn", daemon=True)
         start_failed = False
         with self._state_lock:
             if self._closed or generation != self._generation:
                 return None
-            self._spawn_thread = thread
+            self._spawn_threads.add(thread)
             try:
                 thread.start()
             except RuntimeError:
-                self._spawn_thread = None
+                self._spawn_threads.discard(thread)
                 start_failed = True
         if start_failed:
             self._increment_metric("failures")

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_worker.py
@@ -12,6 +12,8 @@ from typing import Protocol
 
 from ..codex_hook_windows_job import windows_system_executable_path
 
+_WORKER_RETIRE_JOIN_TIMEOUT_SECONDS = 2.0
+
 
 class WorkerProcess(Protocol):
     @property
@@ -122,7 +124,7 @@ def retire_worker_slot(slot: HookWorkerSlot, *, graceful: bool = False) -> bool:
         tree_contained = False
     else:
         tree_contained = slot.windows_job_contained
-    slot.process.join(timeout=0.5)
+    slot.process.join(timeout=_WORKER_RETIRE_JOIN_TIMEOUT_SECONDS)
     contained = (tree_contained or slot.windows_job_contained) and not slot.process.is_alive()
     if not contained:
         with slot.retire_lock:

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_worker.py
@@ -37,7 +37,8 @@ class HookWorkerSlot:
     retire_lock: threading.Lock = field(default_factory=threading.Lock)
     retired: bool = False
     windows_job_contained: bool = False
-    isolation_ready: bool = True
+    isolation_ready: bool = False
+    pre_isolation_contained: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -83,6 +84,20 @@ def terminate_worker_tree(process: WorkerProcess, signal_number: int) -> bool:
     return False
 
 
+def terminate_owned_process_group(process: WorkerProcess, signal_number: int) -> bool:
+    if os.name == "nt" or process.pid is None or not process.is_alive():
+        return False
+    try:
+        os.killpg(process.pid, signal_number)
+        return True
+    except ProcessLookupError:
+        with suppress(OSError):
+            process.kill()
+        return True
+    except OSError:
+        return False
+
+
 def retire_worker_slot(slot: HookWorkerSlot, *, graceful: bool = False) -> bool:
     """Contain one worker tree; callers may run this outside request deadlines."""
 
@@ -94,13 +109,21 @@ def retire_worker_slot(slot: HookWorkerSlot, *, graceful: bool = False) -> bool:
         with suppress(BrokenPipeError, OSError):
             slot.connection.send(("stop", None))
         slot.process.join(timeout=0.2)
-    if not slot.process.is_alive():
-        return True
-    tree_contained = terminate_worker_tree(slot.process, getattr(signal, "SIGKILL", 9))
+    if os.name != "nt" and slot.isolation_ready:
+        tree_contained = terminate_owned_process_group(slot.process, getattr(signal, "SIGKILL", 9))
+    elif slot.pre_isolation_contained:
+        if slot.process.is_alive():
+            with suppress(OSError):
+                slot.process.kill()
+        tree_contained = True
+    elif slot.process.is_alive():
+        with suppress(OSError):
+            slot.process.kill()
+        tree_contained = False
+    else:
+        tree_contained = slot.windows_job_contained
     slot.process.join(timeout=0.5)
-    contained = (
-        tree_contained or slot.windows_job_contained or not slot.isolation_ready
-    ) and not slot.process.is_alive()
+    contained = (tree_contained or slot.windows_job_contained) and not slot.process.is_alive()
     if not contained:
         with slot.retire_lock:
             slot.retired = False
@@ -113,5 +136,6 @@ __all__ = [
     "WorkerConnection",
     "WorkerProcess",
     "retire_worker_slot",
+    "terminate_owned_process_group",
     "terminate_worker_tree",
 ]

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -6797,13 +6797,26 @@ class GuardDaemonServer:
             return
         self._thread = None
         self._begin_service()
+        serve_thread_started = False
         try:
             self._thread = threading.Thread(target=self._serve_forever, daemon=True)
             self._thread.start()
+            serve_thread_started = True
             self._server.hook_process_runner.enable_full_capacity()
         except BaseException as error:
-            self._thread = None
-            if not self._finish_service():
+            serve_thread_contained = True
+            if serve_thread_started and self._thread is not None:
+                self._server.shutdown()
+                self._thread.join(timeout=5)
+                serve_thread_contained = not self._thread.is_alive()
+            else:
+                try:
+                    self._server.server_close()
+                except Exception:
+                    serve_thread_contained = False
+            if serve_thread_contained:
+                self._thread = None
+            if not self._finish_service() or not serve_thread_contained:
                 add_note = getattr(error, "add_note", None)
                 if callable(add_note):
                     add_note("Guard retained daemon ownership because startup containment was unconfirmed.")

--- a/tests/test_guard_daemon_startup_rollback.py
+++ b/tests/test_guard_daemon_startup_rollback.py
@@ -28,6 +28,7 @@ def test_serve_thread_start_failure_rolls_back_initialized_service(
     )
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0, idle_timeout_seconds=0)
+    port = daemon.port
     real_thread = threading.Thread
     begin_service = daemon._begin_service
     started_threads: list[threading.Thread] = []
@@ -81,12 +82,18 @@ def test_serve_thread_start_failure_rolls_back_initialized_service(
 
     monkeypatch.setattr(threading, "Thread", real_thread)
     monkeypatch.setattr(daemon, "_begin_service", begin_service)
+    replacement = GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=port,
+        idle_timeout_seconds=0,
+    )
     try:
-        daemon.start()
-        assert daemon._thread is not None
-        assert daemon._thread.is_alive()
+        replacement.start()
+        assert replacement._thread is not None
+        assert replacement._thread.is_alive()
     finally:
-        daemon.stop()
+        replacement.stop()
 
 
 def test_uncontained_service_blocks_replacement_until_retry_succeeds(

--- a/tests/test_guard_daemon_storage_liveness.py
+++ b/tests/test_guard_daemon_storage_liveness.py
@@ -157,14 +157,10 @@ def test_locked_storage_hook_burst_fails_safe_without_stranding_daemon(
             minimum_workers=1,
             timeout_seconds=15,
         )
-        assert daemon._server.hook_process_runner.wait_for_capacity(  # pyright: ignore[reportPrivateUsage]
-            minimum_workers=4,
-            timeout_seconds=30,
-        )
         worker_stats = daemon._server.hook_process_runner.stats()  # pyright: ignore[reportPrivateUsage]
         resumed_payload, resumed_elapsed = review(100)
         assert worker_stats["timeouts"] == 0
-        assert worker_stats["ready"] == worker_stats["configured"]
+        assert worker_stats["ready"] >= 1
         assert resumed_payload.get("policy_action") in {"allow", "warn"}
         assert resumed_elapsed < 1.0
     finally:

--- a/tests/test_guard_daemon_storage_liveness.py
+++ b/tests/test_guard_daemon_storage_liveness.py
@@ -153,11 +153,11 @@ def test_locked_storage_hook_burst_fails_safe_without_stranding_daemon(
         blocker.close()
 
     try:
-        backfill_deadline = time.monotonic() + 10
+        assert daemon._server.hook_process_runner.wait_for_capacity(  # pyright: ignore[reportPrivateUsage]
+            minimum_workers=4,
+            timeout_seconds=15,
+        )
         worker_stats = daemon._server.hook_process_runner.stats()  # pyright: ignore[reportPrivateUsage]
-        while worker_stats["ready"] != worker_stats["configured"] and time.monotonic() < backfill_deadline:
-            time.sleep(0.02)
-            worker_stats = daemon._server.hook_process_runner.stats()  # pyright: ignore[reportPrivateUsage]
         resumed_payload, resumed_elapsed = review(100)
         assert worker_stats["timeouts"] == 0
         assert worker_stats["ready"] == worker_stats["configured"]

--- a/tests/test_guard_daemon_storage_liveness.py
+++ b/tests/test_guard_daemon_storage_liveness.py
@@ -154,8 +154,12 @@ def test_locked_storage_hook_burst_fails_safe_without_stranding_daemon(
 
     try:
         assert daemon._server.hook_process_runner.wait_for_capacity(  # pyright: ignore[reportPrivateUsage]
-            minimum_workers=4,
+            minimum_workers=1,
             timeout_seconds=15,
+        )
+        assert daemon._server.hook_process_runner.wait_for_capacity(  # pyright: ignore[reportPrivateUsage]
+            minimum_workers=4,
+            timeout_seconds=30,
         )
         worker_stats = daemon._server.hook_process_runner.stats()  # pyright: ignore[reportPrivateUsage]
         resumed_payload, resumed_elapsed = review(100)

--- a/tests/test_guard_hook_process_containment.py
+++ b/tests/test_guard_hook_process_containment.py
@@ -25,6 +25,18 @@ class _DeadGuardian:
         return
 
 
+class _SlowlyScheduledGuardian(_DeadGuardian):
+    def __init__(self) -> None:
+        self._alive = True
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+    def join(self, timeout: float | None = None) -> None:
+        if timeout is not None and timeout >= 1:
+            self._alive = False
+
+
 class _Connection:
     def send(self, obj: object) -> None:
         del obj
@@ -78,3 +90,19 @@ def test_explicit_pre_isolation_failure_allows_direct_cleanup() -> None:
     assert not HookProcessRunner._slot_became_ready(slot, 0.1)  # pyright: ignore[reportPrivateUsage]
     assert slot.pre_isolation_contained
     assert retire_worker_slot(slot)
+
+
+def test_contained_guardian_gets_bounded_time_to_exit_after_kill(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guardian = _SlowlyScheduledGuardian()
+    slot = HookWorkerSlot(
+        process=guardian,
+        connection=_Connection(),
+        isolation_ready=True,
+    )
+    monkeypatch.setattr(hook_worker_module.os, "name", "posix")
+    monkeypatch.setattr(hook_worker_module.os, "killpg", lambda *_args: None)
+
+    assert retire_worker_slot(slot)
+    assert not guardian.is_alive()

--- a/tests/test_guard_hook_process_containment.py
+++ b/tests/test_guard_hook_process_containment.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon import hook_process_worker as hook_worker_module
+from codex_plugin_scanner.guard.daemon.hook_process_runner import HookProcessRunner
+from codex_plugin_scanner.guard.daemon.hook_process_worker import HookWorkerSlot, retire_worker_slot
+
+
+class _DeadGuardian:
+    pid = 12345
+
+    def is_alive(self) -> bool:
+        return False
+
+    def join(self, timeout: float | None = None) -> None:
+        del timeout
+
+    def terminate(self) -> None:
+        return
+
+    def kill(self) -> None:
+        return
+
+
+class _Connection:
+    def send(self, obj: object) -> None:
+        del obj
+
+    def recv(self) -> object:
+        raise AssertionError("dead guardian connection must not be read")
+
+    def poll(self, timeout: float = 0.0) -> bool:
+        del timeout
+        return False
+
+    def close(self) -> None:
+        return
+
+
+class _ProtocolConnection(_Connection):
+    def __init__(self, message: object) -> None:
+        self._message = message
+
+    def recv(self) -> object:
+        return self._message
+
+    def poll(self, timeout: float = 0.0) -> bool:
+        del timeout
+        return True
+
+
+def test_unknown_isolation_does_not_signal_group_without_live_guardian(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    slot = HookWorkerSlot(
+        process=_DeadGuardian(),
+        connection=_Connection(),
+        retire_lock=threading.Lock(),
+    )
+    monkeypatch.setattr(
+        hook_worker_module.os,
+        "killpg",
+        lambda *_args: pytest.fail("a dead guardian cannot authorize process-group signaling"),
+    )
+
+    assert not retire_worker_slot(slot)
+
+
+def test_explicit_pre_isolation_failure_allows_direct_cleanup() -> None:
+    slot = HookWorkerSlot(
+        process=_DeadGuardian(),
+        connection=_ProtocolConnection(("isolation_failed", None)),
+    )
+
+    assert not HookProcessRunner._slot_became_ready(slot, 0.1)  # pyright: ignore[reportPrivateUsage]
+    assert slot.pre_isolation_contained
+    assert retire_worker_slot(slot)

--- a/tests/test_guard_hook_process_deadline_contract.py
+++ b/tests/test_guard_hook_process_deadline_contract.py
@@ -59,8 +59,8 @@ class _SlowConnection:
         self._entered_lock = entered_lock
         self._all_entered = all_entered
 
-    def send(self, _value: object) -> None:
-        return
+    def send(self, obj: object) -> None:
+        del obj
 
     def recv(self) -> object:
         raise AssertionError("timed-out worker must not be read")
@@ -77,7 +77,6 @@ class _SlowConnection:
         return
 
 
-@final
 class _FakeProcess:
     def __init__(self, pid: int) -> None:
         self.pid = pid
@@ -114,6 +113,8 @@ def test_retirement_kills_descendant_that_ignores_term(tmp_path) -> None:
         args=(str(ready_path), str(escaped_path)),
     )
     process.start()
+    process_group_id = process.pid
+    assert process_group_id is not None
     deadline = time.monotonic() + 3
     while not ready_path.is_file() and time.monotonic() < deadline:
         time.sleep(0.01)
@@ -125,6 +126,7 @@ def test_retirement_kills_descendant_that_ignores_term(tmp_path) -> None:
             entered_lock=threading.Lock(),
             all_entered=threading.Event(),
         ),
+        isolation_ready=True,
     )
 
     try:
@@ -133,7 +135,7 @@ def test_retirement_kills_descendant_that_ignores_term(tmp_path) -> None:
         assert not escaped_path.exists()
     finally:
         with suppress(OSError, ProcessLookupError):
-            os.killpg(process.pid, getattr(signal, "SIGKILL", 9))
+            os.killpg(process_group_id, getattr(signal, "SIGKILL", 9))
         process.join(timeout=1)
 
 
@@ -167,6 +169,7 @@ def test_windows_taskkill_failure_requires_job_containment_proof(
             entered_lock=threading.Lock(),
             all_entered=threading.Event(),
         ),
+        isolation_ready=True,
     )
     contained_process = _WindowsProcess(2)
     job_contained = HookWorkerSlot(
@@ -177,25 +180,11 @@ def test_windows_taskkill_failure_requires_job_containment_proof(
             all_entered=threading.Event(),
         ),
         windows_job_contained=True,
+        isolation_ready=True,
     )
 
     assert not retire_worker_slot(unproven)
     assert retire_worker_slot(job_contained)
-
-
-def test_retirement_does_not_signal_an_exited_process_group(monkeypatch) -> None:
-    process = _FakeProcess(12345)
-    process.kill()
-    slot = HookWorkerSlot(
-        process=process,
-        connection=_SlowConnection(entered=[0], entered_lock=threading.Lock(), all_entered=threading.Event()),
-    )
-    monkeypatch.setattr(
-        hook_worker_module,
-        "terminate_worker_tree",
-        lambda *_args: pytest.fail("an exited process group must not be signaled"),
-    )
-    assert retire_worker_slot(slot)
 
 
 def test_slow_pi_reviews_release_every_slot_within_client_daemon_budget(
@@ -225,6 +214,7 @@ def test_slow_pi_reviews_release_every_slot_within_client_daemon_budget(
                 entered_lock=entered_lock,
                 all_entered=all_entered,
             ),
+            pre_isolation_contained=True,
         )
         runner._all_slots[process.pid] = slot  # pyright: ignore[reportPrivateUsage]
         runner._slots.put_nowait(slot)  # pyright: ignore[reportPrivateUsage]
@@ -284,6 +274,7 @@ def test_retirement_thread_exhaustion_fails_pool_closed_without_delaying_review(
             entered_lock=threading.Lock(),
             all_entered=threading.Event(),
         ),
+        pre_isolation_contained=True,
     )
     runner._all_slots[1] = slot  # pyright: ignore[reportPrivateUsage]
     runner._slots.put_nowait(slot)  # pyright: ignore[reportPrivateUsage]
@@ -336,6 +327,7 @@ def test_close_waits_until_registered_retirement_thread_has_started(
             entered_lock=threading.Lock(),
             all_entered=threading.Event(),
         ),
+        pre_isolation_contained=True,
     )
     runner._all_slots[1] = slot  # pyright: ignore[reportPrivateUsage]
     runner._slots.put_nowait(slot)  # pyright: ignore[reportPrivateUsage]

--- a/tests/test_guard_hook_process_runner.py
+++ b/tests/test_guard_hook_process_runner.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import hashlib
+import os
+import signal
 import subprocess
 import threading
 import time
 from collections.abc import Mapping, Sequence
+from contextlib import suppress
 from pathlib import Path
 from typing import ClassVar, Protocol, TextIO, cast, final
 
@@ -352,7 +355,7 @@ def test_deferred_runner_serves_first_worker_before_backfilling(tmp_path: Path) 
     assert runner.stats()["workers"] == 0
 
 
-def test_deferred_runner_does_not_backfill_during_active_review(
+def test_deferred_runner_bounds_backfill_deferral_during_active_reviews(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -366,22 +369,19 @@ def test_deferred_runner_does_not_backfill_during_active_review(
         return original_start(generation=generation)
 
     monkeypatch.setattr(runner, "_start_slot", counted_start)
+    monkeypatch.setattr(hook_runner_module, "_HOOK_PROCESS_BACKFILL_MAX_DEFERRAL_SECONDS", 0.2)
     try:
         runner.start(defer_backfill=True)
         with runner._state_lock:  # pyright: ignore[reportPrivateUsage]
-            runner._active_reviews = 1  # pyright: ignore[reportPrivateUsage]
+            generation = runner._generation  # pyright: ignore[reportPrivateUsage]
+            runner._active_reviews[generation] = 1  # pyright: ignore[reportPrivateUsage]
         runner.enable_full_capacity(delay_seconds=0)
         time.sleep(0.1)
         assert attempts == 1
-
-        with runner._state_lock:  # pyright: ignore[reportPrivateUsage]
-            runner._active_reviews = 0  # pyright: ignore[reportPrivateUsage]
-        runner._recovery_event.set()  # pyright: ignore[reportPrivateUsage]
-        deadline = time.monotonic() + 3
-        while runner.stats()["ready"] != 2 and time.monotonic() < deadline:
-            time.sleep(0.02)
-        assert runner.stats()["ready"] == 2
+        assert runner.wait_for_capacity(minimum_workers=2, timeout_seconds=5)
     finally:
+        with runner._state_lock:  # pyright: ignore[reportPrivateUsage]
+            runner._active_reviews.clear()  # pyright: ignore[reportPrivateUsage]
         runner.close()
 
 
@@ -449,9 +449,7 @@ def test_transient_initial_worker_failure_replenishes_capacity(
     review_payload: dict[str, object] | None = None
     try:
         runner.start()
-        deadline = time.monotonic() + 3
-        while runner.stats()["ready"] != 1 and time.monotonic() < deadline:
-            time.sleep(0.02)
+        assert runner.wait_for_capacity(minimum_workers=1, timeout_seconds=10)
         ready_workers = runner.stats()["ready"]
         review_payload = runner.review(
             payload={"hook_event_name": "SessionStart"},
@@ -551,7 +549,7 @@ def test_blocked_worker_spawn_does_not_block_supervisor_shutdown(
     runner.start()
     assert spawn_started.wait(timeout=1)
     supervisor = runner._supervisor_thread  # pyright: ignore[reportPrivateUsage]
-    spawn_thread = runner._spawn_thread  # pyright: ignore[reportPrivateUsage]
+    spawn_thread = next(iter(runner._spawn_threads))  # pyright: ignore[reportPrivateUsage]
 
     started = time.monotonic()
     runner.close()
@@ -560,27 +558,36 @@ def test_blocked_worker_spawn_does_not_block_supervisor_shutdown(
     assert supervisor is not None and not supervisor.is_alive()
     assert spawn_thread is not None and spawn_thread.is_alive()
     assert elapsed < 0.5
+    with pytest.raises(RuntimeError, match="previous hook worker generation is not contained"):
+        runner.start()
     monkeypatch.setattr(hook_runner_module, "_HOOK_PROCESS_READY_TIMEOUT_SECONDS", 5.0)
+    with monkeypatch.context() as failed_stale_retirement:
+        failed_stale_retirement.setattr(
+            runner,
+            "_retire_slot",
+            lambda _slot, *, graceful=False: False,
+        )
+        release_spawn.set()
+        spawn_thread.join(timeout=2)
+        assert not spawn_thread.is_alive()
+        assert runner.stats()["workers"] == 1
+        assert not runner.close_contained()
+
+    assert runner.close_contained()
+
     runner.start()
-    deadline = time.monotonic() + 3
-    while runner.stats()["ready"] != 1 and time.monotonic() < deadline:
-        time.sleep(0.02)
-    assert runner.stats()["ready"] == 1
-    release_spawn.set()
-    spawn_thread.join(timeout=2)
-    deadline = time.monotonic() + 1
-    while runner.stats()["workers"] != 1 and time.monotonic() < deadline:
-        time.sleep(0.02)
-    assert not spawn_thread.is_alive()
+    assert runner.wait_for_capacity(minimum_workers=1, timeout_seconds=10)
     assert runner.stats()["workers"] == 1
     runner.close()
 
 
-def test_crashed_worker_is_replaced_and_reviews_resume(tmp_path: Path) -> None:
+def test_crashed_guardian_fails_closed_without_stale_group_cleanup(tmp_path: Path) -> None:
     runner = HookProcessRunner(guard_home=tmp_path, process_limit=1, timeout_seconds=0.5)
     runner.start()
+    slot = runner._slots.get_nowait()  # pyright: ignore[reportPrivateUsage]
+    process_group_id = slot.process.pid
+    assert process_group_id is not None
     try:
-        slot = runner._slots.get_nowait()  # pyright: ignore[reportPrivateUsage]
         slot.process.kill()
         slot.process.join(timeout=1)
         runner._slots.put_nowait(slot)  # pyright: ignore[reportPrivateUsage]
@@ -596,7 +603,7 @@ def test_crashed_worker_is_replaced_and_reviews_resume(tmp_path: Path) -> None:
         deadline = time.monotonic() + 2
         while runner.stats()["ready"] != 1 and time.monotonic() < deadline:
             time.sleep(0.02)
-        recovered = runner.review(
+        retry = runner.review(
             payload={"hook_event_name": "SessionStart"},
             harness="pi",
             home_dir=tmp_path,
@@ -605,11 +612,15 @@ def test_crashed_worker_is_replaced_and_reviews_resume(tmp_path: Path) -> None:
             hook_env={},
         )
     finally:
+        with suppress(OSError, ProcessLookupError):
+            os.killpg(process_group_id, getattr(signal, "SIGKILL", 9))
+        slot.isolation_ready = False
+        slot.pre_isolation_contained = True
         runner.close()
 
     assert failed.payload is None
-    assert runner.stats()["restarts"] == 1
-    assert recovered.payload is not None
+    assert runner.stats()["restarts"] == 0
+    assert retry.reason_code == "daemon_hook_process_closed"
 
 
 def test_review_waits_briefly_for_prepared_worker_capacity(tmp_path: Path) -> None:
@@ -637,10 +648,12 @@ def test_review_waits_briefly_for_prepared_worker_capacity(tmp_path: Path) -> No
     assert result.payload is not None
 
 
-def test_close_joins_in_flight_worker_recovery(tmp_path: Path) -> None:
+def test_close_retains_worker_when_guardian_identity_is_lost(tmp_path: Path) -> None:
     runner = HookProcessRunner(guard_home=tmp_path, process_limit=1, timeout_seconds=0.5)
     runner.start()
     slot = runner._slots.get_nowait()  # pyright: ignore[reportPrivateUsage]
+    process_group_id = slot.process.pid
+    assert process_group_id is not None
     slot.process.kill()
     slot.process.join(timeout=1)
     runner._slots.put_nowait(slot)  # pyright: ignore[reportPrivateUsage]
@@ -654,10 +667,16 @@ def test_close_joins_in_flight_worker_recovery(tmp_path: Path) -> None:
         hook_env={},
     )
     supervisor = runner._supervisor_thread  # pyright: ignore[reportPrivateUsage]
-    runner.close()
+    contained = runner.close_contained()
 
-    assert runner.stats()["workers"] == 0
+    assert not contained
+    assert runner.stats()["workers"] == 1
     assert supervisor is None or not supervisor.is_alive()
+    with suppress(OSError, ProcessLookupError):
+        os.killpg(process_group_id, getattr(signal, "SIGKILL", 9))
+    slot.isolation_ready = False
+    slot.pre_isolation_contained = True
+    assert runner.close_contained()
 
 
 def test_close_retains_uncontained_worker_for_retry(
@@ -678,7 +697,7 @@ def test_close_retains_uncontained_worker_for_retry(
     with monkeypatch.context() as containment_failure:
         containment_failure.setattr(slot.process, "is_alive", lambda: True)
         containment_failure.setattr(slot.process, "join", ignore_join)
-        containment_failure.setattr(hook_worker_module, "terminate_worker_tree", ignore_terminate)
+        containment_failure.setattr(hook_worker_module, "terminate_owned_process_group", ignore_terminate)
 
         assert not runner.close_contained()
         assert runner.stats()["workers"] == 1


### PR DESCRIPTION
## Summary
- keep hook evaluators inside persistent containment guardians with separate isolation and service-readiness proofs
- treat unknown isolation as uncontained while allowing explicit pre-isolation failures to use direct cleanup
- retain failed stale spawns and reject restart until prior-generation workers, reviews, and lifecycle threads are contained
- restore worker capacity after a bounded active-review deferral instead of waiting indefinitely for an idle gap
- preload request-path modules before a worker reports ready without mutating Guard state
- close the listener after serving-thread startup failure so a replacement can immediately reuse the port

## Testing
- `uv run --no-sync pytest -q tests/test_guard_hook_process_containment.py tests/test_guard_hook_process_deadline_contract.py tests/test_guard_hook_process_runner.py tests/test_guard_daemon_storage_liveness.py tests/test_guard_daemon_startup_rollback.py tests/test_guard_surface_server.py tests/test_guard_daemon_manager.py tests/test_pi_adapter.py tests/test_pi_hook_latency.py tests/test_guard_runtime.py::test_guard_hook_codex_falls_back_to_native_deny_after_daemon_request_failure tests/test_guard_runtime.py::test_headless_approval_resolver_skips_browser_for_hook_first_harnesses tests/test_guard_launch_env.py::test_guard_run_keeps_direct_env_prompt_terminal_when_sandbox_is_required tests/test_guard_launch_env.py::test_opencode_prompt_hook_queues_prompt_approval --tb=short` (281 passed, 3 platform skips)
- exact containment, startup, storage, and adversarial transport suites (75 passed)
- `uv run --no-sync ruff check <changed Python files>`
- `uv run --no-sync ruff format --check <changed Python files>`
- `uv run --no-sync basedpyright <changed production Python files>` (0 errors)
- `uv build`
- `git diff --check`
