### PR TITLE
fix(ci): add trusted manual Desktop Core feed wake

### DIFF
--- a/.github/workflows/wake-desktop-core-alpha-feed.yml
+++ b/.github/workflows/wake-desktop-core-alpha-feed.yml
@@ -6,6 +6,8 @@ on:
     types: [completed]
   release:
     types: [published]
+  issues:
+    types: [opened]
   push:
     branches:
       - main
@@ -27,6 +29,11 @@ jobs:
     name: Dispatch Desktop Core alpha feed
     if: >-
       github.event_name == 'push' ||
+      (github.event_name == 'issues' &&
+       (github.event.issue.author_association == 'OWNER' ||
+        github.event.issue.author_association == 'MEMBER' ||
+        github.event.issue.author_association == 'COLLABORATOR') &&
+       startsWith(github.event.issue.title, '[desktop-core-feed]')) ||
       (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'alpha/v3.')) ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&

--- a/tests/test_desktop_core_alpha_feed_wake.py
+++ b/tests/test_desktop_core_alpha_feed_wake.py
@@ -17,9 +17,10 @@ def test_desktop_core_feed_wake_is_narrow_and_least_privilege() -> None:
     value = yaml.safe_load(text)
     events = value[True]
     workflow_path = ".github/workflows/wake-desktop-core-alpha-feed.yml"
-    assert set(events) == {"workflow_run", "release", "push", "pull_request"}
+    assert set(events) == {"workflow_run", "release", "issues", "push", "pull_request"}
     assert events["workflow_run"] == {"workflows": ["Publish to PyPI"], "types": ["completed"]}
     assert events["release"] == {"types": ["published"]}
+    assert events["issues"] == {"types": ["opened"]}
     assert events["push"] == {"branches": ["main"], "paths": [workflow_path]}
     assert events["pull_request"] == {"paths": [workflow_path]}
     assert value["permissions"] == {"contents": "read"}
@@ -33,6 +34,11 @@ def test_desktop_core_feed_wake_is_narrow_and_least_privilege() -> None:
     condition = " ".join(wake["if"].split())
     assert condition == (
         "github.event_name == 'push' || "
+        "(github.event_name == 'issues' && "
+        "(github.event.issue.author_association == 'OWNER' || "
+        "github.event.issue.author_association == 'MEMBER' || "
+        "github.event.issue.author_association == 'COLLABORATOR') && "
+        "startsWith(github.event.issue.title, '[desktop-core-feed]')) || "
         "(github.event_name == 'release' && startsWith(github.event.release.tag_name, 'alpha/v3.')) || "
         "(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && "
         "github.event.workflow_run.event == 'push' && startsWith(github.event.workflow_run.head_branch, 'release/3.'))"


### PR DESCRIPTION
## Summary

Adds an explicitly scoped manual recovery path for the signed Desktop Core alpha feed.

- Listens for newly opened issues with the `[desktop-core-feed]` prefix.
- Only repository `OWNER`, `MEMBER`, or `COLLABORATOR` issue authors can trigger the dispatch job.
- Random public issue authors cannot wake the protected producer.
- Dispatches only the existing reviewed `desktop-core-alpha-feed.yml` workflow on `main`.
- Preserves the 3.x publisher/release wake paths and least-privilege `actions: write` boundary.
- Extends the contract test to lock the exact manual-wake event and authorization condition.

## Why

The feed producer's hourly schedule has not produced runs, and the first merge introducing the wake workflow could not trigger its own `push` event because the workflow was not yet registered. This gives maintainers a deterministic, auditable recovery trigger without exposing signing, OIDC, Apple, Tauri, or PyPI credentials to the wake workflow.

## Validation

The change is one commit directly on current `main` and touches only the wake workflow plus its existing contract test.