### PR TITLE
fix(release): restore What's Changed changelog in release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1147,8 +1147,24 @@ jobs:
             exit 0
           fi
           body_file=$(mktemp)
+          # Generate a "What's Changed" changelog from commits since the
+          # previous stable tag (excluding this one).
+          changelog=$(mktemp)
+          prev_tag=$(git tag --list 'v*' --sort=-creatordate \
+            | grep -vx "$tag" | grep -v '^alpha/' | head -n 1 || true)
+          if [[ -n "$prev_tag" ]]; then
+            git log "${prev_tag}..${SOURCE_SHA}" --no-merges \
+              --pretty=format:'- %s (%h)' > "$changelog" || true
+          fi
+          if [[ ! -s "$changelog" ]]; then
+            git log "$SOURCE_SHA" --no-merges -n 20 \
+              --pretty=format:'- %s (%h)' > "$changelog" || true
+          fi
           cat > "$body_file" <<EOF
           Guard ${VERSION}
+
+          ### What's Changed
+          $(cat "$changelog")
 
           Install this release:
 
@@ -1246,8 +1262,24 @@ jobs:
             exit 0
           fi
           body_file=$(mktemp)
+          # Generate a "What's Changed" changelog from commits since the
+          # previous alpha tag (excluding this one).
+          changelog=$(mktemp)
+          prev_tag=$(git tag --list 'alpha/v*' --sort=-creatordate \
+            | grep -vx "$tag" | head -n 1 || true)
+          if [[ -n "$prev_tag" ]]; then
+            git log "${prev_tag}..${SOURCE_SHA}" --no-merges \
+              --pretty=format:'- %s (%h)' > "$changelog" || true
+          fi
+          if [[ ! -s "$changelog" ]]; then
+            git log "$SOURCE_SHA" --no-merges -n 20 \
+              --pretty=format:'- %s (%h)' > "$changelog" || true
+          fi
           cat > "$body_file" <<EOF
           Guard ${VERSION} is an opt-in prerelease. Stable installations remain on the stable channel.
+
+          ### What's Changed
+          $(cat "$changelog")
 
           Install this exact alpha:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1148,17 +1148,22 @@ jobs:
           fi
           body_file=$(mktemp)
           # Generate a "What's Changed" changelog from commits since the
-          # previous stable tag (excluding this one).
+          # previous stable tag reachable from SOURCE_SHA (excluding this
+          # one). Semver-sorted so out-of-order tag pushes still pick the
+          # true previous version.
           changelog=$(mktemp)
-          prev_tag=$(git tag --list 'v*' --sort=-creatordate \
-            | grep -vx "$tag" | grep -v '^alpha/' | head -n 1 || true)
+          prev_tag=$(git tag --list 'v*' --merged "$SOURCE_SHA" \
+            | grep -vxF -- "$tag" | grep -v '^alpha/' \
+            | sort -V | tail -n 1 || true)
           if [[ -n "$prev_tag" ]]; then
             git log "${prev_tag}..${SOURCE_SHA}" --no-merges \
-              --pretty=format:'- %s (%h)' > "$changelog" || true
+              --pretty=format:'- %s (%h)' > "$changelog"
           fi
+          # Only fall back when the range is genuinely empty (e.g. first
+          # release); git failures above already aborted via set -e.
           if [[ ! -s "$changelog" ]]; then
             git log "$SOURCE_SHA" --no-merges -n 20 \
-              --pretty=format:'- %s (%h)' > "$changelog" || true
+              --pretty=format:'- %s (%h)' > "$changelog"
           fi
           cat > "$body_file" <<EOF
           Guard ${VERSION}
@@ -1263,17 +1268,23 @@ jobs:
           fi
           body_file=$(mktemp)
           # Generate a "What's Changed" changelog from commits since the
-          # previous alpha tag (excluding this one).
+          # previous alpha tag for THIS release train (excluding this one),
+          # reachable from SOURCE_SHA. Scoping to the same version prefix
+          # avoids picking another train's most-recent alpha as the bound.
           changelog=$(mktemp)
-          prev_tag=$(git tag --list 'alpha/v*' --sort=-creatordate \
-            | grep -vx "$tag" | head -n 1 || true)
+          version_prefix="${VERSION%%a*}"
+          prev_tag=$(git tag --list "alpha/v${version_prefix}a*" \
+            --merged "$SOURCE_SHA" \
+            | grep -vxF -- "$tag" | sort -V | tail -n 1 || true)
           if [[ -n "$prev_tag" ]]; then
             git log "${prev_tag}..${SOURCE_SHA}" --no-merges \
-              --pretty=format:'- %s (%h)' > "$changelog" || true
+              --pretty=format:'- %s (%h)' > "$changelog"
           fi
+          # Only fall back when the range is genuinely empty (e.g. first
+          # release); git failures above already aborted via set -e.
           if [[ ! -s "$changelog" ]]; then
             git log "$SOURCE_SHA" --no-merges -n 20 \
-              --pretty=format:'- %s (%h)' > "$changelog" || true
+              --pretty=format:'- %s (%h)' > "$changelog"
           fi
           cat > "$body_file" <<EOF
           Guard ${VERSION} is an opt-in prerelease. Stable installations remain on the stable channel.


### PR DESCRIPTION
## What

Automated release notes broke: every stable release since **v2.2.1** shipped with a bare body — just `Guard X / Install this release` — with no changelog. (v2.2.0 had rich notes; v2.2.1 onward lost them.)

The `release/2.2` publish workflow's `release-main` and `release-alpha` jobs build their GitHub release bodies from a hardcoded heredoc containing only the title and an install command. The "What's Changed" changelog that the main publish flow used to generate was dropped on this train.

## Fix

Add a changelog step to both jobs that:

- collects commits since the previous tag — previous **stable** tag (`v*`) for `release-main`, previous **alpha** tag (`alpha/v*`) for `release-alpha`, each excluding the tag being created — via `git log <prev>..<sha> --no-merges`;
- prepends a `### What's Changed` section to the release body;
- falls back to the last 20 commits when no prior tag exists or the range is empty, so the section is never blank.

Both jobs already check out with `fetch-depth: 0`, so full history and tags are available.

## Verification

- YAML parses clean.
- Simulated the exact body-render snippet locally against real tags: prev-tag selection resolves `v2.2.8 → v2.2.7`, and the rendered body shows a clean `### What's Changed` commit list followed by the install block — the same shape the old automated notes produced.

## Backfill

After merge, I'll backfill the bare releases (v2.2.1–v2.2.8) with the regenerated notes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub release notes now automatically include a “What’s Changed” section.
  * Release notes summarize updates since the previous stable or alpha release.
  * If no changelog is available, the release notes include the latest 20 commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->