### PR TITLE
feat(guard): add pinned gVisor reference runtime

### DIFF
--- a/.github/workflows/guard-gvisor-reference.yml
+++ b/.github/workflows/guard-gvisor-reference.yml
@@ -50,7 +50,7 @@ jobs:
           HOL_GUARD_RUNSC_PATH: /tmp/runsc
           HOL_GUARD_BUSYBOX_PATH: /usr/bin/busybox
           HOST_SECRET: must-not-cross-runtime-boundary
-        run: sudo --preserve-env=HOL_GUARD_RUNSC_INTEGRATION,HOL_GUARD_RUNSC_PATH,HOL_GUARD_BUSYBOX_PATH,HOST_SECRET \"$(command -v uv)\" run --no-sync pytest -q tests/test_guard_gvisor_reference_runtime.py
+        run: sudo --preserve-env=HOL_GUARD_RUNSC_INTEGRATION,HOL_GUARD_RUNSC_PATH,HOL_GUARD_BUSYBOX_PATH,HOST_SECRET $(command -v uv) run --no-sync pytest -q tests/test_guard_gvisor_reference_runtime.py
       - name: Verify no residual runsc state
         if: always()
         run: |

--- a/.github/workflows/guard-gvisor-reference.yml
+++ b/.github/workflows/guard-gvisor-reference.yml
@@ -45,12 +45,19 @@ jobs:
           sudo apt-get install -y -qq busybox-static
           /tmp/runsc --version
       - name: Run real isolation corpus
+        id: corpus
+        continue-on-error: true
         env:
           HOL_GUARD_RUNSC_INTEGRATION: "1"
           HOL_GUARD_RUNSC_PATH: /tmp/runsc
           HOL_GUARD_BUSYBOX_PATH: /usr/bin/busybox
           HOST_SECRET: must-not-cross-runtime-boundary
         run: sudo --preserve-env=HOL_GUARD_RUNSC_INTEGRATION,HOL_GUARD_RUNSC_PATH,HOL_GUARD_BUSYBOX_PATH,HOST_SECRET .venv/bin/python -m pytest -q tests/test_guard_gvisor_reference_runtime.py
+      - name: Diagnose corpus setup failure
+        if: steps.corpus.outcome == 'failure'
+        run: |
+          sudo /tmp/hol-guard-test/runsc --root /tmp/hol-guard-test/state --network none --platform systrap run --bundle /tmp/hol-guard-test/bundles/guard-breakout guard-diagnostic
+          exit 1
       - name: Verify no residual runsc state
         if: always()
         run: |

--- a/.github/workflows/guard-gvisor-reference.yml
+++ b/.github/workflows/guard-gvisor-reference.yml
@@ -1,0 +1,57 @@
+name: Guard gVisor reference runtime
+
+on:
+  pull_request:
+    branches: [release/3.1]
+    paths:
+      - "src/codex_plugin_scanner/guard/runtime/gvisor_reference_runtime.py"
+      - "tests/test_guard_gvisor_reference_runtime.py"
+      - ".github/workflows/guard-gvisor-reference.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  runsc-isolation-corpus:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: Install Python dependencies
+        run: uv sync --frozen
+      - name: Install pinned gVisor and static BusyBox
+        env:
+          RUNSC_URL: https://storage.googleapis.com/gvisor/releases/release/20260727.0/x86_64/runsc
+          RUNSC_SHA512: ab99ea1b0e2d169ec95473ea6c44abdac9b6b63d9c483f898487fd2b3c32d63bfa9ea104a3d5eed217b90cfc880ceb7a1130a9f7daef6e50656b6e028a8f52e3
+        run: |
+          python - <<'PY'
+          import hashlib
+          import os
+          import urllib.request
+          from pathlib import Path
+
+          destination = Path("/tmp/runsc")
+          with urllib.request.urlopen(os.environ["RUNSC_URL"], timeout=60) as response:
+              payload = response.read()
+          observed = hashlib.sha512(payload).hexdigest()
+          if observed != os.environ["RUNSC_SHA512"]:
+              raise SystemExit(f"runsc checksum mismatch: {observed}")
+          destination.write_bytes(payload)
+          destination.chmod(0o755)
+          PY
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq busybox-static
+          /tmp/runsc --version
+      - name: Run real isolation corpus
+        env:
+          HOL_GUARD_RUNSC_INTEGRATION: "1"
+          HOL_GUARD_RUNSC_PATH: /tmp/runsc
+          HOL_GUARD_BUSYBOX_PATH: /usr/bin/busybox
+          HOST_SECRET: must-not-cross-runtime-boundary
+        run: sudo --preserve-env=HOL_GUARD_RUNSC_INTEGRATION,HOL_GUARD_RUNSC_PATH,HOL_GUARD_BUSYBOX_PATH,HOST_SECRET uv run --no-sync pytest -q tests/test_guard_gvisor_reference_runtime.py
+      - name: Verify no residual runsc state
+        if: always()
+        run: |
+          test ! -d /tmp/hol-guard-test/state || test -z "$(find /tmp/hol-guard-test/state -mindepth 1 -print -quit)"

--- a/.github/workflows/guard-gvisor-reference.yml
+++ b/.github/workflows/guard-gvisor-reference.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
       - name: Install Python dependencies
-        run: uv sync --frozen
+        run: uv sync --extra dev --frozen
       - name: Install pinned gVisor and static BusyBox
         env:
           RUNSC_URL: https://storage.googleapis.com/gvisor/releases/release/20260727.0/x86_64/runsc
@@ -50,7 +50,7 @@ jobs:
           HOL_GUARD_RUNSC_PATH: /tmp/runsc
           HOL_GUARD_BUSYBOX_PATH: /usr/bin/busybox
           HOST_SECRET: must-not-cross-runtime-boundary
-        run: sudo --preserve-env=HOL_GUARD_RUNSC_INTEGRATION,HOL_GUARD_RUNSC_PATH,HOL_GUARD_BUSYBOX_PATH,HOST_SECRET .venv/bin/pytest -q tests/test_guard_gvisor_reference_runtime.py
+        run: sudo --preserve-env=HOL_GUARD_RUNSC_INTEGRATION,HOL_GUARD_RUNSC_PATH,HOL_GUARD_BUSYBOX_PATH,HOST_SECRET .venv/bin/python -m pytest -q tests/test_guard_gvisor_reference_runtime.py
       - name: Verify no residual runsc state
         if: always()
         run: |

--- a/.github/workflows/guard-gvisor-reference.yml
+++ b/.github/workflows/guard-gvisor-reference.yml
@@ -56,8 +56,11 @@ jobs:
       - name: Diagnose corpus setup failure
         if: steps.corpus.outcome == 'failure'
         run: |
-          sudo /tmp/hol-guard-test/runsc --root /tmp/hol-guard-test/state --network none --platform systrap run --bundle /tmp/hol-guard-test/bundles/guard-breakout guard-diagnostic
-          exit 1
+          set +e
+          sudo /tmp/hol-guard-test/runsc --debug --debug-log=/tmp/runsc-debug.log --root /tmp/hol-guard-test/state --network none --platform systrap run --bundle /tmp/hol-guard-test/bundles/guard-breakout guard-diagnostic
+          code=$?
+          sudo tail -n 80 /tmp/runsc-debug.log
+          exit "$code"
       - name: Verify no residual runsc state
         if: always()
         run: |

--- a/.github/workflows/guard-gvisor-reference.yml
+++ b/.github/workflows/guard-gvisor-reference.yml
@@ -50,7 +50,7 @@ jobs:
           HOL_GUARD_RUNSC_PATH: /tmp/runsc
           HOL_GUARD_BUSYBOX_PATH: /usr/bin/busybox
           HOST_SECRET: must-not-cross-runtime-boundary
-        run: sudo --preserve-env=HOL_GUARD_RUNSC_INTEGRATION,HOL_GUARD_RUNSC_PATH,HOL_GUARD_BUSYBOX_PATH,HOST_SECRET $(command -v uv) run --no-sync pytest -q tests/test_guard_gvisor_reference_runtime.py
+        run: sudo --preserve-env=HOL_GUARD_RUNSC_INTEGRATION,HOL_GUARD_RUNSC_PATH,HOL_GUARD_BUSYBOX_PATH,HOST_SECRET .venv/bin/pytest -q tests/test_guard_gvisor_reference_runtime.py
       - name: Verify no residual runsc state
         if: always()
         run: |

--- a/.github/workflows/guard-gvisor-reference.yml
+++ b/.github/workflows/guard-gvisor-reference.yml
@@ -50,7 +50,7 @@ jobs:
           HOL_GUARD_RUNSC_PATH: /tmp/runsc
           HOL_GUARD_BUSYBOX_PATH: /usr/bin/busybox
           HOST_SECRET: must-not-cross-runtime-boundary
-        run: sudo --preserve-env=HOL_GUARD_RUNSC_INTEGRATION,HOL_GUARD_RUNSC_PATH,HOL_GUARD_BUSYBOX_PATH,HOST_SECRET uv run --no-sync pytest -q tests/test_guard_gvisor_reference_runtime.py
+        run: sudo --preserve-env=HOL_GUARD_RUNSC_INTEGRATION,HOL_GUARD_RUNSC_PATH,HOL_GUARD_BUSYBOX_PATH,HOST_SECRET \"$(command -v uv)\" run --no-sync pytest -q tests/test_guard_gvisor_reference_runtime.py
       - name: Verify no residual runsc state
         if: always()
         run: |

--- a/.github/workflows/guard-gvisor-reference.yml
+++ b/.github/workflows/guard-gvisor-reference.yml
@@ -45,20 +45,13 @@ jobs:
           sudo apt-get install -y -qq busybox-static
           /tmp/runsc --version
       - name: Run real isolation corpus
-        id: corpus
-        continue-on-error: true
         env:
           HOL_GUARD_RUNSC_INTEGRATION: "1"
           HOL_GUARD_RUNSC_PATH: /tmp/runsc
           HOL_GUARD_BUSYBOX_PATH: /usr/bin/busybox
           HOST_SECRET: must-not-cross-runtime-boundary
         run: sudo --preserve-env=HOL_GUARD_RUNSC_INTEGRATION,HOL_GUARD_RUNSC_PATH,HOL_GUARD_BUSYBOX_PATH,HOST_SECRET .venv/bin/python -m pytest -q tests/test_guard_gvisor_reference_runtime.py
-      - name: Diagnose corpus setup failure
-        if: steps.corpus.outcome == 'failure'
-        run: |
-          sudo /tmp/hol-guard-test/runsc --root /tmp/hol-guard-test/state --network none --platform systrap run --bundle /tmp/hol-guard-test/bundles/guard-breakout guard-diagnostic
-          exit 1
       - name: Verify no residual runsc state
         if: always()
         run: |
-          test ! -d /tmp/hol-guard-test/state || test -z "$(find /tmp/hol-guard-test/state -mindepth 1 -print -quit)"
+          sudo test ! -d /tmp/hol-guard-test/state || sudo test -z "$(sudo find /tmp/hol-guard-test/state -mindepth 1 -print -quit)"

--- a/src/codex_plugin_scanner/guard/runtime/gvisor_reference_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/gvisor_reference_runtime.py
@@ -226,12 +226,7 @@ class GVisorReferenceRuntime:
             )
         except subprocess.TimeoutExpired:
             delete = None
-        return (
-            kill is not None
-            and delete is not None
-            and kill.returncode in {0, 128}
-            and delete.returncode in {0, 128}
-        )
+        return kill is not None and delete is not None and kill.returncode in {0, 128} and delete.returncode in {0, 128}
 
 
 __all__ = ["GVisorReferenceRuntime", "GVisorRunResult"]

--- a/src/codex_plugin_scanner/guard/runtime/gvisor_reference_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/gvisor_reference_runtime.py
@@ -1,0 +1,206 @@
+"""Pinned gVisor ``runsc`` reference runtime for Guard-owned OCI bundles.
+
+The runner does not inspect or activate workspace content. It accepts only bundles
+materialized below a Guard-owned root, verifies the configured runtime binary by
+digest before every attempt, disables networking, bounds captured output, and
+forces container deletion on every terminal path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, final
+
+from codex_plugin_scanner.guard.runtime.execution_assurance_contract import framed_digest
+from codex_plugin_scanner.guard.runtime.isolation_provider import ProviderPlanError
+
+_CONTAINER_ID: Final = re.compile(r"\Aguard-[a-z0-9][a-z0-9-]{0,62}\Z")
+_MAX_CAPTURE_BYTES: Final = 1_048_576
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1_048_576):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class GVisorRunResult:
+    """Privacy-preserving terminal result from one fenced runsc attempt."""
+
+    execution_instance: str
+    exit_code: int
+    stdout_digest: str
+    stderr_digest: str
+    stdout_bytes: int
+    stderr_bytes: int
+    duration_milliseconds: int
+    timed_out: bool
+    cleanup_complete: bool
+
+
+@final
+class GVisorReferenceRuntime:
+    """Execute pre-materialized, Guard-owned OCI bundles with pinned runsc."""
+
+    def __init__(
+        self,
+        *,
+        runsc_path: str,
+        runsc_digest: str,
+        bundle_root: str,
+        state_root: str,
+        platform: str = "systrap",
+    ) -> None:
+        self._runsc_path = self._validate_owned_absolute_path(runsc_path, "runsc_path")
+        self._bundle_root = self._validate_owned_absolute_path(bundle_root, "bundle_root")
+        self._state_root = self._validate_owned_absolute_path(state_root, "state_root")
+        if len(runsc_digest) != 64 or not all(char in "0123456789abcdef" for char in runsc_digest):
+            raise ValueError("runsc_digest must be 64 lowercase hexadecimal characters")
+        if platform not in {"systrap", "kvm"}:
+            raise ValueError("platform must be systrap or kvm")
+        self._runsc_digest = runsc_digest
+        self._platform = platform
+
+    @staticmethod
+    def _validate_owned_absolute_path(raw: str, label: str) -> Path:
+        path = Path(raw)
+        if not path.is_absolute():
+            raise ValueError(f"{label} must be absolute")
+        resolved = path.resolve(strict=False)
+        if not (
+            resolved.is_relative_to("/usr/libexec/hol-guard")
+            or resolved.is_relative_to("/var/lib/hol-guard")
+            or resolved.is_relative_to("/tmp/hol-guard-test")
+            or resolved.is_relative_to("/private/tmp/hol-guard-test")
+        ):
+            raise ValueError(f"{label} must be below a Guard-owned root")
+        return resolved
+
+    def verify_binary(self) -> str:
+        """Verify the exact runsc executable bytes configured by the administrator."""
+        try:
+            observed = _sha256_file(self._runsc_path)
+        except OSError as exc:
+            raise ProviderPlanError("configured runsc binary is unavailable") from exc
+        if observed != self._runsc_digest:
+            raise ProviderPlanError("configured runsc binary digest mismatch")
+        if not os.access(self._runsc_path, os.X_OK):
+            raise ProviderPlanError("configured runsc binary is not executable")
+        return observed
+
+    def _bundle_path(self, bundle_name: str) -> Path:
+        if not _CONTAINER_ID.fullmatch(bundle_name):
+            raise ProviderPlanError("invalid Guard execution instance")
+        try:
+            candidate = (self._bundle_root / bundle_name).resolve(strict=True)
+        except OSError as exc:
+            raise ProviderPlanError("bundle has no OCI config.json") from exc
+        if not candidate.is_relative_to(self._bundle_root):
+            raise ProviderPlanError("bundle escapes the Guard-owned root")
+        if not (candidate / "config.json").is_file():
+            raise ProviderPlanError("bundle has no OCI config.json")
+        return candidate
+
+    def _base_command(self) -> tuple[str, ...]:
+        return (
+            str(self._runsc_path),
+            "--root",
+            str(self._state_root),
+            "--network",
+            "none",
+            "--platform",
+            self._platform,
+        )
+
+    def run(self, execution_instance: str, *, timeout_seconds: int = 30) -> GVisorRunResult:
+        """Run one bundle and always force-delete its runtime state afterward."""
+        if timeout_seconds < 1 or timeout_seconds > 300:
+            raise ValueError("timeout_seconds must be between 1 and 300")
+        _ = self.verify_binary()
+        bundle = self._bundle_path(execution_instance)
+        self._state_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        command = (
+            *self._base_command(),
+            "run",
+            "--bundle",
+            str(bundle),
+            execution_instance,
+        )
+        started = time.monotonic_ns()
+        timed_out = False
+        stdout = b""
+        stderr = b""
+        exit_code = 125
+        cleanup_complete = False
+        try:
+            try:
+                completed = subprocess.run(
+                    command,
+                    check=False,
+                    capture_output=True,
+                    timeout=timeout_seconds,
+                    env={"PATH": "/usr/sbin:/usr/bin:/sbin:/bin"},
+                )
+                stdout = completed.stdout[:_MAX_CAPTURE_BYTES]
+                stderr = completed.stderr[:_MAX_CAPTURE_BYTES]
+                exit_code = completed.returncode
+            except subprocess.TimeoutExpired as exc:
+                timed_out = True
+                stdout = (exc.stdout or b"")[:_MAX_CAPTURE_BYTES]
+                stderr = (exc.stderr or b"")[:_MAX_CAPTURE_BYTES]
+                exit_code = 124
+        finally:
+            cleanup = subprocess.run(
+                (*self._base_command(), "delete", "--force", execution_instance),
+                check=False,
+                capture_output=True,
+                timeout=10,
+                env={"PATH": "/usr/sbin:/usr/bin:/sbin:/bin"},
+            )
+            cleanup_complete = cleanup.returncode in {0, 128}
+
+        duration_ms = (time.monotonic_ns() - started) // 1_000_000
+        return GVisorRunResult(
+            execution_instance=execution_instance,
+            exit_code=exit_code,
+            stdout_digest=framed_digest("guard.runsc-stdout.v1", {"bytes": stdout.hex()}),
+            stderr_digest=framed_digest("guard.runsc-stderr.v1", {"bytes": stderr.hex()}),
+            stdout_bytes=len(stdout),
+            stderr_bytes=len(stderr),
+            duration_milliseconds=duration_ms,
+            timed_out=timed_out,
+            cleanup_complete=cleanup_complete,
+        )
+
+    def cancel(self, execution_instance: str) -> bool:
+        """Idempotently signal and delete one Guard-owned execution instance."""
+        if not _CONTAINER_ID.fullmatch(execution_instance):
+            raise ProviderPlanError("invalid Guard execution instance")
+        _ = self.verify_binary()
+        kill = subprocess.run(
+            (*self._base_command(), "kill", execution_instance, "KILL"),
+            check=False,
+            capture_output=True,
+            timeout=10,
+            env={"PATH": "/usr/sbin:/usr/bin:/sbin:/bin"},
+        )
+        delete = subprocess.run(
+            (*self._base_command(), "delete", "--force", execution_instance),
+            check=False,
+            capture_output=True,
+            timeout=10,
+            env={"PATH": "/usr/sbin:/usr/bin:/sbin:/bin"},
+        )
+        return kill.returncode in {0, 128} and delete.returncode in {0, 128}
+
+
+__all__ = ["GVisorReferenceRuntime", "GVisorRunResult"]

--- a/src/codex_plugin_scanner/guard/runtime/gvisor_reference_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/gvisor_reference_runtime.py
@@ -93,8 +93,11 @@ class GVisorReferenceRuntime:
             raise ProviderPlanError("configured runsc binary is unavailable") from exc
         if observed != self._runsc_digest:
             raise ProviderPlanError("configured runsc binary digest mismatch")
-        if not os.access(self._runsc_path, os.X_OK):
-            raise ProviderPlanError("configured runsc binary is not executable")
+        mode = self._runsc_path.stat().st_mode
+        if not os.access(self._runsc_path, os.X_OK) or mode & 0o005 != 0o005:
+            raise ProviderPlanError("configured runsc binary is not executable by its sandbox process")
+        if mode & 0o022:
+            raise ProviderPlanError("configured runsc binary is writable outside its owner")
         return observed
 
     def _bundle_path(self, bundle_name: str) -> Path:

--- a/src/codex_plugin_scanner/guard/runtime/gvisor_reference_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/gvisor_reference_runtime.py
@@ -12,6 +12,7 @@ import hashlib
 import os
 import re
 import subprocess
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -30,6 +31,13 @@ def _sha256_file(path: Path) -> str:
         while chunk := stream.read(1_048_576):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _limit_output_files() -> None:
+    """Hard-limit each inherited output file before executing runsc."""
+    import resource
+
+    resource.setrlimit(resource.RLIMIT_FSIZE, (_MAX_CAPTURE_BYTES, _MAX_CAPTURE_BYTES))
 
 
 @dataclass(frozen=True, slots=True)
@@ -145,31 +153,38 @@ class GVisorReferenceRuntime:
         exit_code = 125
         cleanup_complete = False
         try:
+            with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
+                try:
+                    completed = subprocess.run(
+                        command,
+                        check=False,
+                        stdout=stdout_file,
+                        stderr=stderr_file,
+                        timeout=timeout_seconds,
+                        env={"PATH": "/usr/sbin:/usr/bin:/sbin:/bin"},
+                        preexec_fn=_limit_output_files,
+                    )
+                    exit_code = completed.returncode
+                except subprocess.TimeoutExpired:
+                    timed_out = True
+                    exit_code = 124
+                _ = stdout_file.seek(0)
+                _ = stderr_file.seek(0)
+                stdout = stdout_file.read(_MAX_CAPTURE_BYTES)
+                stderr = stderr_file.read(_MAX_CAPTURE_BYTES)
+        finally:
             try:
-                completed = subprocess.run(
-                    command,
+                cleanup = subprocess.run(
+                    (*self._base_command(), "delete", "--force", execution_instance),
                     check=False,
-                    capture_output=True,
-                    timeout=timeout_seconds,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=10,
                     env={"PATH": "/usr/sbin:/usr/bin:/sbin:/bin"},
                 )
-                stdout = completed.stdout[:_MAX_CAPTURE_BYTES]
-                stderr = completed.stderr[:_MAX_CAPTURE_BYTES]
-                exit_code = completed.returncode
-            except subprocess.TimeoutExpired as exc:
-                timed_out = True
-                stdout = (exc.stdout or b"")[:_MAX_CAPTURE_BYTES]
-                stderr = (exc.stderr or b"")[:_MAX_CAPTURE_BYTES]
-                exit_code = 124
-        finally:
-            cleanup = subprocess.run(
-                (*self._base_command(), "delete", "--force", execution_instance),
-                check=False,
-                capture_output=True,
-                timeout=10,
-                env={"PATH": "/usr/sbin:/usr/bin:/sbin:/bin"},
-            )
-            cleanup_complete = cleanup.returncode in {0, 128}
+                cleanup_complete = cleanup.returncode in {0, 128}
+            except subprocess.TimeoutExpired:
+                cleanup_complete = False
 
         duration_ms = (time.monotonic_ns() - started) // 1_000_000
         return GVisorRunResult(
@@ -189,21 +204,34 @@ class GVisorReferenceRuntime:
         if not _CONTAINER_ID.fullmatch(execution_instance):
             raise ProviderPlanError("invalid Guard execution instance")
         _ = self.verify_binary()
-        kill = subprocess.run(
-            (*self._base_command(), "kill", execution_instance, "KILL"),
-            check=False,
-            capture_output=True,
-            timeout=10,
-            env={"PATH": "/usr/sbin:/usr/bin:/sbin:/bin"},
+        try:
+            kill = subprocess.run(
+                (*self._base_command(), "kill", execution_instance, "KILL"),
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=10,
+                env={"PATH": "/usr/sbin:/usr/bin:/sbin:/bin"},
+            )
+        except subprocess.TimeoutExpired:
+            kill = None
+        try:
+            delete = subprocess.run(
+                (*self._base_command(), "delete", "--force", execution_instance),
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=10,
+                env={"PATH": "/usr/sbin:/usr/bin:/sbin:/bin"},
+            )
+        except subprocess.TimeoutExpired:
+            delete = None
+        return (
+            kill is not None
+            and delete is not None
+            and kill.returncode in {0, 128}
+            and delete.returncode in {0, 128}
         )
-        delete = subprocess.run(
-            (*self._base_command(), "delete", "--force", execution_instance),
-            check=False,
-            capture_output=True,
-            timeout=10,
-            env={"PATH": "/usr/sbin:/usr/bin:/sbin:/bin"},
-        )
-        return kill.returncode in {0, 128} and delete.returncode in {0, 128}
 
 
 __all__ = ["GVisorReferenceRuntime", "GVisorRunResult"]

--- a/tests/test_guard_gvisor_reference_runtime.py
+++ b/tests/test_guard_gvisor_reference_runtime.py
@@ -191,8 +191,8 @@ class TestRealRunscIsolation:
             ],
             "linux": {
                 "resources": {
-                    "memory": {"limit": 67108864},
-                    "pids": {"limit": 16},
+                    "memory": {"limit": 268435456},
+                    "pids": {"limit": 128},
                     "cpu": {"quota": 50000, "period": 100000},
                 },
                 "namespaces": [

--- a/tests/test_guard_gvisor_reference_runtime.py
+++ b/tests/test_guard_gvisor_reference_runtime.py
@@ -1,0 +1,256 @@
+"""Reference-runtime unit tests plus an opt-in real runsc isolation corpus."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import stat
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.execution_assurance_contract import framed_digest
+from codex_plugin_scanner.guard.runtime.gvisor_reference_runtime import GVisorReferenceRuntime
+from codex_plugin_scanner.guard.runtime.isolation_provider import ProviderPlanError
+
+_RUNSC = Path("/tmp/hol-guard-test/runsc")
+_BUNDLES = Path("/tmp/hol-guard-test/bundles")
+_STATE = Path("/tmp/hol-guard-test/state")
+
+
+def _write_fake_runsc() -> str:
+    _RUNSC.parent.mkdir(parents=True, exist_ok=True)
+    _RUNSC.write_bytes(b"fake-runsc")
+    _RUNSC.chmod(_RUNSC.stat().st_mode | stat.S_IXUSR)
+    return hashlib.sha256(_RUNSC.read_bytes()).hexdigest()
+
+
+def _runner(digest: str | None = None) -> GVisorReferenceRuntime:
+    return GVisorReferenceRuntime(
+        runsc_path=str(_RUNSC),
+        runsc_digest=digest or _write_fake_runsc(),
+        bundle_root=str(_BUNDLES),
+        state_root=str(_STATE),
+    )
+
+
+def _bundle(name: str) -> Path:
+    path = _BUNDLES / name
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text("{}", encoding="utf-8")
+    return path
+
+
+class TestConfiguration:
+    def test_rejects_relative_or_non_guard_owned_paths(self) -> None:
+        digest = "1" * 64
+        with pytest.raises(ValueError, match="absolute"):
+            GVisorReferenceRuntime(
+                runsc_path="runsc",
+                runsc_digest=digest,
+                bundle_root=str(_BUNDLES),
+                state_root=str(_STATE),
+            )
+        with pytest.raises(ValueError, match="Guard-owned"):
+            GVisorReferenceRuntime(
+                runsc_path="/usr/bin/runsc",
+                runsc_digest=digest,
+                bundle_root=str(_BUNDLES),
+                state_root=str(_STATE),
+            )
+
+    def test_rejects_invalid_digest_and_platform(self) -> None:
+        with pytest.raises(ValueError, match="64 lowercase"):
+            _runner("not-a-digest")
+        digest = _write_fake_runsc()
+        with pytest.raises(ValueError, match="systrap or kvm"):
+            GVisorReferenceRuntime(
+                runsc_path=str(_RUNSC),
+                runsc_digest=digest,
+                bundle_root=str(_BUNDLES),
+                state_root=str(_STATE),
+                platform="ptrace",
+            )
+
+    def test_binary_digest_mismatch_fails_closed(self) -> None:
+        runner = _runner("1" * 64)
+        with pytest.raises(ProviderPlanError, match="digest mismatch"):
+            runner.verify_binary()
+
+    def test_bundle_traversal_and_unknown_instances_fail(self) -> None:
+        runner = _runner()
+        with pytest.raises(ProviderPlanError, match="invalid"):
+            runner.run("../outside")
+        with pytest.raises(ProviderPlanError, match=r"config\.json"):
+            runner.run("guard-missing")
+
+
+class TestExecution:
+    @patch("subprocess.run")
+    def test_command_pins_network_platform_and_forces_cleanup(self, run: MagicMock) -> None:
+        _bundle("guard-unit")
+        run.side_effect = (
+            MagicMock(returncode=0, stdout=b"ok\n", stderr=b""),
+            MagicMock(returncode=0, stdout=b"", stderr=b""),
+        )
+        result = _runner().run("guard-unit")
+        command = run.call_args_list[0].args[0]
+        assert command[command.index("--network") + 1] == "none"
+        assert command[command.index("--platform") + 1] == "systrap"
+        assert command[-3:] == (
+            "--bundle",
+            str((_BUNDLES / "guard-unit").resolve()),
+            "guard-unit",
+        )
+        cleanup = run.call_args_list[1].args[0]
+        assert cleanup[-3:] == ("delete", "--force", "guard-unit")
+        assert result.exit_code == 0
+        assert result.cleanup_complete is True
+        assert result.stdout_bytes == 3
+
+    @patch("subprocess.run")
+    def test_timeout_is_terminal_and_cleanup_runs(self, run: MagicMock) -> None:
+        _bundle("guard-timeout")
+        run.side_effect = (
+            __import__("subprocess").TimeoutExpired(("runsc",), 1, output=b"partial"),
+            MagicMock(returncode=0, stdout=b"", stderr=b""),
+        )
+        result = _runner().run("guard-timeout", timeout_seconds=1)
+        assert result.timed_out is True
+        assert result.exit_code == 124
+        assert result.cleanup_complete is True
+        assert run.call_count == 2
+
+    @patch("subprocess.run")
+    def test_cancel_is_idempotent_and_validated(self, run: MagicMock) -> None:
+        run.side_effect = (
+            MagicMock(returncode=128),
+            MagicMock(returncode=128),
+        )
+        runner = _runner()
+        assert runner.cancel("guard-cancelled") is True
+        with pytest.raises(ProviderPlanError, match="invalid"):
+            runner.cancel("workspace-controlled/id")
+
+
+@pytest.mark.skipif(
+    os.environ.get("HOL_GUARD_RUNSC_INTEGRATION") != "1",
+    reason="requires pinned Linux runsc + busybox-static",
+)
+class TestRealRunscIsolation:
+    @staticmethod
+    def _materialize(name: str, script: str) -> GVisorReferenceRuntime:
+        runsc_source = Path(os.environ["HOL_GUARD_RUNSC_PATH"])
+        busybox_source = Path(os.environ["HOL_GUARD_BUSYBOX_PATH"])
+        root = Path("/tmp/hol-guard-test")
+        root.mkdir(parents=True, exist_ok=True)
+        runsc = root / "runsc"
+        shutil.copy2(runsc_source, runsc)
+        runsc.chmod(0o700)
+        bundle = root / "bundles" / name
+        rootfs = bundle / "rootfs"
+        (rootfs / "bin").mkdir(parents=True, exist_ok=True)
+        for directory in ("dev", "proc", "tmp", "var/run"):
+            (rootfs / directory).mkdir(parents=True, exist_ok=True)
+        shutil.copy2(busybox_source, rootfs / "bin" / "busybox")
+        config = {
+            "ociVersion": "1.0.2",
+            "process": {
+                "terminal": False,
+                "user": {"uid": 0, "gid": 0},
+                "args": ["/bin/busybox", "sh", "-c", script],
+                "env": ["PATH=/bin"],
+                "cwd": "/",
+                "capabilities": {
+                    "bounding": [],
+                    "effective": [],
+                    "inheritable": [],
+                    "permitted": [],
+                    "ambient": [],
+                },
+                "noNewPrivileges": True,
+            },
+            "root": {"path": "rootfs", "readonly": True},
+            "hostname": "guard-sandbox",
+            "mounts": [
+                {"destination": "/proc", "type": "proc", "source": "proc"},
+                {
+                    "destination": "/dev",
+                    "type": "tmpfs",
+                    "source": "tmpfs",
+                    "options": ["nosuid", "strictatime", "mode=755", "size=65536k"],
+                },
+                {
+                    "destination": "/tmp",
+                    "type": "tmpfs",
+                    "source": "tmpfs",
+                    "options": ["nosuid", "nodev", "noexec", "mode=1777", "size=4096k"],
+                },
+            ],
+            "linux": {
+                "resources": {
+                    "memory": {"limit": 67108864},
+                    "pids": {"limit": 16},
+                    "cpu": {"quota": 50000, "period": 100000},
+                },
+                "namespaces": [
+                    {"type": "pid"},
+                    {"type": "network"},
+                    {"type": "ipc"},
+                    {"type": "uts"},
+                    {"type": "mount"},
+                    {"type": "cgroup"},
+                ],
+                "maskedPaths": ["/proc/kcore", "/proc/keys", "/proc/timer_list"],
+                "readonlyPaths": [
+                    "/proc/asound",
+                    "/proc/bus",
+                    "/proc/fs",
+                    "/proc/irq",
+                    "/proc/sys",
+                    "/proc/sysrq-trigger",
+                ],
+            },
+        }
+        bundle.mkdir(parents=True, exist_ok=True)
+        (bundle / "config.json").write_text(json.dumps(config), encoding="utf-8")
+        digest = hashlib.sha256(runsc.read_bytes()).hexdigest()
+        return GVisorReferenceRuntime(
+            runsc_path=str(runsc),
+            runsc_digest=digest,
+            bundle_root=str(root / "bundles"),
+            state_root=str(root / "state"),
+        )
+
+    def test_breakout_secret_socket_privilege_and_network_denied(self) -> None:
+        script = " && ".join(
+            (
+                "! touch /host-breakout",
+                'test "${HOST_SECRET-unset}" = unset',
+                "test ! -S /var/run/docker.sock",
+                "! mount -t tmpfs tmpfs /tmp",
+                "! wget -q -T 2 -O- http://169.254.169.254/latest/meta-data/",
+                'printf "assurance-ok\\n"',
+            )
+        )
+        runner = self._materialize("guard-breakout", script)
+        result = runner.run("guard-breakout", timeout_seconds=20)
+        expected = framed_digest("guard.runsc-stdout.v1", {"bytes": b"assurance-ok\n".hex()})
+        assert result.exit_code == 0
+        assert result.stdout_digest == expected
+        assert result.cleanup_complete is True
+        assert not (_BUNDLES / "host-breakout").exists()
+
+    def test_runtime_crash_and_timeout_are_cleaned(self) -> None:
+        crash = self._materialize("guard-crash", "kill -SEGV $$")
+        crash_result = crash.run("guard-crash", timeout_seconds=10)
+        assert crash_result.exit_code != 0
+        assert crash_result.cleanup_complete is True
+
+        timeout = self._materialize("guard-sleep", "sleep 10")
+        timeout_result = timeout.run("guard-sleep", timeout_seconds=1)
+        assert timeout_result.timed_out is True
+        assert timeout_result.cleanup_complete is True

--- a/tests/test_guard_gvisor_reference_runtime.py
+++ b/tests/test_guard_gvisor_reference_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 import os
 import shutil
@@ -79,6 +80,16 @@ class TestConfiguration:
         with pytest.raises(ProviderPlanError, match="digest mismatch"):
             runner.verify_binary()
 
+    def test_binary_permissions_fail_closed(self) -> None:
+        digest = _write_fake_runsc()
+        _RUNSC.chmod(0o700)
+        with pytest.raises(ProviderPlanError, match="sandbox process"):
+            _ = _runner(digest).verify_binary()
+        _RUNSC.chmod(0o775)
+        with pytest.raises(ProviderPlanError, match="writable outside"):
+            _ = _runner(digest).verify_binary()
+
+
     def test_bundle_traversal_and_unknown_instances_fail(self) -> None:
         runner = _runner()
         with pytest.raises(ProviderPlanError, match="invalid"):
@@ -91,10 +102,15 @@ class TestExecution:
     @patch("subprocess.run")
     def test_command_pins_network_platform_and_forces_cleanup(self, run: MagicMock) -> None:
         _bundle("guard-unit")
-        run.side_effect = (
-            MagicMock(returncode=0, stdout=b"ok\n", stderr=b""),
-            MagicMock(returncode=0, stdout=b"", stderr=b""),
-        )
+
+        def invoke(command: tuple[str, ...], **kwargs: object) -> MagicMock:
+            if "run" in command:
+                output = kwargs["stdout"]
+                assert isinstance(output, io.BufferedIOBase)
+                output.write(b"ok\n")
+            return MagicMock(returncode=0)
+
+        run.side_effect = invoke
         result = _runner().run("guard-unit")
         command = run.call_args_list[0].args[0]
         assert command[command.index("--network") + 1] == "none"
@@ -113,15 +129,37 @@ class TestExecution:
     @patch("subprocess.run")
     def test_timeout_is_terminal_and_cleanup_runs(self, run: MagicMock) -> None:
         _bundle("guard-timeout")
-        run.side_effect = (
-            __import__("subprocess").TimeoutExpired(("runsc",), 1, output=b"partial"),
-            MagicMock(returncode=0, stdout=b"", stderr=b""),
-        )
+
+        def invoke(command: tuple[str, ...], **kwargs: object) -> MagicMock:
+            if "run" in command:
+                output = kwargs["stdout"]
+                assert isinstance(output, io.BufferedIOBase)
+                output.write(b"partial")
+                raise __import__("subprocess").TimeoutExpired(("runsc",), 1)
+            return MagicMock(returncode=0)
+
+        run.side_effect = invoke
         result = _runner().run("guard-timeout", timeout_seconds=1)
         assert result.timed_out is True
         assert result.exit_code == 124
         assert result.cleanup_complete is True
         assert run.call_count == 2
+
+    @patch("subprocess.run")
+    def test_output_capture_is_hard_bounded(self, run: MagicMock) -> None:
+        _bundle("guard-output")
+
+        def invoke(command: tuple[str, ...], **kwargs: object) -> MagicMock:
+            if "run" in command:
+                output = kwargs["stdout"]
+                assert isinstance(output, io.BufferedIOBase)
+                output.write(b"x" * 2_097_152)
+            return MagicMock(returncode=0)
+
+        run.side_effect = invoke
+        result = _runner().run("guard-output")
+        assert result.stdout_bytes == 1_048_576
+
 
     @patch("subprocess.run")
     def test_cancel_is_idempotent_and_validated(self, run: MagicMock) -> None:

--- a/tests/test_guard_gvisor_reference_runtime.py
+++ b/tests/test_guard_gvisor_reference_runtime.py
@@ -6,7 +6,6 @@ import hashlib
 import json
 import os
 import shutil
-import stat
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -24,7 +23,7 @@ _STATE = Path("/tmp/hol-guard-test/state")
 def _write_fake_runsc() -> str:
     _RUNSC.parent.mkdir(parents=True, exist_ok=True)
     _RUNSC.write_bytes(b"fake-runsc")
-    _RUNSC.chmod(_RUNSC.stat().st_mode | stat.S_IXUSR)
+    _RUNSC.chmod(0o755)
     return hashlib.sha256(_RUNSC.read_bytes()).hexdigest()
 
 
@@ -149,7 +148,7 @@ class TestRealRunscIsolation:
         root.mkdir(parents=True, exist_ok=True)
         runsc = root / "runsc"
         shutil.copy2(runsc_source, runsc)
-        runsc.chmod(0o700)
+        runsc.chmod(0o755)
         bundle = root / "bundles" / name
         rootfs = bundle / "rootfs"
         (rootfs / "bin").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Reference-runtime selection

Selects gVisor `runsc` (`release-20260727.0`) as the single 3.1 alpha reference runtime. This is the OCI/RuntimeClass path already represented by the merged adapters; Kata remains an alternate-runtime characterization, not an alpha blocker.

## Runtime

- Requires an absolute Guard-owned `runsc` path and exact administrator-pinned SHA-256 digest; verifies bytes before every run/cancel.
- Accepts only validated execution-instance IDs and OCI bundles below a Guard-owned root; resolves symlinks and requires `config.json`.
- Forces `--network none`, pinned `systrap`/`kvm` platform, bounded output capture, minimal environment, timeout handling, and forced deletion on every terminal path.
- Returns digest-only stdout/stderr evidence; no raw commands, paths, secrets, or output in receipts.
- Idempotent validated cancellation.

## Real isolation corpus

A dedicated Linux workflow downloads the pinned runsc artifact, verifies the fixed SHA-512, installs static BusyBox, and executes a real OCI bundle with readonly rootfs, no capabilities, no-new-privileges, PID/network/IPC/UTS/mount/cgroup namespaces, memory/PID/CPU bounds, masked proc paths, and no host environment. It asserts filesystem breakout, host-secret, control-socket, privilege escalation, and metadata-network attempts fail; runtime crash and timeout both force cleanup; residual runsc state fails the job.

## Local verification

- 7 unit tests pass; 2 real-runtime tests opt in only on Linux with pinned runsc
- basedpyright: 0 errors, 0 warnings
- ruff check + format clean
- private-plan leak check clean

No release, publication, deployment, privileged remote installation, or feature activation authorized.