### PR TITLE
fix(guard): bound sqlite maintenance contention

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11481,
-  "maximum_test_source_lines": 268146,
+  "maximum_test_source_lines": 268260,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -7551,7 +7551,7 @@ class GuardDaemonServer:
             return
         self._maintain_command_activity_best_effort()
         storage_complete = self._maintain_storage_best_effort()
-        while not self._shutdown_started.wait(3_600 if storage_complete else 1):
+        while not self._shutdown_started.wait(3_600 if storage_complete else 5):
             self._maintain_command_activity_best_effort()
             storage_complete = self._maintain_storage_best_effort()
 

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -26,6 +26,7 @@ from .store_live_request_outbox import ensure_live_request_outbox_schema, seed_l
 from .store_secret_policy_integrity import _POLICY_INTEGRITY_LOOKUP_UNSET
 from .store_storage_maintenance import (
     STORAGE_MAINTENANCE_MIGRATION_VERSION,
+    STORAGE_QUERY_INDEX_MIGRATION_VERSION,
     storage_maintenance_schema_statements,
 )
 from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
@@ -138,7 +139,7 @@ _POLICY_INDEX_STATEMENTS = (
 )
 
 _RECEIPT_WARN_ROLLUP_MIGRATION_VERSION = 16
-_REQUIRED_SCHEMA_MIGRATION_VERSIONS = tuple(range(2, STORAGE_MAINTENANCE_MIGRATION_VERSION + 1))
+_REQUIRED_SCHEMA_MIGRATION_VERSIONS = tuple(range(2, STORAGE_QUERY_INDEX_MIGRATION_VERSION + 1))
 
 
 class StoreConnectionSchemaMixin:
@@ -840,6 +841,10 @@ class StoreConnectionSchemaMixin:
             self._record_schema_version(
                 connection,
                 version=STORAGE_MAINTENANCE_MIGRATION_VERSION,
+            )
+            self._record_schema_version(
+                connection,
+                version=STORAGE_QUERY_INDEX_MIGRATION_VERSION,
             )
             if not self._schema_version_applied(connection, version=2):
                 self._record_schema_version(connection, version=2)

--- a/src/codex_plugin_scanner/guard/store_storage_maintenance.py
+++ b/src/codex_plugin_scanner/guard/store_storage_maintenance.py
@@ -10,11 +10,13 @@ from datetime import datetime, timedelta
 from typing import Final, Protocol, cast
 
 STORAGE_MAINTENANCE_MIGRATION_VERSION: Final = 20
-DEFAULT_STORAGE_MAINTENANCE_BATCH_SIZE: Final = 2_000
+STORAGE_QUERY_INDEX_MIGRATION_VERSION: Final = 21
+DEFAULT_STORAGE_MAINTENANCE_BATCH_SIZE: Final = 500
 DEFAULT_RECEIPT_DETAIL_LIMIT: Final = 250_000
 DEFAULT_GUARD_EVENT_LIMIT: Final = 250_000
 DEFAULT_UPLOADED_CLOUD_EVENT_LIMIT: Final = 10_000
 UPLOADED_CLOUD_EVENT_RETAIN_DAYS: Final = 7
+STORAGE_MAINTENANCE_BUSY_TIMEOUT_MS: Final = 25
 _MAX_BATCH_SIZE: Final = 10_000
 
 
@@ -72,6 +74,7 @@ class StoreStorageMaintenanceMixin:
             uploaded_cloud_event_limit=uploaded_cloud_event_limit,
         )
         with self._connect() as connection:
+            connection.execute(f"pragma busy_timeout={STORAGE_MAINTENANCE_BUSY_TIMEOUT_MS}")
             connection.execute("begin immediate")
             receipts_archived = _archive_receipt_batch(
                 connection,
@@ -120,6 +123,8 @@ class StoreStorageMaintenanceMixin:
                     pages_reclaimed,
                 ),
             )
+        if completed:
+            _run_passive_housekeeping(self)
         return StorageMaintenanceResult(
             ran=True,
             completed=completed,
@@ -155,7 +160,7 @@ def _archive_receipt_batch(
                 where approval.request_id = r.approval_request_id
                   and approval.status = 'pending'
               )
-            order by r.rowid
+            order by r.timestamp
             limit ?
             """,
             (cutoff.isoformat(), boundary, boundary, batch_size),
@@ -212,7 +217,7 @@ def _delete_guard_event_batch(
               select 1 from guard_workflow_capability_authority_transitions as transition
               where transition.event_id = event.event_id
             )
-          order by event.rowid
+          order by event.occurred_at
           limit ?
         )
         """,
@@ -242,7 +247,7 @@ def _delete_uploaded_cloud_event_batch(
           from guard_cloud_events
           where uploaded_at is not null
             and (uploaded_at < ? or (? is not null and rowid <= ?))
-          order by rowid
+          order by uploaded_at, occurred_at
           limit ?
         )
         """,
@@ -282,6 +287,17 @@ def _reclaim_free_pages(connection: sqlite3.Connection, *, batch_size: int) -> i
     return max(before - after, 0)
 
 
+def _run_passive_housekeeping(owner: _ConnectionOwner) -> None:
+    try:
+        with owner._connect() as connection:
+            connection.execute("pragma busy_timeout=0")
+            connection.execute("pragma optimize")
+            connection.execute("pragma wal_checkpoint(passive)")
+    except sqlite3.Error:
+        # Maintenance never delays or fails an enforcement request.
+        return
+
+
 def _validate_inputs(
     *,
     now: datetime,
@@ -311,7 +327,9 @@ __all__ = [
     "DEFAULT_RECEIPT_DETAIL_LIMIT",
     "DEFAULT_STORAGE_MAINTENANCE_BATCH_SIZE",
     "DEFAULT_UPLOADED_CLOUD_EVENT_LIMIT",
+    "STORAGE_MAINTENANCE_BUSY_TIMEOUT_MS",
     "STORAGE_MAINTENANCE_MIGRATION_VERSION",
+    "STORAGE_QUERY_INDEX_MIGRATION_VERSION",
     "StorageMaintenanceResult",
     "StoreStorageMaintenanceMixin",
     "storage_maintenance_schema_statements",

--- a/src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py
@@ -70,6 +70,8 @@ _SCHEMA_STATEMENTS: Final = (
     on guard_workflow_capabilities (revoked_at, expires_at, capability_id)""",
     """create index if not exists idx_guard_workflow_receipt_capability
     on guard_workflow_capability_receipts (capability_id, use_number)""",
+    """create index if not exists idx_guard_workflow_receipt_event
+    on guard_workflow_capability_receipts (event_id)""",
     """create trigger if not exists trg_guard_workflow_capability_claim_immutable
     before update of capability_id, approval_provenance_id, nonce, signed_claim_json, key_id,
       issued_at, not_before, expires_at, max_uses on guard_workflow_capabilities
@@ -137,6 +139,7 @@ _OBJECT_NAMES: Final = (
     ("table", "guard_workflow_capability_authority_transitions"),
     ("index", "idx_guard_workflow_capability_expiry"),
     ("index", "idx_guard_workflow_receipt_capability"),
+    ("index", "idx_guard_workflow_receipt_event"),
     ("trigger", "trg_guard_workflow_capability_claim_immutable"),
     ("trigger", "trg_guard_workflow_capability_no_delete"),
     ("trigger", "trg_guard_workflow_receipt_immutable_update"),

--- a/tests/test_guard_storage_maintenance.py
+++ b/tests/test_guard_storage_maintenance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -200,6 +201,98 @@ def test_storage_maintenance_uses_bounded_batches(tmp_path: Path) -> None:
     assert second.completed is False
 
 
+def test_storage_maintenance_queries_use_time_and_reference_indexes(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    with store._connect() as connection:  # pyright: ignore[reportPrivateUsage]
+        old = "2025-01-01T00:00:00+00:00"
+        connection.executemany(
+            "insert into guard_events (event_name, payload_json, occurred_at) values ('plan', '{}', ?)",
+            [(old,)] * 100,
+        )
+        connection.execute(
+            """
+            insert into guard_workflow_capabilities (
+              capability_id, approval_provenance_id, nonce, signed_claim_json, key_id,
+              issued_at, not_before, expires_at, max_uses
+            ) values ('plan-capability', 'approval', 'plan-nonce', '{}', 'key', ?, ?, ?, 50)
+            """,
+            (old, old, "2027-01-01T00:00:00+00:00"),
+        )
+        event_ids = [int(row["event_id"]) for row in connection.execute("select event_id from guard_events limit 50")]
+        connection.executemany(
+            """
+            insert into guard_workflow_capability_receipts (
+              receipt_id, capability_id, task_id, invocation_id, approval_provenance_id,
+              signed_receipt_json, claimed_at, use_number, event_id
+            ) values (?, 'plan-capability', 'task', ?, 'approval', '{}', ?, ?, ?)
+            """,
+            [
+                (f"receipt-{index}", f"invocation-{index}", old, index + 1, event_id)
+                for index, event_id in enumerate(event_ids)
+            ],
+        )
+        connection.execute("analyze")
+        receipt_plan = connection.execute(
+            """
+            explain query plan
+            select receipt_id from runtime_receipts
+            where timestamp < ?
+            order by timestamp
+            limit 500
+            """,
+            ("2026-01-01T00:00:00+00:00",),
+        ).fetchall()
+        event_plan = connection.execute(
+            """
+            explain query plan
+            select event.event_id
+            from guard_events as event
+            where event.occurred_at < ?
+              and not exists (
+                select 1 from guard_workflow_capability_receipts as receipt
+                where receipt.event_id = event.event_id
+              )
+            order by event.occurred_at
+            limit 500
+            """,
+            ("2026-01-01T00:00:00+00:00",),
+        ).fetchall()
+        cloud_plan = connection.execute(
+            """
+            explain query plan
+            select event_id from guard_cloud_events
+            where uploaded_at is not null and uploaded_at < ?
+            order by uploaded_at, occurred_at
+            limit 500
+            """,
+            ("2026-01-01T00:00:00+00:00",),
+        ).fetchall()
+
+    assert "idx_receipts_timestamp_desc" in " ".join(str(row["detail"]) for row in receipt_plan)
+    assert "idx_guard_workflow_receipt_event" in " ".join(str(row["detail"]) for row in event_plan)
+    assert "idx_guard_cloud_events_sync" in " ".join(str(row["detail"]) for row in cloud_plan)
+
+
+def test_storage_maintenance_yields_quickly_to_hook_writer(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    writer = sqlite3.connect(store.path, timeout=0.1, isolation_level=None)
+    writer.execute("pragma journal_mode=wal")
+    writer.execute("begin immediate")
+    started = time.monotonic()
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            store.maintain_storage(
+                now=datetime(2026, 7, 25, tzinfo=timezone.utc),
+                detail_retain_days=30,
+            )
+    finally:
+        elapsed = time.monotonic() - started
+        writer.rollback()
+        writer.close()
+
+    assert elapsed < 0.25
+
+
 def test_fresh_store_uses_incremental_auto_vacuum(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
     with sqlite3.connect(store.path) as connection:
@@ -238,11 +331,32 @@ def test_current_schema_probe_treats_lock_contention_as_unknown(
     assert store._schema_is_current() is False  # pyright: ignore[reportPrivateUsage]
 
 
+def test_version_21_upgrade_adds_workflow_event_index(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard"
+    store = GuardStore(guard_home, prime_policy_integrity=False)
+    with store._connect() as connection:  # pyright: ignore[reportPrivateUsage]
+        connection.execute("drop index idx_guard_workflow_receipt_event")
+        connection.execute("delete from schema_migrations where version = 21")
+
+    GuardStore(guard_home, prime_policy_integrity=False)
+
+    with sqlite3.connect(store.path) as connection:
+        index = connection.execute(
+            """
+            select 1 from sqlite_master
+            where type = 'index' and name = 'idx_guard_workflow_receipt_event'
+            """
+        ).fetchone()
+        migration = connection.execute("select 1 from schema_migrations where version = 21").fetchone()
+    assert index is not None
+    assert migration is not None
+
+
 def test_schema_upgrade_is_serialized_across_store_processes(tmp_path: Path) -> None:
     guard_home = tmp_path / "guard"
     store = GuardStore(guard_home, prime_policy_integrity=False)
     with store._connect() as connection:  # pyright: ignore[reportPrivateUsage]
-        connection.execute("delete from schema_migrations where version = 20")
+        connection.execute("delete from schema_migrations where version = 21")
         connection.execute("drop table guard_storage_maintenance")
 
     def reopen_store(_index: int) -> GuardStore:
@@ -258,4 +372,4 @@ def test_schema_upgrade_is_serialized_across_store_processes(tmp_path: Path) -> 
 
     assert all(reopened.path == store.path for reopened in stores)
     with store._connect() as connection:  # pyright: ignore[reportPrivateUsage]
-        assert connection.execute("select count(*) from schema_migrations where version = 20").fetchone()[0] == 1
+        assert connection.execute("select count(*) from schema_migrations where version = 21").fetchone()[0] == 1


### PR DESCRIPTION
## Summary
- bound background SQLite maintenance batches and lock waits so hook writes retain priority
- use existing time indexes and add a workflow-event reference index for retention queries
- run passive WAL checkpoint and optimizer housekeeping after completed cleanup cycles
- migrate existing stores through schema version 21 without changing retention safeguards

## Testing
- `uv run --no-sync python -m pytest -q tests/test_guard_storage_maintenance.py tests/test_guard_daemon_storage_liveness.py tests/test_guard_daemon_recovery_resilience.py tests/test_pi_hook_latency.py tests/test_guard_store_migrations.py tests/test_guard_workflow_capability_hardening.py tests/test_guard_workflow_capability_authority_tamper.py tests/test_guard_workflow_capability_rollback.py tests/test_guard_command_shadow_persistence.py tests/test_ci_test_inventory.py tests/test_ci_test_suite_ratchet.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/store_storage_maintenance.py src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py src/codex_plugin_scanner/guard/store_connection_schema.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_storage_maintenance.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/store_storage_maintenance.py src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py src/codex_plugin_scanner/guard/store_connection_schema.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_storage_maintenance.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/store_storage_maintenance.py src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py src/codex_plugin_scanner/guard/store_connection_schema.py tests/test_guard_storage_maintenance.py`
