### PR TITLE
docs(guard): replace internal plan markers with section references

### DIFF
--- a/docs/guard/release-3-1-contract-freeze-abuse-review.md
+++ b/docs/guard/release-3-1-contract-freeze-abuse-review.md
@@ -8,24 +8,24 @@ Method: for each required abuse case, identify the frozen clause that must defea
 
 | # | Abuse case | Defeating clause | Verdict |
 | --- | --- | --- | --- |
-| 1 | Workspace config points Guard at an attacker-controlled provider binary/socket | EAI-024: provider config is Guard/admin-owned, not repository-owned; identity-pinned binaries/sockets | Covered |
-| 2 | Provider claims a higher boundary than it enforces | EAI-021/022: providers never self-label an arbitrary level; Guard derives max level from declared+verified atomic guarantees; `GuardExecutionAttestationTrust` starts `unattested` | Covered |
-| 3 | Attestation replayed from another workspace/device/tenant | EAI-027: schema/signature/freshness/nonce/subject/audience/workspace/policy bindings must verify | Covered |
-| 4 | Health succeeds, provider changes, then execution occurs | EAI-024 + EAI-029: launch binds provider instance/key thumbprint + monotonic generation + plan digest; replacement or generation drift invalidates the launch | Covered |
-| 5 | Required provider fails; code attempts host fallback | EAI-031: mandatory assurance never silently downgrades to host execution; no fallback below a mandatory policy floor | Covered |
-| 6 | Benign action spammed with approvals because optional health is unavailable | EAI-031: optional route falls back only to an explicitly policy-approved lower route with a visible degraded receipt; health cache uses freshness + stale-while-reverify | Covered |
-| 7 | Provider mounts `.env`, `.ssh`, Guard state, VCS metadata, or host sockets | EAI-029/022: immutable input manifest; secret delivery uses mount/descriptor semantics with no ambient env inheritance; `secret` guarantee enforced | Partially covered — see F1 |
-| 8 | Secret values enter context, logs, trace baggage, or Cloud evidence | EAI-020 objective 4 + EAI-023 forbidden fields + EAI-030 serialization denylist | Covered |
-| 9 | Output truncation hides secret or policy-relevant content | EAI-027: terminal statement binds truncation flags + full-stream byte counts/digests; unscanned tail never implicitly allowed | Covered |
-| 10 | Cancellation leaves a process/VM/mount/network rule/secret alive | EAI-031: cleanup retries independently, surfaces orphan incidents, revokes/zeroizes secrets on terminal or orphan handling | Covered |
-| 11 | Retry executes a remote mutation twice | EAI-029: idempotency keyed on attempt nonce; at-most-one provider launch; no changed/unfenced retry after `unknown_outcome` | Covered |
-| 12 | Old policy/provider capability restores after revocation | EAI-028: downgrade prevention + revocation; EAI-029: capability loss invalidates cached eligibility immediately | Covered |
-| 13 | Clock skew extends stale health or attestation validity | EAI-027: freshness binding; EAI-031: cached health expires quickly enough to prevent stale assurance | Partially covered — see F2 |
-| 14 | Root/admin deletes Guard and forges local health | EAI-020 attacker model: explicitly out of scope (fully privileged local adversary) | Accepted non-goal |
-| 15 | Provider capacity exhaustion becomes a broad fail-open | EAI-031: no silent downgrade; mandatory floor holds; degraded only via policy-approved lower route with receipt | Covered |
-| 16 | Environment materializer executes activation hooks during inspection | EAI-024: discovery/health never executes workspace-controlled code; plan is pure/side-effect-free | Covered |
-| 17 | OCI image tag changes under the same human-readable name | EAI-024/028: binaries/images identity-pinned by digest, not tag | Covered |
-| 18 | RuntimeClass name maps to a weaker handler than policy expects | EAI-026: resolver never selects a boundary weaker than the policy-required floor; provenance recorded | Covered |
+| 1 | Workspace config points Guard at an attacker-controlled provider binary/socket | the provider contract: provider config is Guard/admin-owned, not repository-owned; identity-pinned binaries/sockets | Covered |
+| 2 | Provider claims a higher boundary than it enforces | the assurance-levels and atomic-guarantee sections: providers never self-label an arbitrary level; Guard derives max level from declared+verified atomic guarantees; `GuardExecutionAttestationTrust` starts `unattested` | Covered |
+| 3 | Attestation replayed from another workspace/device/tenant | the attestation-statement section: schema/signature/freshness/nonce/subject/audience/workspace/policy bindings must verify | Covered |
+| 4 | Health succeeds, provider changes, then execution occurs | the provider contract + the fenced-retry section: launch binds provider instance/key thumbprint + monotonic generation + plan digest; replacement or generation drift invalidates the launch | Covered |
+| 5 | Required provider fails; code attempts host fallback | the fail-and-recovery matrix: mandatory assurance never silently downgrades to host execution; no fallback below a mandatory policy floor | Covered |
+| 6 | Benign action spammed with approvals because optional health is unavailable | the fail-and-recovery matrix: optional route falls back only to an explicitly policy-approved lower route with a visible degraded receipt; health cache uses freshness + stale-while-reverify | Covered |
+| 7 | Provider mounts `.env`, `.ssh`, Guard state, VCS metadata, or host sockets | the fenced-retry section and the atomic-guarantee schema: immutable input manifest; secret delivery uses mount/descriptor semantics with no ambient env inheritance; `secret` guarantee enforced | Partially covered — see F1 |
+| 8 | Secret values enter context, logs, trace baggage, or Cloud evidence | the security-objectives section objective 4 + the execution-context schema forbidden fields + the privacy contract serialization denylist | Covered |
+| 9 | Output truncation hides secret or policy-relevant content | the attestation-statement section: terminal statement binds truncation flags + full-stream byte counts/digests; unscanned tail never implicitly allowed | Covered |
+| 10 | Cancellation leaves a process/VM/mount/network rule/secret alive | the fail-and-recovery matrix: cleanup retries independently, surfaces orphan incidents, revokes/zeroizes secrets on terminal or orphan handling | Covered |
+| 11 | Retry executes a remote mutation twice | the fenced-retry section: idempotency keyed on attempt nonce; at-most-one provider launch; no changed/unfenced retry after `unknown_outcome` | Covered |
+| 12 | Old policy/provider capability restores after revocation | the trust-and-rotation section: downgrade prevention + revocation; the fenced-retry section: capability loss invalidates cached eligibility immediately | Covered |
+| 13 | Clock skew extends stale health or attestation validity | the attestation-statement section: freshness binding; the fail-and-recovery matrix: cached health expires quickly enough to prevent stale assurance | Partially covered — see F2 |
+| 14 | Root/admin deletes Guard and forges local health | the security-objectives section attacker model: explicitly out of scope (fully privileged local adversary) | Accepted non-goal |
+| 15 | Provider capacity exhaustion becomes a broad fail-open | the fail-and-recovery matrix: no silent downgrade; mandatory floor holds; degraded only via policy-approved lower route with receipt | Covered |
+| 16 | Environment materializer executes activation hooks during inspection | the provider contract: discovery/health never executes workspace-controlled code; plan is pure/side-effect-free | Covered |
+| 17 | OCI image tag changes under the same human-readable name | the provider contract and the trust-and-rotation section: binaries/images identity-pinned by digest, not tag | Covered |
+| 18 | RuntimeClass name maps to a weaker handler than policy expects | the resolver semantics: resolver never selects a boundary weaker than the policy-required floor; provenance recorded | Covered |
 
 ## Blocking findings and resolutions
 
@@ -33,20 +33,20 @@ Method: for each required abuse case, identify the frozen clause that must defea
 
 The freeze spec states secrets use mount/descriptor semantics and an immutable input manifest, but does not explicitly enumerate the forbidden host-mount set or state that the provider contract must reject a plan requesting one.
 
-Resolution (amend EAI-024 and EAI-029): the provider contract's `plan()` validation must reject any input manifest or mount request that targets `.env`, `.ssh`, Guard state directories, VCS metadata, or host sockets (Docker/container control sockets). The `secret` atomic guarantee includes a forbidden-host-path denylist enforced at plan validation, not merely at runtime. This closes the mount-abuse path at the contract's trusted planning boundary rather than trusting the provider to refuse it.
+Resolution (amend the provider contract and the fenced-retry section): the provider contract's `plan` validation must reject any input manifest or mount request that targets `.env`, `.ssh`, Guard state directories, VCS metadata, or host sockets (Docker/container control sockets). The `secret` atomic guarantee includes a forbidden-host-path denylist enforced at plan validation, not merely at runtime. This closes the mount-abuse path at the contract's trusted planning boundary rather than trusting the provider to refuse it.
 
 ### F2 — Abuse case 13: clock skew and staleness bounds
 
 The freeze spec requires freshness binding and quick-expiring cached health but does not bound clock skew or define the staleness window.
 
-Resolution (amend EAI-027 and EAI-031): attestation and health freshness use a bounded validity window with an explicit maximum accepted clock skew; a provider or attestation whose not-before/not-after window, combined with the accepted skew, exceeds the freshness bound is treated as stale and rejected. Cached health carries a `verified_at` timestamp and a hard expiry; the expiry is short enough to prevent stale assurance yet does not force a network round trip per benign local action (stale-while-reverify only for optional routes).
+Resolution (amend the attestation-statement section and the fail-and-recovery matrix): attestation and health freshness use a bounded validity window with an explicit maximum accepted clock skew; a provider or attestation whose not-before/not-after window, combined with the accepted skew, exceeds the freshness bound is treated as stale and rejected. Cached health carries a `verified_at` timestamp and a hard expiry; the expiry is short enough to prevent stale assurance yet does not force a network round trip per benign local action (stale-while-reverify only for optional routes).
 
 ## Amended clauses (applied to `release-3-1-contract-freeze.md`)
 
-- EAI-024 gains: `plan()` rejects any input manifest or mount targeting the forbidden host set (`.env`, `.ssh`, Guard state, VCS metadata, host sockets).
-- EAI-029 gains: the immutable input manifest and secret-delivery lease enforce the same forbidden-host denylist.
-- EAI-027 gains: freshness uses a bounded validity window with a defined maximum clock skew; out-of-window attestations are stale and rejected.
-- EAI-031 gains: cached health carries `verified_at` + hard expiry; stale-while-reverify is allowed only for optional routes.
+- the provider contract gains: `plan` rejects any input manifest or mount targeting the forbidden host set (`.env`, `.ssh`, Guard state, VCS metadata, host sockets).
+- the fenced-retry section gains: the immutable input manifest and secret-delivery lease enforce the same forbidden-host denylist.
+- the attestation-statement section gains: freshness uses a bounded validity window with a defined maximum clock skew; out-of-window attestations are stale and rejected.
+- the fail-and-recovery matrix gains: cached health carries `verified_at` + hard expiry; stale-while-reverify is allowed only for optional routes.
 
 ## Adjudication
 

--- a/docs/guard/release-3-1-contract-freeze.md
+++ b/docs/guard/release-3-1-contract-freeze.md
@@ -2,9 +2,9 @@
 
 Status: contract freeze candidate for the G1 gate. Audience: execution-assurance gate reviewers and wave-two implementers. Pinned ref: `origin/release/3.1` at `97e2408a629acd4946db0677abd4022027d421f4`.
 
-This freezes the execution-assurance contract set as schema specifications. It reuses existing types wherever one exists (the context-identity reuse mandate) and introduces new types only where no home exists. Every new contract is explicitly 3.1 alpha and capability-negotiated. Nothing here is implemented in this wave; wave two implements against these frozen schemas.
+This freezes the execution-assurance contract set as schema specifications. It reuses existing types wherever one exists and introduces new types only where no home exists. Every new contract is explicitly 3.1 alpha and capability-negotiated. Nothing here is implemented in this wave; wave two implements against these frozen schemas.
 
-## Security objectives and non-goals (EAI-020)
+## Security objectives and non-goals
 
 Objectives (invariants to hold under the threat model):
 
@@ -18,64 +18,64 @@ Non-goals for the 3.1 alpha: remote workload grants/execution beyond the separat
 
 Attacker capabilities: malicious workspace/repository/dependency/plugin/skill/MCP server; malicious local standard user; compromised or stale provider endpoint/image; cross-tenant attacker; network attacker replaying/substituting attestations; malicious or buggy harness integration; operator misconfiguration. Out of scope: an attacker with root/admin on the local host (they can delete Guard and forge local health; Guard does not claim protection against a fully privileged local adversary).
 
-## Assurance levels (EAI-021)
+## Assurance levels
 
 The assurance model is a partial-order tuple, not an ordinal:
 
 - `GuardExecutionAssuranceBoundary`: `observed_host` | `controlled_host` | `os_isolated` | `hardware_isolated`.
-- Atomic guarantees (EAI-022): the set actually enforced.
+- Atomic guarantees : the set actually enforced.
 - `GuardExecutionAttestationTrust`: `unattested` | `self_attested` | `verified`.
 
 `ExecutionAssuranceLevel` (name chosen to avoid the existing `mdm/contracts.py:20` `AssuranceLevel`, which is MDM enrollment assurance) is the user-facing projection of that tuple. Labels EA0–EA4 are presentation projections only and never substitute for an unmet atomic guarantee. Naming rule: execution-assurance names must not collide with protection assurance or AIBOM assurance types (distinct namespaces, signers, verifier policies).
 
-## Atomic guarantee schema (EAI-022)
+## Atomic guarantee schema
 
 `AtomicGuarantee` is a bounded, versioned enum value plus an enforcement record. Frozen guarantee kinds: `filesystem`, `secret`, `network`, `process`, `privilege`, `resource`, `kernel_hardware`, `identity`, `output`, `cleanup`, `tenant`. Each carries: `kind`, `enforced: bool`, `evidence_ref` (opaque), `boundary: GuardExecutionAssuranceBoundary`. Compatibility rule: unknown future guarantee kinds are forward-compatible (parseable) but cannot satisfy an existing requirement. The schema is versioned (`guard.atomic-guarantee.v1`); bounded (fixed kind set, max evidence ref length).
 
 Reference mapping to today's containment (`release-3-1-containment-baseline.md`): `filesystem`/`network`/`process`/`privilege`/`resource`/`output`/`cleanup`/`identity` map to the Seatbelt/Bubblewrap enforcement cells; `secret` maps to the env-scrub/secret-handle cells; `kernel_hardware` and `tenant` are not enforced by the local reference backend and are recorded as absent, not inferred.
 
-## Execution-context schema (EAI-023)
+## Execution-context schema
 
-Three digest-bound contracts, reusing the existing context types as inputs rather than replacing them (EAI-023A):
+Three digest-bound contracts, reusing the existing context types as inputs rather than replacing them :
 
-- `DecisionContext` (privacy-safe): digest-bound decision inputs. Reuses `GitRepositoryDigest`, `WorkspaceDigest`, `ExecutableDigest` (`package_execution_context_inputs.py:224/256/288`) and the containment `digest()` framing (`containment_contract.py:94-100`). Forbidden fields (rejected at validation): raw command text, prompt text, file contents, secret/env values, absolute home/workspace paths, user email/account/repo URL/branch/issue-PR body/customer payload, stable cross-workspace personal identifiers.
+- `DecisionContext` (privacy-safe): digest-bound decision inputs. Reuses `GitRepositoryDigest`, `WorkspaceDigest`, `ExecutableDigest` (`package_execution_context_inputs.py:224/256/288`) and the containment `digest` framing (`containment_contract.py:94-100`). Forbidden fields (rejected at validation): raw command text, prompt text, file contents, secret/env values, absolute home/workspace paths, user email/account/repo URL/branch/issue-PR body/customer payload, stable cross-workspace personal identifiers.
 - `LaunchMaterial` / `ProviderPlan` (local-only, sensitive): constructed only by trusted Guard adapter code. Reuses `ShellExecutionContext` (`shell_execution_context.py:69`), `ApprovalContextToken` (`approval_context.py:56`), `GitHubWorkflowDescriptor` (`github_workflow_context.py:46`), and `ContainmentRequest` (`containment_contract.py:110-139`, with `launch_digest`/`executable_digest`). These are inputs to the frozen contracts, not parallel identity models. Uses secret handles, never secret values. Never synced or persisted.
 - `EvidenceSummary` (privacy-safe): bounded decision/evidence summary with the same forbidden-field rejections as `DecisionContext`, plus over-limit and invalid-parentage rejection.
 
 The fifth identity model is explicitly forbidden: `DecisionContext` composes the four existing context identities rather than inventing a new one.
 
-## Provider contract (EAI-024)
+## Provider contract
 
-`guard.isolation-provider.v1`. Every execution-provider adapter implements `identity()`, `capabilities()`, `health_check()`, `plan(context, policy)`, `execute(plan)`, `cancel(execution_id)`, `cleanup(execution_id)`. New types (no existing home): `ExecutionProvider` (Protocol), `ProviderRegistry`, `ProviderHealth`. Provider discovery never executes workspace-controlled code; provider config is Guard/admin-owned, not repository-owned. Plan is pure/side-effect-free; discovery/health receive no workspace/action payload. `execute` is one fenced attempt with stable idempotency and at-most-one provider launch, returning a terminal statement from the same execution instance. `cancel`/`cleanup` are idempotent. `plan()` validation rejects any input manifest or mount request targeting the forbidden host set — `.env`, `.ssh`, Guard state directories, VCS metadata, and host sockets (Docker/container control sockets) — so a malicious plan is refused at the trusted planning boundary rather than trusted away by the provider.
+`guard.isolation-provider.v1`. Every execution-provider adapter implements `identity`, `capabilities`, `health_check`, `plan(context, policy)`, `execute(plan)`, `cancel(execution_id)`, `cleanup(execution_id)`. New types (no existing home): `ExecutionProvider` (Protocol), `ProviderRegistry`, `ProviderHealth`. Provider discovery never executes workspace-controlled code; provider config is Guard/admin-owned, not repository-owned. Plan is pure/side-effect-free; discovery/health receive no workspace/action payload. `execute` is one fenced attempt with stable idempotency and at-most-one provider launch, returning a terminal statement from the same execution instance. `cancel`/`cleanup` are idempotent. `plan` validation rejects any input manifest or mount request targeting the forbidden host set — `.env`, `.ssh`, Guard state directories, VCS metadata, and host sockets (Docker/container control sockets) — so a malicious plan is refused at the trusted planning boundary rather than trusted away by the provider.
 
-## Policy composition (EAI-025)
+## Policy composition
 
-Assurance planning extends the existing effect engine as a single `DecisionFactorSource` variant in `evaluate_effect_decision()` (`effect_decision.py:202`), not a parallel policy authority. New type: `AssurancePlanAssessment` extends `EffectAssessment` (`effect_contract.py:173`). Composition stays pure and monotonic (max-floor); the central safety floor, local/managed strengthening, and fallback rules are unchanged. Assurance requirements only raise floors, never lower them.
+Assurance planning extends the existing effect engine as a single `DecisionFactorSource` variant in `evaluate_effect_decision` (`effect_decision.py:202`), not a parallel policy authority. New type: `AssurancePlanAssessment` extends `EffectAssessment` (`effect_contract.py:173`). Composition stays pure and monotonic (max-floor); the central safety floor, local/managed strengthening, and fallback rules are unchanged. Assurance requirements only raise floors, never lower them.
 
-## Resolver semantics (EAI-026)
+## Resolver semantics
 
 The resolver maps (action, context, policy) to a required `GuardExecutionAssuranceBoundary` + atomic guarantee set. Precedence: explicit user policy > managed strengthening > central safety floor > derived default. Every resolution records its authority source in the decision reason (`DecisionReason`, `effect_decision.py:163`) so the provenance of the required boundary is auditable. No resolution path may select a boundary weaker than the policy-required floor.
 
-## Attestation statement (EAI-027)
+## Attestation statement
 
 A terminal execution statement binds: exit/outcome, full-stream byte counts and digests, truncation flags, declared-output digests, cleanup state, and the exact execution instance. Provider responses are untrusted until schema, signature, freshness, nonce, subject, audience, workspace, and policy bindings verify. Freshness uses a bounded validity window with a defined maximum accepted clock skew; an attestation whose window, combined with the accepted skew, exceeds the freshness bound is treated as stale and rejected. An unscanned output tail is never implicitly allowed.
 
-## Trust and rotation (EAI-028)
+## Trust and rotation
 
 Reuses the policy keyring/signer machinery (`policy_bundle_trusted_keys.py`) for provider trust roots: pinned trust domain, key fingerprints, rotation, revocation, and downgrade prevention. A valid signature never upgrades a claim beyond independently pinned configuration/runtime evidence. New: provider trust anchor type carrying kind/version/digest/signing identity/trust domain.
 
-## Fenced retry (EAI-029)
+## Fenced retry
 
-New types: `ExecutionLease`, `FencingGeneration`, `AttemptNonce`, `UnknownOutcome`, `StartupReconciliation`. Each launch binds plan digest, provider instance/key thumbprint, monotonic provider generation, lease expiry, attempt nonce, and immutable input manifest. Replacement, restart, or generation drift invalidates the launch. Retry never executes a remote mutation twice; idempotency is keyed on the attempt nonce. The immutable input manifest and the secret-delivery lease enforce the same forbidden-host denylist as `plan()`; after `unknown_outcome`, reconciliation determines the terminal state without launching a changed or unfenced retry.
+New types: `ExecutionLease`, `FencingGeneration`, `AttemptNonce`, `UnknownOutcome`, `StartupReconciliation`. Each launch binds plan digest, provider instance/key thumbprint, monotonic provider generation, lease expiry, attempt nonce, and immutable input manifest. Replacement, restart, or generation drift invalidates the launch. Retry never executes a remote mutation twice; idempotency is keyed on the attempt nonce. The immutable input manifest and the secret-delivery lease enforce the same forbidden-host denylist as `plan`; after `unknown_outcome`, reconciliation determines the terminal state without launching a changed or unfenced retry.
 
-## Privacy contract (EAI-030)
+## Privacy contract
 
 `PrivacyContract` with field visibility classes: `local_only` | `cloud_allowed` | `forbidden`. A serialization denylist enforces that `forbidden` fields never serialize to Cloud/sync payloads and `local_only` fields never leave the local store. New types: `PrivacyContract`, `PrivacyField`, `FieldVisibility`, `SerializationDenylist`. Reuses existing receipt redaction levels where present.
 
-## Fail and recovery matrix (EAI-031)
+## Fail and recovery matrix
 
 Provider health is a typed state machine: `unknown`, `verifying`, `healthy`, `degraded`, `unavailable`, `revoked`, `incompatible`. Cached health carries a `verified_at` timestamp and a hard expiry short enough to prevent stale assurance without forcing a network round trip per benign local action; stale-while-reverify is permitted only for optional routes. Optional-provider failure: health cache with freshness + stale-while-reverify for optional routes; a benign action is not spammed with approvals because optional health is unavailable. Mandatory-provider failure: reject stale capability proof after the configured bound; never silently downgrade to host execution (no host fallback for mandatory assurance). Daemon outage/cancellation/cleanup: cleanup retries independently and surfaces orphan incidents; no deadlock, no approval-tab storm. Recovery never auto-installs privileged components without prior managed authorization.
 
-## Freeze conditions (EAI-032)
+## Freeze conditions
 
 Every contract above is explicitly `*.v1` 3.1 alpha, capability-negotiated. Forward compatibility requires an explicitly negotiated schema version; unknown security fields fail closed. Local and Cloud share one versioned contract source — no hand-maintained divergent enums. This freeze was adjudicated by the abuse-case review in `release-3-1-contract-freeze-abuse-review.md` (findings F1/F2 amended above).


### PR DESCRIPTION
## Purpose

The wave-one contract-freeze and abuse-review docs referenced internal task identifiers (EAI-020 through EAI-032) that are plan-tracking markers, not repository concepts. These should not persist in committed docs. This replaces them with the section/contract names they abbreviate, preserving all technical content.

## Change

- `release-3-1-contract-freeze.md` and `release-3-1-contract-freeze-abuse-review.md`: replace `EAI-0NN` references with the corresponding contract/section names; drop the now-redundant `(EAI-0NN)` suffixes from section headers.
- No technical content changed; wording composites cleaned up for readability.

## Verification

- `rg -c 'EAI-' docs/guard/*.md` reports zero matches.
- Documentation-only change.

No release, publication, deployment, or policy activation is authorized.