### PR TITLE
fix(update): report already-current instead of false repaired update

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12085,
-  "maximum_test_source_lines": 283546,
+  "maximum_collected_cases": 12088,
+  "maximum_test_source_lines": 283596,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12088,
-  "maximum_test_source_lines": 283596,
+  "maximum_test_source_lines": 283599,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -59,6 +59,8 @@ from .update_subprocess import (
 _ALREADY_CURRENT_HINTS = (
     "already at latest version",
     "already up-to-date",
+    "nothing to upgrade",
+    "is pinned to",
 )
 _PIPX_LAUNCHER_FAILURE_HINTS = (
     "ModuleNotFoundError: No module named 'pipx'",
@@ -492,7 +494,24 @@ def run_guard_update(
         payload["upgrade_source"] = update_context.source.public_name
         if include_alpha:
             payload["release_channel"] = "alpha"
+    already_current = (
+        requested_wheel_path is None
+        and not force_pypi_reinstall
+        and version_check.get("update_available") is False
+        and str(version_check.get("status") or "") == "current"
+        and local_source_install is None
+        and local_archive_install is None
+        and vcs_install is None
+    )
     if dry_run:
+        if already_current:
+            payload["status"] = "current"
+            payload["changed"] = False
+            payload["resulting_version"] = current_version
+            payload["message"] = "HOL Guard is already current."
+            if trusted_wheel is not None:
+                trusted_wheel.cleanup()
+            return payload, 0
         payload["status"] = "planned"
         payload["changed"] = False
         payload["message"] = _planned_update_message(
@@ -502,6 +521,35 @@ def run_guard_update(
         )
         if trusted_wheel is not None:
             trusted_wheel.cleanup()
+        return payload, 0
+    if already_current:
+        payload["status"] = "current"
+        payload["changed"] = False
+        payload["resulting_version"] = current_version
+        payload["message"] = "HOL Guard is already current."
+        # Skip force-reinstall/upgrade noise when PyPI already reports current.
+        package_shims, package_shim_note = _refresh_package_shims_after_update(
+            context=context,
+            dry_run=dry_run,
+            update_context=update_context,
+        )
+        if package_shims is not None:
+            payload["package_shims"] = package_shims
+        _append_payload_note(payload, package_shim_note)
+        repaired_installs, repair_notes = _repair_supported_harnesses(
+            context=context,
+            store=store,
+            workspace=workspace,
+            now=now,
+            dry_run=dry_run,
+            update_context=update_context,
+        )
+        if repair_notes:
+            payload["notes"] = [*_payload_notes(payload), *repair_notes]
+        if repaired_installs:
+            payload["managed_installs"] = repaired_installs
+            if len(repaired_installs) == 1:
+                payload["managed_install"] = repaired_installs[0]
         return payload, 0
     active_command = execution_command
     active_display_command = command
@@ -924,44 +972,31 @@ def _output_lines(value: str) -> list[str]:
 
 
 def _success_status(payload: dict[str, object]) -> str:
-    if str(payload.get("upgrade_source") or "") == "local_wheel":
-        current_version = str(payload.get("current_version") or "").strip()
-        resulting_version = str(payload.get("resulting_version") or "").strip()
-        if (
-            current_version
-            and resulting_version
-            and current_version != "unknown"
-            and resulting_version != "unknown"
-            and current_version != resulting_version
-        ):
-            return "updated"
-        if (
-            current_version
-            and resulting_version
-            and current_version != "unknown"
-            and resulting_version != "unknown"
-            and current_version == resulting_version
-        ):
-            return "current"
-        output_text = str(payload.get("stdout") or "").lower()
-        if any(hint in output_text for hint in _ALREADY_CURRENT_HINTS):
-            return "current"
-        if "requirement already satisfied: hol-guard" in output_text or "hol-guard is already installed" in output_text:
-            return "current"
-        return "updated"
-    if _is_stale_install(payload):
-        return "stale"
     current_version = str(payload.get("current_version") or "").strip()
     resulting_version = str(payload.get("resulting_version") or "").strip()
-    if (
-        current_version
-        and resulting_version
-        and current_version != "unknown"
-        and resulting_version != "unknown"
-        and current_version != resulting_version
-    ):
-        return "updated"
-    output_text = str(payload.get("stdout") or "").lower()
+    versions_known = (
+        bool(current_version)
+        and bool(resulting_version)
+        and current_version not in {"", "unknown"}
+        and resulting_version not in {"", "unknown"}
+    )
+    is_local_wheel = str(payload.get("upgrade_source") or "") == "local_wheel"
+    versions_differ = versions_known and current_version != resulting_version
+    versions_equal = versions_known and current_version == resulting_version
+    still_behind_pypi = (not is_local_wheel) and _is_stale_install(payload)
+
+    if versions_differ:
+        # Partial upgrades that remain behind PyPI stay "stale".
+        return "stale" if still_behind_pypi else "updated"
+    if still_behind_pypi:
+        # Same resulting version while PyPI has a newer release (pin / no-op upgrade).
+        return "stale"
+    if versions_equal:
+        # Same version after install is "current" unless this was an explicit repair/reinstall.
+        if payload.get("recovery_reinstall") is True or payload.get("recovery_source_install") is True:
+            return "updated"
+        return "current"
+    output_text = str(payload.get("stdout") or "").lower() + "\n" + str(payload.get("stderr") or "").lower()
     if any(hint in output_text for hint in _ALREADY_CURRENT_HINTS):
         return "current"
     if "requirement already satisfied: hol-guard" in output_text or "hol-guard is already installed" in output_text:

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4060,6 +4060,7 @@ args = ["workspace-skill.js", "--changed"]
         monkeypatch.setattr(guard_update_commands_module.sys, "prefix", "/opt/guard-venv")
         monkeypatch.setattr(guard_update_commands_module.sys, "executable", "/opt/guard-venv/bin/python")
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+        monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.18")
         monkeypatch.setattr(
             guard_update_commands_module, "_current_version_from_subprocess", lambda *_args, **_kwargs: "2.0.18"
         )
@@ -4070,9 +4071,10 @@ args = ["workspace-skill.js", "--changed"]
 
         assert rc == 0
         assert output["installer"] == "pip"
-        assert commands == [["/opt/guard-venv/bin/python", "-m", "pip", "install", "--upgrade", "hol-guard"]]
-        assert output["status"] == "updated"
-        assert output["stdout"] == "updated"
+        assert commands == []
+        assert output["status"] == "current"
+        assert output["changed"] is False
+        assert output["message"] == "HOL Guard is already current."
 
     def test_guard_update_uses_pipx_when_running_from_pipx(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
@@ -4085,6 +4087,7 @@ args = ["workspace-skill.js", "--changed"]
         monkeypatch.setattr(guard_update_commands_module.subprocess, "run", fake_run)
         monkeypatch.setattr(guard_update_commands_module.sys, "prefix", "/mock-home/.local/pipx/venvs/hol-guard")
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+        monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.18")
         monkeypatch.setattr(
             guard_update_commands_module, "_current_version_from_subprocess", lambda *_args, **_kwargs: "2.0.18"
         )
@@ -4095,8 +4098,10 @@ args = ["workspace-skill.js", "--changed"]
 
         assert rc == 0
         assert output["installer"] == "pipx"
-        assert commands == [["pipx", "upgrade", "hol-guard"]]
-        assert output["status"] == "updated"
+        assert commands == []
+        assert output["status"] == "current"
+        assert output["changed"] is False
+        assert output["message"] == "HOL Guard is already current."
 
     def test_guard_update_pins_detected_stable_release_from_uv_canary(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
@@ -4156,12 +4161,10 @@ args = ["workspace-skill.js", "--changed"]
 
         assert rc == 0
         assert output["installer"] == "pipx"
-        assert commands == [["pipx", "upgrade", "hol-guard"]]
+        assert commands == []
         assert output["status"] == "current"
+        assert output["changed"] is False
         assert output["message"] == "HOL Guard is already current."
-        assert output["notes"] == ["upgrading shared libraries...", "upgrading hol-guard..."]
-        assert output["stdout"].startswith("hol-guard is already at latest version 2.0.36")
-        assert output["stderr"] == "upgrading shared libraries...\nupgrading hol-guard..."
 
     def test_guard_update_treats_first_install_as_updated_when_only_dependencies_are_current(
         self, tmp_path, monkeypatch, capsys

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -677,3 +677,61 @@ def test_install_native_contract_output_prefers_native_hooks_for_supported_harne
     assert managed_install["native_hooks"] is True
     assert managed_install["primary_integration"] == "native_hooks"
     assert managed_install["manifest"]["mode"] == "codex-mcp-proxy"
+
+
+def test_success_status_same_version_force_reinstall_is_current() -> None:
+    payload = {
+        "current_version": "2.2.31",
+        "resulting_version": "2.2.31",
+        "stdout": "Successfully installed hol-guard-2.2.31 rich-14.3.4",
+        "stderr": "",
+        "version_check": {
+            "status": "current",
+            "update_available": False,
+            "latest_version": "2.2.31",
+        },
+        "upgrade_source": "pypi",
+    }
+    assert update_commands._success_status(payload) == "current"
+    assert update_commands._version_changed("2.2.31", "2.2.31") is False
+
+
+def test_success_status_same_version_explicit_recovery_is_updated() -> None:
+    payload = {
+        "current_version": "2.2.31",
+        "resulting_version": "2.2.31",
+        "stdout": "Successfully installed hol-guard-2.2.31",
+        "stderr": "",
+        "recovery_reinstall": True,
+        "version_check": {
+            "status": "current",
+            "update_available": False,
+            "latest_version": "2.2.31",
+        },
+        "upgrade_source": "pypi",
+    }
+    assert update_commands._success_status(payload) == "updated"
+    assert (
+        update_commands._success_message(
+            status="updated",
+            current_version="2.2.31",
+            resulting_version="2.2.31",
+        )
+        == "HOL Guard source was repaired successfully."
+    )
+
+
+def test_success_status_version_bump_is_updated() -> None:
+    payload = {
+        "current_version": "2.2.30",
+        "resulting_version": "2.2.31",
+        "stdout": "Successfully installed hol-guard-2.2.31",
+        "stderr": "",
+        "version_check": {
+            "status": "current",
+            "update_available": False,
+            "latest_version": "2.2.31",
+        },
+        "upgrade_source": "pypi",
+    }
+    assert update_commands._success_status(payload) == "updated"


### PR DESCRIPTION
## Summary
- When PyPI already reports the installed version as current, `hol-guard update` skips the installer force-reinstall path and returns status `current` with `changed=false`.
- Equal current/resulting versions no longer default to "updated" with a false "source was repaired" message unless an explicit recovery reinstall was requested.
- Preserve `stale` for pins/partial upgrades that remain behind PyPI.

## Testing
- `uv run pytest tests/test_guard_phase03_remainder.py tests/test_guard_phase03_local_install.py -q --tb=line -k 'success_status or update_'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update checks now recognize when the installed version is already current.
  * Update results more clearly distinguish current, updated, and source-repaired installations.
  * Installer output now provides guidance for pinned versions.
  * Dry runs report current status while maintaining package shims and managed harnesses.

* **Bug Fixes**
  * Avoids unnecessary installer runs when no version change is needed.
  * Preserves recovery behavior when an installation requires repair.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->