### PR TITLE
fix(guard): preserve live daemon on transport timeout

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11481,
-  "maximum_test_source_lines": 268106,
+  "maximum_test_source_lines": 268146,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -505,7 +505,7 @@ def recover_guard_daemon_after_hook_failure(
             if current_url is not None:
                 if failure_kind != "authenticated-control-plane-failure" or _daemon_generation_is_recent(state):
                     return current_url
-            elif live_process_url is not None and failure_kind == "overload":
+            elif live_process_url is not None and (failure_kind == "overload" or _daemon_generation_is_recent(state)):
                 return live_process_url
             live_generation_url = current_url or live_process_url
             if live_generation_url is not None:

--- a/tests/test_guard_daemon_recovery_resilience.py
+++ b/tests/test_guard_daemon_recovery_resilience.py
@@ -155,7 +155,7 @@ def test_recovery_preserves_authenticated_live_process_when_health_probe_misses(
     assert recovered == "http://127.0.0.1:4781"
 
 
-def test_transport_recovery_replaces_authenticated_process_when_health_probe_misses(
+def test_transport_recovery_preserves_authenticated_process_when_health_probe_misses(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -165,6 +165,46 @@ def test_transport_recovery_replaces_authenticated_process_when_health_probe_mis
         "source_root": daemon_manager_module._current_guard_daemon_source_root(),
         "runtime_fingerprint": daemon_manager_module._current_guard_daemon_runtime_fingerprint(),
         "started_at": datetime.now(timezone.utc).isoformat(),
+        "pid": 4321,
+        "port": 4781,
+    }
+    monkeypatch.setattr(daemon_manager_module, "load_authenticated_daemon_state", lambda _home: state)
+    monkeypatch.setattr(daemon_manager_module, "load_guard_daemon_url", lambda _home: None)
+    monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_running", lambda _pid: True)
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_guard_daemon_pid_matches_command",
+        lambda _pid, expected_guard_home=None: expected_guard_home == guard_home,
+    )
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "retire_all_guard_daemons_for_home",
+        lambda _home: pytest.fail("a transport timeout must not retire a proven live daemon"),
+    )
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "ensure_guard_daemon",
+        lambda _home, *, home_dir=None: pytest.fail("a proven live generation must not be replaced"),
+    )
+
+    recovered = daemon_manager_module.recover_guard_daemon_after_hook_failure(
+        guard_home,
+        failure_kind="transport-failure",
+    )
+
+    assert recovered == "http://127.0.0.1:4781"
+
+
+def test_transport_recovery_replaces_old_process_when_health_probe_misses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    state = {
+        "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+        "source_root": daemon_manager_module._current_guard_daemon_source_root(),
+        "runtime_fingerprint": daemon_manager_module._current_guard_daemon_runtime_fingerprint(),
+        **_old_generation(),
         "pid": 4321,
         "port": 4781,
     }


### PR DESCRIPTION
## Summary

- preserve an authenticated live daemon when a hook transport probe times out
- keep daemon replacement limited to dead processes and authenticated control-plane failures
- update adversarial recovery coverage to prevent transport timeouts from retiring a live generation

## Testing

- `uv run --no-sync python -m pytest -q tests/test_guard_daemon_recovery_resilience.py tests/test_guard_daemon_manager.py tests/test_pi_hook_latency.py --tb=short`
- `uv run --no-sync python -m pytest -q tests/test_guard_daemon_adversarial_transport.py tests/test_guard_daemon_storage_liveness.py tests/test_guard_daemon_wake.py tests/test_cli_only_hook_resilience.py tests/test_claude_daemon_hook_bridge.py tests/test_codex_daemon_hook_bridge.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/daemon/manager.py tests/test_guard_daemon_recovery_resilience.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/daemon/manager.py tests/test_guard_daemon_recovery_resilience.py`
- real-process recovery check confirmed PID stability after a simulated transport probe miss
