### PR TITLE
test(guard): consolidate platform and CI/CD command corpora

### DIFF
--- a/tests/test_guard_command_cicd_extensions.py
+++ b/tests/test_guard_command_cicd_extensions.py
@@ -4,92 +4,60 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
 from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
+from tests.command_extension_contracts import assert_reviewed_command_cases, assert_safe_command_cases
 
-
-@pytest.mark.parametrize(
-    ("command", "action_class", "rule_id"),
-    [
-        ("gh run cancel 123", "GitHub Actions administrative command", "command.cicd.github.run-administration"),
-        ("gh run delete 123", "GitHub Actions administrative command", "command.cicd.github.run-administration"),
-        (
-            "gh --repo owner/project workflow disable release.yml",
-            "GitHub Actions administrative command",
-            "command.cicd.github.workflow-disable",
-        ),
-        (
-            "glab ci cancel pipeline 1504182795",
-            "GitLab pipeline administrative command",
-            "command.cicd.gitlab.pipeline-cancel",
-        ),
-        (
-            "circleci --host https://ci.example.test pipeline run org-id project-id",
-            "CircleCI pipeline execution command",
-            "command.cicd.circleci.pipeline-run",
-        ),
-        (
-            "gh.exe run --repo owner/project delete 123",
-            "GitHub Actions administrative command",
-            "command.cicd.github.run-administration",
-        ),
-        (
-            "glab.cmd ci cancel --repo group/project pipeline 1504182795",
-            "GitLab pipeline administrative command",
-            "command.cicd.gitlab.pipeline-cancel",
-        ),
-    ],
+CICD_REVIEW_CASES: tuple[tuple[str, str, str], ...] = (
+    ("gh run cancel 123", "GitHub Actions administrative command", "command.cicd.github.run-administration"),
+    ("gh run delete 123", "GitHub Actions administrative command", "command.cicd.github.run-administration"),
+    (
+        "gh --repo owner/project workflow disable release.yml",
+        "GitHub Actions administrative command",
+        "command.cicd.github.workflow-disable",
+    ),
+    (
+        "glab ci cancel pipeline 1504182795",
+        "GitLab pipeline administrative command",
+        "command.cicd.gitlab.pipeline-cancel",
+    ),
+    (
+        "circleci --host https://ci.example.test pipeline run org-id project-id",
+        "CircleCI pipeline execution command",
+        "command.cicd.circleci.pipeline-run",
+    ),
+    (
+        "gh.exe run --repo owner/project delete 123",
+        "GitHub Actions administrative command",
+        "command.cicd.github.run-administration",
+    ),
+    (
+        "glab.cmd ci cancel --repo group/project pipeline 1504182795",
+        "GitLab pipeline administrative command",
+        "command.cicd.gitlab.pipeline-cancel",
+    ),
 )
-def test_cicd_rules_feed_inspection_and_runtime_hooks(
-    command: str,
-    action_class: str,
-    rule_id: str,
-    tmp_path: Path,
-) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
-
-    assert payload["status"] == "review"
-    assert payload["classification"]["action_class"] == action_class
-    assert payload["controlling_rule_id"] == rule_id
-    runtime_match = extract_sensitive_tool_action_request(
-        "Shell",
-        {"command": command},
-        cwd=tmp_path,
-        home_dir=tmp_path,
-    )
-    assert runtime_match is not None
-    assert runtime_match.action_class == action_class
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "gh workflow view release.yml",
-        "gh run view 123",
-        "glab ci cancel pipeline 1504182795 --dry-run",
-        "glab ci cancel pipeline --help",
-        "circleci pipeline run --help",
-        "circleci config validate .circleci/config.yml",
-        "grep 'gh run delete|glab ci cancel' scripts/checks.sh",
-        "printf '%s\\n' 'circleci pipeline run org project'",
-    ],
+def test_cicd_rules_feed_inspection_and_runtime_hooks(tmp_path: Path) -> None:
+    assert_reviewed_command_cases(CICD_REVIEW_CASES, tmp_path)
+
+
+CICD_SAFE_COMMANDS: tuple[str, ...] = (
+    "gh workflow view release.yml",
+    "gh run view 123",
+    "glab ci cancel pipeline 1504182795 --dry-run",
+    "glab ci cancel pipeline --help",
+    "circleci pipeline run --help",
+    "circleci config validate .circleci/config.yml",
+    "grep 'gh run delete|glab ci cancel' scripts/checks.sh",
+    "printf '%s\\n' 'circleci pipeline run org project'",
 )
-def test_cicd_help_preview_and_read_commands_remain_safe(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
 
-    assert payload["status"] == "no_match"
-    assert (
-        extract_sensitive_tool_action_request(
-            "Shell",
-            {"command": command},
-            cwd=tmp_path,
-            home_dir=tmp_path,
-        )
-        is None
-    )
+
+def test_cicd_help_preview_and_read_commands_remain_safe(tmp_path: Path) -> None:
+    assert_safe_command_cases(CICD_SAFE_COMMANDS, tmp_path)
 
 
 def test_github_workflow_mutation_trailing_help_does_not_suppress_review(tmp_path: Path) -> None:

--- a/tests/test_guard_command_platform_extensions.py
+++ b/tests/test_guard_command_platform_extensions.py
@@ -4,114 +4,81 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
-from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
+from tests.command_extension_contracts import assert_reviewed_command_cases, assert_safe_command_cases
 
-
-@pytest.mark.parametrize(
-    ("command", "action_class", "rule_id"),
-    [
-        ("vercel remove app.example.test", "Vercel destructive command", "command.platform.vercel.deletion"),
-        ("vercel rm app.example.test", "Vercel destructive command", "command.platform.vercel.deletion"),
-        ("vercel project rm web", "Vercel destructive command", "command.platform.vercel.deletion"),
-        ("vercel promote deployment-id", "Vercel production command", "command.platform.vercel.production-change"),
-        (
-            "vercel -t token-value -S team promote deployment-id",
-            "Vercel production command",
-            "command.platform.vercel.production-change",
-        ),
-        ("vercel rollback deployment-id", "Vercel production command", "command.platform.vercel.production-change"),
-        ("vercel deploy --prod", "Vercel production command", "command.platform.vercel.production-change"),
-        ("vercel deploy -p", "Vercel production command", "command.platform.vercel.production-change"),
-        ("vercel --prod", "Vercel production command", "command.platform.vercel.production-change"),
-        ("vercel -p", "Vercel production command", "command.platform.vercel.production-change"),
-        (
-            "vercel --scope team --prod",
-            "Vercel production command",
-            "command.platform.vercel.production-change",
-        ),
-        (
-            "netlify sites:delete --site site-id",
-            "Netlify destructive command",
-            "command.platform.netlify.site-deletion",
-        ),
-        (
-            "netlify deploy --prod --dir dist",
-            "Netlify production command",
-            "command.platform.netlify.production-deploy",
-        ),
-        ("netlify deploy -p --dir dist", "Netlify production command", "command.platform.netlify.production-deploy"),
-        ("heroku apps:destroy --app web", "Heroku destructive command", "command.platform.heroku.app-destruction"),
-        ("heroku pipelines:promote -a web", "Heroku release command", "command.platform.heroku.release-change"),
-        ("heroku releases:rollback v42 -a web", "Heroku release command", "command.platform.heroku.release-change"),
-        ("vercel.cmd --scope team project rm web", "Vercel destructive command", "command.platform.vercel.deletion"),
-        (
-            "netlify.exe deploy --site site-id --prod",
-            "Netlify production command",
-            "command.platform.netlify.production-deploy",
-        ),
-        (
-            "netlify --auth token-value deploy --prod",
-            "Netlify production command",
-            "command.platform.netlify.production-deploy",
-        ),
-    ],
+PLATFORM_REVIEW_CASES: tuple[tuple[str, str, str], ...] = (
+    ("vercel remove app.example.test", "Vercel destructive command", "command.platform.vercel.deletion"),
+    ("vercel rm app.example.test", "Vercel destructive command", "command.platform.vercel.deletion"),
+    ("vercel project rm web", "Vercel destructive command", "command.platform.vercel.deletion"),
+    ("vercel promote deployment-id", "Vercel production command", "command.platform.vercel.production-change"),
+    (
+        "vercel -t token-value -S team promote deployment-id",
+        "Vercel production command",
+        "command.platform.vercel.production-change",
+    ),
+    ("vercel rollback deployment-id", "Vercel production command", "command.platform.vercel.production-change"),
+    ("vercel deploy --prod", "Vercel production command", "command.platform.vercel.production-change"),
+    ("vercel deploy -p", "Vercel production command", "command.platform.vercel.production-change"),
+    ("vercel --prod", "Vercel production command", "command.platform.vercel.production-change"),
+    ("vercel -p", "Vercel production command", "command.platform.vercel.production-change"),
+    (
+        "vercel --scope team --prod",
+        "Vercel production command",
+        "command.platform.vercel.production-change",
+    ),
+    (
+        "netlify sites:delete --site site-id",
+        "Netlify destructive command",
+        "command.platform.netlify.site-deletion",
+    ),
+    (
+        "netlify deploy --prod --dir dist",
+        "Netlify production command",
+        "command.platform.netlify.production-deploy",
+    ),
+    ("netlify deploy -p --dir dist", "Netlify production command", "command.platform.netlify.production-deploy"),
+    ("heroku apps:destroy --app web", "Heroku destructive command", "command.platform.heroku.app-destruction"),
+    ("heroku pipelines:promote -a web", "Heroku release command", "command.platform.heroku.release-change"),
+    ("heroku releases:rollback v42 -a web", "Heroku release command", "command.platform.heroku.release-change"),
+    ("vercel.cmd --scope team project rm web", "Vercel destructive command", "command.platform.vercel.deletion"),
+    (
+        "netlify.exe deploy --site site-id --prod",
+        "Netlify production command",
+        "command.platform.netlify.production-deploy",
+    ),
+    (
+        "netlify --auth token-value deploy --prod",
+        "Netlify production command",
+        "command.platform.netlify.production-deploy",
+    ),
 )
-def test_platform_rules_feed_inspection_and_runtime_hooks(
-    command: str,
-    action_class: str,
-    rule_id: str,
-    tmp_path: Path,
-) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
-
-    assert payload["status"] == "review"
-    assert payload["classification"]["action_class"] == action_class
-    assert payload["controlling_rule_id"] == rule_id
-    runtime_match = extract_sensitive_tool_action_request(
-        "Shell",
-        {"command": command},
-        cwd=tmp_path,
-        home_dir=tmp_path,
-    )
-    assert runtime_match is not None
-    assert runtime_match.action_class == action_class
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "vercel remove --help",
-        "vercel --prod --help",
-        "vercel promote status web",
-        "vercel project inspect web",
-        "vercel list --prod",
-        "netlify sites:delete --help",
-        "netlify deploy --dir dist",
-        "netlify build --dry",
-        "heroku apps:destroy --help",
-        "heroku apps:info -a web",
-        "heroku releases:info v42 -a web",
-        "grep 'vercel remove|netlify sites:delete' scripts/checks.sh",
-        "printf '%s\\n' 'heroku apps:destroy -a web'",
-    ],
+def test_platform_rules_feed_inspection_and_runtime_hooks(tmp_path: Path) -> None:
+    assert_reviewed_command_cases(PLATFORM_REVIEW_CASES, tmp_path)
+
+
+PLATFORM_SAFE_COMMANDS: tuple[str, ...] = (
+    "vercel remove --help",
+    "vercel --prod --help",
+    "vercel promote status web",
+    "vercel project inspect web",
+    "vercel list --prod",
+    "netlify sites:delete --help",
+    "netlify deploy --dir dist",
+    "netlify build --dry",
+    "heroku apps:destroy --help",
+    "heroku apps:info -a web",
+    "heroku releases:info v42 -a web",
+    "grep 'vercel remove|netlify sites:delete' scripts/checks.sh",
+    "printf '%s\\n' 'heroku apps:destroy -a web'",
 )
-def test_platform_help_preview_and_read_commands_remain_safe(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
 
-    assert payload["status"] == "no_match"
-    assert (
-        extract_sensitive_tool_action_request(
-            "Shell",
-            {"command": command},
-            cwd=tmp_path,
-            home_dir=tmp_path,
-        )
-        is None
-    )
+
+def test_platform_help_preview_and_read_commands_remain_safe(tmp_path: Path) -> None:
+    assert_safe_command_cases(PLATFORM_SAFE_COMMANDS, tmp_path)
 
 
 def test_platform_safe_variant_does_not_hide_destructive_segment(tmp_path: Path) -> None:

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -893,6 +893,10 @@ class TestGuardSurfaceServer:
         daemon.start()
 
         try:
+            assert daemon._server.hook_process_runner.wait_for_capacity(  # pyright: ignore[reportPrivateUsage]
+                minimum_workers=1,
+                timeout_seconds=15,
+            ), daemon._server.hook_process_runner.stats()  # pyright: ignore[reportPrivateUsage]
             hook_request = urllib.request.Request(
                 (
                     f"http://127.0.0.1:{daemon.port}/v1/hooks/claude-code?"


### PR DESCRIPTION
## Summary

- Migrate platform and CI/CD review and safe matrices to shared command-extension contracts.
- Retain every command variant plus explicit mixed-segment and trailing-help regressions.
- Make the isolated Pi hook surface assertion wait for worker readiness, eliminating its startup race without weakening fail-closed behavior.
- Reduce the platform and CI/CD modules from 54 collected tests to 10.

## Testing

- Focused platform and CI/CD extension suites.
- Five consecutive runs of the isolated Pi hook surface test.
- Focused Ruff validation.
