### PR TITLE
test(guard): consolidate GitHub capability corpus

### DIFF
--- a/scripts/ci/test_inventory.py
+++ b/scripts/ci/test_inventory.py
@@ -151,7 +151,7 @@ def corpus_record_count() -> int:
     )
     from tests.test_guard_command_specialized_variants import SPECIALIZED_SAFE_VARIANT_CASES
     from tests.test_guard_data_flow import BENIGN_DATA_FLOW_CASES, MALICIOUS_DATA_FLOW_CASES
-    from tests.test_guard_github_command_capabilities import GITHUB_REVIEW_FLOORS
+    from tests.test_guard_github_command_capabilities import GITHUB_CAPABILITY_CASES, GITHUB_REVIEW_FLOORS
     from tests.test_guard_github_command_capability_edges import (
         PR_MERGE_ADMIN_CAPABILITY_CASES,
         UNRELATED_DYNAMIC_COMMAND_CASES,
@@ -175,6 +175,7 @@ def corpus_record_count() -> int:
         + len(CRITICAL_COMMAND_FLOORS)
         + len(CRITICAL_NEAR_MISS_COMMANDS)
         + len(GITHUB_REVIEW_FLOORS)
+        + len(GITHUB_CAPABILITY_CASES)
         + len(PR_MERGE_ADMIN_CAPABILITY_CASES)
         + len(UNRELATED_DYNAMIC_COMMAND_CASES)
         + len(SPECIALIZED_SAFE_VARIANT_CASES)

--- a/tests/test_guard_github_command_capabilities.py
+++ b/tests/test_guard_github_command_capabilities.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from hashlib import sha256
 from pathlib import Path
-from typing import Final
 
 import pytest
 
@@ -48,271 +47,273 @@ def test_static_markdown_pr_edit_body_file_operand_rejects_unbounded_edit(args: 
     assert static_markdown_pr_edit_body_file_operand(args) is None
 
 
-@pytest.mark.parametrize(
-    ("args", "capability", "reason_code"),
+GITHUB_CAPABILITY_CASES = (
+    (("pr", "view", "17"), "read_remote", "github.command.proven-read"),
     (
-        (("pr", "view", "17"), "read_remote", "github.command.proven-read"),
-        (
-            ("pr", "create", "--title", "Ready", "--body", "Static summary"),
-            "propose_remote",
-            "github.command.pr-proposal",
-        ),
-        (
-            ("pr", "create", "--title", "Ready", "--body", "- Added focused coverage"),
-            "propose_remote",
-            "github.command.pr-proposal",
-        ),
-        (("pr", "create", "--title", "Ready"), "content_remote", "github.command.content-mutation"),
-        (("pr", "create", "--fill"), "content_remote", "github.command.content-mutation"),
-        (("pr", "create", "-f"), "content_remote", "github.command.content-mutation"),
-        (
-            ("pr", "create", "--title", "Ready", "--body", "Static", "-df"),
-            "content_remote",
-            "github.command.content-mutation",
-        ),
-        (("pr", "create", "-e"), "content_remote", "github.command.content-mutation"),
-        (("pr", "create", "--recover", "input"), "content_remote", "github.command.content-mutation"),
-        (("pr", "create", "--web"), "content_remote", "github.command.content-mutation"),
-        (("pr", "create", "-w"), "content_remote", "github.command.content-mutation"),
-        (("pr", "create", "--body-file", "body.md"), "content_remote", "github.command.content-mutation"),
-        (("pr", "create", "-Fbody.md"), "content_remote", "github.command.content-mutation"),
-        (("pr", "create", "--template", "body.md"), "content_remote", "github.command.content-mutation"),
-        (("pr", "create", "--template=body.md"), "content_remote", "github.command.content-mutation"),
-        (("pr", "create", "-Tbody.md"), "content_remote", "github.command.content-mutation"),
-        (("issue", "list"), "read_remote", "github.command.proven-read"),
-        (("auth", "status"), "read_local", "github.command.local-auth-read"),
-        (("auth", "token"), "secret_remote", "github.command.auth-token-read"),
-        (("auth", "status", "--show-token"), "secret_remote", "github.command.auth-token-read"),
-        (("auth", "status", "-t"), "secret_remote", "github.command.auth-token-read"),
-        (("ssh-key", "list"), "read_remote", "github.command.proven-access-read"),
-        (("gpg-key", "list"), "read_remote", "github.command.proven-access-read"),
-        (("ssh-key", "delete", "123"), "access_remote", "github.command.access-mutation"),
-        (("run", "cancel", "--help"), "workflow_remote", "github.command.workflow-mutation"),
-        (
-            ("--repo", "example/project", "workflow", "view", "release.yml"),
-            "read_remote",
-            "github.command.proven-read",
-        ),
-        (("api", "repos/example/project"), "read_remote", "github.api.proven-get"),
-        (
-            ("api", "repos/example/project", "-X", "GET", "-f", "per_page=1"),
-            "read_remote",
-            "github.api.proven-get",
-        ),
-        (
-            ("api", "graphql", "-f", "query=query { viewer { login } }"),
-            "read_remote",
-            "github.graphql.proven-query",
-        ),
-        (
-            (
-                "api",
-                "graphql",
-                "-f",
-                'query=query($owner:String!){repository(owner:$owner,name:"project"){pullRequests(last:100){nodes{number}}}}',
-                "-f",
-                "owner=example",
-                "--jq",
-                "[.data.repository.pullRequests.nodes[] | .number as $n | {number:$n}]",
-            ),
-            "read_remote",
-            "github.graphql.proven-query",
-        ),
-        (
-            (
-                "api",
-                "graphql",
-                "-f",
-                "query=mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id}}}",
-                "-f",
-                "threadId=PRRT_example",
-            ),
-            "maintain_remote",
-            "github.graphql.maintain",
-        ),
-        (("pr", "merge", "17", "--squash", "--delete-branch"), "delete_remote", "github.command.pr-merge"),
-        (("pr", "merge", "17", "--admin"), "admin_merge_remote", "github.command.pr-admin-merge"),
-        (("pr", "edit", "17", "--title", "updated"), "content_remote", "github.command.content-mutation"),
-        (("issue", "close", "17"), "content_remote", "github.command.content-mutation"),
-        (("issue", "delete", "17"), "delete_remote", "github.command.delete-mutation"),
-        (("cache", "delete", "123"), "delete_remote", "github.command.delete-mutation"),
-        (("release", "create", "v1.2.3"), "publish_remote", "github.command.release-publication"),
-        (("release", "delete", "v1.2.3"), "delete_remote", "github.command.delete-mutation"),
-        (("repo", "edit", "--visibility", "private"), "access_remote", "github.command.repository-access-mutation"),
-        (("repo", "sync", "--force"), "force_remote", "github.command.force-mutation"),
-        (("secret", "set", "TOKEN"), "secret_remote", "github.command.secret-mutation"),
-        (
-            ("api", "repos/example/project", "-f", "name=updated"),
-            "mutate_remote",
-            "github.api.mutate",
-        ),
-        (
-            ("api", "repos/example/project", "-X", "PATCH", "-f", "visibility=private"),
-            "access_remote",
-            "github.api.access",
-        ),
-        (
-            ("api", "graphql", "-f", "query=mutation { updateThing(input: {}) { id } }"),
-            "mutate_remote",
-            "github.graphql.mutate",
-        ),
-        (
-            ("api", "graphql", "-f", "query=mutation { closeIssue(input: {}) { issue { id } } }"),
-            "content_remote",
-            "github.graphql.content",
-        ),
-        (
-            (
-                "api",
-                "graphql",
-                "-f",
-                _text(
-                    'query=fragment Maint on Mutation { resolveReviewThread(input: {threadId: "T_1"}) ',
-                    '{ thread { id } } } mutation { deleteRepository(input: {repositoryId: "R_1"}) ',
-                    "{ repository { id } } }",
-                ),
-            ),
-            "mutate_remote",
-            "github.graphql.remote-mutation",
-        ),
-        (
-            ("api", "graphql", "-f", "query=subscription { eventStream { id } }"),
-            "mutate_remote",
-            "github.graphql.remote-mutation",
-        ),
-        (
-            ("api", "repos/example/project", "-X", "DELETE"),
-            "delete_remote",
-            "github.api.delete",
-        ),
-        (
-            ("api", "repos/example/project/git/refs/heads/main", "-X", "PATCH", "-f", "force=true"),
-            "force_remote",
-            "github.api.force",
-        ),
-        (
-            (
-                "api",
-                "repos/example/project/contents/.github/workflows/ci.yml",
-                "-X",
-                "PUT",
-                "-f",
-                "message=update workflow",
-                "-f",
-                "content=ZWNobyBvaw==",
-            ),
-            "workflow_remote",
-            "github.api.workflow",
-        ),
-        (
-            ("api", "graphql", "-f", "query=mutation { updateRepository(input: {}) { repository { id } } }"),
-            "access_remote",
-            "github.graphql.access",
-        ),
-        (
-            ("api", "graphql", "-f", "query=mutation { createDeployKey(input: {}) { clientMutationId } }"),
-            "access_remote",
-            "github.graphql.access",
-        ),
-        (
-            ("api", "graphql", "-f", "query=mutation { createRef(input: {}) { ref { id } } }"),
-            "mutate_remote",
-            "github.graphql.mutate",
-        ),
-        (
-            ("api", "graphql", "-f", "query=mutation { deleteIssue(input: {}) { clientMutationId } }"),
-            "delete_remote",
-            "github.graphql.delete",
-        ),
-        (
-            (
-                "api",
-                "graphql",
-                "-f",
-                "query=mutation { removeOutsideCollaborator(input: {}) { clientMutationId } }",
-            ),
-            "access_remote",
-            "github.graphql.mixed-mutation",
-        ),
-        (
-            ("api", "repos/example/project/issues/comments/123", "-X", "DELETE"),
-            "delete_remote",
-            "github.api.mixed-mutation",
-        ),
-        (
-            ("api", "orgs/example/memberships/alice", "-X", "PUT", "-f", "role=admin"),
-            "access_remote",
-            "github.api.access",
-        ),
-        (
-            ("api", "repos/example/project/pages", "-X", "POST", "-f", "source=main"),
-            "mutate_remote",
-            "github.api.mutate",
-        ),
-        (
-            ("api", "repos/example/project/actions/runners/registration-token", "-X", "POST"),
-            "secret_remote",
-            "github.api.secret",
-        ),
-        (
-            ("api", "repos/example/project/actions/runs/123/rerun", "-X", "POST"),
-            "workflow_remote",
-            "github.api.workflow",
-        ),
-        (
-            ("api", "repos/example/project/issues/17/lock", "-X", "PUT"),
-            "maintain_remote",
-            "github.api.maintain",
-        ),
-        (
-            ("api", "repos/example/project/issues/17/lock", "-X", "DELETE"),
-            "maintain_remote",
-            "github.api.maintain",
-        ),
-        (
-            ("api", "repos/example/project/issues/17/lock", "-X", "POST"),
-            "mutate_remote",
-            "github.api.mutate",
-        ),
-        (
-            ("api", "repos/example/project/issues/17/lock", "-X", "PATCH"),
-            "mutate_remote",
-            "github.api.mutate",
-        ),
-        (
-            ("api", "repos/example/project/actions/threads/17/resolve", "-X", "POST"),
-            "mutate_remote",
-            "github.api.mutate",
-        ),
-        (
-            (
-                "api",
-                "graphql",
-                "-f",
-                _text(
-                    'query=mutation { resolveReviewThread(input: {threadId: "T_1"}) { thread { id } } ',
-                    'deleteRepository(input: {repositoryId: "R_1"}) { repository { id } } }',
-                ),
-            ),
-            "access_remote",
-            "github.graphql.mixed-mutation",
-        ),
-        (("api", "graphql", "--input", "-"), "unknown", "github.api.input-body"),
-        (
-            ("api", "repos/example/project/issues/17/comments", "-X", "POST", "-F", "body=@body.md"),
-            "unknown",
-            "github.api.external-field-value",
-        ),
-        (("project-alias",), "unknown", "github.command.extension-or-alias"),
+        ("pr", "create", "--title", "Ready", "--body", "Static summary"),
+        "propose_remote",
+        "github.command.pr-proposal",
     ),
+    (
+        ("pr", "create", "--title", "Ready", "--body", "- Added focused coverage"),
+        "propose_remote",
+        "github.command.pr-proposal",
+    ),
+    (("pr", "create", "--title", "Ready"), "content_remote", "github.command.content-mutation"),
+    (("pr", "create", "--fill"), "content_remote", "github.command.content-mutation"),
+    (("pr", "create", "-f"), "content_remote", "github.command.content-mutation"),
+    (
+        ("pr", "create", "--title", "Ready", "--body", "Static", "-df"),
+        "content_remote",
+        "github.command.content-mutation",
+    ),
+    (("pr", "create", "-e"), "content_remote", "github.command.content-mutation"),
+    (("pr", "create", "--recover", "input"), "content_remote", "github.command.content-mutation"),
+    (("pr", "create", "--web"), "content_remote", "github.command.content-mutation"),
+    (("pr", "create", "-w"), "content_remote", "github.command.content-mutation"),
+    (("pr", "create", "--body-file", "body.md"), "content_remote", "github.command.content-mutation"),
+    (("pr", "create", "-Fbody.md"), "content_remote", "github.command.content-mutation"),
+    (("pr", "create", "--template", "body.md"), "content_remote", "github.command.content-mutation"),
+    (("pr", "create", "--template=body.md"), "content_remote", "github.command.content-mutation"),
+    (("pr", "create", "-Tbody.md"), "content_remote", "github.command.content-mutation"),
+    (("issue", "list"), "read_remote", "github.command.proven-read"),
+    (("auth", "status"), "read_local", "github.command.local-auth-read"),
+    (("auth", "token"), "secret_remote", "github.command.auth-token-read"),
+    (("auth", "status", "--show-token"), "secret_remote", "github.command.auth-token-read"),
+    (("auth", "status", "-t"), "secret_remote", "github.command.auth-token-read"),
+    (("ssh-key", "list"), "read_remote", "github.command.proven-access-read"),
+    (("gpg-key", "list"), "read_remote", "github.command.proven-access-read"),
+    (("ssh-key", "delete", "123"), "access_remote", "github.command.access-mutation"),
+    (("run", "cancel", "--help"), "workflow_remote", "github.command.workflow-mutation"),
+    (
+        ("--repo", "example/project", "workflow", "view", "release.yml"),
+        "read_remote",
+        "github.command.proven-read",
+    ),
+    (("api", "repos/example/project"), "read_remote", "github.api.proven-get"),
+    (
+        ("api", "repos/example/project", "-X", "GET", "-f", "per_page=1"),
+        "read_remote",
+        "github.api.proven-get",
+    ),
+    (
+        ("api", "graphql", "-f", "query=query { viewer { login } }"),
+        "read_remote",
+        "github.graphql.proven-query",
+    ),
+    (
+        (
+            "api",
+            "graphql",
+            "-f",
+            'query=query($owner:String!){repository(owner:$owner,name:"project"){pullRequests(last:100){nodes{number}}}}',
+            "-f",
+            "owner=example",
+            "--jq",
+            "[.data.repository.pullRequests.nodes[] | .number as $n | {number:$n}]",
+        ),
+        "read_remote",
+        "github.graphql.proven-query",
+    ),
+    (
+        (
+            "api",
+            "graphql",
+            "-f",
+            "query=mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id}}}",
+            "-f",
+            "threadId=PRRT_example",
+        ),
+        "maintain_remote",
+        "github.graphql.maintain",
+    ),
+    (("pr", "merge", "17", "--squash", "--delete-branch"), "delete_remote", "github.command.pr-merge"),
+    (("pr", "merge", "17", "--admin"), "admin_merge_remote", "github.command.pr-admin-merge"),
+    (("pr", "edit", "17", "--title", "updated"), "content_remote", "github.command.content-mutation"),
+    (("issue", "close", "17"), "content_remote", "github.command.content-mutation"),
+    (("issue", "delete", "17"), "delete_remote", "github.command.delete-mutation"),
+    (("cache", "delete", "123"), "delete_remote", "github.command.delete-mutation"),
+    (("release", "create", "v1.2.3"), "publish_remote", "github.command.release-publication"),
+    (("release", "delete", "v1.2.3"), "delete_remote", "github.command.delete-mutation"),
+    (("repo", "edit", "--visibility", "private"), "access_remote", "github.command.repository-access-mutation"),
+    (("repo", "sync", "--force"), "force_remote", "github.command.force-mutation"),
+    (("secret", "set", "TOKEN"), "secret_remote", "github.command.secret-mutation"),
+    (
+        ("api", "repos/example/project", "-f", "name=updated"),
+        "mutate_remote",
+        "github.api.mutate",
+    ),
+    (
+        ("api", "repos/example/project", "-X", "PATCH", "-f", "visibility=private"),
+        "access_remote",
+        "github.api.access",
+    ),
+    (
+        ("api", "graphql", "-f", "query=mutation { updateThing(input: {}) { id } }"),
+        "mutate_remote",
+        "github.graphql.mutate",
+    ),
+    (
+        ("api", "graphql", "-f", "query=mutation { closeIssue(input: {}) { issue { id } } }"),
+        "content_remote",
+        "github.graphql.content",
+    ),
+    (
+        (
+            "api",
+            "graphql",
+            "-f",
+            _text(
+                'query=fragment Maint on Mutation { resolveReviewThread(input: {threadId: "T_1"}) ',
+                '{ thread { id } } } mutation { deleteRepository(input: {repositoryId: "R_1"}) ',
+                "{ repository { id } } }",
+            ),
+        ),
+        "mutate_remote",
+        "github.graphql.remote-mutation",
+    ),
+    (
+        ("api", "graphql", "-f", "query=subscription { eventStream { id } }"),
+        "mutate_remote",
+        "github.graphql.remote-mutation",
+    ),
+    (
+        ("api", "repos/example/project", "-X", "DELETE"),
+        "delete_remote",
+        "github.api.delete",
+    ),
+    (
+        ("api", "repos/example/project/git/refs/heads/main", "-X", "PATCH", "-f", "force=true"),
+        "force_remote",
+        "github.api.force",
+    ),
+    (
+        (
+            "api",
+            "repos/example/project/contents/.github/workflows/ci.yml",
+            "-X",
+            "PUT",
+            "-f",
+            "message=update workflow",
+            "-f",
+            "content=ZWNobyBvaw==",
+        ),
+        "workflow_remote",
+        "github.api.workflow",
+    ),
+    (
+        ("api", "graphql", "-f", "query=mutation { updateRepository(input: {}) { repository { id } } }"),
+        "access_remote",
+        "github.graphql.access",
+    ),
+    (
+        ("api", "graphql", "-f", "query=mutation { createDeployKey(input: {}) { clientMutationId } }"),
+        "access_remote",
+        "github.graphql.access",
+    ),
+    (
+        ("api", "graphql", "-f", "query=mutation { createRef(input: {}) { ref { id } } }"),
+        "mutate_remote",
+        "github.graphql.mutate",
+    ),
+    (
+        ("api", "graphql", "-f", "query=mutation { deleteIssue(input: {}) { clientMutationId } }"),
+        "delete_remote",
+        "github.graphql.delete",
+    ),
+    (
+        (
+            "api",
+            "graphql",
+            "-f",
+            "query=mutation { removeOutsideCollaborator(input: {}) { clientMutationId } }",
+        ),
+        "access_remote",
+        "github.graphql.mixed-mutation",
+    ),
+    (
+        ("api", "repos/example/project/issues/comments/123", "-X", "DELETE"),
+        "delete_remote",
+        "github.api.mixed-mutation",
+    ),
+    (
+        ("api", "orgs/example/memberships/alice", "-X", "PUT", "-f", "role=admin"),
+        "access_remote",
+        "github.api.access",
+    ),
+    (
+        ("api", "repos/example/project/pages", "-X", "POST", "-f", "source=main"),
+        "mutate_remote",
+        "github.api.mutate",
+    ),
+    (
+        ("api", "repos/example/project/actions/runners/registration-token", "-X", "POST"),
+        "secret_remote",
+        "github.api.secret",
+    ),
+    (
+        ("api", "repos/example/project/actions/runs/123/rerun", "-X", "POST"),
+        "workflow_remote",
+        "github.api.workflow",
+    ),
+    (
+        ("api", "repos/example/project/issues/17/lock", "-X", "PUT"),
+        "maintain_remote",
+        "github.api.maintain",
+    ),
+    (
+        ("api", "repos/example/project/issues/17/lock", "-X", "DELETE"),
+        "maintain_remote",
+        "github.api.maintain",
+    ),
+    (
+        ("api", "repos/example/project/issues/17/lock", "-X", "POST"),
+        "mutate_remote",
+        "github.api.mutate",
+    ),
+    (
+        ("api", "repos/example/project/issues/17/lock", "-X", "PATCH"),
+        "mutate_remote",
+        "github.api.mutate",
+    ),
+    (
+        ("api", "repos/example/project/actions/threads/17/resolve", "-X", "POST"),
+        "mutate_remote",
+        "github.api.mutate",
+    ),
+    (
+        (
+            "api",
+            "graphql",
+            "-f",
+            _text(
+                'query=mutation { resolveReviewThread(input: {threadId: "T_1"}) { thread { id } } ',
+                'deleteRepository(input: {repositoryId: "R_1"}) { repository { id } } }',
+            ),
+        ),
+        "access_remote",
+        "github.graphql.mixed-mutation",
+    ),
+    (("api", "graphql", "--input", "-"), "unknown", "github.api.input-body"),
+    (
+        ("api", "repos/example/project/issues/17/comments", "-X", "POST", "-F", "body=@body.md"),
+        "unknown",
+        "github.api.external-field-value",
+    ),
+    (("project-alias",), "unknown", "github.command.extension-or-alias"),
 )
-def test_classify_github_cli_capabilities(
-    args: tuple[str, ...], capability: GitHubCommandCapability, reason_code: str
-) -> None:
-    assessment = classify_github_cli(args)
+def test_classify_github_cli_capabilities() -> None:
+    failures: list[str] = []
+    for args, capability, reason_code in GITHUB_CAPABILITY_CASES:
+        assessment = classify_github_cli(args)
+        case_id = sha256("\0".join(args).encode()).hexdigest()[:12]
+        if assessment.capability != capability or assessment.reason_code != reason_code:
+            failures.append(
+                f"github-capability-{case_id}: {args!r}; expected=({capability!r}, {reason_code!r}); "
+                f"actual=({assessment.capability!r}, {assessment.reason_code!r})"
+            )
 
-    assert assessment.capability == capability
-    assert assessment.reason_code == reason_code
+    assert not failures, "\n".join(failures)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- consolidate the GitHub CLI capability contract into one complete, aggregate corpus
- preserve all 70 capability and reason-code cases with stable command-derived diagnostics
- register corpus records with the CI inventory so test-count reduction cannot hide coverage

## Verification

- `uv run --no-sync ruff check tests/test_guard_github_command_capabilities.py scripts/ci/test_inventory.py`
- `uv run --no-sync pytest tests/test_guard_github_command_capabilities.py tests/test_ci_test_inventory.py -q --tb=short -k 'classify_github_cli_capabilities or ci_test_inventory'`
- `uv run --with pytest python scripts/ci/test_inventory.py --output /tmp/github-capability-corpus-inventory.json`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory /tmp/github-capability-corpus-inventory.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded GitHub command capability coverage with a centralized set of classification cases.
  * Improved test failure reporting with deterministic case identifiers and detailed mismatch summaries.
  * Updated corpus record tracking to include the additional GitHub capability test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->