### PR TITLE
fix(ci): reconcile missed release/3.1 PyPI alphas

### DIFF
--- a/.github/workflows/reconcile-release-3.1-alpha.yml
+++ b/.github/workflows/reconcile-release-3.1-alpha.yml
@@ -1,0 +1,210 @@
+name: Reconcile release 3.1 alpha publications
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/reconcile-release-3.1-alpha.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reconcile-release-3-1-alpha
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - name: Parse workflow YAML
+        run: python -c "import pathlib,yaml; yaml.safe_load(pathlib.Path('.github/workflows/reconcile-release-3.1-alpha.yml').read_text())"
+
+  reconcile:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Check out full release/3.1 history
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: release/3.1
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - name: Select oldest unpublished release/3.1 commit
+        id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          from __future__ import annotations
+
+          import json
+          import os
+          import re
+          import subprocess
+          import urllib.request
+
+          repo = os.environ["REPOSITORY"]
+          token = os.environ["GH_TOKEN"]
+          alpha_re = re.compile(r"^alpha/v3\.1\.0a(?P<n>[0-9]+)$")
+          version_re = re.compile(r"^3\.1\.0a(?P<n>[0-9]+)$")
+
+          def git(*args: str) -> str:
+              return subprocess.check_output(["git", *args], text=True).strip()
+
+          def api(url: str) -> dict[str, object]:
+              request = urllib.request.Request(
+                  url,
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                      "User-Agent": "hol-guard-release-reconciler",
+                  },
+              )
+              with urllib.request.urlopen(request, timeout=20) as response:
+                  return json.load(response)
+
+          def registry_versions(host: str) -> set[str]:
+              request = urllib.request.Request(
+                  f"https://{host}/pypi/hol-guard/json",
+                  headers={"User-Agent": "hol-guard-release-reconciler"},
+              )
+              with urllib.request.urlopen(request, timeout=20) as response:
+                  payload = json.load(response)
+              releases = payload.get("releases", {})
+              return set(releases) if isinstance(releases, dict) else set()
+
+          for status in ("queued", "in_progress"):
+              payload = api(
+                  f"https://api.github.com/repos/{repo}/actions/workflows/publish.yml/runs"
+                  f"?branch=release%2F3.1&event=workflow_dispatch&status={status}&per_page=10"
+              )
+              runs = payload.get("workflow_runs", [])
+              if isinstance(runs, list) and runs:
+                  print("found=false")
+                  print(f"reason=publisher_{status}")
+                  raise SystemExit(0)
+
+          git("fetch", "--force", "--tags", "origin", "+refs/heads/release/3.1:refs/remotes/origin/release/3.1")
+          branch = "refs/remotes/origin/release/3.1"
+          tag_rows: list[tuple[int, str, str]] = []
+          for tag in git("tag", "--list", "alpha/v3.1.0a*").splitlines():
+              match = alpha_re.fullmatch(tag.strip())
+              if match is None:
+                  continue
+              sha = git("rev-list", "-n", "1", tag)
+              if subprocess.run(["git", "merge-base", "--is-ancestor", sha, branch]).returncode != 0:
+                  continue
+              tag_rows.append((int(match.group("n")), tag, sha))
+          tag_rows.sort()
+          if not tag_rows:
+              print("found=false")
+              print("reason=no_alpha_anchor")
+              raise SystemExit(0)
+
+          pypi = registry_versions("pypi.org")
+          testpypi = registry_versions("test.pypi.org")
+          for _, tag, sha in tag_rows:
+              version = tag.removeprefix("alpha/v")
+              if version not in pypi:
+                  print("found=true")
+                  print(f"source_sha={sha}")
+                  print(f"version={version}")
+                  print("reason=reserved_alpha_missing_from_pypi")
+                  raise SystemExit(0)
+
+          first_alpha_sha = tag_rows[0][2]
+          commits = git("rev-list", "--first-parent", "--reverse", f"{first_alpha_sha}^..{branch}").splitlines()
+          tag_by_sha = {sha: tag for _, tag, sha in tag_rows}
+          for sha in commits:
+              tag = tag_by_sha.get(sha)
+              if tag is not None:
+                  version = tag.removeprefix("alpha/v")
+                  if version in pypi:
+                      continue
+                  print("found=true")
+                  print(f"source_sha={sha}")
+                  print(f"version={version}")
+                  print("reason=tagged_commit_missing_from_pypi")
+                  raise SystemExit(0)
+              max_n = max(
+                  [n for n, _, _ in tag_rows]
+                  + [int(m.group("n")) for value in pypi | testpypi if (m := version_re.fullmatch(value))]
+              )
+              print("found=true")
+              print(f"source_sha={sha}")
+              print(f"version=3.1.0a{max_n + 1}")
+              print("reason=untagged_release_commit")
+              raise SystemExit(0)
+
+          print("found=false")
+          print("reason=fully_reconciled")
+          PY
+      - name: Dispatch trusted publish workflow for exact source
+        if: steps.target.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          SOURCE_SHA: ${{ steps.target.outputs.source_sha }}
+          VERSION: ${{ steps.target.outputs.version }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          repo = os.environ["REPOSITORY"]
+          body = json.dumps(
+              {
+                  "ref": "release/3.1",
+                  "inputs": {
+                      "release_channel": "alpha",
+                      "release_train": "3.1",
+                      "release_version": os.environ["VERSION"],
+                      "expected_sha": os.environ["SOURCE_SHA"],
+                  },
+              }
+          ).encode()
+          request = urllib.request.Request(
+              f"https://api.github.com/repos/{repo}/actions/workflows/publish.yml/dispatches",
+              data=body,
+              method="POST",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                  "Content-Type": "application/json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+                  "User-Agent": "hol-guard-release-reconciler",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=20) as response:
+              if response.status != 204:
+                  raise SystemExit(f"workflow dispatch returned HTTP {response.status}")
+          PY
+      - name: Summarize reconciliation
+        run: |
+          echo "### release/3.1 alpha reconciliation" >> "$GITHUB_STEP_SUMMARY"
+          echo "found: ${{ steps.target.outputs.found }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "reason: ${{ steps.target.outputs.reason }}" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "${{ steps.target.outputs.found }}" == "true" ]]; then
+            echo "source: ${{ steps.target.outputs.source_sha }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "version: ${{ steps.target.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/tests/test_release_3_1_reconciler_workflow.py
+++ b/tests/test_release_3_1_reconciler_workflow.py
@@ -1,0 +1,58 @@
+"""Contracts for backfilling missed release/3.1 alpha publications."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "reconcile-release-3.1-alpha.yml"
+
+
+def workflow() -> dict[object, object]:
+    value = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_reconciler_runs_on_default_branch_schedule() -> None:
+    value = workflow()
+    assert value[True]["schedule"] == [{"cron": "*/5 * * * *"}]
+    assert "workflow_dispatch" in value[True]
+
+
+def test_reconciler_has_only_actions_write_for_dispatch() -> None:
+    jobs = workflow()["jobs"]
+    assert jobs["reconcile"]["permissions"] == {"contents": "read", "actions": "write"}
+    assert jobs["validate"].get("permissions") is None
+
+
+def test_reconciler_processes_one_commit_per_run() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "Select oldest unpublished release/3.1 commit" in text
+    assert "reserved_alpha_missing_from_pypi" in text
+    assert "untagged_release_commit" in text
+    assert text.count("workflow dispatch returned HTTP") == 1
+
+
+def test_reconciler_refuses_to_overlap_active_publish_dispatch() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert 'for status in ("queued", "in_progress")' in text
+    assert "publisher_{status}" in text
+
+
+def test_reconciler_dispatches_existing_trusted_publish_workflow() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "actions/workflows/publish.yml/dispatches" in text
+    assert '"release_channel": "alpha"' in text
+    assert '"release_train": "3.1"' in text
+    assert '"release_version": os.environ["VERSION"]' in text
+    assert '"expected_sha": os.environ["SOURCE_SHA"]' in text
+
+
+def test_reconciler_does_not_receive_pypi_identity_token() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "id-token: write" not in text
+    assert "environment: pypi" not in text
+    assert "pypa/gh-action-pypi-publish" not in text


### PR DESCRIPTION
## Summary

Add a default-branch safety net that reconciles `release/3.1` commits which never received a GitHub Actions `push` event.

This is required because GitHub App/API-authored mutations in this repository can advance `release/3.1` without creating any Actions run. The reconciler preserves the existing PyPI trusted-publisher identity by **never uploading to PyPI itself**; it only dispatches the trusted `release/3.1` `.github/workflows/publish.yml` with an exact source SHA/version.

### Behavior

- runs every five minutes from the default branch;
- refuses to overlap a queued/running trusted publisher dispatch;
- processes at most one missing commit per run, oldest first;
- first repairs an existing `alpha/v3.1.0aN` tag that is missing from PyPI;
- then walks first-parent `release/3.1` history and reserves the next alpha for the oldest untagged commit;
- dispatches exact `release_version` + `expected_sha` through `publish.yml`;
- has no PyPI environment and no OIDC `id-token` permission.

This means normal human pushes publish immediately, while connector/API-authored or otherwise missed events are automatically backfilled without changing PyPI's trusted-publisher workflow identity.
