### PR TITLE
feat: add OWASP Agentic Skills reference mapping

### DIFF
--- a/docs/guard/owasp-agentic-skills-top-10.md
+++ b/docs/guard/owasp-agentic-skills-top-10.md
@@ -25,7 +25,7 @@ A source update must be reviewed before the pinned revision or mappings change.
 | AST02 | Supply Chain Compromise |
 | AST03 | Over-Privileged Skills |
 | AST04 | Insecure Metadata |
-| AST05 | Unsafe Deserialization |
+| AST05 | Untrusted External Instructions |
 | AST06 | Weak Isolation |
 | AST07 | Update Drift |
 | AST08 | Poor Scanning |

--- a/docs/guard/owasp-agentic-skills-top-10.md
+++ b/docs/guard/owasp-agentic-skills-top-10.md
@@ -1,0 +1,91 @@
+# OWASP Agentic Skills Top 10 mapping
+
+HOL Guard maintains a conservative reference mapping between selected scanner
+findings and the OWASP Agentic Skills Top 10 (AST10).
+
+This integration is **not** an OWASP compliance, certification, endorsement, or
+coverage claim. Scanner evidence and standards associations are intentionally
+kept separate.
+
+## Pinned source
+
+The mapping is based on the OWASP `www-project-agentic-skills-top-10` repository:
+
+- Version label: `1.0 (2026 Edition)`
+- Pinned revision: `9faab9ae8d1f0dd132603264a50a679f94b6e955`
+- Source document: `top10.md`
+
+A source update must be reviewed before the pinned revision or mappings change.
+
+## Risk catalog
+
+| ID | Risk |
+| --- | --- |
+| AST01 | Malicious Skills |
+| AST02 | Supply Chain Compromise |
+| AST03 | Over-Privileged Skills |
+| AST04 | Insecure Metadata |
+| AST05 | Unsafe Deserialization |
+| AST06 | Weak Isolation |
+| AST07 | Update Drift |
+| AST08 | Poor Scanning |
+| AST09 | No Governance |
+| AST10 | Cross-Platform Reuse |
+
+## Initial rule mappings
+
+The first version intentionally maps only scanner rules with a narrow, reviewable
+association:
+
+| HOL Guard rule | AST10 association | Rationale |
+| --- | --- | --- |
+| `SECURITY_MD_MISSING` | AST09 | Missing security-reporting guidance is a governance gap. |
+| `RISKY_APPROVAL_DEFAULT` | AST03, AST06 | Default approval bypass or unrestricted sandboxing increases privilege and weakens isolation. |
+
+All other rules return `unmapped`. `unmapped` means only that HOL Guard has not
+encoded a conservative AST10 association for that rule. It does not lower the
+finding's HOL Guard severity or importance.
+
+## Evidence model
+
+`codex_plugin_scanner.standards.owasp_agentic_skills.evidence_record()` emits two
+independent dimensions:
+
+1. `finding.state`: `detected`, `not_detected`, or `not_tested`.
+2. `mapping.status`: `mapped` or `unmapped`, with zero or more AST10 risks.
+
+This separation prevents statements such as "AST03 passed" when HOL Guard only
+observed one scanner signal associated with AST03.
+
+Example:
+
+```json
+{
+  "schema": "hol.guard.owasp-agentic-skills.v1",
+  "finding": {
+    "rule_id": "SECURITY_MD_MISSING",
+    "state": "detected"
+  },
+  "mapping": {
+    "status": "mapped",
+    "risks": [
+      {"id": "AST09", "name": "No Governance"}
+    ]
+  }
+}
+```
+
+The actual payload also includes the pinned source revision and a disclaimer.
+
+## Maintenance rules
+
+- Never change a scanner verdict because of an AST10 mapping.
+- Never infer coverage from a missing finding.
+- Never map a new HOL Guard rule from its name alone; review the detection
+  semantics and the pinned OWASP risk text.
+- Keep MCP-protocol-only findings `unmapped` unless the same rule also applies to
+  an agentic skill boundary documented by AST10.
+- Treat OWASP source changes as data migrations: pin a new revision, review the
+  risk names/semantics, update tests, and record the change.
+- Public upstream feedback follows the contribution channel requested by the
+  OWASP project for the active publication cycle.

--- a/src/codex_plugin_scanner/standards/__init__.py
+++ b/src/codex_plugin_scanner/standards/__init__.py
@@ -1,0 +1,1 @@
+"""Standards reference mappings used by HOL Guard."""

--- a/src/codex_plugin_scanner/standards/owasp_agentic_skills.py
+++ b/src/codex_plugin_scanner/standards/owasp_agentic_skills.py
@@ -1,0 +1,112 @@
+"""OWASP Agentic Skills Top 10 reference mappings for HOL Guard findings.
+
+This module is descriptive metadata only. It does not alter scanner verdicts and
+must not be used to claim OWASP compliance or certification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+OWASP_AST10_VERSION = "1.0 (2026 Edition)"
+OWASP_AST10_SOURCE_REVISION = "9faab9ae8d1f0dd132603264a50a679f94b6e955"
+OWASP_AST10_SOURCE_PATH = "top10.md"
+
+
+@dataclass(frozen=True, slots=True)
+class AstRisk:
+    risk_id: str
+    name: str
+
+
+class EvidenceState(str, Enum):
+    """Scanner evidence state, independent from standards mapping."""
+
+    DETECTED = "detected"
+    NOT_DETECTED = "not_detected"
+    NOT_TESTED = "not_tested"
+
+
+OWASP_AST10_RISKS: dict[str, AstRisk] = {
+    "AST01": AstRisk("AST01", "Malicious Skills"),
+    "AST02": AstRisk("AST02", "Supply Chain Compromise"),
+    "AST03": AstRisk("AST03", "Over-Privileged Skills"),
+    "AST04": AstRisk("AST04", "Insecure Metadata"),
+    "AST05": AstRisk("AST05", "Unsafe Deserialization"),
+    "AST06": AstRisk("AST06", "Weak Isolation"),
+    "AST07": AstRisk("AST07", "Update Drift"),
+    "AST08": AstRisk("AST08", "Poor Scanning"),
+    "AST09": AstRisk("AST09", "No Governance"),
+    "AST10": AstRisk("AST10", "Cross-Platform Reuse"),
+}
+
+# Only map rules when the association is narrow enough to be useful. Everything
+# else is deliberately UNMAPPED rather than inferred from a broad category name.
+_RULE_RISK_IDS: dict[str, tuple[str, ...]] = {
+    "SECURITY_MD_MISSING": ("AST09",),
+    "RISKY_APPROVAL_DEFAULT": ("AST03", "AST06"),
+}
+
+_UNMAPPED_REASON = (
+    "No conservative OWASP Agentic Skills Top 10 association is encoded for this "
+    "HOL Guard rule. This does not mean the finding is unimportant."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AstMapping:
+    rule_id: str
+    risks: tuple[AstRisk, ...]
+    mapped: bool
+    note: str
+
+
+def map_rule_id(rule_id: str) -> AstMapping:
+    """Return a conservative AST10 association for a HOL Guard rule ID."""
+
+    normalized = rule_id.strip().upper()
+    risk_ids = _RULE_RISK_IDS.get(normalized, ())
+    if not risk_ids:
+        return AstMapping(
+            rule_id=normalized,
+            risks=(),
+            mapped=False,
+            note=_UNMAPPED_REASON,
+        )
+    return AstMapping(
+        rule_id=normalized,
+        risks=tuple(OWASP_AST10_RISKS[risk_id] for risk_id in risk_ids),
+        mapped=True,
+        note=(
+            "Reference mapping only. A mapped finding is not evidence of full "
+            "coverage, conformance, compliance, or certification."
+        ),
+    )
+
+
+def evidence_record(rule_id: str, state: EvidenceState) -> dict[str, object]:
+    """Build machine-readable evidence without conflating scan state and risk mapping."""
+
+    mapping = map_rule_id(rule_id)
+    return {
+        "schema": "hol.guard.owasp-agentic-skills.v1",
+        "source": {
+            "version": OWASP_AST10_VERSION,
+            "revision": OWASP_AST10_SOURCE_REVISION,
+            "path": OWASP_AST10_SOURCE_PATH,
+        },
+        "finding": {
+            "rule_id": mapping.rule_id,
+            "state": state.value,
+        },
+        "mapping": {
+            "status": "mapped" if mapping.mapped else "unmapped",
+            "risks": [
+                {"id": risk.risk_id, "name": risk.name}
+                for risk in mapping.risks
+            ],
+            "note": mapping.note,
+        },
+    }

--- a/src/codex_plugin_scanner/standards/owasp_agentic_skills.py
+++ b/src/codex_plugin_scanner/standards/owasp_agentic_skills.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from types import MappingProxyType
+from typing import Mapping
 
 
 OWASP_AST10_VERSION = "1.0 (2026 Edition)"
@@ -29,30 +31,51 @@ class EvidenceState(str, Enum):
     NOT_TESTED = "not_tested"
 
 
-OWASP_AST10_RISKS: dict[str, AstRisk] = {
-    "AST01": AstRisk("AST01", "Malicious Skills"),
-    "AST02": AstRisk("AST02", "Supply Chain Compromise"),
-    "AST03": AstRisk("AST03", "Over-Privileged Skills"),
-    "AST04": AstRisk("AST04", "Insecure Metadata"),
-    "AST05": AstRisk("AST05", "Untrusted External Instructions"),
-    "AST06": AstRisk("AST06", "Weak Isolation"),
-    "AST07": AstRisk("AST07", "Update Drift"),
-    "AST08": AstRisk("AST08", "Poor Scanning"),
-    "AST09": AstRisk("AST09", "No Governance"),
-    "AST10": AstRisk("AST10", "Cross-Platform Reuse"),
-}
+OWASP_AST10_RISKS: Mapping[str, AstRisk] = MappingProxyType(
+    {
+        "AST01": AstRisk("AST01", "Malicious Skills"),
+        "AST02": AstRisk("AST02", "Supply Chain Compromise"),
+        "AST03": AstRisk("AST03", "Over-Privileged Skills"),
+        "AST04": AstRisk("AST04", "Insecure Metadata"),
+        "AST05": AstRisk("AST05", "Untrusted External Instructions"),
+        "AST06": AstRisk("AST06", "Weak Isolation"),
+        "AST07": AstRisk("AST07", "Update Drift"),
+        "AST08": AstRisk("AST08", "Poor Scanning"),
+        "AST09": AstRisk("AST09", "No Governance"),
+        "AST10": AstRisk("AST10", "Cross-Platform Reuse"),
+    }
+)
 
 # Only map rules when the association is narrow enough to be useful. Everything
 # else is deliberately UNMAPPED rather than inferred from a broad category name.
-_RULE_RISK_IDS: dict[str, tuple[str, ...]] = {
-    "SECURITY_MD_MISSING": ("AST09",),
-    "RISKY_APPROVAL_DEFAULT": ("AST03", "AST06"),
-}
+_RULE_RISK_IDS: Mapping[str, tuple[str, ...]] = MappingProxyType(
+    {
+        "SECURITY_MD_MISSING": ("AST09",),
+        "RISKY_APPROVAL_DEFAULT": ("AST03", "AST06"),
+    }
+)
 
 _UNMAPPED_REASON = (
     "No conservative OWASP Agentic Skills Top 10 association is encoded for this "
     "HOL Guard rule. This does not mean the finding is unimportant."
 )
+
+
+def _validate_mapping_catalog() -> None:
+    unknown_risk_ids = sorted(
+        {
+            risk_id
+            for risk_ids in _RULE_RISK_IDS.values()
+            for risk_id in risk_ids
+            if risk_id not in OWASP_AST10_RISKS
+        }
+    )
+    if unknown_risk_ids:
+        unknown = ", ".join(unknown_risk_ids)
+        raise RuntimeError(f"AST10 rule mappings reference unknown risk IDs: {unknown}")
+
+
+_validate_mapping_catalog()
 
 
 @dataclass(frozen=True, slots=True)
@@ -65,6 +88,9 @@ class AstMapping:
 
 def map_rule_id(rule_id: str) -> AstMapping:
     """Return a conservative AST10 association for a HOL Guard rule ID."""
+
+    if not isinstance(rule_id, str):
+        raise TypeError("rule_id must be a string")
 
     normalized = rule_id.strip().upper()
     risk_ids = _RULE_RISK_IDS.get(normalized, ())
@@ -88,6 +114,9 @@ def map_rule_id(rule_id: str) -> AstMapping:
 
 def evidence_record(rule_id: str, state: EvidenceState) -> dict[str, object]:
     """Build machine-readable evidence without conflating scan state and risk mapping."""
+
+    if not isinstance(state, EvidenceState):
+        raise TypeError("state must be an EvidenceState")
 
     mapping = map_rule_id(rule_id)
     return {

--- a/src/codex_plugin_scanner/standards/owasp_agentic_skills.py
+++ b/src/codex_plugin_scanner/standards/owasp_agentic_skills.py
@@ -34,7 +34,7 @@ OWASP_AST10_RISKS: dict[str, AstRisk] = {
     "AST02": AstRisk("AST02", "Supply Chain Compromise"),
     "AST03": AstRisk("AST03", "Over-Privileged Skills"),
     "AST04": AstRisk("AST04", "Insecure Metadata"),
-    "AST05": AstRisk("AST05", "Unsafe Deserialization"),
+    "AST05": AstRisk("AST05", "Untrusted External Instructions"),
     "AST06": AstRisk("AST06", "Weak Isolation"),
     "AST07": AstRisk("AST07", "Update Drift"),
     "AST08": AstRisk("AST08", "Poor Scanning"),

--- a/tests/test_owasp_agentic_skills_crosswalk.py
+++ b/tests/test_owasp_agentic_skills_crosswalk.py
@@ -16,6 +16,7 @@ from codex_plugin_scanner.standards.owasp_agentic_skills import (
 def test_risk_catalog_is_exactly_ast01_through_ast10() -> None:
     assert tuple(OWASP_AST10_RISKS) == tuple(f"AST{index:02d}" for index in range(1, 11))
     assert len({risk.name for risk in OWASP_AST10_RISKS.values()}) == 10
+    assert OWASP_AST10_RISKS["AST05"].name == "Untrusted External Instructions"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_owasp_agentic_skills_crosswalk.py
+++ b/tests/test_owasp_agentic_skills_crosswalk.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from codex_plugin_scanner.standards.owasp_agentic_skills import (
+    EvidenceState,
+    OWASP_AST10_RISKS,
+    OWASP_AST10_SOURCE_REVISION,
+    evidence_record,
+    map_rule_id,
+)
+
+
+def test_risk_catalog_is_exactly_ast01_through_ast10() -> None:
+    assert tuple(OWASP_AST10_RISKS) == tuple(f"AST{index:02d}" for index in range(1, 11))
+    assert len({risk.name for risk in OWASP_AST10_RISKS.values()}) == 10
+
+
+@pytest.mark.parametrize(
+    ("rule_id", "expected"),
+    [
+        ("SECURITY_MD_MISSING", ("AST09",)),
+        ("RISKY_APPROVAL_DEFAULT", ("AST03", "AST06")),
+    ],
+)
+def test_conservative_rule_mappings(rule_id: str, expected: tuple[str, ...]) -> None:
+    mapping = map_rule_id(rule_id)
+
+    assert mapping.mapped is True
+    assert tuple(risk.risk_id for risk in mapping.risks) == expected
+    assert "compliance" in mapping.note
+
+
+@pytest.mark.parametrize(
+    "rule_id",
+    [
+        "HARDCODED_SECRET",
+        "DANGEROUS_MCP_COMMAND",
+        "MCP_REMOTE_URL_INSECURE",
+        "UNKNOWN_FUTURE_RULE",
+    ],
+)
+def test_unreviewed_or_out_of_scope_rules_are_explicitly_unmapped(rule_id: str) -> None:
+    mapping = map_rule_id(rule_id)
+
+    assert mapping.mapped is False
+    assert mapping.risks == ()
+    assert "does not mean the finding is unimportant" in mapping.note
+
+
+@pytest.mark.parametrize("state", list(EvidenceState))
+def test_evidence_keeps_scanner_state_separate_from_mapping(state: EvidenceState) -> None:
+    payload = evidence_record("SECURITY_MD_MISSING", state)
+
+    assert payload["finding"] == {
+        "rule_id": "SECURITY_MD_MISSING",
+        "state": state.value,
+    }
+    assert payload["mapping"]["status"] == "mapped"
+    assert payload["mapping"]["risks"] == [{"id": "AST09", "name": "No Governance"}]
+    assert payload["source"]["revision"] == OWASP_AST10_SOURCE_REVISION
+
+    json.dumps(payload)
+
+
+def test_rule_ids_are_normalized_without_guessing() -> None:
+    assert map_rule_id(" security_md_missing ").rule_id == "SECURITY_MD_MISSING"
+    assert map_rule_id(" never-seen-before ").mapped is False

--- a/tests/test_owasp_agentic_skills_crosswalk.py
+++ b/tests/test_owasp_agentic_skills_crosswalk.py
@@ -62,10 +62,19 @@ def test_evidence_keeps_scanner_state_separate_from_mapping(state: EvidenceState
     assert payload["mapping"]["status"] == "mapped"
     assert payload["mapping"]["risks"] == [{"id": "AST09", "name": "No Governance"}]
     assert payload["source"]["revision"] == OWASP_AST10_SOURCE_REVISION
-
-    json.dumps(payload)
+    assert json.loads(json.dumps(payload)) == payload
 
 
 def test_rule_ids_are_normalized_without_guessing() -> None:
     assert map_rule_id(" security_md_missing ").rule_id == "SECURITY_MD_MISSING"
     assert map_rule_id(" never-seen-before ").mapped is False
+
+
+def test_non_string_rule_id_fails_with_explicit_type_error() -> None:
+    with pytest.raises(TypeError, match="rule_id must be a string"):
+        map_rule_id(None)  # type: ignore[arg-type]
+
+
+def test_invalid_evidence_state_fails_with_explicit_type_error() -> None:
+    with pytest.raises(TypeError, match="state must be an EvidenceState"):
+        evidence_record("SECURITY_MD_MISSING", "detected")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Adds a conservative, version-pinned reference mapping between selected HOL Guard scanner findings and the OWASP Agentic Skills Top 10.

- pins the OWASP source to commit `9faab9ae8d1f0dd132603264a50a679f94b6e955`
- keeps scanner evidence state separate from standards associations
- maps only reviewed rules and returns explicit `unmapped` for everything else
- documents that the mapping is not a compliance, certification, endorsement, or coverage claim
- adds regression tests for the risk catalog, mappings, unmapped behavior, and machine-readable evidence

## Validation

- focused crosswalk test suite: 11 passed
- module/test syntax compilation passed

## Scope

This is additive metadata only. It does not change scanner verdicts, severity, policy enforcement, runtime behavior, or GitHub workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OWASP Agentic Skills Top 10 reference mappings for scanner rules.
  * Added normalized evidence records with detected, not detected, and not tested states.
  * Added source revision metadata and clear handling for mapped and unmapped rules.
  * Documented the risk catalog, mapping methodology, evidence format, and maintenance guidance.

* **Tests**
  * Added coverage for risk mappings, rule normalization, evidence states, metadata, and JSON serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->