### PR TITLE
feat(guard): add fail-closed Kubernetes RuntimeClass adapter

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/k8s_runtimeclass_provider.py
+++ b/src/codex_plugin_scanner/guard/runtime/k8s_runtimeclass_provider.py
@@ -14,19 +14,16 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import Final
+from typing import Final, NoReturn
 
 from codex_plugin_scanner.guard.runtime.execution_assurance_contract import (
     AtomicGuarantee,
     AtomicGuaranteeKind,
     DecisionContext,
     ExecutionLease,
-    ExecutionOutcome,
     GuardExecutionAssuranceBoundary,
-    GuardExecutionAttestationTrust,
     ProviderHealthState,
     ProviderIdentity,
-    TerminalStatement,
     framed_digest,
 )
 from codex_plugin_scanner.guard.runtime.isolation_provider import (
@@ -38,6 +35,12 @@ from codex_plugin_scanner.guard.runtime.isolation_provider import (
 _PROVIDER_KIND: Final = "k8s-runtimeclass"
 _SIGNING_IDENTITY: Final = "guard-k8s-runtimeclass"
 _TRUST_DOMAIN: Final = "guard.k8s"
+_BOUNDARY_ORDER: Final = (
+    GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+    GuardExecutionAssuranceBoundary.CONTROLLED_HOST,
+    GuardExecutionAssuranceBoundary.OS_ISOLATED,
+    GuardExecutionAssuranceBoundary.HARDWARE_ISOLATED,
+)
 
 # Guarantees this provider CAN enforce when all evidence is verified.
 _K8S_ENFORCED: Final = (
@@ -69,6 +72,7 @@ class ClusterTrustEvidence:
 
     ca_pinned: bool
     api_server_verified: bool
+    ca_digest: str | None = None
 
 
 @dataclass(frozen=True)
@@ -141,13 +145,12 @@ def _require_decision_context(value: object) -> DecisionContext:
     return value
 
 
-def _evidence_boundary(evidence: K8sRuntimeClassEvidence) -> GuardExecutionAssuranceBoundary:
+def _evidence_boundary(
+    evidence: K8sRuntimeClassEvidence,
+) -> GuardExecutionAssuranceBoundary:
     """Compute the boundary achievable given the evidence."""
     if not _evidence_sufficient(evidence):
         return GuardExecutionAssuranceBoundary.OBSERVED_HOST
-    if not evidence.runtime.runtime_handler_verified:
-        return GuardExecutionAssuranceBoundary.OBSERVED_HOST
-    # All evidence present and verified → OS_ISOLATED
     return GuardExecutionAssuranceBoundary.OS_ISOLATED
 
 
@@ -161,31 +164,35 @@ def _evidence_sufficient(evidence: K8sRuntimeClassEvidence) -> bool:
         return False
     if evidence.admission.admission_weaker:
         return False
-    # Pod spec must be immutable, digest verified, no mutable changes
-    if not evidence.pod_spec.pod_spec_immutable:
+    # Every asserted verification flag must have the corresponding immutable
+    # identifier. Boolean labels alone never grant assurance.
+    pod = evidence.pod_spec
+    if (
+        not pod.pod_spec_immutable
+        or not pod.image_digest_verified
+        or pod.image_digest is None
+        or len(pod.image_digest) != 64
+        or pod.image_digest_changed
+        or pod.sidecar_unexpected
+        or pod.sidecar_containers
+        or pod.host_network
+        or pod.host_pid
+        or pod.privileged_containers
+    ):
         return False
-    if not evidence.pod_spec.image_digest_verified:
+    rbac = evidence.rbac_network
+    if (
+        not rbac.service_account
+        or not rbac.namespace
+        or not rbac.network_policy_enforced
+        or not rbac.network_policy_name
+    ):
         return False
-    if evidence.pod_spec.image_digest_changed:
+    node = evidence.node
+    if not node.node_id_verified or not node.node_name or not node.node_trust_domain:
         return False
-    # Unexpected sidecars fail closed
-    if evidence.pod_spec.sidecar_unexpected:
-        return False
-    # Host-network, host-PID, privileged containers fail closed
-    if evidence.pod_spec.host_network:
-        return False
-    if evidence.pod_spec.host_pid:
-        return False
-    if evidence.pod_spec.privileged_containers:
-        return False
-    # Network policy must be enforced
-    if not evidence.rbac_network.network_policy_enforced:
-        return False
-    # Node identity must be verified
-    if not evidence.node.node_id_verified:
-        return False
-    # Runtime handler must be verified
-    return evidence.runtime.runtime_handler_verified
+    runtime = evidence.runtime
+    return bool(runtime.runtime_handler_verified and runtime.runtime_handler and runtime.execution_instance)
 
 
 def _map_guarantees(evidence: K8sRuntimeClassEvidence) -> tuple[AtomicGuarantee, ...]:
@@ -245,10 +252,14 @@ class K8sRuntimeClassProvider:
     def __init__(
         self,
         *,
-        trust_ca_digest: str | None = None,
-        expected_runtime_handler: str | None = None,
+        trust_ca_digest: str,
+        expected_runtime_handler: str = "guard-runtimeclass",
     ) -> None:
-        self._trust_ca_digest = trust_ca_digest or ("0" * 64)
+        if len(trust_ca_digest) != 64 or set(trust_ca_digest) == {"0"}:
+            raise ValueError("trust_ca_digest must be a nonzero 64-character digest")
+        if not expected_runtime_handler:
+            raise ValueError("expected_runtime_handler must be non-empty")
+        self._trust_ca_digest = trust_ca_digest
         self._expected_runtime_handler = expected_runtime_handler
 
     @staticmethod
@@ -303,7 +314,7 @@ class K8sRuntimeClassProvider:
 
     def plan(
         self,
-        context: DecisionContext,
+        context: object,
         minimum_boundary: GuardExecutionAssuranceBoundary,
         *,
         evidence: K8sRuntimeClassEvidence | None = None,
@@ -322,72 +333,68 @@ class K8sRuntimeClassProvider:
         if minimum_boundary is GuardExecutionAssuranceBoundary.HARDWARE_ISOLATED:
             raise ProviderPlanError("K8s RuntimeClass cannot provide hardware-isolated boundary")
 
-        # Determine achievable boundary from evidence.
         if evidence is not None:
-            if not _evidence_sufficient(evidence):
-                # Insufficient evidence → refuse to plan above OBSERVED_HOST.
-                achievable = GuardExecutionAssuranceBoundary.OBSERVED_HOST
-            else:
-                achievable = _evidence_boundary(evidence)
+            ca_matches = evidence.cluster.ca_digest == self._trust_ca_digest
+            handler_matches = evidence.runtime.runtime_handler == self._expected_runtime_handler
+            achievable = (
+                _evidence_boundary(evidence)
+                if _evidence_sufficient(evidence) and ca_matches and handler_matches
+                else GuardExecutionAssuranceBoundary.OBSERVED_HOST
+            )
         else:
-            # No evidence → deny-by-default to OBSERVED_HOST.
             achievable = GuardExecutionAssuranceBoundary.OBSERVED_HOST
 
         # If minimum boundary exceeds what evidence provides, refuse.
-        boundary_order = [
-            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
-            GuardExecutionAssuranceBoundary.CONTROLLED_HOST,
-            GuardExecutionAssuranceBoundary.OS_ISOLATED,
-            GuardExecutionAssuranceBoundary.HARDWARE_ISOLATED,
-        ]
-        achievable_idx = boundary_order.index(achievable)
-        minimum_idx = boundary_order.index(minimum_boundary)
+        achievable_idx = _BOUNDARY_ORDER.index(achievable)
+        minimum_idx = _BOUNDARY_ORDER.index(minimum_boundary)
         if minimum_idx > achievable_idx:
             raise ProviderPlanError(
                 f"minimum boundary {minimum_boundary.value} exceeds achievable {achievable.value} from evidence"
             )
 
+        evidence_digest = framed_digest(
+            "guard.k8s-runtimeclass-evidence.v1",
+            {"evidence": repr(evidence) if evidence is not None else "absent"},
+        )
         plan_digest = framed_digest(
             "guard.k8s-runtimeclass-plan.v1",
             {
                 "context_digest": validated_context.context_digest,
                 "minimum_boundary": minimum_boundary.value,
                 "achievable_boundary": achievable.value,
-                "runtime_handler": self._expected_runtime_handler or "",
-                "evidence_present": evidence is not None,
+                "runtime_handler": self._expected_runtime_handler,
+                "evidence_digest": evidence_digest,
             },
         )
+        attempt_nonce = framed_digest(
+            "guard.k8s-runtimeclass-attempt.v1",
+            {
+                "plan_digest": plan_digest,
+                "execution_instance": (evidence.runtime.execution_instance if evidence is not None else "absent"),
+            },
+        )[:32]
         return ExecutionLease(
             plan_digest=plan_digest,
             provider_thumbprint=self.identity().thumbprint(),
-            fencing_generation=1,
+            fencing_generation=int(plan_digest[:8], 16),
             lease_expiry_epoch_seconds=int(time.time()) + self._lease_ttl_seconds(),
-            attempt_nonce=validated_context.context_digest[:16],
+            attempt_nonce=attempt_nonce,
             input_manifest_digest=validated_context.executable_digest,
         )
 
-    def execute(self, lease: ExecutionLease) -> TerminalStatement:
-        """Return a terminal statement with attestation trust.
-
-        No live cluster calls; returns self-attested from the validated plan.
-        """
-        return TerminalStatement(
-            outcome=ExecutionOutcome.SUCCEEDED,
-            exit_code=0,
-            stream_byte_counts=(),
-            stream_digests=(),
-            truncated=False,
-            declared_output_digests=(),
-            cleanup_complete=True,
-            execution_instance=lease.attempt_nonce,
-            attestation_trust=GuardExecutionAttestationTrust.SELF_ATTESTED,
+    def execute(self, _lease: ExecutionLease) -> NoReturn:
+        """Refuse execution: this adapter validates evidence but makes no live calls."""
+        raise ProviderPlanError(
+            "Kubernetes RuntimeClass adapter is planning-only; execution requires an authenticated runner"
         )
 
-    def cancel(self, _execution_instance: str) -> None:
-        return None
+    def cancel(self, execution_instance: str) -> None:
+        if not execution_instance:
+            raise ProviderPlanError("execution_instance must be non-empty")
 
-    def cleanup(self, _execution_instance: str) -> None:
-        return None
+    def cleanup(self, execution_instance: str) -> None:
+        if not execution_instance:
+            raise ProviderPlanError("execution_instance must be non-empty")
 
     @staticmethod
     def evidence_to_guarantees(evidence: K8sRuntimeClassEvidence) -> tuple[AtomicGuarantee, ...]:
@@ -398,12 +405,13 @@ class K8sRuntimeClassProvider:
 def build_k8s_evidence(
     *,
     cluster_ca_pinned: bool = True,
+    cluster_ca_digest: str | None = "a" * 64,
     cluster_api_server_verified: bool = True,
     admission_verified: bool = True,
     admission_policy_name: str = "guard-runtimeclass-policy",
     admission_weaker: bool = False,
     pod_spec_immutable: bool = True,
-    image_digest: str | None = None,
+    image_digest: str | None = "1" * 64,
     image_digest_verified: bool = True,
     image_digest_changed: bool = False,
     sidecar_containers: tuple[str, ...] = (),
@@ -426,6 +434,7 @@ def build_k8s_evidence(
     return K8sRuntimeClassEvidence(
         cluster=ClusterTrustEvidence(
             ca_pinned=cluster_ca_pinned,
+            ca_digest=cluster_ca_digest,
             api_server_verified=cluster_api_server_verified,
         ),
         admission=AdmissionEvidence(
@@ -435,7 +444,7 @@ def build_k8s_evidence(
         ),
         pod_spec=PodSpecEvidence(
             pod_spec_immutable=pod_spec_immutable,
-            image_digest=image_digest or ("1" * 64),
+            image_digest=image_digest,
             image_digest_verified=image_digest_verified,
             image_digest_changed=image_digest_changed,
             sidecar_containers=sidecar_containers,

--- a/src/codex_plugin_scanner/guard/runtime/k8s_runtimeclass_provider.py
+++ b/src/codex_plugin_scanner/guard/runtime/k8s_runtimeclass_provider.py
@@ -1,0 +1,476 @@
+"""Kubernetes RuntimeClass provider adapter.
+
+Validates cluster trust, admission control, immutable pod spec/image digest,
+service account/namespace/network policy, node identity, observed runtime
+handler, and execution instance — then maps verified evidence to atomic
+guarantees. Deny-by-default: handler name ALONE never grants assurance;
+changed/weaker admission, unexpected sidecar, host-network, untrusted node,
+mutable image, or missing runtime evidence all FAIL (lower/refuse assurance).
+
+Pure validation + evidence→guarantee mapping; no live cluster calls.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Final
+
+from codex_plugin_scanner.guard.runtime.execution_assurance_contract import (
+    AtomicGuarantee,
+    AtomicGuaranteeKind,
+    DecisionContext,
+    ExecutionLease,
+    ExecutionOutcome,
+    GuardExecutionAssuranceBoundary,
+    GuardExecutionAttestationTrust,
+    ProviderHealthState,
+    ProviderIdentity,
+    TerminalStatement,
+    framed_digest,
+)
+from codex_plugin_scanner.guard.runtime.isolation_provider import (
+    ProviderHealth,
+    ProviderPlanError,
+    validate_provider_plan_inputs,
+)
+
+_PROVIDER_KIND: Final = "k8s-runtimeclass"
+_SIGNING_IDENTITY: Final = "guard-k8s-runtimeclass"
+_TRUST_DOMAIN: Final = "guard.k8s"
+
+# Guarantees this provider CAN enforce when all evidence is verified.
+_K8S_ENFORCED: Final = (
+    AtomicGuaranteeKind.PROCESS,
+    AtomicGuaranteeKind.NETWORK,
+    AtomicGuaranteeKind.IDENTITY,
+    AtomicGuaranteeKind.PRIVILEGE,
+    AtomicGuaranteeKind.RESOURCE,
+    AtomicGuaranteeKind.CLEANUP,
+    AtomicGuaranteeKind.TENANT,
+)
+
+# Guaranteed enforced but at OS_ISOLATED only (pod scheduling, not strict isolation).
+_K8S_OS_ISOLATED: Final = (
+    AtomicGuaranteeKind.FILESYSTEM,
+    AtomicGuaranteeKind.SECRET,
+)
+
+# Never enforced by RuntimeClass admission alone.
+_K8S_ABSENT: Final = (
+    AtomicGuaranteeKind.KERNEL_HARDWARE,
+    AtomicGuaranteeKind.OUTPUT,
+)
+
+
+@dataclass(frozen=True)
+class ClusterTrustEvidence:
+    """Evidence that the Kubernetes cluster is trusted."""
+
+    ca_pinned: bool
+    api_server_verified: bool
+
+
+@dataclass(frozen=True)
+class AdmissionEvidence:
+    """Evidence from admission control (webhook/validating/mutating)."""
+
+    admission_verified: bool
+    admission_policy_name: str
+    admission_weaker: bool  # True if admission was downgraded
+
+
+@dataclass(frozen=True)
+class PodSpecEvidence:
+    """Evidence from immutable pod spec verification."""
+
+    pod_spec_immutable: bool
+    image_digest: str | None
+    image_digest_verified: bool
+    image_digest_changed: bool
+    sidecar_containers: tuple[str, ...] = ()
+    sidecar_unexpected: bool = False
+    host_network: bool = False
+    host_pid: bool = False
+    privileged_containers: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RBACNetworkEvidence:
+    """Evidence from service account, namespace, and network policy."""
+
+    service_account: str | None
+    namespace: str | None
+    network_policy_enforced: bool
+    network_policy_name: str | None
+
+
+@dataclass(frozen=True)
+class NodeEvidence:
+    """Evidence from node identity verification."""
+
+    node_name: str | None
+    node_id_verified: bool
+    node_trust_domain: str | None
+
+
+@dataclass(frozen=True)
+class RuntimeEvidence:
+    """Evidence from observed runtime handler and execution instance."""
+
+    runtime_handler: str | None
+    runtime_handler_verified: bool
+    execution_instance: str | None
+
+
+@dataclass(frozen=True)
+class K8sRuntimeClassEvidence:
+    """Complete evidence set for the K8s RuntimeClass provider."""
+
+    cluster: ClusterTrustEvidence
+    admission: AdmissionEvidence
+    pod_spec: PodSpecEvidence
+    rbac_network: RBACNetworkEvidence
+    node: NodeEvidence
+    runtime: RuntimeEvidence
+
+
+def _require_decision_context(value: object) -> DecisionContext:
+    if not isinstance(value, DecisionContext):
+        raise ProviderPlanError("context must be a DecisionContext")
+    return value
+
+
+def _evidence_boundary(evidence: K8sRuntimeClassEvidence) -> GuardExecutionAssuranceBoundary:
+    """Compute the boundary achievable given the evidence."""
+    if not _evidence_sufficient(evidence):
+        return GuardExecutionAssuranceBoundary.OBSERVED_HOST
+    if not evidence.runtime.runtime_handler_verified:
+        return GuardExecutionAssuranceBoundary.OBSERVED_HOST
+    # All evidence present and verified → OS_ISOLATED
+    return GuardExecutionAssuranceBoundary.OS_ISOLATED
+
+
+def _evidence_sufficient(evidence: K8sRuntimeClassEvidence) -> bool:
+    """Return True only when all evidence is fully verified and clean."""
+    # Deny-by-default: missing or unverified cluster trust
+    if not evidence.cluster.ca_pinned or not evidence.cluster.api_server_verified:
+        return False
+    # Admission must be verified, not weaker
+    if not evidence.admission.admission_verified:
+        return False
+    if evidence.admission.admission_weaker:
+        return False
+    # Pod spec must be immutable, digest verified, no mutable changes
+    if not evidence.pod_spec.pod_spec_immutable:
+        return False
+    if not evidence.pod_spec.image_digest_verified:
+        return False
+    if evidence.pod_spec.image_digest_changed:
+        return False
+    # Unexpected sidecars fail closed
+    if evidence.pod_spec.sidecar_unexpected:
+        return False
+    # Host-network, host-PID, privileged containers fail closed
+    if evidence.pod_spec.host_network:
+        return False
+    if evidence.pod_spec.host_pid:
+        return False
+    if evidence.pod_spec.privileged_containers:
+        return False
+    # Network policy must be enforced
+    if not evidence.rbac_network.network_policy_enforced:
+        return False
+    # Node identity must be verified
+    if not evidence.node.node_id_verified:
+        return False
+    # Runtime handler must be verified
+    return evidence.runtime.runtime_handler_verified
+
+
+def _map_guarantees(evidence: K8sRuntimeClassEvidence) -> tuple[AtomicGuarantee, ...]:
+    """Map verified evidence to atomic guarantees.
+
+    Deny-by-default: only guarantees supported by the K8s runtimeclass adapter
+    and verified by the evidence are granted. Handler name ALONE grants nothing.
+    """
+    boundary = _evidence_boundary(evidence)
+    enforced = _evidence_sufficient(evidence)
+    guarantees: list[AtomicGuarantee] = []
+
+    for kind in _K8S_ENFORCED:
+        guarantees.append(
+            AtomicGuarantee(
+                kind=kind,
+                enforced=enforced,
+                boundary=boundary if enforced else GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            )
+        )
+
+    for kind in _K8S_OS_ISOLATED:
+        # Filesystem and secret follow deny-by-default: enforced only when ALL
+        # evidence verified.
+        guarantees.append(
+            AtomicGuarantee(
+                kind=kind,
+                enforced=enforced,
+                boundary=boundary if enforced else GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            )
+        )
+
+    for kind in _K8S_ABSENT:
+        guarantees.append(
+            AtomicGuarantee(
+                kind=kind,
+                enforced=False,
+                boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            )
+        )
+
+    return tuple(guarantees)
+
+
+class K8sRuntimeClassProvider:
+    """Kubernetes RuntimeClass isolation provider adapter.
+
+    Validates admission control, immutable pod spec/image digest, service
+    account/namespace/network policy, node identity, and observed runtime
+    handler. Maps verified evidence to atomic guarantees. Pure validation —
+    no live cluster calls.
+    """
+
+    _trust_ca_digest: str
+    _expected_runtime_handler: str | None
+
+    def __init__(
+        self,
+        *,
+        trust_ca_digest: str | None = None,
+        expected_runtime_handler: str | None = None,
+    ) -> None:
+        self._trust_ca_digest = trust_ca_digest or ("0" * 64)
+        self._expected_runtime_handler = expected_runtime_handler
+
+    @staticmethod
+    def _lease_ttl_seconds() -> int:
+        return 60
+
+    def identity(self) -> ProviderIdentity:
+        return ProviderIdentity(
+            provider_kind=_PROVIDER_KIND,
+            implementation_version="1.0.0",
+            binary_or_image_digest=self._trust_ca_digest,
+            signing_identity=_SIGNING_IDENTITY,
+            trust_domain=_TRUST_DOMAIN,
+        )
+
+    def capabilities(self) -> tuple[AtomicGuarantee, ...]:
+        # Static capabilities: what the provider CAN do when all evidence verified.
+        guarantees: list[AtomicGuarantee] = []
+        for kind in _K8S_ENFORCED:
+            guarantees.append(
+                AtomicGuarantee(
+                    kind=kind,
+                    enforced=True,
+                    boundary=GuardExecutionAssuranceBoundary.OS_ISOLATED,
+                )
+            )
+        for kind in _K8S_OS_ISOLATED:
+            guarantees.append(
+                AtomicGuarantee(
+                    kind=kind,
+                    enforced=True,
+                    boundary=GuardExecutionAssuranceBoundary.OS_ISOLATED,
+                )
+            )
+        for kind in _K8S_ABSENT:
+            guarantees.append(
+                AtomicGuarantee(
+                    kind=kind,
+                    enforced=False,
+                    boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                )
+            )
+        return tuple(guarantees)
+
+    def health_check(self) -> ProviderHealth:
+        # Health is derived from capabilities (never self-labeled).
+        return ProviderHealth(
+            state=ProviderHealthState.HEALTHY,
+            guarantees=self.capabilities(),
+            reason=None,
+        )
+
+    def plan(
+        self,
+        context: DecisionContext,
+        minimum_boundary: GuardExecutionAssuranceBoundary,
+        *,
+        evidence: K8sRuntimeClassEvidence | None = None,
+        input_paths: tuple[str, ...] = (),
+        declared_outputs: tuple[str, ...] = (),
+    ) -> ExecutionLease:
+        """Produce a pure, side-effect-free fenced lease or raise ProviderPlanError.
+
+        When ``evidence`` is provided, validates it and computes achievable
+        boundary. Without evidence, defaults to OBSERVED_HOST (deny-by-default).
+        """
+        validated_context: DecisionContext = _require_decision_context(context)
+        validate_provider_plan_inputs(input_paths, declared_outputs)
+
+        # Hardware isolation is never achievable via K8s RuntimeClass alone.
+        if minimum_boundary is GuardExecutionAssuranceBoundary.HARDWARE_ISOLATED:
+            raise ProviderPlanError("K8s RuntimeClass cannot provide hardware-isolated boundary")
+
+        # Determine achievable boundary from evidence.
+        if evidence is not None:
+            if not _evidence_sufficient(evidence):
+                # Insufficient evidence → refuse to plan above OBSERVED_HOST.
+                achievable = GuardExecutionAssuranceBoundary.OBSERVED_HOST
+            else:
+                achievable = _evidence_boundary(evidence)
+        else:
+            # No evidence → deny-by-default to OBSERVED_HOST.
+            achievable = GuardExecutionAssuranceBoundary.OBSERVED_HOST
+
+        # If minimum boundary exceeds what evidence provides, refuse.
+        boundary_order = [
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            GuardExecutionAssuranceBoundary.CONTROLLED_HOST,
+            GuardExecutionAssuranceBoundary.OS_ISOLATED,
+            GuardExecutionAssuranceBoundary.HARDWARE_ISOLATED,
+        ]
+        achievable_idx = boundary_order.index(achievable)
+        minimum_idx = boundary_order.index(minimum_boundary)
+        if minimum_idx > achievable_idx:
+            raise ProviderPlanError(
+                f"minimum boundary {minimum_boundary.value} exceeds achievable {achievable.value} from evidence"
+            )
+
+        plan_digest = framed_digest(
+            "guard.k8s-runtimeclass-plan.v1",
+            {
+                "context_digest": validated_context.context_digest,
+                "minimum_boundary": minimum_boundary.value,
+                "achievable_boundary": achievable.value,
+                "runtime_handler": self._expected_runtime_handler or "",
+                "evidence_present": evidence is not None,
+            },
+        )
+        return ExecutionLease(
+            plan_digest=plan_digest,
+            provider_thumbprint=self.identity().thumbprint(),
+            fencing_generation=1,
+            lease_expiry_epoch_seconds=int(time.time()) + self._lease_ttl_seconds(),
+            attempt_nonce=validated_context.context_digest[:16],
+            input_manifest_digest=validated_context.executable_digest,
+        )
+
+    def execute(self, lease: ExecutionLease) -> TerminalStatement:
+        """Return a terminal statement with attestation trust.
+
+        No live cluster calls; returns self-attested from the validated plan.
+        """
+        return TerminalStatement(
+            outcome=ExecutionOutcome.SUCCEEDED,
+            exit_code=0,
+            stream_byte_counts=(),
+            stream_digests=(),
+            truncated=False,
+            declared_output_digests=(),
+            cleanup_complete=True,
+            execution_instance=lease.attempt_nonce,
+            attestation_trust=GuardExecutionAttestationTrust.SELF_ATTESTED,
+        )
+
+    def cancel(self, _execution_instance: str) -> None:
+        return None
+
+    def cleanup(self, _execution_instance: str) -> None:
+        return None
+
+    @staticmethod
+    def evidence_to_guarantees(evidence: K8sRuntimeClassEvidence) -> tuple[AtomicGuarantee, ...]:
+        """Public static: map evidence directly to atomic guarantees."""
+        return _map_guarantees(evidence)
+
+
+def build_k8s_evidence(
+    *,
+    cluster_ca_pinned: bool = True,
+    cluster_api_server_verified: bool = True,
+    admission_verified: bool = True,
+    admission_policy_name: str = "guard-runtimeclass-policy",
+    admission_weaker: bool = False,
+    pod_spec_immutable: bool = True,
+    image_digest: str | None = None,
+    image_digest_verified: bool = True,
+    image_digest_changed: bool = False,
+    sidecar_containers: tuple[str, ...] = (),
+    sidecar_unexpected: bool = False,
+    host_network: bool = False,
+    host_pid: bool = False,
+    privileged_containers: tuple[str, ...] = (),
+    service_account: str | None = "guard-execution-sa",
+    namespace: str | None = "guard-execution",
+    network_policy_enforced: bool = True,
+    network_policy_name: str | None = "guard-netpol",
+    node_name: str | None = "worker-node-01",
+    node_id_verified: bool = True,
+    node_trust_domain: str | None = "guard.cluster",
+    runtime_handler: str | None = "guard-runtimeclass",
+    runtime_handler_verified: bool = True,
+    execution_instance: str | None = "exec-001",
+) -> K8sRuntimeClassEvidence:
+    """Helper to construct a K8sRuntimeClassEvidence from individual fields."""
+    return K8sRuntimeClassEvidence(
+        cluster=ClusterTrustEvidence(
+            ca_pinned=cluster_ca_pinned,
+            api_server_verified=cluster_api_server_verified,
+        ),
+        admission=AdmissionEvidence(
+            admission_verified=admission_verified,
+            admission_policy_name=admission_policy_name,
+            admission_weaker=admission_weaker,
+        ),
+        pod_spec=PodSpecEvidence(
+            pod_spec_immutable=pod_spec_immutable,
+            image_digest=image_digest or ("1" * 64),
+            image_digest_verified=image_digest_verified,
+            image_digest_changed=image_digest_changed,
+            sidecar_containers=sidecar_containers,
+            sidecar_unexpected=sidecar_unexpected,
+            host_network=host_network,
+            host_pid=host_pid,
+            privileged_containers=privileged_containers,
+        ),
+        rbac_network=RBACNetworkEvidence(
+            service_account=service_account,
+            namespace=namespace,
+            network_policy_enforced=network_policy_enforced,
+            network_policy_name=network_policy_name,
+        ),
+        node=NodeEvidence(
+            node_name=node_name,
+            node_id_verified=node_id_verified,
+            node_trust_domain=node_trust_domain,
+        ),
+        runtime=RuntimeEvidence(
+            runtime_handler=runtime_handler,
+            runtime_handler_verified=runtime_handler_verified,
+            execution_instance=execution_instance,
+        ),
+    )
+
+
+__all__ = [
+    "AdmissionEvidence",
+    "ClusterTrustEvidence",
+    "K8sRuntimeClassEvidence",
+    "K8sRuntimeClassProvider",
+    "NodeEvidence",
+    "PodSpecEvidence",
+    "RBACNetworkEvidence",
+    "RuntimeEvidence",
+    "build_k8s_evidence",
+]

--- a/src/codex_plugin_scanner/guard/runtime/k8s_runtimeclass_provider.py
+++ b/src/codex_plugin_scanner/guard/runtime/k8s_runtimeclass_provider.py
@@ -315,7 +315,7 @@ class K8sRuntimeClassProvider:
     def plan(
         self,
         context: object,
-        minimum_boundary: GuardExecutionAssuranceBoundary,
+        minimum_boundary: object,
         *,
         evidence: K8sRuntimeClassEvidence | None = None,
         input_paths: tuple[str, ...] = (),
@@ -345,6 +345,8 @@ class K8sRuntimeClassProvider:
             achievable = GuardExecutionAssuranceBoundary.OBSERVED_HOST
 
         # If minimum boundary exceeds what evidence provides, refuse.
+        if not isinstance(minimum_boundary, GuardExecutionAssuranceBoundary):
+            raise ProviderPlanError("unknown minimum assurance boundary")
         achievable_idx = _BOUNDARY_ORDER.index(achievable)
         minimum_idx = _BOUNDARY_ORDER.index(minimum_boundary)
         if minimum_idx > achievable_idx:

--- a/tests/test_guard_k8s_runtimeclass_provider.py
+++ b/tests/test_guard_k8s_runtimeclass_provider.py
@@ -1,0 +1,739 @@
+"""Tests for the Kubernetes RuntimeClass provider adapter.
+
+Covers deny-by-default on handler-name-alone, admission downgrade,
+sidecar injection, host-network, untrusted node, mutable image digest,
+missing runtime evidence, and fully-verified pod yielding mapped guarantees.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.execution_assurance_contract import (
+    AtomicGuaranteeKind,
+    DecisionContext,
+    ExecutionOutcome,
+    GuardExecutionAssuranceBoundary,
+    GuardExecutionAttestationTrust,
+    ProviderHealthState,
+)
+from codex_plugin_scanner.guard.runtime.isolation_provider import (
+    IsolationProvider,
+    ProviderPlanError,
+)
+from codex_plugin_scanner.guard.runtime.k8s_runtimeclass_provider import (
+    AdmissionEvidence,
+    ClusterTrustEvidence,
+    K8sRuntimeClassEvidence,
+    K8sRuntimeClassProvider,
+    NodeEvidence,
+    PodSpecEvidence,
+    RBACNetworkEvidence,
+    RuntimeEvidence,
+    _evidence_boundary,
+    _evidence_sufficient,
+    _map_guarantees,
+    build_k8s_evidence,
+)
+
+_SHA = "a" * 64
+_OTHER = "b" * 64
+
+
+def _context() -> DecisionContext:
+    return DecisionContext(
+        repository_digest=_SHA,
+        workspace_digest=_OTHER,
+        executable_digest=_SHA,
+        action_class="execute",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider contract conformance
+# ---------------------------------------------------------------------------
+
+
+class TestProviderContractConformance:
+    def test_satisfies_isolation_provider_protocol(self) -> None:
+        assert isinstance(K8sRuntimeClassProvider(), IsolationProvider)
+
+
+class TestIdentity:
+    def test_identity_fields(self) -> None:
+        provider = K8sRuntimeClassProvider()
+        identity = provider.identity()
+        assert identity.provider_kind == "k8s-runtimeclass"
+        assert identity.signing_identity == "guard-k8s-runtimeclass"
+        assert identity.trust_domain == "guard.k8s"
+        assert len(identity.binary_or_image_digest) == 64
+        assert len(identity.implementation_version) > 0
+
+    def test_identity_thumbprint_stable(self) -> None:
+        p1 = K8sRuntimeClassProvider()
+        p2 = K8sRuntimeClassProvider()
+        assert p1.identity().thumbprint() == p2.identity().thumbprint()
+
+    def test_identity_different_ca_digest(self) -> None:
+        p1 = K8sRuntimeClassProvider(trust_ca_digest="1" * 64)
+        p2 = K8sRuntimeClassProvider(trust_ca_digest="2" * 64)
+        assert p1.identity().thumbprint() != p2.identity().thumbprint()
+
+
+class TestCapabilities:
+    def test_enforced_guarantees(self) -> None:
+        provider = K8sRuntimeClassProvider()
+        caps = provider.capabilities()
+        enforced = [g for g in caps if g.enforced]
+        kinds = {g.kind for g in enforced}
+        assert AtomicGuaranteeKind.PROCESS in kinds
+        assert AtomicGuaranteeKind.NETWORK in kinds
+        assert AtomicGuaranteeKind.IDENTITY in kinds
+        assert AtomicGuaranteeKind.PRIVILEGE in kinds
+        assert AtomicGuaranteeKind.RESOURCE in kinds
+        assert AtomicGuaranteeKind.CLEANUP in kinds
+        assert AtomicGuaranteeKind.TENANT in kinds
+        absent = [g for g in caps if not g.enforced]
+        absent_kinds = {g.kind for g in absent}
+        assert AtomicGuaranteeKind.KERNEL_HARDWARE in absent_kinds
+        assert AtomicGuaranteeKind.OUTPUT in absent_kinds
+
+
+class TestHealthCheck:
+    def test_health_is_derived(self) -> None:
+        provider = K8sRuntimeClassProvider()
+        health = provider.health_check()
+        assert health.state is ProviderHealthState.HEALTHY
+        assert health.guarantees == provider.capabilities()
+        assert health.reason is None
+
+
+class TestEvidenceDataclasses:
+    def _valid_evidence(self) -> K8sRuntimeClassEvidence:
+        return build_k8s_evidence(
+            cluster_ca_pinned=True,
+            cluster_api_server_verified=True,
+            admission_verified=True,
+            admission_weaker=False,
+            pod_spec_immutable=True,
+            image_digest_verified=True,
+            image_digest_changed=False,
+            sidecar_unexpected=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=(),
+            network_policy_enforced=True,
+            node_id_verified=True,
+            runtime_handler_verified=True,
+        )
+
+    def test_valid_evidence_constructs(self) -> None:
+        ev = self._valid_evidence()
+        assert ev.cluster.ca_pinned is True
+        assert ev.runtime.runtime_handler_verified is True
+        assert _evidence_sufficient(ev) is True
+
+
+# ---------------------------------------------------------------------------
+# Handler-name-alone grants nothing
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerNameAloneDenyByDefault:
+    """handler name ALONE never grants assurance — deny-by-default."""
+
+    def test_handler_name_alone_no_guarantees(self) -> None:
+        evidence = build_k8s_evidence(
+            cluster_ca_pinned=False,
+            cluster_api_server_verified=False,
+            admission_verified=False,
+            pod_spec_immutable=False,
+            image_digest_verified=False,
+            image_digest_changed=False,
+            sidecar_unexpected=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=(),
+            network_policy_enforced=False,
+            node_id_verified=False,
+            runtime_handler="guard-runtimeclass",
+            runtime_handler_verified=False,
+        )
+        guarantees = _map_guarantees(evidence)
+        enforced = [g for g in guarantees if g.enforced]
+        assert enforced == []
+
+    def test_handler_name_alone_boundary_observed_host(self) -> None:
+        evidence = build_k8s_evidence(
+            runtime_handler="guard-runtimeclass",
+            runtime_handler_verified=False,
+        )
+        boundary = _evidence_boundary(evidence)
+        assert boundary is GuardExecutionAssuranceBoundary.OBSERVED_HOST
+
+    def test_handler_name_alone_no_evidence_object(self) -> None:
+        provider = K8sRuntimeClassProvider()
+        ctx = _context()
+        with pytest.raises(ProviderPlanError, match="exceeds achievable"):
+            provider.plan(ctx, GuardExecutionAssuranceBoundary.CONTROLLED_HOST)
+
+
+# ---------------------------------------------------------------------------
+# Changed / weaker admission fails
+# ---------------------------------------------------------------------------
+
+
+class TestAdmissionDowngrade:
+    def test_weaker_admission_fails(self) -> None:
+        evidence = build_k8s_evidence(
+            admission_verified=True,
+            admission_weaker=True,
+            pod_spec_immutable=True,
+            image_digest_verified=True,
+            image_digest_changed=False,
+            sidecar_unexpected=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=(),
+            network_policy_enforced=True,
+            node_id_verified=True,
+            runtime_handler_verified=True,
+        )
+        assert _evidence_sufficient(evidence) is False
+        guaranteed = _map_guarantees(evidence)
+        enforced = [g for g in guaranteed if g.enforced]
+        assert enforced == []
+
+    def test_admission_not_verified_fails(self) -> None:
+        evidence = build_k8s_evidence(
+            admission_verified=False,
+            admission_weaker=False,
+            pod_spec_immutable=True,
+            image_digest_verified=True,
+            image_digest_changed=False,
+            sidecar_unexpected=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=(),
+            network_policy_enforced=True,
+            node_id_verified=True,
+            runtime_handler_verified=True,
+        )
+        assert _evidence_sufficient(evidence) is False
+
+    def test_plan_refuses_when_admission_weaker(self) -> None:
+        provider = K8sRuntimeClassProvider()
+        ctx = _context()
+        evidence = build_k8s_evidence(admission_weaker=True)
+        lease = provider.plan(ctx, GuardExecutionAssuranceBoundary.OBSERVED_HOST, evidence=evidence)
+        assert lease is not None
+        with pytest.raises(ProviderPlanError, match="exceeds achievable"):
+            provider.plan(ctx, GuardExecutionAssuranceBoundary.CONTROLLED_HOST, evidence=evidence)
+
+
+# ---------------------------------------------------------------------------
+# Sidecar injection fails
+# ---------------------------------------------------------------------------
+
+
+class TestSidecarInjection:
+    def test_unexpected_sidecar_fails(self) -> None:
+        evidence = build_k8s_evidence(
+            sidecar_containers=("istio-proxy", "envoy"),
+            sidecar_unexpected=True,
+            pod_spec_immutable=True,
+            image_digest_verified=True,
+            image_digest_changed=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=(),
+            network_policy_enforced=True,
+            node_id_verified=True,
+            runtime_handler_verified=True,
+        )
+        assert _evidence_sufficient(evidence) is False
+        guaranteed = _map_guarantees(evidence)
+        enforced = [g for g in guaranteed if g.enforced]
+        assert enforced == []
+
+    def test_expected_sidecars_ok(self) -> None:
+        evidence = build_k8s_evidence(
+            sidecar_containers=("istio-proxy",),
+            sidecar_unexpected=False,
+            pod_spec_immutable=True,
+            image_digest_verified=True,
+            image_digest_changed=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=(),
+            network_policy_enforced=True,
+            node_id_verified=True,
+            runtime_handler_verified=True,
+        )
+        assert _evidence_sufficient(evidence) is True
+
+
+# ---------------------------------------------------------------------------
+# Host-network fails
+# ---------------------------------------------------------------------------
+
+
+class TestHostNetwork:
+    def test_host_network_fails(self) -> None:
+        evidence = build_k8s_evidence(
+            pod_spec_immutable=True,
+            image_digest_verified=True,
+            image_digest_changed=False,
+            sidecar_unexpected=False,
+            host_network=True,
+            host_pid=False,
+            privileged_containers=(),
+            network_policy_enforced=True,
+            node_id_verified=True,
+            runtime_handler_verified=True,
+        )
+        assert _evidence_sufficient(evidence) is False
+        guaranteed = _map_guarantees(evidence)
+        enforced = [g for g in guaranteed if g.enforced]
+        assert enforced == []
+
+    def test_no_host_network_ok(self) -> None:
+        evidence = build_k8s_evidence(
+            pod_spec_immutable=True,
+            image_digest_verified=True,
+            image_digest_changed=False,
+            sidecar_unexpected=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=(),
+            network_policy_enforced=True,
+            node_id_verified=True,
+            runtime_handler_verified=True,
+        )
+        assert _evidence_sufficient(evidence) is True
+
+
+# ---------------------------------------------------------------------------
+# Host-PID and privileged containers fail
+# ---------------------------------------------------------------------------
+
+
+class TestHostPIDAndPrivileged:
+    def test_host_pid_fails(self) -> None:
+        evidence = build_k8s_evidence(
+            pod_spec_immutable=True,
+            image_digest_verified=True,
+            image_digest_changed=False,
+            sidecar_unexpected=False,
+            host_network=False,
+            host_pid=True,
+            privileged_containers=(),
+            network_policy_enforced=True,
+            node_id_verified=True,
+            runtime_handler_verified=True,
+        )
+        assert _evidence_sufficient(evidence) is False
+
+    def test_privileged_containers_fails(self) -> None:
+        evidence = build_k8s_evidence(
+            pod_spec_immutable=True,
+            image_digest_verified=True,
+            image_digest_changed=False,
+            sidecar_unexpected=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=("sidecar-privileged",),
+            network_policy_enforced=True,
+            node_id_verified=True,
+            runtime_handler_verified=True,
+        )
+        assert _evidence_sufficient(evidence) is False
+
+
+# ---------------------------------------------------------------------------
+# Untrusted node fails
+# ---------------------------------------------------------------------------
+
+
+class TestUntrustedNode:
+    def test_node_not_verified_fails(self) -> None:
+        evidence = build_k8s_evidence(
+            pod_spec_immutable=True,
+            image_digest_verified=True,
+            image_digest_changed=False,
+            sidecar_unexpected=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=(),
+            network_policy_enforced=True,
+            node_id_verified=False,
+            node_name="untrusted-worker",
+            node_trust_domain=None,
+            runtime_handler_verified=True,
+        )
+        assert _evidence_sufficient(evidence) is False
+        guaranteed = _map_guarantees(evidence)
+        enforced = [g for g in guaranteed if g.enforced]
+        assert enforced == []
+
+    def test_trusted_node_ok(self) -> None:
+        evidence = build_k8s_evidence(
+            pod_spec_immutable=True,
+            image_digest_verified=True,
+            image_digest_changed=False,
+            sidecar_unexpected=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=(),
+            network_policy_enforced=True,
+            node_id_verified=True,
+            node_name="trusted-worker-01",
+            node_trust_domain="guard.cluster",
+            runtime_handler_verified=True,
+        )
+        assert _evidence_sufficient(evidence) is True
+
+
+# ---------------------------------------------------------------------------
+# Mutable image digest fails
+# ---------------------------------------------------------------------------
+
+
+class TestMutableImageDigest:
+    def test_image_digest_changed_fails(self) -> None:
+        evidence = build_k8s_evidence(
+            pod_spec_immutable=True,
+            image_digest_verified=True,
+            image_digest_changed=True,
+            sidecar_unexpected=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=(),
+            network_policy_enforced=True,
+            node_id_verified=True,
+            runtime_handler_verified=True,
+        )
+        assert _evidence_sufficient(evidence) is False
+        guaranteed = _map_guarantees(evidence)
+        enforced = [g for g in guaranteed if g.enforced]
+        assert enforced == []
+
+    def test_image_digest_not_verified_fails(self) -> None:
+        evidence = build_k8s_evidence(
+            pod_spec_immutable=True,
+            image_digest_verified=False,
+            image_digest_changed=False,
+            sidecar_unexpected=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=(),
+            network_policy_enforced=True,
+            node_id_verified=True,
+            runtime_handler_verified=True,
+        )
+        assert _evidence_sufficient(evidence) is False
+
+    def test_image_digest_ok(self) -> None:
+        evidence = build_k8s_evidence(
+            pod_spec_immutable=True,
+            image_digest_verified=True,
+            image_digest_changed=False,
+            sidecar_unexpected=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=(),
+            network_policy_enforced=True,
+            node_id_verified=True,
+            runtime_handler_verified=True,
+        )
+        assert _evidence_sufficient(evidence) is True
+
+
+# ---------------------------------------------------------------------------
+# Missing runtime evidence fails
+# ---------------------------------------------------------------------------
+
+
+class TestMissingRuntimeEvidence:
+    def test_runtime_handler_not_verified_fails(self) -> None:
+        evidence = build_k8s_evidence(
+            pod_spec_immutable=True,
+            image_digest_verified=True,
+            image_digest_changed=False,
+            sidecar_unexpected=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=(),
+            network_policy_enforced=True,
+            node_id_verified=True,
+            runtime_handler="guard-runtimeclass",
+            runtime_handler_verified=False,
+            execution_instance="exec-001",
+        )
+        assert _evidence_sufficient(evidence) is False
+        guaranteed = _map_guarantees(evidence)
+        enforced = [g for g in guaranteed if g.enforced]
+        assert enforced == []
+
+    def test_missing_cluster_ca_fails(self) -> None:
+        evidence = build_k8s_evidence(cluster_ca_pinned=False)
+        assert _evidence_sufficient(evidence) is False
+
+    def test_missing_api_server_verified_fails(self) -> None:
+        evidence = build_k8s_evidence(cluster_api_server_verified=False)
+        assert _evidence_sufficient(evidence) is False
+
+    def test_missing_pod_spec_immutable_fails(self) -> None:
+        evidence = build_k8s_evidence(pod_spec_immutable=False)
+        assert _evidence_sufficient(evidence) is False
+
+    def test_missing_network_policy_fails(self) -> None:
+        evidence = build_k8s_evidence(network_policy_enforced=False)
+        assert _evidence_sufficient(evidence) is False
+
+    def test_missing_execution_instance_ok(self) -> None:
+        evidence = build_k8s_evidence(
+            execution_instance=None,
+            runtime_handler_verified=True,
+        )
+        assert _evidence_sufficient(evidence) is True
+
+
+# ---------------------------------------------------------------------------
+# Missing evidence = deny-by-default to OBSERVED_HOST
+# ---------------------------------------------------------------------------
+
+
+class TestNoEvidenceDenyByDefault:
+    def test_no_evidence_boundary(self) -> None:
+        provider = K8sRuntimeClassProvider()
+        ctx = _context()
+        lease = provider.plan(ctx, GuardExecutionAssuranceBoundary.OBSERVED_HOST)
+        assert lease is not None
+
+    def test_no_evidence_plan_refuses_controlled_host(self) -> None:
+        provider = K8sRuntimeClassProvider()
+        ctx = _context()
+        with pytest.raises(ProviderPlanError, match="exceeds achievable"):
+            provider.plan(ctx, GuardExecutionAssuranceBoundary.CONTROLLED_HOST)
+
+    def test_no_evidence_plan_refuses_hardware_isolated(self) -> None:
+        provider = K8sRuntimeClassProvider()
+        ctx = _context()
+        with pytest.raises(ProviderPlanError, match="hardware-isolated"):
+            provider.plan(ctx, GuardExecutionAssuranceBoundary.HARDWARE_ISOLATED)
+
+
+# ---------------------------------------------------------------------------
+# Valid fully-verified pod yields mapped guarantees
+# ---------------------------------------------------------------------------
+
+
+class TestFullyVerifiedPod:
+    def _valid_evidence(self) -> K8sRuntimeClassEvidence:
+        return build_k8s_evidence(
+            cluster_ca_pinned=True,
+            cluster_api_server_verified=True,
+            admission_verified=True,
+            admission_policy_name="guard-runtimeclass-policy",
+            admission_weaker=False,
+            pod_spec_immutable=True,
+            image_digest="d" * 64,
+            image_digest_verified=True,
+            image_digest_changed=False,
+            sidecar_containers=(),
+            sidecar_unexpected=False,
+            host_network=False,
+            host_pid=False,
+            privileged_containers=(),
+            service_account="guard-execution-sa",
+            namespace="guard-execution",
+            network_policy_enforced=True,
+            network_policy_name="guard-netpol",
+            node_name="worker-node-01",
+            node_id_verified=True,
+            node_trust_domain="guard.cluster",
+            runtime_handler="guard-runtimeclass",
+            runtime_handler_verified=True,
+            execution_instance="exec-001",
+        )
+
+    def test_evidence_sufficient(self) -> None:
+        evidence = self._valid_evidence()
+        assert _evidence_sufficient(evidence) is True
+
+    def test_evidence_boundary_os_isolated(self) -> None:
+        evidence = self._valid_evidence()
+        assert _evidence_boundary(evidence) is GuardExecutionAssuranceBoundary.OS_ISOLATED
+
+    def test_all_guarantees_mapped(self) -> None:
+        evidence = self._valid_evidence()
+        guarantees = _map_guarantees(evidence)
+        enforced = [g for g in guarantees if g.enforced]
+        enforced_kinds = {g.kind: g.boundary for g in enforced}
+        assert AtomicGuaranteeKind.PROCESS in enforced_kinds
+        assert enforced_kinds[AtomicGuaranteeKind.PROCESS] is GuardExecutionAssuranceBoundary.OS_ISOLATED
+        assert AtomicGuaranteeKind.NETWORK in enforced_kinds
+        assert enforced_kinds[AtomicGuaranteeKind.NETWORK] is GuardExecutionAssuranceBoundary.OS_ISOLATED
+        assert AtomicGuaranteeKind.IDENTITY in enforced_kinds
+        assert AtomicGuaranteeKind.PRIVILEGE in enforced_kinds
+        assert enforced_kinds[AtomicGuaranteeKind.PRIVILEGE] is GuardExecutionAssuranceBoundary.OS_ISOLATED
+        assert AtomicGuaranteeKind.RESOURCE in enforced_kinds
+        assert enforced_kinds[AtomicGuaranteeKind.RESOURCE] is GuardExecutionAssuranceBoundary.OS_ISOLATED
+        assert AtomicGuaranteeKind.CLEANUP in enforced_kinds
+        assert enforced_kinds[AtomicGuaranteeKind.CLEANUP] is GuardExecutionAssuranceBoundary.OS_ISOLATED
+        assert AtomicGuaranteeKind.TENANT in enforced_kinds
+        assert enforced_kinds[AtomicGuaranteeKind.TENANT] is GuardExecutionAssuranceBoundary.OS_ISOLATED
+
+    def test_fs_and_secret_enforced(self) -> None:
+        evidence = self._valid_evidence()
+        guarantees = _map_guarantees(evidence)
+        kinds = {g.kind: g for g in guarantees}
+        assert kinds[AtomicGuaranteeKind.FILESYSTEM].enforced is True
+        assert kinds[AtomicGuaranteeKind.SECRET].enforced is True
+
+    def test_kernel_hardware_not_enforced(self) -> None:
+        evidence = self._valid_evidence()
+        guarantees = _map_guarantees(evidence)
+        kinds = {g.kind: g for g in guarantees}
+        assert kinds[AtomicGuaranteeKind.KERNEL_HARDWARE].enforced is False
+
+    def test_output_not_enforced(self) -> None:
+        evidence = self._valid_evidence()
+        guarantees = _map_guarantees(evidence)
+        kinds = {g.kind: g for g in guarantees}
+        assert kinds[AtomicGuaranteeKind.OUTPUT].enforced is False
+
+    def test_plan_succeeds_at_os_isolated(self) -> None:
+        provider = K8sRuntimeClassProvider()
+        ctx = _context()
+        evidence = self._valid_evidence()
+        lease = provider.plan(ctx, GuardExecutionAssuranceBoundary.OS_ISOLATED, evidence=evidence)
+        assert lease is not None
+        assert lease.attempt_nonce == ctx.context_digest[:16]
+
+    def test_plan_refuses_hardware_isolated(self) -> None:
+        provider = K8sRuntimeClassProvider()
+        ctx = _context()
+        evidence = self._valid_evidence()
+        with pytest.raises(ProviderPlanError, match="hardware-isolated"):
+            provider.plan(ctx, GuardExecutionAssuranceBoundary.HARDWARE_ISOLATED, evidence=evidence)
+
+    def test_execute_returns_terminal_statement(self) -> None:
+        provider = K8sRuntimeClassProvider()
+        ctx = _context()
+        evidence = self._valid_evidence()
+        lease = provider.plan(ctx, GuardExecutionAssuranceBoundary.OS_ISOLATED, evidence=evidence)
+        statement = provider.execute(lease)
+        assert statement.outcome is ExecutionOutcome.SUCCEEDED
+        assert statement.exit_code == 0
+        assert statement.execution_instance == lease.attempt_nonce
+        assert statement.attestation_trust is GuardExecutionAttestationTrust.SELF_ATTESTED
+        assert statement.cleanup_complete is True
+
+
+# ---------------------------------------------------------------------------
+# Provider integration test
+# ---------------------------------------------------------------------------
+
+
+class TestProviderIntegration:
+    def test_plan_and_execute_lifecycle(self) -> None:
+        provider = K8sRuntimeClassProvider()
+        ctx = _context()
+        evidence = build_k8s_evidence()
+        lease = provider.plan(ctx, GuardExecutionAssuranceBoundary.OS_ISOLATED, evidence=evidence)
+        statement = provider.execute(lease)
+        assert statement.outcome is ExecutionOutcome.SUCCEEDED
+        provider.cancel(lease.attempt_nonce)
+        provider.cleanup(lease.attempt_nonce)
+
+    def test_evidence_to_guarantees_static(self) -> None:
+        valid = build_k8s_evidence()
+        invalid = build_k8s_evidence(cluster_ca_pinned=False)
+        valid_guarantees = K8sRuntimeClassProvider.evidence_to_guarantees(valid)
+        invalid_guarantees = K8sRuntimeClassProvider.evidence_to_guarantees(invalid)
+        assert any(g.enforced for g in valid_guarantees)
+        assert not any(g.enforced for g in invalid_guarantees)
+
+
+# ---------------------------------------------------------------------------
+# Deny-by-default: handler name alone — explicit edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestDenyByDefaultHandlerNameAlone:
+    """handler name ALONE grants nothing — deny-by-default."""
+
+    def test_handler_label_only(self) -> None:
+        evidence = K8sRuntimeClassEvidence(
+            cluster=ClusterTrustEvidence(ca_pinned=False, api_server_verified=False),
+            admission=AdmissionEvidence(
+                admission_verified=False,
+                admission_policy_name="",
+                admission_weaker=False,
+            ),
+            pod_spec=PodSpecEvidence(
+                pod_spec_immutable=False,
+                image_digest=None,
+                image_digest_verified=False,
+                image_digest_changed=False,
+            ),
+            rbac_network=RBACNetworkEvidence(
+                service_account=None,
+                namespace=None,
+                network_policy_enforced=False,
+                network_policy_name=None,
+            ),
+            node=NodeEvidence(
+                node_name=None,
+                node_id_verified=False,
+                node_trust_domain=None,
+            ),
+            runtime=RuntimeEvidence(
+                runtime_handler="guard-runtimeclass",
+                runtime_handler_verified=False,
+                execution_instance=None,
+            ),
+        )
+        guarantees = _map_guarantees(evidence)
+        enforced = [g for g in guarantees if g.enforced]
+        assert enforced == [], "handler name alone must not grant any enforcement"
+
+    def test_only_evidence_fields_present_nothing_enforced(self) -> None:
+        evidence = K8sRuntimeClassEvidence(
+            cluster=ClusterTrustEvidence(ca_pinned=False, api_server_verified=False),
+            admission=AdmissionEvidence(
+                admission_verified=False,
+                admission_policy_name="",
+                admission_weaker=False,
+            ),
+            pod_spec=PodSpecEvidence(
+                pod_spec_immutable=False,
+                image_digest=None,
+                image_digest_verified=False,
+                image_digest_changed=False,
+            ),
+            rbac_network=RBACNetworkEvidence(
+                service_account=None,
+                namespace=None,
+                network_policy_enforced=False,
+                network_policy_name=None,
+            ),
+            node=NodeEvidence(
+                node_name=None,
+                node_id_verified=False,
+                node_trust_domain=None,
+            ),
+            runtime=RuntimeEvidence(
+                runtime_handler=None,
+                runtime_handler_verified=False,
+                execution_instance=None,
+            ),
+        )
+        assert _evidence_sufficient(evidence) is False
+        guarantees = _map_guarantees(evidence)
+        boundary = _evidence_boundary(evidence)
+        assert boundary is GuardExecutionAssuranceBoundary.OBSERVED_HOST
+        for g in guarantees:
+            assert not g.enforced or g.boundary is GuardExecutionAssuranceBoundary.OBSERVED_HOST

--- a/tests/test_guard_k8s_runtimeclass_provider.py
+++ b/tests/test_guard_k8s_runtimeclass_provider.py
@@ -230,7 +230,7 @@ class TestAdmissionDowngrade:
         ctx = _context()
         evidence = build_k8s_evidence(admission_weaker=True)
         lease = provider.plan(ctx, GuardExecutionAssuranceBoundary.OBSERVED_HOST, evidence=evidence)
-        assert lease is not None
+        assert len(lease.plan_digest) == 64
         with pytest.raises(ProviderPlanError, match="exceeds achievable"):
             provider.plan(ctx, GuardExecutionAssuranceBoundary.CONTROLLED_HOST, evidence=evidence)
 
@@ -627,6 +627,7 @@ class TestFullyVerifiedPod:
         assert AtomicGuaranteeKind.NETWORK in enforced_kinds
         assert enforced_kinds[AtomicGuaranteeKind.NETWORK] is GuardExecutionAssuranceBoundary.OS_ISOLATED
         assert AtomicGuaranteeKind.IDENTITY in enforced_kinds
+        assert enforced_kinds[AtomicGuaranteeKind.IDENTITY] is GuardExecutionAssuranceBoundary.OS_ISOLATED
         assert AtomicGuaranteeKind.PRIVILEGE in enforced_kinds
         assert enforced_kinds[AtomicGuaranteeKind.PRIVILEGE] is GuardExecutionAssuranceBoundary.OS_ISOLATED
         assert AtomicGuaranteeKind.RESOURCE in enforced_kinds
@@ -790,5 +791,5 @@ class TestDenyByDefaultHandlerNameAlone:
         guarantees = _map_guarantees(evidence)
         boundary = _evidence_boundary(evidence)
         assert boundary is GuardExecutionAssuranceBoundary.OBSERVED_HOST
-        for g in guarantees:
-            assert not g.enforced or g.boundary is GuardExecutionAssuranceBoundary.OBSERVED_HOST
+        assert all(not guarantee.enforced for guarantee in guarantees)
+        assert all(guarantee.boundary is GuardExecutionAssuranceBoundary.OBSERVED_HOST for guarantee in guarantees)

--- a/tests/test_guard_k8s_runtimeclass_provider.py
+++ b/tests/test_guard_k8s_runtimeclass_provider.py
@@ -7,14 +7,14 @@ missing runtime evidence, and fully-verified pod yielding mapped guarantees.
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from codex_plugin_scanner.guard.runtime.execution_assurance_contract import (
     AtomicGuaranteeKind,
     DecisionContext,
-    ExecutionOutcome,
     GuardExecutionAssuranceBoundary,
-    GuardExecutionAttestationTrust,
     ProviderHealthState,
 )
 from codex_plugin_scanner.guard.runtime.isolation_provider import (
@@ -49,6 +49,10 @@ def _context() -> DecisionContext:
     )
 
 
+def _provider() -> K8sRuntimeClassProvider:
+    return K8sRuntimeClassProvider(trust_ca_digest=_SHA)
+
+
 # ---------------------------------------------------------------------------
 # Provider contract conformance
 # ---------------------------------------------------------------------------
@@ -56,12 +60,12 @@ def _context() -> DecisionContext:
 
 class TestProviderContractConformance:
     def test_satisfies_isolation_provider_protocol(self) -> None:
-        assert isinstance(K8sRuntimeClassProvider(), IsolationProvider)
+        assert isinstance(_provider(), IsolationProvider)
 
 
 class TestIdentity:
     def test_identity_fields(self) -> None:
-        provider = K8sRuntimeClassProvider()
+        provider = _provider()
         identity = provider.identity()
         assert identity.provider_kind == "k8s-runtimeclass"
         assert identity.signing_identity == "guard-k8s-runtimeclass"
@@ -70,8 +74,8 @@ class TestIdentity:
         assert len(identity.implementation_version) > 0
 
     def test_identity_thumbprint_stable(self) -> None:
-        p1 = K8sRuntimeClassProvider()
-        p2 = K8sRuntimeClassProvider()
+        p1 = _provider()
+        p2 = _provider()
         assert p1.identity().thumbprint() == p2.identity().thumbprint()
 
     def test_identity_different_ca_digest(self) -> None:
@@ -82,7 +86,7 @@ class TestIdentity:
 
 class TestCapabilities:
     def test_enforced_guarantees(self) -> None:
-        provider = K8sRuntimeClassProvider()
+        provider = _provider()
         caps = provider.capabilities()
         enforced = [g for g in caps if g.enforced]
         kinds = {g.kind for g in enforced}
@@ -101,7 +105,7 @@ class TestCapabilities:
 
 class TestHealthCheck:
     def test_health_is_derived(self) -> None:
-        provider = K8sRuntimeClassProvider()
+        provider = _provider()
         health = provider.health_check()
         assert health.state is ProviderHealthState.HEALTHY
         assert health.guarantees == provider.capabilities()
@@ -172,7 +176,7 @@ class TestHandlerNameAloneDenyByDefault:
         assert boundary is GuardExecutionAssuranceBoundary.OBSERVED_HOST
 
     def test_handler_name_alone_no_evidence_object(self) -> None:
-        provider = K8sRuntimeClassProvider()
+        provider = _provider()
         ctx = _context()
         with pytest.raises(ProviderPlanError, match="exceeds achievable"):
             provider.plan(ctx, GuardExecutionAssuranceBoundary.CONTROLLED_HOST)
@@ -222,7 +226,7 @@ class TestAdmissionDowngrade:
         assert _evidence_sufficient(evidence) is False
 
     def test_plan_refuses_when_admission_weaker(self) -> None:
-        provider = K8sRuntimeClassProvider()
+        provider = _provider()
         ctx = _context()
         evidence = build_k8s_evidence(admission_weaker=True)
         lease = provider.plan(ctx, GuardExecutionAssuranceBoundary.OBSERVED_HOST, evidence=evidence)
@@ -256,7 +260,7 @@ class TestSidecarInjection:
         enforced = [g for g in guaranteed if g.enforced]
         assert enforced == []
 
-    def test_expected_sidecars_ok(self) -> None:
+    def test_unconfigured_sidecars_fail_closed(self) -> None:
         evidence = build_k8s_evidence(
             sidecar_containers=("istio-proxy",),
             sidecar_unexpected=False,
@@ -270,7 +274,7 @@ class TestSidecarInjection:
             node_id_verified=True,
             runtime_handler_verified=True,
         )
-        assert _evidence_sufficient(evidence) is True
+        assert _evidence_sufficient(evidence) is False
 
 
 # ---------------------------------------------------------------------------
@@ -491,12 +495,59 @@ class TestMissingRuntimeEvidence:
         evidence = build_k8s_evidence(network_policy_enforced=False)
         assert _evidence_sufficient(evidence) is False
 
-    def test_missing_execution_instance_ok(self) -> None:
+    def test_missing_execution_instance_fails(self) -> None:
         evidence = build_k8s_evidence(
             execution_instance=None,
             runtime_handler_verified=True,
         )
-        assert _evidence_sufficient(evidence) is True
+        assert _evidence_sufficient(evidence) is False
+
+    def test_verified_image_without_digest_fails(self) -> None:
+        evidence = build_k8s_evidence(image_digest=None)
+        assert _evidence_sufficient(evidence) is False
+
+    def test_missing_rbac_identifiers_fail(self) -> None:
+        evidence = build_k8s_evidence()
+        invalid_values = (
+            replace(evidence.rbac_network, service_account=None),
+            replace(evidence.rbac_network, namespace=None),
+            replace(evidence.rbac_network, network_policy_name=None),
+        )
+        for invalid_rbac in invalid_values:
+            assert _evidence_sufficient(replace(evidence, rbac_network=invalid_rbac)) is False
+
+    def test_missing_node_identifiers_fail(self) -> None:
+        evidence = build_k8s_evidence()
+        invalid_values = (
+            replace(evidence.node, node_name=None),
+            replace(evidence.node, node_trust_domain=None),
+        )
+        for invalid_node in invalid_values:
+            assert _evidence_sufficient(replace(evidence, node=invalid_node)) is False
+
+    def test_mismatched_runtime_handler_refused(self) -> None:
+        provider = _provider()
+        evidence = build_k8s_evidence(runtime_handler="unexpected-runtime")
+        with pytest.raises(ProviderPlanError, match="exceeds achievable"):
+            provider.plan(
+                _context(),
+                GuardExecutionAssuranceBoundary.OS_ISOLATED,
+                evidence=evidence,
+            )
+
+    def test_mismatched_cluster_ca_refused(self) -> None:
+        provider = _provider()
+        evidence = build_k8s_evidence(cluster_ca_digest=_OTHER)
+        with pytest.raises(ProviderPlanError, match="exceeds achievable"):
+            provider.plan(
+                _context(),
+                GuardExecutionAssuranceBoundary.OS_ISOLATED,
+                evidence=evidence,
+            )
+
+    def test_zero_trust_anchor_rejected(self) -> None:
+        with pytest.raises(ValueError, match="nonzero"):
+            K8sRuntimeClassProvider(trust_ca_digest="0" * 64)
 
 
 # ---------------------------------------------------------------------------
@@ -506,19 +557,19 @@ class TestMissingRuntimeEvidence:
 
 class TestNoEvidenceDenyByDefault:
     def test_no_evidence_boundary(self) -> None:
-        provider = K8sRuntimeClassProvider()
+        provider = _provider()
         ctx = _context()
         lease = provider.plan(ctx, GuardExecutionAssuranceBoundary.OBSERVED_HOST)
         assert lease is not None
 
     def test_no_evidence_plan_refuses_controlled_host(self) -> None:
-        provider = K8sRuntimeClassProvider()
+        provider = _provider()
         ctx = _context()
         with pytest.raises(ProviderPlanError, match="exceeds achievable"):
             provider.plan(ctx, GuardExecutionAssuranceBoundary.CONTROLLED_HOST)
 
     def test_no_evidence_plan_refuses_hardware_isolated(self) -> None:
-        provider = K8sRuntimeClassProvider()
+        provider = _provider()
         ctx = _context()
         with pytest.raises(ProviderPlanError, match="hardware-isolated"):
             provider.plan(ctx, GuardExecutionAssuranceBoundary.HARDWARE_ISOLATED)
@@ -605,31 +656,31 @@ class TestFullyVerifiedPod:
         assert kinds[AtomicGuaranteeKind.OUTPUT].enforced is False
 
     def test_plan_succeeds_at_os_isolated(self) -> None:
-        provider = K8sRuntimeClassProvider()
+        provider = _provider()
         ctx = _context()
         evidence = self._valid_evidence()
         lease = provider.plan(ctx, GuardExecutionAssuranceBoundary.OS_ISOLATED, evidence=evidence)
         assert lease is not None
-        assert lease.attempt_nonce == ctx.context_digest[:16]
+        assert len(lease.attempt_nonce) == 32
 
     def test_plan_refuses_hardware_isolated(self) -> None:
-        provider = K8sRuntimeClassProvider()
+        provider = _provider()
         ctx = _context()
         evidence = self._valid_evidence()
         with pytest.raises(ProviderPlanError, match="hardware-isolated"):
             provider.plan(ctx, GuardExecutionAssuranceBoundary.HARDWARE_ISOLATED, evidence=evidence)
 
-    def test_execute_returns_terminal_statement(self) -> None:
-        provider = K8sRuntimeClassProvider()
+    def test_execute_refuses_without_authenticated_runner(self) -> None:
+        provider = _provider()
         ctx = _context()
         evidence = self._valid_evidence()
-        lease = provider.plan(ctx, GuardExecutionAssuranceBoundary.OS_ISOLATED, evidence=evidence)
-        statement = provider.execute(lease)
-        assert statement.outcome is ExecutionOutcome.SUCCEEDED
-        assert statement.exit_code == 0
-        assert statement.execution_instance == lease.attempt_nonce
-        assert statement.attestation_trust is GuardExecutionAttestationTrust.SELF_ATTESTED
-        assert statement.cleanup_complete is True
+        lease = provider.plan(
+            ctx,
+            GuardExecutionAssuranceBoundary.OS_ISOLATED,
+            evidence=evidence,
+        )
+        with pytest.raises(ProviderPlanError, match="planning-only"):
+            provider.execute(lease)
 
 
 # ---------------------------------------------------------------------------
@@ -638,13 +689,17 @@ class TestFullyVerifiedPod:
 
 
 class TestProviderIntegration:
-    def test_plan_and_execute_lifecycle(self) -> None:
-        provider = K8sRuntimeClassProvider()
+    def test_planning_only_lifecycle(self) -> None:
+        provider = _provider()
         ctx = _context()
         evidence = build_k8s_evidence()
-        lease = provider.plan(ctx, GuardExecutionAssuranceBoundary.OS_ISOLATED, evidence=evidence)
-        statement = provider.execute(lease)
-        assert statement.outcome is ExecutionOutcome.SUCCEEDED
+        lease = provider.plan(
+            ctx,
+            GuardExecutionAssuranceBoundary.OS_ISOLATED,
+            evidence=evidence,
+        )
+        with pytest.raises(ProviderPlanError, match="planning-only"):
+            provider.execute(lease)
         provider.cancel(lease.attempt_nonce)
         provider.cleanup(lease.attempt_nonce)
 


### PR DESCRIPTION
## Change

Adds a pure evidence-validation adapter for Kubernetes RuntimeClass execution assurance. It verifies cluster trust, admission identity, immutable pod/image digest, service account, namespace and network policy, node identity, observed runtime handler, execution instance, and sidecar set before mapping evidence to atomic guarantees.

Fail-closed cases include handler-name-only evidence, weaker/changed admission, unexpected sidecars, host networking, untrusted nodes, mutable images, and missing runtime evidence. The runtime handler name alone never grants assurance. No live cluster calls.

## Verification

- 46/46 focused tests pass
- basedpyright: 0 errors, 0 warnings
- ruff check + format clean
- private-plan leak check clean

No release, publication, deployment, or feature activation authorized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes RuntimeClass environment verification.
  * Added checks for cluster trust, admission controls, pod integrity, access and network policies, node identity, and runtime execution.
  * Added execution planning with bounded leases and support for cancellation and cleanup.
  * Added evidence-based assurance reporting with deny-by-default behavior.

* **Tests**
  * Added comprehensive coverage for verification, planning, execution, and assurance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->