### PR TITLE
fix(guard): rebuild damaged extension authority

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 14118,
-  "maximum_test_source_lines": 310182,
+  "maximum_test_source_lines": 310289,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 14118,
-  "maximum_test_source_lines": 310289,
+  "maximum_test_source_lines": 310307,
   "schema_version": 1
 }

--- a/dashboard/e2e/extension-authority-recovery.spec.ts
+++ b/dashboard/e2e/extension-authority-recovery.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import {
+  defaultSettingsPayload,
+  emptyInventoryPayload,
+  emptyPoliciesPayload,
+  emptyReceiptsPayload,
+  freeStateSnapshot,
+} from "./fixture-states";
+
+const DAEMON = "guardDaemon=http://127.0.0.1:4175";
+const catalogDigest = "a".repeat(64);
+const catalog = { schema_version: "1.0.0", catalog_digest: catalogDigest, extensions: [] };
+const authority = (health: "tampered" | "protected") => ({
+  schema_version: "1.0.0",
+  health,
+  revision: health === "protected" ? 0 : 4,
+  catalog_digest: catalogDigest,
+  global_lockdown: false,
+  controls: [],
+  layers: [],
+  failures: health === "tampered" ? [{ code: "snapshot_missing", detail: "Authority snapshot is missing." }] : [],
+});
+
+async function mountRecoveryFixture(page: Page): Promise<void> {
+  let repaired = false;
+  await page.route("**/v1/**", async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    let body: unknown = {};
+    if (path.endsWith("/initialize")) body = { auth_token: "e2e-extension-token" };
+    else if (path.endsWith("/runtime")) body = freeStateSnapshot;
+    else if (path.endsWith("/requests")) body = { items: [], next_cursor: null, total_pending_count: 0, total_count: 0, status: "pending" };
+    else if (path.endsWith("/receipts")) body = emptyReceiptsPayload;
+    else if (path.endsWith("/policy")) body = emptyPoliciesPayload;
+    else if (path.endsWith("/settings")) body = {
+      ...defaultSettingsPayload,
+      settings: {
+        ...defaultSettingsPayload.settings,
+        approval_gate: {
+          ...defaultSettingsPayload.settings.approval_gate,
+          enabled: true,
+          configured: true,
+          totp_enabled: true,
+        },
+      },
+    };
+    else if (path.endsWith("/inventory")) body = emptyInventoryPayload;
+    else if (path.endsWith("/extension-controls/catalog")) body = catalog;
+    else if (path.endsWith("/extension-controls/effective")) body = authority(repaired ? "protected" : "tampered");
+    else if (path.endsWith("/extension-controls/recover-authority")) {
+      const payload = request.postDataJSON() as { approval_totp_code?: string };
+      if (!payload.approval_totp_code) {
+        await route.fulfill({ status: 403, contentType: "application/json", body: JSON.stringify({ error: "approval_gate_required" }) });
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      repaired = true;
+      body = authority("protected");
+    }
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+  });
+}
+
+test("authenticated extension recovery shows progress and reaches protected state", async ({ page }) => {
+  const runtimeErrors: string[] = [];
+  page.on("pageerror", (error) => runtimeErrors.push(error.message));
+  await mountRecoveryFixture(page);
+
+  await page.goto(`/extensions?${DAEMON}`);
+  await page.getByRole("button", { name: "Repair now" }).click();
+  await expect(page.getByRole("dialog", { name: "Repair extension controls" })).toBeVisible();
+  await page.getByLabel("Authenticator code").fill("123456");
+  await page.getByRole("button", { name: "Repair controls" }).click();
+  await expect(
+    page.getByRole("dialog", { name: "Repair extension controls" }).getByRole("button", { name: "Repairing…" }),
+  ).toBeDisabled();
+  await expect(page.getByText("Protected authority")).toBeVisible();
+  await expect(runtimeErrors).toEqual([]);
+});

--- a/dashboard/src/extensions-workspace.test.ts
+++ b/dashboard/src/extensions-workspace.test.ts
@@ -43,8 +43,29 @@ const recoveryMarkup = renderToStaticMarkup(createElement(ExtensionStatusBanner,
 assert.match(recoveryMarkup, /hol-guard guard command controls recover-authority/);
 assert.match(recoveryMarkup, /Copy repair command/);
 assert.match(recoveryMarkup, /Repair now/);
+assert.doesNotMatch(recoveryMarkup, /aria-busy="true"/);
 assert.match(recoveryMarkup, /Check again/);
 assert.doesNotMatch(recoveryMarkup, /bg-slate-950|bg-red-700|border-red-200/);
+
+const busyRecoveryMarkup = renderToStaticMarkup(createElement(ExtensionStatusBanner, {
+  effective: {
+    schema_version: "1.0.0",
+    health: "tampered",
+    revision: 4,
+    catalog_digest: "a".repeat(64),
+    global_lockdown: false,
+    controls: [],
+    failures: [],
+    layers: [],
+  },
+  busy: true,
+  status: "Repairing extension controls…",
+  onRecover: () => undefined,
+  onRetry: () => undefined,
+}));
+assert.match(busyRecoveryMarkup, /aria-busy="true"/);
+assert.match(busyRecoveryMarkup, /Repairing…/);
+assert.match(busyRecoveryMarkup, /role="status"/);
 
 const totpRecoveryMarkup = renderToStaticMarkup(createElement(ApprovalProofModal, {
   title: "Repair extension controls",

--- a/dashboard/src/extensions-workspace.tsx
+++ b/dashboard/src/extensions-workspace.tsx
@@ -130,6 +130,7 @@ export function ExtensionStatusBanner(props: {
   busy?: boolean;
   effective: EffectiveExtensionControls;
   error?: string | null;
+  status?: string | null;
   onRecover?: () => void;
   onRetry: () => void;
 }) {
@@ -165,7 +166,7 @@ export function ExtensionStatusBanner(props: {
           <p className="mt-1 text-sm leading-6 text-slate-700">{recovery?.description}</p>
           <div className="mt-4 flex flex-wrap items-center gap-2">
             {tampered && props.onRecover ? (
-              <button type="button" disabled={props.busy} onClick={props.onRecover} className="inline-flex min-h-10 items-center gap-2 rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-blue disabled:opacity-60">
+              <button type="button" aria-busy={props.busy} disabled={props.busy} onClick={props.onRecover} className="inline-flex min-h-10 items-center gap-2 rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-blue disabled:opacity-60">
                 {props.busy ? <HiMiniArrowPath className="size-4 animate-spin" aria-hidden="true" /> : <HiMiniShieldCheck className="size-4" aria-hidden="true" />}
                 {props.busy ? "Repairing…" : "Repair now"}
               </button>
@@ -187,6 +188,7 @@ export function ExtensionStatusBanner(props: {
             {copyState === "failed" ? <span role="status" className="mt-2 block text-sm text-brand-attention">Copy failed. Select the command above.</span> : null}
           </div>
           {props.error ? <p role="alert" className="mt-3 text-sm font-medium text-brand-attention">{props.error}</p> : null}
+          {props.status ? <p role="status" className="mt-3 text-sm font-medium text-brand-dark">{props.status}</p> : null}
         </div>
       </div>
     </div>
@@ -305,6 +307,7 @@ export function ExtensionsWorkspace() {
   const [recoveryApprovalOpen, setRecoveryApprovalOpen] = useState(false);
   const [recoveryBusy, setRecoveryBusy] = useState(false);
   const [recoveryError, setRecoveryError] = useState<string | null>(null);
+  const [recoveryStatus, setRecoveryStatus] = useState<string | null>(null);
   const [provenanceOpen, setProvenanceOpen] = useState(false);
   const [filters, setFilters] = useState<ExtensionFilterState>(EMPTY_EXTENSION_FILTERS);
   const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(null);
@@ -355,17 +358,20 @@ export function ExtensionsWorkspace() {
     } finally { setBusy(false); }
   }, [load, pending, state]);
   const recoverAuthority = useCallback(async (credentials?: { approval_password?: string; approval_totp_code?: string }) => {
-    setRecoveryBusy(true); setRecoveryError(null);
+    setRecoveryBusy(true); setRecoveryError(null); setRecoveryStatus("Repairing extension controls…");
     try {
       const effective = await recoverExtensionControlAuthority(credentials);
+      if (effective.health !== "protected") throw new Error("Guard could not restore protected extension controls.");
       if (state.kind === "ready") setState({ ...state, effective });
       setRecoveryApprovalOpen(false);
+      setRecoveryStatus("Extension controls repaired.");
     } catch (error) {
       if (credentials === undefined && requiresExtensionRecoveryApproval(error)) {
         await resolveApprovalGate();
         setRecoveryApprovalOpen(true);
       } else {
         setRecoveryError(error instanceof Error ? error.message : "Guard could not repair extension controls.");
+        setRecoveryStatus(null);
       }
     } finally { setRecoveryBusy(false); }
   }, [resolveApprovalGate, state]);
@@ -386,7 +392,7 @@ export function ExtensionsWorkspace() {
         <div><p className="text-xs font-bold uppercase tracking-[0.22em] text-brand-blue">Command safety</p><h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">Extensions</h1><p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">Inspect and govern the capabilities Guard uses to understand development commands.</p></div>
         <button type="button" onClick={toggleLockdown} disabled={locked} className={`inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold ${state.effective.global_lockdown ? "bg-red-700 text-white" : "border border-slate-300 bg-white text-slate-700"} disabled:opacity-50`}><HiMiniLockClosed className="size-4" />{state.effective.global_lockdown ? "Disable lockdown" : "Enable lockdown"}</button>
       </header>
-      <div className="mt-6"><ExtensionStatusBanner busy={recoveryBusy} effective={state.effective} error={recoveryError} onRecover={handleRecover} onRetry={load} /></div>
+      <div className="mt-6"><ExtensionStatusBanner busy={recoveryBusy} effective={state.effective} error={recoveryError} status={recoveryStatus} onRecover={handleRecover} onRetry={load} /></div>
       {state.effective.global_lockdown ? <div className="mt-4 flex items-center gap-3 rounded-2xl bg-slate-950 px-4 py-3 text-sm text-white"><HiMiniLockClosed className="size-5" /><span><strong>Global lockdown active.</strong> Optional extensions remain disabled regardless of individual settings.</span></div> : null}
       <section aria-labelledby="installed-extensions" className="mt-8">
         <div className="flex flex-col gap-1">

--- a/src/codex_plugin_scanner/guard/daemon/extension_control_api.py
+++ b/src/codex_plugin_scanner/guard/daemon/extension_control_api.py
@@ -175,7 +175,12 @@ class ExtensionControlApiService:
             )
         except ApprovalGateError as exc:
             raise ExtensionControlApiError(exc.status, exc.code) from exc
-        view = self._store.recover_extension_control_authority(catalog_digest=self._registry.catalog_digest)
+        try:
+            view = self._store.recover_extension_control_authority(catalog_digest=self._registry.catalog_digest)
+        except ExtensionControlAuthorityError as exc:
+            raise ExtensionControlApiError(503, "authority_recovery_failed") from exc
+        if view.health is not AuthorityHealth.PROTECTED:
+            raise ExtensionControlApiError(503, "authority_recovery_incomplete")
         _ = self._runtime.refresh(view)
         return self.effective()
 

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -562,7 +562,7 @@ function ExtensionStatusBanner(props) {
       /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "font-semibold text-brand-dark", children: recovery?.title }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-6 text-slate-700", children: recovery?.description }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex flex-wrap items-center gap-2", children: [
-        tampered && props.onRecover ? /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", disabled: props.busy, onClick: props.onRecover, className: "inline-flex min-h-10 items-center gap-2 rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-blue disabled:opacity-60", children: [
+        tampered && props.onRecover ? /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", "aria-busy": props.busy, disabled: props.busy, onClick: props.onRecover, className: "inline-flex min-h-10 items-center gap-2 rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-blue disabled:opacity-60", children: [
           props.busy ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "size-4 animate-spin", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "size-4", "aria-hidden": "true" }),
           props.busy ? "Repairing…" : "Repair now"
         ] }) : null,
@@ -582,7 +582,8 @@ function ExtensionStatusBanner(props) {
         ] }),
         copyState === "failed" ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { role: "status", className: "mt-2 block text-sm text-brand-attention", children: "Copy failed. Select the command above." }) : null
       ] }),
-      props.error ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "alert", className: "mt-3 text-sm font-medium text-brand-attention", children: props.error }) : null
+      props.error ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "alert", className: "mt-3 text-sm font-medium text-brand-attention", children: props.error }) : null,
+      props.status ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "status", className: "mt-3 text-sm font-medium text-brand-dark", children: props.status }) : null
     ] })
   ] }) });
 }
@@ -692,6 +693,7 @@ function ExtensionsWorkspace() {
   const [recoveryApprovalOpen, setRecoveryApprovalOpen] = reactExports.useState(false);
   const [recoveryBusy, setRecoveryBusy] = reactExports.useState(false);
   const [recoveryError, setRecoveryError] = reactExports.useState(null);
+  const [recoveryStatus, setRecoveryStatus] = reactExports.useState(null);
   const [provenanceOpen, setProvenanceOpen] = reactExports.useState(false);
   const [filters, setFilters] = reactExports.useState(EMPTY_EXTENSION_FILTERS);
   const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(null);
@@ -754,16 +756,20 @@ function ExtensionsWorkspace() {
   const recoverAuthority = reactExports.useCallback(async (credentials) => {
     setRecoveryBusy(true);
     setRecoveryError(null);
+    setRecoveryStatus("Repairing extension controls…");
     try {
       const effective = await recoverExtensionControlAuthority(credentials);
+      if (effective.health !== "protected") throw new Error("Guard could not restore protected extension controls.");
       if (state.kind === "ready") setState({ ...state, effective });
       setRecoveryApprovalOpen(false);
+      setRecoveryStatus("Extension controls repaired.");
     } catch (error) {
       if (credentials === void 0 && requiresExtensionRecoveryApproval(error)) {
         await resolveApprovalGate();
         setRecoveryApprovalOpen(true);
       } else {
         setRecoveryError(error instanceof Error ? error.message : "Guard could not repair extension controls.");
+        setRecoveryStatus(null);
       }
     } finally {
       setRecoveryBusy(false);
@@ -800,7 +806,7 @@ function ExtensionsWorkspace() {
         state.effective.global_lockdown ? "Disable lockdown" : "Enable lockdown"
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-6", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ExtensionStatusBanner, { busy: recoveryBusy, effective: state.effective, error: recoveryError, onRecover: handleRecover, onRetry: load }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-6", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ExtensionStatusBanner, { busy: recoveryBusy, effective: state.effective, error: recoveryError, status: recoveryStatus, onRecover: handleRecover, onRetry: load }) }),
     state.effective.global_lockdown ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex items-center gap-3 rounded-2xl bg-slate-950 px-4 py-3 text-sm text-white", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniLockClosed, { className: "size-5" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -397,7 +397,7 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                         expected_revision=_row_int(pending, "previous_revision"),
                         key=key,
                     )
-                    if resumed is not None:
+                    if resumed is not None and resumed.health is AuthorityHealth.PROTECTED:
                         return resumed
                     connection.commit()
                 if anchor.revision == current_revision and anchor.snapshot_digest == current_digest:
@@ -425,7 +425,9 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                             layers_json=_row_str(committed, "layers_json"),
                             occurred_at=_row_str(committed, "created_at"),
                         )
-                    return self._read_extension_control_authority_locked(catalog_digest)
+                    recovered = self._read_extension_control_authority_locked(catalog_digest)
+                    if recovered.health is AuthorityHealth.PROTECTED:
+                        return recovered
             return self._reset_extension_control_authority(catalog_digest, key=key)
 
     def _reset_extension_control_authority(

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -353,9 +353,9 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
 
     def recover_extension_control_authority(self, *, catalog_digest: str) -> ExtensionControlAuthorityView:
         with self._extension_control_authority_lock():
-            key = self._authority_key(required=True)
+            key = self._authority_key(required=False)
             if key is None:
-                return self._degraded_view(catalog_digest)
+                return self._reset_extension_control_authority(catalog_digest, key=None)
             anchor = self._read_anchor(key=key)
             with self._connect() as connection:
                 ensure_extension_control_authority_schema(connection)
@@ -363,7 +363,7 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                     "select revision, snapshot_digest from extension_control_authority_snapshot where singleton = 1"
                 ).fetchone()
                 if snapshot is None or anchor is None:
-                    return self._tampered_view(catalog_digest)
+                    return self._reset_extension_control_authority(catalog_digest, key=key)
                 current_revision = _row_int(snapshot, "revision")
                 current_digest = _row_str(snapshot, "snapshot_digest")
                 pending = connection.execute(
@@ -417,7 +417,7 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                             (current_revision, AuthorityPhase.COMMITTED.value),
                         ).fetchone()
                         if committed is None:
-                            return self._tampered_view(catalog_digest)
+                            return self._reset_extension_control_authority(catalog_digest, key=key)
                         self._queue_extension_control_change_event(
                             connection,
                             revision=current_revision,
@@ -426,7 +426,19 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                             occurred_at=_row_str(committed, "created_at"),
                         )
                     return self._read_extension_control_authority_locked(catalog_digest)
-            return self._tampered_view(catalog_digest)
+            return self._reset_extension_control_authority(catalog_digest, key=key)
+
+    def _reset_extension_control_authority(
+        self, catalog_digest: str, *, key: bytes | None
+    ) -> ExtensionControlAuthorityView:
+        # Authenticated recovery must not import rows whose chain cannot be
+        # verified. Re-establish an empty, protected local authority instead.
+        with self._connect() as connection:
+            ensure_extension_control_authority_schema(connection)
+            connection.execute("delete from extension_control_authority_proof")
+            connection.execute("delete from extension_control_authority_transition")
+            connection.execute("delete from extension_control_authority_snapshot")
+        return self._bootstrap_extension_control_authority(catalog_digest, key=key)
 
     def acknowledge_extension_control_degraded_mode(self) -> ExtensionControlAuthorityView:
         self._extension_control_degraded_acknowledged = True

--- a/tests/test_guard_extension_control_api.py
+++ b/tests/test_guard_extension_control_api.py
@@ -29,6 +29,7 @@ from codex_plugin_scanner.guard.runtime.command_extensions import (
 )
 from codex_plugin_scanner.guard.runtime.extension_control_authority import (
     AuthorityHealth,
+    ExtensionControlAuthorityError,
     ExtensionControlAuthorityView,
 )
 from codex_plugin_scanner.guard.runtime.extension_control_proof import ExtensionControlProof
@@ -212,6 +213,64 @@ def test_authority_recovery_rejects_healthy_authority(tmp_path: Path) -> None:
 
     assert denied.value.status == 409
     assert denied.value.code == "authority_not_recoverable"
+
+
+def test_authority_recovery_never_reports_success_while_still_tampered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    tampered = ExtensionControlAuthorityView(
+        AuthorityHealth.TAMPERED,
+        4,
+        BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
+        (),
+    )
+    service = ExtensionControlApiService(
+        store=store,
+        registry=BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+        runtime=ExtensionControlRuntime(tampered),
+    )
+    monkeypatch.setattr(store, "read_extension_control_authority", lambda **_kwargs: tampered)
+    monkeypatch.setattr(store, "recover_extension_control_authority", lambda **_kwargs: tampered)
+    monkeypatch.setattr(extension_control_api_module, "require_extension_control", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(extension_control_api_module, "consume_extension_control_grant", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(ExtensionControlApiError) as denied:
+        service.recover_authority({"approval_password": "secret", "session_nonce": "nonce"})
+
+    assert denied.value.status == 503
+    assert denied.value.code == "authority_recovery_incomplete"
+
+
+def test_authority_recovery_returns_bounded_error_when_store_repair_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    tampered = ExtensionControlAuthorityView(
+        AuthorityHealth.TAMPERED,
+        4,
+        BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
+        (),
+    )
+    service = ExtensionControlApiService(
+        store=store,
+        registry=BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+        runtime=ExtensionControlRuntime(tampered),
+    )
+    monkeypatch.setattr(store, "read_extension_control_authority", lambda **_kwargs: tampered)
+    monkeypatch.setattr(
+        store,
+        "recover_extension_control_authority",
+        lambda **_kwargs: (_ for _ in ()).throw(ExtensionControlAuthorityError("failed")),
+    )
+    monkeypatch.setattr(extension_control_api_module, "require_extension_control", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(extension_control_api_module, "consume_extension_control_grant", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(ExtensionControlApiError) as denied:
+        service.recover_authority({"approval_password": "secret", "session_nonce": "nonce"})
+
+    assert denied.value.status == 503
+    assert denied.value.code == "authority_recovery_failed"
 
 
 def test_legacy_extension_aliases_migrate_to_canonical_catalog_ids(tmp_path: Path) -> None:

--- a/tests/test_guard_extension_control_authority.py
+++ b/tests/test_guard_extension_control_authority.py
@@ -127,6 +127,24 @@ def test_authenticated_recovery_rebuilds_unverifiable_authority(tmp_path: Path) 
     )
 
 
+def test_authenticated_recovery_rebuilds_snapshot_with_invalid_mac(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    with store._connect() as connection:
+        connection.execute(
+            "update extension_control_authority_snapshot set snapshot_mac = ? where singleton = 1",
+            ("invalid",),
+        )
+
+    repaired = store.recover_extension_control_authority(
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+    )
+
+    assert repaired.health is AuthorityHealth.PROTECTED
+    assert repaired.revision == 0
+    assert repaired.layers == ()
+
+
 @pytest.mark.parametrize("missing_part", ("snapshot", "anchor", "key"))
 def test_authenticated_recovery_rebuilds_incomplete_authority(tmp_path: Path, missing_part: str) -> None:
     secrets = MemorySecretStore()

--- a/tests/test_guard_extension_control_authority.py
+++ b/tests/test_guard_extension_control_authority.py
@@ -100,6 +100,54 @@ def _store(
     return store
 
 
+def test_authenticated_recovery_rebuilds_unverifiable_authority(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    with store._connect() as connection:
+        connection.execute(
+            "update extension_control_authority_snapshot set snapshot_digest = ? where singleton = 1",
+            ("f" * 64,),
+        )
+
+    assert (
+        store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest).health
+        is AuthorityHealth.TAMPERED
+    )
+
+    repaired = store.recover_extension_control_authority(
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+    )
+
+    assert repaired.health is AuthorityHealth.PROTECTED
+    assert repaired.revision == 0
+    assert repaired.layers == ()
+    assert (
+        store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest).health
+        is AuthorityHealth.PROTECTED
+    )
+
+
+@pytest.mark.parametrize("missing_part", ("snapshot", "anchor", "key"))
+def test_authenticated_recovery_rebuilds_incomplete_authority(tmp_path: Path, missing_part: str) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    if missing_part == "snapshot":
+        with store._connect() as connection:
+            connection.execute("delete from extension_control_authority_snapshot")
+    else:
+        suffix = ":anchor" if missing_part == "anchor" else ":authentication-key"
+        secret_id = next(secret_id for secret_id in secrets.values if secret_id.endswith(suffix))
+        secrets.delete_secret(secret_id)
+
+    repaired = store.recover_extension_control_authority(
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+    )
+
+    assert repaired.health is AuthorityHealth.PROTECTED
+    assert repaired.revision == 0
+    assert repaired.layers == ()
+
+
 def _enrollment_proof(
     store: GuardStore,
     *,


### PR DESCRIPTION
## Summary

- rebuild incomplete or unverifiable extension-control authority after fresh local authentication
- reject recovery responses that do not restore protected authority
- show visible repair progress and preserve actionable failures in the dashboard

## Verification

- `uv run --no-sync pytest -q tests/test_guard_extension_control_authority.py tests/test_guard_extension_control_api.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/store_extension_control_authority.py src/codex_plugin_scanner/guard/daemon/extension_control_api.py tests/test_guard_extension_control_authority.py tests/test_guard_extension_control_api.py`
- `bun run test`
- `bun run build`
- `bunx playwright test e2e/extension-authority-recovery.spec.ts`
- built-wheel recovery through a real isolated daemon HTTP endpoint
