### PR TITLE
test(ci): refresh release 3.0 suite ratchet

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14061,
-  "maximum_test_source_lines": 310716,
+  "maximum_collected_cases": 14070,
+  "maximum_test_source_lines": 310862,
   "schema_version": 1
 }


### PR DESCRIPTION
Refresh the release/3.0 test-suite ratchet to the exact inventory measured by the failing Desktop contract CI after the latest reviewed test additions.

- collected cases: 14061 -> 14070
- test source lines: 310716 -> 310862
- no product, workflow, policy, or release logic changes

The prior Desktop contract run passed formatting, lint, all Desktop contract tests, and source-bound decision evidence; only this stale reviewed baseline failed.