### PR TITLE
fix(release): verify CLI notarization result

### DIFF
--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -367,11 +367,9 @@ jobs:
             test "$CERTIFICATE_SHA1" = "$SELECTOR_SHA1"
           fi
           grep -Fx "TeamIdentifier=$APPLE_TEAM_ID" "$RUNNER_TEMP/codesign.txt"
-          if ! spctl --assess --type execute --verbose=4 "$BINARY" 2> "$RUNNER_TEMP/spctl.txt"; then
-            cat "$RUNNER_TEMP/spctl.txt" >&2
-            exit 1
+          if [ -f "$RUNNER_TEMP/notary-result.json" ]; then
+            jq -e '.status == "Accepted"' "$RUNNER_TEMP/notary-result.json" >/dev/null
           fi
-          grep -F "source=Notarized Developer ID" "$RUNNER_TEMP/spctl.txt"
           file "$BINARY" | grep -F "Mach-O 64-bit executable arm64"
           cp "$BINARY" "$VERIFY"
           chmod 0755 "$VERIFY"

--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -243,6 +243,7 @@ jobs:
             --base "$BASE" --marker "$BASE.attested.json" --version "$CORE_VERSION" --source-commit "$SOURCE_SHA" \
             --source-tag "$CORE_TAG" --target "$RELEASE_TARGET" --apple-signing-identity "$APPLE_SIGNING_IDENTITY" \
             --apple-team-id "$APPLE_TEAM_ID"
+          echo "PRIOR_FEED_PROVENANCE_VERIFIED=true" >> "$GITHUB_ENV"
       - name: Build standalone Core executable
         if: steps.release.outputs.available == 'true' && steps.existing.outputs.mode == 'build'
         env:
@@ -369,6 +370,8 @@ jobs:
           grep -Fx "TeamIdentifier=$APPLE_TEAM_ID" "$RUNNER_TEMP/codesign.txt"
           if [ -f "$RUNNER_TEMP/notary-result.json" ]; then
             jq -e '.status == "Accepted"' "$RUNNER_TEMP/notary-result.json" >/dev/null
+          else
+            test "${PRIOR_FEED_PROVENANCE_VERIFIED:-}" = "true"
           fi
           file "$BINARY" | grep -F "Mach-O 64-bit executable arm64"
           cp "$BINARY" "$VERIFY"

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -84,8 +84,10 @@ def test_feed_uses_apple_trust_and_no_redundant_manifest_key() -> None:
     assert 'test "$CERTIFICATE_SHA1" = "$SELECTOR_SHA1"' in text
     assert 'grep -Fx "TeamIdentifier=$APPLE_TEAM_ID"' in text
     assert "spctl --assess" not in text
+    assert 'echo "PRIOR_FEED_PROVENANCE_VERIFIED=true" >> "$GITHUB_ENV"' in text
     assert 'if [ -f "$RUNNER_TEMP/notary-result.json" ]' in text
     assert "jq -e '.status == \"Accepted\"'" in text
+    assert 'test "${PRIOR_FEED_PROVENANCE_VERIFIED:-}" = "true"' in text
 
 
 def test_macos_feed_avoids_bash4_only_builtins_and_binds_mode() -> None:

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -83,7 +83,9 @@ def test_feed_uses_apple_trust_and_no_redundant_manifest_key() -> None:
     assert 'grep -Fx "Authority=$APPLE_SIGNING_IDENTITY"' in text
     assert 'test "$CERTIFICATE_SHA1" = "$SELECTOR_SHA1"' in text
     assert 'grep -Fx "TeamIdentifier=$APPLE_TEAM_ID"' in text
-    assert 'grep -F "source=Notarized Developer ID"' in text
+    assert "spctl --assess" not in text
+    assert 'if [ -f "$RUNNER_TEMP/notary-result.json" ]' in text
+    assert "jq -e '.status == \"Accepted\"'" in text
 
 
 def test_macos_feed_avoids_bash4_only_builtins_and_binds_mode() -> None:


### PR DESCRIPTION
## Summary
- verify raw CLI notarization through the accepted notarytool result
- avoid applying Gatekeeper app-bundle assessment semantics to a standalone executable
- retain strict codesign identity, team, architecture, version, and provenance checks

## Verification
- 8 focused security tests passed
- actionlint passed for the Desktop Core workflow
- Ruff check and format verification passed
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS Core feed security verification by validating notarization outcomes more reliably.
  * Verification now confirms an accepted notarization status when results are available.
  * Added provenance-based validation when a direct notarization result is unavailable.
  * Removed reliance on legacy macOS assessment output, improving compatibility with current verification workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->