### PR TITLE
fix(release): bind codesign certificate prefix

### DIFF
--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -347,7 +347,7 @@ jobs:
           codesign --verify --deep --strict --verbose=2 "$BINARY"
           codesign --display --verbose=4 "$BINARY" 2> "$RUNNER_TEMP/codesign.txt"
           if ! grep -Fx "Authority=$APPLE_SIGNING_IDENTITY" "$RUNNER_TEMP/codesign.txt"; then
-            codesign --display --extract-certificates "$RUNNER_TEMP/codesign-cert-" "$BINARY"
+            codesign --display --extract-certificates="$RUNNER_TEMP/codesign-cert-" "$BINARY"
             CERTIFICATE_SHA1=$(openssl x509 -inform DER \
               -in "$RUNNER_TEMP/codesign-cert-0" -noout -fingerprint -sha1 \
               | sed -E 's/^[^=]+=//; s/://g' | tr '[:lower:]' '[:upper:]')

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -77,7 +77,7 @@ def test_feed_uses_apple_trust_and_no_redundant_manifest_key() -> None:
     assert "minisign" not in helper.lower()
     assert "bunx @tauri-apps/cli" not in text
     assert 'grep -Fx "Authority=$APPLE_SIGNING_IDENTITY"' in text
-    assert "codesign --display --extract-certificates" in text
+    assert 'codesign --display --extract-certificates="$RUNNER_TEMP/codesign-cert-"' in text
     assert 'test "$CERTIFICATE_SHA1" = "$SELECTOR_SHA1"' in text
     assert 'grep -Fx "TeamIdentifier=$APPLE_TEAM_ID"' in text
     assert 'grep -F "source=Notarized Developer ID"' in text


### PR DESCRIPTION
## Summary
- bind the codesign certificate extraction prefix as an option value
- preserve exact certificate fingerprint verification for SHA-1 identity selectors
- ratchet the workflow security contract against positional parsing regressions

## Verification
- 8 focused security tests passed
- actionlint passed for the Desktop Core workflow
- Ruff check and format verification passed
- git diff --check passed