### PR TITLE
fix(update): quiet current Pi/OMP repair and harden Codex group permissions

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12098,
-  "maximum_test_source_lines": 283861,
+  "maximum_collected_cases": 12099,
+  "maximum_test_source_lines": 283890,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12091,
-  "maximum_test_source_lines": 283696,
+  "maximum_collected_cases": 12098,
+  "maximum_test_source_lines": 283861,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -33,7 +33,9 @@ from ..adapters.opencode_pretool import (
     managed_plugin_path,
     pretool_plugin_source,
 )
-from ..adapters.pi import legacy_omp_managed_extension_is_verified
+from ..adapters.pi import OmpHarnessAdapter, PiHarnessAdapter, legacy_omp_managed_extension_is_verified
+from ..adapters.pi_extension_source import managed_extension_source
+from ..adapters.pi_support import json_payload
 from ..codex_hook_integrity import CodexHookIntegrityError, load_authenticated_hook_manifest
 from ..config import load_guard_config, resolve_guard_home
 from ..mdm.contracts import ManagedNetworkPolicy, ManagedPolicy
@@ -2271,6 +2273,8 @@ def _repair_pi_family_install(
 
     The extension embeds timeout and daemon-compat constants. Refreshing it after
     update keeps the fast daemon path available and avoids cold CLI timeouts.
+    When the on-disk extension and settings already match the current package,
+    skip the rewrite so already-current updates stay silent.
     """
 
     try:
@@ -2281,6 +2285,8 @@ def _repair_pi_family_install(
         return None, None
     try:
         repair_context, repair_workspace = _repair_context_from_managed_install(context, managed_install)
+        if _pi_family_extension_is_current(harness=harness, context=repair_context):
+            return None, None
         payload = apply_managed_install(
             "install",
             harness,
@@ -2296,6 +2302,41 @@ def _repair_pi_family_install(
     if not isinstance(repaired, dict):
         return None, f"Could not refresh {display_name} protection during update: managed install was not recorded"
     return repaired, None
+
+
+def _pi_family_extension_is_current(*, harness: str, context: HarnessContext) -> bool:
+    """Return whether the managed Pi/OMP extension already matches this package."""
+
+    adapter: PiHarnessAdapter | OmpHarnessAdapter
+    if harness == "pi":
+        adapter = PiHarnessAdapter()
+    elif harness == "omp":
+        adapter = OmpHarnessAdapter()
+    else:
+        return False
+    extension_path = adapter._managed_extension_path(context)
+    settings_path = adapter._managed_settings_path(context)
+    if not extension_path.is_file():
+        return False
+    expected_source = managed_extension_source(
+        guard_home=context.guard_home,
+        home_dir=context.home_dir,
+        settings_path=settings_path,
+        harness=adapter.harness,
+        display_name=adapter.display_name,
+    )
+    try:
+        current_source = extension_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    if current_source != expected_source:
+        return False
+    settings = json_payload(settings_path) if settings_path.is_file() else {}
+    raw_extensions = settings.get("extensions")
+    if not isinstance(raw_extensions, list):
+        return False
+    extension_value = str(extension_path)
+    return any(isinstance(item, str) and item == extension_value for item in raw_extensions)
 
 
 def _repair_cursor_install(

--- a/src/codex_plugin_scanner/guard/codex_hook_file_integrity.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_file_integrity.py
@@ -45,6 +45,12 @@ def _owner_is_only_group_member(owner_uid: int, group_gid: int) -> bool:
     package modules extracted by pip/pipx.  The group write bit is safe only
     when NSS can prove that no other account belongs to that group.  Lookup
     failures remain fail-closed.
+
+    User-private groups often have an empty ``gr_mem`` list (membership is only
+    via ``pw_gid``).  Some restricted NSS configurations also return an empty
+    ``getpwall()`` result.  In that case the classic ``group name == username``
+    user-private-group convention plus matching primary gid is accepted; any
+    evidence of a second member still rejects.
     """
 
     try:
@@ -53,11 +59,21 @@ def _owner_is_only_group_member(owner_uid: int, group_gid: int) -> bool:
 
         owner = pwd.getpwuid(owner_uid)
         group = grp.getgrgid(group_gid)
+        owner_in_group = owner.pw_gid == group_gid or owner.pw_name in set(group.gr_mem)
+        if not owner_in_group:
+            return False
+        accounts = pwd.getpwall()
         member_names = set(group.gr_mem)
-        member_names.update(entry.pw_name for entry in pwd.getpwall() if entry.pw_gid == group_gid)
+        member_names.update(entry.pw_name for entry in accounts if entry.pw_gid == group_gid)
+        other_members = member_names - {owner.pw_name}
+        if other_members:
+            return False
+        if accounts or member_names:
+            return True
+        # Empty NSS account listing: accept only classic user-private groups.
+        return group.gr_name == owner.pw_name and owner.pw_gid == group_gid and not group.gr_mem
     except (ImportError, KeyError, OSError):
         return False
-    return member_names == {owner.pw_name}
 
 
 def _python_package_roots() -> tuple[Path, ...]:
@@ -67,7 +83,9 @@ def _python_package_roots() -> tuple[Path, ...]:
     active interpreter.  The explicit prefix-derived candidates cover common
     POSIX venv and distro layouts, including Debian/Ubuntu ``dist-packages``,
     without trusting an arbitrary directory merely because it has a familiar
-    basename.
+    basename.  ``site`` and the installed ``codex_plugin_scanner`` location cover
+    pipx/venv layouts where the active purelib spelling differs from the path
+    that imported the package.
     """
 
     roots: set[Path] = set()
@@ -88,6 +106,32 @@ def _python_package_roots() -> tuple[Path, ...]:
         value = configured_paths.get(key)
         if isinstance(value, str) and value:
             add_root(value)
+
+    try:
+        import site
+
+        getsitepackages = getattr(site, "getsitepackages", None)
+        if callable(getsitepackages):
+            for value in getsitepackages():
+                if isinstance(value, str) and value:
+                    add_root(value)
+        getusersitepackages = getattr(site, "getusersitepackages", None)
+        if callable(getusersitepackages):
+            user_site = getusersitepackages()
+            if isinstance(user_site, str) and user_site:
+                add_root(user_site)
+    except (AttributeError, OSError, RuntimeError, TypeError, ValueError):
+        pass
+
+    try:
+        import codex_plugin_scanner
+
+        package_file = getattr(codex_plugin_scanner, "__file__", None)
+        if isinstance(package_file, str) and package_file:
+            # site-packages/codex_plugin_scanner/__init__.py -> site-packages
+            add_root(Path(package_file).expanduser().resolve(strict=False).parent.parent)
+    except (ImportError, OSError, RuntimeError, TypeError, ValueError):
+        pass
 
     version_dirs = {
         f"python{sys.version_info.major}",

--- a/src/codex_plugin_scanner/guard/codex_hook_file_integrity.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_file_integrity.py
@@ -74,12 +74,7 @@ def _owner_is_only_group_member(owner_uid: int, group_gid: int) -> bool:
         # Empty NSS listing cannot prove absence of other primary members. Accept
         # only the classic user-private-group convention (group name == username,
         # matching primary gid, empty gr_mem). Partial non-empty listings fail closed.
-        return (
-            not accounts
-            and not group.gr_mem
-            and group.gr_name == owner.pw_name
-            and owner.pw_gid == group_gid
-        )
+        return not accounts and not group.gr_mem and group.gr_name == owner.pw_name and owner.pw_gid == group_gid
     except (ImportError, KeyError, OSError):
         return False
 

--- a/src/codex_plugin_scanner/guard/codex_hook_file_integrity.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_file_integrity.py
@@ -68,10 +68,18 @@ def _owner_is_only_group_member(owner_uid: int, group_gid: int) -> bool:
         other_members = member_names - {owner.pw_name}
         if other_members:
             return False
-        if accounts or member_names:
+        # Proven private membership: the owner is listed and no one else is.
+        if owner.pw_name in member_names:
             return True
-        # Empty NSS account listing: accept only classic user-private groups.
-        return group.gr_name == owner.pw_name and owner.pw_gid == group_gid and not group.gr_mem
+        # Empty NSS listing cannot prove absence of other primary members. Accept
+        # only the classic user-private-group convention (group name == username,
+        # matching primary gid, empty gr_mem). Partial non-empty listings fail closed.
+        return (
+            not accounts
+            and not group.gr_mem
+            and group.gr_name == owner.pw_name
+            and owner.pw_gid == group_gid
+        )
     except (ImportError, KeyError, OSError):
         return False
 
@@ -112,9 +120,11 @@ def _python_package_roots() -> tuple[Path, ...]:
 
         getsitepackages = getattr(site, "getsitepackages", None)
         if callable(getsitepackages):
-            for value in getsitepackages():
-                if isinstance(value, str) and value:
-                    add_root(value)
+            site_packages = getsitepackages()
+            if isinstance(site_packages, (list, tuple)):
+                for value in site_packages:
+                    if isinstance(value, str) and value:
+                        add_root(value)
         getusersitepackages = getattr(site, "getusersitepackages", None)
         if callable(getusersitepackages):
             user_site = getusersitepackages()

--- a/tests/test_codex_hook_file_integrity_linux.py
+++ b/tests/test_codex_hook_file_integrity_linux.py
@@ -73,7 +73,7 @@ def test_private_group_detection_counts_primary_and_explicit_members(
     owner = SimpleNamespace(pw_name="alice", pw_gid=1000)
     other = SimpleNamespace(pw_name="bob", pw_gid=2000)
     monkeypatch.setattr(pwd, "getpwuid", lambda uid: owner)
-    monkeypatch.setattr(grp, "getgrgid", lambda gid: SimpleNamespace(gr_mem=[]))
+    monkeypatch.setattr(grp, "getgrgid", lambda gid: SimpleNamespace(gr_name="alice", gr_mem=[]))
     monkeypatch.setattr(pwd, "getpwall", lambda: [owner, other])
 
     assert integrity._owner_is_only_group_member(1000, 1000) is True
@@ -82,5 +82,33 @@ def test_private_group_detection_counts_primary_and_explicit_members(
     assert integrity._owner_is_only_group_member(1000, 1000) is False
 
     monkeypatch.setattr(pwd, "getpwall", lambda: [owner, other])
-    monkeypatch.setattr(grp, "getgrgid", lambda gid: SimpleNamespace(gr_mem=["bob"]))
+    monkeypatch.setattr(grp, "getgrgid", lambda gid: SimpleNamespace(gr_name="alice", gr_mem=["bob"]))
+    assert integrity._owner_is_only_group_member(1000, 1000) is False
+
+
+def test_private_group_detection_accepts_classic_upg_when_account_listing_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import grp
+    import pwd
+
+    owner = SimpleNamespace(pw_name="alice", pw_gid=1000)
+    monkeypatch.setattr(pwd, "getpwuid", lambda uid: owner)
+    monkeypatch.setattr(grp, "getgrgid", lambda gid: SimpleNamespace(gr_name="alice", gr_mem=[]))
+    monkeypatch.setattr(pwd, "getpwall", lambda: [])
+
+    assert integrity._owner_is_only_group_member(1000, 1000) is True
+
+
+def test_private_group_detection_rejects_empty_account_listing_for_shared_named_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import grp
+    import pwd
+
+    owner = SimpleNamespace(pw_name="alice", pw_gid=1000)
+    monkeypatch.setattr(pwd, "getpwuid", lambda uid: owner)
+    monkeypatch.setattr(grp, "getgrgid", lambda gid: SimpleNamespace(gr_name="users", gr_mem=[]))
+    monkeypatch.setattr(pwd, "getpwall", lambda: [])
+
     assert integrity._owner_is_only_group_member(1000, 1000) is False

--- a/tests/test_codex_hook_file_integrity_linux.py
+++ b/tests/test_codex_hook_file_integrity_linux.py
@@ -112,3 +112,19 @@ def test_private_group_detection_rejects_empty_account_listing_for_shared_named_
     monkeypatch.setattr(pwd, "getpwall", lambda: [])
 
     assert integrity._owner_is_only_group_member(1000, 1000) is False
+
+
+def test_private_group_detection_rejects_partial_account_listing_missing_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import grp
+    import pwd
+
+    owner = SimpleNamespace(pw_name="alice", pw_gid=1000)
+    unrelated = SimpleNamespace(pw_name="carol", pw_gid=2000)
+    monkeypatch.setattr(pwd, "getpwuid", lambda uid: owner)
+    monkeypatch.setattr(grp, "getgrgid", lambda gid: SimpleNamespace(gr_name="alice", gr_mem=[]))
+    # Incomplete NSS returned an unrelated account and omitted the file owner.
+    monkeypatch.setattr(pwd, "getpwall", lambda: [unrelated])
+
+    assert integrity._owner_is_only_group_member(1000, 1000) is False

--- a/tests/test_codex_hook_packaged_permissions_linux.py
+++ b/tests/test_codex_hook_packaged_permissions_linux.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import stat
+import sys
 from pathlib import Path
 
 import pytest
@@ -48,6 +49,34 @@ def test_packaged_bridge_accepts_private_group_write_in_site_packages(
 
     assert metadata.st_uid == os.getuid()
     assert stat.S_IMODE(metadata.st_mode) == 0o664
+
+
+def test_packaged_bridge_accepts_files_under_imported_package_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Imported package tree is trusted even when sysconfig purelib differs."""
+
+    root, bridge = _packaged_file(tmp_path)
+    package_init = root / "codex_plugin_scanner" / "__init__.py"
+    package_init.parent.mkdir(parents=True, exist_ok=True)
+    package_init.write_text("# package\n", encoding="utf-8")
+    fake_package = type(sys)("codex_plugin_scanner")
+    fake_package.__file__ = str(package_init)
+    monkeypatch.setitem(sys.modules, "codex_plugin_scanner", fake_package)
+    monkeypatch.setattr(integrity.sysconfig, "get_paths", lambda: {})
+    monkeypatch.setattr(integrity.sys, "prefix", str(tmp_path / "other-prefix"))
+    monkeypatch.setattr(integrity.sys, "exec_prefix", str(tmp_path / "other-prefix"))
+    import site as site_module
+
+    monkeypatch.setattr(site_module, "getsitepackages", lambda: [])
+    monkeypatch.setattr(site_module, "getusersitepackages", lambda: "")
+    monkeypatch.setattr(integrity, "_owner_is_only_group_member", lambda owner_uid, group_gid: True)
+
+    metadata = validate_regular_file(bridge, role="bridge", executable_required=False)
+
+    assert metadata.st_uid == os.getuid()
+    assert integrity._is_installed_python_package_file(bridge) is True
 
 
 def test_packaged_bridge_accepts_private_group_write_in_dist_packages(

--- a/tests/test_update_pi_family_repair.py
+++ b/tests/test_update_pi_family_repair.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.pi import OmpHarnessAdapter, PiHarnessAdapter
+from codex_plugin_scanner.guard.adapters.pi_extension_source import managed_extension_source
+from codex_plugin_scanner.guard.adapters.pi_support import enable_managed_extension
+from codex_plugin_scanner.guard.cli import update_commands
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    home = tmp_path / "home"
+    home.mkdir()
+    guard_home = home / ".hol-guard"
+    guard_home.mkdir()
+    return HarnessContext(home_dir=home, workspace_dir=None, guard_home=guard_home)
+
+
+def _seed_current_pi_family(
+    *,
+    harness: str,
+    context: HarnessContext,
+    store: GuardStore,
+    now: str,
+) -> None:
+    adapter = PiHarnessAdapter() if harness == "pi" else OmpHarnessAdapter()
+    extension_path = adapter._managed_extension_path(context)
+    settings_path = adapter._managed_settings_path(context)
+    extension_path.parent.mkdir(parents=True, exist_ok=True)
+    extension_path.write_text(
+        managed_extension_source(
+            guard_home=context.guard_home,
+            home_dir=context.home_dir,
+            settings_path=settings_path,
+            harness=adapter.harness,
+            display_name=adapter.display_name,
+        ),
+        encoding="utf-8",
+    )
+    enable_managed_extension(settings_path=settings_path, extension_path=extension_path)
+    store.set_managed_install(
+        harness,
+        True,
+        None,
+        {
+            "harness": harness,
+            "active": True,
+            "config_path": str(extension_path),
+        },
+        now,
+    )
+
+
+@pytest.mark.parametrize("harness,display_name", [("pi", "Pi"), ("omp", "Oh My Pi")])
+def test_pi_family_repair_skips_when_extension_already_current(
+    tmp_path: Path,
+    harness: str,
+    display_name: str,
+) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    now = "2026-08-08T00:00:00+00:00"
+    _seed_current_pi_family(harness=harness, context=context, store=store, now=now)
+
+    repaired, warning = update_commands._repair_pi_family_install(
+        harness=harness,
+        display_name=display_name,
+        context=context,
+        store=store,
+        workspace=None,
+        now=now,
+    )
+
+    assert repaired is None
+    assert warning is None
+
+
+@pytest.mark.parametrize("harness,display_name", [("pi", "Pi"), ("omp", "Oh My Pi")])
+def test_pi_family_repair_rewrites_stale_extension(
+    tmp_path: Path,
+    harness: str,
+    display_name: str,
+) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    now = "2026-08-08T00:00:00+00:00"
+    _seed_current_pi_family(harness=harness, context=context, store=store, now=now)
+    adapter = PiHarnessAdapter() if harness == "pi" else OmpHarnessAdapter()
+    extension_path = adapter._managed_extension_path(context)
+    extension_path.write_text("// stale extension\n", encoding="utf-8")
+
+    repaired, warning = update_commands._repair_pi_family_install(
+        harness=harness,
+        display_name=display_name,
+        context=context,
+        store=store,
+        workspace=None,
+        now=now,
+    )
+
+    assert warning is None
+    assert isinstance(repaired, dict)
+    assert repaired.get("harness") == harness
+    assert extension_path.read_text(encoding="utf-8") != "// stale extension\n"


### PR DESCRIPTION
## Summary
- Skip Pi and Oh My Pi managed-extension rewrites during `hol-guard update` when the on-disk extension source and settings already match the current package, so already-current updates no longer report unnecessary harness repair.
- Harden Codex hook file integrity for Linux pipx installs: accept classic user-private-group writes when NSS account listings are empty, and trust the imported `codex_plugin_scanner` package root when `sysconfig` purelib differs.

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_codex_hook_file_integrity_linux.py tests/test_codex_hook_packaged_permissions_linux.py tests/test_update_pi_family_repair.py -q`

## Notes
- Advances the reviewed test-suite ratchet for the added regression coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of hook file ownership and permissions on Linux, including private-group handling and installed package locations.
  - Enhanced Pi and Oh My Pi extension repair to recognize correctly configured installations and avoid unnecessary rewrites or warnings.
  - Continued repairing extensions when their source or settings are outdated.

- **Tests**
  - Expanded coverage for Linux security validation and Pi-family extension repair scenarios.
  - Updated test baselines to reflect the expanded suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->