### PR TITLE
test(ci): add protected invariant inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
           version: "0.9.26"
           enable-cache: true
       - run: uv sync --frozen --extra dev --python 3.12
+      - name: Validate protected test invariants
+        run: uv run --no-sync python scripts/ci/test_inventory.py --output test-inventory.json
+      - name: Publish test inventory
+        run: cat test-inventory.json
       - run: uv run --no-sync python -m ruff check src/
       - run: uv run --no-sync python -m ruff format --check src/
       - run: uv run --no-sync basedpyright --level error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,12 +142,21 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = ["-m", "not slow"]
 markers = [
+  "adapter_contract: verifies the shared security contract for a harness adapter",
   "daemon_aibom_refresh: enables the daemon AIBOM refresh worker for focused tests",
   "daemon_bundle_refresh: enables the daemon supply-chain bundle refresh worker for focused tests",
   "daemon_headless_queue: enables request-triggered daemon cloud sync for focused tests",
   "daemon_headless_refresh: enables the daemon headless cloud sync worker for focused tests",
   "daemon_service_workers: enables command queue and live request sync workers for focused tests",
+  "installed: requires verification through an installed package artifact",
+  "integration: verifies multiple Guard subsystems together",
+  "parser: verifies parsing or normalization security semantics",
+  "policy: verifies policy composition or enforcement semantics",
+  "regression: protects a previously observed defect or security finding",
+  "release: required for a release-candidate verification gate",
+  "security_critical: protects a Guard security boundary that cannot be removed without an equivalent replacement",
   "slow: marks tests as slow (deselected by default; run with -m slow to include)",
+  "compat: verifies a supported Python or platform compatibility contract",
 ]
 
 [tool.basedpyright]

--- a/scripts/ci/test_inventory.py
+++ b/scripts/ci/test_inventory.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Emit a stable, machine-readable inventory of the collected pytest suite."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Protocol, cast
+
+import pytest
+
+
+class _CollectionSession(Protocol):
+    items: list[pytest.Item]
+
+
+@dataclass(frozen=True)
+class TestInventory:
+    collected_cases: int
+    test_functions: int
+    test_files: int
+    parameterized_cases: int
+    marker_counts: dict[str, int]
+
+
+class _NodeCollector:
+    def __init__(self) -> None:
+        self.items: list[pytest.Item] = []
+
+    def pytest_collection_finish(self, session: _CollectionSession) -> None:
+        self.items = list(session.items)
+
+
+def test_function_id(nodeid: str) -> str:
+    """Normalize a parameterized node id to its owning function."""
+    return nodeid.split("[", maxsplit=1)[0]
+
+
+def build_inventory(
+    node_ids: Sequence[str],
+    marker_names_by_node: Mapping[str, Sequence[str]],
+) -> TestInventory:
+    unique_functions = {test_function_id(nodeid) for nodeid in node_ids}
+    test_files = {nodeid.split("::", maxsplit=1)[0] for nodeid in node_ids}
+    marker_counts: Counter[str] = Counter()
+    for nodeid in node_ids:
+        marker_counts.update(set(marker_names_by_node.get(nodeid, ())))
+    return TestInventory(
+        collected_cases=len(node_ids),
+        test_functions=len(unique_functions),
+        test_files=len(test_files),
+        parameterized_cases=len(node_ids) - len(unique_functions),
+        marker_counts=dict(sorted(marker_counts.items())),
+    )
+
+
+def collect_inventory(root: Path) -> TestInventory:
+    collector = _NodeCollector()
+    result = pytest.main(
+        [str(root / "tests"), "--collect-only", "-p", "no:terminal", "--validate-test-invariants"],
+        plugins=[collector],
+    )
+    if result != pytest.ExitCode.OK:
+        raise RuntimeError(f"pytest collection failed with exit code {result}")
+    node_ids = [item.nodeid for item in collector.items]
+    markers = {item.nodeid: tuple(marker.name for marker in item.iter_markers()) for item in collector.items}
+    return build_inventory(node_ids, markers)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    _ = parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[2]
+    payload = json.dumps(asdict(collect_inventory(root)), indent=2, sort_keys=True) + "\n"
+    output = cast(Path | None, args.output)
+    if output is None:
+        print(payload, end="")
+    else:
+        output.write_text(payload, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.guard_test_invariants import TEST_INVARIANTS, invariant_markers_for_nodeid
+
 SRC_PATH = Path(__file__).resolve().parents[1] / "src"
 SUPPORT_PATH = Path(__file__).resolve().parent / "support"
 
@@ -22,6 +24,33 @@ pythonpath_entries = [entry for entry in existing_pythonpath.split(os.pathsep) i
 pythonpath_prefix = [str(path) for path in (SUPPORT_PATH, SRC_PATH) if str(path) not in pythonpath_entries]
 if pythonpath_prefix:
     os.environ["PYTHONPATH"] = os.pathsep.join([*pythonpath_prefix, *pythonpath_entries])
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--validate-test-invariants",
+        action="store_true",
+        default=False,
+        help="fail collection when a protected invariant no longer resolves to a concrete test",
+    )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    for item in items:
+        for marker in invariant_markers_for_nodeid(item.nodeid):
+            item.add_marker(marker)
+
+    if not config.getoption("--validate-test-invariants"):
+        return
+    collected = {item.nodeid for item in items}
+    missing = [
+        invariant
+        for invariant in TEST_INVARIANTS
+        if not any(nodeid == invariant.selector or nodeid.startswith(f"{invariant.selector}[") for nodeid in collected)
+    ]
+    if missing:
+        details = ", ".join(f"{invariant.invariant_id} ({invariant.selector})" for invariant in missing)
+        raise pytest.UsageError(f"Protected test invariants are missing from collection: {details}")
 
 
 def _test_guard_homes_with_daemon_state(root: Path) -> set[Path]:

--- a/tests/guard_test_invariants.py
+++ b/tests/guard_test_invariants.py
@@ -1,0 +1,136 @@
+"""Stable ownership records for security-critical Guard regression tests.
+
+The registry intentionally covers protected security boundaries rather than every
+ordinary unit assertion. A selector may only point to a concrete test function,
+which makes removal or relocation visible during collection validation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+
+@dataclass(frozen=True)
+class TestInvariant:
+    """A security or release guarantee owned by one concrete test."""
+
+    invariant_id: str
+    selector: str
+    subsystem: str
+    guarantee: str
+    markers: tuple[str, ...]
+
+
+TEST_INVARIANTS: Final[tuple[TestInvariant, ...]] = (
+    TestInvariant(
+        "GUARD-INV-001",
+        "tests/test_guard_command_corpus.py::test_full_guard_evaluation_matches_exact_non_widening_known_gap_baseline",
+        "command-corpus",
+        "Known command-evaluation gaps cannot widen without an explicit reviewed baseline update.",
+        ("security_critical", "regression", "parser", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-002",
+        "tests/test_guard_command_corpus.py::test_ten_reviewed_pairs_have_one_machine_checked_delta_and_run_through_guard",
+        "command-corpus",
+        "Reviewed minimal pairs keep their single semantic delta and Guard decision boundary.",
+        ("security_critical", "regression", "parser", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-003",
+        "tests/test_guard_runtime.py::test_guard_hook_codex_post_tool_use_blocks_credential_looking_output",
+        "hook-output",
+        "Codex post-tool output that resembles a credential is blocked before delivery.",
+        ("security_critical", "regression", "integration", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-004",
+        "tests/test_guard_runtime.py::test_guard_hook_codex_post_tool_use_blocks_named_secret_output",
+        "hook-output",
+        "Named secrets in Codex post-tool output cannot bypass output review.",
+        ("security_critical", "regression", "integration", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-005",
+        "tests/test_guard_runtime.py::test_guard_hook_codex_user_prompt_submit_guard_bypass_hard_blocks_without_approval_url",
+        "hook-policy",
+        "Guard-bypass prompt attempts hard-block without offering an approval escape hatch.",
+        ("security_critical", "regression", "policy", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-006",
+        "tests/test_guard_runtime.py::test_guard_hook_saved_artifact_approval_never_lowers_current_payload_block",
+        "approval",
+        "A remembered artifact approval cannot lower a current payload block.",
+        ("security_critical", "regression", "policy", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-007",
+        "tests/test_guard_runtime.py::test_guard_hook_claude_alias_saved_allow_does_not_lower_canonical_reapproval",
+        "approval",
+        "A Claude alias allow cannot lower canonical reapproval requirements.",
+        ("security_critical", "regression", "policy", "adapter_contract", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-008",
+        "tests/test_guard_runtime.py::test_policy_bundle_validation_rejects_tampered_hash",
+        "managed-policy",
+        "A policy bundle with a tampered hash is rejected.",
+        ("security_critical", "regression", "policy", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-009",
+        "tests/test_guard_runtime.py::test_cached_policy_bundle_revalidation_rejects_expired_last_known_good",
+        "managed-policy",
+        "An expired last-known-good policy bundle cannot be reactivated.",
+        ("security_critical", "regression", "policy", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-010",
+        "tests/test_guard_package_shims.py::test_guard_protect_requires_reapproval_for_untrusted_package_sources_without_cloud",
+        "package-shim",
+        "Untrusted package sources require reapproval without cloud policy support.",
+        ("security_critical", "regression", "policy", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-011",
+        "tests/test_guard_package_shims.py::test_guard_protect_saved_approval_does_not_bypass_new_bundle_block_for_unpinned_package",
+        "package-shim",
+        "A saved package approval cannot bypass a new signed bundle block.",
+        ("security_critical", "regression", "policy", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-012",
+        "tests/test_guard_policy_integrity.py::test_sync_state_tamper_cannot_downgrade_enforcement",
+        "policy-integrity",
+        "Tampered sync state cannot downgrade policy enforcement.",
+        ("security_critical", "regression", "policy", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-013",
+        "tests/test_guard_policy_integrity.py::test_direct_sqlite_insert_is_ignored_when_integrity_is_degraded",
+        "policy-integrity",
+        "Direct policy-row insertion is ignored while integrity is degraded.",
+        ("security_critical", "regression", "policy", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-014",
+        "tests/test_guard_mdm_policy.py::test_native_machine_policy_source_rejects_insecure_provenance",
+        "managed-policy",
+        "Managed policy rejects an insecure machine-policy source.",
+        ("security_critical", "regression", "policy", "release"),
+    ),
+)
+
+
+def invariant_markers_for_nodeid(nodeid: str) -> tuple[str, ...]:
+    """Return the deduplicated markers inherited from matching invariant records."""
+    markers: list[str] = []
+    for invariant in TEST_INVARIANTS:
+        if nodeid != invariant.selector and not nodeid.startswith(f"{invariant.selector}["):
+            continue
+        for marker in invariant.markers:
+            if marker not in markers:
+                markers.append(marker)
+    return tuple(markers)

--- a/tests/test_ci_pytest_shard.py
+++ b/tests/test_ci_pytest_shard.py
@@ -57,6 +57,14 @@ def test_ci_workflow_cancels_stale_runs_and_executes_each_shard() -> None:
     assert "pnpm" not in workflow
 
 
+def test_ci_validates_and_publishes_test_inventory_before_quality_checks() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert "Validate protected test invariants" in workflow
+    assert "scripts/ci/test_inventory.py --output test-inventory.json" in workflow
+    assert "Publish test inventory" in workflow
+
+
 def test_expensive_security_workflows_fit_the_pr_feedback_budget() -> None:
     codeql = CODEQL_WORKFLOW.read_text(encoding="utf-8")
     fuzz = FUZZ_WORKFLOW.read_text(encoding="utf-8")

--- a/tests/test_ci_test_inventory.py
+++ b/tests/test_ci_test_inventory.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "ci" / "test_inventory.py"
+SPEC = importlib.util.spec_from_file_location("test_inventory", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+test_inventory = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = test_inventory
+SPEC.loader.exec_module(test_inventory)
+
+
+def test_function_id_removes_parameter_suffix_only() -> None:
+    assert test_inventory.test_function_id("tests/test_example.py::test_case[value]") == (
+        "tests/test_example.py::test_case"
+    )
+    assert test_inventory.test_function_id("tests/test_example.py::test_case") == "tests/test_example.py::test_case"
+
+
+def test_inventory_counts_cases_functions_files_parameters_and_unique_markers() -> None:
+    node_ids = (
+        "tests/test_alpha.py::test_one[first]",
+        "tests/test_alpha.py::test_one[second]",
+        "tests/test_beta.py::test_two",
+    )
+    inventory = test_inventory.build_inventory(
+        node_ids,
+        {
+            node_ids[0]: ("security_critical", "regression", "regression"),
+            node_ids[1]: ("security_critical",),
+            node_ids[2]: ("parser",),
+        },
+    )
+
+    assert inventory.collected_cases == 3
+    assert inventory.test_functions == 2
+    assert inventory.test_files == 2
+    assert inventory.parameterized_cases == 1
+    assert inventory.marker_counts == {"parser": 1, "regression": 1, "security_critical": 2}

--- a/tests/test_guard_test_invariants.py
+++ b/tests/test_guard_test_invariants.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from tests.guard_test_invariants import TEST_INVARIANTS, invariant_markers_for_nodeid
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _test_names(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_")
+    }
+
+
+def test_invariant_ids_and_selectors_are_unique() -> None:
+    assert len({invariant.invariant_id for invariant in TEST_INVARIANTS}) == len(TEST_INVARIANTS)
+    assert len({invariant.selector for invariant in TEST_INVARIANTS}) == len(TEST_INVARIANTS)
+
+
+def test_each_invariant_points_to_a_concrete_test_function() -> None:
+    for invariant in TEST_INVARIANTS:
+        path_value, separator, test_name = invariant.selector.partition("::")
+        assert separator == "::"
+        path = ROOT / path_value
+        assert path.is_file(), invariant.invariant_id
+        assert test_name in _test_names(path), invariant.invariant_id
+
+
+def test_protected_invariants_include_required_security_markers() -> None:
+    for invariant in TEST_INVARIANTS:
+        markers = invariant_markers_for_nodeid(invariant.selector)
+        assert "security_critical" in markers, invariant.invariant_id
+        assert "regression" in markers, invariant.invariant_id
+        assert "release" in markers, invariant.invariant_id
+
+
+def test_unknown_node_has_no_invariant_markers() -> None:
+    assert invariant_markers_for_nodeid("tests/test_unknown.py::test_unknown") == ()
+
+
+def test_parameterized_case_inherits_base_invariant_markers() -> None:
+    selector = (
+        "tests/test_guard_package_shims.py::"
+        "test_guard_protect_requires_reapproval_for_untrusted_package_sources_without_cloud"
+    )
+    assert invariant_markers_for_nodeid(f"{selector}[npm]") == invariant_markers_for_nodeid(selector)


### PR DESCRIPTION
## Summary

- add stable protected-invariant records for representative Guard security boundaries
- validate invariant selectors during collection and publish suite inventory in CI

## Testing

- `uv run --no-sync pytest tests/test_guard_test_invariants.py tests/test_ci_test_inventory.py tests/test_ci_pytest_shard.py --tb=short`
- `uv run --no-sync python scripts/ci/test_inventory.py --output <inventory.json>`
- `uv run --no-sync python -m ruff check tests/conftest.py tests/guard_test_invariants.py tests/test_guard_test_invariants.py tests/test_ci_test_inventory.py tests/test_ci_pytest_shard.py scripts/ci/test_inventory.py`
