### PR TITLE
fix(desktop): make frozen Core protect Codex

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 14118,
-  "maximum_test_source_lines": 310181,
+  "maximum_test_source_lines": 310182,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 14118,
-  "maximum_test_source_lines": 310027,
+  "maximum_test_source_lines": 310181,
   "schema_version": 1
 }

--- a/scripts/mdm/hol-guard-entry.py
+++ b/scripts/mdm/hol-guard-entry.py
@@ -1,6 +1,14 @@
 """PyInstaller entrypoint for the machine-owned HOL Guard runtime."""
 
+from __future__ import annotations
+
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.frozen_codex_runtime import (
+    install_frozen_codex_runtime,
+    run_frozen_internal_command,
+)
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    install_frozen_codex_runtime()
+    internal_exit_code = run_frozen_internal_command()
+    raise SystemExit(main() if internal_exit_code is None else internal_exit_code)

--- a/src/codex_plugin_scanner/guard/frozen_codex_runtime.py
+++ b/src/codex_plugin_scanner/guard/frozen_codex_runtime.py
@@ -23,13 +23,6 @@ from pathlib import Path
 
 _FROZEN_BRIDGE_ARG = "--_hol-guard-codex-bridge"
 _FROZEN_DAEMON_RECOVER_ARG = "--_hol-guard-codex-daemon-recover"
-_ALLOWED_FAILURE_KINDS = frozenset(
-    {
-        "authenticated-control-plane-failure",
-        "overload",
-        "transport-failure",
-    }
-)
 
 
 def is_frozen_guard_runtime() -> bool:
@@ -135,7 +128,7 @@ def install_frozen_codex_runtime(*, force: bool = False) -> bool:
     codex._hook_command_parts_for_home_mode = frozen_hook_command
     codex._hook_packaged_file_paths = frozen_packaged_paths
     runtime_trust.validate_codex_hook_launch = _validate_frozen_codex_hook_launch
-    codex._HOL_GUARD_FROZEN_CODEX_RUNTIME = True
+    setattr(codex, "_HOL_GUARD_FROZEN_CODEX_RUNTIME", True)
     return True
 
 
@@ -179,8 +172,12 @@ def run_frozen_internal_command(argv: Sequence[str] | None = None) -> int | None
 
     from .daemon import recover_guard_daemon_after_hook_failure
 
-    failure_kind = os.environ.get("HOL_GUARD_HOOK_FAILURE_KIND", "transport-failure")
-    if failure_kind not in _ALLOWED_FAILURE_KINDS:
+    failure_kind_raw = os.environ.get("HOL_GUARD_HOOK_FAILURE_KIND", "transport-failure")
+    if failure_kind_raw == "authenticated-control-plane-failure":
+        failure_kind = "authenticated-control-plane-failure"
+    elif failure_kind_raw == "overload":
+        failure_kind = "overload"
+    else:
         failure_kind = "transport-failure"
     recover_guard_daemon_after_hook_failure(
         guard_home,

--- a/src/codex_plugin_scanner/guard/frozen_codex_runtime.py
+++ b/src/codex_plugin_scanner/guard/frozen_codex_runtime.py
@@ -1,0 +1,353 @@
+"""Frozen-runtime compatibility for authenticated Guard-managed Codex hooks.
+
+The Desktop Core sidecar is a PyInstaller one-file executable. In that shape,
+``sys.executable`` is the Guard executable itself rather than a Python
+interpreter, and Python module ``__file__`` paths live in PyInstaller's
+short-lived extraction directory. The normal Codex hook contract intentionally
+binds source-package files and invokes the Python interpreter with ``-I``.
+
+This module keeps that source-install contract unchanged and installs a strict
+frozen-only equivalent that binds every managed hook role to the signed Guard
+executable and routes private bridge/daemon operations back through that same
+executable. The authenticated manifest therefore still fails closed if the
+runtime bytes, command contract, Guard home, or hook configuration changes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+_FROZEN_BRIDGE_ARG = "--_hol-guard-codex-bridge"
+_FROZEN_DAEMON_RECOVER_ARG = "--_hol-guard-codex-daemon-recover"
+_ALLOWED_FAILURE_KINDS = frozenset(
+    {
+        "authenticated-control-plane-failure",
+        "overload",
+        "transport-failure",
+    }
+)
+
+
+def is_frozen_guard_runtime() -> bool:
+    """Return whether this process is a PyInstaller-style frozen Guard binary."""
+
+    return bool(getattr(sys, "frozen", False)) and Path(sys.executable).is_file()
+
+
+def _compact_json(payload: Mapping[str, object]) -> str:
+    return json.dumps(dict(payload), sort_keys=True, separators=(",", ":"))
+
+
+def _decode_private_payload(raw: str, *, label: str) -> dict[str, object]:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} payload must be valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} payload must be a JSON object")
+    return {str(key): value for key, value in payload.items() if isinstance(key, str)}
+
+
+def install_frozen_codex_runtime(*, force: bool = False) -> bool:
+    """Install the frozen Codex launch contract into the current process.
+
+    ``force`` exists only so focused tests can exercise the compatibility layer
+    without constructing a PyInstaller process. Production callers leave it
+    false and therefore cannot alter source/wheel installations.
+    """
+
+    if not force and not is_frozen_guard_runtime():
+        return False
+
+    from . import codex_hook_runtime_trust as runtime_trust
+    from .adapters import codex
+
+    if bool(getattr(codex, "_HOL_GUARD_FROZEN_CODEX_RUNTIME", False)):
+        return True
+
+    source_local_command = codex._local_hook_command_parts_for_home_mode
+    source_hook_command = codex._hook_command_parts_for_home_mode
+    source_packaged_paths = codex._hook_packaged_file_paths
+
+    def frozen_local_command(
+        context,
+        *,
+        home_is_current: bool,
+        python_executable: str,
+    ) -> tuple[str, ...]:
+        source_argv = source_local_command(
+            context,
+            home_is_current=home_is_current,
+            python_executable=python_executable,
+        )
+        if len(source_argv) < 5 or source_argv[1:3] != ("-I", "-c"):
+            raise RuntimeError("Guard's source Codex fallback contract is not canonical")
+        return (python_executable, *source_argv[4:])
+
+    def frozen_daemon_start_command(
+        guard_home: Path,
+        home_dir: Path,
+        *,
+        python_executable: str = sys.executable,
+    ) -> tuple[str, ...]:
+        payload = _compact_json(
+            {
+                "guard_home": str(guard_home.resolve(strict=False)),
+                "home_dir": str(home_dir.resolve(strict=False)),
+            }
+        )
+        return (python_executable, _FROZEN_DAEMON_RECOVER_ARG, payload)
+
+    def frozen_hook_command(
+        context,
+        *,
+        home_is_current: bool,
+        python_executable: str,
+    ) -> tuple[str, ...]:
+        # Reuse the established config builder after replacing only its child
+        # launch contracts. This keeps query, timeout, home, manifest, and
+        # workspace semantics identical to source installs.
+        source_argv = source_hook_command(
+            context,
+            home_is_current=home_is_current,
+            python_executable=python_executable,
+        )
+        if len(source_argv) != 4:
+            raise RuntimeError("Guard's source Codex bridge contract is not canonical")
+        config_json = source_argv[3]
+        payload = _decode_private_payload(config_json, label="Codex bridge")
+        if not payload:
+            raise RuntimeError("Guard's Codex bridge config is empty")
+        return (python_executable, _FROZEN_BRIDGE_ARG, config_json)
+
+    def frozen_packaged_paths() -> tuple[tuple[str, Path], ...]:
+        executable = Path(sys.executable).expanduser().resolve(strict=True)
+        # Preserve the existing role set but bind every role to the immutable
+        # frozen runtime bytes that actually implement those roles.
+        return tuple((role, executable) for role, _path in source_packaged_paths())
+
+    codex._local_hook_command_parts_for_home_mode = frozen_local_command
+    codex._daemon_start_command = frozen_daemon_start_command
+    codex._hook_command_parts_for_home_mode = frozen_hook_command
+    codex._hook_packaged_file_paths = frozen_packaged_paths
+    runtime_trust.validate_codex_hook_launch = _validate_frozen_codex_hook_launch
+    codex._HOL_GUARD_FROZEN_CODEX_RUNTIME = True
+    return True
+
+
+def run_frozen_internal_command(argv: Sequence[str] | None = None) -> int | None:
+    """Run one private frozen-runtime operation before the public CLI parser."""
+
+    process_argv = tuple(sys.argv if argv is None else argv)
+    if len(process_argv) != 3:
+        return None
+
+    operation, raw_payload = process_argv[1], process_argv[2]
+    if operation == _FROZEN_BRIDGE_ARG:
+        from .adapters.codex_daemon_hook_bridge import _bridge_config_from_argv
+        from .adapters.codex_daemon_hook_bridge import main as bridge_main
+
+        config = _bridge_config_from_argv(("codex_daemon_hook_bridge", raw_payload))
+        return bridge_main(
+            state_path=config["state_path"],
+            manifest_path=config["manifest_path"],
+            fallback_command=config["fallback_command"],
+            start_command=config["start_command"],
+            query=config["query"],
+            hook_timeouts=config["hook_timeouts"],
+            config_json=config["config_json"],
+        )
+
+    if operation != _FROZEN_DAEMON_RECOVER_ARG:
+        return None
+
+    payload = _decode_private_payload(raw_payload, label="Codex daemon recovery")
+    if set(payload) != {"guard_home", "home_dir"}:
+        raise ValueError("Codex daemon recovery payload has unexpected fields")
+    guard_home_value = payload.get("guard_home")
+    home_dir_value = payload.get("home_dir")
+    if not isinstance(guard_home_value, str) or not isinstance(home_dir_value, str):
+        raise ValueError("Codex daemon recovery paths must be strings")
+    guard_home = Path(guard_home_value)
+    home_dir = Path(home_dir_value)
+    if not guard_home.is_absolute() or not home_dir.is_absolute():
+        raise ValueError("Codex daemon recovery paths must be absolute")
+
+    from .daemon import recover_guard_daemon_after_hook_failure
+
+    failure_kind = os.environ.get("HOL_GUARD_HOOK_FAILURE_KIND", "transport-failure")
+    if failure_kind not in _ALLOWED_FAILURE_KINDS:
+        failure_kind = "transport-failure"
+    recover_guard_daemon_after_hook_failure(
+        guard_home,
+        home_dir=home_dir,
+        failure_kind=failure_kind,
+    )
+    return 0
+
+
+def _validate_frozen_codex_hook_launch(
+    *,
+    manifest_path: str | Path,
+    state_path: str | Path,
+    fallback_command: Sequence[str],
+    start_command: Sequence[str],
+    config_json: str,
+):
+    """Authenticate the frozen bridge and its child launch contracts."""
+
+    from . import codex_hook_runtime_trust as trust
+    from .codex_hook_file_integrity import verify_executable_file_identity
+    from .codex_hook_integrity import load_authenticated_hook_manifest_path
+    from .codex_hook_launch_runtime import isolated_hook_environment, private_hook_runtime_cwd
+
+    state = Path(state_path)
+    configured_manifest = Path(manifest_path)
+    if not state.is_absolute() or not configured_manifest.is_absolute():
+        raise ValueError("managed Codex hook paths must be absolute")
+    guard_home = state.parent.resolve(strict=False)
+    expected_managed_directory = (guard_home / "managed" / "codex").resolve(strict=False)
+    manifest_directory = configured_manifest.parent.resolve(strict=False)
+    if state.name != "daemon-state.json" or manifest_directory != expected_managed_directory:
+        raise ValueError("managed Codex hook paths do not belong to this Guard home")
+    if not configured_manifest.name.startswith("hooks-") or not configured_manifest.name.endswith(".manifest.json"):
+        raise ValueError("managed Codex hook manifest path is invalid")
+
+    manifest = load_authenticated_hook_manifest_path(guard_home, configured_manifest)
+    trust._verify_manifest_context(manifest, guard_home=guard_home, manifest_path=configured_manifest)
+    interpreter = trust._mapping(manifest.get("interpreter"), label="interpreter")
+    verify_executable_file_identity(interpreter)
+    packaged_by_role = trust._verified_packaged_files(manifest)
+
+    invocation_path = interpreter.get("invocation_path")
+    target = trust._mapping(interpreter.get("target"), label="interpreter target")
+    target_path = target.get("path")
+    current_invocation = str(Path(sys.executable).expanduser().absolute())
+    if invocation_path != current_invocation or not isinstance(target_path, str):
+        raise ValueError("managed frozen Codex hook executable identity is invalid")
+    if any(identity.get("path") != target_path for identity in packaged_by_role.values()):
+        raise ValueError("managed frozen Codex hook package identity is incomplete")
+
+    _verify_frozen_transport(manifest, packaged_by_role)
+    _verify_frozen_launch_contracts(
+        manifest,
+        interpreter=interpreter,
+        guard_home=guard_home,
+        fallback_command=fallback_command,
+        start_command=start_command,
+    )
+    _verify_frozen_bridge_contract(
+        manifest,
+        interpreter=interpreter,
+        state=state,
+        configured_manifest=configured_manifest,
+        fallback_command=fallback_command,
+        start_command=start_command,
+        config_json=config_json,
+    )
+    return trust.TrustedCodexHookLaunch(
+        cwd=private_hook_runtime_cwd(configured_manifest),
+        environment=isolated_hook_environment(),
+    )
+
+
+def _verify_frozen_transport(
+    manifest: Mapping[str, object],
+    packaged_by_role: Mapping[str, dict[str, object]],
+) -> None:
+    transport = manifest.get("transport")
+    if not isinstance(transport, dict) or transport.get("wrapper") is not None:
+        raise ValueError("managed frozen Codex hook transport identity is invalid")
+    for role in ("bridge", "bridge_runtime", "launch_runtime", "runtime_trust", "windows_job"):
+        if transport.get(role) != packaged_by_role.get(role):
+            raise ValueError("managed frozen Codex hook transport identity is invalid")
+
+
+def _verify_frozen_launch_contracts(
+    manifest: Mapping[str, object],
+    *,
+    interpreter: Mapping[str, object],
+    guard_home: Path,
+    fallback_command: Sequence[str],
+    start_command: Sequence[str],
+) -> None:
+    from . import codex_hook_runtime_trust as trust
+    from .codex_hook_file_integrity import canonical_path
+
+    invocation_path = interpreter.get("invocation_path")
+    if not isinstance(invocation_path, str):
+        raise ValueError("managed frozen Codex hook interpreter path is invalid")
+
+    fallback = trust._mapping(manifest.get("fallback"), label="fallback")
+    fallback_argv = tuple(trust._string_list(fallback.get("argv"), label="fallback argv"))
+    if (
+        fallback_argv != tuple(fallback_command)
+        or fallback.get("interpreter") != interpreter
+        or fallback.get("package_roles") != ["fallback_entrypoint"]
+        or fallback_argv[:5] != (invocation_path, "guard", "hook", "--harness", "codex")
+    ):
+        raise ValueError("managed frozen Codex hook fallback contract is invalid")
+
+    daemon_start = trust._mapping(manifest.get("daemon_start"), label="daemon start")
+    daemon_argv = tuple(trust._string_list(daemon_start.get("argv"), label="daemon start argv"))
+    context = trust._mapping(manifest.get("context"), label="context")
+    authenticated_guard_home = context.get("runtime_guard_home")
+    authenticated_home_dir = context.get("home_dir")
+    if (
+        daemon_argv != tuple(start_command)
+        or daemon_start.get("interpreter") != interpreter
+        or daemon_start.get("package_roles") != ["daemon_entrypoint", "daemon_manager"]
+        or len(daemon_argv) != 3
+        or daemon_argv[:2] != (invocation_path, _FROZEN_DAEMON_RECOVER_ARG)
+        or not isinstance(authenticated_guard_home, str)
+        or not isinstance(authenticated_home_dir, str)
+        or canonical_path(guard_home) != authenticated_guard_home
+    ):
+        raise ValueError("managed frozen Codex hook daemon-start contract is invalid")
+    daemon_payload = _decode_private_payload(daemon_argv[2], label="Codex daemon recovery")
+    if daemon_payload != {
+        "guard_home": authenticated_guard_home,
+        "home_dir": authenticated_home_dir,
+    }:
+        raise ValueError("managed frozen Codex hook daemon-start context is invalid")
+
+
+def _verify_frozen_bridge_contract(
+    manifest: Mapping[str, object],
+    *,
+    interpreter: Mapping[str, object],
+    state: Path,
+    configured_manifest: Path,
+    fallback_command: Sequence[str],
+    start_command: Sequence[str],
+    config_json: str,
+) -> None:
+    invocation_path = interpreter.get("invocation_path")
+    if not isinstance(invocation_path, str):
+        raise ValueError("managed frozen Codex hook interpreter path is invalid")
+    config = _decode_private_payload(config_json, label="Codex bridge")
+    if (
+        config.get("state_path") != str(state)
+        or config.get("manifest_path") != str(configured_manifest)
+        or config.get("fallback_command") != list(fallback_command)
+        or config.get("start_command") != list(start_command)
+    ):
+        raise ValueError("managed frozen Codex hook bridge config is invalid")
+    expected_argv = [invocation_path, _FROZEN_BRIDGE_ARG, config_json]
+    events = manifest.get("events")
+    if not isinstance(events, list) or not events:
+        raise ValueError("managed frozen Codex hook event identity is invalid")
+    for event in events:
+        if not isinstance(event, dict) or event.get("argv") != expected_argv:
+            raise ValueError("managed frozen Codex hook bridge config changed after authentication")
+
+
+__all__ = [
+    "install_frozen_codex_runtime",
+    "is_frozen_guard_runtime",
+    "run_frozen_internal_command",
+]

--- a/src/codex_plugin_scanner/guard/frozen_codex_runtime.py
+++ b/src/codex_plugin_scanner/guard/frozen_codex_runtime.py
@@ -77,9 +77,9 @@ def install_frozen_codex_runtime(*, force: bool = False) -> bool:
             home_is_current=home_is_current,
             python_executable=python_executable,
         )
-        if len(source_argv) < 5 or source_argv[1:3] != ("-I", "-c"):
+        if len(source_argv) < 6 or source_argv[1:3] != ("-I", "-c") or source_argv[4] != "guard":
             raise RuntimeError("Guard's source Codex fallback contract is not canonical")
-        return (python_executable, *source_argv[4:])
+        return (python_executable, *source_argv[5:])
 
     def frozen_daemon_start_command(
         guard_home: Path,
@@ -285,7 +285,7 @@ def _verify_frozen_launch_contracts(
         fallback_argv != tuple(fallback_command)
         or fallback.get("interpreter") != interpreter
         or fallback.get("package_roles") != ["fallback_entrypoint"]
-        or fallback_argv[:5] != (invocation_path, "guard", "hook", "--harness", "codex")
+        or fallback_argv[:4] != (invocation_path, "hook", "--harness", "codex")
     ):
         raise ValueError("managed frozen Codex hook fallback contract is invalid")
 

--- a/src/codex_plugin_scanner/guard/frozen_codex_runtime.py
+++ b/src/codex_plugin_scanner/guard/frozen_codex_runtime.py
@@ -128,7 +128,7 @@ def install_frozen_codex_runtime(*, force: bool = False) -> bool:
     codex._hook_command_parts_for_home_mode = frozen_hook_command
     codex._hook_packaged_file_paths = frozen_packaged_paths
     runtime_trust.validate_codex_hook_launch = _validate_frozen_codex_hook_launch
-    setattr(codex, "_HOL_GUARD_FROZEN_CODEX_RUNTIME", True)
+    codex.__dict__["_HOL_GUARD_FROZEN_CODEX_RUNTIME"] = True
     return True
 
 

--- a/tests/test_frozen_codex_runtime.py
+++ b/tests/test_frozen_codex_runtime.py
@@ -76,7 +76,8 @@ def test_frozen_codex_contract_binds_commands_and_roles_to_one_executable(
     executable_target = Path(sys.executable).expanduser().resolve(strict=True)
 
     assert bridge_argv[:2] == (invocation, "--_hol-guard-codex-bridge")
-    assert fallback_argv[:5] == [invocation, "guard", "hook", "--harness", "codex"]
+    assert fallback_argv[:4] == [invocation, "hook", "--harness", "codex"]
+    assert "guard" not in fallback_argv[:2]
     assert daemon_argv[:2] == [invocation, "--_hol-guard-codex-daemon-recover"]
     assert {path for _role, path in package_paths} == {executable_target}
     assert {role for role, _path in package_paths} == {

--- a/tests/test_frozen_codex_runtime.py
+++ b/tests/test_frozen_codex_runtime.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import shlex
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard import codex_hook_runtime_trust
+from codex_plugin_scanner.guard import frozen_codex_runtime
+from codex_plugin_scanner.guard.adapters import codex as codex_adapter
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
+
+
+@pytest.fixture
+def frozen_codex_contract() -> Iterator[None]:
+    original_local = codex_adapter._local_hook_command_parts_for_home_mode
+    original_daemon = codex_adapter._daemon_start_command
+    original_hook = codex_adapter._hook_command_parts_for_home_mode
+    original_paths = codex_adapter._hook_packaged_file_paths
+    original_validator = codex_hook_runtime_trust.validate_codex_hook_launch
+    had_marker = hasattr(codex_adapter, "_HOL_GUARD_FROZEN_CODEX_RUNTIME")
+    marker_value = getattr(codex_adapter, "_HOL_GUARD_FROZEN_CODEX_RUNTIME", None)
+    try:
+        assert frozen_codex_runtime.install_frozen_codex_runtime(force=True) is True
+        yield
+    finally:
+        codex_adapter._local_hook_command_parts_for_home_mode = original_local
+        codex_adapter._daemon_start_command = original_daemon
+        codex_adapter._hook_command_parts_for_home_mode = original_hook
+        codex_adapter._hook_packaged_file_paths = original_paths
+        codex_hook_runtime_trust.validate_codex_hook_launch = original_validator
+        if had_marker:
+            codex_adapter._HOL_GUARD_FROZEN_CODEX_RUNTIME = marker_value
+        elif hasattr(codex_adapter, "_HOL_GUARD_FROZEN_CODEX_RUNTIME"):
+            delattr(codex_adapter, "_HOL_GUARD_FROZEN_CODEX_RUNTIME")
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    home_dir = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    home_dir.mkdir()
+    workspace.mkdir()
+    guard_home.mkdir(mode=0o700)
+    return HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace,
+        guard_home=guard_home,
+        home_override_explicit=True,
+        workspace_override_explicit=True,
+    )
+
+
+def test_source_runtime_does_not_install_frozen_contract() -> None:
+    if frozen_codex_runtime.is_frozen_guard_runtime():
+        pytest.skip("source-runtime assertion is not meaningful from a frozen test executable")
+    assert frozen_codex_runtime.install_frozen_codex_runtime() is False
+
+
+def test_frozen_codex_contract_binds_commands_and_roles_to_one_executable(
+    tmp_path: Path,
+    frozen_codex_contract: None,
+) -> None:
+    context = _context(tmp_path)
+
+    bridge_argv = codex_adapter._hook_command_parts(context)
+    bridge_config = json.loads(bridge_argv[2])
+    fallback_argv = bridge_config["fallback_command"]
+    daemon_argv = bridge_config["start_command"]
+    package_paths = codex_adapter._hook_packaged_file_paths()
+    invocation = str(Path(sys.executable).expanduser().absolute())
+    executable_target = Path(sys.executable).expanduser().resolve(strict=True)
+
+    assert bridge_argv[:2] == (invocation, "--_hol-guard-codex-bridge")
+    assert fallback_argv[:5] == [invocation, "guard", "hook", "--harness", "codex"]
+    assert daemon_argv[:2] == [invocation, "--_hol-guard-codex-daemon-recover"]
+    assert {path for _role, path in package_paths} == {executable_target}
+    assert {role for role, _path in package_paths} == {
+        "bridge",
+        "bridge_runtime",
+        "daemon_entrypoint",
+        "daemon_manager",
+        "fallback_entrypoint",
+        "launch_runtime",
+        "runtime_trust",
+        "windows_job",
+    }
+
+
+def test_frozen_codex_install_and_runtime_trust_validate_without_source_files(
+    tmp_path: Path,
+    frozen_codex_contract: None,
+) -> None:
+    context = _context(tmp_path)
+    codex_config = context.home_dir / ".codex" / "config.toml"
+    codex_config.parent.mkdir(parents=True)
+    codex_config.write_text("[features]\ncodex_hooks = true\n", encoding="utf-8")
+
+    CodexHarnessAdapter().install(context)
+    state = codex_adapter.codex_native_hook_state(context)
+
+    assert state["managed_hook_installed"] is True
+    assert state["protection_active"] is True
+    assert state["integrity_status"] == "valid"
+
+    config_payload = codex_adapter._read_toml(codex_config)
+    hooks = config_payload["hooks"]
+    pre_tool_group = hooks["PreToolUse"][-1]
+    handler = pre_tool_group["hooks"][0]
+    bridge_argv = shlex.split(handler["command"])
+    bridge_config_json = bridge_argv[2]
+    bridge_config = json.loads(bridge_config_json)
+
+    trusted = codex_hook_runtime_trust.validate_codex_hook_launch(
+        manifest_path=bridge_config["manifest_path"],
+        state_path=bridge_config["state_path"],
+        fallback_command=bridge_config["fallback_command"],
+        start_command=bridge_config["start_command"],
+        config_json=bridge_config_json,
+    )
+
+    assert trusted.cwd == Path(bridge_config["manifest_path"]).parent.resolve(strict=True)
+
+
+def test_frozen_runtime_trust_rejects_bridge_command_tampering(
+    tmp_path: Path,
+    frozen_codex_contract: None,
+) -> None:
+    context = _context(tmp_path)
+    codex_config = context.home_dir / ".codex" / "config.toml"
+    codex_config.parent.mkdir(parents=True)
+    codex_config.write_text("[features]\ncodex_hooks = true\n", encoding="utf-8")
+    CodexHarnessAdapter().install(context)
+
+    config_payload = codex_adapter._read_toml(codex_config)
+    handler = config_payload["hooks"]["PreToolUse"][-1]["hooks"][0]
+    bridge_argv = shlex.split(handler["command"])
+    bridge_config_json = bridge_argv[2]
+    bridge_config = json.loads(bridge_config_json)
+    tampered_fallback = list(bridge_config["fallback_command"])
+    tampered_fallback.append("--policy-action=allow")
+
+    with pytest.raises(ValueError, match="fallback contract|bridge config"):
+        codex_hook_runtime_trust.validate_codex_hook_launch(
+            manifest_path=bridge_config["manifest_path"],
+            state_path=bridge_config["state_path"],
+            fallback_command=tampered_fallback,
+            start_command=bridge_config["start_command"],
+            config_json=bridge_config_json,
+        )


### PR DESCRIPTION
Fixes the production standalone-Core Codex installation failure found by packaged Desktop E2E.

The PyInstaller one-file runtime is not a Python interpreter and its extracted module paths are ephemeral. This change keeps source/wheel installs unchanged while giving the frozen Desktop Core a separate authenticated launch contract:

- binds all managed Codex hook package roles to the standalone Core executable bytes
- routes the private hook bridge and daemon recovery back through strict hidden modes in that executable
- keeps the normal Codex fallback as a direct frozen-Core `hook --harness codex ...` CLI invocation
- validates the signed manifest, executable identity, Guard-home binding, exact fallback/start commands, and exact bridge config before child execution
- rejects command/config tampering
- adds focused regression coverage

Desktop PR #22 is pinned to this exact Core commit and its real production-shape Apple-silicon acceptance test passes: one-file PyInstaller Core, checksum-pinned OpenAI Codex CLI 0.147.0, real Guard protection install, execution of the exact managed Codex hook written to config, production Tauri `.app` build/launch, visible window, refresh/relaunch, and incompatible-Core fail-closed behavior.