### PR TITLE
test(guard): consolidate github review floors

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11660,
-  "maximum_test_source_lines": 265540,
+  "maximum_collected_cases": 11542,
+  "maximum_test_source_lines": 265563,
   "schema_version": 1
 }

--- a/scripts/ci/test_inventory.py
+++ b/scripts/ci/test_inventory.py
@@ -145,6 +145,7 @@ def corpus_record_count() -> int:
     )
     from tests.guard_seeded_faults import PARSER_SEEDED_FAULTS
     from tests.test_guard_command_critical_floors import CRITICAL_COMMAND_FLOORS
+    from tests.test_guard_github_command_capabilities import GITHUB_REVIEW_FLOORS
 
     return (
         sum(1 for _ in iter_benign_corpus())
@@ -153,6 +154,7 @@ def corpus_record_count() -> int:
         + len(COPILOT_NODE_DELETE_DENY_CASES)
         + len(PARSER_SEEDED_FAULTS)
         + len(CRITICAL_COMMAND_FLOORS)
+        + len(GITHUB_REVIEW_FLOORS)
     )
 
 

--- a/tests/guard_test_invariants.py
+++ b/tests/guard_test_invariants.py
@@ -170,6 +170,13 @@ TEST_INVARIANTS: Final[tuple[TestInvariant, ...]] = (
         "Critical destructive, secret, managed-service, and self-protection command floors remain exact.",
         ("security_critical", "regression", "parser", "policy", "release"),
     ),
+    TestInvariant(
+        "GUARD-INV-022",
+        "tests/test_guard_github_command_capabilities.py::test_guard_requires_confirmation_for_github_mutations_and_unverified_compositions",
+        "github-command-corpus",
+        "GitHub mutation and dynamically resolved command forms keep their exact confirmation floors.",
+        ("security_critical", "regression", "parser", "policy", "release"),
+    ),
 )
 
 

--- a/tests/test_guard_github_command_capabilities.py
+++ b/tests/test_guard_github_command_capabilities.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from hashlib import sha256
 from pathlib import Path
+from typing import Final
 
 import pytest
 
@@ -412,200 +414,214 @@ def test_guard_does_not_relax_unproven_home_cd_github_compositions(
     assert match is not None
 
 
-@pytest.mark.parametrize(
-    ("command", "action_class"),
+GITHUB_REVIEW_FLOORS: Final[tuple[tuple[str, str], ...]] = (
     (
-        (
-            _text(
-                'gh api graphql -f \'query=mutation { deleteRepository(input: {repositoryId: "R_1"}) ',
-                "{ clientMutationId } }' | jq -r '.data'",
-            ),
-            "GitHub access mutation command",
+        _text(
+            'gh api graphql -f \'query=mutation { deleteRepository(input: {repositoryId: "R_1"}) ',
+            "{ clientMutationId } }' | jq -r '.data'",
         ),
-        (
-            _text(
-                "gh api graphql -f ",
-                "'query=mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id}} ",
-                "deleteRepository(input:{repositoryId:$threadId}){repository{id}}}' -f threadId=R_123",
-            ),
-            "GitHub access mutation command",
-        ),
-        (
-            _text(
-                "gh api graphql -f ",
-                "'query=mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id}}}' ",
-                "-f threadId=PRRT_example",
-            ),
-            "GitHub bounded maintenance command",
-        ),
-        ("gh pr edit 17 --title updated", "GitHub content mutation command"),
-        ("gh issue close 17", "GitHub content mutation command"),
-        ("gh release create v1.2.3 --notes 'release notes'", "GitHub release publication command"),
-        ("gh api repos/example/project/issues/17/comments -f body='looks good'", "GitHub content mutation command"),
-        ("gh pr merge 17 --repo example/project --squash --delete-branch", "GitHub delete command"),
-        ("gh pr merge 17 --admin", "GitHub administrator pull-request merge command"),
-        ("gh workflow run ci.yml", "GitHub workflow mutation command"),
-        ("gh repo sync --force", "GitHub force mutation command"),
-        ("gh repo delete example/project --yes", "GitHub delete command"),
-        ("gh issue delete 17 --yes", "GitHub delete command"),
-        ("gh release delete v1.2.3 --yes", "GitHub delete command"),
-        ("gh secret set TOKEN --body value", "GitHub secret mutation command"),
-        ("gh secret set TOKEN --body --help", "GitHub secret mutation command"),
-        ("gh pr edit 17 --title --help", "GitHub content mutation command"),
-        ("gh auth token", "GitHub secret mutation command"),
-        ("gh auth status --show-token", "GitHub secret mutation command"),
-        ("gh repo edit --visibility private", "GitHub access mutation command"),
-        ("gh ssh-key delete 123 --yes", "GitHub access mutation command"),
-        ("gh repo set-default o/r", "GitHub local configuration write"),
-        ("gh pr lock 1; gh repo delete o/r --yes", "GitHub delete command"),
-        (
-            _text(
-                "gh api graphql -f 'query=mutation { resolveReviewThread(input: {}) { thread { id } } }'; ",
-                "gh secret set TOKEN --body value",
-            ),
-            "GitHub secret mutation command",
-        ),
-        ("gh api repos/example/project -X DELETE", "GitHub delete command"),
-        ("gh project-alias | jq -r '.'", "Unverified GitHub command capability"),
-        ("gh pr view 17 | tee result.json", "destructive shell command"),
-        ("gh pr view 17 > result.json", "destructive shell command"),
-        ("GH=gh; $GH repo delete example/project --yes", "Unverified GitHub command capability"),
-        ('GH=gh; "$GH" secret set TOKEN --body value', "Unverified GitHub command capability"),
-        ("${GH:-gh} repo delete example/project --yes", "Unverified GitHub command capability"),
-        ("env GH=gh sh -c '$GH repo delete example/project --yes'", "Unverified GitHub command capability"),
-        ("TOOL=gh; $TOOL repo delete example/project --yes", "Unverified GitHub command capability"),
-        ("TOOL=/usr/local/bin/gh; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
-        ("${TOOL:-/usr/local/bin/gh} repo delete o/r --yes", "Unverified GitHub command capability"),
-        ("${TOOL:-gh.exe} repo delete o/r --yes", "Unverified GitHub command capability"),
-        ("${TOOL-gh} repo delete o/r --yes", "Unverified GitHub command capability"),
-        ('echo "$(gh repo delete o/r --yes)"', "GitHub delete command"),
-        ("TOOL=gh; echo $($TOOL repo delete o/r --yes)", "Unverified GitHub command capability"),
-        ("exec gh repo delete o/r --yes", "GitHub delete command"),
-        ("printf o/r | xargs gh repo delete --yes", "Unverified GitHub command capability"),
-        ("timeout 5 gh repo delete o/r --yes", "GitHub delete command"),
-        ("watch gh repo delete o/r --yes", "GitHub delete command"),
-        ("builtin command gh repo delete o/r --yes", "GitHub delete command"),
-        ("echo gh repo delete o/r --yes | sh", "Unverified GitHub command capability"),
-        ("eval 'gh repo delete o/r --yes'", "unresolved shell execution context"),
-        ("eval gh repo delete o/r --yes", "unresolved shell execution context"),
-        ("f(){ gh repo delete o/r --yes; }; f", "Unverified GitHub command capability"),
-        ("g() { gh repo delete o/r --yes; }; g", "Unverified GitHub command capability"),
-        ("g () { gh repo delete o/r --yes; }; g", "Unverified GitHub command capability"),
-        ("g() ( gh repo delete o/r --yes ); g", "Unverified GitHub command capability"),
-        ("function g { gh secret set TOKEN --body value; }; g", "Unverified GitHub command capability"),
-        ("function f() { gh repo delete o/r --yes; }; f", "Unverified GitHub command capability"),
-        ("function f () { $GH repo delete o/r --yes; }; f", "Unverified GitHub command capability"),
-        ("function f() ( /usr/local/bin/gh repo delete o/r --yes ); f", "Unverified GitHub command capability"),
-        ("if true; then gh repo delete o/r --yes; fi", "GitHub delete command"),
-        ("for item in one; do gh repo delete o/r --yes; done", "GitHub delete command"),
-        ("case one in one) gh repo delete o/r --yes;; esac", "GitHub delete command"),
-        ("{ gh repo delete o/r --yes; }", "GitHub delete command"),
-        ("( gh repo delete o/r --yes )", "GitHub delete command"),
-        ("! gh repo delete o/r --yes", "GitHub delete command"),
-        ("coproc gh repo delete o/r --yes", "GitHub delete command"),
-        ("coproc JOB { gh repo delete o/r --yes; }", "GitHub delete command"),
-        ("coproc JOB ( gh repo delete o/r --yes )", "GitHub delete command"),
-        ("trap 'gh repo delete o/r --yes' EXIT", "GitHub delete command"),
-        ('trap "gh repo delete o/r --yes" 0', "GitHub delete command"),
-        ("if ( gh repo delete o/r --yes ); then :; fi", "GitHub delete command"),
-        (
-            "case x in y) echo no;; x) gh repo delete o/r --yes;; esac",
-            "GitHub delete command",
-        ),
-        ("alias zap='gh repo delete o/r --yes'; zap", "Unverified GitHub command capability"),
-        ("TOOL=$(command -v gh); $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
-        ("export TOOL=gh; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
-        ("readonly TOOL=gh; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
-        ("declare TOOL=gh; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
-        ("typeset TOOL=gh; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
-        ("export TOOL=$(command -v gh); $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
-        ("g(){ local TOOL=gh; $TOOL repo delete o/r --yes; }; g", "Unverified GitHub command capability"),
-        ("export TOOL=gh; sh -c '$TOOL repo delete o/r --yes'", "Unverified GitHub command capability"),
-        ("TOOL=gh; false && TOOL=python; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
-        ("TOOL=gh; true || TOOL=python; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
-        ("TOOL=gh; false && unset TOOL; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
-        (
-            "TOOL=gh; if false; then TOOL=python; fi; $TOOL repo delete o/r --yes",
-            "Unverified GitHub command capability",
-        ),
-        (
-            "TOOL=gh; if maybe; then TOOL=python; fi; $TOOL repo delete o/r --yes",
-            "Unverified GitHub command capability",
-        ),
-        (
-            "TOOL=python; case x in x) TOOL=gh;; esac; $TOOL repo delete o/r --yes",
-            "Unverified GitHub command capability",
-        ),
-        (
-            "CMD='echo ok'; case x in x) CMD='gh repo delete o/r --yes';; esac; eval \"$CMD\"",
-            "unresolved shell execution context",
-        ),
-        (
-            "TOOL=gh; while false; do TOOL=python; done; $TOOL repo delete o/r --yes",
-            "Unverified GitHub command capability",
-        ),
-        (
-            "TOOL=gh; until true; do TOOL=python; done; $TOOL repo delete o/r --yes",
-            "Unverified GitHub command capability",
-        ),
-        (
-            "TOOL=gh; for item in; do TOOL=python; done; $TOOL repo delete o/r --yes",
-            "Unverified GitHub command capability",
-        ),
-        (
-            "f(){ local TOOL=python; case x in x) TOOL=gh;; esac; $TOOL repo delete o/r --yes; }; f",
-            "Unverified GitHub command capability",
-        ),
-        (
-            "f(){ local TOOL=gh; while false; do TOOL=python; done; $TOOL repo delete o/r --yes; }; f",
-            "Unverified GitHub command capability",
-        ),
-        ("case x in x) : ;& y) gh repo delete o/r --yes;; esac", "GitHub delete command"),
-        ("case x in x) : ;;& x) gh repo delete o/r --yes;; esac", "GitHub delete command"),
-        (
-            "CMD='gh repo delete o/r --yes'; false && CMD='echo ok'; eval \"$CMD\"",
-            "unresolved shell execution context",
-        ),
-        (
-            "CMD='gh repo delete o/r --yes'; true || CMD='echo ok'; sh -c \"$CMD\"",
-            "Unverified GitHub command capability",
-        ),
-        ('TOOL="$(command -v gh)"; "$TOOL" repo delete o/r --yes', "Unverified GitHub command capability"),
-        ('TOOL="$(which gh)"; "$TOOL" repo delete o/r --yes', "Unverified GitHub command capability"),
-        ('CMD="gh repo delete o/r --yes"; eval "$CMD"', "unresolved shell execution context"),
-        ('CMD="/usr/local/bin/gh repo delete o/r --yes"; eval "$CMD"', "unresolved shell execution context"),
-        ('CMD=\'"gh" repo delete o/r --yes\'; eval "$CMD"', "unresolved shell execution context"),
-        ('CMD="gh secret set TOKEN --body x"; sh -c "$CMD"', "Unverified GitHub command capability"),
-        ('CMD="gh repo delete o/r --yes"; echo "$CMD" | sh', "Unverified GitHub command capability"),
-        ("f(){ $GH repo delete o/r --yes; }; f", "Unverified GitHub command capability"),
-        ("TOOL=gh; f(){ $TOOL repo delete o/r --yes; }; f", "Unverified GitHub command capability"),
-        ("alias zap='$GH repo delete o/r --yes'; zap", "Unverified GitHub command capability"),
-        ("TOOL=gh; alias zap='$TOOL repo delete o/r --yes'; zap", "Unverified GitHub command capability"),
-        ("f(){ /usr/local/bin/gh repo delete o/r --yes; }; f", "Unverified GitHub command capability"),
-        ("alias zap='/usr/local/bin/gh repo delete o/r --yes'; zap", "Unverified GitHub command capability"),
-        ("exec /usr/local/bin/gh repo delete o/r --yes", "GitHub delete command"),
-        ("timeout 5 /usr/local/bin/gh repo delete o/r --yes", "GitHub delete command"),
-        ("exec 'C:\\tools\\gh.exe' repo delete o/r --yes", "GitHub delete command"),
-        ("timeout 5 'C:\\tools\\gh.exe' repo delete o/r --yes", "GitHub delete command"),
-        ("TOOL='C:\\tools\\gh.exe'; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
-        ("CMD='C:\\tools\\gh.exe repo delete o/r --yes'; eval \"$CMD\"", "unresolved shell execution context"),
-        ('gh api repos/o/r --hostname "$HOST"', "Unverified GitHub command capability"),
-        ('gh api repos/o/r --hostname "$(cat host.txt)"', "Unverified GitHub command capability"),
-        ('gh api repos/o/r -H "Authorization: Bearer $TOKEN"', "Unverified GitHub command capability"),
-        ("gh api repos/o/r --cache '$TTL'", "Unverified GitHub command capability"),
-        ("gh api repos/o/r --preview '$FEATURE'", "Unverified GitHub command capability"),
-        ('gh issue lock "$ISSUE" --repo "$REPO"', "Unverified GitHub command capability"),
-        ('gh pr ready "$(cat number)" -R "$REPO"', "Unverified GitHub command capability"),
-        ('gh issue pin "${NUMBER}"', "Unverified GitHub command capability"),
+        "GitHub access mutation command",
     ),
+    (
+        _text(
+            "gh api graphql -f ",
+            "'query=mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id}} ",
+            "deleteRepository(input:{repositoryId:$threadId}){repository{id}}}' -f threadId=R_123",
+        ),
+        "GitHub access mutation command",
+    ),
+    (
+        _text(
+            "gh api graphql -f ",
+            "'query=mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id}}}' ",
+            "-f threadId=PRRT_example",
+        ),
+        "GitHub bounded maintenance command",
+    ),
+    ("gh pr edit 17 --title updated", "GitHub content mutation command"),
+    ("gh issue close 17", "GitHub content mutation command"),
+    ("gh release create v1.2.3 --notes 'release notes'", "GitHub release publication command"),
+    ("gh api repos/example/project/issues/17/comments -f body='looks good'", "GitHub content mutation command"),
+    ("gh pr merge 17 --repo example/project --squash --delete-branch", "GitHub delete command"),
+    ("gh pr merge 17 --admin", "GitHub administrator pull-request merge command"),
+    ("gh workflow run ci.yml", "GitHub workflow mutation command"),
+    ("gh repo sync --force", "GitHub force mutation command"),
+    ("gh repo delete example/project --yes", "GitHub delete command"),
+    ("gh issue delete 17 --yes", "GitHub delete command"),
+    ("gh release delete v1.2.3 --yes", "GitHub delete command"),
+    ("gh secret set TOKEN --body value", "GitHub secret mutation command"),
+    ("gh secret set TOKEN --body --help", "GitHub secret mutation command"),
+    ("gh pr edit 17 --title --help", "GitHub content mutation command"),
+    ("gh auth token", "GitHub secret mutation command"),
+    ("gh auth status --show-token", "GitHub secret mutation command"),
+    ("gh repo edit --visibility private", "GitHub access mutation command"),
+    ("gh ssh-key delete 123 --yes", "GitHub access mutation command"),
+    ("gh repo set-default o/r", "GitHub local configuration write"),
+    ("gh pr lock 1; gh repo delete o/r --yes", "GitHub delete command"),
+    (
+        _text(
+            "gh api graphql -f 'query=mutation { resolveReviewThread(input: {}) { thread { id } } }'; ",
+            "gh secret set TOKEN --body value",
+        ),
+        "GitHub secret mutation command",
+    ),
+    ("gh api repos/example/project -X DELETE", "GitHub delete command"),
+    ("gh project-alias | jq -r '.'", "Unverified GitHub command capability"),
+    ("gh pr view 17 | tee result.json", "destructive shell command"),
+    ("gh pr view 17 > result.json", "destructive shell command"),
+    ("GH=gh; $GH repo delete example/project --yes", "Unverified GitHub command capability"),
+    ('GH=gh; "$GH" secret set TOKEN --body value', "Unverified GitHub command capability"),
+    ("${GH:-gh} repo delete example/project --yes", "Unverified GitHub command capability"),
+    ("env GH=gh sh -c '$GH repo delete example/project --yes'", "Unverified GitHub command capability"),
+    ("TOOL=gh; $TOOL repo delete example/project --yes", "Unverified GitHub command capability"),
+    ("TOOL=/usr/local/bin/gh; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
+    ("${TOOL:-/usr/local/bin/gh} repo delete o/r --yes", "Unverified GitHub command capability"),
+    ("${TOOL:-gh.exe} repo delete o/r --yes", "Unverified GitHub command capability"),
+    ("${TOOL-gh} repo delete o/r --yes", "Unverified GitHub command capability"),
+    ('echo "$(gh repo delete o/r --yes)"', "GitHub delete command"),
+    ("TOOL=gh; echo $($TOOL repo delete o/r --yes)", "Unverified GitHub command capability"),
+    ("exec gh repo delete o/r --yes", "GitHub delete command"),
+    ("printf o/r | xargs gh repo delete --yes", "Unverified GitHub command capability"),
+    ("timeout 5 gh repo delete o/r --yes", "GitHub delete command"),
+    ("watch gh repo delete o/r --yes", "GitHub delete command"),
+    ("builtin command gh repo delete o/r --yes", "GitHub delete command"),
+    ("echo gh repo delete o/r --yes | sh", "Unverified GitHub command capability"),
+    ("eval 'gh repo delete o/r --yes'", "unresolved shell execution context"),
+    ("eval gh repo delete o/r --yes", "unresolved shell execution context"),
+    ("f(){ gh repo delete o/r --yes; }; f", "Unverified GitHub command capability"),
+    ("g() { gh repo delete o/r --yes; }; g", "Unverified GitHub command capability"),
+    ("g () { gh repo delete o/r --yes; }; g", "Unverified GitHub command capability"),
+    ("g() ( gh repo delete o/r --yes ); g", "Unverified GitHub command capability"),
+    ("function g { gh secret set TOKEN --body value; }; g", "Unverified GitHub command capability"),
+    ("function f() { gh repo delete o/r --yes; }; f", "Unverified GitHub command capability"),
+    ("function f () { $GH repo delete o/r --yes; }; f", "Unverified GitHub command capability"),
+    ("function f() ( /usr/local/bin/gh repo delete o/r --yes ); f", "Unverified GitHub command capability"),
+    ("if true; then gh repo delete o/r --yes; fi", "GitHub delete command"),
+    ("for item in one; do gh repo delete o/r --yes; done", "GitHub delete command"),
+    ("case one in one) gh repo delete o/r --yes;; esac", "GitHub delete command"),
+    ("{ gh repo delete o/r --yes; }", "GitHub delete command"),
+    ("( gh repo delete o/r --yes )", "GitHub delete command"),
+    ("! gh repo delete o/r --yes", "GitHub delete command"),
+    ("coproc gh repo delete o/r --yes", "GitHub delete command"),
+    ("coproc JOB { gh repo delete o/r --yes; }", "GitHub delete command"),
+    ("coproc JOB ( gh repo delete o/r --yes )", "GitHub delete command"),
+    ("trap 'gh repo delete o/r --yes' EXIT", "GitHub delete command"),
+    ('trap "gh repo delete o/r --yes" 0', "GitHub delete command"),
+    ("if ( gh repo delete o/r --yes ); then :; fi", "GitHub delete command"),
+    (
+        "case x in y) echo no;; x) gh repo delete o/r --yes;; esac",
+        "GitHub delete command",
+    ),
+    ("alias zap='gh repo delete o/r --yes'; zap", "Unverified GitHub command capability"),
+    ("TOOL=$(command -v gh); $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
+    ("export TOOL=gh; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
+    ("readonly TOOL=gh; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
+    ("declare TOOL=gh; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
+    ("typeset TOOL=gh; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
+    ("export TOOL=$(command -v gh); $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
+    ("g(){ local TOOL=gh; $TOOL repo delete o/r --yes; }; g", "Unverified GitHub command capability"),
+    ("export TOOL=gh; sh -c '$TOOL repo delete o/r --yes'", "Unverified GitHub command capability"),
+    ("TOOL=gh; false && TOOL=python; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
+    ("TOOL=gh; true || TOOL=python; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
+    ("TOOL=gh; false && unset TOOL; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
+    (
+        "TOOL=gh; if false; then TOOL=python; fi; $TOOL repo delete o/r --yes",
+        "Unverified GitHub command capability",
+    ),
+    (
+        "TOOL=gh; if maybe; then TOOL=python; fi; $TOOL repo delete o/r --yes",
+        "Unverified GitHub command capability",
+    ),
+    (
+        "TOOL=python; case x in x) TOOL=gh;; esac; $TOOL repo delete o/r --yes",
+        "Unverified GitHub command capability",
+    ),
+    (
+        "CMD='echo ok'; case x in x) CMD='gh repo delete o/r --yes';; esac; eval \"$CMD\"",
+        "unresolved shell execution context",
+    ),
+    (
+        "TOOL=gh; while false; do TOOL=python; done; $TOOL repo delete o/r --yes",
+        "Unverified GitHub command capability",
+    ),
+    (
+        "TOOL=gh; until true; do TOOL=python; done; $TOOL repo delete o/r --yes",
+        "Unverified GitHub command capability",
+    ),
+    (
+        "TOOL=gh; for item in; do TOOL=python; done; $TOOL repo delete o/r --yes",
+        "Unverified GitHub command capability",
+    ),
+    (
+        "f(){ local TOOL=python; case x in x) TOOL=gh;; esac; $TOOL repo delete o/r --yes; }; f",
+        "Unverified GitHub command capability",
+    ),
+    (
+        "f(){ local TOOL=gh; while false; do TOOL=python; done; $TOOL repo delete o/r --yes; }; f",
+        "Unverified GitHub command capability",
+    ),
+    ("case x in x) : ;& y) gh repo delete o/r --yes;; esac", "GitHub delete command"),
+    ("case x in x) : ;;& x) gh repo delete o/r --yes;; esac", "GitHub delete command"),
+    (
+        "CMD='gh repo delete o/r --yes'; false && CMD='echo ok'; eval \"$CMD\"",
+        "unresolved shell execution context",
+    ),
+    (
+        "CMD='gh repo delete o/r --yes'; true || CMD='echo ok'; sh -c \"$CMD\"",
+        "Unverified GitHub command capability",
+    ),
+    ('TOOL="$(command -v gh)"; "$TOOL" repo delete o/r --yes', "Unverified GitHub command capability"),
+    ('TOOL="$(which gh)"; "$TOOL" repo delete o/r --yes', "Unverified GitHub command capability"),
+    ('CMD="gh repo delete o/r --yes"; eval "$CMD"', "unresolved shell execution context"),
+    ('CMD="/usr/local/bin/gh repo delete o/r --yes"; eval "$CMD"', "unresolved shell execution context"),
+    ('CMD=\'"gh" repo delete o/r --yes\'; eval "$CMD"', "unresolved shell execution context"),
+    ('CMD="gh secret set TOKEN --body x"; sh -c "$CMD"', "Unverified GitHub command capability"),
+    ('CMD="gh repo delete o/r --yes"; echo "$CMD" | sh', "Unverified GitHub command capability"),
+    ("f(){ $GH repo delete o/r --yes; }; f", "Unverified GitHub command capability"),
+    ("TOOL=gh; f(){ $TOOL repo delete o/r --yes; }; f", "Unverified GitHub command capability"),
+    ("alias zap='$GH repo delete o/r --yes'; zap", "Unverified GitHub command capability"),
+    ("TOOL=gh; alias zap='$TOOL repo delete o/r --yes'; zap", "Unverified GitHub command capability"),
+    ("f(){ /usr/local/bin/gh repo delete o/r --yes; }; f", "Unverified GitHub command capability"),
+    ("alias zap='/usr/local/bin/gh repo delete o/r --yes'; zap", "Unverified GitHub command capability"),
+    ("exec /usr/local/bin/gh repo delete o/r --yes", "GitHub delete command"),
+    ("timeout 5 /usr/local/bin/gh repo delete o/r --yes", "GitHub delete command"),
+    ("exec 'C:\\tools\\gh.exe' repo delete o/r --yes", "GitHub delete command"),
+    ("timeout 5 'C:\\tools\\gh.exe' repo delete o/r --yes", "GitHub delete command"),
+    ("TOOL='C:\\tools\\gh.exe'; $TOOL repo delete o/r --yes", "Unverified GitHub command capability"),
+    ("CMD='C:\\tools\\gh.exe repo delete o/r --yes'; eval \"$CMD\"", "unresolved shell execution context"),
+    ('gh api repos/o/r --hostname "$HOST"', "Unverified GitHub command capability"),
+    ('gh api repos/o/r --hostname "$(cat host.txt)"', "Unverified GitHub command capability"),
+    ('gh api repos/o/r -H "Authorization: Bearer $TOKEN"', "Unverified GitHub command capability"),
+    ("gh api repos/o/r --cache '$TTL'", "Unverified GitHub command capability"),
+    ("gh api repos/o/r --preview '$FEATURE'", "Unverified GitHub command capability"),
+    ('gh issue lock "$ISSUE" --repo "$REPO"', "Unverified GitHub command capability"),
+    ('gh pr ready "$(cat number)" -R "$REPO"', "Unverified GitHub command capability"),
+    ('gh issue pin "${NUMBER}"', "Unverified GitHub command capability"),
 )
-def test_guard_requires_confirmation_for_github_mutations_and_unverified_compositions(
-    tmp_path: Path,
-    command: str,
-    action_class: str,
-) -> None:
-    match = extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=tmp_path)
 
-    assert match is not None
-    assert match.action_class == action_class
-    assert "confirm" in match.reason.lower()
+
+def _github_review_floor_case_id(command: str) -> str:
+    """Provide a stable opaque ID alongside the exact command retained in failure diagnostics."""
+
+    return f"github-review-floor-{sha256(command.encode('utf-8')).hexdigest()[:16]}"
+
+
+def test_github_review_floor_case_ids_are_unique() -> None:
+    case_ids = {_github_review_floor_case_id(command) for command, _action_class in GITHUB_REVIEW_FLOORS}
+
+    assert len(case_ids) == len(GITHUB_REVIEW_FLOORS)
+
+
+def test_guard_requires_confirmation_for_github_mutations_and_unverified_compositions(tmp_path: Path) -> None:
+    failures: list[str] = []
+    for command, expected_action_class in GITHUB_REVIEW_FLOORS:
+        match = extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=tmp_path)
+        actual_action_class = match.action_class if match is not None else None
+        includes_confirmation = match is not None and "confirm" in match.reason.lower()
+        if actual_action_class != expected_action_class or not includes_confirmation:
+            failures.append(
+                f"{_github_review_floor_case_id(command)}: expected action={expected_action_class!r} "
+                f"and confirmation=True, got action={actual_action_class!r} "
+                f"and confirmation={includes_confirmation!r}; command={command!r}"
+            )
+    assert not failures, "\n".join(failures)


### PR DESCRIPTION
## Summary
- Consolidate the repeated GitHub review-floor matrix into one diagnostic corpus owner.
- Retain all command/action pairs, add a protected invariant, and publish corpus work separately from pytest nodes.
- Tighten the reviewed suite-size ratchet against the current release tree.

## Testing
- `uv run --no-sync pytest tests/test_guard_github_command_capabilities.py tests/test_guard_test_invariants.py tests/test_ci_test_inventory.py -q --tb=short`
- `uv run --no-sync python scripts/ci/test_inventory.py --output test-inventory.json`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json`
