### PR TITLE
feat(guard): add conditional trust for safe package scans

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11780,
-  "maximum_test_source_lines": 276567,
+  "maximum_collected_cases": 11782,
+  "maximum_test_source_lines": 276588,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11769,
-  "maximum_test_source_lines": 276323,
+  "maximum_collected_cases": 11780,
+  "maximum_test_source_lines": 276567,
   "schema_version": 1
 }

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -233,7 +233,7 @@ export type GuardTemporaryMcpApproval = {
 };
 
 export type GuardLocalToolGrantTarget = "capability" | "version";
-export type GuardLocalToolGrantDuration = "once" | "15m" | "1h" | "5h" | "version";
+export type GuardLocalToolGrantDuration = "once" | "15m" | "1h" | "5h" | "version" | "always";
 
 export type GuardLocalToolApproval = {
   eligible: boolean;
@@ -241,6 +241,8 @@ export type GuardLocalToolApproval = {
   tool_identity_hash: string;
   capability: string;
   read_only_reason: string;
+  trust_basis: "verified-files" | "package-profile";
+  indefinite_allowed: boolean;
   allowed_targets: GuardLocalToolGrantTarget[];
   allowed_durations: GuardLocalToolGrantDuration[];
   hard_risk_exclusions: string[];

--- a/dashboard/src/local-tool-approval-controls.tsx
+++ b/dashboard/src/local-tool-approval-controls.tsx
@@ -16,9 +16,6 @@ type Props = {
   onDurationChange: (duration: GuardLocalToolGrantDuration) => void;
 };
 
-const EXCLUSION_COPY =
-  "Guard rechecks the executable and script before every call. Writes, shell chaining, redirects, embedded commands, environment overrides, and changed tool files still require review.";
-
 export function LocalToolApprovalControls(props: Props) {
   const expiry = localToolExpiryLabel(props.duration);
   const durationDescriptionId = "local-tool-duration-description";
@@ -119,9 +116,16 @@ export function LocalToolApprovalControls(props: Props) {
             Trust ends automatically when the executable, script, or approved output processor changes.
           </p>
         )}
+        {props.duration === "always" && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            Guard still checks package safety, command behavior, paths, and environment settings on every call.
+          </p>
+        )}
       </div>
       <p className="text-xs leading-5 text-brand-dark/70">
-        {EXCLUSION_COPY}
+        {props.options.trust_basis === "package-profile"
+          ? "Only recognized local scan calls are covered. Package risks, URLs, writes, unsafe paths, shell composition, and changed runner files still require review."
+          : "Guard rechecks the executable and script before every call. Writes, shell chaining, redirects, embedded commands, environment overrides, and changed tool files still require review."}
       </p>
     </div>
   );

--- a/dashboard/src/local-tool-approval.test.tsx
+++ b/dashboard/src/local-tool-approval.test.tsx
@@ -29,6 +29,8 @@ const request = {
     tool_identity_hash: "sha256-private-binding",
     capability: "request",
     read_only_reason: "HTTP method GET",
+    trust_basis: "verified-files",
+    indefinite_allowed: false,
     allowed_targets: ["capability", "version"],
     allowed_durations: ["once", "15m", "1h", "5h", "version"],
     hard_risk_exclusions: ["shell_chaining", "mutating_capability"],
@@ -42,6 +44,7 @@ assert(defaultLocalToolTarget(options) === "capability", "narrow capability is t
 assert(defaultLocalToolDuration(options) === "once", "reusable trust requires an explicit duration");
 assert(localToolAllowButtonLabel("5h") === "Allow for 5 hours", "CTA mirrors bounded duration");
 assert(localToolAllowButtonLabel("version") === "Trust this version", "version trust is explicit");
+assert(localToolAllowButtonLabel("always") === "Always trust safe calls", "indefinite trust remains conditional");
 assert(
   localToolSummary(options, "capability", "5h") === "Allow · xads.mjs · request · 5 hours",
   "summary names the tool, capability, and duration",
@@ -98,5 +101,33 @@ assert(html.includes("Writes, shell chaining"), "hard-risk boundary remains visi
 assert(html.includes("executable, script, or approved output processor changes"), "digest invalidation is clear");
 assert(html.includes("min-h-11"), "controls preserve 44px touch targets");
 assert(!html.includes("sha256-private-binding"), "stable tool fingerprint is never rendered");
+
+const packageOptions = localToolApprovalOptions({
+  ...request,
+  local_tool_approval: {
+    ...request.local_tool_approval,
+    tool_name: "impeccable",
+    capability: "scan",
+    read_only_reason: "profile_impeccable_scan",
+    trust_basis: "package-profile",
+    indefinite_allowed: true,
+    allowed_targets: ["capability"],
+    allowed_durations: ["once", "5h", "always"],
+  },
+} as GuardApprovalRequest);
+assert(packageOptions !== null, "package profile trust metadata is accepted");
+if (packageOptions === null) throw new Error("package options unexpectedly unavailable");
+const packageHtml = renderToStaticMarkup(
+  <LocalToolApprovalControls
+    options={packageOptions}
+    target="capability"
+    duration="always"
+    onTargetChange={() => undefined}
+    onDurationChange={() => undefined}
+  />,
+);
+assert(packageHtml.includes("Always"), "indefinite profile trust is visible");
+assert(packageHtml.includes("checks package safety"), "indefinite trust explains continuous package checks");
+assert(packageHtml.includes("URLs, writes, unsafe paths"), "package profile exclusions stay visible");
 
 console.log("local-tool-approval.test.tsx: all tests passed");

--- a/dashboard/src/local-tool-approval.ts
+++ b/dashboard/src/local-tool-approval.ts
@@ -6,7 +6,7 @@ import type {
 } from "./guard-types";
 
 const TARGETS = new Set<GuardLocalToolGrantTarget>(["capability", "version"]);
-const DURATIONS = new Set<GuardLocalToolGrantDuration>(["once", "15m", "1h", "5h", "version"]);
+const DURATIONS = new Set<GuardLocalToolGrantDuration>(["once", "15m", "1h", "5h", "version", "always"]);
 
 export type LocalToolApprovalOptions = Omit<GuardLocalToolApproval, "eligible">;
 
@@ -53,6 +53,8 @@ export function parseLocalToolApproval(value: unknown): GuardLocalToolApproval |
     tool_identity_hash: raw.tool_identity_hash,
     capability: raw.capability.trim(),
     read_only_reason: raw.read_only_reason.trim(),
+    trust_basis: raw.trust_basis === "package-profile" ? "package-profile" : "verified-files",
+    indefinite_allowed: raw.indefinite_allowed === true,
     allowed_targets: allowedTargets,
     allowed_durations: allowedDurations,
     hard_risk_exclusions: Array.isArray(raw.hard_risk_exclusions)
@@ -106,6 +108,7 @@ export function localToolDurationLabel(duration: GuardLocalToolGrantDuration): s
     "1h": "1 hour",
     "5h": "5 hours",
     version: "Until tool changes",
+    always: "Always",
   };
   return labels[duration];
 }
@@ -123,6 +126,7 @@ export function localToolReadOnlyReasonLabel(reason: string): string {
 export function localToolAllowButtonLabel(duration: GuardLocalToolGrantDuration): string {
   if (duration === "once") return "Approve once";
   if (duration === "version") return "Trust this version";
+  if (duration === "always") return "Always trust safe calls";
   return `Allow for ${localToolDurationLabel(duration)}`;
 }
 
@@ -130,7 +134,7 @@ export function localToolExpiryLabel(
   duration: GuardLocalToolGrantDuration,
   now: Date = new Date(),
 ): string | null {
-  if (duration === "once" || duration === "version") return null;
+  if (duration === "once" || duration === "version" || duration === "always") return null;
   const milliseconds = { "15m": 15 * 60_000, "1h": 60 * 60_000, "5h": 5 * 60 * 60_000 }[duration];
   return new Intl.DateTimeFormat(undefined, {
     dateStyle: "medium",

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -76,7 +76,7 @@ def add_approval_parser(
             )
             decision_parser.add_argument(
                 "--trust-duration",
-                choices=("15m", "1h", "5h", "version"),
+                choices=("15m", "1h", "5h", "version", "always"),
                 default="1h",
                 help="How long the local tool grant remains active.",
             )

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -576,7 +576,7 @@ def _evaluate_runtime_artifact_hook(
     raw_runtime_command = _runtime_package_raw_command(payload_map, action_envelope)
     if (
         event_name == "PreToolUse"
-        and runtime_artifact.artifact_type == "tool_action_request"
+        and runtime_artifact.artifact_type in {"tool_action_request", "package_request"}
         and raw_runtime_command is not None
     ):
         local_tool_eligibility = local_tool_approval_eligibility(
@@ -596,7 +596,7 @@ def _evaluate_runtime_artifact_hook(
         and payload_action_normalization is None
         and not data_flow_signals
         and not scanner_evidence
-        and package_evaluation is None
+        and (package_evaluation is None or package_policy_action != "block")
         else None
     )
     if local_tool_eligibility is not None:

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -15551,7 +15551,7 @@ function buildTemporaryMcpResolutionFields(options, target, duration) {
   return { mcp_grant_target: target, mcp_grant_duration: duration };
 }
 const TARGETS = /* @__PURE__ */ new Set(["capability", "version"]);
-const DURATIONS = /* @__PURE__ */ new Set(["once", "15m", "1h", "5h", "version"]);
+const DURATIONS = /* @__PURE__ */ new Set(["once", "15m", "1h", "5h", "version", "always"]);
 function nonEmpty(value) {
   return typeof value === "string" && value.trim().length > 0;
 }
@@ -15586,6 +15586,8 @@ function parseLocalToolApproval(value) {
     tool_identity_hash: raw.tool_identity_hash,
     capability: raw.capability.trim(),
     read_only_reason: raw.read_only_reason.trim(),
+    trust_basis: raw.trust_basis === "package-profile" ? "package-profile" : "verified-files",
+    indefinite_allowed: raw.indefinite_allowed === true,
     allowed_targets: allowedTargets,
     allowed_durations: allowedDurations,
     hard_risk_exclusions: Array.isArray(raw.hard_risk_exclusions) ? raw.hard_risk_exclusions.filter(nonEmpty).map((entry) => entry.trim()) : []
@@ -15621,7 +15623,8 @@ function localToolDurationLabel(duration) {
     "15m": "15 min",
     "1h": "1 hour",
     "5h": "5 hours",
-    version: "Until tool changes"
+    version: "Until tool changes",
+    always: "Always"
   };
   return labels[duration];
 }
@@ -15637,10 +15640,11 @@ function localToolReadOnlyReasonLabel(reason) {
 function localToolAllowButtonLabel(duration) {
   if (duration === "once") return "Approve once";
   if (duration === "version") return "Trust this version";
+  if (duration === "always") return "Always trust safe calls";
   return `Allow for ${localToolDurationLabel(duration)}`;
 }
 function localToolExpiryLabel(duration, now2 = /* @__PURE__ */ new Date()) {
-  if (duration === "once" || duration === "version") return null;
+  if (duration === "once" || duration === "version" || duration === "always") return null;
   const milliseconds = { "15m": 15 * 6e4, "1h": 60 * 6e4, "5h": 5 * 60 * 6e4 }[duration];
   return new Intl.DateTimeFormat(void 0, {
     dateStyle: "medium",
@@ -28424,7 +28428,7 @@ function pastDecisionVerb(decision) {
       return "blocked";
   }
 }
-const EXCLUSION_COPY$1 = "Privileged browser access, file transfer, secrets, command execution, destructive actions, and shared-profile access still require review.";
+const EXCLUSION_COPY = "Privileged browser access, file transfer, secrets, command execution, destructive actions, and shared-profile access still require review.";
 function TemporaryMcpRetryNotice() {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 border-l-2 border-brand-blue bg-brand-blue/[0.04] px-4 py-3", role: "status", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Timed access is not available for this request." }),
@@ -28494,10 +28498,9 @@ function TemporaryMcpApprovalControls(props) {
         ". The Guard service sets the final expiry."
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { id: descriptionId, className: "text-xs leading-5 text-brand-dark/70", children: EXCLUSION_COPY$1 })
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { id: descriptionId, className: "text-xs leading-5 text-brand-dark/70", children: EXCLUSION_COPY })
   ] });
 }
-const EXCLUSION_COPY = "Guard rechecks the executable and script before every call. Writes, shell chaining, redirects, embedded commands, environment overrides, and changed tool files still require review.";
 function LocalToolApprovalControls(props) {
   const expiry = localToolExpiryLabel(props.duration);
   const durationDescriptionId = "local-tool-duration-description";
@@ -28574,9 +28577,10 @@ function LocalToolApprovalControls(props) {
         expiry,
         ". The Guard service sets the final expiry."
       ] }),
-      props.duration === "version" && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-muted-foreground", children: "Trust ends automatically when the executable, script, or approved output processor changes." })
+      props.duration === "version" && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-muted-foreground", children: "Trust ends automatically when the executable, script, or approved output processor changes." }),
+      props.duration === "always" && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-muted-foreground", children: "Guard still checks package safety, command behavior, paths, and environment settings on every call." })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-5 text-brand-dark/70", children: EXCLUSION_COPY })
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-5 text-brand-dark/70", children: props.options.trust_basis === "package-profile" ? "Only recognized local scan calls are covered. Package risks, URLs, writes, unsafe paths, shell composition, and changed runner files still require review." : "Guard rechecks the executable and script before every call. Writes, shell chaining, redirects, embedded commands, environment overrides, and changed tool files still require review." })
   ] });
 }
 const commonScopeValues = /* @__PURE__ */ new Set(["artifact"]);

--- a/src/codex_plugin_scanner/guard/trusted_local_tool_jq.py
+++ b/src/codex_plugin_scanner/guard/trusted_local_tool_jq.py
@@ -1,0 +1,52 @@
+"""Safety checks for read-only jq output processors."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Final
+
+_FILE_OPTIONS: Final = frozenset(
+    {"-f", "-L", "--argfile", "--from-file", "--library-path", "--rawfile", "--run-tests", "--slurpfile"}
+)
+_SAFE_SHORT_OPTION_CHARACTERS: Final = frozenset("RacenrSsjMC")
+_SAFE_LONG_OPTIONS: Final = frozenset(
+    {
+        "--ascii-output",
+        "--compact-output",
+        "--exit-status",
+        "--join-output",
+        "--monochrome-output",
+        "--null-input",
+        "--raw-input",
+        "--raw-output",
+        "--seq",
+        "--slurp",
+        "--sort-keys",
+        "--tab",
+        "--unbuffered",
+    }
+)
+
+
+def safe_jq_arguments(arguments: Sequence[str]) -> bool:
+    filter_seen = False
+    for argument in arguments:
+        if (
+            argument in _FILE_OPTIONS
+            or argument.startswith("-L")
+            or any(argument.startswith(f"{option}=") for option in _FILE_OPTIONS)
+        ):
+            return False
+        if not filter_seen and argument in _SAFE_LONG_OPTIONS:
+            continue
+        if (
+            not filter_seen
+            and argument.startswith("-")
+            and len(argument) > 1
+            and all(character in _SAFE_SHORT_OPTION_CHARACTERS for character in argument[1:])
+        ):
+            continue
+        if filter_seen:
+            return False
+        filter_seen = True
+    return filter_seen

--- a/src/codex_plugin_scanner/guard/trusted_local_tool_jq.py
+++ b/src/codex_plugin_scanner/guard/trusted_local_tool_jq.py
@@ -46,6 +46,8 @@ def safe_jq_arguments(arguments: Sequence[str]) -> bool:
             and all(character in _SAFE_SHORT_OPTION_CHARACTERS for character in argument[1:])
         ):
             continue
+        if argument.startswith("-"):
+            return False
         if filter_seen:
             return False
         filter_seen = True

--- a/src/codex_plugin_scanner/guard/trusted_local_tools.py
+++ b/src/codex_plugin_scanner/guard/trusted_local_tools.py
@@ -14,12 +14,14 @@ from .models import GuardAction, PolicyDecision
 from .runtime.approval_context import build_runtime_launch_identity, runtime_launch_identity_is_reusable
 from .runtime.command_model import CommandSegment, parse_shell_command
 from .runtime.command_tokens import executable_name
+from .trusted_local_tool_jq import safe_jq_arguments
+from .trusted_package_tools import trusted_package_tool_profile
 
 LocalToolGrantTarget = Literal["capability", "version"]
-LocalToolGrantDuration = Literal["15m", "1h", "5h", "version"]
+LocalToolGrantDuration = Literal["15m", "1h", "5h", "version", "always"]
 
 LOCAL_TOOL_GRANT_TARGETS: Final = ("capability", "version")
-LOCAL_TOOL_GRANT_DURATIONS: Final = ("15m", "1h", "5h", "version")
+LOCAL_TOOL_GRANT_DURATIONS: Final = ("15m", "1h", "5h", "version", "always")
 _DURATION_SECONDS: Final = {"15m": 900, "1h": 3600, "5h": 18000}
 _SELECTOR_PREFIX: Final = "local-tool-grant:v1"
 _POLICY_SOURCE: Final = "trusted-local-tool"
@@ -43,36 +45,6 @@ _READ_ONLY_OPERATIONS: Final = frozenset(
 )
 _READ_ONLY_HTTP_METHODS: Final = frozenset({"GET", "HEAD", "OPTIONS"})
 _HTTP_OPERATIONS: Final = frozenset({"api", "fetch", "query", "request"})
-_JQ_FILE_OPTIONS: Final = frozenset(
-    {
-        "-f",
-        "-L",
-        "--argfile",
-        "--from-file",
-        "--library-path",
-        "--rawfile",
-        "--run-tests",
-        "--slurpfile",
-    }
-)
-_JQ_SAFE_SHORT_OPTION_CHARACTERS: Final = frozenset("RacenrSsjMC")
-_JQ_SAFE_LONG_OPTIONS: Final = frozenset(
-    {
-        "--ascii-output",
-        "--compact-output",
-        "--exit-status",
-        "--join-output",
-        "--monochrome-output",
-        "--null-input",
-        "--raw-input",
-        "--raw-output",
-        "--seq",
-        "--slurp",
-        "--sort-keys",
-        "--tab",
-        "--unbuffered",
-    }
-)
 _SIDE_EFFECTING_OPTIONS: Final = frozenset(
     {
         "-o",
@@ -113,6 +85,8 @@ class LocalToolApprovalEligibility:
     tool_identity_hash: str
     capability: str
     read_only_reason: str
+    trust_basis: Literal["verified-files", "package-profile"] = "verified-files"
+    indefinite_allowed: bool = False
 
     def to_evidence(self) -> dict[str, object]:
         return {
@@ -123,13 +97,26 @@ class LocalToolApprovalEligibility:
             "tool_identity_hash": self.tool_identity_hash,
             "capability": self.capability,
             "read_only_reason": self.read_only_reason,
+            "trust_basis": self.trust_basis,
+            "indefinite_allowed": self.indefinite_allowed,
         }
 
     def to_payload(self) -> dict[str, object]:
+        package_profile = self.trust_basis == "package-profile"
+        reusable_durations = (
+            ("15m", "1h", "5h", "always")
+            if package_profile and self.indefinite_allowed
+            else ("15m", "1h", "5h")
+            if package_profile
+            else LOCAL_TOOL_GRANT_DURATIONS[:-1]
+        )
         return {
             **self.to_evidence(),
-            "allowed_targets": list(LOCAL_TOOL_GRANT_TARGETS),
-            "allowed_durations": ["once", *LOCAL_TOOL_GRANT_DURATIONS],
+            "allowed_targets": ["capability"] if package_profile else list(LOCAL_TOOL_GRANT_TARGETS),
+            "allowed_durations": [
+                "once",
+                *reusable_durations,
+            ],
             "hard_risk_exclusions": list(_HARD_RISK_EXCLUSIONS),
         }
 
@@ -159,6 +146,17 @@ def local_tool_approval_eligibility(
     if model.confidence != "exact" or model.redirects or model.embedded_commands or len(model.segments) not in {1, 2}:
         return None
     primary = model.segments[0]
+    package_profile = trusted_package_tool_profile(primary, cwd=cwd, home_dir=home_dir)
+    if package_profile is not None and len(model.segments) == 1:
+        identity_hash = sha256(_canonical_json(package_profile.identity_material)).hexdigest()
+        return LocalToolApprovalEligibility(
+            tool_name=package_profile.tool_name,
+            tool_identity_hash=identity_hash,
+            capability=package_profile.capability,
+            read_only_reason=package_profile.read_only_reason,
+            trust_basis="package-profile",
+            indefinite_allowed=package_profile.indefinite_allowed,
+        )
     if not _safe_top_level_segment(primary, pipeline_index=0):
         return None
     processor_binding: dict[str, object] | None = None
@@ -168,7 +166,7 @@ def local_tool_approval_eligibility(
             return None
         if executable_name(processor.executable) != "jq":
             return None
-        if not _safe_jq_arguments(processor.arguments):
+        if not safe_jq_arguments(processor.arguments):
             return None
         processor_binding = _reusable_launch_binding(processor, cwd=cwd)
         if processor_binding is None:
@@ -217,12 +215,18 @@ def parse_local_tool_grant_selection(
         raise ValueError("local_tool_approval_ineligible")
     if target not in LOCAL_TOOL_GRANT_TARGETS:
         raise ValueError("invalid_local_tool_grant_target")
+    allowed_targets = cast(list[object], eligibility.to_payload()["allowed_targets"])
+    if target not in allowed_targets:
+        raise ValueError("invalid_local_tool_grant_target")
     if duration not in LOCAL_TOOL_GRANT_DURATIONS:
+        raise ValueError("invalid_local_tool_grant_duration")
+    allowed_durations = cast(list[object], eligibility.to_payload()["allowed_durations"])
+    if duration not in allowed_durations:
         raise ValueError("invalid_local_tool_grant_duration")
     typed_target: LocalToolGrantTarget = target
     typed_duration: LocalToolGrantDuration = duration
     expires_at: str | None = None
-    if typed_duration != "version":
+    if typed_duration not in {"version", "always"}:
         parsed_now = datetime.fromisoformat(now.replace("Z", "+00:00"))
         if parsed_now.tzinfo is None:
             parsed_now = parsed_now.replace(tzinfo=timezone.utc)
@@ -305,6 +309,7 @@ def _eligibility_from_request(request: Mapping[str, object]) -> LocalToolApprova
         identity_hash = _nonempty_string(normalized_item.get("tool_identity_hash"))
         capability = _nonempty_string(normalized_item.get("capability"))
         read_only_reason = _nonempty_string(normalized_item.get("read_only_reason"))
+        trust_basis = normalized_item.get("trust_basis", "verified-files")
         if (
             normalized_item.get("eligible") is True
             and tool_name is not None
@@ -312,8 +317,16 @@ def _eligibility_from_request(request: Mapping[str, object]) -> LocalToolApprova
             and _is_sha256(identity_hash)
             and capability is not None
             and read_only_reason is not None
+            and trust_basis in {"verified-files", "package-profile"}
         ):
-            return LocalToolApprovalEligibility(tool_name, identity_hash, capability, read_only_reason)
+            return LocalToolApprovalEligibility(
+                tool_name,
+                identity_hash,
+                capability,
+                read_only_reason,
+                cast(Literal["verified-files", "package-profile"], trust_basis),
+                bool(normalized_item.get("indefinite_allowed", False)),
+            )
     return None
 
 
@@ -443,30 +456,6 @@ def _normalized_option(argument: str) -> str | None:
     if not argument.startswith("-") or argument == "-":
         return None
     return argument.split("=", 1)[0].lower()
-
-
-def _safe_jq_arguments(arguments: Sequence[str]) -> bool:
-    filter_seen = False
-    for argument in arguments:
-        if (
-            argument in _JQ_FILE_OPTIONS
-            or argument.startswith("-L")
-            or any(argument.startswith(f"{option}=") for option in _JQ_FILE_OPTIONS)
-        ):
-            return False
-        if not filter_seen and argument in _JQ_SAFE_LONG_OPTIONS:
-            continue
-        if (
-            not filter_seen
-            and argument.startswith("-")
-            and len(argument) > 1
-            and all(character in _JQ_SAFE_SHORT_OPTION_CHARACTERS for character in argument[1:])
-        ):
-            continue
-        if filter_seen:
-            return False
-        filter_seen = True
-    return filter_seen
 
 
 def _tool_display_name(segment: CommandSegment, binding: Mapping[str, object]) -> str:

--- a/src/codex_plugin_scanner/guard/trusted_package_tools.py
+++ b/src/codex_plugin_scanner/guard/trusted_package_tools.py
@@ -1,0 +1,172 @@
+"""Narrow read-only profiles for package-run CLI trust."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+from urllib.parse import urlparse
+
+from .runtime.approval_context import build_runtime_launch_identity
+from .runtime.command_model import CommandSegment
+from .runtime.command_tokens import executable_name
+from .runtime.secret_file_request_services.request_models import classify_sensitive_path
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedPackageToolProfile:
+    tool_name: str
+    capability: str
+    read_only_reason: str
+    identity_material: Mapping[str, object]
+    indefinite_allowed: bool
+
+
+def trusted_package_tool_profile(
+    segment: CommandSegment,
+    *,
+    cwd: Path,
+    home_dir: Path | None,
+) -> TrustedPackageToolProfile | None:
+    if executable_name(segment.executable) not in {"npx", "bunx"}:
+        return None
+    if segment.path_overridden or segment.wrapper_chain:
+        return None
+    runner = _verified_runner_identity(segment, cwd=cwd)
+    if runner is None:
+        return None
+    return _impeccable_profile(segment, cwd=cwd, home_dir=home_dir, runner=runner)
+
+
+def _impeccable_profile(
+    segment: CommandSegment,
+    *,
+    cwd: Path,
+    home_dir: Path | None,
+    runner: Mapping[str, object],
+) -> TrustedPackageToolProfile | None:
+    arguments = list(segment.arguments)
+    if not arguments:
+        return None
+    package_selector = arguments.pop(0)
+    if not _is_impeccable_selector(package_selector):
+        return None
+    if tuple(segment.environment_names) not in {(), ("IMPECCABLE_CONTEXT_DIR",)}:
+        return None
+    if segment.environment_names and not _safe_context_directory(segment, cwd=cwd, home_dir=home_dir):
+        return None
+    if arguments and arguments[0] == "detect":
+        _ = arguments.pop(0)
+    elif arguments and arguments[0] == "skills":
+        return None
+    if not arguments:
+        return None
+    option_shape: list[str] = []
+    paths: list[str] = []
+    for argument in arguments:
+        if argument in {"--json", "--fast"}:
+            option_shape.append(argument)
+            continue
+        if argument.startswith("-"):
+            return None
+        if not _safe_local_path(argument, cwd=cwd, home_dir=home_dir):
+            return None
+        paths.append(argument)
+    if not paths:
+        return None
+    return TrustedPackageToolProfile(
+        tool_name="impeccable",
+        capability="scan",
+        read_only_reason="profile_impeccable_scan",
+        identity_material={
+            "profile": "impeccable-local-scan:v1",
+            "package": {
+                "name": "impeccable",
+                "selector": package_selector,
+                "trust_mode": "continuous-package-policy-veto",
+            },
+            "runner": runner,
+            "options": sorted(option_shape),
+            "environment_names": list(segment.environment_names),
+        },
+        indefinite_allowed=bool(re.fullmatch(r"impeccable@\d+\.\d+\.\d+", package_selector)),
+    )
+
+
+def _is_impeccable_selector(value: str) -> bool:
+    return value == "impeccable" or bool(re.fullmatch(r"impeccable@(?:latest|\d+\.\d+\.\d+)", value))
+
+
+def _verified_runner_identity(segment: CommandSegment, *, cwd: Path) -> dict[str, object] | None:
+    identity = build_runtime_launch_identity(
+        segment.executable,
+        args=segment.arguments,
+        structured_command=True,
+        cwd=cwd,
+    )
+    executable = identity.get("executable")
+    if not isinstance(executable, Mapping):
+        return None
+    normalized = dict(cast(Mapping[str, object], executable))
+    if normalized.get("status") != "verified":
+        return None
+    return _stable_identity_mapping(normalized)
+
+
+def _stable_identity_mapping(value: Mapping[str, object]) -> dict[str, object]:
+    return {
+        str(key): _stable_identity_value(item)
+        for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        if key not in {"argument_sha256", "reuse_nonce", "script_args_sha256"}
+    }
+
+
+def _stable_identity_value(value: object) -> object:
+    if isinstance(value, Mapping):
+        return _stable_identity_mapping(dict(cast(Mapping[str, object], value)))
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return [_stable_identity_value(item) for item in value]
+    return value
+
+
+def _safe_context_directory(segment: CommandSegment, *, cwd: Path, home_dir: Path | None) -> bool:
+    prefix = next((token for token in segment.tokens if token.startswith("IMPECCABLE_CONTEXT_DIR=")), None)
+    if prefix is None:
+        return False
+    return _safe_local_path(prefix.split("=", 1)[1], cwd=cwd, home_dir=home_dir, require_directory=True)
+
+
+def _safe_local_path(
+    value: str,
+    *,
+    cwd: Path,
+    home_dir: Path | None,
+    require_directory: bool = False,
+) -> bool:
+    if not value or urlparse(value).scheme or any(marker in value for marker in ("$", "`", "*", "?", "[")):
+        return False
+    if value == "~" or value.startswith("~/"):
+        if home_dir is None:
+            return False
+        expanded = home_dir if value == "~" else home_dir / value.removeprefix("~/")
+    else:
+        expanded = Path(value)
+    candidate = expanded if expanded.is_absolute() else cwd / expanded
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError:
+        return False
+    if require_directory and not resolved.is_dir():
+        return False
+    if not require_directory and not (resolved.is_file() or resolved.is_dir()):
+        return False
+    if classify_sensitive_path(str(resolved), cwd=cwd, home_dir=home_dir) is not None:
+        return False
+    in_workspace = resolved == cwd or cwd in resolved.parents
+    in_home = home_dir is None or resolved == home_dir or home_dir in resolved.parents
+    return in_workspace or in_home
+
+
+__all__: Sequence[str] = ("TrustedPackageToolProfile", "trusted_package_tool_profile")

--- a/src/codex_plugin_scanner/guard/trusted_package_tools.py
+++ b/src/codex_plugin_scanner/guard/trusted_package_tools.py
@@ -165,7 +165,7 @@ def _safe_local_path(
     if classify_sensitive_path(str(resolved), cwd=cwd, home_dir=home_dir) is not None:
         return False
     in_workspace = resolved == cwd or cwd in resolved.parents
-    in_home = home_dir is None or resolved == home_dir or home_dir in resolved.parents
+    in_home = home_dir is not None and (resolved == home_dir or home_dir in resolved.parents)
     return in_workspace or in_home
 
 

--- a/tests/test_guard_trusted_local_tools.py
+++ b/tests/test_guard_trusted_local_tools.py
@@ -11,6 +11,7 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.trusted_local_tool_jq import safe_jq_arguments
 from codex_plugin_scanner.guard.trusted_local_tools import (
     local_tool_approval_eligibility,
     parse_local_tool_grant_selection,
@@ -142,6 +143,10 @@ def test_local_tool_eligibility_supports_verified_jq_output_processing(
     assert changed_filter.tool_identity_hash != eligibility.tool_identity_hash
 
 
+def test_jq_trust_rejects_unknown_options() -> None:
+    assert safe_jq_arguments(["--indent"]) is False
+
+
 def test_impeccable_local_scan_can_receive_conditional_package_trust(tmp_path: Path) -> None:
     source = tmp_path / "src"
     source.mkdir()
@@ -177,6 +182,22 @@ def test_impeccable_local_scan_can_receive_conditional_package_trust(tmp_path: P
     )
     assert latest is not None
     assert latest.tool_identity_hash != eligibility.tool_identity_hash
+
+
+def test_impeccable_package_trust_without_home_stays_in_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.tsx"
+    _ = outside.write_text("export const Outside = () => null;\n")
+
+    assert (
+        local_tool_approval_eligibility(
+            f"npx impeccable@3.3.1 --json {outside}",
+            cwd=workspace,
+            home_dir=None,
+        )
+        is None
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_trusted_local_tools.py
+++ b/tests/test_guard_trusted_local_tools.py
@@ -11,7 +11,10 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.store import GuardStore
-from codex_plugin_scanner.guard.trusted_local_tools import local_tool_approval_eligibility
+from codex_plugin_scanner.guard.trusted_local_tools import (
+    local_tool_approval_eligibility,
+    parse_local_tool_grant_selection,
+)
 
 
 def _write_event(
@@ -137,6 +140,158 @@ def test_local_tool_eligibility_supports_verified_jq_output_processing(
     )
     assert changed_filter is not None
     assert changed_filter.tool_identity_hash != eligibility.tool_identity_hash
+
+
+def test_impeccable_local_scan_can_receive_conditional_package_trust(tmp_path: Path) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    target = source / "email.tsx"
+    _ = target.write_text("export const Email = () => null;\n")
+    context = tmp_path / "docs"
+    context.mkdir()
+    command = f"IMPECCABLE_CONTEXT_DIR={context} npx impeccable --json {target}"
+
+    eligibility = local_tool_approval_eligibility(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert eligibility is not None
+    assert eligibility.tool_name == "impeccable"
+    assert eligibility.capability == "scan"
+    assert eligibility.trust_basis == "package-profile"
+    assert eligibility.to_payload()["allowed_durations"] == [
+        "once",
+        "15m",
+        "1h",
+        "5h",
+    ]
+    pinned = local_tool_approval_eligibility(
+        command.replace("npx impeccable", "npx impeccable@3.3.1"),
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+    assert pinned is not None
+    assert "always" in cast(list[object], pinned.to_payload()["allowed_durations"])
+    latest = local_tool_approval_eligibility(
+        command.replace("npx impeccable ", "npx impeccable@latest "),
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+    assert latest is not None
+    assert latest.tool_identity_hash != eligibility.tool_identity_hash
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    (
+        "skills install",
+        "detect https://example.test",
+        "--output report.json src",
+        "--json ~/.ssh",
+    ),
+)
+def test_impeccable_package_trust_rejects_mutating_or_unsafe_calls(tmp_path: Path, arguments: str) -> None:
+    (tmp_path / "src").mkdir()
+    command = f"npx impeccable {arguments}"
+    assert local_tool_approval_eligibility(command, cwd=tmp_path, home_dir=tmp_path) is None
+
+
+def test_indefinite_trust_is_limited_to_package_profiles(
+    local_tool_workspace: tuple[Path, Path],
+) -> None:
+    workspace, _tool = local_tool_workspace
+    direct = local_tool_approval_eligibility(
+        "node xads.mjs request --method=GET --path=/stats",
+        cwd=workspace,
+        home_dir=workspace,
+    )
+    assert direct is not None
+    request = {"scanner_evidence": [direct.to_evidence()]}
+
+    with pytest.raises(ValueError, match="invalid_local_tool_grant_duration"):
+        _ = parse_local_tool_grant_selection(
+            request,
+            target="capability",
+            duration="always",
+            now="2026-08-02T12:00:00+00:00",
+        )
+
+
+def test_impeccable_package_request_exposes_trust_controls_in_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    context = workspace / "docs"
+    context.mkdir()
+    target = workspace / "email.tsx"
+    _ = target.write_text("export const Email = () => null;\n")
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    _ = (guard_home / "config.toml").write_text(
+        'mode = "enforce"\nsecurity_level = "balanced"\ndefault_action = "require-reapproval"\n'
+    )
+    monkeypatch.setenv("CODEX_MANAGED_BY_BUN", "1")
+
+    def schedule_daemon(_guard_home: Path, **_kwargs: object) -> str:
+        return "http://127.0.0.1:4455"
+
+    monkeypatch.setattr(guard_commands_module, "schedule_guard_daemon_ensure", schedule_daemon)
+
+    def unavailable_daemon(_guard_home: Path) -> object:
+        raise RuntimeError("daemon unavailable")
+
+    monkeypatch.setattr(guard_commands_module, "load_guard_surface_daemon_client", unavailable_daemon)
+    event = tmp_path / "impeccable.json"
+    _write_event(
+        event,
+        workspace=workspace,
+        command=f"IMPECCABLE_CONTEXT_DIR={context} npx impeccable@3.3.1 --json {target}",
+        call_id="impeccable",
+    )
+
+    assert _run_hook(guard_home=guard_home, workspace=workspace, event_path=event) == 0
+    _ = capsys.readouterr()
+    pending = GuardStore(guard_home).list_approval_requests(limit=5)
+    assert len(pending) == 1
+    assert pending[0]["artifact_type"] == "package_request"
+    assert "local_tool_approval" in pending[0], [
+        cast(Mapping[str, object], item).get("source")
+        for item in cast(list[object], pending[0].get("scanner_evidence", []))
+        if isinstance(item, Mapping)
+    ]
+    approval = cast(Mapping[str, object], pending[0]["local_tool_approval"])
+    assert approval["tool_name"] == "impeccable"
+    assert approval["capability"] == "scan"
+    assert approval["trust_basis"] == "package-profile"
+    assert "always" in cast(list[object], approval["allowed_durations"])
+
+    resolved = apply_approval_resolution(
+        store=GuardStore(guard_home),
+        request_id=str(pending[0]["request_id"]),
+        action="allow",
+        scope="artifact",
+        workspace=str(workspace),
+        reason="trusted local design scan",
+        now="2026-08-02T12:00:00+00:00",
+        local_tool_grant_target="capability",
+        local_tool_grant_duration="always",
+    )
+    grant = cast(Mapping[str, object], resolved["local_tool_grant"])
+    assert grant["expires_at"] is None
+
+    second_target = workspace / "second-email.tsx"
+    _ = second_target.write_text("export const SecondEmail = () => null;\n")
+    second_event = tmp_path / "impeccable-second.json"
+    _write_event(
+        second_event,
+        workspace=workspace,
+        command=f"IMPECCABLE_CONTEXT_DIR={context} npx impeccable@3.3.1 --json {second_target}",
+        call_id="impeccable-second",
+    )
+    assert _run_hook(guard_home=guard_home, workspace=workspace, event_path=second_event) == 0
+    assert capsys.readouterr().out == ""
+    assert GuardStore(guard_home).list_approval_requests(limit=5) == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Expose safe, profile-bound trust controls for local Impeccable scans launched through package runners.
- Add bounded and indefinite trust choices while rechecking package safety, command semantics, paths, and runner identity on every invocation.
- Keep mutating commands, URLs, unsafe paths, shell composition, and unavailable package safety data fail-closed.

## Testing
- `uv run --no-sync pytest -q tests/test_guard_trusted_local_tools.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/trusted_local_tools.py src/codex_plugin_scanner/guard/trusted_local_tool_jq.py src/codex_plugin_scanner/guard/trusted_package_tools.py src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py src/codex_plugin_scanner/guard/cli/approval_commands.py tests/test_guard_trusted_local_tools.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/trusted_local_tools.py src/codex_plugin_scanner/guard/trusted_local_tool_jq.py src/codex_plugin_scanner/guard/trusted_package_tools.py tests/test_guard_trusted_local_tools.py`
- `tsx src/local-tool-approval.test.tsx`
- `vite build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added “Always” as a local-tool approval duration for eligible trusted package tools.
  - Added package-based trust controls with clearer approval details, restrictions, and continuous package checks.
  - Added support for approving compatible package requests alongside tool actions.

- **Security**
  - Improved validation for trusted package commands and `jq` usage, blocking unsafe options, wrappers, sensitive paths, and mutating operations.
  - Limited indefinite trust to eligible, verified package profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->