### PR TITLE
fix(ci): stamp 3.1 alphas inside source environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,9 +165,10 @@ jobs:
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "Resolved $SOURCE_SHA -> $VERSION ($CHANNEL)"
       - name: Stamp exact package version
+        working-directory: source
         env:
           VERSION: ${{ steps.version.outputs.version }}
-        run: python3 release-tooling/scripts/sync_repo_version.py --repo-root source --version "$VERSION"
+        run: uv run --no-sync python ../release-tooling/scripts/sync_repo_version.py --repo-root . --version "$VERSION"
       - name: Build Guard distribution
         working-directory: source
         run: uv run --no-sync python -m build --wheel --sdist --outdir "$GITHUB_WORKSPACE/dist"

--- a/tests/test_cisco_install_surfaces.py
+++ b/tests/test_cisco_install_surfaces.py
@@ -156,11 +156,12 @@ def test_repo_controlled_surfaces_prefer_cisco_extra_where_supported() -> None:
     assert "uv sync --extra dev --extra cisco --group cisco-mcp" in contributing
 
 
-def test_publish_workflow_builds_only_guard_and_scanner_packages() -> None:
+def test_release_3_1_publish_workflow_builds_only_guard_distribution() -> None:
     publish_workflow = (ROOT / ".github/workflows/publish.yml").read_text(encoding="utf-8")
 
-    assert "Build Guard package (hol-guard)" in publish_workflow
-    assert "Build scanner package (plugin-scanner)" in publish_workflow
+    assert "Build Guard distribution" in publish_workflow
+    assert "Build scanner package" not in publish_workflow
+    assert "plugin_scanner-*" not in publish_workflow
     assert "Build codex compatibility alias" not in publish_workflow
     assert 'name = "codex-plugin-scanner"' not in publish_workflow
     assert 'codex-plugin-scanner = "codex_plugin_scanner.cli:main"' not in publish_workflow

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -111,7 +111,10 @@ def test_distribution_version_is_stamped_in_exact_source_tree() -> None:
     step = next(
         step for step in workflow()["jobs"]["build"]["steps"] if step.get("name") == "Stamp exact package version"
     )
-    assert "--repo-root source" in step["run"]
+    assert step["working-directory"] == "source"
+    assert step["run"] == (
+        'uv run --no-sync python ../release-tooling/scripts/sync_repo_version.py --repo-root . --version "$VERSION"'
+    )
 
 
 def test_publication_reuses_one_build_artifact() -> None:


### PR DESCRIPTION
## Summary

- run `sync_repo_version.py` from the already-synced `source` uv environment instead of the runner system Python
- preserve the exact source-tree stamping behavior while making `packaging` available deterministically
- strengthen the existing release-workflow contract to pin the source working directory and `uv run --no-sync` invocation

This fixes the `ModuleNotFoundError: No module named 'packaging'` failure in the `Build exact 3.1 source` job without weakening PEP 440 validation or changing the release script itself.