### PR TITLE
test(guard): define mutation target contracts

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11432,
-  "maximum_test_source_lines": 265608,
+  "maximum_test_source_lines": 265639,
   "schema_version": 1
 }

--- a/scripts/ci/mutation_gate.py
+++ b/scripts/ci/mutation_gate.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Final, cast
 
+from scripts.ci.mutation_targets import TARGETS
+
 
 @dataclass(frozen=True)
 class MutationBaseline:
@@ -24,7 +26,7 @@ class MutationBaseline:
 BASELINES: Final[dict[str, MutationBaseline]] = {
     "command-model": MutationBaseline(
         target="command-model",
-        source_path="src/codex_plugin_scanner/guard/runtime/command_model.py",
+        source_path=TARGETS["command-model"].source_path,
         minimum_score=64.0,
         expected_total=610,
     ),

--- a/scripts/ci/mutation_targets.py
+++ b/scripts/ci/mutation_targets.py
@@ -1,0 +1,89 @@
+"""Reviewed mutation-test targets and their smallest owning test selections."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+
+@dataclass(frozen=True)
+class MutationTarget:
+    """One source boundary and the focused tests that own its security behavior."""
+
+    name: str
+    source_path: str
+    test_selection: tuple[str, ...]
+
+
+TARGETS: Final[dict[str, MutationTarget]] = {
+    "command-model": MutationTarget(
+        "command-model",
+        "src/codex_plugin_scanner/guard/runtime/command_model.py",
+        (
+            "tests/test_guard_command_model.py",
+            "tests/test_guard_command_critical_floors.py",
+            "tests/test_guard_command_corpus.py",
+        ),
+    ),
+    "secret-flow": MutationTarget(
+        "secret-flow",
+        "src/codex_plugin_scanner/guard/runtime/data_flow.py",
+        ("tests/test_guard_data_flow.py",),
+    ),
+    "hook-output": MutationTarget(
+        "hook-output",
+        "src/codex_plugin_scanner/guard/runtime/hook_review_engine.py",
+        ("tests/test_hook_review_engine.py", "tests/test_hook_security_regressions.py"),
+    ),
+    "approval-reuse": MutationTarget(
+        "approval-reuse",
+        "src/codex_plugin_scanner/guard/runtime/approval_reuse.py",
+        ("tests/test_guard_approval_reuse.py", "tests/test_guard_approval_scope_contract.py"),
+    ),
+    "package-intent": MutationTarget(
+        "package-intent",
+        "src/codex_plugin_scanner/guard/runtime/package_intent_parser.py",
+        ("tests/test_guard_package_intent.py", "tests/test_guard_tier2_package_intent_phase13.py"),
+    ),
+    "package-policy": MutationTarget(
+        "package-policy",
+        "src/codex_plugin_scanner/guard/runtime/package_execution_policy.py",
+        ("tests/test_guard_package_execution_policy.py",),
+    ),
+    "recovery": MutationTarget(
+        "recovery",
+        "src/codex_plugin_scanner/guard/runtime/protection_health_runtime.py",
+        ("tests/test_guard_protection_health.py",),
+    ),
+}
+
+
+def render_mutmut_config(target: MutationTarget) -> str:
+    """Render an isolated mutmut configuration for one reviewed target."""
+
+    test_selection = ", ".join(f'"{path}"' for path in target.test_selection)
+    return "\n".join(
+        (
+            "[tool.mutmut]",
+            'source_paths = ["src"]',
+            f'only_mutate = ["{target.source_path}"]',
+            'also_copy = ["src/codex_plugin_scanner"]',
+            f"pytest_add_cli_args_test_selection = [{test_selection}]",
+            "",
+        )
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render one reviewed mutmut target configuration.")
+    _ = parser.add_argument("--target", choices=sorted(TARGETS), required=True)
+    _ = parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    args.output.write_text(render_mutmut_config(TARGETS[args.target]), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_mutation_gate.py
+++ b/tests/test_ci_mutation_gate.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 
 import pytest
+
+from scripts.ci.mutation_targets import TARGETS, render_mutmut_config
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = ROOT / "scripts" / "ci" / "mutation_gate.py"
@@ -36,9 +39,37 @@ def test_mutation_score_uses_all_evaluated_mutants() -> None:
     assert mutation_gate.mutation_score(_counts()) == pytest.approx(64.4262)
 
 
-def test_mutation_gate_accepts_measured_parser_baseline() -> None:
+def test_mutation_gate_accepts_measured_parser_baseline_and_target_contracts(tmp_path: Path) -> None:
     baseline = mutation_gate.BASELINES["command-model"]
     assert mutation_gate.validation_errors(baseline, _counts()) == ()
+    assert set(TARGETS) == {
+        "command-model",
+        "secret-flow",
+        "hook-output",
+        "approval-reuse",
+        "package-intent",
+        "package-policy",
+        "recovery",
+    }
+    assert len({target.source_path for target in TARGETS.values()}) == len(TARGETS)
+    for target in TARGETS.values():
+        assert (ROOT / target.source_path).is_file(), target.source_path
+        for test_path in target.test_selection:
+            assert (ROOT / test_path).is_file(), test_path
+        config = render_mutmut_config(target)
+        assert 'source_paths = ["src"]' in config
+        assert f'only_mutate = ["{target.source_path}"]' in config
+
+    output = tmp_path / "pyproject.toml"
+    result = subprocess.run(
+        [sys.executable, "scripts/ci/mutation_targets.py", "--target", "secret-flow", "--output", str(output)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert output.read_text(encoding="utf-8") == render_mutmut_config(TARGETS["secret-flow"])
 
 
 def test_mutation_gate_reports_every_failed_constraint() -> None:


### PR DESCRIPTION
## Summary
- define reviewed mutation targets for core Guard security boundaries
- keep the parser gate aligned with the shared target registry

## Testing
- `uv run --no-sync pytest tests/test_ci_mutation_targets.py tests/test_ci_mutation_gate.py -q --tb=short`
- `uv run --no-sync ruff check scripts/ci/mutation_targets.py scripts/ci/mutation_gate.py tests/test_ci_mutation_targets.py`
