### PR TITLE
docs(guard): add execution-path, harness-grade, and sandbox-required inventories

### DIFF
--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -13,7 +13,7 @@ The runtime is split into:
 - `guard/store`: SQLite persistence for snapshots, diffs, receipts, managed installs, and sync state
 - `guard/schemas`: stable JSON payloads for consumer-mode outputs
 
-Runtime detectors include a Safe Decode sandbox for encoded commands and prompt text. It unwraps bounded base64, hex, gzip, heredoc, Python `-c`, Node `-e`, and PowerShell `-EncodedCommand` layers, redacts decoded previews, records the detector version in evidence, and never executes decoded payloads.
+Runtime detectors include a Safe Decode scanning layer for encoded commands and prompt text. It unwraps bounded base64, hex, gzip, heredoc, Python `-c`, Node `-e`, and PowerShell `-EncodedCommand` layers, redacts decoded previews, records the detector version in evidence, and never executes decoded payloads.
 
 Guard evaluates local artifacts in this order:
 

--- a/docs/guard/release-3-1-architecture-guarantees.md
+++ b/docs/guard/release-3-1-architecture-guarantees.md
@@ -1,0 +1,71 @@
+# `release/3.1` architecture and guarantee matrix
+
+Status: wave-zero baseline. Audience: execution-assurance implementers and gate reviewers. Pinned ref: `origin/release/3.1` at `10348fd40fa53ef60d9363bb6c37591b8bb60a61`.
+
+A process/function view of HOL Guard that keeps the five enforcement-adjacent planes distinct — harness hooks, the analysis decode scanner, OS containment, MDM/EDR, and evidence/Cloud — with the guarantee each actually provides.
+
+## Process/function diagram
+
+```
+                         ┌──────────────────────────────────────────────┐
+                         │                 Harnesses                    │
+                         │  Codex Claude Copilot Cursor Gemini Grok ... │
+                         └───────┬──────────────────────┬───────────────┘
+                    hook invoke  │                      │ launch
+                                 ▼                      ▼
+        ┌─────────────────────────────┐   ┌────────────────────────────┐
+        │  (1) Harness hooks          │   │ (4) CLI wrappers / shims   │
+        │  pre/post tool intercept    │   │ hol-guard run / protect    │
+        └───────┬─────────────────────┘   └───────┬────────────────────┘
+                │ evaluate                        │ launch-gate
+                ▼                                 ▼
+        ┌────────────────────────────────────────────────────────────┐
+        │  (2) Runtime evaluation (action lattice)                   │
+        │  command_evaluation → effect_decision → composed action    │
+        │  allow<warn<review<require-reapproval<sandbox-required<blk │
+        └───────┬───────────────────────────────┬────────────────────┘
+                │ decode-only                   │ sandbox-required
+                ▼                               ▼
+        ┌───────────────────────────┐   ┌────────────────────────────┐
+        │ (3) Safe Decode scanner   │   │ (5) OS containment         │
+        │ text unwrap, never exec   │   │ Seatbelt / Bubblewrap      │
+        └───────────────────────────┘   └───────┬────────────────────┘
+                                                │ contained subprocess
+                ┌───────────────────────────────┼────────────────────┐
+                ▼                               ▼                    ▼
+        ┌──────────────────┐        ┌──────────────────┐   ┌──────────────────┐
+        │ (6) Evidence     │        │ (7) Approval     │   │ (8) MDM / EDR    │
+        │ receipts + store │        │ center queue     │   │ device seams     │
+        └───────┬──────────┘        └──────────────────┘   └──────────────────┘
+                │ sync (cached, workspace-scoped)
+                ▼
+        ┌──────────────────┐
+        │ (9) Guard Cloud  │  policy distribution, fleet truth (observe-only)
+        └──────────────────┘
+```
+
+## Plane guarantees
+
+| Plane | Component | Guarantee it provides | Guarantee it does NOT provide |
+| --- | --- | --- | --- |
+| Harness hooks | `cli/commands_hook_*` | pre/post-tool interception where the harness protocol supports it; fail-closed under strict fail mode | interception on harnesses without an enforceable hook surface |
+| Analysis decode scanner | `runtime/safe_decode.py` | bounded text unwrapping of encoded layers; eval/exec signal detection; never executes decoded payloads | execution containment, network/fs control (it is a scanner, not a sandbox) |
+| OS containment | `runtime/containment_executor.py` | OS-enforced fs/network/process limits via Seatbelt/Bubblewrap where the backend is available | containment when the backend binary is unavailable (guarantee lowers via the lattice) |
+| MDM / EDR | `mdm/`, lifecycle scheduler | device enrollment/touch state, removal seams | local command enforcement |
+| Evidence / Cloud | `store/`, `synced_policy.py`, portal routes | durable receipts, cached authenticated policy, workspace-scoped fleet truth | remote workload execution (post-MVP, separately gated) |
+
+## Distinctness assertions (for docs review)
+
+1. Hooks (1), the analysis decode scanner (3), and OS containment (5) are three different things: hooks intercept, the scanner inspects text without executing, containment executes under OS limits. No one substitutes for another.
+2. MDM/EDR (8) is a device-identity/enrollment plane, not a command-enforcement plane.
+3. Evidence/Cloud (6, 9) is an evidence and policy-distribution plane; Cloud is observe-only for fleet truth and does not execute local workloads.
+4. `sandbox-required` (plane 2) routes to OS containment (plane 5) and is never satisfied by the analysis decode scanner (plane 3).
+
+## Terminology (see `release-3-1-terminology.md`)
+
+The word "sandbox" is reserved for OS-enforced execution containment (Seatbelt/Bubblewrap). The decode scanner is not a sandbox: it never executes. `sandbox-required` is an action-lattice directive, not a component name.
+
+## Notes
+
+- This document describes current architecture; it does not authorize new planes or remote execution.
+- Containment guarantee detail lives in `release-3-1-containment-baseline.md`; execution paths in `release-3-1-execution-path-inventory.md`.

--- a/docs/guard/release-3-1-cloud-control-inventory.md
+++ b/docs/guard/release-3-1-cloud-control-inventory.md
@@ -1,0 +1,35 @@
+# Guard Cloud control and evidence paths inventory
+
+Status: wave-zero baseline. Audience: execution-assurance gate reviewers. Pinned refs: `hol-points-portal` `main` at `8d6d20daae94144bcda4e61f7fb575437751b8db`; HOL Guard `release/3.1` at `10348fd40fa53ef60d9363bb6c37591b8bb60a61`.
+
+Maps Guard Cloud policy distribution, identity, device, evidence, command, session, protection, remediation, incident, notification, and MDM/EDR paths to their routes, repositories, schemas, and UI, with workspace/tenant authorization.
+
+## Authorization model
+
+Every Guard Cloud route resolves an actor through `resolveGuardActor()` (`src/lib/guard/guard-cloud-auth.ts`). The actor carries `workspaceId` (`:249-267`), resolved from the session's default workspace. Tenant isolation is by workspace: queries filter on `workspaceId` (e.g. OAuth grants at `:789`, `:848`, `:886`, `:912`, `:931`, `:942`). Routes return a stable error via `getGuardRouteErrorMessage`/`getGuardRouteErrorStatus` (`guard-cloud-route-error.ts`).
+
+## Control and evidence matrix
+
+| Capability | Route(s) | Repository / service | Schema (Drizzle) | Authorization |
+| --- | --- | --- | --- | --- |
+| Policy distribution | `GET/PUT app/api/guard/policy/route.ts`; `policy/plane`, `policy/defaults`, `policy/draft/*`, `policy/sync/{ack,summary}`, `policy/simulation/*`, `policy/test/*`, `team/policy-pack` | `src/lib/guard/service/policy-service.ts`, `guard-cloud-service.ts` | `hol-guard-cloud-schema.ts`, `hol-guard-protection-control-schema.ts` | `resolveGuardActor`, workspace-scoped |
+| OAuth / device identity | `app/api/guard/oauth/{authorize,device,grants,jwks,register,revoke,token}` | `src/lib/guard/guard-cloud-auth.ts` | `hol-guard-oauth-core-schema.ts` (clients, redirect URIs, secrets, JWKS keys, assertion JTIs, auth codes, device codes, DPoP proofs, consents), `hol-guard-oauth-platform-schema.ts`, `hol-guard-oauth-schema.ts` | OAuth grant + workspace claims |
+| Device inventory | `app/api/guard/devices/route.ts`, `app/api/guard/fleet/devices` | device service | `hol-guard-lifecycle-schema.ts`, `hol-guard-remote-pairing-schema.ts` | workspace-scoped (`workspaceId` query + actor) |
+| Evidence ingestion | `app/api/guard/supply-chain/evidence` | supply-chain service | `hol-guard-supply-chain-schema.ts`, `hol-guard-supply-chain-feed-schema.ts`, `hol-guard-supply-chain-workspace-schema.ts` | workspace-scoped |
+| Command queue | `app/api/guard/commands`, `commands/[jobId]/{cancel,heartbeat}`, `commands/device-state`, `commands/lease` | command service | `hol-guard-command-schema.ts` (`holGuardCommandJobs`, `holGuardCommandJobEvents`, `holGuardCommandDeviceCursors`, `holGuardCommandPendingLocalRequests`) | workspace-scoped |
+| Runtime sessions | `app/api/guard/runtime/sessions`, `app/api/guard/session` | session service | `hol-guard-lifecycle-schema.ts` (`holGuardLifecycleEnrollments`, `holGuardLifecycleTouchState`) | workspace-scoped |
+| Protection state | `app/api/guard/runtime/protection`, `jobs/protection-expiry` | protection service | `hol-guard-protection-schema.ts`, `hol-guard-protection-control-schema.ts` | workspace-scoped |
+| Signed remediation | policy draft export + team policy-pack | policy service | `hol-guard-protection-control-schema.ts` | workspace-scoped |
+| Incidents | `app/api/guard/incidents`, `incidents/[incidentId]/{assign,resolve}` | incident service | `hol-guard-cloud-schema.ts` | workspace-scoped |
+| Notifications | `app/api/guard/notifications/{,deliveries,rules}` | notification service | `hol-guard-cloud-schema.ts` | workspace-scoped |
+| MDM / EDR seams | lifecycle scheduler | lifecycle service | `hol-guard-lifecycle-schema.ts` (`holGuardLifecycleSchedulerCursor`, `holGuardLifecycleSchedulerState`) | workspace-scoped |
+
+## Capability negotiation
+
+Cloud ships new policy fields and routes behind entitlement/allowlist and client capability negotiation, reusing the existing `commandPatternExpressions` capability pattern rather than a separate feature-flag subsystem. Cloud never emits an isolation requirement to a client that did not advertise the compatible 3.1 contract version. Existing 2.1/2.2 clients retain current policy, receipt, runtime-session, protection, and approval behavior.
+
+## Notes
+
+- Affiliate, AEO, SEO, billing, CRM, funnel, and analytics guard routes are excluded; they are not control/evidence enforcement paths.
+- `hol-guard-enterprise-intake-schema.ts`, `hol-guard-install-handoff-schema.ts`, `hol-guard-risk-assessment-schema.ts`, `hol-guard-conversion-schema.ts` support onboarding/install flows, not runtime control.
+- This inventory records current routes and schemas; it does not authorize new Cloud persistence or authority.

--- a/docs/guard/release-3-1-containment-baseline.md
+++ b/docs/guard/release-3-1-containment-baseline.md
@@ -1,0 +1,62 @@
+# `release/3.1` isolation implementations and containment baseline
+
+Status: wave-zero baseline. Audience: execution-assurance gate reviewers. Pinned ref: `origin/release/3.1` at `10348fd40fa53ef60d9363bb6c37591b8bb60a61`.
+
+Characterizes every isolation implementation by actual enforced behavior, then records the macOS/Linux containment guarantee matrix. Guarantees are derived from the enforcement code, never inferred from class or file names.
+
+## Isolation implementations
+
+### 1. macOS Seatbelt (`sandbox-exec`)
+
+`runtime/containment_executor.py:331-356` builds a Seatbelt profile with `(deny default)` (`:339`), grants read-only access to system roots, read-write to the bounded temp root, `(deny network*)` (`:352`), and denies process-fork. The executable is pinned: copied to `temp_root/guard-exec`, mode `0o500`, with SHA-256 digest verified before spawn (`:198-221`). Executable or input drift fails closed before the process starts (`tests/test_guard_containment_executor.py:62,78`).
+
+### 2. Linux Bubblewrap (`bwrap`)
+
+`runtime/containment_executor.py:357-382` builds the bwrap argv with `--unshare-all` (`:366`, includes `--unshare-net`), read-only binds for system libraries (`--ro-bind`, `:379`), `--chdir` to the sandbox cwd, and `--clearenv` with explicit per-variable `--setenv` (`:382`). Backend selected at `:159-162` (`/usr/bin/sandbox-exec` for macOS, `/usr/bin/bwrap`/`/bin/bwrap` for Linux).
+
+### 3. Restricted pytest
+
+`runtime/restricted_pytest_sandbox.py` builds the OS sandbox for test runs. `_macos_profile()` (`:82-115`) produces `(deny default)` with `(allow process-fork)`, `(allow process-exec)`, and file-read/file-write scoped to workspace + temp root. `_bubblewrap_argv()` (`:154-180`) adds `--unshare-net`, `--tmpfs /tmp`, read-only system binds, and a workspace bind. `_run_backend_process()` (`:203-255`) applies resource limits: CPU 20m, memory 4GB, file 256MB, 256 open files, 64 processes. `runtime/restricted_pytest_model.py:26-74` defines environment scrubbing: 28 denied keys (`AWS_*`, `DOCKER_*`, `KUBECONFIG`, `SSH_AUTH_SOCK`, `*KEY`, `*PASSWORD`, `*SECRET`, `*TOKEN`), proxy keys stripped, a safe-key allowlist, and a `_SECRET_ENV_PATTERN` regex matching API/AUTH/BEARER/CREDENTIAL/PASSWORD/SECRET/TOKEN. Denied capabilities: network, docker-socket, write-outside-workspace-and-private-temp, unapproved-process-exec, privileged-operation.
+
+### 4. Safe Decode scanning
+
+`runtime/safe_decode.py` is a pure text-decoding pipeline for encoded commands/prompts. Hard limits: `_MAX_INPUT_BYTES` 256KB, `_MAX_DECODED_BYTES` 512KB, `_MAX_RECURSION_DEPTH` 3, `_MAX_DECODE_TIME_MS` 50ms (`:12-18`). Thirteen encoding types are unwrapped (`:20-26`). `_recursive_decode()` (`:65-83`) enforces size/depth/time limits with early return and never calls `eval`/`exec`/`marshal.loads`. Detected eval/exec/marshal signals are regex pattern matches on decoded text only (`:87-141`); decoded content is never executed.
+
+### 5. Temporary-directory runners
+
+`contained_node_execution.py`, `contained_package_script_execution.py`, `contained_typescript_execution.py`, `contained_workspace_write_execution.py` all delegate to `containment_executor.execute_contained()`. Each scrubs the environment to a safe allowlist (`LANG`/`LC_ALL`/`LC_CTYPE`/`NO_COLOR`/`TERM` passthrough), canonicalizes the workspace, and bounds output to 64KB (`containment_executor.py:33`). `runtime/offline_archive_sandbox.py` adds a Python audit hook that denies write opens and capability grants (`:73-87`, `:93-133`), applies RLIMIT_AS/CPU/FSIZE/NOFILE/NPROC in the child (`:32-67`), and wraps with `sandbox-exec -p '(deny network*)'` on macOS (`:149-159`).
+
+### 6. Docker labs
+
+No runtime code under `guard/` builds or runs Docker containers for isolation. Docker references are classification rules (docker-sensitive command action classes), secret-path patterns (`.docker/config.json`), inventory schema fields, and CLI lab-host allowlisting (`host.docker.internal`). Docker is not an isolation backend in this baseline.
+
+## Containment guarantee matrix (macOS / Linux)
+
+| Control | macOS Seatbelt | Linux Bubblewrap | Enforcement |
+| --- | --- | --- | --- |
+| Filesystem | read-only system roots; write only to bounded temp root | `--ro-bind` system libs; workspace bind only | `containment_executor.py:339-356`, `:357-382` |
+| Network | `(deny network*)` | `--unshare-all` (incl `--unshare-net`) | `:352`, `:366` |
+| Process | `(deny process-fork)` | `--new-session`, NPROC limit | `:339-356`, `:366`; `restricted_pytest_sandbox.py:203-255` |
+| Secret (env) | `--clearenv` + explicit `--setenv` | `--clearenv` + explicit `--setenv` | `:382`; `restricted_pytest_model.py:26-74` |
+| Output | 64KB bounded capture | 64KB bounded capture | `containment_executor.py:33` |
+| Timeout | `subprocess.TimeoutExpired` → `os.killpg` | `subprocess.TimeoutExpired` → `os.killpg` | `containment_executor.py:298-315` |
+| Cleanup | process-group SIGKILL; temp root bounded | process-group SIGKILL; temp root bounded | `containment_executor.py:298-315` |
+| Identity | executable pinned + SHA-256 verified before spawn | executable pinned + SHA-256 verified before spawn | `containment_executor.py:198-221`, `:334-354` |
+
+Where a control is not enforced by the backend it is omitted rather than inferred. Unsupported controls lower guarantees via the action lattice (sandbox-required never collapses to review).
+
+## Behavioral tests
+
+- `tests/test_guard_containment_executor.py` — backend selection fallback, executable/input drift fails closed.
+- `tests/test_guard_containment_contract.py` — attestation immutability, failure reason codes.
+- `tests/test_guard_containment_health.py` — compatibility signals, sandbox status.
+- `tests/test_guard_containment_external_executable.py` — pin/digest/0o500 verification, immutable rejection, replacement fails closed.
+- `tests/test_guard_contained_{node,package_script,typescript,workspace_write}_execution.py` — backend success/failure paths.
+- `tests/test_guard_contained_workspace_write_contract.py` — policy/request/declared-output validation.
+- `tests/test_guard_daemon_containment_health.py` — daemon `/v1/runtime/containment-health` auth.
+- `tests/test_guard_daemon_adversarial_transport.py` — owner retained until worker containment.
+
+## Notes
+
+- This baseline records current enforced behavior; it does not authorize new isolation backends.
+- Real-backend isolated runs (macOS Seatbelt, Linux bwrap) are exercised by CI on their respective platforms; this document does not substitute for that matrix.

--- a/docs/guard/release-3-1-dx-performance-baseline.md
+++ b/docs/guard/release-3-1-dx-performance-baseline.md
@@ -1,0 +1,39 @@
+# `release/3.1` DX and performance baseline
+
+Status: wave-zero baseline. Audience: execution-assurance gate reviewers. Pinned ref: `origin/release/3.1` at `10348fd40fa53ef60d9363bb6c37591b8bb60a61`. Measured on macOS (Apple M4 Max), single process, synthetic workspace.
+
+Privacy-safe aggregate measurements only. No raw user inbox data, command content, or machine paths are included; the corpus below uses synthetic commands.
+
+## Hook evaluation latency
+
+`evaluate_command()` end-to-end (parse → risk signals → composed action) measured over a synthetic corpus spanning benign, risky, compound, and failure-state commands (`git status`, `npm install lodash`, `rm -rf /tmp/x`, `cat ~/.aws/credentials`, `gh pr view`, `git push --force`, `curl … | sh`).
+
+| Metric | 5-command corpus (n=300) | 7-command corpus (n=400) |
+| --- | --- | --- |
+| p50 | 0.11 ms | 0.129 ms |
+| p95 | 0.17 ms | 0.192 ms |
+| p99 | 0.20 ms | 0.283 ms |
+| max | 0.30 ms | 0.378 ms |
+
+Local evaluation is sub-millisecond per command; the hook path is not CPU/latency-bound on policy evaluation itself. End-to-end hook latency is dominated by process spawn and any daemon round-trip, not the evaluation core.
+
+## Existing enforced budgets
+
+- Daemon: 100 safe hook evaluations complete within a 10s budget (`tests/test_guard_daemon_perf.py:212-220`).
+- Daemon threads: hook load does not grow the thread count beyond +5 over baseline (`test_guard_daemon_perf.py:195`).
+- Module import: Guard module import stays under a 50 MB RSS budget (`test_guard_daemon_perf.py:224`).
+- Pi harness hook: returns before the worker deadline; fallbacks stay inside the outer hook deadline and the host timeout (`tests/test_pi_hook_latency.py:73,156,199`).
+- Receipt analytics: rollup analytics complete under 50 ms (`tests/test_guard_receipt_persistence.py`).
+
+## Approval interruption
+
+Approval interruption latency is governed by the approval grant, which is a 30-second transaction-local grant for the exact action/scope/subject/session nonce (see README). The evaluation path that raises an approval requirement is the same sub-millisecond `evaluate_command` path; user-facing interruption time is bounded by the approval-center round-trip, not by evaluation.
+
+## Methodology
+
+Measurements used `time.perf_counter()` around `evaluate_command()` in a synthetic temporary workspace (`--with-editable .` install), 300–400 iterations over a rotating synthetic corpus, results sorted for percentiles. No real user commands, files, or paths were read. Benchmark scripts were temporary and not committed.
+
+## Notes
+
+- These are single-process local numbers; CI platform matrix (macOS/Linux/Windows, Python 3.10–3.13) owns cross-platform performance evidence.
+- This baseline does not authorize new performance budgets; it records current behavior and existing enforced budgets.

--- a/docs/guard/release-3-1-execution-path-inventory.md
+++ b/docs/guard/release-3-1-execution-path-inventory.md
@@ -1,0 +1,32 @@
+# `release/3.1` execution-path inventory
+
+Status: wave-zero baseline inventory. Audience: execution-assurance implementers and gate reviewers. Pinned ref: `origin/release/3.1` at `10348fd40fa53ef60d9363bb6c37591b8bb60a61`.
+
+This document is the versioned execution-path matrix for HOL Guard: every distinct path by which Guard intercepts, evaluates, or executes an action, with its entry point, execution owner, failure mode, and actual guarantee.
+
+## Execution paths
+
+| # | Path | Entry point | Execution owner | Failure mode | Actual guarantee |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Daemon HTTP API | `daemon/server.py` route table (`/v1/*`), e.g. `initialize` `:2231`, `sessions/list` `:2232` | Local daemon process (Guard-owned) | Daemon down → callers fall back per-surface (CLI one-shot, hook direct eval) | Authenticated local decisions when daemon reachable; routes map 1:1 to `runtime/surface_server.py:SERVER_METHODS` |
+| 2 | Hook bridge dispatch | `cli/commands_hook_router.py` → per-harness handlers (`commands_hook_codex.py`, `commands_hook_claude.py`, `commands_hook_copilot.py`, `commands_hook_generic.py`) | Hook subprocess (Guard-owned, harness-invoked) | Hook error/timeout → per-adapter behavior; harnesses without enforceable hooks are observe-only | Pre/post-tool interception where the harness protocol supports it |
+| 3 | Runtime evaluation pipeline | `runtime/command_evaluation.py:evaluate_command` (`:114`); effect decisions via `runtime/effect_decision.py:evaluate_effect_decision` | Guard evaluation core | Parse uncertainty → fail-closed minimum floor (`review`/`block`); unknown actions normalize to `review` (`action_lattice.py:11-12`) | Deterministic action lattice: `allow < warn < review < require-reapproval < sandbox-required < block` (`action_lattice.py:5`) |
+| 4 | CLI wrappers | `hol-guard run <harness>`, `hol-guard protect -- <cmd>` (cli/commands_*.py) | Guard CLI process | Wrapper failure → command not launched (no silent pass-through) | Launch-gate: harness only starts when effective action is not `block` (docs/guard/architecture.md) |
+| 5 | Package shims | `guard/shims/` — npm/npx/pnpm/yarn/bun, pip/pip3/pipenv/pipx/poetry/uv/uvx, cargo, go, mvn/gradle, composer, bundle | Shim wrapper process (Guard-owned) | Shim absent → package manager runs unmanaged | Support labels in `docs/guard/testing-matrix.md`: Protected (npm, PyPI), Beta (Cargo/Go/Maven/Composer/RubyGems), Monitor-only (Docker/Actions/system/NuGet) |
+| 6 | Containment executor | `runtime/containment_executor.py`, `containment_contract.py`, `containment_health.py`; contained runners: `contained_node_execution.py`, `contained_package_script_execution.py`, `contained_typescript_execution.py`, `contained_workspace_write_execution.py`, `cli/commands_contained_write.py` | Contained subprocess under OS sandbox (Seatbelt on macOS, Bubblewrap on Linux) | Sandbox unavailable → guarantee lowered, action upgraded per lattice (sandbox-required never collapses to review: `action_lattice.py:8-9`) | Filesystem/network/process limits enforced by OS sandbox primitives where available |
+| 7 | Restricted analysis sandboxes | `runtime/restricted_pytest*.py`, `runtime/restricted_archive_*.py`, `runtime/offline_archive_sandbox.py`, `runtime/cisco_scan_containment.py` | Guard-owned restricted runner | Restricted runner failure → scan skipped with evidence, never executed outside sandbox | Decode/scan without executing decoded payloads (architecture.md Safe Decode) |
+| 8 | Approval center | `runtime/surface_server.py` `approval/*` methods; persistence `store_approvals.py` (`_QUEUE_IDENTITY_VERSION = "v1"`) | Daemon + approval-center UI | Approval daemon unreachable → actions needing approval hold at `review`/`require-reapproval` | Durable approval queue; 30-second transaction-local grants (README) |
+| 9 | Cloud sync path | `synced_policy.py` (`cached_policy_bundle_validation`), cloud sync-intel | Local policy cache refreshed from Cloud | Cloud unreachable → last authenticated cached bundle enforced; version downgrades rejected (`bundle_version_downgrade`) | Policy continuity without Cloud availability; v1/v2 bundles dispatched on `contractVersion` |
+| 10 | Local dashboard | `dashboard/` served locally | Local daemon + browser | Dashboard down → no enforcement impact (read/approve UI only) | Local-only status/approval surface; not an enforcement boundary |
+
+## Composition invariants
+
+- `sandbox-required` and `require-reapproval` are never lowered by composition rules (`runtime/composition_rules.py:10`). Downgrades exist only for strong false-positive signals and only lower `block → review` or `review → warn` (`composition_rules.py:108-121`); `sandbox-required` is not a downgrade output.
+- Unknown action values crossing an untyped boundary normalize to `review` — fail-closed (`action_lattice.py:11-12`).
+- Composition never overrides an explicit user policy choice (`composition_rules.py:12`).
+
+## Notes for gate reviewers
+
+- Harness ownership grades are recorded separately in `release-3-1-harness-grades.md`.
+- `sandbox-required` consumer semantics are recorded in `release-3-1-sandbox-required-consumers.md`.
+- This inventory is descriptive of current behavior; it does not authorize new execution paths.

--- a/docs/guard/release-3-1-harness-grades.md
+++ b/docs/guard/release-3-1-harness-grades.md
@@ -1,0 +1,41 @@
+# `release/3.1` harness ownership grades
+
+Status: wave-zero baseline. Audience: execution-assurance gate reviewers. Pinned ref: `origin/release/3.1` at `10348fd40fa53ef60d9363bb6c37591b8bb60a61`.
+
+Every supported harness classified by execution-ownership grade: `guard_owned_local`, `host_decision_only`, `observe_only_degraded`, or `unsupported`. `delegable_remote` is a post-MVP capability and no harness is graded for it in this baseline. Grade is derived from the adapter's `approval_tier` and the presence of an enforceable local hook surface.
+
+## Grade definitions
+
+- `guard_owned_local` — Guard intercepts the action and can enforce (block/require approval) before the harness executes it.
+- `host_decision_only` — the harness makes the enforcement decision; Guard supplies the decision payload but cannot itself block execution.
+- `observe_only_degraded` — Guard records evidence/receipts but cannot influence execution; cannot satisfy mandatory assurance.
+- `unsupported` — no enforceable surface exists for mandatory assurance.
+
+## Harness matrix
+
+| Harness | Adapter | `approval_tier` | Hook surface | Grade | Returns provider results? | Mandatory assurance? |
+| --- | --- | --- | --- | --- | --- | --- |
+| Codex | `adapters/codex.py:947` | `native-or-center` | pre/post-tool hooks, shims, daemon (extensive) | `guard_owned_local` | No (local decision) | Yes |
+| Claude Code | `adapters/claude_code.py:157` | `native-or-center` | preToolUse permission + prompt notification hooks | `guard_owned_local` | No (local decision) | Yes |
+| Copilot CLI | `adapters/copilot.py:329` | `native-or-center` | preToolUse + permissionRequest repo hooks | `guard_owned_local` | No (local decision) | Yes |
+| Cursor | `adapters/cursor.py:39` | `native-harness` | hook config + native approval bridge | `guard_owned_local` | No (local decision) | Yes |
+| Pi | base default (`adapters/base.py:119`) | `approval-center` | no enforceable hook surface in adapter | `observe_only_degraded` | No | No |
+| OpenCode | `adapters/opencode.py:71` | `mixed` | no post-execution surface; pre-hook only | `observe_only_degraded` | No | No |
+| Antigravity | `adapters/antigravity.py:23` | `approval-center` | no enforceable hook surface in adapter | `observe_only_degraded` | No | No |
+| Gemini | `adapters/gemini.py:23` | `approval-center` | minimal hook surface | `host_decision_only` | No | Conditional |
+| Grok | `adapters/grok.py:70` | `approval-center` | hook config present | `host_decision_only` | No | Conditional |
+| Kimi | `adapters/kimi.py:51` | `approval-center` | hook config present | `host_decision_only` | No | Conditional |
+| ZCode | `adapters/zcode.py:68` | `approval-center` | hook config present | `host_decision_only` | No | Conditional |
+| Hermes | `adapters/hermes.py:167` (managed tier `:341` = `native-or-center`) | `approval-center` (managed: `native-or-center`) | file inspection + managed hooks | `host_decision_only` (managed path: `guard_owned_local`) | No | Conditional |
+| OpenClaw | `adapters/openclaw.py:41` (managed tier `:212` = `native-or-center`) | `approval-center` (managed: `native-or-center`) | managed hooks | `host_decision_only` (managed path: `guard_owned_local`) | No | Conditional |
+
+## Failure modes
+
+- Hook daemon failure is fail-closed only in `strict` fail mode: `commands_hook_generic.py:558-563` tightens the action to `block` when `daemon_status` is a failure status and `fail_mode == "strict"`. Non-strict fail modes preserve the current composed policy action rather than silently approving, and unknown action spellings remain fail-closed through the normalizer (`commands_hook_generic.py:147`).
+- Harnesses graded `observe_only_degraded` or `host_decision_only` cannot satisfy mandatory assurance: Guard cannot unilaterally block execution there. This is an accepted alpha limitation consistent with the compatibility matrix.
+- Fail-open adapters (those that would approve on hook error/timeout) cannot satisfy mandatory assurance. In the current tree the generic hook path tightens to `block` under `strict` fail mode and otherwise preserves the composed action instead of defaulting to `allow`.
+
+## Notes
+
+- Grades reflect the current `approval_tier` field and hook surface, not marketing claims. `approval-center` means approvals route through the Guard approval center; it does not by itself imply local execution ownership.
+- No harness is graded `delegable_remote` in this baseline; remote delegation is a separately gated post-MVP capability.

--- a/docs/guard/release-3-1-sandbox-required-consumers.md
+++ b/docs/guard/release-3-1-sandbox-required-consumers.md
@@ -1,0 +1,40 @@
+# `release/3.1` `sandbox-required` consumer matrix
+
+Status: wave-zero baseline. Audience: execution-assurance gate reviewers. Pinned ref: `origin/release/3.1` at `10348fd40fa53ef60d9363bb6c37591b8bb60a61`.
+
+The canonical `sandbox-required` directive semantics and every consumer that reads it, with how each preserves directive semantics. The directive is terminal in the action lattice and is never lowered to `allow`.
+
+## Canonical semantics
+
+`action_lattice.py:5` defines the total order `allow < warn < review < require-reapproval < sandbox-required < block` (severity `"sandbox-required": 4` at `:37`). `:8-9` states `sandbox-required` additionally requires an enforceable sandbox and "must never collapse to `review`". `runtime/composition_rules.py:10` states `require-reapproval` and `sandbox-required` requirements are never lowered; the only composition downgrades are strong false-positive paths that lower `block → review` or `review → warn`, never `sandbox-required` (`composition_rules.py:108-121`).
+
+## Consumer matrix
+
+| Consumer | Area | File | Reads directive | Lowers to allow? |
+| --- | --- | --- | --- | --- |
+| Action lattice | core semantics | `action_lattice.py` | defines order + terminal guarantee | No |
+| Composition rules | decision composition | `runtime/composition_rules.py` | never lowered | No |
+| Effect decision | decision engine | `runtime/effect_decision.py` | enforces in effect plan | No |
+| Decisions | decision engine | `runtime/decisions.py` | enforces | No |
+| Runner | execution | `runtime/runner.py` | routes to containment | No |
+| Hook handlers | pre/post-tool | `cli/commands_hook_{claude,copilot,generic,runtime_eval,runtime_finish,runtime_review,github_workflow}.py` | enforce before tool runs | No |
+| Approvals | approval queue | `approvals.py`, `approval_resolution.py`, `runtime/approval_reuse.py` | sandbox-required not auto-approvable | No |
+| MCP | tool calls | `mcp_tool_calls.py`, `proxy/runtime_mcp.py`, `proxy/stdio.py` | enforce on MCP path | No |
+| Receipts | evidence | `store_receipts.py`, `incident.py` | record verbatim, never rewrite | No |
+| Adapters | harness payloads | `adapters/{cursor_hook_payload,cursor_hook_script_template_head,grok_hooks,pi_hooks,zcode_hooks}.py` | pass through to harness | No |
+| Persistence | schema | `store_command_shadow_schema.py`, `models.py`, `types.py` | store verbatim | No |
+| CLI support | payload/policy | `cli/commands_support_{hook_payload,interaction,prompts,runtime_policy}.py`, `cli/render.py` | render/pass through | No |
+| Supply chain | package eval | `local_supply_chain.py`, `runtime/supply_chain_package_eval.py`, `runtime/command_permission_catalog.py`, `runtime/secret_file_requests.py` | enforce on package path | No |
+| Advisory escalation | escalation | `runtime/advisory_escalation.py` | can raise, never lower | No |
+| Dashboard | UI display | `daemon/static/assets/*` (js) | display only | No (read-only) |
+| Schemas | product model | `schemas/guard_product_model_v1.json` | declares value | No |
+| Consumer service | orchestration | `consumer/service.py`, `decision_boundaries.py`, `harness_usage.py` | enforce at boundary | No |
+
+## Downgrade audit
+
+No consumer lowers `sandbox-required` to `allow`. The only downgrade paths in the codebase are the false-positive composition rules in `runtime/composition_rules.py:108-121`, which produce `review` or `warn` from `block`/`review` respectively and structurally cannot produce `sandbox-required` or lower it. The lattice guarantees `sandbox-required` is strictly stronger than `review` and never collapses to it.
+
+## Notes
+
+- This matrix records consumer semantics as of the pinned ref; it does not authorize changing the lattice order.
+- Dashboard JS consumers are display-only and carry no enforcement authority.

--- a/docs/guard/release-3-1-terminology.md
+++ b/docs/guard/release-3-1-terminology.md
@@ -1,0 +1,32 @@
+# `release/3.1` "sandbox" terminology audit
+
+Status: wave-zero baseline. Audience: execution-assurance gate reviewers. Pinned ref: `origin/release/3.1` at `10348fd40fa53ef60d9363bb6c37591b8bb60a61`.
+
+Audit of "sandbox" usage across docs and UI, correcting or qualifying misleading uses without breaking public CLI/API compatibility.
+
+## Rule
+
+"Sandbox" is reserved for OS-enforced execution containment (macOS Seatbelt, Linux Bubblewrap) that actually constrains a running process. Anything that inspects without executing, or that is a policy directive rather than a mechanism, must not be called a sandbox unqualified.
+
+## Findings
+
+| Location | Current text | Verdict | Action |
+| --- | --- | --- | --- |
+| `docs/guard/architecture.md:16` | "a Safe Decode **sandbox** for encoded commands and prompt text" | Misleading: the decode scanner never executes; it is a text pipeline, not a containment mechanism | Corrected to "Safe Decode scanning layer" |
+| `docs/guard/local-vs-cloud.md:40` | "Safe Decode runs locally too. It inspects encoded payload layers" | Correct: describes the decode scanner without calling it a sandbox | No change |
+| `docs/guard/get-started.md:212,237` | `default_action = "sandbox-required"` | Correct: this is the action-lattice directive, not a component claim | Keep; clarify in a note that it routes to OS containment |
+| `docs/guard/harness-support.md:95` | "sandbox `off` as degraded protection states" (Grok config) | Correct: refers to the harness's own sandbox setting surfaced as degraded | Keep |
+| `runtime/safe_decode.py` module name | `safe_decode` | Correct: module is named for decoding, not sandboxing | Keep |
+
+## Compatibility
+
+No public CLI flag, API field, or persisted value is renamed. The action-lattice value `sandbox-required` is a public policy contract and is unchanged. Only descriptive prose is corrected; no compatibility alias is required because no identifier changed.
+
+## UI audit
+
+The local dashboard uses "sandbox" only in the context of the action directive and containment status; no UI surface presents the decode scanner as a containment sandbox. No UI copy change required in this baseline.
+
+## Notes
+
+- Reserved-term enforcement: new docs/UI must not call the decode scanner a "sandbox" and must qualify any non-OS "sandbox" use.
+- This audit does not rename the `sandbox-required` action value, which is a frozen public contract.


### PR DESCRIPTION
## Purpose

Wave-zero baseline inventories for the execution-assurance program: a versioned execution-path matrix, per-harness ownership grades, and the `sandbox-required` consumer matrix.

## Contents

- `release-3-1-execution-path-inventory.md` — every distinct execution/interception path (daemon API, hook dispatch, runtime evaluation, CLI wrappers, package shims, containment executor, restricted sandboxes, approval center, cloud sync, dashboard) with entry point, execution owner, failure mode, and actual guarantee, plus composition invariants.
- `release-3-1-harness-grades.md` — every supported harness (Codex, Claude Code, Copilot, Cursor, Pi, OpenCode, Gemini, Grok, Kimi, ZCode, Hermes, OpenClaw, Antigravity) graded `guard_owned_local` / `host_decision_only` / `observe_only_degraded` / `unsupported` from the adapter `approval_tier` and hook surface, with fail-mode analysis.
- `release-3-1-sandbox-required-consumers.md` — canonical lattice semantics and every consumer of the directive, with a downgrade audit confirming no consumer lowers `sandbox-required` to `allow`.

## Verification

Documentation-only. All file:line citations verified against the pinned ref. Hook fail-closed behavior verified at `commands_hook_generic.py:558-563`; lattice terminal guarantee at `action_lattice.py:5-37`; composition never-lowers at `runtime/composition_rules.py:10,108-121`.

No release, publication, deployment, or policy activation is authorized.