### PR TITLE
fix(dashboard): compact alpha channel status

### DIFF
--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type ChangeEvent } from "react";
-import { HiMiniArrowPath } from "react-icons/hi2";
+import { HiMiniAdjustmentsHorizontal, HiMiniArrowPath, HiMiniBeaker } from "react-icons/hi2";
 
 import {
   fetchGuardUpdateStatus,
@@ -176,14 +176,35 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
       {helpCopy ? (
         <p className="text-[11px] leading-relaxed text-brand-dark/70">{helpCopy}</p>
       ) : null}
-      {props.onSetUpdateChannel ? (
+      {props.onSetUpdateChannel && useAlpha ? (
+        <div
+          className="flex items-center justify-between gap-2 rounded-md border border-brand-blue/20 bg-brand-blue/[0.06] px-2 py-1.5"
+          role="status"
+          aria-label="Alpha updates enabled"
+        >
+          <span className="inline-flex min-w-0 items-center gap-1.5 text-[11px] font-semibold text-brand-blue">
+            <HiMiniBeaker className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            Alpha updates
+          </span>
+          <button
+            type="button"
+            onClick={handleOpenAlphaModal}
+            disabled={busy}
+            aria-label="Manage alpha updates"
+            title="Manage alpha updates"
+            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-brand-blue transition-colors hover:bg-brand-blue/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <HiMiniAdjustmentsHorizontal className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      ) : props.onSetUpdateChannel ? (
         <button
           type="button"
           onClick={handleOpenAlphaModal}
           disabled={busy}
           className="inline-flex min-h-9 w-full items-center justify-center rounded-lg border border-brand-blue/25 bg-white px-3 py-2 text-xs font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60"
         >
-          {useAlpha ? "Alpha updates enabled" : "Try alpha updates"}
+          Try alpha updates
         </button>
       ) : null}
       {showUpdateButton && props.onUpdateGuard ? (

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -51,7 +51,9 @@ const alphaMarkup = renderToStaticMarkup(
     onSetUpdateChannel: () => undefined,
   }),
 );
-assert(alphaMarkup.includes("Alpha updates enabled"), "sidebar should show the active alpha channel");
+assert(alphaMarkup.includes('aria-label="Alpha updates enabled"'), "sidebar should show the active alpha channel");
+assert(alphaMarkup.includes('aria-label="Manage alpha updates"'), "sidebar should expose a compact alpha settings control");
+assert(!alphaMarkup.includes("Alpha updates enabled</button>"), "active alpha status should not render as a wide text button");
 assert(!alphaMarkup.includes('type="checkbox"'), "sidebar should open alpha confirmation instead of toggling immediately");
 
 const loadingMarkup = renderToStaticMarkup(

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -18953,14 +18953,39 @@ function GuardUpdatePanel(props) {
     ] }) : null,
     props.updateStatus?.update_available ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/75", children: updateStatusLabel(props.updateStatus) }) : null,
     helpCopy ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/70", children: helpCopy }) : null,
-    props.onSetUpdateChannel ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+    props.onSetUpdateChannel && useAlpha ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "div",
+      {
+        className: "flex items-center justify-between gap-2 rounded-md border border-brand-blue/20 bg-brand-blue/[0.06] px-2 py-1.5",
+        role: "status",
+        "aria-label": "Alpha updates enabled",
+        children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex min-w-0 items-center gap-1.5 text-[11px] font-semibold text-brand-blue", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "h-3.5 w-3.5 shrink-0", "aria-hidden": "true" }),
+            "Alpha updates"
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "button",
+            {
+              type: "button",
+              onClick: handleOpenAlphaModal,
+              disabled: busy,
+              "aria-label": "Manage alpha updates",
+              title: "Manage alpha updates",
+              className: "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-brand-blue transition-colors hover:bg-brand-blue/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60",
+              children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniAdjustmentsHorizontal, { className: "h-4 w-4", "aria-hidden": "true" })
+            }
+          )
+        ]
+      }
+    ) : props.onSetUpdateChannel ? /* @__PURE__ */ jsxRuntimeExports.jsx(
       "button",
       {
         type: "button",
         onClick: handleOpenAlphaModal,
         disabled: busy,
         className: "inline-flex min-h-9 w-full items-center justify-center rounded-lg border border-brand-blue/25 bg-white px-3 py-2 text-xs font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60",
-        children: useAlpha ? "Alpha updates enabled" : "Try alpha updates"
+        children: "Try alpha updates"
       }
     ) : null,
     showUpdateButton && props.onUpdateGuard ? /* @__PURE__ */ jsxRuntimeExports.jsxs(

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -4980,6 +4980,16 @@
       }
     }
 
+    .hover\:bg-brand-blue\/10:hover {
+      background-color: var(--brand-blue);
+    }
+
+    @supports (color: color-mix(in lab, red, red)) {
+      .hover\:bg-brand-blue\/10:hover {
+        background-color: color-mix(in oklab, var(--brand-blue) 10%, transparent);
+      }
+    }
+
     .hover\:bg-brand-blue\/20:hover {
       background-color: var(--brand-blue);
     }


### PR DESCRIPTION
## Summary
- Replace the full-width alpha-enabled button with a compact status row.
- Keep the protected release-channel dialog available through an icon-only manage control.

## Testing
- `cd dashboard && bun run test`
- `cd dashboard && bun run build`
