### PR TITLE
test(guard): isolate mutation target runs

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11460,
-  "maximum_test_source_lines": 265791,
+  "maximum_test_source_lines": 265806,
   "schema_version": 1
 }

--- a/scripts/ci/mutation_targets.py
+++ b/scripts/ci/mutation_targets.py
@@ -71,6 +71,8 @@ def render_mutmut_config(target: MutationTarget) -> str:
             f'only_mutate = ["{target.source_path}"]',
             'also_copy = ["src/codex_plugin_scanner"]',
             f"pytest_add_cli_args_test_selection = [{test_selection}]",
+            "timeout_multiplier = 30.0",
+            "timeout_constant = 5.0",
             "",
         )
     )

--- a/scripts/ci/run_mutation_target.py
+++ b/scripts/ci/run_mutation_target.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Run one reviewed mutmut target from an isolated temporary workspace."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Final
+
+if not __package__:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.ci.mutation_targets import TARGETS, MutationTarget, render_mutmut_config
+
+ROOT: Final = Path(__file__).resolve().parents[2]
+
+
+def prepare_workspace(root: Path, target: MutationTarget, workspace: Path) -> Path:
+    """Create the minimal root mutmut needs without altering the checked-out project."""
+
+    workspace.mkdir(parents=True, exist_ok=True)
+    for name in ("src", "tests"):
+        (workspace / name).symlink_to(root / name, target_is_directory=True)
+    config_path = workspace / "pyproject.toml"
+    config_path.write_text(render_mutmut_config(target), encoding="utf-8")
+    return config_path
+
+
+def run_target(root: Path, target: MutationTarget, output_dir: Path, max_children: int) -> Path:
+    """Run mutmut and retain its summary plus per-mutant status metadata."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = output_dir / f"{target.name}.json"
+    metadata_path = output_dir / f"{target.name}.meta"
+    with tempfile.TemporaryDirectory(prefix=f"guard-mutmut-{target.name}-") as directory:
+        workspace = Path(directory)
+        _ = prepare_workspace(root, target, workspace)
+        for arguments in (
+            ("run", "--max-children", str(max_children)),
+            ("export-cicd-stats",),
+        ):
+            subprocess.run(
+                [sys.executable, "-m", "mutmut", *arguments],
+                cwd=workspace,
+                check=True,
+            )
+        shutil.copy2(workspace / "mutants" / "mutmut-cicd-stats.json", summary_path)
+        shutil.copy2(workspace / "mutants" / f"{target.source_path}.meta", metadata_path)
+    return summary_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run one isolated HOL Guard mutation target.")
+    _ = parser.add_argument("--target", choices=sorted(TARGETS), required=True)
+    _ = parser.add_argument("--output-dir", type=Path, default=Path("artifacts/mutation"))
+    _ = parser.add_argument("--max-children", type=int, default=4)
+    _ = parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    if args.max_children < 1:
+        parser.error("--max-children must be positive")
+    target = TARGETS[args.target]
+    if args.dry_run:
+        print(json.dumps({"target": target.name, "source_path": target.source_path}, sort_keys=True))
+        return 0
+    summary_path = run_target(ROOT, target, args.output_dir, args.max_children)
+    print(json.dumps({"summary": str(summary_path), "target": target.name}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_mutation_gate.py
+++ b/tests/test_ci_mutation_gate.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from scripts.ci.mutation_targets import TARGETS, render_mutmut_config
+from scripts.ci.run_mutation_target import prepare_workspace
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = ROOT / "scripts" / "ci" / "mutation_gate.py"
@@ -70,6 +71,20 @@ def test_mutation_gate_accepts_measured_parser_baseline_and_target_contracts(tmp
     )
     assert result.returncode == 0, result.stderr
     assert output.read_text(encoding="utf-8") == render_mutmut_config(TARGETS["secret-flow"])
+    workspace = tmp_path / "workspace"
+    config_path = prepare_workspace(ROOT, TARGETS["secret-flow"], workspace)
+    assert (workspace / "src").is_symlink()
+    assert (workspace / "tests").is_symlink()
+    assert config_path.read_text(encoding="utf-8") == render_mutmut_config(TARGETS["secret-flow"])
+    runner_result = subprocess.run(
+        [sys.executable, "scripts/ci/run_mutation_target.py", "--target", "secret-flow", "--dry-run"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert runner_result.returncode == 0, runner_result.stderr
+    assert '"target": "secret-flow"' in runner_result.stdout
 
 
 def test_mutation_gate_reports_every_failed_constraint() -> None:


### PR DESCRIPTION
## Summary
- run reviewed mutation targets from isolated temporary workspaces
- retain aggregate and per-mutant result evidence for review

## Testing
- `uv run --no-sync pytest tests/test_ci_mutation_gate.py -q --tb=short`
- `uv run --no-sync ruff check scripts/ci/run_mutation_target.py scripts/ci/mutation_targets.py tests/test_ci_mutation_gate.py`
