### PR TITLE
chore: add GitHub Sponsors funding metadata

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [hashgraph-online]


### PR DESCRIPTION
## Summary

- Add `.github/FUNDING.yml` to the `release/2.2` line.
- Route GitHub Sponsors support to the `hashgraph-online` organization profile.

## Testing

- `yq '.' .github/FUNDING.yml`
- `git diff --check`
