### PR TITLE
fix(guard): show request working directory

### DIFF
--- a/dashboard/src/approval-center-layout.test.ts
+++ b/dashboard/src/approval-center-layout.test.ts
@@ -12,8 +12,11 @@ import {
   scopeLabel,
   buildCodexResumeUx,
   resolveApprovalShareUrl,
+  resolveRequestWorkingDirectory,
 } from "./approval-center-utils";
 import type { GuardActionEnvelope, GuardApprovalRequest, GuardCodexResumeResult } from "./guard-types";
+import { renderToStaticMarkup } from "react-dom/server";
+import { PrimaryActionCard } from "./review-states";
 
 function assert(condition: boolean, message: string): void {
   if (!condition) {
@@ -77,7 +80,8 @@ const shellEnvelope: GuardActionEnvelope = {
 
 const shellRequest: GuardApprovalRequest = {
   ...BASE_REQUEST,
-  action_envelope_json: shellEnvelope
+  workspace: "/workspace/legacy",
+  action_envelope_json: { ...shellEnvelope, workspace: "/workspace/current" }
 };
 
 assert(
@@ -88,6 +92,37 @@ assert(
 assert(
   resolveStoppedCommandText(shellRequest) === "git diff HEAD~1 -- src/",
   "T494: resolveStoppedCommandText returns the envelope command for shell_command item"
+);
+
+assert(
+  resolveRequestWorkingDirectory(shellRequest) === "/workspace/current",
+  "T494: working directory prefers the typed action envelope workspace"
+);
+
+assert(
+  resolveRequestWorkingDirectory({ ...BASE_REQUEST, workspace: "/workspace/legacy" }) === "/workspace/legacy",
+  "T494: working directory falls back to the approval request workspace"
+);
+
+assert(
+  resolveRequestWorkingDirectory({ ...BASE_REQUEST, workspace: "  " }) === null,
+  "T494: working directory omits empty workspace values"
+);
+
+assert(
+  resolveRequestWorkingDirectory({
+    ...BASE_REQUEST,
+    artifact_type: "file_read",
+    workspace: "/workspace/current",
+    action_envelope_json: { ...BASE_ENVELOPE, action_type: "file_read", workspace: "/workspace/current" }
+  }) === null,
+  "T494: working directory stays scoped to executable actions"
+);
+
+const primaryActionMarkup = renderToStaticMarkup(PrimaryActionCard({ item: shellRequest }));
+assert(
+  primaryActionMarkup.includes("Working directory") && primaryActionMarkup.includes("/workspace/current"),
+  "T494: primary action card shows the full working directory next to the stopped command"
 );
 
 const longCommand = "a".repeat(200);

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -583,6 +583,26 @@ export function resolveStoppedCommandText(item: GuardApprovalRequest): string {
   return item.artifact_name.trim() || item.artifact_id;
 }
 
+export function resolveRequestWorkingDirectory(item: GuardApprovalRequest): string | null {
+  const actionType = item.action_envelope_json?.action_type;
+  const artifactType = item.artifact_type.toLowerCase();
+  const isExecutableAction =
+    actionType === "shell_command" ||
+    actionType === "package_script" ||
+    artifactType.includes("command") ||
+    artifactType.includes("shell") ||
+    artifactType.includes("package");
+  if (!isExecutableAction) {
+    return null;
+  }
+  const envelopeWorkspace = item.action_envelope_json?.workspace?.trim();
+  if (envelopeWorkspace) {
+    return envelopeWorkspace;
+  }
+  const requestWorkspace = item.workspace?.trim();
+  return requestWorkspace || null;
+}
+
 function resolvePrimaryReviewText(item: GuardApprovalRequest): string {
   const envelope = item.action_envelope_json;
   if (envelope) {

--- a/dashboard/src/review-states.tsx
+++ b/dashboard/src/review-states.tsx
@@ -2,6 +2,7 @@ import {
   HiMiniArrowPath,
   HiMiniCheckCircle,
   HiMiniExclamationTriangle,
+  HiMiniFolder,
   HiMiniInformationCircle,
   HiMiniShieldCheck,
 } from "react-icons/hi2";
@@ -10,6 +11,7 @@ import {
   buildCodexResumeUx,
   buildPrimaryReviewAction,
   harnessDisplayName,
+  resolveRequestWorkingDirectory,
 } from "./approval-center-utils";
 import type {
   GuardApprovalRequest,
@@ -174,6 +176,7 @@ export function ReviewEmptyState({ runtime, resolutionMessage, codexResume, onRe
 
 export function PrimaryActionCard({ item }: { item: GuardApprovalRequest }) {
   const action = buildPrimaryReviewAction(item);
+  const workingDirectory = resolveRequestWorkingDirectory(item);
 
   return (
     <div className="mt-5 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
@@ -199,6 +202,15 @@ export function PrimaryActionCard({ item }: { item: GuardApprovalRequest }) {
           expandAriaLabel="Expand full stopped action"
           collapseAriaLabel="Collapse full stopped action"
         />
+        {workingDirectory !== null && (
+          <div className="mt-3 flex min-w-0 items-start gap-2 text-xs text-muted-foreground">
+            <HiMiniFolder className="mt-0.5 h-4 w-4 shrink-0 text-brand-blue" aria-hidden="true" />
+            <span className="shrink-0 font-medium text-brand-dark/70">Working directory</span>
+            <code className="min-w-0 break-all font-mono text-brand-dark" title={workingDirectory}>
+              {workingDirectory}
+            </code>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14887,6 +14887,20 @@ function resolveStoppedCommandText(item) {
   }
   return item.artifact_name.trim() || item.artifact_id;
 }
+function resolveRequestWorkingDirectory(item) {
+  const actionType = item.action_envelope_json?.action_type;
+  const artifactType = item.artifact_type.toLowerCase();
+  const isExecutableAction = actionType === "shell_command" || actionType === "package_script" || artifactType.includes("command") || artifactType.includes("shell") || artifactType.includes("package");
+  if (!isExecutableAction) {
+    return null;
+  }
+  const envelopeWorkspace = item.action_envelope_json?.workspace?.trim();
+  if (envelopeWorkspace) {
+    return envelopeWorkspace;
+  }
+  const requestWorkspace = item.workspace?.trim();
+  return requestWorkspace || null;
+}
 function resolvePrimaryReviewText(item) {
   const envelope = item.action_envelope_json;
   if (envelope) {
@@ -28427,6 +28441,7 @@ function ReviewEmptyState({ runtime, resolutionMessage, codexResume, onRetryResu
 }
 function PrimaryActionCard({ item }) {
   const action = buildPrimaryReviewAction(item);
+  const workingDirectory = resolveRequestWorkingDirectory(item);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
@@ -28435,17 +28450,24 @@ function PrimaryActionCard({ item }) {
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "rounded-full border border-brand-blue/15 bg-brand-blue/[0.04] px-3 py-1 font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-brand-blue", children: action.label })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-      LoggedActionPanel,
-      {
-        label: action.label,
-        text: action.text,
-        copyAriaLabel: "Copy full stopped action to clipboard",
-        expandAriaLabel: "Expand full stopped action",
-        collapseAriaLabel: "Collapse full stopped action"
-      },
-      item.request_id
-    ) })
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        LoggedActionPanel,
+        {
+          label: action.label,
+          text: action.text,
+          copyAriaLabel: "Copy full stopped action to clipboard",
+          expandAriaLabel: "Expand full stopped action",
+          collapseAriaLabel: "Collapse full stopped action"
+        },
+        item.request_id
+      ),
+      workingDirectory !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 flex min-w-0 items-start gap-2 text-xs text-muted-foreground", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniFolder, { className: "mt-0.5 h-4 w-4 shrink-0 text-brand-blue", "aria-hidden": "true" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "shrink-0 font-medium text-brand-dark/70", children: "Working directory" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("code", { className: "min-w-0 break-all font-mono text-brand-dark", title: workingDirectory, children: workingDirectory })
+      ] })
+    ] })
   ] });
 }
 function buildWhatWouldHappen(item) {


### PR DESCRIPTION
## Summary
- show the effective request working directory beside stopped executable actions
- prefer the typed action envelope workspace while retaining compatibility with legacy approval records
- include the rebuilt embedded dashboard asset

## Testing
- `cd dashboard && ./node_modules/.bin/tsx src/approval-center-layout.test.ts`
- `cd dashboard && bun run test`
- `cd dashboard && bun run build`
- `git diff --check`

## Notes
- Repository-wide TypeScript validation continues to report pre-existing diagnostics outside the changed files.
