### PR TITLE
fix(release): correct macOS signing certificate extraction

### DIFF
--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -6,6 +6,11 @@ on:
       - .github/workflows/desktop-core-alpha-feed.yml
       - tests/test_desktop_core_alpha_feed_security.py
       - scripts/release/desktop_core_alpha_feed.py
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/desktop-core-alpha-feed.yml
+      - scripts/release/desktop_core_alpha_feed.py
   schedule:
     - cron: "17 * * * *"
   workflow_dispatch:

--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -355,16 +355,23 @@ jobs:
           set -euo pipefail
           BINARY="$RUNNER_TEMP/dist/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
           VERIFY="$RUNNER_TEMP/dist/hol-guard"
-          CERT_PREFIX="$RUNNER_TEMP/codesign-cert"
+          CERT_DIR="$RUNNER_TEMP/codesign-certs"
           chmod 0755 "$BINARY"
           codesign --verify --deep --strict --verbose=2 "$BINARY"
           codesign --display --verbose=4 "$BINARY" 2> "$RUNNER_TEMP/codesign.txt"
           grep -Fx "TeamIdentifier=$APPLE_TEAM_ID" "$RUNNER_TEMP/codesign.txt"
-          rm -f "${CERT_PREFIX}"*
-          codesign --display --extract-certificates "$CERT_PREFIX" "$BINARY" >/dev/null 2>&1
-          test -s "${CERT_PREFIX}0"
+          rm -rf "$CERT_DIR"
+          mkdir -p "$CERT_DIR"
+          if ! (
+            cd "$CERT_DIR"
+            codesign --display --extract-certificates "$BINARY" >/dev/null 2> "$RUNNER_TEMP/codesign-certificates.txt"
+          ); then
+            cat "$RUNNER_TEMP/codesign-certificates.txt" >&2
+            exit 1
+          fi
+          test -s "$CERT_DIR/codesign0"
           EXPECTED_FINGERPRINT=$(tr -d '\r\n' < "$RUNNER_TEMP/apple-signing-fingerprint.txt" | tr '[:lower:]' '[:upper:]')
-          ACTUAL_FINGERPRINT=$(openssl x509 -inform DER -in "${CERT_PREFIX}0" -noout -fingerprint -sha1 \
+          ACTUAL_FINGERPRINT=$(openssl x509 -inform DER -in "$CERT_DIR/codesign0" -noout -fingerprint -sha1 \
             | sed -E 's/^[^=]+=//; s/://g' | tr '[:lower:]' '[:upper:]')
           test -n "$EXPECTED_FINGERPRINT"
           test "$ACTUAL_FINGERPRINT" = "$EXPECTED_FINGERPRINT"

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -73,6 +73,12 @@ def test_feed_uses_apple_trust_and_no_redundant_manifest_key() -> None:
     helper = TOOL.read_text(encoding="utf-8")
     job = publish_job()
     steps = {step.get("name"): step for step in job["steps"]}
+    extraction_line = 'codesign --display --extract-certificates "$BINARY" >/dev/null 2> "$RUNNER_TEMP/codesign-certificates.txt"'
+    extraction_lines = [
+        line.strip()
+        for line in text.splitlines()
+        if "codesign --display --extract-certificates" in line
+    ]
     assert "HOL_GUARD_CORE_UPDATE_PRIVATE_KEY" not in text
     assert "HOL_GUARD_CORE_UPDATE_PUBLIC_KEY" not in text
     assert "json.sig" not in text
@@ -82,7 +88,8 @@ def test_feed_uses_apple_trust_and_no_redundant_manifest_key() -> None:
     assert "security find-identity -v -p codesigning" in text
     assert "apple-signing-fingerprint.txt" in text
     assert 'CERT_DIR="$RUNNER_TEMP/codesign-certs"' in text
-    assert 'codesign --display --extract-certificates "$BINARY"' in text
+    assert 'cd "$CERT_DIR"' in text
+    assert extraction_lines == [extraction_line]
     assert '--extract-certificates "$CERT_DIR"' not in text
     assert '--extract-certificates "$CERT_PREFIX"' not in text
     assert 'test -s "$CERT_DIR/codesign0"' in text

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -35,7 +35,13 @@ def publish_job() -> dict[str, object]:
 def test_feed_is_release_3_0_only_and_wakes_after_publisher() -> None:
     text = workflow_text()
     namespace = runpy.run_path(str(TOOL))
+    trusted_push = """push:
+    branches: [main]
+    paths:
+      - .github/workflows/desktop-core-alpha-feed.yml
+      - scripts/release/desktop_core_alpha_feed.py"""
     assert namespace["SUPPORTED_TRAINS"] == {"3.0"}
+    assert trusted_push in text
     assert "branches: [release/3.0]" in text
     assert 'workflows: ["Publish to PyPI"]' in text
     assert "workflow_run.conclusion == 'success'" in text

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -81,7 +81,12 @@ def test_feed_uses_apple_trust_and_no_redundant_manifest_key() -> None:
     assert steps["Import Apple signing identity"]["if"] == "steps.release.outputs.available == 'true'"
     assert "security find-identity -v -p codesigning" in text
     assert "apple-signing-fingerprint.txt" in text
-    assert "codesign --display --extract-certificates" in text
+    assert 'CERT_DIR="$RUNNER_TEMP/codesign-certs"' in text
+    assert 'codesign --display --extract-certificates "$BINARY"' in text
+    assert '--extract-certificates "$CERT_DIR"' not in text
+    assert '--extract-certificates "$CERT_PREFIX"' not in text
+    assert 'test -s "$CERT_DIR/codesign0"' in text
+    assert 'cat "$RUNNER_TEMP/codesign-certificates.txt" >&2' in text
     assert "openssl x509 -inform DER" in text
     assert 'test "$ACTUAL_FINGERPRINT" = "$EXPECTED_FINGERPRINT"' in text
     assert 'grep -Fx "Authority=$APPLE_SIGNING_IDENTITY"' not in text


### PR DESCRIPTION
Fix the Desktop Core alpha-feed verification failure after successful Apple signing and notarization.

The workflow now runs `codesign --display --extract-certificates` using Apple's documented form from an isolated temporary directory, verifies the generated `codesign0` leaf certificate against the imported signing identity fingerprint, and preserves TeamIdentifier, Gatekeeper/notarization, Core contract, provenance, and attestation checks.

It also adds a narrowly scoped trusted `push` trigger for `main` when the feed workflow or its release helper changes. This makes release-automation changes immediately exercise the real production feed after merge instead of depending on the hourly schedule, while the privileged job remains main-bound and still independently authorizes the exact Core alpha provenance.

Regression contracts pin the complete certificate-extraction command, its isolated output directory, diagnostics, and the trusted main-push trigger.