### PR TITLE
fix(release): resolve scanner package version independently

### DIFF
--- a/.github/workflows/publish-action-repo.yml
+++ b/.github/workflows/publish-action-repo.yml
@@ -66,7 +66,18 @@ jobs:
           if [ -n "$REQUESTED_VERSION" ]; then
             VERSION="$REQUESTED_VERSION"
           else
-            VERSION="$(gh release list --repo "$SOURCE_REPOSITORY" --limit 1 --json tagName --jq '.[0].tagName | ltrimstr("v")')"
+            VERSION="$(python3 - <<'PY'
+          import json
+          import urllib.request
+
+          with urllib.request.urlopen("https://pypi.org/pypi/plugin-scanner/json", timeout=30) as response:
+              payload = json.load(response)
+          version = payload.get("info", {}).get("version")
+          if not isinstance(version, str) or not version.strip():
+              raise SystemExit("PyPI did not return a current plugin-scanner version")
+          print(version.strip())
+          PY
+          )"
           fi
 
           if [ -z "$VERSION" ]; then

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -141,6 +141,7 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert "retrying in 30s" in workflow_text
     assert "Validate publication credentials" in workflow_text
     assert "Resolve published scanner version" in workflow_text
+    assert 'urlopen("https://pypi.org/pypi/plugin-scanner/json", timeout=30)' in workflow_text
     assert "Compute scanner wheel SHA256" in workflow_text
     assert 'workflows: ["Publish to PyPI"]' in workflow_text
     assert 'cp "${GITHUB_WORKSPACE}/action/action.yml" action.yml' in workflow_text

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -151,6 +151,17 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert "git push origin refs/tags/v1 --force" in workflow_text
 
 
+def test_publish_action_repo_scanner_version_heredoc_is_shell_aligned() -> None:
+    yaml = pytest.importorskip("yaml")
+    workflow_path = ROOT / ".github" / "workflows" / "publish-action-repo.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["publish-action-repo"]["steps"]
+    script = next(step["run"] for step in steps if step.get("name") == "Resolve published scanner version")
+
+    assert "\nimport json\nimport urllib.request\n" in script
+    assert '\nPY\n)"' in script
+
+
 def test_action_bundle_docs_reference_hol_guard_source() -> None:
     action_readme = (ROOT / "action" / "README.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- resolve automatic Action releases from plugin-scanner PyPI metadata
- keep explicit scanner-version dispatch overrides
- prevent HOL Guard release tags from being treated as scanner package versions

## Verification
- 6 focused Action bundle tests passed
- actionlint passed for the publication workflow
- Ruff check and format verification passed
- git diff --check passed