### PR TITLE
test(guard): consolidate critical command floors

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11745,
-  "maximum_test_source_lines": 265348,
+  "maximum_collected_cases": 11660,
+  "maximum_test_source_lines": 265540,
   "schema_version": 1
 }

--- a/scripts/ci/test_inventory.py
+++ b/scripts/ci/test_inventory.py
@@ -144,6 +144,7 @@ def corpus_record_count() -> int:
         COPILOT_NODE_DELETE_DENY_CASES,
     )
     from tests.guard_seeded_faults import PARSER_SEEDED_FAULTS
+    from tests.test_guard_command_critical_floors import CRITICAL_COMMAND_FLOORS
 
     return (
         sum(1 for _ in iter_benign_corpus())
@@ -151,6 +152,7 @@ def corpus_record_count() -> int:
         + len(COPILOT_ENCODED_EXEC_DENY_CASES)
         + len(COPILOT_NODE_DELETE_DENY_CASES)
         + len(PARSER_SEEDED_FAULTS)
+        + len(CRITICAL_COMMAND_FLOORS)
     )
 
 

--- a/tests/guard_test_invariants.py
+++ b/tests/guard_test_invariants.py
@@ -163,6 +163,13 @@ TEST_INVARIANTS: Final[tuple[TestInvariant, ...]] = (
         "Curated parser security faults remain rejected or observable through canonical parsing.",
         ("security_critical", "regression", "parser", "release"),
     ),
+    TestInvariant(
+        "GUARD-INV-021",
+        "tests/test_guard_command_critical_floors.py::test_security_critical_commands_retain_exact_floors",
+        "command-floor-corpus",
+        "Critical destructive, secret, managed-service, and self-protection command floors remain exact.",
+        ("security_critical", "regression", "parser", "policy", "release"),
+    ),
 )
 
 

--- a/tests/test_guard_command_critical_floors.py
+++ b/tests/test_guard_command_critical_floors.py
@@ -156,7 +156,7 @@ CRITICAL_COMMAND_FLOORS: Final[tuple[tuple[str, GuardAction], ...]] = (
 
 
 def _critical_floor_case_id(command: str) -> str:
-    """Provide a stable, opaque diagnostic identity without leaking the command in metric keys."""
+    """Provide a stable opaque ID alongside the exact command retained in failure diagnostics."""
 
     return f"critical-floor-{sha256(command.encode('utf-8')).hexdigest()[:16]}"
 

--- a/tests/test_guard_command_critical_floors.py
+++ b/tests/test_guard_command_critical_floors.py
@@ -1,163 +1,181 @@
 from __future__ import annotations
 
+from hashlib import sha256
 from pathlib import Path
+from typing import Final
 
 import pytest
 
 from codex_plugin_scanner.guard.models import GuardAction
 from codex_plugin_scanner.guard.runtime.command_evaluation import evaluate_command
 
-
-@pytest.mark.parametrize(
-    ("command", "expected"),
+CRITICAL_COMMAND_FLOORS: Final[tuple[tuple[str, GuardAction], ...]] = (
+    ("aws route53 delete-hosted-zone --id zone --output json", "block"),
+    ("aws --profile prod route53 delete-hosted-zone --id zone", "block"),
+    ("aws route53 --profile prod delete-hosted-zone --id zone", "block"),
+    ("aws route53 --region us-east-1 delete-hosted-zone --id zone", "block"),
+    ("aws route53 --no-cli-pager delete-hosted-zone --id zone", "block"),
+    ("aws route53 --prof prod delete-hosted-zone --id zone", "block"),
+    ("aws route53 --reg us-east-1 delete-hosted-zone --id zone", "block"),
+    ("aws route53 --prof=prod delete-hosted-zone --id zone", "block"),
     (
-        ("aws route53 delete-hosted-zone --id zone --output json", "block"),
-        ("aws --profile prod route53 delete-hosted-zone --id zone", "block"),
-        ("aws route53 --profile prod delete-hosted-zone --id zone", "block"),
-        ("aws route53 --region us-east-1 delete-hosted-zone --id zone", "block"),
-        ("aws route53 --no-cli-pager delete-hosted-zone --id zone", "block"),
-        ("aws route53 --prof prod delete-hosted-zone --id zone", "block"),
-        ("aws route53 --reg us-east-1 delete-hosted-zone --id zone", "block"),
-        ("aws route53 --prof=prod delete-hosted-zone --id zone", "block"),
-        (
-            "aws route53 --cli-binary-format raw-in-base64-out delete-hosted-zone --id zone",
-            "block",
-        ),
-        (
-            "aws route53 --cli-binary-format=raw-in-base64-out delete-hosted-zone --id zone",
-            "block",
-        ),
-        ("stripe products delete product --description=--help", "block"),
-        ("stripe --api-key key products delete product", "block"),
-        ("stripe products --api-key key delete product", "block"),
-        ("env sh -c 'rm -rf workspace/target'", "block"),
-        ("rm -rf ./BUILD", "block"),
-        ("rm --recurs --for workspace/target", "block"),
-        ("xargs rm -rf BUILD", "block"),
-        ("timeout 5 bash -lc 'rm -rf workspace/target'", "block"),
-        ("timeout 5 /bin/bash -lc 'rm -rf workspace/target'", "block"),
-        ("timeout 5 /bin/sh -c 'rm -rf workspace/target'", "block"),
-        ("timeout 5 /usr/bin/dash -c 'rm -rf workspace/target'", "block"),
-        ("timeout 5 /usr/bin/zsh -c 'rm -rf workspace/target'", "block"),
-        ("timeout 5 /bin/ash -c 'rm -rf workspace/target'", "block"),
-        ("timeout 5 env -S '/bin/bash -c' 'rm -rf workspace/target'", "block"),
-        ("timeout 5 env -S'/bin/bash -c' 'rm -rf workspace/target'", "block"),
-        ("timeout 5 env --split-string='/bin/bash -c' 'rm -rf workspace/target'", "block"),
-        ("timeout 5 env --debug -i -v -S '/bin/bash -c' 'rm -rf workspace/target'", "block"),
-        ("timeout 5 env -iv -S '/bin/bash -c' 'rm -rf workspace/target'", "block"),
-        (
-            "timeout 5 env --ignore-environment --null --list-signal-handling "
-            + "-S '/bin/bash -c' 'rm -rf workspace/target'",
-            "block",
-        ),
-        ("timeout 5 env -0ivS'/bin/bash -c' 'rm -rf workspace/target'", "block"),
-        ("timeout 5 env -u TOKEN -S '/bin/bash -c' 'rm -rf workspace/target'", "block"),
-        (
-            "timeout 5 env -C workspace -P /bin -a shell -u TOKEN -S '/bin/bash -c' 'rm -rf workspace/target'",
-            "block",
-        ),
-        (
-            "timeout 5 env -Cworkspace -P/bin -ashell -uTOKEN -S '/bin/bash -c' 'rm -rf workspace/target'",
-            "block",
-        ),
-        (
-            "timeout 5 env --chdir workspace --argv0 shell --unset TOKEN -S '/bin/bash -c' 'rm -rf workspace/target'",
-            "block",
-        ),
-        (
-            "timeout 5 env --chdir=workspace --argv0=shell --unset=TOKEN -S '/bin/bash -c' 'rm -rf workspace/target'",
-            "block",
-        ),
-        ("timeout 5 env -vS '/bin/bash -c' 'rm -rf workspace/target'", "block"),
-        ("timeout 5 env -iS'/bin/bash -c' 'rm -rf workspace/target'", "block"),
-        ("timeout 5 env -S'bash -c \"rm -rf /\"'", "block"),
-        ("timeout 5 env --split-string='bash -c \"rm -rf /\"'", "block"),
-        ("timeout 5 bash --noprofile -c 'rm -rf workspace/target'", "block"),
-        ("timeout 5 bash -O extglob -c 'rm -rf workspace/target'", "block"),
-        ("sh <<'EOF'\nrm -rf workspace/target\nEOF", "block"),
-        ("gh api graphql -f query='mutation{deletePackageVersion(input:{packageVersionId:\"x\"}){success}}'", "block"),
-        (
-            "gh api --hostname github.com graphql "
-            + "-f query='mutation{deletePackageVersion(input:{packageVersionId:\"x\"}){success}}'",
-            "block",
-        ),
-        (
-            "gh --repo example/repo api graphql "
-            + "-f query='mutation{deletePackageVersion(input:{packageVersionId:\"x\"}){success}}'",
-            "block",
-        ),
-        ("hol-guard capability consume --capability-id x --replay-sequence 2", "block"),
-        ("hol-guard capability --verbose consume --capability-id x", "block"),
-        ("hol-guard uninstall --all", "block"),
-        ("hol-guard policy disable", "block"),
-        ("hol-guard clear --all", "block"),
-        ("xargs hol-guard uninstall --all", "block"),
-        ("xargs -P 4 hol-guard uninstall --all", "block"),
-        ("xargs -P4 hol-guard uninstall --all", "block"),
-        ("xargs -I {} hol-guard uninstall --all", "block"),
-        ("xargs -J % hol-guard uninstall --all", "block"),
-        ("xargs -R 2 hol-guard uninstall --all", "block"),
-        ("xargs -S 128 hol-guard uninstall --all", "block"),
-        (
-            "xargs xargs xargs xargs hol-guard uninstall --all",
-            "block",
-        ),
-        ("parallel -j 4 hol-guard uninstall --all", "block"),
-        ("parallel --jobs 4 hol-guard uninstall --all", "block"),
-        ("parallel --colsep ' +' hol-guard uninstall --all", "block"),
-        ("parallel --colsep=' +' hol-guard uninstall --all", "block"),
-        ("parallel --header : hol-guard uninstall --all", "block"),
-        ("parallel --header=: hol-guard uninstall --all", "block"),
-        ("parallel --tagstring '{#}' hol-guard uninstall --all", "block"),
-        ("parallel --tagstring='{#}' hol-guard uninstall --all", "block"),
-        ("parallel --load 75% hol-guard uninstall --all", "block"),
-        ("parallel --load=75% hol-guard uninstall --all", "block"),
-        ("parallel --tagstring tag rm -rf / ::: x", "block"),
-        ("parallel --header : rm -rf / ::: x", "block"),
-        ("parallel --colsep value rm -rf / ::: x", "block"),
-        ("parallel --load 100% rm -rf / ::: x", "block"),
-        ("parallel --unknown parallel rm -rf / ::: x", "block"),
-        ("find workspace -exec hol-guard uninstall --all {} ';'", "block"),
-        (
-            "find workspace -exec echo {} ';' -exec hol-guard uninstall --all {} ';'",
-            "block",
-        ),
-        ("xargs sh -c 'hol-guard uninstall --all'", "block"),
-        ("find workspace -exec sh -c 'hol-guard uninstall --all' ';'", "block"),
-        ("parallel sh -c 'hol-guard uninstall --all'", "block"),
-        ("xargs aws route53 delete-hosted-zone --id zone", "block"),
-        ("xargs gh pr merge 17 --repo example/repo --squash", "require-reapproval"),
-        ("aws.exe route53 delete-hosted-zone --id zone", "block"),
-        ("/usr/bin/stripe.exe products delete product", "block"),
-        ("hol-guard.exe uninstall --all", "block"),
-        ("rm.exe -rf workspace/target", "block"),
-        ("gh.exe pr merge 17 --repo example/repo --squash", "require-reapproval"),
-        ("PATH=scratch/bin:$PATH hol-guard status", "require-reapproval"),
-        ("export PATH=scratch/bin:$PATH; hol-guard status", "require-reapproval"),
-        ("npx --package tsc@file:./package tsc --noEmit", "require-reapproval"),
-        ("printf '%s' \"$(cat workspace/sensitive)\"", "require-reapproval"),
-        ("cat workspace/sensitive | tee scratch/output", "require-reapproval"),
-        ("keyring get service user", "require-reapproval"),
-        ("gh pr merge 17 --repo example/repo --squash --delete-branch", "require-reapproval"),
-        ("npm view typescript@5.0.0 dist.integrity", "review"),
-        ("docker compose ps", "review"),
-        ("docker inspect container --format '{{.State.Status}}'", "review"),
-        ("aws sts get-caller-identity --profile profile --output json", "review"),
-        ("gcloud projects describe project --format=json", "review"),
-        ("getfacl workspace/service", "review"),
-        ("systemctl status service", "review"),
-        ("hol-guard uninstall --help --installation-id fixture", "review"),
-        ("hol-guard help uninstall", "review"),
-        (
-            "gh api graphql -f query='mutation($threadId:ID!){resolveReviewThread"
-            + "(input:{threadId:$threadId}){thread{id}}}' -f threadId=T",
-            "review",
-        ),
+        "aws route53 --cli-binary-format raw-in-base64-out delete-hosted-zone --id zone",
+        "block",
+    ),
+    (
+        "aws route53 --cli-binary-format=raw-in-base64-out delete-hosted-zone --id zone",
+        "block",
+    ),
+    ("stripe products delete product --description=--help", "block"),
+    ("stripe --api-key key products delete product", "block"),
+    ("stripe products --api-key key delete product", "block"),
+    ("env sh -c 'rm -rf workspace/target'", "block"),
+    ("rm -rf ./BUILD", "block"),
+    ("rm --recurs --for workspace/target", "block"),
+    ("xargs rm -rf BUILD", "block"),
+    ("timeout 5 bash -lc 'rm -rf workspace/target'", "block"),
+    ("timeout 5 /bin/bash -lc 'rm -rf workspace/target'", "block"),
+    ("timeout 5 /bin/sh -c 'rm -rf workspace/target'", "block"),
+    ("timeout 5 /usr/bin/dash -c 'rm -rf workspace/target'", "block"),
+    ("timeout 5 /usr/bin/zsh -c 'rm -rf workspace/target'", "block"),
+    ("timeout 5 /bin/ash -c 'rm -rf workspace/target'", "block"),
+    ("timeout 5 env -S '/bin/bash -c' 'rm -rf workspace/target'", "block"),
+    ("timeout 5 env -S'/bin/bash -c' 'rm -rf workspace/target'", "block"),
+    ("timeout 5 env --split-string='/bin/bash -c' 'rm -rf workspace/target'", "block"),
+    ("timeout 5 env --debug -i -v -S '/bin/bash -c' 'rm -rf workspace/target'", "block"),
+    ("timeout 5 env -iv -S '/bin/bash -c' 'rm -rf workspace/target'", "block"),
+    (
+        "timeout 5 env --ignore-environment --null --list-signal-handling "
+        + "-S '/bin/bash -c' 'rm -rf workspace/target'",
+        "block",
+    ),
+    ("timeout 5 env -0ivS'/bin/bash -c' 'rm -rf workspace/target'", "block"),
+    ("timeout 5 env -u TOKEN -S '/bin/bash -c' 'rm -rf workspace/target'", "block"),
+    (
+        "timeout 5 env -C workspace -P /bin -a shell -u TOKEN -S '/bin/bash -c' 'rm -rf workspace/target'",
+        "block",
+    ),
+    (
+        "timeout 5 env -Cworkspace -P/bin -ashell -uTOKEN -S '/bin/bash -c' 'rm -rf workspace/target'",
+        "block",
+    ),
+    (
+        "timeout 5 env --chdir workspace --argv0 shell --unset TOKEN -S '/bin/bash -c' 'rm -rf workspace/target'",
+        "block",
+    ),
+    (
+        "timeout 5 env --chdir=workspace --argv0=shell --unset=TOKEN -S '/bin/bash -c' 'rm -rf workspace/target'",
+        "block",
+    ),
+    ("timeout 5 env -vS '/bin/bash -c' 'rm -rf workspace/target'", "block"),
+    ("timeout 5 env -iS'/bin/bash -c' 'rm -rf workspace/target'", "block"),
+    ("timeout 5 env -S'bash -c \"rm -rf /\"'", "block"),
+    ("timeout 5 env --split-string='bash -c \"rm -rf /\"'", "block"),
+    ("timeout 5 bash --noprofile -c 'rm -rf workspace/target'", "block"),
+    ("timeout 5 bash -O extglob -c 'rm -rf workspace/target'", "block"),
+    ("sh <<'EOF'\nrm -rf workspace/target\nEOF", "block"),
+    ("gh api graphql -f query='mutation{deletePackageVersion(input:{packageVersionId:\"x\"}){success}}'", "block"),
+    (
+        "gh api --hostname github.com graphql "
+        + "-f query='mutation{deletePackageVersion(input:{packageVersionId:\"x\"}){success}}'",
+        "block",
+    ),
+    (
+        "gh --repo example/repo api graphql "
+        + "-f query='mutation{deletePackageVersion(input:{packageVersionId:\"x\"}){success}}'",
+        "block",
+    ),
+    ("hol-guard capability consume --capability-id x --replay-sequence 2", "block"),
+    ("hol-guard capability --verbose consume --capability-id x", "block"),
+    ("hol-guard uninstall --all", "block"),
+    ("hol-guard policy disable", "block"),
+    ("hol-guard clear --all", "block"),
+    ("xargs hol-guard uninstall --all", "block"),
+    ("xargs -P 4 hol-guard uninstall --all", "block"),
+    ("xargs -P4 hol-guard uninstall --all", "block"),
+    ("xargs -I {} hol-guard uninstall --all", "block"),
+    ("xargs -J % hol-guard uninstall --all", "block"),
+    ("xargs -R 2 hol-guard uninstall --all", "block"),
+    ("xargs -S 128 hol-guard uninstall --all", "block"),
+    (
+        "xargs xargs xargs xargs hol-guard uninstall --all",
+        "block",
+    ),
+    ("parallel -j 4 hol-guard uninstall --all", "block"),
+    ("parallel --jobs 4 hol-guard uninstall --all", "block"),
+    ("parallel --colsep ' +' hol-guard uninstall --all", "block"),
+    ("parallel --colsep=' +' hol-guard uninstall --all", "block"),
+    ("parallel --header : hol-guard uninstall --all", "block"),
+    ("parallel --header=: hol-guard uninstall --all", "block"),
+    ("parallel --tagstring '{#}' hol-guard uninstall --all", "block"),
+    ("parallel --tagstring='{#}' hol-guard uninstall --all", "block"),
+    ("parallel --load 75% hol-guard uninstall --all", "block"),
+    ("parallel --load=75% hol-guard uninstall --all", "block"),
+    ("parallel --tagstring tag rm -rf / ::: x", "block"),
+    ("parallel --header : rm -rf / ::: x", "block"),
+    ("parallel --colsep value rm -rf / ::: x", "block"),
+    ("parallel --load 100% rm -rf / ::: x", "block"),
+    ("parallel --unknown parallel rm -rf / ::: x", "block"),
+    ("find workspace -exec hol-guard uninstall --all {} ';'", "block"),
+    (
+        "find workspace -exec echo {} ';' -exec hol-guard uninstall --all {} ';'",
+        "block",
+    ),
+    ("xargs sh -c 'hol-guard uninstall --all'", "block"),
+    ("find workspace -exec sh -c 'hol-guard uninstall --all' ';'", "block"),
+    ("parallel sh -c 'hol-guard uninstall --all'", "block"),
+    ("xargs aws route53 delete-hosted-zone --id zone", "block"),
+    ("xargs gh pr merge 17 --repo example/repo --squash", "require-reapproval"),
+    ("aws.exe route53 delete-hosted-zone --id zone", "block"),
+    ("/usr/bin/stripe.exe products delete product", "block"),
+    ("hol-guard.exe uninstall --all", "block"),
+    ("rm.exe -rf workspace/target", "block"),
+    ("gh.exe pr merge 17 --repo example/repo --squash", "require-reapproval"),
+    ("PATH=scratch/bin:$PATH hol-guard status", "require-reapproval"),
+    ("export PATH=scratch/bin:$PATH; hol-guard status", "require-reapproval"),
+    ("npx --package tsc@file:./package tsc --noEmit", "require-reapproval"),
+    ("printf '%s' \"$(cat workspace/sensitive)\"", "require-reapproval"),
+    ("cat workspace/sensitive | tee scratch/output", "require-reapproval"),
+    ("keyring get service user", "require-reapproval"),
+    ("gh pr merge 17 --repo example/repo --squash --delete-branch", "require-reapproval"),
+    ("npm view typescript@5.0.0 dist.integrity", "review"),
+    ("docker compose ps", "review"),
+    ("docker inspect container --format '{{.State.Status}}'", "review"),
+    ("aws sts get-caller-identity --profile profile --output json", "review"),
+    ("gcloud projects describe project --format=json", "review"),
+    ("getfacl workspace/service", "review"),
+    ("systemctl status service", "review"),
+    ("hol-guard uninstall --help --installation-id fixture", "review"),
+    ("hol-guard help uninstall", "review"),
+    (
+        "gh api graphql -f query='mutation($threadId:ID!){resolveReviewThread"
+        + "(input:{threadId:$threadId}){thread{id}}}' -f threadId=T",
+        "review",
     ),
 )
-def test_security_critical_commands_retain_exact_floors(command: str, expected: GuardAction) -> None:
-    evaluation = evaluate_command(command, cwd=Path("workspace"), home_dir=Path("home"))
-    assert evaluation.decision_plane.action == expected
+
+
+def _critical_floor_case_id(command: str) -> str:
+    """Provide a stable, opaque diagnostic identity without leaking the command in metric keys."""
+
+    return f"critical-floor-{sha256(command.encode('utf-8')).hexdigest()[:16]}"
+
+
+def test_security_critical_command_floor_case_ids_are_unique() -> None:
+    case_ids = {_critical_floor_case_id(command) for command, _expected in CRITICAL_COMMAND_FLOORS}
+
+    assert len(case_ids) == len(CRITICAL_COMMAND_FLOORS)
+
+
+def test_security_critical_commands_retain_exact_floors() -> None:
+    failures: list[str] = []
+    for command, expected in CRITICAL_COMMAND_FLOORS:
+        actual = evaluate_command(command, cwd=Path("workspace"), home_dir=Path("home")).decision_plane.action
+        if actual != expected:
+            failures.append(
+                f"{_critical_floor_case_id(command)}: expected {expected!r}, got {actual!r}; command={command!r}"
+            )
+    assert not failures, "\n".join(failures)
 
 
 def test_launcher_ambiguity_fanout_fails_closed() -> None:


### PR DESCRIPTION
## Summary
- Consolidate the repeated critical command-floor matrix into one diagnostic corpus owner.
- Keep every command floor, add a protected invariant, and report the corpus records separately from pytest nodes.
- Tighten the case-count ratchet against the current release tree.

## Testing
- `uv run --no-sync pytest tests/test_guard_command_critical_floors.py tests/test_guard_test_invariants.py tests/test_ci_test_inventory.py -q --tb=short`
- `uv run --no-sync python scripts/ci/test_inventory.py --output test-inventory.json`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json`
