### PR TITLE
feat(settings): expose cloud receipt privacy

### DIFF
--- a/dashboard/src/apps/app-catalog.ts
+++ b/dashboard/src/apps/app-catalog.ts
@@ -160,6 +160,7 @@ const SETTINGS_SEARCH_INDEX: SettingSearchMatch[] = [
   { key: "approval_wait_timeout", label: "Approval wait timeout", description: "How long Guard waits for you to respond before resuming.", section: "protection" },
   { key: "telemetry", label: "Telemetry", description: "Send anonymized usage data to improve Guard.", section: "protection" },
   { key: "sync", label: "Cloud sync", description: "Sync decisions and rules with Guard Cloud.", section: "protection" },
+  { key: "redaction", label: "Cloud receipt privacy", description: "Choose how much command detail Guard sends to Guard Cloud.", section: "protection" },
   { key: "billing", label: "Billing features", description: "Enable billing and subscription features.", section: "protection" },
   { key: "clear_approvals", label: "Clear saved approvals", description: "Remove all stored allow or block decisions. Guard will ask again.", section: "maintenance" },
   { key: "clear_evidence", label: "Clear evidence log", description: "Permanently remove all recorded evidence. Cannot be undone.", section: "maintenance" },

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -2207,6 +2207,7 @@ export async function fetchSettings(): Promise<GuardSettingsPayload> {
         approval_browser_immediate_severity: "critical",
         telemetry: false,
         sync: false,
+        receipt_redaction_level: "full",
         billing: false
       }
     };

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -892,6 +892,7 @@ export type GuardSettings = {
   approval_browser_immediate_severity: RiskSignalV2Severity;
   telemetry: boolean;
   sync: boolean;
+  receipt_redaction_level: "full" | "partial" | "none";
   billing: boolean;
   update_channel?: "stable" | "alpha";
   approval_gate?: GuardApprovalGatePublicConfig;

--- a/dashboard/src/settings-workspace.test.ts
+++ b/dashboard/src/settings-workspace.test.ts
@@ -109,6 +109,8 @@ assert(resolveInitialSettingsTab("?section=unknown") === "protection", "settings
 const settingsWorkspaceSource = readFileSync(fileURLToPath(import.meta.url).replace(/\.test\.ts$/, ".tsx"), "utf8");
 assert(settingsWorkspaceSource.includes('window.addEventListener("popstate", handlePopState)'), "settings routing: browser history resyncs the visible section");
 assert(settingsWorkspaceSource.includes('window.removeEventListener("popstate", handlePopState)'), "settings routing: history listener is cleaned up");
+assert(settingsWorkspaceSource.includes('id="receipt-redaction-level"'), "receipt privacy: redaction control is visible in settings");
+assert(settingsWorkspaceSource.includes('handleStringChange("receipt_redaction_level")'), "receipt privacy: redaction changes persist through settings save");
 
 assert(resolveTotpSetupStep(null) === "confirm", "totp-setup: fresh setup starts at password confirmation");
 assert(

--- a/dashboard/src/settings-workspace.tsx
+++ b/dashboard/src/settings-workspace.tsx
@@ -1483,6 +1483,24 @@ export function SettingsWorkspace({ onApprovalGateChange }: SettingsWorkspacePro
                   checked={draft.sync}
                   onChange={handleSyncToggle}
                 />
+                <div>
+                  <label htmlFor="receipt-redaction-level" className="guard-settings-body font-medium text-brand-dark">
+                    Cloud receipt privacy
+                  </label>
+                  <p className="guard-settings-caption text-slate-500">
+                    Choose how much command detail Guard includes when syncing receipts. Secrets are always removed.
+                  </p>
+                  <select
+                    id="receipt-redaction-level"
+                    value={draft.receipt_redaction_level}
+                    onChange={handleStringChange("receipt_redaction_level")}
+                    className="mt-2 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20"
+                  >
+                    <option value="full">Fully redacted - metadata only</option>
+                    <option value="partial">Partially redacted - hide paths and package names</option>
+                    <option value="none">Detailed - include commands, paths, hosts, and packages</option>
+                  </select>
+                </div>
                 <SettingsToggleRow
                   label="Billing features"
                   description="Enable paid supply-chain and blocked-install analytics."

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-catalog.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-catalog.js
@@ -103,6 +103,7 @@ const SETTINGS_SEARCH_INDEX = [
   { key: "approval_wait_timeout", label: "Approval wait timeout", description: "How long Guard waits for you to respond before resuming.", section: "protection" },
   { key: "telemetry", label: "Telemetry", description: "Send anonymized usage data to improve Guard.", section: "protection" },
   { key: "sync", label: "Cloud sync", description: "Sync decisions and rules with Guard Cloud.", section: "protection" },
+  { key: "redaction", label: "Cloud receipt privacy", description: "Choose how much command detail Guard sends to Guard Cloud.", section: "protection" },
   { key: "billing", label: "Billing features", description: "Enable billing and subscription features.", section: "protection" },
   { key: "clear_approvals", label: "Clear saved approvals", description: "Remove all stored allow or block decisions. Guard will ask again.", section: "maintenance" },
   { key: "clear_evidence", label: "Clear evidence log", description: "Permanently remove all recorded evidence. Cannot be undone.", section: "maintenance" },

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
@@ -3610,6 +3610,24 @@ function SettingsWorkspace({ onApprovalGateChange }) {
                   onChange: handleSyncToggle
                 }
               ),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "receipt-redaction-level", className: "guard-settings-body font-medium text-brand-dark", children: "Cloud receipt privacy" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "guard-settings-caption text-slate-500", children: "Choose how much command detail Guard includes when syncing receipts. Secrets are always removed." }),
+                /* @__PURE__ */ jsxRuntimeExports.jsxs(
+                  "select",
+                  {
+                    id: "receipt-redaction-level",
+                    value: draft.receipt_redaction_level,
+                    onChange: handleStringChange("receipt_redaction_level"),
+                    className: "mt-2 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20",
+                    children: [
+                      /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "full", children: "Fully redacted - metadata only" }),
+                      /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "partial", children: "Partially redacted - hide paths and package names" }),
+                      /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "none", children: "Detailed - include commands, paths, hosts, and packages" })
+                    ]
+                  }
+                )
+              ] }),
               /* @__PURE__ */ jsxRuntimeExports.jsx(
                 SettingsToggleRow,
                 {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -17393,6 +17393,7 @@ async function fetchSettings() {
         approval_browser_immediate_severity: "critical",
         telemetry: false,
         sync: false,
+        receipt_redaction_level: "full",
         billing: false
       }
     };


### PR DESCRIPTION
## Summary
- expose Cloud receipt privacy in local Guard settings
- preserve the existing full, partial, and detailed redaction levels
- include the setting in dashboard search and generated assets

## Testing
- `./node_modules/.bin/tsx src/settings-workspace.test.ts`
- `bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Cloud receipt privacy setting with fully redacted, partially redacted, and detailed receipt options.
  * Added the setting to settings search for easier discovery.
  * New configurations default to fully redacted receipts.

* **Tests**
  * Added coverage confirming the privacy control displays and saves selections correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->