### PR TITLE
fix(guard): make watch-only mode non-blocking

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11900,
+  "maximum_collected_cases": 11902,
   "maximum_test_source_lines": 278617,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
@@ -114,104 +114,6 @@ def _copilot_approval_reuse_evidence(
     }
 
 
-def _queue_observed_copilot_approval(
-    *,
-    artifact: GuardArtifact,
-    artifact_hash: str,
-    artifact_name: str,
-    args: argparse.Namespace,
-    action_envelope: GuardActionEnvelope | None,
-    config: GuardConfig,
-    context: HarnessContext,
-    decision: ToolCallDecision,
-    guard_home: Path,
-    managed_install: dict[str, object] | None,
-    payload: Mapping[str, object],
-    runtime_arguments: object,
-    runtime_workspace: Path | None,
-    store: GuardStore,
-) -> list[dict[str, object]]:
-    observed_policy_action = resolve_tool_call_policy_action(decision)
-    approval_center_url = schedule_guard_daemon_ensure(
-        guard_home,
-        home_dir=context.home_dir,
-    )
-    runtime_detection = _runtime_detection(args.harness, artifact)
-    evaluation_payload: dict[str, object] = {
-        "artifacts": [
-            {
-                "artifact_id": artifact.artifact_id,
-                "artifact_name": artifact_name,
-                "artifact_hash": artifact_hash,
-                "policy_action": observed_policy_action,
-                "changed_fields": ["runtime_tool_call", *decision.signals],
-                "artifact_type": artifact.artifact_type,
-                "source_scope": artifact.source_scope,
-                "config_path": artifact.config_path,
-                "launch_target": json.dumps(runtime_arguments, sort_keys=True)
-                if runtime_arguments is not None
-                else artifact.command,
-                "action_envelope_json": _action_envelope_json(action_envelope),
-                "scanner_evidence": list(_copilot_tool_decision_scanner_evidence(decision)),
-            }
-        ]
-    }
-    approval_flow = get_adapter(args.harness).approval_flow(managed_install=managed_install)
-    try:
-        daemon_client = load_guard_surface_daemon_client(guard_home)
-        session = daemon_client.start_session(
-            harness=args.harness,
-            surface="harness-adapter",
-            workspace=str(runtime_workspace) if runtime_workspace else None,
-            client_name=f"{args.harness}-permission-hook",
-            client_title=f"{args.harness} permission hook",
-            client_version="1.0.0",
-            capabilities=["approval-resolution", "receipt-view"],
-        )
-        blocked_operation = daemon_client.queue_blocked_operation(
-            session_id=str(session["session_id"]),
-            operation_type="tool_call",
-            harness=args.harness,
-            metadata={
-                "tool_name": str(payload.get("tool_name", "")),
-                "hook_name": "permissionRequest",
-                "hook_event_name": "PermissionRequest",
-                **_codex_browser_wait_metadata(
-                    args=args,
-                    event_name="PermissionRequest",
-                    policy_action=observed_policy_action,
-                    config=config,
-                    payload=payload,
-                ),
-                "command_text": _hook_command_text(payload),
-                "workspace": str(runtime_workspace) if runtime_workspace else None,
-            },
-            detection=runtime_detection.to_dict(),
-            evaluation=evaluation_payload,
-            approval_center_url=approval_center_url,
-            approval_surface_policy=_approval_surface_policy_for_flow(
-                config.approval_surface_policy,
-                approval_flow,
-            ),
-            open_key=artifact.artifact_id,
-            redaction_level=config.receipt_redaction_level,
-        )
-    except RuntimeError:
-        queued = queue_blocked_approvals(
-            redaction_level=config.receipt_redaction_level,
-            detection=runtime_detection,
-            evaluation=evaluation_payload,
-            store=store,
-            approval_center_url=approval_center_url,
-            now=_now(),
-        )
-    else:
-        queued = blocked_operation.get("approval_requests")
-        if not isinstance(queued, list):
-            queued = []
-    return queued
-
-
 def _run_hook_copilot_pretool(
     args: argparse.Namespace,
     *,
@@ -248,27 +150,9 @@ def _run_hook_copilot_pretool(
     approval_reuse = _copilot_approval_reuse_evidence(decision)
     decision_scanner_evidence = _copilot_tool_decision_scanner_evidence(decision)
     saved_policy_blocks = decision.saved_action == "block"
-    terminal_action = policy_action in {"block", "sandbox-required"}
     now = _now()
     if config.mode == "observe" and policy_action not in {"allow", "warn"}:
         observed_policy_action = policy_action
-        if not terminal_action:
-            _queue_observed_copilot_approval(
-                artifact=runtime_artifact,
-                artifact_hash=runtime_artifact_hash,
-                artifact_name=runtime_artifact.name,
-                args=args,
-                action_envelope=action_envelope,
-                config=config,
-                context=context,
-                decision=decision,
-                guard_home=context.guard_home,
-                managed_install=None,
-                payload=payload,
-                runtime_arguments=runtime_arguments,
-                runtime_workspace=runtime_workspace,
-                store=store,
-            )
         observe_mode_evidence: dict[str, object] = {
             "source": "observe_mode",
             "observed_policy_action": observed_policy_action,
@@ -442,27 +326,7 @@ def _run_hook_copilot_permission_request(
         response_payload["scanner_evidence"] = list(decision_scanner_evidence)
     if config.mode == "observe" and policy_action not in {"allow", "warn"}:
         observed_policy_action = policy_action
-        queued = (
-            []
-            if terminal_action
-            else _queue_observed_copilot_approval(
-                artifact=runtime_artifact,
-                artifact_hash=runtime_artifact_hash,
-                artifact_name=artifact_name,
-                args=args,
-                action_envelope=action_envelope,
-                config=config,
-                context=context,
-                decision=decision,
-                guard_home=guard_home,
-                managed_install=managed_install,
-                payload=payload,
-                runtime_arguments=runtime_arguments,
-                runtime_workspace=runtime_workspace,
-                store=store,
-            )
-        )
-        response_payload["approval_requests"] = queued
+        response_payload["approval_requests"] = []
         if terminal_action:
             response_payload["observed_terminal_action"] = policy_action
         response_payload["observed_policy_action"] = observed_policy_action

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_review.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_review.py
@@ -141,130 +141,7 @@ def _review_runtime_artifact_hook(
             )
     if policy_action in {"review", "require-reapproval", "sandbox-required", "block"} or cursor_native_queue:
         if observe_mode:
-            should_queue_approval_center = not terminal_action and not (
-                policy_action == "block" and stored_policy_action == "block"
-            )
-            if should_queue_approval_center:
-                approval_flow = get_adapter(args.harness).approval_flow(managed_install=managed_install)
-                approval_center_url = schedule_guard_daemon_ensure(
-                    guard_home,
-                    home_dir=context.home_dir,
-                )
-                runtime_detection = _runtime_detection(args.harness, runtime_artifact)
-                package_evaluation_to_dict = getattr(package_evaluation, "to_dict", None)
-                evaluation_payload: dict[str, object] = {
-                    "artifacts": [
-                        {
-                            "artifact_id": artifact_id,
-                            "artifact_name": artifact_name,
-                            "artifact_hash": runtime_artifact_hash,
-                            "policy_action": policy_action,
-                            "changed_fields": changed_capabilities,
-                            "artifact_type": runtime_artifact.artifact_type,
-                            "source_scope": runtime_artifact.source_scope,
-                            "config_path": runtime_artifact.config_path,
-                            "launch_target": _runtime_request_summary(runtime_artifact),
-                            "risk_summary": risk_summary,
-                            "action_envelope_json": _action_envelope_json(action_envelope),
-                            "decision_v2_json": decision_v2_payload,
-                            "scanner_evidence": scanner_evidence_payload,
-                            "supply_chain_evaluation": (
-                                package_evaluation_to_dict() if callable(package_evaluation_to_dict) else None
-                            ),
-                        }
-                    ]
-                }
-                browser_approval_daemon_client = None
-                try:
-                    browser_approval_daemon_client = load_guard_surface_daemon_client(guard_home)
-                    session = browser_approval_daemon_client.start_session(
-                        harness=args.harness,
-                        surface="harness-adapter",
-                        workspace=str(workspace) if workspace else None,
-                        client_name=f"{args.harness}-hook",
-                        client_title=f"{args.harness} hook",
-                        client_version="1.0.0",
-                        capabilities=["approval-resolution", "receipt-view"],
-                    )
-                    response_payload["session_id"] = str(session["session_id"])
-                    blocked_operation = browser_approval_daemon_client.queue_blocked_operation(
-                        session_id=str(session["session_id"]),
-                        operation_type="tool_call",
-                        harness=args.harness,
-                        metadata={
-                            "tool_name": str(payload.get("tool_name", "")),
-                            "event": str(payload.get("event", "")),
-                            "hook_event_name": event_name,
-                            **_codex_browser_wait_metadata(
-                                args=args,
-                                event_name=event_name,
-                                policy_action=policy_action,
-                                config=config,
-                                payload=payload_map,
-                            ),
-                            "command_text": _hook_command_text(payload_map),
-                            "workspace": str(workspace) if workspace else None,
-                            **(
-                                codex_resume_metadata_from_hook_payload(payload_map)
-                                if _canonical_harness_name(args.harness) == "codex"
-                                else {}
-                            ),
-                        },
-                        detection=runtime_detection.to_dict(),
-                        evaluation=evaluation_payload,
-                        approval_center_url=approval_center_url,
-                        approval_surface_policy=_approval_surface_policy_for_flow(
-                            config.approval_surface_policy,
-                            approval_flow,
-                        ),
-                        open_key=artifact_id,
-                        redaction_level=config.receipt_redaction_level,
-                    )
-                except RuntimeError:
-                    queued = queue_blocked_approvals(
-                        detection=runtime_detection,
-                        evaluation=evaluation_payload,
-                        store=store,
-                        approval_center_url=approval_center_url,
-                        now=_now(),
-                        redaction_level=config.receipt_redaction_level,
-                    )
-                else:
-                    operation = blocked_operation.get("operation")
-                    if not isinstance(operation, dict):
-                        operation = {}
-                    queued = blocked_operation.get("approval_requests")
-                    if not isinstance(queued, list):
-                        queued = []
-                    operation_id = _optional_string(operation.get("operation_id"))
-                    if operation_id is not None:
-                        response_payload["operation_id"] = operation_id
-                    response_payload["operation"] = operation
-                    approval_request_ids = operation.get("approval_request_ids")
-                    if isinstance(approval_request_ids, list):
-                        response_payload["approval_request_ids"] = approval_request_ids
-                response_payload["approval_requests"] = queued
-                _attach_primary_approval_link(
-                    response_payload,
-                    harness=_optional_string(args.harness) or args.harness,
-                    approval_center_url=approval_center_url,
-                )
-                response_payload["approval_center_url"] = approval_center_url
-                response_payload["review_hint"] = approval_center_hint(
-                    context=context,
-                    harness=args.harness,
-                    approval_center_url=approval_center_url,
-                    queued=queued,
-                    managed_install=managed_install,
-                    request_id=_optional_string(response_payload.get("primary_approval_request_id")),
-                    artifact_id=_optional_string(response_payload.get("artifact_id")),
-                    review_url=_preferred_approval_review_url(response_payload, harness=args.harness),
-                )
-                response_payload["approval_delivery"] = _approval_delivery_payload(
-                    args.harness,
-                    managed_install=managed_install,
-                )
-                _localize_pending_approval_copy(response_payload, harness=args.harness)
+            response_payload["approval_requests"] = []
             observed_policy_action = policy_action
             set_runtime_artifact_hook_final_action(
                 state,
@@ -274,7 +151,7 @@ def _review_runtime_artifact_hook(
             action_envelope = state.action_envelope
             policy_action = state.policy_action
             response_payload = state.response_payload
-            state.browser_approval_daemon_client = locals().get("browser_approval_daemon_client")
+            state.browser_approval_daemon_client = None
             return None
         native_reason = _runtime_artifact_native_reason(runtime_artifact, response_payload)
         additional_context = _claude_prompt_additional_context(

--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -1201,7 +1201,7 @@ class RuntimeMcpGuardProxy:
                 approval_reuse_claim_disposition=None,
             )
         decision_scanner_evidence = _tool_decision_scanner_evidence(decision)
-        if decision.saved_action == "block":
+        if self.config.mode != "observe" and decision.saved_action == "block":
             return self._stored_tool_block_response(
                 message_id=message.get("id"),
                 artifact=artifact,
@@ -1217,7 +1217,7 @@ class RuntimeMcpGuardProxy:
             decision.action,
             approval_decision=decision,
         )
-        if tool_policy_action in {"block", "sandbox-required"}:
+        if self.config.mode != "observe" and tool_policy_action in {"block", "sandbox-required"}:
             return self._terminal_tool_response(
                 message_id=message.get("id"),
                 artifact=artifact,
@@ -1290,7 +1290,7 @@ class RuntimeMcpGuardProxy:
                     expected_catalog_fingerprint=authority.catalog_fingerprint,
                 )
                 return response, package_event
-            if self._inline_prompt_available and approval_callback is not None:
+            if self.config.mode != "observe" and self._inline_prompt_available and approval_callback is not None:
                 approval_result = approval_callback(self._inline_approval_request(tool_name, decision.summary))
                 if _approval_allows(approval_result):
                     try:
@@ -1465,7 +1465,7 @@ class RuntimeMcpGuardProxy:
                 expected_catalog_state=authority.catalog_state,
                 expected_catalog_fingerprint=authority.catalog_fingerprint,
             )
-        if self._inline_prompt_available and approval_callback is not None:
+        if self.config.mode != "observe" and self._inline_prompt_available and approval_callback is not None:
             approval_result = approval_callback(self._inline_approval_request(tool_name, decision.summary))
             if _approval_allows(approval_result):
                 return self._allow_and_forward(
@@ -1570,45 +1570,10 @@ class RuntimeMcpGuardProxy:
             authority = fresh_authority
             fresh_decision = fresh_authority.decision
             fresh_scanner_evidence = _tool_decision_scanner_evidence(fresh_decision)
-            if fresh_decision.saved_action == "block":
-                return self._stored_tool_block_response(
-                    message_id=message.get("id"),
-                    artifact=artifact,
-                    artifact_hash=tool_artifact_hash,
-                    tool_name=tool_name,
-                    params=params,
-                    signals=fresh_decision.signals,
-                    risk_categories=fresh_decision.risk_categories,
-                    scanner_evidence=fresh_scanner_evidence,
-                    package_request=False,
-                )
             fresh_policy_action = _enforcement_action(
                 fresh_decision.current_action or fresh_decision.action,
                 approval_decision=fresh_decision,
             )
-            if fresh_policy_action in {"block", "sandbox-required"}:
-                return self._terminal_tool_response(
-                    message_id=message.get("id"),
-                    artifact=artifact,
-                    artifact_hash=tool_artifact_hash,
-                    tool_name=tool_name,
-                    params=params,
-                    policy_action=fresh_policy_action,
-                    signals=fresh_decision.signals,
-                    risk_categories=fresh_decision.risk_categories,
-                    scanner_evidence=fresh_scanner_evidence,
-                )
-            if not is_execution_permitted(fresh_policy_action):
-                self._queue_observed_approval_requests(
-                    artifact=artifact,
-                    artifact_hash=tool_artifact_hash,
-                    tool_name=tool_name,
-                    params=params,
-                    policy_action=fresh_policy_action,
-                    risk_summary=fresh_decision.summary,
-                    risk_signals=list(fresh_decision.signals),
-                    extra_fields={"scanner_evidence": list(fresh_scanner_evidence)},
-                )
             observe_override = not is_execution_permitted(fresh_policy_action)
             executed_action: GuardAction = "allow" if observe_override else fresh_policy_action
             observe_evidence = fresh_scanner_evidence
@@ -1792,7 +1757,7 @@ class RuntimeMcpGuardProxy:
                 phase="before_package_revalidation",
                 package_request=True,
             )
-        if package_resolution.saved_policy_blocks:
+        if self.config.mode != "observe" and package_resolution.saved_policy_blocks:
             return self._stored_package_block_response(
                 message_id=message.get("id"),
                 artifact=artifact,
@@ -1804,7 +1769,7 @@ class RuntimeMcpGuardProxy:
             )
 
         package_action = _enforcement_action(package_evaluation.policy_action)
-        if package_action in {"block", "sandbox-required"}:
+        if self.config.mode != "observe" and package_action in {"block", "sandbox-required"}:
             return self._terminal_package_response(
                 message_id=message.get("id"),
                 artifact=artifact,
@@ -1843,7 +1808,7 @@ class RuntimeMcpGuardProxy:
             resolution=fresh_package_resolution,
             tool_evidence=fresh_tool_evidence,
         )
-        if fresh_tool_decision.saved_action == "block":
+        if self.config.mode != "observe" and fresh_tool_decision.saved_action == "block":
             return self._stored_tool_block_response(
                 message_id=message.get("id"),
                 artifact=tool_artifact,
@@ -1855,7 +1820,7 @@ class RuntimeMcpGuardProxy:
                 scanner_evidence=fresh_tool_evidence,
                 package_request=True,
             )
-        if fresh_package_resolution.saved_policy_blocks:
+        if self.config.mode != "observe" and fresh_package_resolution.saved_policy_blocks:
             return self._stored_package_block_response(
                 message_id=message.get("id"),
                 artifact=artifact,
@@ -1872,50 +1837,6 @@ class RuntimeMcpGuardProxy:
                 approval_decision=fresh_tool_decision,
             )
             package_observed_action = _enforcement_action(fresh_package_resolution.current_action)
-            if tool_observed_action in {"block", "sandbox-required"}:
-                return self._terminal_tool_response(
-                    message_id=message.get("id"),
-                    artifact=tool_artifact,
-                    artifact_hash=tool_artifact_hash,
-                    tool_name=tool_name,
-                    params=params,
-                    policy_action=tool_observed_action,
-                    signals=fresh_tool_decision.signals,
-                    risk_categories=fresh_tool_decision.risk_categories,
-                    scanner_evidence=fresh_tool_evidence,
-                )
-            if package_observed_action in {"block", "sandbox-required"}:
-                return self._terminal_package_response(
-                    message_id=message.get("id"),
-                    artifact=artifact,
-                    artifact_hash=fresh_package_resolution.artifact_digest,
-                    tool_name=tool_name,
-                    params=params,
-                    package_evaluation=fresh_package_resolution.evaluation,
-                    policy_action=package_observed_action,
-                    scanner_evidence=fresh_scanner_evidence,
-                )
-            if not is_execution_permitted(tool_observed_action):
-                self._queue_observed_approval_requests(
-                    artifact=tool_artifact,
-                    artifact_hash=tool_artifact_hash,
-                    tool_name=tool_name,
-                    params=params,
-                    policy_action=tool_observed_action,
-                    risk_summary=fresh_tool_decision.summary,
-                    risk_signals=list(fresh_tool_decision.signals),
-                    extra_fields={"scanner_evidence": list(fresh_tool_evidence)},
-                )
-            if not is_execution_permitted(package_observed_action):
-                self._queue_observed_package_request(
-                    artifact=artifact,
-                    artifact_hash=fresh_package_resolution.artifact_digest,
-                    tool_name=tool_name,
-                    params=params,
-                    package_evaluation=fresh_package_resolution.evaluation,
-                    policy_action=package_observed_action,
-                    scanner_evidence=fresh_scanner_evidence,
-                )
             observed_policy_action = most_restrictive_guard_action(
                 tool_observed_action,
                 package_observed_action,
@@ -2419,34 +2340,6 @@ class RuntimeMcpGuardProxy:
             "redacted_params": _safe_mcp_params(params),
             "scanner_evidence": list(scanner_evidence),
         }
-
-    def _queue_observed_package_request(
-        self,
-        *,
-        artifact: Any,
-        artifact_hash: str,
-        tool_name: str,
-        params: dict[str, Any],
-        package_evaluation: Any,
-        policy_action: GuardAction,
-        scanner_evidence: tuple[dict[str, object], ...],
-    ) -> None:
-        decision_v2_payload = self._package_decision_v2(package_evaluation, policy_action)
-        self._queue_observed_approval_requests(
-            artifact=artifact,
-            artifact_hash=artifact_hash,
-            tool_name=tool_name,
-            params=params,
-            policy_action=policy_action,
-            risk_summary=package_evaluation.risk_summary,
-            risk_signals=[str(item.get("message") or item.get("code") or "") for item in package_evaluation.reasons],
-            decision_v2_payload=decision_v2_payload,
-            extra_fields={
-                "changed_fields": ["runtime_tool_call", "package_request"],
-                "scanner_evidence": list(scanner_evidence),
-                "supply_chain_evaluation": package_evaluation.to_dict(),
-            },
-        )
 
     @staticmethod
     def _package_decision_v2(package_evaluation: Any, policy_action: GuardAction) -> dict[str, Any]:
@@ -3593,81 +3486,6 @@ class RuntimeMcpGuardProxy:
         if scanner_evidence:
             queued_event["scanner_evidence"] = list(scanner_evidence)
         return response, queued_event
-
-    def _queue_observed_approval_requests(
-        self,
-        *,
-        artifact: Any,
-        artifact_hash: str,
-        tool_name: str,
-        params: dict[str, Any],
-        policy_action: str,
-        risk_summary: str,
-        risk_signals: list[str],
-        decision_v2_payload: dict[str, Any] | None = None,
-        extra_fields: dict[str, Any] | None = None,
-    ) -> list[dict[str, Any]]:
-        if policy_action not in {"review", "block", "sandbox-required", "require-reapproval"}:
-            return []
-        approval_center_url = ensure_guard_daemon(self.context.guard_home)
-        artifact_payload: dict[str, Any] = {
-            "artifact_id": artifact.artifact_id,
-            "artifact_name": artifact.name,
-            "artifact_hash": artifact_hash,
-            "artifact_type": artifact.artifact_type,
-            "source_scope": artifact.source_scope,
-            "config_path": artifact.config_path,
-            "changed_fields": ["runtime_tool_call"],
-            "policy_action": policy_action,
-            "launch_target": self._launch_target(tool_name, params.get("arguments")),
-            "risk_summary": risk_summary,
-            "risk_signals": risk_signals,
-        }
-        # Include browser intent metadata when present
-        browser_intent = normalize_browser_mcp_intent(artifact, params.get("arguments"))
-        if browser_intent is not None:
-            artifact_payload["changed_fields"].append("runtime_browser_tool_call")
-            target = browser_intent_display_target(browser_intent, params.get("arguments"))
-            artifact_payload["launch_target"] = f"{browser_intent.mcp_server_name} {browser_intent.operation} {target}"
-            artifact_payload["browser_intent"] = _safe_mcp_arguments(
-                {
-                    "version": browser_intent.version,
-                    "intent": browser_intent.intent,
-                    "operation": browser_intent.operation,
-                    "target_url": browser_intent.target_url,
-                    "target_origin": browser_intent.target_origin,
-                    "target_domain": browser_intent.target_domain,
-                    "target_path_prefix": browser_intent.target_path_prefix,
-                    "method": browser_intent.method,
-                    "profile_mode": browser_intent.profile_mode,
-                    "mcp_server_name": browser_intent.mcp_server_name,
-                    "mcp_server_identity_hash": browser_intent.mcp_server_identity_hash,
-                    "mcp_tool_name": browser_intent.mcp_tool_name,
-                    "mcp_tool_identity_hash": browser_intent.mcp_tool_identity_hash,
-                    "mcp_schema_hash": browser_intent.mcp_schema_hash,
-                    "sensitive_surface_flags": list(browser_intent.sensitive_surface_flags),
-                    "volatile_fields_dropped": list(browser_intent.volatile_fields_dropped),
-                    "risk_categories": list(tool_call_risk_categories(artifact, params.get("arguments"))),
-                }
-            )
-        if decision_v2_payload is not None:
-            artifact_payload["decision_v2_json"] = decision_v2_payload
-        if extra_fields:
-            artifact_payload.update(extra_fields)
-        return queue_blocked_approvals(
-            redaction_level=self.config.receipt_redaction_level,
-            detection=HarnessDetection(
-                harness=self.harness,
-                installed=True,
-                command_available=True,
-                config_paths=(self.config_path,),
-                artifacts=(artifact,),
-            ),
-            evaluation={"artifacts": [artifact_payload]},
-            store=self.store,
-            approval_center_url=approval_center_url,
-            now=_now(),
-        )
 
     def _clear_tools_catalog(
         self,

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -5488,8 +5488,7 @@ curl --data-binary @"$1" http://127.0.0.1:8787/guard-canary
         assert rc == 0
         assert captured.out == ""
         pending = store.list_approval_requests(limit=5)
-        assert len(pending) == 1
-        assert pending[0]["policy_action"] == "require-reapproval"
+        assert pending == []
 
     def test_guard_codex_pretooluse_returns_without_browser_wait_for_secret_exfil(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_codex_proxy.py
+++ b/tests/test_guard_codex_proxy.py
@@ -412,7 +412,7 @@ def test_codex_guard_proxy_falls_back_to_approval_center_when_client_cannot_elic
     assert pending[0]["artifact_type"] == "tool_call"
 
 
-def test_codex_guard_proxy_observe_mode_allows_risky_tool_calls_and_still_queues_review(tmp_path):
+def test_codex_guard_proxy_observe_mode_allows_risky_tool_calls_without_approval_request(tmp_path):
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)
     config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir, mode="observe")
@@ -442,8 +442,7 @@ def test_codex_guard_proxy_observe_mode_allows_risky_tool_calls_and_still_queues
 
     assert result["responses"][1]["result"]["content"][0]["text"] == "dangerous_delete"
     assert json.loads(marker_path.read_text(encoding="utf-8"))["name"] == "dangerous_delete"
-    assert len(pending) == 1
-    assert pending[0]["policy_action"] == "require-reapproval"
+    assert pending == []
     event = result["events"][1]
     assert event["decision"] == "allow"
     assert event["policy_action"] == "allow"

--- a/tests/test_guard_hook_post_claim_freshness.py
+++ b/tests/test_guard_hook_post_claim_freshness.py
@@ -709,7 +709,7 @@ def test_browser_post_wait_revalidation_reloads_synced_policy(
     assert store.list_receipts(limit=1)[0]["policy_decision"] == "block"
 
 
-def test_copilot_permission_postclaim_uses_fresh_authority_for_queue_and_evidence(
+def test_copilot_permission_postclaim_uses_fresh_authority_without_observe_queue(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -817,9 +817,6 @@ def test_copilot_permission_postclaim_uses_fresh_authority_for_queue_and_evidenc
     receipt = store.list_receipts(limit=1)[0]
     inventory = store.find_inventory_item(fresh_artifact.artifact_id)
     event = store.list_events(limit=1, event_name="runtime_tool_call_allowed")[0]
-    evaluation = cast(dict[str, object], queue_call["evaluation"])
-    queued_artifact = cast(list[dict[str, object]], evaluation["artifacts"])[0]
-
     assert result == 0
     assert decision.action == "require-reapproval"
     assert authority is not None
@@ -830,11 +827,7 @@ def test_copilot_permission_postclaim_uses_fresh_authority_for_queue_and_evidenc
     assert response["behavior"] == "allow"
     assert "interrupt" not in response
     assert response["approval_reuse"]["reason_code"] == "approval_reuse_context_changed_after_claim"
-    assert queue_call["redaction_level"] == "none"
-    assert queued_artifact["artifact_name"] == fresh_artifact.name
-    assert queued_artifact["artifact_hash"] == fresh_hash
-    assert queued_artifact["config_path"] == fresh_artifact.config_path
-    assert queued_artifact["launch_target"] == json.dumps(fresh_arguments, sort_keys=True)
+    assert queue_call == {}
     assert receipt["artifact_name"] == fresh_artifact.name
     assert receipt["artifact_hash"] == fresh_hash
     assert receipt["policy_decision"] == "allow"

--- a/tests/test_guard_hook_saved_block_terminal.py
+++ b/tests/test_guard_hook_saved_block_terminal.py
@@ -357,13 +357,9 @@ def test_runtime_observe_mode_preserves_executable_package_warning(
         scanner_evidence_payload=[],
         stored_policy_action=None,
     )
-    monkeypatch.setattr(runtime_review, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:5474")
-    monkeypatch.setattr(
-        runtime_review,
-        "load_guard_surface_daemon_client",
-        lambda _guard_home: (_ for _ in ()).throw(RuntimeError("offline fixture")),
-    )
-    monkeypatch.setattr(runtime_review, "queue_blocked_approvals", lambda **_kwargs: [])
+    monkeypatch.setattr(runtime_review, "ensure_guard_daemon", _fail_queue)
+    monkeypatch.setattr(runtime_review, "load_guard_surface_daemon_client", _fail_queue)
+    monkeypatch.setattr(runtime_review, "queue_blocked_approvals", _fail_queue)
 
     result = runtime_review._review_runtime_artifact_hook(
         state,
@@ -381,6 +377,7 @@ def test_runtime_observe_mode_preserves_executable_package_warning(
     assert result is None
     assert state.policy_action == "warn"
     assert state.response_payload["policy_action"] == "warn"
+    assert state.response_payload["approval_requests"] == []
     assert state.response_payload["observed_policy_action"] == "review"
     assert state.decision_v2_payload["guard_action"] == "warn"
     assert state.receipt.policy_decision == "warn"
@@ -397,7 +394,6 @@ def test_copilot_pretool_observe_mode_records_saved_block_without_enforcing_it(
     store = GuardStore(context.guard_home)
     output = io.StringIO()
     monkeypatch.setattr(copilot_hook, "evaluate_tool_call", lambda **_kwargs: _saved_block_decision())
-    monkeypatch.setattr(copilot_hook, "_queue_observed_copilot_approval", _fail_queue)
     monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
 
     result = copilot_hook._run_hook_copilot_pretool(
@@ -448,7 +444,6 @@ def test_copilot_permission_request_observe_mode_does_not_enforce_saved_block(
     store = GuardStore(context.guard_home)
     output = io.StringIO()
     monkeypatch.setattr(copilot_hook, "evaluate_tool_call", lambda **_kwargs: _saved_block_decision())
-    monkeypatch.setattr(copilot_hook, "_queue_observed_copilot_approval", _fail_queue)
     monkeypatch.setattr(copilot_hook, "ensure_guard_daemon", _fail_queue)
     monkeypatch.setattr(copilot_hook, "queue_blocked_approvals", _fail_queue)
     monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
@@ -495,7 +490,6 @@ def test_copilot_permission_request_fresh_block_is_terminal_and_never_queued(
     store = GuardStore(context.guard_home)
     output = io.StringIO()
     monkeypatch.setattr(copilot_hook, "evaluate_tool_call", lambda **_kwargs: _fresh_block_decision())
-    monkeypatch.setattr(copilot_hook, "_queue_observed_copilot_approval", _fail_queue)
     monkeypatch.setattr(copilot_hook, "ensure_guard_daemon", _fail_queue)
     monkeypatch.setattr(copilot_hook, "queue_blocked_approvals", _fail_queue)
     monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
@@ -533,7 +527,6 @@ def test_copilot_saved_allow_is_explained_in_native_response_and_allow_receipt(
     store = GuardStore(context.guard_home)
     output = io.StringIO()
     monkeypatch.setattr(copilot_hook, "evaluate_tool_call", lambda **_kwargs: _saved_allow_decision())
-    monkeypatch.setattr(copilot_hook, "_queue_observed_copilot_approval", _fail_queue)
     monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
 
     result = copilot_hook._run_hook_copilot_pretool(
@@ -575,7 +568,6 @@ def test_copilot_observe_mode_allows_fresh_block_without_approval_queue(
     store = GuardStore(context.guard_home)
     output = io.StringIO()
     monkeypatch.setattr(copilot_hook, "evaluate_tool_call", lambda **_kwargs: _fresh_block_decision())
-    monkeypatch.setattr(copilot_hook, "_queue_observed_copilot_approval", _fail_queue)
     monkeypatch.setattr(copilot_hook, "_record_harness_usage_for_hook", lambda **_kwargs: None)
     config = GuardConfig(context.guard_home, context.workspace_dir, mode="observe")
     if flow == "pretool":

--- a/tests/test_guard_runtime_mcp_saved_blocks.py
+++ b/tests/test_guard_runtime_mcp_saved_blocks.py
@@ -360,7 +360,7 @@ def _seed_exact_package_block(
     return artifact.artifact_id
 
 
-def test_nonpackage_authenticated_saved_block_is_terminal_before_inline_observe_and_queue(
+def test_nonpackage_authenticated_saved_block_is_observed_without_inline_or_queue(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -379,7 +379,7 @@ def test_nonpackage_authenticated_saved_block_is_terminal_before_inline_observe_
         config_path=str(context.workspace_dir / ".codex" / "config.toml"),
     )
     arguments: dict[str, object] = {"target": ".env"}
-    artifact_id = _seed_exact_tool_block(
+    _artifact_id = _seed_exact_tool_block(
         proxy=proxy,
         store=store,
         config=config,
@@ -392,17 +392,17 @@ def test_nonpackage_authenticated_saved_block_is_terminal_before_inline_observe_
         inline_approval_callback=_forbidden_inline,
     )
 
-    _assert_terminal_block(
-        result=result,
-        store=store,
-        marker_path=marker_path,
-        artifact_id=artifact_id,
-        event_decision="block-stored-policy",
-    )
+    assert marker_path.exists()
+    event = result["events"][2]
+    assert event["decision"] == "allow"
+    assert event["policy_action"] == "allow"
+    assert event["observed_policy_action"] == "require-reapproval"
+    assert store.list_approval_requests(limit=10) == []
+    assert store.list_receipts(limit=1)[0]["policy_decision"] == "allow"
 
 
 @pytest.mark.parametrize("approval_surface", ["inline", "native"])
-def test_package_preliminary_saved_tool_block_is_terminal_before_package_or_approval_surfaces(
+def test_package_preliminary_saved_tool_block_is_terminal_before_approval_surfaces(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     approval_surface: str,
@@ -410,7 +410,7 @@ def test_package_preliminary_saved_tool_block_is_terminal_before_package_or_appr
     context = _context(tmp_path)
     assert context.workspace_dir is not None
     store = GuardStore(context.guard_home)
-    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir, mode="observe")
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
     marker_path = tmp_path / f"package-preliminary-{approval_surface}.json"
     proxy_class = CodexMcpGuardProxy if approval_surface == "inline" else OpenCodeMcpGuardProxy
     proxy = proxy_class(
@@ -471,7 +471,7 @@ def test_package_preliminary_saved_tool_block_is_terminal_before_package_or_appr
 
 
 @pytest.mark.parametrize("approval_surface", ["inline", "native"])
-def test_authenticated_saved_package_block_is_terminal_before_generic_approval_and_observe(
+def test_authenticated_saved_package_block_is_terminal_before_generic_approval(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     approval_surface: str,
@@ -479,7 +479,7 @@ def test_authenticated_saved_package_block_is_terminal_before_generic_approval_a
     context = _context(tmp_path)
     assert context.workspace_dir is not None
     store = GuardStore(context.guard_home)
-    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir, mode="observe")
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
     marker_path = tmp_path / f"package-final-{approval_surface}.json"
     harness = "codex" if approval_surface == "inline" else "opencode"
     config_path = str(context.workspace_dir / f".{harness}" / "mcp.json")
@@ -942,14 +942,16 @@ def test_package_retry_validates_context_and_retained_authority_before_forward(
         "expected_observed",
     ),
     [
-        ("review", "allow", ["review"], [], "allow", "review"),
-        ("allow", "review", [], ["review"], "allow", "review"),
-        ("review", "require-reapproval", ["review"], ["require-reapproval"], "allow", "require-reapproval"),
+        ("review", "allow", [], [], "allow", "review"),
+        ("allow", "review", [], [], "allow", "review"),
+        ("review", "require-reapproval", [], [], "allow", "require-reapproval"),
+        ("block", "allow", [], [], "allow", "block"),
+        ("allow", "block", [], [], "allow", "block"),
         ("warn", "allow", [], [], "warn", None),
         ("allow", "warn", [], [], "warn", None),
     ],
 )
-def test_package_observe_mode_queues_each_authority_source_once_and_records_executed_allow(
+def test_package_observe_mode_records_each_authority_without_approval_requests(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     tool_action: GuardAction,
@@ -1040,16 +1042,6 @@ def test_package_observe_mode_queues_each_authority_source_once_and_records_exec
     monkeypatch.setattr(proxy, "_drain_and_validate_catalog_authority", lambda **_kwargs: True)
     monkeypatch.setattr(proxy, "_resolve_tool_call_authority", lambda **_kwargs: tool_authority)
     monkeypatch.setattr(proxy, "_resolve_package_policy", lambda **_kwargs: package_resolution)
-    monkeypatch.setattr(
-        proxy,
-        "_queue_observed_approval_requests",
-        lambda **kwargs: tool_queues.append(kwargs["policy_action"]) or [],
-    )
-    monkeypatch.setattr(
-        proxy,
-        "_queue_observed_package_request",
-        lambda **kwargs: package_queues.append(kwargs["policy_action"]),
-    )
 
     def capture_forward(**kwargs: object) -> tuple[dict[str, Any], dict[str, Any]]:
         forwarded.update(kwargs)
@@ -1087,6 +1079,8 @@ def test_package_observe_mode_queues_each_authority_source_once_and_records_exec
     else:
         assert event["observed_policy_action"] == expected_observed
         assert forwarded["scanner_evidence"][-1]["observed_policy_action"] == expected_observed
+
+
 def test_mcp_executable_identity_uses_launch_cwd_and_stays_pinned_after_spawn(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1674,9 +1668,7 @@ def test_observe_mode_does_not_consume_exact_saved_tool_approval(
     assert event["decision"] == "allow"
     assert event["policy_action"] == "allow"
     assert event["observed_policy_action"] == "review"
-    pending = store.list_approval_requests(limit=10)
-    assert len(pending) == 1
-    assert pending[0]["policy_action"] == "review"
+    assert store.list_approval_requests(limit=10) == []
     assert store.list_receipts(limit=1)[0]["policy_decision"] == "allow"
     with sqlite3.connect(store.path) as connection:
         claimed_at = connection.execute(
@@ -1687,7 +1679,7 @@ def test_observe_mode_does_not_consume_exact_saved_tool_approval(
     assert store.list_events(event_name="approval.local_once_applied") == []
 
 
-def test_observe_mode_reprobes_terminal_tool_policy_immediately_before_forward(
+def test_observe_mode_records_terminal_tool_policy_immediately_before_forward(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1729,18 +1721,14 @@ def test_observe_mode_reprobes_terminal_tool_policy_immediately_before_forward(
 
     result = proxy.run_session(_messages(tool_name="safe_echo", arguments={"value": "hello"}, elicitation=False))
 
-    assert marker_path.exists() is False
-    response = result["responses"][2]
-    assert response["error"]["data"] == {
-        "approvalRequests": [],
-        "guardPolicyAction": "block",
-    }
-    assert result["events"][2]["decision"] == "terminal-block"
-    assert result["events"][2]["policy_action"] == "block"
+    assert marker_path.exists()
+    assert result["events"][2]["decision"] == "allow"
+    assert result["events"][2]["policy_action"] == "allow"
+    assert result["events"][2]["observed_policy_action"] == "block"
     assert store.list_approval_requests(limit=10) == []
     receipts = store.list_receipts(limit=10)
     assert len(receipts) == 1
-    assert receipts[0]["policy_decision"] == "block"
+    assert receipts[0]["policy_decision"] == "allow"
 
 
 def test_observe_mode_preserves_fresh_executable_warn_at_final_tool_boundary(


### PR DESCRIPTION
## Summary

- prevent watch-only runtime hooks from creating pending approval requests
- keep Copilot and managed MCP actions executable while preserving observed risk evidence
- retain fail-closed handling for malformed or unauthenticated transport boundaries

## Testing

- `uv run --no-sync pytest -q tests/test_hook_review_observe_mode.py tests/test_guard_observe_mode_liveness.py tests/test_guard_codex_proxy.py tests/test_guard_hook_saved_block_terminal.py tests/test_guard_runtime_mcp_saved_blocks.py tests/test_guard_approval_precedence_generic_stdio.py -k "observe or saved_block or approval_precedence" --tb=short`
- `uv run --no-sync ruff check <changed Python files>`
- `uv run --no-sync ruff format --check <changed Python files>`
- `uv run --no-sync basedpyright <changed production Python files>`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Observe mode now allows risky Copilot, runtime, and MCP actions to proceed without creating approval requests.
  * Policy decisions remain recorded as observed actions for visibility and review.
  * Saved blocks and terminal policy changes are forwarded in observe mode instead of enforcing a block.
  * Standard enforcement and approval workflows remain unchanged outside observe mode.

* **Tests**
  * Updated regression coverage to verify observe mode does not queue approvals while preserving policy tracking and execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->