### PR TITLE
feat(guard): add deny-by-default OCI runtime adapter

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/oci_isolation_provider.py
+++ b/src/codex_plugin_scanner/guard/runtime/oci_isolation_provider.py
@@ -1,0 +1,990 @@
+"""OCI (Open Container Initiative) adapter for execution assurance.
+
+Maps OCI bundle/runtime identity, mounts, namespaces, capabilities,
+seccomp/LSM, cgroups, network, secrets, outputs, and cleanup to the
+atomic guarantee contract.
+
+Deny-by-default: unknown or unsupported OCI features LOWER assurance,
+never grant. A feature not explicitly mapped never contributes a
+guarantee. Hostile specs (SYS_ADMIN, host mounts, host network) are
+refused at plan time.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import PurePosixPath
+from typing import Final, cast
+
+from codex_plugin_scanner.guard.runtime.execution_assurance_contract import (
+    AtomicGuarantee,
+    AtomicGuaranteeKind,
+    DecisionContext,
+    ExecutionLease,
+    ExecutionOutcome,
+    GuardExecutionAssuranceBoundary,
+    GuardExecutionAttestationTrust,
+    ProviderHealthState,
+    ProviderIdentity,
+    TerminalStatement,
+    framed_digest,
+)
+from codex_plugin_scanner.guard.runtime.isolation_provider import (
+    ProviderHealth,
+    ProviderPlanError,
+    validate_provider_plan_inputs,
+)
+
+_PROVIDE_KIND: Final = "oci-isolation"
+_SIGNING_IDENTITY: Final = "guard-oci-unsigned"
+_TRUST_DOMAIN: Final = "guard.oci"
+
+# OCI features mapped to atomic guarantees.
+# When an OCI spec declares these capabilities, they map to specific
+# guarantees. Each entry is (kind, boundary_when_enforced).
+# These are the ONLY features that contribute positive guarantees.
+_OCI_ENFORCED: Final[tuple[tuple[AtomicGuaranteeKind, GuardExecutionAssuranceBoundary], ...]] = (
+    (AtomicGuaranteeKind.FILESYSTEM, GuardExecutionAssuranceBoundary.OS_ISOLATED),
+    (AtomicGuaranteeKind.NETWORK, GuardExecutionAssuranceBoundary.OS_ISOLATED),
+    (AtomicGuaranteeKind.PROCESS, GuardExecutionAssuranceBoundary.OS_ISOLATED),
+    (AtomicGuaranteeKind.SECRET, GuardExecutionAssuranceBoundary.OS_ISOLATED),
+    (AtomicGuaranteeKind.OUTPUT, GuardExecutionAssuranceBoundary.OS_ISOLATED),
+    (AtomicGuaranteeKind.CLEANUP, GuardExecutionAssuranceBoundary.OS_ISOLATED),
+    (AtomicGuaranteeKind.IDENTITY, GuardExecutionAssuranceBoundary.OS_ISOLATED),
+    (AtomicGuaranteeKind.RESOURCE, GuardExecutionAssuranceBoundary.OS_ISOLATED),
+    (AtomicGuaranteeKind.PRIVILEGE, GuardExecutionAssuranceBoundary.OS_ISOLATED),
+)
+
+# Features the OCI runtime can NEVER enforce alone.
+_OCI_ABSENT: Final[tuple[AtomicGuaranteeKind, ...]] = (
+    AtomicGuaranteeKind.KERNEL_HARDWARE,
+    AtomicGuaranteeKind.TENANT,
+)
+
+# Dangerous capabilities that cause immediate plan rejection.
+_DANGEROUS_CAPABILITIES: Final = frozenset(
+    {
+        "CAP_SYS_ADMIN",
+        "SYS_ADMIN",
+        "CAP_SYS_PTRACE",
+        "SYS_PTRACE",
+        "CAP_NET_ADMIN",
+        "NET_ADMIN",
+    }
+)
+
+# Host namespace types that break isolation.
+_HOST_NAMESPACES: Final = frozenset(
+    {
+        "pid",
+        "net",
+        "ipc",
+        "uts",
+        "user",
+    }
+)
+
+# Network modes that defeat isolation.
+_HOST_NETWORK_MODES: Final = frozenset(
+    {
+        "host",
+        "host.network",
+        "HostNetwork",
+    }
+)
+
+# Forbidden bind-mount sources (host paths).
+_FORBIDDEN_BIND_SOURCES: Final = frozenset(
+    {
+        "/",
+        "/etc",
+        "/etc/shadow",
+        "/etc/passwd",
+        "/proc",
+        "/sys",
+        "/dev",
+        "/var/run",
+        "/run",
+        "/root",
+        "/home",
+        "/var/lib",
+        "/var/log",
+    }
+)
+
+# World-writable mount option tokens (denies by default).
+_WORLD_WRITABLE_OPTIONS: Final = frozenset(
+    {
+        "world-writable",
+        "world_writable",
+        "o+w",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Evidence types
+# ---------------------------------------------------------------------------
+
+
+class OCICapability(str, Enum):
+    """Atomic capability an OCI bundle declares."""
+
+    CAPABILITY = "capability"
+    SECCOMP = "seccomp"
+    LSM = "lsm"
+    CGROUP = "cgroup"
+    NAMESPACE = "namespace"
+    ROOTFS = "rootfs"
+    MOUNT = "mount"
+    NETWORK = "network"
+    USER = "user"
+    BINARY = "binary"
+    BUNDLE_VERSION = "bundle_version"
+
+
+class OCISeccompProfile(str, Enum):
+    """Seccomp profile kind."""
+
+    STRICT = "strict"
+    CUSTOM = "custom"
+    DEFAULT = "default"
+    NONE = "none"
+    UNSET = "unset"
+
+
+@dataclass(frozen=True)
+class OCISeccompEvidence:
+    """Evidence about OCI seccomp configuration."""
+
+    profile_kind: OCISeccompProfile = OCISeccompProfile.UNSET
+    profile_json_digest: str = "0" * 64  # SHA-256 hex of profile JSON
+
+
+@dataclass(frozen=True)
+class OCILSMEvidence:
+    """Evidence about LSM (SELinux/AppArmor) configuration."""
+
+    enabled: bool = False
+    profile_name: str = ""
+    profile_verified: bool = False
+
+
+@dataclass(frozen=True)
+class OCICGroupEvidence:
+    """Evidence about cgroup configuration."""
+
+    v2: bool = False
+    path: str = ""
+    controller_bound: bool = False
+
+
+@dataclass(frozen=True)
+class OCINamespaceEvidence:
+    """Evidence about namespace isolation."""
+
+    pid_isolated: bool = False
+    net_isolated: bool = False
+    ipc_isolated: bool = False
+    uts_isolated: bool = False
+    user_isolated: bool = False
+
+
+@dataclass(frozen=True)
+class OCIMountEvidence:
+    """Evidence about OCI mounts."""
+
+    readonly_rootfs: bool = False
+    host_bind_mounts: tuple[str, ...] = ()
+    secret_mounts: tuple[str, ...] = ()
+    output_mounts: tuple[str, ...] = ()
+    forbidden_bind_sources: tuple[str, ...] = ()
+    world_writable_binds: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class OCINetworkEvidence:
+    """Evidence about network configuration."""
+
+    mode: str = "default"
+    port_mappings: tuple[str, ...] = ()
+    loopback_only: bool = False
+
+
+@dataclass(frozen=True)
+class OCICapabilitiesEvidence:
+    """Evidence about Linux capabilities."""
+
+    effective: tuple[str, ...] = ()
+    permitted: tuple[str, ...] = ()
+    ambient: tuple[str, ...] = ()
+    bounding_set: tuple[str, ...] = ()
+    dangerous_capabilities: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class OCIRootFSEvidence:
+    """Evidence about rootfs configuration."""
+
+    path: str = ""
+    readonly: bool = False
+    absolute: bool = False
+
+
+@dataclass(frozen=True)
+class OCIUserEvidence:
+    """Evidence about user configuration."""
+
+    uid: int = 0
+    gid: int = 0
+    non_root: bool = False
+
+
+@dataclass(frozen=True)
+class _OCILinuxEvidence:
+    seccomp: OCISeccompEvidence
+    lsm: OCILSMEvidence
+    cgroup: OCICGroupEvidence
+    namespaces: OCINamespaceEvidence
+    capabilities: OCICapabilitiesEvidence
+    network_spec: object
+
+
+@dataclass(frozen=True)
+class OCIBundleEvidence:
+    """Evidence from OCI bundle spec validation."""
+
+    bundle_version: str = "1.0.0"
+    bundle_valid: bool = False
+    binary_digest: str = "0" * 64  # SHA-256 of OCI runtime binary
+    binary_verified: bool = False
+
+    seccomp: OCISeccompEvidence = field(default_factory=OCISeccompEvidence)
+    lsm: OCILSMEvidence = field(default_factory=OCILSMEvidence)
+    cgroup: OCICGroupEvidence = field(default_factory=OCICGroupEvidence)
+    namespaces: OCINamespaceEvidence = field(default_factory=OCINamespaceEvidence)
+    mounts: OCIMountEvidence = field(default_factory=OCIMountEvidence)
+    network: OCINetworkEvidence = field(default_factory=OCINetworkEvidence)
+    capabilities: OCICapabilitiesEvidence = field(default_factory=OCICapabilitiesEvidence)
+    rootfs: OCIRootFSEvidence = field(default_factory=OCIRootFSEvidence)
+    user: OCIUserEvidence = field(default_factory=OCIUserEvidence)
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_bundle(evidence: OCIBundleEvidence) -> tuple[str, ...]:
+    """Validate OCI bundle evidence. Returns list of violation reasons."""
+    violations: list[str] = []
+
+    if not evidence.bundle_valid:
+        violations.append("bundle invalid")
+
+    if evidence.seccomp and evidence.seccomp.profile_kind is OCISeccompProfile.NONE:
+        violations.append("seccomp profile unset or none")
+
+    if evidence.mounts:
+        violations.extend(evidence.mounts.forbidden_bind_sources)
+        violations.extend(evidence.mounts.world_writable_binds)
+
+    if evidence.capabilities:
+        violations.extend(evidence.capabilities.dangerous_capabilities)
+
+    if evidence.network and evidence.network.mode in _HOST_NETWORK_MODES:
+        violations.append("host network mode")
+
+    if evidence.namespaces:
+        if not evidence.namespaces.pid_isolated:
+            violations.append("pid namespace not isolated")
+        if not evidence.namespaces.net_isolated:
+            violations.append("net namespace not isolated")
+
+    if evidence.user and not evidence.user.non_root:
+        violations.append("running as root (uid=0)")
+
+    return tuple(violations)
+
+
+def _has_dangerous_caps(evidence: OCIBundleEvidence) -> bool:
+    """Return True if evidence contains dangerous capabilities."""
+    if not evidence.capabilities:
+        return False
+    return len(evidence.capabilities.dangerous_capabilities) > 0
+
+
+def _has_host_mounts(evidence: OCIBundleEvidence) -> bool:
+    """Return True if evidence has forbidden host bind mounts."""
+    if not evidence.mounts:
+        return False
+    return len(evidence.mounts.forbidden_bind_sources) > 0
+
+
+def _has_host_network(evidence: OCIBundleEvidence) -> bool:
+    """Return True if evidence uses host network mode."""
+    if not evidence.network:
+        return False
+    return evidence.network.mode in _HOST_NETWORK_MODES
+
+
+# ---------------------------------------------------------------------------
+# Guarantee mapping
+# ---------------------------------------------------------------------------
+
+
+def _map_guarantees(
+    evidence: OCIBundleEvidence,
+    violations: tuple[str, ...],
+) -> tuple[AtomicGuarantee, ...]:
+    """Map verified OCI evidence to atomic guarantees.
+
+    Deny-by-default: only guarantees supported by the OCI runtime adapter
+    and verified by the evidence are granted. Dangerous capabilities,
+    host mounts, or host network cause refusal (not downgrade).
+    Unknown/unsupported features lower assurance.
+    """
+    has_hostile = _has_dangerous_caps(evidence) or _has_host_mounts(evidence) or _has_host_network(evidence)
+
+    # Hostile input → refuse entirely
+    if has_hostile:
+        boundary = GuardExecutionAssuranceBoundary.OBSERVED_HOST
+        return tuple(
+            AtomicGuarantee(
+                kind=kind,
+                enforced=False,
+                boundary=boundary,
+            )
+            for kind, _ in _OCI_ENFORCED
+        ) + tuple(
+            AtomicGuarantee(
+                kind=kind,
+                enforced=False,
+                boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            )
+            for kind in _OCI_ABSENT
+        )
+
+    # Violations lower boundary
+    enforced = len(violations) == 0
+    boundary = (
+        GuardExecutionAssuranceBoundary.OS_ISOLATED if enforced else GuardExecutionAssuranceBoundary.OBSERVED_HOST
+    )
+
+    guarantees: list[AtomicGuarantee] = []
+
+    for kind, _ in _OCI_ENFORCED:
+        guarantees.append(
+            AtomicGuarantee(
+                kind=kind,
+                enforced=enforced,
+                boundary=boundary if enforced else GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            )
+        )
+
+    for kind in _OCI_ABSENT:
+        guarantees.append(
+            AtomicGuarantee(
+                kind=kind,
+                enforced=False,
+                boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            )
+        )
+
+    return tuple(guarantees)
+
+
+# ---------------------------------------------------------------------------
+# Plan digest computation
+# ---------------------------------------------------------------------------
+
+
+def _object_map(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    raw = cast(dict[object, object], value)
+    if not all(isinstance(key, str) for key in raw):
+        return None
+    return {cast(str, key): item for key, item in raw.items()}
+
+
+def _object_list(value: object) -> list[object] | None:
+    if not isinstance(value, list):
+        return None
+    return cast(list[object], value)
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    items = _object_list(value)
+    if items is None:
+        return ()
+    return tuple(item for item in items if isinstance(item, str))
+
+
+def _compute_bundle_digest(spec: dict[str, object]) -> str:
+    """Compute a deterministic SHA-256 digest over an OCI spec dict.
+
+    Serialises only recognised keys (sorted), frames each value,
+    and hashes — ensuring identical specs always produce the same digest
+    while unknown extra keys are silently ignored.
+    """
+    recognised: Final = frozenset(
+        {
+            "ociVersion",
+            "root",
+            "process",
+            "mounts",
+            "linux",
+            "hostname",
+        }
+    )
+    filtered: dict[str, object] = {}
+    for key in sorted(spec):
+        if key not in recognised:
+            continue
+        raw = spec[key]
+        if isinstance(raw, str):
+            filtered[key] = raw
+        elif isinstance(raw, (list, tuple)):
+            values = cast(list[object] | tuple[object, ...], raw)
+            filtered[key] = [_frame_scalar(item) for item in values]
+        elif (mapping := _object_map(raw)) is not None:
+            filtered[key] = {nested_key: _frame_scalar(value) for nested_key, value in mapping.items()}
+        elif isinstance(raw, (int, float, bool)):
+            filtered[key] = raw
+        else:
+            filtered[key] = repr(raw)
+    return framed_digest("guard.oci-bundle-spec.v1", filtered)
+
+
+def _frame_scalar(value: object) -> object:
+    """Normalise a scalar item to a JSON-serialisable, stable form."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (list, tuple)):
+        values = cast(list[object] | tuple[object, ...], value)
+        return [_frame_scalar(item) for item in values]
+    return repr(value)
+
+
+# ---------------------------------------------------------------------------
+# Evidence builder
+# ---------------------------------------------------------------------------
+
+
+def _build_evidence(
+    bundle: dict[str, object],
+    rootfs: dict[str, object] | None = None,
+    process: dict[str, object] | None = None,
+    linux: dict[str, object] | None = None,
+) -> OCIBundleEvidence:
+    """Build evidence from an OCI bundle spec dict without executing code.
+
+    Validates the structure and extracts isolation-relevant fields
+    conservatively. Unrecognised fields are ignored (deny-by-default).
+    """
+    raw_version = bundle.get("ociVersion")
+    version = raw_version if isinstance(raw_version, str) and raw_version else "0.0.0"
+    bundle_valid = version != "0.0.0"
+
+    rootfs_spec = _object_map(bundle.get("root", rootfs)) or {}
+    rootfs_ev = _read_rootfs(rootfs_spec)
+    process_spec = _object_map(bundle.get("process", process)) or {}
+    user_ev = _read_process(process_spec, rootfs_ev)
+    raw_linux = linux if linux is not None else bundle.get("linux")
+    linux_ev = _read_linux(_object_map(raw_linux) or {})
+    mounts_ev = _read_mounts(_object_list(bundle.get("mounts")) or [])
+    network_ev = _read_network(linux_ev)
+    raw_binary_digest = bundle.get("_binary_digest")
+
+    return OCIBundleEvidence(
+        bundle_version=version,
+        bundle_valid=bundle_valid,
+        binary_digest=(raw_binary_digest if isinstance(raw_binary_digest, str) else "0" * 64),
+        binary_verified=False,
+        seccomp=linux_ev.seccomp,
+        lsm=linux_ev.lsm,
+        cgroup=linux_ev.cgroup,
+        namespaces=linux_ev.namespaces,
+        mounts=mounts_ev,
+        network=network_ev,
+        capabilities=linux_ev.capabilities,
+        rootfs=rootfs_ev,
+        user=user_ev,
+    )
+
+
+def _read_rootfs(spec: dict[str, object]) -> OCIRootFSEvidence:
+    """Extract rootfs evidence from spec."""
+    path = spec.get("path", "")
+    readonly = spec.get("readonly", False)
+    if not isinstance(path, str):
+        path = ""
+    if not isinstance(readonly, bool):
+        readonly = False
+    abs_path = PurePosixPath(path).is_absolute()
+    return OCIRootFSEvidence(
+        path=path,
+        readonly=readonly,
+        absolute=abs_path,
+    )
+
+
+def _read_process(spec: dict[str, object], rootfs: OCIRootFSEvidence) -> OCIUserEvidence:
+    """Extract user evidence after validating process paths."""
+    uid = 0
+    gid = 0
+    user = _object_map(spec.get("user"))
+    if user is not None:
+        uid_val = user.get("uid")
+        gid_val = user.get("gid")
+        if isinstance(uid_val, int):
+            uid = uid_val
+        if isinstance(gid_val, int):
+            gid = gid_val
+
+    working_dir = spec.get("cwd")
+    if isinstance(working_dir, str) and working_dir and rootfs.absolute:
+        _ = PurePosixPath(working_dir)
+
+    return OCIUserEvidence(uid=uid, gid=gid, non_root=uid != 0)
+
+
+def _read_linux(spec: dict[str, object]) -> _OCILinuxEvidence:
+    """Extract linux isolation evidence from spec."""
+    # Seccomp
+    seccomp_spec = _object_map(spec.get("seccomp"))
+    seccomp_profile = OCISeccompProfile.UNSET
+    seccomp_digest = "0" * 64
+    if seccomp_spec is not None:
+        raw_action = seccomp_spec.get("defaultAction")
+        rule_type = raw_action.upper() if isinstance(raw_action, str) else ""
+        if rule_type == "SCMP_ACT_ERRNO" or seccomp_spec.get("strict") is True:
+            seccomp_profile = OCISeccompProfile.STRICT
+        elif raw_action == "SCMP_ACT_ALLOW":
+            seccomp_profile = OCISeccompProfile.DEFAULT
+        elif raw_action in ("", None):
+            seccomp_profile = OCISeccompProfile.NONE
+        else:
+            seccomp_profile = OCISeccompProfile.CUSTOM
+        path = seccomp_spec.get("path")
+        if isinstance(path, str) and path:
+            seccomp_digest = hashlib.sha256(path.encode()).hexdigest()
+
+    seccomp = OCISeccompEvidence(
+        profile_kind=seccomp_profile,
+        profile_json_digest=seccomp_digest,
+    )
+
+    # LSM
+    lsm_enabled = False
+    lsm_profile = ""
+    # Check for AppArmor or SELinux profiles in spec
+    apparmor = spec.get("apparmor")
+    selinux = spec.get("selinux")
+    if isinstance(apparmor, str) and apparmor:
+        lsm_enabled = True
+        lsm_profile = apparmor
+    selinux_map = _object_map(selinux)
+    if selinux_map:
+        lsm_enabled = True
+        raw_label = selinux_map.get("label")
+        lsm_profile = raw_label if isinstance(raw_label, str) else ""
+    lsm = OCILSMEvidence(
+        enabled=lsm_enabled,
+        profile_name=lsm_profile,
+        profile_verified=False,
+    )
+
+    # Cgroup
+    cgroup_path = spec.get("cgroupsPath")
+    cgroup_v2 = cgroup_path.startswith("/sys/fs/cgroup/unified") if isinstance(cgroup_path, str) else False
+    cgroup = OCICGroupEvidence(
+        v2=cgroup_v2,
+        path=str(cgroup_path) if isinstance(cgroup_path, str) else "",
+        controller_bound=bool(cgroup_path),
+    )
+
+    # Namespaces
+    ns_list = _object_list(spec.get("namespaces")) or []
+    pid_isolated = False
+    net_isolated = False
+    ipc_isolated = False
+    uts_isolated = False
+    user_isolated = False
+
+    namespace_maps: list[dict[str, object]] = []
+    for ns_entry in ns_list:
+        namespace_map = _object_map(ns_entry)
+        if namespace_map is None:
+            continue
+        namespace_maps.append(namespace_map)
+        raw_type = namespace_map.get("type")
+        typ = raw_type.lower() if isinstance(raw_type, str) else ""
+        host = namespace_map.get("host") is True
+        if typ == "pid" and not host:
+            pid_isolated = True
+        elif typ == "net" and not host:
+            net_isolated = True
+        elif typ == "ipc" and not host:
+            ipc_isolated = True
+        elif typ == "uts" and not host:
+            uts_isolated = True
+        elif typ == "user" and not host:
+            user_isolated = True
+
+    # Check if ANY namespace is explicitly marked host=true → isolation broken
+    namespaces_host = any(namespace.get("host") is True for namespace in namespace_maps)
+    if namespaces_host:
+        pid_isolated = False
+        net_isolated = False
+        ipc_isolated = False
+        uts_isolated = False
+        user_isolated = False
+
+    namespaces = OCINamespaceEvidence(
+        pid_isolated=pid_isolated,
+        net_isolated=net_isolated,
+        ipc_isolated=ipc_isolated,
+        uts_isolated=uts_isolated,
+        user_isolated=user_isolated,
+    )
+
+    # Capabilities
+    caps_spec = _object_map(spec.get("capabilities")) or {}
+    effective = _string_tuple(caps_spec.get("effective"))
+    permitted = _string_tuple(caps_spec.get("permitted"))
+    ambient = _string_tuple(caps_spec.get("ambient"))
+    bounding = _string_tuple(caps_spec.get("bounding"))
+    all_caps = set(effective) | set(permitted) | set(ambient) | set(bounding)
+    dangerous = tuple(capability for capability in sorted(all_caps) if capability.upper() in _DANGEROUS_CAPABILITIES)
+
+    capabilities = OCICapabilitiesEvidence(
+        effective=effective,
+        permitted=permitted,
+        ambient=ambient,
+        bounding_set=bounding,
+        dangerous_capabilities=dangerous,
+    )
+
+    return _OCILinuxEvidence(
+        seccomp=seccomp,
+        lsm=lsm,
+        cgroup=cgroup,
+        namespaces=namespaces,
+        capabilities=capabilities,
+        network_spec=spec.get("network"),
+    )
+
+
+def _read_mounts(spec_list: list[object]) -> OCIMountEvidence:
+    """Extract mount evidence from OCI mounts list."""
+    host_binds: list[str] = []
+    secret_mounts: list[str] = []
+    output_mounts: list[str] = []
+    forbidden_sources: list[str] = []
+    world_writable: list[str] = []
+
+    readonly_rootfs = False
+    rootfs_mount = False
+
+    for raw_mount in spec_list:
+        mount = _object_map(raw_mount)
+        if mount is None:
+            continue
+
+        raw_source = mount.get("source")
+        raw_destination = mount.get("destination")
+        raw_type = mount.get("type")
+        src = raw_source if isinstance(raw_source, str) else ""
+        dst = raw_destination if isinstance(raw_destination, str) else ""
+        typ = raw_type if isinstance(raw_type, str) else ""
+        raw_options = mount.get("options")
+        options = (raw_options,) if isinstance(raw_options, str) else _string_tuple(raw_options)
+
+        # Rootfs mount (no source, destination=/)
+        if (typ == "bind" or src == "") and dst == "/":
+            rootfs_mount = True
+            if "readonly" in options or "ro" in options:
+                readonly_rootfs = True
+            continue
+
+        # Host bind mount detection
+        if typ == "bind" and src and (src.startswith("/") or src.startswith("./")):
+            is_forbidden = False
+            for forbidden in _FORBIDDEN_BIND_SOURCES:
+                if src == forbidden or src.startswith(forbidden + "/"):
+                    is_forbidden = True
+                    break
+            if not is_forbidden:
+                # Check if it's a world-writable bind
+                for opt in options:
+                    if opt in _WORLD_WRITABLE_OPTIONS:
+                        world_writable.append(dst)
+                        break
+            else:
+                forbidden_sources.append(dst)
+
+            # Classify as secret or output mount
+            secret_keywords = frozenset({".env", ".ssh", "secret", "credential", "private", "token"})
+            output_keywords = frozenset({".hol-guard", "guard", "output", "result", "report"})
+            if secret_keywords & set(PurePosixPath(dst).parts):
+                secret_mounts.append(dst)
+            elif output_keywords & set(PurePosixPath(dst).parts):
+                output_mounts.append(dst)
+            else:
+                host_binds.append(dst)
+
+    return OCIMountEvidence(
+        readonly_rootfs=readonly_rootfs or rootfs_mount,
+        host_bind_mounts=tuple(host_binds),
+        secret_mounts=tuple(secret_mounts),
+        output_mounts=tuple(output_mounts),
+        forbidden_bind_sources=tuple(forbidden_sources),
+        world_writable_binds=tuple(world_writable),
+    )
+
+
+def _read_network(linux_ev: _OCILinuxEvidence) -> OCINetworkEvidence:
+    """Extract network evidence from validated Linux evidence."""
+    mode = "default"
+    port_mappings: tuple[str, ...] = ()
+    loopback_only = linux_ev.namespaces.net_isolated
+    network_spec = _object_map(linux_ev.network_spec)
+    if network_spec is not None:
+        raw_mode = network_spec.get("mode")
+        mode = raw_mode if isinstance(raw_mode, str) else "default"
+        raw_ports = _object_list(network_spec.get("ports"))
+        if raw_ports is not None:
+            port_mappings = tuple(str(port) for port in raw_ports)
+        if mode in _HOST_NETWORK_MODES:
+            loopback_only = False
+
+    return OCINetworkEvidence(
+        mode=mode,
+        port_mappings=port_mappings,
+        loopback_only=loopback_only,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider implementation
+# ---------------------------------------------------------------------------
+
+
+class OCIIsolationProvider:
+    """OCI (Open Container Initiative) bundle isolation provider.
+
+    Validates an OCI bundle spec and maps its features to atomic
+    guarantees. Deny-by-default: every feature must be explicitly
+    verified to contribute a guarantee.
+    """
+
+    _version: str
+
+    def __init__(self, *, version: str = "1.0.0") -> None:
+        self._version = version
+
+    @staticmethod
+    def _lease_ttl_seconds() -> int:
+        return 60
+
+    def identity(self) -> ProviderIdentity:
+        return ProviderIdentity(
+            provider_kind=_PROVIDE_KIND,
+            implementation_version=self._version,
+            binary_or_image_digest="0" * 64,
+            signing_identity=_SIGNING_IDENTITY,
+            trust_domain=_TRUST_DOMAIN,
+        )
+
+    def capabilities(self) -> tuple[AtomicGuarantee, ...]:
+        """Return the atomic guarantees this provider enforces.
+
+        These are the maximum guarantees available when a valid OCI
+        bundle with full isolation is provided to :meth:`plan`.
+        """
+        boundary = GuardExecutionAssuranceBoundary.OS_ISOLATED
+        guarantees = [AtomicGuarantee(kind=kind, enforced=True, boundary=boundary) for kind, _ in _OCI_ENFORCED]
+        for kind in _OCI_ABSENT:
+            guarantees.append(
+                AtomicGuarantee(
+                    kind=kind,
+                    enforced=False,
+                    boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                )
+            )
+        return tuple(guarantees)
+
+    def health_check(self) -> ProviderHealth:
+        """Return bounded provider health.
+
+        The OCI adapter is always available because it operates on
+        bundle specs without executing code.
+        """
+        return ProviderHealth(
+            state=ProviderHealthState.HEALTHY,
+            guarantees=self.capabilities(),
+        )
+
+    def plan(
+        self,
+        context: object,
+        minimum_boundary: GuardExecutionAssuranceBoundary,
+        *,
+        input_paths: tuple[str, ...] = (),
+        declared_outputs: tuple[str, ...] = (),
+        bundle_spec: dict[str, object] | None = None,
+        rootfs_spec: dict[str, object] | None = None,
+        process_spec: dict[str, object] | None = None,
+        linux_spec: dict[str, object] | None = None,
+    ) -> ExecutionLease:
+        """Produce a pure, side-effect-free fenced lease.
+
+            context: Decision context from the effect decision engine.
+            minimum_boundary: Desired minimum isolation boundary.
+            input_paths: Input file paths (validated against forbidden set).
+            declared_outputs: Declared output paths.
+            bundle_spec: OCI bundle spec dict (``bundle.json``).
+            rootfs_spec: Optional rootfs override dict.
+            process_spec: Optional process override dict.
+            linux_spec: Optional linux spec override dict.
+
+        Returns:
+            A bounded :class:`ExecutionLease` with a deterministic digest.
+
+        Raises:
+            ProviderPlanError: On malformed input, hostile spec, or
+                unachievable boundary.
+        """
+        if not isinstance(context, DecisionContext):
+            raise ProviderPlanError("context must be a DecisionContext")
+        validate_provider_plan_inputs(input_paths, declared_outputs)
+
+        # Boundary enforcement
+        if minimum_boundary is GuardExecutionAssuranceBoundary.HARDWARE_ISOLATED:
+            raise ProviderPlanError("OCI bundle isolation cannot provide a hardware-isolated boundary")
+
+        # Build evidence from bundle spec
+        bundle = bundle_spec or {}
+        evidence = _build_evidence(
+            bundle,
+            rootfs=rootfs_spec,
+            process=process_spec,
+            linux=linux_spec,
+        )
+
+        # Validate evidence — produce violation list
+        violations = _validate_bundle(evidence)
+
+        # Host-sensitive evidence is always refused.
+        if evidence.capabilities.dangerous_capabilities:
+            raise ProviderPlanError(
+                "dangerous capabilities detected: " + ", ".join(evidence.capabilities.dangerous_capabilities)
+            )
+        if evidence.mounts.forbidden_bind_sources:
+            raise ProviderPlanError("forbidden host bind mounts: " + ", ".join(evidence.mounts.forbidden_bind_sources))
+
+        if evidence.network and evidence.network.mode in _HOST_NETWORK_MODES:
+            raise ProviderPlanError("host network mode rejected")
+
+        if not evidence.bundle_valid:
+            raise ProviderPlanError("malformed OCI bundle spec")
+
+        # Map evidence to guarantees (deny-by-default)
+        guarantees = _map_guarantees(evidence, violations)
+
+        # If minimum boundary not satisfied by guarantees, raise
+        if minimum_boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED:
+            # All enforced guarantees must have OS_ISOLATED boundary
+            for g in guarantees:
+                if g.enforced and g.boundary is not GuardExecutionAssuranceBoundary.OS_ISOLATED:
+                    raise ProviderPlanError("required boundary is unavailable on this host")
+
+        # Compute deterministic plan digest
+        spec_fields: dict[str, object] = {
+            "context_digest": context.context_digest,
+            "minimum_boundary": minimum_boundary.value,
+            "bundle_digest": _compute_bundle_digest(bundle),
+            "bundle_version": evidence.bundle_version,
+            "violations_count": len(violations),
+        }
+        plan_digest = framed_digest("guard.oci-plan.v1", spec_fields)
+
+        return ExecutionLease(
+            plan_digest=plan_digest,
+            provider_thumbprint=self.identity().thumbprint(),
+            fencing_generation=1,
+            lease_expiry_epoch_seconds=int(time.time()) + self._lease_ttl_seconds(),
+            attempt_nonce=context.context_digest[:16],
+            input_manifest_digest=context.executable_digest,
+        )
+
+    def execute(self, lease: ExecutionLease) -> TerminalStatement:
+        """Return a self-attested statement.
+
+        The OCI adapter is a spec-validated provider; actual execution
+        is delegated to the underlying runtime (containerd, crun, etc.).
+        This method returns the terminal statement for planning purposes.
+        """
+        return TerminalStatement(
+            outcome=ExecutionOutcome.SUCCEEDED,
+            exit_code=0,
+            stream_byte_counts=(),
+            stream_digests=(),
+            truncated=False,
+            declared_output_digests=(),
+            cleanup_complete=True,
+            execution_instance=lease.attempt_nonce,
+            attestation_trust=GuardExecutionAttestationTrust.SELF_ATTESTED,
+        )
+
+    def cancel(self, execution_instance: str) -> None:
+        """Cancel is a no-op for the spec-validated OCI adapter."""
+        _ = execution_instance
+
+    def cleanup(self, execution_instance: str) -> None:
+        """Cleanup is a no-op for the spec-validated OCI adapter."""
+        _ = execution_instance
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_oci_evidence(
+    bundle: dict[str, object],
+    rootfs: dict[str, object] | None = None,
+    process: dict[str, object] | None = None,
+    linux: dict[str, object] | None = None,
+) -> OCIBundleEvidence:
+    """Build OCI bundle evidence from spec dicts."""
+    return _build_evidence(bundle, rootfs=rootfs, process=process, linux=linux)
+
+
+__all__ = [
+    "OCIBundleEvidence",
+    "OCICGroupEvidence",
+    "OCICapabilitiesEvidence",
+    "OCIIsolationProvider",
+    "OCILSMEvidence",
+    "OCIMountEvidence",
+    "OCINamespaceEvidence",
+    "OCINetworkEvidence",
+    "OCIRootFSEvidence",
+    "OCISeccompEvidence",
+    "OCISeccompProfile",
+    "OCIUserEvidence",
+    "_compute_bundle_digest",
+    "_map_guarantees",
+    "_validate_bundle",
+    "build_oci_evidence",
+]

--- a/src/codex_plugin_scanner/guard/runtime/oci_isolation_provider.py
+++ b/src/codex_plugin_scanner/guard/runtime/oci_isolation_provider.py
@@ -285,7 +285,10 @@ def _validate_bundle(evidence: OCIBundleEvidence) -> tuple[str, ...]:
     if not evidence.bundle_valid:
         violations.append("bundle invalid")
 
-    if evidence.seccomp and evidence.seccomp.profile_kind is OCISeccompProfile.NONE:
+    if evidence.seccomp.profile_kind in (
+        OCISeccompProfile.UNSET,
+        OCISeccompProfile.NONE,
+    ):
         violations.append("seccomp profile unset or none")
 
     if evidence.mounts:
@@ -461,17 +464,16 @@ def _compute_bundle_digest(spec: dict[str, object]) -> str:
 
 
 def _frame_scalar(value: object) -> object:
-    """Normalise a scalar item to a JSON-serialisable, stable form."""
-    if isinstance(value, str):
-        return value
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, int):
+    """Normalise nested input to a JSON-serialisable, stable form."""
+    if isinstance(value, (str, bool, int, float)) or value is None:
         return value
     if isinstance(value, (list, tuple)):
         values = cast(list[object] | tuple[object, ...], value)
         return [_frame_scalar(item) for item in values]
-    return repr(value)
+    mapping = _object_map(value)
+    if mapping is not None:
+        return {key: _frame_scalar(mapping[key]) for key in sorted(mapping)}
+    return f"<unsupported:{type(value).__name__}>"
 
 
 # ---------------------------------------------------------------------------
@@ -493,10 +495,9 @@ def _build_evidence(
     raw_version = bundle.get("ociVersion")
     version = raw_version if isinstance(raw_version, str) and raw_version else "0.0.0"
     bundle_valid = version != "0.0.0"
-
-    rootfs_spec = _object_map(bundle.get("root", rootfs)) or {}
+    rootfs_spec = _object_map(rootfs if rootfs is not None else bundle.get("root")) or {}
     rootfs_ev = _read_rootfs(rootfs_spec)
-    process_spec = _object_map(bundle.get("process", process)) or {}
+    process_spec = _object_map(process if process is not None else bundle.get("process")) or {}
     user_ev = _read_process(process_spec, rootfs_ev)
     raw_linux = linux if linux is not None else bundle.get("linux")
     linux_ev = _read_linux(_object_map(raw_linux) or {})
@@ -568,7 +569,7 @@ def _read_linux(spec: dict[str, object]) -> _OCILinuxEvidence:
         rule_type = raw_action.upper() if isinstance(raw_action, str) else ""
         if rule_type == "SCMP_ACT_ERRNO" or seccomp_spec.get("strict") is True:
             seccomp_profile = OCISeccompProfile.STRICT
-        elif raw_action == "SCMP_ACT_ALLOW":
+        elif rule_type == "SCMP_ACT_ALLOW":
             seccomp_profile = OCISeccompProfile.DEFAULT
         elif raw_action in ("", None):
             seccomp_profile = OCISeccompProfile.NONE
@@ -628,7 +629,8 @@ def _read_linux(spec: dict[str, object]) -> _OCILinuxEvidence:
         namespace_maps.append(namespace_map)
         raw_type = namespace_map.get("type")
         typ = raw_type.lower() if isinstance(raw_type, str) else ""
-        host = namespace_map.get("host") is True
+        raw_path = namespace_map.get("path")
+        host = namespace_map.get("host") is True or (isinstance(raw_path, str) and bool(raw_path))
         if typ == "pid" and not host:
             pid_isolated = True
         elif typ == "net" and not host:
@@ -640,8 +642,11 @@ def _read_linux(spec: dict[str, object]) -> _OCILinuxEvidence:
         elif typ == "user" and not host:
             user_isolated = True
 
-    # Check if ANY namespace is explicitly marked host=true → isolation broken
-    namespaces_host = any(namespace.get("host") is True for namespace in namespace_maps)
+    # OCI namespace ``path`` joins an existing namespace and is therefore shared.
+    namespaces_host = any(
+        namespace.get("host") is True or (isinstance((path := namespace.get("path")), str) and bool(path))
+        for namespace in namespace_maps
+    )
     if namespaces_host:
         pid_isolated = False
         net_isolated = False
@@ -693,7 +698,6 @@ def _read_mounts(spec_list: list[object]) -> OCIMountEvidence:
     world_writable: list[str] = []
 
     readonly_rootfs = False
-    rootfs_mount = False
 
     for raw_mount in spec_list:
         mount = _object_map(raw_mount)
@@ -711,7 +715,6 @@ def _read_mounts(spec_list: list[object]) -> OCIMountEvidence:
 
         # Rootfs mount (no source, destination=/)
         if (typ == "bind" or src == "") and dst == "/":
-            rootfs_mount = True
             if "readonly" in options or "ro" in options:
                 readonly_rootfs = True
             continue
@@ -730,7 +733,7 @@ def _read_mounts(spec_list: list[object]) -> OCIMountEvidence:
                         world_writable.append(dst)
                         break
             else:
-                forbidden_sources.append(dst)
+                forbidden_sources.append(src)
 
             # Classify as secret or output mount
             secret_keywords = frozenset({".env", ".ssh", "secret", "credential", "private", "token"})
@@ -743,7 +746,7 @@ def _read_mounts(spec_list: list[object]) -> OCIMountEvidence:
                 host_binds.append(dst)
 
     return OCIMountEvidence(
-        readonly_rootfs=readonly_rootfs or rootfs_mount,
+        readonly_rootfs=readonly_rootfs,
         host_bind_mounts=tuple(host_binds),
         secret_mounts=tuple(secret_mounts),
         output_mounts=tuple(output_mounts),
@@ -901,12 +904,14 @@ class OCIIsolationProvider:
         # Map evidence to guarantees (deny-by-default)
         guarantees = _map_guarantees(evidence, violations)
 
-        # If minimum boundary not satisfied by guarantees, raise
         if minimum_boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED:
-            # All enforced guarantees must have OS_ISOLATED boundary
-            for g in guarantees:
-                if g.enforced and g.boundary is not GuardExecutionAssuranceBoundary.OS_ISOLATED:
-                    raise ProviderPlanError("required boundary is unavailable on this host")
+            required_kinds = {kind for kind, _ in _OCI_ENFORCED}
+            required = tuple(guarantee for guarantee in guarantees if guarantee.kind in required_kinds)
+            if any(
+                not guarantee.enforced or guarantee.boundary is not GuardExecutionAssuranceBoundary.OS_ISOLATED
+                for guarantee in required
+            ):
+                raise ProviderPlanError("required boundary is unavailable on this host")
 
         # Compute deterministic plan digest
         spec_fields: dict[str, object] = {

--- a/src/codex_plugin_scanner/guard/runtime/oci_plan_generator.py
+++ b/src/codex_plugin_scanner/guard/runtime/oci_plan_generator.py
@@ -1,0 +1,995 @@
+"""OCI plan generator: deterministic execution plans from OCI bundle specs.
+
+Produces deny-by-default execution plans from an OCI runtime/bundle spec
+WITHOUT executing workspace code. Validates the spec and rejects hostile
+path/mount/capability inputs by lowering or refusing assurance.
+
+Deterministic output: identical specs always produce identical plan digests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Final, cast
+
+from codex_plugin_scanner.guard.runtime.execution_assurance_contract import (
+    AtomicGuarantee,
+    AtomicGuaranteeKind,
+    DecisionContext,
+    GuardExecutionAssuranceBoundary,
+    framed_digest,
+)
+from codex_plugin_scanner.guard.runtime.isolation_provider import ProviderPlanError
+
+# --- Forbidden / hostile input constants ---
+
+# Capabilities that are always refused.
+_FORBIDDEN_CAPABILITIES: Final = frozenset(
+    {
+        "CAP_SYS_ADMIN",
+        "SYS_ADMIN",
+        "CAP_SYS_PTRACE",
+        "SYS_PTRACE",
+        "CAP_NET_ADMIN",
+        "NET_ADMIN",
+        "CAP_SYS_MODULE",
+        "CAP_SYS_RAWIO",
+        "CAP_MKNOD",
+        "CAP_AUDIT_WRITE",
+    }
+)
+
+# Forbidden host mount sources (absolute paths).
+_FORBIDDEN_MOUNT_SOURCES: Final = frozenset(
+    {
+        "/",
+        "/etc",
+        "/etc/shadow",
+        "/etc/passwd",
+        "/proc",
+        "/sys",
+        "/dev",
+        "/var/run",
+        "/run",
+        "/root",
+        "/home",
+        "/var/lib",
+        "/var/log",
+    }
+)
+
+# Forbidden socket paths.
+_FORBIDDEN_SOCKETS: Final = frozenset(
+    {
+        "/var/run/docker.sock",
+        "/run/docker.sock",
+        "/var/run/containerd/containerd.sock",
+        "/run/containerd/containerd.sock",
+        "/run/crio/crio.sock",
+        "/var/run/crio/crio.sock",
+        "/var/run/kubernetes",
+    }
+)
+
+# Guard state directory names that must never be mounted.
+_GUARD_STATE_NAMES: Final = frozenset({".hol-guard", "guard-state"})
+
+# World-writable mount option tokens.
+_WORLD_WRITABLE_OPTIONS: Final = frozenset({"world-writable", "world_writable", "o+w", "noexec", "nosuid", "nodev"})
+
+# Network modes that defeat isolation.
+_HOST_NETWORK_MODES: Final = frozenset({"host", "host.network", "HostNetwork"})
+
+# Namespace types.
+_NAMESPACE_TYPES: Final = frozenset({"pid", "net", "ipc", "uts", "user", "mount", "cgroup", "time"})
+
+# --- Plan structure ---
+
+
+@dataclass(frozen=True)
+class OCIPlanInput:
+    """An input source for the execution plan."""
+
+    path: str  # Container path
+    source: str  # Host source or "none"
+    readonly: bool
+    mount_type: str  # "bind", "volume", "tmpfs", "none"
+
+
+@dataclass(frozen=True)
+class OCIPlanOutput:
+    """An output source for the execution plan."""
+
+    path: str  # Container path
+    source: str  # Host source or "none"
+    max_bytes: int | None = None
+
+
+@dataclass(frozen=True)
+class OCIPlanSecret:
+    """A secret mount or env reference."""
+
+    container_path: str
+    secret_handle: str
+    readonly: bool = True
+
+
+@dataclass(frozen=True)
+class OCIPlanMount:
+    """A mount entry in the plan."""
+
+    container_path: str
+    mount_type: str
+    readonly: bool
+    source: str = ""
+    options: tuple[str, ...] = ()
+    classification: str = "unclassified"  # "host", "secret", "output", "system"
+
+
+@dataclass(frozen=True)
+class OCIPlanNetwork:
+    """Network configuration in the plan."""
+
+    mode: str  # "default", "host", "bridge", "none"
+    port_mappings: tuple[str, ...] = ()
+    loopback_only: bool = True
+
+
+@dataclass(frozen=True)
+class OCIPlanNamespace:
+    """Namespace isolation in the plan."""
+
+    pid_isolated: bool
+    net_isolated: bool
+    ipc_isolated: bool
+    uts_isolated: bool
+    user_isolated: bool
+    host_namespaces: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class OCIGuaranteeEntry:
+    """A guarantee entry in the plan."""
+
+    kind: AtomicGuaranteeKind
+    enforced: bool
+    boundary: GuardExecutionAssuranceBoundary
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class OCIPlanViolation:
+    """A violation found during plan generation."""
+
+    code: str  # Machine-readable code
+    description: str  # Human-readable
+    severity: str  # "refuse", "lower", "warn"
+
+
+@dataclass(frozen=True)
+class OCIExecutionPlan:
+    """The complete, deterministic execution plan derived from an OCI spec.
+
+    Pure data — no provider, no execution, no side effects.
+    """
+
+    plan_digest: str  # SHA-256 hex
+    bundle_version: str
+    minimum_boundary: GuardExecutionAssuranceBoundary
+    available_boundary: GuardExecutionAssuranceBoundary
+    boundary_lowered: bool
+    inputs: tuple[OCIPlanInput, ...] = ()
+    outputs: tuple[OCIPlanOutput, ...] = ()
+    secrets: tuple[OCIPlanSecret, ...] = ()
+    mounts: tuple[OCIPlanMount, ...] = ()
+    network: OCIPlanNetwork | None = None
+    namespaces: OCIPlanNamespace | None = None
+    capabilities: tuple[str, ...] = ()
+    forbidden_capabilities: tuple[str, ...] = ()
+    seccomp_profile: str = "unset"
+    seccomp_enforced: bool = False
+    lsm_enabled: bool = False
+    lsm_profile: str = ""
+    cgroup_v2: bool = False
+    cgroup_path: str = ""
+    rootfs_path: str = ""
+    rootfs_readonly: bool = False
+    non_root: bool = False
+    violations: tuple[OCIPlanViolation, ...] = ()
+    enforced_guarantees: tuple[AtomicGuarantee, ...] = ()
+    denied_guarantees: tuple[AtomicGuarantee, ...] = ()
+    reason_code: str = "oci.plan"
+
+    def __post_init__(self) -> None:
+        if len(self.plan_digest) != 64:
+            raise ValueError("plan_digest must be 64 hex chars")
+        _ = _require_str(self.bundle_version, "bundle_version")
+        _ = _require_str(self.seccomp_profile, "seccomp_profile")
+        _ = _require_str(self.lsm_profile, "lsm_profile")
+        _ = _require_str(self.cgroup_path, "cgroup_path")
+        _ = _require_str(self.rootfs_path, "rootfs_path")
+
+
+# --- Validators ---
+
+
+def _require_str(value: object, label: str, *, max_length: int = 512) -> str:
+    if not isinstance(value, str) or len(value) > max_length:
+        raise ValueError(f"{label} must be a string of at most {max_length} characters")
+    return value
+
+
+# --- Path validation ---
+
+
+def _is_forbidden_path(path: str) -> str | None:
+    """Return the matching forbidden source, or None."""
+    if not path:
+        return None
+    for forbidden in sorted(_FORBIDDEN_MOUNT_SOURCES):
+        if path == forbidden or path.startswith(forbidden + "/"):
+            return forbidden
+    return None
+
+
+def _is_forbidden_socket(path: str) -> str | None:
+    """Return the matching forbidden socket, or None."""
+    if path in _FORBIDDEN_SOCKETS:
+        return path
+    return None
+
+
+def _object_map(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    raw = cast(dict[object, object], value)
+    if not all(isinstance(key, str) for key in raw):
+        return None
+    return {cast(str, key): item for key, item in raw.items()}
+
+
+def _object_list(value: object) -> list[object] | None:
+    if not isinstance(value, list):
+        return None
+    return cast(list[object], value)
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    items = _object_list(value)
+    if items is None:
+        return ()
+    return tuple(item for item in items if isinstance(item, str))
+
+
+def _is_guard_state_path(path: str) -> bool:
+    """Return True if path targets guard state directories."""
+    if not path:
+        return False
+    return any(guard_name in PurePosixPath(path).parts for guard_name in _GUARD_STATE_NAMES)
+
+
+# --- Capability validation ---
+
+
+def _is_dangerous_cap(cap: str) -> bool:
+    """Return True if a capability is forbidden."""
+    return cap.upper() in _FORBIDDEN_CAPABILITIES
+
+
+def _extract_all_capabilities(
+    caps_spec: dict[str, object],
+) -> tuple[list[str], list[str]]:
+    """Extract all capabilities and their dangerous subset."""
+    all_caps: set[str] = set()
+    for key in ("effective", "permitted", "ambient", "bounding"):
+        all_caps.update(_string_tuple(caps_spec.get(key)))
+    all_list = sorted(all_caps)
+    dangerous = [capability for capability in all_list if _is_dangerous_cap(capability)]
+    return all_list, dangerous
+
+
+# --- Namespace validation ---
+
+
+def _parse_namespaces(ns_list: list[object]) -> OCIPlanNamespace:
+    """Parse namespace list into plan namespace structure."""
+    pid_isolated = False
+    net_isolated = False
+    ipc_isolated = False
+    uts_isolated = False
+    user_isolated = False
+    host_namespaces: list[str] = []
+
+    for ns_entry in ns_list:
+        namespace = _object_map(ns_entry)
+        if namespace is None:
+            continue
+        raw_type = namespace.get("type")
+        typ = raw_type.lower() if isinstance(raw_type, str) else ""
+        raw_host = namespace.get("host")
+        host = raw_host if isinstance(raw_host, bool) else False
+        if typ == "pid":
+            if not host:
+                pid_isolated = True
+            else:
+                host_namespaces.append("pid")
+        elif typ == "net":
+            if not host:
+                net_isolated = True
+            else:
+                host_namespaces.append("net")
+        elif typ == "ipc":
+            if not host:
+                ipc_isolated = True
+            else:
+                host_namespaces.append("ipc")
+        elif typ == "uts":
+            if not host:
+                uts_isolated = True
+            else:
+                host_namespaces.append("uts")
+        elif typ == "user":
+            if not host:
+                user_isolated = True
+            else:
+                host_namespaces.append("user")
+
+    # If any namespace is host, deny all isolation (deny-by-default)
+    if host_namespaces:
+        pid_isolated = False
+        net_isolated = False
+        ipc_isolated = False
+        uts_isolated = False
+        user_isolated = False
+
+    return OCIPlanNamespace(
+        pid_isolated=pid_isolated,
+        net_isolated=net_isolated,
+        ipc_isolated=ipc_isolated,
+        uts_isolated=uts_isolated,
+        user_isolated=user_isolated,
+        host_namespaces=tuple(host_namespaces),
+    )
+
+
+# --- Mount analysis ---
+
+
+def _classify_mount(
+    mount: dict[str, object],
+) -> tuple[str, str, bool, str, tuple[str, ...]]:
+    """Classify a mount entry into path, type, readonly, source, and options."""
+    raw_destination = mount.get("destination")
+    raw_source = mount.get("source")
+    raw_type = mount.get("type")
+    destination = raw_destination if isinstance(raw_destination, str) else ""
+    source = raw_source if isinstance(raw_source, str) else ""
+    mount_type = raw_type if isinstance(raw_type, str) else ""
+    raw_options = mount.get("options")
+    options = (raw_options,) if isinstance(raw_options, str) else _string_tuple(raw_options)
+    readonly = "readonly" in options or "ro" in options
+    return destination, mount_type, readonly, source, options
+
+
+def _analyze_mounts(
+    mounts_list: list[object],
+) -> tuple[
+    list[OCIPlanMount],
+    list[str],  # violations codes
+    bool,  # has_forbidden
+    bool,  # has_hostile
+]:
+    """Analyze mount entries, return plan mounts and violations."""
+    plan_mounts: list[OCIPlanMount] = []
+    violations: list[str] = []
+    has_forbidden = False
+    has_hostile = False
+
+    for raw_mount in mounts_list:
+        mount = _object_map(raw_mount)
+        if mount is None:
+            violations.append("mount:not-object")
+            continue
+        dst, typ, readonly, src, options = _classify_mount(mount)
+
+        # Skip rootfs mount (destination=/, no source)
+        if dst == "/" and (typ == "" or typ == "none"):
+            classification = "system"
+            plan_mounts.append(
+                OCIPlanMount(
+                    container_path=dst,
+                    mount_type=typ or "none",
+                    readonly=True,
+                    source="",
+                    options=tuple(options),
+                    classification=classification,
+                )
+            )
+            continue
+
+        # Host bind mount detection
+        if typ == "bind" or (not typ and src and (src.startswith("/") or src.startswith("./"))):
+            forbidden_match = _is_forbidden_path(src)
+            socket_match = _is_forbidden_socket(dst)
+            guard_match = _is_guard_state_path(dst)
+
+            if forbidden_match:
+                violations.append(f"forbidden-mount-source:{forbidden_match}")
+                has_forbidden = True
+                has_hostile = True
+                classification = "forbidden"
+            elif socket_match:
+                violations.append(f"forbidden-socket:{socket_match}")
+                has_hostile = True
+                classification = "forbidden"
+            elif guard_match:
+                violations.append("guard-state-mount")
+                has_hostile = True
+                classification = "forbidden"
+            else:
+                # Classify as secret or output or host
+                secret_keywords = frozenset({".env", ".ssh", "secret", "credential", "private", "token"})
+                output_keywords = frozenset({".hol-guard", "guard", "output", "result", "report"})
+                if secret_keywords & set(PurePosixPath(dst).parts):
+                    classification = "secret"
+                elif output_keywords & set(PurePosixPath(dst).parts):
+                    classification = "output"
+                else:
+                    classification = "host"
+
+                # Check for world-writable
+                for opt in options:
+                    if opt in _WORLD_WRITABLE_OPTIONS:
+                        violations.append(f"world-writable-mount:{dst}")
+                        break
+
+        else:
+            # Volume or tmpfs mount
+            classification = "system" if typ in ("volume", "tmpfs", "none") else "unclassified"
+
+        plan_mounts.append(
+            OCIPlanMount(
+                container_path=dst,
+                mount_type=typ or "unknown",
+                readonly=readonly,
+                source=src,
+                options=tuple(options),
+                classification=classification,
+            )
+        )
+
+    return plan_mounts, violations, has_forbidden, has_hostile
+
+
+# --- Capability analysis ---
+
+
+def _analyze_capabilities(
+    caps_spec: dict[str, object] | None,
+) -> tuple[
+    list[str],  # all capabilities
+    list[str],  # dangerous
+    bool,  # has_dangerous
+]:
+    """Analyze capabilities from spec."""
+    if not caps_spec:
+        return [], [], False
+
+    all_caps, dangerous = _extract_all_capabilities(caps_spec)
+    return all_caps, dangerous, len(dangerous) > 0
+
+
+# --- LSM analysis ---
+
+
+def _analyze_lsm(spec: dict[str, object]) -> tuple[bool, str]:
+    """Analyze LSM configuration. Returns (enabled, profile_name)."""
+    apparmor = spec.get("apparmor")
+    selinux = _object_map(spec.get("selinux"))
+    if isinstance(apparmor, str) and apparmor:
+        return True, apparmor
+    if selinux:
+        raw_label = selinux.get("label")
+        return True, raw_label if isinstance(raw_label, str) else ""
+    return False, ""
+
+
+# --- Cgroup analysis ---
+
+
+def _analyze_cgroup(spec: dict[str, object]) -> tuple[bool, str]:
+    """Analyze cgroup configuration. Returns (v2, path)."""
+    cgroups_path = spec.get("cgroupsPath", "")
+    v2 = "unified" in str(cgroups_path)
+    path = str(cgroups_path) if isinstance(cgroups_path, str) else ""
+    return v2, path
+
+
+def _analyze_seccomp(linux_spec: dict[str, object]) -> tuple[str, bool]:
+    """Analyze seccomp profile. Returns (kind, enforced)."""
+    seccomp = _object_map(linux_spec.get("seccomp"))
+    if seccomp is None:
+        return "unset", False
+    raw_action = seccomp.get("defaultAction")
+    default_action = raw_action.upper() if isinstance(raw_action, str) else ""
+    strict = seccomp.get("strict") is True
+    if strict or default_action == "SCMP_ACT_ERRNO":
+        return "strict", True
+    if default_action == "SCMP_ACT_ALLOW":
+        return "none", False
+    if isinstance(seccomp.get("path"), str) and seccomp.get("path"):
+        return "custom", True
+    return "none", False
+
+
+# --- User analysis ---
+
+
+def _analyze_user(process_spec: dict[str, object]) -> tuple[int, int, bool]:
+    """Analyze user configuration. Returns (uid, gid, non_root)."""
+    user = _object_map(process_spec.get("user"))
+    if user is None:
+        return 0, 0, False
+    raw_uid = user.get("uid")
+    raw_gid = user.get("gid")
+    uid = raw_uid if isinstance(raw_uid, int) else 0
+    gid = raw_gid if isinstance(raw_gid, int) else 0
+    return uid, gid, uid != 0
+
+
+# --- Network analysis ---
+
+
+def _analyze_network(
+    linux_spec: dict[str, object],
+    namespaces: OCIPlanNamespace,
+) -> OCIPlanNetwork:
+    """Analyze network configuration."""
+    network_spec = _object_map(linux_spec.get("network"))
+    if network_spec is None:
+        return OCIPlanNetwork(
+            mode="default",
+            loopback_only=namespaces.net_isolated,
+        )
+
+    raw_mode = network_spec.get("mode")
+    mode = raw_mode if isinstance(raw_mode, str) else "default"
+    ports = _object_list(network_spec.get("ports")) or []
+    port_mappings = tuple(str(port) for port in ports)
+
+    loopback_only = mode not in _HOST_NETWORK_MODES and namespaces.net_isolated
+
+    if mode in _HOST_NETWORK_MODES:
+        loopback_only = False
+
+    return OCIPlanNetwork(
+        mode=mode,
+        port_mappings=port_mappings,
+        loopback_only=loopback_only,
+    )
+
+
+# --- Rootfs analysis ---
+
+
+def _analyze_rootfs(rootfs_spec: dict[str, object]) -> tuple[str, bool]:
+    """Analyze rootfs. Returns (path, readonly)."""
+    raw_path = rootfs_spec.get("path")
+    raw_readonly = rootfs_spec.get("readonly")
+    path = raw_path if isinstance(raw_path, str) else ""
+    readonly = raw_readonly if isinstance(raw_readonly, bool) else False
+    return path, readonly
+
+
+# --- Evidence → guarantees mapping ---
+
+
+def _map_guarantees(
+    violations_codes: list[str],
+    namespaces: OCIPlanNamespace,
+    rootfs_readonly: bool,
+    non_root: bool,
+    network_loopback: bool,
+    hostile_mounts: bool,
+) -> tuple[tuple[AtomicGuarantee, ...], tuple[AtomicGuarantee, ...]]:
+    """Map validated evidence to enforced and denied guarantees.
+
+    Deny-by-default: a guarantee is enforced only when ALL relevant
+    conditions are satisfied. Any violation lowers or denies it.
+    """
+    enforced_guarantees: list[AtomicGuarantee] = []
+    denied_guarantees: list[AtomicGuarantee] = []
+
+    # Overall: hostile inputs always deny
+    is_hostile = hostile_mounts
+
+    for kind in [
+        AtomicGuaranteeKind.FILESYSTEM,
+        AtomicGuaranteeKind.NETWORK,
+        AtomicGuaranteeKind.PROCESS,
+        AtomicGuaranteeKind.SECRET,
+        AtomicGuaranteeKind.OUTPUT,
+        AtomicGuaranteeKind.CLEANUP,
+        AtomicGuaranteeKind.IDENTITY,
+        AtomicGuaranteeKind.RESOURCE,
+        AtomicGuaranteeKind.PRIVILEGE,
+    ]:
+        if is_hostile:
+            denied_guarantees.append(
+                AtomicGuarantee(
+                    kind=kind,
+                    enforced=False,
+                    boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                )
+            )
+            continue
+
+        # Condition-based enforcement
+        enforced = True
+        reason_parts: list[str] = []
+
+        if kind is AtomicGuaranteeKind.FILESYSTEM and not rootfs_readonly:
+            enforced = False
+            reason_parts.append("rootfs-not-readonly")
+        if kind is AtomicGuaranteeKind.NETWORK and not network_loopback:
+            enforced = False
+            reason_parts.append("network-not-loopback-only")
+        if kind is AtomicGuaranteeKind.PROCESS and not namespaces.pid_isolated:
+            enforced = False
+            reason_parts.append("pid-not-isolated")
+        if kind is AtomicGuaranteeKind.SECRET and not namespaces.net_isolated:
+            enforced = False
+            reason_parts.append("net-not-isolated")
+        if kind is AtomicGuaranteeKind.OUTPUT and not namespaces.pid_isolated:
+            enforced = False
+            reason_parts.append("pid-not-isolated")
+        if kind is AtomicGuaranteeKind.CLEANUP and not namespaces.pid_isolated:
+            enforced = False
+            reason_parts.append("pid-not-isolated")
+        if kind is AtomicGuaranteeKind.IDENTITY and not namespaces.net_isolated:
+            enforced = False
+            reason_parts.append("net-not-isolated")
+        if kind is AtomicGuaranteeKind.RESOURCE and not namespaces.pid_isolated:
+            enforced = False
+            reason_parts.append("pid-not-isolated")
+        if kind is AtomicGuaranteeKind.PRIVILEGE and (not namespaces.user_isolated or not non_root):
+            enforced = False
+            reason_parts.append("user-not-isolated-or-root")
+
+        # Violations always lower
+        if violations_codes:
+            enforced = False
+            reason_parts.append("violations-present")
+
+        boundary = (
+            GuardExecutionAssuranceBoundary.OS_ISOLATED if enforced else GuardExecutionAssuranceBoundary.OBSERVED_HOST
+        )
+
+        if enforced:
+            enforced_guarantees.append(AtomicGuarantee(kind=kind, enforced=True, boundary=boundary))
+        else:
+            denied_guarantees.append(
+                AtomicGuarantee(
+                    kind=kind,
+                    enforced=False,
+                    boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                )
+            )
+
+    # Always absent
+    for kind in (
+        AtomicGuaranteeKind.KERNEL_HARDWARE,
+        AtomicGuaranteeKind.TENANT,
+    ):
+        denied_guarantees.append(
+            AtomicGuarantee(
+                kind=kind,
+                enforced=False,
+                boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            )
+        )
+
+    return tuple(enforced_guarantees), tuple(denied_guarantees)
+
+
+# --- Plan digest computation ---
+
+
+def _plan_digest(fields: dict[str, object]) -> str:
+    """Compute a deterministic plan digest."""
+    return framed_digest("guard.oci-execution-plan.v1", fields)
+
+
+def _build_digest_fields(
+    bundle_version: str,
+    minimum_boundary: GuardExecutionAssuranceBoundary,
+    available_boundary: GuardExecutionAssuranceBoundary,
+    namespace: OCIPlanNamespace,
+    network: OCIPlanNetwork,
+    seccomp_profile: str,
+    seccomp_enforced: bool,
+    lsm_enabled: bool,
+    cgroup_v2: bool,
+    rootfs_readonly: bool,
+    non_root: bool,
+    violations_count: int,
+    forbidden_capabilities_count: int,
+) -> dict[str, object]:
+    """Build deterministic field mapping for plan digest."""
+    return {
+        "bundle_version": bundle_version,
+        "minimum_boundary": minimum_boundary.value,
+        "available_boundary": available_boundary.value,
+        "namespace_pid_isolated": namespace.pid_isolated,
+        "namespace_net_isolated": namespace.net_isolated,
+        "namespace_ipc_isolated": namespace.ipc_isolated,
+        "namespace_uts_isolated": namespace.uts_isolated,
+        "namespace_user_isolated": namespace.user_isolated,
+        "network_mode": network.mode,
+        "network_loopback_only": network.loopback_only,
+        "seccomp_profile": seccomp_profile,
+        "seccomp_enforced": seccomp_enforced,
+        "lsm_enabled": lsm_enabled,
+        "cgroup_v2": cgroup_v2,
+        "rootfs_readonly": rootfs_readonly,
+        "non_root": non_root,
+        "violations_count": violations_count,
+        "forbidden_capabilities_count": forbidden_capabilities_count,
+    }
+
+
+# --- Plan generator ---
+
+
+class OCIPlanGenerator:
+    """Generate deterministic execution plans from OCI bundle specs.
+
+    Does NOT execute any workspace code. Validates the spec and
+    produces deny-by-default guarantees.
+    """
+
+    @staticmethod
+    def generate(
+        context: object,
+        minimum_boundary: GuardExecutionAssuranceBoundary,
+        bundle: object = None,
+        rootfs: dict[str, object] | None = None,
+        process: dict[str, object] | None = None,
+        linux: dict[str, object] | None = None,
+    ) -> OCIExecutionPlan:
+        """Generate an execution plan from an OCI bundle spec.
+
+        Args:
+            context: The decision context.
+            minimum_boundary: Desired minimum isolation boundary.
+            bundle: OCI bundle spec dict (``bundle.json`` contents).
+            rootfs: Optional rootfs override.
+            process: Optional process override.
+            linux: Optional linux spec override.
+
+        Returns:
+            A fully validated ``OCIExecutionPlan``.
+
+        Raises:
+            ProviderPlanError: On malformed spec or hostile inputs.
+        """
+        if not isinstance(context, DecisionContext):
+            raise ProviderPlanError("context must be a DecisionContext")
+
+        bundle_map = _object_map(bundle)
+        if bundle_map is None:
+            raise ProviderPlanError("bundle must be a dict")
+        bundle = bundle_map
+        rootfs = rootfs or _object_map(bundle.get("root")) or {}
+        process = process or _object_map(bundle.get("process")) or {}
+        linux = linux or _object_map(bundle.get("linux")) or {}
+
+        # --- Extract bundle version ---
+        version = bundle.get("ociVersion", "0.0.0")
+        if not isinstance(version, str):
+            version = str(version)
+
+        # --- Validate bundle has required fields ---
+        if "ociVersion" not in bundle:
+            raise ProviderPlanError("malformed OCI spec: missing ociVersion")
+
+        # --- Analyze mounts ---
+        mounts_list = _object_list(bundle.get("mounts")) or []
+        plan_mounts, mount_violations, has_forbidden_mounts, has_hostile_mounts = _analyze_mounts(mounts_list)
+
+        # --- Analyze capabilities ---
+        caps_spec = _object_map(linux.get("capabilities")) or {}
+        all_caps, dangerous_caps, has_dangerous_caps = _analyze_capabilities(caps_spec)
+
+        # --- Reject dangerous capabilities ---
+        if has_dangerous_caps:
+            raise ProviderPlanError("refusing plan: dangerous capabilities " + ", ".join(dangerous_caps))
+
+        # --- Reject forbidden host mounts ---
+        if has_forbidden_mounts:
+            raise ProviderPlanError("refusing plan: forbidden host mounts")
+
+        # --- Reject hostile mounts ---
+        if has_hostile_mounts:
+            raise ProviderPlanError("refusing plan: hostile mount configuration")
+
+        # --- Analyze namespaces ---
+        ns_list = _object_list(linux.get("namespaces")) or []
+        namespace = _parse_namespaces(ns_list)
+
+        # --- Analyze network ---
+        network = _analyze_network(linux or {}, namespace)
+
+        # --- Analyze seccomp ---
+        seccomp_profile, seccomp_enforced = _analyze_seccomp(linux or {})
+
+        # --- Analyze LSM ---
+        lsm_enabled, lsm_profile = _analyze_lsm(linux or {})
+
+        # --- Analyze cgroup ---
+        cgroup_v2, cgroup_path = _analyze_cgroup(linux or {})
+
+        # --- Analyze rootfs ---
+        rootfs_path, rootfs_readonly = _analyze_rootfs(rootfs or {})
+
+        # --- Analyze user ---
+        _, _, non_root = _analyze_user(process)
+
+        # --- Collect all violations ---
+        all_violations_codes = list(mount_violations)
+
+        # Namespace host violations
+        if namespace.host_namespaces:
+            for ns in namespace.host_namespaces:
+                all_violations_codes.append(f"host-namespace:{ns}")
+
+        # Network violations
+        if network.mode in _HOST_NETWORK_MODES:
+            all_violations_codes.append("host-network-mode")
+
+        # Seccomp violation
+        if seccomp_profile == "none":
+            all_violations_codes.append("seccomp-none")
+
+        # --- Compute guaranteed boundary ---
+        violations_present = len(all_violations_codes) > 0
+
+        boundary_lowered = violations_present or (
+            minimum_boundary is not GuardExecutionAssuranceBoundary.OBSERVED_HOST
+            and (not namespace.pid_isolated or not namespace.net_isolated or not rootfs_readonly or violations_present)
+        )
+
+        available_boundary = (
+            GuardExecutionAssuranceBoundary.OS_ISOLATED
+            if not boundary_lowered
+            else GuardExecutionAssuranceBoundary.OBSERVED_HOST
+        )
+
+        # Reject if minimum boundary not achievable
+        if minimum_boundary is GuardExecutionAssuranceBoundary.HARDWARE_ISOLATED:
+            raise ProviderPlanError("OCI bundle isolation cannot provide hardware isolation")
+
+        if minimum_boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED and (
+            not namespace.pid_isolated or not namespace.net_isolated or not rootfs_readonly or violations_present
+        ):
+            raise ProviderPlanError(f"required boundary {minimum_boundary.value} not achievable")
+
+        if minimum_boundary is GuardExecutionAssuranceBoundary.CONTROLLED_HOST and (
+            not rootfs_readonly or violations_present
+        ):
+            raise ProviderPlanError(f"required boundary {minimum_boundary.value} not achievable")
+
+        # --- Map to guarantees ---
+        enforced, denied = _map_guarantees(
+            all_violations_codes,
+            namespace,
+            rootfs_readonly,
+            non_root,
+            network.loopback_only,
+            has_hostile_mounts,
+        )
+
+        # --- Build violations list ---
+        violation_entries: list[OCIPlanViolation] = []
+        for code in sorted(set(all_violations_codes)):
+            severity = "refuse" if code.startswith(("host-namespace:", "forbidden-")) else "lower"
+            description = code.replace(":", " - ")
+            violation_entries.append(OCIPlanViolation(code=code, description=description, severity=severity))
+
+        # --- Compute deterministic plan digest ---
+        digest_fields = _build_digest_fields(
+            bundle_version=version,
+            minimum_boundary=minimum_boundary,
+            available_boundary=available_boundary,
+            namespace=namespace,
+            network=network,
+            seccomp_profile=seccomp_profile,
+            seccomp_enforced=seccomp_enforced,
+            lsm_enabled=lsm_enabled,
+            cgroup_v2=cgroup_v2,
+            rootfs_readonly=rootfs_readonly,
+            non_root=non_root,
+            violations_count=len(all_violations_codes),
+            forbidden_capabilities_count=len(dangerous_caps),
+        )
+        plan_digest = _plan_digest(digest_fields)
+
+        # --- Build input/output structures ---
+        inputs: list[OCIPlanInput] = []
+        outputs: list[OCIPlanOutput] = []
+        secrets: list[OCIPlanSecret] = []
+
+        for pm in plan_mounts:
+            if pm.classification == "secret":
+                secrets.append(
+                    OCIPlanSecret(
+                        container_path=pm.container_path,
+                        secret_handle=f"secret:{pm.container_path}",
+                        readonly=True,
+                    )
+                )
+            elif pm.classification == "host":
+                inputs.append(
+                    OCIPlanInput(
+                        path=pm.container_path,
+                        source=pm.source,
+                        readonly=pm.readonly,
+                        mount_type=pm.mount_type,
+                    )
+                )
+            elif pm.classification == "output":
+                outputs.append(
+                    OCIPlanOutput(
+                        path=pm.container_path,
+                        source=pm.source,
+                    )
+                )
+
+        # --- Build plan ---
+        return OCIExecutionPlan(
+            plan_digest=plan_digest,
+            bundle_version=version,
+            minimum_boundary=minimum_boundary,
+            available_boundary=available_boundary,
+            boundary_lowered=boundary_lowered,
+            inputs=tuple(inputs),
+            outputs=tuple(outputs),
+            secrets=tuple(secrets),
+            mounts=tuple(plan_mounts),
+            network=network,
+            namespaces=namespace,
+            capabilities=tuple(all_caps),
+            forbidden_capabilities=tuple(dangerous_caps),
+            seccomp_profile=seccomp_profile,
+            seccomp_enforced=seccomp_enforced,
+            lsm_enabled=lsm_enabled,
+            lsm_profile=lsm_profile,
+            cgroup_v2=cgroup_v2,
+            cgroup_path=cgroup_path,
+            rootfs_path=rootfs_path,
+            rootfs_readonly=rootfs_readonly,
+            non_root=non_root,
+            violations=tuple(violation_entries),
+            enforced_guarantees=enforced,
+            denied_guarantees=denied,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+__all__ = [
+    "OCIExecutionPlan",
+    "OCIGuaranteeEntry",
+    "OCIPlanGenerator",
+    "OCIPlanInput",
+    "OCIPlanMount",
+    "OCIPlanNamespace",
+    "OCIPlanNetwork",
+    "OCIPlanOutput",
+    "OCIPlanSecret",
+    "OCIPlanViolation",
+]

--- a/src/codex_plugin_scanner/guard/runtime/oci_plan_generator.py
+++ b/src/codex_plugin_scanner/guard/runtime/oci_plan_generator.py
@@ -76,10 +76,30 @@ _FORBIDDEN_SOCKETS: Final = frozenset(
 _GUARD_STATE_NAMES: Final = frozenset({".hol-guard", "guard-state"})
 
 # World-writable mount option tokens.
-_WORLD_WRITABLE_OPTIONS: Final = frozenset({"world-writable", "world_writable", "o+w", "noexec", "nosuid", "nodev"})
+_WORLD_WRITABLE_OPTIONS: Final = frozenset({"world-writable", "world_writable", "o+w", "rw-all"})
 
 # Network modes that defeat isolation.
 _HOST_NETWORK_MODES: Final = frozenset({"host", "host.network", "HostNetwork"})
+_KNOWN_LINUX_FIELDS: Final = frozenset(
+    {
+        "apparmor",
+        "capabilities",
+        "cgroupsPath",
+        "devices",
+        "gidMappings",
+        "maskedPaths",
+        "mountLabel",
+        "namespaces",
+        "network",
+        "readonlyPaths",
+        "resources",
+        "rootfsPropagation",
+        "seccomp",
+        "selinux",
+        "sysctl",
+        "uidMappings",
+    }
+)
 
 # Namespace types.
 _NAMESPACE_TYPES: Final = frozenset({"pid", "net", "ipc", "uts", "user", "mount", "cgroup", "time"})
@@ -308,7 +328,10 @@ def _parse_namespaces(ns_list: list[object]) -> OCIPlanNamespace:
         raw_type = namespace.get("type")
         typ = raw_type.lower() if isinstance(raw_type, str) else ""
         raw_host = namespace.get("host")
-        host = raw_host if isinstance(raw_host, bool) else False
+        namespace_path = namespace.get("path")
+        host = (raw_host if isinstance(raw_host, bool) else False) or (
+            isinstance(namespace_path, str) and bool(namespace_path)
+        )
         if typ == "pid":
             if not host:
                 pid_isolated = True
@@ -400,7 +423,7 @@ def _analyze_mounts(
                 OCIPlanMount(
                     container_path=dst,
                     mount_type=typ or "none",
-                    readonly=True,
+                    readonly=readonly,
                     source="",
                     options=tuple(options),
                     classification=classification,
@@ -411,7 +434,7 @@ def _analyze_mounts(
         # Host bind mount detection
         if typ == "bind" or (not typ and src and (src.startswith("/") or src.startswith("./"))):
             forbidden_match = _is_forbidden_path(src)
-            socket_match = _is_forbidden_socket(dst)
+            socket_match = _is_forbidden_socket(src)
             guard_match = _is_guard_state_path(dst)
 
             if forbidden_match:
@@ -500,9 +523,9 @@ def _analyze_lsm(spec: dict[str, object]) -> tuple[bool, str]:
 
 def _analyze_cgroup(spec: dict[str, object]) -> tuple[bool, str]:
     """Analyze cgroup configuration. Returns (v2, path)."""
-    cgroups_path = spec.get("cgroupsPath", "")
-    v2 = "unified" in str(cgroups_path)
-    path = str(cgroups_path) if isinstance(cgroups_path, str) else ""
+    cgroups_path = spec.get("cgroupsPath")
+    path = cgroups_path if isinstance(cgroups_path, str) else ""
+    v2 = path.startswith("/sys/fs/cgroup/unified")
     return v2, path
 
 
@@ -715,6 +738,9 @@ def _build_digest_fields(
     non_root: bool,
     violations_count: int,
     forbidden_capabilities_count: int,
+    mounts: tuple[OCIPlanMount, ...] = (),
+    capabilities: tuple[str, ...] = (),
+    rootfs_path: str = "",
 ) -> dict[str, object]:
     """Build deterministic field mapping for plan digest."""
     return {
@@ -736,6 +762,19 @@ def _build_digest_fields(
         "non_root": non_root,
         "violations_count": violations_count,
         "forbidden_capabilities_count": forbidden_capabilities_count,
+        "mounts": tuple(
+            (
+                mount.container_path,
+                mount.mount_type,
+                mount.readonly,
+                mount.source,
+                mount.options,
+                mount.classification,
+            )
+            for mount in mounts
+        ),
+        "capabilities": capabilities,
+        "rootfs_path": rootfs_path,
     }
 
 
@@ -852,12 +891,20 @@ class OCIPlanGenerator:
         if seccomp_profile == "none":
             all_violations_codes.append("seccomp-none")
 
+        if not seccomp_enforced:
+            all_violations_codes.append("seccomp-not-enforced")
+        all_violations_codes.extend(
+            f"unsupported-linux-field:{key}" for key in sorted(set(linux) - _KNOWN_LINUX_FIELDS)
+        )
         # --- Compute guaranteed boundary ---
         violations_present = len(all_violations_codes) > 0
 
-        boundary_lowered = violations_present or (
-            minimum_boundary is not GuardExecutionAssuranceBoundary.OBSERVED_HOST
-            and (not namespace.pid_isolated or not namespace.net_isolated or not rootfs_readonly or violations_present)
+        boundary_lowered = (
+            violations_present
+            or not namespace.pid_isolated
+            or not namespace.net_isolated
+            or not rootfs_readonly
+            or not seccomp_enforced
         )
 
         available_boundary = (
@@ -871,7 +918,11 @@ class OCIPlanGenerator:
             raise ProviderPlanError("OCI bundle isolation cannot provide hardware isolation")
 
         if minimum_boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED and (
-            not namespace.pid_isolated or not namespace.net_isolated or not rootfs_readonly or violations_present
+            not namespace.pid_isolated
+            or not namespace.net_isolated
+            or not rootfs_readonly
+            or not seccomp_enforced
+            or violations_present
         ):
             raise ProviderPlanError(f"required boundary {minimum_boundary.value} not achievable")
 
@@ -912,6 +963,9 @@ class OCIPlanGenerator:
             non_root=non_root,
             violations_count=len(all_violations_codes),
             forbidden_capabilities_count=len(dangerous_caps),
+            mounts=tuple(plan_mounts),
+            capabilities=tuple(all_caps),
+            rootfs_path=rootfs_path,
         )
         plan_digest = _plan_digest(digest_fields)
 

--- a/tests/test_guard_oci_isolation_provider.py
+++ b/tests/test_guard_oci_isolation_provider.py
@@ -1,0 +1,601 @@
+"""Tests for OCI isolation provider.
+
+Validates:
+- Unknown/unsupported features lower assurance (deny-by-default)
+- Hostile path/mount/capability inputs are refused
+- Deterministic plan digest (same spec -> same digest)
+- No execution of workspace code
+- Fail-closed on malformed spec
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.execution_assurance_contract import (
+    AtomicGuarantee,
+    AtomicGuaranteeKind,
+    DecisionContext,
+    ExecutionOutcome,
+    GuardExecutionAssuranceBoundary,
+    GuardExecutionAttestationTrust,
+    ProviderHealthState,
+)
+from codex_plugin_scanner.guard.runtime.isolation_provider import (
+    ProviderPlanError,
+)
+from codex_plugin_scanner.guard.runtime.oci_isolation_provider import (
+    OCIIsolationProvider,
+    OCISeccompProfile,
+    _compute_bundle_digest,
+    _map_guarantees,
+    _validate_bundle,
+    build_oci_evidence,
+)
+
+
+@pytest.fixture
+def provider():
+    return OCIIsolationProvider()
+
+
+@pytest.fixture
+def decision_context():
+    mock = MagicMock(spec=DecisionContext)
+    mock.context_digest = "abc123def456"
+    mock.executable_digest = "00" * 32
+    mock.source_label = "test"
+    return mock
+
+
+@pytest.fixture
+def minimal_bundle():
+    return {
+        "ociVersion": "1.0.2",
+        "root": {"path": "rootfs", "readonly": True},
+        "process": {"user": {"uid": 1000, "gid": 1000}, "cwd": "/"},
+        "linux": {
+            "namespaces": [
+                {"type": "pid"},
+                {"type": "net"},
+                {"type": "ipc"},
+                {"type": "uts"},
+                {"type": "user"},
+            ],
+            "seccomp": {"defaultAction": "SCMP_ACT_ERRNO"},
+            "cgroupsPath": "/sys/fs/cgroup/unified/guard/test",
+        },
+        "mounts": [
+            {"destination": "/", "type": "none", "options": ["readonly"]},
+        ],
+    }
+
+
+# === Provider identity and capabilities ===
+
+
+class TestProviderIdentity:
+    def test_identity_kind(self, provider):
+        assert provider.identity().provider_kind == "oci-isolation"
+
+    def test_identity_trust_domain(self, provider):
+        assert provider.identity().trust_domain == "guard.oci"
+
+    def test_identity_version(self):
+        p = OCIIsolationProvider(version="1.2.3")
+        assert p.identity().implementation_version == "1.2.3"
+
+
+class TestProviderCapabilities:
+    def test_all_guarantees(self, provider):
+        caps = provider.capabilities()
+        assert len(caps) == 11
+        for c in caps:
+            assert isinstance(c, AtomicGuarantee)
+
+    def test_enforced_count(self, provider):
+        assert len([c for c in provider.capabilities() if c.enforced]) == 9
+
+    def test_absent_kinds(self, provider):
+        absent = [c for c in provider.capabilities() if not c.enforced]
+        kinds = {c.kind for c in absent}
+        assert kinds == {AtomicGuaranteeKind.KERNEL_HARDWARE, AtomicGuaranteeKind.TENANT}
+
+    def test_enforced_boundary(self, provider):
+        for c in provider.capabilities():
+            if c.enforced:
+                assert c.boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED
+
+
+# === Health check ===
+
+
+class TestProviderHealth:
+    def test_healthy(self, provider):
+        health = provider.health_check()
+        assert health.state is ProviderHealthState.HEALTHY
+        assert len(health.guarantees) == 11
+
+    def test_guarantees_match_capabilities(self, provider):
+        assert set(provider.health_check().guarantees) == set(provider.capabilities())
+
+
+# === Evidence building ===
+
+
+class TestEvidenceBuilding:
+    def test_minimal_bundle(self, minimal_bundle):
+        ev = build_oci_evidence(minimal_bundle)
+        assert ev.bundle_valid is True
+        assert ev.bundle_version == "1.0.2"
+        assert ev.namespaces.pid_isolated is True
+        assert ev.namespaces.net_isolated is True
+        assert ev.rootfs.readonly is True
+        assert ev.user.non_root is True
+        assert ev.capabilities.dangerous_capabilities == ()
+
+    def test_forbidden_mount_evidence(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "mounts": [
+                    {"destination": "/", "type": "none"},
+                    {"destination": "/etc", "type": "bind", "source": "/etc"},
+                ],
+            }
+        )
+        assert ev.mounts.forbidden_bind_sources == ("/etc",)
+
+    def test_dangerous_caps_evidence(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "linux": {"capabilities": {"effective": ["CAP_SYS_ADMIN"]}},
+            }
+        )
+        assert ev.capabilities.dangerous_capabilities == ("CAP_SYS_ADMIN",)
+
+    def test_seccomp_strict(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "linux": {"seccomp": {"defaultAction": "SCMP_ACT_ERRNO"}},
+            }
+        )
+        assert ev.seccomp.profile_kind is OCISeccompProfile.STRICT
+
+    def test_seccomp_default_action_allow(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "linux": {"seccomp": {"defaultAction": "SCMP_ACT_ALLOW"}},
+            }
+        )
+        assert ev.seccomp.profile_kind is OCISeccompProfile.DEFAULT
+
+    def test_seccomp_unset_when_absent(self):
+        ev = build_oci_evidence({"ociVersion": "1.0.2", "root": {"path": "rootfs"}})
+        assert ev.seccomp.profile_kind is OCISeccompProfile.UNSET
+
+    def test_seccomp_none_when_empty_action(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "linux": {"seccomp": {"defaultAction": ""}},
+            }
+        )
+        assert ev.seccomp.profile_kind is OCISeccompProfile.NONE
+
+    def test_host_namespace(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "linux": {"namespaces": [{"type": "pid", "host": True}]},
+            }
+        )
+        assert ev.namespaces.pid_isolated is False
+
+    def test_host_network(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "linux": {"network": {"mode": "host"}},
+            }
+        )
+        assert ev.network.mode == "host"
+
+    def test_world_writable_bind(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "mounts": [
+                    {"destination": "/var/data", "type": "bind", "source": "/var/data", "options": ["world-writable"]},
+                ],
+            }
+        )
+        assert ev.mounts.world_writable_binds == ("/var/data",)
+
+    def test_non_root_user(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "process": {"user": {"uid": 1000, "gid": 1000}},
+            }
+        )
+        assert ev.user.non_root is True
+        assert ev.user.uid == 1000
+
+    def test_root_user(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "process": {"user": {"uid": 0, "gid": 0}},
+            }
+        )
+        assert ev.user.non_root is False
+        assert ev.user.uid == 0
+
+    def test_cgroup_v2(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "linux": {"cgroupsPath": "/sys/fs/cgroup/unified/guard/test"},
+            }
+        )
+        assert ev.cgroup.v2 is True
+
+    def test_no_cgroup(self):
+        ev = build_oci_evidence({"ociVersion": "1.0.2", "root": {"path": "rootfs"}})
+        assert ev.cgroup.v2 is False
+        assert ev.cgroup.controller_bound is False
+
+    def test_lsm_apparmor(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "linux": {"apparmor": "guard-profile"},
+            }
+        )
+        assert ev.lsm.enabled is True
+        assert ev.lsm.profile_name == "guard-profile"
+
+
+# === Validation ===
+
+
+class TestBundleValidation:
+    def test_valid_bundle(self, minimal_bundle):
+        assert _validate_bundle(build_oci_evidence(minimal_bundle)) == ()
+
+    def test_root_user_violation(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "process": {"user": {"uid": 0, "gid": 0}},
+            }
+        )
+        violations = _validate_bundle(ev)
+        assert "running as root (uid=0)" in violations
+
+    def test_host_mount_violation(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "mounts": [
+                    {"destination": "/", "type": "none"},
+                    {"destination": "/etc", "type": "bind", "source": "/etc"},
+                ],
+            }
+        )
+        violations = _validate_bundle(ev)
+        assert "/etc" in violations
+
+    def test_host_network_violation(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "linux": {"network": {"mode": "host"}},
+            }
+        )
+        violations = _validate_bundle(ev)
+        assert "host network mode" in violations
+
+    def test_host_namespace_violation(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "linux": {"namespaces": [{"type": "pid", "host": True}]},
+            }
+        )
+        violations = _validate_bundle(ev)
+        assert "pid namespace not isolated" in violations
+
+
+# === Guarantee mapping ===
+
+
+class TestGuaranteeMapping:
+    def test_all_enforced_when_valid(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs", "readonly": True},
+                "process": {"user": {"uid": 1000, "gid": 1000}},
+                "linux": {
+                    "namespaces": [
+                        {"type": "pid"},
+                        {"type": "net"},
+                        {"type": "ipc"},
+                        {"type": "uts"},
+                        {"type": "user"},
+                    ],
+                },
+                "mounts": [{"destination": "/", "type": "none", "options": ["readonly"]}],
+            }
+        )
+        guarantees = _map_guarantees(ev, ())
+        for g in guarantees[:9]:
+            assert g.enforced is True
+            assert g.boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED
+
+    def test_dangerous_caps_lower_all(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "linux": {"capabilities": {"effective": ["CAP_SYS_ADMIN"]}},
+            }
+        )
+        guarantees = _map_guarantees(ev, ("dangerous capabilities",))
+        for g in guarantees:
+            assert g.enforced is False
+            assert g.boundary is GuardExecutionAssuranceBoundary.OBSERVED_HOST
+
+    def test_absent_guarantees_denied(self):
+        ev = build_oci_evidence({"ociVersion": "1.0.2", "root": {"path": "rootfs"}})
+        guarantees = _map_guarantees(ev, ())
+        absent_kinds = {AtomicGuaranteeKind.KERNEL_HARDWARE, AtomicGuaranteeKind.TENANT}
+        for g in guarantees:
+            if g.kind in absent_kinds:
+                assert g.enforced is False
+                assert g.boundary is GuardExecutionAssuranceBoundary.OBSERVED_HOST
+
+
+# === Plan: refusal ===
+
+
+class TestPlanRefusal:
+    def test_refuse_dangerous_capabilities(self, provider, decision_context):
+        with pytest.raises(ProviderPlanError, match="dangerous capabilities"):
+            provider.plan(
+                decision_context,
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                bundle_spec={"ociVersion": "1.0.2"},
+                linux_spec={"capabilities": {"effective": ["CAP_SYS_ADMIN"]}},
+            )
+
+    def test_refuse_forbidden_host_mounts(self, provider, decision_context):
+        with pytest.raises(ProviderPlanError, match="forbidden"):
+            provider.plan(
+                decision_context,
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                bundle_spec={
+                    "ociVersion": "1.0.2",
+                    "mounts": [
+                        {"destination": "/", "type": "none"},
+                        {"destination": "/etc", "type": "bind", "source": "/etc"},
+                    ],
+                },
+            )
+
+    def test_refuse_host_network(self, provider, decision_context):
+        with pytest.raises(ProviderPlanError, match="host network"):
+            provider.plan(
+                decision_context,
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                bundle_spec={"ociVersion": "1.0.2"},
+                linux_spec={"network": {"mode": "host"}},
+            )
+
+    def test_refuse_hardware_boundary(self, provider, decision_context):
+        with pytest.raises(ProviderPlanError, match="hardware-isolated"):
+            provider.plan(
+                decision_context,
+                GuardExecutionAssuranceBoundary.HARDWARE_ISOLATED,
+            )
+
+    def test_refuse_malformed_spec(self, provider, decision_context):
+        with pytest.raises(ProviderPlanError, match="malformed"):
+            provider.plan(
+                decision_context,
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                bundle_spec={},
+            )
+
+    def test_refuse_wrong_context_type(self, provider):
+        with pytest.raises(ProviderPlanError, match="context must be"):
+            provider.plan(
+                "not-a-context",
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            )
+
+
+# === Plan: success ===
+
+
+class TestPlanSuccess:
+    def test_minimal_plan(self, provider, decision_context, minimal_bundle):
+        lease = provider.plan(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle_spec=minimal_bundle,
+        )
+        assert lease is not None
+        assert len(lease.plan_digest) == 64
+
+    def test_os_isolated_plan(self, provider, decision_context, minimal_bundle):
+        lease = provider.plan(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OS_ISOLATED,
+            bundle_spec=minimal_bundle,
+        )
+        assert lease is not None
+
+    def test_deterministic_digest(self, provider, decision_context, minimal_bundle):
+        l1 = provider.plan(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle_spec=minimal_bundle,
+        )
+        l2 = provider.plan(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle_spec=minimal_bundle,
+        )
+        assert l1.plan_digest == l2.plan_digest
+
+    def test_different_context_different_digest(self, provider, decision_context, minimal_bundle):
+        ctx2 = MagicMock(spec=DecisionContext)
+        ctx2.context_digest = "xyz789"
+        ctx2.executable_digest = "00" * 32
+        ctx2.source_label = "test"
+        l1 = provider.plan(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle_spec=minimal_bundle,
+        )
+        l2 = provider.plan(
+            ctx2,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle_spec=minimal_bundle,
+        )
+        assert l1.plan_digest != l2.plan_digest
+
+
+# === Execute ===
+
+
+class TestExecute:
+    def test_returns_terminal_statement(self, provider, decision_context, minimal_bundle):
+        lease = provider.plan(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle_spec=minimal_bundle,
+        )
+        result = provider.execute(lease)
+        assert result.outcome is ExecutionOutcome.SUCCEEDED
+        assert result.exit_code == 0
+        assert result.execution_instance is not None
+        assert result.attestation_trust is GuardExecutionAttestationTrust.SELF_ATTESTED
+
+
+# === Cancel and cleanup ===
+
+
+class TestCancelCleanup:
+    def test_cancel_noop(self, provider):
+        provider.cancel("some-instance")
+
+    def test_cleanup_noop(self, provider):
+        provider.cleanup("some-instance")
+
+
+# === Digest computation ===
+
+
+class TestDigestComputation:
+    def test_deterministic(self):
+        d1 = _compute_bundle_digest({"ociVersion": "1.0.2", "root": {"path": "rootfs"}})
+        d2 = _compute_bundle_digest({"ociVersion": "1.0.2", "root": {"path": "rootfs"}})
+        assert d1 == d2
+
+    def test_differs_on_change(self):
+        d1 = _compute_bundle_digest({"ociVersion": "1.0.2", "root": {"path": "a"}})
+        d2 = _compute_bundle_digest({"ociVersion": "1.0.2", "root": {"path": "b"}})
+        assert d1 != d2
+
+    def test_ignores_unrecognized_keys(self):
+        d1 = _compute_bundle_digest({"ociVersion": "1.0.2", "root": {"path": "rootfs"}, "x": 1})
+        d2 = _compute_bundle_digest({"ociVersion": "1.0.2", "root": {"path": "rootfs"}})
+        assert d1 == d2
+
+
+# === Unknown features lower assurance ===
+
+
+class TestUnknownFeaturesLowerAssurance:
+    def test_unknown_capability_not_mapped(self, provider, decision_context):
+        lease = provider.plan(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle_spec={"ociVersion": "1.0.2", "linux": {"capabilities": {"effective": ["CAP_UNKNOWN"]}}},
+        )
+        assert lease is not None
+
+    def test_unsupported_feature_not_enforced(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "linux": {"someUnsupportedFeature": "x"},
+            }
+        )
+        guarantees = _map_guarantees(ev, ())
+        for g in guarantees:
+            if g.enforced:
+                assert g.boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED
+
+    def test_no_namespace_isolation(self):
+        ev = build_oci_evidence({"ociVersion": "1.0.2", "root": {"path": "rootfs"}})
+        assert ev.namespaces.pid_isolated is False
+        assert ev.namespaces.net_isolated is False
+
+    def test_missing_linux_no_isolation(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "process": {"user": {"uid": 1000}},
+            }
+        )
+        violations = _validate_bundle(ev)
+        assert len(violations) > 0
+
+    def test_missing_seccomp(self):
+        ev = build_oci_evidence({"ociVersion": "1.0.2", "root": {"path": "rootfs"}})
+        assert ev.seccomp.profile_kind is OCISeccompProfile.UNSET
+
+    def test_missing_cgroup(self):
+        ev = build_oci_evidence({"ociVersion": "1.0.2", "root": {"path": "rootfs"}})
+        assert ev.cgroup.controller_bound is False
+
+    def test_lsm_does_not_boost(self):
+        ev = build_oci_evidence(
+            {
+                "ociVersion": "1.0.2",
+                "root": {"path": "rootfs"},
+                "linux": {"apparmor": "guard-default"},
+            }
+        )
+        assert ev.lsm.enabled is True
+        assert ev.lsm.profile_name == "guard-default"
+        guarantees = _map_guarantees(ev, ())
+        assert len(guarantees) == 11

--- a/tests/test_guard_oci_plan_generator.py
+++ b/tests/test_guard_oci_plan_generator.py
@@ -258,6 +258,19 @@ class TestMountAnalysis:
         )
         assert any("world-writable-mount" in v for v in violations)
 
+    def test_hardening_options_are_not_world_writable(self):
+        _mounts, violations, _, _ = _analyze_mounts(
+            [
+                {
+                    "destination": "/data",
+                    "type": "bind",
+                    "source": "/data",
+                    "options": ["ro", "noexec", "nosuid", "nodev"],
+                },
+            ]
+        )
+        assert not any("world-writable-mount" in violation for violation in violations)
+
     def test_guard_state_mount(self):
         _mounts, violations, _, has_hostile = _analyze_mounts(
             [
@@ -477,8 +490,18 @@ class TestRootfsAnalysis:
         assert path == ""
         assert readonly is False
 
+    # === Guarantee mapping ===
 
-# === Guarantee mapping ===
+    def test_namespace_path_is_shared_not_isolated(self):
+        namespace = _parse_namespaces(
+            [
+                {"type": "pid", "path": "/proc/1/ns/pid"},
+                {"type": "net", "path": "/proc/1/ns/net"},
+            ]
+        )
+        assert namespace.pid_isolated is False
+        assert namespace.net_isolated is False
+        assert set(namespace.host_namespaces) == {"pid", "net"}
 
 
 class TestGuaranteeMapping:
@@ -702,6 +725,45 @@ class TestPlanDigest:
         )
         assert _plan_digest(fields1) != _plan_digest(fields2)
 
+    def test_digest_includes_mount_and_capability_detail(self):
+        ns = _parse_namespaces([{"type": "pid"}])
+        net = MagicMock()
+        net.mode = "default"
+        common = {
+            "bundle_version": "1.0.2",
+            "minimum_boundary": GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            "available_boundary": GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            "namespace": ns,
+            "network": net,
+            "seccomp_profile": "strict",
+            "seccomp_enforced": True,
+            "lsm_enabled": False,
+            "cgroup_v2": False,
+            "rootfs_readonly": True,
+            "non_root": True,
+            "violations_count": 0,
+            "forbidden_capabilities_count": 0,
+        }
+        mount_a, _, _, _ = _analyze_mounts([{"destination": "/a", "type": "tmpfs"}])
+        mount_b, _, _, _ = _analyze_mounts([{"destination": "/b", "type": "tmpfs"}])
+        digest_a = _plan_digest(
+            _build_digest_fields(
+                **common,
+                mounts=tuple(mount_a),
+                capabilities=("CAP_CHOWN",),
+                rootfs_path="rootfs-a",
+            )
+        )
+        digest_b = _plan_digest(
+            _build_digest_fields(
+                **common,
+                mounts=tuple(mount_b),
+                capabilities=("CAP_NET_BIND_SERVICE",),
+                rootfs_path="rootfs-b",
+            )
+        )
+        assert digest_a != digest_b
+
 
 # === Full plan generation ===
 
@@ -900,8 +962,8 @@ class TestUnknownFeaturesLowerAssurance:
             GuardExecutionAssuranceBoundary.OBSERVED_HOST,
             bundle=bundle,
         )
-        # No namespaces -> some guarantees still enforced via default path
-        assert plan.available_boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED
+        # Missing namespace evidence fails closed.
+        assert plan.available_boundary is GuardExecutionAssuranceBoundary.OBSERVED_HOST
 
     def test_unmapped_linux_feature(self, decision_context):
         bundle = {
@@ -918,8 +980,8 @@ class TestUnknownFeaturesLowerAssurance:
             GuardExecutionAssuranceBoundary.OBSERVED_HOST,
             bundle=bundle,
         )
-        # No net namespace -> boundary still achievable
-        assert plan.available_boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED
+        # Unknown fields and missing net isolation lower assurance.
+        assert plan.available_boundary is GuardExecutionAssuranceBoundary.OBSERVED_HOST
 
     def test_missing_seccomp_lowers(self, decision_context):
         bundle = {
@@ -936,8 +998,7 @@ class TestUnknownFeaturesLowerAssurance:
             bundle=bundle,
         )
         # Missing policy is distinct from an explicit allow-all policy.
-        assert plan.seccomp_profile == "unset"
-        assert plan.available_boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED
+        assert plan.available_boundary is GuardExecutionAssuranceBoundary.OBSERVED_HOST
 
     def test_no_lsm_does_not_boost(self, decision_context):
         bundle = {
@@ -996,7 +1057,7 @@ class TestFailClosed:
             GuardExecutionAssuranceBoundary.OBSERVED_HOST,
             bundle=bundle,
         )
-        assert plan.available_boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED
+        assert plan.available_boundary is GuardExecutionAssuranceBoundary.OBSERVED_HOST
 
     def test_os_isolated_boundary_unachievable(self, decision_context):
         bundle = {

--- a/tests/test_guard_oci_plan_generator.py
+++ b/tests/test_guard_oci_plan_generator.py
@@ -1,0 +1,1061 @@
+"""Tests for OCI plan generator.
+
+Validates:
+- Deterministic plan digest (same spec -> same digest)
+- Unknown/unsupported features lower assurance
+- Hostile path/mount/capability inputs are refused
+- No execution of workspace code
+- Fail-closed on malformed spec
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.execution_assurance_contract import (
+    AtomicGuaranteeKind,
+    DecisionContext,
+    GuardExecutionAssuranceBoundary,
+)
+from codex_plugin_scanner.guard.runtime.isolation_provider import ProviderPlanError
+from codex_plugin_scanner.guard.runtime.oci_plan_generator import (
+    OCIExecutionPlan,
+    OCIPlanGenerator,
+    _analyze_capabilities,
+    _analyze_cgroup,
+    _analyze_lsm,
+    _analyze_mounts,
+    _analyze_network,
+    _analyze_rootfs,
+    _analyze_seccomp,
+    _analyze_user,
+    _build_digest_fields,
+    _extract_all_capabilities,
+    _is_dangerous_cap,
+    _is_forbidden_path,
+    _is_forbidden_socket,
+    _is_guard_state_path,
+    _map_guarantees,
+    _parse_namespaces,
+    _plan_digest,
+)
+
+
+@pytest.fixture
+def decision_context():
+    mock = MagicMock(spec=DecisionContext)
+    mock.context_digest = "abc123def456"
+    mock.executable_digest = "00" * 32
+    mock.source_label = "test"
+    return mock
+
+
+@pytest.fixture
+def good_bundle():
+    return {
+        "ociVersion": "1.0.2",
+        "root": {"path": "rootfs", "readonly": True},
+        "process": {"user": {"uid": 1000, "gid": 1000}, "cwd": "/"},
+        "linux": {
+            "namespaces": [
+                {"type": "pid"},
+                {"type": "net"},
+                {"type": "ipc"},
+                {"type": "uts"},
+                {"type": "user"},
+            ],
+            "seccomp": {"defaultAction": "SCMP_ACT_ERRNO"},
+            "cgroupsPath": "/sys/fs/cgroup/unified/guard/test",
+        },
+        "mounts": [
+            {"destination": "/", "type": "none", "options": ["readonly"]},
+        ],
+    }
+
+
+@pytest.fixture
+def minimal_bundle():
+    return {
+        "ociVersion": "1.0.2",
+        "root": {"path": "rootfs"},
+    }
+
+
+# === Path validation ===
+
+
+class TestPathValidation:
+    def test_forbidden_path_root(self):
+        assert _is_forbidden_path("/") == "/"
+
+    def test_forbidden_path_etc(self):
+        # Prefix match: /etc/shadow -> /etc
+        assert _is_forbidden_path("/etc") == "/etc"
+        assert _is_forbidden_path("/etc/shadow") == "/etc"
+
+    def test_forbidden_path_proc(self):
+        assert _is_forbidden_path("/proc") == "/proc"
+
+    def test_non_forbidden_path(self):
+        assert _is_forbidden_path("/var/data") is None
+
+    def test_empty_path_not_forbidden(self):
+        assert _is_forbidden_path("") is None
+
+    def test_forbidden_socket_docker(self):
+        assert _is_forbidden_socket("/var/run/docker.sock") == "/var/run/docker.sock"
+
+    def test_forbidden_socket_containerd(self):
+        assert _is_forbidden_socket("/var/run/containerd/containerd.sock") == "/var/run/containerd/containerd.sock"
+
+    def test_non_forbidden_socket(self):
+        assert _is_forbidden_socket("/tmp/my.sock") is None
+
+    def test_guard_state_hol_guard(self):
+        assert _is_guard_state_path("/mnt/.hol-guard/state") is True
+
+    def test_guard_state_guard_state_dir(self):
+        assert _is_guard_state_path("/run/guard-state/config") is True
+
+    def test_non_guard_state_path(self):
+        assert _is_guard_state_path("/var/data/output") is False
+
+
+# === Capability validation ===
+
+
+class TestCapabilityValidation:
+    def test_dangerous_cap_sys_admin(self):
+        assert _is_dangerous_cap("CAP_SYS_ADMIN") is True
+
+    def test_dangerous_cap_sys_ptrace(self):
+        assert _is_dangerous_cap("SYS_PTRACE") is True
+
+    def test_dangerous_cap_net_admin(self):
+        assert _is_dangerous_cap("CAP_NET_ADMIN") is True
+
+    def test_normal_cap(self):
+        assert _is_dangerous_cap("CAP_NET_BIND_SERVICE") is False
+
+    def test_dangerous_cap_case_insensitive(self):
+        assert _is_dangerous_cap("sys_admin") is True
+        assert _is_dangerous_cap("SYS_ADMIN") is True
+
+    def test_extract_capabilities(self):
+        caps = {
+            "effective": ["CAP_NET_BIND_SERVICE", "CAP_SYS_ADMIN"],
+            "permitted": ["CAP_NET_BIND_SERVICE"],
+            "bounding": ["CAP_SYS_ADMIN", "CAP_NET_ADMIN"],
+        }
+        all_caps, dangerous = _extract_all_capabilities(caps)
+        assert set(all_caps) == {"CAP_NET_BIND_SERVICE", "CAP_SYS_ADMIN", "CAP_NET_ADMIN"}
+        assert "CAP_SYS_ADMIN" in dangerous
+        assert "CAP_NET_ADMIN" in dangerous
+        assert "CAP_NET_BIND_SERVICE" not in dangerous
+
+    def test_extract_no_capabilities(self):
+        all_caps, dangerous = _extract_all_capabilities({})
+        assert all_caps == []
+        assert dangerous == []
+
+    def test_extract_all_capabilities_none(self):
+        all_caps, dangerous, has_dangerous = _analyze_capabilities(None)
+        assert all_caps == []
+        assert dangerous == []
+        assert has_dangerous is False
+
+    def test_extract_capabilities_dangerous(self):
+        _all_caps, dangerous, has_dangerous = _analyze_capabilities(
+            {
+                "effective": ["CAP_SYS_ADMIN"],
+            }
+        )
+        assert has_dangerous is True
+        assert "CAP_SYS_ADMIN" in dangerous
+
+
+# === Namespace parsing ===
+
+
+class TestNamespaceParsing:
+    def test_pid_isolated(self):
+        ns = _parse_namespaces([{"type": "pid"}])
+        assert ns.pid_isolated is True
+
+    def test_pid_host(self):
+        ns = _parse_namespaces([{"type": "pid", "host": True}])
+        assert ns.pid_isolated is False
+
+    def test_all_host_namespaces(self):
+        ns = _parse_namespaces(
+            [
+                {"type": "pid", "host": True},
+                {"type": "net", "host": True},
+            ]
+        )
+        assert ns.pid_isolated is False
+        assert ns.net_isolated is False
+
+    def test_isolated_pids(self):
+        ns = _parse_namespaces([{"type": "pid"}, {"type": "net"}])
+        assert ns.pid_isolated is True
+        assert ns.net_isolated is True
+
+    def test_mixed_host_and_isolated(self):
+        ns = _parse_namespaces(
+            [
+                {"type": "pid", "host": True},
+                {"type": "net"},
+            ]
+        )
+        # Host namespace -> all isolation denied
+        assert ns.pid_isolated is False
+        assert ns.net_isolated is False
+
+
+# === Mount analysis ===
+
+
+class TestMountAnalysis:
+    def test_host_bind_mount(self):
+        mounts, _violations, has_forbidden, has_hostile = _analyze_mounts(
+            [
+                {"destination": "/data", "type": "bind", "source": "/data"},
+            ]
+        )
+        assert len(mounts) == 1
+        assert mounts[0].classification == "host"
+        assert not has_forbidden
+        assert not has_hostile
+
+    def test_forbidden_bind_source(self):
+        _mounts, violations, has_forbidden, has_hostile = _analyze_mounts(
+            [
+                {"destination": "/etc", "type": "bind", "source": "/etc"},
+            ]
+        )
+        assert has_forbidden is True
+        assert has_hostile is True
+        assert any("forbidden-mount-source" in v for v in violations)
+
+    def test_forbidden_socket(self):
+        _mounts, violations, _, has_hostile = _analyze_mounts(
+            [
+                {"destination": "/var/run/docker.sock", "type": "bind", "source": "/var/run/docker.sock"},
+            ]
+        )
+        assert has_hostile is True
+        # source=/var/run/docker.sock matches forbidden source /var/run
+        assert any("forbidden-mount-source" in v for v in violations)
+
+    def test_world_writable_mount(self):
+        _mounts, violations, _, _ = _analyze_mounts(
+            [
+                {"destination": "/data", "type": "bind", "source": "/data", "options": ["world-writable"]},
+            ]
+        )
+        assert any("world-writable-mount" in v for v in violations)
+
+    def test_guard_state_mount(self):
+        _mounts, violations, _, has_hostile = _analyze_mounts(
+            [
+                {"destination": "/mnt/.hol-guard", "type": "bind", "source": "/mnt/.hol-guard"},
+            ]
+        )
+        assert has_hostile is True
+        assert any(v == "guard-state-mount" for v in violations)
+
+    def test_tmpfs_volume(self):
+        mounts, _violations, has_forbidden, _ = _analyze_mounts(
+            [
+                {"destination": "/tmp", "type": "tmpfs"},
+            ]
+        )
+        assert len(mounts) == 1
+        assert mounts[0].classification == "system"
+        assert not has_forbidden
+
+    def test_rootfs_mount(self):
+        mounts, _violations, _, _ = _analyze_mounts(
+            [
+                {"destination": "/", "type": "none", "options": ["readonly"]},
+            ]
+        )
+        assert len(mounts) == 1
+        assert mounts[0].readonly is True
+        assert mounts[0].classification == "system"
+
+    def test_socket_mount_classification(self):
+        # Docker.sock bind mount: source="/var/run/docker.sock" matches
+        # forbidden source "/var/run" first, classification is "forbidden"
+        mounts, _, _, _ = _analyze_mounts(
+            [
+                {"destination": "/var/run/docker.sock", "type": "bind", "source": "/var/run/docker.sock"},
+            ]
+        )
+        assert len(mounts) == 1
+        assert mounts[0].classification == "forbidden"
+
+    def test_secret_mount_forbidden(self):
+        # /var/run/secrets starts with /var/run (in FORBIDDEN_MOUNT_SOURCES)
+        # so it is classified as "forbidden" not "secret"
+        mounts, _, _, _ = _analyze_mounts(
+            [
+                {"destination": "/var/run/secrets", "type": "bind", "source": "/var/run/secrets"},
+            ]
+        )
+        assert len(mounts) == 1
+        assert mounts[0].classification == "forbidden"
+
+    def test_output_mount_guard_state(self):
+        # Guard-state paths are forbidden regardless of their outer mount root.
+        mounts, _, _, _ = _analyze_mounts(
+            [
+                {"destination": "/mnt/.hol-guard/output", "type": "bind", "source": "/mnt/.hol-guard/output"},
+            ]
+        )
+        assert len(mounts) == 1
+        assert mounts[0].classification == "forbidden"
+
+    def test_system_mount(self):
+        # non-bind mount type -> unclassified
+        mounts, _, _, _ = _analyze_mounts(
+            [
+                {"destination": "/proc/sys", "type": "proc"},
+            ]
+        )
+        assert len(mounts) == 1
+        assert mounts[0].classification == "unclassified"
+
+
+# === Seccomp analysis ===
+
+
+class TestSeccompAnalysis:
+    def test_strict_seccomp(self):
+        kind, enforced = _analyze_seccomp({"seccomp": {"defaultAction": "SCMP_ACT_ERRNO"}})
+        assert kind == "strict"
+        assert enforced is True
+
+    def test_default_seccomp(self):
+        # SCMP_ACT_ALLOW -> "none" (no restrictions)
+        kind, enforced = _analyze_seccomp({"seccomp": {"defaultAction": "SCMP_ACT_ALLOW"}})
+        assert kind == "none"
+        assert enforced is False
+
+    def test_custom_seccomp(self):
+        # "path" with specific defaultAction is custom
+        kind, enforced = _analyze_seccomp({"seccomp": {"path": "/etc/seccomp.json", "defaultAction": "SCMP_ACT_KILL"}})
+        assert kind == "custom"
+        assert enforced is True
+
+    def test_none_seccomp(self):
+        kind, enforced = _analyze_seccomp({"seccomp": {}})
+        assert kind == "none"
+        assert enforced is False
+
+    def test_unset_seccomp(self):
+        # No seccomp key at all -> unset
+        kind, enforced = _analyze_seccomp({})
+        assert kind == "unset"
+        assert enforced is False
+
+    def test_strict_seccomp_flag(self):
+        kind, enforced = _analyze_seccomp({"seccomp": {"strict": True}})
+        assert kind == "strict"
+        assert enforced is True
+
+
+# === LSM analysis ===
+
+
+class TestLSMAnalysis:
+    def test_apparmor_enabled(self):
+        enabled, profile = _analyze_lsm({"apparmor": "guard-profile"})
+        assert enabled is True
+        assert profile == "guard-profile"
+
+    def test_selinux_enabled(self):
+        enabled, profile = _analyze_lsm({"selinux": {"label": "system_u:system_r:container_t"}})
+        assert enabled is True
+        assert profile == "system_u:system_r:container_t"
+
+    def test_no_lsm(self):
+        enabled, profile = _analyze_lsm({})
+        assert enabled is False
+        assert profile == ""
+
+
+# === Cgroup analysis ===
+
+
+class TestCgroupAnalysis:
+    def test_cgroup_v2(self):
+        v2, path = _analyze_cgroup({"cgroupsPath": "/sys/fs/cgroup/unified/guard/test"})
+        assert v2 is True
+        assert path == "/sys/fs/cgroup/unified/guard/test"
+
+    def test_cgroup_v1(self):
+        v2, path = _analyze_cgroup({"cgroupsPath": "/sys/fs/cgroup"})
+        assert v2 is False
+        assert path == "/sys/fs/cgroup"
+
+    def test_no_cgroup(self):
+        v2, path = _analyze_cgroup({})
+        assert v2 is False
+        assert path == ""
+
+
+# === User analysis ===
+
+
+class TestUserAnalysis:
+    def test_non_root_user(self):
+        uid, gid, non_root = _analyze_user({"user": {"uid": 1000, "gid": 1000}})
+        assert uid == 1000
+        assert gid == 1000
+        assert non_root is True
+
+    def test_root_user(self):
+        uid, gid, non_root = _analyze_user({"user": {"uid": 0, "gid": 0}})
+        assert uid == 0
+        assert gid == 0
+        assert non_root is False
+
+    def test_no_user_spec(self):
+        uid, _gid, non_root = _analyze_user({})
+        assert uid == 0
+        assert non_root is False
+
+    def test_invalid_uid_type(self):
+        uid, _gid, _non_root = _analyze_user({"user": {"uid": "not-a-number"}})
+        assert uid == 0
+
+
+# === Network analysis ===
+
+
+class TestNetworkAnalysis:
+    def test_isolated_network(self):
+        ns = _parse_namespaces([{"type": "net"}])
+        network = _analyze_network({}, ns)
+        assert network.mode == "default"
+        assert network.loopback_only is True
+
+    def test_host_network_mode(self):
+        ns = _parse_namespaces([{"type": "net"}])
+        network = _analyze_network({"network": {"mode": "host"}}, ns)
+        assert network.mode == "host"
+        assert network.loopback_only is False
+
+    def test_port_mappings(self):
+        ns = _parse_namespaces([{"type": "net"}])
+        network = _analyze_network(
+            {"network": {"mode": "bridge", "ports": ["8080:80", "443:443"]}},
+            ns,
+        )
+        assert network.port_mappings == ("8080:80", "443:443")
+
+
+# === Rootfs analysis ===
+
+
+class TestRootfsAnalysis:
+    def test_readonly_rootfs(self):
+        path, readonly = _analyze_rootfs({"path": "rootfs", "readonly": True})
+        assert path == "rootfs"
+        assert readonly is True
+
+    def test_writable_rootfs(self):
+        _path, readonly = _analyze_rootfs({"path": "rootfs", "readonly": False})
+        assert readonly is False
+
+    def test_no_rootfs(self):
+        path, readonly = _analyze_rootfs({})
+        assert path == ""
+        assert readonly is False
+
+
+# === Guarantee mapping ===
+
+
+class TestGuaranteeMapping:
+    def test_full_isolation_enforces_all(self):
+        ns = _parse_namespaces(
+            [
+                {"type": "pid"},
+                {"type": "net"},
+                {"type": "ipc"},
+                {"type": "uts"},
+                {"type": "user"},
+            ]
+        )
+        enforced, denied = _map_guarantees(
+            violations_codes=[],
+            namespaces=ns,
+            rootfs_readonly=True,
+            non_root=True,
+            network_loopback=True,
+            hostile_mounts=False,
+        )
+        assert len(enforced) == 9
+        assert len(denied) == 2  # KERNEL_HARDWARE, TENANT
+        for g in enforced:
+            assert g.enforced is True
+
+    def test_violations_lower_all(self):
+        ns = _parse_namespaces(
+            [
+                {"type": "pid"},
+                {"type": "net"},
+                {"type": "ipc"},
+                {"type": "uts"},
+                {"type": "user"},
+            ]
+        )
+        enforced, denied = _map_guarantees(
+            violations_codes=["rootfs-not-readonly"],
+            namespaces=ns,
+            rootfs_readonly=False,
+            non_root=True,
+            network_loopback=True,
+            hostile_mounts=False,
+        )
+        assert len(enforced) == 0
+        assert len(denied) == 11
+
+    def test_hostile_mounts_denied(self):
+        ns = _parse_namespaces(
+            [
+                {"type": "pid"},
+                {"type": "net"},
+                {"type": "ipc"},
+                {"type": "uts"},
+                {"type": "user"},
+            ]
+        )
+        enforced, denied = _map_guarantees(
+            violations_codes=[],
+            namespaces=ns,
+            rootfs_readonly=True,
+            non_root=True,
+            network_loopback=True,
+            hostile_mounts=True,
+        )
+        assert len(enforced) == 0
+        assert len(denied) == 11
+
+    def test_pid_not_isolated_denies_process(self):
+        ns = _parse_namespaces([{"type": "net"}])  # No PID
+        enforced, _denied = _map_guarantees(
+            violations_codes=[],
+            namespaces=ns,
+            rootfs_readonly=True,
+            non_root=True,
+            network_loopback=True,
+            hostile_mounts=False,
+        )
+        assert len(enforced) < 9
+
+    def test_non_root_denies_privilege(self):
+        ns = _parse_namespaces(
+            [
+                {"type": "pid"},
+                {"type": "net"},
+                {"type": "ipc"},
+                {"type": "uts"},
+                {"type": "user"},
+            ]
+        )
+        _enforced, denied = _map_guarantees(
+            violations_codes=[],
+            namespaces=ns,
+            rootfs_readonly=True,
+            non_root=False,  # running as root
+            network_loopback=True,
+            hostile_mounts=False,
+        )
+        priv_denied = any(g.kind == AtomicGuaranteeKind.PRIVILEGE for g in denied)
+        assert priv_denied is True
+
+    def test_kernel_hardware_always_absent(self):
+        ns = _parse_namespaces(
+            [
+                {"type": "pid"},
+                {"type": "net"},
+                {"type": "ipc"},
+                {"type": "uts"},
+                {"type": "user"},
+            ]
+        )
+        _enforced, denied = _map_guarantees(
+            violations_codes=[],
+            namespaces=ns,
+            rootfs_readonly=True,
+            non_root=True,
+            network_loopback=True,
+            hostile_mounts=False,
+        )
+        kernel_hw_denied = any(g.kind == AtomicGuaranteeKind.KERNEL_HARDWARE for g in denied)
+        assert kernel_hw_denied is True
+
+
+# === Plan digest ===
+
+
+class TestPlanDigest:
+    def test_digest_deterministic(self):
+        ns = _parse_namespaces([{"type": "pid"}])
+        net = MagicMock()
+        net.mode = "default"
+        fields = _build_digest_fields(
+            bundle_version="1.0.2",
+            minimum_boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            available_boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            namespace=ns,
+            network=net,
+            seccomp_profile="strict",
+            seccomp_enforced=True,
+            lsm_enabled=False,
+            cgroup_v2=False,
+            rootfs_readonly=True,
+            non_root=True,
+            violations_count=0,
+            forbidden_capabilities_count=0,
+        )
+        d1 = _plan_digest(fields)
+        d2 = _plan_digest(fields)
+        assert d1 == d2
+        assert len(d1) > 0
+
+    def test_digest_differs_on_boundary(self):
+        ns = _parse_namespaces([{"type": "pid"}])
+        net = MagicMock()
+        net.mode = "default"
+        fields1 = _build_digest_fields(
+            bundle_version="1.0.2",
+            minimum_boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            available_boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            namespace=ns,
+            network=net,
+            seccomp_profile="strict",
+            seccomp_enforced=True,
+            lsm_enabled=False,
+            cgroup_v2=False,
+            rootfs_readonly=True,
+            non_root=True,
+            violations_count=0,
+            forbidden_capabilities_count=0,
+        )
+        fields2 = _build_digest_fields(
+            bundle_version="1.0.2",
+            minimum_boundary=GuardExecutionAssuranceBoundary.OS_ISOLATED,
+            available_boundary=GuardExecutionAssuranceBoundary.OS_ISOLATED,
+            namespace=ns,
+            network=net,
+            seccomp_profile="strict",
+            seccomp_enforced=True,
+            lsm_enabled=False,
+            cgroup_v2=False,
+            rootfs_readonly=True,
+            non_root=True,
+            violations_count=0,
+            forbidden_capabilities_count=0,
+        )
+        assert _plan_digest(fields1) != _plan_digest(fields2)
+
+    def test_digest_differs_on_violations(self):
+        ns = _parse_namespaces([{"type": "pid"}])
+        net = MagicMock()
+        net.mode = "default"
+        fields1 = _build_digest_fields(
+            bundle_version="1.0.2",
+            minimum_boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            available_boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            namespace=ns,
+            network=net,
+            seccomp_profile="strict",
+            seccomp_enforced=True,
+            lsm_enabled=False,
+            cgroup_v2=False,
+            rootfs_readonly=True,
+            non_root=True,
+            violations_count=0,
+            forbidden_capabilities_count=0,
+        )
+        fields2 = _build_digest_fields(
+            bundle_version="1.0.2",
+            minimum_boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            available_boundary=GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            namespace=ns,
+            network=net,
+            seccomp_profile="strict",
+            seccomp_enforced=True,
+            lsm_enabled=False,
+            cgroup_v2=False,
+            rootfs_readonly=True,
+            non_root=True,
+            violations_count=1,
+            forbidden_capabilities_count=0,
+        )
+        assert _plan_digest(fields1) != _plan_digest(fields2)
+
+
+# === Full plan generation ===
+
+
+class TestPlanGeneration:
+    def test_successful_plan(self, decision_context, good_bundle):
+        plan = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=good_bundle,
+        )
+        assert isinstance(plan, OCIExecutionPlan)
+        assert plan.bundle_version == "1.0.2"
+        assert plan.available_boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED
+        assert plan.boundary_lowered is False
+        assert len(plan.enforced_guarantees) > 0
+        assert len(plan.denied_guarantees) == 2  # KERNEL_HARDWARE, TENANT
+
+    def test_plan_digest_deterministic(self, decision_context, good_bundle):
+        plan1 = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=good_bundle,
+        )
+        plan2 = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=good_bundle,
+        )
+        assert plan1.plan_digest == plan2.plan_digest
+
+    def test_different_spec_different_digest(self, decision_context, good_bundle):
+        bad_bundle = dict(good_bundle)
+        bad_bundle["ociVersion"] = "1.0.0"
+        plan1 = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=good_bundle,
+        )
+        plan2 = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=bad_bundle,
+        )
+        assert plan1.plan_digest != plan2.plan_digest
+
+    def test_hostile_caps_refused(self, decision_context):
+        bundle = {
+            "ociVersion": "1.0.2",
+            "root": {"path": "rootfs", "readonly": True},
+            "process": {"user": {"uid": 1000, "gid": 1000}},
+            "linux": {
+                "namespaces": [{"type": "pid"}, {"type": "net"}],
+                "capabilities": {"effective": ["CAP_SYS_ADMIN"]},
+            },
+        }
+        with pytest.raises(ProviderPlanError, match="dangerous"):
+            OCIPlanGenerator.generate(
+                decision_context,
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                bundle=bundle,
+            )
+
+    def test_hostile_mounts_refused(self, decision_context):
+        bundle = {
+            "ociVersion": "1.0.2",
+            "root": {"path": "rootfs"},
+            "mounts": [
+                {"destination": "/", "type": "none"},
+                {"destination": "/etc", "type": "bind", "source": "/etc"},
+            ],
+        }
+        with pytest.raises(ProviderPlanError, match="forbidden"):
+            OCIPlanGenerator.generate(
+                decision_context,
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                bundle=bundle,
+            )
+
+    def test_forbidden_socket_refused(self, decision_context):
+        # Docker.sock bind mount has source=/var/run/docker.sock
+        # which matches forbidden source /var/run -> refused on "forbidden"
+        bundle = {
+            "ociVersion": "1.0.2",
+            "root": {"path": "rootfs"},
+            "mounts": [
+                {"destination": "/var/run/docker.sock", "type": "bind", "source": "/var/run/docker.sock"},
+            ],
+        }
+        with pytest.raises(ProviderPlanError, match="forbidden"):
+            OCIPlanGenerator.generate(
+                decision_context,
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                bundle=bundle,
+            )
+
+    def test_guard_state_mount_refused(self, decision_context):
+        bundle = {
+            "ociVersion": "1.0.2",
+            "root": {"path": "rootfs"},
+            "mounts": [
+                {"destination": "/mnt/.hol-guard", "type": "bind", "source": "/mnt/.hol-guard"},
+            ],
+        }
+        with pytest.raises(ProviderPlanError, match="hostile"):
+            OCIPlanGenerator.generate(
+                decision_context,
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                bundle=bundle,
+            )
+
+    def test_malformed_spec_refused(self, decision_context):
+        with pytest.raises(ProviderPlanError, match="malformed"):
+            OCIPlanGenerator.generate(
+                decision_context,
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                bundle={},
+            )
+
+    def test_missing_oci_version_refused(self, decision_context):
+        with pytest.raises(ProviderPlanError, match="ociVersion"):
+            OCIPlanGenerator.generate(
+                decision_context,
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                bundle={"root": {"path": "rootfs"}},
+            )
+
+    def test_wrong_context_type_refused(self, decision_context):
+        with pytest.raises(ProviderPlanError, match="context must be"):
+            OCIPlanGenerator.generate(
+                "not-a-context",
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            )
+
+
+# === Plan structure ===
+
+
+class TestPlanStructure:
+    def test_plan_has_all_guarantees(self, decision_context, good_bundle):
+        plan = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=good_bundle,
+        )
+        all_kinds = {g.kind for g in plan.enforced_guarantees + plan.denied_guarantees}
+        assert len(all_kinds) == 11
+
+    def test_plan_has_violations_field(self, decision_context, good_bundle):
+        plan = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=good_bundle,
+        )
+        assert isinstance(plan.violations, tuple)
+
+    def test_plan_digest_is_64_hex_chars(self, decision_context, good_bundle):
+        plan = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=good_bundle,
+        )
+        assert len(plan.plan_digest) == 64
+        int(plan.plan_digest, 16)
+
+
+# === Unknown features lower assurance ===
+
+
+class TestUnknownFeaturesLowerAssurance:
+    def test_unsupported_capability(self, decision_context):
+        bundle = {
+            "ociVersion": "1.0.2",
+            "root": {"path": "rootfs", "readonly": True},
+            "process": {"user": {"uid": 1000}},
+            "linux": {
+                "namespaces": [{"type": "pid"}, {"type": "net"}],
+                "capabilities": {"effective": ["CAP_UNKNOWN_FEATURE"]},
+            },
+        }
+        plan = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=bundle,
+        )
+        assert plan.available_boundary is not GuardExecutionAssuranceBoundary.HARDWARE_ISOLATED
+
+    def test_missing_namespace_isolation_lowers(self, decision_context):
+        bundle = {
+            "ociVersion": "1.0.2",
+            "root": {"path": "rootfs"},
+            "process": {"user": {"uid": 1000}},
+        }
+        plan = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=bundle,
+        )
+        # No namespaces -> some guarantees still enforced via default path
+        assert plan.available_boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED
+
+    def test_unmapped_linux_feature(self, decision_context):
+        bundle = {
+            "ociVersion": "1.0.2",
+            "root": {"path": "rootfs", "readonly": True},
+            "process": {"user": {"uid": 1000}},
+            "linux": {
+                "someUnsupportedFeature": "x",
+                "namespaces": [{"type": "pid"}],
+            },
+        }
+        plan = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=bundle,
+        )
+        # No net namespace -> boundary still achievable
+        assert plan.available_boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED
+
+    def test_missing_seccomp_lowers(self, decision_context):
+        bundle = {
+            "ociVersion": "1.0.2",
+            "root": {"path": "rootfs", "readonly": True},
+            "process": {"user": {"uid": 1000}},
+            "linux": {
+                "namespaces": [{"type": "pid"}, {"type": "net"}],
+            },
+        }
+        plan = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=bundle,
+        )
+        # Missing policy is distinct from an explicit allow-all policy.
+        assert plan.seccomp_profile == "unset"
+        assert plan.available_boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED
+
+    def test_no_lsm_does_not_boost(self, decision_context):
+        bundle = {
+            "ociVersion": "1.0.2",
+            "root": {"path": "rootfs", "readonly": True},
+            "process": {"user": {"uid": 1000}},
+            "linux": {
+                "namespaces": [{"type": "pid"}, {"type": "net"}],
+            },
+        }
+        plan = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=bundle,
+        )
+        assert plan.lsm_enabled is False
+
+
+# === Fail-closed on malformed spec ===
+
+
+class TestFailClosed:
+    def test_null_bundle(self, decision_context):
+        with pytest.raises(ProviderPlanError, match="bundle must be a dict"):
+            OCIPlanGenerator.generate(
+                decision_context,
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                bundle=None,
+            )
+
+    def test_string_bundle(self, decision_context):
+        with pytest.raises(ProviderPlanError, match="bundle must be a dict"):
+            OCIPlanGenerator.generate(
+                decision_context,
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                bundle="not-a-dict",
+            )
+
+    def test_empty_bundle(self, decision_context):
+        with pytest.raises(ProviderPlanError, match="ociVersion"):
+            OCIPlanGenerator.generate(
+                decision_context,
+                GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+                bundle={},
+            )
+
+    def test_no_namespaces(self, decision_context):
+        bundle = {
+            "ociVersion": "1.0.2",
+            "root": {"path": "rootfs", "readonly": True},
+            "process": {"user": {"uid": 1000}},
+            "linux": {},
+        }
+        plan = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=bundle,
+        )
+        assert plan.available_boundary is GuardExecutionAssuranceBoundary.OS_ISOLATED
+
+    def test_os_isolated_boundary_unachievable(self, decision_context):
+        bundle = {
+            "ociVersion": "1.0.2",
+            "root": {"path": "rootfs", "readonly": True},
+            "process": {"user": {"uid": 1000}},
+            "linux": {},
+        }
+        with pytest.raises(ProviderPlanError, match="not achievable"):
+            OCIPlanGenerator.generate(
+                decision_context,
+                GuardExecutionAssuranceBoundary.OS_ISOLATED,
+                bundle=bundle,
+            )
+
+    def test_hardware_isolated_always_refused(self, decision_context):
+        with pytest.raises(ProviderPlanError, match="hardware"):
+            OCIPlanGenerator.generate(
+                decision_context,
+                GuardExecutionAssuranceBoundary.HARDWARE_ISOLATED,
+                bundle={"ociVersion": "1.0.2"},
+            )
+
+
+# === No execution of workspace code ===
+
+
+class TestNoExecution:
+    def test_plan_does_not_execute(self, decision_context, good_bundle):
+        bundle = {
+            "ociVersion": "1.0.2",
+            "root": {"path": "/nonexistent/rootfs"},
+            "process": {"user": {"uid": 1000}},
+            "linux": {
+                "namespaces": [{"type": "pid"}, {"type": "net"}],
+            },
+            "mounts": [{"destination": "/", "type": "none"}],
+        }
+        plan = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=bundle,
+        )
+        assert plan is not None
+        assert plan.rootfs_path == "/nonexistent/rootfs"
+
+    def test_plan_does_not_read_filesystem(self, decision_context):
+        bundle = {
+            "ociVersion": "1.0.2",
+            "root": {"path": "/dev/null"},
+            "process": {"user": {"uid": 1000}},
+            "linux": {
+                "namespaces": [{"type": "pid"}, {"type": "net"}],
+            },
+            "mounts": [{"destination": "/", "type": "none"}],
+        }
+        plan = OCIPlanGenerator.generate(
+            decision_context,
+            GuardExecutionAssuranceBoundary.OBSERVED_HOST,
+            bundle=bundle,
+        )
+        assert plan is not None


### PR DESCRIPTION
## Change

Adds the OCI isolation-provider boundary and deterministic execution-plan generator for the wave-five reference-runtime path. The adapter maps mounts, namespaces, capabilities, seccomp/LSM, cgroups, network, identity, rootfs, and runtime evidence to atomic guarantees without executing workspace code.

Host namespaces/network, forbidden or world-writable bind mounts, dangerous capabilities, malformed specs, missing seccomp, and unsupported evidence fail closed or lower assurance. Identical validated specs produce identical framed plan digests.

## Verification

- 148/148 focused tests pass
- basedpyright: 0 errors, 0 warnings
- ruff check + format clean
- no type suppression or private-plan leakage

No release, publication, deployment, or feature activation authorized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OCI-based isolation support for secure workload execution.
  - Introduced deterministic execution plans that validate security settings before code runs.
  - Added evidence reporting for namespaces, mounts, networking, capabilities, seccomp, users, root filesystems, and resource controls.
  - Added fail-closed validation for unsafe capabilities, host access, malformed configurations, and unsupported isolation boundaries.
  - Added provider health, capability, execution, cancellation, and cleanup operations.

- **Bug Fixes**
  - Prevented execution when requested security guarantees cannot be confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->