### PR TITLE
fix(guard): detach bounded hook recovery

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -363,8 +363,8 @@ def _cursor_recovery_command(
         "import json,sys;"
         f"sys.path[:0]={json.dumps(trusted_roots)};"
         "from pathlib import Path;"
-        "from codex_plugin_scanner.guard.daemon import recover_guard_daemon_after_hook_failure;"
-        f"recover_guard_daemon_after_hook_failure(Path({str(context.guard_home.resolve())!r}),"
+        "from codex_plugin_scanner.guard.daemon import schedule_guard_daemon_recovery;"
+        f"schedule_guard_daemon_recovery(Path({str(context.guard_home.resolve())!r}),"
         f"home_dir=Path({str(context.home_dir.resolve())!r}),failure_kind=sys.argv[1])"
     )
     return [

--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
@@ -67,8 +67,8 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "sys.stderr.write('HOL_GUARD_WINDOWS_JOB_CONTAINED\\n') if _windows_job is not None else None;"
         "sys.stderr.flush() if _windows_job is not None else None;"
         "from pathlib import Path;"
-        "from codex_plugin_scanner.guard.daemon.manager import recover_guard_daemon_after_hook_failure;"
-        f"recover_guard_daemon_after_hook_failure(Path({str(guard_home)!r}),"
+        "from codex_plugin_scanner.guard.daemon import schedule_guard_daemon_recovery;"
+        f"schedule_guard_daemon_recovery(Path({str(guard_home)!r}),"
         f"home_dir=Path({str(home_dir)!r}),failure_kind=sys.argv[1])"
     )
     recovery_command_json = json.dumps(str(Path(sys.executable).expanduser().absolute()))

--- a/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
@@ -155,12 +155,12 @@ def isolated_daemon_start_command(
         "import os,sys;"
         f"sys.path.insert(0, {str(package_root.resolve())!r});"
         "from pathlib import Path;"
-        "from codex_plugin_scanner.guard.daemon import recover_guard_daemon_after_hook_failure;"
+        "from codex_plugin_scanner.guard.daemon import schedule_guard_daemon_recovery;"
         "failure_kind=os.environ.get('HOL_GUARD_HOOK_FAILURE_KIND','transport-failure');"
         "failure_kind=failure_kind if failure_kind in"
         " {'overload','transport-failure','authenticated-control-plane-failure'}"
         " else 'transport-failure';"
-        f"recover_guard_daemon_after_hook_failure(Path({str(guard_home)!r}),"
+        f"schedule_guard_daemon_recovery(Path({str(guard_home)!r}),"
         f"home_dir=Path({str(resolved_home_dir)!r}),failure_kind=failure_kind)"
     )
     return (python_executable, "-I", "-c", bootstrap)

--- a/src/codex_plugin_scanner/guard/daemon/__init__.py
+++ b/src/codex_plugin_scanner/guard/daemon/__init__.py
@@ -9,6 +9,7 @@ from .manager import (
     load_guard_daemon_url,
     recover_guard_daemon_after_hook_failure,
     repair_approval_center_locator,
+    schedule_guard_daemon_recovery,
 )
 
 __all__ = [
@@ -21,6 +22,7 @@ __all__ = [
     "load_guard_surface_daemon_client",
     "recover_guard_daemon_after_hook_failure",
     "repair_approval_center_locator",
+    "schedule_guard_daemon_recovery",
 ]
 
 

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -524,6 +524,49 @@ def recover_guard_daemon_after_hook_failure(
         return ensure_guard_daemon(guard_home, home_dir=home_dir)
 
 
+def schedule_guard_daemon_recovery(
+    guard_home: Path,
+    *,
+    home_dir: Path | None = None,
+    failure_kind: GuardDaemonHookFailureKind = "authenticated-control-plane-failure",
+) -> None:
+    """Run classified daemon recovery independently of a bounded hook process."""
+
+    if failure_kind not in {
+        "authenticated-control-plane-failure",
+        "overload",
+        "transport-failure",
+    }:
+        raise ValueError(f"Unsupported Guard daemon hook failure kind: {failure_kind}")
+    trusted_home = _trusted_daemon_home(home_dir)
+    command = _isolated_python_module_command(
+        "codex_plugin_scanner.guard.daemon.recovery_worker",
+        _trusted_daemon_import_paths(),
+        [str(guard_home), str(trusted_home), failure_kind],
+    )
+    launcher_env = _daemon_launcher_env(home_dir=trusted_home, guard_home=guard_home)
+    if os.name == "nt":
+        subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            cwd=trusted_home,
+            env=launcher_env,
+            creationflags=_windows_daemon_creation_flags(allow_job_breakaway=False),
+        )
+        return
+    subprocess.Popen(
+        command,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        cwd=trusted_home,
+        env=launcher_env,
+        start_new_session=True,
+    )
+
+
 def _authenticated_live_current_daemon_url(
     guard_home: Path,
     state: dict[str, object] | None,

--- a/src/codex_plugin_scanner/guard/daemon/recovery_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/recovery_worker.py
@@ -1,0 +1,33 @@
+"""Detached daemon recovery worker for bounded harness hooks."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import cast
+
+from .manager import GuardDaemonHookFailureKind, recover_guard_daemon_after_hook_failure
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        return 2
+    guard_home, home_dir, raw_failure_kind = sys.argv[1:]
+    failure_kind: GuardDaemonHookFailureKind
+    if raw_failure_kind not in {
+        "authenticated-control-plane-failure",
+        "overload",
+        "transport-failure",
+    }:
+        return 2
+    failure_kind = cast(GuardDaemonHookFailureKind, raw_failure_kind)
+    _ = recover_guard_daemon_after_hook_failure(
+        Path(guard_home),
+        home_dir=Path(home_dir),
+        failure_kind=failure_kind,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pi_hook_latency.py
+++ b/tests/test_pi_hook_latency.py
@@ -250,8 +250,8 @@ def test_pi_extension_keeps_fallbacks_inside_outer_hook_deadline(tmp_path: Path)
     assert 'recoveryKind: "transport-failure"' in timeout_branch
     assert "response.status === 401 || response.status === 403" in source
     assert 'recoveryKind: "authenticated-control-plane-failure"' in source
+    assert "schedule_guard_daemon_recovery" in source
     assert "failure_kind=sys.argv[1]" in source
-    assert "recover_guard_daemon_after_hook_failure" in source
     assert source.count("assign_current_process_to_windows_hook_job") == 4
     assert "_windows_job=assign_current_process_to_windows_hook_job()" in source
     assert "allow_breakaway=True" in source


### PR DESCRIPTION
## Summary
- detach daemon recovery from bounded OMP, Codex, and Cursor hook processes
- preserve the existing local fallback while daemon startup completes independently

## Testing
- `uv run --no-sync pytest -q tests/test_pi_hook_latency.py tests/test_codex_hook_fallback_isolation.py tests/test_guard_hook_process_runner.py -q --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/adapters/pi_extension_source.py tests/test_pi_hook_latency.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/adapters/pi_extension_source.py tests/test_pi_hook_latency.py`
- detached recovery lifecycle probe at 5 and 15 seconds
