### PR TITLE
fix(dashboard): serve the extensions route

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -7840,6 +7840,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/inbox",
             "/protect",
             "/evidence",
+            "/extensions",
             "/supply-chain",
             "/audit",
             "/policy",

--- a/src/codex_plugin_scanner/guard/product_model.py
+++ b/src/codex_plugin_scanner/guard/product_model.py
@@ -220,6 +220,7 @@ LOCAL_ROUTE_OWNERSHIP = (
         auth_required=True,
         writes_state=True,
     ),
+    RouteOwnership(route="/extensions", persona=("solo", "team_manager"), auth_required=True, writes_state=True),
     RouteOwnership(route="/supply-chain", persona=("solo", "security_lead"), auth_required=True, writes_state=True),
     RouteOwnership(route="/audit", persona=("solo", "security_lead"), auth_required=True, writes_state=True),
     RouteOwnership(route="/policy", persona=("solo", "team_manager"), auth_required=True, writes_state=True),

--- a/src/codex_plugin_scanner/guard/schemas/guard_product_model_v1.json
+++ b/src/codex_plugin_scanner/guard/schemas/guard_product_model_v1.json
@@ -337,6 +337,15 @@
             "writes_state": true
         },
         {
+            "route": "/extensions",
+            "persona": [
+                "solo",
+                "team_manager"
+            ],
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
             "route": "/supply-chain",
             "persona": [
                 "solo",

--- a/tests/test_guard_product_model_contracts.py
+++ b/tests/test_guard_product_model_contracts.py
@@ -193,6 +193,7 @@ def test_local_route_and_api_ownership_contracts_are_explicit() -> None:
     assert routes["/protect"].writes_state is True
     assert routes["/apps/{slug}"].writes_state is True
     assert routes["/evidence"].writes_state is True
+    assert routes["/extensions"].writes_state is True
     assert routes["/supply-chain"].writes_state is True
     assert routes["/audit"].writes_state is True
     assert routes["/policy"].writes_state is True

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -482,6 +482,7 @@ class TestGuardSurfaceServer:
                 "/inbox",
                 "/protect",
                 "/evidence",
+                "/extensions",
                 "/supply-chain",
                 "/audit",
                 "/policy",


### PR DESCRIPTION
## Summary
- serve the dashboard shell for the Extensions route
- cover direct Extensions navigation in the daemon surface regression test

## Testing
- `uv run --no-sync pytest -q tests/test_guard_surface_server.py tests/test_guard_extension_control_api.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_surface_server.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_surface_server.py`
- `uv run --no-sync basedpyright --level error src/codex_plugin_scanner/guard/daemon/server.py`
