### PR TITLE
feat: add privacy-safe local outcome receipts

### DIFF
--- a/docs/guard/privacy-safe-outcome-receipts.md
+++ b/docs/guard/privacy-safe-outcome-receipts.md
@@ -1,0 +1,36 @@
+# Privacy-safe local outcome receipts
+
+HOL Guard can represent two local activation milestones without serializing local security content:
+
+- `local_install_verified`: the installer reached a binary-verification or product-corroboration state tied to a server-issued handoff.
+- `first_local_proof_generated`: Guard generated a real local proof and emits only the proof kind plus a SHA-256 digest of the evidence.
+
+The versioned receipt implementation is `codex_plugin_scanner.guard.outcome_receipt`.
+
+## Privacy boundary
+
+A receipt contains only:
+
+- schema version;
+- outcome type;
+- UTC occurrence time;
+- HOL Guard version;
+- verification method;
+- SHA-256 evidence digest;
+- optional handoff identifier;
+- optional bounded proof kind; and
+- `sensitive_content_included: false`.
+
+It must not contain prompts, source code, findings, file paths, commands, secrets, tokens, usernames, hostnames, or report bodies. The helper accepts a precomputed evidence digest so callers do not need to pass sensitive evidence into a transport object.
+
+## Verification boundary
+
+The receipt is operational evidence, not a self-authenticating remote attestation.
+
+A local-install receipt is valid only when the existing install/handoff flow independently verifies the binary or corroborates the installed product. A receipt without a handoff identifier is rejected.
+
+A first-proof receipt proves only that a specific privacy-safe receipt was produced for an already-generated local proof. The underlying proof stays local unless a separate, explicit user flow shares it. A digest is an integrity reference and must not be described as proof that a remote party independently observed the local content.
+
+## Idempotency
+
+`receipt_digest(receipt)` hashes canonical safe JSON and can be used as an idempotency/evidence reference. It does not add authenticity beyond the authoritative product/handoff state described above.

--- a/src/codex_plugin_scanner/guard/outcome_receipt.py
+++ b/src/codex_plugin_scanner/guard/outcome_receipt.py
@@ -1,0 +1,161 @@
+"""Privacy-safe receipts for locally verified Guard outcomes.
+
+These receipts intentionally carry only outcome metadata and a SHA-256 evidence
+digest. They never serialize prompts, source code, findings, file paths, commands,
+secrets, tokens, usernames, hostnames, or report bodies.
+
+A receipt is *operational evidence*, not a self-authenticating remote attestation:
+- ``local_install_verified`` is valid only when tied to a server-issued handoff
+  whose installer flow reached binary verification (or product corroboration).
+- ``first_local_proof_generated`` records a digest of an already-produced local
+  proof and its proof kind. The proof itself remains local unless the user
+  explicitly shares it through another product flow.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+SCHEMA_VERSION = "1"
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+
+Outcome = Literal["local_install_verified", "first_local_proof_generated"]
+Verification = Literal[
+    "binary_verified_handoff",
+    "product_corroborated_handoff",
+    "privacy_safe_local_receipt",
+]
+
+_FORBIDDEN_KEYS = frozenset(
+    {
+        "prompt",
+        "raw_prompt",
+        "path",
+        "file",
+        "filename",
+        "command",
+        "secret",
+        "token",
+        "finding",
+        "source_code",
+        "hostname",
+        "username",
+        "report_body",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GuardOutcomeReceipt:
+    schema_version: Literal["1"]
+    outcome: Outcome
+    occurred_at: str
+    hol_guard_version: str
+    verification: Verification
+    evidence_digest: str
+    handoff_id: str | None
+    proof_kind: str | None
+    sensitive_content_included: Literal[False] = False
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def sha256_digest(data: bytes) -> str:
+    """Hash local evidence without returning or retaining the evidence bytes."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _iso_utc(value: datetime | None) -> str:
+    current = value or datetime.now(UTC)
+    if current.tzinfo is None:
+        raise ValueError("occurred_at must be timezone-aware")
+    return current.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def build_outcome_receipt(
+    *,
+    outcome: Outcome,
+    hol_guard_version: str,
+    verification: Verification,
+    evidence_digest: str,
+    handoff_id: str | None = None,
+    proof_kind: str | None = None,
+    occurred_at: datetime | None = None,
+) -> GuardOutcomeReceipt:
+    """Build a versioned receipt after an authoritative local outcome occurs."""
+    if not hol_guard_version or len(hol_guard_version) > 64:
+        raise ValueError("hol_guard_version must be 1..64 characters")
+    if not _SHA256_RE.fullmatch(evidence_digest):
+        raise ValueError("evidence_digest must be a lowercase SHA-256 digest")
+    if handoff_id is not None and not (1 <= len(handoff_id) <= 128):
+        raise ValueError("handoff_id must be 1..128 characters when present")
+    if proof_kind is not None and not (1 <= len(proof_kind) <= 64):
+        raise ValueError("proof_kind must be 1..64 characters when present")
+
+    if outcome == "local_install_verified":
+        if verification not in {"binary_verified_handoff", "product_corroborated_handoff"}:
+            raise ValueError("local install requires verified handoff evidence")
+        if not handoff_id:
+            raise ValueError("local install verification requires handoff_id")
+        if proof_kind is not None:
+            raise ValueError("local install receipt must not include proof_kind")
+    elif outcome == "first_local_proof_generated":
+        if verification != "privacy_safe_local_receipt":
+            raise ValueError("first local proof requires privacy_safe_local_receipt verification")
+        if not proof_kind:
+            raise ValueError("first local proof requires proof_kind")
+    else:  # pragma: no cover - protected by the type contract at static call sites
+        raise ValueError("unsupported outcome")
+
+    receipt = GuardOutcomeReceipt(
+        schema_version=SCHEMA_VERSION,
+        outcome=outcome,
+        occurred_at=_iso_utc(occurred_at),
+        hol_guard_version=hol_guard_version,
+        verification=verification,
+        evidence_digest=evidence_digest,
+        handoff_id=handoff_id,
+        proof_kind=proof_kind,
+    )
+    assert_privacy_safe_receipt(receipt.to_dict())
+    return receipt
+
+
+def assert_privacy_safe_receipt(payload: dict[str, object]) -> None:
+    """Reject receipt-shaped payloads that add sensitive-content fields."""
+    allowed = {
+        "schema_version",
+        "outcome",
+        "occurred_at",
+        "hol_guard_version",
+        "verification",
+        "evidence_digest",
+        "handoff_id",
+        "proof_kind",
+        "sensitive_content_included",
+    }
+    extras = set(payload) - allowed
+    if extras:
+        raise ValueError(f"outcome receipt has unsupported fields: {sorted(extras)!r}")
+    for key in payload:
+        normalized = key.lower()
+        if normalized in _FORBIDDEN_KEYS:
+            raise ValueError(f"outcome receipt contains forbidden field: {key}")
+    if payload.get("sensitive_content_included") is not False:
+        raise ValueError("outcome receipts must not include sensitive content")
+
+
+def canonical_receipt_bytes(receipt: GuardOutcomeReceipt) -> bytes:
+    """Return deterministic JSON bytes for transport/idempotency hashing."""
+    return json.dumps(receipt.to_dict(), sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def receipt_digest(receipt: GuardOutcomeReceipt) -> str:
+    """Digest the safe receipt itself; this is an integrity/idempotency key."""
+    return sha256_digest(canonical_receipt_bytes(receipt))

--- a/src/codex_plugin_scanner/guard/outcome_receipt.py
+++ b/src/codex_plugin_scanner/guard/outcome_receipt.py
@@ -18,7 +18,7 @@ import hashlib
 import json
 import re
 from dataclasses import asdict, dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Literal
 
 from packaging.version import InvalidVersion, Version
@@ -79,7 +79,7 @@ def _validate_utc_timestamp(value: object) -> None:
         parsed = datetime.fromisoformat(value.removesuffix("Z") + "+00:00")
     except ValueError as exc:
         raise ValueError("occurred_at must be a valid UTC ISO-8601 timestamp") from exc
-    if parsed.utcoffset() != UTC.utcoffset(parsed):
+    if parsed.utcoffset() != timezone.utc.utcoffset(parsed):
         raise ValueError("occurred_at must be UTC")
 
 
@@ -176,10 +176,10 @@ def sha256_digest(data: bytes) -> str:
 
 
 def _iso_utc(value: datetime | None) -> str:
-    current = value or datetime.now(UTC)
+    current = value or datetime.now(timezone.utc)
     if current.tzinfo is None:
         raise ValueError("occurred_at must be timezone-aware")
-    return current.astimezone(UTC).isoformat().replace("+00:00", "Z")
+    return current.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def build_outcome_receipt(

--- a/src/codex_plugin_scanner/guard/outcome_receipt.py
+++ b/src/codex_plugin_scanner/guard/outcome_receipt.py
@@ -21,8 +21,13 @@ from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from typing import Literal
 
+from packaging.version import InvalidVersion, Version
+
 SCHEMA_VERSION = "1"
 _SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_HANDOFF_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_PROOF_KIND_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+_VERSION_TEXT_RE = re.compile(r"^[0-9][0-9A-Za-z.!+_-]{0,63}$")
 
 Outcome = Literal["local_install_verified", "first_local_proof_generated"]
 Verification = Literal[
@@ -31,23 +36,109 @@ Verification = Literal[
     "privacy_safe_local_receipt",
 ]
 
-_FORBIDDEN_KEYS = frozenset(
+_ALLOWED_OUTCOMES = frozenset({"local_install_verified", "first_local_proof_generated"})
+_ALLOWED_VERIFICATIONS = frozenset(
+    {"binary_verified_handoff", "product_corroborated_handoff", "privacy_safe_local_receipt"}
+)
+_RECEIPT_FIELDS = frozenset(
     {
-        "prompt",
-        "raw_prompt",
-        "path",
-        "file",
-        "filename",
-        "command",
-        "secret",
-        "token",
-        "finding",
-        "source_code",
-        "hostname",
-        "username",
-        "report_body",
+        "schema_version",
+        "outcome",
+        "occurred_at",
+        "hol_guard_version",
+        "verification",
+        "evidence_digest",
+        "handoff_id",
+        "proof_kind",
+        "sensitive_content_included",
     }
 )
+_SENSITIVE_VALUE_MARKERS = frozenset(
+    {
+        "password",
+        "private",
+        "prompt",
+        "secret",
+        "sourcecode",
+        "token",
+        "username",
+        "hostname",
+    }
+)
+
+
+def _contains_sensitive_marker(value: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]", "", value.lower())
+    return any(marker in normalized for marker in _SENSITIVE_VALUE_MARKERS)
+
+
+def _validate_utc_timestamp(value: object) -> None:
+    if not isinstance(value, str) or not value.endswith("Z") or len(value) > 40:
+        raise ValueError("occurred_at must be a bounded UTC ISO-8601 timestamp ending in Z")
+    try:
+        parsed = datetime.fromisoformat(value.removesuffix("Z") + "+00:00")
+    except ValueError as exc:
+        raise ValueError("occurred_at must be a valid UTC ISO-8601 timestamp") from exc
+    if parsed.utcoffset() != UTC.utcoffset(parsed):
+        raise ValueError("occurred_at must be UTC")
+
+
+def _validate_guard_version(value: object) -> None:
+    if not isinstance(value, str) or not _VERSION_TEXT_RE.fullmatch(value):
+        raise ValueError("hol_guard_version must be a bounded PEP 440 version string")
+    try:
+        Version(value)
+    except InvalidVersion as exc:
+        raise ValueError("hol_guard_version must be a valid PEP 440 version") from exc
+
+
+def _validate_receipt_values(
+    *,
+    schema_version: object,
+    outcome: object,
+    occurred_at: object,
+    hol_guard_version: object,
+    verification: object,
+    evidence_digest: object,
+    handoff_id: object,
+    proof_kind: object,
+    sensitive_content_included: object,
+) -> None:
+    if schema_version != SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {SCHEMA_VERSION}")
+    if not isinstance(outcome, str) or outcome not in _ALLOWED_OUTCOMES:
+        raise ValueError("unsupported outcome")
+    if not isinstance(verification, str) or verification not in _ALLOWED_VERIFICATIONS:
+        raise ValueError("unsupported verification method")
+    _validate_utc_timestamp(occurred_at)
+    _validate_guard_version(hol_guard_version)
+    if not isinstance(evidence_digest, str) or not _SHA256_RE.fullmatch(evidence_digest):
+        raise ValueError("evidence_digest must be a lowercase SHA-256 digest")
+    if handoff_id is not None:
+        if not isinstance(handoff_id, str) or not _HANDOFF_ID_RE.fullmatch(handoff_id):
+            raise ValueError("handoff_id must use the bounded opaque identifier format")
+        if _contains_sensitive_marker(handoff_id):
+            raise ValueError("handoff_id must not contain sensitive-content markers")
+    if proof_kind is not None:
+        if not isinstance(proof_kind, str) or not _PROOF_KIND_RE.fullmatch(proof_kind):
+            raise ValueError("proof_kind must use the bounded lowercase identifier format")
+        if _contains_sensitive_marker(proof_kind):
+            raise ValueError("proof_kind must not contain sensitive-content markers")
+    if sensitive_content_included is not False:
+        raise ValueError("outcome receipts must not include sensitive content")
+
+    if outcome == "local_install_verified":
+        if verification not in {"binary_verified_handoff", "product_corroborated_handoff"}:
+            raise ValueError("local install requires verified handoff evidence")
+        if handoff_id is None:
+            raise ValueError("local install verification requires handoff_id")
+        if proof_kind is not None:
+            raise ValueError("local install receipt must not include proof_kind")
+    else:
+        if verification != "privacy_safe_local_receipt":
+            raise ValueError("first local proof requires privacy_safe_local_receipt verification")
+        if proof_kind is None:
+            raise ValueError("first local proof requires proof_kind")
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,6 +152,19 @@ class GuardOutcomeReceipt:
     handoff_id: str | None
     proof_kind: str | None
     sensitive_content_included: Literal[False] = False
+
+    def __post_init__(self) -> None:
+        _validate_receipt_values(
+            schema_version=self.schema_version,
+            outcome=self.outcome,
+            occurred_at=self.occurred_at,
+            hol_guard_version=self.hol_guard_version,
+            verification=self.verification,
+            evidence_digest=self.evidence_digest,
+            handoff_id=self.handoff_id,
+            proof_kind=self.proof_kind,
+            sensitive_content_included=self.sensitive_content_included,
+        )
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)
@@ -89,31 +193,7 @@ def build_outcome_receipt(
     occurred_at: datetime | None = None,
 ) -> GuardOutcomeReceipt:
     """Build a versioned receipt after an authoritative local outcome occurs."""
-    if not hol_guard_version or len(hol_guard_version) > 64:
-        raise ValueError("hol_guard_version must be 1..64 characters")
-    if not _SHA256_RE.fullmatch(evidence_digest):
-        raise ValueError("evidence_digest must be a lowercase SHA-256 digest")
-    if handoff_id is not None and not (1 <= len(handoff_id) <= 128):
-        raise ValueError("handoff_id must be 1..128 characters when present")
-    if proof_kind is not None and not (1 <= len(proof_kind) <= 64):
-        raise ValueError("proof_kind must be 1..64 characters when present")
-
-    if outcome == "local_install_verified":
-        if verification not in {"binary_verified_handoff", "product_corroborated_handoff"}:
-            raise ValueError("local install requires verified handoff evidence")
-        if not handoff_id:
-            raise ValueError("local install verification requires handoff_id")
-        if proof_kind is not None:
-            raise ValueError("local install receipt must not include proof_kind")
-    elif outcome == "first_local_proof_generated":
-        if verification != "privacy_safe_local_receipt":
-            raise ValueError("first local proof requires privacy_safe_local_receipt verification")
-        if not proof_kind:
-            raise ValueError("first local proof requires proof_kind")
-    else:  # pragma: no cover - protected by the type contract at static call sites
-        raise ValueError("unsupported outcome")
-
-    receipt = GuardOutcomeReceipt(
+    return GuardOutcomeReceipt(
         schema_version=SCHEMA_VERSION,
         outcome=outcome,
         occurred_at=_iso_utc(occurred_at),
@@ -123,32 +203,27 @@ def build_outcome_receipt(
         handoff_id=handoff_id,
         proof_kind=proof_kind,
     )
-    assert_privacy_safe_receipt(receipt.to_dict())
-    return receipt
 
 
 def assert_privacy_safe_receipt(payload: dict[str, object]) -> None:
-    """Reject receipt-shaped payloads that add sensitive-content fields."""
-    allowed = {
-        "schema_version",
-        "outcome",
-        "occurred_at",
-        "hol_guard_version",
-        "verification",
-        "evidence_digest",
-        "handoff_id",
-        "proof_kind",
-        "sensitive_content_included",
-    }
-    extras = set(payload) - allowed
+    """Validate the complete receipt schema and privacy/value invariants."""
+    extras = set(payload) - _RECEIPT_FIELDS
     if extras:
         raise ValueError(f"outcome receipt has unsupported fields: {sorted(extras)!r}")
-    for key in payload:
-        normalized = key.lower()
-        if normalized in _FORBIDDEN_KEYS:
-            raise ValueError(f"outcome receipt contains forbidden field: {key}")
-    if payload.get("sensitive_content_included") is not False:
-        raise ValueError("outcome receipts must not include sensitive content")
+    missing = _RECEIPT_FIELDS - set(payload)
+    if missing:
+        raise ValueError(f"outcome receipt is missing required fields: {sorted(missing)!r}")
+    _validate_receipt_values(
+        schema_version=payload["schema_version"],
+        outcome=payload["outcome"],
+        occurred_at=payload["occurred_at"],
+        hol_guard_version=payload["hol_guard_version"],
+        verification=payload["verification"],
+        evidence_digest=payload["evidence_digest"],
+        handoff_id=payload["handoff_id"],
+        proof_kind=payload["proof_kind"],
+        sensitive_content_included=payload["sensitive_content_included"],
+    )
 
 
 def canonical_receipt_bytes(receipt: GuardOutcomeReceipt) -> bytes:

--- a/tests/test_guard_outcome_receipt.py
+++ b/tests/test_guard_outcome_receipt.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 import pytest
 
 from codex_plugin_scanner.guard.outcome_receipt import (
+    GuardOutcomeReceipt,
     assert_privacy_safe_receipt,
     build_outcome_receipt,
     receipt_digest,
@@ -64,6 +65,51 @@ def test_first_proof_requires_proof_kind() -> None:
         )
 
 
+def test_direct_dataclass_construction_enforces_privacy_boundary() -> None:
+    with pytest.raises(ValueError, match="opaque identifier format"):
+        GuardOutcomeReceipt(
+            schema_version="1",
+            outcome="local_install_verified",
+            occurred_at="2026-08-09T16:00:00Z",
+            hol_guard_version="3.0.0a1",
+            verification="binary_verified_handoff",
+            evidence_digest="c" * 64,
+            handoff_id="/private/path secret",
+            proof_kind=None,
+        )
+
+
+def test_allowed_identifier_fields_reject_sensitive_markers() -> None:
+    with pytest.raises(ValueError, match="sensitive-content markers"):
+        build_outcome_receipt(
+            outcome="local_install_verified",
+            hol_guard_version="3.0.0a1",
+            verification="binary_verified_handoff",
+            evidence_digest="d" * 64,
+            handoff_id="secret-token",
+            occurred_at=datetime(2026, 8, 9, 16, 2, tzinfo=UTC),
+        )
+
+
+def test_receipt_rejects_unbounded_or_unstructured_metadata() -> None:
+    with pytest.raises(ValueError, match="PEP 440"):
+        build_outcome_receipt(
+            outcome="first_local_proof_generated",
+            hol_guard_version="not-a-version",
+            verification="privacy_safe_local_receipt",
+            evidence_digest="e" * 64,
+            proof_kind="runtime_decision_receipt",
+        )
+    with pytest.raises(ValueError, match="lowercase identifier format"):
+        build_outcome_receipt(
+            outcome="first_local_proof_generated",
+            hol_guard_version="3.0.0a1",
+            verification="privacy_safe_local_receipt",
+            evidence_digest="f" * 64,
+            proof_kind="../../private/path",
+        )
+
+
 def test_privacy_guard_rejects_extra_sensitive_fields() -> None:
     with pytest.raises(ValueError, match="unsupported fields"):
         assert_privacy_safe_receipt(
@@ -73,10 +119,30 @@ def test_privacy_guard_rejects_extra_sensitive_fields() -> None:
                 "occurred_at": "2026-08-09T16:00:00Z",
                 "hol_guard_version": "3.0.0a1",
                 "verification": "privacy_safe_local_receipt",
-                "evidence_digest": "c" * 64,
+                "evidence_digest": "a" * 64,
                 "handoff_id": None,
                 "proof_kind": "runtime_decision_receipt",
                 "sensitive_content_included": False,
                 "raw_prompt": "do not serialize me",
+            }
+        )
+
+
+def test_privacy_guard_validates_required_fields_and_values() -> None:
+    with pytest.raises(ValueError, match="missing required fields"):
+        assert_privacy_safe_receipt({"schema_version": "1"})
+
+    with pytest.raises(ValueError, match="sensitive-content markers"):
+        assert_privacy_safe_receipt(
+            {
+                "schema_version": "1",
+                "outcome": "local_install_verified",
+                "occurred_at": "2026-08-09T16:00:00Z",
+                "hol_guard_version": "3.0.0a1",
+                "verification": "binary_verified_handoff",
+                "evidence_digest": "b" * 64,
+                "handoff_id": "private-token",
+                "proof_kind": None,
+                "sensitive_content_included": False,
             }
         )

--- a/tests/test_guard_outcome_receipt.py
+++ b/tests/test_guard_outcome_receipt.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -21,7 +21,7 @@ def test_verified_install_receipt_requires_verified_handoff() -> None:
         verification="binary_verified_handoff",
         evidence_digest=evidence,
         handoff_id="handoff-safe-id",
-        occurred_at=datetime(2026, 8, 9, 16, 0, tzinfo=UTC),
+        occurred_at=datetime(2026, 8, 9, 16, 0, tzinfo=timezone.utc),
     )
     assert receipt.sensitive_content_included is False
     assert receipt.handoff_id == "handoff-safe-id"
@@ -37,7 +37,7 @@ def test_first_local_proof_receipt_contains_digest_not_evidence() -> None:
         verification="privacy_safe_local_receipt",
         evidence_digest=digest,
         proof_kind="runtime_decision_receipt",
-        occurred_at=datetime(2026, 8, 9, 16, 1, tzinfo=UTC),
+        occurred_at=datetime(2026, 8, 9, 16, 1, tzinfo=timezone.utc),
     )
     serialized = str(receipt.to_dict())
     assert "/private/path" not in serialized
@@ -87,7 +87,7 @@ def test_allowed_identifier_fields_reject_sensitive_markers() -> None:
             verification="binary_verified_handoff",
             evidence_digest="d" * 64,
             handoff_id="secret-token",
-            occurred_at=datetime(2026, 8, 9, 16, 2, tzinfo=UTC),
+            occurred_at=datetime(2026, 8, 9, 16, 2, tzinfo=timezone.utc),
         )
 
 

--- a/tests/test_guard_outcome_receipt.py
+++ b/tests/test_guard_outcome_receipt.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from codex_plugin_scanner.guard.outcome_receipt import (
+    assert_privacy_safe_receipt,
+    build_outcome_receipt,
+    receipt_digest,
+    sha256_digest,
+)
+
+
+def test_verified_install_receipt_requires_verified_handoff() -> None:
+    evidence = sha256_digest(b"binary-version-and-self-check")
+    receipt = build_outcome_receipt(
+        outcome="local_install_verified",
+        hol_guard_version="3.0.0a1",
+        verification="binary_verified_handoff",
+        evidence_digest=evidence,
+        handoff_id="handoff-safe-id",
+        occurred_at=datetime(2026, 8, 9, 16, 0, tzinfo=UTC),
+    )
+    assert receipt.sensitive_content_included is False
+    assert receipt.handoff_id == "handoff-safe-id"
+    assert len(receipt_digest(receipt)) == 64
+
+
+def test_first_local_proof_receipt_contains_digest_not_evidence() -> None:
+    raw_sensitive_evidence = b"/private/path secret-looking-content"
+    digest = sha256_digest(raw_sensitive_evidence)
+    receipt = build_outcome_receipt(
+        outcome="first_local_proof_generated",
+        hol_guard_version="3.0.0a1",
+        verification="privacy_safe_local_receipt",
+        evidence_digest=digest,
+        proof_kind="runtime_decision_receipt",
+        occurred_at=datetime(2026, 8, 9, 16, 1, tzinfo=UTC),
+    )
+    serialized = str(receipt.to_dict())
+    assert "/private/path" not in serialized
+    assert "secret-looking-content" not in serialized
+    assert digest in serialized
+
+
+def test_install_receipt_rejects_unlinked_local_claim() -> None:
+    with pytest.raises(ValueError, match="handoff_id"):
+        build_outcome_receipt(
+            outcome="local_install_verified",
+            hol_guard_version="3.0.0a1",
+            verification="binary_verified_handoff",
+            evidence_digest="a" * 64,
+        )
+
+
+def test_first_proof_requires_proof_kind() -> None:
+    with pytest.raises(ValueError, match="proof_kind"):
+        build_outcome_receipt(
+            outcome="first_local_proof_generated",
+            hol_guard_version="3.0.0a1",
+            verification="privacy_safe_local_receipt",
+            evidence_digest="b" * 64,
+        )
+
+
+def test_privacy_guard_rejects_extra_sensitive_fields() -> None:
+    with pytest.raises(ValueError, match="unsupported fields"):
+        assert_privacy_safe_receipt(
+            {
+                "schema_version": "1",
+                "outcome": "first_local_proof_generated",
+                "occurred_at": "2026-08-09T16:00:00Z",
+                "hol_guard_version": "3.0.0a1",
+                "verification": "privacy_safe_local_receipt",
+                "evidence_digest": "c" * 64,
+                "handoff_id": None,
+                "proof_kind": "runtime_decision_receipt",
+                "sensitive_content_included": False,
+                "raw_prompt": "do not serialize me",
+            }
+        )


### PR DESCRIPTION
Adds a versioned, privacy-safe local outcome receipt contract for verified install and first local proof milestones.

Key properties:
- never serializes prompts, paths, commands, findings, secrets, tokens, usernames, hostnames, or report bodies
- requires verified handoff evidence for install receipts
- stores only a SHA-256 evidence digest for first-proof receipts
- documents that receipts are operational evidence, not self-authenticating remote attestations
- includes focused unit coverage for privacy and verification boundaries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added privacy-safe Guard outcome receipts containing bounded outcome metadata and a SHA-256 evidence digest.
  * Added verification support for local installs and locally generated proofs, including required identifiers and first-proof details.
  * Added deterministic receipt serialization and digest-based idempotency.

* **Documentation**
  * Documented receipt formats, activation milestones, verification requirements, and prohibited sensitive content.

* **Tests**
  * Added coverage for receipt creation, privacy-safe serialization, digest generation, and validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->