### PR TITLE
feat(daemon): add asynchronous diagnostic logs

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11481,
-  "maximum_test_source_lines": 266241,
+  "maximum_test_source_lines": 266242,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/daemon/diagnostics.py
+++ b/src/codex_plugin_scanner/guard/daemon/diagnostics.py
@@ -1,0 +1,175 @@
+"""Asynchronous, bounded diagnostic logging for the local Guard daemon."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue
+import sys
+import threading
+import time
+from contextlib import suppress
+from datetime import datetime, timezone
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+from types import TracebackType
+from typing import Final, final
+
+from typing_extensions import override
+
+_DAEMON_LOG_DIRECTORY: Final = "logs"
+_DAEMON_LOG_FILENAME: Final = "daemon.log"
+_DAEMON_LOG_RETENTION_SECONDS: Final = 7 * 24 * 60 * 60
+_DEFAULT_QUEUE_CAPACITY: Final = 256
+
+
+@final
+class _DaemonLogFormatter(logging.Formatter):
+    @override
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, object] = {
+            "timestamp": datetime.fromtimestamp(record.created, timezone.utc).isoformat(),
+            "level": record.levelname.lower(),
+            "event": getattr(record, "guard_event", record.getMessage()),
+        }
+        detail = getattr(record, "guard_detail", None)
+        if isinstance(detail, str) and detail:
+            payload["detail"] = detail
+        if record.exc_info is not None:
+            payload["exception"] = self.formatException(record.exc_info)
+        return json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+
+
+def _secure_directory(path: Path) -> None:
+    if path.is_symlink():
+        raise OSError("daemon diagnostic directory cannot be a symbolic link")
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    with suppress(OSError):
+        os.chmod(path, 0o700)
+
+
+def cleanup_expired_daemon_logs(log_directory: Path, *, now: float | None = None) -> None:
+    """Delete rotated daemon logs older than the fixed local retention period."""
+
+    cutoff = (time.time() if now is None else now) - _DAEMON_LOG_RETENTION_SECONDS
+    for candidate in log_directory.glob(f"{_DAEMON_LOG_FILENAME}.*"):
+        try:
+            if candidate.lstat().st_mtime < cutoff:
+                candidate.unlink()
+        except OSError:
+            continue
+
+
+@final
+class DaemonDiagnostics:
+    """Queue daemon diagnostics so hook and request threads never perform file I/O."""
+
+    def __init__(
+        self,
+        guard_home: Path,
+        *,
+        queue_capacity: int = _DEFAULT_QUEUE_CAPACITY,
+        start_worker: bool = True,
+    ) -> None:
+        self.log_directory = guard_home / _DAEMON_LOG_DIRECTORY
+        self.log_path = self.log_directory / _DAEMON_LOG_FILENAME
+        self._queue: queue.Queue[logging.LogRecord] = queue.Queue(maxsize=max(1, queue_capacity))
+        self._closed = True
+        self._close_lock = threading.Lock()
+        self._stop_requested = threading.Event()
+        self._handler: TimedRotatingFileHandler | None = None
+        self._thread: threading.Thread | None = None
+        try:
+            _secure_directory(self.log_directory)
+            cleanup_expired_daemon_logs(self.log_directory)
+            if self.log_path.is_symlink():
+                raise OSError("daemon diagnostic log cannot be a symbolic link")
+            self._handler = TimedRotatingFileHandler(
+                self.log_path,
+                when="midnight",
+                interval=1,
+                backupCount=7,
+                encoding="utf-8",
+                utc=True,
+            )
+            self._handler.setFormatter(_DaemonLogFormatter())
+            with suppress(OSError):
+                os.chmod(self.log_path, 0o600)
+        except Exception:
+            return
+        self._closed = False
+        if start_worker:
+            self._thread = threading.Thread(target=self._run, daemon=True, name="guard-daemon-diagnostics")
+            self._thread.start()
+
+    def record(self, event: str, *, detail: str | None = None) -> bool:
+        return self._enqueue(self._record(logging.INFO, event, detail=detail))
+
+    def record_exception(
+        self,
+        event: str,
+        *,
+        detail: str | None = None,
+        exc_info: tuple[type[BaseException], BaseException, TracebackType | None] | None = None,
+    ) -> bool:
+        if exc_info is None:
+            exception_type, exception, traceback = sys.exc_info()
+            if exception_type is not None and exception is not None:
+                exc_info = (exception_type, exception, traceback)
+        return self._enqueue(self._record(logging.ERROR, event, detail=detail, exc_info=exc_info))
+
+    def close(self, *, timeout_seconds: float = 1.0) -> bool:
+        with self._close_lock:
+            if self._handler is None:
+                return True
+            if self._closed:
+                return self._thread is None or not self._thread.is_alive()
+            self._closed = True
+            if self._thread is None:
+                self._handler.close()
+                return True
+            self._stop_requested.set()
+        self._thread.join(timeout=max(0.0, timeout_seconds))
+        return not self._thread.is_alive()
+
+    def _record(
+        self,
+        level: int,
+        event: str,
+        *,
+        detail: str | None,
+        exc_info: tuple[type[BaseException], BaseException, TracebackType | None] | None = None,
+    ) -> logging.LogRecord:
+        record = logging.LogRecord("hol_guard.daemon", level, __file__, 0, event, (), exc_info)
+        record.guard_event = event
+        record.guard_detail = detail
+        return record
+
+    def _enqueue(self, record: logging.LogRecord) -> bool:
+        if self._closed:
+            return False
+        try:
+            self._queue.put_nowait(record)
+        except queue.Full:
+            return False
+        return True
+
+    def _run(self) -> None:
+        try:
+            while not self._stop_requested.is_set() or not self._queue.empty():
+                try:
+                    item = self._queue.get(timeout=0.05)
+                except queue.Empty:
+                    continue
+                try:
+                    handler = self._handler
+                    if handler is not None:
+                        handler.emit(item)
+                except Exception:
+                    continue
+                finally:
+                    self._queue.task_done()
+        finally:
+            if self._handler is not None:
+                self._handler.close()

--- a/src/codex_plugin_scanner/guard/daemon/diagnostics.py
+++ b/src/codex_plugin_scanner/guard/daemon/diagnostics.py
@@ -22,6 +22,7 @@ _DAEMON_LOG_DIRECTORY: Final = "logs"
 _DAEMON_LOG_FILENAME: Final = "daemon.log"
 _DAEMON_LOG_RETENTION_SECONDS: Final = 7 * 24 * 60 * 60
 _DEFAULT_QUEUE_CAPACITY: Final = 256
+_OWNER_ONLY_DIRECTORY_MODE: Final = 0o700
 
 
 @final
@@ -44,9 +45,9 @@ class _DaemonLogFormatter(logging.Formatter):
 def _secure_directory(path: Path) -> None:
     if path.is_symlink():
         raise OSError("daemon diagnostic directory cannot be a symbolic link")
-    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    path.mkdir(mode=_OWNER_ONLY_DIRECTORY_MODE, parents=True, exist_ok=True)
     with suppress(OSError):
-        os.chmod(path, 0o700)
+        os.chmod(path, _OWNER_ONLY_DIRECTORY_MODE)
 
 
 def cleanup_expired_daemon_logs(log_directory: Path, *, now: float | None = None) -> None:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -222,6 +222,7 @@ from .dashboard_reconnect import (
     prepare_dashboard_reconnect_authorization,
 )
 from .dashboard_update import merge_dashboard_update_progress, schedule_guard_dashboard_update
+from .diagnostics import DaemonDiagnostics
 from .discovery import (
     DAEMON_DISCOVERY_CHALLENGE_TTL_SECONDS,
     DAEMON_DISCOVERY_PROTOCOL_VERSION,
@@ -398,6 +399,7 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
     unclassified_watchdog_thread: threading.Thread | None
     hook_process_runner: HookProcessRunner
     runtime_heartbeat: RuntimeHeartbeatWriter
+    diagnostics: DaemonDiagnostics
 
     def handle_error(self, request: object, client_address: tuple[str, int]) -> None:
         """Suppress expected peer disconnects without hiding server defects."""
@@ -406,7 +408,7 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
 
         if isinstance(sys.exc_info()[1], _PEER_DISCONNECT_ERRORS):
             return
-        super().handle_error(cast(socket.socket, request), client_address)
+        self.diagnostics.record_exception("http_request_failed")
 
     def server_close(self) -> None:
         writer = getattr(self, "runtime_hook_evidence_writer", None)
@@ -426,6 +428,7 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
         runtime_started_at: str,
         idle_timeout_seconds: float | None,
         shutdown_started: threading.Event,
+        diagnostics: DaemonDiagnostics,
     ) -> None:
         super().__init__(server_address, handler_class)
         self.store = store
@@ -440,6 +443,7 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
         self.active_stream_clients = 0
         self.active_stream_clients_lock = threading.Lock()
         self.shutdown_started = shutdown_started
+        self.diagnostics = diagnostics
         self.package_firewall_connect_state = None
         self.package_firewall_connect_state_lock = threading.Lock()
         self.guard_cloud_connect_state = None
@@ -7062,7 +7066,13 @@ class GuardDaemonServer:
     ) -> None:
         if not type(self)._retry_quarantined_service(store.guard_home):
             raise RuntimeError("A previous Guard daemon remains quarantined after unconfirmed containment.")
-        _validate_dashboard_bundle()
+        self._diagnostics = DaemonDiagnostics(store.guard_home)
+        try:
+            _validate_dashboard_bundle()
+        except BaseException:
+            self._diagnostics.record_exception("daemon_initialization_failed")
+            self._diagnostics.close(timeout_seconds=0.5)
+            raise
         self._shutdown_started = threading.Event()
         self._finish_service_lock = threading.Lock()
         self._owner_lock: BinaryIO | None = None
@@ -7079,6 +7089,7 @@ class GuardDaemonServer:
                 idle_timeout_seconds=idle_timeout_seconds,
             ),
             shutdown_started=self._shutdown_started,
+            diagnostics=self._diagnostics,
         )
         self.port = self._server.daemon_port()
         self._bundle_refresh_backoff_seconds = bundle_refresh_backoff_seconds
@@ -7116,6 +7127,7 @@ class GuardDaemonServer:
                 active_deferral_seconds=0,
             )
         except BaseException as error:
+            self._diagnostics.record_exception("daemon_start_thread_failed")
             serve_thread_contained = True
             if serve_thread_started and self._thread is not None:
                 self._server.shutdown()
@@ -7144,6 +7156,7 @@ class GuardDaemonServer:
 
     def stop(self) -> None:
         self._record_lifecycle("shutdown_requested", reason="explicit_stop")
+        self._diagnostics.record("daemon_shutdown_requested")
         self._shutdown_started.set()
         self._server.shutdown()
         self._server.server_close()
@@ -7164,6 +7177,7 @@ class GuardDaemonServer:
         try:
             self._begin_owned_service()
         except BaseException as error:
+            self._diagnostics.record_exception("daemon_start_failed")
             self._record_lifecycle("start_failed", reason="initialization_failed")
             if not self._finish_service():
                 add_note = getattr(error, "add_note", None)
@@ -7206,6 +7220,7 @@ class GuardDaemonServer:
         )
         self._start_command_activity_maintenance()
         self._record_lifecycle("ready")
+        self._diagnostics.record("daemon_ready")
 
     def _maintain_command_activity_best_effort(self) -> None:
         now = datetime.now(timezone.utc)
@@ -7298,8 +7313,10 @@ class GuardDaemonServer:
         except BaseException:
             stop_reason = "serve_loop_failed"
             self._record_lifecycle("serve_failed", reason="unexpected_exception")
+            self._diagnostics.record_exception("daemon_serve_failed")
             raise
         finally:
+            self._diagnostics.record("daemon_stopped", detail=stop_reason)
             self._server.server_close()
             _ = self._finish_service()
             self._record_lifecycle("stopped", reason=stop_reason)
@@ -7393,6 +7410,8 @@ class GuardDaemonServer:
                 contained = False
             else:
                 self._owner_lock = None
+        with suppress(Exception):
+            self._diagnostics.close(timeout_seconds=1.0)
         return self._record_quarantine_state(contained=contained)
 
     @staticmethod

--- a/tests/test_guard_daemon_diagnostics.py
+++ b/tests/test_guard_daemon_diagnostics.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from codex_plugin_scanner.guard.daemon.diagnostics import DaemonDiagnostics, cleanup_expired_daemon_logs
+from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def test_daemon_diagnostics_writes_json_records_on_a_background_worker(tmp_path: Path) -> None:
+    diagnostics = DaemonDiagnostics(tmp_path / "guard-home")
+
+    assert diagnostics.record("daemon_ready") is True
+    assert diagnostics.close(timeout_seconds=1.0) is True
+
+    lines = diagnostics.log_path.read_text(encoding="utf-8").splitlines()
+    assert json.loads(lines[-1])["event"] == "daemon_ready"
+    if os.name != "nt":
+        assert diagnostics.log_path.stat().st_mode & 0o777 == 0o600
+        assert diagnostics.log_directory.stat().st_mode & 0o777 == 0o700
+
+
+def test_daemon_diagnostics_records_exception_tracebacks(tmp_path: Path) -> None:
+    diagnostics = DaemonDiagnostics(tmp_path / "guard-home")
+
+    try:
+        raise RuntimeError("diagnostic failure")
+    except RuntimeError:
+        assert diagnostics.record_exception("daemon_serve_failed") is True
+    assert diagnostics.close(timeout_seconds=1.0) is True
+
+    payload = json.loads(diagnostics.log_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert payload["event"] == "daemon_serve_failed"
+    assert "RuntimeError: diagnostic failure" in payload["exception"]
+
+
+def test_daemon_diagnostics_drops_records_when_the_queue_is_full_without_waiting(tmp_path: Path) -> None:
+    diagnostics = DaemonDiagnostics(tmp_path / "guard-home", queue_capacity=1, start_worker=False)
+
+    assert diagnostics.record("first") is True
+    started_at = time.monotonic()
+    assert diagnostics.record("second") is False
+    assert time.monotonic() - started_at < 0.05
+    assert diagnostics.close() is True
+
+
+def test_daemon_diagnostics_removes_rotated_logs_older_than_seven_days(tmp_path: Path) -> None:
+    log_directory = tmp_path / "logs"
+    log_directory.mkdir()
+    old_log = log_directory / "daemon.log.2026-01-01"
+    retained_log = log_directory / "daemon.log.2026-01-02"
+    unrelated_log = log_directory / "other.log.2026-01-01"
+    for path in (old_log, retained_log, unrelated_log):
+        path.write_text("diagnostic\n", encoding="utf-8")
+    now = 1_800_000_000.0
+    os.utime(old_log, (now - 8 * 24 * 60 * 60, now - 8 * 24 * 60 * 60))
+    os.utime(retained_log, (now - 6 * 24 * 60 * 60, now - 6 * 24 * 60 * 60))
+
+    cleanup_expired_daemon_logs(log_directory, now=now)
+
+    assert old_log.exists() is False
+    assert retained_log.exists() is True
+    assert unrelated_log.exists() is True
+
+
+def test_daemon_diagnostics_rotates_daily_with_seven_backups(tmp_path: Path) -> None:
+    diagnostics = DaemonDiagnostics(tmp_path / "guard-home")
+
+    assert diagnostics.record("before_rotation") is True
+    handler = diagnostics._handler
+    assert handler is not None
+    assert handler.backupCount == 7
+    assert handler.utc is True
+    handler.rolloverAt = 0
+    assert diagnostics.record("after_rotation") is True
+    assert diagnostics.close(timeout_seconds=1.0) is True
+
+    assert list(diagnostics.log_directory.glob("daemon.log.*"))
+
+
+def test_daemon_lifecycle_writes_diagnostics(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+
+    daemon.start()
+    daemon.stop()
+
+    records = [json.loads(line) for line in (store.guard_home / "logs" / "daemon.log").read_text().splitlines()]
+    events = [record["event"] for record in records]
+    assert "daemon_ready" in events
+    assert "daemon_shutdown_requested" in events


### PR DESCRIPTION
## Summary
- add bounded asynchronous diagnostics for local daemon lifecycle and unexpected request failures
- rotate daemon logs daily and retain no more than seven days of local history
- keep hook and request paths off the file-I/O path

## Verification
- `pytest -q tests/test_guard_daemon_diagnostics.py tests/test_guard_daemon_lifecycle_journal.py tests/test_guard_daemon_startup_rollback.py --tb=short`
- `ruff check src/codex_plugin_scanner/guard/daemon/diagnostics.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_daemon_diagnostics.py`
- `ruff format --check src/codex_plugin_scanner/guard/daemon/diagnostics.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_daemon_diagnostics.py`
- `uv build`
