### PR TITLE
fix(release): bind signed Core to imported certificate

### DIFF
--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -308,6 +308,11 @@ jobs:
           security set-keychain-settings -lut 21600 "$KEYCHAIN"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security import "$RUNNER_TEMP/certificate.p12" -k "$KEYCHAIN" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          openssl pkcs12 -in "$RUNNER_TEMP/certificate.p12" -clcerts -nokeys \
+            -passin env:APPLE_CERTIFICATE_PASSWORD -out "$RUNNER_TEMP/signing-certificate.pem"
+          IMPORTED_CERTIFICATE_SHA1=$(openssl x509 -in "$RUNNER_TEMP/signing-certificate.pem" \
+            -noout -fingerprint -sha1 | sed -E 's/^[^=]+=//; s/://g' | tr '[:lower:]' '[:upper:]')
+          printf 'IMPORTED_CERTIFICATE_SHA1=%s\n' "$IMPORTED_CERTIFICATE_SHA1" >> "$GITHUB_ENV"
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security list-keychains -d user -s "$KEYCHAIN"
       - name: Sign and notarize new Core sidecar
@@ -346,14 +351,14 @@ jobs:
           chmod 0755 "$BINARY"
           codesign --verify --deep --strict --verbose=2 "$BINARY"
           codesign --display --verbose=4 "$BINARY" 2> "$RUNNER_TEMP/codesign.txt"
-          if ! grep -Fx "Authority=$APPLE_SIGNING_IDENTITY" "$RUNNER_TEMP/codesign.txt"; then
+          if [ -n "${IMPORTED_CERTIFICATE_SHA1:-}" ]; then
             codesign --display --extract-certificates="$RUNNER_TEMP/codesign-cert-" "$BINARY"
             CERTIFICATE_SHA1=$(openssl x509 -inform DER \
               -in "$RUNNER_TEMP/codesign-cert-0" -noout -fingerprint -sha1 \
               | sed -E 's/^[^=]+=//; s/://g' | tr '[:lower:]' '[:upper:]')
-            SELECTOR_SHA1=$(printf '%s' "$APPLE_SIGNING_IDENTITY" \
-              | tr -d '[:space:]:' | tr '[:lower:]' '[:upper:]')
-            test "$CERTIFICATE_SHA1" = "$SELECTOR_SHA1"
+            test "$CERTIFICATE_SHA1" = "$IMPORTED_CERTIFICATE_SHA1"
+          else
+            grep -Fx "Authority=$APPLE_SIGNING_IDENTITY" "$RUNNER_TEMP/codesign.txt"
           fi
           grep -Fx "TeamIdentifier=$APPLE_TEAM_ID" "$RUNNER_TEMP/codesign.txt"
           if ! spctl --assess --type execute --verbose=4 "$BINARY" 2> "$RUNNER_TEMP/spctl.txt"; then

--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -357,8 +357,14 @@ jobs:
               -in "$RUNNER_TEMP/codesign-cert-0" -noout -fingerprint -sha1 \
               | sed -E 's/^[^=]+=//; s/://g' | tr '[:lower:]' '[:upper:]')
             test "$CERTIFICATE_SHA1" = "$IMPORTED_CERTIFICATE_SHA1"
-          else
-            grep -Fx "Authority=$APPLE_SIGNING_IDENTITY" "$RUNNER_TEMP/codesign.txt"
+          elif ! grep -Fx "Authority=$APPLE_SIGNING_IDENTITY" "$RUNNER_TEMP/codesign.txt"; then
+            codesign --display --extract-certificates="$RUNNER_TEMP/codesign-cert-" "$BINARY"
+            CERTIFICATE_SHA1=$(openssl x509 -inform DER \
+              -in "$RUNNER_TEMP/codesign-cert-0" -noout -fingerprint -sha1 \
+              | sed -E 's/^[^=]+=//; s/://g' | tr '[:lower:]' '[:upper:]')
+            SELECTOR_SHA1=$(printf '%s' "$APPLE_SIGNING_IDENTITY" \
+              | tr -d '[:space:]:' | tr '[:lower:]' '[:upper:]')
+            test "$CERTIFICATE_SHA1" = "$SELECTOR_SHA1"
           fi
           grep -Fx "TeamIdentifier=$APPLE_TEAM_ID" "$RUNNER_TEMP/codesign.txt"
           if ! spctl --assess --type execute --verbose=4 "$BINARY" 2> "$RUNNER_TEMP/spctl.txt"; then

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -81,6 +81,7 @@ def test_feed_uses_apple_trust_and_no_redundant_manifest_key() -> None:
     assert 'codesign --display --extract-certificates="$RUNNER_TEMP/codesign-cert-"' in text
     assert 'test "$CERTIFICATE_SHA1" = "$IMPORTED_CERTIFICATE_SHA1"' in text
     assert 'grep -Fx "Authority=$APPLE_SIGNING_IDENTITY"' in text
+    assert 'test "$CERTIFICATE_SHA1" = "$SELECTOR_SHA1"' in text
     assert 'grep -Fx "TeamIdentifier=$APPLE_TEAM_ID"' in text
     assert 'grep -F "source=Notarized Developer ID"' in text
 

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -76,9 +76,11 @@ def test_feed_uses_apple_trust_and_no_redundant_manifest_key() -> None:
     assert "json.sig" not in text
     assert "minisign" not in helper.lower()
     assert "bunx @tauri-apps/cli" not in text
-    assert 'grep -Fx "Authority=$APPLE_SIGNING_IDENTITY"' in text
+    assert "IMPORTED_CERTIFICATE_SHA1=$(openssl x509" in text
+    assert "-passin env:APPLE_CERTIFICATE_PASSWORD" in text
     assert 'codesign --display --extract-certificates="$RUNNER_TEMP/codesign-cert-"' in text
-    assert 'test "$CERTIFICATE_SHA1" = "$SELECTOR_SHA1"' in text
+    assert 'test "$CERTIFICATE_SHA1" = "$IMPORTED_CERTIFICATE_SHA1"' in text
+    assert 'grep -Fx "Authority=$APPLE_SIGNING_IDENTITY"' in text
     assert 'grep -Fx "TeamIdentifier=$APPLE_TEAM_ID"' in text
     assert 'grep -F "source=Notarized Developer ID"' in text
 


### PR DESCRIPTION
## Summary
- derive the trusted leaf fingerprint from the imported Apple signing certificate
- verify newly signed Core binaries against that exact certificate
- retain authority verification for previously published immutable assets

## Verification
- 8 focused security tests passed
- actionlint passed for the Desktop Core workflow
- Ruff check and format verification passed
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification of Apple-signed desktop builds by checking the embedded certificate against the imported signing certificate when available.
  * Retained fallback validation using the signing identity when certificate fingerprint data is unavailable.

* **Tests**
  * Expanded security checks to validate certificate fingerprints and Apple signing authority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->