### PR TITLE
fix(codex): accept safe Linux user-private config permissions

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12047,
-  "maximum_test_source_lines": 281677,
+  "maximum_collected_cases": 12051,
+  "maximum_test_source_lines": 281763,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/codex_hook_file_integrity.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_file_integrity.py
@@ -35,6 +35,28 @@ def split_hook_command(command: object) -> list[str] | None:
         return None
 
 
+def _owner_is_only_group_member(owner_uid: int, group_gid: int) -> bool:
+    """Return whether a POSIX group is provably private to one file owner.
+
+    Linux distributions commonly create one primary group per user and pair it
+    with a 0002 umask, which produces user-owned 0664 config files.  The group
+    write bit is safe only when NSS can prove that no other account belongs to
+    that group.  Lookup failures remain fail-closed.
+    """
+
+    try:
+        import grp
+        import pwd
+
+        owner = pwd.getpwuid(owner_uid)
+        group = grp.getgrgid(group_gid)
+        member_names = set(group.gr_mem)
+        member_names.update(entry.pw_name for entry in pwd.getpwall() if entry.pw_gid == group_gid)
+    except (ImportError, KeyError, OSError):
+        return False
+    return member_names == {owner.pw_name}
+
+
 def canonical_path(path: Path) -> str:
     """Return the non-strict canonical absolute spelling used in identities."""
 
@@ -252,7 +274,15 @@ def validate_regular_file(path: Path, *, role: str, executable_required: bool) -
             # root:root layout.
             or (metadata.st_uid == 0 and metadata.st_gid == 0)
         )
-        unsafe_group_write = bool(mode & stat.S_IWGRP) and not trusted_interpreter_group_write
+        trusted_config_group_write = (
+            role == "config_target"
+            and current_uid is not None
+            and metadata.st_uid == current_uid
+            and _owner_is_only_group_member(current_uid, metadata.st_gid)
+        )
+        unsafe_group_write = bool(mode & stat.S_IWGRP) and not (
+            trusted_interpreter_group_write or trusted_config_group_write
+        )
         if mode & stat.S_IWOTH or unsafe_group_write:
             raise CodexHookIntegrityError(
                 f"codex_hook_{role}_permissions_unsafe",

--- a/tests/test_codex_hook_file_integrity_linux.py
+++ b/tests/test_codex_hook_file_integrity_linux.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import os
+import stat
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from codex_plugin_scanner.guard import codex_hook_file_integrity as integrity
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
 from codex_plugin_scanner.guard.codex_hook_file_integrity import CodexHookIntegrityError, validate_regular_file
 
 
@@ -41,6 +44,24 @@ def test_config_target_rejects_group_write_when_group_is_shared(
         validate_regular_file(config, role="config_target", executable_required=False)
 
     assert error.value.reason == "codex_hook_config_target_permissions_unsafe"
+
+
+def test_codex_install_accepts_private_group_config_and_rewrites_owner_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    config = home_dir / ".codex" / "config.toml"
+    config.parent.mkdir(parents=True)
+    config.write_text('model = "gpt-5"\n', encoding="utf-8")
+    config.chmod(0o664)
+    monkeypatch.setattr(integrity, "_owner_is_only_group_member", lambda owner_uid, group_gid: True)
+    context = HarnessContext(home_dir=home_dir, workspace_dir=None, guard_home=home_dir / ".hol-guard")
+
+    installed = CodexHarnessAdapter().install(context)
+
+    assert installed["active"] is True
+    assert stat.S_IMODE(config.stat().st_mode) == 0o600
 
 
 def test_private_group_detection_counts_primary_and_explicit_members(

--- a/tests/test_codex_hook_file_integrity_linux.py
+++ b/tests/test_codex_hook_file_integrity_linux.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from codex_plugin_scanner.guard import codex_hook_file_integrity as integrity
+from codex_plugin_scanner.guard.codex_hook_file_integrity import CodexHookIntegrityError, validate_regular_file
+
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX ownership and permission semantics are required")
+
+
+def test_config_target_accepts_group_write_when_group_is_private_to_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text('model = "gpt-5"\n', encoding="utf-8")
+    config.chmod(0o664)
+    monkeypatch.setattr(integrity, "_owner_is_only_group_member", lambda owner_uid, group_gid: True)
+
+    metadata = validate_regular_file(config, role="config_target", executable_required=False)
+
+    assert metadata.st_uid == os.getuid()
+    assert metadata.st_mode & 0o777 == 0o664
+
+
+def test_config_target_rejects_group_write_when_group_is_shared(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text('model = "gpt-5"\n', encoding="utf-8")
+    config.chmod(0o664)
+    monkeypatch.setattr(integrity, "_owner_is_only_group_member", lambda owner_uid, group_gid: False)
+
+    with pytest.raises(CodexHookIntegrityError, match="writable by another user") as error:
+        validate_regular_file(config, role="config_target", executable_required=False)
+
+    assert error.value.reason == "codex_hook_config_target_permissions_unsafe"
+
+
+def test_private_group_detection_counts_primary_and_explicit_members(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import grp
+    import pwd
+
+    owner = SimpleNamespace(pw_name="alice", pw_gid=1000)
+    other = SimpleNamespace(pw_name="bob", pw_gid=2000)
+    monkeypatch.setattr(pwd, "getpwuid", lambda uid: owner)
+    monkeypatch.setattr(grp, "getgrgid", lambda gid: SimpleNamespace(gr_mem=[]))
+    monkeypatch.setattr(pwd, "getpwall", lambda: [owner, other])
+
+    assert integrity._owner_is_only_group_member(1000, 1000) is True
+
+    monkeypatch.setattr(pwd, "getpwall", lambda: [owner, SimpleNamespace(pw_name="bob", pw_gid=1000)])
+    assert integrity._owner_is_only_group_member(1000, 1000) is False
+
+    monkeypatch.setattr(pwd, "getpwall", lambda: [owner, other])
+    monkeypatch.setattr(grp, "getgrgid", lambda gid: SimpleNamespace(gr_mem=["bob"]))
+    assert integrity._owner_is_only_group_member(1000, 1000) is False


### PR DESCRIPTION
## Problem

On Linux, `hol-guard init` -> `hol-guard install --all` can fail while protecting Codex with:

`The Codex hook config_target is writable by another user; repair the installation.`

A common Linux user-private-group setup uses umask `0002`, so an existing user-owned `~/.codex/config.toml` is `0664`. The integrity check treated every group-write bit as proof that another user could modify the file, even when NSS shows the group contains only the owning user.

## Fix

- Allow group-write for the `config_target` role only when:
  - the file is owned by the current user, and
  - POSIX/NSS membership proves that the file group contains only that owner.
- Keep lookup failures fail-closed.
- Continue rejecting world-writable configs and genuinely shared group-writable configs.
- Leave packaged hook-file validation unchanged and strict.
- Preserve the existing install transaction, which atomically rewrites the Codex config to mode `0600` after the preflight.

## Regression coverage

- private-group `0664` config is accepted
- shared-group `0664` config remains rejected with `codex_hook_config_target_permissions_unsafe`
- primary and explicit group membership are both considered
- full `CodexHarnessAdapter.install()` regression reproduces the Linux `0664` case and asserts the installed config becomes `0600`

## Reproduction

The pre-fix condition is deterministic: for `role="config_target"`, any `0664` regular file reached `unsafe_group_write=True`, producing the exact error above before Guard's existing `0600` atomic rewrite could run.