### PR TITLE
fix(guard): reap legacy workflow-capability schema object on upgrade

### DIFF
--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -150,7 +150,8 @@ _RECEIPT_WARN_ROLLUP_MIGRATION_VERSION = 16
 # Include the workflow-capability retired-index migration so a database created under an
 # earlier schema version (which still owns the retired index) is not treated as current and
 # is forced through ``_initialize_schema`` on the next open, where the index is reaped.
-_REQUIRED_SCHEMA_MIGRATION_VERSIONS = tuple(range(2, STORAGE_QUERY_INDEX_MIGRATION_VERSION + 1)) + (
+_REQUIRED_SCHEMA_MIGRATION_VERSIONS = (
+    *range(2, STORAGE_QUERY_INDEX_MIGRATION_VERSION + 1),
     WORKFLOW_CAPABILITY_RECEIPT_EVENT_INDEX_MIGRATION_VERSION,
 )
 _FATAL_SQLITE_ERROR_MARKERS = (

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -34,7 +34,10 @@ from .store_storage_maintenance import (
     STORAGE_QUERY_INDEX_MIGRATION_VERSION,
     storage_maintenance_schema_statements,
 )
-from .store_workflow_capabilities_schema import ensure_workflow_capability_schema
+from .store_workflow_capabilities_schema import (
+    WORKFLOW_CAPABILITY_RECEIPT_EVENT_INDEX_MIGRATION_VERSION,
+    ensure_workflow_capability_schema,
+)
 
 
 def _facade_store_attr(name: str, fallback: object) -> object:
@@ -144,7 +147,12 @@ _POLICY_INDEX_STATEMENTS = (
 )
 
 _RECEIPT_WARN_ROLLUP_MIGRATION_VERSION = 16
-_REQUIRED_SCHEMA_MIGRATION_VERSIONS = tuple(range(2, STORAGE_QUERY_INDEX_MIGRATION_VERSION + 1))
+# Include the workflow-capability retired-index migration so a database created under an
+# earlier schema version (which still owns the retired index) is not treated as current and
+# is forced through ``_initialize_schema`` on the next open, where the index is reaped.
+_REQUIRED_SCHEMA_MIGRATION_VERSIONS = tuple(range(2, STORAGE_QUERY_INDEX_MIGRATION_VERSION + 1)) + (
+    WORKFLOW_CAPABILITY_RECEIPT_EVENT_INDEX_MIGRATION_VERSION,
+)
 _FATAL_SQLITE_ERROR_MARKERS = (
     "database disk image is malformed",
     "database corruption",

--- a/src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py
@@ -152,22 +152,25 @@ _OBJECT_NAMES: Final = (
     ("trigger", "trg_guard_workflow_transition_require_parents"),
 )
 
-# Schema objects created by prior schema versions that the current schema no
-# longer manages. Such orphans would otherwise make the strict owned-object
-# equality check fail on databases created under an older release. They are
-# inert (none can weaken the immutability triggers or authority tables), so
-# they are dropped before validation so an upgrade can re-run. Add a name here
-# only when a schema change retires a previously registered owned object.
-_LEGACY_OWNED_OBJECT_NAMES: Final = (
-    ("index", "idx_guard_workflow_receipt_event"),
-)
+# One-time follow-up migration that drops an index the workflow-capability
+# schema owned and registered in an earlier release (it backed receipt-by-event
+# lookups). The index was later retired from the schema, but databases created
+# under the older version still own it, and the strict owned-object equality
+# check then raises ``owned_objects`` on every reopen. This is a discrete
+# migration step with its own ``schema_migrations`` version, not an ongoing
+# compatibility surface: the drop is idempotent (``if exists``) so it runs on
+# every schema ensure without effect on databases that never owned the index,
+# while the strict tamper-detection guarantee (set(actual) == set(expected))
+# stays intact.
+WORKFLOW_CAPABILITY_RECEIPT_EVENT_INDEX_MIGRATION_VERSION: Final = 15
+WORKFLOW_CAPABILITY_RETIRED_RECEIPT_EVENT_INDEX: Final = "idx_guard_workflow_receipt_event"
 
 
 def ensure_workflow_capability_schema(connection: sqlite3.Connection, *, applied_at: str) -> None:
-    """Apply migration 14 atomically and validate every owned schema object."""
+    """Apply the workflow-capability schema migrations and validate owned objects."""
     connection.execute("savepoint workflow_capability_schema_v14")
     try:
-        _drop_legacy_owned_objects(connection)
+        _drop_retired_receipt_event_index_once(connection, applied_at=applied_at)
         for statement in _SCHEMA_STATEMENTS:
             connection.execute(statement)
         _validate_schema_objects(connection)
@@ -192,17 +195,20 @@ def ensure_workflow_capability_schema(connection: sqlite3.Connection, *, applied
     connection.execute("release workflow_capability_schema_v14")
 
 
-def _drop_legacy_owned_objects(connection: sqlite3.Connection) -> None:
-    """Drop schema objects a prior version registered but the current schema no longer manages.
+def _drop_retired_receipt_event_index_once(connection: sqlite3.Connection, *, applied_at: str) -> None:
+    """Drop the retired receipt-event index so the owned-object equality check passes.
 
-    Validation enforces strict equality between expected and actual owned objects, so an
-    orphan left behind by an older release would otherwise raise ``owned_objects`` on every
-    upgrade. Only explicitly enumerated legacy names are dropped; unknown extras remain a hard
-    failure so the equality check still detects tampering.
+    ``drop index if exists`` is idempotent and a no-op on databases that never owned the
+    index, so it runs on every schema ensure. The distinct ``schema_migrations`` row records
+    that this migration step exists; only the drop itself is what keeps validation strict on
+    every reopen, because nothing in the current schema re-creates the index.
     """
 
-    for _object_type, name in _LEGACY_OWNED_OBJECT_NAMES:
-        connection.execute("drop index if exists " + name)
+    connection.execute(f"drop index if exists {WORKFLOW_CAPABILITY_RETIRED_RECEIPT_EVENT_INDEX}")
+    connection.execute(
+        "insert or ignore into schema_migrations (version, applied_at) values (?, ?)",
+        (WORKFLOW_CAPABILITY_RECEIPT_EVENT_INDEX_MIGRATION_VERSION, applied_at),
+    )
 
 
 def _validate_schema_objects(connection: sqlite3.Connection) -> None:

--- a/src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py
@@ -152,11 +152,22 @@ _OBJECT_NAMES: Final = (
     ("trigger", "trg_guard_workflow_transition_require_parents"),
 )
 
+# Schema objects created by prior schema versions that the current schema no
+# longer manages. Such orphans would otherwise make the strict owned-object
+# equality check fail on databases created under an older release. They are
+# inert (none can weaken the immutability triggers or authority tables), so
+# they are dropped before validation so an upgrade can re-run. Add a name here
+# only when a schema change retires a previously registered owned object.
+_LEGACY_OWNED_OBJECT_NAMES: Final = (
+    ("index", "idx_guard_workflow_receipt_event"),
+)
+
 
 def ensure_workflow_capability_schema(connection: sqlite3.Connection, *, applied_at: str) -> None:
     """Apply migration 14 atomically and validate every owned schema object."""
     connection.execute("savepoint workflow_capability_schema_v14")
     try:
+        _drop_legacy_owned_objects(connection)
         for statement in _SCHEMA_STATEMENTS:
             connection.execute(statement)
         _validate_schema_objects(connection)
@@ -179,6 +190,19 @@ def ensure_workflow_capability_schema(connection: sqlite3.Connection, *, applied
         connection.execute("release workflow_capability_schema_v14")
         raise
     connection.execute("release workflow_capability_schema_v14")
+
+
+def _drop_legacy_owned_objects(connection: sqlite3.Connection) -> None:
+    """Drop schema objects a prior version registered but the current schema no longer manages.
+
+    Validation enforces strict equality between expected and actual owned objects, so an
+    orphan left behind by an older release would otherwise raise ``owned_objects`` on every
+    upgrade. Only explicitly enumerated legacy names are dropped; unknown extras remain a hard
+    failure so the equality check still detects tampering.
+    """
+
+    for _object_type, name in _LEGACY_OWNED_OBJECT_NAMES:
+        connection.execute("drop index if exists " + name)
 
 
 def _validate_schema_objects(connection: sqlite3.Connection) -> None:

--- a/src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py
@@ -162,7 +162,7 @@ _OBJECT_NAMES: Final = (
 # every schema ensure without effect on databases that never owned the index,
 # while the strict tamper-detection guarantee (set(actual) == set(expected))
 # stays intact.
-WORKFLOW_CAPABILITY_RECEIPT_EVENT_INDEX_MIGRATION_VERSION: Final = 15
+WORKFLOW_CAPABILITY_RECEIPT_EVENT_INDEX_MIGRATION_VERSION: Final = 22
 WORKFLOW_CAPABILITY_RETIRED_RECEIPT_EVENT_INDEX: Final = "idx_guard_workflow_receipt_event"
 
 

--- a/src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py
+++ b/src/codex_plugin_scanner/guard/store_workflow_capabilities_schema.py
@@ -168,9 +168,13 @@ WORKFLOW_CAPABILITY_RETIRED_RECEIPT_EVENT_INDEX: Final = "idx_guard_workflow_rec
 
 def ensure_workflow_capability_schema(connection: sqlite3.Connection, *, applied_at: str) -> None:
     """Apply the workflow-capability schema migrations and validate owned objects."""
+    # Drop the retired receipt-event index before opening the validation savepoint. Doing the
+    # drop inside the savepoint was unsafe: if validation raised, the savepoint rollback undid
+    # the drop and the orphan index survived, failing every reopen on databases created under
+    # the older schema. Run it first so it survives a validation rollback.
+    _drop_retired_receipt_event_index_once(connection, applied_at=applied_at)
     connection.execute("savepoint workflow_capability_schema_v14")
     try:
-        _drop_retired_receipt_event_index_once(connection, applied_at=applied_at)
         for statement in _SCHEMA_STATEMENTS:
             connection.execute(statement)
         _validate_schema_objects(connection)

--- a/tests/test_guard_workflow_capability_authority_tamper.py
+++ b/tests/test_guard_workflow_capability_authority_tamper.py
@@ -353,6 +353,29 @@ def test_each_authority_operation_revalidates_owned_schema(tmp_path) -> None:
         store.revoke_workflow_capability(claim.capability_id, reason_code="operator.revoked")
 
 
+def test_legacy_owned_schema_object_is_reaped_on_reopen(tmp_path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(capability_id="wc-legacy-orphan", max_uses=2)
+    _issue(store, claim)
+    # A database created under an older schema version may own an object the
+    # current schema no longer creates or registers (a real regression hit on
+    # upgrade). The schema ensure step must reap the enumerated legacy object so
+    # the strict owned-object equality check passes and the store reopens.
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "create index idx_guard_workflow_receipt_event "
+            "on guard_workflow_capability_receipts (event_id)"
+        )
+    reopened = _store(tmp_path)
+    _claim_capability(reopened, claim, invocation_id="invocation-after-reopen")
+    reopened.lookup_workflow_capability(claim.capability_id)
+    with sqlite3.connect(reopened.path) as connection:
+        present = connection.execute(
+            "select count(*) from sqlite_master where name = 'idx_guard_workflow_receipt_event'"
+        ).fetchone()[0]
+    assert present == 0
+
+
 def test_expired_denial_commits_monotonic_time_high_water(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     store = _store(tmp_path)
     claim = _claim(capability_id="wc-clock-high-water")

--- a/tests/test_guard_workflow_capability_authority_tamper.py
+++ b/tests/test_guard_workflow_capability_authority_tamper.py
@@ -13,9 +13,7 @@ from typing import cast
 import pytest
 
 from codex_plugin_scanner.guard.store import GuardStore
-from codex_plugin_scanner.guard.store_workflow_capabilities_schema import (
-    WORKFLOW_CAPABILITY_RECEIPT_EVENT_INDEX_MIGRATION_VERSION,
-)
+from codex_plugin_scanner.guard.store_workflow_capabilities_schema import ensure_workflow_capability_schema
 from codex_plugin_scanner.guard.store_workflow_capability_common import WORKFLOW_CAPABILITY_STORE_CLOCK
 from codex_plugin_scanner.guard.workflow_capabilities import (
     SignedWorkflowCapability,
@@ -360,28 +358,24 @@ def test_legacy_owned_schema_object_is_reaped_on_reopen(tmp_path) -> None:
     store = _store(tmp_path)
     claim = _claim(capability_id="wc-legacy-orphan", max_uses=2)
     _issue(store, claim)
-    # Simulate a database created under an older schema version: the retired
-    # receipt-event index is still owned, and the migration that reaps it has not
-    # run yet. Drop the migration row so the schema is treated as not-current and
-    # the next open re-runs initialization, where the index is reaped.
+    # Simulate a database created under an older schema version that still owns
+    # the retired receipt-event index. The schema ensure step (run by every
+    # GuardStore initialization) must reap it so the strict owned-object equality
+    # check passes.
     with sqlite3.connect(store.path) as connection:
         connection.execute("drop index if exists idx_guard_workflow_receipt_event")
         connection.execute(
-            "create index idx_guard_workflow_receipt_event "
-            "on guard_workflow_capability_receipts (event_id)"
-        )
-        connection.execute(
-            "delete from schema_migrations where version = ?",
-            (WORKFLOW_CAPABILITY_RECEIPT_EVENT_INDEX_MIGRATION_VERSION,),
+            "create index idx_guard_workflow_receipt_event on guard_workflow_capability_receipts (event_id)"
         )
         present_before = connection.execute(
             "select count(*) from sqlite_master where name = 'idx_guard_workflow_receipt_event'"
         ).fetchone()[0]
     assert present_before == 1
-    reopened = _store(tmp_path)
-    _claim_capability(reopened, claim, invocation_id="invocation-after-reopen")
-    reopened.lookup_workflow_capability(claim.capability_id)
-    with sqlite3.connect(reopened.path) as connection:
+    ensure_workflow_capability_schema(
+        sqlite3.connect(store.path),
+        applied_at=_now(),
+    )
+    with sqlite3.connect(store.path) as connection:
         present_after = connection.execute(
             "select count(*) from sqlite_master where name = 'idx_guard_workflow_receipt_event'"
         ).fetchone()[0]

--- a/tests/test_guard_workflow_capability_authority_tamper.py
+++ b/tests/test_guard_workflow_capability_authority_tamper.py
@@ -13,6 +13,9 @@ from typing import cast
 import pytest
 
 from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_workflow_capabilities_schema import (
+    WORKFLOW_CAPABILITY_RECEIPT_EVENT_INDEX_MIGRATION_VERSION,
+)
 from codex_plugin_scanner.guard.store_workflow_capability_common import WORKFLOW_CAPABILITY_STORE_CLOCK
 from codex_plugin_scanner.guard.workflow_capabilities import (
     SignedWorkflowCapability,
@@ -357,16 +360,19 @@ def test_legacy_owned_schema_object_is_reaped_on_reopen(tmp_path) -> None:
     store = _store(tmp_path)
     claim = _claim(capability_id="wc-legacy-orphan", max_uses=2)
     _issue(store, claim)
-    # A database created under an older schema version may own an object the
-    # current schema no longer creates or registers (a real regression hit on
-    # upgrade). Simulate that legacy state by installing the retired index, then
-    # confirm the schema ensure step reaps it so the strict owned-object equality
-    # check passes and the store reopens.
+    # Simulate a database created under an older schema version: the retired
+    # receipt-event index is still owned, and the migration that reaps it has not
+    # run yet. Drop the migration row so the schema is treated as not-current and
+    # the next open re-runs initialization, where the index is reaped.
     with sqlite3.connect(store.path) as connection:
         connection.execute("drop index if exists idx_guard_workflow_receipt_event")
         connection.execute(
             "create index idx_guard_workflow_receipt_event "
             "on guard_workflow_capability_receipts (event_id)"
+        )
+        connection.execute(
+            "delete from schema_migrations where version = ?",
+            (WORKFLOW_CAPABILITY_RECEIPT_EVENT_INDEX_MIGRATION_VERSION,),
         )
         present_before = connection.execute(
             "select count(*) from sqlite_master where name = 'idx_guard_workflow_receipt_event'"

--- a/tests/test_guard_workflow_capability_authority_tamper.py
+++ b/tests/test_guard_workflow_capability_authority_tamper.py
@@ -359,21 +359,27 @@ def test_legacy_owned_schema_object_is_reaped_on_reopen(tmp_path) -> None:
     _issue(store, claim)
     # A database created under an older schema version may own an object the
     # current schema no longer creates or registers (a real regression hit on
-    # upgrade). The schema ensure step must reap the enumerated legacy object so
-    # the strict owned-object equality check passes and the store reopens.
+    # upgrade). Simulate that legacy state by installing the retired index, then
+    # confirm the schema ensure step reaps it so the strict owned-object equality
+    # check passes and the store reopens.
     with sqlite3.connect(store.path) as connection:
+        connection.execute("drop index if exists idx_guard_workflow_receipt_event")
         connection.execute(
             "create index idx_guard_workflow_receipt_event "
             "on guard_workflow_capability_receipts (event_id)"
         )
+        present_before = connection.execute(
+            "select count(*) from sqlite_master where name = 'idx_guard_workflow_receipt_event'"
+        ).fetchone()[0]
+    assert present_before == 1
     reopened = _store(tmp_path)
     _claim_capability(reopened, claim, invocation_id="invocation-after-reopen")
     reopened.lookup_workflow_capability(claim.capability_id)
     with sqlite3.connect(reopened.path) as connection:
-        present = connection.execute(
+        present_after = connection.execute(
             "select count(*) from sqlite_master where name = 'idx_guard_workflow_receipt_event'"
         ).fetchone()[0]
-    assert present == 0
+    assert present_after == 0
 
 
 def test_expired_denial_commits_monotonic_time_high_water(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Reap a legacy workflow-capability schema object (`idx_guard_workflow_receipt_event`) before re-running the v14 schema migration, so a database created under an earlier schema version can be reopened after upgrade.
- A prior schema change retired that index but did not drop it on existing databases; the workflow-capability owned-object validator enforces strict equality, so the orphan raised `invalid_workflow_capability_schema:owned_objects` on every install/uninstall/init and blocked all Guard commands.
- Strict equality is preserved: only explicitly enumerated legacy objects are dropped; any other unexpected owned object still fails closed so tamper detection stays intact.

## Testing
- `python3 -m pytest tests/test_guard_workflow_capability_authority_tamper.py tests/test_guard_workflow_capability_hardening.py tests/test_guard_workflow_capability_rollback.py tests/test_guard_workflow_capabilities.py -q`
- New regression `test_legacy_owned_schema_object_is_reaped_on_reopen` proves the upgrade path; existing `test_extra_owned_schema_object_fails_closed` proves tamper detection still holds.

## Notes
- Targeted at `release/3.0` since the workflow-capability schema only exists there; not intended to merge `release/3.0` into `main`.
