### PR TITLE
feat(mdm): add portable contract lab

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11636,
-  "maximum_test_source_lines": 274352,
+  "maximum_collected_cases": 11638,
+  "maximum_test_source_lines": 274436,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11638,
-  "maximum_test_source_lines": 274436,
+  "maximum_collected_cases": 11640,
+  "maximum_test_source_lines": 274487,
   "schema_version": 1
 }

--- a/scripts/mdm/Dockerfile.local-lab
+++ b/scripts/mdm/Dockerfile.local-lab
@@ -1,0 +1,24 @@
+FROM python:3.13-slim@sha256:c33f0bc4364a6881bed1ec0cc2665e6c53c87a43e774aaeab88e6f17af105e4f
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONPATH=/hol-guard-source/src
+
+WORKDIR /hol-guard-source
+
+COPY docker-requirements.txt /tmp/docker-requirements.txt
+RUN python3 -m venv /hol-guard/.venv && \
+    /hol-guard/.venv/bin/python -m pip install --no-deps --require-hashes -r /tmp/docker-requirements.txt && \
+    /hol-guard/.venv/bin/python -c "import site; from pathlib import Path; Path(site.getsitepackages()[0], 'hol_guard_source.pth').write_text('/hol-guard-source/src\n')"
+
+COPY src /hol-guard-source/src
+COPY scripts/mdm/run-local-lab.py /hol-guard-source/scripts/mdm/run-local-lab.py
+RUN groupadd --system guardlab && \
+    useradd --system --gid guardlab --create-home --home-dir /home/guardlab guardlab && \
+    chown -R guardlab:guardlab /hol-guard /home/guardlab
+
+USER guardlab
+
+ENTRYPOINT ["/hol-guard/.venv/bin/python", "/hol-guard-source/scripts/mdm/run-local-lab.py"]
+CMD ["--json"]

--- a/scripts/mdm/run-local-lab-container.py
+++ b/scripts/mdm/run-local-lab-container.py
@@ -6,12 +6,15 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
+import sys
 from pathlib import Path
 from typing import Final
 
 _REPOSITORY_ROOT: Final = Path(__file__).resolve().parents[2]
 _DOCKERFILE: Final = _REPOSITORY_ROOT / "scripts" / "mdm" / "Dockerfile.local-lab"
 _DEFAULT_IMAGE: Final = "hol-guard-mdm-local-lab:local"
+_COMMAND_TIMEOUT_SECONDS: Final = 300
+
 
 
 def _docker_build_command(image: str) -> list[str]:
@@ -45,9 +48,16 @@ def main() -> int:
         print(json.dumps({"build": build_command, "run": run_command}, sort_keys=True))
         return 0
 
-    if not args.skip_build:
-        subprocess.run(build_command, check=True)
-    return subprocess.run(run_command, check=False).returncode
+    try:
+        if not args.skip_build:
+            subprocess.run(build_command, check=True, timeout=_COMMAND_TIMEOUT_SECONDS)
+        return subprocess.run(run_command, check=False, timeout=_COMMAND_TIMEOUT_SECONDS).returncode
+    except subprocess.TimeoutExpired as error:
+        print(
+            f"local MDM container command timed out after {_COMMAND_TIMEOUT_SECONDS} seconds: {error.cmd}",
+            file=sys.stderr,
+        )
+        return 124
 
 
 if __name__ == "__main__":

--- a/scripts/mdm/run-local-lab-container.py
+++ b/scripts/mdm/run-local-lab-container.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Build and run the portable MDM contract lab without network access."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Final
+
+_REPOSITORY_ROOT: Final = Path(__file__).resolve().parents[2]
+_DOCKERFILE: Final = _REPOSITORY_ROOT / "scripts" / "mdm" / "Dockerfile.local-lab"
+_DEFAULT_IMAGE: Final = "hol-guard-mdm-local-lab:local"
+
+
+def _docker_build_command(image: str) -> list[str]:
+    return ["docker", "build", "--tag", image, "--file", str(_DOCKERFILE), str(_REPOSITORY_ROOT)]
+
+
+def _docker_run_command(image: str) -> list[str]:
+    source_mount = f"type=bind,src={_REPOSITORY_ROOT},dst=/hol-guard-source,readonly"
+    return [
+        "docker",
+        "run",
+        "--rm",
+        "--network=none",
+        "--mount",
+        source_mount,
+        image,
+        "--json",
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", default=_DEFAULT_IMAGE, help="container image tag for the local lab")
+    parser.add_argument("--skip-build", action="store_true", help="run an already-built local lab image")
+    parser.add_argument("--dry-run", action="store_true", help="print the Docker commands without executing them")
+    args = parser.parse_args()
+
+    build_command = _docker_build_command(args.image)
+    run_command = _docker_run_command(args.image)
+    if args.dry_run:
+        print(json.dumps({"build": build_command, "run": run_command}, sort_keys=True))
+        return 0
+
+    if not args.skip_build:
+        subprocess.run(build_command, check=True)
+    return subprocess.run(run_command, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mdm/run-local-lab.py
+++ b/scripts/mdm/run-local-lab.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Run portable HOL Guard MDM contract checks inside the network-isolated lab."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Final
+
+from codex_plugin_scanner.guard.mdm.contracts import MDM_POLICY_SCHEMA_VERSION
+from codex_plugin_scanner.guard.mdm.lifecycle import user_status, validate_user_home
+from codex_plugin_scanner.guard.mdm.policy import parse_managed_policy
+
+_LAB_SCHEMA_VERSION: Final = "hol-guard-mdm-local-lab.v1"
+
+
+def _check_absent_user_status() -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="hol-guard-mdm-local-lab-") as temporary_directory:
+        home = Path(temporary_directory) / "home"
+        home.mkdir()
+        status = user_status(home)
+        expected = {
+            "scope": "user",
+            "state": "absent",
+            "healthy": False,
+            "reasonCodes": ["user_not_activated"],
+        }
+        for key, value in expected.items():
+            if status.get(key) != value:
+                raise RuntimeError(f"absent_user_status_{key}_unexpected")
+        if any(home.iterdir()):
+            raise RuntimeError("absent_user_status_created_files")
+    return {"state": "absent", "sideEffectFree": True}
+
+
+def _check_user_home_rejection() -> dict[str, object]:
+    try:
+        validate_user_home("relative-home")
+    except ValueError as error:
+        if str(error) != "mdm_home_must_be_absolute":
+            raise RuntimeError("relative_home_rejection_code_unexpected") from error
+    else:
+        raise RuntimeError("relative_home_was_accepted")
+    return {"reasonCode": "mdm_home_must_be_absolute"}
+
+
+def _check_managed_policy_parser() -> dict[str, object]:
+    policy = parse_managed_policy(
+        {
+            "schemaVersion": MDM_POLICY_SCHEMA_VERSION,
+            "settings": {"defaultAction": "block"},
+            "lockedSettings": ["defaultAction"],
+        }
+    )
+    if policy.settings != {"defaultAction": "block"} or policy.locked_settings != frozenset({"defaultAction"}):
+        raise RuntimeError("managed_policy_round_trip_unexpected")
+    return {"schemaVersion": policy.schema_version, "lockedSettings": ["defaultAction"]}
+
+
+def _result(identifier: str, run_check: Callable[[], dict[str, object]]) -> dict[str, object]:
+    try:
+        evidence = run_check()
+    except Exception as error:  # pragma: no cover - exercised through the process exit path.
+        return {"id": identifier, "status": "fail", "error": str(error)}
+    return {"id": identifier, "status": "pass", "evidence": evidence}
+
+
+def build_report() -> dict[str, object]:
+    results = [
+        _result("absent-user-status", _check_absent_user_status),
+        _result("relative-home-rejection", _check_user_home_rejection),
+        _result("managed-policy-parser", _check_managed_policy_parser),
+    ]
+    return {
+        "schemaVersion": _LAB_SCHEMA_VERSION,
+        "healthy": all(result["status"] == "pass" for result in results),
+        "results": results,
+        "nativeCertification": {
+            "outcome": "not-evaluated",
+            "reason": "requires real macOS or Windows MDM enrollment and native signing evidence",
+            "requiredGates": [
+                {"id": "macos-mdm-enrollment", "platform": "macOS"},
+                {"id": "macos-package-signing", "platform": "macOS"},
+                {"id": "windows-intune-enrollment", "platform": "Windows"},
+                {"id": "windows-msix-signing", "platform": "Windows"},
+            ],
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit the machine-readable lab report")
+    args = parser.parse_args()
+
+    report = build_report()
+    if args.json:
+        print(json.dumps(report, sort_keys=True))
+    else:
+        outcome = "passed" if report["healthy"] else "failed"
+        print(f"HOL Guard MDM local lab {outcome}. Use --json for the machine-readable report.")
+    return 0 if report["healthy"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_guard_mdm_local_lab.py
+++ b/tests/test_guard_mdm_local_lab.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_RUNNER = _REPOSITORY_ROOT / "scripts" / "mdm" / "run-local-lab.py"
+
+
+def test_local_mdm_lab_reports_portable_contract_checks() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(_RUNNER), "--json"],
+        check=False,
+        cwd=_REPOSITORY_ROOT,
+        env={**os.environ, "PYTHONPATH": str(_REPOSITORY_ROOT / "src")},
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    report = json.loads(completed.stdout)
+
+    assert report["schemaVersion"] == "hol-guard-mdm-local-lab.v1"
+    assert report["healthy"] is True
+    assert [result["id"] for result in report["results"]] == [
+        "absent-user-status",
+        "relative-home-rejection",
+        "managed-policy-parser",
+    ]
+    assert all(result["status"] == "pass" for result in report["results"])
+    assert report["nativeCertification"] == {
+        "outcome": "not-evaluated",
+        "reason": "requires real macOS or Windows MDM enrollment and native signing evidence",
+        "requiredGates": [
+            {"id": "macos-mdm-enrollment", "platform": "macOS"},
+            {"id": "macos-package-signing", "platform": "macOS"},
+            {"id": "windows-intune-enrollment", "platform": "Windows"},
+            {"id": "windows-msix-signing", "platform": "Windows"},
+        ],
+    }

--- a/tests/test_guard_mdm_local_lab_container.py
+++ b/tests/test_guard_mdm_local_lab_container.py
@@ -1,12 +1,27 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
+
+import pytest
 
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 _LAUNCHER = _REPOSITORY_ROOT / "scripts" / "mdm" / "run-local-lab-container.py"
+
+
+def _load_launcher() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("run_local_lab_container", _LAUNCHER)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 
 
 def test_local_mdm_container_launcher_disables_network() -> None:
@@ -39,3 +54,39 @@ def test_local_mdm_container_launcher_disables_network() -> None:
         "hol-guard-mdm-local-lab:local",
         "--json",
     ]
+
+
+def test_local_mdm_container_launcher_applies_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    launcher = _load_launcher()
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, returncode=0)
+
+    monkeypatch.setattr(sys, "argv", [str(_LAUNCHER)])
+    monkeypatch.setattr(launcher.subprocess, "run", fake_run)
+
+    assert launcher.main() == 0
+    assert calls == [
+        (launcher._docker_build_command("hol-guard-mdm-local-lab:local"), {"check": True, "timeout": 300}),
+        (launcher._docker_run_command("hol-guard-mdm-local-lab:local"), {"check": False, "timeout": 300}),
+    ]
+
+
+def test_local_mdm_container_launcher_reports_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    launcher = _load_launcher()
+
+    def timeout_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(command, timeout=300)
+
+    monkeypatch.setattr(sys, "argv", [str(_LAUNCHER)])
+    monkeypatch.setattr(launcher.subprocess, "run", timeout_run)
+
+    assert launcher.main() == 124
+    assert capsys.readouterr().err.startswith("local MDM container command timed out after 300 seconds:")

--- a/tests/test_guard_mdm_local_lab_container.py
+++ b/tests/test_guard_mdm_local_lab_container.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_LAUNCHER = _REPOSITORY_ROOT / "scripts" / "mdm" / "run-local-lab-container.py"
+
+
+def test_local_mdm_container_launcher_disables_network() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(_LAUNCHER), "--dry-run"],
+        check=False,
+        cwd=_REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    commands = json.loads(completed.stdout)
+    assert commands["build"] == [
+        "docker",
+        "build",
+        "--tag",
+        "hol-guard-mdm-local-lab:local",
+        "--file",
+        str(_REPOSITORY_ROOT / "scripts" / "mdm" / "Dockerfile.local-lab"),
+        str(_REPOSITORY_ROOT),
+    ]
+    assert commands["run"] == [
+        "docker",
+        "run",
+        "--rm",
+        "--network=none",
+        "--mount",
+        f"type=bind,src={_REPOSITORY_ROOT},dst=/hol-guard-source,readonly",
+        "hol-guard-mdm-local-lab:local",
+        "--json",
+    ]


### PR DESCRIPTION
## Summary
- Add a network-isolated portable MDM contract lab.
- Report platform-native gates as explicitly not evaluated outside enrolled device environments.
- Add a bounded container launcher that reports timeouts.

## Testing
- `uv run --no-sync pytest tests/test_guard_mdm_local_lab.py tests/test_guard_mdm_local_lab_container.py -q`
- `uv run --no-sync ruff check scripts/mdm/run-local-lab.py scripts/mdm/run-local-lab-container.py tests/test_guard_mdm_local_lab.py tests/test_guard_mdm_local_lab_container.py`
- `uv run --no-sync python scripts/mdm/run-local-lab-container.py`
