### PR TITLE
fix(ci): add scoped manual wake for release/3.1 reconciler

### DIFF
--- a/.github/workflows/wake-release-3.1-reconciler.yml
+++ b/.github/workflows/wake-release-3.1-reconciler.yml
@@ -4,6 +4,8 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+  issues:
+    types: [opened]
   pull_request:
     paths:
       - .github/workflows/wake-release-3.1-reconciler.yml
@@ -14,7 +16,9 @@ permissions:
 
 jobs:
   wake:
-    if: github.event_name == 'workflow_run'
+    if: >-
+      github.event_name == 'workflow_run' ||
+      (github.event_name == 'issues' && startsWith(github.event.issue.title, '[release-reconcile]'))
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch release/3.1 reconciler

--- a/tests/test_release_3_1_reconciler_wake.py
+++ b/tests/test_release_3_1_reconciler_wake.py
@@ -19,3 +19,11 @@ def test_ci_completion_dispatches_only_the_reconciler() -> None:
     assert 'json.dumps({"ref": "main"})' in text
     assert "id-token: write" not in text
     assert "pypa/gh-action-pypi-publish" not in text
+
+
+def test_manual_issue_wake_is_explicitly_scoped() -> None:
+    value = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert value[True]["issues"] == {"types": ["opened"]}
+    condition = value["jobs"]["wake"]["if"]
+    assert "github.event_name == 'issues'" in condition
+    assert "startsWith(github.event.issue.title, '[release-reconcile]')" in condition


### PR DESCRIPTION
## Summary

Add a deterministic manual wake path for the release/3.1 reconciler while retaining CI-completion and scheduled wake-ups.

Only issue-open events whose title starts with `[release-reconcile]` dispatch the reconciler. The helper still has no PyPI environment and no OIDC token; it can only dispatch the existing default-branch reconciliation workflow.

This is primarily an operational escape hatch for testing/recovery when GitHub scheduled events or App-authored push events are delayed or suppressed.
