### PR TITLE
fix(about): point partner CTAs to hol.org instead of non-existent /guard/partners

### DIFF
--- a/dashboard/src/about/about-content.ts
+++ b/dashboard/src/about/about-content.ts
@@ -28,7 +28,7 @@ export const ABOUT_PARTNER_SECTION_TITLE = "Standards partner program";
 export const ABOUT_PARTNER_SECTION_BODY =
   "Join teams building on HOL open standards. Partners get early access to protocol drafts, co-marketing, and direct engineering support.";
 export const ABOUT_PARTNER_CTA = "Explore partner programs";
-export const ABOUT_PARTNER_CTA_HREF = "https://hol.org/guard/partners";
+export const ABOUT_PARTNER_CTA_HREF = "https://hol.org";
 
 export const ABOUT_AFFILIATE_SECTION_TITLE = "Affiliate starter kit";
 export const ABOUT_AFFILIATE_SECTION_BODY =
@@ -174,7 +174,7 @@ export const ABOUT_PATH_CARDS: AboutPathCard[] = [
     description:
       "Contribute to open trust standards for agent identity, registries, and receipts.",
     ctaLabel: "Explore partners",
-    ctaHref: "https://hol.org/guard/partners",
+    ctaHref: "https://hol.org",
     ctaId: "path_standards_partner",
     priority: "tertiary",
     tone: "slate",
@@ -215,7 +215,7 @@ export const ABOUT_AFFILIATE_TERMS: AffiliateTerms = {
   qualificationNote: "Qualified paid customers after approval",
 };
 
-export const ALLOWED_LINKS: Record<AboutLinkId, { host: string; pathPrefix: string }> = {
+export const ALLOWED_LINKS: Record<AboutLinkId, { host: string; pathPrefix: string; exactPath?: boolean }> = {
   guard_docs: { host: "hol.org", pathPrefix: "/guard/docs" },
   hol_home: { host: "hol.org", pathPrefix: "/" },
   hol_guard: { host: "hol.org", pathPrefix: "/guard" },
@@ -223,7 +223,7 @@ export const ALLOWED_LINKS: Record<AboutLinkId, { host: string; pathPrefix: stri
   hol_guard_cloud: { host: "hol.org", pathPrefix: "/guard" },
   plugin_scanner_ci_docs: { host: "hol.org", pathPrefix: "/guard/docs/plugin-scanner" },
   standards_sdk_github: { host: "github.com", pathPrefix: "/hashgraph-online/standards-sdk" },
-  hol_partners: { host: "hol.org", pathPrefix: "/guard/partners" },
+  hol_partners: { host: "hol.org", pathPrefix: "/", exactPath: true },
   hol_affiliates: { host: "hol.org", pathPrefix: "/guard/affiliates" },
   hol_guard_source: { host: "github.com", pathPrefix: "/hashgraph-online/hol-guard" },
 };

--- a/dashboard/src/about/about-external-links.test.ts
+++ b/dashboard/src/about/about-external-links.test.ts
@@ -1,4 +1,5 @@
 import { assertSafeAboutExternalUrl, validateAboutExternalLinkOrThrow, AboutExternalLinkError } from "./about-external-links";
+import { ABOUT_PARTNER_CTA_HREF, ABOUT_PATH_CARDS } from "./about-content";
 import type { AboutLinkId } from "./about-types";
 
 function assert(condition: boolean, message: string): void {
@@ -9,7 +10,7 @@ function assert(condition: boolean, message: string): void {
 
 // Allowed links - correct linkId + href pairs
 assert(
-  assertSafeAboutExternalUrl("hol_partners", "https://hol.org/guard/partners").hostname === "hol.org",
+  assertSafeAboutExternalUrl("hol_partners", "https://hol.org").hostname === "hol.org",
   "hol.org partners is allowed with correct linkId"
 );
 assert(
@@ -39,6 +40,15 @@ try {
 }
 assert(threw, "affiliates linkId with wrong path is rejected");
 
+// Regression: /guard/partners is no longer a valid path for hol_partners
+threw = false;
+try {
+  assertSafeAboutExternalUrl("hol_partners", "https://hol.org/guard/partners");
+} catch (e) {
+  threw = true;
+}
+assert(threw, "hol_partners rejects the old /guard/partners path (exactPath)");
+
 // Wrong repo for source linkId
 threw = false;
 try {
@@ -51,7 +61,7 @@ assert(threw, "github.com/other/repo is rejected for hol_guard_source");
 // Must use HTTPS
 threw = false;
 try {
-  assertSafeAboutExternalUrl("hol_partners", "http://hol.org/guard/partners");
+  assertSafeAboutExternalUrl("hol_partners", "http://hol.org");
 } catch (e) {
   threw = true;
   assert(e instanceof AboutExternalLinkError, "http throws AboutExternalLinkError");
@@ -61,7 +71,7 @@ assert(threw, "http is rejected");
 // Must not contain credentials
 threw = false;
 try {
-  assertSafeAboutExternalUrl("hol_partners", "https://user:pass@hol.org/guard/partners");
+  assertSafeAboutExternalUrl("hol_partners", "https://user:pass@hol.org");
 } catch (e) {
   threw = true;
 }
@@ -70,7 +80,7 @@ assert(threw, "credentials are rejected");
 // Must not point to localhost
 threw = false;
 try {
-  assertSafeAboutExternalUrl("hol_partners", "https://localhost:3000/guard/partners");
+  assertSafeAboutExternalUrl("hol_partners", "https://localhost:3000");
 } catch (e) {
   threw = true;
 }
@@ -78,7 +88,7 @@ assert(threw, "localhost is rejected");
 
 threw = false;
 try {
-  assertSafeAboutExternalUrl("hol_partners", "https://127.0.0.1:3000/guard/partners");
+  assertSafeAboutExternalUrl("hol_partners", "https://127.0.0.1:3000");
 } catch (e) {
   threw = true;
 }
@@ -87,7 +97,7 @@ assert(threw, "127.0.0.1 is rejected");
 // Must not have forbidden params
 threw = false;
 try {
-  assertSafeAboutExternalUrl("hol_partners", "https://hol.org/guard/partners?guard-token=abc");
+  assertSafeAboutExternalUrl("hol_partners", "https://hol.org?guard-token=abc");
 } catch (e) {
   threw = true;
 }
@@ -95,7 +105,7 @@ assert(threw, "guard-token param is rejected");
 
 threw = false;
 try {
-  assertSafeAboutExternalUrl("hol_partners", "https://hol.org/guard/partners?workspace=test");
+  assertSafeAboutExternalUrl("hol_partners", "https://hol.org?workspace=test");
 } catch (e) {
   threw = true;
 }
@@ -113,7 +123,7 @@ assert(threw, "ref param is rejected");
 // Private IP ranges
 threw = false;
 try {
-  assertSafeAboutExternalUrl("hol_partners", "https://10.0.0.1/guard/partners");
+  assertSafeAboutExternalUrl("hol_partners", "https://10.0.0.1");
 } catch (e) {
   threw = true;
 }
@@ -121,7 +131,7 @@ assert(threw, "10.x.x.x is rejected");
 
 threw = false;
 try {
-  assertSafeAboutExternalUrl("hol_partners", "https://192.168.1.1/guard/partners");
+  assertSafeAboutExternalUrl("hol_partners", "https://192.168.1.1");
 } catch (e) {
   threw = true;
 }
@@ -129,7 +139,7 @@ assert(threw, "192.168.x.x is rejected");
 
 threw = false;
 try {
-  assertSafeAboutExternalUrl("hol_partners", "https://172.16.0.1/guard/partners");
+  assertSafeAboutExternalUrl("hol_partners", "https://172.16.0.1");
 } catch (e) {
   threw = true;
 }
@@ -137,7 +147,7 @@ assert(threw, "172.16.x.x is rejected");
 
 threw = false;
 try {
-  assertSafeAboutExternalUrl("hol_partners", "https://172.31.255.255/guard/partners");
+  assertSafeAboutExternalUrl("hol_partners", "https://172.31.255.255");
 } catch (e) {
   threw = true;
 }
@@ -146,7 +156,7 @@ assert(threw, "172.31.x.x is rejected");
 // 172.15 should be allowed (outside 172.16/12)
 let allowed = false;
 try {
-  assertSafeAboutExternalUrl("hol_partners", "https://172.15.0.1/guard/partners");
+  assertSafeAboutExternalUrl("hol_partners", "https://172.15.0.1");
   allowed = true;
 } catch {
   allowed = false;
@@ -154,11 +164,16 @@ try {
 assert(!allowed, "172.15.x.x is outside RFC1918 and should be rejected by host mismatch, not private range");
 
 // Returns correct rel and target
-const result = assertSafeAboutExternalUrl("hol_partners", "https://hol.org/guard/partners");
+const result = assertSafeAboutExternalUrl("hol_partners", "https://hol.org");
 assert(result.rel === "noopener noreferrer", "rel is noopener noreferrer");
 assert(result.target === "_blank", "target is _blank");
 
 // validateAboutExternalLinkOrThrow works
-validateAboutExternalLinkOrThrow("hol_partners", "https://hol.org/guard/partners");
+validateAboutExternalLinkOrThrow("hol_partners", "https://hol.org");
+
+// Content-level: partner CTAs must point to hol.org, not /guard/partners
+assert(ABOUT_PARTNER_CTA_HREF === "https://hol.org", "ABOUT_PARTNER_CTA_HREF is hol.org root");
+const partnerCard = ABOUT_PATH_CARDS.find((c) => c.id === "standards_partner");
+assert(partnerCard?.ctaHref === "https://hol.org", "standards_partner card ctaHref is hol.org root");
 
 console.log("about-external-links.test.ts: all assertions passed");

--- a/dashboard/src/about/about-external-links.ts
+++ b/dashboard/src/about/about-external-links.ts
@@ -92,9 +92,9 @@ export function assertSafeAboutExternalUrl(
     );
   }
 
-  if (!parsed.pathname.startsWith(allowed.pathPrefix)) {
+  if (allowed.exactPath ? parsed.pathname !== allowed.pathPrefix : !parsed.pathname.startsWith(allowed.pathPrefix)) {
     throw new AboutExternalLinkError(
-      `Path prefix mismatch for ${linkId}: expected ${allowed.pathPrefix}, got ${parsed.pathname}`
+      `Path mismatch for ${linkId}: expected ${allowed.exactPath ? "exact" : "prefix"} ${allowed.pathPrefix}, got ${parsed.pathname}`
     );
   }
 

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/about-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/about-workspace.js
@@ -2,7 +2,7 @@ import { j as jsxRuntimeExports, ak as Tag, bF as Surface, M as Badge, r as reac
 const ABOUT_PARTNER_SECTION_TITLE = "Standards partner program";
 const ABOUT_PARTNER_SECTION_BODY = "Join teams building on HOL open standards. Partners get early access to protocol drafts, co-marketing, and direct engineering support.";
 const ABOUT_PARTNER_CTA = "Explore partner programs";
-const ABOUT_PARTNER_CTA_HREF = "https://hol.org/guard/partners";
+const ABOUT_PARTNER_CTA_HREF = "https://hol.org";
 const ABOUT_AFFILIATE_SECTION_TITLE = "Affiliate starter kit";
 const ABOUT_AFFILIATE_SECTION_BODY = "Approved affiliates can share Guard with their community and receive recurring commission on qualified paid referrals.";
 const ABOUT_AFFILIATE_CTA = "Learn about affiliates";
@@ -136,7 +136,7 @@ const ABOUT_PATH_CARDS = [
     title: "Standards partner program",
     description: "Contribute to open trust standards for agent identity, registries, and receipts.",
     ctaLabel: "Explore partners",
-    ctaHref: "https://hol.org/guard/partners",
+    ctaHref: "https://hol.org",
     ctaId: "path_standards_partner",
     priority: "tertiary",
     tone: "slate"
@@ -181,7 +181,7 @@ const ALLOWED_LINKS = {
   hol_guard_cloud: { host: "hol.org", pathPrefix: "/guard" },
   plugin_scanner_ci_docs: { host: "hol.org", pathPrefix: "/guard/docs/plugin-scanner" },
   standards_sdk_github: { host: "github.com", pathPrefix: "/hashgraph-online/standards-sdk" },
-  hol_partners: { host: "hol.org", pathPrefix: "/guard/partners" },
+  hol_partners: { host: "hol.org", pathPrefix: "/", exactPath: true },
   hol_affiliates: { host: "hol.org", pathPrefix: "/guard/affiliates" },
   hol_guard_source: { host: "github.com", pathPrefix: "/hashgraph-online/hol-guard" }
 };
@@ -308,9 +308,9 @@ function assertSafeAboutExternalUrl(linkId, raw) {
       `Host mismatch for ${linkId}: expected ${allowed.host}, got ${parsed.hostname}`
     );
   }
-  if (!parsed.pathname.startsWith(allowed.pathPrefix)) {
+  if (allowed.exactPath ? parsed.pathname !== allowed.pathPrefix : !parsed.pathname.startsWith(allowed.pathPrefix)) {
     throw new AboutExternalLinkError(
-      `Path prefix mismatch for ${linkId}: expected ${allowed.pathPrefix}, got ${parsed.pathname}`
+      `Path mismatch for ${linkId}: expected ${allowed.exactPath ? "exact" : "prefix"} ${allowed.pathPrefix}, got ${parsed.pathname}`
     );
   }
   const forbiddenParams = ["guard-token", "guardDaemon", "workspace", "device", "install", "user", "referral", "ref"];


### PR DESCRIPTION
## Problem

The About page in the Guard Local Daemon (`127.0.0.1:5474/about`) links to `https://hol.org/guard/partners`, which does not exist. Partner program CTAs should go to `https://hol.org`; affiliate program CTAs already correctly point to `https://hol.org/guard/affiliates`.

## Fix

- Changed `ABOUT_PARTNER_CTA_HREF` and the `standards_partner` pathway card `ctaHref` from `https://hol.org/guard/partners` to `https://hol.org`.
- Added `exactPath?: boolean` to the `ALLOWED_LINKS` type. Set `hol_partners` to `{ host: "hol.org", pathPrefix: "/", exactPath: true }` so the validator only accepts the root path — the old `/guard/partners` URL is now rejected.
- Updated `assertSafeAboutExternalUrl` to use `===` when `exactPath` is set, `startsWith` otherwise.
- Rebuilt the daemon static bundle (`about-workspace.js`) via `bun run build`.

## Verification

- `about-external-links.test.ts`: all assertions pass, including:
  - Regression: `hol_partners` with `https://hol.org/guard/partners` throws
  - Content-level: `ABOUT_PARTNER_CTA_HREF === "https://hol.org"` and `standards_partner` card `ctaHref === "https://hol.org"`
- `tsc --noEmit`: 35 pre-existing errors on `release/2.2`, zero in `about-*` files.
- `bun run build`: regenerated `about-workspace.js` with the fix confirmed in build output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Standards partner program links to direct visitors to the main HOL website.
  * Added stricter URL path validation for approved external links, including exact-path matching where required.

* **Bug Fixes**
  * Prevented previously accepted partner URLs with unintended subpaths from passing validation.
  * Improved URL validation error details for path mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->