### PR TITLE
ci: add owner-only Desktop Core feed trigger

### DIFF
--- a/.github/workflows/desktop-core-alpha-feed-request.yml
+++ b/.github/workflows/desktop-core-alpha-feed-request.yml
@@ -1,0 +1,33 @@
+name: Request Desktop Core alpha feed
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch reviewed Desktop Core feed
+    if: >-
+      github.repository == 'hashgraph-online/hol-guard' &&
+      github.event.issue.title == '[desktop-core-feed] publish latest 3.x alpha' &&
+      (github.actor_id == 6068672 || github.actor_id == 301892678)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch existing reviewed feed on main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "hashgraph-online/hol-guard"
+          test "$GITHUB_ACTOR_ID" = "6068672" -o "$GITHUB_ACTOR_ID" = "301892678"
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/desktop-core-alpha-feed.yml/dispatches" \
+            -f ref=main


### PR DESCRIPTION
Adds a narrow GitHub-native trigger for the already-reviewed Desktop Core alpha feed so maintainers can run the production signing/notarization pipeline without broadening the feed workflow itself.

Security boundary:
- issue-open events only
- exact trigger title
- only the two existing approved maintainer actor IDs
- repository identity checked again in shell
- wrapper has only `actions: write` + `contents: read`
- dispatches the existing `desktop-core-alpha-feed.yml` on immutable `main`
- accepts no user-supplied version, SHA, command, or ref inputs

This is intended for release operations and end-to-end Desktop acceptance testing.