### PR TITLE
fix(protect): make Watch only non-blocking for package firewall

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12065,
-  "maximum_test_source_lines": 282640,
+  "maximum_collected_cases": 12083,
+  "maximum_test_source_lines": 283384,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -1240,6 +1240,7 @@ class _PackageProtectAuthority:
     launch_environment: Mapping[str, str]
     additional_current_action: object | None
     additional_policy_context: dict[str, object] | None
+    observe_mode: bool
 
 
 _PackageApprovalClaimDisposition = Literal["consumed", "retained"]
@@ -1456,6 +1457,7 @@ def _build_package_protect_authority(
             launch_environment=launch_environment,
             additional_current_action=additional_current_action,
             additional_policy_context=additional_policy_context,
+            observe_mode=config is not None and config.mode == "observe",
         )
     except BaseException:
         _cleanup_external_archive_downloads(evaluation)
@@ -1563,18 +1565,10 @@ def _final_package_protect_authority(
             claim_saved_approval=False,
         )
         if _evaluation_uses_saved_package_approval(refreshed_saved_policy):
-            # Persistent and explicitly reusable approvals must still exist
-            # and match at the final boundary. The fresh resolver has already
-            # composed any newly inserted block or integrity failure.
             return current, refreshed_saved_policy
         if _package_approval_reuse_evidence(refreshed_saved_policy):
-            # A fresh saved-policy result exists but is no longer an accepted
-            # exact allow (for example, a new block or tampered authority).
             return current, refreshed_saved_policy
         if saved_approval_claim_disposition != "consumed":
-            # Retained package local-once and persistent policy grants remain
-            # authoritative after a successful claim. Their disappearance is
-            # a post-claim revocation, never evidence of one-shot consumption.
             reuse = evaluate_approval_reuse(
                 current.current_action,
                 "allow",
@@ -1582,9 +1576,6 @@ def _final_package_protect_authority(
                 validation_reason=APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
             )
             return current, _package_evaluation_with_rejected_reuse(current_evaluation, reuse)
-        # Only a consuming one-shot is expected to disappear at claim time.
-        # Carry its atomic proof after the fresh lookup establishes that no
-        # newer saved authority applies and every current context still matches.
         reuse = evaluate_approval_reuse(
             current.current_action,
             "allow",
@@ -1637,6 +1628,18 @@ def _final_package_protect_authority(
     return current, resolved
 
 
+def _package_execution_policy_action(
+    authority: _PackageProtectAuthority,
+    evaluation: Any,
+) -> GuardAction:
+    """Project package policy into execution without discarding watch-only evidence."""
+
+    observed_action = _protect_action_for_policy_action(evaluation.policy_action)
+    if not authority.observe_mode:
+        return observed_action
+    return "warn" if observed_action == "warn" else "allow"
+
+
 def _apply_package_protect_projection(
     *,
     payload: dict[str, object],
@@ -1645,6 +1648,7 @@ def _apply_package_protect_projection(
     command: Sequence[str],
     blocking: bool,
     executed: bool,
+    execution_policy_action: GuardAction | None = None,
 ) -> _PackageProtectProjection:
     """Project one authority/evaluation pair into every user and audit surface."""
 
@@ -1652,7 +1656,15 @@ def _apply_package_protect_projection(
     public_targets = [target.to_dict() for target in intent.targets]
     artifact = authority.artifact
     artifact_hash = authority.artifact_hash
-    verdict_action = _protect_action_for_policy_action(evaluation.policy_action)
+    observed_policy_action = _protect_action_for_policy_action(evaluation.policy_action)
+    verdict_action = execution_policy_action or observed_policy_action
+    observe_projected = authority.observe_mode and verdict_action != observed_policy_action
+    verdict_reason = evaluation.user_copy.summary
+    if observe_projected:
+        verdict_reason = (
+            f"Watch only observed a `{observed_policy_action}` package-policy decision. "
+            "HOL Guard allowed the install to continue."
+        )
     risk_signals = tuple(_evaluation_risk_signals(evaluation))
     approval_reuse_evidence = _package_approval_reuse_evidence(evaluation)
     receipt_policy_metadata: dict[str, object] = {
@@ -1664,6 +1676,9 @@ def _apply_package_protect_projection(
         "policy_version": evaluation.policy_version,
         "redacted_command": intent.redacted_command,
     }
+    if observe_projected:
+        receipt_policy_metadata["observe_mode"] = True
+        receipt_policy_metadata["observed_policy_action"] = observed_policy_action
     if evaluation.bundle_version is not None:
         receipt_policy_metadata["bundle_version"] = evaluation.bundle_version
     if authority.additional_policy_context is not None:
@@ -1675,7 +1690,7 @@ def _apply_package_protect_projection(
         artifact_id=artifact.artifact_id,
         artifact_hash=artifact_hash,
         policy_decision=verdict_action,
-        capabilities_summary=evaluation.user_copy.summary,
+        capabilities_summary=verdict_reason,
         changed_capabilities=[
             target.package_name or str(public_target.get("raw_spec") or "")
             for target, public_target in zip(intent.targets, public_targets, strict=True)
@@ -1701,11 +1716,14 @@ def _apply_package_protect_projection(
     payload["targets"] = [_protect_target_payload(target) for target in intent.targets]
     payload["verdict"] = {
         "action": verdict_action,
-        "reason": evaluation.user_copy.summary,
+        "reason": verdict_reason,
         "risk_signals": list(risk_signals),
         "matched_advisories": matched_advisories,
         "blocking": blocking,
     }
+    if observe_projected:
+        payload["verdict"]["observe_mode"] = True
+        payload["verdict"]["observed_policy_action"] = observed_policy_action
     payload["receipt"] = {
         **receipt.to_dict(),
         "action_envelope_json": receipt_policy_metadata,
@@ -1807,7 +1825,8 @@ def build_package_protect_payload(
     effective_dry_run = dry_run and not (
         allow_saved_approval_execution and _evaluation_uses_saved_package_approval(evaluation)
     )
-    execution_permitted = is_execution_permitted(evaluation.policy_action)
+    execution_policy_action = _package_execution_policy_action(authority, evaluation)
+    execution_permitted = is_execution_permitted(execution_policy_action)
     payload: dict[str, object] = {
         "generated_at": now,
         "executed": False,
@@ -1820,6 +1839,7 @@ def build_package_protect_payload(
         command=command,
         blocking=not execution_permitted,
         executed=False,
+        execution_policy_action=execution_policy_action,
     )
     if config is not None:
         payload["supply_chain"] = build_local_supply_chain_posture(store, config, now=now)
@@ -1841,13 +1861,10 @@ def build_package_protect_payload(
             },
             now,
         )
-        return (payload, _package_execution_exit_code(evaluation.policy_action))
-    saved_approval_claimed = _evaluation_uses_saved_package_approval(evaluation)
+        return (payload, _package_execution_exit_code(execution_policy_action))
+    saved_approval_claimed = not authority.observe_mode and _evaluation_uses_saved_package_approval(evaluation)
     saved_approval_claim_disposition: _PackageApprovalClaimDisposition | None = None
     if saved_approval_claimed:
-        # Claim the one-shot first, then rebuild every current input. Mutations
-        # performed while the store claim is in flight cannot inherit the old
-        # authorization at the subsequent launch boundary.
         claimed_resolution = _resolve_stored_package_policy_override(
             current_evaluation,
             store=store,
@@ -1860,7 +1877,8 @@ def build_package_protect_payload(
             claim_saved_approval=True,
         )
         claimed_evaluation = claimed_resolution.evaluation
-        if not is_execution_permitted(claimed_evaluation.policy_action):
+        claimed_execution_action = _package_execution_policy_action(authority, claimed_evaluation)
+        if not is_execution_permitted(claimed_execution_action):
             return _package_protect_denied_after_final_boundary(
                 payload=payload,
                 authority=authority,
@@ -1882,7 +1900,8 @@ def build_package_protect_payload(
         current_config_provider=current_config_provider,
         additional_authority_provider=additional_authority_provider,
     )
-    if not is_execution_permitted(final_evaluation.policy_action):
+    final_execution_action = _package_execution_policy_action(final_authority, final_evaluation)
+    if not is_execution_permitted(final_execution_action):
         denied = _package_protect_denied_after_final_boundary(
             payload=payload,
             authority=final_authority,
@@ -1951,6 +1970,7 @@ def build_package_protect_payload(
         command=command,
         blocking=False,
         executed=True,
+        execution_policy_action=final_execution_action,
     )
     verdict_action = final_projection.verdict_action
     risk_signals = final_projection.risk_signals
@@ -2322,8 +2342,6 @@ def package_saved_allow_validation_reason(
 
     if decision.get("action") != "allow":
         return None
-    # A matching legacy digest is still missing workspace, executable,
-    # capability, policy, and sandbox bindings. Require two valid v1 tokens.
     return approval_context_tokens_validation_reason(decision.get("artifact_hash"), artifact_hash)
 
 
@@ -2719,11 +2737,6 @@ def compose_current_package_policy_action(
         actions.append(additional_current_action)
     if config is not None:
         config_policy = _package_config_policy_context(artifact=artifact, config=config)
-        # Resolve specificity inside each configuration family first.  A
-        # harness risk action replaces its global risk action, and an exact
-        # artifact/publisher/harness action is one precedence chain.  The
-        # resulting configuration actions remain independent of the package
-        # feed/evaluator action and therefore cannot erase a feed block.
         for key in ("effective_package_script_action", "resolved_override"):
             action = config_policy.get(key)
             if action is not None:

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -129,7 +129,8 @@ def build_protect_payload(
     request = parse_protect_command(command)
     advisories = store.list_cached_advisories(limit=None)
     cached_verdict = evaluate_protect_request(request, advisories)
-    cached_gate = cached_verdict.blocking
+    observe_mode = config is not None and config.mode == "observe"
+    cached_gate = cached_verdict.blocking and not observe_mode
     cached_policy_context = _cached_advisory_policy_context(cached_verdict)
     from .local_supply_chain import build_package_protect_payload
 
@@ -155,7 +156,8 @@ def build_protect_payload(
     if package_payload is not None:
         current_cached_verdict = evaluate_protect_request(request, store.list_cached_advisories(limit=None))
         if (
-            current_cached_verdict.blocking
+            not observe_mode
+            and current_cached_verdict.blocking
             and package_payload[0].get("executed") is False
             and not _package_payload_uses_saved_approval(package_payload[0])
         ):
@@ -167,7 +169,7 @@ def build_protect_payload(
                 now=now,
             )
         return package_payload
-    verdict = cached_verdict
+    verdict = _observe_only_verdict(cached_verdict) if observe_mode else cached_verdict
     receipt = _build_install_receipt(request, verdict)
     payload: dict[str, object] = {
         "generated_at": now,
@@ -179,6 +181,10 @@ def build_protect_payload(
         "receipt": receipt.to_dict(),
         "matched_advisories": list(verdict.matched_advisories),
     }
+    if observe_mode and cached_verdict.blocking:
+        payload["observed_verdict"] = cached_verdict.to_dict()
+        payload["verdict"]["observed_action"] = cached_verdict.action
+        payload["verdict"]["observe_mode"] = True
     if verdict.blocking or dry_run:
         store.add_receipt(receipt)
         store.add_event(
@@ -242,6 +248,19 @@ def build_protect_payload(
             now,
         )
     return (payload, int(execution.returncode))
+
+
+def _observe_only_verdict(verdict: ProtectVerdict) -> ProtectVerdict:
+    """Project a watch-only verdict to execution while retaining observed evidence separately."""
+
+    if not verdict.blocking:
+        return verdict
+    return ProtectVerdict(
+        "allow",
+        f"Watch only observed a `{verdict.action}` install decision. HOL Guard allowed the command to continue.",
+        verdict.risk_signals,
+        verdict.matched_advisories,
+    )
 
 
 def _cached_advisory_policy_context(verdict: ProtectVerdict) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -171,11 +171,15 @@ def build_protect_payload(
         return package_payload
     verdict = _observe_only_verdict(cached_verdict) if observe_mode else cached_verdict
     receipt = _build_install_receipt(request, verdict)
+    verdict_payload = verdict.to_dict()
+    if observe_mode and cached_verdict.blocking:
+        verdict_payload["observed_action"] = cached_verdict.action
+        verdict_payload["observe_mode"] = True
     payload: dict[str, object] = {
         "generated_at": now,
         "request": request.to_dict(),
         "targets": [target.to_dict() for target in request.targets],
-        "verdict": verdict.to_dict(),
+        "verdict": verdict_payload,
         "executed": False,
         "dry_run": dry_run,
         "receipt": receipt.to_dict(),
@@ -183,8 +187,6 @@ def build_protect_payload(
     }
     if observe_mode and cached_verdict.blocking:
         payload["observed_verdict"] = cached_verdict.to_dict()
-        payload["verdict"]["observed_action"] = cached_verdict.action
-        payload["verdict"]["observe_mode"] = True
     if verdict.blocking or dry_run:
         store.add_receipt(receipt)
         store.add_event(

--- a/tests/test_guard_watch_only_package_firewall.py
+++ b/tests/test_guard_watch_only_package_firewall.py
@@ -1,0 +1,123 @@
+"""Watch-only regressions for install-time package protection."""
+
+from __future__ import annotations
+
+import os
+import shlex
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+import codex_plugin_scanner.guard.local_supply_chain as local_supply_chain_module
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.protect import build_protect_payload
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
+    PackageRequestEvaluation,
+    SupplyChainUserCopy,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+@pytest.fixture(autouse=True)
+def _fake_policy_integrity_keyring(install_fake_system_keyring) -> None:
+    install_fake_system_keyring()
+
+
+def _cloud_validation_block() -> PackageRequestEvaluation:
+    message = (
+        "Guard Cloud could not validate this package request. Guard blocked the install "
+        "rather than bypassing Cloud package protection."
+    )
+    return PackageRequestEvaluation(
+        decision="block",
+        policy_action="block",
+        enforcement="cloud",
+        entitlement_state="active",
+        cache_status="miss",
+        package_intent_hash="server-memory-intent",
+        policy_version="cloud-policy-v1",
+        bundle_version="cloud-bundle-v1",
+        workspace_fingerprint="watch-only-workspace",
+        reasons=({"code": "cloud_validation_error", "message": message, "severity": "high"},),
+        packages=({"name": "@modelcontextprotocol/server-memory", "decision": "block"},),
+        risk_summary=message,
+        user_copy=SupplyChainUserCopy(
+            title="Package validation unavailable",
+            summary=message,
+            next_step="Retry package validation.",
+            dashboard_url=None,
+            harness_message=message,
+        ),
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="uses a POSIX package-manager fixture")
+def test_watch_only_observes_cloud_validation_block_but_executes_package_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    guard_home = tmp_path / "guard-home"
+    home = tmp_path / "home"
+    home.mkdir()
+    marker = tmp_path / "npm-ran.txt"
+    executable_dir = tmp_path / "bin"
+    executable_dir.mkdir()
+    npm = executable_dir / "npm"
+    npm.write_text(
+        "#!/bin/sh\n"
+        f"printf '%s' \"$*\" > {shlex.quote(str(marker))}\n",
+        encoding="utf-8",
+    )
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(executable_dir))
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _cloud_validation_block(),
+    )
+    config = replace(
+        GuardConfig(
+            guard_home=guard_home,
+            workspace=workspace,
+            security_level="custom",
+            risk_actions={"package_script": "allow", "cloud_advisory": "allow"},
+        ),
+        mode="observe",
+    )
+    store = GuardStore(guard_home)
+
+    payload, exit_code = build_protect_payload(
+        command=["npm", "install", "@modelcontextprotocol/server-memory@latest"],
+        store=store,
+        workspace_dir=workspace,
+        dry_run=False,
+        now="2026-08-08T02:00:00Z",
+        config=config,
+        unsafe_raw_output=False,
+    )
+
+    assert exit_code == 0
+    assert payload["executed"] is True
+    assert marker.read_text(encoding="utf-8") == "install @modelcontextprotocol/server-memory@latest"
+    verdict = payload["verdict"]
+    assert isinstance(verdict, dict)
+    assert verdict["action"] == "allow"
+    assert verdict["blocking"] is False
+    assert verdict["observe_mode"] is True
+    assert verdict["observed_policy_action"] == "block"
+    assert "Watch only observed" in str(verdict["reason"])
+    evaluation = payload["supply_chain_evaluation"]
+    assert isinstance(evaluation, dict)
+    assert evaluation["policy_action"] == "block"
+    receipt = payload["receipt"]
+    assert isinstance(receipt, dict)
+    assert receipt["policy_decision"] == "allow"
+    envelope = receipt["action_envelope_json"]
+    assert isinstance(envelope, dict)
+    assert envelope["policy_action"] == "allow"
+    assert envelope["observe_mode"] is True
+    assert envelope["observed_policy_action"] == "block"


### PR DESCRIPTION
Superseded by #2116. The original branch was created from an older `main` and later conflicted with the test-suite ratchet baseline after concurrent merges. #2116 carries the same Watch-only package-firewall fix rebased as a single commit on the current `main`.