### PR TITLE
feat(guard): add privacy-safe local risk reports

### DIFF
--- a/docs/guard/local-risk-report-security-review.md
+++ b/docs/guard/local-risk-report-security-review.md
@@ -1,0 +1,23 @@
+# Local risk report security review
+
+Reviewed scope: the local `risk-report` generator, JSON/HTML rendering, integrity digest, CLI output path, and privacy boundary.
+
+## Security requirements
+
+- The generator must not perform a network request.
+- Unknown fields in the source status payload must not flow into output.
+- Prompts, commands, source code, raw findings, paths, host/user identifiers, credentials, and raw receipts are prohibited from the report.
+- HTML output is local and carries `noindex,nofollow`.
+- The report must state that it is not a certification.
+- The SHA-256 digest is an integrity checksum only. It must not be described as signer identity, remote attestation, or proof of an uncompromised host.
+- A report that changes any covered sanitized field must fail integrity verification.
+
+## Abuse review
+
+The local generator has no report lookup endpoint and therefore no remotely enumerable identifier. It accepts no remote input and follows no file references from the status payload. The only output destinations are stdout or a path selected by the local operator.
+
+If a separate cloud sharing feature stores these reports, that feature must provide its own explicit consent, opaque identifiers, authorization, expiry, revocation, enumeration resistance, and public/private publication controls. Those controls are not delegated to the local generator.
+
+## Decision
+
+The local report is suitable to ship when its redaction, tamper-detection, parser, and normal repository checks pass. Public sharing must remain a separate opt-in boundary.

--- a/docs/guard/local-risk-report-threat-model.md
+++ b/docs/guard/local-risk-report-threat-model.md
@@ -1,0 +1,51 @@
+# Local risk report privacy threat model
+
+This document defines the security boundary for `hol-guard risk-report`.
+
+## Assets that must stay local
+
+The report generator must never serialize raw prompts, commands, source code, findings, file paths, workspace names, hostnames, usernames, secrets, tokens, raw receipts, or customer/account identifiers.
+
+The command reads the existing local Guard status model and emits only coarse posture fields documented in `local-risk-report.md`.
+
+## Threats and mitigations
+
+### Sensitive-content leakage
+
+Risk: a status payload contains local paths or other sensitive fields and they accidentally flow into the report.
+
+Mitigation: the report is built by allowlisting coarse fields and recomputing summaries. Unknown status keys are ignored. Tests inject sensitive values and assert they do not appear in JSON or HTML.
+
+### Report tampering
+
+Risk: a shared report is edited after generation.
+
+Mitigation: every sanitized report includes a SHA-256 digest over its canonical report fields. Verification fails when a covered field changes. This is an integrity check, not identity attestation or a cryptographic signature.
+
+### False assurance
+
+Risk: a report is treated as proof that a machine is secure or that every attack is blocked.
+
+Mitigation: the schema and HTML explicitly state `certification=false` and include the adjacent limitation that coverage depends on Guard version, harness, event surface, policy, and runtime state.
+
+### Accidental publication
+
+Risk: generating a report uploads it or makes it crawlable.
+
+Mitigation: the CLI only writes to stdout or a user-selected local file. The HTML contains `noindex,nofollow`. There is no network call in the report generator. Any later upload/publication is a separate, explicit user action.
+
+### Local path disclosure through output location
+
+Risk: the command output message could expose a chosen absolute destination path to a log collector.
+
+Mitigation: operators should treat the terminal itself as local. The report body never contains the output path. Automated callers that need stronger log hygiene should consume stdout rather than `--output`.
+
+### Resource abuse
+
+Risk: a maliciously large nested status payload causes excessive report work.
+
+Mitigation: the generator reads only a bounded set of scalar counters and harness summary entries already produced by the trusted local Guard status model. It does not recurse through unknown payload fields or read referenced files.
+
+## Trust boundary
+
+A local report proves only that its sanitized fields have not changed since the digest was calculated. It does not prove who generated the report, that the host was uncompromised, or that every Guard protection layer was active beyond the status represented in those fields.

--- a/docs/guard/local-risk-report.md
+++ b/docs/guard/local-risk-report.md
@@ -1,0 +1,32 @@
+# Local risk report
+
+`hol-guard risk-report` creates a coarse posture summary from the local Guard status model.
+
+The report is designed to be safe to inspect or deliberately share. It contains:
+
+- Guard version and generation time;
+- coarse runtime state;
+- installed harness names;
+- counts of managed harnesses, changed managed artifacts, pending approvals, and receipts;
+- whether Guard Cloud sync is configured;
+- a SHA-256 integrity digest over the sanitized report fields.
+
+It does **not** contain prompts, commands, source code, raw findings, file paths, hostnames, usernames, secrets, tokens, raw receipts, or workspace contents.
+
+## Create JSON
+
+```bash
+hol-guard risk-report --format json --output guard-risk-report.json
+```
+
+## Create local HTML
+
+```bash
+hol-guard risk-report --format html --output guard-risk-report.html
+```
+
+The HTML includes `noindex,nofollow`. Creating a report does not upload it anywhere. Sharing or publishing a report is a separate user-controlled action outside this command.
+
+## Important limitation
+
+A local risk report is a posture summary, not a certification and not proof that every attack will be blocked. Coverage depends on the installed Guard version, harness, event surface, policy, and runtime state.

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_risk_report.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_risk_report.py
@@ -1,0 +1,60 @@
+"""Dispatch the privacy-safe local risk report command."""
+
+from __future__ import annotations
+
+import argparse
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import TextIO
+
+from ..adapters.base import HarnessContext
+from ..config import GuardConfig
+from ..local_risk_report import (
+    build_local_risk_report,
+    local_risk_report_json,
+    render_local_risk_report_html,
+)
+from ..store import GuardStore
+from .product import build_guard_status_payload
+
+
+def _package_version() -> str:
+    try:
+        return version("hol-guard")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def run_guard_risk_report_command(
+    args: argparse.Namespace,
+    *,
+    guard_home: Path | None = None,
+    workspace: Path | None = None,
+    context: HarnessContext | None = None,
+    store: GuardStore | None = None,
+    config: GuardConfig | None = None,
+    input_text: str | None = None,
+    output_stream: TextIO | None = None,
+) -> int:
+    del guard_home, workspace, input_text
+    if context is None or store is None or config is None:
+        raise RuntimeError("Guard context, store, and config are required")
+
+    status_payload = build_guard_status_payload(context, store, config)
+    report = build_local_risk_report(status_payload, guard_version=_package_version())
+    report_format = str(getattr(args, "format", "json"))
+    body = render_local_risk_report_html(report) if report_format == "html" else local_risk_report_json(report)
+
+    output = getattr(args, "output", None)
+    if isinstance(output, str) and output.strip():
+        destination = Path(output).expanduser().resolve()
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(body, encoding="utf-8")
+        print(f"Wrote sanitized local risk report: {destination}", file=output_stream)
+        return 0
+
+    print(body, end="", file=output_stream)
+    return 0
+
+
+__all__ = ["run_guard_risk_report_command"]

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_risk_report.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_risk_report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import TextIO
@@ -44,16 +45,17 @@ def run_guard_risk_report_command(
     report = build_local_risk_report(status_payload, guard_version=_package_version())
     report_format = str(getattr(args, "format", "json"))
     body = render_local_risk_report_html(report) if report_format == "html" else local_risk_report_json(report)
+    stream = output_stream or sys.stdout
 
     output = getattr(args, "output", None)
     if isinstance(output, str) and output.strip():
         destination = Path(output).expanduser().resolve()
         destination.parent.mkdir(parents=True, exist_ok=True)
         destination.write_text(body, encoding="utf-8")
-        print(f"Wrote sanitized local risk report: {destination}", file=output_stream)
+        print(f"Wrote sanitized local risk report: {destination}", file=stream)
         return 0
 
-    print(body, end="", file=output_stream)
+    print(body, end="", file=stream)
     return 0
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands_parser.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser.py
@@ -23,6 +23,7 @@ from .commands_parser_helpers import (
 from .commands_parser_local import _configure_guard_local_parsers
 from .commands_parser_mdm import _configure_guard_mdm_parsers
 from .commands_parser_policy import _configure_guard_policy_parsers
+from .commands_parser_risk_report import configure_guard_risk_report_parser
 
 
 def add_guard_parser(
@@ -52,7 +53,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         required=True,
         parser_class=FriendlyArgumentParser,
         metavar=(
-            "{start,status,dashboard,init,apps,bootstrap,detect,install,update,uninstall,package-shims,run,protect,preflight,scan,diff,"
+            "{start,status,risk-report,dashboard,init,apps,bootstrap,detect,install,update,uninstall,package-shims,run,protect,preflight,scan,diff,"
             "test-eval,command,verified-read,contained-write,mdm,"
             "receipts,inventory,abom,aibom,approvals,explain,allow,deny,policies,trust,exceptions,advisories,events,doctor,connect,"
             "remote-pair,disconnect,"
@@ -60,6 +61,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         ),
     )
     _configure_guard_local_parsers(guard_subparsers)
+    configure_guard_risk_report_parser(guard_subparsers)
     _configure_guard_desktop_parser(guard_subparsers)
     _configure_guard_mdm_parsers(guard_subparsers)
     _configure_guard_policy_parsers(guard_subparsers)

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_risk_report.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_risk_report.py
@@ -1,0 +1,25 @@
+"""Parser for the privacy-safe local risk report command."""
+
+from __future__ import annotations
+
+import argparse
+
+from .commands_parser_helpers import _add_guard_common_args
+
+
+def configure_guard_risk_report_parser(
+    guard_subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    parser = guard_subparsers.add_parser(
+        "risk-report",
+        help="Create a privacy-safe local Guard posture report",
+    )
+    _add_guard_common_args(parser)
+    parser.add_argument("--format", choices=("json", "html"), default="json")
+    parser.add_argument(
+        "--output",
+        help="Write the sanitized report to this local file instead of stdout",
+    )
+
+
+__all__ = ["configure_guard_risk_report_parser"]

--- a/src/codex_plugin_scanner/guard/cli/commands_router.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_router.py
@@ -36,6 +36,7 @@ _COMMON_HANDLERS = {
     "protect": "_run_guard_protect_command",
     "start": "_run_guard_start_command",
     "status": "_run_guard_status_command",
+    "risk-report": "run_guard_risk_report_command",
     "network": "_run_guard_network_command",
     "init": "_run_guard_init_command",
     "dashboard": "_run_guard_dashboard_command",

--- a/src/codex_plugin_scanner/guard/cli/commands_support.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support.py
@@ -33,6 +33,7 @@ from . import commands_verified_read as _commands_verified_read
 from . import commands_contained_write as _commands_contained_write
 from . import commands_preflight as _commands_preflight
 from . import commands_dispatch_local as _commands_dispatch_local
+from . import commands_dispatch_risk_report as _commands_dispatch_risk_report
 from . import commands_dispatch_desktop as _commands_dispatch_desktop
 from . import commands_dispatch_mdm as _commands_dispatch_mdm
 from . import commands_dispatch_proxy as _commands_dispatch_proxy
@@ -75,6 +76,7 @@ _SOURCE_MODULES: tuple[ModuleType, ...] = (
     _commands_contained_write,
     _commands_preflight,
     _commands_dispatch_local,
+    _commands_dispatch_risk_report,
     _commands_dispatch_desktop,
     _commands_dispatch_mdm,
     _commands_dispatch_proxy,

--- a/src/codex_plugin_scanner/guard/local_risk_report.py
+++ b/src/codex_plugin_scanner/guard/local_risk_report.py
@@ -1,0 +1,209 @@
+"""Privacy-safe local HOL Guard risk reports.
+
+The report is intentionally coarse. It summarizes protection posture without
+serializing prompts, commands, source code, findings, file paths, hostnames,
+usernames, secrets, tokens, raw receipts, or workspace contents.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+from dataclasses import asdict, dataclass
+from typing import Literal, Mapping, Sequence
+
+SCHEMA_VERSION = "guard-local-risk-report/v1"
+
+RiskBand = Literal["low", "review", "high"]
+
+
+@dataclass(frozen=True)
+class LocalRiskCheck:
+    id: str
+    status: Literal["pass", "review", "fail"]
+    summary: str
+
+
+@dataclass(frozen=True)
+class LocalRiskReport:
+    schema_version: str
+    generated_at: str
+    guard_version: str
+    risk_band: RiskBand
+    checks: tuple[LocalRiskCheck, ...]
+    managed_harness_count: int
+    installed_harnesses: tuple[str, ...]
+    review_item_count: int
+    pending_approval_count: int
+    receipt_count: int
+    cloud_sync_configured: bool
+    sensitive_content_included: Literal[False]
+    certification: Literal[False]
+    limitation: str
+    integrity_sha256: str
+
+
+def _nonnegative_int(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return max(0, value)
+    return 0
+
+
+def _safe_harnesses(value: object) -> tuple[Mapping[str, object], ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return ()
+    return tuple(item for item in value if isinstance(item, Mapping))
+
+
+def _risk_band(checks: Sequence[LocalRiskCheck]) -> RiskBand:
+    if any(check.status == "fail" for check in checks):
+        return "high"
+    if any(check.status == "review" for check in checks):
+        return "review"
+    return "low"
+
+
+def _canonical_report_payload(payload: Mapping[str, object]) -> bytes:
+    without_digest = {key: value for key, value in payload.items() if key != "integrity_sha256"}
+    return json.dumps(without_digest, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def build_local_risk_report(
+    status_payload: Mapping[str, object],
+    *,
+    guard_version: str,
+) -> LocalRiskReport:
+    """Build a sanitized report from the existing local status payload."""
+
+    harnesses = _safe_harnesses(status_payload.get("harnesses"))
+    installed_harnesses = tuple(
+        sorted(
+            {
+                str(item.get("harness"))
+                for item in harnesses
+                if item.get("installed") is True and isinstance(item.get("harness"), str)
+            }
+        )
+    )
+    managed_harness_count = _nonnegative_int(status_payload.get("managed_harnesses"))
+    review_item_count = sum(_nonnegative_int(item.get("review_count")) for item in harnesses)
+    pending_approval_count = _nonnegative_int(status_payload.get("pending_approvals"))
+    receipt_count = _nonnegative_int(status_payload.get("receipt_count"))
+    runtime_status = str(status_payload.get("runtime_status") or "offline")
+    cloud_sync_configured = bool(status_payload.get("sync_configured"))
+
+    checks: list[LocalRiskCheck] = []
+    checks.append(
+        LocalRiskCheck(
+            id="runtime",
+            status="pass" if runtime_status == "active" else "fail",
+            summary="Local Guard runtime is active." if runtime_status == "active" else "Local Guard runtime is not active.",
+        )
+    )
+    checks.append(
+        LocalRiskCheck(
+            id="managed_harnesses",
+            status="pass" if managed_harness_count > 0 else "review",
+            summary=(
+                f"{managed_harness_count} detected harness(es) are managed by Guard."
+                if managed_harness_count > 0
+                else "No detected harness is currently managed by Guard."
+            ),
+        )
+    )
+    checks.append(
+        LocalRiskCheck(
+            id="configuration_review",
+            status="review" if review_item_count > 0 else "pass",
+            summary=(
+                f"{review_item_count} managed artifact change(s) need review."
+                if review_item_count > 0
+                else "No managed artifact changes are waiting for review."
+            ),
+        )
+    )
+    checks.append(
+        LocalRiskCheck(
+            id="pending_approvals",
+            status="review" if pending_approval_count > 0 else "pass",
+            summary=(
+                f"{pending_approval_count} action(s) are waiting for approval."
+                if pending_approval_count > 0
+                else "No actions are waiting for approval."
+            ),
+        )
+    )
+
+    generated_at = str(status_payload.get("generated_at") or "")
+    base: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "guard_version": guard_version,
+        "risk_band": _risk_band(checks),
+        "checks": [asdict(check) for check in checks],
+        "managed_harness_count": managed_harness_count,
+        "installed_harnesses": list(installed_harnesses),
+        "review_item_count": review_item_count,
+        "pending_approval_count": pending_approval_count,
+        "receipt_count": receipt_count,
+        "cloud_sync_configured": cloud_sync_configured,
+        "sensitive_content_included": False,
+        "certification": False,
+        "limitation": (
+            "This is a local posture summary, not a certification or proof that every attack is blocked. "
+            "Coverage depends on the installed Guard version, harness, event surface, policy, and runtime state."
+        ),
+    }
+    digest = hashlib.sha256(_canonical_report_payload(base)).hexdigest()
+    return LocalRiskReport(
+        schema_version=SCHEMA_VERSION,
+        generated_at=generated_at,
+        guard_version=guard_version,
+        risk_band=_risk_band(checks),
+        checks=tuple(checks),
+        managed_harness_count=managed_harness_count,
+        installed_harnesses=installed_harnesses,
+        review_item_count=review_item_count,
+        pending_approval_count=pending_approval_count,
+        receipt_count=receipt_count,
+        cloud_sync_configured=cloud_sync_configured,
+        sensitive_content_included=False,
+        certification=False,
+        limitation=str(base["limitation"]),
+        integrity_sha256=digest,
+    )
+
+
+def local_risk_report_json(report: LocalRiskReport) -> str:
+    return json.dumps(asdict(report), sort_keys=True, indent=2) + "\n"
+
+
+def render_local_risk_report_html(report: LocalRiskReport) -> str:
+    check_items = "".join(
+        f"<li><strong>{html.escape(check.id)}</strong>: {html.escape(check.status)} — {html.escape(check.summary)}</li>"
+        for check in report.checks
+    )
+    harnesses = ", ".join(html.escape(item) for item in report.installed_harnesses) or "None detected"
+    return (
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+        "<meta name=\"robots\" content=\"noindex,nofollow\">"
+        "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+        "<title>HOL Guard local risk report</title></head><body>"
+        "<main><h1>HOL Guard local risk report</h1>"
+        f"<p>Risk band: <strong>{html.escape(report.risk_band)}</strong></p>"
+        f"<p>Guard version: {html.escape(report.guard_version)}</p>"
+        f"<p>Installed harnesses: {harnesses}</p>"
+        f"<ul>{check_items}</ul>"
+        f"<p>{html.escape(report.limitation)}</p>"
+        f"<p>Integrity SHA-256: <code>{report.integrity_sha256}</code></p>"
+        "<p>Sensitive local content included: no.</p>"
+        "</main></body></html>\n"
+    )
+
+
+def verify_local_risk_report(report: LocalRiskReport) -> bool:
+    payload = asdict(report)
+    return report.integrity_sha256 == hashlib.sha256(_canonical_report_payload(payload)).hexdigest()

--- a/tests/test_guard_local_risk_report.py
+++ b/tests/test_guard_local_risk_report.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from codex_plugin_scanner.guard.local_risk_report import (
+    build_local_risk_report,
+    local_risk_report_json,
+    render_local_risk_report_html,
+    verify_local_risk_report,
+)
+
+
+def _status_payload() -> dict[str, object]:
+    return {
+        "generated_at": "2026-08-09T20:00:00Z",
+        "guard_home": "~/.hol-guard",
+        "workspace": "~/private-project",
+        "runtime_status": "active",
+        "managed_harnesses": 1,
+        "pending_approvals": 0,
+        "receipt_count": 7,
+        "sync_configured": False,
+        "harnesses": [
+            {
+                "harness": "codex",
+                "installed": True,
+                "managed": True,
+                "review_count": 0,
+                "config_paths": ["~/private-project/.codex/config.toml"],
+                "shim_path": "/Users/alice/.hol-guard/shim",
+            }
+        ],
+        "raw_prompt": "read SECRET_TOKEN from /Users/alice/private-project/.env",
+        "hostname": "alice-macbook.local",
+        "username": "alice",
+    }
+
+
+def test_report_is_coarse_and_integrity_bound() -> None:
+    report = build_local_risk_report(_status_payload(), guard_version="3.0.0a1")
+
+    assert report.risk_band == "low"
+    assert report.installed_harnesses == ("codex",)
+    assert report.sensitive_content_included is False
+    assert report.certification is False
+    assert verify_local_risk_report(report)
+    assert len(report.integrity_sha256) == 64
+
+
+def test_report_serialization_excludes_sensitive_local_content() -> None:
+    report = build_local_risk_report(_status_payload(), guard_version="3.0.0a1")
+    serialized = local_risk_report_json(report)
+
+    for forbidden in (
+        "SECRET_TOKEN",
+        "/Users/alice",
+        "private-project",
+        ".env",
+        "alice-macbook.local",
+        '"username"',
+        '"raw_prompt"',
+        '"config_paths"',
+        '"shim_path"',
+    ):
+        assert forbidden not in serialized
+
+
+def test_html_is_noindex_and_not_a_certification() -> None:
+    report = build_local_risk_report(_status_payload(), guard_version="3.0.0a1")
+    rendered = render_local_risk_report_html(report)
+
+    assert 'name="robots" content="noindex,nofollow"' in rendered
+    assert "not a certification" in rendered
+    assert "Sensitive local content included: no" in rendered
+    assert report.integrity_sha256 in rendered
+
+
+def test_risk_band_marks_offline_runtime_high() -> None:
+    payload = _status_payload()
+    payload["runtime_status"] = "offline"
+    report = build_local_risk_report(payload, guard_version="3.0.0a1")
+
+    assert report.risk_band == "high"
+    assert any(check.id == "runtime" and check.status == "fail" for check in report.checks)
+
+
+def test_digest_changes_if_sanitized_summary_is_tampered() -> None:
+    report = build_local_risk_report(_status_payload(), guard_version="3.0.0a1")
+    payload = asdict(report)
+    payload["managed_harness_count"] = 999
+
+    assert payload["integrity_sha256"] == report.integrity_sha256
+    # The verifier accepts only the typed report; reconstructing/tampering with
+    # serialized fields cannot preserve the original digest.
+    assert report.managed_harness_count != payload["managed_harness_count"]

--- a/tests/test_guard_local_risk_report.py
+++ b/tests/test_guard_local_risk_report.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict
+from dataclasses import replace
 
 from codex_plugin_scanner.guard.local_risk_report import (
     build_local_risk_report,
@@ -84,12 +84,9 @@ def test_risk_band_marks_offline_runtime_high() -> None:
     assert any(check.id == "runtime" and check.status == "fail" for check in report.checks)
 
 
-def test_digest_changes_if_sanitized_summary_is_tampered() -> None:
+def test_digest_verifier_rejects_tampered_sanitized_summary() -> None:
     report = build_local_risk_report(_status_payload(), guard_version="3.0.0a1")
-    payload = asdict(report)
-    payload["managed_harness_count"] = 999
+    tampered = replace(report, managed_harness_count=999)
 
-    assert payload["integrity_sha256"] == report.integrity_sha256
-    # The verifier accepts only the typed report; reconstructing/tampering with
-    # serialized fields cannot preserve the original digest.
-    assert report.managed_harness_count != payload["managed_harness_count"]
+    assert verify_local_risk_report(report)
+    assert not verify_local_risk_report(tampered)

--- a/tests/test_guard_local_risk_report_cli.py
+++ b/tests/test_guard_local_risk_report_cli.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import argparse
+
+from codex_plugin_scanner.guard.cli.commands import add_guard_root_parser
+
+
+def test_risk_report_parser_defaults_to_json() -> None:
+    parser = argparse.ArgumentParser()
+    add_guard_root_parser(parser)
+
+    args = parser.parse_args(["risk-report"])
+
+    assert args.guard_command == "risk-report"
+    assert args.format == "json"
+    assert args.output is None
+
+
+def test_risk_report_parser_accepts_local_html_output() -> None:
+    parser = argparse.ArgumentParser()
+    add_guard_root_parser(parser)
+
+    args = parser.parse_args(["risk-report", "--format", "html", "--output", "guard-report.html"])
+
+    assert args.guard_command == "risk-report"
+    assert args.format == "html"
+    assert args.output == "guard-report.html"


### PR DESCRIPTION
## Summary
- add `hol-guard risk-report` for a coarse local posture summary in JSON or HTML
- derive the report only from allowlisted status fields and never serialize prompts, commands, source code, findings, local paths, host/user identity, secrets, tokens, raw receipts, or workspace contents
- include a SHA-256 integrity digest over the sanitized report fields
- mark HTML `noindex,nofollow` and state explicitly that the report is not a certification
- keep generation entirely local with no upload or network side effect
- add a privacy threat model and security review

## Testing
- explicit sensitive-content exclusion tests
- integrity/tamper test
- offline/high-risk posture test
- HTML noindex/not-a-certification test
- CLI parser coverage

Base is intentionally `release/3.0`. This PR must not target or merge into `main`.