### PR TITLE
fix(update): recover from delayed releases and broken pipx

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11968,
-  "maximum_test_source_lines": 280168,
+  "maximum_collected_cases": 11969,
+  "maximum_test_source_lines": 280197,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11969,
-  "maximum_test_source_lines": 280197,
+  "maximum_collected_cases": 11970,
+  "maximum_test_source_lines": 280222,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11963,
-  "maximum_test_source_lines": 279971,
+  "maximum_collected_cases": 11967,
+  "maximum_test_source_lines": 280108,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 11967,
-  "maximum_test_source_lines": 280108,
+  "maximum_collected_cases": 11968,
+  "maximum_test_source_lines": 280168,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1769,6 +1769,7 @@ def _render_update(console: Console, payload: dict[str, object]) -> None:
         "blocked": "red",
         "updated": "green",
         "skipped": "yellow",
+        "deferred": "yellow",
         "failed": "red",
     }.get(status, "red")
     console.print(Panel(body, title=f"Guard update: {status}", border_style=border_style))

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -59,6 +59,14 @@ _ALREADY_CURRENT_HINTS = (
     "already at latest version",
     "already up-to-date",
 )
+_PIPX_LAUNCHER_FAILURE_HINTS = (
+    "ModuleNotFoundError: No module named 'pipx'",
+    'ModuleNotFoundError: No module named "pipx"',
+)
+_PYPI_PROPAGATION_FAILURE_HINTS = (
+    "No matching distribution found for hol-guard==",
+    "Could not find a version that satisfies the requirement hol-guard==",
+)
 _PYPI_JSON_URL = "https://pypi.org/pypi/hol-guard/json"
 _PYPI_TIMEOUT_SECONDS = 3.0
 _PYPI_RESPONSE_LIMIT_BYTES = 8 * 1024 * 1024
@@ -477,6 +485,7 @@ def run_guard_update(
     active_command = execution_command
     active_display_command = command
     attempted_force_retry = False
+    attempted_pipx_recovery = False
     installer_execution_started = False
     while True:
         try:
@@ -538,8 +547,37 @@ def run_guard_update(
                     retain_trusted_wheel=installer_execution_started,
                 )
         if result.returncode != 0:
+            installer_output = _installer_output_text(payload.get("stdout"), payload.get("stderr"))
+            if (
+                installer == "pipx"
+                and not attempted_pipx_recovery
+                and _contains_any(installer_output, _PIPX_LAUNCHER_FAILURE_HINTS)
+            ):
+                pip_display_command = _update_command(
+                    "pip",
+                    use_pypi=True,
+                    target_version=target_version,
+                )
+                try:
+                    active_command = update_context.build_python_pip_command(pip_display_command)
+                except UpdateSubprocessError as error:
+                    return _trusted_update_failure(payload, error, trusted_wheel=trusted_wheel)
+                attempted_pipx_recovery = True
+                active_display_command = pip_display_command
+                payload["installer_recovery"] = "trusted_python_pip"
+                continue
+            if _contains_any(installer_output, _PYPI_PROPAGATION_FAILURE_HINTS):
+                payload["status"] = "deferred"
+                payload["changed"] = False
+                payload["reason_code"] = "update_release_propagating"
+                payload["message"] = (
+                    "The newest HOL Guard release is still reaching PyPI. "
+                    "Your current installation remains active; try the update again shortly."
+                )
+                payload.pop("retry_command", None)
+                return payload, 0
             conflict_message = _dependency_conflict_message(
-                _installer_output_text(payload.get("stdout"), payload.get("stderr")),
+                installer_output,
             )
             if conflict_message:
                 payload["status"] = "blocked"
@@ -1379,6 +1417,10 @@ def _target_version_is_prerelease(target_version: str | None) -> bool:
 
 def _installer_output_text(stdout: object, stderr: object) -> str:
     return "\n".join(part.strip() for part in (str(stdout or "").strip(), str(stderr or "").strip()) if part.strip())
+
+
+def _contains_any(value: str, candidates: tuple[str, ...]) -> bool:
+    return any(candidate in value for candidate in candidates)
 
 
 def _dependency_conflict_message(installer_output: str) -> str | None:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -67,6 +67,26 @@ _PYPI_PROPAGATION_FAILURE_HINTS = (
     "No matching distribution found for hol-guard==",
     "Could not find a version that satisfies the requirement hol-guard==",
 )
+_PYPI_PROPAGATION_EXCLUSION_HINTS = (
+    "401",
+    "403",
+    "authentication",
+    "certificate verify failed",
+    "connection error",
+    "connection refused",
+    "connection reset",
+    "could not fetch url",
+    "credential",
+    "forbidden",
+    "invalid index",
+    "name or service not known",
+    "ssl",
+    "temporary failure in name resolution",
+    "timed out",
+    "timeout",
+    "tls",
+    "unauthorized",
+)
 _PYPI_JSON_URL = "https://pypi.org/pypi/hol-guard/json"
 _PYPI_TIMEOUT_SECONDS = 3.0
 _PYPI_RESPONSE_LIMIT_BYTES = 8 * 1024 * 1024
@@ -557,10 +577,7 @@ def run_guard_update(
                 active_display_command = pip_display_command
                 payload["installer_recovery"] = "trusted_python_pip"
                 continue
-            if requested_wheel_path is None and _contains_any(
-                installer_output,
-                _PYPI_PROPAGATION_FAILURE_HINTS,
-            ):
+            if requested_wheel_path is None and _is_pypi_propagation_failure(installer_output):
                 payload["status"] = "deferred"
                 payload["changed"] = False
                 payload["reason_code"] = "update_release_propagating"
@@ -1431,6 +1448,13 @@ def _installer_output_text(stdout: object, stderr: object) -> str:
 
 def _contains_any(value: str, candidates: tuple[str, ...]) -> bool:
     return any(candidate in value for candidate in candidates)
+
+
+def _is_pypi_propagation_failure(installer_output: str) -> bool:
+    if not _contains_any(installer_output, _PYPI_PROPAGATION_FAILURE_HINTS):
+        return False
+    lowered = installer_output.lower()
+    return not _contains_any(lowered, _PYPI_PROPAGATION_EXCLUSION_HINTS)
 
 
 def _dependency_conflict_message(installer_output: str) -> str | None:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -557,7 +557,10 @@ def run_guard_update(
                 active_display_command = pip_display_command
                 payload["installer_recovery"] = "trusted_python_pip"
                 continue
-            if _contains_any(installer_output, _PYPI_PROPAGATION_FAILURE_HINTS):
+            if requested_wheel_path is None and _contains_any(
+                installer_output,
+                _PYPI_PROPAGATION_FAILURE_HINTS,
+            ):
                 payload["status"] = "deferred"
                 payload["changed"] = False
                 payload["reason_code"] = "update_release_propagating"

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -530,22 +530,6 @@ def run_guard_update(
             )
         initial_version_check = payload.get("version_check")
         resulting_version = str(payload.get("resulting_version") or current_version)
-        if trusted_wheel is not None:
-            try:
-                if Version(resulting_version) != Version(trusted_wheel.version):
-                    return _trusted_update_failure(
-                        payload,
-                        UpdateSubprocessError("update_version_mismatch"),
-                        trusted_wheel=trusted_wheel,
-                        retain_trusted_wheel=installer_execution_started,
-                    )
-            except InvalidVersion:
-                return _trusted_update_failure(
-                    payload,
-                    UpdateSubprocessError("update_version_output_invalid"),
-                    trusted_wheel=trusted_wheel,
-                    retain_trusted_wheel=installer_execution_started,
-                )
         if result.returncode != 0:
             installer_output = _installer_output_text(payload.get("stdout"), payload.get("stderr"))
             if (
@@ -555,11 +539,18 @@ def run_guard_update(
             ):
                 pip_display_command = _update_command(
                     "pip",
-                    use_pypi=True,
+                    use_pypi=trusted_wheel is None,
                     target_version=target_version,
+                    wheel_path=requested_wheel_path if trusted_wheel is not None else None,
+                )
+                pip_execution_display_command = _update_command(
+                    "pip",
+                    use_pypi=trusted_wheel is None,
+                    target_version=target_version,
+                    wheel_path=trusted_wheel.staged_path if trusted_wheel is not None else None,
                 )
                 try:
-                    active_command = update_context.build_python_pip_command(pip_display_command)
+                    active_command = update_context.build_python_pip_command(pip_execution_display_command)
                 except UpdateSubprocessError as error:
                     return _trusted_update_failure(payload, error, trusted_wheel=trusted_wheel)
                 attempted_pipx_recovery = True
@@ -595,6 +586,22 @@ def run_guard_update(
             if trusted_wheel is not None:
                 _retain_local_wheel_staging(payload)
             return payload, 1
+        if trusted_wheel is not None:
+            try:
+                if Version(resulting_version) != Version(trusted_wheel.version):
+                    return _trusted_update_failure(
+                        payload,
+                        UpdateSubprocessError("update_version_mismatch"),
+                        trusted_wheel=trusted_wheel,
+                        retain_trusted_wheel=installer_execution_started,
+                    )
+            except InvalidVersion:
+                return _trusted_update_failure(
+                    payload,
+                    UpdateSubprocessError("update_version_output_invalid"),
+                    trusted_wheel=trusted_wheel,
+                    retain_trusted_wheel=installer_execution_started,
+                )
         if trusted_wheel is not None:
             _record_verified_local_wheel_receipt(
                 payload,

--- a/src/codex_plugin_scanner/guard/cli/update_subprocess.py
+++ b/src/codex_plugin_scanner/guard/cli/update_subprocess.py
@@ -503,6 +503,20 @@ class TrustedUpdateContext:
             )
         raise UpdateSubprocessError("update_installer_untrusted")
 
+    def build_python_pip_command(self, display_command: list[str]) -> list[str]:
+        """Build a pip command through the authenticated Guard interpreter."""
+
+        if len(display_command) < 4 or display_command[1:3] != ["-m", "pip"]:
+            raise UpdateSubprocessError("update_installer_command_invalid")
+        command = self.python_module_command(
+            "pip",
+            "--isolated",
+            "--disable-pip-version-check",
+            "--no-input",
+            *display_command[3:],
+        )
+        return _append_pip_source(command, self.source.index_url)
+
     def run(
         self,
         command: list[str],

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6961,6 +6961,31 @@ url = http://127.0.0.1:8787/guard-canary
         assert "stdout" in output
         assert "pipx could not upgrade hol-guard in the current environment" in output
 
+    def test_guard_update_deferred_output_keeps_propagation_detail_calm(self, capsys):
+        emit_guard_payload(
+            "update",
+            {
+                "current_version": "2.2.1",
+                "installer": "pipx",
+                "command": ["pipx", "install", "--force", "hol-guard==2.2.3"],
+                "dry_run": False,
+                "resulting_version": "2.2.1",
+                "status": "deferred",
+                "message": (
+                    "The newest HOL Guard release is still reaching PyPI. "
+                    "Your current installation remains active; try the update again shortly."
+                ),
+                "stderr": "ERROR: No matching distribution found for hol-guard==2.2.3",
+            },
+            False,
+        )
+
+        output = capsys.readouterr().out
+
+        assert "Guard update: deferred" in output
+        assert "current installation remains active" in output
+        assert "stderr" not in output
+
     def test_guard_uninstall_auto_detects_managed_harnesses(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -212,7 +212,7 @@ def test_update_defers_when_latest_release_is_still_propagating(monkeypatch: pyt
 
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
-    assert exit_code == 0
+    assert exit_code == 0, json.dumps(payload, sort_keys=True)
     assert payload["status"] == "deferred"
     assert payload["reason_code"] == "update_release_propagating"
     assert payload["changed"] is False
@@ -253,7 +253,7 @@ def test_update_recovers_from_broken_pipx_launcher_with_trusted_python(
 
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
-    assert exit_code == 0
+    assert exit_code == 0, payload
     assert payload["status"] == "updated"
     assert payload["installer_recovery"] == "trusted_python_pip"
     assert commands == [
@@ -266,6 +266,66 @@ def test_update_recovers_from_broken_pipx_launcher_with_trusted_python(
             "--upgrade",
             "--force-reinstall",
             "hol-guard==2.2.3",
+        ],
+    ]
+
+
+def test_update_preserves_requested_wheel_during_broken_pipx_recovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wheel = tmp_path / "hol_guard-2.2.3-py3-none-any.whl"
+    wheel.write_bytes(b"wheel")
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.2.1")
+    resulting_versions = iter(("2.2.1", "2.2.3"))
+    monkeypatch.setattr(
+        update_commands,
+        "_current_version_from_subprocess",
+        lambda *_args, **_kwargs: next(resulting_versions),
+    )
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.3")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(update_commands.sys, "executable", "/opt/guard/bin/python")
+    monkeypatch.setattr(update_commands, "_refresh_package_shims_after_update", lambda **_: (None, None))
+    monkeypatch.setattr(update_commands, "_repair_supported_harnesses", lambda **_: ([], []))
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        if command[0] == "pipx":
+            return subprocess.CompletedProcess(
+                command,
+                1,
+                "",
+                "ModuleNotFoundError: No module named 'pipx'",
+            )
+        return subprocess.CompletedProcess(command, 0, "installed local wheel", "")
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False, wheel=str(wheel))
+
+    assert exit_code == 0, json.dumps(payload, sort_keys=True)
+    assert payload["status"] == "updated"
+    assert payload["installer_recovery"] == "trusted_python_pip"
+    assert payload["command"] == [
+        "/opt/guard/bin/python",
+        "-m",
+        "pip",
+        "install",
+        "--force-reinstall",
+        str(wheel),
+    ]
+    assert commands == [
+        ["pipx", "install", "--force", str(wheel)],
+        [
+            "/opt/guard/bin/python",
+            "-m",
+            "pip",
+            "install",
+            "--force-reinstall",
+            str(wheel),
         ],
     ]
 

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -330,6 +330,35 @@ def test_update_preserves_requested_wheel_during_broken_pipx_recovery(
     ]
 
 
+def test_update_does_not_defer_local_wheel_failure_as_registry_propagation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wheel = tmp_path / "hol_guard-2.2.3-py3-none-any.whl"
+    wheel.write_bytes(b"wheel")
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.2.1")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda *_args, **_kwargs: "2.2.1")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.3")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.subprocess,
+        "run",
+        lambda command, **_: subprocess.CompletedProcess(
+            command,
+            1,
+            "",
+            "ERROR: No matching distribution found for hol-guard==2.2.3",
+        ),
+    )
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False, wheel=str(wheel))
+
+    assert exit_code == 1
+    assert payload["status"] == "failed"
+    assert payload["reason_code"] == "update_installer_failed"
+
+
 def test_update_binary_diagnostics_accepts_same_environment_script(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
     monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -193,6 +193,83 @@ def test_update_failure_redacts_output_and_returns_retry_command(monkeypatch: py
     assert payload["binary_diagnostics"]["path_status"] == "path_mismatch"
 
 
+def test_update_defers_when_latest_release_is_still_propagating(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.2.1")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda *_args, **_kwargs: "2.2.1")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.3")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.subprocess,
+        "run",
+        lambda command, **_: subprocess.CompletedProcess(
+            command,
+            1,
+            "",
+            "ERROR: No matching distribution found for hol-guard==2.2.3",
+        ),
+    )
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 0
+    assert payload["status"] == "deferred"
+    assert payload["reason_code"] == "update_release_propagating"
+    assert payload["changed"] is False
+    assert "current installation remains active" in str(payload["message"])
+    assert "retry_command" not in payload
+
+
+def test_update_recovers_from_broken_pipx_launcher_with_trusted_python(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.2.1")
+    resulting_versions = iter(("2.2.1", "2.2.3"))
+    monkeypatch.setattr(
+        update_commands,
+        "_current_version_from_subprocess",
+        lambda *_args, **_kwargs: next(resulting_versions),
+    )
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.3")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(update_commands.sys, "executable", "/opt/guard/bin/python")
+    monkeypatch.setattr(update_commands, "_refresh_package_shims_after_update", lambda **_: (None, None))
+    monkeypatch.setattr(update_commands, "_repair_supported_harnesses", lambda **_: ([], []))
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        if command[0] == "pipx":
+            return subprocess.CompletedProcess(
+                command,
+                1,
+                "",
+                "ModuleNotFoundError: No module named 'pipx'",
+            )
+        return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.2.3", "")
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 0
+    assert payload["status"] == "updated"
+    assert payload["installer_recovery"] == "trusted_python_pip"
+    assert commands == [
+        ["pipx", "install", "--force", "hol-guard==2.2.3"],
+        [
+            "/opt/guard/bin/python",
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "--force-reinstall",
+            "hol-guard==2.2.3",
+        ],
+    ]
+
+
 def test_update_binary_diagnostics_accepts_same_environment_script(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
     monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -359,6 +359,31 @@ def test_update_does_not_defer_local_wheel_failure_as_registry_propagation(
     assert payload["reason_code"] == "update_installer_failed"
 
 
+def test_update_does_not_hide_registry_auth_failure_as_propagation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.2.1")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda *_args, **_kwargs: "2.2.1")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.3")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pip")
+    monkeypatch.setattr(
+        update_commands.subprocess,
+        "run",
+        lambda command, **_: subprocess.CompletedProcess(
+            command,
+            1,
+            "",
+            "ERROR: HTTP error 401 while fetching package index\n"
+            "ERROR: No matching distribution found for hol-guard==2.2.3",
+        ),
+    )
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 1
+    assert payload["status"] == "failed"
+    assert payload["reason_code"] == "update_installer_failed"
+
+
 def test_update_binary_diagnostics_accepts_same_environment_script(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
     monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)

--- a/tests/test_guard_update_subprocess.py
+++ b/tests/test_guard_update_subprocess.py
@@ -690,6 +690,38 @@ def test_pip_execution_argv_is_isolated_absolute_and_source_pinned(
     ]
 
 
+def test_manager_recovery_pip_uses_authenticated_python_and_pinned_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context, _manager = _build_manager_context(
+        tmp_path,
+        monkeypatch,
+        "pipx",
+        source_url="https://packages.enterprise.example/simple",
+    )
+    display = [str(context.python.launch_path), "-m", "pip", "install", "hol-guard==2.2.3"]
+
+    command = context.build_python_pip_command(display)
+
+    assert command == [
+        str(context.python.launch_path),
+        *update_subprocess_module._trusted_python_flags(),
+        "-S",
+        "-c",
+        update_subprocess_module._TRUSTED_MODULE_BOOTSTRAP,
+        json.dumps([str(path) for path in context.python_import_paths], separators=(",", ":")),
+        "pip",
+        "--isolated",
+        "--disable-pip-version-check",
+        "--no-input",
+        "install",
+        "hol-guard==2.2.3",
+        "--index-url",
+        "https://packages.enterprise.example/simple",
+    ]
+
+
 @pytest.mark.skipif(
     os.name == "nt",
     reason="uses an extensionless POSIX shebang executable as the uv manager fixture",

--- a/tests/update_context_test_support.py
+++ b/tests/update_context_test_support.py
@@ -68,6 +68,9 @@ class LegacyUpdateContext:
     def build_installer_command(self, display_command: list[str]) -> list[str]:
         return list(display_command)
 
+    def build_python_pip_command(self, display_command: list[str]) -> list[str]:
+        return list(display_command)
+
     def python_command(self, script: str, *args: str) -> list[str]:
         return [sys.executable, *_trusted_python_flags(), "-c", script, *args]
 


### PR DESCRIPTION
## Summary
- treat a newly announced release that has not reached the package index as a deferred update while keeping the current installation active
- recover a broken pipx launcher through the authenticated Guard interpreter and its trusted package source
- render propagation delays as a calm, retryable state instead of an installation failure

## Testing
- `uv run --no-sync pytest -q tests/test_guard_phase03_local_install.py tests/test_guard_update_subprocess.py tests/test_ci_test_suite_ratchet.py tests/test_guard_command_decision_diff.py tests/test_guard_cli.py::TestGuardCli::test_guard_update_deferred_output_keeps_propagation_detail_calm --tb=short`
- `uv run --no-sync python -m ruff check src/`
- `uv run --no-sync python -m ruff format --check src/`
- `uv run --no-sync basedpyright --level error`
- `uv build`
- `uv tool run --from dist/hol_guard-2.2.0-py3-none-any.whl hol-guard --version`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update recovery when the pipx launcher is unavailable by retrying through a trusted Python/pip installation.
  * Updates now gracefully defer when the latest release is still propagating, with clearer status messaging and without exposing raw error details.
  * Added visual support for deferred update statuses.

* **Tests**
  * Added coverage for deferred releases, launcher recovery, secure installation commands, and user-facing output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->