### PR TITLE
fix(dashboard): require proof for alpha channel changes

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11481,
-  "maximum_test_source_lines": 266208,
+  "maximum_test_source_lines": 266241,
   "schema_version": 1
 }

--- a/dashboard/src/alpha-update-channel-dialog.tsx
+++ b/dashboard/src/alpha-update-channel-dialog.tsx
@@ -1,0 +1,97 @@
+import type { ChangeEvent } from "react";
+import { HiMiniXMark } from "react-icons/hi2";
+
+import { ApprovalProofFieldInputs, isApprovalProofSubmitDisabled } from "./approval-proof-inline";
+import type { GuardApprovalGatePublicConfig } from "./guard-types";
+
+export type AlphaChannelDialogProps = {
+  useAlpha: boolean;
+  pending: boolean;
+  error: string | null;
+  approvalGate: GuardApprovalGatePublicConfig | null;
+  approvalPassword: string;
+  approvalTotpCode: string;
+  onClose: () => void;
+  onConfirm: () => void;
+  onApprovalPasswordChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onApprovalTotpCodeChange: (event: ChangeEvent<HTMLInputElement>) => void;
+};
+
+export function AlphaChannelDialog({
+  useAlpha,
+  pending,
+  error,
+  approvalGate,
+  approvalPassword,
+  approvalTotpCode,
+  onClose,
+  onConfirm,
+  onApprovalPasswordChange,
+  onApprovalTotpCodeChange,
+}: AlphaChannelDialogProps) {
+  const title = useAlpha ? "Return to stable updates" : "Try alpha updates";
+  const description = useAlpha
+    ? "Stable updates receive the most thoroughly tested Guard releases. You can enable alpha updates again whenever you need early access."
+    : "Alpha releases arrive before stable builds. They can include unfinished changes and may require a restart.";
+  const confirmLabel = useAlpha ? "Use stable updates" : "Enable alpha updates";
+  const confirmDisabled =
+    pending ||
+    (approvalGate?.enabled === true &&
+      isApprovalProofSubmitDisabled(approvalGate, { approvalPassword, approvalTotpCode }, false));
+
+  return (
+    <div className="rounded-lg bg-white shadow-xl">
+      <div className="flex items-start justify-between gap-4 border-b border-slate-100 px-5 py-4">
+        <div>
+          <h2 className="text-base font-semibold text-brand-dark">{title}</h2>
+          <p className="mt-1 text-sm leading-relaxed text-brand-dark/70">{description}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={pending}
+          aria-label="Close update channel dialog"
+          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-brand-dark/55 transition-colors hover:bg-slate-100 hover:text-brand-dark disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <HiMiniXMark className="h-5 w-5" aria-hidden="true" />
+        </button>
+      </div>
+      <div className="space-y-3 px-5 py-4 text-sm leading-relaxed text-brand-dark/75">
+        {!useAlpha ? (
+          <p>Guard will keep stable updates until you confirm this change. This does not install an update immediately.</p>
+        ) : null}
+        {approvalGate?.enabled ? (
+          <div className="rounded-lg border border-brand-blue/20 bg-brand-blue/[0.04] p-3">
+            <p className="mb-3 text-sm font-semibold text-brand-dark">Confirm this channel change</p>
+            <ApprovalProofFieldInputs
+              approvalGate={approvalGate}
+              approvalPassword={approvalPassword}
+              approvalTotpCode={approvalTotpCode}
+              onApprovalPasswordChange={onApprovalPasswordChange}
+              onApprovalTotpCodeChange={onApprovalTotpCodeChange}
+            />
+          </div>
+        ) : null}
+        {error ? <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p> : null}
+      </div>
+      <div className="flex flex-col-reverse gap-2 border-t border-slate-100 px-5 py-4 sm:flex-row sm:justify-end">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={pending}
+          className="min-h-10 rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-brand-dark transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={confirmDisabled}
+          className="min-h-10 rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-blue/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {pending ? "Saving…" : confirmLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -233,6 +233,7 @@ export function ApprovalCenterLayout(props: LayoutProps) {
         onUpdateGuard={onUpdateGuard}
         onReinstallGuard={onReinstallGuard}
         onSetUpdateChannel={onSetUpdateChannel}
+        approvalGate={props.approvalGate ?? null}
         cloudUserProfile={
           props.runtime.kind === "ready"
             ? props.runtime.snapshot.cloud_user_profile

--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -31,7 +31,8 @@ import { guardAwareHref } from "./guard-api";
 import { EMPTY_QUEUE_TITLE } from "./approval-center-utils";
 import { GuardUpdatePanel } from "./guard-update-panel";
 import { CloudUserMenu } from "./cloud-user-menu";
-import type { GuardCloudUserProfile } from "./guard-types";
+import type { GuardApprovalGatePublicConfig, GuardCloudUserProfile } from "./guard-types";
+import type { GuardUpdateChannelProof } from "./guard-api";
 import { GITHUB_ISSUE_BUTTON_LABEL, GITHUB_ISSUE_LINK } from "./github-issue-link";
 import type { GuardUpdatePhase, GuardUpdateStatus } from "./guard-types";
 
@@ -176,7 +177,8 @@ export function ShellSidebar(props: {
   updateStatus?: GuardUpdateStatus | null;
   onUpdateGuard?: () => void;
   onReinstallGuard?: () => void;
-  onSetUpdateChannel?: (channel: "stable" | "alpha") => void;
+  approvalGate?: GuardApprovalGatePublicConfig | null;
+  onSetUpdateChannel?: (channel: "stable" | "alpha", proof?: GuardUpdateChannelProof) => void | Promise<void>;
   updatePhase?: GuardUpdatePhase;
   cloudUserProfile?: GuardCloudUserProfile | null;
   workspaceId?: string | null;
@@ -289,6 +291,7 @@ export function ShellSidebar(props: {
                   onUpdateGuard={props.onUpdateGuard}
                   onReinstallGuard={props.onReinstallGuard}
                   onSetUpdateChannel={props.onSetUpdateChannel}
+                  approvalGate={props.approvalGate}
                 />
               </div>
             </div>

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -3137,7 +3137,15 @@ export async function scheduleGuardUpdate(
   };
 }
 
-export async function setGuardUpdateChannel(channel: "stable" | "alpha"): Promise<GuardUpdateStatus> {
+export type GuardUpdateChannelProof = {
+  approval_password?: string;
+  approval_totp_code?: string;
+};
+
+export async function setGuardUpdateChannel(
+  channel: "stable" | "alpha",
+  proof?: GuardUpdateChannelProof,
+): Promise<GuardUpdateStatus> {
   if (isGuardDemoMode()) {
     return normalizeGuardUpdateStatus({
       ...(await fetchGuardUpdateStatus()),
@@ -3147,7 +3155,7 @@ export async function setGuardUpdateChannel(channel: "stable" | "alpha"): Promis
   const response = await fetchWithGuardAuth("/v1/update/channel", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ update_channel: channel }),
+    body: JSON.stringify({ update_channel: channel, ...proof }),
   });
   const payload = await response.json().catch(() => ({}));
   if (!response.ok) {

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { HiMiniArrowPath, HiMiniXMark } from "react-icons/hi2";
+import { useCallback, useEffect, useRef, useState, type ChangeEvent } from "react";
+import { HiMiniArrowPath } from "react-icons/hi2";
 
 import {
   fetchGuardUpdateStatus,
@@ -9,8 +9,12 @@ import {
   redirectToGuardDaemonOrigin,
   scheduleGuardUpdate,
   setGuardUpdateChannel,
+  type GuardUpdateChannelProof,
 } from "./guard-api";
+import { AlphaChannelDialog } from "./alpha-update-channel-dialog";
+import { buildApprovalProofCredentials } from "./approval-proof-inline";
 import type {
+  GuardApprovalGatePublicConfig,
   GuardDaemonReconnectAuthorization,
   GuardUpdatePhase,
   GuardUpdateStatus,
@@ -27,16 +31,9 @@ export type GuardUpdatePanelProps = {
   updatePhase?: GuardUpdatePhase;
   onUpdateGuard?: () => void;
   onReinstallGuard?: () => void;
-  onSetUpdateChannel?: (channel: "stable" | "alpha") => void | Promise<void>;
+  approvalGate?: GuardApprovalGatePublicConfig | null;
+  onSetUpdateChannel?: (channel: "stable" | "alpha", proof?: GuardUpdateChannelProof) => void | Promise<void>;
   compact?: boolean;
-};
-
-type AlphaChannelDialogProps = {
-  useAlpha: boolean;
-  pending: boolean;
-  error: string | null;
-  onClose: () => void;
-  onConfirm: () => void;
 };
 
 function updateStatusLabel(status: GuardUpdateStatus | null | undefined): string {
@@ -102,58 +99,6 @@ function updateHelpCopy(status: GuardUpdateStatus | null | undefined, phase: Gua
   return null;
 }
 
-export function AlphaChannelDialog({ useAlpha, pending, error, onClose, onConfirm }: AlphaChannelDialogProps) {
-  const title = useAlpha ? "Return to stable updates" : "Try alpha updates";
-  const description = useAlpha
-    ? "Stable updates receive the most thoroughly tested Guard releases. You can enable alpha updates again whenever you need early access."
-    : "Alpha releases arrive before stable builds. They can include unfinished changes and may require a restart.";
-  const confirmLabel = useAlpha ? "Use stable updates" : "Enable alpha updates";
-
-  return (
-    <div className="rounded-lg bg-white shadow-xl">
-      <div className="flex items-start justify-between gap-4 border-b border-slate-100 px-5 py-4">
-        <div>
-          <h2 className="text-base font-semibold text-brand-dark">{title}</h2>
-          <p className="mt-1 text-sm leading-relaxed text-brand-dark/70">{description}</p>
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          disabled={pending}
-          aria-label="Close update channel dialog"
-          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-brand-dark/55 transition-colors hover:bg-slate-100 hover:text-brand-dark disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          <HiMiniXMark className="h-5 w-5" aria-hidden="true" />
-        </button>
-      </div>
-      <div className="space-y-3 px-5 py-4 text-sm leading-relaxed text-brand-dark/75">
-        {!useAlpha ? (
-          <p>Guard will keep stable updates until you confirm this change. This does not install an update immediately.</p>
-        ) : null}
-        {error ? <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p> : null}
-      </div>
-      <div className="flex flex-col-reverse gap-2 border-t border-slate-100 px-5 py-4 sm:flex-row sm:justify-end">
-        <button
-          type="button"
-          onClick={onClose}
-          disabled={pending}
-          className="min-h-10 rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-brand-dark transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Cancel
-        </button>
-        <button
-          type="button"
-          onClick={onConfirm}
-          disabled={pending}
-          className="min-h-10 rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-blue/90 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {pending ? "Saving…" : confirmLabel}
-        </button>
-      </div>
-    </div>
-  );
-}
-
 export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
   const version = props.guardVersion ?? props.updateStatus?.current_version ?? null;
   const phase = props.updatePhase ?? "idle";
@@ -170,11 +115,15 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
   const [alphaModalOpen, setAlphaModalOpen] = useState(false);
   const [alphaSavePending, setAlphaSavePending] = useState(false);
   const [alphaSaveError, setAlphaSaveError] = useState<string | null>(null);
+  const [alphaApprovalPassword, setAlphaApprovalPassword] = useState("");
+  const [alphaApprovalTotpCode, setAlphaApprovalTotpCode] = useState("");
   const targetChannel = useAlpha ? "stable" : "alpha";
   const modalTitle = useAlpha ? "Return to stable updates" : "Try alpha updates";
 
   const handleOpenAlphaModal = useCallback(() => {
     setAlphaSaveError(null);
+    setAlphaApprovalPassword("");
+    setAlphaApprovalTotpCode("");
     setAlphaModalOpen(true);
   }, []);
   const handleCloseAlphaModal = useCallback(() => {
@@ -183,6 +132,8 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
     }
     setAlphaModalOpen(false);
     setAlphaSaveError(null);
+    setAlphaApprovalPassword("");
+    setAlphaApprovalTotpCode("");
   }, [alphaSavePending]);
   const handleConfirmAlphaChannel = useCallback(async () => {
     if (!props.onSetUpdateChannel) {
@@ -191,14 +142,26 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
     setAlphaSavePending(true);
     setAlphaSaveError(null);
     try {
-      await props.onSetUpdateChannel(targetChannel);
+      const proof = props.approvalGate?.enabled
+        ? buildApprovalProofCredentials(props.approvalGate, {
+            approvalPassword: alphaApprovalPassword,
+            approvalTotpCode: alphaApprovalTotpCode,
+          })
+        : undefined;
+      await props.onSetUpdateChannel(targetChannel, proof);
       setAlphaModalOpen(false);
-    } catch {
-      setAlphaSaveError("Guard could not change the update channel. Try again.");
+    } catch (error) {
+      setAlphaSaveError(error instanceof Error ? error.message : "Guard could not change the update channel. Try again.");
     } finally {
       setAlphaSavePending(false);
     }
-  }, [props.onSetUpdateChannel, targetChannel]);
+  }, [alphaApprovalPassword, alphaApprovalTotpCode, props.approvalGate, props.onSetUpdateChannel, targetChannel]);
+  const handleApprovalPasswordChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setAlphaApprovalPassword(event.target.value);
+  }, []);
+  const handleApprovalTotpCodeChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setAlphaApprovalTotpCode(event.target.value);
+  }, []);
 
   return (
     <div className={props.compact ? "space-y-1" : "space-y-2"}>
@@ -255,8 +218,13 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
             useAlpha={useAlpha}
             pending={alphaSavePending}
             error={alphaSaveError}
+            approvalGate={props.approvalGate ?? null}
+            approvalPassword={alphaApprovalPassword}
+            approvalTotpCode={alphaApprovalTotpCode}
             onClose={handleCloseAlphaModal}
             onConfirm={handleConfirmAlphaChannel}
+            onApprovalPasswordChange={handleApprovalPasswordChange}
+            onApprovalTotpCodeChange={handleApprovalTotpCodeChange}
           />
         </GuardModalLayer>
       ) : null}
@@ -430,8 +398,8 @@ export function useGuardUpdate(options?: { onReconnected?: () => void; enabled?:
     });
   }, [scheduleAndWait, updateStatus]);
 
-  const onSetUpdateChannel = useCallback(async (channel: "stable" | "alpha") => {
-    setUpdateStatus(await setGuardUpdateChannel(channel));
+  const onSetUpdateChannel = useCallback(async (channel: "stable" | "alpha", proof?: GuardUpdateChannelProof) => {
+    setUpdateStatus(await setGuardUpdateChannel(channel, proof));
   }, []);
 
   return {

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -2,7 +2,8 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { buildGuardDaemonCandidatePorts, normalizeGuardUpdateStatus, updateReconnectSucceeded } from "./guard-api";
-import { AlphaChannelDialog, GuardUpdatePanel } from "./guard-update-panel";
+import { AlphaChannelDialog } from "./alpha-update-channel-dialog";
+import { GuardUpdatePanel } from "./guard-update-panel";
 
 function assert(condition: boolean, message: string): void {
   if (!condition) {
@@ -65,8 +66,13 @@ const alphaDialogMarkup = renderToStaticMarkup(
     useAlpha: false,
     pending: false,
     error: "Guard could not change the update channel. Try again.",
+    approvalGate: null,
+    approvalPassword: "",
+    approvalTotpCode: "",
     onClose: () => undefined,
     onConfirm: () => undefined,
+    onApprovalPasswordChange: () => undefined,
+    onApprovalTotpCodeChange: () => undefined,
   }),
 );
 assert(alphaDialogMarkup.includes("Try alpha updates"), "alpha dialog should explain the selected release channel");
@@ -79,12 +85,43 @@ const stableDialogMarkup = renderToStaticMarkup(
     useAlpha: true,
     pending: false,
     error: null,
+    approvalGate: null,
+    approvalPassword: "",
+    approvalTotpCode: "",
     onClose: () => undefined,
     onConfirm: () => undefined,
+    onApprovalPasswordChange: () => undefined,
+    onApprovalTotpCodeChange: () => undefined,
   }),
 );
 assert(stableDialogMarkup.includes("Return to stable updates"), "alpha users should be able to return to stable updates");
 assert(stableDialogMarkup.includes("Use stable updates"), "stable fallback should require explicit confirmation");
+
+const protectedAlphaDialogMarkup = renderToStaticMarkup(
+  createElement(AlphaChannelDialog, {
+    useAlpha: false,
+    pending: false,
+    error: null,
+    approvalGate: {
+      enabled: true,
+      configured: true,
+      cooldown_seconds: 0,
+      cooldown_active: false,
+      cooldown_expires_at: null,
+      locked_until: null,
+      fail_closed: false,
+      strict_all_decisions: false,
+      totp_enabled: true,
+    },
+    approvalPassword: "",
+    approvalTotpCode: "",
+    onClose: () => undefined,
+    onConfirm: () => undefined,
+    onApprovalPasswordChange: () => undefined,
+    onApprovalTotpCodeChange: () => undefined,
+  }),
+);
+assert(protectedAlphaDialogMarkup.includes("Authenticator code"), "protected alpha enrollment should collect a TOTP proof");
 
 const blocked = normalizeGuardUpdateStatus({
   auto_updatable: false,

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -560,10 +560,15 @@ def update_guard_settings(
     return load_guard_config(guard_home)
 
 
-def update_guard_update_channel(guard_home: Path, update_channel: object) -> GuardConfig:
+def update_guard_update_channel(
+    guard_home: Path,
+    update_channel: object,
+    *,
+    approval_gate_grant: ApprovalGateGrant | None = None,
+) -> GuardConfig:
     """Persist the local release channel selected from the update surface."""
 
-    require_settings_write(guard_home)
+    require_settings_write(guard_home, approval_gate_grant=approval_gate_grant)
     if not isinstance(update_channel, str) or update_channel not in VALID_UPDATE_CHANNELS:
         raise ValueError("Update channel must be stable or alpha.")
     current_config = load_guard_config(guard_home)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -4595,7 +4595,16 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     def _handle_update_channel(self, payload: dict[str, object]) -> None:
         guard_home = self.server.store.guard_home  # type: ignore[attr-defined]
         try:
-            update_guard_update_channel(guard_home, payload.get("update_channel"))
+            approval_gate_grant = require_high_risk(
+                guard_home,
+                purpose="settings_write",
+                approval_gate_input=approval_gate_input_from_mapping(payload),
+            )
+            update_guard_update_channel(
+                guard_home,
+                payload.get("update_channel"),
+                approval_gate_grant=approval_gate_grant,
+            )
         except ApprovalGateError as error:
             self._write_approval_gate_error(error)
             return

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -17963,7 +17963,7 @@ async function scheduleGuardUpdate(options) {
     error: stringValue$1(payload.error) ?? void 0
   };
 }
-async function setGuardUpdateChannel(channel) {
+async function setGuardUpdateChannel(channel, proof) {
   if (isGuardDemoMode()) {
     return normalizeGuardUpdateStatus({
       ...await fetchGuardUpdateStatus(),
@@ -17973,7 +17973,7 @@ async function setGuardUpdateChannel(channel) {
   const response = await fetchWithGuardAuth("/v1/update/channel", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ update_channel: channel })
+    body: JSON.stringify({ update_channel: channel, ...proof })
   });
   const payload = await response.json().catch(() => ({}));
   if (!response.ok) {
@@ -18531,6 +18531,181 @@ function ShellFooter() {
     )) })
   ] }) });
 }
+function approvalProofRequiresPassword(gate) {
+  return gate?.totp_enabled !== true;
+}
+function isApprovalProofSubmitDisabled(gate, credentials, busy) {
+  if (busy) {
+    return true;
+  }
+  if (approvalProofRequiresPassword(gate)) {
+    return credentials.approvalPassword.trim() === "";
+  }
+  return credentials.approvalTotpCode.trim() === "";
+}
+function buildApprovalProofCredentials(gate, credentials) {
+  if (approvalProofRequiresPassword(gate)) {
+    return { approval_password: credentials.approvalPassword };
+  }
+  return { approval_totp_code: credentials.approvalTotpCode };
+}
+function ApprovalProofFieldInputs(props) {
+  const needsPassword = approvalProofRequiresPassword(props.approvalGate);
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-3", children: needsPassword ? /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-semibold text-brand-dark", children: "Approval password" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "input",
+      {
+        ref: props.passwordRef,
+        type: "password",
+        autoComplete: "current-password",
+        value: props.approvalPassword,
+        onChange: props.onApprovalPasswordChange,
+        className: "mt-1 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+      }
+    )
+  ] }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-semibold text-brand-dark", children: "Authenticator code" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "input",
+      {
+        type: "text",
+        inputMode: "numeric",
+        pattern: "[0-9]*",
+        autoComplete: "one-time-code",
+        value: props.approvalTotpCode,
+        onChange: props.onApprovalTotpCodeChange,
+        className: "mt-1 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+      }
+    )
+  ] }) });
+}
+function ApprovalProofInline(props) {
+  const passwordRef = reactExports.useRef(null);
+  reactExports.useEffect(() => {
+    const timer = window.setTimeout(() => {
+      passwordRef.current?.focus();
+    }, 50);
+    return () => window.clearTimeout(timer);
+  }, []);
+  const submitDisabled = isApprovalProofSubmitDisabled(
+    props.approvalGate,
+    {
+      approvalPassword: props.approvalPassword,
+      approvalTotpCode: props.approvalTotpCode
+    },
+    props.submitBusy
+  );
+  const handleKeyDown = reactExports.useCallback(
+    (event) => {
+      if (event.key === "Enter" && !submitDisabled) {
+        event.preventDefault();
+        props.onSubmit();
+      }
+    },
+    [props.onSubmit, submitDisabled]
+  );
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-5", onKeyDown: handleKeyDown, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] px-4 py-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-blue/10", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniKey, { className: "h-5 w-5 text-brand-blue", "aria-hidden": "true" }) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-sm font-semibold text-brand-dark", children: "Approval proof required" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-slate-600", children: "Enter your local approval proof before Guard syncs supply-chain intel on this device." })
+      ] })
+    ] }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      ApprovalProofFieldInputs,
+      {
+        approvalGate: props.approvalGate,
+        approvalPassword: props.approvalPassword,
+        approvalTotpCode: props.approvalTotpCode,
+        passwordRef,
+        onApprovalPasswordChange: props.onApprovalPasswordChange,
+        onApprovalTotpCodeChange: props.onApprovalTotpCodeChange
+      }
+    ),
+    props.error !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-attention", role: "alert", children: props.error }) : null,
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-2 sm:flex-row sm:items-center", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "primary", onClick: props.onSubmit, disabled: submitDisabled, children: props.submitLabel }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: props.onBack, disabled: props.submitBusy, children: "Go back" })
+    ] })
+  ] });
+}
+function AlphaChannelDialog({
+  useAlpha,
+  pending,
+  error,
+  approvalGate,
+  approvalPassword,
+  approvalTotpCode,
+  onClose,
+  onConfirm,
+  onApprovalPasswordChange,
+  onApprovalTotpCodeChange
+}) {
+  const title = useAlpha ? "Return to stable updates" : "Try alpha updates";
+  const description = useAlpha ? "Stable updates receive the most thoroughly tested Guard releases. You can enable alpha updates again whenever you need early access." : "Alpha releases arrive before stable builds. They can include unfinished changes and may require a restart.";
+  const confirmLabel = useAlpha ? "Use stable updates" : "Enable alpha updates";
+  const confirmDisabled = pending || approvalGate?.enabled === true && isApprovalProofSubmitDisabled(approvalGate, { approvalPassword, approvalTotpCode }, false);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-lg bg-white shadow-xl", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start justify-between gap-4 border-b border-slate-100 px-5 py-4", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-base font-semibold text-brand-dark", children: title }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-brand-dark/70", children: description })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          type: "button",
+          onClick: onClose,
+          disabled: pending,
+          "aria-label": "Close update channel dialog",
+          className: "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-brand-dark/55 transition-colors hover:bg-slate-100 hover:text-brand-dark disabled:cursor-not-allowed disabled:opacity-50",
+          children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniXMark, { className: "h-5 w-5", "aria-hidden": "true" })
+        }
+      )
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3 px-5 py-4 text-sm leading-relaxed text-brand-dark/75", children: [
+      !useAlpha ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Guard will keep stable updates until you confirm this change. This does not install an update immediately." }) : null,
+      approvalGate?.enabled ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-lg border border-brand-blue/20 bg-brand-blue/[0.04] p-3", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mb-3 text-sm font-semibold text-brand-dark", children: "Confirm this channel change" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          ApprovalProofFieldInputs,
+          {
+            approvalGate,
+            approvalPassword,
+            approvalTotpCode,
+            onApprovalPasswordChange,
+            onApprovalTotpCodeChange
+          }
+        )
+      ] }) : null,
+      error ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "rounded-md bg-red-50 px-3 py-2 text-sm text-red-700", children: error }) : null
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col-reverse gap-2 border-t border-slate-100 px-5 py-4 sm:flex-row sm:justify-end", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          type: "button",
+          onClick: onClose,
+          disabled: pending,
+          className: "min-h-10 rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-brand-dark transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50",
+          children: "Cancel"
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          type: "button",
+          onClick: onConfirm,
+          disabled: confirmDisabled,
+          className: "min-h-10 rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-blue/90 disabled:cursor-not-allowed disabled:opacity-60",
+          children: pending ? "Saving…" : confirmLabel
+        }
+      )
+    ] })
+  ] });
+}
 var reactDomExports = requireReactDom();
 function getFocusableElements(container2) {
   const selector = [
@@ -18716,56 +18891,6 @@ function updateHelpCopy(status, phase) {
   }
   return null;
 }
-function AlphaChannelDialog({ useAlpha, pending, error, onClose, onConfirm }) {
-  const title = useAlpha ? "Return to stable updates" : "Try alpha updates";
-  const description = useAlpha ? "Stable updates receive the most thoroughly tested Guard releases. You can enable alpha updates again whenever you need early access." : "Alpha releases arrive before stable builds. They can include unfinished changes and may require a restart.";
-  const confirmLabel = useAlpha ? "Use stable updates" : "Enable alpha updates";
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-lg bg-white shadow-xl", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start justify-between gap-4 border-b border-slate-100 px-5 py-4", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-base font-semibold text-brand-dark", children: title }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-brand-dark/70", children: description })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "button",
-        {
-          type: "button",
-          onClick: onClose,
-          disabled: pending,
-          "aria-label": "Close update channel dialog",
-          className: "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-brand-dark/55 transition-colors hover:bg-slate-100 hover:text-brand-dark disabled:cursor-not-allowed disabled:opacity-50",
-          children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniXMark, { className: "h-5 w-5", "aria-hidden": "true" })
-        }
-      )
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3 px-5 py-4 text-sm leading-relaxed text-brand-dark/75", children: [
-      !useAlpha ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Guard will keep stable updates until you confirm this change. This does not install an update immediately." }) : null,
-      error ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "rounded-md bg-red-50 px-3 py-2 text-sm text-red-700", children: error }) : null
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col-reverse gap-2 border-t border-slate-100 px-5 py-4 sm:flex-row sm:justify-end", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "button",
-        {
-          type: "button",
-          onClick: onClose,
-          disabled: pending,
-          className: "min-h-10 rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-brand-dark transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50",
-          children: "Cancel"
-        }
-      ),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "button",
-        {
-          type: "button",
-          onClick: onConfirm,
-          disabled: pending,
-          className: "min-h-10 rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-blue/90 disabled:cursor-not-allowed disabled:opacity-60",
-          children: pending ? "Saving…" : confirmLabel
-        }
-      )
-    ] })
-  ] });
-}
 function GuardUpdatePanel(props) {
   const version = props.guardVersion ?? props.updateStatus?.current_version ?? null;
   const phase = props.updatePhase ?? "idle";
@@ -18777,10 +18902,14 @@ function GuardUpdatePanel(props) {
   const [alphaModalOpen, setAlphaModalOpen] = reactExports.useState(false);
   const [alphaSavePending, setAlphaSavePending] = reactExports.useState(false);
   const [alphaSaveError, setAlphaSaveError] = reactExports.useState(null);
+  const [alphaApprovalPassword, setAlphaApprovalPassword] = reactExports.useState("");
+  const [alphaApprovalTotpCode, setAlphaApprovalTotpCode] = reactExports.useState("");
   const targetChannel = useAlpha ? "stable" : "alpha";
   const modalTitle = useAlpha ? "Return to stable updates" : "Try alpha updates";
   const handleOpenAlphaModal = reactExports.useCallback(() => {
     setAlphaSaveError(null);
+    setAlphaApprovalPassword("");
+    setAlphaApprovalTotpCode("");
     setAlphaModalOpen(true);
   }, []);
   const handleCloseAlphaModal = reactExports.useCallback(() => {
@@ -18789,6 +18918,8 @@ function GuardUpdatePanel(props) {
     }
     setAlphaModalOpen(false);
     setAlphaSaveError(null);
+    setAlphaApprovalPassword("");
+    setAlphaApprovalTotpCode("");
   }, [alphaSavePending]);
   const handleConfirmAlphaChannel = reactExports.useCallback(async () => {
     if (!props.onSetUpdateChannel) {
@@ -18797,14 +18928,24 @@ function GuardUpdatePanel(props) {
     setAlphaSavePending(true);
     setAlphaSaveError(null);
     try {
-      await props.onSetUpdateChannel(targetChannel);
+      const proof = props.approvalGate?.enabled ? buildApprovalProofCredentials(props.approvalGate, {
+        approvalPassword: alphaApprovalPassword,
+        approvalTotpCode: alphaApprovalTotpCode
+      }) : void 0;
+      await props.onSetUpdateChannel(targetChannel, proof);
       setAlphaModalOpen(false);
-    } catch {
-      setAlphaSaveError("Guard could not change the update channel. Try again.");
+    } catch (error) {
+      setAlphaSaveError(error instanceof Error ? error.message : "Guard could not change the update channel. Try again.");
     } finally {
       setAlphaSavePending(false);
     }
-  }, [props.onSetUpdateChannel, targetChannel]);
+  }, [alphaApprovalPassword, alphaApprovalTotpCode, props.approvalGate, props.onSetUpdateChannel, targetChannel]);
+  const handleApprovalPasswordChange = reactExports.useCallback((event) => {
+    setAlphaApprovalPassword(event.target.value);
+  }, []);
+  const handleApprovalTotpCodeChange = reactExports.useCallback((event) => {
+    setAlphaApprovalTotpCode(event.target.value);
+  }, []);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: props.compact ? "space-y-1" : "space-y-2", children: [
     version ? /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "font-mono text-[10px] text-brand-dark/60", "aria-label": `Guard version ${version}`, children: [
       "v",
@@ -18856,8 +18997,13 @@ function GuardUpdatePanel(props) {
         useAlpha,
         pending: alphaSavePending,
         error: alphaSaveError,
+        approvalGate: props.approvalGate ?? null,
+        approvalPassword: alphaApprovalPassword,
+        approvalTotpCode: alphaApprovalTotpCode,
         onClose: handleCloseAlphaModal,
-        onConfirm: handleConfirmAlphaChannel
+        onConfirm: handleConfirmAlphaChannel,
+        onApprovalPasswordChange: handleApprovalPasswordChange,
+        onApprovalTotpCodeChange: handleApprovalTotpCodeChange
       }
     ) }) : null
   ] });
@@ -19008,8 +19154,8 @@ function useGuardUpdate(options) {
       expectedLatestVersion: null
     });
   }, [scheduleAndWait, updateStatus]);
-  const onSetUpdateChannel = reactExports.useCallback(async (channel) => {
-    setUpdateStatus(await setGuardUpdateChannel(channel));
+  const onSetUpdateChannel = reactExports.useCallback(async (channel, proof) => {
+    setUpdateStatus(await setGuardUpdateChannel(channel, proof));
   }, []);
   return {
     guardVersion: updateStatus?.current_version ?? null,
@@ -19378,7 +19524,8 @@ function ShellSidebar(props) {
               updatePhase: props.updatePhase,
               onUpdateGuard: props.onUpdateGuard,
               onReinstallGuard: props.onReinstallGuard,
-              onSetUpdateChannel: props.onSetUpdateChannel
+              onSetUpdateChannel: props.onSetUpdateChannel,
+              approvalGate: props.approvalGate
             }
           )
         ] }) }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col items-center gap-2", children: [
@@ -26995,106 +27142,6 @@ function requiresApprovalPasswordPrompt(cooldownActive, strictAllDecisions, sele
   }
   return strictAllDecisions;
 }
-function approvalProofRequiresPassword(gate) {
-  return gate?.totp_enabled !== true;
-}
-function isApprovalProofSubmitDisabled(gate, credentials, busy) {
-  if (busy) {
-    return true;
-  }
-  if (approvalProofRequiresPassword(gate)) {
-    return credentials.approvalPassword.trim() === "";
-  }
-  return credentials.approvalTotpCode.trim() === "";
-}
-function buildApprovalProofCredentials(gate, credentials) {
-  if (approvalProofRequiresPassword(gate)) {
-    return { approval_password: credentials.approvalPassword };
-  }
-  return { approval_totp_code: credentials.approvalTotpCode };
-}
-function ApprovalProofFieldInputs(props) {
-  const needsPassword = approvalProofRequiresPassword(props.approvalGate);
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-3", children: needsPassword ? /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-semibold text-brand-dark", children: "Approval password" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      "input",
-      {
-        ref: props.passwordRef,
-        type: "password",
-        autoComplete: "current-password",
-        value: props.approvalPassword,
-        onChange: props.onApprovalPasswordChange,
-        className: "mt-1 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-      }
-    )
-  ] }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-semibold text-brand-dark", children: "Authenticator code" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      "input",
-      {
-        type: "text",
-        inputMode: "numeric",
-        pattern: "[0-9]*",
-        autoComplete: "one-time-code",
-        value: props.approvalTotpCode,
-        onChange: props.onApprovalTotpCodeChange,
-        className: "mt-1 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-      }
-    )
-  ] }) });
-}
-function ApprovalProofInline(props) {
-  const passwordRef = reactExports.useRef(null);
-  reactExports.useEffect(() => {
-    const timer = window.setTimeout(() => {
-      passwordRef.current?.focus();
-    }, 50);
-    return () => window.clearTimeout(timer);
-  }, []);
-  const submitDisabled = isApprovalProofSubmitDisabled(
-    props.approvalGate,
-    {
-      approvalPassword: props.approvalPassword,
-      approvalTotpCode: props.approvalTotpCode
-    },
-    props.submitBusy
-  );
-  const handleKeyDown = reactExports.useCallback(
-    (event) => {
-      if (event.key === "Enter" && !submitDisabled) {
-        event.preventDefault();
-        props.onSubmit();
-      }
-    },
-    [props.onSubmit, submitDisabled]
-  );
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-5", onKeyDown: handleKeyDown, children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] px-4 py-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-blue/10", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniKey, { className: "h-5 w-5 text-brand-blue", "aria-hidden": "true" }) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-sm font-semibold text-brand-dark", children: "Approval proof required" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-slate-600", children: "Enter your local approval proof before Guard syncs supply-chain intel on this device." })
-      ] })
-    ] }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      ApprovalProofFieldInputs,
-      {
-        approvalGate: props.approvalGate,
-        approvalPassword: props.approvalPassword,
-        approvalTotpCode: props.approvalTotpCode,
-        passwordRef,
-        onApprovalPasswordChange: props.onApprovalPasswordChange,
-        onApprovalTotpCodeChange: props.onApprovalTotpCodeChange
-      }
-    ),
-    props.error !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-attention", role: "alert", children: props.error }) : null,
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-2 sm:flex-row sm:items-center", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "primary", onClick: props.onSubmit, disabled: submitDisabled, children: props.submitLabel }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: props.onBack, disabled: props.submitBusy, children: "Go back" })
-    ] })
-  ] });
-}
 function ApprovalPasswordModal(props) {
   const passwordRef = reactExports.useRef(null);
   const totpRef = reactExports.useRef(null);
@@ -29255,6 +29302,7 @@ function ApprovalCenterLayout(props) {
         onUpdateGuard,
         onReinstallGuard,
         onSetUpdateChannel,
+        approvalGate: props.approvalGate ?? null,
         cloudUserProfile: props.runtime.kind === "ready" ? props.runtime.snapshot.cloud_user_profile : null,
         workspaceId: props.runtime.kind === "ready" ? props.runtime.snapshot.cloud_pairing_state.workspace_id ?? null : null,
         planId: props.runtime.kind === "ready" ? props.runtime.snapshot.cloud_pairing_state.plan_id ?? null : null

--- a/tests/test_dashboard_update.py
+++ b/tests/test_dashboard_update.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
 from codex_plugin_scanner.guard.cli.update_commands import build_guard_update_status_payload
 from codex_plugin_scanner.guard.config import load_guard_config
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
@@ -135,15 +136,17 @@ def test_update_status_uses_persisted_alpha_channel(tmp_path: Path, monkeypatch:
     seen: dict[str, object] = {}
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.cli.update_commands._version_check_payload",
-        lambda current_version, **kwargs: seen.update(kwargs)
-        or {
-            "source": "pypi",
-            "release_channel": "alpha",
-            "status": "stale",
-            "current_version": current_version,
-            "latest_version": "1.2.4a1",
-            "update_available": True,
-        },
+        lambda current_version, **kwargs: (
+            seen.update(kwargs)
+            or {
+                "source": "pypi",
+                "release_channel": "alpha",
+                "status": "stale",
+                "current_version": current_version,
+                "latest_version": "1.2.4a1",
+                "update_available": True,
+            }
+        ),
     )
 
     payload = build_guard_update_status_payload(guard_home=guard_home)
@@ -272,6 +275,43 @@ def test_alpha_update_channel_persists_and_schedules_alpha(tmp_path: Path, monke
     assert payload["scheduled"] is True
     assert load_guard_config(store.guard_home).update_channel == "alpha"
     assert scheduled["include_alpha"] is True
+
+
+def test_alpha_update_channel_requires_and_accepts_approval_proof(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    update_approval_gate_settings(
+        store.guard_home,
+        {
+            "enabled": True,
+            "new_password": "test-approval-password",
+            "confirm_password": "test-approval-password",
+            "cooldown_seconds": 0,
+        },
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        missing_proof_status, missing_proof_payload = _post_json_body(
+            daemon,
+            "/v1/update/channel",
+            {"update_channel": "alpha"},
+        )
+        verified_status, verified_payload = _post_json_body(
+            daemon,
+            "/v1/update/channel",
+            {
+                "update_channel": "alpha",
+                "approval_password": "test-approval-password",
+            },
+        )
+    finally:
+        daemon.stop()
+
+    assert missing_proof_status == 403
+    assert missing_proof_payload["error"] == "approval_gate_required"
+    assert verified_status == 200
+    assert verified_payload["release_channel"] == "alpha"
+    assert load_guard_config(store.guard_home).update_channel == "alpha"
 
 
 def test_daemon_update_schedule_rejects_non_updatable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Collect the configured local approval proof before changing the update channel.
- Preserve approval-gate protection for alpha enrollment while returning precise errors.
- Update the reviewed test-size baseline for the protected endpoint regression test.

## Testing
- `cd dashboard && bun run test`
- `uv run --no-sync pytest -q tests/test_dashboard_update.py --tb=short`
- `cd dashboard && bun run build`
