### PR TITLE
fix(inbox): clear covered approval requests

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11481,
-  "maximum_test_source_lines": 267642,
+  "maximum_test_source_lines": 267647,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2647,7 +2647,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 workspace=self._optional_string(payload.get("workspace")),
                 reason=self._optional_string(payload.get("reason")),
                 return_queue_result=True,
-                resolve_scope_matches=False,
+                resolve_scope_matches=True,
                 approval_gate_input=approval_gate_input_from_mapping(payload),
                 persist_policy=persist_policy,
                 scope_contract_version=scope_contract_version,

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -2514,6 +2514,7 @@ class TestGuardApprovals:
         assert payload["resolved_request"]["review_command"] == f"hol-guard approvals {action} {request_id}"
         other_request_id = f"{request_id}-other"
         resolves_publisher_match = action == "block" and scope == "publisher"
+        assert payload.get("resolved_scope_ids", []) == ([other_request_id] if resolves_publisher_match else [])
         assert payload["remaining_pending_count"] == (0 if resolves_publisher_match else 1)
         assert payload["next_selectable_request_id"] == (None if resolves_publisher_match else other_request_id)
         assert store.get_approval_request(other_request_id)["status"] == (

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -2438,9 +2438,7 @@ class TestGuardApprovals:
 
     @pytest.mark.parametrize("action", ["approve", "block"])
     @pytest.mark.parametrize("scope", ["artifact", "workspace", "publisher", "harness", "global"])
-    def test_guard_daemon_resolution_route_accepts_all_scope_kinds_without_clearing_queue(
-        self, tmp_path, action, scope
-    ):
+    def test_guard_daemon_resolution_route_resolves_only_scope_covered_reviews(self, tmp_path, action, scope):
         store = GuardStore(tmp_path / "guard-home")
         workspace = tmp_path / "workspace"
         request_id = f"req-{action}-{scope}"
@@ -2514,9 +2512,13 @@ class TestGuardApprovals:
         assert payload["applied_scope"] == expected_scope
         assert payload["resolved_request"]["approval_url"] == "http://127.0.0.1/pending"
         assert payload["resolved_request"]["review_command"] == f"hol-guard approvals {action} {request_id}"
-        assert payload["remaining_pending_count"] == 1
-        assert payload["next_selectable_request_id"] == f"{request_id}-other"
-        assert store.get_approval_request(f"{request_id}-other")["status"] == "pending"
+        other_request_id = f"{request_id}-other"
+        resolves_publisher_match = action == "block" and scope == "publisher"
+        assert payload["remaining_pending_count"] == (0 if resolves_publisher_match else 1)
+        assert payload["next_selectable_request_id"] == (None if resolves_publisher_match else other_request_id)
+        assert store.get_approval_request(other_request_id)["status"] == (
+            "resolved" if resolves_publisher_match else "pending"
+        )
 
     def test_guard_daemon_approve_route_requires_auth_token(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -690,7 +690,7 @@ def test_broad_scope_resolution_keeps_other_reviews_pending(tmp_path: Path) -> N
     assert decisions == []
 
 
-def test_artifact_scope_resolution_keeps_same_artifact_review_pending(tmp_path: Path) -> None:
+def test_artifact_scope_resolution_removes_same_artifact_review_from_queue(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     shared_artifact = "codex:project:shared-tool"
     _populate(
@@ -714,10 +714,12 @@ def test_artifact_scope_resolution_keeps_same_artifact_review_pending(tmp_path: 
     finally:
         daemon.stop()
 
-    assert payload["remaining_pending_count"] == 2
+    assert payload["resolved_scope_ids"] == ["req-covered"]
+    assert payload["remaining_pending_count"] == 1
     assert payload["next_selectable_request_id"] == "req-unrelated"
-    assert payload.get("resolved_scope_ids") in (None, [])
-    assert store.get_approval_request("req-covered")["status"] == "pending"
+    assert store.get_approval_request("req-covered")["status"] == "resolved"
+    assert store.get_approval_request("req-covered")["resolution_action"] == "allow"
+    assert store.get_approval_request("req-unrelated")["status"] == "pending"
 
 
 def test_same_resolution_is_idempotent_and_different_resolution_conflicts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Remove pending inbox entries once an approval resolves the same scoped action.
- Keep unrelated requests pending and preserve the existing scope boundaries.

## Testing

- `uv run --no-sync pytest -q tests/test_guard_queue_api_contract.py tests/test_guard_approvals.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_queue_api_contract.py tests/test_guard_approvals.py`
- `uv build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Approval resolutions now clear pending reviews covered by the requested scope.
  * Artifact-scoped approvals resolve other pending reviews for the same artifact while leaving unrelated reviews pending.
  * Queue counts and the next selectable approval now update accurately after resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->