### PR TITLE
fix(guard): preserve Pi fallback deadline

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
@@ -17,10 +17,10 @@ from .pi_extension_content_source import CONTENT_REVIEW_HELPERS_SOURCE
 # recovery/fallback paths below that host deadline so a fail-safe result returns.
 GUARD_HOOK_TIMEOUT_MS = 4_250
 GUARD_HOOK_DEADLINE_RESERVE_MS = 250
-GUARD_DAEMON_HOOK_TIMEOUT_MS = 2_500
+GUARD_DAEMON_HOOK_TIMEOUT_MS = 1_700
 GUARD_DAEMON_RECOVERY_TIMEOUT_MS = 250
 GUARD_DAEMON_RETRY_TIMEOUT_MS = 150
-GUARD_CLI_HOOK_TIMEOUT_MS = 900
+GUARD_CLI_HOOK_TIMEOUT_MS = 1_400
 GUARD_HOOK_TEXT_LIMIT_CHARS = 12_000
 GUARD_HOOK_CONTENT_ITEM_LIMIT = 24
 GUARD_HOOK_OBJECT_KEY_LIMIT = 24
@@ -249,8 +249,9 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "    };\n"
         "  } catch (error) {\n"
         "    if (error instanceof Error && error.name === 'AbortError') {\n"
-        "      // Classified transport recovery preserves a live overloaded daemon.\n"
-        '      return { response: null, recoveryKind: "transport-failure" };\n'
+        "      // A request timeout does not prove the live daemon is unhealthy. Preserve the\n"
+        "      // remaining host deadline for fail-safe review instead of restarting it.\n"
+        "      return { response: null, recoveryKind: null };\n"
         "    }\n"
         '    return { response: null, recoveryKind: "transport-failure" };\n'
         "  } finally {\n"

--- a/tests/test_pi_hook_latency.py
+++ b/tests/test_pi_hook_latency.py
@@ -238,16 +238,16 @@ def test_pi_extension_keeps_fallbacks_inside_outer_hook_deadline(tmp_path: Path)
 
     assert "const GUARD_TIMEOUT_MS = 4250;" in source
     assert "const GUARD_DEADLINE_RESERVE_MS = 250;" in source
-    assert "const GUARD_DAEMON_TIMEOUT_MS = 2500;" in source
+    assert "const GUARD_DAEMON_TIMEOUT_MS = 1700;" in source
     assert "const GUARD_DAEMON_RECOVERY_TIMEOUT_MS = 250;" in source
     assert "const GUARD_DAEMON_RETRY_TIMEOUT_MS = 150;" in source
-    assert "const GUARD_CLI_TIMEOUT_MS = 900;" in source
+    assert "const GUARD_CLI_TIMEOUT_MS = 1400;" in source
     assert 'const GUARD_ARGS = ["hook", "--json"' in source
     assert "compatibility_version !== GUARD_COMPATIBILITY_VERSION" in source
     assert "error.name === 'AbortError'" in source
     assert source.index("error.name === 'AbortError'") > source.index("await fetch")
     timeout_branch = source[source.index("error.name === 'AbortError'") :]
-    assert 'recoveryKind: "transport-failure"' in timeout_branch
+    assert "return { response: null, recoveryKind: null }" in timeout_branch
     assert "response.status === 401 || response.status === 403" in source
     assert 'recoveryKind: "authenticated-control-plane-failure"' in source
     assert "schedule_guard_daemon_recovery" in source


### PR DESCRIPTION
## Summary
- distinguish a live daemon request timeout from a transport outage
- preserve enough of the Pi hook deadline for bounded fail-safe review

## Testing
- `uv run --no-sync pytest -q tests/test_pi_adapter.py tests/test_pi_hook_latency.py --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_daemon_adversarial_transport.py tests/test_guard_runtime_hook_scheduler.py tests/test_pi_hook_latency.py tests/test_pi_adapter.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/adapters/pi_extension_source.py tests/test_pi_hook_latency.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/adapters/pi_extension_source.py tests/test_pi_hook_latency.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/adapters/pi_extension_source.py tests/test_pi_hook_latency.py`
