### PR TITLE
fix(daemon): keep persistent Guard service alive

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11604,
-  "maximum_test_source_lines": 274050,
+  "maximum_test_source_lines": 274055,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11604,
-  "maximum_test_source_lines": 274035,
+  "maximum_test_source_lines": 274050,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11603,
-  "maximum_test_source_lines": 274026,
+  "maximum_collected_cases": 11604,
+  "maximum_test_source_lines": 274035,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -928,7 +928,6 @@ def _runtime_hook_env_overlay_from_payload(payload: Mapping[str, object]) -> dic
     return overlay
 
 
-_DEFAULT_GUARD_DAEMON_IDLE_TIMEOUT_SECONDS = 30 * 60
 _DEFAULT_SUPPLY_CHAIN_REFRESH_BACKOFF_SECONDS = 60.0
 _DEFAULT_SUPPLY_CHAIN_REFRESH_INTERVAL_SECONDS = 15 * 60.0
 _EPHEMERAL_GUARD_DAEMON_IDLE_TIMEOUT_SECONDS = 5
@@ -8258,7 +8257,7 @@ def _guard_daemon_idle_timeout_seconds(
             return None
     if _guard_home_is_ephemeral(guard_home):
         return _EPHEMERAL_GUARD_DAEMON_IDLE_TIMEOUT_SECONDS
-    return _DEFAULT_GUARD_DAEMON_IDLE_TIMEOUT_SECONDS
+    return None
 
 
 def _guard_home_is_ephemeral(guard_home: Path) -> bool:

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -2825,14 +2825,23 @@ class TestGuardSurfaceServer:
         assert runtime_state is not None
         assert daemon_thread_alive is True
 
-    def test_guard_daemon_idle_timeout_ignores_invalid_env_value(self, tmp_path, monkeypatch) -> None:
+    @pytest.mark.parametrize("configured_timeout", (None, "ten"))
+    def test_persistent_guard_daemon_keeps_running_without_valid_idle_timeout(
+        self,
+        tmp_path,
+        monkeypatch,
+        configured_timeout: str | None,
+    ) -> None:
         guard_home = tmp_path / "guard-home"
-        monkeypatch.setenv("GUARD_DAEMON_IDLE_TIMEOUT_SECONDS", "ten")
+        if configured_timeout is not None:
+            monkeypatch.setenv("GUARD_DAEMON_IDLE_TIMEOUT_SECONDS", configured_timeout)
+        else:
+            monkeypatch.delenv("GUARD_DAEMON_IDLE_TIMEOUT_SECONDS", raising=False)
         monkeypatch.setattr(daemon_server_module, "_guard_home_is_ephemeral", lambda _guard_home: False)
 
         idle_timeout = daemon_server_module._guard_daemon_idle_timeout_seconds(guard_home)
 
-        assert idle_timeout == 30 * 60
+        assert idle_timeout is None
 
     def test_surface_server_contract_is_exposed_during_initialize(self, tmp_path) -> None:
         contract = build_surface_server_contract()

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1242,6 +1242,7 @@ class TestGuardSurfaceServer:
         store = GuardStore(tmp_path / "guard-home")
         daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
         daemon.start()
+        events = store.list_events(event_name="daemon.hook.path_rejected")
 
         try:
             request = urllib.request.Request(
@@ -1255,13 +1256,17 @@ class TestGuardSurfaceServer:
             )
             with pytest.raises(urllib.error.HTTPError) as error:
                 urllib.request.urlopen(request, timeout=5)
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline and not events:
+                events = store.list_events(event_name="daemon.hook.path_rejected")
+                if not events:
+                    time.sleep(0.01)
         finally:
             daemon.stop()
 
         assert error.value.code == 400
         payload = json.loads(error.value.read().decode("utf-8"))
         assert payload["error"] == "invalid_hook_workspace_path"
-        events = store.list_events(event_name="daemon.hook.path_rejected")
         assert events[-1]["payload"]["parameter"] == "workspace"
         assert events[-1]["payload"]["reason"] == "relative_path"
 

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -2840,8 +2840,23 @@ class TestGuardSurfaceServer:
         monkeypatch.setattr(daemon_server_module, "_guard_home_is_ephemeral", lambda _guard_home: False)
 
         idle_timeout = daemon_server_module._guard_daemon_idle_timeout_seconds(guard_home)
+        store = GuardStore(guard_home)
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0, idle_timeout_seconds=idle_timeout)
+        daemon.start()
 
-        assert idle_timeout is None
+        try:
+            time.sleep(0.75)
+            daemon_thread = daemon._thread
+            daemon_thread_alive = daemon_thread is not None and daemon_thread.is_alive()
+            runtime_state = store.get_runtime_state()
+            effective_timeout = daemon._server.idle_timeout_seconds
+        finally:
+            daemon.stop()
+
+        assert effective_timeout is None
+        assert daemon_thread is not None
+        assert daemon_thread_alive is True
+        assert runtime_state is not None
 
     def test_surface_server_contract_is_exposed_during_initialize(self, tmp_path) -> None:
         contract = build_surface_server_contract()


### PR DESCRIPTION
## Summary
- keep persistent Guard daemons running instead of stopping after 30 minutes of inactivity
- retain configurable idle shutdown and short ephemeral-test cleanup behavior

## Testing
- `uv run --no-sync pytest -q tests/test_guard_surface_server.py -k 'idle_timeout or idle_shutdown or auto_stops_after_idle' --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_surface_server.py -k 'idle_timeout or idle_shutdown or auto_stops_after_idle' tests/test_guard_daemon_manager.py -k 'recovery or ensure' --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_surface_server.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_surface_server.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Guard daemons no longer use a fixed idle-shutdown timeout when the idle-timeout setting is missing or invalid.
  * Daemons now stay running until an explicit valid idle timeout is configured.
* **Tests**
  * Improved coverage for audit-event recording and added polling to verify events arrive after requests.
  * Added/updated tests to confirm daemon persistence for both unset and invalid idle-timeout values.
  * Updated test-suite baseline coverage thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->