### PR TITLE
fix(ci): wake Desktop Core alpha feed immediately

### DIFF
--- a/.github/workflows/wake-desktop-core-alpha-feed.yml
+++ b/.github/workflows/wake-desktop-core-alpha-feed.yml
@@ -1,0 +1,78 @@
+name: Wake Desktop Core alpha feed
+
+on:
+  workflow_run:
+    workflows: ["Publish to PyPI"]
+    types: [completed]
+  release:
+    types: [published]
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/wake-desktop-core-alpha-feed.yml
+  pull_request:
+    paths:
+      - .github/workflows/wake-desktop-core-alpha-feed.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wake-desktop-core-alpha-feed
+  cancel-in-progress: false
+
+jobs:
+  wake:
+    name: Dispatch Desktop Core alpha feed
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'alpha/v3.')) ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       startsWith(github.event.workflow_run.head_branch, 'release/3.'))
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch feed producer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.error
+          import urllib.request
+
+          class NoRedirect(urllib.request.HTTPRedirectHandler):
+              def redirect_request(self, req, fp, code, msg, headers, newurl):
+                  raise urllib.error.HTTPError(req.full_url, code, "redirect refused", headers, fp)
+
+          request = urllib.request.Request(
+              f"https://api.github.com/repos/{os.environ['REPOSITORY']}/actions/workflows/desktop-core-alpha-feed.yml/dispatches",
+              data=json.dumps({"ref": "main"}).encode(),
+              method="POST",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                  "Content-Type": "application/json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+                  "User-Agent": "hol-guard-desktop-core-feed-wake",
+              },
+          )
+          opener = urllib.request.build_opener(NoRedirect())
+          try:
+              with opener.open(request, timeout=20) as response:
+                  if response.status != 204:
+                      detail = response.read(4096).decode("utf-8", errors="replace")
+                      raise SystemExit(f"Desktop Core feed dispatch returned HTTP {response.status}: {detail}")
+          except urllib.error.HTTPError as exc:
+              detail = exc.read(4096).decode("utf-8", errors="replace")
+              raise SystemExit(f"Desktop Core feed dispatch returned HTTP {exc.code}: {detail}") from None
+          PY

--- a/tests/test_desktop_core_alpha_feed_wake.py
+++ b/tests/test_desktop_core_alpha_feed_wake.py
@@ -1,0 +1,95 @@
+"""Contract for the privileged Desktop Core alpha-feed wake workflow."""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "wake-desktop-core-alpha-feed.yml"
+
+
+def test_desktop_core_feed_wake_is_narrow_and_least_privilege() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    value = yaml.safe_load(text)
+    events = value[True]
+    workflow_path = ".github/workflows/wake-desktop-core-alpha-feed.yml"
+    assert set(events) == {"workflow_run", "release", "push", "pull_request"}
+    assert events["workflow_run"] == {"workflows": ["Publish to PyPI"], "types": ["completed"]}
+    assert events["release"] == {"types": ["published"]}
+    assert events["push"] == {"branches": ["main"], "paths": [workflow_path]}
+    assert events["pull_request"] == {"paths": [workflow_path]}
+    assert value["permissions"] == {"contents": "read"}
+    assert set(value["jobs"]) == {"wake"}
+    wake = value["jobs"]["wake"]
+    assert wake["permissions"] == {"actions": "write", "contents": "read"}
+    actions_write_jobs = [
+        name for name, job in value["jobs"].items() if job.get("permissions", {}).get("actions") == "write"
+    ]
+    assert actions_write_jobs == ["wake"]
+    condition = " ".join(wake["if"].split())
+    assert condition == (
+        "github.event_name == 'push' || "
+        "(github.event_name == 'release' && startsWith(github.event.release.tag_name, 'alpha/v3.')) || "
+        "(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && "
+        "github.event.workflow_run.event == 'push' && startsWith(github.event.workflow_run.head_branch, 'release/3.'))"
+    )
+    dispatch_steps = [step for step in wake["steps"] if step.get("name") == "Dispatch feed producer"]
+    assert len(dispatch_steps) == 1
+    dispatch = dispatch_steps[0]
+    assert dispatch["env"] == {"GH_TOKEN": "${{ github.token }}", "REPOSITORY": "${{ github.repository }}"}
+    parsed_values = json.dumps(value)
+    assert not re.search(r"\$\{\{\s*secrets\.", parsed_values)
+    assert "id-token: write" not in parsed_values
+    assert "pypa/gh-action-pypi-publish" not in parsed_values
+
+    run = dispatch["run"]
+    python_source = run.split("python3 - <<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
+    tree = ast.parse(python_source)
+    requests = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "Request"
+    ]
+    assert len(requests) == 1
+    request = requests[0]
+    assert len(request.args) == 1 and isinstance(request.args[0], ast.JoinedStr)
+    url_parts = request.args[0].values
+    assert len(url_parts) == 3
+    assert isinstance(url_parts[0], ast.Constant) and url_parts[0].value == "https://api.github.com/repos/"
+    assert isinstance(url_parts[1], ast.FormattedValue)
+    assert ast.unparse(url_parts[1].value) == "os.environ['REPOSITORY']"
+    assert isinstance(url_parts[2], ast.Constant)
+    assert url_parts[2].value == "/actions/workflows/desktop-core-alpha-feed.yml/dispatches"
+    keywords = {item.arg: item.value for item in request.keywords if item.arg is not None}
+    assert isinstance(keywords["method"], ast.Constant) and keywords["method"].value == "POST"
+    data = keywords["data"]
+    assert isinstance(data, ast.Call) and isinstance(data.func, ast.Attribute) and data.func.attr == "encode"
+    dumps = data.func.value
+    assert isinstance(dumps, ast.Call)
+    assert isinstance(dumps.func, ast.Attribute)
+    assert ast.unparse(dumps.func) == "json.dumps"
+    payload = dumps.args[0]
+    assert isinstance(payload, ast.Dict)
+    payload_items = [(ast.literal_eval(key), ast.literal_eval(item)) for key, item in zip(payload.keys, payload.values)]
+    assert payload_items == [("ref", "main")]
+
+    redirect_classes = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and node.name == "NoRedirect"
+        and any(ast.unparse(base) == "urllib.request.HTTPRedirectHandler" for base in node.bases)
+    ]
+    assert len(redirect_classes) == 1
+    redirect_method = next(
+        node
+        for node in redirect_classes[0].body
+        if isinstance(node, ast.FunctionDef) and node.name == "redirect_request"
+    )
+    assert any(isinstance(node, ast.Raise) and "HTTPError" in ast.unparse(node) for node in ast.walk(redirect_method))
+    assert "urllib.request.build_opener(NoRedirect())" in python_source
+    assert "urllib.request.urlopen" not in python_source


### PR DESCRIPTION
## Summary

Makes the signed HOL Guard Desktop Core feed run promptly for Core 3.x alpha publications instead of relying only on the hourly scheduler.

- Dispatches `.github/workflows/desktop-core-alpha-feed.yml` after successful `Publish to PyPI` **push** runs on `release/3.*`.
- Also handles manually published `alpha/v3.*` GitHub releases.
- Adds a one-time `main` push trigger scoped to this workflow file, so merging this PR immediately reconciles the currently published Core alpha.
- Keeps workflow-level permissions read-only; only the wake job gets `actions: write` for the dispatch call.
- Does not expose OIDC, PyPI, Apple, or Tauri signing authority to the wake workflow.
- Reports bounded GitHub API error details without logging the bearer token.
- Adds a contract test that locks event scope, default-branch dispatch, least privilege, and absence of signing/OIDC authority.

## Why `workflow_run`

GitHub intentionally prevents most events created with a workflow `GITHUB_TOKEN` from recursively starting another workflow. The Core alpha publisher can therefore create a release without reliably causing a separate `release: published` wake. Listening to successful `Publish to PyPI` push completions on `release/3.*` provides a deterministic post-publish wake, while the existing hourly schedule remains the independent reconciliation safety net.

## Security boundary

This helper can only dispatch the already-reviewed default-branch feed producer. The producer retains all Core version validation, bootstrap-contract verification, signing/notarization, immutable asset validation, and release upload authority. A PR run cannot dispatch because the job condition accepts only the scoped push, release, or successful release-branch workflow completion events.

## Current production gap

The feed producer is active on `main`, but it has recorded zero runs and the latest published Core alpha currently lacks the Desktop sidecar update assets. Merging this PR exercises the feed immediately against the current 3.x alpha without moving signing authority out of the feed producer.