### PR TITLE
fix(packaging): constrain baseline LiteLLM resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.13"]
+        python-version: ["3.10", "3.11", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
@@ -191,6 +191,7 @@ jobs:
           tests/test_cli.py
           tests/test_verification.py
           tests/test_action_runner.py
+          tests/test_cisco_install_surfaces.py
           tests/test_policy.py
           tests/test_policy_bundle_parser.py
           --tb=short

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ source .venv/bin/activate
 pip install -e ".[dev,cisco]"
 ```
 
-The editable Cisco extra is intended for Python 3.11+ contributor environments and keeps published metadata resolver-safe. Use uv with `--group cisco-mcp` when you need the repo-controlled Cisco MCP scanner surface.
+The editable Cisco extra is intended for Python 3.11+ contributor environments. The baseline package directly constrains its LiteLLM transitive dependency so published bare installs stay resolver-safe; use uv with `--group cisco-mcp` when you need the repo-controlled Cisco MCP scanner surface.
 
 ## Validation Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ source .venv/bin/activate
 pip install -e ".[dev,cisco]"
 ```
 
-The editable Cisco extra is intended for Python 3.11+ contributor environments. The baseline package directly constrains its LiteLLM transitive dependency so published bare installs stay resolver-safe; use uv with `--group cisco-mcp` when you need the repo-controlled Cisco MCP scanner surface.
+The editable Cisco extra is intended for Python 3.11 through 3.14 contributor environments. The baseline package directly constrains its LiteLLM transitive dependency so published bare installs stay resolver-safe; use uv with `--group cisco-mcp` when you need the repo-controlled Cisco MCP scanner surface.
 
 ## Validation Requirements
 

--- a/README.md
+++ b/README.md
@@ -374,11 +374,11 @@ Scanner package:
 pip install plugin-scanner
 ```
 
-The lean baseline keeps Python 3.10+ support intact. It includes the shipped `cisco-ai-skill-scanner` integration on Python 3.10 through 3.14 with LiteLLM 1.93+ for resolver-safe Cisco evidence.
+The lean baseline keeps Python 3.10+ support intact. It includes the shipped `cisco-ai-skill-scanner` integration on Python 3.10 through 3.14 and directly pins LiteLLM 1.93.0 so bare `pip` and `pipx` installs cannot drift to an unverified LiteLLM release.
 
 ### Resolver-safe Cisco extra
 
-Install the Cisco extra on Python 3.11 through 3.14 when you want the Cisco-compatible LiteLLM pin in addition to the baseline skill scanner:
+Install the Cisco extra on Python 3.11 through 3.14 when you want to explicitly select the Cisco dependency surface in addition to the baseline skill scanner:
 
 ```bash
 pip install "hol-guard[cisco]"

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 11962,
-  "maximum_test_source_lines": 279887,
+  "maximum_test_source_lines": 279893,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11961,
-  "maximum_test_source_lines": 279865,
+  "maximum_collected_cases": 11962,
+  "maximum_test_source_lines": 279887,
   "schema_version": 1
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "requests>=2.32,<3",
     "tomli>=2.0; python_version < '3.11'",
     "cisco-ai-skill-scanner~=2.0.12",
+    "litellm==1.93.0; python_version < '3.15'",
     "mcp>=1.28.1,<2; python_version >= '3.10'",
 ]
 

--- a/tests/test_cisco_install_surfaces.py
+++ b/tests/test_cisco_install_surfaces.py
@@ -68,8 +68,14 @@ def test_installed_metadata_constrains_baseline_litellm_on_python_314() -> None:
     assert len(baseline_litellm) == 1
     assert str(baseline_litellm[0].specifier) == "==1.93.0"
 
-    python_314 = default_environment() | {"python_full_version": "3.14.6", "python_version": "3.14"}
-    python_315 = default_environment() | {"python_full_version": "3.15.0", "python_version": "3.15"}
+    python_314: dict[str, str] = default_environment() | {
+        "python_full_version": "3.14.6",
+        "python_version": "3.14",
+    }
+    python_315: dict[str, str] = default_environment() | {
+        "python_full_version": "3.15.0",
+        "python_version": "3.15",
+    }
     assert baseline_litellm[0].marker is not None
     assert baseline_litellm[0].marker.evaluate(python_314)
     assert not baseline_litellm[0].marker.evaluate(python_315)

--- a/tests/test_cisco_install_surfaces.py
+++ b/tests/test_cisco_install_surfaces.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import sys
+from importlib.metadata import metadata
 from pathlib import Path
+
+from packaging.markers import default_environment
+from packaging.requirements import Requirement
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -32,6 +36,7 @@ def test_pyproject_keeps_cisco_mcp_scanner_optional() -> None:
     assert "python_version < '3.15'" in cisco_extra
     assert "python_full_version >= '3.11.4'" in cisco_mcp_group
     assert "cisco-ai-skill-scanner~=2.0.12" in dependency_entries
+    assert "litellm==1.93.0; python_version < '3.15'" in dependency_entries
     assert "requests>=2.32,<3" in dependency_entries
     assert "aiohttp==3.14.1" in override_entries
     assert "click==8.4.1" in override_entries
@@ -51,6 +56,23 @@ def test_pyproject_keeps_cisco_mcp_scanner_optional() -> None:
     assert "cisco-ai-a2a-scanner" not in cisco_extra
     assert "rich>=14.0,<15" in dependency_entries
     assert "rich>=15.0.0" not in dependency_entries
+
+
+def test_installed_metadata_constrains_baseline_litellm_on_python_314() -> None:
+    requirements = [Requirement(value) for value in metadata("hol-guard").get_all("Requires-Dist", [])]
+    baseline_litellm = [
+        requirement
+        for requirement in requirements
+        if requirement.name == "litellm" and "extra" not in str(requirement.marker)
+    ]
+    assert len(baseline_litellm) == 1
+    assert str(baseline_litellm[0].specifier) == "==1.93.0"
+
+    python_314 = default_environment() | {"python_full_version": "3.14.6", "python_version": "3.14"}
+    python_315 = default_environment() | {"python_full_version": "3.15.0", "python_version": "3.15"}
+    assert baseline_litellm[0].marker is not None
+    assert baseline_litellm[0].marker.evaluate(python_314)
+    assert not baseline_litellm[0].marker.evaluate(python_315)
 
 
 def test_pyproject_exposes_guard_and_scanner_commands_without_codex_alias() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -323,8 +323,8 @@ name = "cachecontrol"
 version = "0.14.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "msgpack", marker = "python_full_version >= '3.11.4'" },
-    { name = "requests", marker = "python_full_version >= '3.11.4'" },
+    { name = "msgpack" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
 wheels = [
@@ -333,7 +333,7 @@ wheels = [
 
 [package.optional-dependencies]
 filecache = [
-    { name = "filelock", marker = "python_full_version >= '3.11.4'" },
+    { name = "filelock" },
 ]
 
 [[package]]
@@ -537,29 +537,29 @@ name = "cisco-ai-mcp-scanner"
 version = "4.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "expandvars", marker = "python_full_version >= '3.11.4'" },
-    { name = "fastapi", marker = "python_full_version >= '3.11.4'" },
-    { name = "httpx", marker = "python_full_version >= '3.11.4'" },
-    { name = "litellm", marker = "python_full_version >= '3.11.4'" },
-    { name = "mcp", extra = ["cli"], marker = "python_full_version >= '3.11.4'" },
-    { name = "pip-audit", marker = "python_full_version >= '3.11.4'" },
-    { name = "puremagic", version = "1.30", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11.4' and python_full_version < '3.12'" },
+    { name = "expandvars" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "litellm" },
+    { name = "mcp", extra = ["cli"] },
+    { name = "pip-audit" },
+    { name = "puremagic", version = "1.30", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "puremagic", version = "2.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11.4'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.11.4'" },
-    { name = "tree-sitter", marker = "python_full_version >= '3.11.4'" },
-    { name = "tree-sitter-c-sharp", marker = "python_full_version >= '3.11.4'" },
-    { name = "tree-sitter-go", marker = "python_full_version >= '3.11.4'" },
-    { name = "tree-sitter-java", marker = "python_full_version >= '3.11.4'" },
-    { name = "tree-sitter-javascript", marker = "python_full_version >= '3.11.4'" },
-    { name = "tree-sitter-kotlin", marker = "python_full_version >= '3.11.4'" },
-    { name = "tree-sitter-php", marker = "python_full_version >= '3.11.4'" },
-    { name = "tree-sitter-python", marker = "python_full_version >= '3.11.4'" },
-    { name = "tree-sitter-ruby", marker = "python_full_version >= '3.11.4'" },
-    { name = "tree-sitter-rust", marker = "python_full_version >= '3.11.4'" },
-    { name = "tree-sitter-typescript", marker = "python_full_version >= '3.11.4'" },
-    { name = "uvicorn", marker = "python_full_version >= '3.11.4'" },
-    { name = "yara-python", marker = "python_full_version >= '3.11.4'" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-c-sharp" },
+    { name = "tree-sitter-go" },
+    { name = "tree-sitter-java" },
+    { name = "tree-sitter-javascript" },
+    { name = "tree-sitter-kotlin" },
+    { name = "tree-sitter-php" },
+    { name = "tree-sitter-python" },
+    { name = "tree-sitter-ruby" },
+    { name = "tree-sitter-rust" },
+    { name = "tree-sitter-typescript" },
+    { name = "uvicorn" },
+    { name = "yara-python" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4f/ba/06769744615e2cf7b765dbc161c2368fa94b0d08470b515e9cc326d9df56/cisco_ai_mcp_scanner-4.8.1.tar.gz", hash = "sha256:7555dad407e50f5cd144de682732cba1a471bc507e87661f6001bdf054c208c5", size = 552101, upload-time = "2026-07-21T19:10:55.721Z" }
 wheels = [
@@ -631,7 +631,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly", marker = "python_full_version < '3.13'" },
+    { name = "humanfriendly" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -827,12 +827,12 @@ name = "cyclonedx-python-lib"
 version = "11.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonschema", marker = "python_full_version >= '3.11.4'" },
-    { name = "license-expression", marker = "python_full_version >= '3.11.4'" },
-    { name = "packageurl-python", marker = "python_full_version >= '3.11.4'" },
-    { name = "py-serializable", marker = "python_full_version >= '3.11.4'" },
-    { name = "sortedcontainers", marker = "python_full_version >= '3.11.4'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11.4' and python_full_version < '3.13'" },
+    { name = "jsonschema" },
+    { name = "license-expression" },
+    { name = "packageurl-python" },
+    { name = "py-serializable" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/75/c9/5d0ccdd19bc7d8ab803b90695c1706aa2ea8529685d18e682dc2524d2630/cyclonedx_python_lib-11.11.0.tar.gz", hash = "sha256:4b3194db72b613717f2912447e67ab618c75ff7dcac6c4af3c0e9e1ac617c102", size = 1442983, upload-time = "2026-06-17T11:57:49.055Z" }
 wheels = [
@@ -889,7 +889,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1180,6 +1180,7 @@ dependencies = [
     { name = "cisco-ai-skill-scanner" },
     { name = "cryptography" },
     { name = "keyring" },
+    { name = "litellm" },
     { name = "mcp" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -1224,6 +1225,7 @@ requires-dist = [
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.26.0" },
     { name = "keyring", specifier = ">=25.0" },
     { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.15' and extra == 'cisco'", specifier = "==1.93.0" },
+    { name = "litellm", marker = "python_full_version < '3.15'", specifier = "==1.93.0" },
     { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.28.1,<2" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pyinstaller", marker = "extra == 'mdm-build'", specifier = ">=6.16,<7" },
@@ -1347,7 +1349,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -1668,7 +1670,7 @@ name = "license-expression"
 version = "30.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "boolean-py", marker = "python_full_version >= '3.11.4'" },
+    { name = "boolean-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
 wheels = [
@@ -1724,7 +1726,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph", marker = "sys_platform != 'win32'" },
+    { name = "altgraph" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -1877,8 +1879,8 @@ wheels = [
 
 [package.optional-dependencies]
 cli = [
-    { name = "python-dotenv", marker = "python_full_version >= '3.11.4'" },
-    { name = "typer", marker = "python_full_version >= '3.11.4'" },
+    { name = "python-dotenv" },
+    { name = "typer" },
 ]
 
 [[package]]
@@ -2410,13 +2412,13 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "coloredlogs", marker = "python_full_version < '3.13'" },
-    { name = "flatbuffers", marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "packaging", marker = "python_full_version < '3.13'" },
-    { name = "protobuf", marker = "python_full_version < '3.13'" },
-    { name = "sympy", marker = "python_full_version < '3.13'" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/28/99f903b0eb1cd6f3faa0e343217d9fb9f47b84bca98bd9859884631336ee/onnxruntime-1.20.1-cp310-cp310-macosx_13_0_universal2.whl", hash = "sha256:e50ba5ff7fed4f7d9253a6baf801ca2883cc08491f9d32d78a80da57256a5439", size = 30996314, upload-time = "2024-11-21T00:48:31.43Z" },
@@ -2453,10 +2455,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "flatbuffers", marker = "python_full_version >= '3.13'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "packaging", marker = "python_full_version >= '3.13'" },
-    { name = "protobuf", marker = "python_full_version >= '3.13'" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "protobuf" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/e4/5353d7e09ced4a8f473f843223fc75d726b2b5519dcefc12f22a6c92852d/onnxruntime-1.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8ba14a38c570087f3cdb8cfba33f7a38a1e826c1e5b29e17c28ceda0cc910016", size = 18416484, upload-time = "2026-06-15T22:43:43.894Z" },
@@ -2567,7 +2569,7 @@ name = "pip-api"
 version = "0.0.34"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pip", marker = "python_full_version >= '3.11.4'" },
+    { name = "pip" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
 wheels = [
@@ -2579,16 +2581,16 @@ name = "pip-audit"
 version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cachecontrol", extra = ["filecache"], marker = "python_full_version >= '3.11.4'" },
-    { name = "cyclonedx-python-lib", marker = "python_full_version >= '3.11.4'" },
-    { name = "packaging", marker = "python_full_version >= '3.11.4'" },
-    { name = "pip-api", marker = "python_full_version >= '3.11.4'" },
-    { name = "pip-requirements-parser", marker = "python_full_version >= '3.11.4'" },
-    { name = "platformdirs", marker = "python_full_version >= '3.11.4'" },
-    { name = "requests", marker = "python_full_version >= '3.11.4'" },
-    { name = "rich", marker = "python_full_version >= '3.11.4'" },
-    { name = "tomli", marker = "python_full_version >= '3.11.4'" },
-    { name = "tomli-w", marker = "python_full_version >= '3.11.4'" },
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "cyclonedx-python-lib" },
+    { name = "packaging" },
+    { name = "pip-api" },
+    { name = "pip-requirements-parser" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a4/f21d5f0a0edabcbce31560b73c7c5a6f72ae87af4236fd1069c8f59a353d/pip_audit-2.10.1.tar.gz", hash = "sha256:1eb4565d19ebe5d48996f4b770b4d2b32887e12cb12cfa637f1a064011b55ffc", size = 54275, upload-time = "2026-06-10T22:17:01.744Z" }
 wheels = [
@@ -2600,8 +2602,8 @@ name = "pip-requirements-parser"
 version = "32.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "python_full_version >= '3.11.4'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.11.4'" },
+    { name = "packaging" },
+    { name = "pyparsing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
 wheels = [
@@ -2790,7 +2792,7 @@ name = "py-serializable"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "defusedxml", marker = "python_full_version >= '3.11.4'" },
+    { name = "defusedxml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
 wheels = [
@@ -3574,8 +3576,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -3733,7 +3735,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath", marker = "python_full_version < '3.13'" },
+    { name = "mpmath" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- constrain the baseline `hol-guard` dependency graph to LiteLLM 1.93.0 on supported Python versions
- add Python 3.14 to compatibility CI and verify the installed distribution metadata activates the constraint
- update installation and contributor documentation to describe the resolver-safe baseline

## Root cause

`hol-guard` installs `cisco-ai-skill-scanner` by default, but its known-good LiteLLM 1.93.0 constraint was declared only in the optional `cisco` extra. The public installer installs bare `hol-guard`, so Cisco's broad `litellm>=1.84,<2` requirement floated to LiteLLM 1.95.0.

On macOS ARM with CPython 3.14, LiteLLM 1.95.0 fell back to a Rust source build. Its resolved AWS crates require Rust 1.94.1, causing installation to fail on systems with Rust 1.92.0. Package-index retries could not change that deterministic resolution.

## Impact

Bare `pip` and `pipx` installs now select the validated LiteLLM 1.93.0 release instead of drifting to an incompatible future release, while preserving Cisco scanner support on Python 3.10 through 3.14.

## Validation

- 60 focused packaging, Cisco runtime, release, lockfile, and workflow tests passed
- Ruff lint and formatting checks passed
- `uv lock --check` passed
- built the release wheel successfully
- installed the wheel and all 100 dependencies in an isolated macOS Python 3.14.5 environment
- verified the resolved versions: `hol-guard==2.2.0`, `cisco-ai-skill-scanner==2.0.12`, and `litellm==1.93.0`
- verified `hol-guard --version` and Cisco/LiteLLM imports


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved installation compatibility for Python 3.14.
  * Added validation to ensure Cisco installation surfaces remain correctly configured across supported Python versions.

* **Documentation**
  * Clarified installation guidance for the baseline Cisco skill-scanner integration.
  * Updated instructions for editable Cisco installations and the Cisco MCP workflow.

* **Tests**
  * Expanded compatibility coverage across supported Python versions.
  * Updated test coverage thresholds to reflect the growing test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->