### PR TITLE
fix(dashboard): ship alpha channel opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,7 @@ jobs:
       - name: Dashboard build and bundle-size report (L331)
         run: |
           cd dashboard && bun run build
+          git diff --exit-code -- ../src/codex_plugin_scanner/guard/daemon/static
           js_size=$(du -sh dist/assets/*.js 2>/dev/null | awk '{print $1}' | head -1)
           css_size=$(du -sh dist/assets/*.css 2>/dev/null | awk '{print $1}' | head -1)
           echo "Bundle JS: ${js_size:-unknown}, CSS: ${css_size:-unknown}"

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11745,
-  "maximum_test_source_lines": 265348,
+  "maximum_collected_cases": 11760,
+  "maximum_test_source_lines": 265515,
   "schema_version": 1
 }

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -127,7 +127,7 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
       {helpCopy ? (
         <p className="text-[11px] leading-relaxed text-brand-dark/70">{helpCopy}</p>
       ) : null}
-      {props.updateStatus && props.onSetUpdateChannel ? (
+      {props.onSetUpdateChannel ? (
         <label className="flex cursor-pointer items-start gap-2 text-[11px] leading-relaxed text-brand-dark/70">
           <input
             type="checkbox"

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -53,6 +53,13 @@ const alphaMarkup = renderToStaticMarkup(
 assert(alphaMarkup.includes("Use alpha updates"), "sidebar should expose the alpha opt-in");
 assert(alphaMarkup.includes("Alpha releases may be unstable"), "alpha opt-in should include a risk disclaimer");
 
+const loadingMarkup = renderToStaticMarkup(
+  createElement(GuardUpdatePanel, {
+    onSetUpdateChannel: () => undefined,
+  }),
+);
+assert(loadingMarkup.includes("Use alpha updates"), "sidebar should expose the alpha opt-in while version status loads");
+
 const blocked = normalizeGuardUpdateStatus({
   auto_updatable: false,
   update_available: false,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -17914,7 +17914,8 @@ function normalizeGuardUpdateStatus(raw) {
     update_in_progress: typeof value.update_in_progress === "boolean" ? value.update_in_progress : void 0,
     update_suppressed: value.update_suppressed === true ? true : void 0,
     retry_command: typeof value.retry_command === "string" ? value.retry_command : void 0,
-    update_attempt_message: typeof value.update_attempt_message === "string" ? value.update_attempt_message : void 0
+    update_attempt_message: typeof value.update_attempt_message === "string" ? value.update_attempt_message : void 0,
+    release_channel: value.release_channel === "alpha" ? "alpha" : "stable"
   };
 }
 async function fetchGuardUpdateStatus() {
@@ -17961,6 +17962,25 @@ async function scheduleGuardUpdate(options) {
     message: stringValue$1(payload.message) ?? void 0,
     error: stringValue$1(payload.error) ?? void 0
   };
+}
+async function setGuardUpdateChannel(channel) {
+  if (isGuardDemoMode()) {
+    return normalizeGuardUpdateStatus({
+      ...await fetchGuardUpdateStatus(),
+      release_channel: channel
+    });
+  }
+  const response = await fetchWithGuardAuth("/v1/update/channel", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ update_channel: channel })
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const value = isRecord$1(payload) ? payload : {};
+    throw new Error(stringValue$1(value.message) ?? `Update channel failed with ${response.status}`);
+  }
+  return normalizeGuardUpdateStatus(payload);
 }
 async function setupDesktopNotifications() {
   if (isGuardDemoMode()) {
@@ -18576,6 +18596,13 @@ function GuardUpdatePanel(props) {
   const showUpdateButton = props.updateStatus?.update_available === true && props.updateStatus.auto_updatable && props.updateStatus.update_suppressed !== true && phase !== "updating" && phase !== "reconnecting";
   const showReinstallButton = shouldPromptRecoveryReinstall(props.updateStatus) && phase !== "updating" && phase !== "reconnecting";
   const busy = phase === "updating" || phase === "reconnecting";
+  const useAlpha = props.updateStatus?.release_channel === "alpha";
+  const handleAlphaChange = reactExports.useCallback(
+    (event) => {
+      props.onSetUpdateChannel?.(event.target.checked ? "alpha" : "stable");
+    },
+    [props.onSetUpdateChannel]
+  );
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: props.compact ? "space-y-1" : "space-y-2", children: [
     version ? /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "font-mono text-[10px] text-brand-dark/60", "aria-label": `Guard version ${version}`, children: [
       "v",
@@ -18583,6 +18610,22 @@ function GuardUpdatePanel(props) {
     ] }) : null,
     props.updateStatus?.update_available ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/75", children: updateStatusLabel(props.updateStatus) }) : null,
     helpCopy ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/70", children: helpCopy }) : null,
+    props.onSetUpdateChannel ? /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "flex cursor-pointer items-start gap-2 text-[11px] leading-relaxed text-brand-dark/70", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          type: "checkbox",
+          checked: useAlpha,
+          disabled: busy,
+          onChange: handleAlphaChange,
+          className: "mt-0.5 h-3.5 w-3.5 shrink-0 rounded border-slate-300 text-brand-blue focus:ring-brand-blue"
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
+        "Use alpha updates",
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "block text-brand-dark/55", children: "Alpha releases may be unstable and can include unfinished changes." })
+      ] })
+    ] }) : null,
     showUpdateButton && props.onUpdateGuard ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "button",
       {
@@ -18759,12 +18802,20 @@ function useGuardUpdate(options) {
       expectedLatestVersion: null
     });
   }, [scheduleAndWait, updateStatus]);
+  const onSetUpdateChannel = reactExports.useCallback(async (channel) => {
+    try {
+      setUpdateStatus(await setGuardUpdateChannel(channel));
+    } catch {
+      setUpdatePhase("error");
+    }
+  }, []);
   return {
     guardVersion: updateStatus?.current_version ?? null,
     updateStatus,
     updatePhase,
     onUpdateGuard,
     onReinstallGuard,
+    onSetUpdateChannel,
     refreshUpdateStatus
   };
 }
@@ -19124,7 +19175,8 @@ function ShellSidebar(props) {
               updateStatus: props.updateStatus,
               updatePhase: props.updatePhase,
               onUpdateGuard: props.onUpdateGuard,
-              onReinstallGuard: props.onReinstallGuard
+              onReinstallGuard: props.onReinstallGuard,
+              onSetUpdateChannel: props.onSetUpdateChannel
             }
           )
         ] }) }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col items-center gap-2", children: [
@@ -29098,7 +29150,8 @@ function ApprovalCenterLayout(props) {
     updateStatus,
     updatePhase,
     onUpdateGuard,
-    onReinstallGuard
+    onReinstallGuard,
+    onSetUpdateChannel
   } = useGuardUpdate({ onReconnected: props.onGuardReconnected, enabled: props.enableUpdateStatus });
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-h-screen bg-white text-brand-dark", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -29126,6 +29179,7 @@ function ApprovalCenterLayout(props) {
         updatePhase,
         onUpdateGuard,
         onReinstallGuard,
+        onSetUpdateChannel,
         cloudUserProfile: props.runtime.kind === "ready" ? props.runtime.snapshot.cloud_user_profile : null,
         workspaceId: props.runtime.kind === "ready" ? props.runtime.snapshot.cloud_pairing_state.workspace_id ?? null : null,
         planId: props.runtime.kind === "ready" ? props.runtime.snapshot.cloud_pairing_state.plan_id ?? null : null

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -4142,6 +4142,16 @@
     }
   }
 
+  .text-brand-dark\/55 {
+    color: var(--brand-dark);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .text-brand-dark\/55 {
+      color: color-mix(in oklab, var(--brand-dark) 55%, transparent);
+    }
+  }
+
   .text-brand-dark\/60 {
     color: var(--brand-dark);
   }
@@ -5318,7 +5328,7 @@
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
 
-  .focus\:ring-brand-blue\/15:focus {
+  .focus\:ring-brand-blue:focus, .focus\:ring-brand-blue\/15:focus {
     --tw-ring-color: var(--brand-blue);
   }
 


### PR DESCRIPTION
## Summary
- Ship the dashboard alpha-update opt-in in the packaged static assets.
- Keep the opt-in visible while update status is loading and verify generated dashboard assets in CI.

## Testing
- `cd dashboard && bun run test`
- `uv run --no-sync pytest -q tests/test_dashboard_update.py --tb=short`
- `cd dashboard && bun run build`
