### PR TITLE
fix(update): preserve pipx venv identity on Linux

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/update_subprocess.py
+++ b/src/codex_plugin_scanner/guard/cli/update_subprocess.py
@@ -56,6 +56,7 @@ _TRUSTED_MODULE_BOOTSTRAP = (
     "import json,runpy,sys; "
     "import_paths=json.loads(sys.argv.pop(1)); "
     "extra_import_paths=json.loads(sys.argv.pop(1)) if sys.argv[1].startswith('[') else []; "
+    "install_prefix=sys.argv.pop(1); sys.prefix=install_prefix; sys.exec_prefix=install_prefix; "
     "module=sys.argv.pop(1); "
     "sys.path[:0]=import_paths; "
     "sys.path.extend(extra_import_paths); "
@@ -469,7 +470,7 @@ class TrustedUpdateContext:
         ]
         if extra_import_paths:
             command.append(json.dumps(extra_import_paths, separators=(",", ":")))
-        return [*command, module, *args]
+        return [*command, str(self.install_prefix), module, *args]
 
     def _python_import_paths_json(self) -> str:
         return json.dumps([str(path) for path in self.python_import_paths], separators=(",", ":"))

--- a/tests/test_guard_update_pipx_recovery.py
+++ b/tests/test_guard_update_pipx_recovery.py
@@ -73,7 +73,7 @@ def _run_trusted_module(
             "-c",
             _TRUSTED_MODULE_BOOTSTRAP,
             json.dumps([str(site_packages)], separators=(",", ":")),
-            json.dumps([str(path) for path in extra_import_paths], separators=(",", ":")),
+            json.dumps([str(path) for path in extra_import_paths], separators=(",", ":")), str(python.parent.parent),
             module,
             *args,
         ],
@@ -93,7 +93,7 @@ def test_trusted_pip_bootstrap_uses_validated_pipx_shared_path_without_site_hook
     pip_package.mkdir()
     (pip_package / "__init__.py").write_text("", encoding="utf-8")
     (pip_package / "__main__.py").write_text(
-        "import json, sys\nprint(json.dumps({'marker': 'pipx-shared-pip', 'argv': sys.argv[1:]}))\n",
+        "import json, sys\nassert sys.prefix != sys.base_prefix, (sys.prefix, sys.base_prefix)\nprint(json.dumps({'marker': 'pipx-shared-pip', 'argv': sys.argv[1:]}))\n",
         encoding="utf-8",
     )
     hook_marker = tmp_path / "pth-hook-ran"

--- a/tests/test_guard_update_pipx_recovery.py
+++ b/tests/test_guard_update_pipx_recovery.py
@@ -93,7 +93,7 @@ def test_trusted_pip_bootstrap_uses_validated_pipx_shared_path_without_site_hook
     pip_package.mkdir()
     (pip_package / "__init__.py").write_text("", encoding="utf-8")
     (pip_package / "__main__.py").write_text(
-        "import json, sys\nassert sys.prefix != sys.base_prefix, (sys.prefix, sys.base_prefix)\nprint(json.dumps({'marker': 'pipx-shared-pip', 'argv': sys.argv[1:]}))\n",
+        f"import json, sys\nassert sys.prefix == {str(python.parent.parent)!r}, (sys.prefix, sys.base_prefix)\nprint(json.dumps({{'marker': 'pipx-shared-pip', 'argv': sys.argv[1:]}}))\n",
         encoding="utf-8",
     )
     hook_marker = tmp_path / "pth-hook-ran"

--- a/tests/test_guard_update_subprocess.py
+++ b/tests/test_guard_update_subprocess.py
@@ -677,7 +677,7 @@ def test_pip_execution_argv_is_isolated_absolute_and_source_pinned(
         "-S",
         "-c",
         update_subprocess_module._TRUSTED_MODULE_BOOTSTRAP,
-        json.dumps([str(path) for path in context.python_import_paths], separators=(",", ":")),
+        json.dumps([str(path) for path in context.python_import_paths], separators=(",", ":")), str(context.install_prefix),
         "pip",
         "--isolated",
         "--disable-pip-version-check",
@@ -710,7 +710,7 @@ def test_manager_recovery_pip_uses_authenticated_python_and_pinned_source(
         "-S",
         "-c",
         update_subprocess_module._TRUSTED_MODULE_BOOTSTRAP,
-        json.dumps([str(path) for path in context.python_import_paths], separators=(",", ":")),
+        json.dumps([str(path) for path in context.python_import_paths], separators=(",", ":")), str(context.install_prefix),
         "pip",
         "--isolated",
         "--disable-pip-version-check",
@@ -870,7 +870,7 @@ def test_workspace_path_collision_is_excluded_and_never_executes(
 
 @pytest.mark.skipif(
     os.name == "nt",
-    reason="uses extensionless POSIX shebang files as the ambient and trusted manager fixtures",
+    reason="uses an extensionless POSIX shebang executable as the ambient and trusted manager fixtures",
 )
 def test_nonstandard_ambient_manager_path_is_rejected_without_workspace_context(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Fixes `hol-guard update` for Linux installations managed by pipx when the updater falls back to the authenticated Guard interpreter + pip.

On Debian/Ubuntu Python with PEP 668, the fallback currently launches the pipx venv interpreter with `-S` to suppress `site` and `.pth` hooks. On Python 3.12/3.13, `-S` also prevents virtual-environment prefix initialization, so `sys.prefix` collapses to the externally managed system Python prefix. Pip then aborts with `error: externally-managed-environment`, even though HOL Guard is actually installed inside a pipx venv.

This change keeps the updater's existing `-S` isolation boundary, but restores the already-authenticated install prefix before executing pip:

- pass `TrustedUpdateContext.install_prefix` into the trusted module bootstrap;
- set `sys.prefix` and `sys.exec_prefix` to that trusted prefix before `runpy.run_module("pip", ...)`;
- retain the validated pipx shared import path and continue suppressing executable `.pth` hooks;
- add a regression assertion proving the isolated pip bootstrap still presents itself as a venv rather than the system interpreter.

No `--break-system-packages` bypass is introduced and the system Python environment is not modified.

## Reproduction

A pipx install on Debian/Ubuntu can fail during `hol-guard update` with:

```text
error: externally-managed-environment
× This environment is externally managed
```

while the updater reports `Installer: pipx` but the recovery command is the pipx venv Python running `-m pip install ...`.

## Validation

Run the full CI/security/review loop and merge only when the exact head is green, review-clean, and caught up with `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trusted module execution to use the correct installation and virtual environment context.
  * Fixed pipx recovery behavior by ensuring package operations run inside the expected virtual environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->