### PR TITLE
fix(release): align 3.0 security contracts

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/protect_approvals.py
+++ b/src/codex_plugin_scanner/guard/cli/protect_approvals.py
@@ -184,6 +184,12 @@ def _protect_approval_item(
         if reason_code in reason_codes:
             decision_v2_payload["package_review_cloud_reason_code"] = reason_code
             break
+    action_envelope = receipt.get("action_envelope_json")
+    projected_action_envelope = dict(action_envelope) if isinstance(action_envelope, dict) else None
+    if projected_action_envelope is not None and projected_action_envelope.get("observe_mode") is True:
+        projected_action_envelope["policy_action"] = policy_action
+        projected_action_envelope.pop("observe_mode", None)
+        projected_action_envelope.pop("observed_policy_action", None)
     return {
         "artifact_id": artifact.artifact_id,
         "artifact_name": artifact.name,
@@ -195,9 +201,7 @@ def _protect_approval_item(
         "changed_fields": _protect_target_labels(response_payload),
         "risk_summary": risk_summary,
         "risk_signals": _string_list(verdict.get("risk_signals")),
-        "action_envelope_json": (
-            receipt.get("action_envelope_json") if isinstance(receipt.get("action_envelope_json"), dict) else None
-        ),
+        "action_envelope_json": projected_action_envelope,
         "decision_v2_json": decision_v2_payload,
         "scanner_evidence": scanner_evidence,
     }

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -10,7 +10,8 @@ ROOT = Path(__file__).resolve().parents[1]
 PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "publish.yml"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 CODEOWNERS = ROOT / ".github" / "CODEOWNERS"
-RELEASE_BRANCHES = ["main", "release/3.0", "release/3.1"]
+CI_BRANCHES = ["main", "release/3.0", "release/3.1"]
+RELEASE_BRANCHES = ["main", "release/3.0"]
 PR_CANARY_BRANCHES = ["main", "release/3.0"]
 RELEASE_MAINTAINERS = {"@kantorcodes", "@deep-purple-boots"}
 
@@ -33,7 +34,7 @@ def test_release_branches_run_ci_and_pr_canaries() -> None:
     ci = _workflow(CI_WORKFLOW)
     publish = _workflow(PUBLISH_WORKFLOW)
 
-    assert ci[True]["push"]["branches"] == RELEASE_BRANCHES
+    assert ci[True]["push"]["branches"] == CI_BRANCHES
     assert ci[True]["pull_request"]["branches"] == PR_CANARY_BRANCHES
     assert publish[True]["push"]["branches"] == RELEASE_BRANCHES
     assert publish[True]["pull_request"]["branches"] == PR_CANARY_BRANCHES
@@ -53,7 +54,7 @@ def test_release_branch_pushes_publish_alpha_while_main_pushes_publish_stable() 
         condition = jobs[job_name]["if"]
         assert "github.event_name == 'workflow_dispatch'" in condition
         assert "github.event_name == 'push'" in condition
-        assert "startsWith(github.ref, 'refs/heads/release/3.')" in condition
+        assert "github.ref == 'refs/heads/release/3.0'" in condition
     for job_name in ("publish-main-testpypi", "publish-main-pypi", "release-main"):
         condition = jobs[job_name]["if"]
         assert "github.event_name == 'push'" in condition
@@ -78,11 +79,9 @@ def test_main_push_build_computes_a_registry_derived_stable_version() -> None:
     stamp_run = stamp_step["run"]
 
     assert 'VERSION="$BASE_VERSION"' in compute_run
-    assert (
-        'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ ^refs/heads/release/3\\.[0-9]+$ ]]' in compute_run
-    )
+    assert 'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/release/3.0" ]]' in compute_run
     assert 'SOURCE_SHA" != "$GITHUB_SHA"' in compute_run
-    assert 'TRAIN="${GITHUB_REF#refs/heads/release/}"' in compute_run
+    assert 'TRAIN="3.0"' in compute_run
     assert "compute_alpha_release_version.py" in compute_run
     assert "validate_alpha_release.py" in compute_run
     assert 'elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]' in compute_run
@@ -109,7 +108,7 @@ def test_alpha_only_dispatch_and_pr_version_stamping_contracts() -> None:
     stamp_run = next(step["run"] for step in build_steps if step.get("name") == "Stamp package version when needed")
 
     assert 'if [[ "$CHANNEL" != "alpha" ]]' in compute_run
-    assert "The selected release train is alpha-only" in compute_run
+    assert "The release/3.0 train is alpha-only" in compute_run
     assert 'elif [[ "$CHANNEL" == "stable" ]]' not in compute_run
     assert "VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py" in compute_run
     assert 'VERSION=$(BASE_VERSION="$BASE_VERSION" PR_NUMBER="$PR_NUMBER"' in compute_run
@@ -123,7 +122,7 @@ def test_release_dispatch_binds_channel_train_version_and_sha() -> None:
     build_steps = workflow["jobs"]["build"]["steps"]
 
     assert inputs["release_channel"]["options"] == ["alpha"]
-    assert inputs["release_train"]["options"] == ["3.0", "3.1"]
+    assert inputs["release_train"]["options"] == ["3.0"]
     assert inputs["release_version"]["required"] is True
     assert inputs["expected_sha"]["required"] is True
     assert "promotion_pr" not in inputs
@@ -144,12 +143,11 @@ def test_release_dispatch_binds_channel_train_version_and_sha() -> None:
     assert '"$GITHUB_ACTOR_ID" != "301892678"' in dispatch_gate["run"]
     assert '"$RELEASE_CHANNEL" != "alpha"' in dispatch_gate["run"]
     assert '"$RELEASE_TRAIN" != "3.0"' in dispatch_gate["run"]
-    assert '"$RELEASE_TRAIN" != "3.1"' in dispatch_gate["run"]
     assert '"$EXPECTED_SHA" != "$GITHUB_SHA"' in dispatch_gate["run"]
     assert jobs["build"]["needs"] == "authorize-release"
     build_condition = jobs["build"]["if"]
     assert "github.event_name != 'workflow_dispatch' || github.run_attempt == 1" in build_condition
-    assert "github.event_name != 'push' || github.run_attempt == 1" not in build_condition
+    assert "github.event_name != 'push' || github.run_attempt == 1" in build_condition
     assert "alpha-cross-platform" not in jobs
     for job_name in (
         "publish-alpha-testpypi",
@@ -160,7 +158,7 @@ def test_release_dispatch_binds_channel_train_version_and_sha() -> None:
         assert "github.run_attempt == 1" in jobs[job_name]["if"]
     compute_run = next(step["run"] for step in build_steps if step.get("name") == "Compute publish version")
     assert 'if [[ "$CHANNEL" != "alpha" ]]' in compute_run
-    assert 'if [[ "$TRAIN" != "3.0" && "$TRAIN" != "3.1" ]]' in compute_run
+    assert 'if [[ "$TRAIN" != "3.0" ]]' in compute_run
     assert 'if [[ "$GITHUB_REF" != "$TRAIN_REF" ]]' in compute_run
     assert '"$GITHUB_RUN_ATTEMPT" != "1"' in compute_run
     assert '"$GITHUB_ACTOR_ID" != "6068672"' in compute_run
@@ -186,9 +184,9 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
     assert "distribution-sha256" in {
         step.get("with", {}).get("name") for step in jobs["build"]["steps"] if isinstance(step, dict)
     }
-    assert jobs["publish-alpha-pypi"]["needs"] == ["build", "reserve-alpha-tag"]
-    assert "needs.publish-alpha-testpypi.result == 'success'" not in jobs["publish-alpha-pypi"]["if"]
-    assert "vars.ALPHA_TESTPYPI_ENABLED == 'true'" in jobs["publish-alpha-testpypi"]["if"]
+    assert jobs["publish-alpha-pypi"]["needs"] == ["build", "reserve-alpha-tag", "publish-alpha-testpypi"]
+    assert "needs.publish-alpha-testpypi.result == 'success'" in jobs["publish-alpha-pypi"]["if"]
+    assert "vars.ALPHA_TESTPYPI_ENABLED" not in jobs["publish-alpha-testpypi"]["if"]
     for job_name in (
         "publish-alpha-testpypi",
         "publish-alpha-pypi",
@@ -297,8 +295,8 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
         if step.get("name") == "Revalidate alpha publication authorization"
     )
     assert "list-versions --registry pypi" in alpha_run
-    assert "git fetch --no-tags origin" in alpha_run
-    assert "git merge-base --is-ancestor" in alpha_run
+    assert 'git ls-remote --exit-code origin "$train_ref"' in alpha_run
+    assert '"$remote_train_sha" != "$SOURCE_SHA"' in alpha_run
     assert "validate_alpha_release.py" in alpha_run
     assert "refs/tags/alpha/v${VERSION}" in alpha_run
     assert 'awk -v candidate="$VERSION"' in alpha_run
@@ -333,17 +331,17 @@ def test_release_tags_are_bound_to_the_exact_published_source() -> None:
         for step in jobs["publish-alpha-testpypi"]["steps"]
         if step.get("name") == "Revalidate alpha source before TestPyPI"
     )
-    assert "git fetch --no-tags origin" in alpha_test_run
-    assert "git merge-base --is-ancestor" in alpha_test_run
+    assert 'git ls-remote --exit-code origin "$train_ref"' in alpha_test_run
+    assert '"$remote_train_sha" != "$SOURCE_SHA"' in alpha_test_run
     assert "refs/tags/alpha/v${VERSION}" in alpha_test_run
-    assert '[[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]' in alpha_test_run
+    assert '"$remote_alpha_tag_sha" != "$SOURCE_SHA"' in alpha_test_run
 
     alpha_pypi_run = next(
         step["run"]
         for step in jobs["publish-alpha-pypi"]["steps"]
         if step.get("name") == "Revalidate alpha publication authorization"
     )
-    assert '[[ -n "$remote_alpha_tag_sha" && "$remote_alpha_tag_sha" != "$SOURCE_SHA" ]]' in alpha_pypi_run
+    assert '"$remote_alpha_tag_sha" != "$SOURCE_SHA"' in alpha_pypi_run
 
     release_run = next(
         step["run"]
@@ -384,7 +382,7 @@ def test_release_3x_alpha_branches_remain_alpha_while_main_is_stable() -> None:
 
     assert "channel == 'alpha'" in jobs["release-alpha"]["if"]
     assert "github.event_name == 'push'" in jobs["release-alpha"]["if"]
-    assert "startsWith(github.ref, 'refs/heads/release/3.')" in jobs["release-alpha"]["if"]
+    assert "github.ref == 'refs/heads/release/3.0'" in jobs["release-alpha"]["if"]
     assert "channel == 'stable'" in jobs["publish-container"]["if"]
     assert jobs["publish-container"]["needs"] == [
         "build",


### PR DESCRIPTION
## Summary

- align release tests with the 3.0-only alpha publication contract while retaining 3.1 CI coverage
- require assertions for first-attempt pushes, TestPyPI-before-PyPI, and exact remote source/tag identity
- project watch-only package findings back to their authoritative review action without mutating receipt evidence

## Verification

- focused release workflow and approval-decision tests
- Ruff check and formatting verification
- basedpyright
- test-suite ratchet and deterministic decision evidence checks
- independent adversarial review
