### PR TITLE
fix(ci): wake release/3.1 reconciler after CI

### DIFF
--- a/.github/workflows/wake-release-3.1-reconciler.yml
+++ b/.github/workflows/wake-release-3.1-reconciler.yml
@@ -1,0 +1,45 @@
+name: Wake release 3.1 alpha reconciler
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  pull_request:
+    paths:
+      - .github/workflows/wake-release-3.1-reconciler.yml
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  wake:
+    if: github.event_name == 'workflow_run'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch release/3.1 reconciler
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          request = urllib.request.Request(
+              f"https://api.github.com/repos/{os.environ['REPOSITORY']}/actions/workflows/reconcile-release-3.1-alpha.yml/dispatches",
+              data=json.dumps({"ref": "main"}).encode(),
+              method="POST",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                  "Content-Type": "application/json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+                  "User-Agent": "hol-guard-release-reconciler-wake",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=20) as response:
+              if response.status != 204:
+                  raise SystemExit(f"reconciler dispatch returned HTTP {response.status}")
+          PY

--- a/tests/test_release_3_1_reconciler_wake.py
+++ b/tests/test_release_3_1_reconciler_wake.py
@@ -1,0 +1,21 @@
+"""Contract for immediate release/3.1 reconciliation wake-ups."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "wake-release-3.1-reconciler.yml"
+
+
+def test_ci_completion_dispatches_only_the_reconciler() -> None:
+    value = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert value[True]["workflow_run"]["workflows"] == ["CI"]
+    assert value[True]["workflow_run"]["types"] == ["completed"]
+    assert value["permissions"] == {"actions": "write", "contents": "read"}
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "actions/workflows/reconcile-release-3.1-alpha.yml/dispatches" in text
+    assert 'json.dumps({"ref": "main"})' in text
+    assert "id-token: write" not in text
+    assert "pypa/gh-action-pypi-publish" not in text


### PR DESCRIPTION
## Summary

Add an immediate wake-up path for the default-branch `release/3.1` reconciler.

The five-minute schedule remains the independent safety net. This workflow also dispatches the reconciler whenever the repository's existing `CI` workflow completes, which gives us a deterministic way to exercise reconciliation without granting this helper any PyPI identity.

Security boundary:
- only `actions: write` + `contents: read`;
- no OIDC token;
- no PyPI environment;
- no package upload logic;
- it can only dispatch the existing `reconcile-release-3.1-alpha.yml` workflow on `main`.
