### PR TITLE
fix(protect): align watch-only approval authority

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12100,
-  "maximum_test_source_lines": 283912,
+  "maximum_test_source_lines": 283899,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12091,
-  "maximum_test_source_lines": 283696,
+  "maximum_collected_cases": 12092,
+  "maximum_test_source_lines": 283718,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/protect_approvals.py
+++ b/src/codex_plugin_scanner/guard/cli/protect_approvals.py
@@ -177,6 +177,10 @@ def _protect_approval_item(
     decision_reason = risk_summary or f"package_supply_chain_{policy_action.replace('-', '_')}"
     decision_v2 = build_decision_v2(policy_action, reason=decision_reason)
     decision_v2_payload = decision_v2.to_dict()
+    action_envelope = _protect_approval_action_envelope(
+        receipt.get("action_envelope_json"),
+        policy_action=policy_action,
+    )
     reasons = supply_chain_evaluation.get("reasons")
     reason_items = reasons if isinstance(reasons, list) else []
     reason_codes = {str(reason.get("code") or "") for reason in reason_items if isinstance(reason, dict)}
@@ -195,12 +199,31 @@ def _protect_approval_item(
         "changed_fields": _protect_target_labels(response_payload),
         "risk_summary": risk_summary,
         "risk_signals": _string_list(verdict.get("risk_signals")),
-        "action_envelope_json": (
-            receipt.get("action_envelope_json") if isinstance(receipt.get("action_envelope_json"), dict) else None
-        ),
+        "action_envelope_json": action_envelope,
         "decision_v2_json": decision_v2_payload,
         "scanner_evidence": scanner_evidence,
     }
+
+
+def _protect_approval_action_envelope(
+    value: object,
+    *,
+    policy_action: GuardAction,
+) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    envelope = dict(value)
+    if envelope.get("observe_mode") is not True:
+        return envelope
+    observed_action = _normalize_protect_policy_action(envelope.get("observed_policy_action"))
+    if observed_action != policy_action:
+        return envelope
+    envelope.pop("observe_mode", None)
+    envelope.pop("observed_policy_action", None)
+    for key in ("policy_action", "policyAction", "pre_execution_result", "preExecutionResult"):
+        if key in envelope:
+            envelope[key] = policy_action
+    return envelope
 
 
 def _annotate_package_execution_context_change(

--- a/tests/test_guard_protect_approval_decision.py
+++ b/tests/test_guard_protect_approval_decision.py
@@ -8,7 +8,7 @@ import pytest
 
 from codex_plugin_scanner.guard.cli.protect_approvals import _protect_approval_item
 from codex_plugin_scanner.guard.models import GuardArtifact
-from codex_plugin_scanner.guard.runtime.decisions import GuardDecisionV2
+from codex_plugin_scanner.guard.runtime.decisions import GuardDecisionV2, authoritative_decision_from_artifact
 
 
 def _artifact(workspace: Path) -> GuardArtifact:
@@ -141,6 +141,28 @@ def test_protect_approval_supplies_nonempty_reason_when_scanners_have_no_copy(tm
     assert isinstance(decision_payload, dict)
     decision = GuardDecisionV2.from_dict(decision_payload)
     assert decision.reason == "package_supply_chain_review"
+
+
+def test_protect_approval_projects_watch_only_envelope_to_observed_action(tmp_path: Path) -> None:
+    response = _response(verdict_action="allow", supply_action="require-reapproval")
+    receipt = response["receipt"]
+    assert isinstance(receipt, dict)
+    receipt["action_envelope_json"] = {
+        "policy_action": "allow",
+        "observe_mode": True,
+        "observed_policy_action": "require-reapproval",
+        "package_manager": "npm",
+    }
+
+    item = _protect_approval_item(response, workspace=tmp_path, artifact=_artifact(tmp_path))
+
+    assert item is not None
+    assert receipt["action_envelope_json"]["policy_action"] == "allow"
+    assert item["action_envelope_json"] == {
+        "policy_action": "require-reapproval",
+        "package_manager": "npm",
+    }
+    assert authoritative_decision_from_artifact(item).action == "require-reapproval"
 
 
 def test_strict_decision_parser_still_rejects_the_old_partial_protect_shape() -> None:


### PR DESCRIPTION
## Summary
- align watch-only package approval envelopes with the observed policy decision
- preserve the execution receipt's watch-only allow projection while keeping strict authority validation

## Testing
- `uv run pytest -q tests/test_guard_protect_approval_decision.py tests/test_guard_protect.py`
- `uv run --no-sync python -m ruff check src/codex_plugin_scanner/guard/cli/protect_approvals.py tests/test_guard_protect_approval_decision.py`
- `uv run --no-sync basedpyright --level error`
- `uv build`
