### PR TITLE
test(guard): ratchet suite size metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
         run: uv run --no-sync python scripts/ci/test_inventory.py --output test-inventory.json
       - name: Publish test inventory
         run: cat test-inventory.json
+      - name: Enforce test-suite size ratchet
+        run: |
+          uv run --no-sync python scripts/ci/test_suite_ratchet.py \
+            --baseline ci/test-suite-ratchet-baseline.json \
+            --inventory test-inventory.json
       - name: Publish exact test-body duplicate candidates
         run: |
           uv run --no-sync python scripts/ci/test_duplicate_candidates.py \

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,0 +1,5 @@
+{
+  "maximum_collected_cases": 11745,
+  "maximum_test_source_lines": 265348,
+  "schema_version": 1
+}

--- a/scripts/ci/test_inventory.py
+++ b/scripts/ci/test_inventory.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import gzip
 import json
+import sys
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
@@ -13,6 +14,9 @@ from pathlib import Path
 from typing import Protocol, cast
 
 import pytest
+
+if not __package__:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 
 class _CollectionSession(Protocol):

--- a/scripts/ci/test_inventory.py
+++ b/scripts/ci/test_inventory.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import gzip
 import json
 from collections import Counter
 from collections.abc import Mapping, Sequence
@@ -25,6 +26,32 @@ class TestInventory:
     test_files: int
     parameterized_cases: int
     marker_counts: dict[str, int]
+
+
+@dataclass(frozen=True)
+class DurationSummary:
+    """The privacy-preserving duration evidence available to the inventory job."""
+
+    known_node_count: int
+    predicted_runtime_seconds: float
+    observed_at: str
+
+
+@dataclass(frozen=True)
+class TestSuiteMetrics:
+    """Reviewable test-suite health data that cannot hide corpus work in node counts."""
+
+    inventory: TestInventory
+    test_source_lines: int
+    product_source_lines: int
+    test_to_product_loc_ratio: float
+    protected_invariant_count: int
+    corpus_records: int
+    property_examples: int
+    duration: DurationSummary | None
+    mutation_score: None = None
+    branch_coverage: None = None
+    flake_rate: None = None
 
 
 class _NodeCollector:
@@ -71,12 +98,85 @@ def collect_inventory(root: Path) -> TestInventory:
     return build_inventory(node_ids, markers)
 
 
+def count_python_source_lines(root: Path) -> int:
+    """Count source lines deterministically without including generated environments."""
+
+    return sum(
+        len(path.read_text(encoding="utf-8").splitlines())
+        for path in sorted(root.rglob("*.py"))
+        if "__pycache__" not in path.parts
+    )
+
+
+def load_duration_summary(path: Path) -> DurationSummary | None:
+    """Read manifest aggregates while preserving hashed per-node identities."""
+
+    if not path.is_file():
+        return None
+    raw = gzip.decompress(path.read_bytes()) if path.suffix == ".gz" else path.read_bytes()
+    payload = cast(object, json.loads(raw))
+    if not isinstance(payload, dict):
+        raise ValueError("pytest duration manifest must be an object")
+    observed_at = payload.get("observed_at")
+    durations = payload.get("node_durations_seconds")
+    if not isinstance(observed_at, str) or not isinstance(durations, dict):
+        raise ValueError("pytest duration manifest is missing summary fields")
+    values = tuple(durations.values())
+    if not all(isinstance(value, (int, float)) and not isinstance(value, bool) for value in values):
+        raise ValueError("pytest duration manifest contains an invalid duration")
+    return DurationSummary(
+        known_node_count=len(values),
+        predicted_runtime_seconds=round(sum(float(value) for value in values), 3),
+        observed_at=observed_at,
+    )
+
+
+def corpus_record_count() -> int:
+    """Count corpus work outside pytest parametrization so node reductions stay reviewable."""
+
+    from tests.guard_command_corpus import iter_adversarial_corpus, iter_benign_corpus
+    from tests.guard_copilot_hook_command_corpus import (
+        COPILOT_ENCODED_EXEC_DENY_CASES,
+        COPILOT_NODE_DELETE_DENY_CASES,
+    )
+    from tests.guard_seeded_faults import PARSER_SEEDED_FAULTS
+
+    return (
+        sum(1 for _ in iter_benign_corpus())
+        + sum(1 for _ in iter_adversarial_corpus())
+        + len(COPILOT_ENCODED_EXEC_DENY_CASES)
+        + len(COPILOT_NODE_DELETE_DENY_CASES)
+        + len(PARSER_SEEDED_FAULTS)
+    )
+
+
+def build_suite_metrics(root: Path, inventory: TestInventory) -> TestSuiteMetrics:
+    """Build the single CI report used to review count, LOC, corpus, and runtime evidence."""
+
+    test_source_lines = count_python_source_lines(root / "tests")
+    product_source_lines = count_python_source_lines(root / "src")
+    if product_source_lines == 0:
+        raise ValueError("product source line count must be positive")
+    from tests.guard_test_invariants import TEST_INVARIANTS
+
+    return TestSuiteMetrics(
+        inventory=inventory,
+        test_source_lines=test_source_lines,
+        product_source_lines=product_source_lines,
+        test_to_product_loc_ratio=round(test_source_lines / product_source_lines, 4),
+        protected_invariant_count=len(TEST_INVARIANTS),
+        corpus_records=corpus_record_count(),
+        property_examples=0,
+        duration=load_duration_summary(root / "ci" / "pytest-duration-manifest.json.gz"),
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     _ = parser.add_argument("--output", type=Path)
     args = parser.parse_args()
     root = Path(__file__).resolve().parents[2]
-    payload = json.dumps(asdict(collect_inventory(root)), indent=2, sort_keys=True) + "\n"
+    payload = json.dumps(asdict(build_suite_metrics(root, collect_inventory(root))), indent=2, sort_keys=True) + "\n"
     output = cast(Path | None, args.output)
     if output is None:
         print(payload, end="")

--- a/scripts/ci/test_suite_ratchet.py
+++ b/scripts/ci/test_suite_ratchet.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Reject unexplained pytest-node and test-LOC growth in CI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+
+@dataclass(frozen=True)
+class TestSuiteRatchetBaseline:
+    """Reviewed upper bounds for the two anti-gaming dimensions collected in every PR."""
+
+    maximum_collected_cases: int
+    maximum_test_source_lines: int
+
+
+def load_baseline(path: Path) -> TestSuiteRatchetBaseline:
+    """Load the checked-in baseline with strict schema validation."""
+
+    payload = cast(Mapping[str, object], json.loads(path.read_text(encoding="utf-8")))
+    if payload.get("schema_version") != 1:
+        raise ValueError("unsupported test-suite ratchet baseline")
+    values = {
+        "maximum_collected_cases": payload.get("maximum_collected_cases"),
+        "maximum_test_source_lines": payload.get("maximum_test_source_lines"),
+    }
+    for key, value in values.items():
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            raise ValueError(f"test-suite ratchet baseline has invalid {key!r}")
+    return TestSuiteRatchetBaseline(**cast(dict[str, int], values))
+
+
+def load_inventory_metrics(path: Path) -> tuple[int, int]:
+    """Read only the metrics required for this narrow, always-on ratchet."""
+
+    payload = cast(Mapping[str, object], json.loads(path.read_text(encoding="utf-8")))
+    inventory = payload.get("inventory")
+    if not isinstance(inventory, Mapping):
+        raise ValueError("test inventory is missing inventory metrics")
+    collected_cases = inventory.get("collected_cases")
+    test_source_lines = payload.get("test_source_lines")
+    for key, value in {
+        "collected_cases": collected_cases,
+        "test_source_lines": test_source_lines,
+    }.items():
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ValueError(f"test inventory has invalid {key!r}")
+    return cast(int, collected_cases), cast(int, test_source_lines)
+
+
+def validation_errors(
+    baseline: TestSuiteRatchetBaseline,
+    *,
+    collected_cases: int,
+    test_source_lines: int,
+) -> tuple[str, ...]:
+    """Report every exceeded bound so maintainers can make one reviewed update."""
+
+    errors: list[str] = []
+    if collected_cases > baseline.maximum_collected_cases:
+        errors.append(
+            f"collected cases grew from {baseline.maximum_collected_cases} to {collected_cases}; "
+            "update the reviewed ratchet baseline if this is intentional"
+        )
+    if test_source_lines > baseline.maximum_test_source_lines:
+        errors.append(
+            f"test source lines grew from {baseline.maximum_test_source_lines} to {test_source_lines}; "
+            "update the reviewed ratchet baseline if this is intentional"
+        )
+    return tuple(errors)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    _ = parser.add_argument("--baseline", type=Path, required=True)
+    _ = parser.add_argument("--inventory", type=Path, required=True)
+    args = parser.parse_args()
+    baseline = load_baseline(args.baseline)
+    collected_cases, test_source_lines = load_inventory_metrics(args.inventory)
+    errors = validation_errors(
+        baseline,
+        collected_cases=collected_cases,
+        test_source_lines=test_source_lines,
+    )
+    for error in errors:
+        print(f"test-suite ratchet: {error}")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_test_inventory.py
+++ b/tests/test_ci_test_inventory.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import gzip
 import importlib.util
+import json
 import sys
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = ROOT / "scripts" / "ci" / "test_inventory.py"
@@ -40,3 +44,35 @@ def test_inventory_counts_cases_functions_files_parameters_and_unique_markers() 
     assert inventory.test_files == 2
     assert inventory.parameterized_cases == 1
     assert inventory.marker_counts == {"parser": 1, "regression": 1, "security_critical": 2}
+
+
+def test_duration_summary_is_aggregated_without_exposing_node_ids(tmp_path: Path) -> None:
+    path = tmp_path / "durations.json.gz"
+    path.write_bytes(
+        gzip.compress(
+            json.dumps(
+                {
+                    "observed_at": "2026-07-26T16:49:42Z",
+                    "node_durations_seconds": {"hashed-node-a": 1.25, "hashed-node-b": 2.5},
+                }
+            ).encode("utf-8"),
+            mtime=0,
+        )
+    )
+
+    assert test_inventory.load_duration_summary(path) == test_inventory.DurationSummary(
+        known_node_count=2,
+        predicted_runtime_seconds=3.75,
+        observed_at="2026-07-26T16:49:42Z",
+    )
+
+
+def test_duration_summary_rejects_non_numeric_values(tmp_path: Path) -> None:
+    path = tmp_path / "durations.json"
+    path.write_text(
+        json.dumps({"observed_at": "2026-07-26T16:49:42Z", "node_durations_seconds": {"node": "fast"}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="invalid duration"):
+        test_inventory.load_duration_summary(path)

--- a/tests/test_ci_test_suite_ratchet.py
+++ b/tests/test_ci_test_suite_ratchet.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "ci" / "test_suite_ratchet.py"
+SPEC = importlib.util.spec_from_file_location("test_suite_ratchet", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+test_suite_ratchet = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = test_suite_ratchet
+SPEC.loader.exec_module(test_suite_ratchet)
+
+
+def test_ratchet_accepts_current_or_smaller_metrics() -> None:
+    baseline = test_suite_ratchet.TestSuiteRatchetBaseline(100, 200)
+
+    assert test_suite_ratchet.validation_errors(baseline, collected_cases=100, test_source_lines=199) == ()
+
+
+def test_ratchet_reports_every_unexplained_growth() -> None:
+    baseline = test_suite_ratchet.TestSuiteRatchetBaseline(100, 200)
+
+    assert test_suite_ratchet.validation_errors(baseline, collected_cases=101, test_source_lines=201) == (
+        "collected cases grew from 100 to 101; update the reviewed ratchet baseline if this is intentional",
+        "test source lines grew from 200 to 201; update the reviewed ratchet baseline if this is intentional",
+    )
+
+
+def test_load_inventory_metrics_requires_nested_inventory_shape(tmp_path: Path) -> None:
+    path = tmp_path / "inventory.json"
+    path.write_text(json.dumps({"inventory": {"collected_cases": 4}, "test_source_lines": 20}), encoding="utf-8")
+
+    assert test_suite_ratchet.load_inventory_metrics(path) == (4, 20)
+    path.write_text(json.dumps({"test_source_lines": 20}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing inventory"):
+        test_suite_ratchet.load_inventory_metrics(path)
+
+
+def test_load_baseline_rejects_invalid_schema(tmp_path: Path) -> None:
+    path = tmp_path / "baseline.json"
+    path.write_text(json.dumps({"schema_version": 2}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unsupported"):
+        test_suite_ratchet.load_baseline(path)


### PR DESCRIPTION
## Summary
- Publish one reviewable test-suite metrics artifact with node, LOC, corpus, invariant, and duration evidence.
- Enforce reviewed upper bounds for collected pytest cases and test source lines in CI.

## Testing
- `uv run --no-sync pytest tests/test_ci_test_inventory.py tests/test_ci_test_suite_ratchet.py -q --tb=short`
- `uv run --no-sync python scripts/ci/test_inventory.py --output test-inventory.json`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json`
