### PR TITLE
fix(guard): consume Solo Cloud entitlement boundaries

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12047,
-  "maximum_test_source_lines": 281677,
+  "maximum_collected_cases": 12060,
+  "maximum_test_source_lines": 281969,
   "schema_version": 1
 }

--- a/docs/guard/local-vs-cloud.md
+++ b/docs/guard/local-vs-cloud.md
@@ -30,8 +30,9 @@ Available without a Cloud subscription or sign-in:
   let an operator detect unsigned, unknown-key, or tampered local policy rows
   and move to enforce mode deliberately.
 - **Cloud-outage independence** — if Guard Cloud is unavailable, you are signed
-  out, or never connected, local interception, policy, blocking, receipts, and
-  approvals continue on the machine.
+  out, your trial ends, a subscription is past due or canceled, or you never
+  connected, local interception, policy, blocking, receipts, and approvals
+  continue on the machine.
 
 Guard does not meter local safety features. You can detect harnesses, install
 launchers, diff changes, prompt for approval, and inspect receipts without
@@ -46,22 +47,51 @@ when optional Cloud receipt sync is enabled.
 Guard Cloud is a personal AI safety cockpit and memory layer. It does not gate
 baseline local protection.
 
-Paid Cloud value for a solo developer or vibe coder includes:
+### Solo
 
-- **Synced history** across sessions, devices, and hosted or local agents
-- **Searchable activity** — blocked actions, approvals, package installs,
-  MCP/Skill changes, and risky activity in one timeline
-- **Decision memory and policy suggestions** — safe repeated choices stop
-  becoming repeated interruptions
-- **MCP/Skill drift visibility over time** — changed schemas, commands,
-  transports, scopes, and dependencies stay visible after first trust
-- **Incident-style summaries** — what happened, why it mattered, and what to
-  do next without digging through raw logs
-- **Cloud Firewall UI** — package risk, feed freshness, remediation guidance,
-  and safer fix paths on top of local enforcement
-- **Exports and shareable records** — audit-ready evidence packages when you
-  need to show what Guard handled
-- **Digests and notifications** — calm routing for what needs attention
+Solo is the personal continuity tier for one developer. It adds Cloud value
+without changing what Guard can protect locally:
+
+- Cloud receipt and decision-memory sync for **two Cloud-connected devices**
+- **30 days** of searchable Cloud history
+- **1 GB** of Cloud storage
+- basic history search
+- a weekly personal security digest
+- matched critical advisory email
+- individual receipt download and a retained-history basic CSV/JSON export
+
+The two-device limit is a Cloud-sync limit only. A third machine still installs,
+intercepts, prompts, blocks, and writes local receipts normally. If the Portal
+returns `device_limit_reached` or `cloud_sync_paused_plan_limit`, the client must
+report Cloud sync as limited while continuing to report local protection
+accurately.
+
+### Pro
+
+Pro remains the personal power-user tier. Portal-provided entitlements are the
+source of truth, but the product boundary includes longer history and storage,
+all supported personal-device Cloud continuity subject to the current service
+policy, real-time alerting, policy version history, advanced search, and full
+evidence export. The local client does not hardcode plan prices or use plan
+names as enforcement logic.
+
+### Cloud error contract
+
+Cloud clients consume machine-actionable plan errors rather than parsing human
+messages. Known normal plan boundaries include:
+
+- `feature_not_in_plan`
+- `device_limit_reached`
+- `retention_limit_reached`
+- `storage_limit_reached`
+- `subscription_past_due`
+- `trial_expired`
+- `cloud_sync_paused_plan_limit`
+
+These codes describe Cloud state only. A network outage, billing state, trial
+state, retention limit, storage limit, or device limit must never be translated
+into “protection expired,” “device blocked,” or another claim that local Guard
+stopped working.
 
 Optional Cloud pairing commands:
 
@@ -109,16 +139,18 @@ on top of the individual Cloud value:
 
 ## Quick comparison
 
-| Capability | Local Guard | Guard Cloud |
-| --- | --- | --- |
-| Launch interception and local policy | Included | Included |
-| Local blocking/warnings on supported actions | Included | Included |
-| Local receipts and approvals | Included | Included |
-| Works when Cloud is offline | Yes | Local protection continues; sync pauses |
-| Cross-device history and search | Device-local only | Included on paid plans |
-| Decision memory across machines | No | Included on paid plans |
-| Cloud Firewall UI and exports | No | Included on paid plans |
-| Team RBAC, routing, and shared policy | No | Team plans |
+| Capability | Local Guard | Solo Cloud | Pro Cloud | Team Cloud |
+| --- | --- | --- | --- | --- |
+| Launch interception and local policy | Included | Included | Included | Included |
+| Local blocking/warnings on supported actions | Included | Included | Included | Included |
+| Local receipts and approvals | Included | Included | Included | Included |
+| Works when Cloud is offline | Yes | Local protection continues; sync pauses | Local protection continues; sync pauses | Local protection continues; sync pauses |
+| Cloud-connected personal devices | None required | 2 | Portal entitlement | Managed by workspace |
+| Cloud history | None required | 30 days | Portal entitlement | Workspace policy |
+| Decision memory across machines | No | Included | Included | Included |
+| Real-time Cloud activity alerts | No | Not included | Portal entitlement | Team routing |
+| Full evidence bundles | Local export only | Not included | Portal entitlement | Team evidence |
+| Team RBAC, routing, and shared policy | No | No | No | Included |
 
 ## Related docs
 

--- a/src/codex_plugin_scanner/guard/cloud_entitlements.py
+++ b/src/codex_plugin_scanner/guard/cloud_entitlements.py
@@ -273,9 +273,15 @@ def guard_cloud_status_copy(error: GuardCloudPlanError) -> str:
     """Human copy that never implies a Cloud problem disabled local Guard."""
 
     if error.code == "device_limit_reached":
+        if error.plan_id == "solo" and error.limit == 2:
+            return (
+                "Your machine is still protected. Solo includes Cloud sync for two devices. "
+                "Choose a device to replace or upgrade to Pro to sync all your personal machines."
+            )
+        limit_copy = f" ({error.limit} devices)" if error.limit is not None else ""
         return (
-            "Your machine is still protected. Solo includes Cloud sync for two devices. "
-            "Choose a device to replace or upgrade to Pro to sync all your personal machines."
+            f"Your machine is still protected. Guard Cloud reached this plan's synced-device limit{limit_copy}. "
+            "Manage your synced devices or change plans to resume Cloud sync."
         )
     if error.code == "cloud_sync_paused_plan_limit":
         return "Cloud sync is paused by your plan limit. Local protection is active."

--- a/src/codex_plugin_scanner/guard/cloud_entitlements.py
+++ b/src/codex_plugin_scanner/guard/cloud_entitlements.py
@@ -1,0 +1,288 @@
+"""Typed Guard Cloud entitlement and plan-boundary helpers.
+
+This module deliberately lives outside the local enforcement path. It parses
+optional Guard Cloud state so CLI/dashboard surfaces can explain Cloud limits
+without ever treating billing or connectivity as a local protection verdict.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Literal
+from urllib.parse import urlparse
+
+GuardPlanId = Literal["free", "solo", "pro", "team", "enterprise"]
+GuardSubscriptionStatus = Literal[
+    "free",
+    "trialing",
+    "active",
+    "past_due",
+    "canceled",
+]
+GuardCloudErrorCategory = Literal[
+    "plan_limit",
+    "billing",
+    "trial",
+    "sync_paused",
+    "authentication",
+    "cloud_error",
+]
+
+_GUARD_PLAN_IDS = frozenset({"free", "solo", "pro", "team", "enterprise"})
+_GUARD_SUBSCRIPTION_STATUSES = frozenset({"free", "trialing", "active", "past_due", "canceled"})
+_PLAN_LIMIT_CODES = frozenset(
+    {
+        "feature_not_in_plan",
+        "device_limit_reached",
+        "retention_limit_reached",
+        "storage_limit_reached",
+    }
+)
+_BILLING_CODES = frozenset({"subscription_past_due"})
+_TRIAL_CODES = frozenset({"trial_expired"})
+_SYNC_PAUSED_CODES = frozenset({"cloud_sync_paused_plan_limit"})
+_KNOWN_PLAN_ERROR_CODES = _PLAN_LIMIT_CODES | _BILLING_CODES | _TRIAL_CODES | _SYNC_PAUSED_CODES
+_ALLOWED_FEATURE_VALUE_TYPES = (bool, str, int, float, type(None))
+
+
+@dataclass(frozen=True)
+class GuardCloudEntitlements:
+    """Forward-compatible subset of the Portal effective-entitlement contract."""
+
+    plan_id: GuardPlanId
+    plan_version: str | None = None
+    subscription_status: GuardSubscriptionStatus | None = None
+    current_period_end: str | None = None
+    trial_end: str | None = None
+    max_synced_devices: int | None = None
+    active_synced_devices: int | None = None
+    retention_days: int | None = None
+    cloud_storage_bytes: int | None = None
+    cloud_storage_used_bytes: int | None = None
+    features: dict[str, bool | str | int | float | None] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GuardCloudPlanError:
+    """Normalized Cloud failure that is explicitly separate from local safety."""
+
+    code: str
+    category: GuardCloudErrorCategory
+    message: str
+    http_status: int | None = None
+    plan_id: GuardPlanId | None = None
+    limit: int | None = None
+    current: int | None = None
+    upgrade_plan_id: GuardPlanId | None = None
+    manage_url: str | None = None
+    upgrade_url: str | None = None
+    local_protection_affected: bool = False
+
+
+def _mapping(value: object) -> Mapping[str, object] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _optional_string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _optional_nonnegative_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value >= 0 else None
+    if isinstance(value, float) and value.is_integer() and value >= 0:
+        return int(value)
+    return None
+
+
+def _plan_id(value: object) -> GuardPlanId | None:
+    normalized = _optional_string(value)
+    if normalized is None:
+        return None
+    lowered = normalized.lower()
+    return lowered if lowered in _GUARD_PLAN_IDS else None  # type: ignore[return-value]
+
+
+def _subscription_status(value: object) -> GuardSubscriptionStatus | None:
+    normalized = _optional_string(value)
+    if normalized is None:
+        return None
+    lowered = normalized.lower()
+    return lowered if lowered in _GUARD_SUBSCRIPTION_STATUSES else None  # type: ignore[return-value]
+
+
+def _feature_values(value: object) -> dict[str, bool | str | int | float | None]:
+    source = _mapping(value)
+    if source is None:
+        return {}
+    result: dict[str, bool | str | int | float | None] = {}
+    for raw_key, raw_value in source.items():
+        if not isinstance(raw_key, str) or not raw_key.strip():
+            continue
+        if isinstance(raw_value, _ALLOWED_FEATURE_VALUE_TYPES):
+            result[raw_key.strip()] = raw_value
+    return result
+
+
+def _safe_action_url(value: object) -> str | None:
+    url = _optional_string(value)
+    if url is None:
+        return None
+    if url.startswith("/") and not url.startswith("//"):
+        return url
+    parsed = urlparse(url)
+    if parsed.scheme == "https" and parsed.hostname in {"hol.org", "www.hol.org"}:
+        return url
+    return None
+
+
+def parse_guard_cloud_entitlements(payload: object) -> GuardCloudEntitlements | None:
+    """Parse Portal entitlement state while ignoring unknown additive fields.
+
+    Supports both the full effective-entitlement response (camelCase) and the
+    compact OAuth ``guard_local_entitlement`` response (snake_case). The compact
+    response intentionally yields ``None`` for fields the server did not send;
+    the client never invents plan limits locally.
+    """
+
+    root = _mapping(payload)
+    if root is None:
+        return None
+    nested = _mapping(root.get("guard_local_entitlement"))
+    source = nested or root
+
+    plan_id = _plan_id(source.get("planId") or source.get("plan_id") or source.get("tier"))
+    if plan_id is None:
+        return None
+
+    features = _feature_values(source.get("features"))
+    if not features:
+        features = _feature_values(source.get("cloudValueGates") or source.get("cloud_value_gates"))
+    supply_chain_firewall = source.get("supply_chain_firewall")
+    if isinstance(supply_chain_firewall, bool):
+        features.setdefault("guard.cloud.supply_chain_firewall", supply_chain_firewall)
+
+    cloud_storage_bytes = _optional_nonnegative_int(
+        source.get("cloudStorageBytes") or source.get("cloud_storage_bytes")
+    )
+    if cloud_storage_bytes is None:
+        storage_gb = source.get("includedStorageGb") or source.get("included_storage_gb")
+        if isinstance(storage_gb, (int, float)) and not isinstance(storage_gb, bool) and storage_gb >= 0:
+            cloud_storage_bytes = int(float(storage_gb) * 1024 * 1024 * 1024)
+
+    return GuardCloudEntitlements(
+        plan_id=plan_id,
+        plan_version=_optional_string(source.get("planVersion") or source.get("plan_version")),
+        subscription_status=_subscription_status(
+            source.get("subscriptionStatus") or source.get("subscription_status")
+        ),
+        current_period_end=_optional_string(
+            source.get("currentPeriodEnd") or source.get("current_period_end")
+        ),
+        trial_end=_optional_string(source.get("trialEnd") or source.get("trial_end")),
+        max_synced_devices=_optional_nonnegative_int(
+            source.get("maxSyncedDevices")
+            or source.get("max_synced_devices")
+            or source.get("deviceLimit")
+            or source.get("device_limit")
+        ),
+        active_synced_devices=_optional_nonnegative_int(
+            source.get("activeSyncedDevices") or source.get("active_synced_devices")
+        ),
+        retention_days=_optional_nonnegative_int(
+            source.get("retentionDays") or source.get("retention_days")
+        ),
+        cloud_storage_bytes=cloud_storage_bytes,
+        cloud_storage_used_bytes=_optional_nonnegative_int(
+            source.get("cloudStorageUsedBytes")
+            or source.get("cloud_storage_used_bytes")
+            or source.get("storageUsedBytes")
+            or source.get("storage_used_bytes")
+        ),
+        features=features,
+    )
+
+
+def parse_guard_cloud_plan_error(
+    payload: object,
+    *,
+    http_status: int | None = None,
+) -> GuardCloudPlanError | None:
+    """Normalize machine-actionable Portal plan errors without parsing prose."""
+
+    root = _mapping(payload)
+    if root is None:
+        return None
+    nested = _mapping(root.get("error"))
+    source = nested or root
+    code = _optional_string(source.get("code"))
+
+    if code in _PLAN_LIMIT_CODES:
+        category: GuardCloudErrorCategory = "plan_limit"
+    elif code in _BILLING_CODES:
+        category = "billing"
+    elif code in _TRIAL_CODES:
+        category = "trial"
+    elif code in _SYNC_PAUSED_CODES:
+        category = "sync_paused"
+    elif http_status in {401, 403}:
+        category = "authentication"
+    elif code is not None or (http_status is not None and http_status >= 400):
+        category = "cloud_error"
+    else:
+        return None
+
+    message = _optional_string(source.get("message")) or "Guard Cloud request failed."
+    return GuardCloudPlanError(
+        code=code or "cloud_request_failed",
+        category=category,
+        message=message,
+        http_status=http_status,
+        plan_id=_plan_id(source.get("planId") or source.get("plan_id")),
+        limit=_optional_nonnegative_int(source.get("limit")),
+        current=_optional_nonnegative_int(source.get("current")),
+        upgrade_plan_id=_plan_id(source.get("upgradePlanId") or source.get("upgrade_plan_id")),
+        manage_url=_safe_action_url(source.get("manageUrl") or source.get("manage_url")),
+        upgrade_url=_safe_action_url(source.get("upgradeUrl") or source.get("upgrade_url")),
+    )
+
+
+def guard_cloud_status_copy(error: GuardCloudPlanError) -> str:
+    """Human copy that never implies a Cloud problem disabled local Guard."""
+
+    if error.code == "device_limit_reached":
+        return (
+            "Your machine is still protected. Solo includes Cloud sync for two devices. "
+            "Choose a device to replace or upgrade to Pro to sync all your personal machines."
+        )
+    if error.code == "cloud_sync_paused_plan_limit":
+        return "Cloud sync is paused by your plan limit. Local protection is active."
+    if error.code == "storage_limit_reached":
+        return "Cloud sync is paused because your Cloud storage limit was reached. Local protection continues."
+    if error.code == "subscription_past_due":
+        return "Guard Cloud billing needs attention. Local protection remains active."
+    if error.code == "trial_expired":
+        return "Your Guard Cloud trial ended. Local protection remains active."
+    if error.category == "cloud_error":
+        return "Guard Cloud is unavailable or the request failed. Local protection continues."
+    return f"{error.message} Local protection remains active."
+
+
+def guard_cloud_history_copy(entitlements: GuardCloudEntitlements) -> str | None:
+    """Plan-aware Cloud history label with no embedded prices."""
+
+    if entitlements.retention_days is None:
+        return None
+    if entitlements.retention_days <= 0:
+        return "Cloud history is not included on this plan."
+    return f"{entitlements.retention_days}-day Cloud history"
+
+
+def is_known_guard_plan_error_code(code: str) -> bool:
+    return code in _KNOWN_PLAN_ERROR_CODES

--- a/src/codex_plugin_scanner/guard/cloud_entitlements.py
+++ b/src/codex_plugin_scanner/guard/cloud_entitlements.py
@@ -30,9 +30,7 @@ GuardCloudErrorCategory = Literal[
 ]
 
 _GUARD_PLAN_IDS = frozenset({"free", "solo", "pro", "team", "enterprise"})
-_GUARD_SUBSCRIPTION_STATUSES = frozenset(
-    {"free", "trialing", "active", "past_due", "canceled"}
-)
+_GUARD_SUBSCRIPTION_STATUSES = frozenset({"free", "trialing", "active", "past_due", "canceled"})
 _PLAN_LIMIT_CODES = frozenset(
     {
         "feature_not_in_plan",
@@ -44,9 +42,7 @@ _PLAN_LIMIT_CODES = frozenset(
 _BILLING_CODES = frozenset({"subscription_past_due"})
 _TRIAL_CODES = frozenset({"trial_expired"})
 _SYNC_PAUSED_CODES = frozenset({"cloud_sync_paused_plan_limit"})
-_KNOWN_PLAN_ERROR_CODES = (
-    _PLAN_LIMIT_CODES | _BILLING_CODES | _TRIAL_CODES | _SYNC_PAUSED_CODES
-)
+_KNOWN_PLAN_ERROR_CODES = _PLAN_LIMIT_CODES | _BILLING_CODES | _TRIAL_CODES | _SYNC_PAUSED_CODES
 _ALLOWED_FEATURE_VALUE_TYPES = (bool, str, int, float, type(None))
 _ALLOWED_ACTION_HOSTS = frozenset({"hol.org", "www.hol.org"})
 
@@ -190,40 +186,24 @@ def parse_guard_cloud_entitlements(payload: object) -> GuardCloudEntitlements | 
 
     features = _feature_values(_first_value(source, "features"))
     if not features:
-        features = _feature_values(
-            _first_value(source, "cloudValueGates", "cloud_value_gates")
-        )
-    supply_chain_firewall = _first_value(
-        source, "supplyChainFirewall", "supply_chain_firewall"
-    )
+        features = _feature_values(_first_value(source, "cloudValueGates", "cloud_value_gates"))
+    supply_chain_firewall = _first_value(source, "supplyChainFirewall", "supply_chain_firewall")
     if isinstance(supply_chain_firewall, bool):
         features.setdefault("guard.cloud.supply_chain_firewall", supply_chain_firewall)
 
-    cloud_storage_bytes = _optional_nonnegative_int(
-        _first_value(source, "cloudStorageBytes", "cloud_storage_bytes")
-    )
+    cloud_storage_bytes = _optional_nonnegative_int(_first_value(source, "cloudStorageBytes", "cloud_storage_bytes"))
     if cloud_storage_bytes is None:
         storage_gb = _first_value(source, "includedStorageGb", "included_storage_gb")
-        if (
-            isinstance(storage_gb, (int, float))
-            and not isinstance(storage_gb, bool)
-            and storage_gb >= 0
-        ):
+        if isinstance(storage_gb, (int, float)) and not isinstance(storage_gb, bool) and storage_gb >= 0:
             # Guard's canonical plan contract defines displayed GB storage in
             # binary byte units (Solo 1 GB == 1_073_741_824 bytes).
             cloud_storage_bytes = int(float(storage_gb) * 1024 * 1024 * 1024)
 
     return GuardCloudEntitlements(
         plan_id=plan_id,
-        plan_version=_optional_string(
-            _first_value(source, "planVersion", "plan_version")
-        ),
-        subscription_status=_subscription_status(
-            _first_value(source, "subscriptionStatus", "subscription_status")
-        ),
-        current_period_end=_optional_string(
-            _first_value(source, "currentPeriodEnd", "current_period_end")
-        ),
+        plan_version=_optional_string(_first_value(source, "planVersion", "plan_version")),
+        subscription_status=_subscription_status(_first_value(source, "subscriptionStatus", "subscription_status")),
+        current_period_end=_optional_string(_first_value(source, "currentPeriodEnd", "current_period_end")),
         trial_end=_optional_string(_first_value(source, "trialEnd", "trial_end")),
         max_synced_devices=_optional_nonnegative_int(
             _first_value(
@@ -237,9 +217,7 @@ def parse_guard_cloud_entitlements(payload: object) -> GuardCloudEntitlements | 
         active_synced_devices=_optional_nonnegative_int(
             _first_value(source, "activeSyncedDevices", "active_synced_devices")
         ),
-        retention_days=_optional_nonnegative_int(
-            _first_value(source, "retentionDays", "retention_days")
-        ),
+        retention_days=_optional_nonnegative_int(_first_value(source, "retentionDays", "retention_days")),
         cloud_storage_bytes=cloud_storage_bytes,
         cloud_storage_used_bytes=_optional_nonnegative_int(
             _first_value(
@@ -292,13 +270,9 @@ def parse_guard_cloud_plan_error(
         plan_id=_plan_id(_first_value(source, "planId", "plan_id")),
         limit=_optional_nonnegative_int(source.get("limit")),
         current=_optional_nonnegative_int(source.get("current")),
-        upgrade_plan_id=_plan_id(
-            _first_value(source, "upgradePlanId", "upgrade_plan_id")
-        ),
+        upgrade_plan_id=_plan_id(_first_value(source, "upgradePlanId", "upgrade_plan_id")),
         manage_url=_safe_action_url(_first_value(source, "manageUrl", "manage_url")),
-        upgrade_url=_safe_action_url(
-            _first_value(source, "upgradeUrl", "upgrade_url")
-        ),
+        upgrade_url=_safe_action_url(_first_value(source, "upgradeUrl", "upgrade_url")),
     )
 
 
@@ -306,27 +280,15 @@ def guard_cloud_status_copy(error: GuardCloudPlanError) -> str:
     """Human copy that never implies a Cloud problem disabled local Guard."""
 
     if error.code == "device_limit_reached":
-        upgrade_target = (
-            error.upgrade_plan_id.capitalize()
-            if error.upgrade_plan_id is not None
-            else None
-        )
+        upgrade_target = error.upgrade_plan_id.capitalize() if error.upgrade_plan_id is not None else None
         if error.plan_id == "solo" and error.limit == 2:
-            upgrade_copy = (
-                f"upgrade to {upgrade_target}"
-                if upgrade_target is not None
-                else "change plans"
-            )
+            upgrade_copy = f"upgrade to {upgrade_target}" if upgrade_target is not None else "change plans"
             return (
                 "Your machine is still protected. Solo includes Cloud sync for two devices. "
                 f"Choose a device to replace or {upgrade_copy} to sync more personal machines."
             )
         limit_copy = f" ({error.limit} devices)" if error.limit is not None else ""
-        upgrade_copy = (
-            f"upgrade to {upgrade_target}"
-            if upgrade_target is not None
-            else "change plans"
-        )
+        upgrade_copy = f"upgrade to {upgrade_target}" if upgrade_target is not None else "change plans"
         return (
             f"Your machine is still protected. Guard Cloud reached this plan's synced-device limit{limit_copy}. "
             f"Manage your synced devices or {upgrade_copy} to resume Cloud sync."
@@ -334,10 +296,7 @@ def guard_cloud_status_copy(error: GuardCloudPlanError) -> str:
     if error.code == "cloud_sync_paused_plan_limit":
         return "Cloud sync is paused by your plan limit. Local protection is active."
     if error.code == "storage_limit_reached":
-        return (
-            "Cloud sync is paused because your Cloud storage limit was reached. "
-            "Local protection continues."
-        )
+        return "Cloud sync is paused because your Cloud storage limit was reached. Local protection continues."
     if error.code == "subscription_past_due":
         return "Guard Cloud billing needs attention. Local protection remains active."
     if error.code == "trial_expired":

--- a/src/codex_plugin_scanner/guard/cloud_entitlements.py
+++ b/src/codex_plugin_scanner/guard/cloud_entitlements.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, cast
 from urllib.parse import urlparse
 
 GuardPlanId = Literal["free", "solo", "pro", "team", "enterprise"]
@@ -44,6 +44,7 @@ _TRIAL_CODES = frozenset({"trial_expired"})
 _SYNC_PAUSED_CODES = frozenset({"cloud_sync_paused_plan_limit"})
 _KNOWN_PLAN_ERROR_CODES = _PLAN_LIMIT_CODES | _BILLING_CODES | _TRIAL_CODES | _SYNC_PAUSED_CODES
 _ALLOWED_FEATURE_VALUE_TYPES = (bool, str, int, float, type(None))
+_ALLOWED_ACTION_HOSTS = frozenset({"hol.org", "www.hol.org"})
 
 
 @dataclass(frozen=True)
@@ -116,7 +117,9 @@ def _plan_id(value: object) -> GuardPlanId | None:
     if normalized is None:
         return None
     lowered = normalized.lower()
-    return lowered if lowered in _GUARD_PLAN_IDS else None  # type: ignore[return-value]
+    if lowered not in _GUARD_PLAN_IDS:
+        return None
+    return cast(GuardPlanId, lowered)
 
 
 def _subscription_status(value: object) -> GuardSubscriptionStatus | None:
@@ -124,7 +127,9 @@ def _subscription_status(value: object) -> GuardSubscriptionStatus | None:
     if normalized is None:
         return None
     lowered = normalized.lower()
-    return lowered if lowered in _GUARD_SUBSCRIPTION_STATUSES else None  # type: ignore[return-value]
+    if lowered not in _GUARD_SUBSCRIPTION_STATUSES:
+        return None
+    return cast(GuardSubscriptionStatus, lowered)
 
 
 def _feature_values(value: object) -> dict[str, bool | str | int | float | None]:
@@ -142,14 +147,22 @@ def _feature_values(value: object) -> dict[str, bool | str | int | float | None]
 
 def _safe_action_url(value: object) -> str | None:
     url = _optional_string(value)
-    if url is None:
+    if url is None or "\\" in url:
         return None
     if url.startswith("/") and not url.startswith("//"):
         return url
     parsed = urlparse(url)
-    if parsed.scheme == "https" and parsed.hostname in {"hol.org", "www.hol.org"}:
-        return url
-    return None
+    if parsed.scheme != "https" or parsed.hostname not in _ALLOWED_ACTION_HOSTS:
+        return None
+    if parsed.username is not None or parsed.password is not None:
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    if port not in {None, 443}:
+        return None
+    return url
 
 
 def parse_guard_cloud_entitlements(payload: object) -> GuardCloudEntitlements | None:
@@ -174,7 +187,7 @@ def parse_guard_cloud_entitlements(payload: object) -> GuardCloudEntitlements | 
     features = _feature_values(_first_value(source, "features"))
     if not features:
         features = _feature_values(_first_value(source, "cloudValueGates", "cloud_value_gates"))
-    supply_chain_firewall = source.get("supply_chain_firewall")
+    supply_chain_firewall = _first_value(source, "supplyChainFirewall", "supply_chain_firewall")
     if isinstance(supply_chain_firewall, bool):
         features.setdefault("guard.cloud.supply_chain_firewall", supply_chain_firewall)
 
@@ -184,6 +197,8 @@ def parse_guard_cloud_entitlements(payload: object) -> GuardCloudEntitlements | 
     if cloud_storage_bytes is None:
         storage_gb = _first_value(source, "includedStorageGb", "included_storage_gb")
         if isinstance(storage_gb, (int, float)) and not isinstance(storage_gb, bool) and storage_gb >= 0:
+            # Guard's canonical plan contract defines displayed GB storage in
+            # binary byte units (Solo 1 GB == 1_073_741_824 bytes).
             cloud_storage_bytes = int(float(storage_gb) * 1024 * 1024 * 1024)
 
     return GuardCloudEntitlements(
@@ -273,15 +288,18 @@ def guard_cloud_status_copy(error: GuardCloudPlanError) -> str:
     """Human copy that never implies a Cloud problem disabled local Guard."""
 
     if error.code == "device_limit_reached":
+        upgrade_target = error.upgrade_plan_id.capitalize() if error.upgrade_plan_id is not None else None
         if error.plan_id == "solo" and error.limit == 2:
+            upgrade_copy = f"upgrade to {upgrade_target}" if upgrade_target is not None else "change plans"
             return (
                 "Your machine is still protected. Solo includes Cloud sync for two devices. "
-                "Choose a device to replace or upgrade to Pro to sync all your personal machines."
+                f"Choose a device to replace or {upgrade_copy} to sync more personal machines."
             )
         limit_copy = f" ({error.limit} devices)" if error.limit is not None else ""
+        upgrade_copy = f"upgrade to {upgrade_target}" if upgrade_target is not None else "change plans"
         return (
             f"Your machine is still protected. Guard Cloud reached this plan's synced-device limit{limit_copy}. "
-            "Manage your synced devices or change plans to resume Cloud sync."
+            f"Manage your synced devices or {upgrade_copy} to resume Cloud sync."
         )
     if error.code == "cloud_sync_paused_plan_limit":
         return "Cloud sync is paused by your plan limit. Local protection is active."

--- a/src/codex_plugin_scanner/guard/cloud_entitlements.py
+++ b/src/codex_plugin_scanner/guard/cloud_entitlements.py
@@ -30,7 +30,9 @@ GuardCloudErrorCategory = Literal[
 ]
 
 _GUARD_PLAN_IDS = frozenset({"free", "solo", "pro", "team", "enterprise"})
-_GUARD_SUBSCRIPTION_STATUSES = frozenset({"free", "trialing", "active", "past_due", "canceled"})
+_GUARD_SUBSCRIPTION_STATUSES = frozenset(
+    {"free", "trialing", "active", "past_due", "canceled"}
+)
 _PLAN_LIMIT_CODES = frozenset(
     {
         "feature_not_in_plan",
@@ -42,7 +44,9 @@ _PLAN_LIMIT_CODES = frozenset(
 _BILLING_CODES = frozenset({"subscription_past_due"})
 _TRIAL_CODES = frozenset({"trial_expired"})
 _SYNC_PAUSED_CODES = frozenset({"cloud_sync_paused_plan_limit"})
-_KNOWN_PLAN_ERROR_CODES = _PLAN_LIMIT_CODES | _BILLING_CODES | _TRIAL_CODES | _SYNC_PAUSED_CODES
+_KNOWN_PLAN_ERROR_CODES = (
+    _PLAN_LIMIT_CODES | _BILLING_CODES | _TRIAL_CODES | _SYNC_PAUSED_CODES
+)
 _ALLOWED_FEATURE_VALUE_TYPES = (bool, str, int, float, type(None))
 _ALLOWED_ACTION_HOSTS = frozenset({"hol.org", "www.hol.org"})
 
@@ -186,8 +190,12 @@ def parse_guard_cloud_entitlements(payload: object) -> GuardCloudEntitlements | 
 
     features = _feature_values(_first_value(source, "features"))
     if not features:
-        features = _feature_values(_first_value(source, "cloudValueGates", "cloud_value_gates"))
-    supply_chain_firewall = _first_value(source, "supplyChainFirewall", "supply_chain_firewall")
+        features = _feature_values(
+            _first_value(source, "cloudValueGates", "cloud_value_gates")
+        )
+    supply_chain_firewall = _first_value(
+        source, "supplyChainFirewall", "supply_chain_firewall"
+    )
     if isinstance(supply_chain_firewall, bool):
         features.setdefault("guard.cloud.supply_chain_firewall", supply_chain_firewall)
 
@@ -196,14 +204,20 @@ def parse_guard_cloud_entitlements(payload: object) -> GuardCloudEntitlements | 
     )
     if cloud_storage_bytes is None:
         storage_gb = _first_value(source, "includedStorageGb", "included_storage_gb")
-        if isinstance(storage_gb, (int, float)) and not isinstance(storage_gb, bool) and storage_gb >= 0:
+        if (
+            isinstance(storage_gb, (int, float))
+            and not isinstance(storage_gb, bool)
+            and storage_gb >= 0
+        ):
             # Guard's canonical plan contract defines displayed GB storage in
             # binary byte units (Solo 1 GB == 1_073_741_824 bytes).
             cloud_storage_bytes = int(float(storage_gb) * 1024 * 1024 * 1024)
 
     return GuardCloudEntitlements(
         plan_id=plan_id,
-        plan_version=_optional_string(_first_value(source, "planVersion", "plan_version")),
+        plan_version=_optional_string(
+            _first_value(source, "planVersion", "plan_version")
+        ),
         subscription_status=_subscription_status(
             _first_value(source, "subscriptionStatus", "subscription_status")
         ),
@@ -278,9 +292,13 @@ def parse_guard_cloud_plan_error(
         plan_id=_plan_id(_first_value(source, "planId", "plan_id")),
         limit=_optional_nonnegative_int(source.get("limit")),
         current=_optional_nonnegative_int(source.get("current")),
-        upgrade_plan_id=_plan_id(_first_value(source, "upgradePlanId", "upgrade_plan_id")),
+        upgrade_plan_id=_plan_id(
+            _first_value(source, "upgradePlanId", "upgrade_plan_id")
+        ),
         manage_url=_safe_action_url(_first_value(source, "manageUrl", "manage_url")),
-        upgrade_url=_safe_action_url(_first_value(source, "upgradeUrl", "upgrade_url")),
+        upgrade_url=_safe_action_url(
+            _first_value(source, "upgradeUrl", "upgrade_url")
+        ),
     )
 
 
@@ -288,15 +306,27 @@ def guard_cloud_status_copy(error: GuardCloudPlanError) -> str:
     """Human copy that never implies a Cloud problem disabled local Guard."""
 
     if error.code == "device_limit_reached":
-        upgrade_target = error.upgrade_plan_id.capitalize() if error.upgrade_plan_id is not None else None
+        upgrade_target = (
+            error.upgrade_plan_id.capitalize()
+            if error.upgrade_plan_id is not None
+            else None
+        )
         if error.plan_id == "solo" and error.limit == 2:
-            upgrade_copy = f"upgrade to {upgrade_target}" if upgrade_target is not None else "change plans"
+            upgrade_copy = (
+                f"upgrade to {upgrade_target}"
+                if upgrade_target is not None
+                else "change plans"
+            )
             return (
                 "Your machine is still protected. Solo includes Cloud sync for two devices. "
                 f"Choose a device to replace or {upgrade_copy} to sync more personal machines."
             )
         limit_copy = f" ({error.limit} devices)" if error.limit is not None else ""
-        upgrade_copy = f"upgrade to {upgrade_target}" if upgrade_target is not None else "change plans"
+        upgrade_copy = (
+            f"upgrade to {upgrade_target}"
+            if upgrade_target is not None
+            else "change plans"
+        )
         return (
             f"Your machine is still protected. Guard Cloud reached this plan's synced-device limit{limit_copy}. "
             f"Manage your synced devices or {upgrade_copy} to resume Cloud sync."
@@ -304,7 +334,10 @@ def guard_cloud_status_copy(error: GuardCloudPlanError) -> str:
     if error.code == "cloud_sync_paused_plan_limit":
         return "Cloud sync is paused by your plan limit. Local protection is active."
     if error.code == "storage_limit_reached":
-        return "Cloud sync is paused because your Cloud storage limit was reached. Local protection continues."
+        return (
+            "Cloud sync is paused because your Cloud storage limit was reached. "
+            "Local protection continues."
+        )
     if error.code == "subscription_past_due":
         return "Guard Cloud billing needs attention. Local protection remains active."
     if error.code == "trial_expired":

--- a/src/codex_plugin_scanner/guard/cloud_entitlements.py
+++ b/src/codex_plugin_scanner/guard/cloud_entitlements.py
@@ -84,6 +84,16 @@ def _mapping(value: object) -> Mapping[str, object] | None:
     return value if isinstance(value, Mapping) else None
 
 
+def _first_value(source: Mapping[str, object], *keys: str) -> object | None:
+    """Return the first present non-None value without dropping 0/False."""
+
+    for key in keys:
+        value = source.get(key)
+        if value is not None:
+            return value
+    return None
+
+
 def _optional_string(value: object) -> str | None:
     if not isinstance(value, str):
         return None
@@ -157,53 +167,59 @@ def parse_guard_cloud_entitlements(payload: object) -> GuardCloudEntitlements | 
     nested = _mapping(root.get("guard_local_entitlement"))
     source = nested or root
 
-    plan_id = _plan_id(source.get("planId") or source.get("plan_id") or source.get("tier"))
+    plan_id = _plan_id(_first_value(source, "planId", "plan_id", "tier"))
     if plan_id is None:
         return None
 
-    features = _feature_values(source.get("features"))
+    features = _feature_values(_first_value(source, "features"))
     if not features:
-        features = _feature_values(source.get("cloudValueGates") or source.get("cloud_value_gates"))
+        features = _feature_values(_first_value(source, "cloudValueGates", "cloud_value_gates"))
     supply_chain_firewall = source.get("supply_chain_firewall")
     if isinstance(supply_chain_firewall, bool):
         features.setdefault("guard.cloud.supply_chain_firewall", supply_chain_firewall)
 
     cloud_storage_bytes = _optional_nonnegative_int(
-        source.get("cloudStorageBytes") or source.get("cloud_storage_bytes")
+        _first_value(source, "cloudStorageBytes", "cloud_storage_bytes")
     )
     if cloud_storage_bytes is None:
-        storage_gb = source.get("includedStorageGb") or source.get("included_storage_gb")
+        storage_gb = _first_value(source, "includedStorageGb", "included_storage_gb")
         if isinstance(storage_gb, (int, float)) and not isinstance(storage_gb, bool) and storage_gb >= 0:
             cloud_storage_bytes = int(float(storage_gb) * 1024 * 1024 * 1024)
 
     return GuardCloudEntitlements(
         plan_id=plan_id,
-        plan_version=_optional_string(source.get("planVersion") or source.get("plan_version")),
+        plan_version=_optional_string(_first_value(source, "planVersion", "plan_version")),
         subscription_status=_subscription_status(
-            source.get("subscriptionStatus") or source.get("subscription_status")
+            _first_value(source, "subscriptionStatus", "subscription_status")
         ),
         current_period_end=_optional_string(
-            source.get("currentPeriodEnd") or source.get("current_period_end")
+            _first_value(source, "currentPeriodEnd", "current_period_end")
         ),
-        trial_end=_optional_string(source.get("trialEnd") or source.get("trial_end")),
+        trial_end=_optional_string(_first_value(source, "trialEnd", "trial_end")),
         max_synced_devices=_optional_nonnegative_int(
-            source.get("maxSyncedDevices")
-            or source.get("max_synced_devices")
-            or source.get("deviceLimit")
-            or source.get("device_limit")
+            _first_value(
+                source,
+                "maxSyncedDevices",
+                "max_synced_devices",
+                "deviceLimit",
+                "device_limit",
+            )
         ),
         active_synced_devices=_optional_nonnegative_int(
-            source.get("activeSyncedDevices") or source.get("active_synced_devices")
+            _first_value(source, "activeSyncedDevices", "active_synced_devices")
         ),
         retention_days=_optional_nonnegative_int(
-            source.get("retentionDays") or source.get("retention_days")
+            _first_value(source, "retentionDays", "retention_days")
         ),
         cloud_storage_bytes=cloud_storage_bytes,
         cloud_storage_used_bytes=_optional_nonnegative_int(
-            source.get("cloudStorageUsedBytes")
-            or source.get("cloud_storage_used_bytes")
-            or source.get("storageUsedBytes")
-            or source.get("storage_used_bytes")
+            _first_value(
+                source,
+                "cloudStorageUsedBytes",
+                "cloud_storage_used_bytes",
+                "storageUsedBytes",
+                "storage_used_bytes",
+            )
         ),
         features=features,
     )
@@ -244,12 +260,12 @@ def parse_guard_cloud_plan_error(
         category=category,
         message=message,
         http_status=http_status,
-        plan_id=_plan_id(source.get("planId") or source.get("plan_id")),
+        plan_id=_plan_id(_first_value(source, "planId", "plan_id")),
         limit=_optional_nonnegative_int(source.get("limit")),
         current=_optional_nonnegative_int(source.get("current")),
-        upgrade_plan_id=_plan_id(source.get("upgradePlanId") or source.get("upgrade_plan_id")),
-        manage_url=_safe_action_url(source.get("manageUrl") or source.get("manage_url")),
-        upgrade_url=_safe_action_url(source.get("upgradeUrl") or source.get("upgrade_url")),
+        upgrade_plan_id=_plan_id(_first_value(source, "upgradePlanId", "upgrade_plan_id")),
+        manage_url=_safe_action_url(_first_value(source, "manageUrl", "manage_url")),
+        upgrade_url=_safe_action_url(_first_value(source, "upgradeUrl", "upgrade_url")),
     )
 
 

--- a/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from .cloud_entitlements import parse_guard_cloud_entitlements
 from .package_firewall_defaults import (
     PACKAGE_FIREWALL_PAID_TIERS,
     build_guard_local_entitlement_defaults,
@@ -46,7 +47,22 @@ def build_oauth_package_firewall_entitlement(
     record = payload.get("guard_local_entitlement")
     if not isinstance(record, dict):
         return None
-    return build_guard_local_entitlement_defaults(record, now=now)
+    defaults = build_guard_local_entitlement_defaults(record, now=now)
+    if defaults is None:
+        return None
+
+    # The typed Cloud parser is the authoritative path for canonical Guard
+    # plan IDs. Retain the legacy defaults path for older paid-tier aliases so
+    # existing OAuth grants are not invalidated during rollout.
+    parsed = parse_guard_cloud_entitlements(payload)
+    if parsed is None:
+        return defaults
+    defaults["plan_id"] = parsed.plan_id
+    defaults["supply_chain_plan_id"] = parsed.plan_id
+    firewall = parsed.features.get("guard.cloud.supply_chain_firewall")
+    if isinstance(firewall, bool):
+        defaults["supply_chain_firewall"] = firewall
+    return defaults
 
 
 def _bundle_entitlement(payload: object) -> dict[str, object] | None:

--- a/tests/test_guard_cloud_entitlements.py
+++ b/tests/test_guard_cloud_entitlements.py
@@ -1,0 +1,189 @@
+from codex_plugin_scanner.guard.cloud_entitlements import (
+    GuardCloudEntitlements,
+    guard_cloud_history_copy,
+    guard_cloud_status_copy,
+    is_known_guard_plan_error_code,
+    parse_guard_cloud_entitlements,
+    parse_guard_cloud_plan_error,
+)
+
+
+def test_parses_full_solo_effective_entitlements_and_ignores_unknown_fields() -> None:
+    parsed = parse_guard_cloud_entitlements(
+        {
+            "planId": "solo",
+            "planVersion": "2026-08-01",
+            "subscriptionStatus": "active",
+            "currentPeriodEnd": "2026-09-07T00:00:00Z",
+            "trialEnd": None,
+            "maxSyncedDevices": 2,
+            "activeSyncedDevices": 2,
+            "retentionDays": 30,
+            "cloudStorageBytes": 1_073_741_824,
+            "cloudStorageUsedBytes": 12_345,
+            "features": {
+                "guard.cloud.receipt_sync": True,
+                "guard.cloud.history.basic": True,
+                "guard.cloud.alerts.slack": False,
+                "future.object": {"ignored": True},
+            },
+            "futureTopLevelField": "ignored",
+        }
+    )
+
+    assert parsed == GuardCloudEntitlements(
+        plan_id="solo",
+        plan_version="2026-08-01",
+        subscription_status="active",
+        current_period_end="2026-09-07T00:00:00Z",
+        trial_end=None,
+        max_synced_devices=2,
+        active_synced_devices=2,
+        retention_days=30,
+        cloud_storage_bytes=1_073_741_824,
+        cloud_storage_used_bytes=12_345,
+        features={
+            "guard.cloud.receipt_sync": True,
+            "guard.cloud.history.basic": True,
+            "guard.cloud.alerts.slack": False,
+        },
+    )
+    assert guard_cloud_history_copy(parsed) == "30-day Cloud history"
+
+
+def test_parses_compact_oauth_entitlement_without_inventing_limits() -> None:
+    parsed = parse_guard_cloud_entitlements(
+        {
+            "access_token": "redacted",
+            "guard_local_entitlement": {
+                "plan_id": "solo",
+                "tier": "solo",
+                "expires_at": "2026-08-07T17:00:00Z",
+                "supply_chain_firewall": False,
+                "future_field": "ignored",
+            },
+        }
+    )
+
+    assert parsed is not None
+    assert parsed.plan_id == "solo"
+    assert parsed.max_synced_devices is None
+    assert parsed.retention_days is None
+    assert parsed.cloud_storage_bytes is None
+    assert parsed.features == {"guard.cloud.supply_chain_firewall": False}
+
+
+def test_preserves_explicit_zero_values_for_free_plan() -> None:
+    parsed = parse_guard_cloud_entitlements(
+        {
+            "planId": "free",
+            "maxSyncedDevices": 0,
+            "activeSyncedDevices": 0,
+            "retentionDays": 0,
+            "cloudStorageBytes": 0,
+            "cloudStorageUsedBytes": 0,
+            "features": {},
+        }
+    )
+
+    assert parsed is not None
+    assert parsed.max_synced_devices == 0
+    assert parsed.active_synced_devices == 0
+    assert parsed.retention_days == 0
+    assert parsed.cloud_storage_bytes == 0
+    assert parsed.cloud_storage_used_bytes == 0
+    assert guard_cloud_history_copy(parsed) == "Cloud history is not included on this plan."
+
+
+def test_rejects_unknown_plan_identity() -> None:
+    assert parse_guard_cloud_entitlements({"planId": "starter"}) is None
+    assert parse_guard_cloud_entitlements({"retentionDays": 30}) is None
+
+
+def test_normalizes_device_limit_without_affecting_local_protection() -> None:
+    error = parse_guard_cloud_plan_error(
+        {
+            "error": {
+                "code": "device_limit_reached",
+                "message": "Solo includes two cloud-connected devices.",
+                "planId": "solo",
+                "limit": 2,
+                "current": 2,
+                "upgradePlanId": "pro",
+                "manageUrl": "/guard/settings/devices",
+                "upgradeUrl": "/guard/pricing?from=device_limit",
+            }
+        },
+        http_status=409,
+    )
+
+    assert error is not None
+    assert error.category == "plan_limit"
+    assert error.plan_id == "solo"
+    assert error.limit == 2
+    assert error.current == 2
+    assert error.upgrade_plan_id == "pro"
+    assert error.local_protection_affected is False
+    assert error.manage_url == "/guard/settings/devices"
+    assert "still protected" in guard_cloud_status_copy(error)
+    assert "$" not in guard_cloud_status_copy(error)
+
+
+def test_normalizes_billing_trial_paused_and_outage_separately() -> None:
+    past_due = parse_guard_cloud_plan_error(
+        {"error": {"code": "subscription_past_due", "message": "Payment required."}},
+        http_status=402,
+    )
+    expired = parse_guard_cloud_plan_error(
+        {"error": {"code": "trial_expired", "message": "Trial ended."}},
+        http_status=403,
+    )
+    paused = parse_guard_cloud_plan_error(
+        {"error": {"code": "cloud_sync_paused_plan_limit", "message": "Sync paused."}},
+        http_status=409,
+    )
+    outage = parse_guard_cloud_plan_error({}, http_status=503)
+
+    assert past_due is not None and past_due.category == "billing"
+    assert expired is not None and expired.category == "trial"
+    assert paused is not None and paused.category == "sync_paused"
+    assert outage is not None and outage.category == "cloud_error"
+    assert all(
+        error.local_protection_affected is False
+        for error in (past_due, expired, paused, outage)
+    )
+    assert "Local protection" in guard_cloud_status_copy(past_due)
+    assert "Local protection" in guard_cloud_status_copy(expired)
+    assert "Local protection" in guard_cloud_status_copy(paused)
+    assert "Local protection" in guard_cloud_status_copy(outage)
+
+
+def test_rejects_untrusted_action_urls() -> None:
+    error = parse_guard_cloud_plan_error(
+        {
+            "error": {
+                "code": "feature_not_in_plan",
+                "manageUrl": "https://evil.example/manage",
+                "upgradeUrl": "//evil.example/upgrade",
+            }
+        },
+        http_status=403,
+    )
+
+    assert error is not None
+    assert error.manage_url is None
+    assert error.upgrade_url is None
+
+
+def test_known_plan_error_registry_is_explicit() -> None:
+    for code in (
+        "feature_not_in_plan",
+        "device_limit_reached",
+        "retention_limit_reached",
+        "storage_limit_reached",
+        "subscription_past_due",
+        "trial_expired",
+        "cloud_sync_paused_plan_limit",
+    ):
+        assert is_known_guard_plan_error_code(code)
+    assert not is_known_guard_plan_error_code("generic_403")

--- a/tests/test_guard_cloud_entitlements.py
+++ b/tests/test_guard_cloud_entitlements.py
@@ -21,6 +21,7 @@ def test_parses_full_solo_effective_entitlements_and_ignores_unknown_fields() ->
             "retentionDays": 30,
             "cloudStorageBytes": 1_073_741_824,
             "cloudStorageUsedBytes": 12_345,
+            "supplyChainFirewall": False,
             "features": {
                 "guard.cloud.receipt_sync": True,
                 "guard.cloud.history.basic": True,
@@ -46,6 +47,7 @@ def test_parses_full_solo_effective_entitlements_and_ignores_unknown_fields() ->
             "guard.cloud.receipt_sync": True,
             "guard.cloud.history.basic": True,
             "guard.cloud.alerts.slack": False,
+            "guard.cloud.supply_chain_firewall": False,
         },
     )
     assert guard_cloud_history_copy(parsed) == "30-day Cloud history"
@@ -95,6 +97,18 @@ def test_preserves_explicit_zero_values_for_free_plan() -> None:
     assert guard_cloud_history_copy(parsed) == "Cloud history is not included on this plan."
 
 
+def test_legacy_storage_gb_fallback_matches_canonical_guard_binary_bytes() -> None:
+    parsed = parse_guard_cloud_entitlements(
+        {
+            "planId": "solo",
+            "includedStorageGb": 1,
+        }
+    )
+
+    assert parsed is not None
+    assert parsed.cloud_storage_bytes == 1_073_741_824
+
+
 def test_rejects_unknown_plan_identity() -> None:
     assert parse_guard_cloud_entitlements({"planId": "starter"}) is None
     assert parse_guard_cloud_entitlements({"retentionDays": 30}) is None
@@ -127,6 +141,7 @@ def test_normalizes_device_limit_without_affecting_local_protection() -> None:
     assert error.manage_url == "/guard/settings/devices"
     assert "still protected" in guard_cloud_status_copy(error)
     assert "Solo includes Cloud sync for two devices" in guard_cloud_status_copy(error)
+    assert "upgrade to Pro" in guard_cloud_status_copy(error)
     assert "$" not in guard_cloud_status_copy(error)
 
 
@@ -139,6 +154,7 @@ def test_device_limit_copy_does_not_mislabel_other_plans_as_solo() -> None:
                 "planId": "team",
                 "limit": 25,
                 "current": 25,
+                "upgradePlanId": "enterprise",
             }
         },
         http_status=409,
@@ -148,6 +164,7 @@ def test_device_limit_copy_does_not_mislabel_other_plans_as_solo() -> None:
     copy = guard_cloud_status_copy(error)
     assert "still protected" in copy
     assert "25 devices" in copy
+    assert "upgrade to Enterprise" in copy
     assert "Solo" not in copy
 
 
@@ -180,21 +197,44 @@ def test_normalizes_billing_trial_paused_and_outage_separately() -> None:
     assert "Local protection" in guard_cloud_status_copy(outage)
 
 
-def test_rejects_untrusted_action_urls() -> None:
+def test_rejects_untrusted_action_urls_and_nonstandard_origins() -> None:
+    for manage_url, upgrade_url in (
+        ("https://evil.example/manage", "//evil.example/upgrade"),
+        ("/\\evil.example/manage", "/guard/pricing\\@evil.example"),
+        ("https://hol.org:8443/manage", "https://www.hol.org:8080/upgrade"),
+        ("https://user@hol.org/manage", "https://user:pass@www.hol.org/upgrade"),
+    ):
+        error = parse_guard_cloud_plan_error(
+            {
+                "error": {
+                    "code": "feature_not_in_plan",
+                    "manageUrl": manage_url,
+                    "upgradeUrl": upgrade_url,
+                }
+            },
+            http_status=403,
+        )
+
+        assert error is not None
+        assert error.manage_url is None
+        assert error.upgrade_url is None
+
+
+def test_accepts_relative_and_standard_https_hol_action_urls() -> None:
     error = parse_guard_cloud_plan_error(
         {
             "error": {
-                "code": "feature_not_in_plan",
-                "manageUrl": "https://evil.example/manage",
-                "upgradeUrl": "//evil.example/upgrade",
+                "code": "device_limit_reached",
+                "manageUrl": "/guard/settings/devices",
+                "upgradeUrl": "https://hol.org/guard/pricing?from=device_limit",
             }
         },
-        http_status=403,
+        http_status=409,
     )
 
     assert error is not None
-    assert error.manage_url is None
-    assert error.upgrade_url is None
+    assert error.manage_url == "/guard/settings/devices"
+    assert error.upgrade_url == "https://hol.org/guard/pricing?from=device_limit"
 
 
 def test_known_plan_error_registry_is_explicit() -> None:

--- a/tests/test_guard_cloud_entitlements.py
+++ b/tests/test_guard_cloud_entitlements.py
@@ -126,7 +126,29 @@ def test_normalizes_device_limit_without_affecting_local_protection() -> None:
     assert error.local_protection_affected is False
     assert error.manage_url == "/guard/settings/devices"
     assert "still protected" in guard_cloud_status_copy(error)
+    assert "Solo includes Cloud sync for two devices" in guard_cloud_status_copy(error)
     assert "$" not in guard_cloud_status_copy(error)
+
+
+def test_device_limit_copy_does_not_mislabel_other_plans_as_solo() -> None:
+    error = parse_guard_cloud_plan_error(
+        {
+            "error": {
+                "code": "device_limit_reached",
+                "message": "Device limit reached.",
+                "planId": "team",
+                "limit": 25,
+                "current": 25,
+            }
+        },
+        http_status=409,
+    )
+
+    assert error is not None
+    copy = guard_cloud_status_copy(error)
+    assert "still protected" in copy
+    assert "25 devices" in copy
+    assert "Solo" not in copy
 
 
 def test_normalizes_billing_trial_paused_and_outage_separately() -> None:

--- a/tests/test_guard_package_firewall_entitlement.py
+++ b/tests/test_guard_package_firewall_entitlement.py
@@ -33,6 +33,47 @@ def test_build_oauth_package_firewall_entitlement_preserves_team_tier() -> None:
     }
 
 
+def test_build_oauth_package_firewall_entitlement_consumes_solo_plan_identity() -> None:
+    entitlement = build_oauth_package_firewall_entitlement(
+        {
+            "guard_local_entitlement": {
+                "plan_id": "solo",
+                "tier": "solo",
+                "supply_chain_firewall": False,
+                "expires_at": "2026-09-07T00:00:00.000Z",
+            }
+        },
+        now=datetime(2026, 8, 7, tzinfo=timezone.utc),
+    )
+
+    assert entitlement == {
+        "plan_id": "solo",
+        "supply_chain_entitlement_expires_at": "2026-09-07T00:00:00.000Z",
+        "supply_chain_firewall": False,
+        "supply_chain_plan_id": "solo",
+    }
+
+
+def test_build_oauth_package_firewall_entitlement_keeps_legacy_paid_alias_compatible() -> None:
+    entitlement = build_oauth_package_firewall_entitlement(
+        {
+            "guard_local_entitlement": {
+                "plan_id": "paid",
+                "tier": "paid",
+                "expires_at": "2026-09-07T00:00:00.000Z",
+            }
+        },
+        now=datetime(2026, 8, 7, tzinfo=timezone.utc),
+    )
+
+    assert entitlement == {
+        "plan_id": "paid",
+        "supply_chain_entitlement_expires_at": "2026-09-07T00:00:00.000Z",
+        "supply_chain_firewall": True,
+        "supply_chain_plan_id": "paid",
+    }
+
+
 def test_reconcile_connect_state_clears_stale_sync_not_available_for_paid_oauth(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Companion implementation for `hashgraph-online/points-portal#4865` and HOL Guard Solo.

## Scope

Keeps local enforcement plan-independent while adding a forward-compatible Cloud entitlement/error contract for `free`, `solo`, `pro`, `team`, and `enterprise`.

- parses full effective-entitlement responses and the existing compact OAuth `guard_local_entitlement` response while ignoring unknown additive fields
- normalizes feature/device/retention/storage/billing/trial/sync-paused Cloud errors without parsing human prose
- keeps every normalized Cloud failure explicitly separate from local protection state
- uses Portal-provided plan/device/upgrade values for Cloud-limit copy and never hardcodes plan prices
- restricts server-provided manage/upgrade navigation to safe relative HOL paths or standard HTTPS HOL origins; rejects backslash authority escapes, credentials, and non-standard ports
- consumes the typed canonical plan identity in the existing OAuth package-firewall entitlement path while preserving legacy paid-tier aliases during rollout
- adds Solo/Free/Team, zero-limit, compatibility, hostile-URL, billing/trial/outage, legacy-alias, and local-first regression coverage
- updates `docs/guard/local-vs-cloud.md` with Solo two-device / 30-day semantics and explicit Cloud-vs-local failure behavior

## Product boundary

Portal remains the entitlement source of truth. This PR does not put subscription checks into interception, local policy, approvals, receipts, or offline protection. Missing/unknown Cloud fields are not invented locally, and Cloud/billing failures never imply local Guard stopped working.

## Review notes

Current review findings around device-limit copy, URL-origin validation, camelCase entitlement compatibility, typed narrowing, and storage-byte semantics have been addressed. The legacy `includedStorageGb` fallback intentionally uses 1,073,741,824 bytes per displayed GB because that matches the canonical Guard plan contract (including Solo's 1 GB entitlement), with explicit regression coverage.
