### PR TITLE
fix(claude): reserve fallback review deadline

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -141,6 +141,14 @@ def _remaining_seconds(deadline: float | None, *, cap: float) -> float:
     return min(cap, max(0.0, deadline - time.monotonic()))
 
 
+def _deadline_with_reserve(deadline: float | None, *, reserve_seconds: float) -> float | None:
+    """Keep time for a required later operation inside one absolute hook deadline."""
+
+    if deadline is None:
+        return None
+    return max(time.monotonic(), deadline - reserve_seconds)
+
+
 def _post_to_loopback_daemon(
     endpoint: str,
     data: str,
@@ -392,14 +400,25 @@ def _recover_retry_or_fallback(
 ) -> str:
     if recovery_command and _run_recovery_command(
         recovery_command,
-        deadline=deadline,
+        deadline=_deadline_with_reserve(
+            deadline,
+            reserve_seconds=_DAEMON_IO_TIMEOUT_SECONDS + _FALLBACK_TIMEOUT_SECONDS,
+        ),
         failure_kind=failure_kind,
     ):
         try:
             endpoint = urljoin(_daemon_url(state_path, fallback_daemon_url), f"/v1/hooks/claude-code?{query}")
             _assert_loopback_http_url(endpoint)
             return _valid_hook_json_or_degraded(
-                _post_to_loopback_daemon(endpoint, data, state_path=state_path, deadline=deadline),
+                _post_to_loopback_daemon(
+                    endpoint,
+                    data,
+                    state_path=state_path,
+                    deadline=_deadline_with_reserve(
+                        deadline,
+                        reserve_seconds=_FALLBACK_TIMEOUT_SECONDS,
+                    ),
+                ),
                 reason=f"{reason}; recovered daemon returned malformed hook JSON",
                 data=data,
             )

--- a/tests/test_claude_daemon_hook_bridge.py
+++ b/tests/test_claude_daemon_hook_bridge.py
@@ -337,6 +337,61 @@ def test_main_recovers_missing_daemon_and_retries_hook(
     assert json.loads(capsys.readouterr().out)["hookSpecificOutput"]["permissionDecision"] == "allow"
 
 
+def test_recovery_retry_reserves_time_for_local_package_review(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = [2.0]
+    recovery_deadlines: list[float | None] = []
+    retry_deadlines: list[float | None] = []
+
+    monkeypatch.setattr(bridge.time, "monotonic", lambda: now[0])
+
+    def fake_recover(
+        command: tuple[str, ...],
+        *,
+        deadline: float | None = None,
+        failure_kind: str,
+    ) -> bool:
+        del command, failure_kind
+        recovery_deadlines.append(deadline)
+        assert deadline is not None
+        now[0] = min(deadline, now[0] + bridge._RECOVERY_TIMEOUT_SECONDS)
+        return True
+
+    def fake_post(
+        endpoint: str,
+        data: str,
+        *,
+        state_path: str | Path,
+        deadline: float | None = None,
+    ) -> str:
+        del endpoint, data, state_path
+        retry_deadlines.append(deadline)
+        assert deadline is not None
+        now[0] = min(deadline, now[0] + bridge._DAEMON_IO_TIMEOUT_SECONDS)
+        raise TimeoutError("recovered daemon unavailable")
+
+    monkeypatch.setattr(bridge, "_run_recovery_command", fake_recover)
+    monkeypatch.setattr(bridge, "_post_to_loopback_daemon", fake_post)
+
+    response = bridge._recover_retry_or_fallback(
+        "daemon unavailable",
+        json.dumps({"hook_event_name": "PreToolUse"}),
+        state_path="/missing/daemon-state.json",
+        fallback_daemon_url="http://127.0.0.1:5474",
+        fallback_command=(
+            sys.executable,
+            "-c",
+            "import time;time.sleep(1.25);print('{\"review\":true}')",
+        ),
+        recovery_command=(sys.executable, "-c", "pass"),
+        query="",
+        deadline=8.0,
+    )
+
+    assert json.loads(response) == {"review": True}
+    assert recovery_deadlines == [4.0]
+    assert retry_deadlines == [6.0]
+
+
 def test_recovery_only_restarts_for_transport_auth_and_server_failures() -> None:
     assert not bridge._daemon_failure_is_recoverable(ValueError("invalid loopback URL"))
     assert not bridge._daemon_failure_is_recoverable(


### PR DESCRIPTION
## Summary

- Reserve local review time when daemon recovery and retry do not succeed.
- Cover the absolute-deadline fallback path with a deterministic regression test.

## Testing

- `uv run --no-sync pytest tests/test_claude_daemon_hook_bridge.py tests/test_guard_package_hook_phase14.py::test_phase14_claude_daemon_hook_bridge_queues_package_install_without_node -q --tb=short`
- `uv run --no-sync pytest tests/test_claude_daemon_hook_bridge.py::test_recovery_retry_reserves_time_for_local_package_review tests/test_guard_package_hook_phase14.py::test_phase14_claude_daemon_hook_bridge_queues_package_install_without_node -q --tb=short` (5 runs)
