### PR TITLE
test(guard): reject unknown pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM", "RUF"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
-addopts = ["-m", "not slow"]
+addopts = ["--strict-markers", "-m", "not slow"]
 markers = [
   "adapter_contract: verifies the shared security contract for a harness adapter",
   "daemon_aibom_refresh: enables the daemon AIBOM refresh worker for focused tests",


### PR DESCRIPTION
## Summary

- enable pytest strict-marker validation for every test invocation
- make unknown or misspelled execution-tier markers fail at collection time

## Evidence

- `uv run --no-sync pytest --collect-only -q`
- `uv run --no-sync pytest tests/test_pytest_config_semantics.py -q --tb=short`
