### PR TITLE
test(guard): consolidate Copilot encoded-exec cases

### DIFF
--- a/tests/guard_copilot_hook_command_corpus.py
+++ b/tests/guard_copilot_hook_command_corpus.py
@@ -1,0 +1,74 @@
+"""Stable Copilot hook command cases with one owner integration test."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+
+@dataclass(frozen=True, slots=True)
+class CopilotHookCommandCase:
+    """A security-relevant Copilot shell payload and its reviewed identity."""
+
+    case_id: str
+    command: str
+    security_reference: str
+
+
+COPILOT_ENCODED_EXEC_DENY_CASES: Final[tuple[CopilotHookCommandCase, ...]] = (
+    CopilotHookCommandCase(
+        case_id="COPILOT-ENCODED-EXEC-001",
+        command="echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash",
+        security_reference="encoded-payload-decode-and-execute",
+    ),
+    CopilotHookCommandCase(
+        case_id="COPILOT-ENCODED-EXEC-002",
+        command="echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -D | bash",
+        security_reference="bsd-base64-decode-and-execute",
+    ),
+    CopilotHookCommandCase(
+        case_id="COPILOT-ENCODED-EXEC-003",
+        command="echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | /bin/bash",
+        security_reference="path-qualified-shell-decode-and-execute",
+    ),
+    CopilotHookCommandCase(
+        case_id="COPILOT-ENCODED-EXEC-004",
+        command="echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -di | bash",
+        security_reference="clustered-base64-flag-decode-and-execute",
+    ),
+    CopilotHookCommandCase(
+        case_id="COPILOT-ENCODED-EXEC-005",
+        command="echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | dash",
+        security_reference="alternate-shell-decode-and-execute",
+    ),
+    CopilotHookCommandCase(
+        case_id="COPILOT-ENCODED-EXEC-006",
+        command="echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env bash",
+        security_reference="environment-wrapper-decode-and-execute",
+    ),
+    CopilotHookCommandCase(
+        case_id="COPILOT-ENCODED-EXEC-007",
+        command="echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env -i bash",
+        security_reference="environment-option-wrapper-decode-and-execute",
+    ),
+    CopilotHookCommandCase(
+        case_id="COPILOT-ENCODED-EXEC-008",
+        command="echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | /usr/bin/env -i bash",
+        security_reference="path-qualified-environment-wrapper-decode-and-execute",
+    ),
+    CopilotHookCommandCase(
+        case_id="COPILOT-ENCODED-EXEC-009",
+        command="echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env -u FOO bash",
+        security_reference="environment-unset-wrapper-decode-and-execute",
+    ),
+    CopilotHookCommandCase(
+        case_id="COPILOT-ENCODED-EXEC-010",
+        command="echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env --unset=FOO bash",
+        security_reference="environment-unset-equals-wrapper-decode-and-execute",
+    ),
+    CopilotHookCommandCase(
+        case_id="COPILOT-ENCODED-EXEC-011",
+        command="echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -i -d | bash",
+        security_reference="base64-flag-order-decode-and-execute",
+    ),
+)

--- a/tests/test_guard_copilot_hook_command_corpus.py
+++ b/tests/test_guard_copilot_hook_command_corpus.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import re
+
+from tests.guard_copilot_hook_command_corpus import COPILOT_ENCODED_EXEC_DENY_CASES
+
+
+def test_copilot_encoded_exec_corpus_has_stable_unique_security_cases() -> None:
+    assert len(COPILOT_ENCODED_EXEC_DENY_CASES) == 11
+    assert len({case.case_id for case in COPILOT_ENCODED_EXEC_DENY_CASES}) == len(COPILOT_ENCODED_EXEC_DENY_CASES)
+    assert all(re.fullmatch(r"COPILOT-ENCODED-EXEC-\d{3}", case.case_id) for case in COPILOT_ENCODED_EXEC_DENY_CASES)
+    assert all(case.security_reference and case.command for case in COPILOT_ENCODED_EXEC_DENY_CASES)

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -88,6 +88,7 @@ from codex_plugin_scanner.guard.store import (
     runtime_tool_action_exact_match_context,
 )
 from codex_plugin_scanner.guard.synced_policy import synced_policy_payload
+from tests.guard_copilot_hook_command_corpus import COPILOT_ENCODED_EXEC_DENY_CASES
 from tests.policy_bundle_signing_helpers import (
     policy_bundle_test_keyring,
     policy_bundle_test_verification_key,
@@ -5188,428 +5189,40 @@ def test_guard_hook_emits_copilot_native_ask_response_for_destructive_shell_redi
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
-def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_exec_command(
-    tmp_path,
-    capsys,
-    monkeypatch,
-):
-    home_dir = tmp_path / "home"
-    workspace_dir = tmp_path / "workspace"
-    _build_guard_fixture(home_dir, workspace_dir)
-    event = {
-        "toolName": "bash",
-        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash"}),
-        "sourceScope": "project",
-    }
-    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+def test_guard_hook_copilot_encoded_exec_corpus(tmp_path, capsys, monkeypatch):
     monkeypatch.setattr(
         guard_commands_module, "schedule_guard_daemon_ensure", lambda _guard_home, **_kwargs: "http://127.0.0.1:4455"
     )
+    for case in COPILOT_ENCODED_EXEC_DENY_CASES:
+        case_root = tmp_path / case.case_id
+        home_dir = case_root / "home"
+        workspace_dir = case_root / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        event = {
+            "toolName": "bash",
+            "toolArgs": json.dumps({"command": case.command}),
+            "sourceScope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
 
-    rc = main(
-        [
-            "guard",
-            "hook",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--harness",
-            "copilot",
-        ]
-    )
-    output = json.loads(capsys.readouterr().out)
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "copilot",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
 
-    assert rc == 0
-    assert output["permissionDecision"] == "deny"
-    assert "hol guard" in output["permissionDecisionReason"].lower()
-    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
-
-
-def test_guard_hook_emits_copilot_native_ask_response_for_bsd_base64_decode_and_exec_command(
-    tmp_path,
-    capsys,
-    monkeypatch,
-):
-    home_dir = tmp_path / "home"
-    workspace_dir = tmp_path / "workspace"
-    _build_guard_fixture(home_dir, workspace_dir)
-    event = {
-        "toolName": "bash",
-        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -D | bash"}),
-        "sourceScope": "project",
-    }
-    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
-    monkeypatch.setattr(
-        guard_commands_module, "schedule_guard_daemon_ensure", lambda _guard_home, **_kwargs: "http://127.0.0.1:4455"
-    )
-
-    rc = main(
-        [
-            "guard",
-            "hook",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--harness",
-            "copilot",
-        ]
-    )
-    output = json.loads(capsys.readouterr().out)
-
-    assert rc == 0
-    assert output["permissionDecision"] == "deny"
-    assert "hol guard" in output["permissionDecisionReason"].lower()
-    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
-
-
-def test_guard_hook_emits_copilot_native_ask_response_for_path_qualified_base64_decode_and_exec_command(
-    tmp_path,
-    capsys,
-    monkeypatch,
-):
-    home_dir = tmp_path / "home"
-    workspace_dir = tmp_path / "workspace"
-    _build_guard_fixture(home_dir, workspace_dir)
-    event = {
-        "toolName": "bash",
-        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | /bin/bash"}),
-        "sourceScope": "project",
-    }
-    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
-    monkeypatch.setattr(
-        guard_commands_module, "schedule_guard_daemon_ensure", lambda _guard_home, **_kwargs: "http://127.0.0.1:4455"
-    )
-
-    rc = main(
-        [
-            "guard",
-            "hook",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--harness",
-            "copilot",
-        ]
-    )
-    output = json.loads(capsys.readouterr().out)
-
-    assert rc == 0
-    assert output["permissionDecision"] == "deny"
-    assert "hol guard" in output["permissionDecisionReason"].lower()
-    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
-
-
-def test_guard_hook_emits_copilot_native_ask_response_for_clustered_base64_decode_and_exec_command(
-    tmp_path,
-    capsys,
-    monkeypatch,
-):
-    home_dir = tmp_path / "home"
-    workspace_dir = tmp_path / "workspace"
-    _build_guard_fixture(home_dir, workspace_dir)
-    event = {
-        "toolName": "bash",
-        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -di | bash"}),
-        "sourceScope": "project",
-    }
-    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
-    monkeypatch.setattr(
-        guard_commands_module, "schedule_guard_daemon_ensure", lambda _guard_home, **_kwargs: "http://127.0.0.1:4455"
-    )
-
-    rc = main(
-        [
-            "guard",
-            "hook",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--harness",
-            "copilot",
-        ]
-    )
-    output = json.loads(capsys.readouterr().out)
-
-    assert rc == 0
-    assert output["permissionDecision"] == "deny"
-    assert "hol guard" in output["permissionDecisionReason"].lower()
-    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
-
-
-def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_dash_exec_command(
-    tmp_path,
-    capsys,
-    monkeypatch,
-):
-    home_dir = tmp_path / "home"
-    workspace_dir = tmp_path / "workspace"
-    _build_guard_fixture(home_dir, workspace_dir)
-    event = {
-        "toolName": "bash",
-        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | dash"}),
-        "sourceScope": "project",
-    }
-    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
-    monkeypatch.setattr(
-        guard_commands_module, "schedule_guard_daemon_ensure", lambda _guard_home, **_kwargs: "http://127.0.0.1:4455"
-    )
-
-    rc = main(
-        [
-            "guard",
-            "hook",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--harness",
-            "copilot",
-        ]
-    )
-    output = json.loads(capsys.readouterr().out)
-
-    assert rc == 0
-    assert output["permissionDecision"] == "deny"
-    assert "hol guard" in output["permissionDecisionReason"].lower()
-    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
-
-
-def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_env_wrapped_exec_command(
-    tmp_path,
-    capsys,
-    monkeypatch,
-):
-    home_dir = tmp_path / "home"
-    workspace_dir = tmp_path / "workspace"
-    _build_guard_fixture(home_dir, workspace_dir)
-    event = {
-        "toolName": "bash",
-        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env bash"}),
-        "sourceScope": "project",
-    }
-    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
-    monkeypatch.setattr(
-        guard_commands_module, "schedule_guard_daemon_ensure", lambda _guard_home, **_kwargs: "http://127.0.0.1:4455"
-    )
-
-    rc = main(
-        [
-            "guard",
-            "hook",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--harness",
-            "copilot",
-        ]
-    )
-    output = json.loads(capsys.readouterr().out)
-
-    assert rc == 0
-    assert output["permissionDecision"] == "deny"
-    assert "hol guard" in output["permissionDecisionReason"].lower()
-    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
-
-
-def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_env_option_wrapped_exec_command(
-    tmp_path,
-    capsys,
-    monkeypatch,
-):
-    home_dir = tmp_path / "home"
-    workspace_dir = tmp_path / "workspace"
-    _build_guard_fixture(home_dir, workspace_dir)
-    event = {
-        "toolName": "bash",
-        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env -i bash"}),
-        "sourceScope": "project",
-    }
-    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
-    monkeypatch.setattr(
-        guard_commands_module, "schedule_guard_daemon_ensure", lambda _guard_home, **_kwargs: "http://127.0.0.1:4455"
-    )
-
-    rc = main(
-        [
-            "guard",
-            "hook",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--harness",
-            "copilot",
-        ]
-    )
-    output = json.loads(capsys.readouterr().out)
-
-    assert rc == 0
-    assert output["permissionDecision"] == "deny"
-    assert "hol guard" in output["permissionDecisionReason"].lower()
-    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
-
-
-def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_path_qualified_env_wrapped_exec_command(
-    tmp_path,
-    capsys,
-    monkeypatch,
-):
-    home_dir = tmp_path / "home"
-    workspace_dir = tmp_path / "workspace"
-    _build_guard_fixture(home_dir, workspace_dir)
-    event = {
-        "toolName": "bash",
-        "toolArgs": json.dumps(
-            {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | /usr/bin/env -i bash"}
-        ),
-        "sourceScope": "project",
-    }
-    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
-    monkeypatch.setattr(
-        guard_commands_module, "schedule_guard_daemon_ensure", lambda _guard_home, **_kwargs: "http://127.0.0.1:4455"
-    )
-
-    rc = main(
-        [
-            "guard",
-            "hook",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--harness",
-            "copilot",
-        ]
-    )
-    output = json.loads(capsys.readouterr().out)
-
-    assert rc == 0
-    assert output["permissionDecision"] == "deny"
-    assert "hol guard" in output["permissionDecisionReason"].lower()
-    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
-
-
-def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_env_unset_wrapped_exec_command(
-    tmp_path,
-    capsys,
-    monkeypatch,
-):
-    home_dir = tmp_path / "home"
-    workspace_dir = tmp_path / "workspace"
-    _build_guard_fixture(home_dir, workspace_dir)
-    event = {
-        "toolName": "bash",
-        "toolArgs": json.dumps(
-            {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env -u FOO bash"}
-        ),
-        "sourceScope": "project",
-    }
-    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
-    monkeypatch.setattr(
-        guard_commands_module, "schedule_guard_daemon_ensure", lambda _guard_home, **_kwargs: "http://127.0.0.1:4455"
-    )
-
-    rc = main(
-        [
-            "guard",
-            "hook",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--harness",
-            "copilot",
-        ]
-    )
-    output = json.loads(capsys.readouterr().out)
-
-    assert rc == 0
-    assert output["permissionDecision"] == "deny"
-    assert "hol guard" in output["permissionDecisionReason"].lower()
-    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
-
-
-def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_env_unset_equals_wrapped_exec_command(
-    tmp_path,
-    capsys,
-    monkeypatch,
-):
-    home_dir = tmp_path / "home"
-    workspace_dir = tmp_path / "workspace"
-    _build_guard_fixture(home_dir, workspace_dir)
-    event = {
-        "toolName": "bash",
-        "toolArgs": json.dumps(
-            {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env --unset=FOO bash"}
-        ),
-        "sourceScope": "project",
-    }
-    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
-    monkeypatch.setattr(
-        guard_commands_module, "schedule_guard_daemon_ensure", lambda _guard_home, **_kwargs: "http://127.0.0.1:4455"
-    )
-
-    rc = main(
-        [
-            "guard",
-            "hook",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--harness",
-            "copilot",
-        ]
-    )
-    output = json.loads(capsys.readouterr().out)
-
-    assert rc == 0
-    assert output["permissionDecision"] == "deny"
-    assert "hol guard" in output["permissionDecisionReason"].lower()
-    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
-
-
-def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_when_flag_not_first(
-    tmp_path,
-    capsys,
-    monkeypatch,
-):
-    home_dir = tmp_path / "home"
-    workspace_dir = tmp_path / "workspace"
-    _build_guard_fixture(home_dir, workspace_dir)
-    event = {
-        "toolName": "bash",
-        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -i -d | bash"}),
-        "sourceScope": "project",
-    }
-    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
-    monkeypatch.setattr(
-        guard_commands_module, "schedule_guard_daemon_ensure", lambda _guard_home, **_kwargs: "http://127.0.0.1:4455"
-    )
-
-    rc = main(
-        [
-            "guard",
-            "hook",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--harness",
-            "copilot",
-        ]
-    )
-    output = json.loads(capsys.readouterr().out)
-
-    assert rc == 0
-    assert output["permissionDecision"] == "deny"
-    assert "hol guard" in output["permissionDecisionReason"].lower()
-    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+        assert rc == 0, case.case_id
+        assert output["permissionDecision"] == "deny", case.case_id
+        assert "hol guard" in output["permissionDecisionReason"].lower(), case.case_id
+        assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower(), case.case_id
 
 
 def test_guard_hook_keeps_allow_response_for_bash_s_stdin_mode_with_same_named_local_file(


### PR DESCRIPTION
## Summary

- Replace eleven repeated Copilot encoded-exec hook tests with a typed stable-ID corpus runner.
- Preserve every encoded payload variant and surface its case ID on failure.
- Keep safe look-alike coverage explicit and validate corpus identity/reference integrity separately.

## Testing

- `uv run --group dev --extra dev pytest tests/test_guard_runtime.py tests/test_guard_copilot_hook_command_corpus.py -q --tb=short`
- `uv run --group dev --extra dev python scripts/ci/test_inventory.py --output /tmp/guard-test-inventory-copilot-corpus.json`
- `ruff check tests/guard_copilot_hook_command_corpus.py tests/test_guard_copilot_hook_command_corpus.py tests/test_guard_runtime.py`
