### PR TITLE
test(guard): consolidate redundant test scenarios

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,7 @@ EXPECTED_GOOD_PLUGIN_SCORE = 91
 
 
 class TestFormatJson:
-    def test_valid_json_output(self):
+    def test_good_plugin_json_output_has_expected_schema_and_category_structure(self):
         result = scan_plugin(FIXTURES / "good-plugin")
         output = format_json(result)
         parsed = json.loads(output)
@@ -40,10 +40,6 @@ class TestFormatJson:
         assert "summary" in parsed
         assert "findings" in parsed
 
-    def test_categories_have_correct_structure(self):
-        result = scan_plugin(FIXTURES / "good-plugin")
-        output = format_json(result)
-        parsed = json.loads(output)
         cat = parsed["categories"][0]
         assert "name" in cat
         assert "score" in cat
@@ -66,22 +62,15 @@ class TestFormatJson:
 
 
 class TestFormatText:
-    def test_contains_header(self):
+    def test_good_plugin_text_output_contains_summary_and_categories(self):
         result = scan_plugin(FIXTURES / "good-plugin")
         output = format_text(result)
         assert "Plugin Scanner" in output
         assert f"{result.score}/100" in output
         assert "Excellent" in output
 
-    def test_contains_category_names(self):
-        result = scan_plugin(FIXTURES / "good-plugin")
-        output = format_text(result)
         assert "Manifest Validation" in output
         assert "Security" in output
-
-    def test_contains_final_score_line(self):
-        result = scan_plugin(FIXTURES / "good-plugin")
-        output = format_text(result)
         assert "Final Score" in output
 
     def test_bad_plugin_output(self):

--- a/tests/test_guard_harness_contracts.py
+++ b/tests/test_guard_harness_contracts.py
@@ -95,11 +95,6 @@ class TestContractFor:
         assert c is not None
         assert c.harness == "claude-code"
 
-    def test_codex_cli_alias(self) -> None:
-        c = contract_for("codex")
-        assert c is not None
-        assert "codex" in c.install_aliases
-
     def test_claude_code_alias(self) -> None:
         c = contract_for("claude-code")
         assert c is not None

--- a/tests/test_guard_threat_intel.py
+++ b/tests/test_guard_threat_intel.py
@@ -399,10 +399,6 @@ class TestFreeplanFallback:
         bundle = _make_bundle(advisories=())
         assert len(bundle.advisories) == 0
 
-    def test_no_error_on_no_cached_bundle(self) -> None:
-        conn = _in_memory_db()
-        assert latest_cached_bundle(conn) is None
-
 
 class TestOfflineFallback:
     """T545 — offline fallback stub: no advisories = no matches."""

--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -237,43 +237,37 @@ class TestOpenCodeConfigPrecedence:
 
 
 class TestOpenCodeInstall:
-    def test_install_creates_managed_config_file(self, tmp_path: Path) -> None:
+    def test_fresh_install_creates_contract_and_is_idempotent(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
-        result = OpenCodeHarnessAdapter().install(ctx)
-        managed_config = Path(result["managed_config_path"])
+        adapter = OpenCodeHarnessAdapter()
+        first_result = adapter.install(ctx)
+
+        managed_config = Path(first_result["managed_config_path"])
         assert managed_config.is_file()
 
-    def test_install_creates_backup_file(self, tmp_path: Path) -> None:
-        ctx = _ctx(tmp_path)
-        result = OpenCodeHarnessAdapter().install(ctx)
-        backup_path = Path(result["backup_path"])
+        backup_path = Path(first_result["backup_path"])
         assert backup_path.is_file()
 
-    def test_install_creates_state_file(self, tmp_path: Path) -> None:
-        ctx = _ctx(tmp_path)
-        result = OpenCodeHarnessAdapter().install(ctx)
-        state_path = Path(result["state_path"])
+        state_path = Path(first_result["state_path"])
         assert state_path.is_file()
 
-    def test_install_creates_runtime_config(self, tmp_path: Path) -> None:
-        ctx = _ctx(tmp_path)
-        result = OpenCodeHarnessAdapter().install(ctx)
-        runtime_path = Path(result["runtime_config_path"])
+        runtime_path = Path(first_result["runtime_config_path"])
         assert runtime_path.is_file()
-
-    def test_install_runtime_config_has_schema(self, tmp_path: Path) -> None:
-        ctx = _ctx(tmp_path)
-        result = OpenCodeHarnessAdapter().install(ctx)
-        runtime_path = Path(result["runtime_config_path"])
         payload = json.loads(runtime_path.read_text(encoding="utf-8"))
         assert "$schema" in payload
 
-    def test_install_backup_records_no_prior_content_when_new(self, tmp_path: Path) -> None:
-        ctx = _ctx(tmp_path)
-        result = OpenCodeHarnessAdapter().install(ctx)
-        backup_path = Path(result["backup_path"])
         backup_payload = json.loads(backup_path.read_text(encoding="utf-8"))
         assert backup_payload["existed"] is False
+
+        assert first_result["active"] is True
+        assert first_result["harness"] == "opencode"
+        assert isinstance(first_result["notes"], list)
+        assert len(first_result["notes"]) > 0
+        assert first_result["runtime_env_var"] == "OPENCODE_CONFIG_CONTENT"
+
+        second_result = adapter.install(ctx)
+        assert first_result["managed_config_path"] == second_result["managed_config_path"]
+        assert Path(second_result["managed_config_path"]).is_file()
 
     def test_install_backup_preserves_original_content(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
@@ -287,19 +281,6 @@ class TestOpenCodeInstall:
         assert backup_payload["existed"] is True
         assert backup_payload["content"] == original
 
-    def test_install_marks_harness_as_active(self, tmp_path: Path) -> None:
-        ctx = _ctx(tmp_path)
-        result = OpenCodeHarnessAdapter().install(ctx)
-        assert result["active"] is True
-        assert result["harness"] == "opencode"
-
-    def test_install_is_idempotent(self, tmp_path: Path) -> None:
-        ctx = _ctx(tmp_path)
-        result1 = OpenCodeHarnessAdapter().install(ctx)
-        result2 = OpenCodeHarnessAdapter().install(ctx)
-        assert result1["managed_config_path"] == result2["managed_config_path"]
-        assert Path(result2["managed_config_path"]).is_file()
-
     def test_install_with_existing_mcp_adds_permission_rules(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
         target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
@@ -308,17 +289,6 @@ class TestOpenCodeInstall:
         OpenCodeHarnessAdapter().install(ctx)
         managed_config = json.loads(target.read_text(encoding="utf-8"))
         assert "permission" in managed_config
-
-    def test_install_report_includes_notes(self, tmp_path: Path) -> None:
-        ctx = _ctx(tmp_path)
-        result = OpenCodeHarnessAdapter().install(ctx)
-        assert isinstance(result["notes"], list)
-        assert len(result["notes"]) > 0
-
-    def test_install_report_includes_runtime_env_var(self, tmp_path: Path) -> None:
-        ctx = _ctx(tmp_path)
-        result = OpenCodeHarnessAdapter().install(ctx)
-        assert result["runtime_env_var"] == "OPENCODE_CONFIG_CONTENT"
 
     def test_install_keeps_original_mcp_servers_on_disk(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
@@ -505,26 +475,18 @@ class TestOpenCodeUninstall:
         OpenCodeHarnessAdapter().uninstall(ctx)
         assert target.read_text(encoding="utf-8") == original
 
-    def test_uninstall_removes_file_when_no_prior_config_existed(self, tmp_path: Path) -> None:
+    def test_fresh_uninstall_removes_artifacts_and_marks_harness_inactive(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
-        OpenCodeHarnessAdapter().install(ctx)
-        target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
-        OpenCodeHarnessAdapter().uninstall(ctx)
-        assert not target.is_file()
-
-    def test_uninstall_marks_harness_inactive(self, tmp_path: Path) -> None:
-        ctx = _ctx(tmp_path)
-        OpenCodeHarnessAdapter().install(ctx)
-        result = OpenCodeHarnessAdapter().uninstall(ctx)
-        assert result["active"] is False
-        assert result["harness"] == "opencode"
-
-    def test_uninstall_removes_state_file(self, tmp_path: Path) -> None:
-        ctx = _ctx(tmp_path)
-        install_result = OpenCodeHarnessAdapter().install(ctx)
+        adapter = OpenCodeHarnessAdapter()
+        install_result = adapter.install(ctx)
+        target = adapter._managed_install_config_path(ctx)
         state_path = Path(install_result["state_path"])
         assert state_path.is_file()
-        OpenCodeHarnessAdapter().uninstall(ctx)
+
+        result = adapter.uninstall(ctx)
+        assert not target.is_file()
+        assert result["active"] is False
+        assert result["harness"] == "opencode"
         assert not state_path.is_file()
 
 


### PR DESCRIPTION
## Summary
- consolidate repeated OpenCode install and uninstall scenarios while preserving their assertions
- combine repeated scanner formatting checks and remove two exact duplicate contracts
- reduce the default collected suite by 16 cases without changing production behavior

## Testing
- `uv run --no-sync pytest -q tests/test_cli.py tests/test_guard_harness_contracts.py tests/test_guard_threat_intel.py tests/test_opencode_adapter.py --tb=short`
- `uv run --no-sync ruff check tests/test_cli.py tests/test_guard_harness_contracts.py tests/test_guard_threat_intel.py tests/test_opencode_adapter.py`
- `uv run --no-sync ruff format --check tests/test_cli.py tests/test_guard_harness_contracts.py tests/test_guard_threat_intel.py tests/test_opencode_adapter.py`
- `uv run --no-sync basedpyright`
- `git diff --check`
