### PR TITLE
fix(guard): prevent benign Codex hook replay

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11481,
-  "maximum_test_source_lines": 268294,
+  "maximum_test_source_lines": 268356,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_commands.py
@@ -164,8 +164,44 @@ def _codex_post_tool_command_is_read_only_source_inspection(
     command_texts = _codex_post_tool_command_texts(payload)
     return bool(command_texts) and all(
         _codex_command_is_read_only_source_inspection(command_text, cwd=cwd, home_dir=home_dir)
+        or _codex_command_is_read_only_git_metadata(command_text)
         for command_text in command_texts
     )
+
+
+def _codex_command_is_read_only_git_metadata(command_text: str) -> bool:
+    if any(marker in command_text for marker in ("\n", "\r", ";", "&", "|", "<", ">", "`", "$(")):
+        return False
+    try:
+        parts = shlex.split(command_text)
+    except ValueError:
+        return False
+    if not parts or Path(parts[0]).name.lower() != "git":
+        return False
+    args = parts[1:]
+    while args:
+        arg = args[0]
+        if arg in _CODEX_GIT_GLOBAL_VALUE_FLAGS:
+            if len(args) < 2:
+                return False
+            args = args[2:]
+            continue
+        if any(arg.startswith(f"{flag}=") for flag in _CODEX_GIT_GLOBAL_VALUE_FLAGS) or (
+            arg.startswith("-C") and len(arg) > 2
+        ):
+            args = args[1:]
+            continue
+        if arg in _CODEX_SAFE_GIT_GLOBAL_BOOLEAN_FLAGS:
+            args = args[1:]
+            continue
+        break
+    if not args:
+        return False
+    if args[0] == "status":
+        return True
+    if args[0:2] == ["worktree", "list"]:
+        return True
+    return args[0:2] == ["branch", "--list"]
 
 
 def _codex_post_tool_command_text(payload: dict[str, object]) -> str:

--- a/tests/test_claude_daemon_hook_bridge.py
+++ b/tests/test_claude_daemon_hook_bridge.py
@@ -333,7 +333,7 @@ def test_main_recovers_missing_daemon_and_retries_hook(
     assert attempts == 2
     assert len(recovery_commands) == 1
     assert recovery_commands[0][1:3] == ("-I", "-c")
-    assert "recover_guard_daemon_after_hook_failure" in recovery_commands[0][3]
+    assert "schedule_guard_daemon_recovery" in recovery_commands[0][3]
     assert json.loads(capsys.readouterr().out)["hookSpecificOutput"]["permissionDecision"] == "allow"
 
 
@@ -476,7 +476,7 @@ def test_recovery_command_preserves_custom_home_and_guard_home(tmp_path: Path) -
     )
 
     assert command[1:3] == ("-I", "-c")
-    assert "recover_guard_daemon_after_hook_failure" in command[3]
+    assert "schedule_guard_daemon_recovery" in command[3]
     assert str(guard_home) in command[3]
     assert str(home_dir) in command[3]
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -8706,6 +8706,70 @@ def test_hook_runtime_artifact_allows_codex_apply_patch_command_for_source_file(
     assert artifact is None
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git status --short --branch",
+        "git worktree list --porcelain",
+        "git branch --list '*alpha*'",
+        "git --no-pager status",
+        "git -C/workspace status",
+        "git --git-dir=/workspace/.git status",
+    ],
+)
+def test_hook_runtime_artifact_does_not_reclassify_safe_codex_post_tool_command(tmp_path: Path, command: str) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "tool_response": {"output": "## main"},
+        "source_scope": "project",
+    }
+    action = guard_commands_module._hook_action_envelope(
+        harness="codex",
+        payload=payload,
+        home_dir=tmp_path,
+        workspace=workspace_dir,
+    )
+
+    artifact = guard_commands_module._hook_runtime_artifact(
+        harness="codex",
+        payload=payload,
+        action_envelope=action,
+        home_dir=tmp_path,
+        guard_home=tmp_path / "guard",
+        workspace=workspace_dir,
+    )
+
+    assert artifact is None
+
+
+def test_hook_runtime_artifact_reclassifies_compound_codex_post_tool_command(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "git status && npm install react@18.3.0"},
+        "source_scope": "project",
+    }
+    action = guard_commands_module._hook_action_envelope(
+        harness="codex", payload=payload, home_dir=tmp_path, workspace=tmp_path
+    )
+
+    artifact = guard_commands_module._hook_runtime_artifact(
+        harness="codex",
+        payload=payload,
+        action_envelope=action,
+        home_dir=tmp_path,
+        guard_home=tmp_path / "guard",
+        workspace=tmp_path,
+    )
+
+    assert artifact is not None
+    assert artifact.artifact_type == "package_request"
+
+
 def test_hook_runtime_artifact_reviews_codex_apply_patch_command_for_protected_file(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"


### PR DESCRIPTION
## Summary
- prevent Codex and Pi post-tool hooks from replaying explicit read-only Git metadata commands
- preserve fallback enforcement for package installs, sensitive output, and mixed command batches
- align detached daemon-recovery assertions and the reviewed test-size ratchet with current behavior

## Testing
- `uv run --no-sync pytest -q tests/test_claude_daemon_hook_bridge.py tests/test_guard_runtime.py -k 'recovers_missing_daemon or preserves_custom_home or does_not_reclassify_safe_codex_post_tool_command or routes_post_tool_package_installs_without_pretool_decision or post_tool_use_asks_for_local_secret_file_output or post_tool_use_blocks_credential_looking_output' --tb=short`
- `uv run --no-sync python scripts/ci/test_inventory.py --output test-inventory.json && uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py src/codex_plugin_scanner/guard/cli/commands_support_codex_commands.py tests/test_guard_runtime.py tests/test_claude_daemon_hook_bridge.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py src/codex_plugin_scanner/guard/cli/commands_support_codex_commands.py tests/test_guard_runtime.py tests/test_claude_daemon_hook_bridge.py`
- `git diff --check`
