### PR TITLE
fix(daemon): keep observe mode non-blocking

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11484,
-  "maximum_test_source_lines": 271315,
+  "maximum_test_source_lines": 271379,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11484,
-  "maximum_test_source_lines": 271180,
+  "maximum_test_source_lines": 271315,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5590,7 +5590,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                         "permissionDecision": "allow",
                     },
                 }
-            return {"reason_code": reason_code}
+            return {
+                "continue": True,
+                "reason_code": reason_code,
+                "observed_review_failure": True,
+            }
         if harness == "pi":
             return {
                 "decision": "deny",

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5557,6 +5557,40 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         runtime_harness = self._optional_string(params.get("runtime-harness", [None])[-1])
         harness = (runtime_harness or default_harness).strip().lower().replace("_", "-")
         event = self._optional_string(payload.get("hook_event_name", payload.get("event"))) or "PreToolUse"
+        daemon_server = getattr(self, "server", None)
+        try:
+            observe_mode = (
+                daemon_server is not None
+                and load_guard_config(cast(_GuardDaemonHttpServer, daemon_server).store.guard_home).mode == "observe"
+            )
+        except (OSError, RuntimeError, TypeError, ValueError):
+            observe_mode = False
+        if observe_mode:
+            if harness == "pi":
+                return {
+                    "decision": "allow",
+                    "reason_code": reason_code,
+                    "observed_review_failure": True,
+                }
+            if event == "PermissionRequest":
+                return {
+                    "reason_code": reason_code,
+                    "hookSpecificOutput": {
+                        "hookEventName": event,
+                        "decision": {
+                            "behavior": "allow",
+                        },
+                    },
+                }
+            if event == "PreToolUse":
+                return {
+                    "reason_code": reason_code,
+                    "hookSpecificOutput": {
+                        "hookEventName": event,
+                        "permissionDecision": "allow",
+                    },
+                }
+            return {"reason_code": reason_code}
         if harness == "pi":
             return {
                 "decision": "deny",

--- a/tests/test_guard_observe_mode_liveness.py
+++ b/tests/test_guard_observe_mode_liveness.py
@@ -22,6 +22,7 @@ def _review_request(
     daemon: GuardDaemonServer,
     *,
     endpoint: str,
+    event: str = "PreToolUse",
     guard_home: Path,
     workspace: Path,
 ) -> dict[str, object]:
@@ -33,7 +34,7 @@ def _review_request(
         ),
         data=json.dumps(
             {
-                "hook_event_name": "PreToolUse",
+                "hook_event_name": event,
                 "tool_name": "Bash",
                 "tool_input": {"command": "git status --short"},
             }
@@ -106,9 +107,67 @@ def test_observe_mode_does_not_block_failed_local_review(
     assert payload == expected
 
 
+@pytest.mark.parametrize(
+    ("event", "expected"),
+    (
+        (
+            "PermissionRequest",
+            {
+                "reason_code": _DEADLINE_REASON,
+                "hookSpecificOutput": {
+                    "hookEventName": "PermissionRequest",
+                    "decision": {"behavior": "allow"},
+                },
+            },
+        ),
+        (
+            "PostToolUse",
+            {
+                "continue": True,
+                "reason_code": _DEADLINE_REASON,
+                "observed_review_failure": True,
+            },
+        ),
+    ),
+)
+def test_observe_mode_uses_native_nonblocking_claude_responses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    event: str,
+    expected: dict[str, object],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    guard_home.mkdir(parents=True)
+    (guard_home / "config.toml").write_text('mode = "observe"\n', encoding="utf-8")
+    daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
+    daemon.start()
+    monkeypatch.setattr(
+        daemon._server.hook_process_runner,  # pyright: ignore[reportPrivateUsage]
+        "review",
+        _failed_review,
+    )
+
+    try:
+        payload = _review_request(
+            daemon,
+            endpoint="claude-code",
+            event=event,
+            guard_home=guard_home,
+            workspace=workspace,
+        )
+    finally:
+        daemon.stop()
+
+    assert payload == expected
+
+
+@pytest.mark.parametrize("endpoint", ("pi", "claude-code"))
 def test_prompt_mode_still_blocks_failed_local_review(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    endpoint: str,
 ) -> None:
     guard_home = tmp_path / "guard-home"
     workspace = tmp_path / "workspace"
@@ -124,12 +183,17 @@ def test_prompt_mode_still_blocks_failed_local_review(
     try:
         payload = _review_request(
             daemon,
-            endpoint="pi",
+            endpoint=endpoint,
             guard_home=guard_home,
             workspace=workspace,
         )
     finally:
         daemon.stop()
 
-    assert payload["decision"] == "deny"
+    if endpoint == "pi":
+        assert payload["decision"] == "deny"
+    else:
+        hook_output = payload["hookSpecificOutput"]
+        assert isinstance(hook_output, dict)
+        assert hook_output["permissionDecision"] == "deny"
     assert payload["reason_code"] == _DEADLINE_REASON

--- a/tests/test_guard_observe_mode_liveness.py
+++ b/tests/test_guard_observe_mode_liveness.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.daemon.hook_process_runner import HookProcessReview
+from codex_plugin_scanner.guard.store import GuardStore
+
+_DEADLINE_REASON = "daemon_hook_process_deadline_exhausted"
+
+
+def _failed_review(**_kwargs: object) -> HookProcessReview:
+    return HookProcessReview(None, _DEADLINE_REASON)
+
+
+def _review_request(
+    daemon: GuardDaemonServer,
+    *,
+    endpoint: str,
+    guard_home: Path,
+    workspace: Path,
+) -> dict[str, object]:
+    request = urllib.request.Request(
+        (
+            f"http://127.0.0.1:{daemon.port}/v1/hooks/{endpoint}?"
+            f"guard-home={urllib.parse.quote(str(guard_home))}&"
+            f"workspace={urllib.parse.quote(str(workspace))}"
+        ),
+        data=json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "git status --short"},
+            }
+        ).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "X-Guard-Token": daemon._server.auth_token,  # pyright: ignore[reportPrivateUsage]
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        assert response.status == 200
+        payload = json.loads(response.read())
+    assert isinstance(payload, dict)
+    return payload
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "expected"),
+    (
+        (
+            "pi",
+            {
+                "decision": "allow",
+                "reason_code": _DEADLINE_REASON,
+                "observed_review_failure": True,
+            },
+        ),
+        (
+            "claude-code",
+            {
+                "reason_code": _DEADLINE_REASON,
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "allow",
+                },
+            },
+        ),
+    ),
+)
+def test_observe_mode_does_not_block_failed_local_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: str,
+    expected: dict[str, object],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    guard_home.mkdir(parents=True)
+    (guard_home / "config.toml").write_text('mode = "observe"\n', encoding="utf-8")
+    daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
+    daemon.start()
+    monkeypatch.setattr(
+        daemon._server.hook_process_runner,  # pyright: ignore[reportPrivateUsage]
+        "review",
+        _failed_review,
+    )
+
+    try:
+        payload = _review_request(
+            daemon,
+            endpoint=endpoint,
+            guard_home=guard_home,
+            workspace=workspace,
+        )
+    finally:
+        daemon.stop()
+
+    assert payload == expected
+
+
+def test_prompt_mode_still_blocks_failed_local_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True)
+    daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
+    daemon.start()
+    monkeypatch.setattr(
+        daemon._server.hook_process_runner,  # pyright: ignore[reportPrivateUsage]
+        "review",
+        _failed_review,
+    )
+
+    try:
+        payload = _review_request(
+            daemon,
+            endpoint="pi",
+            guard_home=guard_home,
+            workspace=workspace,
+        )
+    finally:
+        daemon.stop()
+
+    assert payload["decision"] == "deny"
+    assert payload["reason_code"] == _DEADLINE_REASON


### PR DESCRIPTION
## Summary
- keep observe mode non-blocking when isolated local hook review cannot complete
- preserve fail-closed behavior for prompt and enforcement modes
- cover Pi and structured hook response contracts

## Testing
- `uv run --no-sync pytest -q tests/test_guard_observe_mode_liveness.py tests/test_guard_hook_process_deadline_contract.py tests/test_guard_omp_fast_path_regression.py tests/test_guard_daemon_storage_liveness.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_observe_mode_liveness.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_observe_mode_liveness.py`
- `uv run --no-sync basedpyright --level error`
- `git diff --check`
