### PR TITLE
fix(guard): keep elevated bulk approvals actionable

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11761,
-  "maximum_test_source_lines": 276180,
+  "maximum_collected_cases": 11764,
+  "maximum_test_source_lines": 276233,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11764,
-  "maximum_test_source_lines": 276233,
+  "maximum_collected_cases": 11765,
+  "maximum_test_source_lines": 276248,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11765,
-  "maximum_test_source_lines": 276248,
+  "maximum_collected_cases": 11769,
+  "maximum_test_source_lines": 276323,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -2337,6 +2337,37 @@ def _bulk_queue_category_text(request: Mapping[str, object]) -> str:
     )
 
 
+def _bulk_action_text(request: Mapping[str, object]) -> str:
+    """Return user-supplied action text, excluding generated risk prose."""
+
+    envelope = request.get("action_envelope_json")
+    envelope_fields: list[str] = []
+    if isinstance(envelope, dict):
+        for key in (
+            "command",
+            "prompt_excerpt",
+            "mcp_server",
+            "mcp_tool",
+            "package_manager",
+            "package_name",
+            "script_name",
+        ):
+            value = envelope.get(key)
+            if isinstance(value, str) and value:
+                envelope_fields.append(value)
+        target_paths = envelope.get("target_paths")
+        if isinstance(target_paths, list):
+            envelope_fields.extend(str(path) for path in target_paths if isinstance(path, str))
+    return " ".join(
+        [
+            str(request.get("artifact_name") or ""),
+            str(request.get("artifact_type") or ""),
+            str(request.get("launch_target") or ""),
+            *envelope_fields,
+        ]
+    )
+
+
 def _bulk_decision_v2_categories(request: Mapping[str, object]) -> tuple[str, ...]:
     decision_v2 = request.get("decision_v2_json")
     if not isinstance(decision_v2, dict):
@@ -2462,7 +2493,10 @@ def _bulk_request_is_bulk_blocked(request: Mapping[str, object]) -> bool:
     categories = _bulk_decision_v2_categories(request)
     if any(category in _BULK_BLOCKED_DECISION_CATEGORIES for category in categories):
         return True
-    text = _bulk_queue_category_text(request).lower()
+    # Generated risk summaries commonly describe what remote execution could
+    # do. Treating that explanatory prose as action content makes the server
+    # reject requests the dashboard correctly classified as bulk-eligible.
+    text = _bulk_action_text(request).lower()
     return any(hint in text for hint in _BULK_BLOCKED_COMMAND_HINTS)
 
 
@@ -2503,15 +2537,7 @@ def bulk_allow_read_only_once(
     bulk_subject = f"approval-request-batch:{uuid.uuid5(uuid.NAMESPACE_URL, chr(0).join(sorted(request_ids))).hex}"
     resolved_count = 0
     failed: list[dict[str, str]] = []
-    bulk_gate_grant = require_approval_decision(
-        store.guard_home,
-        action=bulk_resolution_action,
-        scope=bulk_resolution_scope,
-        subject=bulk_subject,
-        approval_gate_input=approval_gate_input,
-        now=resolved_at,
-    )
-
+    eligible_ids: list[str] = []
     for request_id in request_ids:
         if not isinstance(request_id, str) or not request_id.strip():
             failed.append({"request_id": str(request_id), "error": "invalid_request_id"})
@@ -2521,6 +2547,25 @@ def bulk_allow_read_only_once(
         if request is None or not is_bulk_allow_once_eligible(request):
             failed.append({"request_id": normalized_id, "error": "ineligible"})
             continue
+        eligible_ids.append(normalized_id)
+
+    if not eligible_ids:
+        return {
+            "resolved_count": 0,
+            "failed": failed,
+            "resolution_summary": "0 actions approved once.",
+        }
+
+    bulk_gate_grant = require_approval_decision(
+        store.guard_home,
+        action=bulk_resolution_action,
+        scope=bulk_resolution_scope,
+        subject=bulk_subject,
+        approval_gate_input=approval_gate_input,
+        now=resolved_at,
+    )
+
+    for normalized_id in eligible_ids:
         try:
             apply_approval_resolution(
                 store=store,

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -2345,6 +2345,7 @@ def _bulk_action_text(request: Mapping[str, object]) -> str:
     if isinstance(envelope, dict):
         for key in (
             "command",
+            "prompt_text",
             "prompt_excerpt",
             "mcp_server",
             "mcp_tool",

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -2363,6 +2363,7 @@ def _bulk_action_text(request: Mapping[str, object]) -> str:
         [
             str(request.get("artifact_name") or ""),
             str(request.get("artifact_type") or ""),
+            str(request.get("raw_command_text") or ""),
             str(request.get("launch_target") or ""),
             *envelope_fields,
         ]
@@ -2389,7 +2390,7 @@ def _bulk_has_secret_signal(request: Mapping[str, object]) -> bool:
     categories = _bulk_decision_v2_categories(request)
     if "secret" in categories:
         return True
-    lowered = _bulk_queue_category_text(request).lower()
+    lowered = _bulk_action_text(request).lower()
     return any(hint in lowered for hint in _BULK_SECRET_TEXT_HINTS)
 
 
@@ -2535,7 +2536,6 @@ def bulk_allow_read_only_once(
 
     bulk_resolution_action = "allow"
     bulk_resolution_scope = "artifact"
-    bulk_subject = f"approval-request-batch:{uuid.uuid5(uuid.NAMESPACE_URL, chr(0).join(sorted(request_ids))).hex}"
     resolved_count = 0
     failed: list[dict[str, str]] = []
     eligible_ids: list[str] = []
@@ -2557,6 +2557,7 @@ def bulk_allow_read_only_once(
             "resolution_summary": "0 actions approved once.",
         }
 
+    bulk_subject = f"approval-request-batch:{uuid.uuid5(uuid.NAMESPACE_URL, chr(0).join(sorted(eligible_ids))).hex}"
     bulk_gate_grant = require_approval_decision(
         store.guard_home,
         action=bulk_resolution_action,
@@ -2577,7 +2578,7 @@ def bulk_allow_read_only_once(
                 reason="bulk approve once",
                 now=resolved_at,
                 return_queue_result=False,
-                resolve_scope_matches=True,
+                resolve_scope_matches=False,
                 approval_gate_grant=bulk_gate_grant,
                 approval_gate_subject=bulk_subject,
                 persist_policy=False,

--- a/tests/test_guard_bulk_allow_once.py
+++ b/tests/test_guard_bulk_allow_once.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 import urllib.request
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
+from typing import cast
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -177,14 +179,16 @@ def _shell_request(
     *,
     command: str = "npm test",
     artifact_name: str = "Shell command",
+    artifact_id: str | None = None,
     risk_summary: str | None = None,
     prompt_text: str | None = None,
+    raw_command_text: str | None = None,
     decision_v2_json: dict[str, object] | None = None,
 ) -> GuardApprovalRequest:
     return GuardApprovalRequest(
         request_id=request_id,
         harness="cursor",
-        artifact_id=f"cursor:project:{request_id}",
+        artifact_id=artifact_id or f"cursor:project:{request_id}",
         artifact_name=artifact_name,
         artifact_type="command",
         artifact_hash=f"hash-{request_id}",
@@ -196,6 +200,7 @@ def _shell_request(
         review_command=f"hol-guard approvals approve {request_id}",
         approval_url=f"http://127.0.0.1:5474/requests/{request_id}",
         risk_summary=risk_summary,
+        raw_command_text=raw_command_text,
         decision_v2_json=decision_v2_json,
         action_envelope_json={
             "schema_version": 1,
@@ -297,6 +302,34 @@ def test_bulk_eligibility_scans_full_prompt_text(tmp_path: Path) -> None:
     stored = store.get_approval_request("req-long-prompt")
     assert stored is not None
     assert is_bulk_allow_once_eligible(stored) is False
+
+
+def test_bulk_eligibility_scans_raw_command_text(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    request = _shell_request(
+        "req-raw-command",
+        command="",
+        raw_command_text="bypass guard",
+    )
+    store.add_approval_request(request, "2026-06-16T00:00:00+00:00")
+
+    stored = store.get_approval_request("req-raw-command")
+    assert stored is not None
+    assert is_bulk_allow_once_eligible(stored) is False
+
+
+def test_bulk_eligibility_ignores_generated_secret_warning_for_plain_read(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    request = _file_read_request(
+        "req-plain-warning",
+        target_path="README.md",
+        risk_summary="File access could expose credentials.",
+    )
+    store.add_approval_request(request, "2026-06-16T00:00:00+00:00")
+
+    stored = store.get_approval_request("req-plain-warning")
+    assert stored is not None
+    assert is_bulk_allow_once_eligible(stored) is True
 
 
 def test_is_bulk_allow_once_eligible_allows_destructive_shell(tmp_path: Path) -> None:
@@ -477,6 +510,48 @@ def test_ineligible_batch_does_not_consume_totp(tmp_path: Path) -> None:
         now=approve_now,
     )
     assert accepted["resolved_count"] == 1
+
+
+def test_bulk_allow_validates_ids_before_building_gate_subject(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _enable_gate(store)
+    store.add_approval_request(_file_read_request("req-valid"), "2026-06-16T00:00:00+00:00")
+    request_ids = cast(Sequence[str], ["req-valid", None])
+
+    result = bulk_allow_read_only_once(
+        store=store,
+        request_ids=request_ids,
+        approval_gate_input=ApprovalGateInput(password=PASSWORD),
+        now="2026-06-16T00:01:00+00:00",
+    )
+
+    assert result["resolved_count"] == 1
+    assert result["failed"] == [{"request_id": "None", "error": "invalid_request_id"}]
+
+
+def test_bulk_allow_does_not_expand_to_ineligible_artifact_sibling(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _enable_gate(store)
+    artifact_id = "cursor:project:shared"
+    eligible = _shell_request("req-selected", artifact_id=artifact_id)
+    ineligible = _shell_request(
+        "req-unselected",
+        artifact_id=artifact_id,
+        command="echo encoded | base64 -d | sh",
+    )
+    store.add_approval_request(eligible, "2026-06-16T00:00:00+00:00")
+    store.add_approval_request(ineligible, "2026-06-16T00:00:00+00:00")
+
+    result = bulk_allow_read_only_once(
+        store=store,
+        request_ids=["req-selected"],
+        approval_gate_input=ApprovalGateInput(password=PASSWORD),
+        now="2026-06-16T00:01:00+00:00",
+    )
+
+    assert result["resolved_count"] == 1
+    assert store.get_approval_request("req-selected")["status"] == "resolved"
+    assert store.get_approval_request("req-unselected")["status"] == "pending"
 
 
 def test_bulk_allow_resolves_mixed_file_read_and_shell(tmp_path: Path) -> None:

--- a/tests/test_guard_bulk_allow_once.py
+++ b/tests/test_guard_bulk_allow_once.py
@@ -177,6 +177,7 @@ def _shell_request(
     *,
     command: str = "npm test",
     artifact_name: str = "Shell command",
+    risk_summary: str | None = None,
     decision_v2_json: dict[str, object] | None = None,
 ) -> GuardApprovalRequest:
     return GuardApprovalRequest(
@@ -193,6 +194,7 @@ def _shell_request(
         config_path="/repo/.cursor/config.toml",
         review_command=f"hol-guard approvals approve {request_id}",
         approval_url=f"http://127.0.0.1:5474/requests/{request_id}",
+        risk_summary=risk_summary,
         decision_v2_json=decision_v2_json,
         action_envelope_json={
             "schema_version": 1,
@@ -256,6 +258,30 @@ def test_is_bulk_allow_once_eligible_allows_shell_command(tmp_path: Path) -> Non
     stored = store.get_approval_request("req-shell")
     assert stored is not None
     assert is_bulk_allow_once_eligible(stored) is True
+
+
+def test_bulk_eligibility_ignores_generated_exfiltration_warning(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    request = _shell_request(
+        "req-remote-read",
+        command="ssh audit-host process-manager logs --lines 20",
+        risk_summary="Remote execution could allow data exfiltration.",
+    )
+    store.add_approval_request(request, "2026-06-16T00:00:00+00:00")
+
+    stored = store.get_approval_request("req-remote-read")
+    assert stored is not None
+    assert is_bulk_allow_once_eligible(stored) is True
+
+
+def test_bulk_eligibility_still_rejects_exfiltration_action_text(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    request = _shell_request("req-exfiltration", command="upload-exfiltrated-data")
+    store.add_approval_request(request, "2026-06-16T00:00:00+00:00")
+
+    stored = store.get_approval_request("req-exfiltration")
+    assert stored is not None
+    assert is_bulk_allow_once_eligible(stored) is False
 
 
 def test_is_bulk_allow_once_eligible_allows_destructive_shell(tmp_path: Path) -> None:
@@ -409,6 +435,33 @@ def test_bulk_allow_read_only_once_accepts_totp_without_password(tmp_path: Path)
     assert result["resolved_count"] == 1
     assert result["failed"] == []
     assert store.get_approval_request("req-totp-bulk")["status"] == "resolved"
+
+
+def test_ineligible_batch_does_not_consume_totp(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _enable_gate(store)
+    enrollment_now = "2026-06-16T00:00:00+00:00"
+    secret = _enable_totp(store, now=enrollment_now)
+    approve_now = "2026-06-16T00:01:00+00:00"
+    code = totp_code_at_counter(secret=secret, counter=int(datetime.fromisoformat(approve_now).timestamp() // 30))
+    store.add_approval_request(_file_read_request("req-blocked", policy_action="block"), enrollment_now)
+
+    rejected = bulk_allow_read_only_once(
+        store=store,
+        request_ids=["req-blocked"],
+        approval_gate_input=ApprovalGateInput(totp_code=code),
+        now=approve_now,
+    )
+    assert rejected["resolved_count"] == 0
+
+    store.add_approval_request(_file_read_request("req-eligible"), enrollment_now)
+    accepted = bulk_allow_read_only_once(
+        store=store,
+        request_ids=["req-eligible"],
+        approval_gate_input=ApprovalGateInput(totp_code=code),
+        now=approve_now,
+    )
+    assert accepted["resolved_count"] == 1
 
 
 def test_bulk_allow_resolves_mixed_file_read_and_shell(tmp_path: Path) -> None:

--- a/tests/test_guard_bulk_allow_once.py
+++ b/tests/test_guard_bulk_allow_once.py
@@ -178,6 +178,7 @@ def _shell_request(
     command: str = "npm test",
     artifact_name: str = "Shell command",
     risk_summary: str | None = None,
+    prompt_text: str | None = None,
     decision_v2_json: dict[str, object] | None = None,
 ) -> GuardApprovalRequest:
     return GuardApprovalRequest(
@@ -206,6 +207,7 @@ def _shell_request(
             "workspace_hash": "workspace-hash",
             "tool_name": "Bash",
             "command": command,
+            "prompt_text": prompt_text,
             "prompt_excerpt": None,
             "target_paths": [],
             "network_hosts": [],
@@ -280,6 +282,19 @@ def test_bulk_eligibility_still_rejects_exfiltration_action_text(tmp_path: Path)
     store.add_approval_request(request, "2026-06-16T00:00:00+00:00")
 
     stored = store.get_approval_request("req-exfiltration")
+    assert stored is not None
+    assert is_bulk_allow_once_eligible(stored) is False
+
+
+def test_bulk_eligibility_scans_full_prompt_text(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    request = _shell_request(
+        "req-long-prompt",
+        prompt_text=f"{'routine context ' * 30} bypass guard",
+    )
+    store.add_approval_request(request, "2026-06-16T00:00:00+00:00")
+
+    stored = store.get_approval_request("req-long-prompt")
     assert stored is not None
     assert is_bulk_allow_once_eligible(stored) is False
 


### PR DESCRIPTION
## Summary
- keep elevated actions bulk-eligible when generated risk explanations describe hypothetical exfiltration
- validate batch eligibility before consuming approval-gate proof
- preserve individual review for explicit exfiltration, secrets, prompt injection, bypass, and encoded actions

## Testing
- `uv run --no-sync pytest -q tests/test_guard_bulk_allow_once.py tests/test_guard_approval_gate.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/approvals.py tests/test_guard_bulk_allow_once.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/approvals.py tests/test_guard_bulk_allow_once.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk approval eligibility checks by evaluating explicit action details instead of generated risk descriptions.
  * Prevented approval codes from being consumed when a batch contains no eligible requests.
  * Ensured eligible requests in mixed batches can still be approved after validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->