### PR TITLE
style: apply ruff format to cloud exception requests

### DIFF
--- a/src/codex_plugin_scanner/guard/cloud_exception_requests.py
+++ b/src/codex_plugin_scanner/guard/cloud_exception_requests.py
@@ -127,10 +127,18 @@ def validate_command_policy_exception_payload(payload: dict[str, object]) -> dic
 
     # Reject forbidden keys — no command/graph/policy material crosses
     # the dashboard-to-Cloud boundary.
-    forbidden_keys = frozenset({
-        "rawCommand", "command", "commandExpression", "graph", "proposedGraph",
-        "expression", "regex", "pattern",
-    })
+    forbidden_keys = frozenset(
+        {
+            "rawCommand",
+            "command",
+            "commandExpression",
+            "graph",
+            "proposedGraph",
+            "expression",
+            "regex",
+            "pattern",
+        }
+    )
     for key in forbidden_keys:
         if key in payload:
             raise ValueError(f"Command-policy request must not include '{key}'.")


### PR DESCRIPTION
## Problem

`release/3.1` CI `quality` job fails on `ruff format --check src/` because `src/codex_plugin_scanner/guard/cloud_exception_requests.py` (merged in #1965) was not formatted. The `ci (3.12)` rollup job fails as a consequence; the actual test matrix passes.

## Change

Apply `ruff format` to the single offending file. No behavioral change.

## Verification

- `ruff format --check src/`: 632 files already formatted
- `ruff check` on the file: OK
- focused cloud-exception tests: 35 passed

No release or deployment is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted an internal validation configuration for improved readability.
  * No user-visible behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->