### PR TITLE
fix(guard): tolerate authenticated daemon rollover

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11870,
-  "maximum_test_source_lines": 278043,
+  "maximum_test_source_lines": 278085,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11869,
-  "maximum_test_source_lines": 277996,
+  "maximum_collected_cases": 11870,
+  "maximum_test_source_lines": 278043,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_auth.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_auth.py
@@ -1,0 +1,239 @@
+"""Authenticated transport primitives for the Codex daemon hook bridge."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import http.client
+import json
+import os
+import secrets
+import stat
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from urllib.parse import urlparse
+
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+_DISCOVERY_PROTOCOL_VERSION = 1
+_DISCOVERY_CHALLENGE_TTL_SECONDS = 5
+_MAX_DAEMON_RESPONSE_BYTES = 1_000_000
+_MINIMUM_OPERATION_SECONDS = 0.01
+
+
+class _DaemonResponseError(ValueError):
+    def __init__(self, status: int, detail: str, *, authenticated: bool) -> None:
+        super().__init__(f"daemon returned HTTP {status}")
+        self.status = status
+        self.detail = detail
+        self.authenticated = authenticated
+
+
+def _assert_loopback_http_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme != "http":
+        raise ValueError(f"daemon URL must use http, not {parsed.scheme!r}")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("daemon URL must not contain credentials")
+    host = (parsed.hostname or "").lower()
+    if host not in _LOOPBACK_HOSTS:
+        raise ValueError(f"daemon URL must target loopback, not {host!r}")
+    if parsed.port is None:
+        raise ValueError("daemon URL must include an explicit port")
+
+
+def _json_object(text: str) -> dict[str, object] | None:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _private_file_text(path: Path, *, label: str) -> str:
+    try:
+        parent_metadata = path.parent.lstat()
+        metadata = path.lstat()
+    except OSError as error:
+        raise ValueError(f"{label} is unavailable") from error
+    if not stat.S_ISDIR(parent_metadata.st_mode):
+        raise ValueError("Guard home is not a directory")
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise ValueError(f"{label} must be a regular file")
+    if os.name != "nt":
+        if parent_metadata.st_uid != os.getuid() or metadata.st_uid != os.getuid():
+            raise ValueError(f"{label} ownership does not match the current user")
+        if stat.S_IMODE(parent_metadata.st_mode) & 0o077 or stat.S_IMODE(metadata.st_mode) & 0o077:
+            raise ValueError(f"{label} permissions are not owner-only")
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError as error:
+        raise ValueError(f"{label} is unreadable") from error
+
+
+def _canonical_discovery_payload(payload: dict[str, object]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def _sign_discovery_payload(discovery_key: str, payload: dict[str, object]) -> str:
+    try:
+        key = bytes.fromhex(discovery_key)
+    except ValueError as error:
+        raise ValueError("daemon discovery key is malformed") from error
+    if len(key) != 32:
+        raise ValueError("daemon discovery key is malformed")
+    return hmac.new(key, _canonical_discovery_payload(payload), hashlib.sha256).hexdigest()
+
+
+def _authenticated_state(state_path: str | Path) -> tuple[dict[str, object], str]:
+    path = Path(state_path)
+    discovery_key = _private_file_text(path.parent / "daemon-discovery-key", label="daemon discovery key")
+    try:
+        payload = json.loads(_private_file_text(path, label="daemon state"))
+    except json.JSONDecodeError as error:
+        raise ValueError("daemon state is malformed") from error
+    if not isinstance(payload, dict):
+        raise ValueError("daemon state must be a JSON object")
+    signature = payload.get("state_signature")
+    unsigned = {key: value for key, value in payload.items() if key != "state_signature"}
+    try:
+        expected_key_id = hashlib.sha256(bytes.fromhex(discovery_key)).hexdigest()
+    except ValueError as error:
+        raise ValueError("daemon discovery key is malformed") from error
+    if (
+        not isinstance(signature, str)
+        or unsigned.get("discovery_protocol_version") != _DISCOVERY_PROTOCOL_VERSION
+        or unsigned.get("discovery_key_id") != expected_key_id
+        or not secrets.compare_digest(signature, _sign_discovery_payload(discovery_key, unsigned))
+    ):
+        raise ValueError("daemon state authentication failed")
+    host = unsigned.get("host")
+    port = unsigned.get("port")
+    pid = unsigned.get("pid")
+    state_id = unsigned.get("state_id")
+    started_at = unsigned.get("started_at")
+    guard_home = unsigned.get("guard_home")
+    auth_token_id = unsigned.get("auth_token_id")
+    if (
+        not isinstance(host, str)
+        or host.lower() not in _LOOPBACK_HOSTS
+        or not isinstance(port, int)
+        or not 0 < port <= 65535
+        or not isinstance(pid, int)
+        or pid <= 0
+        or not isinstance(state_id, str)
+        or not state_id
+        or not isinstance(started_at, str)
+        or not started_at
+        or not isinstance(guard_home, str)
+        or not isinstance(auth_token_id, str)
+    ):
+        raise ValueError("daemon state identity is incomplete")
+    try:
+        expected_guard_home = str(path.parent.resolve())
+        state_guard_home = str(Path(guard_home).resolve())
+    except OSError as error:
+        raise ValueError("daemon state Guard home is invalid") from error
+    if state_guard_home != expected_guard_home:
+        raise ValueError("daemon state belongs to a different Guard home")
+    return payload, discovery_key
+
+
+def _daemon_url(state_path: str | Path) -> str:
+    payload, _discovery_key = _authenticated_state(state_path)
+    host = str(payload["host"])
+    port = payload.get("port")
+    rendered_host = f"[{host}]" if ":" in host else host
+    return f"http://{rendered_host}:{port}"
+
+
+def _daemon_auth_token(state_path: str | Path, state: Mapping[str, object]) -> str:
+    path = Path(state_path)
+    token = _private_file_text(path.parent / "daemon-auth-token", label="daemon auth token")
+    expected_token_id = state.get("auth_token_id")
+    actual_token_id = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    if (
+        not token
+        or not isinstance(expected_token_id, str)
+        or not secrets.compare_digest(actual_token_id, expected_token_id)
+    ):
+        raise ValueError("daemon auth token does not match authenticated state")
+    return token
+
+
+def _http_json_response(
+    response: http.client.HTTPResponse,
+    *,
+    label: str,
+    connection: http.client.HTTPConnection,
+    deadline: float,
+    authenticated: bool,
+) -> dict[str, object]:
+    body = bytearray()
+    while len(body) <= _MAX_DAEMON_RESPONSE_BYTES:
+        remaining = _remaining_seconds(deadline)
+        if remaining < _MINIMUM_OPERATION_SECONDS:
+            raise TimeoutError(f"{label} exceeded the hook deadline")
+        if connection.sock is not None:
+            connection.sock.settimeout(remaining)
+        chunk = response.read1(min(64 * 1024, _MAX_DAEMON_RESPONSE_BYTES + 1 - len(body)))
+        if not chunk:
+            break
+        body.extend(chunk)
+    if len(body) > _MAX_DAEMON_RESPONSE_BYTES:
+        raise ValueError(f"{label} response is too large")
+    if response.status != 200:
+        raise _DaemonResponseError(
+            response.status,
+            body.decode("utf-8", errors="replace").strip(),
+            authenticated=authenticated,
+        )
+    payload = _json_object(bytes(body).decode("utf-8", errors="replace").strip())
+    if payload is None:
+        raise ValueError(f"{label} returned malformed JSON")
+    return payload
+
+
+def _verify_challenge_response(
+    response: dict[str, object],
+    *,
+    state: Mapping[str, object],
+    discovery_key: str,
+    nonce: str,
+    hook_event: str,
+) -> str:
+    proof = response.get("proof")
+    unsigned = {key: value for key, value in response.items() if key != "proof"}
+    expected_fields = {
+        "protocol_version": _DISCOVERY_PROTOCOL_VERSION,
+        "nonce": nonce,
+        "state_id": state.get("state_id"),
+        "host": state.get("host"),
+        "port": state.get("port"),
+        "pid": state.get("pid"),
+        "started_at": state.get("started_at"),
+        "guard_home": state.get("guard_home"),
+        "hook_event": hook_event,
+    }
+    if any(unsigned.get(key) != value for key, value in expected_fields.items()):
+        raise ValueError("daemon identity challenge did not match authenticated state")
+    issued_at_ms = unsigned.get("issued_at_ms")
+    expires_at_ms = unsigned.get("expires_at_ms")
+    now_ms = int(time.time() * 1000)
+    if (
+        not isinstance(issued_at_ms, int)
+        or not isinstance(expires_at_ms, int)
+        or issued_at_ms > now_ms + 1000
+        or expires_at_ms < now_ms
+        or expires_at_ms - issued_at_ms > _DISCOVERY_CHALLENGE_TTL_SECONDS * 1000
+    ):
+        raise ValueError("daemon identity challenge expired")
+    expected_proof = _sign_discovery_payload(discovery_key, unsigned)
+    if not isinstance(proof, str) or not secrets.compare_digest(proof, expected_proof):
+        raise ValueError("daemon identity challenge authentication failed")
+    return proof
+
+
+def _remaining_seconds(deadline: float, *, cap: float | None = None) -> float:
+    remaining = max(0.0, deadline - time.monotonic())
+    return remaining if cap is None else min(remaining, cap)

--- a/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
@@ -76,6 +76,10 @@ class _DaemonResponseError(ValueError):
         self.authenticated = authenticated
 
 
+class _DaemonGenerationChangedError(ValueError):
+    """The authenticated daemon generation rotated during one hook request."""
+
+
 def _assert_loopback_http_url(url: str) -> None:
     parsed = urlparse(url)
     if parsed.scheme != "http":
@@ -416,7 +420,11 @@ def _run_local_fallback(
     return _json_object(result.stdout.strip())
 
 
-def _daemon_response(
+def _daemon_generation_identity(state: Mapping[str, object]) -> tuple[object, ...]:
+    return tuple(state.get(field) for field in ("state_id", "auth_token_id", "host", "port", "pid", "started_at"))
+
+
+def _daemon_response_once(
     *,
     state_path: str | Path,
     query: str,
@@ -468,8 +476,14 @@ def _daemon_response(
         )
         current_state, current_key = _authenticated_state(state_path)
         if current_state != state or not secrets.compare_digest(current_key, discovery_key):
-            raise ValueError("daemon state changed during identity verification")
-        auth_token = _daemon_auth_token(state_path, state)
+            raise _DaemonGenerationChangedError("daemon state changed during identity verification")
+        try:
+            auth_token = _daemon_auth_token(state_path, state)
+        except ValueError as error:
+            current_state, current_key = _authenticated_state(state_path)
+            if current_state != state or not secrets.compare_digest(current_key, discovery_key):
+                raise _DaemonGenerationChangedError("daemon state changed before token authentication") from error
+            raise
         remaining = _remaining_seconds(deadline)
         if remaining < _MINIMUM_OPERATION_SECONDS:
             raise TimeoutError("daemon identity challenge exhausted the hook deadline")
@@ -490,15 +504,46 @@ def _daemon_response(
                 "X-Guard-Daemon-Proof": proof,
             },
         )
-        return _http_json_response(
-            connection.getresponse(),
-            label="daemon hook",
-            connection=connection,
-            deadline=deadline,
-            authenticated=True,
-        )
+        try:
+            return _http_json_response(
+                connection.getresponse(),
+                label="daemon hook",
+                connection=connection,
+                deadline=deadline,
+                authenticated=True,
+            )
+        except _DaemonResponseError as error:
+            if error.status in {401, 403}:
+                current_state, current_key = _authenticated_state(state_path)
+                if _daemon_generation_identity(current_state) != _daemon_generation_identity(
+                    state
+                ) or not secrets.compare_digest(current_key, discovery_key):
+                    raise _DaemonGenerationChangedError("daemon state changed before hook authentication") from error
+            raise
     finally:
         connection.close()
+
+
+def _daemon_response(
+    *,
+    state_path: str | Path,
+    query: str,
+    data: str,
+    timeout_seconds: float,
+) -> dict[str, object] | None:
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    for attempt in range(2):
+        try:
+            return _daemon_response_once(
+                state_path=state_path,
+                query=query,
+                data=data,
+                timeout_seconds=_remaining_seconds(deadline),
+            )
+        except _DaemonGenerationChangedError:
+            if attempt > 0 or _remaining_seconds(deadline) < _MINIMUM_OPERATION_SECONDS:
+                raise
+    raise AssertionError("unreachable")
 
 
 def _daemon_process_failed(response: Mapping[str, object]) -> bool:

--- a/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
@@ -2,19 +2,14 @@
 
 from __future__ import annotations
 
-import hashlib
-import hmac
 import http.client
 import json
-import os
 import secrets
-import stat
 import sys
 import time
 import urllib.error
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
-from urllib.parse import urlparse
 
 if __package__:
     from ..codex_hook_bridge_runtime import BridgeConfig
@@ -24,10 +19,19 @@ if __package__:
     from ..codex_hook_bridge_runtime import trusted_hook_launch as _trusted_hook_launch
     from ..codex_hook_launch_runtime import isolated_hook_environment as _isolated_hook_environment
     from ..codex_hook_launch_runtime import run_isolated_hook_process as _run_isolated_hook_process
+    from .codex_daemon_hook_auth import _DaemonResponseError
+    from .codex_daemon_hook_transport import _daemon_response_once, _DaemonGenerationChangedError
 else:  # pragma: no cover - exercised by subprocess integration tests
     _package_root = str(Path(__file__).resolve().parents[3])
     if _package_root not in sys.path:
         sys.path.insert(0, _package_root)
+    from codex_plugin_scanner.guard.adapters.codex_daemon_hook_auth import (
+        _DaemonResponseError,
+    )
+    from codex_plugin_scanner.guard.adapters.codex_daemon_hook_transport import (
+        _daemon_response_once,
+        _DaemonGenerationChangedError,
+    )
     from codex_plugin_scanner.guard.codex_hook_bridge_runtime import (
         BridgeConfig,
     )
@@ -50,12 +54,9 @@ else:  # pragma: no cover - exercised by subprocess integration tests
         run_isolated_hook_process as _run_isolated_hook_process,
     )
 
-_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 _HOOK_TIMEOUT_GRACE_SECONDS = 2
 _DAEMON_START_TIMEOUT_SECONDS = 8
 _DISCOVERY_PROTOCOL_VERSION = 1
-_DISCOVERY_CHALLENGE_TTL_SECONDS = 5
-_MAX_DAEMON_RESPONSE_BYTES = 1_000_000
 _MAX_HOOK_INPUT_BYTES = 1_000_000
 _FAIL_CLOSED_REASON = "HOL Guard could not authenticate the local daemon. Run `hol-guard daemon repair`, then retry."
 _LAUNCH_INTEGRITY_REASON = (
@@ -68,45 +69,12 @@ _OVERLOAD_REASON = (
 )
 
 
-class _DaemonResponseError(ValueError):
-    def __init__(self, status: int, detail: str, *, authenticated: bool) -> None:
-        super().__init__(f"daemon returned HTTP {status}")
-        self.status = status
-        self.detail = detail
-        self.authenticated = authenticated
-
-
-class _DaemonGenerationChangedError(ValueError):
-    """The authenticated daemon generation rotated during one hook request."""
-
-
-def _assert_loopback_http_url(url: str) -> None:
-    parsed = urlparse(url)
-    if parsed.scheme != "http":
-        raise ValueError(f"daemon URL must use http, not {parsed.scheme!r}")
-    if parsed.username is not None or parsed.password is not None:
-        raise ValueError("daemon URL must not contain credentials")
-    host = (parsed.hostname or "").lower()
-    if host not in _LOOPBACK_HOSTS:
-        raise ValueError(f"daemon URL must target loopback, not {host!r}")
-    if parsed.port is None:
-        raise ValueError("daemon URL must include an explicit port")
-
-
 def _json_object(text: str) -> dict[str, object] | None:
     try:
         payload = json.loads(text)
     except json.JSONDecodeError:
         return None
     return payload if isinstance(payload, dict) else None
-
-
-def _with_remaining_hint(data: str, deadline: float) -> str:
-    payload = _json_object(data)
-    if payload is None:
-        return data
-    payload["guard_remaining_ms"] = min(60_000, max(1, int((deadline - time.monotonic()) * 1000)))
-    return json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
 
 
 def _transient_overload(error: BaseException) -> tuple[int, int] | None:
@@ -140,190 +108,6 @@ def _retry_transient_overload(
         return None
     time.sleep(jitter_ms / 1000)
     return request()
-
-
-def _private_file_text(path: Path, *, label: str) -> str:
-    try:
-        parent_metadata = path.parent.lstat()
-        metadata = path.lstat()
-    except OSError as error:
-        raise ValueError(f"{label} is unavailable") from error
-    if not stat.S_ISDIR(parent_metadata.st_mode):
-        raise ValueError("Guard home is not a directory")
-    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
-        raise ValueError(f"{label} must be a regular file")
-    if os.name != "nt":
-        if parent_metadata.st_uid != os.getuid() or metadata.st_uid != os.getuid():
-            raise ValueError(f"{label} ownership does not match the current user")
-        if stat.S_IMODE(parent_metadata.st_mode) & 0o077 or stat.S_IMODE(metadata.st_mode) & 0o077:
-            raise ValueError(f"{label} permissions are not owner-only")
-    try:
-        return path.read_text(encoding="utf-8").strip()
-    except OSError as error:
-        raise ValueError(f"{label} is unreadable") from error
-
-
-def _canonical_discovery_payload(payload: dict[str, object]) -> bytes:
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
-
-
-def _sign_discovery_payload(discovery_key: str, payload: dict[str, object]) -> str:
-    try:
-        key = bytes.fromhex(discovery_key)
-    except ValueError as error:
-        raise ValueError("daemon discovery key is malformed") from error
-    if len(key) != 32:
-        raise ValueError("daemon discovery key is malformed")
-    return hmac.new(key, _canonical_discovery_payload(payload), hashlib.sha256).hexdigest()
-
-
-def _authenticated_state(state_path: str | Path) -> tuple[dict[str, object], str]:
-    path = Path(state_path)
-    discovery_key = _private_file_text(path.parent / "daemon-discovery-key", label="daemon discovery key")
-    try:
-        payload = json.loads(_private_file_text(path, label="daemon state"))
-    except json.JSONDecodeError as error:
-        raise ValueError("daemon state is malformed") from error
-    if not isinstance(payload, dict):
-        raise ValueError("daemon state must be a JSON object")
-    signature = payload.get("state_signature")
-    unsigned = {key: value for key, value in payload.items() if key != "state_signature"}
-    try:
-        expected_key_id = hashlib.sha256(bytes.fromhex(discovery_key)).hexdigest()
-    except ValueError as error:
-        raise ValueError("daemon discovery key is malformed") from error
-    if (
-        not isinstance(signature, str)
-        or unsigned.get("discovery_protocol_version") != _DISCOVERY_PROTOCOL_VERSION
-        or unsigned.get("discovery_key_id") != expected_key_id
-        or not secrets.compare_digest(signature, _sign_discovery_payload(discovery_key, unsigned))
-    ):
-        raise ValueError("daemon state authentication failed")
-    host = unsigned.get("host")
-    port = unsigned.get("port")
-    pid = unsigned.get("pid")
-    state_id = unsigned.get("state_id")
-    started_at = unsigned.get("started_at")
-    guard_home = unsigned.get("guard_home")
-    auth_token_id = unsigned.get("auth_token_id")
-    if (
-        not isinstance(host, str)
-        or host.lower() not in _LOOPBACK_HOSTS
-        or not isinstance(port, int)
-        or not 0 < port <= 65535
-        or not isinstance(pid, int)
-        or pid <= 0
-        or not isinstance(state_id, str)
-        or not state_id
-        or not isinstance(started_at, str)
-        or not started_at
-        or not isinstance(guard_home, str)
-        or not isinstance(auth_token_id, str)
-    ):
-        raise ValueError("daemon state identity is incomplete")
-    try:
-        expected_guard_home = str(path.parent.resolve())
-        state_guard_home = str(Path(guard_home).resolve())
-    except OSError as error:
-        raise ValueError("daemon state Guard home is invalid") from error
-    if state_guard_home != expected_guard_home:
-        raise ValueError("daemon state belongs to a different Guard home")
-    return payload, discovery_key
-
-
-def _daemon_url(state_path: str | Path) -> str:
-    payload, _discovery_key = _authenticated_state(state_path)
-    host = str(payload["host"])
-    port = payload.get("port")
-    rendered_host = f"[{host}]" if ":" in host else host
-    return f"http://{rendered_host}:{port}"
-
-
-def _daemon_auth_token(state_path: str | Path, state: Mapping[str, object]) -> str:
-    path = Path(state_path)
-    token = _private_file_text(path.parent / "daemon-auth-token", label="daemon auth token")
-    expected_token_id = state.get("auth_token_id")
-    actual_token_id = hashlib.sha256(token.encode("utf-8")).hexdigest()
-    if (
-        not token
-        or not isinstance(expected_token_id, str)
-        or not secrets.compare_digest(actual_token_id, expected_token_id)
-    ):
-        raise ValueError("daemon auth token does not match authenticated state")
-    return token
-
-
-def _http_json_response(
-    response: http.client.HTTPResponse,
-    *,
-    label: str,
-    connection: http.client.HTTPConnection,
-    deadline: float,
-    authenticated: bool,
-) -> dict[str, object]:
-    body = bytearray()
-    while len(body) <= _MAX_DAEMON_RESPONSE_BYTES:
-        remaining = _remaining_seconds(deadline)
-        if remaining < _MINIMUM_OPERATION_SECONDS:
-            raise TimeoutError(f"{label} exceeded the hook deadline")
-        if connection.sock is not None:
-            connection.sock.settimeout(remaining)
-        chunk = response.read1(min(64 * 1024, _MAX_DAEMON_RESPONSE_BYTES + 1 - len(body)))
-        if not chunk:
-            break
-        body.extend(chunk)
-    if len(body) > _MAX_DAEMON_RESPONSE_BYTES:
-        raise ValueError(f"{label} response is too large")
-    if response.status != 200:
-        raise _DaemonResponseError(
-            response.status,
-            body.decode("utf-8", errors="replace").strip(),
-            authenticated=authenticated,
-        )
-    payload = _json_object(bytes(body).decode("utf-8", errors="replace").strip())
-    if payload is None:
-        raise ValueError(f"{label} returned malformed JSON")
-    return payload
-
-
-def _verify_challenge_response(
-    response: dict[str, object],
-    *,
-    state: Mapping[str, object],
-    discovery_key: str,
-    nonce: str,
-    hook_event: str,
-) -> str:
-    proof = response.get("proof")
-    unsigned = {key: value for key, value in response.items() if key != "proof"}
-    expected_fields = {
-        "protocol_version": _DISCOVERY_PROTOCOL_VERSION,
-        "nonce": nonce,
-        "state_id": state.get("state_id"),
-        "host": state.get("host"),
-        "port": state.get("port"),
-        "pid": state.get("pid"),
-        "started_at": state.get("started_at"),
-        "guard_home": state.get("guard_home"),
-        "hook_event": hook_event,
-    }
-    if any(unsigned.get(key) != value for key, value in expected_fields.items()):
-        raise ValueError("daemon identity challenge did not match authenticated state")
-    issued_at_ms = unsigned.get("issued_at_ms")
-    expires_at_ms = unsigned.get("expires_at_ms")
-    now_ms = int(time.time() * 1000)
-    if (
-        not isinstance(issued_at_ms, int)
-        or not isinstance(expires_at_ms, int)
-        or issued_at_ms > now_ms + 1000
-        or expires_at_ms < now_ms
-        or expires_at_ms - issued_at_ms > _DISCOVERY_CHALLENGE_TTL_SECONDS * 1000
-    ):
-        raise ValueError("daemon identity challenge expired")
-    expected_proof = _sign_discovery_payload(discovery_key, unsigned)
-    if not isinstance(proof, str) or not secrets.compare_digest(proof, expected_proof):
-        raise ValueError("daemon identity challenge authentication failed")
-    return proof
 
 
 def _event_name(data: str) -> str:
@@ -418,110 +202,6 @@ def _run_local_fallback(
     if not result.stdout.strip():
         return {}
     return _json_object(result.stdout.strip())
-
-
-def _daemon_generation_identity(state: Mapping[str, object]) -> tuple[object, ...]:
-    return tuple(state.get(field) for field in ("state_id", "auth_token_id", "host", "port", "pid", "started_at"))
-
-
-def _daemon_response_once(
-    *,
-    state_path: str | Path,
-    query: str,
-    data: str,
-    timeout_seconds: float,
-) -> dict[str, object] | None:
-    deadline = time.monotonic() + max(0.0, timeout_seconds)
-    state, discovery_key = _authenticated_state(state_path)
-    host = str(state["host"])
-    port_value = state["port"]
-    if not isinstance(port_value, int):
-        raise ValueError("daemon state port is invalid")
-    port = port_value
-    rendered_host = f"[{host}]" if ":" in host else host
-    endpoint = f"http://{rendered_host}:{port}/v1/hooks/codex?{query}"
-    _assert_loopback_http_url(endpoint)
-    hook_event = _event_name(data)
-    nonce = secrets.token_hex(32)
-    connection = http.client.HTTPConnection(host, port, timeout=timeout_seconds)
-    try:
-        challenge_body = json.dumps(
-            {
-                "protocol_version": _DISCOVERY_PROTOCOL_VERSION,
-                "nonce": nonce,
-                "state_id": state["state_id"],
-                "hook_event": hook_event,
-            },
-            separators=(",", ":"),
-        )
-        connection.request(
-            "POST",
-            "/v1/daemon/identity-challenge",
-            body=challenge_body.encode("utf-8"),
-            headers={"Content-Type": "application/json", "Connection": "keep-alive"},
-        )
-        challenge = _http_json_response(
-            connection.getresponse(),
-            label="daemon identity challenge",
-            connection=connection,
-            deadline=deadline,
-            authenticated=False,
-        )
-        proof = _verify_challenge_response(
-            challenge,
-            state=state,
-            discovery_key=discovery_key,
-            nonce=nonce,
-            hook_event=hook_event,
-        )
-        current_state, current_key = _authenticated_state(state_path)
-        if current_state != state or not secrets.compare_digest(current_key, discovery_key):
-            raise _DaemonGenerationChangedError("daemon state changed during identity verification")
-        try:
-            auth_token = _daemon_auth_token(state_path, state)
-        except ValueError as error:
-            current_state, current_key = _authenticated_state(state_path)
-            if current_state != state or not secrets.compare_digest(current_key, discovery_key):
-                raise _DaemonGenerationChangedError("daemon state changed before token authentication") from error
-            raise
-        remaining = _remaining_seconds(deadline)
-        if remaining < _MINIMUM_OPERATION_SECONDS:
-            raise TimeoutError("daemon identity challenge exhausted the hook deadline")
-        connection.timeout = remaining
-        if connection.sock is not None:
-            connection.sock.settimeout(remaining)
-        hook_path = f"/v1/hooks/codex?{query}"
-        hinted_data = _with_remaining_hint(data, deadline)
-        connection.request(
-            "POST",
-            hook_path,
-            body=hinted_data.encode("utf-8"),
-            headers={
-                "Content-Type": "application/json",
-                "Connection": "close",
-                "X-Guard-Token": auth_token,
-                "X-Guard-Daemon-Nonce": nonce,
-                "X-Guard-Daemon-Proof": proof,
-            },
-        )
-        try:
-            return _http_json_response(
-                connection.getresponse(),
-                label="daemon hook",
-                connection=connection,
-                deadline=deadline,
-                authenticated=True,
-            )
-        except _DaemonResponseError as error:
-            if error.status in {401, 403}:
-                current_state, current_key = _authenticated_state(state_path)
-                if _daemon_generation_identity(current_state) != _daemon_generation_identity(
-                    state
-                ) or not secrets.compare_digest(current_key, discovery_key):
-                    raise _DaemonGenerationChangedError("daemon state changed before hook authentication") from error
-            raise
-    finally:
-        connection.close()
 
 
 def _daemon_response(

--- a/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_transport.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_transport.py
@@ -1,0 +1,159 @@
+"""Authenticated daemon hook request transport."""
+
+from __future__ import annotations
+
+import http.client
+import json
+import secrets
+import time
+from collections.abc import Mapping
+from pathlib import Path
+
+from .codex_daemon_hook_auth import (
+    _assert_loopback_http_url,
+    _authenticated_state,
+    _daemon_auth_token,
+    _DaemonResponseError,
+    _http_json_response,
+    _verify_challenge_response,
+)
+
+_DISCOVERY_PROTOCOL_VERSION = 1
+_MINIMUM_OPERATION_SECONDS = 0.01
+
+
+class _DaemonGenerationChangedError(ValueError):
+    """The authenticated daemon generation rotated during one hook request."""
+
+
+def _json_object(text: str) -> dict[str, object] | None:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _with_remaining_hint(data: str, deadline: float) -> str:
+    payload = _json_object(data)
+    if payload is None:
+        return data
+    payload["guard_remaining_ms"] = min(60_000, max(1, int((deadline - time.monotonic()) * 1000)))
+    return json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+
+
+def _event_name(data: str) -> str:
+    payload = _json_object(data)
+    if payload is None:
+        return "PreToolUse"
+    value = payload.get("hook_event_name", payload.get("event", "PreToolUse"))
+    return value.strip() if isinstance(value, str) and value.strip() else "PreToolUse"
+
+
+def _remaining_seconds(deadline: float, *, cap: float | None = None) -> float:
+    remaining = max(0.0, deadline - time.monotonic())
+    return remaining if cap is None else min(remaining, cap)
+
+
+def _daemon_generation_identity(state: Mapping[str, object]) -> tuple[object, ...]:
+    return tuple(state.get(field) for field in ("state_id", "auth_token_id", "host", "port", "pid", "started_at"))
+
+
+def _daemon_response_once(
+    *,
+    state_path: str | Path,
+    query: str,
+    data: str,
+    timeout_seconds: float,
+) -> dict[str, object] | None:
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    state, discovery_key = _authenticated_state(state_path)
+    host = str(state["host"])
+    port_value = state["port"]
+    if not isinstance(port_value, int):
+        raise ValueError("daemon state port is invalid")
+    port = port_value
+    rendered_host = f"[{host}]" if ":" in host else host
+    endpoint = f"http://{rendered_host}:{port}/v1/hooks/codex?{query}"
+    _assert_loopback_http_url(endpoint)
+    hook_event = _event_name(data)
+    nonce = secrets.token_hex(32)
+    connection = http.client.HTTPConnection(host, port, timeout=timeout_seconds)
+    try:
+        challenge_body = json.dumps(
+            {
+                "protocol_version": _DISCOVERY_PROTOCOL_VERSION,
+                "nonce": nonce,
+                "state_id": state["state_id"],
+                "hook_event": hook_event,
+            },
+            separators=(",", ":"),
+        )
+        connection.request(
+            "POST",
+            "/v1/daemon/identity-challenge",
+            body=challenge_body.encode("utf-8"),
+            headers={"Content-Type": "application/json", "Connection": "keep-alive"},
+        )
+        challenge = _http_json_response(
+            connection.getresponse(),
+            label="daemon identity challenge",
+            connection=connection,
+            deadline=deadline,
+            authenticated=False,
+        )
+        proof = _verify_challenge_response(
+            challenge,
+            state=state,
+            discovery_key=discovery_key,
+            nonce=nonce,
+            hook_event=hook_event,
+        )
+        current_state, current_key = _authenticated_state(state_path)
+        if current_state != state or not secrets.compare_digest(current_key, discovery_key):
+            raise _DaemonGenerationChangedError("daemon state changed during identity verification")
+        try:
+            auth_token = _daemon_auth_token(state_path, state)
+        except ValueError as error:
+            current_state, current_key = _authenticated_state(state_path)
+            if current_state != state or not secrets.compare_digest(current_key, discovery_key):
+                raise _DaemonGenerationChangedError("daemon state changed before token authentication") from error
+            raise
+        remaining = _remaining_seconds(deadline)
+        if remaining < _MINIMUM_OPERATION_SECONDS:
+            raise TimeoutError("daemon identity challenge exhausted the hook deadline")
+        connection.timeout = remaining
+        if connection.sock is not None:
+            connection.sock.settimeout(remaining)
+        hook_path = f"/v1/hooks/codex?{query}"
+        hinted_data = _with_remaining_hint(data, deadline)
+        connection.request(
+            "POST",
+            hook_path,
+            body=hinted_data.encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "Connection": "close",
+                "X-Guard-Token": auth_token,
+                "X-Guard-Daemon-Nonce": nonce,
+                "X-Guard-Daemon-Proof": proof,
+            },
+        )
+        try:
+            return _http_json_response(
+                connection.getresponse(),
+                label="daemon hook",
+                connection=connection,
+                deadline=deadline,
+                authenticated=True,
+            )
+        except _DaemonResponseError as error:
+            if error.status in {401, 403}:
+                current_state, current_key = _authenticated_state(state_path)
+                if _daemon_generation_identity(current_state) != _daemon_generation_identity(
+                    state
+                ) or not secrets.compare_digest(current_key, discovery_key):
+                    raise _DaemonGenerationChangedError("daemon state changed before hook authentication") from error
+            raise
+    finally:
+        connection.close()

--- a/tests/codex_daemon_hook_bridge_fixtures.py
+++ b/tests/codex_daemon_hook_bridge_fixtures.py
@@ -1,0 +1,139 @@
+"""Shared authenticated daemon bridge test fixtures."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from http.server import BaseHTTPRequestHandler
+from pathlib import Path
+from typing import ClassVar
+
+from codex_plugin_scanner.guard.daemon import manager as daemon_manager
+from codex_plugin_scanner.guard.daemon.discovery import (
+    DAEMON_DISCOVERY_CHALLENGE_TTL_SECONDS,
+    authenticated_challenge_payload,
+    load_daemon_discovery_key,
+)
+
+
+class _DaemonHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    captured_challenge_guard_token: ClassVar[str | None] = None
+    captured_guard_token: ClassVar[str | None] = None
+    captured_hook_body: ClassVar[str | None] = None
+    response_body: ClassVar[bytes] = b"{}"
+    guard_home: ClassVar[Path | None] = None
+    auth_token: ClassVar[str] = "fixture-token"
+    challenge_mode: ClassVar[str] = "valid"
+    challenge_count: ClassVar[int] = 0
+
+    def _write_json(self, payload: dict[str, object], *, status: int = 200, keep_alive: bool = False) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "keep-alive" if keep_alive else "close")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        raw_body = self.rfile.read(length).decode("utf-8")
+        if self.path == "/v1/daemon/identity-challenge":
+            type(self).challenge_count += 1
+            type(self).captured_challenge_guard_token = self.headers.get("X-Guard-Token")
+            if type(self).challenge_mode == "redirect":
+                self.send_response(302)
+                self.send_header("Location", f"http://127.0.0.1:{self.server.server_address[1]}/redirected")
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            request = json.loads(raw_body)
+            guard_home = type(self).guard_home
+            assert guard_home is not None
+            state = json.loads((guard_home / "daemon-state.json").read_text(encoding="utf-8"))
+            discovery_key = load_daemon_discovery_key(guard_home)
+            assert discovery_key is not None
+            issued_at_ms = int(time.time() * 1000)
+            expires_at_ms = issued_at_ms + DAEMON_DISCOVERY_CHALLENGE_TTL_SECONDS * 1000
+            if type(self).challenge_mode == "expired":
+                issued_at_ms -= 10_000
+                expires_at_ms -= 10_000
+            response = authenticated_challenge_payload(
+                discovery_key=discovery_key,
+                state=state,
+                nonce=request["nonce"],
+                hook_event=request["hook_event"],
+                issued_at_ms=issued_at_ms,
+                expires_at_ms=expires_at_ms,
+            )
+            if type(self).challenge_mode == "wrong-proof":
+                response["proof"] = "0" * 64
+            if type(self).challenge_mode == "replace-state":
+                daemon_manager.write_guard_daemon_state(
+                    guard_home,
+                    self.server.server_address[1],
+                    type(self).auth_token,
+                    pid=os.getpid(),
+                    state_id="replacement-state",
+                )
+                type(self).challenge_mode = "valid"
+            self._write_json(response, keep_alive=True)
+            return
+        type(self).captured_guard_token = self.headers.get("X-Guard-Token")
+        type(self).captured_hook_body = raw_body
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(type(self).response_body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(type(self).response_body)
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        return
+
+
+class _ProxyHandler(BaseHTTPRequestHandler):
+    captured_paths: ClassVar[list[str]] = []
+
+    def do_POST(self) -> None:
+        type(self).captured_paths.append(self.path)
+        self.send_response(502)
+        self.end_headers()
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        return
+
+
+def _bridge_config(guard_home: Path, port: int) -> dict[str, object]:
+    return {
+        "state_path": str(guard_home / "daemon-state.json"),
+        "fallback_command": [sys.executable, "-c", "print('{}')"],
+        "start_command": [sys.executable, "-c", "raise SystemExit(1)"],
+        "query": f"guard-home={guard_home}",
+        "hook_timeouts": {
+            "PreToolUse": 10,
+            "PermissionRequest": 10,
+            "UserPromptSubmit": 10,
+            "PostToolUse": 10,
+        },
+    }
+
+
+def _write_authenticated_daemon_files(guard_home: Path, port: int) -> None:
+    daemon_manager.write_guard_daemon_state(
+        guard_home,
+        port,
+        _DaemonHandler.auth_token,
+        pid=os.getpid(),
+        state_id="fixture-state",
+    )
+    _DaemonHandler.guard_home = guard_home
+    _DaemonHandler.captured_challenge_guard_token = None
+    _DaemonHandler.captured_guard_token = None
+    _DaemonHandler.captured_hook_body = None
+    _DaemonHandler.response_body = b"{}"
+    _DaemonHandler.challenge_mode = "valid"
+    _DaemonHandler.challenge_count = 0

--- a/tests/test_codex_daemon_hook_bridge.py
+++ b/tests/test_codex_daemon_hook_bridge.py
@@ -90,6 +90,7 @@ class _DaemonHandler(BaseHTTPRequestHandler):
                     pid=os.getpid(),
                     state_id="replacement-state",
                 )
+                type(self).challenge_mode = "valid"
             self._write_json(response, keep_alive=True)
             return
         type(self).captured_guard_token = self.headers.get("X-Guard-Token")
@@ -294,7 +295,6 @@ def test_main_posts_to_authenticated_daemon(
         pytest.param("wrong-proof", id="stale-port-reused-by-unproven-process"),
         pytest.param("expired", id="stale-expired-challenge"),
         pytest.param("redirect", id="redirect-refused"),
-        pytest.param("replace-state", id="concurrent-restart-replaces-state"),
     ],
 )
 def test_failed_daemon_identity_never_receives_token_or_hook_payload(
@@ -322,6 +322,53 @@ def test_failed_daemon_identity_never_receives_token_or_hook_payload(
     assert _DaemonHandler.captured_guard_token is None
     assert _DaemonHandler.captured_hook_body is None
     assert json.loads(capsys.readouterr().out) == {}
+
+
+def test_authenticated_generation_rollover_is_rediscovered_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    daemon = HTTPServer(("127.0.0.1", 0), _DaemonHandler)
+    daemon_thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    daemon_thread.start()
+    _write_authenticated_daemon_files(guard_home, daemon.server_address[1])
+    _DaemonHandler.challenge_mode = "replace-state"
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "UserPromptSubmit"})))
+
+    try:
+        exit_code = bridge.main(**_bridge_config(guard_home, daemon.server_address[1]))
+    finally:
+        daemon.shutdown()
+        daemon_thread.join(timeout=5)
+
+    assert exit_code == 0
+    assert _DaemonHandler.challenge_count == 2
+    assert _DaemonHandler.captured_guard_token == "fixture-token"
+    assert json.loads(str(_DaemonHandler.captured_hook_body))["hook_event_name"] == "UserPromptSubmit"
+    assert json.loads(capsys.readouterr().out) == {}
+
+
+def test_repeated_generation_rollover_stays_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = 0
+
+    def changed_generation(**_kwargs: object) -> dict[str, object]:
+        nonlocal attempts
+        attempts += 1
+        raise bridge._DaemonGenerationChangedError("fixture rollover")
+
+    monkeypatch.setattr(bridge, "_daemon_response_once", changed_generation)
+
+    with pytest.raises(bridge._DaemonGenerationChangedError):
+        bridge._daemon_response(
+            state_path="unused",
+            query="",
+            data='{"hook_event_name":"UserPromptSubmit"}',
+            timeout_seconds=1,
+        )
+
+    assert attempts == 2
 
 
 def test_tampered_state_is_rejected_before_candidate_contact(

--- a/tests/test_codex_daemon_hook_bridge.py
+++ b/tests/test_codex_daemon_hook_bridge.py
@@ -2,160 +2,36 @@
 
 from __future__ import annotations
 
-import http.client
 import io
 import json
 import os
-import subprocess
 import sys
 import threading
-import time
-import urllib.error
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import HTTPServer
 from pathlib import Path
-from typing import ClassVar
 from urllib.parse import urlencode
 
 import pytest
 
+from codex_plugin_scanner.guard.adapters import codex_daemon_hook_auth as hook_auth
 from codex_plugin_scanner.guard.adapters import codex_daemon_hook_bridge as bridge
 from codex_plugin_scanner.guard.daemon import manager as daemon_manager
-from codex_plugin_scanner.guard.daemon.discovery import (
-    DAEMON_DISCOVERY_CHALLENGE_TTL_SECONDS,
-    authenticated_challenge_payload,
-    load_daemon_discovery_key,
-)
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.store import GuardStore
-
-
-class _DaemonHandler(BaseHTTPRequestHandler):
-    protocol_version = "HTTP/1.1"
-    captured_challenge_guard_token: ClassVar[str | None] = None
-    captured_guard_token: ClassVar[str | None] = None
-    captured_hook_body: ClassVar[str | None] = None
-    response_body: ClassVar[bytes] = b"{}"
-    guard_home: ClassVar[Path | None] = None
-    auth_token: ClassVar[str] = "fixture-token"
-    challenge_mode: ClassVar[str] = "valid"
-    challenge_count: ClassVar[int] = 0
-
-    def _write_json(self, payload: dict[str, object], *, status: int = 200, keep_alive: bool = False) -> None:
-        body = json.dumps(payload).encode("utf-8")
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.send_header("Connection", "keep-alive" if keep_alive else "close")
-        self.end_headers()
-        self.wfile.write(body)
-
-    def do_POST(self) -> None:
-        length = int(self.headers.get("Content-Length", "0"))
-        raw_body = self.rfile.read(length).decode("utf-8")
-        if self.path == "/v1/daemon/identity-challenge":
-            type(self).challenge_count += 1
-            type(self).captured_challenge_guard_token = self.headers.get("X-Guard-Token")
-            if type(self).challenge_mode == "redirect":
-                self.send_response(302)
-                self.send_header("Location", f"http://127.0.0.1:{self.server.server_address[1]}/redirected")
-                self.send_header("Content-Length", "0")
-                self.end_headers()
-                return
-            request = json.loads(raw_body)
-            guard_home = type(self).guard_home
-            assert guard_home is not None
-            state = json.loads((guard_home / "daemon-state.json").read_text(encoding="utf-8"))
-            discovery_key = load_daemon_discovery_key(guard_home)
-            assert discovery_key is not None
-            issued_at_ms = int(time.time() * 1000)
-            expires_at_ms = issued_at_ms + DAEMON_DISCOVERY_CHALLENGE_TTL_SECONDS * 1000
-            if type(self).challenge_mode == "expired":
-                issued_at_ms -= 10_000
-                expires_at_ms -= 10_000
-            response = authenticated_challenge_payload(
-                discovery_key=discovery_key,
-                state=state,
-                nonce=request["nonce"],
-                hook_event=request["hook_event"],
-                issued_at_ms=issued_at_ms,
-                expires_at_ms=expires_at_ms,
-            )
-            if type(self).challenge_mode == "wrong-proof":
-                response["proof"] = "0" * 64
-            if type(self).challenge_mode == "replace-state":
-                daemon_manager.write_guard_daemon_state(
-                    guard_home,
-                    self.server.server_address[1],
-                    type(self).auth_token,
-                    pid=os.getpid(),
-                    state_id="replacement-state",
-                )
-                type(self).challenge_mode = "valid"
-            self._write_json(response, keep_alive=True)
-            return
-        type(self).captured_guard_token = self.headers.get("X-Guard-Token")
-        type(self).captured_hook_body = raw_body
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(type(self).response_body)))
-        self.send_header("Connection", "close")
-        self.end_headers()
-        self.wfile.write(type(self).response_body)
-
-    def log_message(self, fmt: str, *args: object) -> None:
-        return
-
-
-class _ProxyHandler(BaseHTTPRequestHandler):
-    captured_paths: ClassVar[list[str]] = []
-
-    def do_POST(self) -> None:
-        type(self).captured_paths.append(self.path)
-        self.send_response(502)
-        self.end_headers()
-
-    def log_message(self, fmt: str, *args: object) -> None:
-        return
-
-
-def _bridge_config(guard_home: Path, port: int) -> dict[str, object]:
-    return {
-        "state_path": str(guard_home / "daemon-state.json"),
-        "fallback_command": [sys.executable, "-c", "print('{}')"],
-        "start_command": [sys.executable, "-c", "raise SystemExit(1)"],
-        "query": f"guard-home={guard_home}",
-        "hook_timeouts": {
-            "PreToolUse": 10,
-            "PermissionRequest": 10,
-            "UserPromptSubmit": 10,
-            "PostToolUse": 10,
-        },
-    }
-
-
-def _write_authenticated_daemon_files(guard_home: Path, port: int) -> None:
-    daemon_manager.write_guard_daemon_state(
-        guard_home,
-        port,
-        _DaemonHandler.auth_token,
-        pid=os.getpid(),
-        state_id="fixture-state",
-    )
-    _DaemonHandler.guard_home = guard_home
-    _DaemonHandler.captured_challenge_guard_token = None
-    _DaemonHandler.captured_guard_token = None
-    _DaemonHandler.captured_hook_body = None
-    _DaemonHandler.response_body = b"{}"
-    _DaemonHandler.challenge_mode = "valid"
-    _DaemonHandler.challenge_count = 0
+from tests.codex_daemon_hook_bridge_fixtures import (
+    _bridge_config,
+    _DaemonHandler,
+    _ProxyHandler,
+    _write_authenticated_daemon_files,
+)
 
 
 def test_assert_loopback_http_url_rejects_remote_and_credentialed_urls() -> None:
     with pytest.raises(ValueError, match="loopback"):
-        bridge._assert_loopback_http_url("http://evil.example:5474/v1/hooks/codex")
+        hook_auth._assert_loopback_http_url("http://evil.example:5474/v1/hooks/codex")
     with pytest.raises(ValueError, match="credentials"):
-        bridge._assert_loopback_http_url("http://attacker@127.0.0.1:5474/v1/hooks/codex")
-    bridge._assert_loopback_http_url("http://[::1]:5474/v1/hooks/codex")
+        hook_auth._assert_loopback_http_url("http://attacker@127.0.0.1:5474/v1/hooks/codex")
+    hook_auth._assert_loopback_http_url("http://[::1]:5474/v1/hooks/codex")
 
 
 @pytest.mark.parametrize(
@@ -179,12 +55,12 @@ def test_daemon_url_accepts_only_authenticated_ipv4_and_ipv6_loopback_state(
         host=host,
     )
 
-    assert bridge._daemon_url(guard_home / "daemon-state.json") == expected_url
+    assert hook_auth._daemon_url(guard_home / "daemon-state.json") == expected_url
 
 
 def test_daemon_url_requires_authenticated_guard_owned_state(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="unavailable"):
-        bridge._daemon_url(
+        hook_auth._daemon_url(
             tmp_path / "missing-daemon-state.json",
         )
 
@@ -196,7 +72,7 @@ def test_daemon_url_requires_authenticated_guard_owned_state(tmp_path: Path) -> 
         host="192.0.2.1",
     )
     with pytest.raises(ValueError, match="identity is incomplete"):
-        bridge._daemon_url(guard_home / "daemon-state.json")
+        hook_auth._daemon_url(guard_home / "daemon-state.json")
 
 
 def test_fail_closed_uses_supported_codex_deny_shapes() -> None:
@@ -568,367 +444,3 @@ def test_bridge_real_daemon_emits_schema_exact_post_tool_response(
 
     assert exit_code == 0
     assert json.loads(capsys.readouterr().out) == {"hookSpecificOutput": {"hookEventName": "PostToolUse"}}
-
-
-def test_real_daemon_rejects_consumed_challenge_replay(tmp_path: Path) -> None:
-    guard_home = tmp_path / "guard-home"
-    workspace = tmp_path / "workspace"
-    workspace.mkdir()
-    daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
-    daemon.start()
-    state = json.loads((guard_home / "daemon-state.json").read_text(encoding="utf-8"))
-    nonce = "a" * 64
-    challenge_body = json.dumps(
-        {
-            "protocol_version": 1,
-            "nonce": nonce,
-            "state_id": state["state_id"],
-            "hook_event": "PreToolUse",
-        }
-    )
-    hook_body = json.dumps(
-        {
-            "hook_event_name": "PreToolUse",
-            "tool_name": "Bash",
-            "tool_input": {"command": "echo hello"},
-        }
-    )
-    hook_path = "/v1/hooks/codex?" + urlencode(
-        {
-            "guard-home": str(guard_home),
-            "home": str(tmp_path),
-            "workspace": str(workspace),
-        }
-    )
-
-    try:
-        connection = http.client.HTTPConnection("127.0.0.1", daemon.port, timeout=5)
-        connection.request(
-            "POST",
-            "/v1/daemon/identity-challenge",
-            body=challenge_body,
-            headers={"Content-Type": "application/json", "Connection": "keep-alive"},
-        )
-        challenge_response = connection.getresponse()
-        challenge = json.loads(challenge_response.read())
-        proof_headers = {
-            "Content-Type": "application/json",
-            "Connection": "close",
-            "X-Guard-Token": daemon._server.auth_token,
-            "X-Guard-Daemon-Nonce": nonce,
-            "X-Guard-Daemon-Proof": challenge["proof"],
-        }
-        connection.request("POST", hook_path, body=hook_body, headers=proof_headers)
-        first_response = connection.getresponse()
-        _ = first_response.read()
-        connection.close()
-
-        replay_connection = http.client.HTTPConnection("127.0.0.1", daemon.port, timeout=5)
-        replay_connection.request("POST", hook_path, body=hook_body, headers=proof_headers)
-        replay_response = replay_connection.getresponse()
-        _ = replay_response.read()
-        replay_connection.close()
-    finally:
-        daemon.stop()
-
-    assert challenge_response.status == 200
-    assert first_response.status == 200
-    assert replay_response.status == 401
-
-
-def test_malformed_daemon_and_fallback_outputs_fail_closed(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    guard_home = tmp_path / "guard-home"
-    daemon = HTTPServer(("127.0.0.1", 0), _DaemonHandler)
-    daemon_thread = threading.Thread(target=daemon.serve_forever, daemon=True)
-    daemon_thread.start()
-    port = daemon.server_address[1]
-    _write_authenticated_daemon_files(guard_home, port)
-    _DaemonHandler.response_body = b"not-json"
-    config = _bridge_config(guard_home, port)
-    config["fallback_command"] = [sys.executable, "-c", "print('still-not-json')"]
-    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "PreToolUse"})))
-
-    try:
-        exit_code = bridge.main(**config)
-    finally:
-        daemon.shutdown()
-        daemon_thread.join(timeout=5)
-
-    assert exit_code == 0
-    output = json.loads(capsys.readouterr().out)
-    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
-
-
-def test_post_tool_use_stdout_is_exactly_one_json_object_with_noisy_fallback(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    guard_home = tmp_path / "guard-home"
-    guard_home.mkdir()
-    config = _bridge_config(guard_home, 1)
-    config["fallback_command"] = [
-        sys.executable,
-        "-c",
-        "print('Guard integrity warning'); print('{\"continue\": true}')",
-    ]
-    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "PostToolUse"})))
-
-    exit_code = bridge.main(**config)
-
-    captured = capsys.readouterr()
-    output = json.loads(captured.out)
-    assert exit_code == 0
-    assert output["continue"] is False
-    assert captured.out == json.dumps(output, separators=(",", ":"))
-    assert captured.err == ""
-
-
-def test_unavailable_daemon_preserves_local_fallback_denial(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    guard_home = tmp_path / "guard-home"
-    guard_home.mkdir()
-    denial = {
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "deny",
-            "permissionDecisionReason": "blocked by fixture policy",
-        }
-    }
-    config = _bridge_config(guard_home, 1)
-    config["fallback_command"] = [
-        sys.executable,
-        "-c",
-        f"import json; print(json.dumps({denial!r}))",
-    ]
-    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "PreToolUse"})))
-
-    exit_code = bridge.main(**config)
-
-    assert exit_code == 0
-    assert json.loads(capsys.readouterr().out) == denial
-
-
-def test_main_starts_daemon_once_then_retries_hook(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    guard_home = tmp_path / "guard-home"
-    guard_home.mkdir()
-    responses: list[dict[str, object] | None] = []
-    starts: list[tuple[str, ...]] = []
-
-    def daemon_response(**kwargs: object) -> dict[str, object]:
-        responses.append(None)
-        if len(responses) == 1:
-            raise urllib.error.URLError("daemon cold")
-        return {}
-
-    def start_daemon(
-        command: tuple[str, ...],
-        *,
-        timeout_seconds: float,
-        failure_kind: str,
-    ) -> bool:
-        starts.append(tuple(command))
-        assert 7.9 < timeout_seconds <= 8
-        assert failure_kind == "transport-failure"
-        return True
-
-    config = _bridge_config(guard_home, 1)
-    monkeypatch.setattr(bridge, "_daemon_response", daemon_response)
-    monkeypatch.setattr(bridge, "_run_daemon_start", start_daemon)
-    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "PreToolUse"})))
-
-    exit_code = bridge.main(**config)
-
-    assert exit_code == 0
-    assert len(responses) == 2
-    assert starts == [tuple(config["start_command"])]
-    assert json.loads(capsys.readouterr().out) == {}
-
-    fallback_calls: list[str] = []
-    monkeypatch.setattr(
-        bridge,
-        "_daemon_response",
-        lambda **_kwargs: {
-            "continue": False,
-            "stopReason": "isolated review failed",
-            "systemMessage": "isolated review failed",
-            "reason_code": "daemon_hook_process_failed",
-        },
-    )
-    monkeypatch.setattr(
-        bridge,
-        "_run_local_fallback",
-        lambda _command, *, data, timeout_seconds: (
-            fallback_calls.append(data) or {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}
-        ),
-    )
-    prompt = {
-        "hook_event_name": "UserPromptSubmit",
-        "prompt": "Reassess the current implementation.",
-    }
-    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(prompt)))
-
-    assert bridge.main(**config) == 0
-    assert fallback_calls == [json.dumps(prompt)]
-    assert json.loads(capsys.readouterr().out) == {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}
-
-
-def test_authenticated_overload_fails_closed_without_fallback_or_restart(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    guard_home = tmp_path / "guard-home"
-    guard_home.mkdir()
-    starts: list[tuple[str, ...]] = []
-
-    def overloaded_daemon(**kwargs: object) -> dict[str, object]:
-        del kwargs
-        raise bridge._DaemonResponseError(429, '{"error":"hook_capacity_exhausted"}', authenticated=True)
-
-    def start_daemon(
-        command: tuple[str, ...],
-        *,
-        timeout_seconds: float,
-        failure_kind: str,
-    ) -> bool:
-        del timeout_seconds, failure_kind
-        starts.append(command)
-        return True
-
-    config = _bridge_config(guard_home, 1)
-    monkeypatch.setattr(bridge, "_daemon_response", overloaded_daemon)
-    monkeypatch.setattr(bridge, "_run_daemon_start", start_daemon)
-    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "PreToolUse"})))
-
-    assert bridge.main(**config) == 0
-    assert starts == []
-    payload = json.loads(capsys.readouterr().out)
-    output = payload["hookSpecificOutput"]
-    assert output["permissionDecision"] == "deny"
-    assert "temporarily saturated" in output["permissionDecisionReason"]
-
-
-def test_typed_transient_overload_retries_once_when_deadline_fits(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    attempts = 0
-
-    def daemon_response(**kwargs: object) -> dict[str, object]:
-        del kwargs
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
-            raise bridge._DaemonResponseError(
-                503,
-                '{"reason_code":"transient_overload","retry_after_ms":25,"estimated_service_ms":100}',
-                authenticated=True,
-            )
-        return {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}
-
-    guard_home = tmp_path / "guard-home"
-    guard_home.mkdir()
-    monkeypatch.setattr(bridge, "_daemon_response", daemon_response)
-    monkeypatch.setattr(bridge.time, "sleep", lambda _seconds: None)
-    monkeypatch.setattr("sys.stdin", io.StringIO('{"hook_event_name":"PreToolUse"}'))
-
-    assert bridge.main(**_bridge_config(guard_home, 1)) == 0
-    assert attempts == 2
-    assert json.loads(capsys.readouterr().out)["hookSpecificOutput"]["permissionDecision"] == "allow"
-
-
-def test_daemon_failure_kind_separates_overload_transport_and_control_plane() -> None:
-    assert (
-        bridge._daemon_failure_kind(
-            bridge._DaemonResponseError(429, '{"error":"hook_capacity_exhausted"}', authenticated=True)
-        )
-        == "overload"
-    )
-    assert bridge._daemon_failure_kind(TimeoutError("deadline")) == "transport-failure"
-    assert bridge._daemon_failure_kind(ValueError("state authentication failed")) == (
-        "authenticated-control-plane-failure"
-    )
-
-
-@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group assertion")
-def test_untrusted_fallback_timeout_kills_descendants(tmp_path: Path) -> None:
-    marker = tmp_path / "escaped-child.marker"
-    child = f"import time;from pathlib import Path;time.sleep(.3);Path({str(marker)!r}).write_text('escaped')"
-    parent = f"import subprocess,sys,time;subprocess.Popen([sys.executable,'-c',{child!r}]);time.sleep(10)"
-
-    response = bridge._run_local_fallback(
-        (sys.executable, "-c", parent),
-        data="{}",
-        timeout_seconds=0.05,
-    )
-    time.sleep(0.4)
-
-    assert response is None
-    assert not marker.exists()
-
-
-def test_bridge_script_cold_start_stays_below_hook_budget(tmp_path: Path) -> None:
-    guard_home = tmp_path / "guard-home"
-    daemon = HTTPServer(("127.0.0.1", 0), _DaemonHandler)
-    daemon_thread = threading.Thread(target=daemon.serve_forever, daemon=True)
-    daemon_thread.start()
-    port = daemon.server_address[1]
-    _write_authenticated_daemon_files(guard_home, port)
-    config = _bridge_config(guard_home, port)
-    config["manifest_path"] = str(guard_home / "managed" / "codex" / "hooks-fixture.manifest.json")
-    bridge_path = str(Path(bridge.__file__).resolve())
-    timing_wrapper = """
-import runpy
-import sys
-import time
-
-bridge_path = sys.argv.pop(1)
-started_at = time.perf_counter()
-try:
-    runpy.run_path(bridge_path, run_name="__main__")
-except SystemExit:
-    print(f"bridge-elapsed={time.perf_counter() - started_at}", file=sys.stderr)
-    raise
-"""
-    command = [sys.executable, "-I", "-c", timing_wrapper, bridge_path, json.dumps(config)]
-    payload = json.dumps({"hook_event_name": "PreToolUse"})
-
-    results: list[subprocess.CompletedProcess[str]] = []
-    try:
-        for _ in range(3):
-            results.append(
-                subprocess.run(
-                    command,
-                    input=payload,
-                    capture_output=True,
-                    text=True,
-                    timeout=2,
-                    check=False,
-                )
-            )
-    finally:
-        daemon.shutdown()
-        daemon_thread.join(timeout=5)
-
-    assert all(result.returncode == 0 for result in results), [
-        (result.returncode, result.stdout, result.stderr) for result in results
-    ]
-    assert all(json.loads(result.stdout) == {} for result in results)
-    elapsed_samples = [float(result.stderr.rsplit("bridge-elapsed=", 1)[1]) for result in results]
-    # The process timeout enforces the hard two-second wall-clock budget. The
-    # in-process sample retains the one-second bridge budget without charging
-    # interpreter startup and runner dispatch to bridge execution.
-    assert min(elapsed_samples) < 1.0

--- a/tests/test_codex_daemon_hook_bridge_resilience.py
+++ b/tests/test_codex_daemon_hook_bridge_resilience.py
@@ -1,0 +1,391 @@
+"""Security and latency tests for the Codex daemon hook bridge."""
+
+from __future__ import annotations
+
+import http.client
+import io
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+from http.server import HTTPServer
+from pathlib import Path
+from urllib.parse import urlencode
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import codex_daemon_hook_bridge as bridge
+from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.store import GuardStore
+from tests.codex_daemon_hook_bridge_fixtures import (
+    _bridge_config,
+    _DaemonHandler,
+    _write_authenticated_daemon_files,
+)
+
+
+def test_real_daemon_rejects_consumed_challenge_replay(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
+    daemon.start()
+    state = json.loads((guard_home / "daemon-state.json").read_text(encoding="utf-8"))
+    nonce = "a" * 64
+    challenge_body = json.dumps(
+        {
+            "protocol_version": 1,
+            "nonce": nonce,
+            "state_id": state["state_id"],
+            "hook_event": "PreToolUse",
+        }
+    )
+    hook_body = json.dumps(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo hello"},
+        }
+    )
+    hook_path = "/v1/hooks/codex?" + urlencode(
+        {
+            "guard-home": str(guard_home),
+            "home": str(tmp_path),
+            "workspace": str(workspace),
+        }
+    )
+
+    try:
+        connection = http.client.HTTPConnection("127.0.0.1", daemon.port, timeout=5)
+        connection.request(
+            "POST",
+            "/v1/daemon/identity-challenge",
+            body=challenge_body,
+            headers={"Content-Type": "application/json", "Connection": "keep-alive"},
+        )
+        challenge_response = connection.getresponse()
+        challenge = json.loads(challenge_response.read())
+        proof_headers = {
+            "Content-Type": "application/json",
+            "Connection": "close",
+            "X-Guard-Token": daemon._server.auth_token,
+            "X-Guard-Daemon-Nonce": nonce,
+            "X-Guard-Daemon-Proof": challenge["proof"],
+        }
+        connection.request("POST", hook_path, body=hook_body, headers=proof_headers)
+        first_response = connection.getresponse()
+        _ = first_response.read()
+        connection.close()
+
+        replay_connection = http.client.HTTPConnection("127.0.0.1", daemon.port, timeout=5)
+        replay_connection.request("POST", hook_path, body=hook_body, headers=proof_headers)
+        replay_response = replay_connection.getresponse()
+        _ = replay_response.read()
+        replay_connection.close()
+    finally:
+        daemon.stop()
+
+    assert challenge_response.status == 200
+    assert first_response.status == 200
+    assert replay_response.status == 401
+
+
+def test_malformed_daemon_and_fallback_outputs_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    daemon = HTTPServer(("127.0.0.1", 0), _DaemonHandler)
+    daemon_thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    daemon_thread.start()
+    port = daemon.server_address[1]
+    _write_authenticated_daemon_files(guard_home, port)
+    _DaemonHandler.response_body = b"not-json"
+    config = _bridge_config(guard_home, port)
+    config["fallback_command"] = [sys.executable, "-c", "print('still-not-json')"]
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "PreToolUse"})))
+
+    try:
+        exit_code = bridge.main(**config)
+    finally:
+        daemon.shutdown()
+        daemon_thread.join(timeout=5)
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_post_tool_use_stdout_is_exactly_one_json_object_with_noisy_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    config = _bridge_config(guard_home, 1)
+    config["fallback_command"] = [
+        sys.executable,
+        "-c",
+        "print('Guard integrity warning'); print('{\"continue\": true}')",
+    ]
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "PostToolUse"})))
+
+    exit_code = bridge.main(**config)
+
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert exit_code == 0
+    assert output["continue"] is False
+    assert captured.out == json.dumps(output, separators=(",", ":"))
+    assert captured.err == ""
+
+
+def test_unavailable_daemon_preserves_local_fallback_denial(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    denial = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": "blocked by fixture policy",
+        }
+    }
+    config = _bridge_config(guard_home, 1)
+    config["fallback_command"] = [
+        sys.executable,
+        "-c",
+        f"import json; print(json.dumps({denial!r}))",
+    ]
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "PreToolUse"})))
+
+    exit_code = bridge.main(**config)
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == denial
+
+
+def test_main_starts_daemon_once_then_retries_hook(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    responses: list[dict[str, object] | None] = []
+    starts: list[tuple[str, ...]] = []
+
+    def daemon_response(**kwargs: object) -> dict[str, object]:
+        responses.append(None)
+        if len(responses) == 1:
+            raise urllib.error.URLError("daemon cold")
+        return {}
+
+    def start_daemon(
+        command: tuple[str, ...],
+        *,
+        timeout_seconds: float,
+        failure_kind: str,
+    ) -> bool:
+        starts.append(tuple(command))
+        assert 7.9 < timeout_seconds <= 8
+        assert failure_kind == "transport-failure"
+        return True
+
+    config = _bridge_config(guard_home, 1)
+    monkeypatch.setattr(bridge, "_daemon_response", daemon_response)
+    monkeypatch.setattr(bridge, "_run_daemon_start", start_daemon)
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "PreToolUse"})))
+
+    exit_code = bridge.main(**config)
+
+    assert exit_code == 0
+    assert len(responses) == 2
+    assert starts == [tuple(config["start_command"])]
+    assert json.loads(capsys.readouterr().out) == {}
+
+    fallback_calls: list[str] = []
+    monkeypatch.setattr(
+        bridge,
+        "_daemon_response",
+        lambda **_kwargs: {
+            "continue": False,
+            "stopReason": "isolated review failed",
+            "systemMessage": "isolated review failed",
+            "reason_code": "daemon_hook_process_failed",
+        },
+    )
+    monkeypatch.setattr(
+        bridge,
+        "_run_local_fallback",
+        lambda _command, *, data, timeout_seconds: (
+            fallback_calls.append(data) or {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}
+        ),
+    )
+    prompt = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Reassess the current implementation.",
+    }
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(prompt)))
+
+    assert bridge.main(**config) == 0
+    assert fallback_calls == [json.dumps(prompt)]
+    assert json.loads(capsys.readouterr().out) == {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}
+
+
+def test_authenticated_overload_fails_closed_without_fallback_or_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    starts: list[tuple[str, ...]] = []
+
+    def overloaded_daemon(**kwargs: object) -> dict[str, object]:
+        del kwargs
+        raise bridge._DaemonResponseError(429, '{"error":"hook_capacity_exhausted"}', authenticated=True)
+
+    def start_daemon(
+        command: tuple[str, ...],
+        *,
+        timeout_seconds: float,
+        failure_kind: str,
+    ) -> bool:
+        del timeout_seconds, failure_kind
+        starts.append(command)
+        return True
+
+    config = _bridge_config(guard_home, 1)
+    monkeypatch.setattr(bridge, "_daemon_response", overloaded_daemon)
+    monkeypatch.setattr(bridge, "_run_daemon_start", start_daemon)
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "PreToolUse"})))
+
+    assert bridge.main(**config) == 0
+    assert starts == []
+    payload = json.loads(capsys.readouterr().out)
+    output = payload["hookSpecificOutput"]
+    assert output["permissionDecision"] == "deny"
+    assert "temporarily saturated" in output["permissionDecisionReason"]
+
+
+def test_typed_transient_overload_retries_once_when_deadline_fits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    attempts = 0
+
+    def daemon_response(**kwargs: object) -> dict[str, object]:
+        del kwargs
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise bridge._DaemonResponseError(
+                503,
+                '{"reason_code":"transient_overload","retry_after_ms":25,"estimated_service_ms":100}',
+                authenticated=True,
+            )
+        return {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}
+
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    monkeypatch.setattr(bridge, "_daemon_response", daemon_response)
+    monkeypatch.setattr(bridge.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr("sys.stdin", io.StringIO('{"hook_event_name":"PreToolUse"}'))
+
+    assert bridge.main(**_bridge_config(guard_home, 1)) == 0
+    assert attempts == 2
+    assert json.loads(capsys.readouterr().out)["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+def test_daemon_failure_kind_separates_overload_transport_and_control_plane() -> None:
+    assert (
+        bridge._daemon_failure_kind(
+            bridge._DaemonResponseError(429, '{"error":"hook_capacity_exhausted"}', authenticated=True)
+        )
+        == "overload"
+    )
+    assert bridge._daemon_failure_kind(TimeoutError("deadline")) == "transport-failure"
+    assert bridge._daemon_failure_kind(ValueError("state authentication failed")) == (
+        "authenticated-control-plane-failure"
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group assertion")
+def test_untrusted_fallback_timeout_kills_descendants(tmp_path: Path) -> None:
+    marker = tmp_path / "escaped-child.marker"
+    child = f"import time;from pathlib import Path;time.sleep(.3);Path({str(marker)!r}).write_text('escaped')"
+    parent = f"import subprocess,sys,time;subprocess.Popen([sys.executable,'-c',{child!r}]);time.sleep(10)"
+
+    response = bridge._run_local_fallback(
+        (sys.executable, "-c", parent),
+        data="{}",
+        timeout_seconds=0.05,
+    )
+    time.sleep(0.4)
+
+    assert response is None
+    assert not marker.exists()
+
+
+def test_bridge_script_cold_start_stays_below_hook_budget(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    daemon = HTTPServer(("127.0.0.1", 0), _DaemonHandler)
+    daemon_thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    daemon_thread.start()
+    port = daemon.server_address[1]
+    _write_authenticated_daemon_files(guard_home, port)
+    config = _bridge_config(guard_home, port)
+    config["manifest_path"] = str(guard_home / "managed" / "codex" / "hooks-fixture.manifest.json")
+    bridge_path = str(Path(bridge.__file__).resolve())
+    timing_wrapper = """
+import runpy
+import sys
+import time
+
+bridge_path = sys.argv.pop(1)
+started_at = time.perf_counter()
+try:
+    runpy.run_path(bridge_path, run_name="__main__")
+except SystemExit:
+    print(f"bridge-elapsed={time.perf_counter() - started_at}", file=sys.stderr)
+    raise
+"""
+    command = [sys.executable, "-I", "-c", timing_wrapper, bridge_path, json.dumps(config)]
+    payload = json.dumps({"hook_event_name": "PreToolUse"})
+
+    results: list[subprocess.CompletedProcess[str]] = []
+    try:
+        for _ in range(3):
+            results.append(
+                subprocess.run(
+                    command,
+                    input=payload,
+                    capture_output=True,
+                    text=True,
+                    timeout=2,
+                    check=False,
+                )
+            )
+    finally:
+        daemon.shutdown()
+        daemon_thread.join(timeout=5)
+
+    assert all(result.returncode == 0 for result in results), [
+        (result.returncode, result.stdout, result.stderr) for result in results
+    ]
+    assert all(json.loads(result.stdout) == {} for result in results)
+    elapsed_samples = [float(result.stderr.rsplit("bridge-elapsed=", 1)[1]) for result in results]
+    # The process timeout enforces the hard two-second wall-clock budget. The
+    # in-process sample retains the one-second bridge budget without charging
+    # interpreter startup and runner dispatch to bridge execution.
+    assert min(elapsed_samples) < 1.0


### PR DESCRIPTION
## Summary

- rediscover authenticated daemon state once when the daemon generation changes during a hook request
- keep invalid, unchanged, and repeatedly changing daemon identities fail closed
- cover the `UserPromptSubmit` rollover race and bounded retry behavior

## Verification

- `uv run pytest -q tests/test_codex_daemon_hook_bridge.py --tb=short`
- `uv run pytest -q tests/test_guard_daemon_recovery_resilience.py tests/test_guard_daemon_wake.py tests/test_guard_daemon_manager.py --tb=short`
- `uv run pytest -q tests/test_guard_codex_install.py tests/test_guard_phase04_harness_ux.py --tb=short`
- `uv run ruff check src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py tests/test_codex_daemon_hook_bridge.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py tests/test_codex_daemon_hook_bridge.py`
- `uv run basedpyright src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py`
- `git diff --check`
