### PR TITLE
fix(guard): preserve hook decisions during daemon recovery

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11481,
-  "maximum_test_source_lines": 268451,
+  "maximum_test_source_lines": 268525,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -42,11 +42,11 @@ _RISKY_PROMPT_ADDITIONAL_CONTEXT = (
 _HARNESS_TIMEOUT_BUDGET_SECONDS = 10
 _DAEMON_IO_TIMEOUT_SECONDS = 2
 _RECOVERY_TIMEOUT_SECONDS = 3
+_RECOVERY_SCHEDULING_TIMEOUT_SECONDS = 0.25
 _FALLBACK_TIMEOUT_SECONDS = 2
 _MAX_DAEMON_RESPONSE_BYTES = 1_000_000
 _MAX_HOOK_INPUT_BYTES = 1_000_000
 _HOOK_DEADLINE_SECONDS = 8
-_FALLBACK_SCHEDULING_RESERVE_SECONDS = 0.5
 _MINIMUM_OPERATION_SECONDS = 0.01
 _OVERLOAD_RESERVE_MS = 100
 _OVERLOAD_REASON = (
@@ -128,11 +128,8 @@ def main(
             response_body = _recover_retry_or_fallback(
                 reason,
                 data,
-                state_path=state_path,
-                fallback_daemon_url=fallback_daemon_url,
                 fallback_command=fallback_command,
                 recovery_command=recovery_command,
-                query=query,
                 deadline=deadline,
                 failure_kind=failure_kind,
             )
@@ -174,14 +171,6 @@ def _remaining_seconds(deadline: float | None, *, cap: float) -> float:
     if deadline is None:
         return cap
     return min(cap, max(0.0, deadline - time.monotonic()))
-
-
-def _deadline_with_reserve(deadline: float | None, *, reserve_seconds: float) -> float | None:
-    """Keep time for a required later operation inside one absolute hook deadline."""
-
-    if deadline is None:
-        return None
-    return max(time.monotonic(), deadline - reserve_seconds)
 
 
 def _post_to_loopback_daemon(
@@ -487,43 +476,22 @@ def _recover_retry_or_fallback(
     reason: str,
     data: str,
     *,
-    state_path: str | Path,
-    fallback_daemon_url: str,
     fallback_command: tuple[str, ...],
     recovery_command: tuple[str, ...],
-    query: str,
     deadline: float | None = None,
     failure_kind: str = "transport-failure",
 ) -> str:
-    if recovery_command and _run_recovery_command(
-        recovery_command,
-        deadline=_deadline_with_reserve(
-            deadline,
-            reserve_seconds=(
-                _DAEMON_IO_TIMEOUT_SECONDS + _FALLBACK_TIMEOUT_SECONDS + _FALLBACK_SCHEDULING_RESERVE_SECONDS
-            ),
-        ),
-        failure_kind=failure_kind,
-    ):
-        try:
-            endpoint = urljoin(_daemon_url(state_path, fallback_daemon_url), f"/v1/hooks/claude-code?{query}")
-            _assert_loopback_http_url(endpoint)
-            return _valid_hook_json_or_degraded(
-                _post_to_loopback_daemon(
-                    endpoint,
-                    data,
-                    state_path=state_path,
-                    deadline=_deadline_with_reserve(
-                        deadline,
-                        reserve_seconds=_FALLBACK_TIMEOUT_SECONDS + _FALLBACK_SCHEDULING_RESERVE_SECONDS,
-                    ),
-                ),
-                reason=f"{reason}; recovered daemon returned malformed hook JSON",
-                data=data,
-            )
-        except Exception as retry_error:
-            reason = f"{reason}; daemon recovery retry failed: {retry_error}"
-    return _run_local_fallback(reason, data, fallback_command, deadline=deadline)
+    fallback_response = _run_local_fallback(reason, data, fallback_command, deadline=deadline)
+    if recovery_command:
+        recovery_deadline = time.monotonic() + _RECOVERY_SCHEDULING_TIMEOUT_SECONDS
+        if deadline is not None:
+            recovery_deadline = min(deadline, recovery_deadline)
+        _ = _run_recovery_command(
+            recovery_command,
+            deadline=recovery_deadline,
+            failure_kind=failure_kind,
+        )
+    return fallback_response
 
 
 def _run_recovery_command(

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5316,9 +5316,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 roots=self._hook_safe_roots(),
             )
             guard_home = self._validated_hook_guard_home(self._optional_string(params.get("guard-home", [None])[-1]))
+            workspace_query = self._normalized_hook_workspace_string(params.get("workspace", [None])[-1])
+            workspace_candidate = (
+                workspace_query if "workspace" in params else self._optional_string(payload.get("cwd"))
+            )
             workspace = self._validated_hook_directory_string(
                 "workspace",
-                self._normalized_hook_workspace_string(params.get("workspace", [None])[-1]),
+                workspace_candidate,
                 roots=self._hook_safe_roots(),
             )
         except _HookPathValidationError as error:

--- a/tests/test_claude_daemon_hook_bridge.py
+++ b/tests/test_claude_daemon_hook_bridge.py
@@ -278,7 +278,7 @@ def test_bridge_timeouts_stay_under_harness_budget() -> None:
     ) + bridge._RECOVERY_TIMEOUT_SECONDS + bridge._FALLBACK_TIMEOUT_SECONDS < bridge._HARNESS_TIMEOUT_BUDGET_SECONDS
 
 
-def test_main_recovers_missing_daemon_and_retries_hook(
+def test_main_falls_back_before_scheduling_missing_daemon_recovery(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -296,16 +296,7 @@ def test_main_recovers_missing_daemon_and_retries_hook(
         del endpoint, data, state_path, deadline
         nonlocal attempts
         attempts += 1
-        if attempts == 1:
-            raise urllib.error.URLError("daemon unavailable")
-        return json.dumps(
-            {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "allow",
-                }
-            }
-        )
+        raise urllib.error.URLError("daemon unavailable")
 
     def fake_recover(
         command: tuple[str, ...],
@@ -330,17 +321,17 @@ def test_main_recovers_missing_daemon_and_retries_hook(
     )
 
     assert result == 0
-    assert attempts == 2
+    assert attempts == 1
     assert len(recovery_commands) == 1
     assert recovery_commands[0][1:3] == ("-I", "-c")
     assert "schedule_guard_daemon_recovery" in recovery_commands[0][3]
-    assert json.loads(capsys.readouterr().out)["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert json.loads(capsys.readouterr().out)["hookSpecificOutput"]["permissionDecision"] == "ask"
 
 
-def test_recovery_retry_reserves_time_for_local_package_review(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_local_package_review_precedes_daemon_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
     now = [2.0]
+    call_order: list[str] = []
     recovery_deadlines: list[float | None] = []
-    retry_deadlines: list[float | None] = []
 
     monkeypatch.setattr(bridge.time, "monotonic", lambda: now[0])
 
@@ -351,45 +342,42 @@ def test_recovery_retry_reserves_time_for_local_package_review(monkeypatch: pyte
         failure_kind: str,
     ) -> bool:
         del command, failure_kind
+        call_order.append("recover")
         recovery_deadlines.append(deadline)
         assert deadline is not None
         now[0] = min(deadline, now[0] + bridge._RECOVERY_TIMEOUT_SECONDS)
         return True
 
-    def fake_post(
-        endpoint: str,
+    def fake_fallback(
+        reason: str,
         data: str,
+        command: tuple[str, ...],
         *,
-        state_path: str | Path,
         deadline: float | None = None,
     ) -> str:
-        del endpoint, data, state_path
-        retry_deadlines.append(deadline)
-        assert deadline is not None
-        now[0] = min(deadline, now[0] + bridge._DAEMON_IO_TIMEOUT_SECONDS)
-        raise TimeoutError("recovered daemon unavailable")
+        del reason, data, command
+        call_order.append("fallback")
+        assert deadline == 8.0
+        return '{"review":true}'
 
     monkeypatch.setattr(bridge, "_run_recovery_command", fake_recover)
-    monkeypatch.setattr(bridge, "_post_to_loopback_daemon", fake_post)
+    monkeypatch.setattr(bridge, "_run_local_fallback", fake_fallback)
 
     response = bridge._recover_retry_or_fallback(
         "daemon unavailable",
         json.dumps({"hook_event_name": "PreToolUse"}),
-        state_path="/missing/daemon-state.json",
-        fallback_daemon_url="http://127.0.0.1:5474",
         fallback_command=(
             sys.executable,
             "-c",
             "import time;time.sleep(1.25);print('{\"review\":true}')",
         ),
         recovery_command=(sys.executable, "-c", "pass"),
-        query="",
         deadline=8.0,
     )
 
     assert json.loads(response) == {"review": True}
-    assert recovery_deadlines == [3.5]
-    assert retry_deadlines == [5.5]
+    assert call_order == ["fallback", "recover"]
+    assert recovery_deadlines == [2.25]
 
 
 def test_recovery_only_restarts_for_transport_auth_and_server_failures() -> None:

--- a/tests/test_codex_daemon_hook_bridge.py
+++ b/tests/test_codex_daemon_hook_bridge.py
@@ -421,6 +421,42 @@ def test_bridge_authenticates_real_daemon_before_hook_delivery(
     assert "could not authenticate the local daemon" not in json.dumps(response).lower()
 
 
+def test_bridge_real_daemon_uses_payload_cwd_for_bounded_compound_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
+    daemon.start()
+    config = _bridge_config(guard_home, daemon.port)
+    config["query"] = urlencode({"guard-home": str(guard_home), "home": str(tmp_path)})
+    config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(
+            json.dumps(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "shell",
+                    "tool_input": {"command": 'pwd; git status --short --branch; sed -n "1,5p" README.md'},
+                    "cwd": str(workspace),
+                }
+            )
+        ),
+    )
+
+    try:
+        exit_code = bridge.main(**config)
+    finally:
+        daemon.stop()
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == {}
+
+
 def test_real_daemon_rejects_consumed_challenge_replay(tmp_path: Path) -> None:
     guard_home = tmp_path / "guard-home"
     workspace = tmp_path / "workspace"
@@ -774,7 +810,9 @@ except SystemExit:
         daemon.shutdown()
         daemon_thread.join(timeout=5)
 
-    assert all(result.returncode == 0 for result in results)
+    assert all(result.returncode == 0 for result in results), [
+        (result.returncode, result.stdout, result.stderr) for result in results
+    ]
     assert all(json.loads(result.stdout) == {} for result in results)
     elapsed_samples = [float(result.stderr.rsplit("bridge-elapsed=", 1)[1]) for result in results]
     # The process timeout enforces the hard two-second wall-clock budget. The

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1795,6 +1795,54 @@ class TestGuardSurfaceServer:
         assert response.status == 200
         assert payload == {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}
 
+    def test_guard_daemon_runtime_hook_uses_validated_payload_cwd_when_query_omits_workspace(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        captured: dict[str, str | None] = {}
+
+        def fake_review(**kwargs):
+            captured["workspace"] = str(kwargs["workspace"])
+            from codex_plugin_scanner.guard.daemon.hook_process_runner import HookProcessReview
+
+            return HookProcessReview({}, None)
+
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+        monkeypatch.setattr(daemon._server.hook_process_runner, "review", fake_review)
+
+        try:
+            request = urllib.request.Request(
+                (
+                    f"http://127.0.0.1:{daemon.port}/v1/hooks/claude-code?"
+                    f"guard-home={urllib.parse.quote(str(store.guard_home))}&"
+                    f"home={urllib.parse.quote(str(tmp_path))}"
+                ),
+                data=json.dumps(
+                    {
+                        "hook_event_name": "PreToolUse",
+                        "tool_name": "shell",
+                        "tool_input": {"command": "pwd; git status --short --branch"},
+                        "cwd": str(workspace_dir),
+                    }
+                ).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert response.status == 200
+        assert payload == {}
+        assert captured["workspace"] == str(workspace_dir)
+
     def test_guard_daemon_claude_hook_endpoint_preserves_workspace_trailing_none_sentinel(
         self, tmp_path, monkeypatch
     ) -> None:


### PR DESCRIPTION
## Summary
- preserve validated hook working-directory context when managed bridges omit a workspace query parameter
- complete isolated fallback review before bounded daemon recovery scheduling
- cover authenticated Codex compound reads and dead-daemon fallback ordering

## Testing
- `uv run --no-sync pytest -q tests/test_codex_daemon_hook_bridge.py tests/test_claude_daemon_hook_bridge.py tests/test_guard_package_hook_phase14.py::test_phase14_claude_daemon_hook_bridge_queues_package_install_without_node tests/test_guard_surface_server.py::TestGuardSurfaceServer::test_guard_daemon_runtime_hook_uses_validated_payload_cwd_when_query_omits_workspace tests/test_guard_surface_server.py::TestGuardSurfaceServer::test_guard_daemon_claude_hook_endpoint_preserves_workspace_none_sentinel --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py tests/test_codex_daemon_hook_bridge.py tests/test_claude_daemon_hook_bridge.py tests/test_guard_surface_server.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py tests/test_codex_daemon_hook_bridge.py tests/test_claude_daemon_hook_bridge.py tests/test_guard_surface_server.py`
- `git diff --check`
