### PR TITLE
ci: publish signed Desktop Core alpha sidecars

### DIFF
--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: desktop-core-alpha-feed-${{ github.event_name }}
+  group: desktop-core-alpha-feed
   cancel-in-progress: false
 
 jobs:
@@ -36,7 +36,8 @@ jobs:
         run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
 
       - name: Validate workflow syntax
-        run: "$(go env GOPATH)/bin/actionlint" .github/workflows/desktop-core-alpha-feed.yml
+        run: |
+          "$(go env GOPATH)/bin/actionlint" .github/workflows/desktop-core-alpha-feed.yml
 
   publish-macos-arm64:
     name: Publish signed macOS arm64 Core sidecar
@@ -52,9 +53,6 @@ jobs:
     env:
       RELEASE_TARGET: aarch64-apple-darwin
       MINIMUM_DESKTOP_VERSION: 0.1.0-alpha.0
-      GH_TOKEN: ${{ github.token }}
-      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.HOL_GUARD_CORE_UPDATE_PRIVATE_KEY }}
-      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.HOL_GUARD_CORE_UPDATE_PRIVATE_KEY_PASSWORD }}
     steps:
       - name: Check out release automation
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
@@ -66,11 +64,13 @@ jobs:
 
       - name: Discover newest published Core 3.x alpha
         id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
             > "$RUNNER_TEMP/release-pages.json"
-          python - <<'PY' >> "$GITHUB_OUTPUT"
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json
           import os
           import re
@@ -108,7 +108,9 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          PUBLIC_KEY: ${{ secrets.HOL_GUARD_CORE_UPDATE_PUBLIC_KEY }}
+          CORE_UPDATE_PRIVATE_KEY: ${{ secrets.HOL_GUARD_CORE_UPDATE_PRIVATE_KEY }}
+          CORE_UPDATE_PRIVATE_KEY_PASSWORD: ${{ secrets.HOL_GUARD_CORE_UPDATE_PRIVATE_KEY_PASSWORD }}
+          CORE_UPDATE_PUBLIC_KEY: ${{ secrets.HOL_GUARD_CORE_UPDATE_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           test -n "$APPLE_CERTIFICATE"
@@ -117,8 +119,9 @@ jobs:
           test -n "$APPLE_ID"
           test -n "$APPLE_PASSWORD"
           test -n "$APPLE_TEAM_ID"
-          test -n "$TAURI_SIGNING_PRIVATE_KEY"
-          test -n "$PUBLIC_KEY"
+          test -n "$CORE_UPDATE_PRIVATE_KEY"
+          test -n "$CORE_UPDATE_PRIVATE_KEY_PASSWORD"
+          test -n "$CORE_UPDATE_PUBLIC_KEY"
 
       - name: Inspect immutable asset state
         if: steps.release.outputs.available == 'true'
@@ -126,13 +129,14 @@ jobs:
         env:
           CORE_TAG: ${{ steps.release.outputs.tag }}
           CORE_VERSION: ${{ steps.release.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           BASE="hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
           gh release view "$CORE_TAG" --repo "$GITHUB_REPOSITORY" --json assets \
             > "$RUNNER_TEMP/release-assets.json"
           export BASE
-          python - <<'PY' >> "$GITHUB_OUTPUT"
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json
           import os
           from pathlib import Path
@@ -156,6 +160,12 @@ jobs:
               raise SystemExit("Metadata exists without its immutable Core binary")
           if expected["signature"] in names and expected["manifest"] not in names:
               raise SystemExit("A signature exists without its signed manifest")
+          if expected["attestation"] in names and not {
+              expected["binary"],
+              expected["manifest"],
+              expected["signature"],
+          } <= names:
+              raise SystemExit("An attestation marker exists without its complete signed asset set")
           PY
 
       - name: Set up Python
@@ -199,6 +209,7 @@ jobs:
         env:
           CORE_TAG: ${{ steps.release.outputs.tag }}
           CORE_VERSION: ${{ steps.release.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/dist"
@@ -309,7 +320,17 @@ jobs:
             --apple-id "$APPLE_ID" \
             --password "$APPLE_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
-            --wait
+            --wait \
+            --output-format json > "$RUNNER_TEMP/notary-result.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads((Path(os.environ["RUNNER_TEMP"]) / "notary-result.json").read_text())
+          if payload.get("status") != "Accepted":
+              raise SystemExit(f"Apple notarization was not accepted: {payload.get('status', 'unknown')}")
+          PY
 
       - name: Verify local immutable binary
         if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
@@ -341,7 +362,7 @@ jobs:
           PY
           rm -f "$VERIFY"
 
-      - name: Download or create signed update manifest
+      - name: Download or create update manifest
         if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
         env:
           CORE_VERSION: ${{ steps.release.outputs.version }}
@@ -349,6 +370,7 @@ jobs:
           SOURCE_SHA: ${{ steps.source.outputs.sha }}
           MANIFEST_PRESENT: ${{ steps.existing.outputs.manifest_present }}
           SIGNATURE_PRESENT: ${{ steps.existing.outputs.signature_present }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           DIST="$RUNNER_TEMP/dist"
@@ -417,10 +439,27 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --pattern "$(basename "$MANIFEST").sig" \
               --dir "$DIST"
-          else
-            bunx @tauri-apps/cli@2.11.4 signer sign "$MANIFEST"
           fi
+
+      - name: Sign missing update manifest
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true' && steps.existing.outputs.signature_present != 'true'
+        env:
+          CORE_VERSION: ${{ steps.release.outputs.version }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.HOL_GUARD_CORE_UPDATE_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.HOL_GUARD_CORE_UPDATE_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          MANIFEST="$RUNNER_TEMP/dist/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}.json"
+          bunx @tauri-apps/cli@2.11.4 signer sign "$MANIFEST"
           test -s "$MANIFEST.sig"
+
+      - name: Require local manifest signature
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
+        env:
+          CORE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          test -s "$RUNNER_TEMP/dist/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}.json.sig"
 
       - name: Upload only missing immutable assets
         if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
@@ -430,6 +469,7 @@ jobs:
           BINARY_PRESENT: ${{ steps.existing.outputs.binary_present }}
           MANIFEST_PRESENT: ${{ steps.existing.outputs.manifest_present }}
           SIGNATURE_PRESENT: ${{ steps.existing.outputs.signature_present }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           DIST="$RUNNER_TEMP/dist"
@@ -474,6 +514,7 @@ jobs:
           CORE_VERSION: ${{ steps.release.outputs.version }}
           CORE_TAG: ${{ steps.release.outputs.tag }}
           SOURCE_SHA: ${{ steps.source.outputs.sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           MARKER="$RUNNER_TEMP/dist/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}.attested.json"

--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -318,12 +318,28 @@ jobs:
         run: |
           set -euo pipefail
           BINARY="$RUNNER_TEMP/dist/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
+          VERIFY="$RUNNER_TEMP/dist/hol-guard"
           chmod 0755 "$BINARY"
           codesign --verify --strict --verbose=2 "$BINARY"
-          test "$("$BINARY" --version | sed -E 's/^hol-guard[[:space:]]+//')" = "$CORE_VERSION"
+          cp "$BINARY" "$VERIFY"
+          chmod 0755 "$VERIFY"
+          codesign --verify --strict --verbose=2 "$VERIFY"
+          test "$("$VERIFY" --version | sed -E 's/^hol-guard[[:space:]]+//')" = "$CORE_VERSION"
           export HOL_GUARD_HOME="$RUNNER_TEMP/verify-home"
           mkdir -p "$HOL_GUARD_HOME"
-          "$BINARY" desktop bootstrap --json > "$RUNNER_TEMP/bootstrap.json"
+          "$VERIFY" desktop bootstrap --json > "$RUNNER_TEMP/bootstrap.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads((Path(os.environ["RUNNER_TEMP"]) / "bootstrap.json").read_text())
+          if payload.get("schema") != "guard-desktop-bootstrap.v1":
+              raise SystemExit("Immutable Core does not expose the Desktop bootstrap contract")
+          if payload.get("coreVersion") != os.environ["CORE_VERSION"]:
+              raise SystemExit("Immutable Core returned the wrong version")
+          PY
+          rm -f "$VERIFY"
 
       - name: Download or create signed update manifest
         if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'

--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -1,0 +1,300 @@
+name: Publish Desktop Core alpha feed
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: desktop-core-alpha-feed
+  cancel-in-progress: false
+
+jobs:
+  publish-macos-arm64:
+    name: Publish signed macOS arm64 Core sidecar
+    runs-on: macos-15
+    timeout-minutes: 75
+    environment: core-alpha-desktop
+    env:
+      RELEASE_TARGET: aarch64-apple-darwin
+      MINIMUM_DESKTOP_VERSION: 0.1.0-alpha.0
+      GH_TOKEN: ${{ github.token }}
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.HOL_GUARD_CORE_UPDATE_PRIVATE_KEY }}
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.HOL_GUARD_CORE_UPDATE_PRIVATE_KEY_PASSWORD }}
+    steps:
+      - name: Check out release automation
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: Discover newest published Core 3.x alpha
+        id: release
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > "$RUNNER_TEMP/releases.json"
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          releases = json.loads((Path(os.environ["RUNNER_TEMP"]) / "releases.json").read_text())
+          candidates = []
+          pattern = re.compile(r"^alpha/v(3\.(\d+)\.(\d+)a(\d+))$")
+          for release in releases:
+              match = pattern.fullmatch(str(release.get("tag_name") or ""))
+              if not match or release.get("draft") or not release.get("prerelease"):
+                  continue
+              candidates.append(((int(match.group(2)), int(match.group(3)), int(match.group(4))), match.group(1), release["tag_name"]))
+          if not candidates:
+              print("available=false")
+              raise SystemExit(0)
+          _, version, tag = max(candidates)
+          print("available=true")
+          print(f"version={version}")
+          print(f"tag={tag}")
+          PY
+
+      - name: Stop when no Core alpha is published
+        if: steps.release.outputs.available != 'true'
+        run: echo "No published HOL Guard Core 3.x alpha release is available yet."
+
+      - name: Require signing and notarization configuration
+        if: steps.release.outputs.available == 'true'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          PUBLIC_KEY: ${{ secrets.HOL_GUARD_CORE_UPDATE_PUBLIC_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$APPLE_CERTIFICATE"
+          test -n "$APPLE_CERTIFICATE_PASSWORD"
+          test -n "$APPLE_SIGNING_IDENTITY"
+          test -n "$APPLE_ID"
+          test -n "$APPLE_PASSWORD"
+          test -n "$APPLE_TEAM_ID"
+          test -n "$TAURI_SIGNING_PRIVATE_KEY"
+          test -n "$PUBLIC_KEY"
+
+      - name: Detect already-published immutable assets
+        if: steps.release.outputs.available == 'true'
+        id: existing
+        env:
+          CORE_TAG: ${{ steps.release.outputs.tag }}
+          CORE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          BASE="hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
+          release_json=$(gh release view "$CORE_TAG" --repo "$GITHUB_REPOSITORY" --json assets)
+          present=0
+          for name in "$BASE" "$BASE.json" "$BASE.json.sig"; do
+            if jq -e --arg name "$name" '.assets[] | select(.name == $name)' <<< "$release_json" >/dev/null; then
+              present=$((present + 1))
+            fi
+          done
+          if [[ "$present" == "3" ]]; then
+            echo "complete=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$present" == "0" ]]; then
+            echo "complete=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "The Core alpha release contains a partial Desktop update asset set." >&2
+            exit 1
+          fi
+
+      - name: Set up Python
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+
+      - name: Set up Bun signer
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.14
+
+      - name: Fetch exact tagged Core source
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        id: source
+        env:
+          CORE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          SOURCE="$RUNNER_TEMP/hol-guard-core"
+          git init "$SOURCE"
+          git -C "$SOURCE" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git -C "$SOURCE" fetch --depth=1 origin "refs/tags/$CORE_TAG"
+          git -C "$SOURCE" checkout --detach FETCH_HEAD
+          SOURCE_SHA=$(git -C "$SOURCE" rev-parse 'HEAD^{commit}')
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test -z "$(git -C "$SOURCE" status --porcelain)"
+          echo "sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Build standalone Core sidecar
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        env:
+          CORE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          SOURCE="$RUNNER_TEMP/hol-guard-core"
+          DIST="$RUNNER_TEMP/dist"
+          mkdir -p "$DIST" "$RUNNER_TEMP/pyinstaller" "$RUNNER_TEMP/spec"
+          uv sync --directory "$SOURCE" --frozen --extra mdm-build --python 3.12
+          (
+            cd "$SOURCE"
+            uv run --no-sync python scripts/sync_repo_version.py --version "$CORE_VERSION"
+            test "$(uv run --no-sync python scripts/sync_repo_version.py --check)" = "$CORE_VERSION"
+          )
+          uv sync --directory "$SOURCE" --frozen --extra mdm-build --python 3.12
+          git -C "$SOURCE" diff --check
+          while IFS= read -r changed_path; do
+            [[ -z "$changed_path" ]] && continue
+            case "$changed_path" in
+              pyproject.toml|src/codex_plugin_scanner/version.py|uv.lock) ;;
+              *) echo "Version stamping changed an unexpected Core file: $changed_path" >&2; exit 1 ;;
+            esac
+          done < <(git -C "$SOURCE" diff --name-only)
+          (
+            cd "$SOURCE"
+            uv run --no-sync pyinstaller \
+              --clean \
+              --noconfirm \
+              --onefile \
+              --name "hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}" \
+              --collect-submodules codex_plugin_scanner \
+              --collect-data codex_plugin_scanner \
+              --distpath "$DIST" \
+              --workpath "$RUNNER_TEMP/pyinstaller" \
+              --specpath "$RUNNER_TEMP/spec" \
+              scripts/mdm/hol-guard-entry.py
+          )
+          BINARY="$DIST/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
+          chmod 0755 "$BINARY"
+          test "$("$BINARY" --version | sed -E 's/^hol-guard[[:space:]]+//')" = "$CORE_VERSION"
+          export HOL_GUARD_HOME="$RUNNER_TEMP/smoke-home"
+          mkdir -p "$HOL_GUARD_HOME"
+          "$BINARY" desktop bootstrap --json > "$RUNNER_TEMP/bootstrap.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads((Path(os.environ["RUNNER_TEMP"]) / "bootstrap.json").read_text())
+          if payload.get("schema") != "guard-desktop-bootstrap.v1":
+              raise SystemExit("Standalone Core does not expose the Desktop bootstrap contract")
+          if payload.get("coreVersion") != os.environ["CORE_VERSION"]:
+              raise SystemExit("Standalone Core returned the wrong version")
+          PY
+
+      - name: Import Apple signing identity
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/core-update.keychain-db"
+          KEYCHAIN_PASSWORD=$(openssl rand -hex 24)
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$RUNNER_TEMP/certificate.p12" -k "$KEYCHAIN" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN"
+
+      - name: Sign and notarize Core sidecar
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        env:
+          CORE_VERSION: ${{ steps.release.outputs.version }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          BINARY="$RUNNER_TEMP/dist/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
+          codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$BINARY"
+          codesign --verify --strict --verbose=2 "$BINARY"
+          ditto -c -k --keepParent "$BINARY" "$RUNNER_TEMP/core-update-notary.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/core-update-notary.zip" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+
+      - name: Create and sign update manifest
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        env:
+          CORE_VERSION: ${{ steps.release.outputs.version }}
+          CORE_TAG: ${{ steps.release.outputs.tag }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+        run: |
+          set -euo pipefail
+          DIST="$RUNNER_TEMP/dist"
+          BINARY="$DIST/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
+          MANIFEST="$BINARY.json"
+          export BINARY MANIFEST
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          binary = Path(os.environ["BINARY"])
+          payload = {
+              "schema": "hol-guard-core-update.v1",
+              "channel": "alpha",
+              "version": os.environ["CORE_VERSION"],
+              "sourceCommit": os.environ["SOURCE_SHA"],
+              "sourceTag": os.environ["CORE_TAG"],
+              "target": os.environ["RELEASE_TARGET"],
+              "artifact": binary.name,
+              "sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
+              "size": binary.stat().st_size,
+              "bootstrapSchema": "guard-desktop-bootstrap.v1",
+              "minimumDesktopVersion": os.environ["MINIMUM_DESKTOP_VERSION"],
+              "publishedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+          }
+          Path(os.environ["MANIFEST"]).write_text(json.dumps(payload, indent=2) + "\n")
+          PY
+          bunx @tauri-apps/cli@2.11.4 signer sign "$MANIFEST"
+          test -s "$MANIFEST.sig"
+
+      - name: Publish immutable assets to the Core alpha release
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        env:
+          CORE_VERSION: ${{ steps.release.outputs.version }}
+          CORE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          DIST="$RUNNER_TEMP/dist"
+          BASE="$DIST/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
+          gh release upload "$CORE_TAG" \
+            "$BASE" \
+            "$BASE.json" \
+            "$BASE.json.sig" \
+            --repo "$GITHUB_REPOSITORY"
+
+      - name: Attest Core sidecar provenance
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
+        with:
+          subject-path: ${{ runner.temp }}/dist/*

--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -1,25 +1,54 @@
 name: Publish Desktop Core alpha feed
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/desktop-core-alpha-feed.yml
   schedule:
     - cron: "17 * * * *"
   workflow_dispatch:
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 concurrency:
-  group: desktop-core-alpha-feed
+  group: desktop-core-alpha-feed-${{ github.event_name }}
   cancel-in-progress: false
 
 jobs:
+  validate:
+    name: Validate workflow
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version: "1.24.2"
+          cache: false
+
+      - name: Install Actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.11
+
+      - name: Validate workflow syntax
+        run: "$(go env GOPATH)/bin/actionlint" .github/workflows/desktop-core-alpha-feed.yml
+
   publish-macos-arm64:
     name: Publish signed macOS arm64 Core sidecar
+    if: github.event_name != 'pull_request'
+    needs: validate
     runs-on: macos-15
-    timeout-minutes: 75
+    timeout-minutes: 90
     environment: core-alpha-desktop
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     env:
       RELEASE_TARGET: aarch64-apple-darwin
       MINIMUM_DESKTOP_VERSION: 0.1.0-alpha.0
@@ -32,25 +61,31 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Verify runner architecture
+        run: test "$(uname -m)" = "arm64"
+
       - name: Discover newest published Core 3.x alpha
         id: release
         run: |
           set -euo pipefail
-          gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > "$RUNNER_TEMP/releases.json"
+          gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            > "$RUNNER_TEMP/release-pages.json"
           python - <<'PY' >> "$GITHUB_OUTPUT"
           import json
           import os
           import re
           from pathlib import Path
 
-          releases = json.loads((Path(os.environ["RUNNER_TEMP"]) / "releases.json").read_text())
+          pages = json.loads((Path(os.environ["RUNNER_TEMP"]) / "release-pages.json").read_text())
+          releases = [release for page in pages for release in page]
           candidates = []
           pattern = re.compile(r"^alpha/v(3\.(\d+)\.(\d+)a(\d+))$")
           for release in releases:
               match = pattern.fullmatch(str(release.get("tag_name") or ""))
               if not match or release.get("draft") or not release.get("prerelease"):
                   continue
-              candidates.append(((int(match.group(2)), int(match.group(3)), int(match.group(4))), match.group(1), release["tag_name"]))
+              order = (int(match.group(2)), int(match.group(3)), int(match.group(4)))
+              candidates.append((order, match.group(1), release["tag_name"]))
           if not candidates:
               print("available=false")
               raise SystemExit(0)
@@ -85,7 +120,7 @@ jobs:
           test -n "$TAURI_SIGNING_PRIVATE_KEY"
           test -n "$PUBLIC_KEY"
 
-      - name: Detect already-published immutable assets
+      - name: Inspect immutable asset state
         if: steps.release.outputs.available == 'true'
         id: existing
         env:
@@ -94,43 +129,56 @@ jobs:
         run: |
           set -euo pipefail
           BASE="hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
-          release_json=$(gh release view "$CORE_TAG" --repo "$GITHUB_REPOSITORY" --json assets)
-          present=0
-          for name in "$BASE" "$BASE.json" "$BASE.json.sig"; do
-            if jq -e --arg name "$name" '.assets[] | select(.name == $name)' <<< "$release_json" >/dev/null; then
-              present=$((present + 1))
-            fi
-          done
-          if [[ "$present" == "3" ]]; then
-            echo "complete=true" >> "$GITHUB_OUTPUT"
-          elif [[ "$present" == "0" ]]; then
-            echo "complete=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "The Core alpha release contains a partial Desktop update asset set." >&2
-            exit 1
-          fi
+          gh release view "$CORE_TAG" --repo "$GITHUB_REPOSITORY" --json assets \
+            > "$RUNNER_TEMP/release-assets.json"
+          export BASE
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads((Path(os.environ["RUNNER_TEMP"]) / "release-assets.json").read_text())
+          names = {asset["name"] for asset in payload.get("assets", [])}
+          base = os.environ["BASE"]
+          expected = {
+              "binary": base,
+              "manifest": f"{base}.json",
+              "signature": f"{base}.json.sig",
+              "attestation": f"{base}.attested.json",
+          }
+          for key, name in expected.items():
+              print(f"{key}_present={'true' if name in names else 'false'}")
+          if expected["binary"] not in names and (
+              expected["manifest"] in names
+              or expected["signature"] in names
+              or expected["attestation"] in names
+          ):
+              raise SystemExit("Metadata exists without its immutable Core binary")
+          if expected["signature"] in names and expected["manifest"] not in names:
+              raise SystemExit("A signature exists without its signed manifest")
+          PY
 
       - name: Set up Python
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 
       - name: Set up uv
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           version: "0.9.26"
           enable-cache: true
 
       - name: Set up Bun signer
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: 1.3.14
 
       - name: Fetch exact tagged Core source
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
         id: source
         env:
           CORE_TAG: ${{ steps.release.outputs.tag }}
@@ -146,8 +194,21 @@ jobs:
           test -z "$(git -C "$SOURCE" status --porcelain)"
           echo "sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
 
-      - name: Build standalone Core sidecar
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+      - name: Download existing immutable binary
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true' && steps.existing.outputs.binary_present == 'true'
+        env:
+          CORE_TAG: ${{ steps.release.outputs.tag }}
+          CORE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/dist"
+          gh release download "$CORE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}" \
+            --dir "$RUNNER_TEMP/dist"
+
+      - name: Build standalone Core executable
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true' && steps.existing.outputs.binary_present != 'true'
         env:
           CORE_VERSION: ${{ steps.release.outputs.version }}
         run: |
@@ -176,7 +237,7 @@ jobs:
               --clean \
               --noconfirm \
               --onefile \
-              --name "hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}" \
+              --name hol-guard \
               --collect-submodules codex_plugin_scanner \
               --collect-data codex_plugin_scanner \
               --distpath "$DIST" \
@@ -184,12 +245,13 @@ jobs:
               --specpath "$RUNNER_TEMP/spec" \
               scripts/mdm/hol-guard-entry.py
           )
-          BINARY="$DIST/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
-          chmod 0755 "$BINARY"
-          test "$("$BINARY" --version | sed -E 's/^hol-guard[[:space:]]+//')" = "$CORE_VERSION"
+          BUILT="$DIST/hol-guard"
+          ASSET="$DIST/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
+          chmod 0755 "$BUILT"
+          test "$("$BUILT" --version | sed -E 's/^hol-guard[[:space:]]+//')" = "$CORE_VERSION"
           export HOL_GUARD_HOME="$RUNNER_TEMP/smoke-home"
           mkdir -p "$HOL_GUARD_HOME"
-          "$BINARY" desktop bootstrap --json > "$RUNNER_TEMP/bootstrap.json"
+          "$BUILT" desktop bootstrap --json > "$RUNNER_TEMP/bootstrap.json"
           python - <<'PY'
           import json
           import os
@@ -201,9 +263,10 @@ jobs:
           if payload.get("coreVersion") != os.environ["CORE_VERSION"]:
               raise SystemExit("Standalone Core returned the wrong version")
           PY
+          mv "$BUILT" "$ASSET"
 
       - name: Import Apple signing identity
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true' && steps.existing.outputs.binary_present != 'true'
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -211,7 +274,16 @@ jobs:
           set -euo pipefail
           KEYCHAIN="$RUNNER_TEMP/core-update.keychain-db"
           KEYCHAIN_PASSWORD=$(openssl rand -hex 24)
-          echo "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          export APPLE_CERTIFICATE
+          python - <<'PY'
+          import base64
+          import os
+          from pathlib import Path
+
+          Path(os.environ["RUNNER_TEMP"], "certificate.p12").write_bytes(
+              base64.b64decode(os.environ["APPLE_CERTIFICATE"], validate=True)
+          )
+          PY
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security set-keychain-settings -lut 21600 "$KEYCHAIN"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
@@ -219,8 +291,8 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security list-keychains -d user -s "$KEYCHAIN"
 
-      - name: Sign and notarize Core sidecar
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+      - name: Sign and notarize new Core sidecar
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true' && steps.existing.outputs.binary_present != 'true'
         env:
           CORE_VERSION: ${{ steps.release.outputs.version }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
@@ -239,19 +311,41 @@ jobs:
             --team-id "$APPLE_TEAM_ID" \
             --wait
 
-      - name: Create and sign update manifest
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+      - name: Verify local immutable binary
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
+        env:
+          CORE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          BINARY="$RUNNER_TEMP/dist/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
+          chmod 0755 "$BINARY"
+          codesign --verify --strict --verbose=2 "$BINARY"
+          test "$("$BINARY" --version | sed -E 's/^hol-guard[[:space:]]+//')" = "$CORE_VERSION"
+          export HOL_GUARD_HOME="$RUNNER_TEMP/verify-home"
+          mkdir -p "$HOL_GUARD_HOME"
+          "$BINARY" desktop bootstrap --json > "$RUNNER_TEMP/bootstrap.json"
+
+      - name: Download or create signed update manifest
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
         env:
           CORE_VERSION: ${{ steps.release.outputs.version }}
           CORE_TAG: ${{ steps.release.outputs.tag }}
           SOURCE_SHA: ${{ steps.source.outputs.sha }}
+          MANIFEST_PRESENT: ${{ steps.existing.outputs.manifest_present }}
+          SIGNATURE_PRESENT: ${{ steps.existing.outputs.signature_present }}
         run: |
           set -euo pipefail
           DIST="$RUNNER_TEMP/dist"
           BINARY="$DIST/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
           MANIFEST="$BINARY.json"
-          export BINARY MANIFEST
-          python - <<'PY'
+          if [[ "$MANIFEST_PRESENT" == "true" ]]; then
+            gh release download "$CORE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "$(basename "$MANIFEST")" \
+              --dir "$DIST"
+          else
+            export BINARY MANIFEST
+            python - <<'PY'
           import hashlib
           import json
           import os
@@ -275,26 +369,114 @@ jobs:
           }
           Path(os.environ["MANIFEST"]).write_text(json.dumps(payload, indent=2) + "\n")
           PY
-          bunx @tauri-apps/cli@2.11.4 signer sign "$MANIFEST"
+          fi
+          export BINARY MANIFEST
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          binary = Path(os.environ["BINARY"])
+          payload = json.loads(Path(os.environ["MANIFEST"]).read_text())
+          expected = {
+              "schema": "hol-guard-core-update.v1",
+              "channel": "alpha",
+              "version": os.environ["CORE_VERSION"],
+              "sourceCommit": os.environ["SOURCE_SHA"],
+              "sourceTag": os.environ["CORE_TAG"],
+              "target": os.environ["RELEASE_TARGET"],
+              "artifact": binary.name,
+              "sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
+              "size": binary.stat().st_size,
+              "bootstrapSchema": "guard-desktop-bootstrap.v1",
+              "minimumDesktopVersion": os.environ["MINIMUM_DESKTOP_VERSION"],
+          }
+          for key, value in expected.items():
+              if payload.get(key) != value:
+                  raise SystemExit(f"Manifest mismatch for {key}")
+          PY
+          if [[ "$SIGNATURE_PRESENT" == "true" ]]; then
+            gh release download "$CORE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "$(basename "$MANIFEST").sig" \
+              --dir "$DIST"
+          else
+            bunx @tauri-apps/cli@2.11.4 signer sign "$MANIFEST"
+          fi
           test -s "$MANIFEST.sig"
 
-      - name: Publish immutable assets to the Core alpha release
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+      - name: Upload only missing immutable assets
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
         env:
           CORE_VERSION: ${{ steps.release.outputs.version }}
           CORE_TAG: ${{ steps.release.outputs.tag }}
+          BINARY_PRESENT: ${{ steps.existing.outputs.binary_present }}
+          MANIFEST_PRESENT: ${{ steps.existing.outputs.manifest_present }}
+          SIGNATURE_PRESENT: ${{ steps.existing.outputs.signature_present }}
         run: |
           set -euo pipefail
           DIST="$RUNNER_TEMP/dist"
           BASE="$DIST/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
-          gh release upload "$CORE_TAG" \
-            "$BASE" \
-            "$BASE.json" \
-            "$BASE.json.sig" \
-            --repo "$GITHUB_REPOSITORY"
+          if [[ "$BINARY_PRESENT" != "true" ]]; then
+            gh release upload "$CORE_TAG" "$BASE" --repo "$GITHUB_REPOSITORY"
+          fi
+          if [[ "$MANIFEST_PRESENT" != "true" ]]; then
+            gh release upload "$CORE_TAG" "$BASE.json" --repo "$GITHUB_REPOSITORY"
+          fi
+          if [[ "$SIGNATURE_PRESENT" != "true" ]]; then
+            gh release upload "$CORE_TAG" "$BASE.json.sig" --repo "$GITHUB_REPOSITORY"
+          fi
+          gh release view "$CORE_TAG" --repo "$GITHUB_REPOSITORY" --json assets \
+            > "$RUNNER_TEMP/final-assets.json"
+          export BASE
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          names = {
+              asset["name"]
+              for asset in json.loads((Path(os.environ["RUNNER_TEMP"]) / "final-assets.json").read_text()).get("assets", [])
+          }
+          base = Path(os.environ["BASE"]).name
+          expected = {base, f"{base}.json", f"{base}.json.sig"}
+          missing = expected - names
+          if missing:
+              raise SystemExit(f"Missing release assets: {sorted(missing)}")
+          PY
 
       - name: Attest Core sidecar provenance
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.complete != 'true'
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
         with:
           subject-path: ${{ runner.temp }}/dist/*
+
+      - name: Record completed provenance
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
+        env:
+          CORE_VERSION: ${{ steps.release.outputs.version }}
+          CORE_TAG: ${{ steps.release.outputs.tag }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+        run: |
+          set -euo pipefail
+          MARKER="$RUNNER_TEMP/dist/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}.attested.json"
+          export MARKER
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          payload = {
+              "schema": "hol-guard-core-attestation.v1",
+              "version": os.environ["CORE_VERSION"],
+              "sourceCommit": os.environ["SOURCE_SHA"],
+              "sourceTag": os.environ["CORE_TAG"],
+              "target": os.environ["RELEASE_TARGET"],
+              "workflowRun": os.environ["GITHUB_RUN_ID"],
+              "attestedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+          }
+          Path(os.environ["MARKER"]).write_text(json.dumps(payload, indent=2) + "\n")
+          PY
+          gh release upload "$CORE_TAG" "$MARKER" --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Summary

Adds the public, signed HOL Guard Core 3.x alpha feed consumed by HOL Guard Desktop's automatic updater.

### Feed behavior

- Runs hourly and supports manual dispatch from the default branch.
- Discovers the newest published, non-draft `alpha/v3.<minor>.<patch>a<serial>` release across all release pages.
- Treats binary, manifest, signature, and provenance completion independently so interrupted publication is resumable without clobbering immutable assets.
- Fetches and builds the exact alpha tag source.
- Stamps the authorized version with Core's existing `sync_repo_version.py` release tooling and permits only the expected version files to change.
- Builds as the canonical `hol-guard` executable, verifies `--version` and `guard-desktop-bootstrap.v1`, then renames only the immutable release asset.

### Signing and verification

- Serializes scheduled/manual publication to prevent competing uploads.
- Keeps GitHub and Core signing credentials out of tagged Core build steps.
- Signs the macOS arm64 sidecar with the Apple Developer ID identity and requires an Accepted Apple notarization result.
- Emits `hol-guard-core-update.v1`, binding version, source tag/SHA, target, artifact, byte size, SHA-256, bootstrap schema, minimum Desktop version, and publication time.
- Signs the manifest with the dedicated Tauri/Minisign Core-update key.
- Revalidates downloaded immutable binaries under the canonical `hol-guard` stem, including bootstrap schema/version.
- Uploads only missing immutable assets and refuses inconsistent partial states.
- Attests provenance and records an independent completion marker.

### Required protected environment

The `core-alpha-desktop` environment must provide the dedicated Core update signing keypair and Apple signing/notarization secrets. Pull-request workflows never receive these secrets.

Companion Desktop updater: https://github.com/hashgraph-online/hol-guard-desktop/pull/15