### PR TITLE
fix(release): wake Desktop Core feed for 3.x

### DIFF
--- a/.github/workflows/wake-desktop-core-alpha-feed.yml
+++ b/.github/workflows/wake-desktop-core-alpha-feed.yml
@@ -34,11 +34,11 @@ jobs:
         github.event.issue.author_association == 'MEMBER' ||
         github.event.issue.author_association == 'COLLABORATOR') &&
        startsWith(github.event.issue.title, '[desktop-core-feed]')) ||
-      (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'alpha/v3.0.')) ||
+      (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'alpha/v3.')) ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
-       github.event.workflow_run.head_branch == 'release/3.0')
+       startsWith(github.event.workflow_run.head_branch, 'release/3.'))
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:

--- a/tests/test_desktop_core_alpha_feed_wake.py
+++ b/tests/test_desktop_core_alpha_feed_wake.py
@@ -39,9 +39,10 @@ def test_desktop_core_feed_wake_is_narrow_and_least_privilege() -> None:
         "github.event.issue.author_association == 'MEMBER' || "
         "github.event.issue.author_association == 'COLLABORATOR') && "
         "startsWith(github.event.issue.title, '[desktop-core-feed]')) || "
-        "(github.event_name == 'release' && startsWith(github.event.release.tag_name, 'alpha/v3.0.')) || "
+        "(github.event_name == 'release' && startsWith(github.event.release.tag_name, 'alpha/v3.')) || "
         "(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && "
-        "github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'release/3.0')"
+        "github.event.workflow_run.event == 'push' && "
+        "startsWith(github.event.workflow_run.head_branch, 'release/3.'))"
     )
     dispatch_steps = [step for step in wake["steps"] if step.get("name") == "Dispatch feed producer"]
     assert len(dispatch_steps) == 1
@@ -80,7 +81,9 @@ def test_desktop_core_feed_wake_is_narrow_and_least_privilege() -> None:
     assert ast.unparse(dumps.func) == "json.dumps"
     payload = dumps.args[0]
     assert isinstance(payload, ast.Dict)
-    payload_items = [(ast.literal_eval(key), ast.literal_eval(item)) for key, item in zip(payload.keys, payload.values)]
+    payload_items = [
+        (ast.literal_eval(key), ast.literal_eval(item)) for key, item in zip(payload.keys, payload.values, strict=True)
+    ]
     assert payload_items == [("ref", "main")]
 
     redirect_classes = [


### PR DESCRIPTION
## Summary
- wake the Desktop Core feed for any 3.x alpha or release branch publication
- preserve the hardened release feed producer and update its wake contract

## Testing
- `uv run --no-sync python -m pytest -q tests/test_desktop_core_alpha_feed_security.py tests/test_desktop_core_alpha_feed_wake.py --tb=short`
- `uv run --no-sync ruff check tests/test_desktop_core_alpha_feed_wake.py`
- `uv run --no-sync ruff format --check tests/test_desktop_core_alpha_feed_wake.py`
- `git diff --check`
