### PR TITLE
ci(guard): publish pytest duration artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,15 @@ jobs:
             --shard-count 16 \
             --granularity node > pytest-nodes.txt
           test -s pytest-nodes.txt
-          uv run --no-sync pytest @pytest-nodes.txt --tb=short
+          PYTHONPATH=scripts/ci GUARD_PYTEST_DURATION_OUTPUT=pytest-durations.json \
+            uv run --no-sync pytest -p pytest_duration_report @pytest-nodes.txt --tb=short
+      - name: Upload pytest duration artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: pytest-durations-${{ matrix.shard-index }}
+          path: pytest-durations.json
+          if-no-files-found: warn
 
   compatibility:
     runs-on: ubuntu-latest

--- a/scripts/ci/pytest_duration_report.py
+++ b/scripts/ci/pytest_duration_report.py
@@ -1,0 +1,72 @@
+"""Emit deterministic per-node pytest call durations for CI sharding evidence."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Protocol, cast
+
+OUTPUT_ENV = "GUARD_PYTEST_DURATION_OUTPUT"
+SCHEMA_VERSION = 1
+
+
+class _Report(Protocol):
+    when: str
+    nodeid: str
+    duration: float
+
+
+class _Config(Protocol):
+    workerinput: Mapping[str, object] | None
+
+
+_DURATIONS: dict[str, float] = {}
+
+
+def pytest_runtest_logreport(report: _Report) -> None:
+    """Keep only the call phase, keyed by the exact collected node id."""
+
+    if report.when == "call" and report.duration >= 0:
+        _DURATIONS[report.nodeid] = report.duration
+
+
+def pytest_sessionstart() -> None:
+    """Prevent stale in-process values when pytest is invoked repeatedly."""
+
+    _DURATIONS.clear()
+
+
+def pytest_sessionfinish(session: object, exitstatus: int) -> None:
+    """Write the shard artifact only when CI requested a destination."""
+
+    _ = session, exitstatus
+    output_value = os.environ.get(OUTPUT_ENV)
+    if not output_value:
+        return
+    output = Path(output_value)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "node_durations_seconds": dict(sorted(_DURATIONS.items())),
+    }
+    output.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def load_duration_report(path: Path) -> dict[str, float]:
+    """Validate a report before it is used as future shard input."""
+
+    payload = cast(object, json.loads(path.read_text(encoding="utf-8")))
+    if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("unsupported pytest duration report")
+    values = payload.get("node_durations_seconds")
+    if not isinstance(values, dict):
+        raise ValueError("pytest duration report requires node_durations_seconds")
+    durations: dict[str, float] = {}
+    for node_id, value in values.items():
+        if not isinstance(node_id, str) or not node_id:
+            raise ValueError("pytest duration report has an invalid node id")
+        if not isinstance(value, (int, float)) or isinstance(value, bool) or value < 0:
+            raise ValueError(f"pytest duration report has an invalid duration for {node_id!r}")
+        durations[node_id] = float(value)
+    return durations

--- a/tests/test_ci_pytest_duration_report.py
+++ b/tests/test_ci_pytest_duration_report.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "ci" / "pytest_duration_report.py"
+SPEC = importlib.util.spec_from_file_location("pytest_duration_report", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+duration_report = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = duration_report
+SPEC.loader.exec_module(duration_report)
+
+
+@dataclass(frozen=True)
+class _Report:
+    when: str
+    nodeid: str
+    duration: float
+
+
+def test_duration_report_writes_sorted_call_phase_nodes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    output = tmp_path / "durations.json"
+    monkeypatch.setenv(duration_report.OUTPUT_ENV, str(output))
+    duration_report.pytest_sessionstart()
+    duration_report.pytest_runtest_logreport(_Report("setup", "tests/test_a.py::test_a", 8.0))
+    duration_report.pytest_runtest_logreport(_Report("call", "tests/test_b.py::test_b", 2.5))
+    duration_report.pytest_runtest_logreport(_Report("call", "tests/test_a.py::test_a", 1.0))
+
+    duration_report.pytest_sessionfinish(object(), 0)
+
+    assert json.loads(output.read_text(encoding="utf-8")) == {
+        "node_durations_seconds": {
+            "tests/test_a.py::test_a": 1.0,
+            "tests/test_b.py::test_b": 2.5,
+        },
+        "schema_version": 1,
+    }
+    assert duration_report.load_duration_report(output) == {
+        "tests/test_a.py::test_a": 1.0,
+        "tests/test_b.py::test_b": 2.5,
+    }
+
+
+def test_duration_report_rejects_invalid_values(tmp_path: Path) -> None:
+    output = tmp_path / "durations.json"
+    output.write_text('{"schema_version": 1, "node_durations_seconds": {"node": -1}}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid duration"):
+        duration_report.load_duration_report(output)

--- a/tests/test_ci_pytest_shard.py
+++ b/tests/test_ci_pytest_shard.py
@@ -53,7 +53,10 @@ def test_ci_workflow_cancels_stale_runs_and_executes_each_shard() -> None:
     assert workflow.count("uv run --no-sync python scripts/ci/pytest_shard.py") == 2
     assert "--shard-count 16" in tests_job
     assert "--granularity node" in tests_job
-    assert "pytest @pytest-nodes.txt" in tests_job
+    assert "PYTHONPATH=scripts/ci GUARD_PYTEST_DURATION_OUTPUT=pytest-durations.json" in tests_job
+    assert "-p pytest_duration_report @pytest-nodes.txt" in tests_job
+    assert "Upload pytest duration artifact" in tests_job
+    assert "pytest-durations-${{ matrix.shard-index }}" in tests_job
     assert "mapfile -t files" not in workflow
     assert "name: ci (3.12)" in workflow
     assert "needs: [quality, tests, compatibility]" in workflow


### PR DESCRIPTION
## Summary

- Emit deterministic per-node pytest call-duration JSON from every CI shard.
- Upload each shard report as a pinned-action artifact for the duration-aware sharding manifest.
- Validate report schema and the exact CI plugin invocation with focused tests.

## Testing

- `PYTHONPATH=scripts/ci GUARD_PYTEST_DURATION_OUTPUT=/tmp/guard-duration-plugin-smoke.json uv run --group dev --extra dev pytest -p pytest_duration_report tests/test_ci_pytest_duration_report.py -q --tb=short`
- `uv run --group dev --extra dev pytest tests/test_ci_pytest_duration_report.py tests/test_ci_pytest_shard.py -q --tb=short`
- `ruff check scripts/ci/pytest_duration_report.py tests/test_ci_pytest_duration_report.py tests/test_ci_pytest_shard.py`
