### PR TITLE
test(updates): cover alpha channel daemon restart

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11481,
-  "maximum_test_source_lines": 268294,
+  "maximum_test_source_lines": 268298,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11481,
-  "maximum_test_source_lines": 268362,
+  "maximum_test_source_lines": 268369,
   "schema_version": 1
 }

--- a/tests/test_claude_daemon_hook_bridge.py
+++ b/tests/test_claude_daemon_hook_bridge.py
@@ -333,7 +333,7 @@ def test_main_recovers_missing_daemon_and_retries_hook(
     assert attempts == 2
     assert len(recovery_commands) == 1
     assert recovery_commands[0][1:3] == ("-I", "-c")
-    assert "recover_guard_daemon_after_hook_failure" in recovery_commands[0][3]
+    assert "schedule_guard_daemon_recovery" in recovery_commands[0][3]
     assert json.loads(capsys.readouterr().out)["hookSpecificOutput"]["permissionDecision"] == "allow"
 
 
@@ -476,7 +476,7 @@ def test_recovery_command_preserves_custom_home_and_guard_home(tmp_path: Path) -
     )
 
     assert command[1:3] == ("-I", "-c")
-    assert "recover_guard_daemon_after_hook_failure" in command[3]
+    assert "schedule_guard_daemon_recovery" in command[3]
     assert str(guard_home) in command[3]
     assert str(home_dir) in command[3]
 

--- a/tests/test_dashboard_update.py
+++ b/tests/test_dashboard_update.py
@@ -280,10 +280,16 @@ def test_alpha_update_channel_persists_and_schedules_alpha(tmp_path: Path, monke
         status, payload = _post_json_body(daemon, "/v1/update/channel", {"update_channel": "alpha"})
         assert status == 200
         assert payload["release_channel"] == "alpha"
-        refreshed_payload, refreshed_headers = _get_json_with_headers(daemon, "/v1/update/status")
-        status, payload = _post_json(daemon, "/v1/update")
     finally:
         daemon.stop()
+
+    restarted_daemon = GuardDaemonServer(GuardStore(store.guard_home), host="127.0.0.1", port=0)
+    restarted_daemon.start()
+    try:
+        refreshed_payload, refreshed_headers = _get_json_with_headers(restarted_daemon, "/v1/update/status")
+        status, payload = _post_json(restarted_daemon, "/v1/update")
+    finally:
+        restarted_daemon.stop()
 
     assert status == 200
     assert payload["scheduled"] is True

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1367,7 +1367,14 @@ class TestGuardSurfaceServer:
             "transaction_ms",
             "commit_ms",
         }
-        assert health["sqlite_migration_gate"]["conclusion"] == "insufficient_end_to_end_profile"
+        migration_gate = health["sqlite_migration_gate"]
+        assert migration_gate["store_wait_gate_tripped"] is None
+        expected_conclusion = (
+            "sqlite_migration_evaluation_required"
+            if migration_gate["busy_locked_gate_tripped"]
+            else "insufficient_end_to_end_profile"
+        )
+        assert migration_gate["conclusion"] == expected_conclusion
         assert health["hook_evidence_writer"]["degraded"] is False
 
     def test_guard_daemon_queues_hook_burst_until_active_review_completes(


### PR DESCRIPTION
## Summary

- Restart the local daemon before verifying that the selected alpha channel remains active.
- Keep update scheduling coverage bound to the persisted channel after process replacement.

## Testing

- `uv run --no-sync pytest -q tests/test_dashboard_update.py --tb=short`
- `uv run --no-sync pytest -q tests/test_dashboard_update.py -k 'alpha_update_channel_persists_and_schedules_alpha' --tb=short`
- `uv run --no-sync pytest -q tests/test_claude_daemon_hook_bridge.py --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_package_hook_phase14.py::test_phase14_claude_daemon_hook_bridge_queues_package_install_without_node --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_surface_server.py::TestGuardSurfaceServer::test_guard_daemon_hook_queue_bytes_fail_closed_and_reports_health tests/test_guard_hook_process_runner.py::test_scheduler_and_runner_complete_48_routine_reviews_without_capacity_denial --tb=short`
- `uv run --no-sync ruff check tests/test_dashboard_update.py`
- `uv run --no-sync ruff format --check tests/test_dashboard_update.py`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory <inventory-file>`
- installed `hol-guard==2.2.0a78` in an isolated container and verified alpha selection across browser reload and container replacement


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved coverage for update-channel persistence and scheduling after a daemon restart.
  - Added validation that migration-gate health reporting reflects busy or locked database conditions accurately.
  - Confirmed store-wait gate status is reported correctly.

- **Chores**
  - Updated the test-suite baseline to reflect the current test source size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->