### PR TITLE
test(guard): report exact duplicate candidates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
         run: uv run --no-sync python scripts/ci/test_inventory.py --output test-inventory.json
       - name: Publish test inventory
         run: cat test-inventory.json
+      - name: Publish exact test-body duplicate candidates
+        run: |
+          uv run --no-sync python scripts/ci/test_duplicate_candidates.py \
+            --output test-duplicate-candidates.json
+          cat test-duplicate-candidates.json
       - run: uv run --no-sync python -m ruff check src/
       - run: uv run --no-sync python -m ruff format --check src/
       - run: uv run --no-sync basedpyright --level error

--- a/scripts/ci/test_duplicate_candidates.py
+++ b/scripts/ci/test_duplicate_candidates.py
@@ -30,7 +30,7 @@ class DuplicateCandidate:
 
 
 def iter_test_bodies(path: Path, *, root: Path) -> Iterator[TestBody]:
-    """Yield test functions, retaining class context while ignoring decorators."""
+    """Yield test functions with their decorators and class context."""
 
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     relative_path = path.relative_to(root).as_posix()

--- a/scripts/ci/test_duplicate_candidates.py
+++ b/scripts/ci/test_duplicate_candidates.py
@@ -60,9 +60,13 @@ def _test_fingerprint(
     test_node.name = ""
     parts = [ast.dump(test_node, include_attributes=False)]
     if class_node is not None:
-        class_context = copy.deepcopy(class_node)
-        class_context.name = ""
-        class_context.body = []
+        class_context = ast.ClassDef(
+            name="",
+            bases=copy.deepcopy(class_node.bases),
+            keywords=copy.deepcopy(class_node.keywords),
+            body=[],
+            decorator_list=copy.deepcopy(class_node.decorator_list),
+        )
         parts.append(ast.dump(class_context, include_attributes=False))
     return "\n".join(parts)
 

--- a/scripts/ci/test_duplicate_candidates.py
+++ b/scripts/ci/test_duplicate_candidates.py
@@ -90,7 +90,7 @@ def main() -> int:
     _ = parser.add_argument("--output", type=Path)
     args = parser.parse_args()
     root = Path(__file__).resolve().parents[2]
-    candidates = duplicate_candidates((root / "tests").glob("test_*.py"), root=root)
+    candidates = duplicate_candidates((root / "tests").rglob("test_*.py"), root=root)
     payload = json.dumps([asdict(candidate) for candidate in candidates], indent=2, sort_keys=True) + "\n"
     if args.output is None:
         print(payload, end="")

--- a/scripts/ci/test_duplicate_candidates.py
+++ b/scripts/ci/test_duplicate_candidates.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Report exact pytest test-body duplicates for manual consolidation review."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import copy
+import json
+from collections import defaultdict
+from collections.abc import Iterable, Iterator
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TestBody:
+    """A concrete pytest test function and its normalized executable body."""
+
+    node_id: str
+    body_fingerprint: str
+
+
+@dataclass(frozen=True)
+class DuplicateCandidate:
+    """Tests with identical executable AST bodies that require human review."""
+
+    body_fingerprint: str
+    node_ids: tuple[str, ...]
+
+
+def iter_test_bodies(path: Path, *, root: Path) -> Iterator[TestBody]:
+    """Yield test functions, retaining class context while ignoring decorators."""
+
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    relative_path = path.relative_to(root).as_posix()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+            yield TestBody(
+                node_id=f"{relative_path}::{node.name}",
+                body_fingerprint=_test_fingerprint(node),
+            )
+        elif isinstance(node, ast.ClassDef):
+            for child in node.body:
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name.startswith("test_"):
+                    yield TestBody(
+                        node_id=f"{relative_path}::{node.name}::{child.name}",
+                        body_fingerprint=_test_fingerprint(child, class_node=node),
+                    )
+
+
+def _test_fingerprint(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    *,
+    class_node: ast.ClassDef | None = None,
+) -> str:
+    """Include decorators, signature, and class setup so matrices are not conflated."""
+
+    test_node = copy.deepcopy(node)
+    test_node.name = ""
+    parts = [ast.dump(test_node, include_attributes=False)]
+    if class_node is not None:
+        class_context = copy.deepcopy(class_node)
+        class_context.name = ""
+        class_context.body = []
+        parts.append(ast.dump(class_context, include_attributes=False))
+    return "\n".join(parts)
+
+
+def duplicate_candidates(paths: Iterable[Path], *, root: Path) -> tuple[DuplicateCandidate, ...]:
+    """Return stable groups with exactly equal test bodies, excluding singletons."""
+
+    grouped: dict[str, list[str]] = defaultdict(list)
+    for path in sorted(paths):
+        for test_body in iter_test_bodies(path, root=root):
+            grouped[test_body.body_fingerprint].append(test_body.node_id)
+    return tuple(
+        DuplicateCandidate(body_fingerprint=fingerprint, node_ids=tuple(sorted(node_ids)))
+        for fingerprint, node_ids in sorted(grouped.items())
+        if len(node_ids) > 1
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    _ = parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[2]
+    candidates = duplicate_candidates((root / "tests").glob("test_*.py"), root=root)
+    payload = json.dumps([asdict(candidate) for candidate in candidates], indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(payload, end="")
+    else:
+        args.output.write_text(payload, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_test_duplicate_candidates.py
+++ b/tests/test_ci_test_duplicate_candidates.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "ci" / "test_duplicate_candidates.py"
+SPEC = importlib.util.spec_from_file_location("test_duplicate_candidates", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+duplicate_candidates = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = duplicate_candidates
+SPEC.loader.exec_module(duplicate_candidates)
+
+
+def test_duplicate_candidates_group_exact_bodies_but_not_different_assertions(tmp_path: Path) -> None:
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    first = tests / "test_first.py"
+    first.write_text(
+        "def test_one():\n    assert value == 1\n\ndef test_two():\n    assert value == 1\n",
+        encoding="utf-8",
+    )
+    second = tests / "test_second.py"
+    second.write_text("def test_three():\n    assert value == 2\n", encoding="utf-8")
+
+    candidates = duplicate_candidates.duplicate_candidates((first, second), root=tmp_path)
+
+    assert len(candidates) == 1
+    assert candidates[0].node_ids == ("tests/test_first.py::test_one", "tests/test_first.py::test_two")
+
+
+def test_duplicate_candidates_keep_parameterized_matrices_distinct(tmp_path: Path) -> None:
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    path = tests / "test_matrix.py"
+    path.write_text(
+        "import pytest\n\n"
+        "@pytest.mark.parametrize('value', [1])\n"
+        "def test_one(value):\n    assert value\n\n"
+        "@pytest.mark.parametrize('value', [2])\n"
+        "def test_two(value):\n    assert value\n",
+        encoding="utf-8",
+    )
+
+    assert duplicate_candidates.duplicate_candidates((path,), root=tmp_path) == ()
+
+
+def test_duplicate_candidates_include_test_methods_with_class_context(tmp_path: Path) -> None:
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    path = tests / "test_methods.py"
+    path.write_text(
+        "class First:\n    def test_one(self):\n        assert True\n\n"
+        "class Second:\n    def test_two(self):\n        assert True\n",
+        encoding="utf-8",
+    )
+
+    candidates = duplicate_candidates.duplicate_candidates((path,), root=tmp_path)
+
+    assert candidates[0].node_ids == (
+        "tests/test_methods.py::First::test_one",
+        "tests/test_methods.py::Second::test_two",
+    )

--- a/tests/test_ci_test_duplicate_candidates.py
+++ b/tests/test_ci_test_duplicate_candidates.py
@@ -62,3 +62,18 @@ def test_duplicate_candidates_include_test_methods_with_class_context(tmp_path: 
         "tests/test_methods.py::First::test_one",
         "tests/test_methods.py::Second::test_two",
     )
+
+
+def test_duplicate_candidates_discover_nested_test_files(tmp_path: Path) -> None:
+    tests = tmp_path / "tests"
+    nested = tests / "adapter"
+    nested.mkdir(parents=True)
+    (tests / "test_root.py").write_text("def test_one():\n    assert True\n", encoding="utf-8")
+    (nested / "test_nested.py").write_text("def test_two():\n    assert True\n", encoding="utf-8")
+
+    candidates = duplicate_candidates.duplicate_candidates(tests.rglob("test_*.py"), root=tmp_path)
+
+    assert candidates[0].node_ids == (
+        "tests/adapter/test_nested.py::test_two",
+        "tests/test_root.py::test_one",
+    )

--- a/tests/test_guard_phase04_install_reason_proofs.py
+++ b/tests/test_guard_phase04_install_reason_proofs.py
@@ -43,45 +43,6 @@ def test_install_lifecycle_script_risk_blocks_local_package(tmp_path: Path) -> N
     assert result.packages[0]["reasons"][0]["code"] == "install_script_risk"
 
 
-def test_dependency_confusion_policy_blocks_reserved_internal_name(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    home_dir = tmp_path / "home"
-    workspace_dir = tmp_path / "workspace"
-    workspace_dir.mkdir()
-    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
-    store = GuardStore(home_dir)
-    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
-    store.cache_supply_chain_bundle(
-        WORKSPACE_ID,
-        _bundle_response(
-            packages=[],
-            policy_rules=[
-                {
-                    "action": "block",
-                    "ruleId": "reserve-internal-tool",
-                    "ecosystemSelector": "npm",
-                    "enabled": True,
-                    "expiresAt": None,
-                    "harnessSelector": None,
-                    "packageSelector": "@hashgraph/internal-tool",
-                    "priority": 1,
-                    "severityThreshold": None,
-                    "versionRangeSelector": None,
-                }
-            ],
-        ),
-        "2026-05-19T00:00:00Z",
-    )
-
-    artifact = _artifact_from_command("npm install internal-tool@1.0.0", workspace=workspace_dir)
-    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
-
-    assert result.decision == "block"
-    assert result.packages[0]["reasons"][0]["code"] == "dependency_confusion_risk"
-
-
 def test_maintainer_compromise_reason_blocks_high_risk_package(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- Report exact test-body duplicate candidates in CI for manual consolidation review.
- Include decorators and class context so parameterized matrices are not falsely reported as duplicates.
- Keep the dependency-confusion policy proof in its supply-chain owner and remove its exact duplicate from the phase-four reason suite.

## Testing

- `uv run --group dev --extra dev pytest tests/test_ci_test_duplicate_candidates.py tests/test_ci_pytest_shard.py tests/test_ci_test_inventory.py -q --tb=short`
- `uv run --group dev --extra dev python scripts/ci/test_duplicate_candidates.py --output test-duplicate-candidates.json`
