### PR TITLE
fix(guard): keep daemon hooks on durable paths

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11481,
-  "maximum_test_source_lines": 268260,
+  "maximum_test_source_lines": 268294,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
@@ -501,6 +501,15 @@ def _daemon_response(
         connection.close()
 
 
+def _daemon_process_failed(response: Mapping[str, object]) -> bool:
+    reason_code = response.get("reason_code")
+    return isinstance(reason_code, str) and reason_code.startswith("daemon_hook_process_")
+
+
+def _codex_hook_response(response: Mapping[str, object]) -> dict[str, object]:
+    return {key: value for key, value in response.items() if key != "reason_code"}
+
+
 def main(
     *,
     state_path: str | Path,
@@ -587,6 +596,8 @@ def main(
                 )
             except (OSError, ValueError, http.client.HTTPException, urllib.error.URLError):
                 response = None
+    if response is not None and _daemon_process_failed(response):
+        response = None
     if response is None and not daemon_overloaded:
         if trusted_launch is not None:
             fallback_stdout = trusted_launch.run_fallback(
@@ -611,7 +622,7 @@ def main(
             else _FAIL_CLOSED_REASON
         )
         response = _fail_closed(event_name, failure_reason)
-    sys.stdout.write(json.dumps(response, separators=(",", ":")))
+    sys.stdout.write(json.dumps(_codex_hook_response(response), separators=(",", ":")))
     return 0
 
 

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -310,6 +310,7 @@ def ensure_guard_daemon(
 ) -> str:
     timeout = GUARD_DAEMON_START_TIMEOUT_SECONDS if start_timeout is None else start_timeout
     start_deadline = time.monotonic() + max(0.0, timeout)
+    launch_cwd = _trusted_daemon_home(home_dir)
     _schedule_stale_ephemeral_guard_daemon_reap(exclude_guard_home=guard_home)
     state_path = _state_path(guard_home)
     existing_url = load_guard_daemon_url(guard_home)
@@ -382,6 +383,7 @@ def ensure_guard_daemon(
                     stdin=subprocess.PIPE,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
+                    cwd=launch_cwd,
                     env=_daemon_launcher_env(home_dir=home_dir, guard_home=guard_home),
                     creationflags=_windows_daemon_creation_flags(
                         allow_job_breakaway=allow_windows_job_breakaway,
@@ -393,6 +395,7 @@ def ensure_guard_daemon(
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
+                    cwd=launch_cwd,
                     env=_daemon_launcher_env(home_dir=home_dir, guard_home=guard_home),
                     start_new_session=True,
                 )
@@ -783,6 +786,7 @@ def schedule_guard_daemon_ensure(
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                cwd=trusted_home,
                 env=launcher_env,
                 creationflags=_windows_daemon_creation_flags(allow_job_breakaway=False),
             )
@@ -792,6 +796,7 @@ def schedule_guard_daemon_ensure(
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                cwd=trusted_home,
                 env=launcher_env,
                 start_new_session=True,
             )

--- a/tests/test_codex_daemon_hook_bridge.py
+++ b/tests/test_codex_daemon_hook_bridge.py
@@ -224,7 +224,9 @@ def test_main_posts_to_authenticated_daemon(
     proxy_thread.start()
     port = daemon.server_address[1]
     _write_authenticated_daemon_files(guard_home, port)
-    _DaemonHandler.response_body = b'{"hookSpecificOutput":{"hookEventName":"PreToolUse"}}'
+    _DaemonHandler.response_body = (
+        b'{"hookSpecificOutput":{"hookEventName":"PreToolUse"},"reason_code":"daemon_hook_queue_capacity"}'
+    )
     _ProxyHandler.captured_paths = []
     monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{proxy.server_address[1]}")
     monkeypatch.setenv("http_proxy", f"http://127.0.0.1:{proxy.server_address[1]}")
@@ -603,6 +605,34 @@ def test_main_starts_daemon_once_then_retries_hook(
     assert len(responses) == 2
     assert starts == [tuple(config["start_command"])]
     assert json.loads(capsys.readouterr().out) == {}
+
+    fallback_calls: list[str] = []
+    monkeypatch.setattr(
+        bridge,
+        "_daemon_response",
+        lambda **_kwargs: {
+            "continue": False,
+            "stopReason": "isolated review failed",
+            "systemMessage": "isolated review failed",
+            "reason_code": "daemon_hook_process_failed",
+        },
+    )
+    monkeypatch.setattr(
+        bridge,
+        "_run_local_fallback",
+        lambda _command, *, data, timeout_seconds: (
+            fallback_calls.append(data) or {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}
+        ),
+    )
+    prompt = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Reassess the current implementation.",
+    }
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(prompt)))
+
+    assert bridge.main(**config) == 0
+    assert fallback_calls == [json.dumps(prompt)]
+    assert json.loads(capsys.readouterr().out) == {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}
 
 
 def test_authenticated_overload_fails_closed_without_fallback_or_restart(

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -176,6 +176,7 @@ def test_schedule_guard_daemon_ensure_is_reserved_and_nonblocking(
     assert kwargs["stdin"] == daemon_manager_module.subprocess.DEVNULL
     assert kwargs["stdout"] == daemon_manager_module.subprocess.DEVNULL
     assert kwargs["stderr"] == daemon_manager_module.subprocess.DEVNULL
+    assert kwargs["cwd"] == tmp_path
     assert kwargs.get("start_new_session") is (os.name != "nt")
 
 
@@ -1316,6 +1317,7 @@ def test_ensure_guard_daemon_spawns_with_current_package_import_path(tmp_path, m
     responses = iter((None, None, "http://127.0.0.1:5412"))
     captured_command: list[str] = []
     captured_env: dict[str, str] = {}
+    captured_cwd: list[Path] = []
 
     _disable_daemon_adoption(monkeypatch)
     _disable_duplicate_retire(monkeypatch)
@@ -1326,6 +1328,7 @@ def test_ensure_guard_daemon_spawns_with_current_package_import_path(tmp_path, m
     def fake_popen(command, **kwargs):
         captured_command.extend(command)
         captured_env.update(kwargs.get("env", {}))
+        captured_cwd.append(kwargs["cwd"])
         return SimpleNamespace(poll=lambda: None)
 
     monkeypatch.setenv("PYTHONPATH", str(tmp_path / "poisoned-pythonpath"))
@@ -1351,6 +1354,7 @@ def test_ensure_guard_daemon_spawns_with_current_package_import_path(tmp_path, m
     assert captured_command[bootstrap_index + 4] == "codex_plugin_scanner.cli"
     assert captured_command[captured_command.index("--home") + 1] == str(home_dir.resolve())
     assert captured_env["HOME"] == str(home_dir.resolve())
+    assert captured_cwd == [home_dir.resolve()]
     if os.name == "nt":
         assert captured_env["USERPROFILE"] == str(home_dir.resolve())
     rendered_command = daemon_manager_module.shlex.join(captured_command)


### PR DESCRIPTION
## Summary
- launch Guard daemon processes from a durable home directory so hook workers survive disposable worktree removal
- retry trusted local Codex evaluation after isolated worker failures and omit internal diagnostics from native hook JSON

## Testing
- `uv run --no-sync pytest -q tests/test_codex_daemon_hook_bridge.py tests/test_guard_daemon_manager.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py src/codex_plugin_scanner/guard/daemon/manager.py tests/test_codex_daemon_hook_bridge.py tests/test_guard_daemon_manager.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py src/codex_plugin_scanner/guard/daemon/manager.py tests/test_codex_daemon_hook_bridge.py tests/test_guard_daemon_manager.py`
