### PR TITLE
fix(update): pass prerelease flag correctly to pipx

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -1423,7 +1423,7 @@ def _update_command(
         if installer == "pipx":
             command = ["pipx", "install", "--force", package]
             if allow_prerelease:
-                command.extend(["--pip-args", "--pre"])
+                command.append("--pip-args=--pre")
             return command
         command = [sys.executable, "-m", "pip", "install", "--upgrade", "--force-reinstall"]
         if allow_prerelease:

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -96,8 +96,7 @@ def test_update_alpha_pins_latest_alpha_in_installed_major(monkeypatch: pytest.M
         "install",
         "--force",
         "hol-guard==2.1.0a35",
-        "--pip-args",
-        "--pre",
+        "--pip-args=--pre",
     ]
     assert payload["retry_command"] == "hol-guard update --alpha"
     assert payload["release_channel"] == "alpha"
@@ -114,7 +113,7 @@ def test_update_command_allows_prerelease_for_alpha_pins() -> None:
         "pipx",
         use_pypi=True,
         target_version="2.1.0a51",
-    ) == ["pipx", "install", "--force", "hol-guard==2.1.0a51", "--pip-args", "--pre"]
+    ) == ["pipx", "install", "--force", "hol-guard==2.1.0a51", "--pip-args=--pre"]
     assert update_commands._update_command(
         "pip",
         use_pypi=True,


### PR DESCRIPTION
## Summary
- pass pip prerelease arguments to pipx as a single option value
- restore alpha updates for existing stable pipx installations
- cover alpha update command construction with regression expectations

## Testing
- `uv run --no-sync pytest -q tests/test_guard_phase03_remainder.py -k 'update_alpha or update_command_allows_prerelease' --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_phase03_remainder.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_phase03_remainder.py`
- `git diff --check`
