### PR TITLE
fix(guard): preserve Watch-only safeguards

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
@@ -37,6 +37,8 @@ _HOOK_PROCESS_BACKFILL_DELAY_SECONDS = 2.0
 _HOOK_PROCESS_BACKFILL_MAX_DEFERRAL_SECONDS = 5.0
 _HOOK_PROCESS_RETRY_MAX_SECONDS = 5.0
 _HOOK_PROCESS_RETRY_READY_SECONDS = 0.75
+_HOOK_PROCESS_TRANSIENT_NOT_READY_RETRIES = 2
+_HOOK_PROCESS_TRANSIENT_NOT_READY_BACKOFF_SECONDS = 0.025
 
 
 @final
@@ -166,7 +168,7 @@ class HookProcessRunner:
         workspace: Path | None,
         hook_env: Mapping[str, str],
         deadline: float | None = None,
-        _retry_transient_not_ready: bool = True,
+        _transient_not_ready_retries: int = _HOOK_PROCESS_TRANSIENT_NOT_READY_RETRIES,
     ) -> HookProcessReview:
         with self._state_lock:
             if self._closed:
@@ -290,11 +292,17 @@ class HookProcessRunner:
         response = typed_result.get("payload")
         if response is None:
             if (
-                _retry_transient_not_ready
+                _transient_not_ready_retries > 0
                 and reason_code == "daemon_hook_process_not_ready"
                 and _runtime_hook_review_is_idempotent(payload)
                 and time.monotonic() < review_deadline
             ):
+                time.sleep(
+                    min(
+                        _HOOK_PROCESS_TRANSIENT_NOT_READY_BACKOFF_SECONDS,
+                        max(0.0, review_deadline - time.monotonic()),
+                    )
+                )
                 return self.review(
                     payload=payload,
                     harness=harness,
@@ -303,7 +311,7 @@ class HookProcessRunner:
                     workspace=workspace,
                     hook_env=hook_env,
                     deadline=review_deadline,
-                    _retry_transient_not_ready=False,
+                    _transient_not_ready_retries=_transient_not_ready_retries - 1,
                 )
             return HookProcessReview(
                 None,

--- a/src/codex_plugin_scanner/guard/decision_boundaries.py
+++ b/src/codex_plugin_scanner/guard/decision_boundaries.py
@@ -32,10 +32,12 @@ _ACTION_ENVELOPE_ACTION_FIELDS = frozenset(
         "action_type",
         "policy_action",
         "pre_execution_result",
+        "observed_policy_action",
         "actionId",
         "actionType",
         "policyAction",
         "preExecutionResult",
+        "observedPolicyAction",
     }
 )
 
@@ -80,7 +82,12 @@ def canonical_receipt_decision(
     *,
     reject_contradiction: bool,
 ) -> CanonicalReceiptDecision:
-    """Synchronize final-action fields in a receipt-owned envelope."""
+    """Synchronize final-action fields in a receipt-owned envelope.
+
+    ``observed_policy_action`` is explicit Watch-only evidence, not execution
+    authority. It must still be a recognized Guard action, but it may differ
+    from the final receipt decision by design.
+    """
 
     normalization = normalize_guard_action_result(
         policy_decision,
@@ -98,6 +105,7 @@ def canonical_receipt_decision(
             ("action_type", "actionType"),
             ("policy_action", "policyAction"),
             ("pre_execution_result", "preExecutionResult"),
+            ("observed_policy_action", "observedPolicyAction"),
         )
     )
     candidates: list[GuardAction] = _action_candidates(envelope, unknown_action_fields)
@@ -119,6 +127,16 @@ def canonical_receipt_decision(
                 candidates.append(candidate.action)
                 if not candidate.recognized or candidate.action != projected_action:
                     contradiction = True
+        for field in ("observed_policy_action", "observedPolicyAction"):
+            raw_observed_action = envelope.get(field)
+            if raw_observed_action is None:
+                continue
+            observed = normalize_guard_action_result(
+                raw_observed_action,
+                unknown_action="require-reapproval",
+            )
+            if not observed.recognized:
+                contradiction = True
 
     if reject_contradiction and (invalid_payload or contradiction):
         raise ValueError(AUTHORITATIVE_DECISION_INCONSISTENT)
@@ -322,7 +340,11 @@ def _resolved_approval_envelope(
         if isinstance(key, str) and is_action_bearing_key(key) and key not in _ACTION_ENVELOPE_ACTION_FIELDS:
             envelope.pop(key, None)
             contract_error = AUTHORITATIVE_DECISION_INCONSISTENT
-    for snake_key, camel_key in (("action_id", "actionId"), ("action_type", "actionType")):
+    for snake_key, camel_key in (
+        ("action_id", "actionId"),
+        ("action_type", "actionType"),
+        ("observed_policy_action", "observedPolicyAction"),
+    ):
         if _aliases_conflict(envelope, snake_key, camel_key):
             envelope.pop(camel_key, None)
             contract_error = AUTHORITATIVE_DECISION_INCONSISTENT

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -1240,6 +1240,7 @@ class _PackageProtectAuthority:
     launch_environment: Mapping[str, str]
     additional_current_action: object | None
     additional_policy_context: dict[str, object] | None
+    observe_mode: bool
 
 
 _PackageApprovalClaimDisposition = Literal["consumed", "retained"]
@@ -1456,6 +1457,7 @@ def _build_package_protect_authority(
             launch_environment=launch_environment,
             additional_current_action=additional_current_action,
             additional_policy_context=additional_policy_context,
+            observe_mode=config is not None and config.mode == "observe",
         )
     except BaseException:
         _cleanup_external_archive_downloads(evaluation)
@@ -1465,8 +1467,8 @@ def _build_package_protect_authority(
 def _final_package_protect_authority(
     *,
     initial: _PackageProtectAuthority,
-    saved_approval_claimed: bool,
-    saved_approval_claim_disposition: _PackageApprovalClaimDisposition | None,
+    initial_saved_evaluation: Any,
+    saved_approval_pending: bool,
     command: Sequence[str],
     store: Any,
     workspace_dir: Path,
@@ -1475,7 +1477,7 @@ def _final_package_protect_authority(
     current_config_provider: Callable[[], GuardConfig] | None,
     additional_authority_provider: Callable[[], tuple[object | None, dict[str, object] | None]] | None,
 ) -> tuple[_PackageProtectAuthority, Any]:
-    """Rebuild all current authority after a claim and immediately before spawn."""
+    """Refresh mode, claim required approval, then rebuild authority before spawn."""
 
     additional_action: object | None = initial.additional_current_action
     additional_context: dict[str, object] | None = initial.additional_policy_context
@@ -1488,6 +1490,31 @@ def _final_package_protect_authority(
                 raise TypeError("current config provider returned an invalid value")
         except Exception:
             config_refresh_failed = True
+    saved_approval_claimed = False
+    saved_approval_claim_disposition: _PackageApprovalClaimDisposition | None = None
+    saved_approval_claim_failure: Any | None = None
+    if (
+        saved_approval_pending
+        and not config_refresh_failed
+        and (current_config is None or current_config.mode != "observe")
+    ):
+        claimed_resolution = _resolve_stored_package_policy_override(
+            initial_saved_evaluation,
+            store=store,
+            artifact=initial.artifact,
+            artifact_hash=initial.artifact_hash,
+            workspace_dir=workspace_dir,
+            now=now,
+            execution_context=initial.execution_context,
+            current_action=initial.current_action,
+            claim_saved_approval=True,
+        )
+        claimed_action = _protect_action_for_policy_action(claimed_resolution.evaluation.policy_action)
+        if not is_execution_permitted(claimed_action):
+            saved_approval_claim_failure = claimed_resolution.evaluation
+        else:
+            saved_approval_claimed = True
+            saved_approval_claim_disposition = claimed_resolution.claim_disposition
     if additional_authority_provider is not None:
         try:
             additional_action, additional_context = additional_authority_provider()
@@ -1542,6 +1569,13 @@ def _final_package_protect_authority(
         current.evaluation,
         current_action=current.current_action,
     )
+    if saved_approval_claim_failure is not None:
+        return current, _package_evaluation_with_current_policy_action(
+            saved_approval_claim_failure,
+            current_action=current.current_action,
+        )
+    if current.observe_mode:
+        return current, current_evaluation
     if saved_approval_claimed:
         if validation_reason is not None:
             reuse = evaluate_approval_reuse(
@@ -1563,18 +1597,10 @@ def _final_package_protect_authority(
             claim_saved_approval=False,
         )
         if _evaluation_uses_saved_package_approval(refreshed_saved_policy):
-            # Persistent and explicitly reusable approvals must still exist
-            # and match at the final boundary. The fresh resolver has already
-            # composed any newly inserted block or integrity failure.
             return current, refreshed_saved_policy
         if _package_approval_reuse_evidence(refreshed_saved_policy):
-            # A fresh saved-policy result exists but is no longer an accepted
-            # exact allow (for example, a new block or tampered authority).
             return current, refreshed_saved_policy
         if saved_approval_claim_disposition != "consumed":
-            # Retained package local-once and persistent policy grants remain
-            # authoritative after a successful claim. Their disappearance is
-            # a post-claim revocation, never evidence of one-shot consumption.
             reuse = evaluate_approval_reuse(
                 current.current_action,
                 "allow",
@@ -1582,9 +1608,6 @@ def _final_package_protect_authority(
                 validation_reason=APPROVAL_REUSE_CONTEXT_CHANGED_AFTER_CLAIM,
             )
             return current, _package_evaluation_with_rejected_reuse(current_evaluation, reuse)
-        # Only a consuming one-shot is expected to disappear at claim time.
-        # Carry its atomic proof after the fresh lookup establishes that no
-        # newer saved authority applies and every current context still matches.
         reuse = evaluate_approval_reuse(
             current.current_action,
             "allow",
@@ -1637,6 +1660,18 @@ def _final_package_protect_authority(
     return current, resolved
 
 
+def _package_execution_policy_action(
+    authority: _PackageProtectAuthority,
+    evaluation: Any,
+) -> GuardAction:
+    """Project package policy into execution without discarding watch-only evidence."""
+
+    observed_action = _protect_action_for_policy_action(evaluation.policy_action)
+    if not authority.observe_mode:
+        return observed_action
+    return "warn" if observed_action == "warn" else "allow"
+
+
 def _apply_package_protect_projection(
     *,
     payload: dict[str, object],
@@ -1645,6 +1680,7 @@ def _apply_package_protect_projection(
     command: Sequence[str],
     blocking: bool,
     executed: bool,
+    execution_policy_action: GuardAction | None = None,
 ) -> _PackageProtectProjection:
     """Project one authority/evaluation pair into every user and audit surface."""
 
@@ -1652,7 +1688,15 @@ def _apply_package_protect_projection(
     public_targets = [target.to_dict() for target in intent.targets]
     artifact = authority.artifact
     artifact_hash = authority.artifact_hash
-    verdict_action = _protect_action_for_policy_action(evaluation.policy_action)
+    observed_policy_action = _protect_action_for_policy_action(evaluation.policy_action)
+    verdict_action = execution_policy_action or observed_policy_action
+    observe_projected = authority.observe_mode and verdict_action != observed_policy_action
+    verdict_reason = evaluation.user_copy.summary
+    if observe_projected:
+        verdict_reason = (
+            f"Watch only observed a `{observed_policy_action}` package-policy decision. "
+            "HOL Guard allowed the install to continue."
+        )
     risk_signals = tuple(_evaluation_risk_signals(evaluation))
     approval_reuse_evidence = _package_approval_reuse_evidence(evaluation)
     receipt_policy_metadata: dict[str, object] = {
@@ -1664,6 +1708,9 @@ def _apply_package_protect_projection(
         "policy_version": evaluation.policy_version,
         "redacted_command": intent.redacted_command,
     }
+    if observe_projected:
+        receipt_policy_metadata["observe_mode"] = True
+        receipt_policy_metadata["observed_policy_action"] = observed_policy_action
     if evaluation.bundle_version is not None:
         receipt_policy_metadata["bundle_version"] = evaluation.bundle_version
     if authority.additional_policy_context is not None:
@@ -1675,7 +1722,7 @@ def _apply_package_protect_projection(
         artifact_id=artifact.artifact_id,
         artifact_hash=artifact_hash,
         policy_decision=verdict_action,
-        capabilities_summary=evaluation.user_copy.summary,
+        capabilities_summary=verdict_reason,
         changed_capabilities=[
             target.package_name or str(public_target.get("raw_spec") or "")
             for target, public_target in zip(intent.targets, public_targets, strict=True)
@@ -1701,11 +1748,14 @@ def _apply_package_protect_projection(
     payload["targets"] = [_protect_target_payload(target) for target in intent.targets]
     payload["verdict"] = {
         "action": verdict_action,
-        "reason": evaluation.user_copy.summary,
+        "reason": verdict_reason,
         "risk_signals": list(risk_signals),
         "matched_advisories": matched_advisories,
         "blocking": blocking,
     }
+    if observe_projected:
+        payload["verdict"]["observe_mode"] = True
+        payload["verdict"]["observed_policy_action"] = observed_policy_action
     payload["receipt"] = {
         **receipt.to_dict(),
         "action_envelope_json": receipt_policy_metadata,
@@ -1788,7 +1838,6 @@ def build_package_protect_payload(
     sanitized_intent = authority.intent
     artifact = authority.artifact
     evaluation = authority.evaluation
-    current_evaluation = evaluation
     current_action = authority.current_action
     package_execution_context = authority.execution_context
     artifact_hash = authority.artifact_hash
@@ -1807,7 +1856,8 @@ def build_package_protect_payload(
     effective_dry_run = dry_run and not (
         allow_saved_approval_execution and _evaluation_uses_saved_package_approval(evaluation)
     )
-    execution_permitted = is_execution_permitted(evaluation.policy_action)
+    execution_policy_action = _package_execution_policy_action(authority, evaluation)
+    execution_permitted = is_execution_permitted(execution_policy_action)
     payload: dict[str, object] = {
         "generated_at": now,
         "executed": False,
@@ -1820,6 +1870,7 @@ def build_package_protect_payload(
         command=command,
         blocking=not execution_permitted,
         executed=False,
+        execution_policy_action=execution_policy_action,
     )
     if config is not None:
         payload["supply_chain"] = build_local_supply_chain_posture(store, config, now=now)
@@ -1841,39 +1892,11 @@ def build_package_protect_payload(
             },
             now,
         )
-        return (payload, _package_execution_exit_code(evaluation.policy_action))
-    saved_approval_claimed = _evaluation_uses_saved_package_approval(evaluation)
-    saved_approval_claim_disposition: _PackageApprovalClaimDisposition | None = None
-    if saved_approval_claimed:
-        # Claim the one-shot first, then rebuild every current input. Mutations
-        # performed while the store claim is in flight cannot inherit the old
-        # authorization at the subsequent launch boundary.
-        claimed_resolution = _resolve_stored_package_policy_override(
-            current_evaluation,
-            store=store,
-            artifact=artifact,
-            artifact_hash=artifact_hash,
-            workspace_dir=workspace_dir,
-            now=now,
-            execution_context=package_execution_context,
-            current_action=current_action,
-            claim_saved_approval=True,
-        )
-        claimed_evaluation = claimed_resolution.evaluation
-        if not is_execution_permitted(claimed_evaluation.policy_action):
-            return _package_protect_denied_after_final_boundary(
-                payload=payload,
-                authority=authority,
-                evaluation=claimed_evaluation,
-                command=command,
-                store=store,
-                now=now,
-            )
-        saved_approval_claim_disposition = claimed_resolution.claim_disposition
+        return (payload, _package_execution_exit_code(execution_policy_action))
     final_authority, final_evaluation = _final_package_protect_authority(
         initial=authority,
-        saved_approval_claimed=saved_approval_claimed,
-        saved_approval_claim_disposition=saved_approval_claim_disposition,
+        initial_saved_evaluation=evaluation,
+        saved_approval_pending=_evaluation_uses_saved_package_approval(evaluation),
         command=command,
         store=store,
         workspace_dir=workspace_dir,
@@ -1882,7 +1905,8 @@ def build_package_protect_payload(
         current_config_provider=current_config_provider,
         additional_authority_provider=additional_authority_provider,
     )
-    if not is_execution_permitted(final_evaluation.policy_action):
+    final_execution_action = _package_execution_policy_action(final_authority, final_evaluation)
+    if not is_execution_permitted(final_execution_action):
         denied = _package_protect_denied_after_final_boundary(
             payload=payload,
             authority=final_authority,
@@ -1951,6 +1975,7 @@ def build_package_protect_payload(
         command=command,
         blocking=False,
         executed=True,
+        execution_policy_action=final_execution_action,
     )
     verdict_action = final_projection.verdict_action
     risk_signals = final_projection.risk_signals
@@ -2332,8 +2357,6 @@ def package_saved_allow_validation_reason(
 
     if decision.get("action") != "allow":
         return None
-    # A matching legacy digest is still missing workspace, executable,
-    # capability, policy, and sandbox bindings. Require two valid v1 tokens.
     return approval_context_tokens_validation_reason(decision.get("artifact_hash"), artifact_hash)
 
 
@@ -2729,11 +2752,6 @@ def compose_current_package_policy_action(
         actions.append(additional_current_action)
     if config is not None:
         config_policy = _package_config_policy_context(artifact=artifact, config=config)
-        # Resolve specificity inside each configuration family first.  A
-        # harness risk action replaces its global risk action, and an exact
-        # artifact/publisher/harness action is one precedence chain.  The
-        # resulting configuration actions remain independent of the package
-        # feed/evaluator action and therefore cannot erase a feed block.
         for key in ("effective_package_script_action", "resolved_override"):
             action = config_policy.get(key)
             if action is not None:

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -8,7 +8,7 @@ import os
 import shlex
 import subprocess
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
@@ -129,13 +129,80 @@ def build_protect_payload(
     request = parse_protect_command(command)
     advisories = store.list_cached_advisories(limit=None)
     cached_verdict = evaluate_protect_request(request, advisories)
-    cached_gate = cached_verdict.blocking
+    observe_mode = config is not None and config.mode == "observe"
+    cached_gate = cached_verdict.blocking and not observe_mode
     cached_policy_context = _cached_advisory_policy_context(cached_verdict)
     from .local_supply_chain import build_package_protect_payload
 
     def current_cached_advisory_authority() -> tuple[object | None, dict[str, object] | None]:
         current_verdict = evaluate_protect_request(request, store.list_cached_advisories(limit=None))
         return current_verdict.action, _cached_advisory_policy_context(current_verdict)
+
+    final_config_provider = current_config_provider
+    final_advisory_provider: Callable[[], tuple[object | None, dict[str, object] | None]] = (
+        current_cached_advisory_authority
+    )
+    if observe_mode:
+        refresh_state: dict[str, object] = {"additional_ready": False, "force_block": False}
+
+        def refresh_additional_authority() -> tuple[object | None, dict[str, object] | None]:
+            if not bool(refresh_state.get("additional_ready")):
+                try:
+                    action, context = current_cached_advisory_authority()
+                except Exception as error:
+                    refresh_state["force_block"] = True
+                    action = "block"
+                    context = {
+                        "available": False,
+                        "error": type(error).__name__,
+                        "status": "authority_refresh_failed",
+                        "version": 1,
+                    }
+                refresh_state["additional_action"] = action
+                refresh_state["additional_context"] = context
+                refresh_state["additional_ready"] = True
+            if bool(refresh_state.get("force_block")):
+                context = refresh_state.get("additional_context")
+                return (
+                    "block",
+                    context
+                    if isinstance(context, dict)
+                    else {
+                        "available": False,
+                        "status": "authority_refresh_failed",
+                        "version": 1,
+                    },
+                )
+            context = refresh_state.get("additional_context")
+            return refresh_state.get("additional_action"), context if isinstance(context, dict) else None
+
+        def refresh_current_config() -> GuardConfig:
+            current_config = config
+            if current_config_provider is not None:
+                try:
+                    candidate = current_config_provider()
+                    if not isinstance(candidate, GuardConfig):
+                        raise TypeError("current config provider returned an invalid value")
+                    current_config = candidate
+                except Exception as error:
+                    refresh_state["force_block"] = True
+                    refresh_state["additional_context"] = {
+                        "available": False,
+                        "error": type(error).__name__,
+                        "reason_code": "package_config_refresh_failed",
+                        "status": "authority_refresh_failed",
+                        "version": 1,
+                    }
+                    refresh_state["additional_ready"] = True
+            _ = refresh_additional_authority()
+            if bool(refresh_state.get("force_block")):
+                assert current_config is not None
+                return replace(current_config, mode="enforce")
+            assert current_config is not None
+            return current_config
+
+        final_config_provider = refresh_current_config
+        final_advisory_provider = refresh_additional_authority
 
     package_payload = build_package_protect_payload(
         command=command,
@@ -149,13 +216,14 @@ def build_protect_payload(
         timeout_seconds=_protect_command_timeout_seconds(),
         additional_current_action=cached_verdict.action,
         additional_policy_context=cached_policy_context,
-        current_config_provider=current_config_provider,
-        additional_authority_provider=current_cached_advisory_authority,
+        current_config_provider=final_config_provider,
+        additional_authority_provider=final_advisory_provider,
     )
     if package_payload is not None:
         current_cached_verdict = evaluate_protect_request(request, store.list_cached_advisories(limit=None))
         if (
-            current_cached_verdict.blocking
+            not observe_mode
+            and current_cached_verdict.blocking
             and package_payload[0].get("executed") is False
             and not _package_payload_uses_saved_approval(package_payload[0])
         ):
@@ -167,18 +235,24 @@ def build_protect_payload(
                 now=now,
             )
         return package_payload
-    verdict = cached_verdict
+    verdict = _observe_only_verdict(cached_verdict) if observe_mode else cached_verdict
     receipt = _build_install_receipt(request, verdict)
+    verdict_payload = verdict.to_dict()
+    if observe_mode and cached_verdict.blocking:
+        verdict_payload["observed_action"] = cached_verdict.action
+        verdict_payload["observe_mode"] = True
     payload: dict[str, object] = {
         "generated_at": now,
         "request": request.to_dict(),
         "targets": [target.to_dict() for target in request.targets],
-        "verdict": verdict.to_dict(),
+        "verdict": verdict_payload,
         "executed": False,
         "dry_run": dry_run,
         "receipt": receipt.to_dict(),
         "matched_advisories": list(verdict.matched_advisories),
     }
+    if observe_mode and cached_verdict.blocking:
+        payload["observed_verdict"] = cached_verdict.to_dict()
     if verdict.blocking or dry_run:
         store.add_receipt(receipt)
         store.add_event(
@@ -242,6 +316,19 @@ def build_protect_payload(
             now,
         )
     return (payload, int(execution.returncode))
+
+
+def _observe_only_verdict(verdict: ProtectVerdict) -> ProtectVerdict:
+    """Project a watch-only verdict to execution while retaining observed evidence separately."""
+
+    if not verdict.blocking:
+        return verdict
+    return ProtectVerdict(
+        "allow",
+        f"Watch only observed a `{verdict.action}` install decision. HOL Guard allowed the command to continue.",
+        verdict.risk_signals,
+        verdict.matched_advisories,
+    )
 
 
 def _cached_advisory_policy_context(verdict: ProtectVerdict) -> dict[str, object]:

--- a/tests/test_guard_hook_process_runner.py
+++ b/tests/test_guard_hook_process_runner.py
@@ -464,10 +464,11 @@ def test_non_idempotent_review_does_not_retry_transient_evaluator_not_ready(tmp_
     assert connection.send.call_count == 1
 
 
-def test_idempotent_review_retries_transient_not_ready_only_once(tmp_path: Path) -> None:
+def test_idempotent_review_bounds_transient_not_ready_retries(tmp_path: Path) -> None:
     runner, connection = _transient_not_ready_test_runner(
         tmp_path,
         [
+            ("result", {"payload": None, "reason_code": "daemon_hook_process_not_ready"}),
             ("result", {"payload": None, "reason_code": "daemon_hook_process_not_ready"}),
             ("result", {"payload": None, "reason_code": "daemon_hook_process_not_ready"}),
         ],
@@ -489,7 +490,7 @@ def test_idempotent_review_retries_transient_not_ready_only_once(tmp_path: Path)
     )
 
     assert result == HookProcessReview(None, "daemon_hook_process_not_ready")
-    assert connection.send.call_count == 2
+    assert connection.send.call_count == 3
 
 
 def test_scheduler_and_runner_complete_48_routine_reviews_without_capacity_denial(

--- a/tests/test_guard_watch_only_package_firewall.py
+++ b/tests/test_guard_watch_only_package_firewall.py
@@ -1,0 +1,247 @@
+"""Watch-only regressions for install-time package protection."""
+
+from __future__ import annotations
+
+import os
+import shlex
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+import codex_plugin_scanner.guard.local_supply_chain as local_supply_chain_module
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.protect import build_protect_payload
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
+    PackageRequestEvaluation,
+    SupplyChainUserCopy,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+@pytest.fixture(autouse=True)
+def _fake_policy_integrity_keyring(install_fake_system_keyring) -> None:
+    install_fake_system_keyring()
+
+
+def _cloud_validation_block() -> PackageRequestEvaluation:
+    message = (
+        "Guard Cloud could not validate this package request. Guard blocked the install "
+        "rather than bypassing Cloud package protection."
+    )
+    return PackageRequestEvaluation(
+        decision="block",
+        policy_action="block",
+        enforcement="cloud",
+        entitlement_state="active",
+        cache_status="miss",
+        package_intent_hash="server-memory-intent",
+        policy_version="cloud-policy-v1",
+        bundle_version="cloud-bundle-v1",
+        workspace_fingerprint="watch-only-workspace",
+        reasons=({"code": "cloud_validation_error", "message": message, "severity": "high"},),
+        packages=({"name": "@modelcontextprotocol/server-memory", "decision": "block"},),
+        risk_summary=message,
+        user_copy=SupplyChainUserCopy(
+            title="Package validation unavailable",
+            summary=message,
+            next_step="Retry package validation.",
+            dashboard_url=None,
+            harness_message=message,
+        ),
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="uses a POSIX package-manager fixture")
+def test_watch_only_observes_cloud_validation_block_but_executes_package_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    guard_home = tmp_path / "guard-home"
+    home = tmp_path / "home"
+    home.mkdir()
+    marker = tmp_path / "npm-ran.txt"
+    executable_dir = tmp_path / "bin"
+    executable_dir.mkdir()
+    npm = executable_dir / "npm"
+    npm.write_text(
+        f"#!/bin/sh\nprintf '%s' \"$*\" > {shlex.quote(str(marker))}\n",
+        encoding="utf-8",
+    )
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(executable_dir))
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _cloud_validation_block(),
+    )
+    config = replace(
+        GuardConfig(
+            guard_home=guard_home,
+            workspace=workspace,
+            security_level="custom",
+            risk_actions={"package_script": "allow", "cloud_advisory": "allow"},
+        ),
+        mode="observe",
+    )
+    store = GuardStore(guard_home)
+
+    payload, exit_code = build_protect_payload(
+        command=["npm", "install", "@modelcontextprotocol/server-memory@latest"],
+        store=store,
+        workspace_dir=workspace,
+        dry_run=False,
+        now="2026-08-08T02:00:00Z",
+        config=config,
+        unsafe_raw_output=False,
+    )
+
+    assert exit_code == 0
+    assert payload["executed"] is True
+    assert marker.read_text(encoding="utf-8") == "install @modelcontextprotocol/server-memory@latest"
+    verdict = payload["verdict"]
+    assert isinstance(verdict, dict)
+    assert verdict["action"] == "allow"
+    assert verdict["blocking"] is False
+    assert verdict["observe_mode"] is True
+    assert verdict["observed_policy_action"] == "block"
+    assert "Watch only observed" in str(verdict["reason"])
+    evaluation = payload["supply_chain_evaluation"]
+    assert isinstance(evaluation, dict)
+    assert evaluation["policy_action"] == "block"
+    receipt = payload["receipt"]
+    assert isinstance(receipt, dict)
+    assert receipt["policy_decision"] == "allow"
+    envelope = receipt["action_envelope_json"]
+    assert isinstance(envelope, dict)
+    assert envelope["policy_action"] == "allow"
+    assert envelope["observe_mode"] is True
+    assert envelope["observed_policy_action"] == "block"
+
+    marker.unlink()
+
+    def failed_config_refresh() -> GuardConfig:
+        raise RuntimeError("simulated final authority refresh failure")
+
+    blocked_payload, blocked_exit_code = build_protect_payload(
+        command=["npm", "install", "@modelcontextprotocol/server-memory@latest"],
+        store=store,
+        workspace_dir=workspace,
+        dry_run=False,
+        now="2026-08-08T02:00:01Z",
+        config=config,
+        current_config_provider=failed_config_refresh,
+        unsafe_raw_output=False,
+    )
+
+    assert blocked_exit_code == 2
+    assert blocked_payload["executed"] is False
+    assert marker.exists() is False
+    blocked_verdict = blocked_payload["verdict"]
+    assert isinstance(blocked_verdict, dict)
+    assert blocked_verdict["action"] == "block"
+    assert blocked_verdict["blocking"] is True
+
+
+@pytest.mark.skipif(os.name == "nt", reason="uses a POSIX package-manager fixture")
+def test_final_watch_only_refresh_preserves_unused_one_shot_package_approval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    guard_home = tmp_path / "guard-home"
+    executable_dir = tmp_path / "bin"
+    executable_dir.mkdir()
+    marker = tmp_path / "npm-ran.txt"
+    npm = executable_dir / "npm"
+    npm.write_text(f"#!/bin/sh\nprintf 'ran' > {shlex.quote(str(marker))}\n", encoding="utf-8")
+    npm.chmod(0o755)
+    monkeypatch.setenv("PATH", str(executable_dir))
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: replace(
+            _cloud_validation_block(),
+            decision="review",
+            policy_action="review",
+        ),
+    )
+    enforcing_config = GuardConfig(
+        guard_home=guard_home,
+        workspace=workspace,
+        security_level="custom",
+        risk_actions={"package_script": "allow", "cloud_advisory": "allow"},
+    )
+    watch_only_config = replace(enforcing_config, mode="observe")
+    store = GuardStore(guard_home)
+    command = ["npm", "install", "@modelcontextprotocol/server-memory@latest"]
+    blocked_payload, blocked_exit_code = build_protect_payload(
+        command=command,
+        store=store,
+        workspace_dir=workspace,
+        dry_run=True,
+        now="2026-08-08T02:10:00Z",
+        config=enforcing_config,
+        unsafe_raw_output=False,
+    )
+    assert blocked_exit_code == 2
+    receipt = blocked_payload["receipt"]
+    assert isinstance(receipt, dict)
+    approval_id = store.record_local_once_approval(
+        request_id="watch-only-final-refresh",
+        harness="guard-cli",
+        artifact_id=str(receipt["artifact_id"]),
+        artifact_hash=str(receipt["artifact_hash"]),
+        workspace=None,
+        publisher=None,
+        action="allow",
+        created_at="2026-08-08T02:10:01Z",
+        expires_at="2026-08-09T02:10:00Z",
+    )
+    assert approval_id is not None
+
+    payload, exit_code = build_protect_payload(
+        command=command,
+        store=store,
+        workspace_dir=workspace,
+        dry_run=False,
+        now="2026-08-08T02:10:02Z",
+        config=enforcing_config,
+        current_config_provider=lambda: watch_only_config,
+        unsafe_raw_output=False,
+    )
+
+    assert exit_code == 0
+    assert payload["executed"] is True
+    assert marker.read_text(encoding="utf-8") == "ran"
+    assert (
+        store.resolve_policy_decision(
+            "guard-cli",
+            str(receipt["artifact_id"]),
+            str(receipt["artifact_hash"]),
+            now="2026-08-08T02:10:03Z",
+            consume_one_shot=False,
+        )
+        is not None
+    )
+
+    marker.unlink()
+    monkeypatch.setattr(store, "claim_local_once_approval", lambda *_args, **_kwargs: False)
+    denied_payload, denied_exit_code = build_protect_payload(
+        command=command,
+        store=store,
+        workspace_dir=workspace,
+        dry_run=False,
+        now="2026-08-08T02:10:04Z",
+        config=watch_only_config,
+        current_config_provider=lambda: enforcing_config,
+        unsafe_raw_output=False,
+    )
+
+    assert denied_exit_code == 2
+    assert denied_payload["executed"] is False
+    assert marker.exists() is False


### PR DESCRIPTION
## Summary
- preserve non-blocking package evaluation in Watch-only mode
- keep authority refresh and approval transitions fail-closed
- bound transient evaluator retries and add regression coverage

## Testing
- `uv run --no-sync python -m pytest -q tests/test_guard_hook_process_runner.py tests/test_guard_watch_only_package_firewall.py tests/test_desktop_core_alpha_feed_security.py tests/test_desktop_core_alpha_feed_wake.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/daemon/hook_process_runner.py src/codex_plugin_scanner/guard/decision_boundaries.py src/codex_plugin_scanner/guard/local_supply_chain.py src/codex_plugin_scanner/guard/protect.py tests/test_guard_hook_process_runner.py tests/test_guard_watch_only_package_firewall.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/daemon/hook_process_runner.py src/codex_plugin_scanner/guard/decision_boundaries.py src/codex_plugin_scanner/guard/local_supply_chain.py src/codex_plugin_scanner/guard/protect.py tests/test_guard_hook_process_runner.py tests/test_guard_watch_only_package_firewall.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/daemon/hook_process_runner.py src/codex_plugin_scanner/guard/decision_boundaries.py src/codex_plugin_scanner/guard/local_supply_chain.py src/codex_plugin_scanner/guard/protect.py`
- `git diff --check`
