### PR TITLE
fix(dashboard): make protection repair converge

### DIFF
--- a/dashboard/e2e/protection-health-ui.spec.ts
+++ b/dashboard/e2e/protection-health-ui.spec.ts
@@ -143,6 +143,65 @@ test("degraded protection copy remains visible on mobile", async ({ page }, test
   await page.screenshot({ path: testInfo.outputPath("protection-health-mobile.png"), fullPage: true });
 });
 
+test("fleet repair targets only the app with failed hook proof and verifies recovery", async ({ page }) => {
+  const protectedSnapshot = snapshotForState("protected");
+  const protectedChecks = protectedSnapshot.protection_health.checks;
+  const failedChecks = protectedChecks.map((check) => check.check_id === "harness_hooks"
+    ? { ...check, status: "fail" as const, reason_code: "hook_verification_failed" }
+    : check);
+  let currentSnapshot = {
+    ...protectedSnapshot,
+    managed_installs: [
+      ...protectedSnapshot.managed_installs,
+      { ...protectedSnapshot.managed_installs[0], harness: "grok" },
+    ],
+    protection_health: {
+      ...protectedSnapshot.protection_health,
+      state: "degraded" as const,
+      checks: failedChecks,
+      apps: [
+        { ...protectedSnapshot.protection_health.apps[0], checks: protectedChecks },
+        {
+          ...protectedSnapshot.protection_health.apps[0],
+          harness: "grok",
+          state: "degraded" as const,
+          checks: failedChecks,
+        },
+      ],
+    },
+  };
+  const repairedHarnesses: string[] = [];
+  await page.route("**/v1/**", async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    let body: unknown = {};
+    if (path.includes("/initialize")) body = { auth_token: "e2e-protection-token" };
+    else if (path.endsWith("/runtime")) body = currentSnapshot;
+    else if (/\/v1\/harnesses\/[^/]+\/repair$/.test(path)) {
+      const harness = path.split("/")[3];
+      repairedHarnesses.push(harness);
+      body = { harness, action: "repair", dry_run: false, managed_install: { harness, active: true } };
+    } else if (path.endsWith("/protection/repair")) {
+      currentSnapshot = protectedSnapshot;
+      body = { repaired: true, repair_scope: "local_integrity", check_ids: PROTECTION_CHECK_IDS, message: "Protection restored." };
+    } else if (path.endsWith("/daemon/repair")) body = { repaired: true, cleared: [] };
+    else if (path.endsWith("/receipts")) body = emptyReceiptsPayload;
+    else if (path.endsWith("/policy")) body = emptyPoliciesPayload;
+    else if (path.endsWith("/settings")) body = defaultSettingsPayload;
+    else if (path.endsWith("/inventory")) body = emptyInventoryPayload;
+    else if (path.endsWith("/command-activity/events")) {
+      await route.fulfill({ status: 200, contentType: "text/event-stream", body: "" });
+      return;
+    }
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+  });
+
+  await page.goto(`/protect?${DAEMON}`);
+  await page.getByRole("button", { name: "Repair protection" }).click();
+  await expect(page.getByRole("heading", { name: "Your apps are covered" })).toBeVisible();
+  expect(repairedHarnesses).toEqual(["grok"]);
+});
+
 for (const expected of [
   { state: "protected", heading: "All clear", badge: "Protected" },
   { state: "partial", heading: "Protection is partial", badge: "Partially protected" },

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -29,6 +29,7 @@ import type { AppView } from "./approval-center-primitives";
 import { buildClearPayload } from "./clear-policy-payload";
 import { harnessDisplayName, normalizeHarnessSlug } from "./approval-center-utils";
 import { ErrorBoundary } from "./error-boundary";
+import { protectionHealthFor } from "./protection-health";
 import { selectNextAfterResolution } from "./queue-state";
 import { useRouteFocus } from "./use-route-focus";
 
@@ -579,7 +580,12 @@ export function App() {
         message: inventoryResult.reason instanceof Error ? inventoryResult.reason.message : "Unable to load watched app inventory.",
       });
     }
+    return inboxResult.status === "fulfilled" ? inboxResult.value.snapshot : null;
   }, [setRuntime, setRequests, setReceipts, setPolicies, setInventory]);
+
+  const refreshStateWithoutResult = useCallback(async () => {
+    await refreshStateAfterAction();
+  }, [refreshStateAfterAction]);
 
   const handleClearPolicies = useCallback(async (scope: { harness?: string; all?: boolean }) => {
     setClearConfirm(scope);
@@ -803,9 +809,22 @@ export function App() {
     } catch (error: unknown) {
       failures.push(error instanceof Error ? error.message : "integrity protection");
     }
-    await refreshStateAfterAction();
+    const refreshedSnapshot = await refreshStateAfterAction();
     if (failures.length > 0) {
       throw new Error(`Repair paused at ${failures.join(", ")}. Retry repair to continue from this page.`);
+    }
+    if (refreshedSnapshot === null) {
+      throw new Error("Repair completed, but Guard could not recheck protection. Check again in a moment.");
+    }
+    const remainingHealth = protectionHealthFor(refreshedSnapshot);
+    if (remainingHealth.state !== "protected") {
+      const failedApps = remainingHealth.apps
+        .filter((app) => app.checks.some((check) => check.status === "fail"))
+        .map((app) => harnessDisplayName(app.harness));
+      const remaining = failedApps.length > 0
+        ? `${failedApps.join(", ")} still ${failedApps.length === 1 ? "needs" : "need"} repair.`
+        : "A local protection check still needs attention.";
+      throw new Error(`${remaining} Open the repair details below for the exact check.`);
     }
     return "Automatic repairs completed. Guard rechecked every protection layer below.";
   }, [refreshStateAfterAction]);
@@ -826,10 +845,10 @@ export function App() {
         onOpenRequest={handleOpenRequest}
         onClearAppPolicies={handleClearAppPolicies}
         onClearPolicy={handleClearPolicy}
-        onManagedInstallChanged={refreshStateAfterAction}
+        onManagedInstallChanged={refreshStateWithoutResult}
       />
     );
-  }, [view, appDetailHarness, runtime, receipts, policies, inventory, requests, handleGoHome, handleOpenRequest, handleClearAppPolicies, handleClearPolicy, refreshStateAfterAction]);
+  }, [view, appDetailHarness, runtime, receipts, policies, inventory, requests, handleGoHome, handleOpenRequest, handleClearAppPolicies, handleClearPolicy, refreshStateWithoutResult]);
 
   const policyContent = useMemo(() => {
     if (runtime.kind !== "ready") {
@@ -970,7 +989,7 @@ export function App() {
 	              onOpenSettings={handleOpenSettings}
 	              onGoHome={handleGoHome}
               onNavigate={navigate}
-              onRuntimeRefresh={refreshStateAfterAction}
+              onRuntimeRefresh={refreshStateWithoutResult}
             />
           </Suspense>
         ) : null

--- a/dashboard/src/fleet-workspace.test.ts
+++ b/dashboard/src/fleet-workspace.test.ts
@@ -1,5 +1,5 @@
 import { cloudPolicyRecoveryHint } from "./fleet-protection-recovery";
-import { resolveFleetHeroCopy } from "./fleet-workspace";
+import { repairHarnessesFor, resolveFleetHeroCopy } from "./fleet-workspace";
 import type { FleetHeroCopy } from "./fleet-workspace";
 
 function assert(condition: boolean, message: string): void {
@@ -102,6 +102,47 @@ const degradedWithApps = resolveFleetHeroCopy("paired_active", 2, "degraded", ur
 assert(degradedWithApps.status === "degraded", "active installs cannot imply protected fleet health");
 assert(degradedWithApps.headline === "App protection is degraded", "degraded fleet copy is explicit");
 assert(pairedActiveNoApps.status === "setup_gap", "F5: paired_active no apps status should be setup_gap");
+
+const targetedRepairs = repairHarnessesFor(
+  [
+    { harness: "codex", active: true },
+    { harness: "grok", active: true },
+    { harness: "cursor", active: false },
+  ],
+  {
+    schema_version: "guard.protection-health.v1",
+    state: "degraded",
+    label: "Degraded",
+    detail: "One app needs repair.",
+    evidence_gap: false,
+    checks: [],
+    reason_codes: [],
+    apps: [
+      {
+        harness: "codex",
+        state: "protected",
+        label: "Protected",
+        detail: "Hooks verified.",
+        evidence_gap: false,
+        checks: [{ check_id: "harness_hooks", status: "pass", reason_code: "hooks_verified" }],
+        reason_codes: ["hooks_verified"],
+      },
+      {
+        harness: "grok",
+        state: "degraded",
+        label: "Degraded",
+        detail: "Hooks need repair.",
+        evidence_gap: false,
+        checks: [{ check_id: "harness_hooks", status: "fail", reason_code: "hook_verification_failed" }],
+        reason_codes: ["hook_verification_failed"],
+      },
+    ],
+  },
+);
+assert(
+  targetedRepairs.length === 1 && targetedRepairs[0] === "grok",
+  "F8: fleet repair must reinstall only active apps with failed hook proof",
+);
 
 const allStates: FleetHeroCopy[] = [localOnlyWithApps, pairedWaitingWithApps, pairedActiveWithApps];
 for (const state of allStates) {

--- a/dashboard/src/fleet-workspace.test.ts
+++ b/dashboard/src/fleet-workspace.test.ts
@@ -140,8 +140,8 @@ const targetedRepairs = repairHarnessesFor(
   },
 );
 assert(
-  targetedRepairs.length === 1 && targetedRepairs[0] === "grok",
-  "F8: fleet repair must reinstall only active apps with failed hook proof",
+  targetedRepairs.length === 2 && targetedRepairs[0] === "grok" && targetedRepairs[1] === "cursor",
+  "F8: fleet repair must reinstall inactive apps and active apps with failed hook proof",
 );
 
 const allStates: FleetHeroCopy[] = [localOnlyWithApps, pairedWaitingWithApps, pairedActiveWithApps];

--- a/dashboard/src/fleet-workspace.tsx
+++ b/dashboard/src/fleet-workspace.tsx
@@ -32,6 +32,7 @@ import type {
   GuardInventoryItem,
   GuardPolicyDecision,
   GuardProtectionAppHealth,
+  GuardProtectionHealth,
   GuardProtectionState,
   GuardReceipt,
   GuardRuntimeSnapshot,
@@ -150,6 +151,20 @@ function formatCount(value: number): string {
 }
 
 type AppStatus = "protected" | "partial" | "found_unprotected" | "needs_repair" | "not_found";
+
+export function repairHarnessesFor(
+  installs: Array<{ harness: string; active?: boolean }>,
+  health: GuardProtectionHealth,
+): string[] {
+  return Array.from(new Set(
+    installs
+      .filter((install) => install.active === true)
+      .filter((install) => health.apps.find((app) => app.harness === install.harness)?.checks.some(
+        (check) => check.check_id === "harness_hooks" && check.status === "fail"
+      ) === true)
+      .map((install) => install.harness)
+  ));
+}
 
 function resolveAppStatus(
   install: { active?: boolean } | undefined,
@@ -270,7 +285,7 @@ export function FleetWorkspace(props: FleetWorkspaceProps) {
     ?? visibleHarnesses.find((harness) => protectionHealthFor(props.runtime, harness).checks.some(
       (check) => check.check_id === "harness_hooks" && check.status === "fail"
     ));
-  const repairHarnesses = Array.from(new Set(managedInstalls.map((install) => install.harness)));
+  const repairHarnesses = repairHarnessesFor(managedInstalls, protectionHealth);
 
   const heroCopy = resolveFleetHeroCopy(
     props.runtime.cloud_state,

--- a/dashboard/src/fleet-workspace.tsx
+++ b/dashboard/src/fleet-workspace.tsx
@@ -158,10 +158,9 @@ export function repairHarnessesFor(
 ): string[] {
   return Array.from(new Set(
     installs
-      .filter((install) => install.active === true)
-      .filter((install) => health.apps.find((app) => app.harness === install.harness)?.checks.some(
-        (check) => check.check_id === "harness_hooks" && check.status === "fail"
-      ) === true)
+      .filter((install) => install.active !== true || health.apps.find(
+        (app) => app.harness === install.harness
+      )?.checks.some((check) => check.check_id === "harness_hooks" && check.status === "fail") === true)
       .map((install) => install.harness)
   ));
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/fleet-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/fleet-workspace.js
@@ -264,6 +264,13 @@ function renderReceiptContext(receipt) {
 function formatCount(value) {
   return value.toLocaleString();
 }
+function repairHarnessesFor(installs, health) {
+  return Array.from(new Set(
+    installs.filter((install) => install.active === true).filter((install) => health.apps.find((app) => app.harness === install.harness)?.checks.some(
+      (check) => check.check_id === "harness_hooks" && check.status === "fail"
+    ) === true).map((install) => install.harness)
+  ));
+}
 function resolveAppStatus(install, protectionHealth, hasInventory, hasReceipts) {
   if (install !== void 0) {
     const hookCheck = protectionHealth.checks.find((check) => check.check_id === "harness_hooks");
@@ -363,7 +370,7 @@ function FleetWorkspace(props) {
   const repairHarness = managedInstalls.find((install) => !install.active)?.harness ?? visibleHarnesses.find((harness) => protectionHealthFor(props.runtime, harness).checks.some(
     (check) => check.check_id === "harness_hooks" && check.status === "fail"
   ));
-  const repairHarnesses = Array.from(new Set(managedInstalls.map((install) => install.harness)));
+  const repairHarnesses = repairHarnessesFor(managedInstalls, protectionHealth);
   const heroCopy = resolveFleetHeroCopy(
     props.runtime.cloud_state,
     activeInstalls.length,
@@ -545,5 +552,6 @@ function SetupStep(props) {
 }
 export {
   FleetWorkspace,
+  repairHarnessesFor,
   resolveFleetHeroCopy
 };

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/fleet-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/fleet-workspace.js
@@ -266,9 +266,9 @@ function formatCount(value) {
 }
 function repairHarnessesFor(installs, health) {
   return Array.from(new Set(
-    installs.filter((install) => install.active === true).filter((install) => health.apps.find((app) => app.harness === install.harness)?.checks.some(
-      (check) => check.check_id === "harness_hooks" && check.status === "fail"
-    ) === true).map((install) => install.harness)
+    installs.filter((install) => install.active !== true || health.apps.find(
+      (app) => app.harness === install.harness
+    )?.checks.some((check) => check.check_id === "harness_hooks" && check.status === "fail") === true).map((install) => install.harness)
   ));
 }
 function resolveAppStatus(install, protectionHealth, hasInventory, hasReceipts) {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -30099,7 +30099,11 @@ function App() {
         message: inventoryResult.reason instanceof Error ? inventoryResult.reason.message : "Unable to load watched app inventory."
       });
     }
+    return inboxResult.status === "fulfilled" ? inboxResult.value.snapshot : null;
   }, [setRuntime, setRequests, setReceipts, setPolicies, setInventory]);
+  const refreshStateWithoutResult = reactExports.useCallback(async () => {
+    await refreshStateAfterAction();
+  }, [refreshStateAfterAction]);
   const handleClearPolicies = reactExports.useCallback(async (scope) => {
     setClearConfirm(scope);
   }, []);
@@ -30286,9 +30290,18 @@ function App() {
     } catch (error) {
       failures.push(error instanceof Error ? error.message : "integrity protection");
     }
-    await refreshStateAfterAction();
+    const refreshedSnapshot = await refreshStateAfterAction();
     if (failures.length > 0) {
       throw new Error(`Repair paused at ${failures.join(", ")}. Retry repair to continue from this page.`);
+    }
+    if (refreshedSnapshot === null) {
+      throw new Error("Repair completed, but Guard could not recheck protection. Check again in a moment.");
+    }
+    const remainingHealth = protectionHealthFor(refreshedSnapshot);
+    if (remainingHealth.state !== "protected") {
+      const failedApps = remainingHealth.apps.filter((app) => app.checks.some((check) => check.status === "fail")).map((app) => harnessDisplayName(app.harness));
+      const remaining = failedApps.length > 0 ? `${failedApps.join(", ")} still ${failedApps.length === 1 ? "needs" : "need"} repair.` : "A local protection check still needs attention.";
+      throw new Error(`${remaining} Open the repair details below for the exact check.`);
     }
     return "Automatic repairs completed. Guard rechecked every protection layer below.";
   }, [refreshStateAfterAction]);
@@ -30309,10 +30322,10 @@ function App() {
         onOpenRequest: handleOpenRequest,
         onClearAppPolicies: handleClearAppPolicies,
         onClearPolicy: handleClearPolicy,
-        onManagedInstallChanged: refreshStateAfterAction
+        onManagedInstallChanged: refreshStateWithoutResult
       }
     );
-  }, [view, appDetailHarness, runtime, receipts, policies, inventory, requests, handleGoHome, handleOpenRequest, handleClearAppPolicies, handleClearPolicy, refreshStateAfterAction]);
+  }, [view, appDetailHarness, runtime, receipts, policies, inventory, requests, handleGoHome, handleOpenRequest, handleClearAppPolicies, handleClearPolicy, refreshStateWithoutResult]);
   const policyContent = reactExports.useMemo(() => {
     if (runtime.kind !== "ready") {
       return null;
@@ -30428,7 +30441,7 @@ function App() {
             onOpenSettings: handleOpenSettings,
             onGoHome: handleGoHome,
             onNavigate: navigate,
-            onRuntimeRefresh: refreshStateAfterAction
+            onRuntimeRefresh: refreshStateWithoutResult
           }
         ) }) : null,
         policyContent,


### PR DESCRIPTION
## Summary
- repair only app integrations with failed hook proof instead of reinstalling every managed app
- verify refreshed protection health before reporting repair success
- cover targeted repair and banner recovery in browser tests

## Testing
- `bun run test`
- `bun run build`
- `bunx playwright test e2e/protection-health-ui.spec.ts --reporter=line`
