### PR TITLE
fix(guard): honor selected alpha update channel

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11481,
-  "maximum_test_source_lines": 267823,
+  "maximum_test_source_lines": 267849,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py
@@ -213,6 +213,13 @@ def _run_guard_update_command(
         except (OSError, RuntimeError, sqlite3.Error) as error:
             store = None
             update_store_error = error
+    try:
+        local_config = config or load_guard_config(guard_home, workspace=workspace)
+    except (OSError, ValueError):
+        local_config = None
+    include_alpha = bool(getattr(args, "alpha", False)) or (
+        local_config is not None and local_config.update_channel == "alpha"
+    )
     payload, exit_code = run_guard_update(
         dry_run=dry_run,
         context=context,
@@ -221,7 +228,7 @@ def _run_guard_update_command(
         now=_now(),
         wheel=getattr(args, "wheel", None),
         guard_home=guard_home,
-        include_alpha=bool(getattr(args, "alpha", False)),
+        include_alpha=include_alpha,
         force_pypi_reinstall=bool(getattr(args, "force_pypi_reinstall", False)),
     )
     if update_store_error is not None:

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4218,16 +4218,21 @@ args = ["workspace-skill.js", "--changed"]
     def test_guard_update_ignores_malformed_guard_config(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
         _write_text(home_dir / "config.toml", "[broken\n")
+        captured_alpha: list[object] = []
         monkeypatch.setattr(
             guard_commands_module,
             "run_guard_update",
-            lambda **_: ({"status": "updated", "message": "ok"}, 0),
+            lambda **kwargs: (
+                captured_alpha.append(kwargs.get("include_alpha")) or {"status": "updated", "message": "ok"},
+                0,
+            ),
         )
 
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
 
         assert rc == 0
+        assert captured_alpha == [False]
         assert output["status"] == "updated"
         assert output["message"] == "ok"
 
@@ -4291,6 +4296,27 @@ args = ["workspace-skill.js", "--changed"]
         )
 
         rc = main(["guard", "update", "--home", str(home_dir), "--alpha", "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert captured_alpha == [True]
+        assert output["status"] == "planned"
+
+    def test_guard_update_uses_persisted_alpha_channel(self, tmp_path, monkeypatch, capsys):
+        home_dir = tmp_path / "home"
+        _write_text(home_dir / "config.toml", 'update_channel = "alpha"\n')
+        captured_alpha: list[object] = []
+
+        monkeypatch.setattr(
+            guard_commands_module,
+            "run_guard_update",
+            lambda **kwargs: (
+                captured_alpha.append(kwargs.get("include_alpha")) or {"status": "planned", "message": "ok"},
+                0,
+            ),
+        )
+
+        rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
 
         assert rc == 0


### PR DESCRIPTION
## Summary
- Honor the persisted alpha update channel for terminal updates.
- Keep malformed local configuration on the stable update path.

## Testing
- `uv run --no-sync pytest -q tests/test_guard_cli.py tests/test_guard_phase03_remainder.py -k 'guard_update or update_alpha or update_command_allows_prerelease or latest_alpha_version' --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py tests/test_guard_cli.py`
