### PR TITLE
fix(release): validate CLI notarization without app assessment

### DIFF
--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -355,6 +355,7 @@ jobs:
         env:
           CORE_VERSION: ${{ steps.release.outputs.version }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          MODE: ${{ steps.existing.outputs.mode }}
         shell: bash
         run: |
           set -euo pipefail
@@ -380,11 +381,11 @@ jobs:
             | sed -E 's/^[^=]+=//; s/://g' | tr '[:lower:]' '[:upper:]')
           test -n "$EXPECTED_FINGERPRINT"
           test "$ACTUAL_FINGERPRINT" = "$EXPECTED_FINGERPRINT"
-          if ! spctl --assess --type execute --verbose=4 "$BINARY" 2> "$RUNNER_TEMP/spctl.txt"; then
-            cat "$RUNNER_TEMP/spctl.txt" >&2
-            exit 1
+          if [[ "$MODE" == "build" ]]; then
+            test -s "$RUNNER_TEMP/notary-result.json"
+            jq -e '.status == "Accepted" and (.id | type == "string" and length > 0)' \
+              "$RUNNER_TEMP/notary-result.json" >/dev/null
           fi
-          grep -F "source=Notarized Developer ID" "$RUNNER_TEMP/spctl.txt"
           file "$BINARY" | grep -F "Mach-O 64-bit executable arm64"
           cp "$BINARY" "$VERIFY"
           chmod 0755 "$VERIFY"

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -85,6 +85,9 @@ def test_feed_uses_apple_trust_and_no_redundant_manifest_key() -> None:
         for line in text.splitlines()
         if "codesign --display --extract-certificates" in line
     ]
+    verify = steps["Verify exact Apple identity, notarization, and Core contract"]
+    verify_run = verify["run"]
+    assert isinstance(verify_run, str)
     assert "HOL_GUARD_CORE_UPDATE_PRIVATE_KEY" not in text
     assert "HOL_GUARD_CORE_UPDATE_PUBLIC_KEY" not in text
     assert "json.sig" not in text
@@ -104,7 +107,10 @@ def test_feed_uses_apple_trust_and_no_redundant_manifest_key() -> None:
     assert 'test "$ACTUAL_FINGERPRINT" = "$EXPECTED_FINGERPRINT"' in text
     assert 'grep -Fx "Authority=$APPLE_SIGNING_IDENTITY"' not in text
     assert 'grep -Fx "TeamIdentifier=$APPLE_TEAM_ID"' in text
-    assert 'grep -F "source=Notarized Developer ID"' in text
+    assert verify["env"]["MODE"] == "${{ steps.existing.outputs.mode }}"
+    assert "spctl --assess" not in verify_run
+    assert 'test -s "$RUNNER_TEMP/notary-result.json"' in verify_run
+    assert ".status == \"Accepted\" and (.id | type == \"string\" and length > 0)" in verify_run
 
 
 def test_macos_feed_avoids_bash4_only_builtins_and_binds_mode() -> None:


### PR DESCRIPTION
Fix the remaining Desktop Core alpha-feed failure after Apple accepts notarization.

The sidecar is a standalone command-line executable, not a macOS app bundle. `spctl --assess --type execute` rejects that shape with `the code is valid but does not seem to be an app` even after the notary service returns Accepted.

This change removes only that app-oriented assessment. For newly built sidecars it revalidates the persisted `notarytool --wait` result as `Accepted` with a non-empty submission ID, while preserving strict codesign verification, exact signing-certificate fingerprint matching, TeamIdentifier verification, arm64 verification, Core bootstrap/version checks, release provenance, immutable marker validation, and GitHub build attestations.

The regression contract explicitly forbids reintroducing `spctl --assess` into the standalone CLI verification step.