### PR TITLE
fix(guard): recover automatically from sqlite corruption

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11773,
-  "maximum_test_source_lines": 276412,
+  "maximum_collected_cases": 11785,
+  "maximum_test_source_lines": 276634,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11794,
-  "maximum_test_source_lines": 276810,
+  "maximum_collected_cases": 11795,
+  "maximum_test_source_lines": 276819,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -36,12 +36,14 @@ NON_MIGRATED_GUARD_RUNTIME_FILES = frozenset(
         "guard.db-shm",
         "guard.db-wal",
         "schema-migration.lock",
+        "storage-access.lock",
     }
 )
 GUARD_HOME_METADATA_FILES = frozenset(
     {
         "oauth-keychain-access.json",
         "schema-migration.lock",
+        "storage-access.lock",
         "system-keyring-availability.json",
     }
 )

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -5,9 +5,11 @@
 from __future__ import annotations
 
 import threading
+from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import ClassVar
+from uuid import uuid4
 
 from .sqlite_profile import (
     SQLiteMigrationGateReport,
@@ -142,6 +144,12 @@ _POLICY_INDEX_STATEMENTS = (
 
 _RECEIPT_WARN_ROLLUP_MIGRATION_VERSION = 16
 _REQUIRED_SCHEMA_MIGRATION_VERSIONS = tuple(range(2, STORAGE_QUERY_INDEX_MIGRATION_VERSION + 1))
+_FATAL_SQLITE_ERROR_MARKERS = (
+    "database disk image is malformed",
+    "database corruption",
+    "file is not a database",
+)
+_SQLITE_IO_ERROR_MARKER = "disk i/o error"
 
 
 @dataclass
@@ -162,6 +170,124 @@ class StoreConnectionSchemaMixin:
         _POLICY_INTEGRITY_LOOKUP_UNSET
     )
     _startup_prefetched_policy_integrity_repair_failed = False
+    _storage_recovery_local: ClassVar[threading.local] = threading.local()
+
+    def _current_thread_owns_storage_recovery(self) -> bool:
+        return getattr(self._storage_recovery_local, "owner", None) == id(self)
+
+    @staticmethod
+    def _is_fatal_sqlite_error(error: BaseException) -> bool:
+        return isinstance(error, sqlite3.DatabaseError) and any(
+            marker in str(error).lower() for marker in _FATAL_SQLITE_ERROR_MARKERS
+        )
+
+    @contextmanager
+    def _hold_storage_gate(self, *, exclusive: bool) -> Iterator[None]:
+        path = self.guard_home / "storage-access.lock"
+        deadline = time.monotonic() + sqlite_connect_timeout_seconds()
+        with path.open("a+b") as handle:
+            while True:
+                try:
+                    if os.name == "nt":
+                        import msvcrt
+
+                        handle.seek(0)
+                        if not handle.read(1):
+                            handle.write(b"0")
+                            handle.flush()
+                        handle.seek(0)
+                        mode = msvcrt.LK_NBLCK if exclusive else msvcrt.LK_NBRLCK
+                        msvcrt.locking(handle.fileno(), mode, 1)
+                    else:
+                        import fcntl
+
+                        mode = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+                        fcntl.flock(handle.fileno(), mode | fcntl.LOCK_NB)
+                    break
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError("Timed out waiting for Guard storage access.") from None
+                    time.sleep(0.01)
+            try:
+                yield
+            finally:
+                if os.name == "nt":
+                    import msvcrt
+
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    def _store_is_proven_unusable(self, error: BaseException) -> bool:
+        if self._is_fatal_sqlite_error(error):
+            return True
+        if _SQLITE_IO_ERROR_MARKER not in str(error).lower():
+            return False
+        # An I/O error alone does not prove corruption. Only replace the active
+        # path when the same directory supports a fresh SQLite transaction and
+        # the existing database remains unreadable on a second probe.
+        probe_path = self.guard_home / f"storage-probe-{uuid4().hex}.db"
+        try:
+            with sqlite3.connect(probe_path, timeout=0.1) as probe:
+                probe.execute("create table probe (value integer)")
+                probe.execute("insert into probe values (1)")
+            with sqlite3.connect(self.path, timeout=0.1) as existing:
+                _ = existing.execute("pragma schema_version").fetchone()
+                return False
+        except sqlite3.DatabaseError as probe_error:
+            return _SQLITE_IO_ERROR_MARKER in str(probe_error).lower() and probe_path.is_file()
+        finally:
+            with suppress(OSError):
+                probe_path.unlink()
+
+    def _recover_fatal_sqlite_store(self, error: BaseException) -> bool:
+        is_io_error = _SQLITE_IO_ERROR_MARKER in str(error).lower()
+        if (
+            not isinstance(error, sqlite3.DatabaseError)
+            or (not self._is_fatal_sqlite_error(error) and not is_io_error)
+            or self._current_thread_owns_storage_recovery()
+            or self.path.is_symlink()
+        ):
+            return False
+        try:
+            failed_stat = self.path.stat()
+            failed_identity = failed_stat.st_dev, failed_stat.st_ino
+        except OSError:
+            failed_identity = None
+        with self._hold_storage_gate(exclusive=True):
+            # Another process may already have replaced the failed store.
+            try:
+                current_stat = self.path.stat()
+                current_identity = current_stat.st_dev, current_stat.st_ino
+            except OSError:
+                current_identity = None
+            if current_identity != failed_identity:
+                return True
+
+            if not self._store_is_proven_unusable(error):
+                return False
+
+            stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+            quarantine_id = f"{stamp}-{uuid4().hex[:8]}"
+            for suffix in ("", "-wal", "-shm"):
+                source = Path(f"{self.path}{suffix}")
+                if not source.exists() or source.is_symlink():
+                    continue
+                destination = self.guard_home / f"guard.db.corrupt-{quarantine_id}{suffix}"
+                source.replace(destination)
+            _store_logger.error(
+                "Guard quarantined an unusable SQLite store after a fatal storage error: %s",
+                type(error).__name__,
+            )
+            self._storage_recovery_local.owner = id(self)
+            try:
+                self._initialize_schema()
+            finally:
+                self._storage_recovery_local.owner = None
+            return True
 
     def _sqlite_profiler(self) -> SQLiteProfiler:
         profiler = self.__dict__.get("_guard_sqlite_profiler")
@@ -185,6 +311,23 @@ class StoreConnectionSchemaMixin:
 
     @contextmanager
     def _connect(self) -> Iterator[sqlite3.Connection]:
+        if self._current_thread_owns_storage_recovery():
+            with self._connect_once() as connection:
+                yield connection
+            return
+        fatal_error: sqlite3.DatabaseError | None = None
+        with self._hold_storage_gate(exclusive=False):
+            try:
+                with self._connect_once() as connection:
+                    yield connection
+            except sqlite3.DatabaseError as error:
+                fatal_error = error
+        if fatal_error is not None:
+            self._recover_fatal_sqlite_store(fatal_error)
+            raise fatal_error
+
+    @contextmanager
+    def _connect_once(self) -> Iterator[sqlite3.Connection]:
         connect_timeout_seconds = sqlite_connect_timeout_seconds()
         profiler = self._sqlite_profiler()
         connect_started = time.monotonic()
@@ -199,6 +342,7 @@ class StoreConnectionSchemaMixin:
         connection.row_factory = sqlite3.Row
         start = time.monotonic()
         notification: dict[str, object] | None = None
+        database_failed = False
         try:
             connection.execute(f"pragma busy_timeout={int(connect_timeout_seconds * 1000)}")
             # Hot-path tuning: synchronous=NORMAL is only safe once the database
@@ -219,12 +363,16 @@ class StoreConnectionSchemaMixin:
                 profiler.record_commit((time.monotonic() - commit_started) * 1000)
             notification = self._take_policy_integrity_state_notification(connection)
         except sqlite3.OperationalError as error:
+            database_failed = True
             if sqlite_error_is_busy_locked(error):
                 profiler.record_busy_locked()
             raise
+        except sqlite3.DatabaseError:
+            database_failed = True
+            raise
         finally:
             profiler.record_transaction((time.monotonic() - start) * 1000)
-            if notification is None:
+            if notification is None and not database_failed:
                 self._take_policy_integrity_state_notification(connection)
             connection.close()
             elapsed_ms = (time.monotonic() - start) * 1000
@@ -331,6 +479,17 @@ class StoreConnectionSchemaMixin:
                     _release_advisory_file_lock(handle)
 
     def _initialize_serialized(self) -> None:
+        try:
+            self._initialize_serialized_once()
+        except sqlite3.DatabaseError as error:
+            if self._schema_is_current():
+                self._initialize_policy_integrity()
+                return
+            if not self._recover_fatal_sqlite_store(error):
+                raise
+            self._initialize_policy_integrity()
+
+    def _initialize_serialized_once(self) -> None:
         daemon_managed = getattr(self, "_daemon_managed_schema", False)
         if daemon_managed and self._schema_is_current():
             self._initialize_policy_integrity()
@@ -932,39 +1091,38 @@ class StoreConnectionSchemaMixin:
             return False
         timeout_seconds = sqlite_connect_timeout_seconds()
         try:
-            connection = sqlite3.connect(self.path, timeout=timeout_seconds)
-            try:
-                connection.execute(f"pragma busy_timeout={int(timeout_seconds * 1000)}")
-                placeholders = ", ".join("?" for _ in _REQUIRED_SCHEMA_MIGRATION_VERSIONS)
-                row = connection.execute(
-                    f"select count(*) from schema_migrations where version in ({placeholders})",
-                    _REQUIRED_SCHEMA_MIGRATION_VERSIONS,
-                ).fetchone()
-                storage_row = connection.execute(
-                    """
-                    select 1 from sqlite_master
-                    where type = 'table' and name = 'guard_storage_maintenance'
-                    """
-                ).fetchone()
-                approval_columns = {
-                    str(column[1]) for column in connection.execute("pragma table_info(approval_requests)")
-                }
-                required_approval_columns = {
-                    "guard_version",
-                    "first_seen_guard_version",
-                    "last_seen_guard_version",
-                }
-                return (
-                    row is not None
-                    and int(row[0]) == len(_REQUIRED_SCHEMA_MIGRATION_VERSIONS)
-                    and storage_row is not None
-                    and required_approval_columns <= approval_columns
-                )
-            finally:
-                connection.close()
-        except sqlite3.OperationalError as error:
-            if "locked" in str(error).lower() or "busy" in str(error).lower():
-                return False
+            with self._hold_storage_gate(exclusive=False):
+                connection = sqlite3.connect(self.path, timeout=timeout_seconds)
+                try:
+                    connection.execute(f"pragma busy_timeout={int(timeout_seconds * 1000)}")
+                    placeholders = ", ".join("?" for _ in _REQUIRED_SCHEMA_MIGRATION_VERSIONS)
+                    row = connection.execute(
+                        f"select count(*) from schema_migrations where version in ({placeholders})",
+                        _REQUIRED_SCHEMA_MIGRATION_VERSIONS,
+                    ).fetchone()
+                    storage_row = connection.execute(
+                        """
+                        select 1 from sqlite_master
+                        where type = 'table' and name = 'guard_storage_maintenance'
+                        """
+                    ).fetchone()
+                    approval_columns = {
+                        str(column[1]) for column in connection.execute("pragma table_info(approval_requests)")
+                    }
+                    required_approval_columns = {
+                        "guard_version",
+                        "first_seen_guard_version",
+                        "last_seen_guard_version",
+                    }
+                    return (
+                        row is not None
+                        and int(row[0]) == len(_REQUIRED_SCHEMA_MIGRATION_VERSIONS)
+                        and storage_row is not None
+                        and required_approval_columns <= approval_columns
+                    )
+                finally:
+                    connection.close()
+        except sqlite3.DatabaseError:
             return False
 
     @staticmethod

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -171,6 +171,7 @@ class StoreConnectionSchemaMixin:
     )
     _startup_prefetched_policy_integrity_repair_failed = False
     _storage_recovery_local: ClassVar[threading.local] = threading.local()
+    _storage_gate_local: ClassVar[threading.local] = threading.local()
 
     def _current_thread_owns_storage_recovery(self) -> bool:
         return getattr(self._storage_recovery_local, "owner", None) == id(self)
@@ -183,6 +184,16 @@ class StoreConnectionSchemaMixin:
 
     @contextmanager
     def _hold_storage_gate(self, *, exclusive: bool) -> Iterator[None]:
+        local = self._storage_gate_local
+        if getattr(local, "owner", None) == id(self) and getattr(local, "depth", 0) > 0:
+            if exclusive and getattr(local, "exclusive", False) is False:
+                raise RuntimeError("Cannot upgrade an active Guard storage read gate.")
+            local.depth += 1
+            try:
+                yield
+            finally:
+                local.depth -= 1
+            return
         path = self.guard_home / "storage-access.lock"
         deadline = time.monotonic() + sqlite_connect_timeout_seconds()
         with path.open("a+b") as handle:
@@ -208,9 +219,15 @@ class StoreConnectionSchemaMixin:
                     if time.monotonic() >= deadline:
                         raise TimeoutError("Timed out waiting for Guard storage access.") from None
                     time.sleep(0.01)
+            local.owner = id(self)
+            local.depth = 1
+            local.exclusive = exclusive
             try:
                 yield
             finally:
+                local.owner = None
+                local.depth = 0
+                local.exclusive = False
                 if os.name == "nt":
                     import msvcrt
 

--- a/src/codex_plugin_scanner/guard/store_receipts.py
+++ b/src/codex_plugin_scanner/guard/store_receipts.py
@@ -784,7 +784,10 @@ class StoreReceiptsRuntimeMixin:
 
         bounded_timeout = min(max(timeout_seconds, 0.0), 1.0)
         try:
-            with closing(sqlite3.connect(self.path, timeout=bounded_timeout)) as connection:
+            with (
+                self._hold_storage_gate(exclusive=False),
+                closing(sqlite3.connect(self.path, timeout=bounded_timeout)) as connection,
+            ):
                 connection.execute(f"pragma busy_timeout={int(bounded_timeout * 1000)}")
                 connection.execute(
                     """

--- a/src/codex_plugin_scanner/guard/store_secret_policy_integrity.py
+++ b/src/codex_plugin_scanner/guard/store_secret_policy_integrity.py
@@ -1081,35 +1081,37 @@ class StoreSecretPolicyIntegrityMixin:
 
         def compute_prepared_state(base_state: dict[str, object]) -> dict[str, object]:
             connect_timeout_seconds = sqlite_connect_timeout_seconds()
-            connection = sqlite3.connect(self.path, timeout=connect_timeout_seconds)
-            connection.row_factory = sqlite3.Row
-            try:
-                connection.execute(f"pragma busy_timeout={int(connect_timeout_seconds * 1000)}")
-                return self._prepared_startup_policy_integrity_state(
-                    connection,
-                    key=raw_key,
-                    key_id=key_id,
-                    trusted_state=base_state,
-                )
-            finally:
-                connection.close()
+            with self._hold_storage_gate(exclusive=False):
+                connection = sqlite3.connect(self.path, timeout=connect_timeout_seconds)
+                connection.row_factory = sqlite3.Row
+                try:
+                    connection.execute(f"pragma busy_timeout={int(connect_timeout_seconds * 1000)}")
+                    return self._prepared_startup_policy_integrity_state(
+                        connection,
+                        key=raw_key,
+                        key_id=key_id,
+                        trusted_state=base_state,
+                    )
+                finally:
+                    connection.close()
 
         prepared_state = compute_prepared_state(trusted_state)
         current_trusted_state = self._load_policy_integrity_control_state(create=False)
         if current_trusted_state is None:
             connect_timeout_seconds = sqlite_connect_timeout_seconds()
-            connection = sqlite3.connect(self.path, timeout=connect_timeout_seconds)
-            connection.row_factory = sqlite3.Row
-            try:
-                connection.execute(f"pragma busy_timeout={int(connect_timeout_seconds * 1000)}")
-                still_matches = self._prefetched_startup_state_still_matches_local_rows(
-                    connection,
-                    key=raw_key,
-                    key_id=key_id,
-                    trusted_state=trusted_state,
-                )
-            finally:
-                connection.close()
+            with self._hold_storage_gate(exclusive=False):
+                connection = sqlite3.connect(self.path, timeout=connect_timeout_seconds)
+                connection.row_factory = sqlite3.Row
+                try:
+                    connection.execute(f"pragma busy_timeout={int(connect_timeout_seconds * 1000)}")
+                    still_matches = self._prefetched_startup_state_still_matches_local_rows(
+                        connection,
+                        key=raw_key,
+                        key_id=key_id,
+                        trusted_state=trusted_state,
+                    )
+                finally:
+                    connection.close()
             if prepared_state == trusted_state and still_matches:
                 self._startup_prefetched_policy_integrity_trusted_state = trusted_state
                 return

--- a/tests/test_guard_sqlite_failure_containment.py
+++ b/tests/test_guard_sqlite_failure_containment.py
@@ -180,6 +180,15 @@ def test_unrelated_sql_error_does_not_enter_recovery(tmp_path: Path) -> None:
     assert _quarantined_databases(store.guard_home) == []
 
 
+def test_storage_gate_allows_nested_reads_on_one_thread(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+
+    with store._connect() as outer:  # pyright: ignore[reportPrivateUsage]
+        assert outer.execute("pragma schema_version").fetchone() is not None
+        with store._connect() as inner:  # pyright: ignore[reportPrivateUsage]
+            assert inner.execute("pragma schema_version").fetchone() is not None
+
+
 def test_replacement_remains_exclusive_until_schema_is_ready(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_sqlite_failure_containment.py
+++ b/tests/test_guard_sqlite_failure_containment.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard import store_connection_schema
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _corrupt_store(path: Path) -> bytes:
+    corrupt_bytes = b"not-a-sqlite-database\x00guard-recovery-fixture"
+    path.write_bytes(corrupt_bytes)
+    return corrupt_bytes
+
+
+def _quarantined_databases(guard_home: Path) -> list[Path]:
+    return sorted(guard_home.glob("guard.db.corrupt-*"))
+
+
+def test_store_startup_quarantines_corruption_and_recovers(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard"
+    guard_home.mkdir()
+    corrupt_bytes = _corrupt_store(guard_home / "guard.db")
+
+    store = GuardStore(guard_home, prime_policy_integrity=False)
+
+    quarantined = _quarantined_databases(guard_home)
+    assert len(quarantined) == 1
+    assert quarantined[0].read_bytes() == corrupt_bytes
+    with sqlite3.connect(store.path) as connection:
+        assert connection.execute("pragma quick_check").fetchone() == ("ok",)
+
+
+def test_daemon_managed_startup_quarantines_corruption(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard"
+    guard_home.mkdir()
+    _corrupt_store(guard_home / "guard.db")
+
+    store = GuardStore(
+        guard_home,
+        prime_policy_integrity=False,
+        daemon_managed_schema=True,
+    )
+
+    assert len(_quarantined_databases(guard_home)) == 1
+    with sqlite3.connect(store.path) as connection:
+        assert connection.execute("pragma quick_check").fetchone() == ("ok",)
+
+
+def test_live_store_recovers_after_fatal_sqlite_error(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard"
+    store = GuardStore(guard_home, prime_policy_integrity=False)
+    corrupt_bytes = _corrupt_store(store.path)
+
+    with pytest.raises(sqlite3.DatabaseError, match="file is not a database"):
+        store.get_runtime_state()
+
+    with sqlite3.connect(store.path) as connection:
+        assert connection.execute("pragma quick_check").fetchone() == ("ok",)
+    quarantined = _quarantined_databases(guard_home)
+    assert len(quarantined) == 1
+    assert quarantined[0].read_bytes() == corrupt_bytes
+
+
+def test_concurrent_startup_performs_one_recovery(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard"
+    guard_home.mkdir()
+    _corrupt_store(guard_home / "guard.db")
+
+    def open_store(_index: int) -> bool:
+        store = GuardStore(guard_home, prime_policy_integrity=False)
+        with sqlite3.connect(store.path) as connection:
+            return connection.execute("pragma quick_check").fetchone() == ("ok",)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(open_store, range(16)))
+
+    assert all(results)
+    assert len(_quarantined_databases(guard_home)) == 1
+
+
+def test_lock_contention_does_not_quarantine_healthy_store(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard"
+    store = GuardStore(guard_home, prime_policy_integrity=False)
+    writer = sqlite3.connect(store.path, timeout=0.1)
+    writer.execute("begin exclusive")
+    try:
+        assert store._is_fatal_sqlite_error(sqlite3.OperationalError("database is locked")) is False
+    finally:
+        writer.rollback()
+        writer.close()
+
+    assert _quarantined_databases(guard_home) == []
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "database disk image is malformed",
+        "database corruption at line 1",
+        "file is not a database",
+    ],
+)
+def test_fatal_storage_errors_are_recognized(message: str) -> None:
+    assert GuardStore._is_fatal_sqlite_error(sqlite3.DatabaseError(message)) is True
+
+
+def test_transient_io_error_does_not_quarantine_healthy_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    real_connect = store_connection_schema.sqlite3.connect
+    attempts = 0
+
+    def fail_once(database: str | Path, timeout: float = 5.0) -> sqlite3.Connection:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise sqlite3.OperationalError("disk I/O error")
+        return real_connect(database, timeout=timeout)
+
+    monkeypatch.setattr(store_connection_schema.sqlite3, "connect", fail_once)
+
+    with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+        store.get_runtime_state()
+
+    assert _quarantined_databases(store.guard_home) == []
+    assert store.get_runtime_state() is None
+
+
+def test_recovery_waits_for_in_flight_connection(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def hold_connection() -> None:
+        with store._connect():  # pyright: ignore[reportPrivateUsage]
+            entered.set()
+            assert release.wait(timeout=2)
+
+    holder = threading.Thread(target=hold_connection)
+    holder.start()
+    assert entered.wait(timeout=1)
+    corrupt_bytes = _corrupt_store(store.path)
+    recovered: list[bool] = []
+    recovery = threading.Thread(
+        target=lambda: recovered.append(
+            store._recover_fatal_sqlite_store(  # pyright: ignore[reportPrivateUsage]
+                sqlite3.DatabaseError("database disk image is malformed")
+            )
+        )
+    )
+    recovery.start()
+    time.sleep(0.05)
+    assert recovery.is_alive()
+
+    release.set()
+    holder.join(timeout=2)
+    recovery.join(timeout=2)
+
+    assert recovered == [True]
+    assert _quarantined_databases(store.guard_home)[0].read_bytes() == corrupt_bytes
+
+
+def test_unrelated_sql_error_does_not_enter_recovery(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+
+    with (
+        pytest.raises(sqlite3.OperationalError, match="no such table"),
+        store._connect() as connection,  # pyright: ignore[reportPrivateUsage]
+    ):
+        connection.execute("select * from intentionally_missing_table")
+
+    assert _quarantined_databases(store.guard_home) == []
+
+
+def test_replacement_remains_exclusive_until_schema_is_ready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    _corrupt_store(store.path)
+    initializing = threading.Event()
+    release = threading.Event()
+    original_initialize = store._initialize_schema  # pyright: ignore[reportPrivateUsage]
+
+    def delayed_initialize() -> None:
+        initializing.set()
+        assert release.wait(timeout=2)
+        original_initialize()
+
+    monkeypatch.setattr(store, "_initialize_schema", delayed_initialize)
+    recovery = threading.Thread(
+        target=lambda: store._recover_fatal_sqlite_store(  # pyright: ignore[reportPrivateUsage]
+            sqlite3.DatabaseError("database disk image is malformed")
+        )
+    )
+    recovery.start()
+    assert initializing.wait(timeout=1)
+    reader_finished = threading.Event()
+
+    def read_store() -> None:
+        with store._connect() as connection:  # pyright: ignore[reportPrivateUsage]
+            _ = connection.execute("select count(*) from schema_migrations").fetchone()
+            reader_finished.set()
+
+    reader = threading.Thread(target=read_store)
+    reader.start()
+    time.sleep(0.05)
+    assert reader_finished.is_set() is False
+
+    release.set()
+    recovery.join(timeout=2)
+    reader.join(timeout=2)
+
+    assert reader_finished.is_set() is True


### PR DESCRIPTION
## Summary

- coordinate SQLite access with shared transaction and exclusive recovery gates
- quarantine proven corruption while preserving failed database files for recovery
- rebuild a healthy schema atomically after fatal corruption or isolated persistent I/O failure
- keep transient I/O, lock contention, and unrelated SQL errors out of recovery

## Verification

- focused store, hook, daemon recovery, storage-liveness, deadline, and performance tests
- Ruff lint and format checks
- basedpyright
- fresh-process corruption recovery smoke test
- independent adversarial review
