### PR TITLE
test(guard): consolidate action lattice corpus

### DIFF
--- a/scripts/ci/test_inventory.py
+++ b/scripts/ci/test_inventory.py
@@ -144,6 +144,7 @@ def corpus_record_count() -> int:
         COPILOT_NODE_DELETE_DENY_CASES,
     )
     from tests.guard_seeded_faults import PARSER_SEEDED_FAULTS
+    from tests.test_guard_action_lattice import ACTION_LATTICE_PAIR_CASES
     from tests.test_guard_command_critical_floors import (
         CRITICAL_COMMAND_FLOORS,
         CRITICAL_NEAR_MISS_COMMANDS,
@@ -155,6 +156,7 @@ def corpus_record_count() -> int:
         PR_MERGE_ADMIN_CAPABILITY_CASES,
         UNRELATED_DYNAMIC_COMMAND_CASES,
     )
+    from tests.test_guard_package_shims import PACKAGE_SHIM_GUARD_CASES
     from tests.test_guard_risk import (
         ENCODED_EXEC_PIPELINE_CASES,
         LOCAL_COMPOSE_SAFE_CASES,
@@ -162,7 +164,6 @@ def corpus_record_count() -> int:
         MUTATING_PYTHON_MODULE_DENY_CASES,
         SENSITIVE_DOCKER_DENY_CASES,
     )
-    from tests.test_guard_package_shims import PACKAGE_SHIM_GUARD_CASES
 
     return (
         sum(1 for _ in iter_benign_corpus())
@@ -170,6 +171,7 @@ def corpus_record_count() -> int:
         + len(COPILOT_ENCODED_EXEC_DENY_CASES)
         + len(COPILOT_NODE_DELETE_DENY_CASES)
         + len(PARSER_SEEDED_FAULTS)
+        + len(ACTION_LATTICE_PAIR_CASES)
         + len(CRITICAL_COMMAND_FLOORS)
         + len(CRITICAL_NEAR_MISS_COMMANDS)
         + len(GITHUB_REVIEW_FLOORS)

--- a/tests/test_guard_action_lattice.py
+++ b/tests/test_guard_action_lattice.py
@@ -40,6 +40,8 @@ EXPECTED_LATTICE: tuple[GuardAction, ...] = (
     "sandbox-required",
     "block",
 )
+ACTION_LATTICE_PAIR_CASES = tuple(product(EXPECTED_LATTICE, repeat=2))
+ACTION_LATTICE_COMPOSERS = (most_restrictive_guard_action, _merge_strongest_actions, _strongest_security_value)
 
 
 def test_lattice_is_exhaustive_ordered_and_contiguous() -> None:
@@ -49,17 +51,16 @@ def test_lattice_is_exhaustive_ordered_and_contiguous() -> None:
     assert tuple(GUARD_ACTION_SEVERITY.values()) == tuple(range(len(EXPECTED_LATTICE)))
 
 
-@pytest.mark.parametrize(("left", "right"), product(EXPECTED_LATTICE, repeat=2))
-def test_most_restrictive_composition_is_commutative_for_every_valid_pair(
-    left: GuardAction,
-    right: GuardAction,
-) -> None:
-    expected = max((left, right), key=EXPECTED_LATTICE.index)
+def test_most_restrictive_composition_is_commutative_for_every_valid_pair() -> None:
+    failures: list[str] = []
+    for left, right in ACTION_LATTICE_PAIR_CASES:
+        expected = max((left, right), key=EXPECTED_LATTICE.index)
+        actuals = tuple(compose(left, right) for compose in ACTION_LATTICE_COMPOSERS)
+        actuals += (most_restrictive_guard_action(right, left),)
+        if any(actual != expected for actual in actuals):
+            failures.append(f"action-lattice-{left}-{right}: expected={expected!r}, actuals={actuals!r}")
 
-    assert most_restrictive_guard_action(left, right) == expected
-    assert most_restrictive_guard_action(right, left) == expected
-    assert _merge_strongest_actions(left, right) == expected
-    assert _strongest_security_value(left, right) == expected
+    assert not failures, "\n".join(failures)
 
 
 def test_most_restrictive_composition_is_idempotent_and_associative() -> None:


### PR DESCRIPTION
## Summary

- consolidate all pairwise Guard action-lattice composition contracts into one aggregate invariant
- retain every ordered pair across canonical, reversed, managed-policy, and strongest-value paths
- register the pair corpus in CI inventory accounting

## Verification

- `uv run --no-sync ruff check tests/test_guard_action_lattice.py scripts/ci/test_inventory.py`
- `uv run --no-sync pytest tests/test_guard_action_lattice.py tests/test_ci_test_inventory.py -q --tb=short -k 'most_restrictive_composition_is_commutative_for_every_valid_pair or ci_test_inventory'`
- `uv run --with pytest python scripts/ci/test_inventory.py --output /tmp/action-lattice-corpus-inventory.json`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory /tmp/action-lattice-corpus-inventory.json`
