### PR TITLE
fix(hooks): allow verified non-sensitive patches

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12088,
-  "maximum_test_source_lines": 283599,
+  "maximum_collected_cases": 12091,
+  "maximum_test_source_lines": 283696,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -536,6 +536,7 @@ def _generic_hook_approval_reuse(
 
 def _should_relax_configured_default(
     *,
+    action_envelope: GuardActionEnvelope | None = None,
     configured_action: GuardAction,
     harness: str = "codex",
     has_narrow_override: bool,
@@ -578,6 +579,17 @@ def _should_relax_configured_default(
             payload=dict(payload),
             cwd=runtime_workspace,
             home_dir=home_dir,
+        )
+    if (
+        event_name == "PreToolUse"
+        and runtime_artifact_checked
+        and _canonical_harness_name(harness) == "codex"
+        and str(payload.get("tool_name", "")).strip().lower() == "apply_patch"
+    ):
+        return (
+            action_envelope is not None
+            and action_envelope.action_type == "file_write"
+            and bool(action_envelope.target_paths)
         )
     return event_name == "PreToolUse" and is_explicitly_benign_tool_action_request(
         payload.get("tool_name"),
@@ -638,12 +650,13 @@ def _run_hook_generic_payload(
             cwd=runtime_workspace or Path.cwd(),
             home_dir=home_dir,
         )
-    verified_benign_classifier = (
-        "_codex_post_tool_command_is_read_only_source_inspection"
-        if hook_event_name == "PostToolUse"
-        else "is_explicitly_benign_tool_action_request"
-    )
+    verified_benign_classifier = "is_explicitly_benign_tool_action_request"
+    if hook_event_name == "PostToolUse":
+        verified_benign_classifier = "_codex_post_tool_command_is_read_only_source_inspection"
+    elif hook_event_name == "PreToolUse" and str(payload_map.get("tool_name", "")).strip().lower() == "apply_patch":
+        verified_benign_classifier = "runtime_artifact_verified_non_sensitive_apply_patch"
     verified_benign_default = _should_relax_configured_default(
+        action_envelope=action_envelope,
         configured_action=configured_policy_normalization.action,
         harness=args.harness,
         has_narrow_override=configured_narrow_override is not None,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -8713,6 +8713,103 @@ def test_hook_runtime_artifact_allows_codex_apply_patch_command_for_source_file(
 
 
 @pytest.mark.parametrize(
+    "strict_config",
+    (
+        'default_action = "require-reapproval"\n',
+        '[harnesses.codex]\ndefault_action = "require-reapproval"\n',
+    ),
+    ids=("global", "harness"),
+)
+def test_guard_hook_codex_strict_default_allows_verified_non_sensitive_apply_patch(
+    strict_config: str,
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", strict_config)
+    patch = """*** Begin Patch
+*** Update File: docs/notes.md
+@@
++Updated project status.
+*** End Patch"""
+    event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "apply_patch",
+        "tool_input": {"command": patch},
+        "source_scope": "project",
+        "cwd": str(workspace_dir),
+    }
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    store = GuardStore(home_dir)
+
+    assert rc == 0
+    assert output == ""
+    assert store.list_approval_requests(limit=10) == []
+    assert store.list_receipts(limit=1) == []
+
+
+def test_guard_hook_codex_strict_default_reviews_protected_apply_patch(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        home_dir / "config.toml",
+        'default_action = "require-reapproval"\napproval_wait_timeout_seconds = 0\n',
+    )
+    protected_path = home_dir / ".codex" / "config.toml"
+    patch = f"""*** Begin Patch
+*** Update File: {protected_path}
+@@
++notify = true
+*** End Patch"""
+    event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "apply_patch",
+        "tool_input": {"command": patch},
+        "source_scope": "project",
+        "cwd": str(workspace_dir),
+    }
+    monkeypatch.setattr(
+        guard_commands_module,
+        "schedule_guard_daemon_ensure",
+        lambda _guard_home, **_kwargs: "http://127.0.0.1:4455",
+    )
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+        as_json=True,
+    )
+    store = GuardStore(home_dir)
+
+    assert rc == 1
+    assert output["policy_action"] == "require-reapproval"
+    assert output["artifact_type"] == "tool_action_request"
+    requests = store.list_approval_requests(limit=10)
+    assert len(requests) == 1
+    assert requests[0]["artifact_type"] == "tool_action_request"
+
+
+@pytest.mark.parametrize(
     "command",
     [
         "git status --short --branch",


### PR DESCRIPTION
## Summary
- allow parsed non-sensitive Codex patch operations after runtime safety checks complete
- preserve review for protected configuration writes and explicit policy overrides

## Testing
- `uv run --no-sync pytest -q tests/test_guard_runtime.py --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_user_prompt_policy.py tests/test_guard_codex_prompt_attachments.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/commands_hook_generic.py tests/test_guard_runtime.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/cli/commands_hook_generic.py tests/test_guard_runtime.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Verified, non-sensitive file updates made through Codex can proceed without additional approval.
  - Updates targeting protected configuration files still require review and approval.

- **Bug Fixes**
  - Improved handling of strict approval settings for Codex actions.
  - Preserved separate handling for read-only inspections and other benign actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->