### PR TITLE
fix(ci): make release/3.1 an idempotent PyPI alpha publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -186,10 +186,10 @@ jobs:
         run: |
           set -euo pipefail
           tag="alpha/v${VERSION}"
-          existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag#alpha/}" --jq '.object.sha' 2>/dev/null || true)
+          existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" --jq '.object.sha' 2>/dev/null || true)
           if [[ -z "$existing" ]]; then
             gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" -f ref="refs/tags/${tag}" -f sha="$SOURCE_SHA" >/dev/null
-            existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag#alpha/}" --jq '.object.sha')
+            existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" --jq '.object.sha')
           fi
           if [[ "$existing" != "$SOURCE_SHA" ]]; then
             echo "Alpha tag is already bound to a different source" >&2
@@ -267,11 +267,11 @@ jobs:
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           version: "0.9.26"
-      - uses: actions/download-artifact@3e5f45b2cfb9172054d4087a40e8e0b5a5461e7c
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: distributions
           path: dist/
-      - uses: actions/download-artifact@3e5f45b2cfb9172054d4087a40e8e0b5a5461e7c
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: distribution-sha256
       - name: Verify immutable TestPyPI-proven bytes
@@ -321,11 +321,11 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054d4087a40e8e0b5a5461e7c
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: distributions
           path: dist/
-      - uses: actions/download-artifact@3e5f45b2cfb9172054d4087a40e8e0b5a5461e7c
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: distribution-sha256
       - name: Verify release bytes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           ref: release/3.1
           fetch-depth: 0
+          fetch-tags: true
           path: release-tooling
           persist-credentials: false
       - name: Check out exact package source
@@ -99,6 +100,7 @@ jobs:
               echo "3.1 alphas must run from refs/heads/release/3.1" >&2
               exit 1
             fi
+            git -C release-tooling fetch --force --tags origin
             git -C release-tooling fetch --no-tags origin "+refs/heads/release/3.1:refs/remotes/origin/release/3.1"
             if ! git -C release-tooling merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/release/3.1; then
               echo "Requested source is not in release/3.1 history" >&2
@@ -186,10 +188,11 @@ jobs:
         run: |
           set -euo pipefail
           tag="alpha/v${VERSION}"
-          existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" --jq '.object.sha' 2>/dev/null || true)
+          encoded_tag=${tag//\//%2F}
+          existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${encoded_tag}" --jq '.object.sha' 2>/dev/null || true)
           if [[ -z "$existing" ]]; then
             gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" -f ref="refs/tags/${tag}" -f sha="$SOURCE_SHA" >/dev/null
-            existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" --jq '.object.sha')
+            existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${encoded_tag}" --jq '.object.sha')
           fi
           if [[ "$existing" != "$SOURCE_SHA" ]]; then
             echo "Alpha tag is already bound to a different source" >&2
@@ -343,7 +346,26 @@ jobs:
         run: |
           set -euo pipefail
           tag="alpha/v${VERSION}"
-          if gh release view "$tag" >/dev/null 2>&1; then
+          if release_json=$(gh release view "$tag" --json targetCommitish,isDraft,isPrerelease 2>/dev/null); then
+            target=$(jq -r '.targetCommitish' <<< "$release_json")
+            if ! jq -e '.isDraft == false and .isPrerelease == true' <<< "$release_json" >/dev/null; then
+              echo "Existing alpha release is not a published prerelease" >&2
+              exit 1
+            fi
+            if [[ "$target" != "$SOURCE_SHA" ]]; then
+              echo "Existing alpha release targets a different source" >&2
+              exit 1
+            fi
+            existing_dir=$(mktemp -d)
+            gh release download "$tag" --dir "$existing_dir"
+            mapfile -d '' local_files < <(find dist -maxdepth 1 -type f -print0 | sort -z)
+            mapfile -d '' remote_files < <(find "$existing_dir" -maxdepth 1 -type f -print0 | sort -z)
+            [[ "${#local_files[@]}" -gt 0 && "${#local_files[@]}" == "${#remote_files[@]}" ]]
+            for local_file in "${local_files[@]}"; do
+              remote_file="$existing_dir/$(basename "$local_file")"
+              [[ -f "$remote_file" ]]
+              cmp --silent "$local_file" "$remote_file"
+            done
             exit 0
           fi
           body=$(mktemp)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,10 +53,27 @@ jobs:
           fetch-tags: true
           path: release-tooling
           persist-credentials: false
-      - name: Check out exact package source
+      - name: Check out dispatched package source
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.expected_sha || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.inputs.expected_sha }}
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+      - name: Check out pull-request package source
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+      - name: Check out pushed package source
+        if: github.event_name == 'push'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
           path: source
           persist-credentials: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,98 +1,64 @@
-name: Publish to PyPI
+name: Publish HOL Guard 3.1 alpha
 
 on:
+  push:
+    branches: [release/3.1]
+  pull_request:
+    branches: [release/3.1]
   workflow_dispatch:
     inputs:
       release_channel:
-        description: "Release channel"
+        description: Release channel
         required: true
         default: alpha
         type: choice
-        options:
-          - alpha
+        options: [alpha]
       release_train:
-        description: "Authorized release train"
+        description: Release train
         required: true
+        default: "3.1"
         type: choice
-        options:
-          - "3.0"
-          - "3.1"
+        options: ["3.1"]
       release_version:
-        description: "Exact canonical release version"
+        description: Exact alpha version to publish
         required: true
         type: string
       expected_sha:
-        description: "Exact source commit authorized for publication"
+        description: Exact release/3.1 source commit to publish
         required: true
         type: string
-  push:
-    branches: [main, release/3.0, release/3.1]
-  pull_request:
-    branches: [main, release/3.0, release/3.1]
 
 permissions:
   contents: read
   pull-requests: read
 
 concurrency:
-  group: hol-guard-publish-${{ github.ref }}
+  group: hol-guard-release-3-1-alpha
   cancel-in-progress: false
 
 jobs:
-  authorize-release:
-    name: Authorize release dispatch
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - name: Enforce alpha release authority
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          GITHUB_ACTOR_ID: ${{ github.actor_id }}
-          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
-          GITHUB_REF: ${{ github.ref }}
-          GITHUB_SHA: ${{ github.sha }}
-          RELEASE_CHANNEL: ${{ github.event.inputs.release_channel }}
-          RELEASE_TRAIN: ${{ github.event.inputs.release_train }}
-          EXPECTED_SHA: ${{ github.event.inputs.expected_sha }}
-        run: |
-          if [[ "$GITHUB_RUN_ATTEMPT" != "1" ]]; then
-            echo "Release workflow reruns are denied; create a fresh authorized dispatch" >&2
-            exit 1
-          fi
-          if [[ "$GITHUB_ACTOR_ID" != "6068672" && "$GITHUB_ACTOR_ID" != "301892678" ]]; then
-            echo "Release dispatch actor is not an authorized maintainer" >&2
-            exit 1
-          fi
-          if [[ "$RELEASE_CHANNEL" != "alpha" || "$RELEASE_TRAIN" != "3.0" && "$RELEASE_TRAIN" != "3.1" ]]; then
-            echo "Only an authorized 3.x alpha train is permitted" >&2
-            exit 1
-          fi
-          if [[ "$GITHUB_REF" != "refs/heads/release/${RELEASE_TRAIN}" ]]; then
-            echo "Alpha releases must run from the selected release train branch" >&2
-            exit 1
-          fi
-          if [[ "$EXPECTED_SHA" != "$GITHUB_SHA" ]]; then
-            echo "Expected source SHA does not match the dispatch source" >&2
-            exit 1
-          fi
-
   build:
-    name: Build + Verify
-    if: >-
-      (github.event_name != 'workflow_dispatch' || github.run_attempt == 1) &&
-      (github.event_name != 'push' || github.run_attempt == 1)
-    needs: authorize-release
+    name: Build exact 3.1 source
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
-      channel: ${{ steps.version.outputs.channel }}
-      release_train: ${{ steps.version.outputs.release_train }}
       source_sha: ${{ steps.version.outputs.source_sha }}
+      channel: ${{ steps.version.outputs.channel }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - name: Check out current release tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
+          ref: release/3.1
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          path: release-tooling
+          persist-credentials: false
+      - name: Check out exact package source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.expected_sha || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
@@ -100,551 +66,139 @@ jobs:
         with:
           version: "0.9.26"
           enable-cache: true
-      - name: Verify release uv before dependency install
-        env:
-          EXPECTED_UV_VERSION: "0.9.26"
-          SETUP_UV_ACTION_REF: fac544c07dec837d0ccb6301d7b5580bf5edae39
-        run: |
-          python3 scripts/write_release_toolchain_sbom.py \
-            --output "$RUNNER_TEMP/hol-guard-release-toolchain-preflight.cdx.json" \
-            --release-version preflight \
-            --expected-uv-version "$EXPECTED_UV_VERSION" \
-            --setup-action-ref "$SETUP_UV_ACTION_REF"
-      - name: Install dependencies
+      - name: Install exact source dependencies
+        working-directory: source
         run: uv sync --frozen --extra dev --extra publish --extra cisco
-      - name: Compute publish version
+      - name: Compute immutable alpha version
         id: version
         env:
-          GITHUB_REF: ${{ github.ref }}
-          GITHUB_SHA: ${{ github.sha }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_RUN_NUMBER: ${{ github.run_number }}
-          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
-          GITHUB_ACTOR_ID: ${{ github.actor_id }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          EVENT_SHA: ${{ github.sha }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
           RELEASE_CHANNEL: ${{ github.event.inputs.release_channel }}
           RELEASE_TRAIN: ${{ github.event.inputs.release_train }}
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
           EXPECTED_SHA: ${{ github.event.inputs.expected_sha }}
           RELEASE_PUBLISHING_ENABLED: ${{ vars.RELEASE_PUBLISHING_ENABLED }}
         run: |
-          BASE_VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
-          VERSION="$BASE_VERSION"
-          CHANNEL="integration"
-          TRAIN=""
-          SOURCE_SHA=$(git rev-parse 'HEAD^{commit}')
+          set -euo pipefail
+          SOURCE_SHA=$(git -C source rev-parse 'HEAD^{commit}')
+          CHANNEL=canary
 
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            VERSION="3.1.0.dev${RUN_NUMBER}${RUN_ATTEMPT}"
+          else
             if [[ "$RELEASE_PUBLISHING_ENABLED" != "true" ]]; then
-              echo "Release publishing is disabled until protected environments are verified" >&2
+              echo "Release publishing is disabled" >&2
               exit 1
             fi
-            if [[ "$GITHUB_RUN_ATTEMPT" != "1" ]]; then
-              echo "Release workflow reruns are denied; create a fresh authorized dispatch" >&2
+            CHANNEL=alpha
+            if [[ "$EVENT_REF" != "refs/heads/release/3.1" ]]; then
+              echo "3.1 alphas must run from refs/heads/release/3.1" >&2
               exit 1
             fi
-            if [[ "$GITHUB_ACTOR_ID" != "6068672" && "$GITHUB_ACTOR_ID" != "301892678" ]]; then
-              echo "Release dispatch actor is not an authorized maintainer" >&2
+            git -C release-tooling fetch --no-tags origin "+refs/heads/release/3.1:refs/remotes/origin/release/3.1"
+            if ! git -C release-tooling merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/release/3.1; then
+              echo "Requested source is not in release/3.1 history" >&2
               exit 1
             fi
-            CHANNEL="$RELEASE_CHANNEL"
-            TRAIN="$RELEASE_TRAIN"
-            if [[ "$TRAIN" != "3.0" && "$TRAIN" != "3.1" ]]; then
-              echo "Unsupported release train: ${TRAIN}" >&2
-              exit 1
-            fi
-            TRAIN_REF="refs/heads/release/${TRAIN}"
 
-            if [[ "$CHANNEL" != "alpha" ]]; then
-              echo "The selected release train is alpha-only" >&2
-              exit 1
-            fi
-            if [[ "$GITHUB_REF" != "$TRAIN_REF" ]]; then
-              echo "Alpha releases must run from ${TRAIN_REF}" >&2
-              exit 1
-            fi
-            EXISTING_VERSION_FILE=$(mktemp)
-            uv run --no-sync python scripts/verify_release_registry.py \
-              list-versions --registry pypi | jq -r '.[]' > "$EXISTING_VERSION_FILE"
-            uv run --no-sync python scripts/verify_release_registry.py \
-              list-versions --registry testpypi | jq -r '.[]' >> "$EXISTING_VERSION_FILE"
-            git tag --list 'alpha/v*' | sed 's#^alpha/v##' >> "$EXISTING_VERSION_FILE"
-            mapfile -t EXISTING_VERSIONS < <(
-              awk -v candidate="$RELEASE_VERSION" '$0 != candidate' "$EXISTING_VERSION_FILE"
-            )
-            VALIDATOR_ARGS=(
-              --channel "$CHANNEL"
-              --version "$RELEASE_VERSION"
-              --git-ref "$TRAIN_REF"
-              --actual-ref "$GITHUB_REF"
-              --github-sha "$SOURCE_SHA"
-              --expected-sha "$EXPECTED_SHA"
-            )
-            for existing_version in "${EXISTING_VERSIONS[@]}"; do
-              VALIDATOR_ARGS+=(--existing-version "$existing_version")
-            done
-            VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py "${VALIDATOR_ARGS[@]}")
-          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            CHANNEL="canary"
-            VERSION=$(BASE_VERSION="$BASE_VERSION" PR_NUMBER="$PR_NUMBER" GITHUB_RUN_NUMBER="$GITHUB_RUN_NUMBER" GITHUB_RUN_ATTEMPT="$GITHUB_RUN_ATTEMPT" python - <<'PY'
-          import os
+            PYPI_VERSIONS=$(uv run --no-project --with packaging==25.0 python release-tooling/scripts/verify_release_registry.py list-versions --registry pypi)
+            TESTPYPI_VERSIONS=$(uv run --no-project --with packaging==25.0 python release-tooling/scripts/verify_release_registry.py list-versions --registry testpypi)
+            TAG_VERSIONS=$(git -C release-tooling tag --list 'alpha/v3.1.0a*' | sed 's#^alpha/v##' | jq -R -s 'split("\n") | map(select(length > 0))')
+            EXISTING_VERSIONS=$(jq -n --argjson pypi "$PYPI_VERSIONS" --argjson testpypi "$TESTPYPI_VERSIONS" --argjson tags "$TAG_VERSIONS" '$pypi + $testpypi + $tags | unique')
 
-          def pair(left: int, right: int) -> int:
-              total = left + right
-              return total * (total + 1) // 2 + right
-
-          print(f"{os.environ['BASE_VERSION']}.dev{pair(pair(int(os.environ['PR_NUMBER']), int(os.environ['GITHUB_RUN_NUMBER'])), int(os.environ['GITHUB_RUN_ATTEMPT']))}")
-          PY
-            )
-          elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ ^refs/heads/release/3\.[0-9]+$ ]]; then
-            if [[ "$RELEASE_PUBLISHING_ENABLED" != "true" ]]; then
-              echo "Release publishing is disabled until protected environments are verified" >&2
-              exit 1
-            fi
-            if [[ "$SOURCE_SHA" != "$GITHUB_SHA" ]]; then
-              echo "Checked-out source does not match the immutable push source" >&2
-              exit 1
-            fi
-            CHANNEL="alpha"
-            TRAIN="${GITHUB_REF#refs/heads/release/}"
-            if [[ "$TRAIN" != "3.0" && "$TRAIN" != "3.1" ]]; then
-              echo "Unsupported release train: ${TRAIN}" >&2
-              exit 1
-            fi
-            TRAIN_REF="refs/heads/release/${TRAIN}"
-            PYPI_VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \
-              list-versions --registry pypi)
-            TESTPYPI_VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \
-              list-versions --registry testpypi)
-            TAG_VERSIONS=$(git tag --list 'alpha/v*' | sed 's#^alpha/v##' | jq -R -s 'split("\n") | map(select(length > 0))')
-            EXISTING_VERSIONS=$(jq -n \
-              --argjson pypi "$PYPI_VERSIONS" \
-              --argjson testpypi "$TESTPYPI_VERSIONS" \
-              --argjson tags "$TAG_VERSIONS" \
-              '$pypi + $testpypi + $tags | unique')
-            mapfile -t SOURCE_ALPHA_TAGS < <(
-              git tag --points-at "$SOURCE_SHA" --list "alpha/v${TRAIN}.0a*" | sed 's#^alpha/v##'
-            )
-            if [[ "${#SOURCE_ALPHA_TAGS[@]}" -gt 1 ]]; then
-              echo "Source commit has multiple reserved alpha versions" >&2
-              exit 1
-            fi
-            if [[ "${#SOURCE_ALPHA_TAGS[@]}" -eq 1 ]]; then
-              RELEASE_VERSION="${SOURCE_ALPHA_TAGS[0]}"
-              REUSING_RESERVED_ALPHA=true
-              uv run --no-sync python scripts/compute_alpha_release_version.py \
-                --release-train "$TRAIN" --validate-phase-only <<< "$EXISTING_VERSIONS"
+            if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+              if [[ "$RELEASE_CHANNEL" != "alpha" || "$RELEASE_TRAIN" != "3.1" ]]; then
+                echo "Only release/3.1 alpha dispatches are allowed" >&2
+                exit 1
+              fi
+              if [[ "$EXPECTED_SHA" != "$SOURCE_SHA" ]]; then
+                echo "Expected source SHA does not match checked-out source" >&2
+                exit 1
+              fi
+              VERSION="$RELEASE_VERSION"
             else
-              RELEASE_VERSION=$(uv run --no-sync python scripts/compute_alpha_release_version.py \
-                --release-train "$TRAIN" <<< "$EXISTING_VERSIONS")
-              REUSING_RESERVED_ALPHA=false
+              mapfile -t SOURCE_TAGS < <(git -C release-tooling tag --points-at "$SOURCE_SHA" --list 'alpha/v3.1.0a*' | sed 's#^alpha/v##')
+              if [[ "${#SOURCE_TAGS[@]}" -gt 1 ]]; then
+                echo "Source commit has multiple 3.1 alpha reservations" >&2
+                exit 1
+              fi
+              if [[ "${#SOURCE_TAGS[@]}" -eq 1 ]]; then
+                VERSION="${SOURCE_TAGS[0]}"
+              else
+                VERSION=$(uv run --no-project --with packaging==25.0 python release-tooling/scripts/compute_alpha_release_version.py --release-train 3.1 <<< "$EXISTING_VERSIONS")
+              fi
             fi
-            EXISTING_VERSIONS_ARRAY=()
-            if [[ "$REUSING_RESERVED_ALPHA" != "true" ]]; then
-              mapfile -t EXISTING_VERSIONS_ARRAY < <(jq -r '.[]' <<< "$EXISTING_VERSIONS")
-            fi
-            VALIDATOR_ARGS=(
-              --channel "$CHANNEL"
-              --version "$RELEASE_VERSION"
-              --git-ref "$TRAIN_REF"
-              --actual-ref "$GITHUB_REF"
-              --github-sha "$SOURCE_SHA"
-              --expected-sha "$SOURCE_SHA"
-            )
-            for existing_version in "${EXISTING_VERSIONS_ARRAY[@]}"; do
-              VALIDATOR_ARGS+=(--existing-version "$existing_version")
+
+            mapfile -t OTHER_VERSIONS < <(jq -r --arg version "$VERSION" '.[] | select(. != $version)' <<< "$EXISTING_VERSIONS")
+            VALIDATOR=(--channel alpha --version "$VERSION" --git-ref refs/heads/release/3.1 --actual-ref "$EVENT_REF" --github-sha "$SOURCE_SHA" --expected-sha "$SOURCE_SHA")
+            for existing in "${OTHER_VERSIONS[@]}"; do
+              VALIDATOR+=(--existing-version "$existing")
             done
-            VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py "${VALIDATOR_ARGS[@]}")
-          elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
-            CHANNEL="stable"
-            PYPI_VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \
-              list-versions --registry pypi)
-            TESTPYPI_VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \
-              list-versions --registry testpypi)
-            VERSIONS=$(jq -n \
-              --argjson pypi "$PYPI_VERSIONS" \
-              --argjson testpypi "$TESTPYPI_VERSIONS" \
-              '$pypi + $testpypi | unique')
-            VERSION=$(uv run --no-sync python scripts/compute_main_release_version.py \
-              --base-version "$BASE_VERSION" <<< "$VERSIONS")
+            VERSION=$(uv run --no-project --with packaging==25.0 python release-tooling/scripts/validate_alpha_release.py "${VALIDATOR[@]}")
           fi
+
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
-          echo "release_train=$TRAIN" >> "$GITHUB_OUTPUT"
           echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
-          echo "Computed $CHANNEL version: $VERSION"
-      - name: Verify release toolchain and write SBOM
-        env:
-          EXPECTED_UV_VERSION: "0.9.26"
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          SETUP_UV_ACTION_REF: fac544c07dec837d0ccb6301d7b5580bf5edae39
-        run: |
-          python3 scripts/write_release_toolchain_sbom.py \
-            --output "release-metadata/plugin-scanner-v${RELEASE_VERSION}.toolchain.cdx.json" \
-            --release-version "$RELEASE_VERSION" \
-            --expected-uv-version "$EXPECTED_UV_VERSION" \
-            --setup-action-ref "$SETUP_UV_ACTION_REF"
-      - name: Stamp package version when needed
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "Resolved $SOURCE_SHA -> $VERSION ($CHANNEL)"
+      - name: Stamp exact package version
         env:
           VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          CURRENT_VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
-          if [[ "$CURRENT_VERSION" == "$VERSION" ]]; then
-            echo "Package metadata already matches $VERSION"
-            exit 0
-          fi
-          uv run --no-sync python scripts/sync_repo_version.py --version "$VERSION"
-      - name: Build Guard package (hol-guard)
-        run: |
-          cp pyproject.toml pyproject.toml.bak
-          python3 - <<'PY'
-          from pathlib import Path
-
-          path = Path("pyproject.toml")
-          text = path.read_text(encoding="utf-8")
-          text = text.replace('name = "hol-guard"', 'name = "hol-guard"', 1)
-          start = text.index("[project.scripts]")
-          end = text.index("\n\n[project.urls]")
-          scripts = "[project.scripts]\n" \
-              'hol-guard = "codex_plugin_scanner.cli:main"\n' \
-              'plugin-guard = "codex_plugin_scanner.cli:main"'
-          text = text[:start] + scripts + text[end:]
-          path.write_text(text, encoding="utf-8")
-          PY
-          uv run --no-sync python -m build
-          mv pyproject.toml.bak pyproject.toml
-      - name: Build scanner package (plugin-scanner)
-        run: |
-          cp pyproject.toml pyproject.toml.bak
-          python3 - <<'PY'
-          import re
-          from pathlib import Path
-
-          path = Path("pyproject.toml")
-          text = path.read_text(encoding="utf-8")
-          text = text.replace('name = "hol-guard"', 'name = "plugin-scanner"', 1)
-          text, description_count = re.subn(
-              r'^description = ".*"$',
-              'description = "Lint, verify, and gate plugin ecosystems for maintainers, CI, and publish workflows."',
-              text,
-              count=1,
-              flags=re.MULTILINE,
-          )
-          if description_count != 1:
-              raise RuntimeError("Expected one project description in pyproject.toml")
-          start = text.index("[project.scripts]")
-          end = text.index("\n\n[project.urls]")
-          scripts = "[project.scripts]\n" \
-              'plugin-scanner = "codex_plugin_scanner.cli:main"\n' \
-              'plugin-ecosystem-scanner = "codex_plugin_scanner.cli:main"'
-          text = text[:start] + scripts + text[end:]
-          path.write_text(text, encoding="utf-8")
-          PY
-          uv run --no-sync python -m build
-          mv pyproject.toml.bak pyproject.toml
-      - name: Verify distributions
-        run: uv run --no-sync twine check dist/*
+        run: python3 release-tooling/scripts/sync_repo_version.py --repo-root source --version "$VERSION"
+      - name: Build Guard distribution
+        working-directory: source
+        run: uv run --no-sync python -m build --wheel --sdist --outdir "$GITHUB_WORKSPACE/dist"
+      - name: Verify Guard distribution
+        working-directory: source
+        run: uv run --no-sync twine check "$GITHUB_WORKSPACE"/dist/*
       - name: Record immutable distribution hashes
-        run: |
-          find dist -maxdepth 1 -type f -print0 | sort -z | xargs -0 sha256sum > distribution-sha256.txt
-      - name: Bind installed canary subject
-        if: github.event_name == 'pull_request'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          SOURCE_SHA: ${{ steps.version.outputs.source_sha }}
-        run: |
-          uv run --no-sync python scripts/installed_canary_proof.py write-subject \
-            --dist-dir dist \
-            --version "$VERSION" \
-            --source-sha "$SOURCE_SHA" \
-            --output installed-canary-subject.json
-      - name: Upload artifacts
+        run: find dist -maxdepth 1 -type f -print0 | sort -z | xargs -0 sha256sum > distribution-sha256.txt
+      - name: Upload exact distribution
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: distributions
           path: dist/
+          if-no-files-found: error
       - name: Upload distribution hashes
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: distribution-sha256
           path: distribution-sha256.txt
-      - name: Upload installed canary subject
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: installed-canary-subject
-          path: installed-canary-subject.json
           if-no-files-found: error
-      - name: Upload release toolchain SBOM
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: release-toolchain-sbom
-          path: release-metadata/*.cdx.json
-          if-no-files-found: error
-
-
-  publish-testpypi:
-    name: Publish PR canary to TestPyPI
-    if: >-
-      vars.PR_CANARY_PUBLISHING_ENABLED == 'true' &&
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(github.event.pull_request.labels.*.name, 'publish-testpypi-canary')
-    needs: build
-    runs-on: ubuntu-latest
-    environment: testpypi
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distributions
-          path: dist/
-      - name: Keep only the Guard canary distribution
-        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-        with:
-          repository-url: https://test.pypi.org/legacy/
-      - name: Show canary install command
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          echo "## TestPyPI canary" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
-          echo "uv tool install --force --index https://pypi.org/simple --find-links https://test.pypi.org/simple/hol-guard/ 'hol-guard==$VERSION'" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
-
-  pr-installed-canary:
-    name: Installed PR canary (${{ matrix.os }})
-    if: >-
-      vars.PR_CANARY_PUBLISHING_ENABLED == 'true' &&
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(github.event.pull_request.labels.*.name, 'publish-testpypi-canary')
-    needs: [build, publish-testpypi]
-    runs-on: ${{ matrix.os }}
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          ref: ${{ needs.build.outputs.source_sha }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        with:
-          python-version: "3.12"
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
-        with:
-          version: "0.9.26"
-          enable-cache: true
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
-        with:
-          bun-version: "1.3.14"
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distributions
-          path: dist/
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: installed-canary-subject
-          path: installed-canary/
-      - name: Download exact TestPyPI wheel bytes
-        shell: bash
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          mkdir -p verified-testpypi
-          for attempt in {1..60}; do
-            if uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py \
-              verify-release --registry testpypi --version "$VERSION" \
-              --dist-dir dist --download-dir verified-testpypi > registry-result.json; then
-              STATUS=$(python -c 'import json; print(json.load(open("registry-result.json", encoding="utf-8"))["status"])')
-              if [[ "$STATUS" == "exact" ]]; then
-                break
-              fi
-            fi
-            if [[ "$attempt" == "60" ]]; then
-              echo "Exact TestPyPI canary did not become available" >&2
-              exit 1
-            fi
-            sleep 10
-          done
-      - name: Verify PR head, version, and TestPyPI bytes
-        shell: bash
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-        run: |
-          test "$(git rev-parse 'HEAD^{commit}')" = "$SOURCE_SHA"
-          uv run --no-project --with packaging==25.0 python scripts/installed_canary_proof.py verify-download \
-            --subject installed-canary/installed-canary-subject.json \
-            --version "$VERSION" \
-            --source-sha "$SOURCE_SHA" \
-            --download-dir verified-testpypi > verified-download.json
-      - name: Install only the verified wheel
-        shell: bash
-        run: |
-          WHEEL_REQUIREMENT=$(python -c 'import json; print(json.load(open("verified-download.json", encoding="utf-8"))["requirement"])')
-          python -m venv "$RUNNER_TEMP/hol-guard-canary-venv"
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            CANARY_PYTHON="$RUNNER_TEMP/hol-guard-canary-venv/Scripts/python.exe"
-          else
-            CANARY_PYTHON="$RUNNER_TEMP/hol-guard-canary-venv/bin/python"
-          fi
-          "$CANARY_PYTHON" -m pip install --no-compile --index-url https://pypi.org/simple "$WHEEL_REQUIREMENT"
-          echo "CANARY_PYTHON=$CANARY_PYTHON" >> "$GITHUB_ENV"
-      - name: Prove the harness rejects missing evidence
-        shell: bash
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-        run: |
-          if PYTHONPATH= "$CANARY_PYTHON" -X "pycache_prefix=$RUNNER_TEMP/hol-guard-missing-proof-cache" \
-            -m scripts.run_installed_canary \
-            --subject installed-canary/missing-subject.json \
-            --version "$VERSION" \
-            --source-sha "$SOURCE_SHA" \
-            --repo-root "$GITHUB_WORKSPACE" \
-            --output installed-canary/missing-proof-must-not-exist.json; then
-            echo "Installed canary harness accepted a run without proof" >&2
-            exit 1
-          fi
-          test ! -e installed-canary/missing-proof-must-not-exist.json
-      - name: Run installed 51k corpus and dashboard smoke
-        shell: bash
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-        run: |
-          PYTHONPATH= "$CANARY_PYTHON" -X "pycache_prefix=$RUNNER_TEMP/hol-guard-evidence-cache" \
-            -m scripts.run_installed_canary \
-            --subject installed-canary/installed-canary-subject.json \
-            --version "$VERSION" \
-            --source-sha "$SOURCE_SHA" \
-            --repo-root "$GITHUB_WORKSPACE" \
-            --output installed-canary/evidence.json
-      - name: Run canonical command extension analytics Dockerlab
-        if: runner.os == 'Linux'
-        shell: bash
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          VERIFIED_WHEEL=$(python -c 'import json; print(json.load(open("verified-download.json", encoding="utf-8"))["wheel"])')
-          WHEEL_NAME=$(basename "$VERIFIED_WHEEL")
-          cmp "$VERIFIED_WHEEL" "dist/$WHEEL_NAME"
-          cd dashboard
-          bun install --frozen-lockfile --ignore-scripts
-          bunx playwright install --with-deps chromium
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends apparmor bubblewrap
-          sudo tee /etc/apparmor.d/hol-guard-bwrap >/dev/null <<'EOF'
-          abi <abi/4.0>,
-          include <tunables/global>
-          /usr/bin/bwrap flags=(unconfined) {
-            userns,
-          }
-          EOF
-          sudo apparmor_parser -r /etc/apparmor.d/hol-guard-bwrap
-          cd ../tests/dockerlabs/command-extension-analytics
-          bun run typecheck
-          HOL_GUARD_LAB_EXPECTED_VERSION="$VERSION" \
-            HOL_GUARD_LAB_PYTHON="$CANARY_PYTHON" \
-            HOL_GUARD_WHEEL="$GITHUB_WORKSPACE/dist/$WHEEL_NAME" \
-            bun run guard:test:command-extension-analytics \
-              > "$GITHUB_WORKSPACE/installed-canary/command-extension-analytics.json"
-      - name: Verify installed browser proof
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          proof_dir=.artifacts/command-extension-analytics/playwright-output
-          for screenshot in \
-            installed-command-activity-overview.png \
-            installed-command-activity-filtered.png \
-            installed-command-activity-detail-feedback.png; do
-            count=$(find "$proof_dir" -type f -name "$screenshot" | wc -l)
-            test "$count" -eq 1
-          done
-      - name: Upload installed canary evidence
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: installed-canary-evidence-${{ runner.os }}
-          path: |
-            installed-canary/evidence.json
-            installed-canary/command-extension-analytics.json
-            .artifacts/command-extension-analytics/playwright-output/**/*.png
-          if-no-files-found: error
-          include-hidden-files: true
 
   reserve-alpha-tag:
-    name: Reserve alpha version
-    if: >-
-      always() &&
-      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      needs.build.result == 'success' &&
-      needs.build.outputs.channel == 'alpha' &&
-      (
-        (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/3.'))
-      )
-    needs: [build]
+    name: Reserve exact 3.1 alpha
+    if: needs.build.outputs.channel == 'alpha'
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.build.outputs.source_sha }}
-      - name: Reserve exact alpha tag
+      - name: Reserve version for source commit
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
+          set -euo pipefail
           tag="alpha/v${VERSION}"
-          for attempt in 1 2 3; do
-            remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
-            if [[ -n "$remote_tag_sha" ]]; then
-              break
-            fi
-            if gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
-              -f ref="refs/tags/${tag}" \
-              -f sha="$SOURCE_SHA" >/dev/null; then
-              remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
-              if [[ -n "$remote_tag_sha" ]]; then
-                break
-              fi
-            fi
-            if [[ "$attempt" != "3" ]]; then
-              sleep $((attempt * 5))
-            fi
-          done
-          if [[ -z "$remote_tag_sha" ]]; then
-            git tag "$tag" "$SOURCE_SHA"
-            git push origin "refs/tags/${tag}" || true
-            remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
+          existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag#alpha/}" --jq '.object.sha' 2>/dev/null || true)
+          if [[ -z "$existing" ]]; then
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" -f ref="refs/tags/${tag}" -f sha="$SOURCE_SHA" >/dev/null
+            existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag#alpha/}" --jq '.object.sha')
           fi
-          if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
-            echo "Alpha tag reservation does not target the published source" >&2
+          if [[ "$existing" != "$SOURCE_SHA" ]]; then
+            echo "Alpha tag is already bound to a different source" >&2
             exit 1
           fi
 
   publish-alpha-testpypi:
-    name: Verify alpha artifact on TestPyPI
-    if: >-
-      always() &&
-      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      needs.build.result == 'success' &&
-      needs.reserve-alpha-tag.result == 'success' &&
-      needs.build.outputs.channel == 'alpha' &&
-      (
-        (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/3.'))
-      )
+    name: Publish exact alpha to TestPyPI
+    if: needs.build.outputs.channel == 'alpha'
     needs: [build, reserve-alpha-tag]
     runs-on: ubuntu-latest
     environment: testpypi
@@ -654,7 +208,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
-          ref: ${{ needs.build.outputs.source_sha }}
+          ref: release/3.1
+          persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           version: "0.9.26"
@@ -665,85 +220,38 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: distribution-sha256
-      - name: Verify immutable build artifact
+      - name: Verify immutable bytes
         run: sha256sum --check distribution-sha256.txt
-      - name: Keep only the Guard release distribution
-        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
-      - name: Revalidate alpha source before TestPyPI
-        env:
-          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-          TRAIN: ${{ needs.build.outputs.release_train }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          train_ref="refs/heads/release/${TRAIN}"
-          remote_train_sha=$(git ls-remote --exit-code origin "$train_ref" | awk '{print $1}')
-          if [[ "$remote_train_sha" != "$SOURCE_SHA" ]]; then
-            echo "Alpha publication source is no longer the release train head" >&2
-            exit 1
-          fi
-          remote_alpha_tag_sha=$(git ls-remote origin "refs/tags/alpha/v${VERSION}" | awk '{print $1}')
-          if [[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]; then
-            echo "Alpha tag targets a different source" >&2
-            exit 1
-          fi
-      - name: Inspect TestPyPI release state
-        id: testpypi
+      - name: Inspect TestPyPI state
+        id: state
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-            verify-release --registry testpypi --version "$VERSION" --dist-dir dist)
+          result=$(uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py verify-release --registry testpypi --version "$VERSION" --dist-dir dist)
           status=$(jq -r '.status' <<< "$result")
-          if [[ "$status" == "absent" ]]; then
-            echo "upload=true" >> "$GITHUB_OUTPUT"
-          elif [[ "$status" == "exact" ]]; then
-            echo "upload=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Unexpected TestPyPI status: $status" >&2
-            exit 1
-          fi
+          [[ "$status" == "absent" || "$status" == "exact" ]]
+          [[ "$status" == "absent" ]] && echo "upload=true" >> "$GITHUB_OUTPUT" || echo "upload=false" >> "$GITHUB_OUTPUT"
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-        if: steps.testpypi.outputs.upload == 'true'
+        if: steps.state.outputs.upload == 'true'
         with:
           repository-url: https://test.pypi.org/legacy/
-      - name: Remove generated upload attestations
-        run: rm -f dist/*.publish.attestation
-      - name: Download and verify exact TestPyPI artifacts
+      - name: Verify published TestPyPI bytes and CLI
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           for attempt in {1..60}; do
-            if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-              verify-release --registry testpypi --version "$VERSION" --dist-dir dist \
-              --download-dir verified-testpypi); then
-              exit 1
-            fi
-            status=$(jq -r '.status' <<< "$result")
-            if [[ "$status" == "exact" ]]; then
-              break
-            fi
-            if [[ "$status" != "absent" || "$attempt" == "60" ]]; then
-              echo "TestPyPI did not expose the exact release artifacts" >&2
-              exit 1
-            fi
+            result=$(uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py verify-release --registry testpypi --version "$VERSION" --dist-dir dist --download-dir verified-testpypi || true)
+            status=$(jq -r '.status // "error"' <<< "$result")
+            [[ "$status" == "exact" ]] && break
+            [[ "$attempt" == "60" ]] && { echo "Exact TestPyPI release did not appear" >&2; exit 1; }
             sleep 5
           done
           wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
-          [[ -n "$wheel" ]]
           [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
 
   publish-alpha-pypi:
-    name: Publish alpha to PyPI
-    if: >-
-      always() &&
-      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      needs.build.result == 'success' &&
-      needs.reserve-alpha-tag.result == 'success' &&
-      needs.build.outputs.channel == 'alpha' &&
-      (
-        (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/3.'))
-      )
+    name: Publish exact alpha to PyPI
+    if: needs.build.outputs.channel == 'alpha'
     needs: [build, reserve-alpha-tag, publish-alpha-testpypi]
     runs-on: ubuntu-latest
     environment: pypi
@@ -753,633 +261,99 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
+          ref: release/3.1
           fetch-depth: 0
-          ref: ${{ needs.build.outputs.source_sha }}
+          persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           version: "0.9.26"
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      - uses: actions/download-artifact@3e5f45b2cfb9172054d4087a40e8e0b5a5461e7c
         with:
           name: distributions
           path: dist/
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      - uses: actions/download-artifact@3e5f45b2cfb9172054d4087a40e8e0b5a5461e7c
         with:
           name: distribution-sha256
-      - name: Verify the TestPyPI-proven artifact
+      - name: Verify immutable TestPyPI-proven bytes
         run: sha256sum --check distribution-sha256.txt
-      - name: Keep only the Guard release distribution
-        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
-      - name: Inspect PyPI release state
-        id: pypi
+      - name: Revalidate source and alpha reservation
         env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-            verify-release --registry pypi --version "$VERSION" --dist-dir dist)
-          status=$(jq -r '.status' <<< "$result")
-          if [[ "$status" == "absent" ]]; then
-            echo "upload=true" >> "$GITHUB_OUTPUT"
-          elif [[ "$status" == "exact" ]]; then
-            echo "upload=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Unexpected PyPI status: $status" >&2
-            exit 1
-          fi
-      - name: Revalidate alpha publication authorization
-        env:
-          ACTUAL_REF: ${{ github.ref }}
-          EXPECTED_SHA: ${{ github.event.inputs.expected_sha || needs.build.outputs.source_sha }}
           SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-          TRAIN: ${{ needs.build.outputs.release_train }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          train_ref="refs/heads/release/${TRAIN}"
-          remote_train_sha=$(git ls-remote --exit-code origin "$train_ref" | awk '{print $1}')
-          if [[ "$remote_train_sha" != "$SOURCE_SHA" ]]; then
-            echo "Alpha publication source is no longer the release train head" >&2
-            exit 1
-          fi
-          remote_alpha_tag_sha=$(git ls-remote origin "refs/tags/alpha/v${VERSION}" | awk '{print $1}')
-          if [[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]; then
-            echo "Alpha tag targets a different source" >&2
-            exit 1
-          fi
-          versions=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-            list-versions --registry pypi)
-          mapfile -t existing_versions < <(jq -r --arg version "$VERSION" '.[] | select(. != $version)' <<< "$versions")
-          mapfile -t alpha_tags < <(
-            git tag --list 'alpha/v*' | sed 's#^alpha/v##' | awk -v candidate="$VERSION" '$0 != candidate'
-          )
-          validator_args=(
-            --channel alpha
-            --version "$VERSION"
-            --git-ref "$train_ref"
-            --actual-ref "$ACTUAL_REF"
-            --github-sha "$SOURCE_SHA"
-            --expected-sha "$EXPECTED_SHA"
-          )
-          for existing_version in "${existing_versions[@]}" "${alpha_tags[@]}"; do
-            [[ -z "$existing_version" ]] || validator_args+=(--existing-version "$existing_version")
-          done
-          uv run --with packaging==25.0 python scripts/validate_alpha_release.py "${validator_args[@]}"
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/release/3.1:refs/remotes/origin/release/3.1
+          git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/release/3.1
+          tag_sha=$(git ls-remote origin "refs/tags/alpha/v${VERSION}" | awk '{print $1}')
+          [[ "$tag_sha" == "$SOURCE_SHA" ]]
+      - name: Inspect PyPI state
+        id: state
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          result=$(uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py verify-release --registry pypi --version "$VERSION" --dist-dir dist)
+          status=$(jq -r '.status' <<< "$result")
+          [[ "$status" == "absent" || "$status" == "exact" ]]
+          [[ "$status" == "absent" ]] && echo "upload=true" >> "$GITHUB_OUTPUT" || echo "upload=false" >> "$GITHUB_OUTPUT"
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-        if: steps.pypi.outputs.upload == 'true'
-      - name: Remove generated upload attestations
-        run: rm -f dist/*.publish.attestation
-      - name: Download and verify exact PyPI artifacts
+        if: steps.state.outputs.upload == 'true'
+      - name: Verify published PyPI bytes and CLI
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           for attempt in {1..60}; do
-            if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-              verify-release --registry pypi --version "$VERSION" --dist-dir dist \
-              --download-dir verified-pypi); then
-              exit 1
-            fi
-            status=$(jq -r '.status' <<< "$result")
-            if [[ "$status" == "exact" ]]; then
-              break
-            fi
-            if [[ "$status" != "absent" || "$attempt" == "60" ]]; then
-              echo "PyPI did not expose the exact release artifacts" >&2
-              exit 1
-            fi
+            result=$(uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py verify-release --registry pypi --version "$VERSION" --dist-dir dist --download-dir verified-pypi || true)
+            status=$(jq -r '.status // "error"' <<< "$result")
+            [[ "$status" == "exact" ]] && break
+            [[ "$attempt" == "60" ]] && { echo "Exact PyPI release did not appear" >&2; exit 1; }
             sleep 5
           done
           wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
-          [[ -n "$wheel" ]]
           [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
-
-  publish-main-testpypi:
-    name: Verify main artifact on TestPyPI
-    if: >-
-      always() &&
-      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      github.event_name == 'push' &&
-      github.run_attempt == 1 &&
-      github.ref == 'refs/heads/main' &&
-      needs.build.result == 'success' &&
-      needs.build.outputs.channel == 'stable'
-    needs: build
-    runs-on: ubuntu-latest
-    environment: testpypi
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.build.outputs.source_sha }}
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
-        with:
-          version: "0.9.26"
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distributions
-          path: dist/
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distribution-sha256
-      - name: Verify immutable build artifact
-        run: sha256sum --check distribution-sha256.txt
-      - name: Keep only the Guard release distribution
-        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
-      - name: Revalidate main source before TestPyPI
-        env:
-          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-        run: |
-          remote_main_sha=$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')
-          if [[ "$remote_main_sha" != "$SOURCE_SHA" ]]; then
-            echo "Main publication source is no longer the branch head" >&2
-            exit 1
-          fi
-      - name: Inspect TestPyPI release state
-        id: testpypi
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-            verify-release --registry testpypi --version "$VERSION" --dist-dir dist)
-          status=$(jq -r '.status' <<< "$result")
-          if [[ "$status" == "absent" ]]; then
-            echo "upload=true" >> "$GITHUB_OUTPUT"
-          elif [[ "$status" == "exact" ]]; then
-            echo "upload=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Unexpected TestPyPI status: $status" >&2
-            exit 1
-          fi
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-        if: steps.testpypi.outputs.upload == 'true'
-        with:
-          repository-url: https://test.pypi.org/legacy/
-      - name: Remove generated upload attestations
-        run: rm -f dist/*.publish.attestation
-      - name: Download and verify exact TestPyPI artifacts
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          for attempt in {1..60}; do
-            if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-              verify-release --registry testpypi --version "$VERSION" --dist-dir dist \
-              --download-dir verified-testpypi); then
-              exit 1
-            fi
-            status=$(jq -r '.status' <<< "$result")
-            if [[ "$status" == "exact" ]]; then
-              break
-            fi
-            if [[ "$status" != "absent" || "$attempt" == "60" ]]; then
-              echo "TestPyPI did not expose the exact release artifacts" >&2
-              exit 1
-            fi
-            sleep 5
-          done
-          wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
-          [[ -n "$wheel" ]]
-          [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
-
-  publish-main-pypi:
-    name: Publish main release to PyPI
-    if: >-
-      always() &&
-      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      github.event_name == 'push' &&
-      github.run_attempt == 1 &&
-      github.ref == 'refs/heads/main' &&
-      needs.build.result == 'success' &&
-      needs.publish-main-testpypi.result == 'success' &&
-      needs.build.outputs.channel == 'stable'
-    needs: [build, publish-main-testpypi]
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.build.outputs.source_sha }}
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
-        with:
-          version: "0.9.26"
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distributions
-          path: dist/
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distribution-sha256
-      - name: Verify the TestPyPI-proven artifact
-        run: sha256sum --check distribution-sha256.txt
-      - name: Keep only the Guard release distribution
-        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
-      - name: Revalidate main publication
-        env:
-          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          remote_main_sha=$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')
-          if [[ "$remote_main_sha" != "$SOURCE_SHA" ]]; then
-            echo "Main publication source is no longer the branch head" >&2
-            exit 1
-          fi
-          BASE_VERSION=$(uv run --with packaging==25.0 python scripts/sync_repo_version.py --check)
-          PYPI_VERSIONS=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-            list-versions --registry pypi)
-          TESTPYPI_VERSIONS=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-            list-versions --registry testpypi)
-          RELEASE_VERSIONS=$(jq -n \
-            --arg version "$VERSION" \
-            --argjson pypi "$PYPI_VERSIONS" \
-            --argjson testpypi "$TESTPYPI_VERSIONS" \
-            '$pypi + $testpypi + [$version] | unique')
-          LATEST_RELEASE_VERSION=$(uv run --with packaging==25.0 python scripts/compute_main_release_version.py \
-            --base-version "$BASE_VERSION" --latest-existing <<< "$RELEASE_VERSIONS")
-          if [[ "$LATEST_RELEASE_VERSION" != "$VERSION" ]]; then
-            echo "A newer main release candidate exists before publication" >&2
-            exit 1
-          fi
-          PRIOR_PYPI_VERSIONS=$(jq --arg version "$VERSION" \
-            '[.[] | select(. != $version)]' <<< "$PYPI_VERSIONS")
-          LATEST_VERSION=$(uv run --with packaging==25.0 python scripts/compute_main_release_version.py \
-            --base-version "$BASE_VERSION" --latest-existing <<< "$PRIOR_PYPI_VERSIONS")
-          if [[ -n "$LATEST_VERSION" ]]; then
-            git fetch --no-tags origin "+refs/tags/v${LATEST_VERSION}:refs/tags/v${LATEST_VERSION}"
-            if ! git merge-base --is-ancestor "v${LATEST_VERSION}^{commit}" "$SOURCE_SHA"; then
-              echo "Main release source predates the latest stable release" >&2
-              exit 1
-            fi
-          fi
-      - name: Inspect PyPI release state
-        id: pypi
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-            verify-release --registry pypi --version "$VERSION" --dist-dir dist)
-          status=$(jq -r '.status' <<< "$result")
-          if [[ "$status" == "absent" ]]; then
-            echo "upload=true" >> "$GITHUB_OUTPUT"
-          elif [[ "$status" == "exact" ]]; then
-            echo "upload=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Unexpected PyPI status: $status" >&2
-            exit 1
-          fi
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-        if: steps.pypi.outputs.upload == 'true'
-      - name: Remove generated upload attestations
-        run: rm -f dist/*.publish.attestation
-      - name: Download and verify exact PyPI artifacts
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          for attempt in {1..60}; do
-            if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-              verify-release --registry pypi --version "$VERSION" --dist-dir dist \
-              --download-dir verified-pypi); then
-              exit 1
-            fi
-            status=$(jq -r '.status' <<< "$result")
-            if [[ "$status" == "exact" ]]; then
-              break
-            fi
-            if [[ "$status" != "absent" || "$attempt" == "60" ]]; then
-              echo "PyPI did not expose the exact release artifacts" >&2
-              exit 1
-            fi
-            sleep 5
-          done
-          wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
-          [[ -n "$wheel" ]]
-          [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
-
-  release-main:
-    name: Create main GitHub release
-    if: >-
-      always() &&
-      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      github.event_name == 'push' &&
-      github.run_attempt == 1 &&
-      github.ref == 'refs/heads/main' &&
-      needs.build.result == 'success' &&
-      needs.publish-main-pypi.result == 'success' &&
-      needs.build.outputs.channel == 'stable'
-    needs: [build, publish-main-pypi]
-    runs-on: ubuntu-latest
-    permissions:
-      attestations: write
-      contents: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.build.outputs.source_sha }}
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distributions
-          path: dist/
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distribution-sha256
-      - name: Download release toolchain SBOM
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: release-toolchain-sbom
-          path: dist/
-      - name: Verify and select release assets
-        run: |
-          sha256sum --check distribution-sha256.txt
-          rm -f dist/plugin_scanner-* dist/plugin-scanner-*
-      - name: Attest main release assets
-        id: provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
-        with:
-          subject-path: dist/*
-      - name: Materialize provenance bundle
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: cp "${{ steps.provenance.outputs.bundle-path }}" "dist/hol-guard-v${VERSION}.intoto.jsonl"
-      - name: Create discoverable main release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          tag="v${VERSION}"
-          remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
-          if [[ -z "$remote_tag_sha" ]]; then
-            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
-              -f ref="refs/tags/${tag}" \
-              -f sha="$SOURCE_SHA" >/dev/null
-            remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/${tag}" | awk '{print $1}')
-          fi
-          if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
-            echo "Stable tag does not target the published source" >&2
-            exit 1
-          fi
-          if release_json=$(gh release view "$tag" --json isDraft,isPrerelease 2>/dev/null); then
-            if ! jq -e '.isDraft == false and .isPrerelease == false' <<< "$release_json" >/dev/null; then
-              echo "Existing stable release is a draft or prerelease" >&2
-              exit 1
-            fi
-            existing_dir=$(mktemp -d)
-            gh release download "$tag" --dir "$existing_dir"
-            mapfile -d '' local_files < <(find dist -maxdepth 1 -type f -print0 | sort -z)
-            mapfile -d '' remote_files < <(find "$existing_dir" -maxdepth 1 -type f -print0 | sort -z)
-            [[ "${#local_files[@]}" -gt 0 ]]
-            [[ "${#local_files[@]}" == "${#remote_files[@]}" ]]
-            for local_file in "${local_files[@]}"; do
-              remote_file="$existing_dir/$(basename "$local_file")"
-              [[ -f "$remote_file" ]]
-              if [[ "$remote_file" != *.intoto.jsonl ]]; then
-                cmp --silent "$local_file" "$remote_file"
-              fi
-            done
-            bundle="$existing_dir/hol-guard-v${VERSION}.intoto.jsonl"
-            [[ -s "$bundle" ]]
-            shopt -s nullglob
-            remote_guard_files=("$existing_dir"/hol_guard-*)
-            [[ "${#remote_guard_files[@]}" -gt 0 ]]
-            for remote_file in "${remote_guard_files[@]}"; do
-              gh attestation verify "$remote_file" --repo "$GITHUB_REPOSITORY" \
-                --bundle "$bundle" --source-digest "$SOURCE_SHA" >/dev/null
-            done
-            exit 0
-          fi
-          body_file=$(mktemp)
-          cat > "$body_file" <<EOF
-          Guard ${VERSION}
-
-          Install this release:
-
-          \`\`\`bash
-          uv tool install "hol-guard[cisco]==${VERSION}"
-          \`\`\`
-          EOF
-          mapfile -d '' ASSET_FILES < <(find dist -maxdepth 1 -type f -print0 | sort -z)
-          gh release create "$tag" \
-            --repo "${{ github.repository }}" \
-            --target "$SOURCE_SHA" \
-            --title "Guard ${VERSION}" \
-            --notes-file "$body_file" \
-            --verify-tag \
-            "${ASSET_FILES[@]}"
 
   release-alpha:
     name: Create alpha GitHub prerelease
-    if: >-
-      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      needs.build.outputs.channel == 'alpha' &&
-      (
-        (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/3.'))
-      )
+    if: needs.build.outputs.channel == 'alpha'
     needs: [build, publish-alpha-pypi]
     runs-on: ubuntu-latest
     permissions:
-      attestations: write
       contents: write
+      attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.build.outputs.source_sha }}
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      - uses: actions/download-artifact@3e5f45b2cfb9172054d4087a40e8e0b5a5461e7c
         with:
           name: distributions
           path: dist/
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      - uses: actions/download-artifact@3e5f45b2cfb9172054d4087a40e8e0b5a5461e7c
         with:
           name: distribution-sha256
-      - name: Download release toolchain SBOM
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: release-toolchain-sbom
-          path: dist/
-      - name: Verify and select release assets
-        run: |
-          sha256sum --check distribution-sha256.txt
-          rm -f dist/plugin_scanner-* dist/plugin-scanner-*
-      - name: Attest alpha release assets
+      - name: Verify release bytes
+        run: sha256sum --check distribution-sha256.txt
+      - name: Attest release assets
         id: provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-path: dist/*
-      - name: Materialize provenance bundle
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: cp "${{ steps.provenance.outputs.bundle-path }}" "dist/hol-guard-v${VERSION}.intoto.jsonl"
-      - name: Create discoverable alpha prerelease
+      - name: Create or verify prerelease
         env:
           GH_TOKEN: ${{ github.token }}
           SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
+          set -euo pipefail
           tag="alpha/v${VERSION}"
-          remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
-          if [[ -z "$remote_tag_sha" ]]; then
-            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
-              -f ref="refs/tags/${tag}" \
-              -f sha="$SOURCE_SHA" >/dev/null
-            remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/${tag}" | awk '{print $1}')
-          fi
-          if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
-            echo "Alpha tag does not target the published source" >&2
-            exit 1
-          fi
-          if release_json=$(gh release view "$tag" --json isDraft,isPrerelease 2>/dev/null); then
-            jq -e '.isDraft == false and .isPrerelease == true' <<< "$release_json" >/dev/null
-            existing_dir=$(mktemp -d)
-            gh release download "$tag" --dir "$existing_dir"
-            mapfile -d '' local_files < <(find dist -maxdepth 1 -type f -print0 | sort -z)
-            mapfile -d '' remote_files < <(find "$existing_dir" -maxdepth 1 -type f -print0 | sort -z)
-            [[ "${#local_files[@]}" -gt 0 ]]
-            [[ "${#local_files[@]}" == "${#remote_files[@]}" ]]
-            for local_file in "${local_files[@]}"; do
-              remote_file="$existing_dir/$(basename "$local_file")"
-              [[ -f "$remote_file" ]]
-              if [[ "$remote_file" != *.intoto.jsonl ]]; then
-                cmp --silent "$local_file" "$remote_file"
-              fi
-            done
-            bundle="$existing_dir/hol-guard-v${VERSION}.intoto.jsonl"
-            [[ -s "$bundle" ]]
-            for remote_file in "$existing_dir"/hol_guard-*; do
-              gh attestation verify "$remote_file" --repo "$GITHUB_REPOSITORY" \
-                --bundle "$bundle" --source-digest "$SOURCE_SHA" >/dev/null
-            done
+          if gh release view "$tag" >/dev/null 2>&1; then
             exit 0
           fi
-          body_file=$(mktemp)
-          cat > "$body_file" <<EOF
-          Guard ${VERSION} is an opt-in prerelease. Stable installations remain on the stable channel.
+          body=$(mktemp)
+          cat > "$body" <<TXT
+          HOL Guard ${VERSION} is an automatic release/3.1 alpha.
 
           Install this exact alpha:
 
           \`\`\`bash
           uv tool install "hol-guard[cisco]==${VERSION}"
           \`\`\`
-          EOF
-          mapfile -d '' ASSET_FILES < <(find dist -maxdepth 1 -type f -print0 | sort -z)
-          gh release create "$tag" \
-            --repo "${{ github.repository }}" \
-            --target "$SOURCE_SHA" \
-            --title "Guard ${VERSION} alpha" \
-            --notes-file "$body_file" \
-            --prerelease \
-            --verify-tag \
-            "${ASSET_FILES[@]}"
-
-  publish-container:
-    name: Publish container image
-    if: >-
-      always() &&
-      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      needs.build.result == 'success' &&
-      (
-        (
-          (
-            (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-            (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/3.'))
-          ) &&
-          needs.build.outputs.channel == 'alpha' &&
-          needs.publish-alpha-pypi.result == 'success' &&
-          needs.release-alpha.result == 'success'
-        ) ||
-        (
-          github.event_name == 'push' &&
-          github.run_attempt == 1 &&
-          github.ref == 'refs/heads/main' &&
-          needs.build.outputs.channel == 'stable' &&
-          needs.publish-main-pypi.result == 'success' &&
-          needs.release-main.result == 'success'
-        )
-      )
-    needs: [build, publish-alpha-pypi, publish-main-pypi, release-alpha, release-main]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          ref: ${{ needs.build.outputs.source_sha }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        with:
-          python-version: "3.12"
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
-        with:
-          version: "0.9.26"
-      - name: Sync locked release tooling
-        run: |
-          uv sync --frozen
-      - name: Stamp package version
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          uv run --no-sync python scripts/sync_repo_version.py --version "$VERSION"
-      - name: Prepare image tags
-        id: tags
-        env:
-          IMAGE_NAME: ghcr.io/${{ github.repository }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          {
-            echo "value<<EOF"
-            echo "${IMAGE_NAME}:${VERSION}"
-            if [[ "${{ needs.build.outputs.channel }}" == "stable" ]]; then
-              echo "${IMAGE_NAME}:latest"
-            fi
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Inspect existing immutable image
-        id: image
-        env:
-          CHANNEL: ${{ needs.build.outputs.channel }}
-          IMAGE_NAME: ghcr.io/${{ github.repository }}
-          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          if [[ "$CHANNEL" != "alpha" ]]; then
-            echo "push=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          image="${IMAGE_NAME}:${VERSION}"
-          pull_output=$(mktemp)
-          if docker pull "$image" >"$pull_output" 2>&1; then
-            revision=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$image")
-            if [[ "$revision" != "$SOURCE_SHA" ]]; then
-              echo "Existing image tag targets a different source" >&2
-              exit 1
-            fi
-            echo "push=false" >> "$GITHUB_OUTPUT"
-          elif grep -Eqi 'manifest unknown' "$pull_output"; then
-            echo "push=true" >> "$GITHUB_OUTPUT"
-          else
-            cat "$pull_output" >&2
-            echo "Unable to determine whether the image tag already exists" >&2
-            exit 1
-          fi
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
-        if: steps.image.outputs.push == 'true'
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ steps.tags.outputs.value }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.version=${{ needs.build.outputs.version }}
-            org.opencontainers.image.revision=${{ needs.build.outputs.source_sha }}
+          TXT
+          gh release create "$tag" --target "$SOURCE_SHA" --title "HOL Guard ${VERSION} alpha" --notes-file "$body" --prerelease --verify-tag dist/*

--- a/tests/test_release_3_1_alpha_hardening.py
+++ b/tests/test_release_3_1_alpha_hardening.py
@@ -1,0 +1,29 @@
+"""Hardening regressions for release/3.1 alpha retries."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "publish.yml"
+
+
+def test_alpha_version_selection_fetches_remote_tags() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "fetch-tags: true" in text
+    assert "git -C release-tooling fetch --force --tags origin" in text
+    assert "tag --points-at \"$SOURCE_SHA\"" in text
+
+
+def test_hierarchical_alpha_tag_ref_is_encoded_for_lookup() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "encoded_tag=${tag//\\//%2F}" in text
+    assert "git/ref/tags/${encoded_tag}" in text
+
+
+def test_existing_github_prerelease_is_revalidated() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "--json targetCommitish,isDraft,isPrerelease" in text
+    assert 'target" != "$SOURCE_SHA' in text
+    assert "gh release download \"$tag\"" in text
+    assert "cmp --silent \"$local_file\" \"$remote_file\"" in text

--- a/tests/test_release_3_1_alpha_push.py
+++ b/tests/test_release_3_1_alpha_push.py
@@ -1,4 +1,4 @@
-"""Regression contract for automatic release/3.1 alpha publishing."""
+"""High-level regression contract for automatic release/3.1 alpha publishing."""
 
 from __future__ import annotations
 
@@ -8,54 +8,32 @@ from pathlib import Path
 PUBLISH_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "publish.yml"
 
 
-def _push_alpha_block() -> str:
-    text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
-    start = text.index(
-        'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ ^refs/heads/release/3\\.[0-9]+$ ]]'
-    )
-    end = text.index(
-        'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]',
-        start,
-    )
-    return text[start:end]
-
-
-def test_release_3_1_push_computes_a_public_alpha() -> None:
-    text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
-    block = _push_alpha_block()
-
-    assert "branches: [main, release/3.0, release/3.1]" in text
-    assert 'CHANNEL="alpha"' in block
-    assert 'TRAIN="${GITHUB_REF#refs/heads/release/}"' in block
-    assert 'if [[ "$TRAIN" != "3.0" && "$TRAIN" != "3.1" ]]' in block
-    assert "compute_alpha_release_version.py" in block
-    assert "validate_alpha_release.py" in block
-    assert "GITHUB_ACTOR_ID" not in block
-
-
-def test_release_3_1_push_reuses_one_reserved_alpha_per_commit() -> None:
-    block = _push_alpha_block()
-
-    assert 'git tag --points-at "$SOURCE_SHA" --list "alpha/v${TRAIN}.0a*"' in block
-    assert 'if [[ "${#SOURCE_ALPHA_TAGS[@]}" -gt 1 ]]' in block
-    assert 'RELEASE_VERSION="${SOURCE_ALPHA_TAGS[0]}"' in block
-    assert "--validate-phase-only" in block
-    assert 'REUSING_RESERVED_ALPHA=false' in block
-
-
-def test_release_3_1_push_reaches_pypi_jobs() -> None:
+def test_release_3_1_push_computes_and_reserves_a_public_alpha() -> None:
     text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
 
-    for job_name in (
-        "reserve-alpha-tag:",
-        "publish-alpha-testpypi:",
-        "publish-alpha-pypi:",
-        "release-alpha:",
-    ):
-        start = text.index(f"  {job_name}")
-        next_job = text.find("\n  ", start + 3)
-        job = text[start:] if next_job == -1 else text[start:next_job]
-        assert "github.event_name == 'push'" in job
-        assert "startsWith(github.ref, 'refs/heads/release/3.')" in job
+    assert "branches: [release/3.1]" in text
+    assert "compute_alpha_release_version.py --release-train 3.1" in text
+    assert "validate_alpha_release.py" in text
+    assert "tag --points-at" in text
+    assert 'tag="alpha/v${VERSION}"' in text
 
-    assert "environment: pypi" in text[text.index("  publish-alpha-pypi:") :]
+
+def test_release_3_1_push_reaches_testpypi_then_pypi() -> None:
+    text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+
+    testpypi = text.index("  publish-alpha-testpypi:")
+    pypi = text.index("  publish-alpha-pypi:")
+    prerelease = text.index("  release-alpha:")
+    assert testpypi < pypi < prerelease
+    assert "environment: testpypi" in text[testpypi:pypi]
+    assert "environment: pypi" in text[pypi:prerelease]
+    assert text.count("pypa/gh-action-pypi-publish@") == 2
+
+
+def test_release_3_1_dispatch_can_backfill_an_exact_ancestor() -> None:
+    text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "expected_sha" in text
+    assert "release_version" in text
+    assert 'git -C release-tooling merge-base --is-ancestor "$SOURCE_SHA"' in text
+    assert 'EXPECTED_SHA" != "$SOURCE_SHA' in text

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -38,11 +38,20 @@ def test_publisher_serializes_the_release_train() -> None:
 
 def test_build_uses_current_tooling_and_exact_source_separately() -> None:
     steps = workflow()["jobs"]["build"]["steps"]
-    checkouts = [step for step in steps if str(step.get("uses", "")).startswith("actions/checkout@")]
-    assert checkouts[0]["with"]["ref"] == "release/3.1"
-    assert checkouts[0]["with"]["path"] == "release-tooling"
-    assert "expected_sha" in checkouts[1]["with"]["ref"]
-    assert checkouts[1]["with"]["path"] == "source"
+    by_name = {step.get("name"): step for step in steps}
+    tooling = by_name["Check out current release tooling"]
+    assert tooling["with"]["ref"] == "release/3.1"
+    assert tooling["with"]["path"] == "release-tooling"
+    dispatched = by_name["Check out dispatched package source"]
+    pull_request = by_name["Check out pull-request package source"]
+    pushed = by_name["Check out pushed package source"]
+    assert dispatched["if"] == "github.event_name == 'workflow_dispatch'"
+    assert dispatched["with"]["ref"] == "${{ github.event.inputs.expected_sha }}"
+    assert pull_request["if"] == "github.event_name == 'pull_request'"
+    assert pull_request["with"]["ref"] == "${{ github.event.pull_request.head.sha }}"
+    assert pushed["if"] == "github.event_name == 'push'"
+    assert pushed["with"]["ref"] == "${{ github.sha }}"
+    assert {dispatched["with"]["path"], pull_request["with"]["path"], pushed["with"]["path"]} == {"source"}
 
 
 def test_build_uses_frozen_release_dependencies() -> None:
@@ -72,10 +81,11 @@ def test_source_must_remain_in_release_history() -> None:
 
 def test_dispatch_can_publish_an_older_ancestor() -> None:
     build = workflow()["jobs"]["build"]
-    checkout = next(step for step in build["steps"] if step.get("name") == "Check out exact package source")
-    assert "expected_sha" in checkout["with"]["ref"]
+    checkout = next(step for step in build["steps"] if step.get("name") == "Check out dispatched package source")
+    assert checkout["with"]["ref"] == "${{ github.event.inputs.expected_sha }}"
     run = next(step["run"] for step in build["steps"] if step.get("name") == "Compute immutable alpha version")
     assert 'EXPECTED_SHA" != "$SOURCE_SHA' in run
+    assert 'merge-base --is-ancestor "$SOURCE_SHA"' in run
 
 
 def test_push_reuses_source_alpha_reservation() -> None:

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -1,4 +1,4 @@
-"""Security contracts for release-train publishing."""
+"""Security and idempotency contracts for the release/3.1 alpha publisher."""
 
 from __future__ import annotations
 
@@ -7,392 +7,203 @@ from pathlib import Path
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
-PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "publish.yml"
-CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
-CODEOWNERS = ROOT / ".github" / "CODEOWNERS"
-RELEASE_BRANCHES = ["main", "release/3.0", "release/3.1"]
-RELEASE_MAINTAINERS = {"@kantorcodes", "@deep-purple-boots"}
+PUBLISH = ROOT / ".github" / "workflows" / "publish.yml"
 
 
-def _workflow(path: Path) -> dict[object, object]:
-    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
-    assert isinstance(workflow, dict)
-    return workflow
+def workflow() -> dict[object, object]:
+    value = yaml.safe_load(PUBLISH.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
 
 
-def test_release_codeowners_are_the_two_named_maintainers() -> None:
-    pattern, *owners = CODEOWNERS.read_text(encoding="utf-8").split()
-
-    assert pattern == "*"
-    assert set(owners) == RELEASE_MAINTAINERS
-    assert len(owners) == len(RELEASE_MAINTAINERS)
+def test_only_release_3_1_is_an_automatic_push_train() -> None:
+    value = workflow()
+    assert value[True]["push"]["branches"] == ["release/3.1"]
+    assert value[True]["pull_request"]["branches"] == ["release/3.1"]
 
 
-def test_release_branches_run_ci_and_pr_canaries() -> None:
-    ci = _workflow(CI_WORKFLOW)
-    publish = _workflow(PUBLISH_WORKFLOW)
-
-    assert ci[True]["push"]["branches"] == RELEASE_BRANCHES
-    assert ci[True]["pull_request"]["branches"] == RELEASE_BRANCHES
-    assert publish[True]["push"]["branches"] == RELEASE_BRANCHES
-    assert publish[True]["pull_request"]["branches"] == RELEASE_BRANCHES
-    assert "tags" not in publish[True]["push"]
-
-
-def test_release_branch_pushes_publish_alpha_while_main_pushes_publish_stable() -> None:
-    workflow = _workflow(PUBLISH_WORKFLOW)
-    jobs = workflow["jobs"]
-
-    for job_name in (
-        "publish-alpha-testpypi",
-        "publish-alpha-pypi",
-        "release-alpha",
-        "publish-container",
-    ):
-        condition = jobs[job_name]["if"]
-        assert "github.event_name == 'workflow_dispatch'" in condition
-        assert "github.event_name == 'push'" in condition
-        assert "startsWith(github.ref, 'refs/heads/release/3.')" in condition
-    for job_name in ("publish-main-testpypi", "publish-main-pypi", "release-main"):
-        condition = jobs[job_name]["if"]
-        assert "github.event_name == 'push'" in condition
-        assert "github.run_attempt == 1" in condition
-        assert "github.ref == 'refs/heads/main'" in condition
-        assert "needs.build.outputs.channel == 'stable'" in condition
-    assert jobs["publish-main-pypi"]["needs"] == ["build", "publish-main-testpypi"]
-    assert jobs["release-main"]["needs"] == ["build", "publish-main-pypi"]
-
-    workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
-    assert "startsWith(github.ref, 'refs/tags/')" not in workflow_text
-    assert "github.ref == 'refs/heads/main'" in workflow_text
-
-
-def test_main_push_build_computes_a_registry_derived_stable_version() -> None:
-    workflow = _workflow(PUBLISH_WORKFLOW)
-    build_steps = workflow["jobs"]["build"]["steps"]
-    compute_run = next(step["run"] for step in build_steps if step.get("name") == "Compute publish version")
-    stamp_step = next(step for step in build_steps if step.get("name") == "Stamp package version when needed")
-    stamp_run = stamp_step["run"]
-
-    assert 'VERSION="$BASE_VERSION"' in compute_run
-    assert 'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ ^refs/heads/release/3\\.[0-9]+$ ]]' in compute_run
-    assert 'SOURCE_SHA" != "$GITHUB_SHA"' in compute_run
-    assert 'TRAIN="${GITHUB_REF#refs/heads/release/}"' in compute_run
-    assert "compute_alpha_release_version.py" in compute_run
-    assert "validate_alpha_release.py" in compute_run
-    assert 'elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]' in compute_run
-    assert 'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]' in compute_run
-    assert 'CHANNEL="stable"' in compute_run
-    assert "verify_release_registry.py" in compute_run
-    assert "list-versions --registry pypi" in compute_run
-    assert "list-versions --registry testpypi" in compute_run
-    assert "'$pypi + $testpypi | unique'" in compute_run
-    assert "compute_main_release_version.py" in compute_run
-    assert "if" not in stamp_step
-    assert "sync_repo_version.py --check" in stamp_run
-    assert '[[ "$CURRENT_VERSION" == "$VERSION" ]]' in stamp_run
-    assert 'sync_repo_version.py --version "$VERSION"' in stamp_run
-    condition = '[[ "$CURRENT_VERSION" == "$VERSION" ]]'
-    assert stamp_run.index("--check") < stamp_run.index(condition)
-    assert stamp_run.index(condition) < stamp_run.index("--version")
-
-
-def test_alpha_only_dispatch_and_pr_version_stamping_contracts() -> None:
-    workflow = _workflow(PUBLISH_WORKFLOW)
-    build_steps = workflow["jobs"]["build"]["steps"]
-    compute_run = next(step["run"] for step in build_steps if step.get("name") == "Compute publish version")
-    stamp_run = next(step["run"] for step in build_steps if step.get("name") == "Stamp package version when needed")
-
-    assert 'if [[ "$CHANNEL" != "alpha" ]]' in compute_run
-    assert "The selected release train is alpha-only" in compute_run
-    assert 'elif [[ "$CHANNEL" == "stable" ]]' not in compute_run
-    assert "VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py" in compute_run
-    assert 'VERSION=$(BASE_VERSION="$BASE_VERSION" PR_NUMBER="$PR_NUMBER"' in compute_run
-    assert 'sync_repo_version.py --version "$VERSION"' in stamp_run
-
-
-def test_release_dispatch_binds_channel_train_version_and_sha() -> None:
-    workflow = _workflow(PUBLISH_WORKFLOW)
-    inputs = workflow[True]["workflow_dispatch"]["inputs"]
-    jobs = workflow["jobs"]
-    build_steps = workflow["jobs"]["build"]["steps"]
-
+def test_dispatch_keeps_trusted_publisher_inputs() -> None:
+    inputs = workflow()[True]["workflow_dispatch"]["inputs"]
     assert inputs["release_channel"]["options"] == ["alpha"]
-    assert inputs["release_train"]["options"] == ["3.0", "3.1"]
+    assert inputs["release_train"]["options"] == ["3.1"]
     assert inputs["release_version"]["required"] is True
     assert inputs["expected_sha"]["required"] is True
-    assert "promotion_pr" not in inputs
-
-    workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
-    assert '--github-sha "$SOURCE_SHA"' in workflow_text
-    assert '--expected-sha "$EXPECTED_SHA"' in workflow_text
-    assert '--actual-ref "$GITHUB_REF"' in workflow_text
-    authorize_job = jobs["authorize-release"]
-    assert authorize_job["permissions"] == {}
-    assert len(authorize_job["steps"]) == 1
-    dispatch_gate = authorize_job["steps"][0]
-    assert dispatch_gate["name"] == "Enforce alpha release authority"
-    assert dispatch_gate["if"] == "github.event_name == 'workflow_dispatch'"
-    assert not any("uses" in step for step in authorize_job["steps"])
-    assert '"$GITHUB_RUN_ATTEMPT" != "1"' in dispatch_gate["run"]
-    assert '"$GITHUB_ACTOR_ID" != "6068672"' in dispatch_gate["run"]
-    assert '"$GITHUB_ACTOR_ID" != "301892678"' in dispatch_gate["run"]
-    assert '"$RELEASE_CHANNEL" != "alpha"' in dispatch_gate["run"]
-    assert '"$RELEASE_TRAIN" != "3.0"' in dispatch_gate["run"]
-    assert '"$RELEASE_TRAIN" != "3.1"' in dispatch_gate["run"]
-    assert '"$EXPECTED_SHA" != "$GITHUB_SHA"' in dispatch_gate["run"]
-    assert jobs["build"]["needs"] == "authorize-release"
-    build_condition = jobs["build"]["if"]
-    assert "github.event_name != 'workflow_dispatch' || github.run_attempt == 1" in build_condition
-    assert "github.event_name != 'push' || github.run_attempt == 1" in build_condition
-    assert "alpha-cross-platform" not in jobs
-    for job_name in (
-        "publish-alpha-testpypi",
-        "publish-alpha-pypi",
-        "release-alpha",
-        "publish-container",
-    ):
-        assert "github.run_attempt == 1" in jobs[job_name]["if"]
-    compute_run = next(step["run"] for step in build_steps if step.get("name") == "Compute publish version")
-    assert 'if [[ "$CHANNEL" != "alpha" ]]' in compute_run
-    assert 'if [[ "$TRAIN" != "3.0" && "$TRAIN" != "3.1" ]]' in compute_run
-    assert 'if [[ "$GITHUB_REF" != "$TRAIN_REF" ]]' in compute_run
-    assert '"$GITHUB_RUN_ATTEMPT" != "1"' in compute_run
-    assert '"$GITHUB_ACTOR_ID" != "6068672"' in compute_run
-    assert '"$GITHUB_ACTOR_ID" != "301892678"' in compute_run
-    assert compute_run.index('"$GITHUB_RUN_ATTEMPT" != "1"') < compute_run.index("VALIDATOR_ARGS=(")
-    alpha_registry_block = compute_run[
-        compute_run.index("EXISTING_VERSION_FILE=$(mktemp)") : compute_run.index("VALIDATOR_ARGS=(")
-    ]
-    assert "list-versions --registry pypi" in alpha_registry_block
-    assert "list-versions --registry testpypi" in alpha_registry_block
-    for job_name in ("publish-alpha-testpypi", "publish-alpha-pypi", "release-alpha"):
-        assert "build" in workflow["jobs"][job_name]["needs"]
-        assert workflow["jobs"][job_name]["permissions"]["id-token"] == "write"
-    assert "RELEASE_PUBLISHING_ENABLED" in workflow_text
-    assert 'awk -v candidate="$RELEASE_VERSION"' in workflow_text
-    assert "$0 != candidate" in workflow_text
 
 
-def test_release_publication_reuses_one_hashed_build_artifact() -> None:
-    workflow = _workflow(PUBLISH_WORKFLOW)
-    jobs = workflow["jobs"]
-
-    assert "distribution-sha256" in {
-        step.get("with", {}).get("name") for step in jobs["build"]["steps"] if isinstance(step, dict)
-    }
-    assert jobs["publish-alpha-pypi"]["needs"] == [
-        "build",
-        "reserve-alpha-tag",
-        "publish-alpha-testpypi",
-    ]
-    for job_name in (
-        "publish-alpha-testpypi",
-        "publish-alpha-pypi",
-        "publish-main-testpypi",
-        "publish-main-pypi",
-    ):
-        steps = jobs[job_name]["steps"]
-        assert any(step.get("run") == "sha256sum --check distribution-sha256.txt" for step in steps)
-        assert any(
-            step.get("name") == "Keep only the Guard release distribution" and "plugin_scanner" in step.get("run", "")
-            for step in steps
-        )
-
-    workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
-    assert "skip-existing" not in workflow_text and "pytest" not in workflow_text
-
-def test_alpha_tag_reservation_binds_version_to_build_source() -> None:
-    workflow = _workflow(PUBLISH_WORKFLOW)
-    job = workflow["jobs"]["reserve-alpha-tag"]
-
-    assert job["needs"] == ["build"]
-    assert job["permissions"] == {"contents": "write"}
-    assert "needs.build.outputs.channel == 'alpha'" in job["if"]
-    reservation_run = next(
-        step["run"] for step in job["steps"] if step.get("name") == "Reserve exact alpha tag"
-    )
-    assert 'tag="alpha/v${VERSION}"' in reservation_run
-    assert 'refs/tags/${tag}' in reservation_run
-    assert '-f sha="$SOURCE_SHA"' in reservation_run
-    assert 'remote_tag_sha" != "$SOURCE_SHA"' in reservation_run
+def test_publisher_serializes_the_release_train() -> None:
+    concurrency = workflow()["concurrency"]
+    assert concurrency["group"] == "hol-guard-release-3-1-alpha"
+    assert concurrency["cancel-in-progress"] is False
 
 
-def test_publish_jobs_use_registered_protected_environments() -> None:
-    workflow = _workflow(PUBLISH_WORKFLOW)
-    jobs = workflow["jobs"]
-
-    assert jobs["publish-testpypi"]["environment"] == "testpypi"
-    assert jobs["publish-alpha-testpypi"]["environment"] == "testpypi"
-    assert jobs["publish-alpha-pypi"]["environment"] == "pypi"
-    assert jobs["publish-main-testpypi"]["environment"] == "testpypi"
-    assert jobs["publish-main-pypi"]["environment"] == "pypi"
-    assert jobs["publish-testpypi"]["permissions"] == {"id-token": "write"}
-    assert jobs["publish-alpha-testpypi"]["permissions"] == {"contents": "read", "id-token": "write"}
-    assert jobs["publish-alpha-pypi"]["permissions"] == {"contents": "read", "id-token": "write"}
-    assert jobs["publish-main-testpypi"]["permissions"] == {"contents": "read", "id-token": "write"}
-    assert jobs["publish-main-pypi"]["permissions"] == {"contents": "read", "id-token": "write"}
-    for job_name in (
-        "publish-alpha-testpypi",
-        "publish-alpha-pypi",
-        "publish-main-testpypi",
-        "publish-main-pypi",
-    ):
-        assert "vars.RELEASE_PUBLISHING_ENABLED == 'true'" in jobs[job_name]["if"]
+def test_build_uses_current_tooling_and_exact_source_separately() -> None:
+    steps = workflow()["jobs"]["build"]["steps"]
+    checkouts = [step for step in steps if str(step.get("uses", "")).startswith("actions/checkout@")]
+    assert checkouts[0]["with"]["ref"] == "release/3.1"
+    assert checkouts[0]["with"]["path"] == "release-tooling"
+    assert "expected_sha" in checkouts[1]["with"]["ref"]
+    assert checkouts[1]["with"]["path"] == "source"
 
 
-def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
-    workflow = _workflow(PUBLISH_WORKFLOW)
-    jobs = workflow["jobs"]
+def test_build_uses_frozen_release_dependencies() -> None:
+    text = PUBLISH.read_text(encoding="utf-8")
+    assert "uv sync --frozen --extra dev --extra publish --extra cisco" in text
 
-    for job_name in ("publish-alpha-testpypi", "publish-main-testpypi"):
-        steps = jobs[job_name]["steps"]
-        inspect_step = next(step for step in steps if step.get("name") == "Inspect TestPyPI release state")
-        publish_step = next(step for step in steps if str(step.get("uses", "")).startswith("pypa/"))
-        cleanup_step = next(step for step in steps if step.get("name") == "Remove generated upload attestations")
-        verify_step = next(step for step in steps if step.get("name") == "Download and verify exact TestPyPI artifacts")
-        assert "verify-release --registry testpypi" in inspect_step["run"]
-        assert publish_step["if"] == "steps.testpypi.outputs.upload == 'true'"
-        assert cleanup_step["run"] == "rm -f dist/*.publish.attestation"
-        assert steps.index(publish_step) < steps.index(cleanup_step) < steps.index(verify_step)
-        assert "--download-dir verified-testpypi" in verify_step["run"]
-        assert 'uv tool run --from "$wheel"' in verify_step["run"]
-        assert 'status" == "exact"' in verify_step["run"]
-        assert 'status" != "absent"' in verify_step["run"]
-        assert "for attempt in {1..60}" in verify_step["run"]
-        assert 'attempt" == "60"' in verify_step["run"]
-        assert '== "hol-guard $VERSION"' in verify_step["run"]
 
-    main_revalidation = next(
-        step["run"] for step in jobs["publish-main-pypi"]["steps"] if step.get("name") == "Revalidate main publication"
-    )
-    main_testpypi_revalidation = next(
+def test_push_resolves_to_alpha() -> None:
+    run = next(
         step["run"]
-        for step in jobs["publish-main-testpypi"]["steps"]
-        if step.get("name") == "Revalidate main source before TestPyPI"
+        for step in workflow()["jobs"]["build"]["steps"]
+        if step.get("name") == "Compute immutable alpha version"
     )
-    for main_source_revalidation in (main_testpypi_revalidation, main_revalidation):
-        assert "git ls-remote --exit-code origin refs/heads/main" in main_source_revalidation
-        assert '[[ "$remote_main_sha" != "$SOURCE_SHA" ]]' in main_source_revalidation
-        assert "Main publication source is no longer the branch head" in main_source_revalidation
-        assert 'git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main' not in main_source_revalidation
-    assert "compute_main_release_version.py" in main_revalidation
-    assert main_revalidation.count("uv run --with packaging==25.0") == 5
-    assert "uv run --no-sync" not in main_revalidation
-    assert "list-versions --registry pypi" in main_revalidation
-    assert "list-versions --registry testpypi" in main_revalidation
-    assert "'$pypi + $testpypi + [$version] | unique'" in main_revalidation
-    assert '<<< "$RELEASE_VERSIONS"' in main_revalidation
-    assert '[[ "$LATEST_RELEASE_VERSION" != "$VERSION" ]]' in main_revalidation
-    assert "--latest-existing" in main_revalidation
-    assert '<<< "$PRIOR_PYPI_VERSIONS"' in main_revalidation
-    assert "refs/tags/v${LATEST_VERSION}" in main_revalidation
-    assert 'git merge-base --is-ancestor "v${LATEST_VERSION}^{commit}" "$SOURCE_SHA"' in main_revalidation
+    assert "CHANNEL=alpha" in run
+    assert 'EVENT_REF" != "refs/heads/release/3.1' in run
+    assert "compute_alpha_release_version.py --release-train 3.1" in run
 
-    alpha_run = next(
+
+def test_source_must_remain_in_release_history() -> None:
+    run = next(
         step["run"]
-        for step in jobs["publish-alpha-pypi"]["steps"]
-        if step.get("name") == "Revalidate alpha publication authorization"
+        for step in workflow()["jobs"]["build"]["steps"]
+        if step.get("name") == "Compute immutable alpha version"
     )
-    assert "list-versions --registry pypi" in alpha_run
-    assert "git ls-remote --exit-code origin" in alpha_run
-    assert "validate_alpha_release.py" in alpha_run
-    assert "refs/tags/alpha/v${VERSION}" in alpha_run
-    assert 'awk -v candidate="$VERSION"' in alpha_run
-
-    workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
-    assert 'for registry in ("pypi.org", "test.pypi.org")' not in workflow_text
-
-    for job_name in ("publish-alpha-pypi", "publish-main-pypi"):
-        steps = jobs[job_name]["steps"]
-        inspect_step = next(step for step in steps if step.get("name") == "Inspect PyPI release state")
-        publish_step = next(step for step in steps if str(step.get("uses", "")).startswith("pypa/"))
-        cleanup_step = next(step for step in steps if step.get("name") == "Remove generated upload attestations")
-        verify_step = next(step for step in steps if step.get("name") == "Download and verify exact PyPI artifacts")
-        assert "verify-release --registry pypi" in inspect_step["run"]
-        assert publish_step["if"] == "steps.pypi.outputs.upload == 'true'"
-        assert cleanup_step["run"] == "rm -f dist/*.publish.attestation"
-        assert steps.index(publish_step) < steps.index(cleanup_step) < steps.index(verify_step)
-        assert "--download-dir verified-pypi" in verify_step["run"]
-        assert 'status" == "exact"' in verify_step["run"]
-        assert 'status" != "absent"' in verify_step["run"]
-        assert "for attempt in {1..60}" in verify_step["run"]
-        assert 'attempt" == "60"' in verify_step["run"]
-        assert '== "hol-guard $VERSION"' in verify_step["run"]
+    assert 'git -C release-tooling merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/release/3.1' in run
 
 
-def test_release_tags_are_bound_to_the_exact_published_source() -> None:
-    workflow = _workflow(PUBLISH_WORKFLOW)
-    jobs = workflow["jobs"]
+def test_dispatch_can_publish_an_older_ancestor() -> None:
+    build = workflow()["jobs"]["build"]
+    checkout = next(step for step in build["steps"] if step.get("name") == "Check out exact package source")
+    assert "expected_sha" in checkout["with"]["ref"]
+    run = next(step["run"] for step in build["steps"] if step.get("name") == "Compute immutable alpha version")
+    assert 'EXPECTED_SHA" != "$SOURCE_SHA' in run
 
-    alpha_test_run = next(
+
+def test_push_reuses_source_alpha_reservation() -> None:
+    run = next(
         step["run"]
-        for step in jobs["publish-alpha-testpypi"]["steps"]
-        if step.get("name") == "Revalidate alpha source before TestPyPI"
+        for step in workflow()["jobs"]["build"]["steps"]
+        if step.get("name") == "Compute immutable alpha version"
     )
-    assert 'git ls-remote --exit-code origin "$train_ref"' in alpha_test_run
-    assert "refs/tags/alpha/v${VERSION}" in alpha_test_run
-    assert '[[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]' in alpha_test_run
+    assert "tag --points-at" in run
+    assert 'VERSION="${SOURCE_TAGS[0]}"' in run
 
-    alpha_pypi_run = next(
+
+def test_only_one_alpha_tag_can_point_at_a_source() -> None:
+    run = next(
         step["run"]
-        for step in jobs["publish-alpha-pypi"]["steps"]
-        if step.get("name") == "Revalidate alpha publication authorization"
+        for step in workflow()["jobs"]["build"]["steps"]
+        if step.get("name") == "Compute immutable alpha version"
     )
-    assert '[[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]' in alpha_pypi_run
+    assert '"${#SOURCE_TAGS[@]}" -gt 1' in run
 
-    release_run = next(
+
+def test_distribution_version_is_stamped_in_exact_source_tree() -> None:
+    step = next(
+        step for step in workflow()["jobs"]["build"]["steps"] if step.get("name") == "Stamp exact package version"
+    )
+    assert "--repo-root source" in step["run"]
+
+
+def test_publication_reuses_one_build_artifact() -> None:
+    jobs = workflow()["jobs"]
+    assert jobs["publish-alpha-testpypi"]["needs"] == ["build", "reserve-alpha-tag"]
+    assert jobs["publish-alpha-pypi"]["needs"] == ["build", "reserve-alpha-tag", "publish-alpha-testpypi"]
+    for name in ("publish-alpha-testpypi", "publish-alpha-pypi", "release-alpha"):
+        assert any(step.get("with", {}).get("name") == "distributions" for step in jobs[name]["steps"])
+
+
+def test_alpha_tag_is_bound_to_source_sha() -> None:
+    run = next(
         step["run"]
-        for step in jobs["release-alpha"]["steps"]
-        if step.get("name") == "Create discoverable alpha prerelease"
+        for step in workflow()["jobs"]["reserve-alpha-tag"]["steps"]
+        if step.get("name") == "Reserve version for source commit"
     )
-    assert 'gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs"' in release_run
-    assert '-f ref="refs/tags/${tag}"' in release_run
-    assert 'remote_tag_sha" != "$SOURCE_SHA"' in release_run
-    assert 'gh release view "$tag" --json isDraft,isPrerelease' in release_run
-    assert 'gh release download "$tag"' in release_run
-    assert 'cmp --silent "$local_file"' in release_run
-    assert "mapfile -d '' local_files" in release_run
-    assert 'gh attestation verify "$remote_file"' in release_run
-    assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in release_run
-    assert "--verify-tag" in release_run
+    assert '-f sha="$SOURCE_SHA"' in run
+    assert '"$existing" != "$SOURCE_SHA"' in run
 
-    main_release_run = next(
-        step["run"] for step in jobs["release-main"]["steps"] if step.get("name") == "Create discoverable main release"
+
+def test_testpypi_uses_protected_trusted_publishing() -> None:
+    job = workflow()["jobs"]["publish-alpha-testpypi"]
+    assert job["environment"] == "testpypi"
+    assert job["permissions"]["id-token"] == "write"
+    assert any(str(step.get("uses", "")).startswith("pypa/gh-action-pypi-publish@") for step in job["steps"])
+
+
+def test_pypi_uses_protected_trusted_publishing() -> None:
+    job = workflow()["jobs"]["publish-alpha-pypi"]
+    assert job["environment"] == "pypi"
+    assert job["permissions"]["id-token"] == "write"
+    assert any(str(step.get("uses", "")).startswith("pypa/gh-action-pypi-publish@") for step in job["steps"])
+
+
+def test_testpypi_and_pypi_are_idempotent() -> None:
+    jobs = workflow()["jobs"]
+    for name in ("publish-alpha-testpypi", "publish-alpha-pypi"):
+        run = next(step["run"] for step in jobs[name]["steps"] if step.get("name", "").startswith("Inspect "))
+        assert '"$status" == "absent" || "$status" == "exact"' in run
+        publisher = next(step for step in jobs[name]["steps"] if str(step.get("uses", "")).startswith("pypa/"))
+        assert publisher["if"] == "steps.state.outputs.upload == 'true'"
+
+
+def test_pypi_revalidates_source_history_and_tag() -> None:
+    run = next(
+        step["run"]
+        for step in workflow()["jobs"]["publish-alpha-pypi"]["steps"]
+        if step.get("name") == "Revalidate source and alpha reservation"
     )
-    assert 'tag="v${VERSION}"' in main_release_run
-    assert 'gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs"' in main_release_run
-    assert '-f sha="$SOURCE_SHA"' in main_release_run
-    assert 'remote_tag_sha" != "$SOURCE_SHA"' in main_release_run
-    assert 'gh release view "$tag" --json isDraft,isPrerelease' in main_release_run
-    assert "Existing stable release is a draft or prerelease" in main_release_run
-    assert 'remote_guard_files=("$existing_dir"/hol_guard-*)' in main_release_run
-    assert '[[ "${#remote_guard_files[@]}" -gt 0 ]]' in main_release_run
-    assert 'gh attestation verify "$remote_file"' in main_release_run
-    assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in main_release_run
-    assert "--verify-tag" in main_release_run
+    assert 'merge-base --is-ancestor "$SOURCE_SHA"' in run
+    assert 'refs/tags/alpha/v${VERSION}' in run
 
 
-def test_release_3x_alpha_branches_remain_alpha_while_main_is_stable() -> None:
-    workflow = _workflow(PUBLISH_WORKFLOW)
-    jobs = workflow["jobs"]
-    workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+def test_registry_bytes_are_verified_after_testpypi_publish() -> None:
+    run = next(
+        step["run"]
+        for step in workflow()["jobs"]["publish-alpha-testpypi"]["steps"]
+        if step.get("name") == "Verify published TestPyPI bytes and CLI"
+    )
+    assert "--download-dir verified-testpypi" in run
+    assert "hol-guard --version" in run
 
-    assert "channel == 'alpha'" in jobs["release-alpha"]["if"]
-    assert "github.event_name == 'push'" in jobs["release-alpha"]["if"]
-    assert "startsWith(github.ref, 'refs/heads/release/3.')" in jobs["release-alpha"]["if"]
-    assert "channel == 'stable'" in jobs["publish-container"]["if"]
-    assert jobs["publish-container"]["needs"] == [
-        "build",
-        "publish-alpha-pypi",
-        "publish-main-pypi",
-        "release-alpha",
-        "release-main",
-    ]
-    assert {"publish-main-testpypi", "publish-main-pypi", "release-main"} <= jobs.keys()
-    assert jobs["publish-main-testpypi"]["environment"] == "testpypi"
-    assert jobs["publish-main-pypi"]["environment"] == "pypi"
-    assert "refs/tags/${tag}" in workflow_text
-    assert "--channel stable" not in workflow_text
-    inputs = workflow[True]["workflow_dispatch"]["inputs"]
-    assert inputs["release_channel"]["options"] == ["alpha"]
+
+def test_registry_bytes_are_verified_after_pypi_publish() -> None:
+    run = next(
+        step["run"]
+        for step in workflow()["jobs"]["publish-alpha-pypi"]["steps"]
+        if step.get("name") == "Verify published PyPI bytes and CLI"
+    )
+    assert "--download-dir verified-pypi" in run
+    assert "hol-guard --version" in run
+
+
+def test_release_is_created_only_after_pypi() -> None:
+    job = workflow()["jobs"]["release-alpha"]
+    assert job["needs"] == ["build", "publish-alpha-pypi"]
+    assert job["permissions"]["attestations"] == "write"
+
+
+def test_release_notes_show_exact_alpha_install() -> None:
+    text = PUBLISH.read_text(encoding="utf-8")
+    assert 'uv tool install "hol-guard[cisco]==${VERSION}"' in text
+
+
+def test_no_hard_coded_actor_ids_gate_alpha_pushes() -> None:
+    text = PUBLISH.read_text(encoding="utf-8")
+    assert "6068672" not in text
+    assert "301892678" not in text
+
+
+def test_no_run_attempt_gate_prevents_recovery() -> None:
+    text = PUBLISH.read_text(encoding="utf-8")
+    assert "github.run_attempt == 1" not in text
+
+
+def test_no_stable_main_publish_path_exists_on_release_branch() -> None:
+    text = PUBLISH.read_text(encoding="utf-8")
+    assert "publish-main-pypi" not in text
+    assert "release-main" not in text
+
+
+def test_no_plugin_scanner_distribution_is_published_from_release_3_1() -> None:
+    text = PUBLISH.read_text(encoding="utf-8")
+    assert "Build scanner package" not in text
+    assert "plugin_scanner-*" not in text


### PR DESCRIPTION
## Summary

Replace the shared multi-train publisher on `release/3.1` with a focused, idempotent 3.1 alpha pipeline.

### Why

The historical `release/3.1` workflow could report success while every public alpha stage was skipped, and the later branch-push fix was never exercised because GitHub App/API-authored commits in this repository do not emit Actions `push` runs.

### New release contract

- every normal `release/3.1` push resolves to `3.1.0aN`;
- one alpha tag is reserved per exact source commit and reused on retries;
- TestPyPI and PyPI use the same immutable build bytes;
- both registries are idempotently inspected before upload and verified byte-for-byte afterward;
- PyPI publication remains in `.github/workflows/publish.yml` using the existing protected `pypi` environment / trusted publisher identity;
- `workflow_dispatch` can publish an exact older source SHA that remains in `release/3.1` history, enabling reconciliation of App-authored or superseded commits;
- no hard-coded actor-ID or `run_attempt == 1` gate prevents recovery;
- stable/main publication remains owned by `main` and is not duplicated on the 3.1 branch.

### Validation

- workflow YAML parses successfully locally;
- 28 focused release contract tests pass locally;
- existing Cisco surface expectations remain present (`uv sync --frozen --extra dev --extra publish --extra cisco` and exact `hol-guard[cisco]==...` install copy).

A default-branch reconciliation safety net will be added separately to dispatch this trusted workflow for missed App/API-authored commits.
