### PR TITLE
test(guard): batch remote and storage contracts

### DIFF
--- a/tests/guard_test_invariants.py
+++ b/tests/guard_test_invariants.py
@@ -142,6 +142,20 @@ TEST_INVARIANTS: Final[tuple[TestInvariant, ...]] = (
         "Database mutation variants remain reviewable through inspection and runtime enforcement.",
         ("security_critical", "regression", "parser", "release"),
     ),
+    TestInvariant(
+        "GUARD-INV-018",
+        "tests/test_guard_command_remote_extensions.py::test_remote_rules_feed_runtime_hooks",
+        "command-extension",
+        "Remote execution and overwrite variants remain reviewable through inspection and runtime enforcement.",
+        ("security_critical", "regression", "parser", "release"),
+    ),
+    TestInvariant(
+        "GUARD-INV-019",
+        "tests/test_guard_command_storage_extensions.py::test_storage_rules_feed_runtime_hooks",
+        "command-extension",
+        "Object-storage deletion variants remain reviewable through inspection and runtime enforcement.",
+        ("security_critical", "regression", "parser", "release"),
+    ),
 )
 
 

--- a/tests/test_guard_command_remote_extensions.py
+++ b/tests/test_guard_command_remote_extensions.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from codex_plugin_scanner.guard.runtime.command_extensions import (
     BUILT_IN_COMMAND_EXTENSION_REGISTRY,
     risk_classes_for_command_action,
@@ -16,180 +14,142 @@ from codex_plugin_scanner.guard.runtime.command_structured_matchers import (
     LeadingOperandCountMatcher,
     OptionValueKeyMatcher,
 )
-from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
-
-
-@pytest.mark.parametrize(
-    ("command", "action_class", "rule_id"),
-    [
-        ("ssh host.example uptime", "SSH remote execution command", "command.remote.ssh.execution"),
-        (
-            "ssh -p 2222 host.example sudo systemctl restart api",
-            "SSH remote execution command",
-            "command.remote.ssh.execution",
-        ),
-        (
-            "ssh.exe -oStrictHostKeyChecking=no host.example -- uname -a",
-            "SSH remote execution command",
-            "command.remote.ssh.execution",
-        ),
-        ("ssh -g host.example uptime", "SSH remote execution command", "command.remote.ssh.execution"),
-        (
-            "ssh -o 'RemoteCommand=uname -a' host.example",
-            "SSH configured execution command",
-            "command.remote.ssh.configured-execution",
-        ),
-        (
-            "ssh -oProxyCommand='sh -c id' host.example",
-            "SSH configured execution command",
-            "command.remote.ssh.configured-execution",
-        ),
-        (
-            "ssh -oKnownHostsCommand='sh -c id' host.example",
-            "SSH configured execution command",
-            "command.remote.ssh.configured-execution",
-        ),
-        (
-            "ssh -voProxyCommand='sh -c id' host.example",
-            "SSH configured execution command",
-            "command.remote.ssh.configured-execution",
-        ),
-        (
-            "ssh -4oRemoteCommand='id' host.example",
-            "SSH configured execution command",
-            "command.remote.ssh.configured-execution",
-        ),
-        (
-            "ssh -oLocalCommand='sh -c id' -oPermitLocalCommand=yes host.example",
-            "SSH configured execution command",
-            "command.remote.ssh.configured-execution",
-        ),
-        ("scp artifact.zip host.example:/srv/app/", "SCP overwrite command", "command.remote.scp.transfer"),
-        ("scp -p artifact.zip host.example:/srv/app/", "SCP overwrite command", "command.remote.scp.transfer"),
-        (
-            "scp.cmd -P2222 host.example:/srv/app/config ./config",
-            "SCP overwrite command",
-            "command.remote.scp.transfer",
-        ),
-        (
-            "rsync -av --delete ./out/ host.example:/srv/app/",
-            "Rsync destructive command",
-            "command.remote.rsync.deletion",
-        ),
-        (
-            "rsync.exe --remove-source-files ./queue/ host.example:/archive/",
-            "Rsync destructive command",
-            "command.remote.rsync.deletion",
-        ),
-        (
-            "rsync --rsync-path='sh -c id' ./out/ host.example:/srv/app/",
-            "Rsync remote shell command",
-            "command.remote.rsync.remote-shell",
-        ),
-        (
-            "rsync -e 'sh -c id' ./out/ host.example:/srv/app/",
-            "Rsync remote shell command",
-            "command.remote.rsync.remote-shell",
-        ),
-        (
-            "RSYNC_RSH='sh -c id' rsync ./out/ host.example:/srv/app/",
-            "Rsync remote shell command",
-            "command.remote.rsync.remote-shell",
-        ),
-        (
-            "env RSYNC_RSH='sh -c id' rsync ./out/ host.example:/srv/app/",
-            "Rsync remote shell command",
-            "command.remote.rsync.remote-shell",
-        ),
-    ],
+from tests.command_extension_contracts import (
+    assert_review_required_cases,
+    assert_reviewed_command_cases,
+    assert_safe_command_cases,
 )
-def test_remote_rules_feed_runtime_hooks(
-    command: str,
-    action_class: str,
-    rule_id: str,
-    tmp_path: Path,
-) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
 
-    assert payload["status"] == "review"
-    assert payload["classification"]["action_class"] == action_class
-    assert payload["controlling_rule_id"] == rule_id
-    runtime_match = extract_sensitive_tool_action_request(
-        "Shell",
-        {"command": command},
-        cwd=tmp_path,
-        home_dir=tmp_path,
-    )
-    assert runtime_match is not None
-    assert runtime_match.action_class == action_class
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
-        "ssh host.example",
-        "ssh -G host.example uptime",
-        "ssh -vG host.example uptime",
-        "ssh -vGoProxyCommand='sh -c id' host.example",
-        "ssh -V",
-        "ssh -V host.example uptime",
-        "ssh -Q cipher host.example uptime",
-        "ssh -N host.example uptime",
-        "ssh -W jump.example:22 host.example uptime",
-        "ssh -O check host.example uptime",
-        "ssh -o StrictHostKeyChecking=no host.example",
-        "ssh -vo StrictHostKeyChecking=no host.example",
-        "ssh -voStrictHostKeyChecking=no host.example",
-        "ssh -voProxyCommand=none host.example",
-        "ssh -G -oProxyCommand='sh -c id' host.example",
-        "ssh -oProxyCommand=none host.example",
-        "ssh -oLocalCommand='sh -c id' host.example",
-        "ssh -oPermitLocalCommand=no -oLocalCommand='sh -c id' host.example",
-        "scp -h",
-        "scp -vo StrictHostKeyChecking=no source",
-        "rsync -av ./out/ host.example:/srv/app/",
-        "rsync -av --delete ./out/ host.example:/srv/app/ --dry-run",
-        "rsync -avn --delete ./out/ host.example:/srv/app/",
-        "rsync -av --delete ./out/ host.example:/srv/app/ --no-dry-run --dry-run",
-        "rsync -av --delete ./out/ host.example:/srv/app/ --no-dry-run -n",
-        "grep 'ssh host command|scp source target|rsync --delete' docs",
-        "echo ssh host.example uptime",
-    ],
+REMOTE_REVIEW_CASES: tuple[tuple[str, str, str], ...] = (
+    ("ssh host.example uptime", "SSH remote execution command", "command.remote.ssh.execution"),
+    (
+        "ssh -p 2222 host.example sudo systemctl restart api",
+        "SSH remote execution command",
+        "command.remote.ssh.execution",
+    ),
+    (
+        "ssh.exe -oStrictHostKeyChecking=no host.example -- uname -a",
+        "SSH remote execution command",
+        "command.remote.ssh.execution",
+    ),
+    ("ssh -g host.example uptime", "SSH remote execution command", "command.remote.ssh.execution"),
+    (
+        "ssh -o 'RemoteCommand=uname -a' host.example",
+        "SSH configured execution command",
+        "command.remote.ssh.configured-execution",
+    ),
+    (
+        "ssh -oProxyCommand='sh -c id' host.example",
+        "SSH configured execution command",
+        "command.remote.ssh.configured-execution",
+    ),
+    (
+        "ssh -oKnownHostsCommand='sh -c id' host.example",
+        "SSH configured execution command",
+        "command.remote.ssh.configured-execution",
+    ),
+    (
+        "ssh -voProxyCommand='sh -c id' host.example",
+        "SSH configured execution command",
+        "command.remote.ssh.configured-execution",
+    ),
+    (
+        "ssh -4oRemoteCommand='id' host.example",
+        "SSH configured execution command",
+        "command.remote.ssh.configured-execution",
+    ),
+    (
+        "ssh -oLocalCommand='sh -c id' -oPermitLocalCommand=yes host.example",
+        "SSH configured execution command",
+        "command.remote.ssh.configured-execution",
+    ),
+    ("scp artifact.zip host.example:/srv/app/", "SCP overwrite command", "command.remote.scp.transfer"),
+    ("scp -p artifact.zip host.example:/srv/app/", "SCP overwrite command", "command.remote.scp.transfer"),
+    (
+        "scp.cmd -P2222 host.example:/srv/app/config ./config",
+        "SCP overwrite command",
+        "command.remote.scp.transfer",
+    ),
+    (
+        "rsync -av --delete ./out/ host.example:/srv/app/",
+        "Rsync destructive command",
+        "command.remote.rsync.deletion",
+    ),
+    (
+        "rsync.exe --remove-source-files ./queue/ host.example:/archive/",
+        "Rsync destructive command",
+        "command.remote.rsync.deletion",
+    ),
+    (
+        "rsync --rsync-path='sh -c id' ./out/ host.example:/srv/app/",
+        "Rsync remote shell command",
+        "command.remote.rsync.remote-shell",
+    ),
+    (
+        "rsync -e 'sh -c id' ./out/ host.example:/srv/app/",
+        "Rsync remote shell command",
+        "command.remote.rsync.remote-shell",
+    ),
+    (
+        "RSYNC_RSH='sh -c id' rsync ./out/ host.example:/srv/app/",
+        "Rsync remote shell command",
+        "command.remote.rsync.remote-shell",
+    ),
+    (
+        "env RSYNC_RSH='sh -c id' rsync ./out/ host.example:/srv/app/",
+        "Rsync remote shell command",
+        "command.remote.rsync.remote-shell",
+    ),
 )
-def test_remote_observer_and_preview_commands_remain_safe(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
-
-    assert payload["status"] == "no_match"
-    assert (
-        extract_sensitive_tool_action_request(
-            "Shell",
-            {"command": command},
-            cwd=tmp_path,
-            home_dir=tmp_path,
-        )
-        is None
-    )
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "rsync -av --delete ./out/ host.example:/srv/app/ --dry-run --no-dry-run",
-        "rsync -avn --delete ./out/ host.example:/srv/app/ --no-dry-run",
-    ],
+def test_remote_rules_feed_runtime_hooks(tmp_path: Path) -> None:
+    assert_reviewed_command_cases(REMOTE_REVIEW_CASES, tmp_path)
+
+
+REMOTE_SAFE_COMMANDS: tuple[str, ...] = (
+    "ssh host.example",
+    "ssh -G host.example uptime",
+    "ssh -vG host.example uptime",
+    "ssh -vGoProxyCommand='sh -c id' host.example",
+    "ssh -V",
+    "ssh -V host.example uptime",
+    "ssh -Q cipher host.example uptime",
+    "ssh -N host.example uptime",
+    "ssh -W jump.example:22 host.example uptime",
+    "ssh -O check host.example uptime",
+    "ssh -o StrictHostKeyChecking=no host.example",
+    "ssh -vo StrictHostKeyChecking=no host.example",
+    "ssh -voStrictHostKeyChecking=no host.example",
+    "ssh -voProxyCommand=none host.example",
+    "ssh -G -oProxyCommand='sh -c id' host.example",
+    "ssh -oProxyCommand=none host.example",
+    "ssh -oLocalCommand='sh -c id' host.example",
+    "ssh -oPermitLocalCommand=no -oLocalCommand='sh -c id' host.example",
+    "scp -h",
+    "scp -vo StrictHostKeyChecking=no source",
+    "rsync -av ./out/ host.example:/srv/app/",
+    "rsync -av --delete ./out/ host.example:/srv/app/ --dry-run",
+    "rsync -avn --delete ./out/ host.example:/srv/app/",
+    "rsync -av --delete ./out/ host.example:/srv/app/ --no-dry-run --dry-run",
+    "rsync -av --delete ./out/ host.example:/srv/app/ --no-dry-run -n",
+    "grep 'ssh host command|scp source target|rsync --delete' docs",
+    "echo ssh host.example uptime",
 )
-def test_rsync_disabled_preview_aliases_remain_live_execution(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
 
-    assert payload["status"] == "review"
-    runtime_match = extract_sensitive_tool_action_request(
-        "Shell",
-        {"command": command},
-        cwd=tmp_path,
-        home_dir=tmp_path,
+
+def test_remote_observer_and_preview_commands_remain_safe(tmp_path: Path) -> None:
+    assert_safe_command_cases(REMOTE_SAFE_COMMANDS, tmp_path)
+
+
+def test_rsync_disabled_preview_aliases_remain_live_execution(tmp_path: Path) -> None:
+    assert_review_required_cases(
+        (
+            "rsync -av --delete ./out/ host.example:/srv/app/ --dry-run --no-dry-run",
+            "rsync -avn --delete ./out/ host.example:/srv/app/ --no-dry-run",
+        ),
+        tmp_path,
     )
-    assert runtime_match is not None
-    assert runtime_match.action_class == "Rsync destructive command"
 
 
 def test_remote_extensions_publish_official_references() -> None:
@@ -249,17 +209,14 @@ def test_remote_execution_actions_publish_risk_classes() -> None:
     )
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
+def test_rsync_option_values_cannot_forge_dry_run(tmp_path: Path) -> None:
+    for command in (
         "rsync --delete --exclude -n src/ dst/",
         "rsync --delete --exclude=-n src/ dst/",
         "rsync --delete -f -n src/ dst/",
         "rsync --delete --log-format -n src/ dst/",
-    ],
-)
-def test_rsync_option_values_cannot_forge_dry_run(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+    ):
+        payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
 
-    assert payload["status"] == "review"
-    assert payload["controlling_rule_id"] == "command.remote.rsync.deletion"
+        assert payload["status"] == "review", command
+        assert payload["controlling_rule_id"] == "command.remote.rsync.deletion", command

--- a/tests/test_guard_command_storage_extensions.py
+++ b/tests/test_guard_command_storage_extensions.py
@@ -4,168 +4,136 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
 from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
+from tests.command_extension_contracts import assert_reviewed_command_cases, assert_safe_command_cases
 
-
-@pytest.mark.parametrize(
-    ("command", "action_class", "rule_id"),
-    [
-        (
-            "aws s3 rm s3://archive/private.json",
-            "AWS storage destructive command",
-            "command.storage.aws-s3.deletion",
-        ),
-        (
-            "aws s3 --region us-east-1 sync ./out s3://archive --delete",
-            "AWS storage destructive command",
-            "command.storage.aws-s3.deletion",
-        ),
-        (
-            "aws.exe s3api delete-objects --bucket archive --delete file://objects.json",
-            "AWS storage destructive command",
-            "command.storage.aws-s3.deletion",
-        ),
-        (
-            "aws --no-cli-pager s3 rm s3://archive/private.json",
-            "AWS storage destructive command",
-            "command.storage.aws-s3.deletion",
-        ),
-        (
-            "aws --future-global-option account s3 rm s3://archive/private.json",
-            "AWS storage destructive command",
-            "command.storage.aws-s3.deletion",
-        ),
-        (
-            "gcloud storage --project app-prod rm --recursive gs://archive/old",
-            "Google storage destructive command",
-            "command.storage.google-cloud.deletion",
-        ),
-        (
-            "gsutil.cmd -m rsync -d ./out gs://archive",
-            "Google storage destructive command",
-            "command.storage.google-cloud.deletion",
-        ),
-        (
-            "gcloud storage rsync ./out gs://archive --delete-unmatched-destination-objects -n",
-            "Google storage destructive command",
-            "command.storage.google-cloud.deletion",
-        ),
-        (
-            "gcloud --quiet storage rm gs://archive/private.json",
-            "Google storage destructive command",
-            "command.storage.google-cloud.deletion",
-        ),
-        (
-            "gcloud --filter active storage rm gs://archive/private.json",
-            "Google storage destructive command",
-            "command.storage.google-cloud.deletion",
-        ),
-        (
-            "az.cmd storage blob delete-batch --subscription app-prod --source archive",
-            "Azure storage destructive command",
-            "command.storage.azure-blob.deletion",
-        ),
-        (
-            "az --debug storage blob delete --container-name archive --name private.json",
-            "Azure storage destructive command",
-            "command.storage.azure-blob.deletion",
-        ),
-        (
-            "az -otable storage blob delete --container-name archive --name private.json",
-            "Azure storage destructive command",
-            "command.storage.azure-blob.deletion",
-        ),
-        (
-            "az --future-global-option tenant storage blob delete --container-name archive --name private.json",
-            "Azure storage destructive command",
-            "command.storage.azure-blob.deletion",
-        ),
-        (
-            "mc.exe mirror --remove ./out prod/archive",
-            "MinIO storage destructive command",
-            "command.storage.minio.deletion",
-        ),
-        (
-            "mc --config-dir /tmp/mc rm prod/archive/private.json",
-            "MinIO storage destructive command",
-            "command.storage.minio.deletion",
-        ),
-        (
-            "mc --json mirror --remove ./out prod/archive",
-            "MinIO storage destructive command",
-            "command.storage.minio.deletion",
-        ),
-        (
-            "mc -C/tmp/mc rm prod/archive/private.json",
-            "MinIO storage destructive command",
-            "command.storage.minio.deletion",
-        ),
-    ],
+STORAGE_REVIEW_CASES: tuple[tuple[str, str, str], ...] = (
+    (
+        "aws s3 rm s3://archive/private.json",
+        "AWS storage destructive command",
+        "command.storage.aws-s3.deletion",
+    ),
+    (
+        "aws s3 --region us-east-1 sync ./out s3://archive --delete",
+        "AWS storage destructive command",
+        "command.storage.aws-s3.deletion",
+    ),
+    (
+        "aws.exe s3api delete-objects --bucket archive --delete file://objects.json",
+        "AWS storage destructive command",
+        "command.storage.aws-s3.deletion",
+    ),
+    (
+        "aws --no-cli-pager s3 rm s3://archive/private.json",
+        "AWS storage destructive command",
+        "command.storage.aws-s3.deletion",
+    ),
+    (
+        "aws --future-global-option account s3 rm s3://archive/private.json",
+        "AWS storage destructive command",
+        "command.storage.aws-s3.deletion",
+    ),
+    (
+        "gcloud storage --project app-prod rm --recursive gs://archive/old",
+        "Google storage destructive command",
+        "command.storage.google-cloud.deletion",
+    ),
+    (
+        "gsutil.cmd -m rsync -d ./out gs://archive",
+        "Google storage destructive command",
+        "command.storage.google-cloud.deletion",
+    ),
+    (
+        "gcloud storage rsync ./out gs://archive --delete-unmatched-destination-objects -n",
+        "Google storage destructive command",
+        "command.storage.google-cloud.deletion",
+    ),
+    (
+        "gcloud --quiet storage rm gs://archive/private.json",
+        "Google storage destructive command",
+        "command.storage.google-cloud.deletion",
+    ),
+    (
+        "gcloud --filter active storage rm gs://archive/private.json",
+        "Google storage destructive command",
+        "command.storage.google-cloud.deletion",
+    ),
+    (
+        "az.cmd storage blob delete-batch --subscription app-prod --source archive",
+        "Azure storage destructive command",
+        "command.storage.azure-blob.deletion",
+    ),
+    (
+        "az --debug storage blob delete --container-name archive --name private.json",
+        "Azure storage destructive command",
+        "command.storage.azure-blob.deletion",
+    ),
+    (
+        "az -otable storage blob delete --container-name archive --name private.json",
+        "Azure storage destructive command",
+        "command.storage.azure-blob.deletion",
+    ),
+    (
+        "az --future-global-option tenant storage blob delete --container-name archive --name private.json",
+        "Azure storage destructive command",
+        "command.storage.azure-blob.deletion",
+    ),
+    (
+        "mc.exe mirror --remove ./out prod/archive",
+        "MinIO storage destructive command",
+        "command.storage.minio.deletion",
+    ),
+    (
+        "mc --config-dir /tmp/mc rm prod/archive/private.json",
+        "MinIO storage destructive command",
+        "command.storage.minio.deletion",
+    ),
+    (
+        "mc --json mirror --remove ./out prod/archive",
+        "MinIO storage destructive command",
+        "command.storage.minio.deletion",
+    ),
+    (
+        "mc -C/tmp/mc rm prod/archive/private.json",
+        "MinIO storage destructive command",
+        "command.storage.minio.deletion",
+    ),
 )
-def test_storage_rules_feed_runtime_hooks(
-    command: str,
-    action_class: str,
-    rule_id: str,
-    tmp_path: Path,
-) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
-
-    assert payload["status"] == "review"
-    assert payload["classification"]["action_class"] == action_class
-    assert payload["controlling_rule_id"] == rule_id
-    runtime_match = extract_sensitive_tool_action_request(
-        "Shell",
-        {"command": command},
-        cwd=tmp_path,
-        home_dir=tmp_path,
-    )
-    assert runtime_match is not None
-    assert runtime_match.action_class == action_class
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "aws s3 rm s3://archive/private.json --dryrun",
-        "aws s3 sync ./out s3://archive --delete --dryrun",
-        "aws s3 rm s3://archive/private.json --no-dryrun --dryrun",
-        "gcloud storage rsync ./out gs://archive --delete-unmatched-destination-objects --dry-run",
-        "gsutil -m rsync -d -n ./out gs://archive",
-        "az storage blob delete-batch --source archive --dryrun",
-        "aws --future-global-option account s3 rm s3://archive/private.json --dryrun",
-        "gcloud --future-global-option account storage rm gs://archive/private.json --help",
-        "az --future-global-option tenant storage blob delete --container-name archive --name private.json --help",
-        "mc rm --help",
-        "aws s3 ls s3://archive",
-        "aws --future-global-option account s3 ls s3://archive",
-        "gcloud storage ls gs://archive",
-        "gcloud --filter active storage ls gs://archive",
-        "az storage blob list --container-name archive",
-        "az --future-global-option tenant storage blob list --container-name archive",
-        "mc ls prod/archive",
-        "mc --config-dir /tmp/mc ls prod/archive",
-        "mc --help rm prod/archive",
-        "grep 's3 rm|storage rm|blob delete|mc rm' scripts/guard-test",
-        "printf '%s\\n' 'aws s3 rm s3://archive/private.json'",
-    ],
+def test_storage_rules_feed_runtime_hooks(tmp_path: Path) -> None:
+    assert_reviewed_command_cases(STORAGE_REVIEW_CASES, tmp_path)
+
+
+STORAGE_SAFE_COMMANDS: tuple[str, ...] = (
+    "aws s3 rm s3://archive/private.json --dryrun",
+    "aws s3 sync ./out s3://archive --delete --dryrun",
+    "aws s3 rm s3://archive/private.json --no-dryrun --dryrun",
+    "gcloud storage rsync ./out gs://archive --delete-unmatched-destination-objects --dry-run",
+    "gsutil -m rsync -d -n ./out gs://archive",
+    "az storage blob delete-batch --source archive --dryrun",
+    "aws --future-global-option account s3 rm s3://archive/private.json --dryrun",
+    "gcloud --future-global-option account storage rm gs://archive/private.json --help",
+    "az --future-global-option tenant storage blob delete --container-name archive --name private.json --help",
+    "mc rm --help",
+    "aws s3 ls s3://archive",
+    "aws --future-global-option account s3 ls s3://archive",
+    "gcloud storage ls gs://archive",
+    "gcloud --filter active storage ls gs://archive",
+    "az storage blob list --container-name archive",
+    "az --future-global-option tenant storage blob list --container-name archive",
+    "mc ls prod/archive",
+    "mc --config-dir /tmp/mc ls prod/archive",
+    "mc --help rm prod/archive",
+    "grep 's3 rm|storage rm|blob delete|mc rm' scripts/guard-test",
+    "printf '%s\\n' 'aws s3 rm s3://archive/private.json'",
 )
-def test_storage_preview_and_read_commands_remain_safe(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
 
-    assert payload["status"] == "no_match"
-    assert (
-        extract_sensitive_tool_action_request(
-            "Shell",
-            {"command": command},
-            cwd=tmp_path,
-            home_dir=tmp_path,
-        )
-        is None
-    )
+
+def test_storage_preview_and_read_commands_remain_safe(tmp_path: Path) -> None:
+    assert_safe_command_cases(STORAGE_SAFE_COMMANDS, tmp_path)
 
 
 def test_storage_disabled_dry_run_alias_remains_runtime_sensitive(tmp_path: Path) -> None:
@@ -190,7 +158,10 @@ def test_storage_safe_segment_does_not_hide_later_deletion(tmp_path: Path) -> No
         home_dir=tmp_path,
     )
 
-    assert [rule["rule_id"] for rule in payload["rules"]] == ["command.storage.minio.deletion"]
+    rules = payload.get("rules")
+    assert isinstance(rules, list)
+    rule_ids = [rule["rule_id"] for rule in rules if isinstance(rule, dict) and "rule_id" in rule]
+    assert rule_ids == ["command.storage.minio.deletion"]
 
 
 def test_storage_extensions_publish_official_references() -> None:


### PR DESCRIPTION
## Summary
- batch structurally identical remote and object-storage command contract assertions
- retain every destructive, safe, dry-run, and option-value variant through both inspection and runtime enforcement
- register remote and storage destructive contracts as protected invariants

## Verification
- focused remote, storage, and invariant tests pass
- focused Ruff and strict type checks pass
- inventory reports 11,843 collected cases, down 85 from the previous release baseline