### PR TITLE
refactor: authenticate Desktop Core feed with Apple trust

### DIFF
--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -99,7 +99,7 @@ jobs:
         if: steps.release.outputs.available != 'true'
         run: echo "No published HOL Guard Core 3.x alpha release is available yet."
 
-      - name: Require signing and notarization configuration
+      - name: Require Apple signing and notarization configuration
         if: steps.release.outputs.available == 'true'
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -108,9 +108,6 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CORE_UPDATE_PRIVATE_KEY: ${{ secrets.HOL_GUARD_CORE_UPDATE_PRIVATE_KEY }}
-          CORE_UPDATE_PRIVATE_KEY_PASSWORD: ${{ secrets.HOL_GUARD_CORE_UPDATE_PRIVATE_KEY_PASSWORD }}
-          CORE_UPDATE_PUBLIC_KEY: ${{ secrets.HOL_GUARD_CORE_UPDATE_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           test -n "$APPLE_CERTIFICATE"
@@ -119,9 +116,6 @@ jobs:
           test -n "$APPLE_ID"
           test -n "$APPLE_PASSWORD"
           test -n "$APPLE_TEAM_ID"
-          test -n "$CORE_UPDATE_PRIVATE_KEY"
-          test -n "$CORE_UPDATE_PRIVATE_KEY_PASSWORD"
-          test -n "$CORE_UPDATE_PUBLIC_KEY"
 
       - name: Inspect immutable asset state
         if: steps.release.outputs.available == 'true'
@@ -147,25 +141,18 @@ jobs:
           expected = {
               "binary": base,
               "manifest": f"{base}.json",
-              "signature": f"{base}.json.sig",
               "attestation": f"{base}.attested.json",
           }
           for key, name in expected.items():
               print(f"{key}_present={'true' if name in names else 'false'}")
           if expected["binary"] not in names and (
-              expected["manifest"] in names
-              or expected["signature"] in names
-              or expected["attestation"] in names
+              expected["manifest"] in names or expected["attestation"] in names
           ):
               raise SystemExit("Metadata exists without its immutable Core binary")
-          if expected["signature"] in names and expected["manifest"] not in names:
-              raise SystemExit("A signature exists without its signed manifest")
           if expected["attestation"] in names and not {
-              expected["binary"],
-              expected["manifest"],
-              expected["signature"],
+              expected["binary"], expected["manifest"]
           } <= names:
-              raise SystemExit("An attestation marker exists without its complete signed asset set")
+              raise SystemExit("An attestation marker exists without its complete Core asset set")
           PY
 
       - name: Set up Python
@@ -180,12 +167,6 @@ jobs:
         with:
           version: "0.9.26"
           enable-cache: true
-
-      - name: Set up Bun signer
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
-        with:
-          bun-version: 1.3.14
 
       - name: Fetch exact tagged Core source
         if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
@@ -332,16 +313,19 @@ jobs:
               raise SystemExit(f"Apple notarization was not accepted: {payload.get('status', 'unknown')}")
           PY
 
-      - name: Verify local immutable binary
+      - name: Verify local immutable binary and Apple team
         if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
         env:
           CORE_VERSION: ${{ steps.release.outputs.version }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
           BINARY="$RUNNER_TEMP/dist/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
           VERIFY="$RUNNER_TEMP/dist/hol-guard"
           chmod 0755 "$BINARY"
           codesign --verify --strict --verbose=2 "$BINARY"
+          codesign --display --verbose=4 "$BINARY" 2> "$RUNNER_TEMP/codesign.txt"
+          grep -Fx "TeamIdentifier=$APPLE_TEAM_ID" "$RUNNER_TEMP/codesign.txt"
           cp "$BINARY" "$VERIFY"
           chmod 0755 "$VERIFY"
           codesign --verify --strict --verbose=2 "$VERIFY"
@@ -369,7 +353,6 @@ jobs:
           CORE_TAG: ${{ steps.release.outputs.tag }}
           SOURCE_SHA: ${{ steps.source.outputs.sha }}
           MANIFEST_PRESENT: ${{ steps.existing.outputs.manifest_present }}
-          SIGNATURE_PRESENT: ${{ steps.existing.outputs.signature_present }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -408,6 +391,7 @@ jobs:
           Path(os.environ["MANIFEST"]).write_text(json.dumps(payload, indent=2) + "\n")
           PY
           fi
+
           export BINARY MANIFEST
           python - <<'PY'
           import hashlib
@@ -434,32 +418,6 @@ jobs:
               if payload.get(key) != value:
                   raise SystemExit(f"Manifest mismatch for {key}")
           PY
-          if [[ "$SIGNATURE_PRESENT" == "true" ]]; then
-            gh release download "$CORE_TAG" \
-              --repo "$GITHUB_REPOSITORY" \
-              --pattern "$(basename "$MANIFEST").sig" \
-              --dir "$DIST"
-          fi
-
-      - name: Sign missing update manifest
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true' && steps.existing.outputs.signature_present != 'true'
-        env:
-          CORE_VERSION: ${{ steps.release.outputs.version }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.HOL_GUARD_CORE_UPDATE_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.HOL_GUARD_CORE_UPDATE_PRIVATE_KEY_PASSWORD }}
-        run: |
-          set -euo pipefail
-          MANIFEST="$RUNNER_TEMP/dist/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}.json"
-          bunx @tauri-apps/cli@2.11.4 signer sign "$MANIFEST"
-          test -s "$MANIFEST.sig"
-
-      - name: Require local manifest signature
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
-        env:
-          CORE_VERSION: ${{ steps.release.outputs.version }}
-        run: |
-          set -euo pipefail
-          test -s "$RUNNER_TEMP/dist/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}.json.sig"
 
       - name: Upload only missing immutable assets
         if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
@@ -468,7 +426,6 @@ jobs:
           CORE_TAG: ${{ steps.release.outputs.tag }}
           BINARY_PRESENT: ${{ steps.existing.outputs.binary_present }}
           MANIFEST_PRESENT: ${{ steps.existing.outputs.manifest_present }}
-          SIGNATURE_PRESENT: ${{ steps.existing.outputs.signature_present }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -479,9 +436,6 @@ jobs:
           fi
           if [[ "$MANIFEST_PRESENT" != "true" ]]; then
             gh release upload "$CORE_TAG" "$BASE.json" --repo "$GITHUB_REPOSITORY"
-          fi
-          if [[ "$SIGNATURE_PRESENT" != "true" ]]; then
-            gh release upload "$CORE_TAG" "$BASE.json.sig" --repo "$GITHUB_REPOSITORY"
           fi
           gh release view "$CORE_TAG" --repo "$GITHUB_REPOSITORY" --json assets \
             > "$RUNNER_TEMP/final-assets.json"
@@ -496,7 +450,7 @@ jobs:
               for asset in json.loads((Path(os.environ["RUNNER_TEMP"]) / "final-assets.json").read_text()).get("assets", [])
           }
           base = Path(os.environ["BASE"]).name
-          expected = {base, f"{base}.json", f"{base}.json.sig"}
+          expected = {base, f"{base}.json"}
           missing = expected - names
           if missing:
               raise SystemExit(f"Missing release assets: {sorted(missing)}")
@@ -506,7 +460,9 @@ jobs:
         if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
         with:
-          subject-path: ${{ runner.temp }}/dist/*
+          subject-path: |
+            ${{ runner.temp }}/dist/hol-guard-core-${{ steps.release.outputs.version }}-aarch64-apple-darwin
+            ${{ runner.temp }}/dist/hol-guard-core-${{ steps.release.outputs.version }}-aarch64-apple-darwin.json
 
       - name: Record completed provenance
         if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'

--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -169,7 +169,7 @@ jobs:
           enable-cache: true
 
       - name: Fetch exact tagged Core source
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
+        if: steps.release.outputs.available == 'true'
         id: source
         env:
           CORE_TAG: ${{ steps.release.outputs.tag }}
@@ -186,7 +186,7 @@ jobs:
           echo "sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Download existing immutable binary
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true' && steps.existing.outputs.binary_present == 'true'
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.binary_present == 'true'
         env:
           CORE_TAG: ${{ steps.release.outputs.tag }}
           CORE_VERSION: ${{ steps.release.outputs.version }}
@@ -244,7 +244,7 @@ jobs:
           export HOL_GUARD_HOME="$RUNNER_TEMP/smoke-home"
           mkdir -p "$HOL_GUARD_HOME"
           "$BUILT" desktop bootstrap --json > "$RUNNER_TEMP/bootstrap.json"
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           import os
           from pathlib import Path
@@ -267,7 +267,7 @@ jobs:
           KEYCHAIN="$RUNNER_TEMP/core-update.keychain-db"
           KEYCHAIN_PASSWORD=$(openssl rand -hex 24)
           export APPLE_CERTIFICATE
-          python - <<'PY'
+          python3 - <<'PY'
           import base64
           import os
           from pathlib import Path
@@ -303,7 +303,7 @@ jobs:
             --team-id "$APPLE_TEAM_ID" \
             --wait \
             --output-format json > "$RUNNER_TEMP/notary-result.json"
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           import os
           from pathlib import Path
@@ -314,7 +314,7 @@ jobs:
           PY
 
       - name: Verify local immutable binary and Apple team
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
+        if: steps.release.outputs.available == 'true'
         env:
           CORE_VERSION: ${{ steps.release.outputs.version }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -333,7 +333,7 @@ jobs:
           export HOL_GUARD_HOME="$RUNNER_TEMP/verify-home"
           mkdir -p "$HOL_GUARD_HOME"
           "$VERIFY" desktop bootstrap --json > "$RUNNER_TEMP/bootstrap.json"
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           import os
           from pathlib import Path
@@ -347,7 +347,7 @@ jobs:
           rm -f "$VERIFY"
 
       - name: Download or create update manifest
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
+        if: steps.release.outputs.available == 'true'
         env:
           CORE_VERSION: ${{ steps.release.outputs.version }}
           CORE_TAG: ${{ steps.release.outputs.tag }}
@@ -366,7 +366,7 @@ jobs:
               --dir "$DIST"
           else
             export BINARY MANIFEST
-            python - <<'PY'
+            python3 - <<'PY'
           import hashlib
           import json
           import os
@@ -393,7 +393,7 @@ jobs:
           fi
 
           export BINARY MANIFEST
-          python - <<'PY'
+          python3 - <<'PY'
           import hashlib
           import json
           import os
@@ -440,7 +440,7 @@ jobs:
           gh release view "$CORE_TAG" --repo "$GITHUB_REPOSITORY" --json assets \
             > "$RUNNER_TEMP/final-assets.json"
           export BASE
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           import os
           from pathlib import Path
@@ -461,8 +461,8 @@ jobs:
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
         with:
           subject-path: |
-            ${{ runner.temp }}/dist/hol-guard-core-${{ steps.release.outputs.version }}-aarch64-apple-darwin
-            ${{ runner.temp }}/dist/hol-guard-core-${{ steps.release.outputs.version }}-aarch64-apple-darwin.json
+            ${{ runner.temp }}/dist/hol-guard-core-${{ steps.release.outputs.version }}-${{ env.RELEASE_TARGET }}
+            ${{ runner.temp }}/dist/hol-guard-core-${{ steps.release.outputs.version }}-${{ env.RELEASE_TARGET }}.json
 
       - name: Record completed provenance
         if: steps.release.outputs.available == 'true' && steps.existing.outputs.attestation_present != 'true'
@@ -475,7 +475,7 @@ jobs:
           set -euo pipefail
           MARKER="$RUNNER_TEMP/dist/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}.attested.json"
           export MARKER
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           import os
           from datetime import datetime, timezone

--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -313,7 +313,7 @@ jobs:
               raise SystemExit(f"Apple notarization was not accepted: {payload.get('status', 'unknown')}")
           PY
 
-      - name: Verify local immutable binary and Apple team
+      - name: Verify local immutable binary and Apple trust
         if: steps.release.outputs.available == 'true'
         env:
           CORE_VERSION: ${{ steps.release.outputs.version }}
@@ -325,7 +325,9 @@ jobs:
           chmod 0755 "$BINARY"
           codesign --verify --strict --verbose=2 "$BINARY"
           codesign --display --verbose=4 "$BINARY" 2> "$RUNNER_TEMP/codesign.txt"
+          grep -F "Authority=Developer ID Application:" "$RUNNER_TEMP/codesign.txt"
           grep -Fx "TeamIdentifier=$APPLE_TEAM_ID" "$RUNNER_TEMP/codesign.txt"
+          spctl --assess --type execute --verbose=4 "$BINARY"
           cp "$BINARY" "$VERIFY"
           chmod 0755 "$VERIFY"
           codesign --verify --strict --verbose=2 "$VERIFY"


### PR DESCRIPTION
## Summary

Aligns the public Core alpha feed with the final HOL Guard Desktop trust model.

- removes the redundant Tauri/Minisign Core-update keypair and `.sig` asset
- keeps the immutable GitHub release binary + checksum/source-bound manifest + provenance marker
- requires Apple Developer ID code signing and an Accepted notarization result
- verifies published/resumed binaries report the expected Core version/bootstrap contract
- verifies the binary TeamIdentifier exactly matches `APPLE_TEAM_ID`
- preserves resumable immutable publication and concurrency protection
- reduces the feed to the existing Apple release credentials already required for Desktop signing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security & Verification**
  - Improved desktop release validation using Apple-specific signing configuration.
  - Simplified asset verification to focus on the application binary and its manifest.
  - Added checks to confirm the expected Apple team identity during local verification.
  - Refined release provenance attestation to cover the application binary and manifest.
  - Improved handling of existing binaries and manifests during verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->