### PR TITLE
fix(guard): wait for hook worker during bootstrap instead of failing-fast on overload

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
@@ -483,8 +483,12 @@ class HookProcessRunner:
         with self._state_lock:
             spawn_alive = any(thread.is_alive() for thread in self._spawn_threads)
             capacity_target = self._capacity_target
+            total_workers = len(self._all_slots)
         ready = self._slots.qsize()
-        return spawn_alive or (capacity_target > 0 and ready == 0)
+        # Bootstrap is the absence of any spawned worker; under genuine
+        # saturation workers exist (checked out), so we must NOT extend the
+        # acquire window there — that would turn fail-fast into a long wait.
+        return spawn_alive or (capacity_target > 0 and total_workers == 0 and ready == 0)
 
     def _increment_metric(self, metric: str) -> None:
         with self._metrics_lock:

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
@@ -128,10 +128,26 @@ class HookProcessRunner:
             self._active_reviews[generation] = self._active_reviews.get(generation, 0) + 1
         started_at = time.monotonic()
         try:
-            try:
-                slot = self._slots.get(timeout=min(_HOOK_PROCESS_ACQUIRE_TIMEOUT_SECONDS, self._timeout_seconds))
-            except queue.Empty:
-                return HookProcessReview(None, "daemon_hook_process_overloaded")
+            slot: HookWorkerSlot | None = None
+            # Fail fast only when the pool is genuinely saturated. While the
+            # supervisor is building or replacing workers (spawn threads active
+            # or no worker yet ready after a transient failure), give a new
+            # worker a bounded window to become ready instead of declaring the
+            # pool overloaded 0.2s after an acquire attempt.
+            acquire_deadline = started_at + min(_HOOK_PROCESS_ACQUIRE_TIMEOUT_SECONDS, self._timeout_seconds)
+            bootstrap_deadline = started_at + min(_HOOK_PROCESS_READY_TIMEOUT_SECONDS, self._timeout_seconds)
+            while slot is None:
+                now = time.monotonic()
+                building = self._capacity_building()
+                deadline = bootstrap_deadline if building else acquire_deadline
+                remaining = deadline - now
+                if remaining <= 0:
+                    return HookProcessReview(None, "daemon_hook_process_overloaded")
+                try:
+                    slot = self._slots.get(timeout=min(0.05, remaining))
+                except queue.Empty:
+                    if not building and now >= acquire_deadline:
+                        return HookProcessReview(None, "daemon_hook_process_overloaded")
             try:
                 request = {
                     "payload": dict(payload),
@@ -454,6 +470,21 @@ class HookProcessRunner:
             self._generation += 1
         self._recovery_event.set()
         self._increment_metric("failures")
+
+    def _capacity_building(self) -> bool:
+        """Whether the supervisor is actively bringing a worker online.
+
+        True while a spawn replacement thread is alive or no worker is ready
+        yet despite a non-zero capacity target (a transient failure that has not
+        yet been backfilled), so the acquire path waits for a worker to become
+        ready rather than misclassifying bootstrap as overload.
+        """
+
+        with self._state_lock:
+            spawn_alive = any(thread.is_alive() for thread in self._spawn_threads)
+            capacity_target = self._capacity_target
+        ready = self._slots.qsize()
+        return spawn_alive or (capacity_target > 0 and ready == 0)
 
     def _increment_metric(self, metric: str) -> None:
         with self._metrics_lock:

--- a/tests/test_guard_hook_process_runner.py
+++ b/tests/test_guard_hook_process_runner.py
@@ -765,3 +765,24 @@ def test_trusted_recovery_overlays_only_valid_failure_kind(
 
     assert environments[0]["HOL_GUARD_HOOK_FAILURE_KIND"] == "overload"
     assert environments[1]["HOL_GUARD_HOOK_FAILURE_KIND"] == "transport-failure"
+
+
+def test_acquire_fails_fast_when_saturated_with_existing_workers(tmp_path) -> None:
+    """Under genuine saturation (workers exist, all checked out), acquire must
+    not wait for the bootstrap window — it fails fast as overload."""
+    from codex_plugin_scanner.guard.daemon.hook_process_runner import HookProcessRunner
+
+    runner = HookProcessRunner(guard_home=tmp_path, process_limit=1, timeout_seconds=2.0)
+    runner.start()
+    try:
+        assert runner.wait_for_capacity(minimum_workers=1, timeout_seconds=15.0)
+        # Hold the single worker by occupying the pool: spawn a second acquire
+        # while the first review is in-flight is hard to stage deterministically,
+        # so assert the saturation predicate directly.
+        # _capacity_building must be False once workers exist even when busy.
+        with runner._state_lock:  # pyright: ignore[reportPrivateUsage]
+            total = len(runner._all_slots)  # pyright: ignore[reportPrivateUsage]
+        assert total >= 1
+        assert not runner._capacity_building()  # pyright: ignore[reportPrivateUsage]
+    finally:
+        runner.close()


### PR DESCRIPTION
## Problem

The hook process runner's `review()` acquires a worker with a hard 0.2s window (`_HOOK_PROCESS_ACQUIRE_TIMEOUT_SECONDS`) and returns `daemon_hook_process_overloaded` on `queue.Empty`. This is correct fail-fast for genuine saturation, but under heavy CI load (16-worker shards) a worker that failed transiently is being rebuilt by the supervisor, so the pool is at `ready: 0` while not saturated. The acquire then fails after 0.2s even though a worker would become ready within the ready window, producing the recurring `worker_stats: failures: 2, ready: 0` flake in `test_guard_daemon_pi_hook_endpoint_returns_blocked_runtime_review_payload` and the headless/adversarial transport tests on `release/3.1`.

## Change

- Add `_capacity_building()`: true while a spawn replacement thread is alive or no worker is yet ready despite a non-zero capacity target.
- In `review()`, when the pool is building (not saturated), acquire with a bounded wait up to the worker ready timeout instead of failing after 0.2s; keep the 0.2s fail-fast only when the pool is genuinely saturated.

This preserves overload-shedding under true saturation and only lengthens the window during bootstrap/planned-scale-down, which the existing supervisor will fulfill.

## Verification

- `tests/test_guard_hook_process_runner.py`: 28 passed (including transient worker spawn failure and replacement).
- `tests/test_guard_surface_server.py::...pi_hook...` and `tests/test_guard_daemon_adversarial_transport.py`: 21 passed.
- `basedpyright`: 0 errors/0 warnings; `ruff` clean.

No release or deployment is authorized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review request handling during worker startup and replacement.
  * Prevented temporary capacity-building states from being incorrectly reported as overloads.
  * Added fast failure when all existing workers are actively occupied and no capacity is available.
* **Tests**
  * Added coverage for saturated worker pool behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->