### PR TITLE
fix(daemon): launch frozen Core directly

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14134,
-  "maximum_test_source_lines": 311686,
+  "maximum_collected_cases": 14136,
+  "maximum_test_source_lines": 311735,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -285,6 +285,23 @@ def _guard_daemon_launch_command(
     gate_on_stdin: bool = False,
 ) -> list[str]:
     trusted_home = _trusted_daemon_home(home_dir)
+    if bool(getattr(sys, "frozen", False)):
+        executable = Path(sys.executable).expanduser()
+        if not executable.is_absolute() or not executable.is_file():
+            raise RuntimeError("Frozen Guard daemon requires the signed Guard executable.")
+        if gate_on_stdin:
+            raise RuntimeError("Frozen Guard daemon gated launch is unavailable on this platform.")
+        return [
+            str(executable.resolve(strict=True)),
+            "daemon",
+            "--serve",
+            "--guard-home",
+            str(guard_home),
+            "--home",
+            str(trusted_home),
+            "--port",
+            str(port),
+        ]
     return _isolated_python_module_command(
         "codex_plugin_scanner.cli",
         _trusted_daemon_import_paths(),

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -136,6 +136,55 @@ def test_malformed_process_command_only_blocks_proven_daemon_launchers() -> None
     assert daemon_manager_module._malformed_command_may_launch_guard(daemon_command)
 
 
+def test_frozen_daemon_launch_uses_signed_guard_executable(tmp_path, monkeypatch) -> None:
+    executable = tmp_path / "hol-guard"
+    executable.write_bytes(b"guard")
+    executable.chmod(0o755)
+    guard_home = tmp_path / ".hol-guard"
+    guard_home.mkdir()
+
+    monkeypatch.setattr(daemon_manager_module.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(daemon_manager_module.sys, "executable", str(executable))
+
+    command = daemon_manager_module._guard_daemon_launch_command(
+        guard_home,
+        4781,
+        home_dir=tmp_path,
+    )
+
+    assert command == [
+        str(executable.resolve()),
+        "daemon",
+        "--serve",
+        "--guard-home",
+        str(guard_home),
+        "--home",
+        str(tmp_path.resolve()),
+        "--port",
+        "4781",
+    ]
+    assert "-c" not in command
+    assert "-I" not in command
+
+
+def test_frozen_daemon_launch_rejects_unreleased_windows_gate(tmp_path, monkeypatch) -> None:
+    executable = tmp_path / "hol-guard"
+    executable.write_bytes(b"guard")
+    executable.chmod(0o755)
+    guard_home = tmp_path / ".hol-guard"
+    guard_home.mkdir()
+
+    monkeypatch.setattr(daemon_manager_module.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(daemon_manager_module.sys, "executable", str(executable))
+
+    with pytest.raises(RuntimeError, match="gated launch is unavailable"):
+        daemon_manager_module._guard_daemon_launch_command(
+            guard_home,
+            4781,
+            home_dir=tmp_path,
+            gate_on_stdin=True,
+        )
+
 def test_schedule_guard_daemon_ensure_is_reserved_and_nonblocking(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
Fix the standalone/PyInstaller Core daemon launcher so `hol-guard daemon ensure` spawns the signed frozen Guard executable through its public daemon serve CLI instead of treating `sys.executable` as a Python interpreter. Adds focused regression coverage. Targets release/3.0 only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved daemon startup for packaged or frozen application builds by launching the signed executable directly.
  - Added safeguards to reject unsupported gated launches in frozen environments.
  - Preserved existing isolated runtime behavior for standard installations.

- **Tests**
  - Added coverage for frozen-mode daemon launches and unsupported gated launch requests.
  - Updated test baselines to accommodate the expanded test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->