### PR TITLE
fix(dashboard): repair extension authority in place

### DIFF
--- a/dashboard/src/extension-controls-api.ts
+++ b/dashboard/src/extension-controls-api.ts
@@ -96,6 +96,20 @@ export function fetchEffectiveExtensionControls(): Promise<EffectiveExtensionCon
   return request("/v1/extension-controls/effective");
 }
 
+export function recoverExtensionControlAuthority(credentials?: {
+  approval_password?: string;
+  approval_totp_code?: string;
+}): Promise<EffectiveExtensionControls> {
+  return request("/v1/extension-controls/recover-authority", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      session_nonce: crypto.randomUUID().replaceAll("-", ""),
+      ...credentials,
+    }),
+  });
+}
+
 export function previewExtensionMutation(payload: ExtensionMutationPayload): Promise<Record<string, unknown>> {
   return request("/v1/extension-controls/preview", {
     method: "POST",

--- a/dashboard/src/extensions-workspace.test.ts
+++ b/dashboard/src/extensions-workspace.test.ts
@@ -34,10 +34,12 @@ const recoveryMarkup = renderToStaticMarkup(createElement(ExtensionStatusBanner,
     failures: [{ code: "anchor_mismatch", detail: "Authority anchor does not match." }],
     layers: [],
   },
+  onRecover: () => undefined,
   onRetry: () => undefined,
 }));
 assert.match(recoveryMarkup, /hol-guard guard command controls recover-authority/);
 assert.match(recoveryMarkup, /Copy repair command/);
+assert.match(recoveryMarkup, /Repair now/);
 assert.match(recoveryMarkup, /Check again/);
 
 const state = {

--- a/dashboard/src/extensions-workspace.test.ts
+++ b/dashboard/src/extensions-workspace.test.ts
@@ -6,7 +6,9 @@ import {
   buildExtensionMutation,
   ExtensionStatusBanner,
   extensionRecoveryAction,
+  requiresExtensionRecoveryApproval,
 } from "./extensions-workspace";
+import { ExtensionControlApiError } from "./extension-controls-api";
 
 assert.equal(extensionRecoveryAction("protected"), null);
 assert.deepEqual(extensionRecoveryAction("unenrolled"), {
@@ -41,6 +43,14 @@ assert.match(recoveryMarkup, /hol-guard guard command controls recover-authority
 assert.match(recoveryMarkup, /Copy repair command/);
 assert.match(recoveryMarkup, /Repair now/);
 assert.match(recoveryMarkup, /Check again/);
+assert.equal(
+  requiresExtensionRecoveryApproval(new ExtensionControlApiError("approval_gate_required", 403, "approval_gate_required")),
+  true,
+);
+assert.equal(
+  requiresExtensionRecoveryApproval(new ExtensionControlApiError("authority_not_recoverable", 409, "authority_not_recoverable")),
+  false,
+);
 
 const state = {
   kind: "ready" as const,

--- a/dashboard/src/extensions-workspace.tsx
+++ b/dashboard/src/extensions-workspace.tsx
@@ -19,6 +19,7 @@ import {
   fetchEffectiveExtensionControls,
   fetchExtensionCatalog,
   previewExtensionMutation,
+  recoverExtensionControlAuthority,
   type EffectiveExtensionControls,
   type ExtensionCatalogItem,
   type ExtensionCatalogResponse,
@@ -111,7 +112,13 @@ function effectiveState(effective: EffectiveExtensionControls, extension: Extens
   return extension.required || control?.state !== "disabled";
 }
 
-export function ExtensionStatusBanner(props: { effective: EffectiveExtensionControls; onRetry: () => void }) {
+export function ExtensionStatusBanner(props: {
+  busy?: boolean;
+  effective: EffectiveExtensionControls;
+  error?: string | null;
+  onRecover?: () => void;
+  onRetry: () => void;
+}) {
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
   const recovery = extensionRecoveryAction(props.effective.health);
   const handleCopy = useCallback(async () => {
@@ -142,6 +149,12 @@ export function ExtensionStatusBanner(props: { effective: EffectiveExtensionCont
           <p className="mt-1 text-sm leading-6 text-slate-700">{recovery?.description}</p>
           <code className="mt-3 block overflow-x-auto rounded-lg bg-slate-950 px-3 py-2 text-xs text-white">{recovery?.command}</code>
           <div className="mt-3 flex flex-wrap items-center gap-2">
+            {tampered && props.onRecover ? (
+              <button type="button" disabled={props.busy} onClick={props.onRecover} className="inline-flex items-center gap-2 rounded-lg bg-red-700 px-3 py-2 text-sm font-semibold text-white hover:bg-red-800 disabled:opacity-60">
+                {props.busy ? <HiMiniArrowPath className="size-4 animate-spin" aria-hidden="true" /> : <HiMiniShieldCheck className="size-4" aria-hidden="true" />}
+                {props.busy ? "Repairing…" : "Repair now"}
+              </button>
+            ) : null}
             <button type="button" onClick={handleCopy} className="inline-flex items-center gap-2 rounded-lg bg-slate-950 px-3 py-2 text-sm font-semibold text-white hover:bg-slate-800">
               {copyState === "copied" ? <HiMiniClipboardDocumentCheck className="size-4" aria-hidden="true" /> : <HiMiniClipboard className="size-4" aria-hidden="true" />}
               {copyState === "copied" ? "Copied" : recovery?.copyLabel}
@@ -152,6 +165,7 @@ export function ExtensionStatusBanner(props: { effective: EffectiveExtensionCont
             </button>
             {copyState === "failed" ? <span role="status" className="text-sm text-red-700">Copy failed. Select the command above.</span> : null}
           </div>
+          {props.error ? <p role="alert" className="mt-3 text-sm font-medium text-red-800">{props.error}</p> : null}
         </div>
       </div>
     </div>
@@ -250,11 +264,47 @@ function ReviewModal(props: {
   );
 }
 
+function AuthorityRecoveryModal(props: {
+  busy: boolean;
+  error: string | null;
+  onCancel: () => void;
+  onConfirm: (password: string, totp: string) => void;
+}) {
+  const [password, setPassword] = useState("");
+  const [totp, setTotp] = useState("");
+  const handlePasswordChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(event.target.value);
+  }, []);
+  const handleTotpChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setTotp(event.target.value);
+  }, []);
+  const handleSubmit = useCallback((event: React.FormEvent) => {
+    event.preventDefault();
+    props.onConfirm(password, totp);
+  }, [password, props, totp]);
+  return (
+    <div className="fixed inset-0 z-50 grid place-items-center bg-slate-950/45 p-4 backdrop-blur-sm" role="presentation">
+      <form onSubmit={handleSubmit} role="dialog" aria-modal="true" aria-labelledby="authority-recovery-title" className="w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl">
+        <p className="text-xs font-bold uppercase tracking-[0.18em] text-brand-blue">Local approval required</p>
+        <h2 id="authority-recovery-title" className="mt-2 text-xl font-semibold text-slate-950">Repair extension controls</h2>
+        <p className="mt-2 text-sm leading-6 text-slate-600">Authenticate this repair on your device. Guard uses the proof once and does not store it.</p>
+        <label className="mt-5 block text-sm font-medium text-slate-700">Approval password<input autoFocus type="password" autoComplete="current-password" value={password} onChange={handlePasswordChange} className="mt-2 w-full rounded-xl border border-slate-300 px-3 py-2.5 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-blue-100" /></label>
+        <label className="mt-4 block text-sm font-medium text-slate-700">Authenticator code<input inputMode="numeric" autoComplete="one-time-code" value={totp} onChange={handleTotpChange} className="mt-2 w-full rounded-xl border border-slate-300 px-3 py-2.5 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-blue-100" /></label>
+        {props.error ? <p role="alert" className="mt-4 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-700">{props.error}</p> : null}
+        <div className="mt-6 flex justify-end gap-3"><button type="button" disabled={props.busy} onClick={props.onCancel} className="rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100">Cancel</button><button type="submit" disabled={props.busy} className="rounded-xl bg-red-700 px-5 py-2.5 text-sm font-semibold text-white hover:bg-red-800 disabled:opacity-60">{props.busy ? "Repairing…" : "Authenticate and repair"}</button></div>
+      </form>
+    </div>
+  );
+}
+
 export function ExtensionsWorkspace() {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
   const [pending, setPending] = useState<PendingChange | null>(null);
   const [busy, setBusy] = useState(false);
   const [mutationError, setMutationError] = useState<string | null>(null);
+  const [recoveryApprovalOpen, setRecoveryApprovalOpen] = useState(false);
+  const [recoveryBusy, setRecoveryBusy] = useState(false);
+  const [recoveryError, setRecoveryError] = useState<string | null>(null);
   const [provenanceOpen, setProvenanceOpen] = useState(false);
   const load = useCallback(async () => {
     setState({ kind: "loading" });
@@ -289,6 +339,25 @@ export function ExtensionsWorkspace() {
       setMutationError(`${error instanceof Error ? error.message : "Change failed"}${recovery ? ` · ${recovery}` : ""}`);
     } finally { setBusy(false); }
   }, [load, pending, state]);
+  const recoverAuthority = useCallback(async (credentials?: { approval_password?: string; approval_totp_code?: string }) => {
+    setRecoveryBusy(true); setRecoveryError(null);
+    try {
+      const effective = await recoverExtensionControlAuthority(credentials);
+      if (state.kind === "ready") setState({ ...state, effective });
+      setRecoveryApprovalOpen(false);
+    } catch (error) {
+      if (credentials === undefined && error instanceof ExtensionControlApiError && error.code === "approval_required") {
+        setRecoveryApprovalOpen(true);
+      } else {
+        setRecoveryError(error instanceof Error ? error.message : "Guard could not repair extension controls.");
+      }
+    } finally { setRecoveryBusy(false); }
+  }, [state]);
+  const handleRecover = useCallback(() => { void recoverAuthority(); }, [recoverAuthority]);
+  const handleRecoveryConfirm = useCallback((password: string, totp: string) => {
+    void recoverAuthority({ approval_password: password, approval_totp_code: totp });
+  }, [recoverAuthority]);
+  const handleRecoveryCancel = useCallback(() => { if (!recoveryBusy) setRecoveryApprovalOpen(false); }, [recoveryBusy]);
   const toggleProvenance = useCallback(() => setProvenanceOpen((value) => !value), []);
   const toggleLockdown = useCallback(() => { if (state.kind === "ready") handleChange({ globalLockdown: !state.effective.global_lockdown }); }, [handleChange, state]);
 
@@ -301,11 +370,12 @@ export function ExtensionsWorkspace() {
         <div><p className="text-xs font-bold uppercase tracking-[0.22em] text-brand-blue">Command safety</p><h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">Extensions</h1><p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">Inspect and govern the capabilities Guard uses to understand development commands.</p></div>
         <button type="button" onClick={toggleLockdown} disabled={locked} className={`inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold ${state.effective.global_lockdown ? "bg-red-700 text-white" : "border border-slate-300 bg-white text-slate-700"} disabled:opacity-50`}><HiMiniLockClosed className="size-4" />{state.effective.global_lockdown ? "Disable lockdown" : "Enable lockdown"}</button>
       </header>
-      <div className="mt-6"><ExtensionStatusBanner effective={state.effective} onRetry={load} /></div>
+      <div className="mt-6"><ExtensionStatusBanner busy={recoveryBusy} effective={state.effective} error={recoveryError} onRecover={handleRecover} onRetry={load} /></div>
       {state.effective.global_lockdown ? <div className="mt-4 flex items-center gap-3 rounded-2xl bg-slate-950 px-4 py-3 text-sm text-white"><HiMiniLockClosed className="size-5" /><span><strong>Global lockdown active.</strong> Optional extensions remain disabled regardless of individual settings.</span></div> : null}
       <section aria-labelledby="installed-extensions" className="mt-8"><div className="flex items-center justify-between"><h2 id="installed-extensions" className="text-lg font-semibold text-slate-950">Installed extensions</h2><span className="text-sm text-slate-500">{sortedExtensions.length} available</span></div><div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">{sortedExtensions.map((extension) => <ExtensionCard key={extension.extension_id} extension={extension} enabled={effectiveState(state.effective, extension)} locked={locked || state.effective.global_lockdown} onChange={handleChange} />)}</div></section>
       <section className="mt-8 overflow-hidden rounded-3xl border border-slate-200 bg-white"><button type="button" onClick={toggleProvenance} aria-expanded={provenanceOpen} className="flex w-full items-center justify-between p-5 text-left"><span><span className="block font-semibold text-slate-950">Policy provenance</span><span className="mt-1 block text-sm text-slate-500">Catalog {state.catalog.catalog_digest.slice(0, 12)}… · {state.effective.layers.length} authority layer{state.effective.layers.length === 1 ? "" : "s"}</span></span>{provenanceOpen ? <HiMiniChevronUp className="size-5" /> : <HiMiniChevronDown className="size-5" />}</button>{provenanceOpen ? <div className="border-t border-slate-200 p-5"><div className="grid gap-3 sm:grid-cols-2">{state.effective.layers.map((layer: ExtensionControlLayer) => <div key={`${layer.kind}-${layer.catalog_digest}`} className="rounded-2xl bg-slate-50 p-4"><div className="flex items-center gap-2"><HiMiniCheckCircle className="size-5 text-emerald-600" /><strong className="text-sm text-slate-900">{layer.kind === "local-admin" ? "Local administrator" : "Signed cloud policy"}</strong></div><p className="mt-2 text-xs text-slate-500">{layer.controls.length} explicit controls · catalog {layer.catalog_digest.slice(0, 12)}…</p></div>)}</div></div> : null}</section>
       {pending ? <ReviewModal change={pending} busy={busy} error={mutationError} onCancel={handleCancel} onConfirm={handleConfirm} /> : null}
+      {recoveryApprovalOpen ? <AuthorityRecoveryModal busy={recoveryBusy} error={recoveryError} onCancel={handleRecoveryCancel} onConfirm={handleRecoveryConfirm} /> : null}
     </main>
   );
 }

--- a/dashboard/src/extensions-workspace.tsx
+++ b/dashboard/src/extensions-workspace.tsx
@@ -63,6 +63,11 @@ export function extensionRecoveryAction(
   };
 }
 
+export function requiresExtensionRecoveryApproval(error: unknown): boolean {
+  return error instanceof ExtensionControlApiError &&
+    (error.code === "approval_required" || error.code?.startsWith("approval_gate_") === true);
+}
+
 function randomToken(): string {
   return crypto.randomUUID().replaceAll("-", "");
 }
@@ -346,7 +351,7 @@ export function ExtensionsWorkspace() {
       if (state.kind === "ready") setState({ ...state, effective });
       setRecoveryApprovalOpen(false);
     } catch (error) {
-      if (credentials === undefined && error instanceof ExtensionControlApiError && error.code === "approval_required") {
+      if (credentials === undefined && requiresExtensionRecoveryApproval(error)) {
         setRecoveryApprovalOpen(true);
       } else {
         setRecoveryError(error instanceof Error ? error.message : "Guard could not repair extension controls.");

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -977,7 +977,7 @@ export async function fetchCommandActivityApi(input: RequestInfo, init?: Request
 export async function fetchExtensionControlApi(input: RequestInfo, init?: RequestInit): Promise<Response> {
   const approvedPath =
     typeof input === "string" &&
-    /^\/v1\/extension-controls\/(?:catalog|effective|preview|apply|refresh)$/.test(input);
+    /^\/v1\/extension-controls\/(?:catalog|effective|preview|apply|refresh|recover-authority)$/.test(input);
   if (!approvedPath) {
     throw new Error("Invalid extension-control API path");
   }

--- a/src/codex_plugin_scanner/guard/daemon/client.py
+++ b/src/codex_plugin_scanner/guard/daemon/client.py
@@ -165,6 +165,9 @@ class GuardSurfaceDaemonClient:
     def refresh_extension_controls(self) -> dict[str, object]:
         return self._post("/v1/extension-controls/refresh", {})
 
+    def recover_extension_control_authority(self, payload: dict[str, object]) -> dict[str, object]:
+        return self._post("/v1/extension-controls/recover-authority", payload)
+
     def acknowledge_degraded_extension_controls(self, payload: dict[str, object]) -> dict[str, object]:
         return self._post("/v1/extension-controls/acknowledge-degraded", payload)
 

--- a/src/codex_plugin_scanner/guard/daemon/extension_control_api.py
+++ b/src/codex_plugin_scanner/guard/daemon/extension_control_api.py
@@ -151,6 +151,34 @@ class ExtensionControlApiService:
         _ = self._runtime.refresh(view)
         return self.effective()
 
+    def recover_authority(self, payload: dict[str, object]) -> dict[str, object]:
+        current = self._store.read_extension_control_authority(catalog_digest=self._registry.catalog_digest)
+        if current.health not in {AuthorityHealth.TAMPERED, AuthorityHealth.RECOVERY_REQUIRED}:
+            raise ExtensionControlApiError(409, "authority_not_recoverable")
+        session_nonce = self._required_string(payload, "session_nonce")
+        action = "recover-authority"
+        subject = f"{action}:{current.health.value}:{current.revision}:{self._registry.catalog_digest}"
+        try:
+            grant = require_extension_control(
+                self._store.guard_home,
+                approval_gate_input=input_from_mapping(payload),
+                action=action,
+                subject=subject,
+                session_nonce=session_nonce,
+            )
+            consume_extension_control_grant(
+                self._store.guard_home,
+                grant,
+                action=action,
+                subject=subject,
+                session_nonce=session_nonce,
+            )
+        except ApprovalGateError as exc:
+            raise ExtensionControlApiError(exc.status, exc.code) from exc
+        view = self._store.recover_extension_control_authority(catalog_digest=self._registry.catalog_digest)
+        _ = self._runtime.refresh(view)
+        return self.effective()
+
     def acknowledge_degraded(self, payload: dict[str, object]) -> dict[str, object]:
         if self._runtime.current().health is not AuthorityHealth.DEGRADED_UNACKNOWLEDGED:
             raise ExtensionControlApiError(409, "authority_not_degraded")

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2461,6 +2461,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/extension-controls/preview",
             "/v1/extension-controls/apply",
             "/v1/extension-controls/refresh",
+            "/v1/extension-controls/recover-authority",
             "/v1/extension-controls/acknowledge-degraded",
         }
         if parsed.path in extension_control_paths and not self._header_token_is_valid():
@@ -2549,6 +2550,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     response = self._daemon_server().extension_control_api.apply(payload)
                 elif parsed.path.endswith("/acknowledge-degraded"):
                     response = self._daemon_server().extension_control_api.acknowledge_degraded(payload)
+                elif parsed.path.endswith("/recover-authority"):
+                    response = self._daemon_server().extension_control_api.recover_authority(payload)
                 else:
                     response = self._daemon_server().extension_control_api.refresh()
             except ExtensionControlApiError as error:
@@ -7102,6 +7105,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/extension-controls/preview",
             "/v1/extension-controls/apply",
             "/v1/extension-controls/refresh",
+            "/v1/extension-controls/recover-authority",
             "/v1/harnesses",
             "/v1/notifications/setup",
             "/v1/policy",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -71,6 +71,9 @@ function extensionRecoveryAction(health) {
     command: "hol-guard guard command controls enroll"
   };
 }
+function requiresExtensionRecoveryApproval(error) {
+  return error instanceof ExtensionControlApiError && (error.code === "approval_required" || error.code?.startsWith("approval_gate_") === true);
+}
 function randomToken() {
   return crypto.randomUUID().replaceAll("-", "");
 }
@@ -345,7 +348,7 @@ function ExtensionsWorkspace() {
       if (state.kind === "ready") setState({ ...state, effective });
       setRecoveryApprovalOpen(false);
     } catch (error) {
-      if (credentials === void 0 && error instanceof ExtensionControlApiError && error.code === "approval_required") {
+      if (credentials === void 0 && requiresExtensionRecoveryApproval(error)) {
         setRecoveryApprovalOpen(true);
       } else {
         setRecoveryError(error instanceof Error ? error.message : "Guard could not repair extension controls.");
@@ -439,5 +442,6 @@ export {
   ExtensionStatusBanner,
   ExtensionsWorkspace,
   buildExtensionMutation,
-  extensionRecoveryAction
+  extensionRecoveryAction,
+  requiresExtensionRecoveryApproval
 };

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -1,4 +1,4 @@
-import { an as fetchExtensionControlApi, r as reactExports, j as jsxRuntimeExports, o as HiMiniShieldCheck, J as HiMiniExclamationTriangle, U as HiMiniClipboardDocumentCheck, V as HiMiniClipboard, ao as HiMiniArrowPath, Z as HiMiniLockClosed, x as HiMiniChevronUp, y as HiMiniChevronDown, l as HiMiniCheckCircle, ap as HiMiniPuzzlePiece, w as HiMiniXMark } from "../guard-dashboard.js";
+import { an as fetchExtensionControlApi, r as reactExports, j as jsxRuntimeExports, o as HiMiniShieldCheck, J as HiMiniExclamationTriangle, ao as HiMiniArrowPath, U as HiMiniClipboardDocumentCheck, V as HiMiniClipboard, Z as HiMiniLockClosed, x as HiMiniChevronUp, y as HiMiniChevronDown, l as HiMiniCheckCircle, ap as HiMiniPuzzlePiece, w as HiMiniXMark } from "../guard-dashboard.js";
 class ExtensionControlApiError extends Error {
   constructor(message, status, code, recoveryAction) {
     super(message);
@@ -29,6 +29,16 @@ function fetchExtensionCatalog() {
 }
 function fetchEffectiveExtensionControls() {
   return request("/v1/extension-controls/effective");
+}
+function recoverExtensionControlAuthority(credentials) {
+  return request("/v1/extension-controls/recover-authority", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      session_nonce: crypto.randomUUID().replaceAll("-", ""),
+      ...credentials
+    })
+  });
 }
 function previewExtensionMutation(payload) {
   return request("/v1/extension-controls/preview", {
@@ -134,6 +144,10 @@ function ExtensionStatusBanner(props) {
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-6 text-slate-700", children: recovery?.description }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("code", { className: "mt-3 block overflow-x-auto rounded-lg bg-slate-950 px-3 py-2 text-xs text-white", children: recovery?.command }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 flex flex-wrap items-center gap-2", children: [
+        tampered && props.onRecover ? /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", disabled: props.busy, onClick: props.onRecover, className: "inline-flex items-center gap-2 rounded-lg bg-red-700 px-3 py-2 text-sm font-semibold text-white hover:bg-red-800 disabled:opacity-60", children: [
+          props.busy ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "size-4 animate-spin", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "size-4", "aria-hidden": "true" }),
+          props.busy ? "Repairing…" : "Repair now"
+        ] }) : null,
         /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", onClick: handleCopy, className: "inline-flex items-center gap-2 rounded-lg bg-slate-950 px-3 py-2 text-sm font-semibold text-white hover:bg-slate-800", children: [
           copyState === "copied" ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocumentCheck, { className: "size-4", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboard, { className: "size-4", "aria-hidden": "true" }),
           copyState === "copied" ? "Copied" : recovery?.copyLabel
@@ -143,7 +157,8 @@ function ExtensionStatusBanner(props) {
           "Check again"
         ] }),
         copyState === "failed" ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { role: "status", className: "text-sm text-red-700", children: "Copy failed. Select the command above." }) : null
-      ] })
+      ] }),
+      props.error ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "alert", className: "mt-3 text-sm font-medium text-red-800", children: props.error }) : null
     ] })
   ] }) });
 }
@@ -238,11 +253,46 @@ function ReviewModal(props) {
     ] })
   ] }) });
 }
+function AuthorityRecoveryModal(props) {
+  const [password, setPassword] = reactExports.useState("");
+  const [totp, setTotp] = reactExports.useState("");
+  const handlePasswordChange = reactExports.useCallback((event) => {
+    setPassword(event.target.value);
+  }, []);
+  const handleTotpChange = reactExports.useCallback((event) => {
+    setTotp(event.target.value);
+  }, []);
+  const handleSubmit = reactExports.useCallback((event) => {
+    event.preventDefault();
+    props.onConfirm(password, totp);
+  }, [password, props, totp]);
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "fixed inset-0 z-50 grid place-items-center bg-slate-950/45 p-4 backdrop-blur-sm", role: "presentation", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("form", { onSubmit: handleSubmit, role: "dialog", "aria-modal": "true", "aria-labelledby": "authority-recovery-title", className: "w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-bold uppercase tracking-[0.18em] text-brand-blue", children: "Local approval required" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "authority-recovery-title", className: "mt-2 text-xl font-semibold text-slate-950", children: "Repair extension controls" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-slate-600", children: "Authenticate this repair on your device. Guard uses the proof once and does not store it." }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "mt-5 block text-sm font-medium text-slate-700", children: [
+      "Approval password",
+      /* @__PURE__ */ jsxRuntimeExports.jsx("input", { autoFocus: true, type: "password", autoComplete: "current-password", value: password, onChange: handlePasswordChange, className: "mt-2 w-full rounded-xl border border-slate-300 px-3 py-2.5 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-blue-100" })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "mt-4 block text-sm font-medium text-slate-700", children: [
+      "Authenticator code",
+      /* @__PURE__ */ jsxRuntimeExports.jsx("input", { inputMode: "numeric", autoComplete: "one-time-code", value: totp, onChange: handleTotpChange, className: "mt-2 w-full rounded-xl border border-slate-300 px-3 py-2.5 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-blue-100" })
+    ] }),
+    props.error ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "alert", className: "mt-4 rounded-xl bg-red-50 px-3 py-2 text-sm text-red-700", children: props.error }) : null,
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-6 flex justify-end gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", disabled: props.busy, onClick: props.onCancel, className: "rounded-xl px-4 py-2.5 text-sm font-semibold text-slate-600 hover:bg-slate-100", children: "Cancel" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "submit", disabled: props.busy, className: "rounded-xl bg-red-700 px-5 py-2.5 text-sm font-semibold text-white hover:bg-red-800 disabled:opacity-60", children: props.busy ? "Repairing…" : "Authenticate and repair" })
+    ] })
+  ] }) });
+}
 function ExtensionsWorkspace() {
   const [state, setState] = reactExports.useState({ kind: "loading" });
   const [pending, setPending] = reactExports.useState(null);
   const [busy, setBusy] = reactExports.useState(false);
   const [mutationError, setMutationError] = reactExports.useState(null);
+  const [recoveryApprovalOpen, setRecoveryApprovalOpen] = reactExports.useState(false);
+  const [recoveryBusy, setRecoveryBusy] = reactExports.useState(false);
+  const [recoveryError, setRecoveryError] = reactExports.useState(null);
   const [provenanceOpen, setProvenanceOpen] = reactExports.useState(false);
   const load = reactExports.useCallback(async () => {
     setState({ kind: "loading" });
@@ -287,6 +337,32 @@ function ExtensionsWorkspace() {
       setBusy(false);
     }
   }, [load, pending, state]);
+  const recoverAuthority = reactExports.useCallback(async (credentials) => {
+    setRecoveryBusy(true);
+    setRecoveryError(null);
+    try {
+      const effective = await recoverExtensionControlAuthority(credentials);
+      if (state.kind === "ready") setState({ ...state, effective });
+      setRecoveryApprovalOpen(false);
+    } catch (error) {
+      if (credentials === void 0 && error instanceof ExtensionControlApiError && error.code === "approval_required") {
+        setRecoveryApprovalOpen(true);
+      } else {
+        setRecoveryError(error instanceof Error ? error.message : "Guard could not repair extension controls.");
+      }
+    } finally {
+      setRecoveryBusy(false);
+    }
+  }, [state]);
+  const handleRecover = reactExports.useCallback(() => {
+    void recoverAuthority();
+  }, [recoverAuthority]);
+  const handleRecoveryConfirm = reactExports.useCallback((password, totp) => {
+    void recoverAuthority({ approval_password: password, approval_totp_code: totp });
+  }, [recoverAuthority]);
+  const handleRecoveryCancel = reactExports.useCallback(() => {
+    if (!recoveryBusy) setRecoveryApprovalOpen(false);
+  }, [recoveryBusy]);
   const toggleProvenance = reactExports.useCallback(() => setProvenanceOpen((value) => !value), []);
   const toggleLockdown = reactExports.useCallback(() => {
     if (state.kind === "ready") handleChange({ globalLockdown: !state.effective.global_lockdown });
@@ -309,7 +385,7 @@ function ExtensionsWorkspace() {
         state.effective.global_lockdown ? "Disable lockdown" : "Enable lockdown"
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-6", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ExtensionStatusBanner, { effective: state.effective, onRetry: load }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-6", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ExtensionStatusBanner, { busy: recoveryBusy, effective: state.effective, error: recoveryError, onRecover: handleRecover, onRetry: load }) }),
     state.effective.global_lockdown ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex items-center gap-3 rounded-2xl bg-slate-950 px-4 py-3 text-sm text-white", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniLockClosed, { className: "size-5" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
@@ -355,7 +431,8 @@ function ExtensionsWorkspace() {
         ] })
       ] }, `${layer.kind}-${layer.catalog_digest}`)) }) }) : null
     ] }),
-    pending ? /* @__PURE__ */ jsxRuntimeExports.jsx(ReviewModal, { change: pending, busy, error: mutationError, onCancel: handleCancel, onConfirm: handleConfirm }) : null
+    pending ? /* @__PURE__ */ jsxRuntimeExports.jsx(ReviewModal, { change: pending, busy, error: mutationError, onCancel: handleCancel, onConfirm: handleConfirm }) : null,
+    recoveryApprovalOpen ? /* @__PURE__ */ jsxRuntimeExports.jsx(AuthorityRecoveryModal, { busy: recoveryBusy, error: recoveryError, onCancel: handleRecoveryCancel, onConfirm: handleRecoveryConfirm }) : null
   ] });
 }
 export {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16241,7 +16241,7 @@ async function fetchCommandActivityApi(input, init) {
   return fetchWithGuardAuth(input, init);
 }
 async function fetchExtensionControlApi(input, init) {
-  const approvedPath = typeof input === "string" && /^\/v1\/extension-controls\/(?:catalog|effective|preview|apply|refresh)$/.test(input);
+  const approvedPath = typeof input === "string" && /^\/v1\/extension-controls\/(?:catalog|effective|preview|apply|refresh|recover-authority)$/.test(input);
   if (!approvedPath) {
     throw new Error("Invalid extension-control API path");
   }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -5304,6 +5304,10 @@
       }
     }
 
+    .hover\:bg-red-800:hover {
+      background-color: var(--color-red-800);
+    }
+
     .hover\:bg-slate-50:hover {
       background-color: var(--color-slate-50);
     }

--- a/tests/test_guard_extension_control_api.py
+++ b/tests/test_guard_extension_control_api.py
@@ -162,6 +162,58 @@ def test_degraded_acknowledgement_rejects_missing_daemon_approval(tmp_path: Path
     assert service.effective()["health"] == AuthorityHealth.DEGRADED_UNACKNOWLEDGED.value
 
 
+def test_authority_recovery_consumes_daemon_bound_approval_before_repair(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    tampered = ExtensionControlAuthorityView(
+        AuthorityHealth.TAMPERED,
+        4,
+        BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
+        (),
+    )
+    protected = replace(tampered, health=AuthorityHealth.PROTECTED, revision=5)
+    service = ExtensionControlApiService(
+        store=store,
+        registry=BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+        runtime=ExtensionControlRuntime(tampered),
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(store, "read_extension_control_authority", lambda **_kwargs: tampered)
+    monkeypatch.setattr(
+        store,
+        "recover_extension_control_authority",
+        lambda **_kwargs: calls.append("recover") or protected,
+    )
+    monkeypatch.setattr(
+        extension_control_api_module,
+        "require_extension_control",
+        lambda *_args, **_kwargs: calls.append("require") or object(),
+    )
+    monkeypatch.setattr(
+        extension_control_api_module,
+        "consume_extension_control_grant",
+        lambda *_args, **_kwargs: calls.append("consume"),
+    )
+
+    effective = service.recover_authority({"approval_password": "secret", "session_nonce": "nonce"})
+
+    assert effective["health"] == AuthorityHealth.PROTECTED.value
+    assert effective["revision"] == 5
+    assert calls == ["require", "consume", "recover"]
+
+
+def test_authority_recovery_rejects_healthy_authority(tmp_path: Path) -> None:
+    service = _service(GuardStore(tmp_path / "guard-home"))
+
+    with pytest.raises(ExtensionControlApiError) as denied:
+        service.recover_authority({"session_nonce": "nonce"})
+
+    assert denied.value.status == 409
+    assert denied.value.code == "authority_not_recoverable"
+
+
 def test_legacy_extension_aliases_migrate_to_canonical_catalog_ids(tmp_path: Path) -> None:
     legacy_id = "command.legacy-control-id"
     first = BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions[0]
@@ -367,6 +419,10 @@ def test_http_routes_authenticate_before_reading_sensitive_post_body(tmp_path: P
         client = GuardSurfaceDaemonClient(f"http://127.0.0.1:{daemon.port}", auth_token)
         refreshed = client.refresh_extension_controls()
         assert refreshed["health"] == "unenrolled"
+        with pytest.raises(GuardDaemonRequestError) as not_recoverable:
+            client.recover_extension_control_authority({"session_nonce": "nonce"})
+        assert not_recoverable.value.status == 409
+        assert not_recoverable.value.code == "authority_not_recoverable"
         with pytest.raises(GuardDaemonRequestError) as not_degraded:
             client.acknowledge_degraded_extension_controls({})
         assert not_degraded.value.status == 409


### PR DESCRIPTION
## Summary

- add an authenticated daemon action that repairs damaged extension-control authority
- require and consume the existing one-time local approval proof before recovery
- replace the extension-page dead end with an in-place Repair now flow while retaining the CLI fallback
- refresh the effective extension state immediately after successful repair

## Verification

- `uv run --no-sync pytest -q tests/test_guard_extension_control_api.py tests/test_guard_extension_control_authority.py tests/test_guard_extension_controls_cli.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/daemon/client.py src/codex_plugin_scanner/guard/daemon/extension_control_api.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_extension_control_api.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/daemon/client.py src/codex_plugin_scanner/guard/daemon/extension_control_api.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_extension_control_api.py`
- `bunx tsx src/extensions-workspace.test.ts`
- `bun run test`
- `bun run build`
- `git diff --check`
