### PR TITLE
test(quality): restore G6 release gate hygiene

### DIFF
--- a/tests/test_cloud_exception_requests.py
+++ b/tests/test_cloud_exception_requests.py
@@ -201,7 +201,16 @@ def test_validate_command_policy_payload_normalizes_valid_input() -> None:
 def test_validate_command_policy_payload_proves_no_command_crosses_boundary() -> None:
     """The single most important test: prove no raw command, regex,
     pattern, graph, or expression key survives validation."""
-    forbidden = ["rawCommand", "command", "commandExpression", "expression", "regex", "pattern", "graph", "proposedGraph"]
+    forbidden = [
+        "rawCommand",
+        "command",
+        "commandExpression",
+        "expression",
+        "regex",
+        "pattern",
+        "graph",
+        "proposedGraph",
+    ]
     normalized = validate_command_policy_exception_payload(
         {
             "kind": "command-policy",

--- a/tests/test_guard_codex_interpreter_migration.py
+++ b/tests/test_guard_codex_interpreter_migration.py
@@ -87,6 +87,7 @@ def test_guard_install_codex_ignores_proxy_with_scalar_args(
     assert installed["migrated_proxy_servers"] == []
     assert installed["runtime_restart_required"] is False
 
+
 def test_reauthentication_rejects_incomplete_package_identity() -> None:
     manifest = {
         "schema_version": HOOK_MANIFEST_SCHEMA_VERSION,

--- a/tests/test_guard_execution_assurance_receipt.py
+++ b/tests/test_guard_execution_assurance_receipt.py
@@ -6,7 +6,6 @@ import sys
 from dataclasses import FrozenInstanceError
 from hashlib import sha256
 from pathlib import Path
-from typing import cast
 
 import pytest
 
@@ -18,8 +17,8 @@ from codex_plugin_scanner.guard.runtime.execution_assurance_contract import (
     GuardExecutionAttestationTrust,
 )
 from codex_plugin_scanner.guard.runtime.execution_assurance_receipt import (
-    ExecutionAssuranceReceipt,
     SCHEMA_VERSION,
+    ExecutionAssuranceReceipt,
     receipt_assurance_payload,
     validate_assurance_receipt_schema_version,
 )
@@ -44,6 +43,7 @@ GOOD = {
 # ---------------------------------------------------------------------------
 # Schema version validation
 # ---------------------------------------------------------------------------
+
 
 class TestSchemaVersionValidation:
     def test_current_version_accepted_str(self) -> None:
@@ -78,13 +78,16 @@ class TestSchemaVersionValidation:
 # Typed boundary / attestation fields
 # ---------------------------------------------------------------------------
 
+
 class TestTypedFields:
     def test_minimal_valid(self) -> None:
-        rec = ExecutionAssuranceReceipt(**{
-            "achieved_boundary": GuardExecutionAssuranceBoundary.OS_ISOLATED,
-            "attestation_trust": GuardExecutionAttestationTrust.SELF_ATTESTED,
-            "execution_context_digest": DIGEST,
-        })
+        rec = ExecutionAssuranceReceipt(
+            **{
+                "achieved_boundary": GuardExecutionAssuranceBoundary.OS_ISOLATED,
+                "attestation_trust": GuardExecutionAttestationTrust.SELF_ATTESTED,
+                "execution_context_digest": DIGEST,
+            }
+        )
         assert rec.achieved_boundary == GuardExecutionAssuranceBoundary.OS_ISOLATED
         assert rec.attestation_trust == GuardExecutionAttestationTrust.SELF_ATTESTED
         assert rec.execution_context_digest == DIGEST
@@ -185,6 +188,7 @@ class TestTypedFields:
 # Absent vs enforced guarantee lists
 # ---------------------------------------------------------------------------
 
+
 class TestAbsentVsEnforced:
     def test_both_lists(self) -> None:
         rec = ExecutionAssuranceReceipt(
@@ -213,6 +217,7 @@ class TestAbsentVsEnforced:
 # ---------------------------------------------------------------------------
 # Privacy-safe to_receipt_fields
 # ---------------------------------------------------------------------------
+
 
 class TestPrivacySafeReceiptFields:
     def _make_receipt_with_sensitive_proof(self) -> ExecutionAssuranceReceipt:
@@ -290,6 +295,7 @@ class TestPrivacySafeReceiptFields:
 # ---------------------------------------------------------------------------
 # Immutability
 # ---------------------------------------------------------------------------
+
 
 class TestImmutability:
     def test_mutation_raises_frozen_instance_error(self) -> None:

--- a/tests/test_guard_execution_context_propagation.py
+++ b/tests/test_guard_execution_context_propagation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
+
 import pytest
 
 from codex_plugin_scanner.guard.runtime.execution_assurance_contract import framed_digest
@@ -11,11 +13,10 @@ from codex_plugin_scanner.guard.runtime.execution_context_propagation import (
     _MAX_FIELD_LENGTH,
     construct_execution_context_link,
     derive_child_link,
-    ExecutionContextLink,
 )
 
-
 # ── Construction ──────────────────────────────────────────────────────────
+
 
 class TestConstructExecutionContextLink:
     """Basic construction and validation of ExecutionContextLink."""
@@ -104,7 +105,7 @@ class TestConstructExecutionContextLink:
             root_id="root-1",
             attempt_nonce="nonce-a",
         )
-        with pytest.raises(Exception):
+        with pytest.raises(FrozenInstanceError):
             link.depth = 99
 
     def test_depth_zero_is_valid(self) -> None:
@@ -137,16 +138,20 @@ class TestConstructExecutionContextLink:
 
 # ── Validation ────────────────────────────────────────────────────────────
 
+
 class TestValidation:
     """Field-level validation on ExecutionContextLink."""
 
-    @pytest.mark.parametrize("label", [
-        "correlation_id",
-        "parent_correlation_id",
-        "retry_of_correlation_id",
-        "attempt_nonce",
-        "root_id",
-    ])
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "correlation_id",
+            "parent_correlation_id",
+            "retry_of_correlation_id",
+            "attempt_nonce",
+            "root_id",
+        ],
+    )
     def test_empty_strings_rejected(self, label: str) -> None:
         kwargs: dict = {
             "correlation_id": "root-1",
@@ -157,13 +162,16 @@ class TestValidation:
         with pytest.raises(ValueError):
             construct_execution_context_link(**kwargs)
 
-    @pytest.mark.parametrize("label", [
-        "correlation_id",
-        "parent_correlation_id",
-        "retry_of_correlation_id",
-        "attempt_nonce",
-        "root_id",
-    ])
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "correlation_id",
+            "parent_correlation_id",
+            "retry_of_correlation_id",
+            "attempt_nonce",
+            "root_id",
+        ],
+    )
     def test_too_long_strings_rejected(self, label: str) -> None:
         long_str = "x" * (_MAX_FIELD_LENGTH + 1)
         kwargs: dict = {
@@ -220,6 +228,7 @@ class TestValidation:
 
 
 # ── derive_child_link ─────────────────────────────────────────────────────
+
 
 class TestDeriveChildLink:
     """Parent → child linkage via derive_child_link."""
@@ -345,6 +354,7 @@ class TestDeriveChildLink:
 
 
 # ── Freeze / immutability ────────────────────────────────────────────────
+
 
 class TestFrozenProperties:
     """ExecutionContextLink is a frozen dataclass with slots."""

--- a/tests/test_guard_gvisor_reference_runtime.py
+++ b/tests/test_guard_gvisor_reference_runtime.py
@@ -89,7 +89,6 @@ class TestConfiguration:
         with pytest.raises(ProviderPlanError, match="writable outside"):
             _ = _runner(digest).verify_binary()
 
-
     def test_bundle_traversal_and_unknown_instances_fail(self) -> None:
         runner = _runner()
         with pytest.raises(ProviderPlanError, match="invalid"):
@@ -159,7 +158,6 @@ class TestExecution:
         run.side_effect = invoke
         result = _runner().run("guard-output")
         assert result.stdout_bytes == 1_048_576
-
 
     @patch("subprocess.run")
     def test_cancel_is_idempotent_and_validated(self, run: MagicMock) -> None:

--- a/tests/test_guard_mdm_manifest_generation.py
+++ b/tests/test_guard_mdm_manifest_generation.py
@@ -61,6 +61,7 @@ def test_generator_rejects_runtime_symlink(tmp_path: Path) -> None:
     assert "runtime contains a symlink" in result.stderr
     assert not output.exists()
 
+
 def test_generator_materializes_internal_file_symlink_when_enabled(tmp_path: Path) -> None:
     root = Path(__file__).parents[1]
     runtime = tmp_path / "runtime"

--- a/tests/test_guard_oauth_reconnect.py
+++ b/tests/test_guard_oauth_reconnect.py
@@ -257,6 +257,7 @@ def test_runtime_source_identity_covers_non_runner_modules(tmp_path) -> None:
 
     assert guard_runner_module._hol_guard_runtime_source_sha256(package_root) != initial_digest
 
+
 def test_prepare_guard_cloud_connect_authorization_tolerates_network_errors(tmp_path, monkeypatch) -> None:
     store = _store_with_oauth_credentials(tmp_path)
 

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -125,8 +125,6 @@ class TestGuardSurfaceServer:
         assert rolled_back_state is not None
         assert rolled_back_state["trust_status"] == degraded
 
-
-
     def test_local_dashboard_session_preserves_reserved_claims(self) -> None:
         token = build_local_dashboard_session_token(
             auth_token="daemon-auth-token",

--- a/tests/test_policy_document_cli.py
+++ b/tests/test_policy_document_cli.py
@@ -27,7 +27,6 @@ def test_hol_guard_routes_policy_export_format_as_a_top_level_command() -> None:
     ) == ["guard", "policy", "export", "--format", "yaml"]
 
 
-
 def test_policy_capabilities_advertise_command_expression_runtime(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -107,6 +106,7 @@ spec:
     assert return_code == 0
     assert payload["action"] == "block"
     assert payload["matching_rule_ids"] == ["block-docker"]
+
 
 def test_policy_export_validate_format_and_diff(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     home = tmp_path / "home"

--- a/tests/test_policy_document_yaml.py
+++ b/tests/test_policy_document_yaml.py
@@ -347,7 +347,6 @@ def test_canonical_object_keys_use_utf16_order() -> None:
     assert canonical.index('"😀"') < canonical.index('"\ue000"')
 
 
-
 def test_command_expression_round_trips_without_flattening_boolean_semantics() -> None:
     value = _basic_mapping()
     spec = value["spec"]


### PR DESCRIPTION
## Scope
- fix existing Ruff violations in execution-assurance tests
- apply the repository formatter to the seven outstanding test files

## Verification
- focused tests: 81 passed
- ruff check: passed
- ruff format --check: passed across 1,254 files
- basedpyright error-level: passed
- sdist and wheel build: passed

No deploy or release action is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for execution-context immutability by verifying that frozen links reject mutation.
  * Reformatted test cases and parameter lists for clearer readability.
  * Cleaned up unused imports and inconsistent spacing across validation, policy, authentication, and runtime tests.
  * No changes to application behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->