### PR TITLE
test(guard): stabilize OMP resident scanner burst

### DIFF
--- a/tests/test_guard_omp_fast_path_regression.py
+++ b/tests/test_guard_omp_fast_path_regression.py
@@ -11,6 +11,7 @@ from typing import TypeGuard, cast
 
 import pytest
 
+from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -28,6 +29,7 @@ def test_omp_post_tool_read_burst_uses_resident_scanner(
     workspace.mkdir(parents=True)
     store = GuardStore(home_dir)
     monkeypatch.setenv("HOL_GUARD_HOOK_FAST_PATH", "1")
+    monkeypatch.setattr(daemon_server_module, "_RUNTIME_HOOK_ADMISSION_TIMEOUT_SECONDS", 5.0)
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     query = urllib.parse.urlencode(


### PR DESCRIPTION
## Summary

- Give the resident-scanner burst fixture a test-local admission deadline.
- Preserve assertions for allowed results and zero worker timeouts or restarts.

## Testing

- `uv run --no-sync pytest tests/test_guard_omp_fast_path_regression.py::test_omp_post_tool_read_burst_uses_resident_scanner -q --tb=short` (5 runs)
- `uv run --no-sync pytest tests/test_guard_omp_fast_path_regression.py tests/test_ci_test_inventory.py -q --tb=short`
