### PR TITLE
fix(cline): enforce live secret mediation

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cline_plugin.py
+++ b/src/codex_plugin_scanner/guard/adapters/cline_plugin.py
@@ -88,6 +88,18 @@ const PROOFS = {{
 function proof(name, outcome) {{
   try {{
     const target = PROOFS[name];
+    const durableOutcome = name === "pretool" ? "blocked" : name === "posttool" ? "replaced" : undefined;
+    if (durableOutcome && outcome !== durableOutcome) {{
+      try {{
+        const current = JSON.parse(readFileSync(target, "utf8"));
+        if (
+          current &&
+          current.source === "cline-plugin" &&
+          current.proof === name &&
+          current.outcome === durableOutcome
+        ) return;
+      }} catch {{}}
+    }}
     mkdirSync(dirname(target), {{ recursive: true }});
     const temporary = `${{target}}.tmp`;
     writeFileSync(temporary, JSON.stringify({{
@@ -384,6 +396,9 @@ def install_cline_plugin(context: HarnessContext) -> dict[str, object]:
         raise RuntimeError("Guard refused a symlinked Cline plugin destination")
     if index_path.exists() and not _is_managed_plugin(index_path):
         raise RuntimeError(f"Cline plugin path is user-owned; Guard will not overwrite {index_path}")
+    for proof_name in ("loaded", "pretool", "posttool"):
+        with suppress(OSError):
+            _proof_path(context, proof_name).unlink()
     attested = resolve_attested_guard_cli(context)
     source = _plugin_source(context, [*attested.command, "guard", "hook"])
     root.mkdir(parents=True, exist_ok=True)

--- a/src/codex_plugin_scanner/guard/cli/commands_hook.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook.py
@@ -85,6 +85,10 @@ def _run_guard_hook_command(
         input_text=input_text,
         harness=args.harness,
     )
+    if _canonical_harness_name(args.harness) == "cline":
+        from ..adapters.cline_hook_payload import prepare_cline_hook_payload
+
+        payload = _normalize_hook_payload(prepare_cline_hook_payload(payload), harness=args.harness)
     if _canonical_harness_name(args.harness) == "cursor":
         from ..adapters.cursor_hooks import prepare_cursor_hook_payload
 

--- a/src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py
@@ -464,6 +464,7 @@ def _load_hook_payload(
 _ACTION_ENVELOPE_HARNESSES = frozenset(
     {
         "codex",
+        "cline",
         "claude-code",
         "opencode",
         "copilot",

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
@@ -560,7 +560,7 @@ def _hook_runtime_artifact(
 ) -> GuardArtifact | None:
     harness = _canonical_harness_name(harness)
     event_name = _hook_event_name(payload)
-    if harness in {"codex", "pi", "omp"} and event_name == "PostToolUse":
+    if harness in {"codex", "cline", "pi", "omp"} and event_name == "PostToolUse":
         output_artifact = _codex_post_tool_output_artifact(
             harness=harness,
             payload=payload,
@@ -850,7 +850,7 @@ def _codex_post_tool_output_artifact(
     home_dir: Path | None = None,
 ) -> GuardArtifact | None:
     canonical_harness = _canonical_harness_name(harness)
-    harness_label = {"pi": "Pi", "omp": "Oh My Pi"}.get(canonical_harness, "Codex")
+    harness_label = {"cline": "Cline", "pi": "Pi", "omp": "Oh My Pi"}.get(canonical_harness, "Codex")
     response_text = _collect_codex_tool_response_text(payload.get("tool_response"))
     stdout_text = _optional_string(payload.get("stdout"))
     if stdout_text:

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -248,6 +248,21 @@ def build_harness_verification(
         verification.update(_opencode_protection_checks(context, store))
     if adapter.harness == "grok":
         verification.update(_grok_protection_checks(context))
+    if isinstance(adapter, ClineHarnessAdapter):
+        runtime_probe = adapter.runtime_probe(context)
+        verification["runtime"] = runtime_probe or {}
+        verification["warnings"] = adapter.diagnostic_warnings(adapter.detect(context), runtime_probe)
+        active_transport = runtime_probe.get("active_transport") if isinstance(runtime_probe, dict) else None
+        requested_transport = surface if surface in {"hooks", "plugin"} else active_transport
+        state_key = "plugin" if requested_transport == "plugin" else "native_hooks"
+        runtime_state = runtime_probe.get(state_key) if isinstance(runtime_probe, dict) else None
+        verification["active_transport"] = active_transport
+        verification["requested_transport"] = requested_transport
+        verification["ready"] = bool(
+            requested_transport == active_transport
+            and isinstance(runtime_state, dict)
+            and runtime_state.get("ready") is True
+        )
     payload: dict[str, object] = {
         "harness": adapter.harness,
         "safe": True,

--- a/tests/test_cline_completion_gates.py
+++ b/tests/test_cline_completion_gates.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -12,10 +13,12 @@ import pytest
 
 from codex_plugin_scanner.cli import _build_parser
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.cline import ClineHarnessAdapter
 from codex_plugin_scanner.guard.adapters.cline_hooks import _hook_source
 from codex_plugin_scanner.guard.adapters.cline_plugin import _plugin_source, cline_plugin_state
 from codex_plugin_scanner.guard.adapters.contracts import contract_for
 from codex_plugin_scanner.guard.cli.commands_support_interaction import _apps_disconnect_confirm_command
+from codex_plugin_scanner.guard.cli.install_commands import build_harness_verification
 from codex_plugin_scanner.guard.product_model import (
     CANONICAL_HARNESS_VALUES,
     SUPPORTED_HARNESS_VALUES,
@@ -180,6 +183,19 @@ def test_plugin_proofs_distinguish_allow_block_and_replacement(tmp_path: Path) -
         _run_plugin(
             source,
             tmp_path,
+            (
+                'plugin.hooks.beforeTool({toolCall:{toolCallId:"2b",toolName:"run_commands"},'
+                'input:{commands:["echo safe again"]}})'
+            ),
+        )
+        is None
+    )
+    assert json.loads(pre_path.read_text(encoding="utf-8"))["outcome"] == "blocked"
+
+    assert (
+        _run_plugin(
+            source,
+            tmp_path,
             'plugin.hooks.afterTool({toolCall:{toolCallId:"3",toolName:"read_files"},input:{paths:["README.md"]},result:{output:"safe",isError:false}})',
         )
         is None
@@ -193,6 +209,19 @@ def test_plugin_proofs_distinguish_allow_block_and_replacement(tmp_path: Path) -
         'plugin.hooks.afterTool({toolCall:{toolCallId:"4",toolName:"read_files"},input:{paths:["README.md"]},result:{output:"SECRET_OUTPUT",isError:false}})',
     )
     assert isinstance(replaced, dict) and replaced["result"]["isError"] is True
+    assert json.loads(post_path.read_text(encoding="utf-8"))["outcome"] == "replaced"
+
+    assert (
+        _run_plugin(
+            source,
+            tmp_path,
+            (
+                'plugin.hooks.afterTool({toolCall:{toolCallId:"4b",toolName:"read_files"},'
+                'input:{paths:["README.md"]},result:{output:"safe again",isError:false}})'
+            ),
+        )
+        is None
+    )
     assert json.loads(post_path.read_text(encoding="utf-8"))["outcome"] == "replaced"
 
 
@@ -246,3 +275,153 @@ def test_plugin_ready_requires_block_and_replacement_proofs(tmp_path: Path) -> N
     assert state["pretool_blocking_proven"] is True
     assert state["posttool_replacement_proven"] is True
     assert state["ready"] is True
+
+
+def test_real_guard_policy_requires_review_for_cline_env_read(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    secret_path = context.workspace_dir / ".env"
+    secret_name = "OPENAI_" + "API_KEY"
+    secret_value = "HOL_GUARD_CLINE_" + "TEST_ONLY"
+    secret_path.write_text(f"{secret_name}={secret_value}\n", encoding="utf-8")
+    payload = {
+        "hookName": "PreToolUse",
+        "hook_event_name": "PreToolUse",
+        "tool_call": {
+            "id": "cline-live-regression",
+            "name": "read_files",
+            "input": {"path": str(secret_path)},
+        },
+        "preToolUse": {
+            "toolName": "read_files",
+            "parameters": {"path": str(secret_path)},
+        },
+    }
+    env = dict(os.environ)
+    env["HOME"] = str(context.home_dir)
+    env["HOL_GUARD_HOME"] = str(context.guard_home)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "codex_plugin_scanner.cli",
+            "guard",
+            "hook",
+            "--harness",
+            "cline",
+            "--json",
+        ],
+        cwd=context.workspace_dir,
+        env=env,
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    response = json.loads(result.stdout)
+    assert response["policy_action"] == "require-reapproval"
+    assert response["artifact_id"].startswith("cline:project:file-read:")
+    assert response["policy_composition"]["current_config_action"] == "require-reapproval"
+
+
+def test_real_guard_policy_withholds_cline_credential_output(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    source_path = context.workspace_dir / "public.txt"
+    credential = "AKIA" + ("A" * 16)
+    source_path.write_text(f"{credential}\n", encoding="utf-8")
+    command = f"cat {source_path}"
+    payload = {
+        "hookName": "PostToolUse",
+        "hook_event_name": "PostToolUse",
+        "tool_result": {
+            "id": "cline-live-posttool-regression",
+            "name": "run_commands",
+            "input": {"commands": [command]},
+            "output": credential,
+        },
+    }
+    env = dict(os.environ)
+    env["HOME"] = str(context.home_dir)
+    env["HOL_GUARD_HOME"] = str(context.guard_home)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "codex_plugin_scanner.cli",
+            "guard",
+            "hook",
+            "--harness",
+            "cline",
+            "--json",
+        ],
+        cwd=context.workspace_dir,
+        env=env,
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    response = json.loads(result.stdout)
+    assert response["policy_action"] == "require-reapproval"
+    assert ":tool-output:" in response["artifact_id"]
+    assert response["policy_composition"]["current_config_action"] == "require-reapproval"
+    serialized = json.dumps(response)
+    assert credential not in serialized
+
+
+def test_cline_safe_verification_reports_live_plugin_readiness(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    context = _context(tmp_path)
+    runtime = {
+        "hosts": ["cli"],
+        "cli_version": "3.0.51",
+        "vscode_versions": [],
+        "jetbrains_detected": False,
+        "active_transport": "plugin",
+        "native_hooks": {"installed": False, "ready": False},
+        "plugin": {
+            "installed": True,
+            "integrity_ok": True,
+            "pretool_blocking_proven": True,
+            "posttool_replacement_proven": True,
+            "ready": True,
+        },
+        "mcp": {"configured": False, "ready": True},
+        "duplicate_managed_transports": False,
+    }
+    monkeypatch.setattr(ClineHarnessAdapter, "runtime_probe", lambda self, _context: runtime)
+
+    payload = build_harness_verification("cline", context, surface="plugin")
+
+    verification = payload["verification"]
+    assert verification["runtime"] == runtime
+    assert verification["active_transport"] == "plugin"
+    assert verification["requested_transport"] == "plugin"
+    assert verification["ready"] is True
+
+
+def test_cline_safe_verification_does_not_trust_inactive_plugin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    context = _context(tmp_path)
+    runtime = {
+        "hosts": ["cli"],
+        "cli_version": "3.0.51",
+        "vscode_versions": [],
+        "jetbrains_detected": False,
+        "active_transport": "hooks",
+        "native_hooks": {"installed": True, "ready": True},
+        "plugin": {"installed": True, "integrity_ok": True, "ready": True},
+        "mcp": {"configured": False, "ready": True},
+        "duplicate_managed_transports": True,
+    }
+    monkeypatch.setattr(ClineHarnessAdapter, "runtime_probe", lambda self, _context: runtime)
+
+    payload = build_harness_verification("cline", context, surface="plugin")
+
+    verification = payload["verification"]
+    assert verification["active_transport"] == "hooks"
+    assert verification["requested_transport"] == "plugin"
+    assert verification["ready"] is False


### PR DESCRIPTION
## Summary
- route Cline hook payloads through Guard's shared typed action-envelope path
- prepare Cline payloads at CLI ingress so native tool results reach shared runtime policy scanners
- mediate credential-bearing Cline post-tool output before it becomes model-visible
- preserve strong live proof so later benign tool calls cannot downgrade a prior block/replacement
- invalidate Cline live proofs whenever the managed plugin is reinstalled
- make `hol-guard apps test cline --surface plugin --json` report the active transport, live runtime proof state, and readiness

## Problems found by live testing
A real current Cline 3.0.51 terminal session exposed gaps that the existing adapter contract did not catch:

1. Cline was missing from the shared action-envelope harness gate, so sensitive file reads could fall back to generic hook handling instead of the configured secret-read policy.
2. Cline `PostToolUse` payloads were not prepared at CLI ingress or included in the shared credential-output scanner.
3. A later benign tool call could overwrite a previously strong `blocked` or `replaced` proof.
4. Reinstalling the managed plugin could otherwise leave stale readiness evidence unless live proof files were invalidated.
5. The documented `apps test cline` verification path did not expose Cline's live plugin proof/readiness state.

## Validation
- real Cline 3.0.51 CLI, installed from `cline@latest`
- free local Ollama inference with `qwen3:1.7b`
- exact PR-head HOL Guard wheel built and installed before testing
- managed-plugin reinstall clears prior loaded/pre-tool/post-tool proof and reports `ready: false` until new live evidence exists
- safe real Cline file creation/read succeeds
- real `.env` read is synchronously review-gated and the actual dynamic secret canary never appears in Cline output
- real credential-bearing command output is review-gated/replaced and the actual dynamic credential canary never appears in Cline output
- final `hol-guard apps test cline --surface plugin --json` reports plugin `ready: true`, `pretool_blocking_proven: true`, and `posttool_replacement_proven: true`
- focused Cline regressions, Ruff, format, `git diff --check`, cross-platform Cline contract, Security Gates, CodeQL, PyPI/package validation, and the complete 16-shard CI suite all pass on exact head `02c1cb9851550f7f0765a2c98b27b71c10436b0b`
- no unresolved inline review threads; automated review checks report no actionable findings

Target: `release/3.0`. Do not merge to `main`.