### PR TITLE
test(guard): close PR #2110 local-vault tamper coverage

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12065,
-  "maximum_test_source_lines": 282620,
+  "maximum_test_source_lines": 282640,
   "schema_version": 1
 }

--- a/tests/test_guard_policy_integrity_local_vault.py
+++ b/tests/test_guard_policy_integrity_local_vault.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,7 @@ import pytest
 from codex_plugin_scanner.guard import local_trust_controller as local_trust_controller_module
 from codex_plugin_scanner.guard import store_policy_integrity_backend as policy_integrity_backend_module
 from codex_plugin_scanner.guard.local_trust_controller import resolve_passive_trust_state
+from codex_plugin_scanner.guard.models import PolicyDecision
 from codex_plugin_scanner.guard.store import (
     EncryptedFileSecretStore,
     GuardStore,
@@ -42,6 +44,24 @@ def test_linux_policy_integrity_uses_local_vault_without_system_keyring(
     assert repaired["mode"] == "protected"
     assert repaired["trust_status"]["runtime_protection"] == "protected"
     assert repaired["trust_status"]["remembered_rules"] == "enforced"
+
+    artifact_id = "codex:project:tampered-local-vault"
+    store.upsert_policy(
+        PolicyDecision(harness="codex", scope="artifact", action="allow", artifact_id=artifact_id, artifact_hash="hash"),
+        "2026-08-07T20:01:00Z",
+    )
+    with sqlite3.connect(store.guard_home / "guard.db") as connection:
+        connection.execute("update policy_decisions set payload_mac = ? where artifact_id = ?", ("deadbeef", artifact_id))
+        before_row = connection.execute("select * from policy_decisions where artifact_id = ?", (artifact_id,)).fetchone()
+    assert store.verify_policy_integrity()["counts"]["tampered"] == 1
+
+    rerun = store.setup_policy_integrity(now="2026-08-07T20:02:00Z", include_items=False)
+    with sqlite3.connect(store.guard_home / "guard.db") as connection:
+        after_row = connection.execute("select * from policy_decisions where artifact_id = ?", (artifact_id,)).fetchone()
+
+    assert rerun["mode"] == "protected"
+    assert after_row == before_row
+    assert store.verify_policy_integrity()["counts"]["tampered"] == 1
 
 
 def test_linux_system_keyring_remains_authoritative_for_policy_integrity(


### PR DESCRIPTION
## Summary

Follow-up to #2110. That PR merged while its final CodeRabbit nitpick was being addressed, so this PR lands the already-prepared regression coverage that was not included in the squash merge.

The added regression proves the Linux no-keyring local-vault setup path does **not** reset or re-sign an existing tampered local policy:

- establish protected local-vault integrity;
- create a signed local allow policy;
- corrupt its stored MAC;
- verify it is reported as tampered;
- rerun `setup_policy_integrity()`;
- assert the persisted row is unchanged and remains tampered.

This preserves the security boundary documented in #2110: local repair may establish integrity infrastructure, but it must not silently bless invalid local rules.

Also advances the reviewed test-suite ratchet by the exact added source-line count.

## Validation

Run the full GitHub CI/security/review loop and merge only when the exact head is green, review-clean, and caught up with `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integrity checks for local vault policy records, including detection of tampered data.
  * Confirmed that tampered records remain flagged after integrity setup is rerun.

* **Tests**
  * Added regression coverage for database-level modification of policy decision authentication data.
  * Updated test baselines to reflect the expanded test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->