### PR TITLE
test(guard): resolve bare python3 against system PATH in interpreter trust tests

### DIFF
--- a/tests/test_guard_interpreter_identity.py
+++ b/tests/test_guard_interpreter_identity.py
@@ -20,6 +20,26 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _strip_venv_from_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve bare `python3` against the system PATH, not the active venv.
+
+    Under `uv run` the venv's ``bin`` directory is prepended to ``PATH`` so a
+    bare ``python3`` resolves into ``$HOME/.venv`` and is classified as
+    ``user_controlled``. These tests assert the trusted-system-interpreter
+    contract, so resolve ``python3`` as it would resolve on a system PATH.
+    """
+
+    path = os.environ.get("PATH", "")
+    parts = path.split(os.pathsep) if path else []
+    venv = os.environ.get("VIRTUAL_ENV")
+    if not venv:
+        return
+    venv_bin = os.path.join(venv, "bin")
+    cleaned = [part for part in parts if os.path.normpath(part) != os.path.normpath(venv_bin)]
+    monkeypatch.setenv("PATH", os.pathsep.join(cleaned))
+
+
 def _write_interpreter(path: Path, body: bytes = b"#!/bin/sh\nexit 0\n", *, executable: bool = True) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(body)


### PR DESCRIPTION
## Problem

`test_verified_system_interpreter_keeps_normal_read_only_path_prompt_free` and `test_bare_interpreter_uses_effective_path_and_keeps_trusted_resolution_prompt_free` fail intermittently on Linux CI. Tests run under `uv run --no-sync pytest`, which prepends the virtualenv's `bin` directory to `PATH`, so a bare `python3` resolves into `$HOME/.venv` and is classified `user_controlled`. The tests assert the trusted-system-interpreter contract, but the venv-augmented PATH breaks that assumption. Production trust resolution is correct — this is a test-environment defect.

## Change

Add an autouse fixture that strips the active virtualenv's `bin` directory from `PATH` for this test module, so a bare `python3` resolves against the system PATH the way the contract intends. Test-only change; no production code touched.

## Verification

- `tests/test_guard_interpreter_identity.py`: 19 passed
- `tests/test_guard_shell_command_wrappers.py` + `tests/test_guard_launch_identity_environment.py`: 56 passed combined
- ruff check/format clean

No release or deployment is authorized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test consistency by ensuring interpreter identity checks use the system `PATH` rather than an active virtual environment’s path.
  * Prevented virtual environment settings from affecting interpreter resolution during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->