### PR TITLE
test(ci): align release suite ratchet

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14061,
-  "maximum_test_source_lines": 310716,
+  "maximum_collected_cases": 14070,
+  "maximum_test_source_lines": 310862,
   "schema_version": 1
 }


### PR DESCRIPTION
## Summary
- align the release test-suite ratchet with the exact checked-in inventory
- preserve fail-closed detection for any subsequent unreviewed test growth

## Testing
- `python scripts/ci/test_inventory.py --output <inventory.json>`
- `python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory <inventory.json>`
- `pytest -q tests/test_ci_test_inventory.py tests/test_ci_test_suite_ratchet.py --tb=short`
- `git diff --check`
