### PR TITLE
test(guard): batch command extension contracts

### DIFF
--- a/tests/command_extension_contracts.py
+++ b/tests/command_extension_contracts.py
@@ -1,0 +1,90 @@
+"""Shared assertions for declarative command-extension security contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
+from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
+
+ReviewedCommandCase = tuple[str, str, str]
+
+
+def assert_reviewed_command_cases(cases: tuple[ReviewedCommandCase, ...], tmp_path: Path) -> None:
+    """Prove every destructive command reaches both inspection and runtime review.
+
+    This deliberately evaluates every case before failing, so a single pytest
+    node retains the same diagnostic signal as the former repeated test bodies.
+    """
+    failures: list[str] = []
+    for command, action_class, rule_id in cases:
+        payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+        classification = payload.get("classification")
+        actual_action_class = classification.get("action_class") if isinstance(classification, dict) else None
+        raw_rules = payload.get("rules")
+        rule_ids: set[str] = set()
+        if isinstance(raw_rules, list):
+            for rule in raw_rules:
+                if isinstance(rule, dict) and isinstance(rule_id_value := rule.get("rule_id"), str):
+                    rule_ids.add(rule_id_value)
+        runtime_match = extract_sensitive_tool_action_request(
+            "Shell",
+            {"command": command},
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        actual_runtime_action = runtime_match.action_class if runtime_match is not None else None
+        if (
+            payload.get("status") != "review"
+            or actual_action_class != action_class
+            or rule_id not in rule_ids
+            or payload.get("controlling_rule_id") != rule_id
+            or actual_runtime_action != action_class
+        ):
+            failures.append(
+                f"{command!r}: status={payload.get('status')!r}, "
+                f"inspection_action={actual_action_class!r}, "
+                f"rules={sorted(rule_ids)!r}, controlling_rule={payload.get('controlling_rule_id')!r}, "
+                f"runtime_action={actual_runtime_action!r}; expected "
+                f"action={action_class!r}, rule={rule_id!r}"
+            )
+    assert not failures, "\n".join(failures)
+
+
+def assert_review_required_cases(cases: tuple[str, ...], tmp_path: Path) -> None:
+    """Prove a command remains reviewable without duplicating its rule contract."""
+    failures: list[str] = []
+    for command in cases:
+        payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+        runtime_match = extract_sensitive_tool_action_request(
+            "Shell",
+            {"command": command},
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        if payload.get("status") != "review" or runtime_match is None:
+            failures.append(
+                f"{command!r}: status={payload.get('status')!r}, "
+                f"runtime_action={runtime_match.action_class if runtime_match is not None else None!r}; expected review"
+            )
+    assert not failures, "\n".join(failures)
+
+
+def assert_safe_command_cases(cases: tuple[str, ...], tmp_path: Path) -> None:
+    """Prove preview, help, and observer cases remain non-reviewable."""
+    failures: list[str] = []
+    for command in cases:
+        payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+        runtime_match = extract_sensitive_tool_action_request(
+            "Shell",
+            {"command": command},
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        if payload.get("status") != "no_match" or runtime_match is not None:
+            failures.append(
+                f"{command!r}: status={payload.get('status')!r}, "
+                f"runtime_action={runtime_match.action_class if runtime_match is not None else None!r}; "
+                "expected no_match"
+            )
+    assert not failures, "\n".join(failures)

--- a/tests/guard_test_invariants.py
+++ b/tests/guard_test_invariants.py
@@ -121,6 +121,27 @@ TEST_INVARIANTS: Final[tuple[TestInvariant, ...]] = (
         "Managed policy rejects an insecure machine-policy source.",
         ("security_critical", "regression", "policy", "release"),
     ),
+    TestInvariant(
+        "GUARD-INV-015",
+        "tests/test_guard_command_backup_extensions.py::test_backup_rules_feed_runtime_hooks",
+        "command-extension",
+        "Backup mutation variants remain reviewable through inspection and runtime enforcement.",
+        ("security_critical", "regression", "parser", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-016",
+        "tests/test_guard_command_domain_extensions.py::test_domain_rules_feed_inspection_and_runtime_hooks",
+        "command-extension",
+        "Container, Kubernetes, and infrastructure mutation variants remain reviewable through both enforcement paths.",
+        ("security_critical", "regression", "parser", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-017",
+        "tests/test_guard_command_database_extensions.py::test_database_rules_feed_runtime_hooks",
+        "command-extension",
+        "Database mutation variants remain reviewable through inspection and runtime enforcement.",
+        ("security_critical", "regression", "parser", "release"),
+    ),
 )
 
 

--- a/tests/test_command_extension_contracts.py
+++ b/tests/test_command_extension_contracts.py
@@ -1,0 +1,70 @@
+"""Regression coverage for declarative command-extension contract assertions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tests import command_extension_contracts
+
+
+def test_reviewed_cases_report_every_failing_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        command_extension_contracts,
+        "inspect_command",
+        lambda command, **_: {
+            "status": "no_match",
+            "classification": {},
+            "rules": [],
+            "controlling_rule_id": None,
+        },
+    )
+    monkeypatch.setattr(
+        command_extension_contracts,
+        "extract_sensitive_tool_action_request",
+        lambda *_args, **_kwargs: None,
+    )
+
+    with pytest.raises(AssertionError) as error:
+        command_extension_contracts.assert_reviewed_command_cases(
+            (
+                ("first destructive command", "destructive", "rule.first"),
+                ("second destructive command", "destructive", "rule.second"),
+            ),
+            tmp_path,
+        )
+
+    message = str(error.value)
+    assert "first destructive command" in message
+    assert "second destructive command" in message
+
+
+def test_safe_cases_report_every_unexpected_review(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        command_extension_contracts,
+        "inspect_command",
+        lambda command, **_: {"status": "review"},
+    )
+    monkeypatch.setattr(
+        command_extension_contracts,
+        "extract_sensitive_tool_action_request",
+        lambda *_args, **_kwargs: SimpleNamespace(action_class="unexpected"),
+    )
+
+    with pytest.raises(AssertionError) as error:
+        command_extension_contracts.assert_safe_command_cases(
+            ("first safe command", "second safe command"),
+            tmp_path,
+        )
+
+    message = str(error.value)
+    assert "first safe command" in message
+    assert "second safe command" in message

--- a/tests/test_guard_command_backup_extensions.py
+++ b/tests/test_guard_command_backup_extensions.py
@@ -14,259 +14,229 @@ from codex_plugin_scanner.guard.runtime.command_option_parsing import (
     matches_subcommands_conservatively,
 )
 from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
+from tests.command_extension_contracts import assert_reviewed_command_cases, assert_safe_command_cases
 
-
-@pytest.mark.parametrize(
-    ("command", "action_class", "rule_id"),
-    [
-        ("rclone sync source: destination:", "Rclone destructive command", "command.backup.rclone.mutation"),
-        ("rclone.exe move source: destination:", "Rclone destructive command", "command.backup.rclone.mutation"),
-        (
-            "rclone --config --dry-run purge remote:archive",
-            "Rclone destructive command",
-            "command.backup.rclone.mutation",
-        ),
-        (
-            "rclone --log-level DEBUG purge remote:archive",
-            "Rclone destructive command",
-            "command.backup.rclone.mutation",
-        ),
-        (
-            "rclone --log-level=DEBUG purge remote:archive",
-            "Rclone destructive command",
-            "command.backup.rclone.mutation",
-        ),
-        (
-            "rclone --future-global-option --dry-run purge remote:archive",
-            "Rclone destructive command",
-            "command.backup.rclone.mutation",
-        ),
-        (
-            "rclone purge remote:archive --dry-run=false",
-            "Rclone destructive command",
-            "command.backup.rclone.mutation",
-        ),
-        (
-            "rclone purge remote:archive --dry-run=0",
-            "Rclone destructive command",
-            "command.backup.rclone.mutation",
-        ),
-        (
-            "rclone purge remote:archive --dry-run --dry-run=false",
-            "Rclone destructive command",
-            "command.backup.rclone.mutation",
-        ),
-        (
-            "rclone purge remote:archive --dry-run=true --dry-run=false",
-            "Rclone destructive command",
-            "command.backup.rclone.mutation",
-        ),
-        (
-            "rclone -ab value purge remote:archive",
-            "Rclone destructive command",
-            "command.backup.rclone.mutation",
-        ),
-        (
-            "rclone -ab --dry-run purge remote:archive",
-            "Rclone destructive command",
-            "command.backup.rclone.mutation",
-        ),
-        ("restic -r s3:archive forget latest --prune", "Restic destructive command", "command.backup.restic.mutation"),
-        (
-            "restic --compression max forget latest --prune",
-            "Restic destructive command",
-            "command.backup.restic.mutation",
-        ),
-        (
-            "restic --compression=max forget latest --prune",
-            "Restic destructive command",
-            "command.backup.restic.mutation",
-        ),
-        (
-            "restic --future-global-option --dry-run forget latest --prune",
-            "Restic destructive command",
-            "command.backup.restic.mutation",
-        ),
-        (
-            "restic -qr repository forget latest --prune",
-            "Restic destructive command",
-            "command.backup.restic.mutation",
-        ),
-        (
-            "restic -qrs3:archive forget latest --prune",
-            "Restic destructive command",
-            "command.backup.restic.mutation",
-        ),
-        (
-            "restic forget latest --dry-run --dry-run=false",
-            "Restic destructive command",
-            "command.backup.restic.mutation",
-        ),
-        ("restic rewrite --forget latest", "Restic destructive command", "command.backup.restic.mutation"),
-        ("borg.cmd prune --keep-daily 7 /archive", "Borg destructive command", "command.backup.borg.mutation"),
-        ("borg delete /archive::old", "Borg destructive command", "command.backup.borg.mutation"),
-        ("borg --repo /archive prune --keep-daily 7", "Borg destructive command", "command.backup.borg.mutation"),
-        ("borg -r/archive delete old", "Borg destructive command", "command.backup.borg.mutation"),
-        (
-            "borg --remote-ratelimit 1000 delete /archive::old",
-            "Borg destructive command",
-            "command.backup.borg.mutation",
-        ),
-        (
-            "borg --remote-ratelimit=1000 delete /archive::old",
-            "Borg destructive command",
-            "command.backup.borg.mutation",
-        ),
-        (
-            "borg --future-global-option --dry-run delete /archive::old",
-            "Borg destructive command",
-            "command.backup.borg.mutation",
-        ),
-        (
-            "borg -Pfoo-n prune --keep-daily 7 /archive",
-            "Borg destructive command",
-            "command.backup.borg.mutation",
-        ),
-        (
-            "borg -afoo-n prune --keep-daily 7 /archive",
-            "Borg destructive command",
-            "command.backup.borg.mutation",
-        ),
-        (
-            "borg -efoo-n recreate /archive",
-            "Borg destructive command",
-            "command.backup.borg.mutation",
-        ),
-        (
-            "borg -vr /archive prune --keep-daily 7",
-            "Borg destructive command",
-            "command.backup.borg.mutation",
-        ),
-        (
-            "borg -vr/archive prune --keep-daily 7",
-            "Borg destructive command",
-            "command.backup.borg.mutation",
-        ),
-        (
-            "borg prune --keep-daily 7 /archive --dry-run --dry-run=false",
-            "Borg destructive command",
-            "command.backup.borg.mutation",
-        ),
-        ("velero backup delete release-1", "Velero destructive command", "command.backup.velero.deletion"),
-        (
-            "velero --namespace prod backup delete release-1",
-            "Velero destructive command",
-            "command.backup.velero.deletion",
-        ),
-        (
-            "velero --kubeconfig=config-file restore delete release-1",
-            "Velero destructive command",
-            "command.backup.velero.deletion",
-        ),
-        ("velero -nprod schedule delete nightly", "Velero destructive command", "command.backup.velero.deletion"),
-        (
-            "velero -vnprod backup delete release-1",
-            "Velero destructive command",
-            "command.backup.velero.deletion",
-        ),
-        (
-            "velero backup delete release-1 --help --help=false",
-            "Velero destructive command",
-            "command.backup.velero.deletion",
-        ),
-        (
-            "velero --future-global-option cluster backup delete release-1",
-            "Velero destructive command",
-            "command.backup.velero.deletion",
-        ),
-        (
-            "velero --future-global-option=cluster backup delete release-1",
-            "Velero destructive command",
-            "command.backup.velero.deletion",
-        ),
-        (
-            "velero --future-global-option --help backup delete release-1",
-            "Velero destructive command",
-            "command.backup.velero.deletion",
-        ),
-    ],
+BACKUP_REVIEW_CASES: tuple[tuple[str, str, str], ...] = (
+    ("rclone sync source: destination:", "Rclone destructive command", "command.backup.rclone.mutation"),
+    ("rclone.exe move source: destination:", "Rclone destructive command", "command.backup.rclone.mutation"),
+    (
+        "rclone --config --dry-run purge remote:archive",
+        "Rclone destructive command",
+        "command.backup.rclone.mutation",
+    ),
+    (
+        "rclone --log-level DEBUG purge remote:archive",
+        "Rclone destructive command",
+        "command.backup.rclone.mutation",
+    ),
+    (
+        "rclone --log-level=DEBUG purge remote:archive",
+        "Rclone destructive command",
+        "command.backup.rclone.mutation",
+    ),
+    (
+        "rclone --future-global-option --dry-run purge remote:archive",
+        "Rclone destructive command",
+        "command.backup.rclone.mutation",
+    ),
+    (
+        "rclone purge remote:archive --dry-run=false",
+        "Rclone destructive command",
+        "command.backup.rclone.mutation",
+    ),
+    (
+        "rclone purge remote:archive --dry-run=0",
+        "Rclone destructive command",
+        "command.backup.rclone.mutation",
+    ),
+    (
+        "rclone purge remote:archive --dry-run --dry-run=false",
+        "Rclone destructive command",
+        "command.backup.rclone.mutation",
+    ),
+    (
+        "rclone purge remote:archive --dry-run=true --dry-run=false",
+        "Rclone destructive command",
+        "command.backup.rclone.mutation",
+    ),
+    (
+        "rclone -ab value purge remote:archive",
+        "Rclone destructive command",
+        "command.backup.rclone.mutation",
+    ),
+    (
+        "rclone -ab --dry-run purge remote:archive",
+        "Rclone destructive command",
+        "command.backup.rclone.mutation",
+    ),
+    ("restic -r s3:archive forget latest --prune", "Restic destructive command", "command.backup.restic.mutation"),
+    (
+        "restic --compression max forget latest --prune",
+        "Restic destructive command",
+        "command.backup.restic.mutation",
+    ),
+    (
+        "restic --compression=max forget latest --prune",
+        "Restic destructive command",
+        "command.backup.restic.mutation",
+    ),
+    (
+        "restic --future-global-option --dry-run forget latest --prune",
+        "Restic destructive command",
+        "command.backup.restic.mutation",
+    ),
+    (
+        "restic -qr repository forget latest --prune",
+        "Restic destructive command",
+        "command.backup.restic.mutation",
+    ),
+    (
+        "restic -qrs3:archive forget latest --prune",
+        "Restic destructive command",
+        "command.backup.restic.mutation",
+    ),
+    (
+        "restic forget latest --dry-run --dry-run=false",
+        "Restic destructive command",
+        "command.backup.restic.mutation",
+    ),
+    ("restic rewrite --forget latest", "Restic destructive command", "command.backup.restic.mutation"),
+    ("borg.cmd prune --keep-daily 7 /archive", "Borg destructive command", "command.backup.borg.mutation"),
+    ("borg delete /archive::old", "Borg destructive command", "command.backup.borg.mutation"),
+    ("borg --repo /archive prune --keep-daily 7", "Borg destructive command", "command.backup.borg.mutation"),
+    ("borg -r/archive delete old", "Borg destructive command", "command.backup.borg.mutation"),
+    (
+        "borg --remote-ratelimit 1000 delete /archive::old",
+        "Borg destructive command",
+        "command.backup.borg.mutation",
+    ),
+    (
+        "borg --remote-ratelimit=1000 delete /archive::old",
+        "Borg destructive command",
+        "command.backup.borg.mutation",
+    ),
+    (
+        "borg --future-global-option --dry-run delete /archive::old",
+        "Borg destructive command",
+        "command.backup.borg.mutation",
+    ),
+    (
+        "borg -Pfoo-n prune --keep-daily 7 /archive",
+        "Borg destructive command",
+        "command.backup.borg.mutation",
+    ),
+    (
+        "borg -afoo-n prune --keep-daily 7 /archive",
+        "Borg destructive command",
+        "command.backup.borg.mutation",
+    ),
+    (
+        "borg -efoo-n recreate /archive",
+        "Borg destructive command",
+        "command.backup.borg.mutation",
+    ),
+    (
+        "borg -vr /archive prune --keep-daily 7",
+        "Borg destructive command",
+        "command.backup.borg.mutation",
+    ),
+    (
+        "borg -vr/archive prune --keep-daily 7",
+        "Borg destructive command",
+        "command.backup.borg.mutation",
+    ),
+    (
+        "borg prune --keep-daily 7 /archive --dry-run --dry-run=false",
+        "Borg destructive command",
+        "command.backup.borg.mutation",
+    ),
+    ("velero backup delete release-1", "Velero destructive command", "command.backup.velero.deletion"),
+    (
+        "velero --namespace prod backup delete release-1",
+        "Velero destructive command",
+        "command.backup.velero.deletion",
+    ),
+    (
+        "velero --kubeconfig=config-file restore delete release-1",
+        "Velero destructive command",
+        "command.backup.velero.deletion",
+    ),
+    ("velero -nprod schedule delete nightly", "Velero destructive command", "command.backup.velero.deletion"),
+    (
+        "velero -vnprod backup delete release-1",
+        "Velero destructive command",
+        "command.backup.velero.deletion",
+    ),
+    (
+        "velero backup delete release-1 --help --help=false",
+        "Velero destructive command",
+        "command.backup.velero.deletion",
+    ),
+    (
+        "velero --future-global-option cluster backup delete release-1",
+        "Velero destructive command",
+        "command.backup.velero.deletion",
+    ),
+    (
+        "velero --future-global-option=cluster backup delete release-1",
+        "Velero destructive command",
+        "command.backup.velero.deletion",
+    ),
+    (
+        "velero --future-global-option --help backup delete release-1",
+        "Velero destructive command",
+        "command.backup.velero.deletion",
+    ),
 )
-def test_backup_rules_feed_runtime_hooks(
-    command: str,
-    action_class: str,
-    rule_id: str,
-    tmp_path: Path,
-) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
-
-    assert payload["status"] == "review"
-    assert payload["classification"]["action_class"] == action_class
-    assert payload["controlling_rule_id"] == rule_id
-    runtime_match = extract_sensitive_tool_action_request(
-        "Shell",
-        {"command": command},
-        cwd=tmp_path,
-        home_dir=tmp_path,
-    )
-    assert runtime_match is not None
-    assert runtime_match.action_class == action_class
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "rclone sync source: destination: --dry-run",
-        "rclone purge remote:archive --dry-run=true",
-        "rclone purge remote:archive --dry-run=1",
-        "rclone purge remote:archive --dry-run=false --dry-run",
-        "rclone purge remote:archive --dry-run=false --dry-run=true",
-        "rclone -n purge remote:archive",
-        "restic -r s3:archive forget latest --dry-run",
-        "restic rewrite --forget latest --dry-run",
-        "borg prune --keep-daily 7 /archive --dry-run",
-        "borg recreate /archive --dry-run",
-        "borg --repo /archive prune --keep-daily 7 --dry-run",
-        "velero backup delete --help",
-        "rclone --log-level DEBUG purge remote:archive --dry-run",
-        "restic --compression max forget latest --dry-run",
-        "borg --remote-ratelimit 1000 prune --keep-daily 7 /archive --dry-run",
-        "velero --future-global-option cluster backup delete release-1 --help",
-        "rclone lsl remote:archive",
-        "rclone --log-level DEBUG lsl remote:archive",
-        "rclone -ab value lsl remote:archive",
-        "rclone -vn purge remote:archive",
-        "restic snapshots",
-        "restic --compression max snapshots",
-        "restic -qr forget snapshots",
-        "restic -qrforget snapshots",
-        "restic forget latest --dry-run=false --dry-run",
-        "borg list /archive",
-        "borg --remote-ratelimit 1000 list /archive",
-        "borg prune -Pfoo -n --keep-daily 7 /archive",
-        "borg prune -afoo -n --keep-daily 7 /archive",
-        "borg recreate -efoo -n /archive",
-        "borg -vr prune list",
-        "borg prune --keep-daily 7 /archive --dry-run=false --dry-run",
-        "velero backup describe release-1",
-        "velero --future-global-option cluster backup describe release-1",
-        "velero -vnprod backup describe release-1",
-        "velero backup delete release-1 --help=false --help",
-        "grep 'rclone sync|restic forget|borg prune|velero backup delete' docs",
-    ],
+def test_backup_rules_feed_runtime_hooks(tmp_path: Path) -> None:
+    assert_reviewed_command_cases(BACKUP_REVIEW_CASES, tmp_path)
+
+
+BACKUP_SAFE_COMMANDS: tuple[str, ...] = (
+    "rclone sync source: destination: --dry-run",
+    "rclone purge remote:archive --dry-run=true",
+    "rclone purge remote:archive --dry-run=1",
+    "rclone purge remote:archive --dry-run=false --dry-run",
+    "rclone purge remote:archive --dry-run=false --dry-run=true",
+    "rclone -n purge remote:archive",
+    "restic -r s3:archive forget latest --dry-run",
+    "restic rewrite --forget latest --dry-run",
+    "borg prune --keep-daily 7 /archive --dry-run",
+    "borg recreate /archive --dry-run",
+    "borg --repo /archive prune --keep-daily 7 --dry-run",
+    "velero backup delete --help",
+    "rclone --log-level DEBUG purge remote:archive --dry-run",
+    "restic --compression max forget latest --dry-run",
+    "borg --remote-ratelimit 1000 prune --keep-daily 7 /archive --dry-run",
+    "velero --future-global-option cluster backup delete release-1 --help",
+    "rclone lsl remote:archive",
+    "rclone --log-level DEBUG lsl remote:archive",
+    "rclone -ab value lsl remote:archive",
+    "rclone -vn purge remote:archive",
+    "restic snapshots",
+    "restic --compression max snapshots",
+    "restic -qr forget snapshots",
+    "restic -qrforget snapshots",
+    "restic forget latest --dry-run=false --dry-run",
+    "borg list /archive",
+    "borg --remote-ratelimit 1000 list /archive",
+    "borg prune -Pfoo -n --keep-daily 7 /archive",
+    "borg prune -afoo -n --keep-daily 7 /archive",
+    "borg recreate -efoo -n /archive",
+    "borg -vr prune list",
+    "borg prune --keep-daily 7 /archive --dry-run=false --dry-run",
+    "velero backup describe release-1",
+    "velero --future-global-option cluster backup describe release-1",
+    "velero -vnprod backup describe release-1",
+    "velero backup delete release-1 --help=false --help",
+    "grep 'rclone sync|restic forget|borg prune|velero backup delete' docs",
 )
-def test_backup_preview_and_read_commands_remain_safe(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
 
-    assert payload["status"] == "no_match"
-    assert (
-        extract_sensitive_tool_action_request(
-            "Shell",
-            {"command": command},
-            cwd=tmp_path,
-            home_dir=tmp_path,
-        )
-        is None
-    )
+
+def test_backup_preview_and_read_commands_remain_safe(tmp_path: Path) -> None:
+    assert_safe_command_cases(BACKUP_SAFE_COMMANDS, tmp_path)
 
 
 def test_backup_interactive_mode_remains_reviewable(tmp_path: Path) -> None:

--- a/tests/test_guard_command_database_extensions.py
+++ b/tests/test_guard_command_database_extensions.py
@@ -4,188 +4,134 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from codex_plugin_scanner.guard.runtime.command_database_matchers import LeadingSubcommandMatcher
 from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
-from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
 from codex_plugin_scanner.guard.runtime.command_model import parse_shell_command
-from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
-
-
-@pytest.mark.parametrize(
-    ("command", "action_class", "rule_id"),
-    [
-        ("dropdb production", "PostgreSQL destructive command", "command.database.postgresql.drop"),
-        (
-            "dropdb.exe -h db.example -U admin production",
-            "PostgreSQL destructive command",
-            "command.database.postgresql.drop",
-        ),
-        ("mysqladmin drop production", "MySQL destructive command", "command.database.mysql.drop"),
-        ("mysqladmin status drop production", "MySQL destructive command", "command.database.mysql.drop"),
-        ("mysqladmin dr production", "MySQL destructive command", "command.database.mysql.drop"),
-        (
-            "mysqladmin.cmd -P 3306 -u root drop production",
-            "MySQL destructive command",
-            "command.database.mysql.drop",
-        ),
-        (
-            "mysqladmin --connect-timeout 5 status drop production",
-            "MySQL destructive command",
-            "command.database.mysql.drop",
-        ),
-        (
-            "mongorestore --drop --archive=backup.archive",
-            "MongoDB destructive command",
-            "command.database.mongodb.restore-drop",
-        ),
-        ("redis-cli FLUSHALL", "Redis destructive command", "command.database.redis.delete"),
-        ("redis-cli -n 3 DEL session:1", "Redis destructive command", "command.database.redis.delete"),
-        ("redis-cli -a secret -n 3 FLUSHDB", "Redis destructive command", "command.database.redis.delete"),
-        ("redis-cli -t 1 FLUSHALL", "Redis destructive command", "command.database.redis.delete"),
-        ("redis-cli -X tag DEL key", "Redis destructive command", "command.database.redis.delete"),
-        ("redis-cli --show-pushes no FLUSHDB", "Redis destructive command", "command.database.redis.delete"),
-        ("redis-cli.exe --raw UNLINK queue:1", "Redis destructive command", "command.database.redis.delete"),
-        (
-            'sqlite3 app.db ".restore backup.db"',
-            "SQLite destructive command",
-            "command.database.sqlite.restore",
-        ),
-        ('sqlite3.cmd app.db ".rest backup.db"', "SQLite destructive command", "command.database.sqlite.restore"),
-        ("supabase db reset --linked", "Supabase destructive command", "command.database.supabase.reset"),
-        (
-            "supabase --workdir ./backend db reset --linked",
-            "Supabase destructive command",
-            "command.database.supabase.reset",
-        ),
-        (
-            "supabase --agent yes db reset --linked",
-            "Supabase destructive command",
-            "command.database.supabase.reset",
-        ),
-        (
-            "npx supabase db reset --linked",
-            "Supabase destructive command",
-            "command.database.supabase.reset",
-        ),
-        (
-            "pnpm supabase migration down --linked --last 1",
-            "Supabase destructive command",
-            "command.database.supabase.reset",
-        ),
-        (
-            "yarn dlx supabase db reset --linked",
-            "Supabase destructive command",
-            "command.database.supabase.reset",
-        ),
-        (
-            "supabase.exe migration down --linked --last 1",
-            "Supabase destructive command",
-            "command.database.supabase.reset",
-        ),
-    ],
+from tests.command_extension_contracts import (
+    assert_review_required_cases,
+    assert_reviewed_command_cases,
+    assert_safe_command_cases,
 )
-def test_database_rules_feed_runtime_hooks(
-    command: str,
-    action_class: str,
-    rule_id: str,
-    tmp_path: Path,
-) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
 
-    assert payload["status"] == "review"
-    assert payload["classification"]["action_class"] == action_class
-    assert payload["controlling_rule_id"] == rule_id
-    runtime_match = extract_sensitive_tool_action_request(
-        "Shell",
-        {"command": command},
-        cwd=tmp_path,
-        home_dir=tmp_path,
-    )
-    assert runtime_match is not None
-    assert runtime_match.action_class == action_class
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
-        "dropdb --help production",
-        "dropdb -V production",
-        "mysqladmin --help drop production",
-        "mysqladmin -? drop production",
-        "mysqladmin password drop",
-        "mysqladmin status",
-        "mongorestore --drop --dryRun --archive=backup.archive",
-        "mongorestore --drop --help",
-        "mongorestore --archive=backup.archive",
-        "redis-cli --help FLUSHALL",
-        "redis-cli GET session:1",
-        "redis-cli --eval readonly.lua FLUSHALL",
-        "sqlite3 app.db '.help .restore'",
-        "sqlite3 .help .restore",
-        "sqlite3 app.db .restore backup.db",
-        "supabase db reset --help",
-        "supabase db dump --linked",
-        "grep 'dropdb|mysqladmin drop|mongorestore --drop|redis-cli FLUSHALL|sqlite3 .restore' docs",
-    ],
+DATABASE_REVIEW_CASES: tuple[tuple[str, str, str], ...] = (
+    ("dropdb production", "PostgreSQL destructive command", "command.database.postgresql.drop"),
+    (
+        "dropdb.exe -h db.example -U admin production",
+        "PostgreSQL destructive command",
+        "command.database.postgresql.drop",
+    ),
+    ("mysqladmin drop production", "MySQL destructive command", "command.database.mysql.drop"),
+    ("mysqladmin status drop production", "MySQL destructive command", "command.database.mysql.drop"),
+    ("mysqladmin dr production", "MySQL destructive command", "command.database.mysql.drop"),
+    (
+        "mysqladmin.cmd -P 3306 -u root drop production",
+        "MySQL destructive command",
+        "command.database.mysql.drop",
+    ),
+    (
+        "mysqladmin --connect-timeout 5 status drop production",
+        "MySQL destructive command",
+        "command.database.mysql.drop",
+    ),
+    (
+        "mongorestore --drop --archive=backup.archive",
+        "MongoDB destructive command",
+        "command.database.mongodb.restore-drop",
+    ),
+    ("redis-cli FLUSHALL", "Redis destructive command", "command.database.redis.delete"),
+    ("redis-cli -n 3 DEL session:1", "Redis destructive command", "command.database.redis.delete"),
+    ("redis-cli -a secret -n 3 FLUSHDB", "Redis destructive command", "command.database.redis.delete"),
+    ("redis-cli -t 1 FLUSHALL", "Redis destructive command", "command.database.redis.delete"),
+    ("redis-cli -X tag DEL key", "Redis destructive command", "command.database.redis.delete"),
+    ("redis-cli --show-pushes no FLUSHDB", "Redis destructive command", "command.database.redis.delete"),
+    ("redis-cli.exe --raw UNLINK queue:1", "Redis destructive command", "command.database.redis.delete"),
+    (
+        'sqlite3 app.db ".restore backup.db"',
+        "SQLite destructive command",
+        "command.database.sqlite.restore",
+    ),
+    ('sqlite3.cmd app.db ".rest backup.db"', "SQLite destructive command", "command.database.sqlite.restore"),
+    ("supabase db reset --linked", "Supabase destructive command", "command.database.supabase.reset"),
+    (
+        "supabase --workdir ./backend db reset --linked",
+        "Supabase destructive command",
+        "command.database.supabase.reset",
+    ),
+    (
+        "supabase --agent yes db reset --linked",
+        "Supabase destructive command",
+        "command.database.supabase.reset",
+    ),
+    (
+        "npx supabase db reset --linked",
+        "Supabase destructive command",
+        "command.database.supabase.reset",
+    ),
+    (
+        "pnpm supabase migration down --linked --last 1",
+        "Supabase destructive command",
+        "command.database.supabase.reset",
+    ),
+    (
+        "yarn dlx supabase db reset --linked",
+        "Supabase destructive command",
+        "command.database.supabase.reset",
+    ),
+    (
+        "supabase.exe migration down --linked --last 1",
+        "Supabase destructive command",
+        "command.database.supabase.reset",
+    ),
 )
-def test_database_observer_and_preview_commands_remain_safe(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
 
-    assert payload["status"] == "no_match"
-    assert (
-        extract_sensitive_tool_action_request(
-            "Shell",
-            {"command": command},
-            cwd=tmp_path,
-            home_dir=tmp_path,
-        )
-        is None
+
+def test_database_rules_feed_runtime_hooks(tmp_path: Path) -> None:
+    assert_reviewed_command_cases(DATABASE_REVIEW_CASES, tmp_path)
+
+
+DATABASE_SAFE_COMMANDS: tuple[str, ...] = (
+    "dropdb --help production",
+    "dropdb -V production",
+    "mysqladmin --help drop production",
+    "mysqladmin -? drop production",
+    "mysqladmin password drop",
+    "mysqladmin status",
+    "mongorestore --drop --dryRun --archive=backup.archive",
+    "mongorestore --drop --help",
+    "mongorestore --archive=backup.archive",
+    "redis-cli --help FLUSHALL",
+    "redis-cli GET session:1",
+    "redis-cli --eval readonly.lua FLUSHALL",
+    "sqlite3 app.db '.help .restore'",
+    "sqlite3 .help .restore",
+    "sqlite3 app.db .restore backup.db",
+    "supabase db reset --help",
+    "supabase db dump --linked",
+    "grep 'dropdb|mysqladmin drop|mongorestore --drop|redis-cli FLUSHALL|sqlite3 .restore' docs",
+)
+
+
+def test_database_observer_and_preview_commands_remain_safe(tmp_path: Path) -> None:
+    assert_safe_command_cases(DATABASE_SAFE_COMMANDS, tmp_path)
+
+
+def test_mongodb_false_or_overridden_dry_run_remains_live_execution(tmp_path: Path) -> None:
+    assert_review_required_cases(
+        (
+            "mongorestore --drop --dryRun=false --archive=backup.archive",
+            "mongorestore --drop --dryRun --dryRun=false --archive=backup.archive",
+        ),
+        tmp_path,
     )
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "mongorestore --drop --dryRun=false --archive=backup.archive",
-        "mongorestore --drop --dryRun --dryRun=false --archive=backup.archive",
-    ],
-)
-def test_mongodb_false_or_overridden_dry_run_remains_live_execution(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
-
-    assert payload["status"] == "review"
-    assert (
-        extract_sensitive_tool_action_request(
-            "Shell",
-            {"command": command},
-            cwd=tmp_path,
-            home_dir=tmp_path,
-        )
-        is not None
-    )
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
-        "mongorestore --drop --dryRun=true --archive=backup.archive",
-        "mongorestore --drop --dryRun=false --dryRun --archive=backup.archive",
-    ],
-)
-def test_mongodb_truthy_or_effective_dry_run_remains_quiet(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
-
-    assert payload["status"] == "no_match"
-    assert (
-        extract_sensitive_tool_action_request(
-            "Shell",
-            {"command": command},
-            cwd=tmp_path,
-            home_dir=tmp_path,
-        )
-        is None
+def test_mongodb_truthy_or_effective_dry_run_remains_quiet(tmp_path: Path) -> None:
+    assert_safe_command_cases(
+        (
+            "mongorestore --drop --dryRun=true --archive=backup.archive",
+            "mongorestore --drop --dryRun=false --dryRun --archive=backup.archive",
+        ),
+        tmp_path,
     )
 
 

--- a/tests/test_guard_command_domain_extensions.py
+++ b/tests/test_guard_command_domain_extensions.py
@@ -4,222 +4,176 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
-from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
-
-
-@pytest.mark.parametrize(
-    ("command", "action_class", "rule_id"),
-    [
-        (
-            "docker --context local system prune -a --volumes",
-            "docker-sensitive command",
-            "command.container-runtime.system-prune",
-        ),
-        (
-            "docker container rm --force api",
-            "docker-sensitive command",
-            "command.container-runtime.forced-container-removal",
-        ),
-        (
-            "docker rm -f api",
-            "docker-sensitive command",
-            "command.container-runtime.forced-container-removal",
-        ),
-        (
-            "docker container rm -f api",
-            "docker-sensitive command",
-            "command.container-runtime.forced-container-removal",
-        ),
-        (
-            "docker run --privileged alpine sh",
-            "docker-sensitive command",
-            "command.container-runtime.privileged-run",
-        ),
-        (
-            "kubectl --context prod delete deployment api",
-            "Kubernetes destructive command",
-            "command.kubernetes-operations.delete-resources",
-        ),
-        (
-            "kubectl --kubeconfig cluster.yaml drain node-a",
-            "Kubernetes destructive command",
-            "command.kubernetes-operations.drain-node",
-        ),
-        (
-            "helm --namespace prod uninstall api",
-            "Kubernetes destructive command",
-            "command.kubernetes-operations.helm-uninstall",
-        ),
-        (
-            "terraform -chdir=infra destroy -auto-approve",
-            "infrastructure destructive command",
-            "command.infrastructure-as-code.destroy",
-        ),
-        (
-            "tofu apply -destroy -auto-approve",
-            "infrastructure destructive command",
-            "command.infrastructure-as-code.destroy",
-        ),
-        (
-            "pulumi --stack prod destroy --yes",
-            "infrastructure destructive command",
-            "command.infrastructure-as-code.destroy",
-        ),
-    ],
+from tests.command_extension_contracts import (
+    assert_review_required_cases,
+    assert_reviewed_command_cases,
+    assert_safe_command_cases,
 )
-def test_domain_rules_feed_inspection_and_runtime_hooks(
-    command: str,
-    action_class: str,
-    rule_id: str,
-    tmp_path: Path,
-) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
 
-    assert payload["status"] == "review"
-    assert payload["classification"]["action_class"] == action_class
-    assert rule_id in {rule["rule_id"] for rule in payload["rules"]}
-    assert payload["controlling_rule_id"] == rule_id
-    runtime_match = extract_sensitive_tool_action_request(
-        "Shell",
-        {"command": command},
-        cwd=tmp_path,
-        home_dir=tmp_path,
-    )
-    assert runtime_match is not None
-    assert runtime_match.action_class == action_class
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
-        "docker system prune --help",
-        "docker rm --force --help",
-        "docker run --privileged --help",
-        "kubectl delete deployment api --dry-run=client",
-        "kubectl drain node-a --dry-run=server",
-        "helm uninstall api --dry-run",
-        "terraform plan -destroy",
-        "terraform destroy --help",
-        "tofu plan -destroy",
-        "pulumi preview",
-        "pulumi destroy --preview-only",
-        "grep 'docker system prune|kubectl delete|terraform destroy' scripts/guard-test",
-        "printf '%s\\n' 'kubectl delete namespace prod'",
-    ],
+DOMAIN_REVIEW_CASES: tuple[tuple[str, str, str], ...] = (
+    (
+        "docker --context local system prune -a --volumes",
+        "docker-sensitive command",
+        "command.container-runtime.system-prune",
+    ),
+    (
+        "docker container rm --force api",
+        "docker-sensitive command",
+        "command.container-runtime.forced-container-removal",
+    ),
+    (
+        "docker rm -f api",
+        "docker-sensitive command",
+        "command.container-runtime.forced-container-removal",
+    ),
+    (
+        "docker container rm -f api",
+        "docker-sensitive command",
+        "command.container-runtime.forced-container-removal",
+    ),
+    (
+        "docker run --privileged alpine sh",
+        "docker-sensitive command",
+        "command.container-runtime.privileged-run",
+    ),
+    (
+        "kubectl --context prod delete deployment api",
+        "Kubernetes destructive command",
+        "command.kubernetes-operations.delete-resources",
+    ),
+    (
+        "kubectl --kubeconfig cluster.yaml drain node-a",
+        "Kubernetes destructive command",
+        "command.kubernetes-operations.drain-node",
+    ),
+    (
+        "helm --namespace prod uninstall api",
+        "Kubernetes destructive command",
+        "command.kubernetes-operations.helm-uninstall",
+    ),
+    (
+        "terraform -chdir=infra destroy -auto-approve",
+        "infrastructure destructive command",
+        "command.infrastructure-as-code.destroy",
+    ),
+    (
+        "tofu apply -destroy -auto-approve",
+        "infrastructure destructive command",
+        "command.infrastructure-as-code.destroy",
+    ),
+    (
+        "pulumi --stack prod destroy --yes",
+        "infrastructure destructive command",
+        "command.infrastructure-as-code.destroy",
+    ),
 )
-def test_domain_preview_and_help_commands_remain_safe(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
-
-    assert payload["status"] == "no_match"
-    assert extract_sensitive_tool_action_request(
-        "Shell",
-        {"command": command},
-        cwd=tmp_path,
-        home_dir=tmp_path,
-    ) is None
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "kubectl delete deployment api --dry-run=none",
-        "kubectl drain node-a --dry-run=none",
-    ],
+def test_domain_rules_feed_inspection_and_runtime_hooks(tmp_path: Path) -> None:
+    assert_reviewed_command_cases(DOMAIN_REVIEW_CASES, tmp_path)
+
+
+DOMAIN_SAFE_COMMANDS: tuple[str, ...] = (
+    "docker system prune --help",
+    "docker rm --force --help",
+    "docker run --privileged --help",
+    "kubectl delete deployment api --dry-run=client",
+    "kubectl drain node-a --dry-run=server",
+    "helm uninstall api --dry-run",
+    "terraform plan -destroy",
+    "terraform destroy --help",
+    "tofu plan -destroy",
+    "pulumi preview",
+    "pulumi destroy --preview-only",
+    "grep 'docker system prune|kubectl delete|terraform destroy' scripts/guard-test",
+    "printf '%s\\n' 'kubectl delete namespace prod'",
 )
-def test_kubernetes_dry_run_none_remains_live_execution(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
-
-    assert payload["status"] == "review"
-    assert payload["classification"]["action_class"] == "Kubernetes destructive command"
-    assert extract_sensitive_tool_action_request(
-        "Shell",
-        {"command": command},
-        cwd=tmp_path,
-        home_dir=tmp_path,
-    ) is not None
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "docker system prune --help=false",
-        "docker system prune --help --help=false",
-        "kubectl delete deployment api --help=false",
-        "kubectl delete deployment api --dry-run=client --dry-run=none",
-        "kubectl drain node-a --dry-run=server --dry-run=false",
-        "helm uninstall api --dry-run=false",
-        "helm uninstall api --dry-run --dry-run=false",
-        "terraform destroy --help=false",
-        "tofu destroy --help --help=false",
-        "pulumi destroy --preview-only=false",
-        "pulumi destroy --preview-only --preview-only=false",
-    ],
-)
-def test_false_or_overridden_safe_variants_remain_live_execution(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+def test_domain_preview_and_help_commands_remain_safe(tmp_path: Path) -> None:
+    assert_safe_command_cases(DOMAIN_SAFE_COMMANDS, tmp_path)
 
-    assert payload["status"] == "review"
-    assert (
-        extract_sensitive_tool_action_request(
-            "Shell",
-            {"command": command},
-            cwd=tmp_path,
-            home_dir=tmp_path,
-        )
-        is not None
+
+def test_kubernetes_dry_run_none_remains_live_execution(tmp_path: Path) -> None:
+    assert_reviewed_command_cases(
+        (
+            (
+                "kubectl delete deployment api --dry-run=none",
+                "Kubernetes destructive command",
+                "command.kubernetes-operations.delete-resources",
+            ),
+            (
+                "kubectl drain node-a --dry-run=none",
+                "Kubernetes destructive command",
+                "command.kubernetes-operations.drain-node",
+            ),
+        ),
+        tmp_path,
     )
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "docker system prune --help=true",
-        "kubectl delete deployment api --help=true",
-        "kubectl delete deployment api --dry-run=none --dry-run=client",
-        "helm uninstall api --dry-run=true",
-        "terraform destroy --help=true",
-        "tofu destroy --help=false --help",
-        "pulumi destroy --preview-only=true",
-        "pulumi destroy --preview-only=false --preview-only=yes",
-    ],
+DOMAIN_UNSAFE_VARIANTS: tuple[str, ...] = (
+    "docker system prune --help=false",
+    "docker system prune --help --help=false",
+    "kubectl delete deployment api --help=false",
+    "kubectl delete deployment api --dry-run=client --dry-run=none",
+    "kubectl drain node-a --dry-run=server --dry-run=false",
+    "helm uninstall api --dry-run=false",
+    "helm uninstall api --dry-run --dry-run=false",
+    "terraform destroy --help=false",
+    "tofu destroy --help --help=false",
+    "pulumi destroy --preview-only=false",
+    "pulumi destroy --preview-only --preview-only=false",
 )
-def test_truthy_or_effective_safe_variants_remain_quiet(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
 
-    assert payload["status"] == "no_match"
-    assert (
-        extract_sensitive_tool_action_request(
-            "Shell",
-            {"command": command},
-            cwd=tmp_path,
-            home_dir=tmp_path,
-        )
-        is None
-    )
+
+def test_false_or_overridden_safe_variants_remain_live_execution(tmp_path: Path) -> None:
+    assert_review_required_cases(DOMAIN_UNSAFE_VARIANTS, tmp_path)
+
+
+DOMAIN_EFFECTIVE_SAFE_VARIANTS: tuple[str, ...] = (
+    "docker system prune --help=true",
+    "kubectl delete deployment api --help=true",
+    "kubectl delete deployment api --dry-run=none --dry-run=client",
+    "helm uninstall api --dry-run=true",
+    "terraform destroy --help=true",
+    "tofu destroy --help=false --help",
+    "pulumi destroy --preview-only=true",
+    "pulumi destroy --preview-only=false --preview-only=yes",
+)
+
+
+def test_truthy_or_effective_safe_variants_remain_quiet(tmp_path: Path) -> None:
+    assert_safe_command_cases(DOMAIN_EFFECTIVE_SAFE_VARIANTS, tmp_path)
 
 
 def test_container_argument_named_help_remains_runtime_execution(tmp_path: Path) -> None:
     payload = inspect_command("docker run alpine --help", cwd=tmp_path, home_dir=tmp_path)
 
     assert payload["status"] == "review"
-    assert payload["classification"]["action_class"] == "docker-sensitive command"
+    classification = payload.get("classification")
+    assert isinstance(classification, dict)
+    assert classification.get("action_class") == "docker-sensitive command"
 
 
 def test_container_short_host_flag_remains_runtime_execution(tmp_path: Path) -> None:
     payload = inspect_command("docker run -h api.internal alpine", cwd=tmp_path, home_dir=tmp_path)
 
     assert payload["status"] == "review"
-    assert payload["classification"]["action_class"] == "docker-sensitive command"
+    classification = payload.get("classification")
+    assert isinstance(classification, dict)
+    assert classification.get("action_class") == "docker-sensitive command"
 
 
 def test_container_structured_rule_controls_compatibility_evidence(tmp_path: Path) -> None:
     payload = inspect_command("docker system prune --volumes", cwd=tmp_path, home_dir=tmp_path)
 
-    assert [rule["rule_id"] for rule in payload["rules"]] == [
+    rules = payload.get("rules")
+    assert isinstance(rules, list)
+    rule_ids = [rule["rule_id"] for rule in rules if isinstance(rule, dict) and "rule_id" in rule]
+    assert rule_ids == [
         "command.container-runtime.system-prune",
         "command.container-runtime.docker-sensitive",
     ]
@@ -233,7 +187,10 @@ def test_safe_domain_variant_does_not_hide_destructive_segment(tmp_path: Path) -
         home_dir=tmp_path,
     )
 
-    assert [rule["rule_id"] for rule in payload["rules"]] == ["command.infrastructure-as-code.destroy"]
+    rules = payload.get("rules")
+    assert isinstance(rules, list)
+    rule_ids = [rule["rule_id"] for rule in rules if isinstance(rule, dict) and "rule_id" in rule]
+    assert rule_ids == ["command.infrastructure-as-code.destroy"]
     assert payload["controlling_rule_id"] == "command.infrastructure-as-code.destroy"
 
 


### PR DESCRIPTION
## Summary
- replace duplicated backup, infrastructure, and database command assertion scaffolding with shared contract runners
- preserve every destructive, preview, help, dry-run, and observer command variant while aggregating per-command failures
- register the three destructive-command contract batches as protected security invariants

## Verification
- focused contract, invariant, and inventory tests pass
- protected security-invariant selection passes
- focused static type checking passes
- test inventory reports 11,928 collected cases, down 157 from the release baseline