### PR TITLE
test(guard): stabilize headless approval resume

### DIFF
--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12470,7 +12470,7 @@ def test_guard_run_headless_waits_for_local_approval_and_resumes(tmp_path, capsy
 def test_guard_run_headless_redetects_before_persisted_resume(tmp_path, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
-    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 1\n")
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 5\n")
 
     store = GuardStore(home_dir)
     baseline = GuardArtifact(
@@ -12535,6 +12535,16 @@ def test_guard_run_headless_redetects_before_persisted_resume(tmp_path, monkeypa
     call_count = {"detect": 0}
     monkeypatch.setattr(
         guard_commands_module, "schedule_guard_daemon_ensure", lambda _guard_home, **_kwargs: "http://127.0.0.1:4455"
+    )
+
+    class FailingDaemonClient:
+        def start_session(self, **_kwargs):
+            raise RuntimeError("Guard daemon request failed: timed out")
+
+    monkeypatch.setattr(
+        guard_commands_module,
+        "load_guard_surface_daemon_client",
+        lambda _guard_home: FailingDaemonClient(),
     )
     monkeypatch.setattr(
         guard_runner_module.subprocess,


### PR DESCRIPTION
## Summary

- make the persisted headless-approval test independent of an ambient daemon
- align its configured approval wait with its resolver contract
- retain the redetection-before-resume behavior while removing CI timing flakiness

## Verification

- `uv run --no-sync ruff check tests/test_guard_runtime.py`
- five sequential runs of `uv run --no-sync pytest tests/test_guard_runtime.py::test_guard_run_headless_redetects_before_persisted_resume -q --tb=short`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for headless runtime behavior when session startup times out.
  * Extended test configuration and daemon-client simulation to verify reliable recovery before resuming persisted sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->