### PR TITLE
fix(release): decouple alpha publish from TestPyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -636,6 +636,7 @@ jobs:
     if: >-
       always() &&
       vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      vars.ALPHA_TESTPYPI_ENABLED == 'true' &&
       needs.build.result == 'success' &&
       needs.reserve-alpha-tag.result == 'success' &&
       needs.build.outputs.channel == 'alpha' &&
@@ -737,13 +738,12 @@ jobs:
       vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
       needs.build.result == 'success' &&
       needs.reserve-alpha-tag.result == 'success' &&
-      needs.publish-alpha-testpypi.result == 'success' &&
       needs.build.outputs.channel == 'alpha' &&
       (
         (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
         (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0')
       )
-    needs: [build, reserve-alpha-tag, publish-alpha-testpypi]
+    needs: [build, reserve-alpha-tag]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 14081,
-  "maximum_test_source_lines": 311088,
+  "maximum_test_source_lines": 311089,
   "schema_version": 1
 }

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -184,9 +184,9 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
     assert "distribution-sha256" in {
         step.get("with", {}).get("name") for step in jobs["build"]["steps"] if isinstance(step, dict)
     }
-    assert jobs["publish-alpha-pypi"]["needs"] == ["build", "reserve-alpha-tag", "publish-alpha-testpypi"]
-    assert "needs.publish-alpha-testpypi.result == 'success'" in jobs["publish-alpha-pypi"]["if"]
-    assert "vars.ALPHA_TESTPYPI_ENABLED" not in jobs["publish-alpha-testpypi"]["if"]
+    assert jobs["publish-alpha-pypi"]["needs"] == ["build", "reserve-alpha-tag"]
+    assert "needs.publish-alpha-testpypi" not in jobs["publish-alpha-pypi"]["if"]
+    assert "vars.ALPHA_TESTPYPI_ENABLED == 'true'" in jobs["publish-alpha-testpypi"]["if"]
     for job_name in (
         "publish-alpha-testpypi",
         "publish-alpha-pypi",

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -186,6 +186,7 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
     }
     assert jobs["publish-alpha-pypi"]["needs"] == ["build", "reserve-alpha-tag"]
     assert "needs.publish-alpha-testpypi" not in jobs["publish-alpha-pypi"]["if"]
+    assert "vars.ALPHA_TESTPYPI_ENABLED" not in jobs["publish-alpha-pypi"]["if"]
     assert "vars.ALPHA_TESTPYPI_ENABLED == 'true'" in jobs["publish-alpha-testpypi"]["if"]
     for job_name in (
         "publish-alpha-testpypi",


### PR DESCRIPTION
## Summary

- make the TestPyPI alpha mirror explicitly optional
- allow the signed, reserved alpha artifact to publish directly to PyPI
- ratchet the release workflow contract with focused tests

## Verification

- `uv run --no-sync pytest -q tests/test_release_train_workflow.py tests/test_release_toolchain_sbom.py --tb=short`
- `uv run --no-sync ruff check tests/test_release_train_workflow.py tests/test_release_toolchain_sbom.py`
- `git diff --check`
