### PR TITLE
fix(daemon): bound transport and preserve evidence

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
@@ -137,6 +137,7 @@ def record_post_hook_command_activity_best_effort(
     event: str,
     payload: Mapping[str, object],
     succeeded: bool,
+    raise_on_persistence_error: bool = False,
 ) -> bool:
     """Transition strong pairs or record a fact-minimal unpaired command post."""
 
@@ -180,6 +181,8 @@ def record_post_hook_command_activity_best_effort(
         return store.record_command_activity(evidence)
     except Exception:
         _record_persistence_failure(store, "post_record_failed")
+        if raise_on_persistence_error:
+            raise
         return False
 
 

--- a/src/codex_plugin_scanner/guard/daemon/runtime_hook_evidence_writer.py
+++ b/src/codex_plugin_scanner/guard/daemon/runtime_hook_evidence_writer.py
@@ -142,6 +142,7 @@ class RuntimeHookEvidenceWriter:
                             event=record.event,
                             payload=record.payload,
                             succeeded=record.succeeded,
+                            raise_on_persistence_error=True,
                         )
                 except Exception:
                     with self._condition:

--- a/src/codex_plugin_scanner/guard/daemon/runtime_hook_evidence_writer.py
+++ b/src/codex_plugin_scanner/guard/daemon/runtime_hook_evidence_writer.py
@@ -7,7 +7,7 @@ import threading
 from collections import deque
 from collections.abc import Mapping
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TypedDict, final
 
 from ..cli.commands_support_command_activity import record_post_hook_command_activity_best_effort
@@ -32,6 +32,7 @@ class _CommandActivityRecord:
     payload: dict[str, object]
     succeeded: bool
     payload_bytes: int
+    attempts: int = 0
 
 
 @final
@@ -121,10 +122,6 @@ class RuntimeHookEvidenceWriter:
 
     def stop(self, *, timeout_seconds: float = 1.0) -> bool:
         with self._condition:
-            if self._records:
-                self._dropped += len(self._records)
-                self._records.clear()
-                self._queued_bytes = 0
             self._stopping = True
             self._condition.notify_all()
         self._thread.join(timeout=max(0.0, timeout_seconds))
@@ -135,11 +132,7 @@ class RuntimeHookEvidenceWriter:
             batch = self._next_batch()
             if not batch:
                 return
-            for index, record in enumerate(batch):
-                with self._condition:
-                    if self._stopping:
-                        self._dropped += len(batch) - index
-                        return
+            for record in batch:
                 try:
                     with sqlite_connect_timeout_override(self._sqlite_timeout_seconds):
                         _ = record_post_hook_command_activity_best_effort(
@@ -153,9 +146,13 @@ class RuntimeHookEvidenceWriter:
                 except Exception:
                     with self._condition:
                         self._failures += 1
-                finally:
-                    with self._condition:
-                        self._processed += 1
+                        if record.attempts < 2:
+                            self._records.appendleft(replace(record, attempts=record.attempts + 1))
+                            self._queued_bytes += record.payload_bytes
+                            self._condition.notify()
+                            continue
+                with self._condition:
+                    self._processed += 1
 
     def _next_batch(self) -> list[_CommandActivityRecord]:
         with self._condition:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -6449,14 +6449,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "limit": daemon_server.request_capacity_limit,
                 "rejected": daemon_server.rejected_requests,
             }
-        if evidence_writer_stats["failures"]:
+        if evidence_writer_stats["failures"] and evidence_writer_stats["queued"]:
             load_state = "store-contended"
             load_detail = "Evidence persistence is retrying outside the security decision path."
-        elif (
-            scheduler_stats["expired"]
-            or process_scheduler_stats["expired"]
-            or daemon_server.rejected_hook_requests
-        ):
+        elif scheduler_stats["expired"] or process_scheduler_stats["expired"] or daemon_server.rejected_hook_requests:
             load_state = "saturated"
             load_detail = "Secure review capacity was exhausted; recovery is automatic as load falls."
         elif scheduler_stats["queued"] or process_scheduler_stats["queued"]:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -20,7 +20,6 @@ import time
 import uuid
 import webbrowser
 from collections.abc import Mapping
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -381,7 +380,6 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
     runtime_hook_scheduler: RuntimeHookScheduler
     runtime_hook_process_scheduler: RuntimeHookScheduler
     runtime_hook_evidence_writer: RuntimeHookEvidenceWriter
-    connection_executor: ThreadPoolExecutor
     request_capacity: threading.BoundedSemaphore
     request_capacity_limit: int
     connection_capacity: threading.BoundedSemaphore
@@ -411,9 +409,6 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
         super().handle_error(cast(socket.socket, request), client_address)
 
     def server_close(self) -> None:
-        executor = getattr(self, "connection_executor", None)
-        if executor is not None:
-            executor.shutdown(wait=True, cancel_futures=True)
         writer = getattr(self, "runtime_hook_evidence_writer", None)
         if writer is not None:
             _ = writer.stop(timeout_seconds=1.0)
@@ -468,10 +463,6 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
         self.runtime_hook_scheduler = RuntimeHookScheduler(
             active_limit=_MAX_CONCURRENT_RUNTIME_HOOKS,
             per_harness_active_limit=_MAX_CONCURRENT_RUNTIME_HOOKS_PER_HARNESS,
-        )
-        self.connection_executor = ThreadPoolExecutor(
-            max_workers=_MAX_CONCURRENT_DAEMON_CONNECTIONS,
-            thread_name_prefix="hol-guard-http",
         )
         self.runtime_hook_process_scheduler = RuntimeHookScheduler(
             active_limit=0,
@@ -533,11 +524,7 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
         with self.request_capacity_lock:
             self.active_requests += 1
         try:
-            _ = self.connection_executor.submit(
-                self.process_request_thread,
-                request_socket,
-                client_address,
-            )
+            super().process_request(request_socket, client_address)
         except BaseException:
             self._release_request_capacity(request_socket)
             raise

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -20,6 +20,7 @@ import time
 import uuid
 import webbrowser
 from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -378,6 +379,7 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
     hook_capacity_lock: threading.Lock
     runtime_hook_scheduler: RuntimeHookScheduler
     runtime_hook_evidence_writer: RuntimeHookEvidenceWriter
+    connection_executor: ThreadPoolExecutor
     request_capacity: threading.BoundedSemaphore
     request_capacity_limit: int
     connection_capacity: threading.BoundedSemaphore
@@ -407,6 +409,9 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
         super().handle_error(cast(socket.socket, request), client_address)
 
     def server_close(self) -> None:
+        executor = getattr(self, "connection_executor", None)
+        if executor is not None:
+            executor.shutdown(wait=True, cancel_futures=True)
         writer = getattr(self, "runtime_hook_evidence_writer", None)
         if writer is not None:
             _ = writer.stop(timeout_seconds=1.0)
@@ -462,6 +467,10 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
             active_limit=_MAX_CONCURRENT_RUNTIME_HOOKS,
             per_harness_active_limit=_MAX_CONCURRENT_RUNTIME_HOOKS_PER_HARNESS,
         )
+        self.connection_executor = ThreadPoolExecutor(
+            max_workers=_MAX_CONCURRENT_DAEMON_CONNECTIONS,
+            thread_name_prefix="hol-guard-http",
+        )
         self.request_capacity_limit = _MAX_CONCURRENT_DAEMON_REQUESTS
         self.request_capacity = threading.BoundedSemaphore(self.request_capacity_limit)
         self.connection_capacity_limit = _MAX_CONCURRENT_DAEMON_CONNECTIONS
@@ -516,7 +525,11 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
         with self.request_capacity_lock:
             self.active_requests += 1
         try:
-            super().process_request(request_socket, client_address)
+            _ = self.connection_executor.submit(
+                self.process_request_thread,
+                request_socket,
+                client_address,
+            )
         except BaseException:
             self._release_request_capacity(request_socket)
             raise
@@ -6397,6 +6410,18 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "limit": daemon_server.request_capacity_limit,
                 "rejected": daemon_server.rejected_requests,
             }
+        if evidence_writer_stats["failures"]:
+            load_state = "store-contended"
+            load_detail = "Evidence persistence is retrying outside the security decision path."
+        elif scheduler_stats["expired"] or daemon_server.rejected_hook_requests:
+            load_state = "saturated"
+            load_detail = "Secure review capacity was exhausted; recovery is automatic as load falls."
+        elif scheduler_stats["queued"]:
+            load_state = "backlogged"
+            load_detail = "Queued reviews are draining automatically."
+        else:
+            load_state = "healthy"
+            load_detail = "Review capacity is available."
         return {
             "ok": True,
             "receipts": len(store.list_receipts(limit=500)),
@@ -6421,6 +6446,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "schema_version": activity_health.schema_version,
             },
             "hook_capacity": hook_capacity,
+            "hook_load": {
+                "state": load_state,
+                "detail": load_detail,
+            },
             "hook_workers": daemon_server.hook_process_runner.stats(),
             "request_capacity": request_capacity,
         }

--- a/tests/test_guard_runtime_hook_evidence_writer.py
+++ b/tests/test_guard_runtime_hook_evidence_writer.py
@@ -112,6 +112,7 @@ def test_writer_stops_with_bounded_sqlite_contention(tmp_path: Path) -> None:
         started = time.monotonic()
         assert writer.stop(timeout_seconds=1)
         assert time.monotonic() - started < 0.5
+        assert writer.stats()["failures"] == 3
     finally:
         lock.rollback()
         lock.close()


### PR DESCRIPTION
## Summary

- run accepted daemon connections through a bounded executor
- drain queued hook evidence during orderly shutdown
- retry transient evidence persistence outside security-decision workers
- expose actionable hook load states in detailed health

## Testing

- `uv run --no-sync pytest -q tests/test_guard_surface_server.py::TestGuardSurfaceServer::test_guard_daemon_hook_queue_bytes_fail_closed_and_reports_health tests/test_guard_runtime_hook_evidence_writer.py tests/test_guard_daemon_adversarial_transport.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/daemon/runtime_hook_evidence_writer.py src/codex_plugin_scanner/guard/daemon/server.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/daemon/runtime_hook_evidence_writer.py src/codex_plugin_scanner/guard/daemon/server.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/daemon/runtime_hook_evidence_writer.py src/codex_plugin_scanner/guard/daemon/server.py`
