### PR TITLE
fix(codex): accept pipx private-group hook files

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12064,
-  "maximum_test_source_lines": 282055,
+  "maximum_collected_cases": 12068,
+  "maximum_test_source_lines": 282186,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12068,
-  "maximum_test_source_lines": 282186,
+  "maximum_collected_cases": 12070,
+  "maximum_test_source_lines": 282228,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/codex_hook_file_integrity.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_file_integrity.py
@@ -39,9 +39,10 @@ def _owner_is_only_group_member(owner_uid: int, group_gid: int) -> bool:
     """Return whether a POSIX group is provably private to one file owner.
 
     Linux distributions commonly create one primary group per user and pair it
-    with a 0002 umask, which produces user-owned 0664 config files.  The group
-    write bit is safe only when NSS can prove that no other account belongs to
-    that group.  Lookup failures remain fail-closed.
+    with a 0002 umask.  That can produce user-owned 0664 config files and
+    package modules extracted by pip/pipx.  The group write bit is safe only
+    when NSS can prove that no other account belongs to that group.  Lookup
+    failures remain fail-closed.
     """
 
     try:
@@ -55,6 +56,12 @@ def _owner_is_only_group_member(owner_uid: int, group_gid: int) -> bool:
     except (ImportError, KeyError, OSError):
         return False
     return member_names == {owner.pw_name}
+
+
+def _is_installed_python_package_file(path: Path) -> bool:
+    """Return whether a file lives under a conventional Python package root."""
+
+    return any(part in {"site-packages", "dist-packages"} for part in path.parts)
 
 
 def canonical_path(path: Path) -> str:
@@ -274,14 +281,14 @@ def validate_regular_file(path: Path, *, role: str, executable_required: bool) -
             # root:root layout.
             or (metadata.st_uid == 0 and metadata.st_gid == 0)
         )
-        trusted_config_group_write = (
-            role == "config_target"
-            and current_uid is not None
+        trusted_user_private_group_write = (
+            current_uid is not None
             and metadata.st_uid == current_uid
+            and (role == "config_target" or _is_installed_python_package_file(path))
             and _owner_is_only_group_member(current_uid, metadata.st_gid)
         )
         unsafe_group_write = bool(mode & stat.S_IWGRP) and not (
-            trusted_interpreter_group_write or trusted_config_group_write
+            trusted_interpreter_group_write or trusted_user_private_group_write
         )
         if mode & stat.S_IWOTH or unsafe_group_write:
             raise CodexHookIntegrityError(

--- a/src/codex_plugin_scanner/guard/codex_hook_file_integrity.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_file_integrity.py
@@ -12,6 +12,8 @@ import hmac
 import os
 import shlex
 import stat
+import sys
+import sysconfig
 from pathlib import Path
 
 
@@ -58,10 +60,69 @@ def _owner_is_only_group_member(owner_uid: int, group_gid: int) -> bool:
     return member_names == {owner.pw_name}
 
 
-def _is_installed_python_package_file(path: Path) -> bool:
-    """Return whether a file lives under a conventional Python package root."""
+def _python_package_roots() -> tuple[Path, ...]:
+    """Return package roots belonging to the running Python installation.
 
-    return any(part in {"site-packages", "dist-packages"} for part in path.parts)
+    ``sysconfig`` supplies the authoritative purelib/platlib locations for the
+    active interpreter.  The explicit prefix-derived candidates cover common
+    POSIX venv and distro layouts, including Debian/Ubuntu ``dist-packages``,
+    without trusting an arbitrary directory merely because it has a familiar
+    basename.
+    """
+
+    roots: set[Path] = set()
+
+    def add_root(value: str | Path | None) -> None:
+        if value is None:
+            return
+        try:
+            roots.add(Path(value).expanduser().resolve(strict=False))
+        except (OSError, RuntimeError):
+            return
+
+    try:
+        configured_paths = sysconfig.get_paths()
+    except (AttributeError, OSError, ValueError):
+        configured_paths = {}
+    for key in ("purelib", "platlib"):
+        value = configured_paths.get(key)
+        if isinstance(value, str) and value:
+            add_root(value)
+
+    version_dirs = {
+        f"python{sys.version_info.major}",
+        f"python{sys.version_info.major}.{sys.version_info.minor}",
+    }
+    for prefix_value in {sys.prefix, sys.exec_prefix}:
+        if not prefix_value:
+            continue
+        try:
+            prefix = Path(prefix_value).expanduser().resolve(strict=False)
+        except (OSError, RuntimeError):
+            continue
+        for lib_dir in ("lib", "lib64"):
+            for version_dir in version_dirs:
+                for package_dir in ("site-packages", "dist-packages"):
+                    add_root(prefix / lib_dir / version_dir / package_dir)
+
+    return tuple(sorted(roots, key=str))
+
+
+def _is_installed_python_package_file(path: Path) -> bool:
+    """Return whether a file is under a package root for this interpreter."""
+
+    try:
+        canonical = path.expanduser().resolve(strict=False)
+    except (OSError, RuntimeError):
+        return False
+    for root in _python_package_roots():
+        try:
+            relative = canonical.relative_to(root)
+        except ValueError:
+            continue
+        if relative.parts:
+            return True
+    return False
 
 
 def canonical_path(path: Path) -> str:

--- a/tests/test_codex_hook_packaged_permissions_linux.py
+++ b/tests/test_codex_hook_packaged_permissions_linux.py
@@ -14,29 +14,48 @@ from codex_plugin_scanner.guard.codex_hook_manifest import CodexHookManifestSpec
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX ownership and permission semantics are required")
 
 
-def _site_packages_file(tmp_path: Path, name: str = "codex_daemon_hook_bridge.py") -> Path:
-    path = (
-        tmp_path
-        / "venv"
-        / "lib"
-        / "python3.12"
-        / "site-packages"
-        / "codex_plugin_scanner"
-        / "guard"
-        / "adapters"
-        / name
-    )
+def _package_root(tmp_path: Path, package_dir: str = "site-packages") -> Path:
+    return tmp_path / "venv" / "lib" / "python3.12" / package_dir
+
+
+def _packaged_file(
+    tmp_path: Path,
+    *,
+    package_dir: str = "site-packages",
+    name: str = "codex_daemon_hook_bridge.py",
+) -> tuple[Path, Path]:
+    root = _package_root(tmp_path, package_dir)
+    path = root / "codex_plugin_scanner" / "guard" / "adapters" / name
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("# packaged fixture\n", encoding="utf-8")
     path.chmod(0o664)
-    return path
+    return root, path
+
+
+def _trust_package_root(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr(integrity, "_python_package_roots", lambda: (root.resolve(strict=False),))
 
 
 def test_packaged_bridge_accepts_private_group_write_in_site_packages(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    bridge = _site_packages_file(tmp_path)
+    root, bridge = _packaged_file(tmp_path)
+    _trust_package_root(monkeypatch, root)
+    monkeypatch.setattr(integrity, "_owner_is_only_group_member", lambda owner_uid, group_gid: True)
+
+    metadata = validate_regular_file(bridge, role="bridge", executable_required=False)
+
+    assert metadata.st_uid == os.getuid()
+    assert stat.S_IMODE(metadata.st_mode) == 0o664
+
+
+def test_packaged_bridge_accepts_private_group_write_in_dist_packages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, bridge = _packaged_file(tmp_path, package_dir="dist-packages")
+    _trust_package_root(monkeypatch, root)
     monkeypatch.setattr(integrity, "_owner_is_only_group_member", lambda owner_uid, group_gid: True)
 
     metadata = validate_regular_file(bridge, role="bridge", executable_required=False)
@@ -49,8 +68,27 @@ def test_packaged_bridge_rejects_shared_group_write_in_site_packages(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    bridge = _site_packages_file(tmp_path)
+    root, bridge = _packaged_file(tmp_path)
+    _trust_package_root(monkeypatch, root)
     monkeypatch.setattr(integrity, "_owner_is_only_group_member", lambda owner_uid, group_gid: False)
+
+    with pytest.raises(CodexHookIntegrityError, match="writable by another user") as error:
+        validate_regular_file(bridge, role="bridge", executable_required=False)
+
+    assert error.value.reason == "codex_hook_bridge_permissions_unsafe"
+
+
+def test_named_site_packages_directory_is_not_enough_to_trust_group_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trusted_root = _package_root(tmp_path)
+    _trust_package_root(monkeypatch, trusted_root)
+    bridge = tmp_path / "home" / "site-packages" / "codex_daemon_hook_bridge.py"
+    bridge.parent.mkdir(parents=True)
+    bridge.write_text("# lookalike fixture\n", encoding="utf-8")
+    bridge.chmod(0o664)
+    monkeypatch.setattr(integrity, "_owner_is_only_group_member", lambda owner_uid, group_gid: True)
 
     with pytest.raises(CodexHookIntegrityError, match="writable by another user") as error:
         validate_regular_file(bridge, role="bridge", executable_required=False)
@@ -62,6 +100,8 @@ def test_non_package_bridge_still_rejects_group_write_even_for_private_group(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    trusted_root = _package_root(tmp_path)
+    _trust_package_root(monkeypatch, trusted_root)
     bridge = tmp_path / "codex_daemon_hook_bridge.py"
     bridge.write_text("# unpackaged fixture\n", encoding="utf-8")
     bridge.chmod(0o664)
@@ -77,6 +117,8 @@ def test_manifest_build_accepts_private_group_pipx_style_packaged_files(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    package_root = _package_root(tmp_path)
+    _trust_package_root(monkeypatch, package_root)
     monkeypatch.setattr(integrity, "_owner_is_only_group_member", lambda owner_uid, group_gid: True)
     home_dir = tmp_path / "home"
     guard_home = home_dir / ".hol-guard"
@@ -90,7 +132,7 @@ def test_manifest_build_accepts_private_group_pipx_style_packaged_files(
     interpreter.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     interpreter.chmod(0o755)
 
-    package_root = tmp_path / "venv" / "lib" / "python3.12" / "site-packages" / "codex_plugin_scanner"
+    scanner_root = package_root / "codex_plugin_scanner"
     roles = (
         "bridge",
         "bridge_runtime",
@@ -103,7 +145,7 @@ def test_manifest_build_accepts_private_group_pipx_style_packaged_files(
     )
     packaged_files: list[tuple[str, Path]] = []
     for role in roles:
-        path = package_root / f"{role}.py"
+        path = scanner_root / f"{role}.py"
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(f"# {role}\n", encoding="utf-8")
         path.chmod(0o664)

--- a/tests/test_codex_hook_packaged_permissions_linux.py
+++ b/tests/test_codex_hook_packaged_permissions_linux.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard import codex_hook_file_integrity as integrity
+from codex_plugin_scanner.guard.codex_hook_file_integrity import CodexHookIntegrityError, validate_regular_file
+from codex_plugin_scanner.guard.codex_hook_manifest import CodexHookManifestSpec, build_authenticated_hook_manifest
+
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="POSIX ownership and permission semantics are required")
+
+
+def _site_packages_file(tmp_path: Path, name: str = "codex_daemon_hook_bridge.py") -> Path:
+    path = (
+        tmp_path
+        / "venv"
+        / "lib"
+        / "python3.12"
+        / "site-packages"
+        / "codex_plugin_scanner"
+        / "guard"
+        / "adapters"
+        / name
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# packaged fixture\n", encoding="utf-8")
+    path.chmod(0o664)
+    return path
+
+
+def test_packaged_bridge_accepts_private_group_write_in_site_packages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge = _site_packages_file(tmp_path)
+    monkeypatch.setattr(integrity, "_owner_is_only_group_member", lambda owner_uid, group_gid: True)
+
+    metadata = validate_regular_file(bridge, role="bridge", executable_required=False)
+
+    assert metadata.st_uid == os.getuid()
+    assert stat.S_IMODE(metadata.st_mode) == 0o664
+
+
+def test_packaged_bridge_rejects_shared_group_write_in_site_packages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge = _site_packages_file(tmp_path)
+    monkeypatch.setattr(integrity, "_owner_is_only_group_member", lambda owner_uid, group_gid: False)
+
+    with pytest.raises(CodexHookIntegrityError, match="writable by another user") as error:
+        validate_regular_file(bridge, role="bridge", executable_required=False)
+
+    assert error.value.reason == "codex_hook_bridge_permissions_unsafe"
+
+
+def test_non_package_bridge_still_rejects_group_write_even_for_private_group(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge = tmp_path / "codex_daemon_hook_bridge.py"
+    bridge.write_text("# unpackaged fixture\n", encoding="utf-8")
+    bridge.chmod(0o664)
+    monkeypatch.setattr(integrity, "_owner_is_only_group_member", lambda owner_uid, group_gid: True)
+
+    with pytest.raises(CodexHookIntegrityError, match="writable by another user") as error:
+        validate_regular_file(bridge, role="bridge", executable_required=False)
+
+    assert error.value.reason == "codex_hook_bridge_permissions_unsafe"
+
+
+def test_manifest_build_accepts_private_group_pipx_style_packaged_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(integrity, "_owner_is_only_group_member", lambda owner_uid, group_gid: True)
+    home_dir = tmp_path / "home"
+    guard_home = home_dir / ".hol-guard"
+    config_path = home_dir / ".codex" / "config.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text('model = "gpt-5"\n', encoding="utf-8")
+    config_path.chmod(0o600)
+
+    interpreter = tmp_path / "venv" / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    interpreter.chmod(0o755)
+
+    package_root = tmp_path / "venv" / "lib" / "python3.12" / "site-packages" / "codex_plugin_scanner"
+    roles = (
+        "bridge",
+        "bridge_runtime",
+        "fallback_entrypoint",
+        "daemon_entrypoint",
+        "daemon_manager",
+        "launch_runtime",
+        "runtime_trust",
+        "windows_job",
+    )
+    packaged_files: list[tuple[str, Path]] = []
+    for role in roles:
+        path = package_root / f"{role}.py"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"# {role}\n", encoding="utf-8")
+        path.chmod(0o664)
+        packaged_files.append((role, path))
+
+    manifest = build_authenticated_hook_manifest(
+        CodexHookManifestSpec(
+            guard_home=guard_home,
+            home_dir=home_dir,
+            runtime_guard_home=guard_home,
+            workspace_dir=None,
+            config_path=config_path,
+            interpreter_path=interpreter,
+            package_version="test",
+            packaged_file_paths=tuple(packaged_files),
+            fallback_argv=(str(interpreter), "-c", "pass"),
+            daemon_start_argv=(str(interpreter), "-c", "pass"),
+            event_bindings=(),
+        )
+    )
+
+    identities = manifest["packaged_files"]
+    assert isinstance(identities, list)
+    assert len(identities) == len(roles)
+    assert all(isinstance(identity, dict) and identity["mode"] == 0o664 for identity in identities)


### PR DESCRIPTION
## Summary

Fixes the remaining Linux Codex install failure after #2106:

`The Codex hook bridge is writable by another user; repair the installation.`

## Root cause

#2106 correctly allowed a user-owned `~/.codex/config.toml` at mode `0664` when NSS proves its group is private to that user, but packaged Codex hook files remained deliberately fail-closed for any group-write bit. On Linux systems using a `0002` umask, pip/pipx extraction can create user-owned package modules in `site-packages` as `0664`, so a normal pipx install reaches the bridge identity check and fails before Guard can authenticate the hook manifest.

## Fix

- Keep world-writable files rejected.
- Keep shared-group writable files rejected.
- Keep arbitrary group-writable hook files outside installed Python package roots rejected.
- Permit user-owned group-writable files under `site-packages` / `dist-packages` only when NSS proves the group contains no other account.
- Preserve exact path, owner, mode, size, and SHA-256 manifest binding after the baseline is created.

## Regression coverage

Adds Linux tests covering:

- pipx-style `site-packages` bridge at `0664` with a private user group: accepted;
- the same bridge with a shared group: rejected;
- a group-writable bridge outside an installed package root: still rejected;
- authenticated manifest construction with all packaged Codex runtime files at `0664`, reproducing the stage that failed in the reported install.

Reported failing flow was on stable `hol-guard 2.2.18` after the config-target fix from #2106.