### PR TITLE
fix(dashboard): clarify paused package actions and evidence navigation

### DIFF
--- a/dashboard/src/consolidated-evidence-alert.test.ts
+++ b/dashboard/src/consolidated-evidence-alert.test.ts
@@ -25,6 +25,7 @@ describe("ConsolidatedEvidenceAlert", () => {
     assert.ok(html.includes("Scanner evidence"));
     assert.ok(html.includes("Found 2 signals"));
     assert.ok(!html.includes("Next"));
+    assert.ok(!html.includes("Previous"));
     assert.ok(!html.includes("1 of 1"));
   });
 
@@ -35,6 +36,7 @@ describe("ConsolidatedEvidenceAlert", () => {
     ];
     const html = renderToString(createElement(ConsolidatedEvidenceAlert, { items }));
     assert.ok(html.includes("Scanner evidence"));
+    assert.ok(html.includes("Previous"));
     assert.ok(html.includes("Next"));
     assert.ok(/1.*of.*2/.test(html));
   });

--- a/dashboard/src/consolidated-evidence-alert.tsx
+++ b/dashboard/src/consolidated-evidence-alert.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type ComponentType, type ReactNode } from "react";
-import { HiMiniChevronRight, HiMiniInformationCircle } from "react-icons/hi2";
+import { HiMiniChevronLeft, HiMiniChevronRight, HiMiniInformationCircle } from "react-icons/hi2";
 
 export interface EvidenceItem {
   id: string;
@@ -25,6 +25,10 @@ export function ConsolidatedEvidenceAlert({ items }: { items: EvidenceItem[] }) 
 
   const handleNext = useCallback(() => {
     setIndex((prev) => (prev + 1) % items.length);
+  }, [items.length]);
+
+  const handlePrevious = useCallback(() => {
+    setIndex((prev) => (prev - 1 + items.length) % items.length);
   }, [items.length]);
 
   if (items.length === 0) return null;
@@ -60,6 +64,15 @@ export function ConsolidatedEvidenceAlert({ items }: { items: EvidenceItem[] }) 
             <span className="text-xs font-medium text-muted-foreground tabular-nums">
               {index + 1} of {items.length}
             </span>
+            <button
+              type="button"
+              onClick={handlePrevious}
+              className="flex items-center gap-1 rounded-lg border border-slate-200 px-2.5 py-1 text-xs font-medium text-brand-dark transition-colors hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+              aria-label="Previous insight"
+            >
+              <HiMiniChevronLeft className="h-3.5 w-3.5" aria-hidden="true" />
+              Previous
+            </button>
             <button
               type="button"
               onClick={handleNext}

--- a/dashboard/src/evidence/plain-english.test.ts
+++ b/dashboard/src/evidence/plain-english.test.ts
@@ -109,27 +109,42 @@ function buildShellRequest(overrides: Partial<GuardApprovalRequest> = {}): Guard
   assert(reason.includes("mutates project dependencies"), `T7: command fallback should explain dependency mutation, got "${reason}"`);
 }
 
-// T8: whyPaused for non-shell unknowns should use generic reason
+// T8: compound commands retain the incomplete-inspection explanation
+{
+  const request = buildShellRequest({
+    action_envelope_json: {
+      action_type: "shell_command",
+      command: "cd project && bun install --frozen-lockfile",
+      package_manager: "bun",
+      package_intent_kind: "install",
+    } as unknown as GuardActionEnvelope | null,
+  });
+  const reason = whyPaused(request);
+  assert(reason.includes("could not fully inspect"), `T8: compound reason should explain incomplete inspection, got "${reason}"`);
+  assert(!reason.includes("mutates project dependencies"), `T8: compound reason must not hide incomplete inspection, got "${reason}"`);
+}
+
+// T9: whyPaused for non-shell unknowns should use generic reason
 {
   const request = buildShellRequest({
     artifact_type: "unknown_type",
   });
   const reason = whyPaused(request);
-  assert(reason === "Guard paused this so you can review it first.", `T8: expected generic pause reason, got "${reason}"`);
+  assert(reason === "Guard paused this so you can review it first.", `T9: expected generic pause reason, got "${reason}"`);
 }
 
-// T9: humanFileName returns human-friendly names for known file types
+// T10: humanFileName returns human-friendly names for known file types
 {
-  assert(humanFileName(".env") === "your secrets file", "T9: .env should be 'your secrets file'");
-  assert(humanFileName("config.json") === "a settings file", "T9: config.json should be 'a settings file'");
-  assert(humanFileName("script.sh") === "a shell script", "T9: script.sh should be 'a shell script'");
+  assert(humanFileName(".env") === "your secrets file", "T10: .env should be 'your secrets file'");
+  assert(humanFileName("config.json") === "a settings file", "T10: config.json should be 'a settings file'");
+  assert(humanFileName("script.sh") === "a shell script", "T10: script.sh should be 'a shell script'");
 }
 
-// T10: humanFileName returns a file for empty input
+// T11: humanFileName returns a file for empty input
 {
-  assert(humanFileName(null) === "a file", "T10: null should be 'a file'");
-  assert(humanFileName(undefined) === "a file", "T10: undefined should be 'a file'");
-  assert(humanFileName("") === "a file", "T10: empty string should be 'a file'");
+  assert(humanFileName(null) === "a file", "T11: null should be 'a file'");
+  assert(humanFileName(undefined) === "a file", "T11: undefined should be 'a file'");
+  assert(humanFileName("") === "a file", "T11: empty string should be 'a file'");
 }
 
 console.log("plain-english.test.ts: all tests passed");

--- a/dashboard/src/evidence/plain-english.test.ts
+++ b/dashboard/src/evidence/plain-english.test.ts
@@ -81,27 +81,55 @@ function buildShellRequest(overrides: Partial<GuardApprovalRequest> = {}): Guard
   assert(!reason.includes("compound"), `T5: pause reason must not contain 'compound', got "${reason}"`);
 }
 
-// T6: whyPaused for non-shell unknowns should use generic reason
+// T6: package installs should explain the dependency mutation risk
+{
+  const request = buildShellRequest({
+    action_envelope_json: {
+      action_type: "shell_command",
+      command: "bun install --frozen-lockfile",
+      package_manager: "bun",
+      package_intent_kind: "install",
+    } as unknown as GuardActionEnvelope | null,
+  });
+  const reason = whyPaused(request);
+  assert(reason.includes("mutates project dependencies"), `T6: package reason should explain dependency mutation, got "${reason}"`);
+  assert(reason.includes("installed packages"), `T6: package reason should mention installed packages, got "${reason}"`);
+  assert(!reason.includes("could not fully inspect"), `T6: package reason must not claim incomplete inspection, got "${reason}"`);
+}
+
+// T7: command text still identifies a package install when envelope metadata is incomplete
+{
+  const request = buildShellRequest({
+    action_envelope_json: {
+      action_type: "shell_command",
+      command: "bun install --frozen-lockfile",
+    } as unknown as GuardActionEnvelope | null,
+  });
+  const reason = whyPaused(request);
+  assert(reason.includes("mutates project dependencies"), `T7: command fallback should explain dependency mutation, got "${reason}"`);
+}
+
+// T8: whyPaused for non-shell unknowns should use generic reason
 {
   const request = buildShellRequest({
     artifact_type: "unknown_type",
   });
   const reason = whyPaused(request);
-  assert(reason === "Guard paused this so you can review it first.", `T6: expected generic pause reason, got "${reason}"`);
+  assert(reason === "Guard paused this so you can review it first.", `T8: expected generic pause reason, got "${reason}"`);
 }
 
-// T7: humanFileName returns human-friendly names for known file types
+// T9: humanFileName returns human-friendly names for known file types
 {
-  assert(humanFileName(".env") === "your secrets file", "T7: .env should be 'your secrets file'");
-  assert(humanFileName("config.json") === "a settings file", "T7: config.json should be 'a settings file'");
-  assert(humanFileName("script.sh") === "a shell script", "T7: script.sh should be 'a shell script'");
+  assert(humanFileName(".env") === "your secrets file", "T9: .env should be 'your secrets file'");
+  assert(humanFileName("config.json") === "a settings file", "T9: config.json should be 'a settings file'");
+  assert(humanFileName("script.sh") === "a shell script", "T9: script.sh should be 'a shell script'");
 }
 
-// T8: humanFileName returns a file for empty input
+// T10: humanFileName returns a file for empty input
 {
-  assert(humanFileName(null) === "a file", "T8: null should be 'a file'");
-  assert(humanFileName(undefined) === "a file", "T8: undefined should be 'a file'");
-  assert(humanFileName("") === "a file", "T8: empty string should be 'a file'");
+  assert(humanFileName(null) === "a file", "T10: null should be 'a file'");
+  assert(humanFileName(undefined) === "a file", "T10: undefined should be 'a file'");
+  assert(humanFileName("") === "a file", "T10: empty string should be 'a file'");
 }
 
 console.log("plain-english.test.ts: all tests passed");

--- a/dashboard/src/evidence/plain-english.ts
+++ b/dashboard/src/evidence/plain-english.ts
@@ -318,6 +318,25 @@ function isShellCommandRequest(request: GuardApprovalRequest): boolean {
   );
 }
 
+function isPackageDependencyMutationRequest(request: GuardApprovalRequest): boolean {
+  const envelope = request.action_envelope_json;
+  const intentKind = envelope?.package_intent_kind?.trim().toLowerCase();
+  if (intentKind === "install" || intentKind === "sync") {
+    return true;
+  }
+
+  const command = [envelope?.command, request.raw_command_text, request.launch_target]
+    .find((value) => value?.trim())
+    ?.trim();
+  if (!command) {
+    return false;
+  }
+
+  return /\b(?:npm|pnpm|yarn|bun|pip|pipx|uv|poetry|brew|cargo|gem|go)\s+(?:add|i|install|remove|uninstall|update|upgrade)\b/i.test(
+    command,
+  );
+}
+
 export function plainEnglishRequestTitle(request: GuardApprovalRequest): string {
   const category = detectCategory({
     ...request,
@@ -371,6 +390,9 @@ export function whyPaused(request: GuardApprovalRequest): string {
     case "tool-call":
       return "This uses an outside tool. Guard stops new tools by default.";
     default:
+      if (isPackageDependencyMutationRequest(request)) {
+        return "This package install mutates project dependencies and installed packages. Guard pauses dependency changes so you can review them before running.";
+      }
       if (isShellCommandRequest(request)) {
         return "This shell command has parts Guard could not fully inspect. Guard pauses these so you can review before running.";
       }

--- a/dashboard/src/evidence/plain-english.ts
+++ b/dashboard/src/evidence/plain-english.ts
@@ -320,14 +320,18 @@ function isShellCommandRequest(request: GuardApprovalRequest): boolean {
 
 function isPackageDependencyMutationRequest(request: GuardApprovalRequest): boolean {
   const envelope = request.action_envelope_json;
+  const command = [envelope?.command, request.raw_command_text, request.launch_target]
+    .find((value) => value?.trim())
+    ?.trim();
+  if (command && /(?:&&|[;|]|\r?\n)/.test(command)) {
+    return false;
+  }
+
   const intentKind = envelope?.package_intent_kind?.trim().toLowerCase();
   if (intentKind === "install" || intentKind === "sync") {
     return true;
   }
 
-  const command = [envelope?.command, request.raw_command_text, request.launch_target]
-    .find((value) => value?.trim())
-    ?.trim();
   if (!command) {
     return false;
   }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14475,11 +14475,14 @@ function isShellCommandRequest(request) {
 }
 function isPackageDependencyMutationRequest(request) {
   const envelope = request.action_envelope_json;
+  const command = [envelope?.command, request.raw_command_text, request.launch_target].find((value) => value?.trim())?.trim();
+  if (command && /(?:&&|[;|]|\r?\n)/.test(command)) {
+    return false;
+  }
   const intentKind = envelope?.package_intent_kind?.trim().toLowerCase();
   if (intentKind === "install" || intentKind === "sync") {
     return true;
   }
-  const command = [envelope?.command, request.raw_command_text, request.launch_target].find((value) => value?.trim())?.trim();
   if (!command) {
     return false;
   }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14473,6 +14473,20 @@ function isShellCommandRequest(request) {
   const actionType = (request.action_envelope_json?.action_type ?? "").toLowerCase();
   return actionType === "shell_command" || artifactType.includes("shell") || artifactType.includes("command");
 }
+function isPackageDependencyMutationRequest(request) {
+  const envelope = request.action_envelope_json;
+  const intentKind = envelope?.package_intent_kind?.trim().toLowerCase();
+  if (intentKind === "install" || intentKind === "sync") {
+    return true;
+  }
+  const command = [envelope?.command, request.raw_command_text, request.launch_target].find((value) => value?.trim())?.trim();
+  if (!command) {
+    return false;
+  }
+  return /\b(?:npm|pnpm|yarn|bun|pip|pipx|uv|poetry|brew|cargo|gem|go)\s+(?:add|i|install|remove|uninstall|update|upgrade)\b/i.test(
+    command
+  );
+}
 function plainEnglishRequestTitle(request) {
   const category = detectCategory({
     ...request,
@@ -14523,6 +14537,9 @@ function whyPaused(request) {
     case "tool-call":
       return "This uses an outside tool. Guard stops new tools by default.";
     default:
+      if (isPackageDependencyMutationRequest(request)) {
+        return "This package install mutates project dependencies and installed packages. Guard pauses dependency changes so you can review them before running.";
+      }
       if (isShellCommandRequest(request)) {
         return "This shell command has parts Guard could not fully inspect. Guard pauses these so you can review before running.";
       }
@@ -27605,6 +27622,9 @@ function ConsolidatedEvidenceAlert({ items }) {
   const handleNext = reactExports.useCallback(() => {
     setIndex((prev) => (prev + 1) % items.length);
   }, [items.length]);
+  const handlePrevious = reactExports.useCallback(() => {
+    setIndex((prev) => (prev - 1 + items.length) % items.length);
+  }, [items.length]);
   if (items.length === 0) return null;
   const current = items[Math.min(index, items.length - 1)];
   const hasMultiple = items.length > 1;
@@ -27633,6 +27653,19 @@ function ConsolidatedEvidenceAlert({ items }) {
           " of ",
           items.length
         ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "button",
+          {
+            type: "button",
+            onClick: handlePrevious,
+            className: "flex items-center gap-1 rounded-lg border border-slate-200 px-2.5 py-1 text-xs font-medium text-brand-dark transition-colors hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-brand-blue/20",
+            "aria-label": "Previous insight",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronLeft, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
+              "Previous"
+            ]
+          }
+        ),
         /* @__PURE__ */ jsxRuntimeExports.jsxs(
           "button",
           {


### PR DESCRIPTION
## Summary
- Add Previous navigation to grouped evidence alerts.
- Explain package install pauses as dependency mutations in review copy.

## Testing
- `./node_modules/.bin/tsx src/evidence/plain-english.test.ts`
- `./node_modules/.bin/tsx src/consolidated-evidence-alert.test.ts`
- `./node_modules/.bin/vite build`

## Notes
- The full dashboard TypeScript check still reports pre-existing unrelated type errors.
