### PR TITLE
docs(guard): add public research and correction project links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,8 @@ plugin-ecosystem-scanner = "codex_plugin_scanner.cli:main"
 [project.urls]
 Homepage = "https://hol.org/guard"
 Documentation = "https://github.com/hashgraph-online/hol-guard/tree/main/docs/guard"
+Research = "https://hol.org/guard/research"
+Corrections = "https://hol.org/guard/methodology/corrections"
 Repository = "https://github.com/hashgraph-online/hol-guard"
 Issues = "https://github.com/hashgraph-online/hol-guard/issues"
 Changelog = "https://github.com/hashgraph-online/hol-guard/releases"


### PR DESCRIPTION
Adds two neutral PyPI project links to existing public HOL Guard resources:

- Research: https://hol.org/guard/research
- Corrections: https://hol.org/guard/methodology/corrections

No product claims, runtime behavior, dependencies, release configuration, or internal program details change.