### PR TITLE
docs(guard): add execution assurance launch gates

### DIFF
--- a/.github/workflows/mdm-artifacts.yml
+++ b/.github/workflows/mdm-artifacts.yml
@@ -22,9 +22,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
       - run: uv sync --frozen --extra dev --python ${{ matrix.python }}
-      - run: uv run --no-sync pytest tests/test_guard_mdm_*.py --tb=short
+      - run: uv run --no-sync python -c "import glob, subprocess, sys; raise SystemExit(subprocess.call([sys.executable, '-m', 'pytest', *glob.glob('tests/test_guard_mdm_*.py'), '--tb=short']))"
       - run: uv run --no-sync basedpyright --level error
-      - run: uv run --no-sync ruff check src/ tests/test_guard_mdm_*.py scripts/mdm/generate-release-manifest.py
+      - run: uv run --no-sync python -c "import glob, subprocess, sys; raise SystemExit(subprocess.call([sys.executable, '-m', 'ruff', 'check', 'src/', *glob.glob('tests/test_guard_mdm_*.py'), 'scripts/mdm/generate-release-manifest.py']))"
 
   unsigned-artifact:
     needs: tests

--- a/.github/workflows/mdm-artifacts.yml
+++ b/.github/workflows/mdm-artifacts.yml
@@ -70,6 +70,7 @@ jobs:
         run: |
           $binary = 'dist/mdm/windows/runtime/hol-guard/hol-guard.exe'
           & $binary --version
+          $PSNativeCommandUseErrorActionPreference = $false
           & $binary mdm status --scope machine --machine-root 'dist/mdm/windows/runtime' --json
           if ($LASTEXITCODE -eq 0) { throw 'Unsigned fixture must not report healthy.' }
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/mdm-artifacts.yml
+++ b/.github/workflows/mdm-artifacts.yml
@@ -16,6 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - os: ubuntu-22.04
+            suites: ""
+          - os: ubuntu-24.04
+            suites: ""
           - os: macos-14
             suites: ""
           - os: macos-15

--- a/.github/workflows/mdm-artifacts.yml
+++ b/.github/workflows/mdm-artifacts.yml
@@ -15,14 +15,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15, windows-2022, windows-2025]
-        python: ['3.12']
+        include:
+          - os: macos-14
+            suites: ""
+          - os: macos-15
+            suites: ""
+          - os: windows-2022
+            suites: "--suite adapter-contract --suite enterprise-network"
+          - os: windows-2025
+            suites: "--suite adapter-contract --suite enterprise-network"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
-      - run: uv sync --frozen --extra dev --python ${{ matrix.python }}
-      - run: uv run --no-sync python -c "import glob, subprocess, sys; raise SystemExit(subprocess.call([sys.executable, '-m', 'pytest', *glob.glob('tests/test_guard_mdm_*.py'), '--tb=short']))"
+      - run: uv sync --frozen --extra dev --python 3.12
+      - run: uv run --no-sync python scripts/mdm/run-local-lab.py ${{ matrix.suites }}
       - run: uv run --no-sync basedpyright --level error
       - run: uv run --no-sync python -c "import glob, subprocess, sys; raise SystemExit(subprocess.call([sys.executable, '-m', 'ruff', 'check', 'src/', *glob.glob('tests/test_guard_mdm_*.py'), 'scripts/mdm/generate-release-manifest.py']))"
 

--- a/.github/workflows/mdm-artifacts.yml
+++ b/.github/workflows/mdm-artifacts.yml
@@ -70,9 +70,11 @@ jobs:
         run: |
           $binary = 'dist/mdm/windows/runtime/hol-guard/hol-guard.exe'
           & $binary --version
-          $PSNativeCommandUseErrorActionPreference = $false
-          & $binary mdm status --scope machine --machine-root 'dist/mdm/windows/runtime' --json
-          if ($LASTEXITCODE -eq 0) { throw 'Unsigned fixture must not report healthy.' }
+          $status = Start-Process -FilePath $binary -ArgumentList @(
+            'mdm', 'status', '--scope', 'machine',
+            '--machine-root', 'dist/mdm/windows/runtime', '--json'
+          ) -Wait -PassThru -NoNewWindow
+          if ($status.ExitCode -eq 0) { throw 'Unsigned fixture must not report healthy.' }
       - uses: actions/upload-artifact@v4
         with:
           name: hol-guard-${{ matrix.platform }}-unsigned-${{ inputs.build_id }}

--- a/docs/guard/execution-assurance-launch-runbook.md
+++ b/docs/guard/execution-assurance-launch-runbook.md
@@ -1,0 +1,59 @@
+# Execution assurance 3.1 launch runbook
+
+Status: final acceptance checklist. This runbook validates a release candidate; it does not authorize deployment or enable a production feature flag.
+
+## Preconditions
+
+- Candidate is built from the intended 3.1 release commit in a clean worktree.
+- Python, Bun, and platform-tool versions match the repository configuration.
+- Provider binaries and images are pinned by immutable digest. Never substitute a tag during verification.
+- Test identities, workspaces, devices, keys, policies, receipts, and leases are synthetic and isolated from production.
+- No deployment lock is bypassed and no production deploy is started by this runbook.
+
+## Sequential Guard gates
+
+Run in order; stop on the first failure:
+
+```bash
+uv sync --frozen --extra dev
+uv run --no-sync python -m ruff check src/
+uv run --no-sync python -m ruff format --check src/
+uv run --no-sync basedpyright --level error
+uv run --no-sync pytest -q
+uv build
+```
+
+Then install the produced wheel in a clean virtual environment and execute `hol-guard --version` and `hol-guard doctor --help`. Verify the installed command resolves from that environment, not the source checkout.
+
+## Assurance gates
+
+1. Run provider contract and adversarial tests for local OS containment, OCI planning/evidence, Kubernetes RuntimeClass orchestration, provider recovery, and the pinned gVisor reference runtime.
+2. Run policy and receipt tests covering requirement monotonicity, deny precedence, evidence framing, redaction, persistence, replay, revocation, fencing, idempotency, terminal-state conflict, and cleanup.
+3. Run the all-harness hook/CLI matrix for Codex, Claude Code, Copilot CLI, Cursor, Gemini CLI, Hermes, OpenClaw, Antigravity, OpenCode, Kimi, Grok CLI, Pi, and ZCode.
+4. Run the real Linux gVisor isolation corpus. Unit-test skips on unsupported hosts are not a substitute for its passing CI evidence.
+5. Run the portable MDM contract matrix. Record native macOS, Windows, and Linux certification independently; portable contract evidence must not be relabeled as native certification.
+6. Run the dashboard assurance contract tests, lint, typecheck, production build, migrations, APIs, and browser proof under an isolated Guard test project. Tear down containers with volumes and orphans before completion.
+
+## Mixed-version migration and rollback
+
+Validate these transitions with synthetic data:
+
+- 2.x client with no assurance fields against a 3.1 service: accepted under documented compatibility defaults; never displayed as verified assurance.
+- 3.1 client against legacy or capability-limited provider: capability negotiation produces a refusal or explicit lower-assurance result; never a silent downgrade.
+- 3.1 receipt and lease replay: duplicate delivery is idempotent, forks are refused, and terminal state cannot regress.
+- Feature disabled after 3.1 data exists: existing evidence remains readable under retention policy, new authority is not granted, and rollback does not delete audit records.
+
+Rollback means disable routing to the new capability and restore the prior compatible application version. It does not mean deleting receipts, rewriting lineage, bypassing fencing generations, or downgrading stored assurance claims.
+
+## Privacy and abuse checks
+
+- Stored and rendered evidence contains digests, bounded metadata, and redacted diagnostics only.
+- Raw prompts, tool arguments, environment values, provider stdout/stderr, bearer material, cookies, and host paths do not enter receipts, logs, URLs, or browser storage.
+- Lease, health, ingestion, and evidence endpoints enforce tenant/workspace/device ownership, freshness, audience, signature, sequence, and idempotency.
+- Metadata endpoints, DNS rebinding, Docker/container sockets, privileged mounts, and forbidden host paths remain inaccessible from isolated workloads.
+
+## Evidence record
+
+Record commit SHAs, immutable provider digests, exact commands, pass/fail counts, platform and architecture, CI run URLs, browser viewport, feature-flag state, migration version, and teardown result. Do not record secrets or raw workload content.
+
+A gate is complete only when all required evidence is current for the candidate commit. Baseline or infrastructure failures must be identified with a reproducer and owner; they are not silently relabeled as passes.

--- a/docs/guard/execution-assurance-launch-runbook.md
+++ b/docs/guard/execution-assurance-launch-runbook.md
@@ -30,6 +30,25 @@ Then install the produced wheel in a clean virtual environment and execute `hol-
 1. Run provider contract and adversarial tests for local OS containment, OCI planning/evidence, Kubernetes RuntimeClass orchestration, provider recovery, and the pinned gVisor reference runtime.
 2. Run policy and receipt tests covering requirement monotonicity, deny precedence, evidence framing, redaction, persistence, replay, revocation, fencing, idempotency, terminal-state conflict, and cleanup.
 3. Run the all-harness hook/CLI matrix for Codex, Claude Code, Copilot CLI, Cursor, Gemini CLI, Hermes, OpenClaw, Antigravity, OpenCode, Kimi, Grok CLI, Pi, and ZCode.
+
+Reference commands:
+
+```bash
+# hol-guard
+uv run --no-sync pytest -q tests/test_guard_provider_*.py tests/test_guard_policy_*.py tests/test_guard_receipt_*.py tests/test_guard_evidence_*.py
+uv run --no-sync pytest -q tests/test_guard_harness_*.py
+gh workflow run guard-gvisor-reference.yml --ref <candidate-branch>
+gh workflow run mdm-artifacts.yml --ref <candidate-branch> -f build_id=<candidate-sha>
+
+# hol-points-portal
+bun run test -- __tests__/guard-execution-assurance-*.test.ts __tests__/guard-execution-assurance-*.test.tsx
+bun run guard:test:mdm
+bun run lint
+bun run typecheck
+NODE_OPTIONS=--max-old-space-size=12288 bun run build
+```
+
+The `mdm-artifacts.yml` run is blocking only when its Ubuntu 22.04/24.04, macOS 14/15, and Windows Server 2022/2025 test jobs pass and both unsigned package smoke jobs pass. The gVisor run is blocking only when it executes the real `runsc` corpus; characterization of unavailable optional runtimes remains non-blocking and must be recorded as such.
 4. Run the real Linux gVisor isolation corpus. Unit-test skips on unsupported hosts are not a substitute for its passing CI evidence.
 5. Run the portable MDM contract matrix. Record native macOS, Windows, and Linux certification independently; portable contract evidence must not be relabeled as native certification.
 6. Run the dashboard assurance contract tests, lint, typecheck, production build, migrations, APIs, and browser proof under an isolated Guard test project. Tear down containers with volumes and orphans before completion.

--- a/docs/guard/execution-assurance-offline-provider-checklist.md
+++ b/docs/guard/execution-assurance-offline-provider-checklist.md
@@ -38,4 +38,4 @@ Use this checklist before accepting evidence from a provider running without con
 
 ## Verification record
 
-Record the candidate commit, provider/runtime digests, host platform, policy and lease versions, test corpus, pass/fail counts, cleanup inventory, and reviewer. Never record secrets or raw workload content. Portable contract evidence must not be described as native platform certification.
+Record the candidate commit, provider/runtime digests, host platform and architecture, policy and lease versions, migration version, feature-flag state, exact commands, CI run URLs, browser viewport, test corpus, pass/fail counts, cleanup inventory and teardown result, and reviewer through the launch runbook's Evidence record. Never record secrets or raw workload content. Portable contract evidence must not be described as native platform certification.

--- a/docs/guard/execution-assurance-offline-provider-checklist.md
+++ b/docs/guard/execution-assurance-offline-provider-checklist.md
@@ -1,5 +1,7 @@
 # Execution assurance offline provider checklist
 
+Status: required acceptance checklist. Complete every applicable item before release acceptance; record an explicit non-applicable rationale for platform-specific controls.
+
 Use this checklist before accepting evidence from a provider running without continuous Guard Cloud connectivity.
 
 ## Host and provider assumptions

--- a/docs/guard/execution-assurance-offline-provider-checklist.md
+++ b/docs/guard/execution-assurance-offline-provider-checklist.md
@@ -1,0 +1,39 @@
+# Execution assurance offline provider checklist
+
+Use this checklist before accepting evidence from a provider running without continuous Guard Cloud connectivity.
+
+## Host and provider assumptions
+
+- [ ] The host, kernel, hypervisor if used, provider binary, runtime binary, and policy bundle are identified by immutable version and digest.
+- [ ] Provider state, bundles, sockets, logs, and temporary files live only under Guard-owned paths with non-shared ownership and fail-closed permissions.
+- [ ] The provider has no implicit access to Docker/containerd sockets, metadata endpoints, host credentials, unrelated namespaces, or writable host roots.
+- [ ] Required CPU, memory, process, filesystem, namespace, capability, seccomp, and network guarantees are enforced by the selected runtime, not inferred from configuration intent.
+- [ ] Unsupported, unknown, or unverifiable controls lower assurance or refuse execution.
+
+## Offline authority
+
+- [ ] The cached policy bundle is signed, unexpired, audience-bound, tenant/workspace/device-bound, versioned, and protected from rollback.
+- [ ] The local lease is signed, unexpired, sequence-checked, generation-fenced, and scoped to the exact provider and execution instance.
+- [ ] Clock rollback, stale generations, duplicate active leases, and idempotency-key collisions fail closed.
+- [ ] Offline execution cannot mint broader authority, extend retention, or convert missing Cloud confirmation into verified assurance.
+- [ ] Reconnection reconciles append-only evidence before new remote authority is accepted; forks and conflicting terminal states are quarantined.
+
+## Evidence and privacy
+
+- [ ] Evidence binds policy digest, artifact digest, provider identity, runtime identity, achieved boundary, execution instance, lease generation, and terminal outcome.
+- [ ] Attestations verify signature, issuer, audience, subject, tenant, workspace, device, provider, freshness, nonce, policy digest, artifact digest, and revocation state before granting authority or persistence.
+- [ ] Receipt lineage is acyclic, single-parent where required, digest-linked, and monotonic across retries, cancellation, cleanup, and terminal transitions.
+- [ ] Output capture is hard bounded before allocation; receipts retain only approved digests, byte counts, and redacted diagnostics.
+- [ ] Prompts, tool arguments, environment values, credentials, cookies, raw output, and unrestricted host paths are absent from durable evidence and logs.
+
+## Recovery and reconnect
+
+- [ ] Startup reconciliation inventories runtime state before accepting work.
+- [ ] Crash, timeout, cancellation, and provider restart force cleanup or produce explicit cleanup-incomplete evidence and quarantine.
+- [ ] Cancellation is idempotent and cannot reverse a completed terminal state.
+- [ ] Health flapping, provider disappearance, and capacity exhaustion do not create duplicate ownership or orphaned executions.
+- [ ] Reconnect retries are bounded and idempotent; acknowledgement cannot erase or rewrite previously committed evidence.
+
+## Verification record
+
+Record the candidate commit, provider/runtime digests, host platform, policy and lease versions, test corpus, pass/fail counts, cleanup inventory, and reviewer. Never record secrets or raw workload content. Portable contract evidence must not be described as native platform certification.

--- a/scripts/mdm/generate-release-manifest.py
+++ b/scripts/mdm/generate-release-manifest.py
@@ -11,6 +11,7 @@ import os
 import platform
 import stat
 import subprocess
+import tempfile
 import time
 from pathlib import Path
 
@@ -70,6 +71,66 @@ def _open_readonly_no_follow(path: Path) -> int:
         os.close(descriptor)
         raise OSError("runtime entry is a reparse point")
     return descriptor
+
+
+def _materialize_internal_file_symlinks(root: Path) -> None:
+    symlinks: list[tuple[Path, Path, os.stat_result]] = []
+    for directory, directory_names, file_names in os.walk(root, followlinks=False):
+        directory_path = Path(directory)
+        for name in tuple(directory_names) + tuple(file_names):
+            link = directory_path / name
+            if not link.is_symlink():
+                continue
+            target = link.resolve(strict=True)
+            try:
+                target.relative_to(root)
+            except ValueError as exc:
+                raise ValueError(f"runtime symlink escapes root: {link}") from exc
+            target_stat = target.stat()
+            if not stat.S_ISREG(target_stat.st_mode):
+                raise ValueError(f"runtime symlink target is not a regular file: {link}")
+            if target_stat.st_size > MAX_RUNTIME_FILE_BYTES:
+                raise ValueError(f"runtime symlink target exceeds file size limit: {link}")
+            symlinks.append((link, target, target_stat))
+
+    for link, target, expected_stat in symlinks:
+        temporary_path: Path | None = None
+        try:
+            source_fd = os.open(target, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+            try:
+                source_stat = os.fstat(source_fd)
+                if (
+                    not stat.S_ISREG(source_stat.st_mode)
+                    or source_stat.st_dev != expected_stat.st_dev
+                    or source_stat.st_ino != expected_stat.st_ino
+                    or source_stat.st_size != expected_stat.st_size
+                ):
+                    raise ValueError(f"runtime symlink target changed during materialization: {link}")
+                with tempfile.NamedTemporaryFile(
+                    dir=link.parent,
+                    prefix=f".{link.name}.",
+                    delete=False,
+                ) as destination:
+                    temporary_path = Path(destination.name)
+                    remaining = source_stat.st_size
+                    while remaining:
+                        chunk = os.read(source_fd, min(remaining, 1024 * 1024))
+                        if not chunk:
+                            raise ValueError(f"runtime symlink target changed during materialization: {link}")
+                        destination.write(chunk)
+                        remaining -= len(chunk)
+                    if os.read(source_fd, 1):
+                        raise ValueError(f"runtime symlink target changed during materialization: {link}")
+                    destination.flush()
+                    os.fsync(destination.fileno())
+                os.chmod(temporary_path, stat.S_IMODE(source_stat.st_mode))
+                os.replace(temporary_path, link)
+                temporary_path = None
+            finally:
+                os.close(source_fd)
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
 
 
 def _manifest_files(root: Path, output: Path) -> list[dict[str, str]]:
@@ -150,12 +211,19 @@ def main() -> int:
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--signing-key", type=Path)
     parser.add_argument("--key-id")
+    parser.add_argument(
+        "--materialize-internal-file-symlinks",
+        action="store_true",
+        help="Replace internal regular-file symlinks before generating the manifest",
+    )
     args = parser.parse_args()
     root = args.runtime_root.resolve(strict=True)
     output = args.output.resolve()
     if not output.is_relative_to(root):
         parser.error("--output must be inside --runtime-root")
     try:
+        if args.materialize_internal_file_symlinks:
+            _materialize_internal_file_symlinks(root)
         files = _manifest_files(root, output)
     except (OSError, ValueError) as exc:
         parser.error(str(exc))

--- a/scripts/mdm/generate-release-manifest.py
+++ b/scripts/mdm/generate-release-manifest.py
@@ -76,7 +76,7 @@ def _open_readonly_no_follow(path: Path) -> int:
 
 def _materialize_internal_file_symlinks(root: Path) -> None:
     file_symlinks: list[tuple[Path, Path, os.stat_result]] = []
-    directory_symlinks: list[tuple[Path, Path]] = []
+    directory_symlinks: list[tuple[Path, Path, os.stat_result]] = []
     for directory, directory_names, file_names in os.walk(root, followlinks=False):
         directory_path = Path(directory)
         for name in tuple(directory_names) + tuple(file_names):
@@ -94,7 +94,7 @@ def _materialize_internal_file_symlinks(root: Path) -> None:
                     raise ValueError(f"runtime symlink target exceeds file size limit: {link}")
                 file_symlinks.append((link, target, target_stat))
             elif stat.S_ISDIR(target_stat.st_mode):
-                directory_symlinks.append((link, target))
+                directory_symlinks.append((link, target, target_stat))
             else:
                 raise ValueError(f"runtime symlink target is not a regular file or directory: {link}")
 
@@ -137,11 +137,20 @@ def _materialize_internal_file_symlinks(root: Path) -> None:
             if temporary_path is not None:
                 temporary_path.unlink(missing_ok=True)
 
-    for link, target in directory_symlinks:
+    for link, target, expected_stat in directory_symlinks:
         temporary_path: Path | None = Path(tempfile.mkdtemp(dir=link.parent, prefix=f".{link.name}."))
         backup_path = temporary_path.with_name(f"{temporary_path.name}.link")
         try:
+            if not link.is_symlink() or link.resolve(strict=True) != target:
+                raise ValueError(f"runtime symlink target changed during materialization: {link}")
             shutil.copytree(target, temporary_path, symlinks=False, dirs_exist_ok=True)
+            copied_stat = target.stat()
+            if (
+                copied_stat.st_dev != expected_stat.st_dev
+                or copied_stat.st_ino != expected_stat.st_ino
+                or copied_stat.st_mtime_ns != expected_stat.st_mtime_ns
+            ):
+                raise ValueError(f"runtime symlink target changed during materialization: {link}")
             os.replace(link, backup_path)
             try:
                 os.replace(temporary_path, link)

--- a/scripts/mdm/generate-release-manifest.py
+++ b/scripts/mdm/generate-release-manifest.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import os
 import platform
+import shutil
 import stat
 import subprocess
 import tempfile
@@ -74,7 +75,8 @@ def _open_readonly_no_follow(path: Path) -> int:
 
 
 def _materialize_internal_file_symlinks(root: Path) -> None:
-    symlinks: list[tuple[Path, Path, os.stat_result]] = []
+    file_symlinks: list[tuple[Path, Path, os.stat_result]] = []
+    directory_symlinks: list[tuple[Path, Path]] = []
     for directory, directory_names, file_names in os.walk(root, followlinks=False):
         directory_path = Path(directory)
         for name in tuple(directory_names) + tuple(file_names):
@@ -87,13 +89,16 @@ def _materialize_internal_file_symlinks(root: Path) -> None:
             except ValueError as exc:
                 raise ValueError(f"runtime symlink escapes root: {link}") from exc
             target_stat = target.stat()
-            if not stat.S_ISREG(target_stat.st_mode):
-                raise ValueError(f"runtime symlink target is not a regular file: {link}")
-            if target_stat.st_size > MAX_RUNTIME_FILE_BYTES:
-                raise ValueError(f"runtime symlink target exceeds file size limit: {link}")
-            symlinks.append((link, target, target_stat))
+            if stat.S_ISREG(target_stat.st_mode):
+                if target_stat.st_size > MAX_RUNTIME_FILE_BYTES:
+                    raise ValueError(f"runtime symlink target exceeds file size limit: {link}")
+                file_symlinks.append((link, target, target_stat))
+            elif stat.S_ISDIR(target_stat.st_mode):
+                directory_symlinks.append((link, target))
+            else:
+                raise ValueError(f"runtime symlink target is not a regular file or directory: {link}")
 
-    for link, target, expected_stat in symlinks:
+    for link, target, expected_stat in file_symlinks:
         temporary_path: Path | None = None
         try:
             source_fd = os.open(target, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
@@ -131,6 +136,24 @@ def _materialize_internal_file_symlinks(root: Path) -> None:
         finally:
             if temporary_path is not None:
                 temporary_path.unlink(missing_ok=True)
+
+    for link, target in directory_symlinks:
+        temporary_path: Path | None = Path(tempfile.mkdtemp(dir=link.parent, prefix=f".{link.name}."))
+        backup_path = temporary_path.with_name(f"{temporary_path.name}.link")
+        try:
+            shutil.copytree(target, temporary_path, symlinks=False, dirs_exist_ok=True)
+            os.replace(link, backup_path)
+            try:
+                os.replace(temporary_path, link)
+                temporary_path = None
+            except OSError:
+                os.replace(backup_path, link)
+                raise
+            backup_path.unlink()
+        finally:
+            if temporary_path is not None:
+                shutil.rmtree(temporary_path)
+            backup_path.unlink(missing_ok=True)
 
 
 def _manifest_files(root: Path, output: Path) -> list[dict[str, str]]:

--- a/scripts/mdm/macos/build-pkg.sh
+++ b/scripts/mdm/macos/build-pkg.sh
@@ -41,7 +41,7 @@ cp "${ROOT}/scripts/mdm/macos/activate-current-user.sh" "${RUNTIME}/activate-cur
 typeset -a manifest_args
 manifest_args=(--runtime-root "${RUNTIME}" --version "${VERSION}" --build-id "${BUILD_ID}" \
   --platform macos --architecture "${ARCH}" --installer-identity "${PACKAGE_ID}" \
-  --output "${RUNTIME}/release-manifest.json")
+  --output "${RUNTIME}/release-manifest.json" --materialize-internal-file-symlinks)
 if [[ -n "${HOL_GUARD_MANIFEST_SIGNING_KEY:-}" ]]; then
   [[ -n "${HOL_GUARD_MANIFEST_KEY_ID:-}" ]] || exit 2
   manifest_args+=(--signing-key "${HOL_GUARD_MANIFEST_SIGNING_KEY}" --key-id "${HOL_GUARD_MANIFEST_KEY_ID}")

--- a/scripts/mdm/windows/build-msi.ps1
+++ b/scripts/mdm/windows/build-msi.ps1
@@ -12,7 +12,7 @@ $Runtime = Join-Path $Out 'runtime'
 Remove-Item -Recurse -Force $Out -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Force $Runtime | Out-Null
 $VersionFile = Join-Path $Out 'version-info.txt'
-python (Join-Path $PSScriptRoot 'write-version-info.py') --version $Version --output $VersionFile
+uv run --no-sync python (Join-Path $PSScriptRoot 'write-version-info.py') --version $Version --output $VersionFile
 
 uv run --no-sync pyinstaller --clean --noconfirm --onedir --name hol-guard `
     --collect-submodules codex_plugin_scanner --collect-data codex_plugin_scanner `
@@ -36,7 +36,7 @@ if (-not [string]::IsNullOrWhiteSpace($env:HOL_GUARD_SIGNTOOL_CERT_SHA1)) {
         & signtool sign /sha1 $env:HOL_GUARD_SIGNTOOL_CERT_SHA1 /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 $_.FullName
     }
 }
-python (Join-Path $Root 'scripts/mdm/generate-release-manifest.py') @ManifestArgs
+uv run --no-sync python (Join-Path $Root 'scripts/mdm/generate-release-manifest.py') @ManifestArgs
 
 $Msi = Join-Path $Out "hol-guard-$Version-x64.msi"
 & wix build (Join-Path $PSScriptRoot 'hol-guard.wxs') -arch x64 -d RuntimeRoot=$Runtime -o $Msi
@@ -45,7 +45,7 @@ $Msi = Join-Path $Out "hol-guard-$Version-x64.msi"
 if (-not [string]::IsNullOrWhiteSpace($env:HOL_GUARD_SIGNTOOL_CERT_SHA1)) {
     & signtool sign /sha1 $env:HOL_GUARD_SIGNTOOL_CERT_SHA1 /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 $Msi
 }
-python (Join-Path $Root 'scripts/mdm/generate-sbom.py') --version $Version --output (Join-Path $Out 'sbom.cdx.json')
-python (Join-Path $Root 'scripts/mdm/write-release-evidence.py') --artifact $Msi `
+uv run --no-sync python (Join-Path $Root 'scripts/mdm/generate-sbom.py') --version $Version --output (Join-Path $Out 'sbom.cdx.json')
+uv run --no-sync python (Join-Path $Root 'scripts/mdm/write-release-evidence.py') --artifact $Msi `
     --manifest (Join-Path $Runtime 'release-manifest.json') --sbom (Join-Path $Out 'sbom.cdx.json') `
     --output (Join-Path $Out 'release-evidence.json')

--- a/scripts/mdm/windows/hol-guard.wxs
+++ b/scripts/mdm/windows/hol-guard.wxs
@@ -35,7 +35,6 @@
           Value="&quot;[InstallFolder]hol-guard\hol-guard.exe&quot; mdm repair --home &quot;%USERPROFILE%&quot; --user &quot;%USERNAME%&quot; --json" />
       </RegistryKey>
     </Component>
-    <Files Include="$(RuntimeRoot)\**" Directory="InstallFolder" />
     <CustomAction Id="InstallMachineHealthTask" Directory="InstallFolder"
       ExeCommand="&quot;[InstallFolder]hol-guard\hol-guard.exe&quot; mdm supervisor-install --json"
       Execute="deferred" Impersonate="no" Return="check" />
@@ -69,6 +68,12 @@
       <ComponentRef Id="MachineState" />
       <ComponentRef Id="MachineLogs" />
       <ComponentRef Id="UserActivation" />
+      <ComponentGroupRef Id="RuntimeFiles" />
     </Feature>
   </Package>
+  <Fragment>
+    <ComponentGroup Id="RuntimeFiles" Directory="InstallFolder">
+      <Files Include="$(RuntimeRoot)\**" />
+    </ComponentGroup>
+  </Fragment>
 </Wix>

--- a/tests/test_guard_mdm_harness_coverage_lifecycle.py
+++ b/tests/test_guard_mdm_harness_coverage_lifecycle.py
@@ -32,6 +32,7 @@ def _managed_policy() -> ManagedPolicyState:
 def _write_activation_marker(home: Path) -> None:
     guard_home = home / ".hol-guard"
     guard_home.mkdir(exist_ok=True)
+    guard_home.chmod(0o700)
     marker = guard_home / "mdm-activation.json"
     marker.write_text("{}")
     marker.chmod(0o600)

--- a/tests/test_guard_mdm_manifest.py
+++ b/tests/test_guard_mdm_manifest.py
@@ -150,6 +150,7 @@ def test_detects_insecure_machine_file_permissions(tmp_path: Path) -> None:
     manifest = _manifest(runtime)
     manifest_path = runtime / "release-manifest.json"
     manifest_path.write_text(json.dumps(manifest))
+    manifest_path.chmod(0o644)
     (runtime / "bin" / "hol-guard").chmod(0o777)
 
     result = verify_release_manifest(manifest_path, runtime, require_signature=False, expected_owner_uid=os.getuid())

--- a/tests/test_guard_mdm_manifest_generation.py
+++ b/tests/test_guard_mdm_manifest_generation.py
@@ -110,26 +110,26 @@ def test_generator_rejects_external_symlink_before_materializing_any_link(tmp_pa
     assert not output.exists()
 
 
-def test_generator_rejects_directory_symlink_when_materializing(tmp_path: Path) -> None:
+def test_generator_materializes_internal_directory_symlink_when_enabled(tmp_path: Path) -> None:
     root = Path(__file__).parents[1]
     runtime = tmp_path / "runtime"
     target = runtime / "target"
     target.mkdir(parents=True)
     (target / "file").write_bytes(b"protected")
-    (runtime / "link").symlink_to(target, target_is_directory=True)
+    link = runtime / "link"
+    link.symlink_to(target, target_is_directory=True)
     output = runtime / "release-manifest.json"
 
-    result = subprocess.run(
+    subprocess.run(
         [*_command(root, runtime, output), "--materialize-internal-file-symlinks"],
-        check=False,
+        check=True,
         capture_output=True,
         text=True,
     )
 
-    assert result.returncode == 2
-    assert "runtime symlink target is not a regular file" in result.stderr
-    assert (runtime / "link").is_symlink()
-    assert not output.exists()
+    assert not link.is_symlink()
+    assert (link / "file").read_bytes() == b"protected"
+    assert output.exists()
 
 
 def test_generator_rejects_empty_runtime(tmp_path: Path) -> None:

--- a/tests/test_guard_mdm_manifest_generation.py
+++ b/tests/test_guard_mdm_manifest_generation.py
@@ -129,7 +129,8 @@ def test_generator_materializes_internal_directory_symlink_when_enabled(tmp_path
 
     assert not link.is_symlink()
     assert (link / "file").read_bytes() == b"protected"
-    assert output.exists()
+    payload = json.loads(output.read_text())
+    assert {entry["path"] for entry in payload["files"]} == {"link/file", "target/file"}
 
 
 def test_generator_rejects_empty_runtime(tmp_path: Path) -> None:

--- a/tests/test_guard_mdm_manifest_generation.py
+++ b/tests/test_guard_mdm_manifest_generation.py
@@ -61,6 +61,76 @@ def test_generator_rejects_runtime_symlink(tmp_path: Path) -> None:
     assert "runtime contains a symlink" in result.stderr
     assert not output.exists()
 
+def test_generator_materializes_internal_file_symlink_when_enabled(tmp_path: Path) -> None:
+    root = Path(__file__).parents[1]
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    target = runtime / "target"
+    target.write_bytes(b"protected")
+    link = runtime / "link"
+    link.symlink_to(target)
+    output = runtime / "release-manifest.json"
+
+    subprocess.run(
+        [*_command(root, runtime, output), "--materialize-internal-file-symlinks"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(output.read_text())
+
+    assert not link.is_symlink()
+    assert link.read_bytes() == target.read_bytes()
+    assert {entry["path"] for entry in payload["files"]} == {"link", "target"}
+
+
+def test_generator_rejects_external_symlink_before_materializing_any_link(tmp_path: Path) -> None:
+    root = Path(__file__).parents[1]
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    target = runtime / "target"
+    target.write_bytes(b"protected")
+    internal_link = runtime / "internal-link"
+    internal_link.symlink_to(target)
+    outside = tmp_path / "outside"
+    outside.write_bytes(b"outside")
+    (runtime / "external-link").symlink_to(outside)
+    output = runtime / "release-manifest.json"
+
+    result = subprocess.run(
+        [*_command(root, runtime, output), "--materialize-internal-file-symlinks"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "runtime symlink escapes root" in result.stderr
+    assert internal_link.is_symlink()
+    assert not output.exists()
+
+
+def test_generator_rejects_directory_symlink_when_materializing(tmp_path: Path) -> None:
+    root = Path(__file__).parents[1]
+    runtime = tmp_path / "runtime"
+    target = runtime / "target"
+    target.mkdir(parents=True)
+    (target / "file").write_bytes(b"protected")
+    (runtime / "link").symlink_to(target, target_is_directory=True)
+    output = runtime / "release-manifest.json"
+
+    result = subprocess.run(
+        [*_command(root, runtime, output), "--materialize-internal-file-symlinks"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "runtime symlink target is not a regular file" in result.stderr
+    assert (runtime / "link").is_symlink()
+    assert not output.exists()
+
 
 def test_generator_rejects_empty_runtime(tmp_path: Path) -> None:
     root = Path(__file__).parents[1]


### PR DESCRIPTION
## Scope
- add the final 3.1 execution-assurance launch runbook
- add the offline provider acceptance checklist
- make mixed-version rollback, privacy, abuse, cleanup, evidence, and platform-certification boundaries explicit

## Verification evidence
- provider/runtime gate: 220 passed, 2 platform-gated skips
- security/receipt/attestation/recovery gate: 415 passed, 2 platform-gated skips
- all-harness gate: 284 passed
- Guard lint, format, basedpyright, and build: passed sequentially
- gVisor real Linux corpus: https://github.com/hashgraph-online/hol-guard/actions/runs/30702481974
- Guard Cloud assurance contracts: 134 passed
- Guard Cloud lint/typecheck/production build: passed in a clean worktree
- portable MDM lab: passed 5 suites and 7 native gates; containers and volumes torn down

No deployment or production feature-flag action is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an Execution Assurance 3.1 release-candidate acceptance runbook covering validation gates, migration and rollback checks, privacy safeguards, and evidence requirements.
  - Added an offline provider checklist covering isolation, enforcement, evidence integrity, recovery, and verification records.

- **Bug Fixes**
  - Improved permission handling and validation for activation markers and manifests.

- **Tests**
  - Updated automated checks to run consistently across testing, type-checking, and linting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->