### PR TITLE
fix(updates): persist alpha channel across reloads

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11481,
-  "maximum_test_source_lines": 267647,
+  "maximum_test_source_lines": 267663,
   "schema_version": 1
 }

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -762,6 +762,7 @@ export async function fetchGuardUpdateStatusAtOrigin(
   }
   const { response, payload } = await fetchGuardDaemonCandidateJson(`${candidateOrigin}/v1/update/status`, {
     headers: guardToken ? { "X-Guard-Dashboard-Session": guardToken } : {},
+    cache: "no-store",
     redirect: "error",
   });
   if (!response.ok) {
@@ -3145,7 +3146,7 @@ export async function fetchGuardUpdateStatus(): Promise<GuardUpdateStatus> {
       blocked_reason: null,
     });
   }
-  const payload = await readJson<unknown>("/v1/update/status");
+  const payload = await readJson<unknown>("/v1/update/status", { cache: "no-store" });
   return normalizeGuardUpdateStatus(payload);
 }
 

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -259,6 +259,9 @@ export function useGuardUpdate(options?: { onReconnected?: () => void; enabled?:
   const [updatePhase, setUpdatePhase] = useState<GuardUpdatePhase>(enabled ? "checking" : "idle");
   const reconnectStartedAt = useRef<number | null>(null);
   const updatePhaseRef = useRef<GuardUpdatePhase>("checking");
+  const updateStatusEpoch = useRef(0);
+  const channelMutationId = useRef(0);
+  const channelMutationPending = useRef(false);
 
   useEffect(() => {
     updatePhaseRef.current = updatePhase;
@@ -268,8 +271,17 @@ export function useGuardUpdate(options?: { onReconnected?: () => void; enabled?:
     if (!enabled) {
       return;
     }
+    const epoch = updateStatusEpoch.current;
+    const mutationId = channelMutationId.current;
     try {
       const status = await fetchGuardUpdateStatus();
+      if (
+        epoch !== updateStatusEpoch.current ||
+        mutationId !== channelMutationId.current ||
+        channelMutationPending.current
+      ) {
+        return;
+      }
       setUpdateStatus(status);
       if (updatePhaseRef.current === "checking" || updatePhaseRef.current === "idle") {
         setUpdatePhase("idle");
@@ -287,10 +299,20 @@ export function useGuardUpdate(options?: { onReconnected?: () => void; enabled?:
       return;
     }
     let cancelled = false;
+    const epoch = updateStatusEpoch.current;
+    const mutationId = channelMutationId.current;
     void fetchGuardUpdateStatus()
       .then((status) => {
-        if (!cancelled && (updatePhaseRef.current === "checking" || updatePhaseRef.current === "idle")) {
-          setUpdateStatus(status);
+        if (
+          cancelled ||
+          epoch !== updateStatusEpoch.current ||
+          mutationId !== channelMutationId.current ||
+          channelMutationPending.current
+        ) {
+          return;
+        }
+        setUpdateStatus(status);
+        if (updatePhaseRef.current === "checking" || updatePhaseRef.current === "idle") {
           setUpdatePhase("idle");
         }
       })
@@ -339,6 +361,7 @@ export function useGuardUpdate(options?: { onReconnected?: () => void; enabled?:
             redirectToGuardDaemonOrigin(origin, readGuardToken());
             return true;
           }
+          updateStatusEpoch.current += 1;
           setUpdateStatus(reconnectResult.status);
           setUpdatePhase("idle");
           options?.onReconnected?.();
@@ -420,7 +443,23 @@ export function useGuardUpdate(options?: { onReconnected?: () => void; enabled?:
   }, [scheduleAndWait, updateStatus]);
 
   const onSetUpdateChannel = useCallback(async (channel: "stable" | "alpha", proof?: GuardUpdateChannelProof) => {
-    setUpdateStatus(await setGuardUpdateChannel(channel, proof));
+    const mutationId = ++channelMutationId.current;
+    updateStatusEpoch.current += 1;
+    channelMutationPending.current = true;
+    try {
+      const status = await setGuardUpdateChannel(channel, proof);
+      if (mutationId === channelMutationId.current) {
+        updateStatusEpoch.current += 1;
+        setUpdateStatus(status);
+        if (updatePhaseRef.current === "checking" || updatePhaseRef.current === "idle") {
+          setUpdatePhase("idle");
+        }
+      }
+    } finally {
+      if (mutationId === channelMutationId.current) {
+        channelMutationPending.current = false;
+      }
+    }
   }, []);
 
   return {

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -262,13 +262,21 @@ export function useGuardUpdate(options?: { onReconnected?: () => void; enabled?:
   const updateStatusEpoch = useRef(0);
   const channelMutationId = useRef(0);
   const channelMutationPending = useRef(false);
+  const isMounted = useRef(false);
 
   useEffect(() => {
     updatePhaseRef.current = updatePhase;
   }, [updatePhase]);
 
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
   const refreshUpdateStatus = useCallback(async () => {
-    if (!enabled) {
+    if (!enabled || !isMounted.current || channelMutationPending.current) {
       return;
     }
     const epoch = updateStatusEpoch.current;
@@ -276,6 +284,7 @@ export function useGuardUpdate(options?: { onReconnected?: () => void; enabled?:
     try {
       const status = await fetchGuardUpdateStatus();
       if (
+        !isMounted.current ||
         epoch !== updateStatusEpoch.current ||
         mutationId !== channelMutationId.current ||
         channelMutationPending.current
@@ -287,7 +296,7 @@ export function useGuardUpdate(options?: { onReconnected?: () => void; enabled?:
         setUpdatePhase("idle");
       }
     } catch {
-      if (updatePhaseRef.current === "checking") {
+      if (isMounted.current && updatePhaseRef.current === "checking") {
         setUpdatePhase("idle");
       }
     }

--- a/dashboard/src/guard-update-reconnect-security.test.ts
+++ b/dashboard/src/guard-update-reconnect-security.test.ts
@@ -144,14 +144,19 @@ assert(
 
 type FetchMode = "prepare" | "shape-only" | "authenticated";
 let mode: FetchMode = "prepare";
-const fetchEvents: Array<{ url: string; credentialed: boolean; redirect: RequestRedirect | undefined }> = [];
+const fetchEvents: Array<{
+  url: string;
+  credentialed: boolean;
+  cache: RequestCache | undefined;
+  redirect: RequestRedirect | undefined;
+}> = [];
 let clientProofAccepted = false;
 
 globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
   const url = String(input);
   const headers = new Headers(init?.headers);
   const credentialed = headers.has("X-Guard-Dashboard-Session") || headers.has("Authorization");
-  fetchEvents.push({ url, credentialed, redirect: init?.redirect });
+  fetchEvents.push({ url, credentialed, cache: init?.cache, redirect: init?.redirect });
 
   if (url.endsWith("/v1/update/reconnect/prepare")) {
     assert(credentialed, "prepare must use the already authenticated dashboard session");
@@ -245,6 +250,7 @@ assert(
   fetchEvents[0]?.url === "http://127.0.0.1:4781/v1/update/status",
   "a hostile daemon fragment must not replace the origin bound to a stored dashboard credential",
 );
+assert(fetchEvents[0]?.cache === "no-store", "update status must not reuse a stale release channel response");
 const authorization = await prepareGuardDaemonReconnect();
 assert(
   authorization.verifier === authorizationRaw.verifier,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2031,7 +2031,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 merge_dashboard_update_progress(
                     store.guard_home,
                     build_guard_update_status_payload(guard_home=store.guard_home),
-                )
+                ),
+                extra_headers={"Cache-Control": "no-store, max-age=0"},
             )
             return
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "sessions"] and path_parts[3] == "resume":
@@ -4790,7 +4791,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         except ValueError as error:
             self._write_json({"error": "invalid_update_channel", "message": str(error)}, status=400)
             return
-        self._write_json(build_guard_update_status_payload(guard_home=guard_home))
+        self._write_json(
+            build_guard_update_status_payload(guard_home=guard_home),
+            extra_headers={"Cache-Control": "no-store, max-age=0"},
+        )
 
     def _handle_settings_import(self, payload: dict[str, object]) -> None:
         settings = payload.get("settings")

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16147,6 +16147,7 @@ async function fetchGuardUpdateStatusAtOrigin(origin, guardToken) {
   }
   const { response, payload } = await fetchGuardDaemonCandidateJson(`${candidateOrigin}/v1/update/status`, {
     headers: guardToken ? { "X-Guard-Dashboard-Session": guardToken } : {},
+    cache: "no-store",
     redirect: "error"
   });
   if (!response.ok) {
@@ -17986,7 +17987,7 @@ async function fetchGuardUpdateStatus() {
       blocked_reason: null
     });
   }
-  const payload = await readJson("/v1/update/status");
+  const payload = await readJson("/v1/update/status", { cache: "no-store" });
   return normalizeGuardUpdateStatus(payload);
 }
 async function scheduleGuardUpdate(options) {
@@ -19089,6 +19090,9 @@ function useGuardUpdate(options) {
   const [updatePhase, setUpdatePhase] = reactExports.useState(enabled ? "checking" : "idle");
   const reconnectStartedAt = reactExports.useRef(null);
   const updatePhaseRef = reactExports.useRef("checking");
+  const updateStatusEpoch = reactExports.useRef(0);
+  const channelMutationId = reactExports.useRef(0);
+  const channelMutationPending = reactExports.useRef(false);
   reactExports.useEffect(() => {
     updatePhaseRef.current = updatePhase;
   }, [updatePhase]);
@@ -19096,8 +19100,13 @@ function useGuardUpdate(options) {
     if (!enabled) {
       return;
     }
+    const epoch = updateStatusEpoch.current;
+    const mutationId = channelMutationId.current;
     try {
       const status = await fetchGuardUpdateStatus();
+      if (epoch !== updateStatusEpoch.current || mutationId !== channelMutationId.current || channelMutationPending.current) {
+        return;
+      }
       setUpdateStatus(status);
       if (updatePhaseRef.current === "checking" || updatePhaseRef.current === "idle") {
         setUpdatePhase("idle");
@@ -19114,9 +19123,14 @@ function useGuardUpdate(options) {
       return;
     }
     let cancelled = false;
+    const epoch = updateStatusEpoch.current;
+    const mutationId = channelMutationId.current;
     void fetchGuardUpdateStatus().then((status) => {
-      if (!cancelled && (updatePhaseRef.current === "checking" || updatePhaseRef.current === "idle")) {
-        setUpdateStatus(status);
+      if (cancelled || epoch !== updateStatusEpoch.current || mutationId !== channelMutationId.current || channelMutationPending.current) {
+        return;
+      }
+      setUpdateStatus(status);
+      if (updatePhaseRef.current === "checking" || updatePhaseRef.current === "idle") {
         setUpdatePhase("idle");
       }
     }).catch(() => {
@@ -19159,6 +19173,7 @@ function useGuardUpdate(options) {
             redirectToGuardDaemonOrigin(origin, readGuardToken());
             return true;
           }
+          updateStatusEpoch.current += 1;
           setUpdateStatus(reconnectResult.status);
           setUpdatePhase("idle");
           options?.onReconnected?.();
@@ -19230,7 +19245,23 @@ function useGuardUpdate(options) {
     });
   }, [scheduleAndWait, updateStatus]);
   const onSetUpdateChannel = reactExports.useCallback(async (channel, proof) => {
-    setUpdateStatus(await setGuardUpdateChannel(channel, proof));
+    const mutationId = ++channelMutationId.current;
+    updateStatusEpoch.current += 1;
+    channelMutationPending.current = true;
+    try {
+      const status = await setGuardUpdateChannel(channel, proof);
+      if (mutationId === channelMutationId.current) {
+        updateStatusEpoch.current += 1;
+        setUpdateStatus(status);
+        if (updatePhaseRef.current === "checking" || updatePhaseRef.current === "idle") {
+          setUpdatePhase("idle");
+        }
+      }
+    } finally {
+      if (mutationId === channelMutationId.current) {
+        channelMutationPending.current = false;
+      }
+    }
   }, []);
   return {
     guardVersion: updateStatus?.current_version ?? null,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19093,18 +19093,25 @@ function useGuardUpdate(options) {
   const updateStatusEpoch = reactExports.useRef(0);
   const channelMutationId = reactExports.useRef(0);
   const channelMutationPending = reactExports.useRef(false);
+  const isMounted = reactExports.useRef(false);
   reactExports.useEffect(() => {
     updatePhaseRef.current = updatePhase;
   }, [updatePhase]);
+  reactExports.useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
   const refreshUpdateStatus = reactExports.useCallback(async () => {
-    if (!enabled) {
+    if (!enabled || !isMounted.current || channelMutationPending.current) {
       return;
     }
     const epoch = updateStatusEpoch.current;
     const mutationId = channelMutationId.current;
     try {
       const status = await fetchGuardUpdateStatus();
-      if (epoch !== updateStatusEpoch.current || mutationId !== channelMutationId.current || channelMutationPending.current) {
+      if (!isMounted.current || epoch !== updateStatusEpoch.current || mutationId !== channelMutationId.current || channelMutationPending.current) {
         return;
       }
       setUpdateStatus(status);
@@ -19112,7 +19119,7 @@ function useGuardUpdate(options) {
         setUpdatePhase("idle");
       }
     } catch {
-      if (updatePhaseRef.current === "checking") {
+      if (isMounted.current && updatePhaseRef.current === "checking") {
         setUpdatePhase("idle");
       }
     }

--- a/tests/test_dashboard_update.py
+++ b/tests/test_dashboard_update.py
@@ -61,6 +61,19 @@ def _get_json(daemon: GuardDaemonServer, path: str) -> dict[str, object]:
     return payload
 
 
+def _get_json_with_headers(daemon: GuardDaemonServer, path: str) -> tuple[dict[str, object], dict[str, str]]:
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{daemon.port}{path}",
+        headers={"X-Guard-Token": daemon._server.auth_token},
+        method="GET",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+        headers = dict(response.headers.items())
+    assert isinstance(payload, dict)
+    return payload, headers
+
+
 def _post_json(daemon: GuardDaemonServer, path: str) -> tuple[int, dict[str, object]]:
     request = urllib.request.Request(
         f"http://127.0.0.1:{daemon.port}{path}",
@@ -267,6 +280,7 @@ def test_alpha_update_channel_persists_and_schedules_alpha(tmp_path: Path, monke
         status, payload = _post_json_body(daemon, "/v1/update/channel", {"update_channel": "alpha"})
         assert status == 200
         assert payload["release_channel"] == "alpha"
+        refreshed_payload, refreshed_headers = _get_json_with_headers(daemon, "/v1/update/status")
         status, payload = _post_json(daemon, "/v1/update")
     finally:
         daemon.stop()
@@ -274,6 +288,8 @@ def test_alpha_update_channel_persists_and_schedules_alpha(tmp_path: Path, monke
     assert status == 200
     assert payload["scheduled"] is True
     assert load_guard_config(store.guard_home).update_channel == "alpha"
+    assert refreshed_payload["release_channel"] == "alpha"
+    assert refreshed_headers["Cache-Control"] == "no-store, max-age=0"
     assert scheduled["include_alpha"] is True
 
 


### PR DESCRIPTION
## Summary

- Revalidate the persisted update channel instead of reusing cached status responses.
- Prevent older dashboard status reads from replacing a confirmed channel change.
- Cover the persisted alpha channel response and rebuilt dashboard behavior.

## Verification

- `uv run --no-sync pytest -q tests/test_dashboard_update.py --tb=short`
- `bun src/guard-update.test.ts`
- `bun src/guard-update-reconnect-security.test.ts`
- `bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Update status now consistently reflects the latest information instead of cached results.
  * Prevented outdated update responses from overwriting newer channel selections or reconnect status.
  * Added cache-control safeguards to update-status responses.

* **Tests**
  * Added coverage verifying fresh status requests, cache-control headers, and accurate channel updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->