### PR TITLE
fix(ci): wake Desktop Core feed for all 3.x alphas

### DIFF
--- a/.github/workflows/wake-desktop-core-alpha-feed.yml
+++ b/.github/workflows/wake-desktop-core-alpha-feed.yml
@@ -34,11 +34,11 @@ jobs:
         github.event.issue.author_association == 'MEMBER' ||
         github.event.issue.author_association == 'COLLABORATOR') &&
        startsWith(github.event.issue.title, '[desktop-core-feed]')) ||
-      (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'alpha/v3.0.')) ||
+      (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'alpha/v3.')) ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
-       github.event.workflow_run.head_branch == 'release/3.0')
+       startsWith(github.event.workflow_run.head_branch, 'release/3.'))
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:

--- a/tests/test_desktop_core_alpha_feed_wake.py
+++ b/tests/test_desktop_core_alpha_feed_wake.py
@@ -39,9 +39,10 @@ def test_desktop_core_feed_wake_is_narrow_and_least_privilege() -> None:
         "github.event.issue.author_association == 'MEMBER' || "
         "github.event.issue.author_association == 'COLLABORATOR') && "
         "startsWith(github.event.issue.title, '[desktop-core-feed]')) || "
-        "(github.event_name == 'release' && startsWith(github.event.release.tag_name, 'alpha/v3.0.')) || "
+        "(github.event_name == 'release' && startsWith(github.event.release.tag_name, 'alpha/v3.')) || "
         "(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && "
-        "github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'release/3.0')"
+        "github.event.workflow_run.event == 'push' && "
+        "startsWith(github.event.workflow_run.head_branch, 'release/3.'))"
     )
     dispatch_steps = [step for step in wake["steps"] if step.get("name") == "Dispatch feed producer"]
     assert len(dispatch_steps) == 1


### PR DESCRIPTION
## Summary

- extend the existing least-privilege Desktop Core feed wake from 3.0-only to all `alpha/v3.*` releases and `release/3.*` publish completions
- update the existing exact-condition contract test, preserving the success/push guards and single dispatch-only step

This is the minimal current-main replacement for stale overlapping PR #2127 after the Apple-trust feed refactor landed separately.