### PR TITLE
test(guard): consolidate cloud command corpus

### DIFF
--- a/tests/test_guard_command_cloud_extensions.py
+++ b/tests/test_guard_command_cloud_extensions.py
@@ -11,262 +11,232 @@ from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMA
 from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
 from codex_plugin_scanner.guard.runtime.command_rules import AnyMatcher, ExecutableMatcher
 from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
+from tests.command_extension_contracts import assert_reviewed_command_cases, assert_safe_command_cases
 
-
-@pytest.mark.parametrize(
-    ("command", "action_class", "rule_id"),
-    [
-        (
-            "aws --profile prod --region us-east-1 ec2 terminate-instances --instance-ids i-123",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "aws --profile=prod ec2 terminate-instances --instance-ids i-123",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "aws --future-global-option account ec2 terminate-instances --instance-ids i-123",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "aws --future-global-option=account ec2 terminate-instances --instance-ids i-123",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "aws --future-global-option --help ec2 terminate-instances --instance-ids i-123",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "aws rds delete-db-instance --db-instance-identifier app-db",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "aws eks delete-cluster --name app-cluster",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "gcloud --project app-prod compute instances delete api-1 --zone us-central1-a --quiet",
-            "Google Cloud destructive command",
-            "command.cloud.gcp.resource-deletion",
-        ),
-        (
-            "gcloud --filter active compute instances delete api-1",
-            "Google Cloud destructive command",
-            "command.cloud.gcp.resource-deletion",
-        ),
-        (
-            "gcloud --filter=active compute instances delete api-1",
-            "Google Cloud destructive command",
-            "command.cloud.gcp.resource-deletion",
-        ),
-        (
-            "gcloud --future-global-option --help compute instances delete api-1",
-            "Google Cloud destructive command",
-            "command.cloud.gcp.resource-deletion",
-        ),
-        (
-            "gcloud beta sql instances delete app-db",
-            "Google Cloud destructive command",
-            "command.cloud.gcp.resource-deletion",
-        ),
-        (
-            "az --subscription app-prod vm delete --resource-group app --name api-1 --yes",
-            "Azure destructive command",
-            "command.cloud.azure.resource-deletion",
-        ),
-        (
-            "az --subscription=app-prod vm delete --resource-group app --name api-1 --yes",
-            "Azure destructive command",
-            "command.cloud.azure.resource-deletion",
-        ),
-        (
-            "az --future-global-option tenant vm delete --resource-group app --name api-1 --yes",
-            "Azure destructive command",
-            "command.cloud.azure.resource-deletion",
-        ),
-        (
-            "az --future-global-option=tenant vm delete --resource-group app --name api-1 --yes",
-            "Azure destructive command",
-            "command.cloud.azure.resource-deletion",
-        ),
-        (
-            "az --future-global-option --help vm delete --resource-group app --name api-1 --yes",
-            "Azure destructive command",
-            "command.cloud.azure.resource-deletion",
-        ),
-        (
-            "aws ec2 terminate-instances --instance-ids i-123 --dry-run --dry-run=false",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "gcloud compute instances delete api-1 --help --help=false",
-            "Google Cloud destructive command",
-            "command.cloud.gcp.resource-deletion",
-        ),
-        (
-            "az vm delete --resource-group app --name api-1 --help --help=false",
-            "Azure destructive command",
-            "command.cloud.azure.resource-deletion",
-        ),
-        (
-            "aws.exe ec2 --region us-east-1 terminate-instances --instance-ids i-123",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "aws --no-cli-pager ec2 terminate-instances --instance-ids i-123",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "aws --no-paginate ec2 terminate-instances --instance-ids i-123",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "aws ec2 --cli-auto-prompt terminate-instances --instance-ids i-123",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "aws ec2 terminate-instances --no-cli-auto-prompt --instance-ids i-123",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "aws --no-color ec2 terminate-instances --instance-ids i-123",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "aws -- ec2 terminate-instances --instance-ids i-123",
-            "AWS destructive command",
-            "command.cloud.aws.resource-deletion",
-        ),
-        (
-            "gcloud.cmd compute --project app-prod instances delete api-1",
-            "Google Cloud destructive command",
-            "command.cloud.gcp.resource-deletion",
-        ),
-        (
-            "gcloud --quiet compute instances delete api-1",
-            "Google Cloud destructive command",
-            "command.cloud.gcp.resource-deletion",
-        ),
-        (
-            "gcloud -q compute instances delete api-1",
-            "Google Cloud destructive command",
-            "command.cloud.gcp.resource-deletion",
-        ),
-        (
-            "gcloud --no-log-http sql instances delete app-db",
-            "Google Cloud destructive command",
-            "command.cloud.gcp.resource-deletion",
-        ),
-        (
-            "az.cmd vm --subscription app-prod delete --resource-group app --name api-1 --yes",
-            "Azure destructive command",
-            "command.cloud.azure.resource-deletion",
-        ),
-        (
-            "az --only-show-errors vm delete --resource-group app --name api-1 --yes",
-            "Azure destructive command",
-            "command.cloud.azure.resource-deletion",
-        ),
-        (
-            "az -otable vm delete --resource-group app --name api-1 --yes",
-            "Azure destructive command",
-            "command.cloud.azure.resource-deletion",
-        ),
-        (
-            "az vm -otable delete --resource-group app --name api-1 --yes",
-            "Azure destructive command",
-            "command.cloud.azure.resource-deletion",
-        ),
-        (
-            "az --output table vm delete --resource-group app --name api-1 --yes",
-            "Azure destructive command",
-            "command.cloud.azure.resource-deletion",
-        ),
-        (
-            "az vm --output table delete --resource-group app --name api-1 --yes",
-            "Azure destructive command",
-            "command.cloud.azure.resource-deletion",
-        ),
-    ],
+CLOUD_REVIEW_CASES: tuple[tuple[str, str, str], ...] = (
+    (
+        "aws --profile prod --region us-east-1 ec2 terminate-instances --instance-ids i-123",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "aws --profile=prod ec2 terminate-instances --instance-ids i-123",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "aws --future-global-option account ec2 terminate-instances --instance-ids i-123",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "aws --future-global-option=account ec2 terminate-instances --instance-ids i-123",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "aws --future-global-option --help ec2 terminate-instances --instance-ids i-123",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "aws rds delete-db-instance --db-instance-identifier app-db",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "aws eks delete-cluster --name app-cluster",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "gcloud --project app-prod compute instances delete api-1 --zone us-central1-a --quiet",
+        "Google Cloud destructive command",
+        "command.cloud.gcp.resource-deletion",
+    ),
+    (
+        "gcloud --filter active compute instances delete api-1",
+        "Google Cloud destructive command",
+        "command.cloud.gcp.resource-deletion",
+    ),
+    (
+        "gcloud --filter=active compute instances delete api-1",
+        "Google Cloud destructive command",
+        "command.cloud.gcp.resource-deletion",
+    ),
+    (
+        "gcloud --future-global-option --help compute instances delete api-1",
+        "Google Cloud destructive command",
+        "command.cloud.gcp.resource-deletion",
+    ),
+    (
+        "gcloud beta sql instances delete app-db",
+        "Google Cloud destructive command",
+        "command.cloud.gcp.resource-deletion",
+    ),
+    (
+        "az --subscription app-prod vm delete --resource-group app --name api-1 --yes",
+        "Azure destructive command",
+        "command.cloud.azure.resource-deletion",
+    ),
+    (
+        "az --subscription=app-prod vm delete --resource-group app --name api-1 --yes",
+        "Azure destructive command",
+        "command.cloud.azure.resource-deletion",
+    ),
+    (
+        "az --future-global-option tenant vm delete --resource-group app --name api-1 --yes",
+        "Azure destructive command",
+        "command.cloud.azure.resource-deletion",
+    ),
+    (
+        "az --future-global-option=tenant vm delete --resource-group app --name api-1 --yes",
+        "Azure destructive command",
+        "command.cloud.azure.resource-deletion",
+    ),
+    (
+        "az --future-global-option --help vm delete --resource-group app --name api-1 --yes",
+        "Azure destructive command",
+        "command.cloud.azure.resource-deletion",
+    ),
+    (
+        "aws ec2 terminate-instances --instance-ids i-123 --dry-run --dry-run=false",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "gcloud compute instances delete api-1 --help --help=false",
+        "Google Cloud destructive command",
+        "command.cloud.gcp.resource-deletion",
+    ),
+    (
+        "az vm delete --resource-group app --name api-1 --help --help=false",
+        "Azure destructive command",
+        "command.cloud.azure.resource-deletion",
+    ),
+    (
+        "aws.exe ec2 --region us-east-1 terminate-instances --instance-ids i-123",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "aws --no-cli-pager ec2 terminate-instances --instance-ids i-123",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "aws --no-paginate ec2 terminate-instances --instance-ids i-123",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "aws ec2 --cli-auto-prompt terminate-instances --instance-ids i-123",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "aws ec2 terminate-instances --no-cli-auto-prompt --instance-ids i-123",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "aws --no-color ec2 terminate-instances --instance-ids i-123",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "aws -- ec2 terminate-instances --instance-ids i-123",
+        "AWS destructive command",
+        "command.cloud.aws.resource-deletion",
+    ),
+    (
+        "gcloud.cmd compute --project app-prod instances delete api-1",
+        "Google Cloud destructive command",
+        "command.cloud.gcp.resource-deletion",
+    ),
+    (
+        "gcloud --quiet compute instances delete api-1",
+        "Google Cloud destructive command",
+        "command.cloud.gcp.resource-deletion",
+    ),
+    (
+        "gcloud -q compute instances delete api-1",
+        "Google Cloud destructive command",
+        "command.cloud.gcp.resource-deletion",
+    ),
+    (
+        "gcloud --no-log-http sql instances delete app-db",
+        "Google Cloud destructive command",
+        "command.cloud.gcp.resource-deletion",
+    ),
+    (
+        "az.cmd vm --subscription app-prod delete --resource-group app --name api-1 --yes",
+        "Azure destructive command",
+        "command.cloud.azure.resource-deletion",
+    ),
+    (
+        "az --only-show-errors vm delete --resource-group app --name api-1 --yes",
+        "Azure destructive command",
+        "command.cloud.azure.resource-deletion",
+    ),
+    (
+        "az -otable vm delete --resource-group app --name api-1 --yes",
+        "Azure destructive command",
+        "command.cloud.azure.resource-deletion",
+    ),
+    (
+        "az vm -otable delete --resource-group app --name api-1 --yes",
+        "Azure destructive command",
+        "command.cloud.azure.resource-deletion",
+    ),
+    (
+        "az --output table vm delete --resource-group app --name api-1 --yes",
+        "Azure destructive command",
+        "command.cloud.azure.resource-deletion",
+    ),
+    (
+        "az vm --output table delete --resource-group app --name api-1 --yes",
+        "Azure destructive command",
+        "command.cloud.azure.resource-deletion",
+    ),
 )
-def test_cloud_rules_feed_inspection_and_runtime_hooks(
-    command: str,
-    action_class: str,
-    rule_id: str,
-    tmp_path: Path,
-) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
-
-    assert payload["status"] == "review"
-    assert payload["classification"]["action_class"] == action_class
-    assert payload["controlling_rule_id"] == rule_id
-    runtime_match = extract_sensitive_tool_action_request(
-        "Shell",
-        {"command": command},
-        cwd=tmp_path,
-        home_dir=tmp_path,
-    )
-    assert runtime_match is not None
-    assert runtime_match.action_class == action_class
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "aws ec2 terminate-instances --help",
-        "aws ec2 terminate-instances --instance-ids i-123 --dry-run",
-        "aws ec2 terminate-instances --instance-ids i-123 --no-dry-run --dry-run",
-        "aws ec2 terminate-instances --instance-ids i-123 --no-dry-run=false",
-        "aws rds delete-db-instance --generate-cli-skeleton input",
-        "aws rds delete-db-instance --generate-cli-skeleton=output",
-        "aws rds delete-db-instance --generate-cli-skeleton=yaml-input",
-        "aws rds delete-db-instance --generate-cli-skeleton=bogus --generate-cli-skeleton=output",
-        "gcloud compute instances delete --help",
-        "gcloud preview sql instances delete --help",
-        "az vm delete --help",
-        "aws --future-global-option account ec2 terminate-instances --instance-ids i-123 --dry-run",
-        "gcloud --future-global-option account compute instances delete api-1 --help",
-        "az --future-global-option tenant vm delete --resource-group app --name api-1 --help",
-        "aws ec2 terminate-instances --instance-ids i-123 --dry-run=false --dry-run",
-        "gcloud compute instances delete api-1 --help=false --help",
-        "az vm delete --resource-group app --name api-1 --help=false --help",
-        "aws ec2 describe-instances --instance-ids i-123",
-        "aws --future-global-option account ec2 describe-instances --instance-ids i-123",
-        "gcloud compute instances describe api-1",
-        "gcloud --filter active compute instances describe api-1",
-        "az vm show --resource-group app --name api-1",
-        "az --future-global-option tenant vm show --resource-group app --name api-1",
-        "grep 'terminate-instances|instances delete|vm delete' scripts/guard-test",
-        "printf '%s\\n' 'aws eks delete-cluster --name app-cluster'",
-    ],
+def test_cloud_rules_feed_inspection_and_runtime_hooks(tmp_path: Path) -> None:
+    assert_reviewed_command_cases(CLOUD_REVIEW_CASES, tmp_path)
+
+
+CLOUD_SAFE_COMMANDS: tuple[str, ...] = (
+    "aws ec2 terminate-instances --help",
+    "aws ec2 terminate-instances --instance-ids i-123 --dry-run",
+    "aws ec2 terminate-instances --instance-ids i-123 --no-dry-run --dry-run",
+    "aws ec2 terminate-instances --instance-ids i-123 --no-dry-run=false",
+    "aws rds delete-db-instance --generate-cli-skeleton input",
+    "aws rds delete-db-instance --generate-cli-skeleton=output",
+    "aws rds delete-db-instance --generate-cli-skeleton=yaml-input",
+    "aws rds delete-db-instance --generate-cli-skeleton=bogus --generate-cli-skeleton=output",
+    "gcloud compute instances delete --help",
+    "gcloud preview sql instances delete --help",
+    "az vm delete --help",
+    "aws --future-global-option account ec2 terminate-instances --instance-ids i-123 --dry-run",
+    "gcloud --future-global-option account compute instances delete api-1 --help",
+    "az --future-global-option tenant vm delete --resource-group app --name api-1 --help",
+    "aws ec2 terminate-instances --instance-ids i-123 --dry-run=false --dry-run",
+    "gcloud compute instances delete api-1 --help=false --help",
+    "az vm delete --resource-group app --name api-1 --help=false --help",
+    "aws ec2 describe-instances --instance-ids i-123",
+    "aws --future-global-option account ec2 describe-instances --instance-ids i-123",
+    "gcloud compute instances describe api-1",
+    "gcloud --filter active compute instances describe api-1",
+    "az vm show --resource-group app --name api-1",
+    "az --future-global-option tenant vm show --resource-group app --name api-1",
+    "grep 'terminate-instances|instances delete|vm delete' scripts/guard-test",
+    "printf '%s\\n' 'aws eks delete-cluster --name app-cluster'",
 )
-def test_cloud_help_preview_and_read_commands_remain_safe(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
 
-    assert payload["status"] == "no_match"
-    assert (
-        extract_sensitive_tool_action_request(
-            "Shell",
-            {"command": command},
-            cwd=tmp_path,
-            home_dir=tmp_path,
-        )
-        is None
-    )
+
+def test_cloud_help_preview_and_read_commands_remain_safe(tmp_path: Path) -> None:
+    assert_safe_command_cases(CLOUD_SAFE_COMMANDS, tmp_path)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Cloud command review and safe matrices now use the shared extension contract. Explicit unsafe-option, matcher, and mixed-segment regressions remain. Focused suite: 10 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored cloud command safety and review tests to use shared case definitions and assertion helpers.
  * Continued validating destructive commands, runtime action handling, and expected rule classifications.
  * Continued verifying that help, preview, and read-only commands remain safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->