### PR TITLE
fix(dashboard): finish cloud sign-in recovery

### DIFF
--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -41,7 +41,12 @@ import {
   deriveSkillRiskSignals,
   deriveSupplyChainRiskSignals,
 } from "./approval-center-utils";
-import { packageReviewNeedsCloudRecovery, ReviewCloudRecovery } from "./review-cloud-recovery";
+import {
+  cloudRecoveryContent,
+  packageReviewNeedsCloudRecovery,
+  ReviewCloudRecovery,
+  waitForCloudConnection,
+} from "./review-cloud-recovery";
 
 function assert(condition: boolean, message: string): void {
   if (!condition) {
@@ -1370,6 +1375,42 @@ assert(
 assert(
   !packageReviewNeedsCloudRecovery({ ...CLOUD_EVIDENCE_UNAVAILABLE_REQUEST, artifact_type: "command" }),
   "GR224-12: unrelated approvals do not offer package recovery",
+);
+
+let cloudStatusChecks = 0;
+const connectedCloudStatus = await waitForCloudConnection(
+  {
+    connect_required: true,
+    connect_flow: {
+      state: "running",
+      title: "Connect Guard Cloud",
+      detail: "Waiting for sign-in",
+      action_label: "Open sign-in",
+      connect_url: "https://example.com/connect",
+      authorize_url: "https://example.com/authorize",
+      browser_opened: true,
+      request_id: "cloud-connect-request",
+      poll_after_ms: 1000,
+    },
+  },
+  {
+    signal: new AbortController().signal,
+    wait: async () => undefined,
+    fetchStatus: async () => {
+      cloudStatusChecks += 1;
+      return { connect_required: false, connect_flow: null };
+    },
+  },
+);
+assert(
+  !connectedCloudStatus.connect_required && cloudStatusChecks === 1,
+  "GR224-13: recovery polling observes completed Cloud sign-in",
+);
+const connectedRecoveryContent = cloudRecoveryContent(true);
+assert(
+  connectedRecoveryContent.title === "Guard Cloud connected" &&
+    connectedRecoveryContent.detail.includes("Run the install command again"),
+  "GR224-14: completed Cloud sign-in replaces stale authorization guidance",
 );
 
 console.log("phase09-review.test.ts: all tests passed");

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -1412,5 +1412,26 @@ assert(
     connectedRecoveryContent.detail.includes("Run the install command again"),
   "GR224-14: completed Cloud sign-in replaces stale authorization guidance",
 );
+let canceledPollWaits = 0;
+const canceledPollController = new AbortController();
+canceledPollController.abort();
+const canceledPollRejected = await waitForCloudConnection(
+  { connect_required: true, connect_flow: null },
+  {
+    signal: canceledPollController.signal,
+    wait: async () => {
+      canceledPollWaits += 1;
+    },
+    maxAttempts: 1,
+  },
+).then(
+  () => false,
+  (error: unknown) =>
+    typeof error === "object" && error !== null && "name" in error && error.name === "AbortError",
+);
+assert(
+  canceledPollRejected && canceledPollWaits === 0,
+  "GR224-15: canceled recovery polling schedules no additional work",
+);
 
 console.log("phase09-review.test.ts: all tests passed");

--- a/dashboard/src/review-cloud-recovery.tsx
+++ b/dashboard/src/review-cloud-recovery.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { HiMiniCloudArrowUp } from "react-icons/hi2";
 import { ActionButton } from "./approval-center-primitives";
 import type { GuardApprovalRequest } from "./guard-types";
@@ -16,18 +16,40 @@ const unavailableEvidencePhrases = [
   "current package safety data was unavailable",
 ];
 
-async function withCloudRequestTimeout<T>(request: (signal: AbortSignal) => Promise<T>): Promise<T> {
+async function withCloudRequestTimeout<T>(
+  request: (signal: AbortSignal) => Promise<T>,
+  parentSignal?: AbortSignal,
+): Promise<T> {
   const controller = new AbortController();
-  const timeout = window.setTimeout(() => controller.abort(), 5000);
+  const abort = () => controller.abort();
+  parentSignal?.addEventListener("abort", abort, { once: true });
+  const timeout = globalThis.setTimeout(() => controller.abort(), 5000);
   try {
     return await request(controller.signal);
   } finally {
-    window.clearTimeout(timeout);
+    globalThis.clearTimeout(timeout);
+    parentSignal?.removeEventListener("abort", abort);
   }
+}
+
+function waitForPoll(delayMs: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const finish = () => {
+      signal.removeEventListener("abort", abort);
+      resolve();
+    };
+    const timeout = globalThis.setTimeout(finish, delayMs);
+    const abort = () => {
+      globalThis.clearTimeout(timeout);
+      reject(new DOMException("Cloud connection polling stopped", "AbortError"));
+    };
+    signal.addEventListener("abort", abort, { once: true });
+  });
 }
 
 async function waitForAuthorizeUrl(
   initialStatus: GuardCloudConnectStatusResponse,
+  signal: AbortSignal,
 ): Promise<GuardCloudConnectStatusResponse> {
   let status = initialStatus;
   for (let attempt = 0; attempt < 10; attempt += 1) {
@@ -36,8 +58,34 @@ async function waitForAuthorizeUrl(
       return status;
     }
     const pollDelayMs = Math.max(100, Math.min(5000, flow.poll_after_ms ?? 1000));
-    await new Promise<void>((resolve) => window.setTimeout(resolve, pollDelayMs));
-    status = await withCloudRequestTimeout(fetchGuardCloudConnectStatus);
+    await waitForPoll(pollDelayMs, signal);
+    status = await withCloudRequestTimeout(fetchGuardCloudConnectStatus, signal);
+  }
+  return status;
+}
+
+type CloudConnectionPollOptions = {
+  signal: AbortSignal;
+  fetchStatus?: (signal?: AbortSignal) => Promise<GuardCloudConnectStatusResponse>;
+  wait?: (delayMs: number, signal: AbortSignal) => Promise<void>;
+  maxAttempts?: number;
+};
+
+export async function waitForCloudConnection(
+  initialStatus: GuardCloudConnectStatusResponse,
+  {
+    signal,
+    fetchStatus = fetchGuardCloudConnectStatus,
+    wait = waitForPoll,
+    maxAttempts = 300,
+  }: CloudConnectionPollOptions,
+): Promise<GuardCloudConnectStatusResponse> {
+  let status = initialStatus;
+  for (let attempt = 0; attempt < maxAttempts && status.connect_required; attempt += 1) {
+    if (status.connect_flow?.state === "failed") return status;
+    const pollDelayMs = Math.max(250, Math.min(5000, status.connect_flow?.poll_after_ms ?? 1000));
+    await wait(pollDelayMs, signal);
+    status = await withCloudRequestTimeout(fetchStatus, signal);
   }
   return status;
 }
@@ -55,65 +103,107 @@ export function packageReviewNeedsCloudRecovery(item: GuardApprovalRequest): boo
   return unavailableEvidencePhrases.some((phrase) => evidence.includes(phrase));
 }
 
+export function cloudRecoveryContent(connected: boolean): { title: string; detail: string } {
+  return connected
+    ? {
+        title: "Guard Cloud connected",
+        detail: "Run the install command again for a current package safety check.",
+      }
+    : {
+        title: "Check this package with Guard Cloud",
+        detail:
+          "Guard could not load current safety data for this package. This does not mean the package is unsafe.",
+      };
+}
+
 export function ReviewCloudRecovery({ item }: { item: GuardApprovalRequest }) {
   const [connecting, setConnecting] = useState(false);
+  const [connected, setConnected] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [manualConnectUrl, setManualConnectUrl] = useState<string | null>(null);
+  const connectControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => () => connectControllerRef.current?.abort(), []);
 
   const handleConnect = useCallback(async () => {
+    connectControllerRef.current?.abort();
+    const controller = new AbortController();
+    connectControllerRef.current = controller;
     setConnecting(true);
+    setConnected(false);
     setMessage(null);
     setManualConnectUrl(null);
     try {
-      const status = await waitForAuthorizeUrl(await withCloudRequestTimeout(startGuardCloudConnect));
+      const status = await waitForAuthorizeUrl(
+        await withCloudRequestTimeout(startGuardCloudConnect, controller.signal),
+        controller.signal,
+      );
       const flow = status.connect_flow;
       if (flow?.authorize_url) {
         setManualConnectUrl(flow.authorize_url);
         setMessage(
           openPackageFirewallAuthorizeFallback(flow.authorize_url, flow.browser_opened)
-            ? "Finish signing in, then retry the install."
+            ? "Complete sign-in in the opened window. This page will update automatically."
             : PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE,
         );
+        const connectedStatus = await waitForCloudConnection(status, { signal: controller.signal });
+        if (!connectedStatus.connect_required) {
+          setConnected(true);
+          setManualConnectUrl(null);
+          setMessage(null);
+          return;
+        }
+        setMessage("Sign-in is still pending. Complete it in the opened window, or open sign-in again.");
         return;
       }
       if (status.connect_required && flow?.connect_url) {
-        setMessage("Guard could not finish starting sign-in. Open sign-in and try again.");
+        setMessage("Open sign-in to continue. This page will update automatically.");
         setManualConnectUrl(flow.connect_url);
+        const connectedStatus = await waitForCloudConnection(status, { signal: controller.signal });
+        if (!connectedStatus.connect_required) {
+          setConnected(true);
+          setManualConnectUrl(null);
+          setMessage(null);
+          return;
+        }
+        setMessage("Sign-in is still pending. Complete it in the opened window, or open sign-in again.");
         return;
       }
       setMessage(
         status.connect_required
-          ? "Finish signing in, then retry the install."
-          : "Guard Cloud is connected. Retry the install for a fresh safety check.",
+          ? "Guard could not finish starting sign-in. Try again."
+          : null,
       );
+      setConnected(!status.connect_required);
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") return;
       setMessage(error instanceof Error ? error.message : "Guard could not start sign-in. Try again.");
     } finally {
-      setConnecting(false);
+      if (!controller.signal.aborted) setConnecting(false);
     }
   }, []);
 
   if (!packageReviewNeedsCloudRecovery(item)) return null;
+  const content = cloudRecoveryContent(connected);
 
   return (
     <div className="mt-4 rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] p-4">
-      <p className="text-sm font-semibold text-brand-dark">Get a current package safety check</p>
-      <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-        Guard could not load current safety data for this package. This does not mean the package is unsafe.
-        Connect Guard Cloud and retry, or approve this install once.
-      </p>
-      <div className="mt-3 flex flex-wrap items-center gap-3">
-        <ActionButton onClick={handleConnect} disabled={connecting} variant="outline">
-          <HiMiniCloudArrowUp className="h-4 w-4" aria-hidden="true" />
-          {connecting ? "Starting sign-in..." : "Connect Guard Cloud"}
-        </ActionButton>
-        {manualConnectUrl ? (
-          <ActionButton href={manualConnectUrl} variant="quiet">
-            Open sign-in
+      <p className="text-sm font-semibold text-brand-dark">{content.title}</p>
+      <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{content.detail}</p>
+      {!connected ? (
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <ActionButton onClick={handleConnect} disabled={connecting} variant="outline">
+            <HiMiniCloudArrowUp className="h-4 w-4" aria-hidden="true" />
+            {connecting ? "Waiting for sign-in..." : "Connect Guard Cloud"}
           </ActionButton>
-        ) : null}
-        {message ? <p className="text-sm text-muted-foreground" role="status">{message}</p> : null}
-      </div>
+          {manualConnectUrl ? (
+            <ActionButton href={manualConnectUrl} variant="quiet">
+              Open sign-in
+            </ActionButton>
+          ) : null}
+          {message ? <p className="text-sm text-muted-foreground" role="status">{message}</p> : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/dashboard/src/review-cloud-recovery.tsx
+++ b/dashboard/src/review-cloud-recovery.tsx
@@ -20,6 +20,9 @@ async function withCloudRequestTimeout<T>(
   request: (signal: AbortSignal) => Promise<T>,
   parentSignal?: AbortSignal,
 ): Promise<T> {
+  if (parentSignal?.aborted) {
+    throw new DOMException("Cloud connection request stopped", "AbortError");
+  }
   const controller = new AbortController();
   const abort = () => controller.abort();
   parentSignal?.addEventListener("abort", abort, { once: true });
@@ -33,6 +36,9 @@ async function withCloudRequestTimeout<T>(
 }
 
 function waitForPoll(delayMs: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.reject(new DOMException("Cloud connection polling stopped", "AbortError"));
+  }
   return new Promise<void>((resolve, reject) => {
     const finish = () => {
       signal.removeEventListener("abort", abort);
@@ -51,6 +57,9 @@ async function waitForAuthorizeUrl(
   initialStatus: GuardCloudConnectStatusResponse,
   signal: AbortSignal,
 ): Promise<GuardCloudConnectStatusResponse> {
+  if (signal.aborted) {
+    throw new DOMException("Cloud connection polling stopped", "AbortError");
+  }
   let status = initialStatus;
   for (let attempt = 0; attempt < 10; attempt += 1) {
     const flow = status.connect_flow;
@@ -80,6 +89,9 @@ export async function waitForCloudConnection(
     maxAttempts = 300,
   }: CloudConnectionPollOptions,
 ): Promise<GuardCloudConnectStatusResponse> {
+  if (signal.aborted) {
+    throw new DOMException("Cloud connection polling stopped", "AbortError");
+  }
   let status = initialStatus;
   for (let attempt = 0; attempt < maxAttempts && status.connect_required; attempt += 1) {
     if (status.connect_flow?.state === "failed") return status;
@@ -123,7 +135,14 @@ export function ReviewCloudRecovery({ item }: { item: GuardApprovalRequest }) {
   const [manualConnectUrl, setManualConnectUrl] = useState<string | null>(null);
   const connectControllerRef = useRef<AbortController | null>(null);
 
-  useEffect(() => () => connectControllerRef.current?.abort(), []);
+  useEffect(() => {
+    connectControllerRef.current?.abort();
+    setConnecting(false);
+    setConnected(false);
+    setMessage(null);
+    setManualConnectUrl(null);
+    return () => connectControllerRef.current?.abort();
+  }, [item.request_id]);
 
   const handleConnect = useCallback(async () => {
     connectControllerRef.current?.abort();
@@ -176,7 +195,7 @@ export function ReviewCloudRecovery({ item }: { item: GuardApprovalRequest }) {
       );
       setConnected(!status.connect_required);
     } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") return;
+      if (controller.signal.aborted) return;
       setMessage(error instanceof Error ? error.message : "Guard could not start sign-in. Try again.");
     } finally {
       if (!controller.signal.aborted) setConnecting(false);

--- a/dashboard/src/review-decision-card.tsx
+++ b/dashboard/src/review-decision-card.tsx
@@ -443,7 +443,7 @@ export function ReviewDecisionCard(props: {
           </div>
         )}
 
-        {resolutionBlockReason === null ? <ReviewCloudRecovery item={item} /> : null}
+        {resolutionBlockReason === null ? <ReviewCloudRecovery key={item.request_id} item={item} /> : null}
 
         {whatWouldHappen && (
           <div className="mt-5">

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -27967,16 +27967,33 @@ const unavailableEvidencePhrases = [
   "cloud evaluation could not validate",
   "current package safety data was unavailable"
 ];
-async function withCloudRequestTimeout(request) {
+async function withCloudRequestTimeout(request, parentSignal) {
   const controller = new AbortController();
-  const timeout = window.setTimeout(() => controller.abort(), 5e3);
+  const abort = () => controller.abort();
+  parentSignal?.addEventListener("abort", abort, { once: true });
+  const timeout = globalThis.setTimeout(() => controller.abort(), 5e3);
   try {
     return await request(controller.signal);
   } finally {
-    window.clearTimeout(timeout);
+    globalThis.clearTimeout(timeout);
+    parentSignal?.removeEventListener("abort", abort);
   }
 }
-async function waitForAuthorizeUrl(initialStatus) {
+function waitForPoll(delayMs, signal) {
+  return new Promise((resolve, reject) => {
+    const finish = () => {
+      signal.removeEventListener("abort", abort);
+      resolve();
+    };
+    const timeout = globalThis.setTimeout(finish, delayMs);
+    const abort = () => {
+      globalThis.clearTimeout(timeout);
+      reject(new DOMException("Cloud connection polling stopped", "AbortError"));
+    };
+    signal.addEventListener("abort", abort, { once: true });
+  });
+}
+async function waitForAuthorizeUrl(initialStatus, signal) {
   let status = initialStatus;
   for (let attempt = 0; attempt < 10; attempt += 1) {
     const flow = status.connect_flow;
@@ -27984,8 +28001,23 @@ async function waitForAuthorizeUrl(initialStatus) {
       return status;
     }
     const pollDelayMs = Math.max(100, Math.min(5e3, flow.poll_after_ms ?? 1e3));
-    await new Promise((resolve) => window.setTimeout(resolve, pollDelayMs));
-    status = await withCloudRequestTimeout(fetchGuardCloudConnectStatus);
+    await waitForPoll(pollDelayMs, signal);
+    status = await withCloudRequestTimeout(fetchGuardCloudConnectStatus, signal);
+  }
+  return status;
+}
+async function waitForCloudConnection(initialStatus, {
+  signal,
+  fetchStatus = fetchGuardCloudConnectStatus,
+  wait = waitForPoll,
+  maxAttempts = 300
+}) {
+  let status = initialStatus;
+  for (let attempt = 0; attempt < maxAttempts && status.connect_required; attempt += 1) {
+    if (status.connect_flow?.state === "failed") return status;
+    const pollDelayMs = Math.max(250, Math.min(5e3, status.connect_flow?.poll_after_ms ?? 1e3));
+    await wait(pollDelayMs, signal);
+    status = await withCloudRequestTimeout(fetchStatus, signal);
   }
   return status;
 }
@@ -27995,50 +28027,88 @@ function packageReviewNeedsCloudRecovery(item) {
   const evidence = [item.risk_headline, item.risk_summary, ...item.risk_signals ?? []].filter((value) => typeof value === "string").join(" ").toLowerCase();
   return unavailableEvidencePhrases.some((phrase) => evidence.includes(phrase));
 }
+function cloudRecoveryContent(connected) {
+  return connected ? {
+    title: "Guard Cloud connected",
+    detail: "Run the install command again for a current package safety check."
+  } : {
+    title: "Check this package with Guard Cloud",
+    detail: "Guard could not load current safety data for this package. This does not mean the package is unsafe."
+  };
+}
 function ReviewCloudRecovery({ item }) {
   const [connecting, setConnecting] = reactExports.useState(false);
+  const [connected, setConnected] = reactExports.useState(false);
   const [message, setMessage] = reactExports.useState(null);
   const [manualConnectUrl, setManualConnectUrl] = reactExports.useState(null);
+  const connectControllerRef = reactExports.useRef(null);
+  reactExports.useEffect(() => () => connectControllerRef.current?.abort(), []);
   const handleConnect = reactExports.useCallback(async () => {
+    connectControllerRef.current?.abort();
+    const controller = new AbortController();
+    connectControllerRef.current = controller;
     setConnecting(true);
+    setConnected(false);
     setMessage(null);
     setManualConnectUrl(null);
     try {
-      const status = await waitForAuthorizeUrl(await withCloudRequestTimeout(startGuardCloudConnect));
+      const status = await waitForAuthorizeUrl(
+        await withCloudRequestTimeout(startGuardCloudConnect, controller.signal),
+        controller.signal
+      );
       const flow = status.connect_flow;
       if (flow?.authorize_url) {
         setManualConnectUrl(flow.authorize_url);
         setMessage(
-          openPackageFirewallAuthorizeFallback(flow.authorize_url, flow.browser_opened) ? "Finish signing in, then retry the install." : PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE
+          openPackageFirewallAuthorizeFallback(flow.authorize_url, flow.browser_opened) ? "Complete sign-in in the opened window. This page will update automatically." : PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE
         );
+        const connectedStatus = await waitForCloudConnection(status, { signal: controller.signal });
+        if (!connectedStatus.connect_required) {
+          setConnected(true);
+          setManualConnectUrl(null);
+          setMessage(null);
+          return;
+        }
+        setMessage("Sign-in is still pending. Complete it in the opened window, or open sign-in again.");
         return;
       }
       if (status.connect_required && flow?.connect_url) {
-        setMessage("Guard could not finish starting sign-in. Open sign-in and try again.");
+        setMessage("Open sign-in to continue. This page will update automatically.");
         setManualConnectUrl(flow.connect_url);
+        const connectedStatus = await waitForCloudConnection(status, { signal: controller.signal });
+        if (!connectedStatus.connect_required) {
+          setConnected(true);
+          setManualConnectUrl(null);
+          setMessage(null);
+          return;
+        }
+        setMessage("Sign-in is still pending. Complete it in the opened window, or open sign-in again.");
         return;
       }
       setMessage(
-        status.connect_required ? "Finish signing in, then retry the install." : "Guard Cloud is connected. Retry the install for a fresh safety check."
+        status.connect_required ? "Guard could not finish starting sign-in. Try again." : null
       );
+      setConnected(!status.connect_required);
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") return;
       setMessage(error instanceof Error ? error.message : "Guard could not start sign-in. Try again.");
     } finally {
-      setConnecting(false);
+      if (!controller.signal.aborted) setConnecting(false);
     }
   }, []);
   if (!packageReviewNeedsCloudRecovery(item)) return null;
+  const content = cloudRecoveryContent(connected);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] p-4", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: "Get a current package safety check" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-muted-foreground", children: "Guard could not load current safety data for this package. This does not mean the package is unsafe. Connect Guard Cloud and retry, or approve this install once." }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 flex flex-wrap items-center gap-3", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: content.title }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-muted-foreground", children: content.detail }),
+    !connected ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 flex flex-wrap items-center gap-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { onClick: handleConnect, disabled: connecting, variant: "outline", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "h-4 w-4", "aria-hidden": "true" }),
-        connecting ? "Starting sign-in..." : "Connect Guard Cloud"
+        connecting ? "Waiting for sign-in..." : "Connect Guard Cloud"
       ] }),
       manualConnectUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: manualConnectUrl, variant: "quiet", children: "Open sign-in" }) : null,
       message ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-muted-foreground", role: "status", children: message }) : null
-    ] })
+    ] }) : null
   ] });
 }
 function ReviewScopeControls(props) {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -27968,6 +27968,9 @@ const unavailableEvidencePhrases = [
   "current package safety data was unavailable"
 ];
 async function withCloudRequestTimeout(request, parentSignal) {
+  if (parentSignal?.aborted) {
+    throw new DOMException("Cloud connection request stopped", "AbortError");
+  }
   const controller = new AbortController();
   const abort = () => controller.abort();
   parentSignal?.addEventListener("abort", abort, { once: true });
@@ -27980,6 +27983,9 @@ async function withCloudRequestTimeout(request, parentSignal) {
   }
 }
 function waitForPoll(delayMs, signal) {
+  if (signal.aborted) {
+    return Promise.reject(new DOMException("Cloud connection polling stopped", "AbortError"));
+  }
   return new Promise((resolve, reject) => {
     const finish = () => {
       signal.removeEventListener("abort", abort);
@@ -27994,6 +28000,9 @@ function waitForPoll(delayMs, signal) {
   });
 }
 async function waitForAuthorizeUrl(initialStatus, signal) {
+  if (signal.aborted) {
+    throw new DOMException("Cloud connection polling stopped", "AbortError");
+  }
   let status = initialStatus;
   for (let attempt = 0; attempt < 10; attempt += 1) {
     const flow = status.connect_flow;
@@ -28012,6 +28021,9 @@ async function waitForCloudConnection(initialStatus, {
   wait = waitForPoll,
   maxAttempts = 300
 }) {
+  if (signal.aborted) {
+    throw new DOMException("Cloud connection polling stopped", "AbortError");
+  }
   let status = initialStatus;
   for (let attempt = 0; attempt < maxAttempts && status.connect_required; attempt += 1) {
     if (status.connect_flow?.state === "failed") return status;
@@ -28042,7 +28054,14 @@ function ReviewCloudRecovery({ item }) {
   const [message, setMessage] = reactExports.useState(null);
   const [manualConnectUrl, setManualConnectUrl] = reactExports.useState(null);
   const connectControllerRef = reactExports.useRef(null);
-  reactExports.useEffect(() => () => connectControllerRef.current?.abort(), []);
+  reactExports.useEffect(() => {
+    connectControllerRef.current?.abort();
+    setConnecting(false);
+    setConnected(false);
+    setMessage(null);
+    setManualConnectUrl(null);
+    return () => connectControllerRef.current?.abort();
+  }, [item.request_id]);
   const handleConnect = reactExports.useCallback(async () => {
     connectControllerRef.current?.abort();
     const controller = new AbortController();
@@ -28090,7 +28109,7 @@ function ReviewCloudRecovery({ item }) {
       );
       setConnected(!status.connect_required);
     } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") return;
+      if (controller.signal.aborted) return;
       setMessage(error instanceof Error ? error.message : "Guard could not start sign-in. Try again.");
     } finally {
       if (!controller.signal.aborted) setConnecting(false);
@@ -28851,7 +28870,7 @@ function ReviewDecisionCard(props) {
         ] })
       ] }) }),
       topAlertItems.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-5 rounded-xl border border-slate-100 bg-slate-50/50 p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ConsolidatedEvidenceAlert, { items: topAlertItems }, item.request_id) }),
-      resolutionBlockReason === null ? /* @__PURE__ */ jsxRuntimeExports.jsx(ReviewCloudRecovery, { item }) : null,
+      resolutionBlockReason === null ? /* @__PURE__ */ jsxRuntimeExports.jsx(ReviewCloudRecovery, { item }, item.request_id) : null,
       whatWouldHappen && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs(
           "button",


### PR DESCRIPTION
## Summary
- keep the package recovery card synchronized while Guard Cloud sign-in is pending
- replace stale authorization controls with a concise connected state after authentication completes
- cancel bounded status polling when the review surface unmounts

## Testing
- `cd dashboard && bun run test`
- `cd dashboard && bun run build`
- `uv run --no-sync python scripts/ci/test_inventory.py --output test-inventory.json`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json`

## Notes
- The repository-wide TypeScript check retains pre-existing baseline errors; changed files introduce no new diagnostics.
