### PR TITLE
feat(guard): add Guarded Repository scan attestations

### DIFF
--- a/.github/workflows/guarded-repository.yml
+++ b/.github/workflows/guarded-repository.yml
@@ -1,0 +1,81 @@
+name: Guarded Repository
+
+on:
+  workflow_call:
+    inputs:
+      profile:
+        description: HOL Guard scanner policy profile
+        required: false
+        type: string
+        default: strict-security
+      min_score:
+        description: Minimum accepted scanner score
+        required: false
+        type: number
+        default: 0
+      fail_on_severity:
+        description: Fail when a finding reaches this severity
+        required: false
+        type: string
+        default: critical
+      upload_sarif:
+        description: Upload SARIF to GitHub code scanning
+        required: false
+        type: boolean
+        default: true
+      visibility:
+        description: Portal verification visibility, public or private
+        required: false
+        type: string
+        default: private
+    outputs:
+      score:
+        description: Scanner score
+        value: ${{ jobs.scan.outputs.score }}
+      grade:
+        description: Scanner grade
+        value: ${{ jobs.scan.outputs.grade }}
+      verification_status:
+        description: Portal verification status
+        value: ${{ jobs.scan.outputs.verification_status }}
+      verification_url:
+        description: Public verification URL when visibility is public
+        value: ${{ jobs.scan.outputs.verification_url }}
+      badge_url:
+        description: Expiring public badge URL when visibility is public
+        value: ${{ jobs.scan.outputs.badge_url }}
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+  artifact-metadata: write
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      score: ${{ steps.guard.outputs.score }}
+      grade: ${{ steps.guard.outputs.grade }}
+      verification_status: ${{ steps.guard.outputs.verification_status }}
+      verification_url: ${{ steps.guard.outputs.verification_url }}
+      badge_url: ${{ steps.guard.outputs.badge_url }}
+    steps:
+      - name: Check out caller repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: Scan, attest, and register
+        id: guard
+        uses: hashgraph-online/hol-guard/guarded-repository@4f2dbdfc45c232c5e4c6dabedd66f3ffa43e578a
+        with:
+          profile: ${{ inputs.profile }}
+          min_score: ${{ inputs.min_score }}
+          fail_on_severity: ${{ inputs.fail_on_severity }}
+          upload_sarif: ${{ inputs.upload_sarif }}
+          visibility: ${{ inputs.visibility }}
+          register_verification: true
+          verification_endpoint: https://hol.org/api/guard/repository-attestations

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14136,
-  "maximum_test_source_lines": 311735,
+  "maximum_collected_cases": 14142,
+  "maximum_test_source_lines": 311939,
   "schema_version": 1
 }

--- a/docs/guard/guarded-repository-attestation.md
+++ b/docs/guard/guarded-repository-attestation.md
@@ -1,0 +1,33 @@
+# Guarded Repository attestation
+
+Guarded Repository is a repository-scan provenance workflow for HOL Guard. It runs the existing scanner, can upload SARIF to GitHub code scanning, produces sanitized scan evidence, and asks GitHub to attest that evidence artifact.
+
+The supported claim is intentionally narrow:
+
+> Guarded Repository means this commit completed a versioned HOL Guard repository scan under the recorded configuration and produced a GitHub-signed provenance attestation. It does not mean vulnerability-free and does not prove runtime protection.
+
+## Trusted workflow
+
+Portal registration is supported only through `.github/workflows/guarded-repository.yml`. The verifier uses GitHub OIDC `job_workflow_ref` and `job_workflow_sha` to distinguish the HOL-owned reusable workflow from an arbitrary caller workflow.
+
+The workflow uses read-only repository contents, GitHub OIDC, artifact-attestation permissions, artifact metadata, and optional code-scanning upload. Checkout does not persist credentials.
+
+Direct use of `guarded-repository/action.yml` remains available for scan, SARIF, and GitHub provenance, but portal registration defaults off.
+
+## Evidence contract
+
+Only coarse scan metadata is sent to the verifier: repository and exact commit SHA, workflow run ID, scanner version/profile, score/grade, maximum finding severity, finding count, SARIF SHA-256, generated time, and evidence visibility.
+
+The evidence does not include source code, raw SARIF findings, local paths, prompts, commands, credentials, tokens, or runtime data.
+
+## Registration identity
+
+The registration helper requests a fresh GitHub OIDC token with audience `hol-guard-repository:<evidence-sha256>`. The token is sent as a bearer credential and is not embedded in the JSON evidence. The verifier rejects repository, commit, workflow-run, reusable-workflow, runner, or audience mismatches.
+
+## Public and private modes
+
+Public mode is for public GitHub repositories whose evidence subject can be observed through GitHub's public attestations API. Public verification produces a short-lived page and badge. Private mode stores no public URL or badge.
+
+## Renewal
+
+A verification is tied to one commit and expires seven days after the evidence was generated. Re-run the workflow for a new commit or refreshed scan. An expired badge must not be represented as current evidence.

--- a/guarded-repository/README.md
+++ b/guarded-repository/README.md
@@ -1,0 +1,54 @@
+# HOL Guarded Repository
+
+HOL Guarded Repository runs the current HOL Guard scanner against a repository, emits SARIF, creates sanitized scan evidence, and asks GitHub to produce signed provenance for that evidence.
+
+Public or private verification at `hol.org` is available only through the trusted reusable workflow in `.github/workflows/guarded-repository.yml`. The verifier requires GitHub's `job_workflow_ref` claim for that HOL-owned workflow instead of trusting an arbitrary caller workflow.
+
+## What this means
+
+> Guarded Repository means this commit completed a versioned HOL Guard repository scan under the recorded configuration and produced a GitHub-signed provenance attestation. It does not mean vulnerability-free and does not prove runtime protection.
+
+Do not shorten this into “secure repository,” “certified secure,” or any claim that a repository scan proves local runtime enforcement.
+
+## Recommended usage
+
+During the 3.0 alpha cycle, call the reusable workflow from `release/3.0`. Pin an immutable reviewed release or commit when available for production use.
+
+```yaml
+name: Guarded Repository
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  guard:
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+      security-events: write
+    uses: hashgraph-online/hol-guard/.github/workflows/guarded-repository.yml@release/3.0
+    with:
+      profile: strict-security
+      fail_on_severity: critical
+      upload_sarif: true
+      visibility: public
+```
+
+The reusable workflow checks out the caller repository with credentials disabled, runs the scanner, optionally uploads SARIF, creates GitHub provenance for the sanitized evidence file, then requests an OIDC token whose audience is bound to that evidence digest before registration.
+
+`security-events: write` is used only for the optional SARIF upload step. `artifact-metadata: write` is required by GitHub's attestation action. No repository-content write permission, issue permission, pull-request permission, package permission, or long-lived signing secret is required.
+
+## Direct action usage
+
+`guarded-repository/action.yml` can be used directly for scan, SARIF, and GitHub provenance without portal registration. Its `register_verification` input defaults to `false`.
+
+Do not enable portal registration from an arbitrary direct caller workflow. The verifier intentionally requires the HOL Guard reusable workflow identity.
+
+## Evidence and expiry
+
+The portal receives only repository/commit/run identity, scanner metadata, aggregate scan counts, and hashes. It does not receive source code, raw SARIF findings, prompts, commands, paths, credentials, tokens, or runtime data.
+
+`visibility: private` creates no public URL or badge. `visibility: public` is available only for public GitHub repositories and exposes a short-lived verification. A verification expires seven days after the evidence was generated and must be renewed by running the workflow again.

--- a/guarded-repository/action.yml
+++ b/guarded-repository/action.yml
@@ -1,0 +1,235 @@
+name: "HOL Guarded Repository"
+description: "Scan a repository, emit SARIF, create GitHub-signed provenance, and optionally register an expiring Guarded Repository verification."
+author: "HOL"
+
+inputs:
+  plugin_dir:
+    description: "Repository path to scan"
+    required: false
+    default: "."
+  profile:
+    description: "HOL Guard scanner policy profile"
+    required: false
+    default: "strict-security"
+  min_score:
+    description: "Minimum accepted scanner score (0-100)"
+    required: false
+    default: "0"
+  fail_on_severity:
+    description: "Fail if a finding reaches this severity"
+    required: false
+    default: "critical"
+  upload_sarif:
+    description: "Upload SARIF to GitHub code scanning"
+    required: false
+    default: "false"
+  visibility:
+    description: "Portal evidence visibility: public or private"
+    required: false
+    default: "private"
+  register_verification:
+    description: "Register evidence with the HOL Guard verifier. Use the trusted reusable workflow for this mode."
+    required: false
+    default: "false"
+  verification_endpoint:
+    description: "HTTPS Guarded Repository verification endpoint"
+    required: false
+    default: "https://hol.org/api/guard/repository-attestations"
+
+outputs:
+  score:
+    description: "Scanner score"
+    value: ${{ steps.scan.outputs.score }}
+  grade:
+    description: "Scanner grade"
+    value: ${{ steps.scan.outputs.grade }}
+  max_severity:
+    description: "Most severe finding"
+    value: ${{ steps.scan.outputs.max_severity }}
+  findings_total:
+    description: "Total scanner findings"
+    value: ${{ steps.scan.outputs.findings_total }}
+  sarif_path:
+    description: "Generated SARIF path"
+    value: ${{ steps.scan.outputs.report_path }}
+  evidence_path:
+    description: "Sanitized evidence path"
+    value: ${{ steps.evidence.outputs.evidence_path }}
+  evidence_sha256:
+    description: "Sanitized evidence SHA-256"
+    value: ${{ steps.evidence.outputs.evidence_sha256 }}
+  attestation_url:
+    description: "GitHub artifact attestation URL"
+    value: ${{ steps.attest.outputs.attestation-url }}
+  verification_status:
+    description: "Portal verification status"
+    value: ${{ steps.register.outputs.verification_status }}
+  verification_url:
+    description: "Public verification URL when available"
+    value: ${{ steps.register.outputs.verification_url }}
+  badge_url:
+    description: "Expiring public badge URL when available"
+    value: ${{ steps.register.outputs.badge_url }}
+
+branding:
+  icon: "shield"
+  color: "blue"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        VISIBILITY: ${{ inputs.visibility }}
+        REGISTER_VERIFICATION: ${{ inputs.register_verification }}
+        VERIFICATION_ENDPOINT: ${{ inputs.verification_endpoint }}
+      run: |
+        set -euo pipefail
+        case "$VISIBILITY" in public|private) ;; *) echo "visibility must be public or private" >&2; exit 2 ;; esac
+        case "$REGISTER_VERIFICATION" in true|false) ;; *) echo "register_verification must be true or false" >&2; exit 2 ;; esac
+        if [ "$REGISTER_VERIFICATION" = "true" ] && [[ "$VERIFICATION_ENDPOINT" != https://* ]]; then
+          echo "verification_endpoint must use HTTPS" >&2
+          exit 2
+        fi
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      with:
+        python-version: "3.12"
+
+    - name: Install action source
+      shell: bash
+      run: |
+        set -euo pipefail
+        python3 -P -m pip install "$GITHUB_ACTION_PATH/.."
+
+    - name: Scan repository to SARIF
+      id: scan
+      shell: bash
+      env:
+        MODE: scan
+        PLUGIN_DIR: ${{ inputs.plugin_dir }}
+        FORMAT: sarif
+        OUTPUT: ${{ runner.temp }}/guarded-repository.sarif
+        PROFILE: ${{ inputs.profile }}
+        MIN_SCORE: ${{ inputs.min_score }}
+        FAIL_ON: ${{ inputs.fail_on_severity }}
+        CISCO_SCAN: "off"
+        CISCO_MCP_SCAN: "off"
+        WRITE_STEP_SUMMARY: "true"
+        PR_COMMENT: "off"
+        SUBMISSION_ENABLED: "false"
+        PYTHONNOUSERSITE: "1"
+        PYTHONSAFEPATH: "1"
+      run: python3 -P -m codex_plugin_scanner.action_runner
+
+    - name: Upload SARIF
+      if: ${{ inputs.upload_sarif == 'true' && steps.scan.outputs.report_path != '' }}
+      uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7
+      with:
+        sarif_file: ${{ steps.scan.outputs.report_path }}
+        category: guarded-repository
+
+    - name: Build sanitized evidence
+      id: evidence
+      shell: bash
+      env:
+        REPOSITORY: ${{ github.repository }}
+        COMMIT_SHA: ${{ github.sha }}
+        RUN_ID: ${{ github.run_id }}
+        PROFILE: ${{ inputs.profile }}
+        SCORE: ${{ steps.scan.outputs.score }}
+        GRADE: ${{ steps.scan.outputs.grade }}
+        MAX_SEVERITY: ${{ steps.scan.outputs.max_severity }}
+        FINDINGS_TOTAL: ${{ steps.scan.outputs.findings_total }}
+        SARIF_PATH: ${{ steps.scan.outputs.report_path }}
+        VISIBILITY: ${{ inputs.visibility }}
+        EVIDENCE_PATH: ${{ runner.temp }}/guarded-repository-evidence.json
+      run: |
+        set -euo pipefail
+        python3 -P - <<'PY'
+        import os
+        from pathlib import Path
+        from codex_plugin_scanner import __version__ as scanner_version
+        from codex_plugin_scanner.guarded_repository_evidence import (
+            build_guarded_repository_evidence,
+            file_sha256,
+            guarded_repository_evidence_json,
+            guarded_repository_evidence_sha256,
+        )
+        evidence = build_guarded_repository_evidence(
+            repository=os.environ["REPOSITORY"],
+            commit_sha=os.environ["COMMIT_SHA"],
+            workflow_run_id=os.environ["RUN_ID"],
+            scanner_version=scanner_version,
+            scanner_profile=os.environ["PROFILE"],
+            score=int(os.environ["SCORE"] or "0"),
+            grade=os.environ["GRADE"] or "unknown",
+            max_severity=os.environ["MAX_SEVERITY"] or "none",
+            findings_total=int(os.environ["FINDINGS_TOTAL"] or "0"),
+            sarif_sha256=file_sha256(Path(os.environ["SARIF_PATH"])),
+            visibility=os.environ["VISIBILITY"],
+        )
+        path = Path(os.environ["EVIDENCE_PATH"])
+        path.write_text(guarded_repository_evidence_json(evidence), encoding="utf-8")
+        digest = guarded_repository_evidence_sha256(evidence)
+        with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
+            handle.write(f"evidence_path={path}\n")
+            handle.write(f"evidence_sha256={digest}\n")
+        PY
+
+    - name: Create GitHub-signed provenance attestation
+      id: attest
+      uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d
+      with:
+        subject-path: ${{ steps.evidence.outputs.evidence_path }}
+        show-summary: true
+
+    - name: Register verification
+      id: register
+      shell: bash
+      env:
+        REGISTER_VERIFICATION: ${{ inputs.register_verification }}
+        VERIFICATION_ENDPOINT: ${{ inputs.verification_endpoint }}
+        EVIDENCE_PATH: ${{ steps.evidence.outputs.evidence_path }}
+        ATTESTATION_URL: ${{ steps.attest.outputs.attestation-url }}
+        ATTESTATION_ID: ${{ steps.attest.outputs.attestation-id }}
+      run: |
+        set -euo pipefail
+        if [ "$REGISTER_VERIFICATION" != "true" ]; then
+          echo "verification_status=disabled" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        python3 -P - <<'PY'
+        import datetime
+        import json
+        import os
+        from pathlib import Path
+        from codex_plugin_scanner.guarded_repository_evidence import build_guarded_repository_evidence
+        from codex_plugin_scanner.guarded_repository_registration import register_guarded_repository_evidence
+        raw = json.loads(Path(os.environ["EVIDENCE_PATH"]).read_text(encoding="utf-8"))
+        evidence = build_guarded_repository_evidence(
+            repository=raw["repository"], commit_sha=raw["commit_sha"], workflow_run_id=raw["workflow_run_id"],
+            scanner_version=raw["scanner_version"], scanner_profile=raw["scanner_profile"], score=raw["score"],
+            grade=raw["grade"], max_severity=raw["max_severity"], findings_total=raw["findings_total"],
+            sarif_sha256=raw["sarif_sha256"], visibility=raw["visibility"],
+            generated_at=datetime.datetime.fromisoformat(raw["generated_at"].replace("Z", "+00:00")),
+        )
+        try:
+            result = register_guarded_repository_evidence(
+                evidence=evidence,
+                attestation_url=os.environ["ATTESTATION_URL"],
+                attestation_id=os.environ["ATTESTATION_ID"],
+                endpoint=os.environ["VERIFICATION_ENDPOINT"],
+                oidc_request_url=os.environ["ACTIONS_ID_TOKEN_REQUEST_URL"],
+                oidc_request_token=os.environ["ACTIONS_ID_TOKEN_REQUEST_TOKEN"],
+            )
+        except Exception as error:
+            print(f"Guarded Repository portal registration unavailable: {type(error).__name__}")
+            result = {"status": "unavailable"}
+        with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
+            handle.write(f"verification_status={result.get('status', 'unavailable')}\n")
+            handle.write(f"verification_url={result.get('verificationUrl', '')}\n")
+            handle.write(f"badge_url={result.get('badgeUrl', '')}\n")
+        PY

--- a/src/codex_plugin_scanner/guarded_repository_evidence.py
+++ b/src/codex_plugin_scanner/guarded_repository_evidence.py
@@ -1,0 +1,124 @@
+"""Sanitized evidence contract for the Guarded Repository GitHub Action.
+
+The evidence intentionally records scan/run metadata only. Scanner findings,
+repository file paths, source content, prompts, commands, credentials, actor
+identity, and private workflow inputs are excluded.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+SCHEMA_VERSION = "guarded-repository/v1"
+CLAIM = (
+    "Guarded Repository means this commit completed a versioned HOL Guard repository "
+    "scan under the recorded configuration and produced a GitHub-signed provenance "
+    "attestation. It does not mean vulnerability-free and does not prove runtime protection."
+)
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_SHA_RE = re.compile(r"^[a-f0-9]{40}$")
+
+Visibility = Literal["public", "private"]
+
+
+@dataclass(frozen=True)
+class GuardedRepositoryEvidence:
+    schema_version: Literal["guarded-repository/v1"]
+    repository: str
+    commit_sha: str
+    workflow_run_id: str
+    scanner_version: str
+    scanner_profile: str
+    score: int
+    grade: str
+    max_severity: str
+    findings_total: int
+    sarif_sha256: str
+    generated_at: str
+    visibility: Visibility
+    claim: str
+    runtime_coverage_claimed: Literal[False]
+    sensitive_content_included: Literal[False]
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def build_guarded_repository_evidence(
+    *,
+    repository: str,
+    commit_sha: str,
+    workflow_run_id: str,
+    scanner_version: str,
+    scanner_profile: str,
+    score: int,
+    grade: str,
+    max_severity: str,
+    findings_total: int,
+    sarif_sha256: str,
+    visibility: Visibility,
+    generated_at: datetime | None = None,
+) -> GuardedRepositoryEvidence:
+    if not _REPOSITORY_RE.fullmatch(repository):
+        raise ValueError("repository must be owner/name")
+    if not _SHA_RE.fullmatch(commit_sha):
+        raise ValueError("commit_sha must be a lowercase 40-character git SHA")
+    if not workflow_run_id.isdigit() or len(workflow_run_id) > 32:
+        raise ValueError("workflow_run_id must be numeric")
+    if not scanner_version or len(scanner_version) > 64:
+        raise ValueError("scanner_version is invalid")
+    if not scanner_profile or len(scanner_profile) > 64:
+        raise ValueError("scanner_profile is invalid")
+    if not isinstance(score, int) or isinstance(score, bool) or not 0 <= score <= 100:
+        raise ValueError("score must be an integer from 0 to 100")
+    if not grade or len(grade) > 8:
+        raise ValueError("grade is invalid")
+    if max_severity not in {"none", "info", "low", "medium", "high", "critical"}:
+        raise ValueError("max_severity is invalid")
+    if not isinstance(findings_total, int) or isinstance(findings_total, bool) or findings_total < 0:
+        raise ValueError("findings_total must be a non-negative integer")
+    if not _SHA256_RE.fullmatch(sarif_sha256):
+        raise ValueError("sarif_sha256 must be lowercase SHA-256")
+    if visibility not in {"public", "private"}:
+        raise ValueError("visibility must be public or private")
+    observed = generated_at or datetime.now(timezone.utc)
+    if observed.tzinfo is None:
+        raise ValueError("generated_at must be timezone-aware")
+    return GuardedRepositoryEvidence(
+        schema_version=SCHEMA_VERSION,
+        repository=repository,
+        commit_sha=commit_sha,
+        workflow_run_id=workflow_run_id,
+        scanner_version=scanner_version,
+        scanner_profile=scanner_profile,
+        score=score,
+        grade=grade,
+        max_severity=max_severity,
+        findings_total=findings_total,
+        sarif_sha256=sarif_sha256,
+        generated_at=observed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+        visibility=visibility,
+        claim=CLAIM,
+        runtime_coverage_claimed=False,
+        sensitive_content_included=False,
+    )
+
+
+def guarded_repository_evidence_json(evidence: GuardedRepositoryEvidence) -> str:
+    return json.dumps(asdict(evidence), sort_keys=True, indent=2, ensure_ascii=True) + "\n"
+
+
+def guarded_repository_evidence_sha256(evidence: GuardedRepositoryEvidence) -> str:
+    return hashlib.sha256(guarded_repository_evidence_json(evidence).encode("utf-8")).hexdigest()

--- a/src/codex_plugin_scanner/guarded_repository_registration.py
+++ b/src/codex_plugin_scanner/guarded_repository_registration.py
@@ -1,0 +1,76 @@
+"""Register sanitized Guarded Repository evidence with the public verifier."""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from dataclasses import asdict
+
+from .guarded_repository_evidence import (
+    GuardedRepositoryEvidence,
+    guarded_repository_evidence_sha256,
+)
+
+
+def _github_oidc_token(*, request_url: str, request_token: str, audience: str) -> str:
+    if not request_url.startswith("https://"):
+        raise ValueError("GitHub OIDC request URL must use HTTPS")
+    separator = "&" if "?" in request_url else "?"
+    url = f"{request_url}{separator}{urllib.parse.urlencode({'audience': audience})}"
+    request = urllib.request.Request(
+        url,
+        method="GET",
+        headers={"Authorization": f"Bearer {request_token}", "Accept": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    token = payload.get("value") if isinstance(payload, Mapping) else None
+    if not isinstance(token, str) or not token:
+        raise ValueError("GitHub OIDC response did not contain a token")
+    return token
+
+
+def register_guarded_repository_evidence(
+    *,
+    evidence: GuardedRepositoryEvidence,
+    attestation_url: str,
+    attestation_id: str,
+    endpoint: str,
+    oidc_request_url: str,
+    oidc_request_token: str,
+) -> Mapping[str, object]:
+    if not endpoint.startswith("https://"):
+        raise ValueError("verification endpoint must use HTTPS")
+    evidence_digest = guarded_repository_evidence_sha256(evidence)
+    oidc_token = _github_oidc_token(
+        request_url=oidc_request_url,
+        request_token=oidc_request_token,
+        audience=f"hol-guard-repository:{evidence_digest}",
+    )
+    body = json.dumps(
+        {
+            "evidence": asdict(evidence),
+            "evidenceSha256": evidence_digest,
+            "attestationUrl": attestation_url,
+            "attestationId": attestation_id,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        endpoint,
+        method="POST",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {oidc_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=15) as response:
+        result = json.loads(response.read().decode("utf-8"))
+    if not isinstance(result, Mapping):
+        raise ValueError("verification endpoint returned an invalid response")
+    return result

--- a/tests/test_guarded_repository_action_contract.py
+++ b/tests/test_guarded_repository_action_contract.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTION = ROOT / "guarded-repository" / "action.yml"
+WORKFLOW = ROOT / ".github" / "workflows" / "guarded-repository.yml"
+
+
+def test_composite_action_defaults_portal_registration_off() -> None:
+    text = ACTION.read_text(encoding="utf-8")
+
+    assert 'register_verification:' in text
+    assert 'default: "false"' in text
+    assert 'uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d' in text
+    assert 'subject-path: ${{ steps.evidence.outputs.evidence_path }}' in text
+    assert 'ACTIONS_ID_TOKEN_REQUEST_URL' in text
+    assert 'ACTIONS_ID_TOKEN_REQUEST_TOKEN' in text
+    assert 'default: "https://hol.org/api/guard/repository-attestations"' in text
+
+
+def test_reusable_workflow_is_least_privilege_and_trusted() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "workflow_call:" in text
+    assert "contents: read" in text
+    assert "id-token: write" in text
+    assert "attestations: write" in text
+    assert "artifact-metadata: write" in text
+    assert "security-events: write" in text
+    assert "contents: write" not in text
+    assert "pull-requests: write" not in text
+    assert "issues: write" not in text
+    assert "packages: write" not in text
+    assert "register_verification: true" in text
+    assert "verification_endpoint: https://hol.org/api/guard/repository-attestations" in text
+    match = re.search(r"uses: hashgraph-online/hol-guard/guarded-repository@([a-f0-9]{40})", text)
+    assert match is not None
+
+
+def test_reusable_workflow_checkout_does_not_persist_credentials() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" in text
+    assert "persist-credentials: false" in text

--- a/tests/test_guarded_repository_evidence.py
+++ b/tests/test_guarded_repository_evidence.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from codex_plugin_scanner.guarded_repository_evidence import (
+    CLAIM,
+    build_guarded_repository_evidence,
+    guarded_repository_evidence_json,
+    guarded_repository_evidence_sha256,
+)
+
+
+def _evidence():
+    return build_guarded_repository_evidence(
+        repository="hashgraph-online/example",
+        commit_sha="a" * 40,
+        workflow_run_id="123456",
+        scanner_version="3.0.0a1",
+        scanner_profile="strict-security",
+        score=93,
+        grade="A",
+        max_severity="medium",
+        findings_total=2,
+        sarif_sha256="b" * 64,
+        visibility="public",
+        generated_at=datetime(2026, 8, 9, 20, 0, tzinfo=UTC),
+    )
+
+
+def test_evidence_is_deterministic_and_sanitized() -> None:
+    evidence = _evidence()
+    rendered = guarded_repository_evidence_json(evidence)
+
+    assert guarded_repository_evidence_sha256(evidence) == "b730be19205f36f9a8fdcad6d2f65b8c1fb746790338a53f255fa88c8fb01f0c"
+    assert evidence.claim == CLAIM
+    assert evidence.runtime_coverage_claimed is False
+    assert evidence.sensitive_content_included is False
+    for forbidden in ("raw_sarif", "finding", "file_path", "source_code", "prompt", "command", "credential", "token"):
+        assert f'"{forbidden}"' not in rendered
+
+
+def test_evidence_rejects_invalid_identity_and_bounds() -> None:
+    with pytest.raises(ValueError, match="repository"):
+        build_guarded_repository_evidence(
+            repository="invalid",
+            commit_sha="a" * 40,
+            workflow_run_id="123",
+            scanner_version="3.0.0a1",
+            scanner_profile="strict-security",
+            score=93,
+            grade="A",
+            max_severity="medium",
+            findings_total=2,
+            sarif_sha256="b" * 64,
+            visibility="private",
+        )
+    with pytest.raises(ValueError, match="score"):
+        build_guarded_repository_evidence(
+            repository="hashgraph-online/example",
+            commit_sha="a" * 40,
+            workflow_run_id="123",
+            scanner_version="3.0.0a1",
+            scanner_profile="strict-security",
+            score=101,
+            grade="A",
+            max_severity="medium",
+            findings_total=2,
+            sarif_sha256="b" * 64,
+            visibility="private",
+        )

--- a/tests/test_guarded_repository_registration.py
+++ b/tests/test_guarded_repository_registration.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from urllib.parse import parse_qs, urlparse
+
+from codex_plugin_scanner.guarded_repository_evidence import (
+    build_guarded_repository_evidence,
+    guarded_repository_evidence_sha256,
+)
+from codex_plugin_scanner.guarded_repository_registration import register_guarded_repository_evidence
+
+
+class _Response:
+    def __init__(self, payload: dict[str, object]):
+        self._payload = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+def _evidence():
+    return build_guarded_repository_evidence(
+        repository="hashgraph-online/example",
+        commit_sha="a" * 40,
+        workflow_run_id="123456",
+        scanner_version="3.0.0a1",
+        scanner_profile="strict-security",
+        score=93,
+        grade="A",
+        max_severity="medium",
+        findings_total=2,
+        sarif_sha256="b" * 64,
+        visibility="public",
+        generated_at=datetime(2026, 8, 9, 20, 0, tzinfo=UTC),
+    )
+
+
+def test_registration_binds_oidc_audience_and_keeps_token_out_of_body(monkeypatch) -> None:
+    evidence = _evidence()
+    digest = guarded_repository_evidence_sha256(evidence)
+    requests = []
+
+    def fake_urlopen(request, timeout):
+        requests.append((request, timeout))
+        if len(requests) == 1:
+            return _Response({"value": "oidc-secret-token"})
+        return _Response(
+            {
+                "status": "verified",
+                "verificationUrl": "/guard/security/repository-attestations/example",
+                "badgeUrl": "/api/guard/repository-attestations/example/badge.svg",
+            }
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    result = register_guarded_repository_evidence(
+        evidence=evidence,
+        attestation_url="https://github.com/hashgraph-online/example/attestations/123456",
+        attestation_id="123456",
+        endpoint="https://hol.org/api/guard/repository-attestations",
+        oidc_request_url="https://token.actions.githubusercontent.com/request?base=1",
+        oidc_request_token="runner-request-token",
+    )
+
+    oidc_request, oidc_timeout = requests[0]
+    registration_request, registration_timeout = requests[1]
+    oidc_query = parse_qs(urlparse(oidc_request.full_url).query)
+    registration_body = json.loads(registration_request.data.decode("utf-8"))
+
+    assert oidc_timeout == 10
+    assert oidc_query["audience"] == [f"hol-guard-repository:{digest}"]
+    assert oidc_request.get_header("Authorization") == "Bearer runner-request-token"
+    assert registration_timeout == 15
+    assert registration_request.full_url == "https://hol.org/api/guard/repository-attestations"
+    assert registration_request.get_header("Authorization") == "Bearer oidc-secret-token"
+    assert registration_body["evidenceSha256"] == digest
+    assert registration_body["attestationId"] == "123456"
+    assert "oidc" not in json.dumps(registration_body).lower()
+    assert result["status"] == "verified"


### PR DESCRIPTION
## Summary
- add a reusable Guarded Repository workflow around the existing HOL Guard scanner and SARIF output
- generate a strict sanitized evidence record for one exact repository commit and create GitHub artifact provenance for that evidence
- bind portal registration to a fresh GitHub OIDC token whose audience contains the evidence SHA-256
- default direct composite-action portal registration off; enable registration only through the trusted HOL Guard reusable workflow
- pin the reusable workflow to the reviewed composite-action implementation commit
- use read-only repository contents, non-persistent checkout credentials, OIDC, attestation, artifact-metadata, and optional SARIF permissions only
- support public/private evidence modes without exposing source code, raw findings, prompts, commands, paths, credentials, or runtime data
- add deterministic evidence, OIDC registration, immutable pin, and permission-boundary tests

## Wording boundary
Guarded Repository means the recorded commit completed the recorded HOL Guard repository scan and produced GitHub provenance for the sanitized evidence. It is not a certification, vulnerability-free claim, or proof of HOL Guard runtime protection.

Base is intentionally `release/3.0`. This PR must not target or merge into `main`.