### PR TITLE
fix(guard): restore exact action approvals

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12195,
-  "maximum_test_source_lines": 284695,
+  "maximum_collected_cases": 12196,
+  "maximum_test_source_lines": 284706,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12194,
-  "maximum_test_source_lines": 284643,
+  "maximum_collected_cases": 12195,
+  "maximum_test_source_lines": 284695,
   "schema_version": 1
 }

--- a/dashboard/src/approval-scopes.test.ts
+++ b/dashboard/src/approval-scopes.test.ts
@@ -11,6 +11,7 @@ import {
   taskCapabilityExplanation,
 } from "./approval-scopes";
 import type { GuardApprovalRequest } from "./guard-types";
+import { ReviewScopeControls } from "./review-scope-controls";
 
 function assert(condition: boolean, message: string): void {
   if (!condition) {
@@ -39,7 +40,7 @@ const BASE_REQUEST: GuardApprovalRequest = {
   policy_action: "require-reapproval",
   recommended_scope: "artifact",
   allowed_scopes: ["artifact", "workspace", "harness", "global"],
-  scope_contract_version: "guard.approval-scopes.v4",
+  scope_contract_version: "guard.approval-scopes.v5",
   scope_contract_digest: "scope-digest",
   allowed_scopes_by_action: {
     allow: ["artifact", "workspace", "harness", "global"],
@@ -51,6 +52,7 @@ const BASE_REQUEST: GuardApprovalRequest = {
     eligible: false,
     reason_codes: ["task_capability_not_enabled"],
   },
+  exact_action_persistence_eligible: true,
   changed_fields: ["first_seen"],
   source_scope: "project",
   config_path: "./config.toml",
@@ -79,9 +81,57 @@ const allowPayload = buildDecisionPayload({
 assert(allowPayload.scope === "global", "T-AS-01: eligible Everywhere selection is preserved");
 assert(allowPayload.workspace === undefined, "T-AS-02: artifact allow does not send a workspace");
 assert(
-  allowPayload.scope_contract_version === "guard.approval-scopes.v4" &&
+  allowPayload.scope_contract_version === "guard.approval-scopes.v5" &&
     allowPayload.scope_contract_digest === "scope-digest",
   "T-AS-03: resolution payload binds the displayed scope contract",
+);
+
+const rememberedExactPayload = buildDecisionPayload({
+  item: BASE_REQUEST,
+  action: "allow",
+  scope: "artifact",
+  reason: "approved in review",
+  persistExactAction: true,
+});
+assert(rememberedExactPayload.persist_policy === true, "T-AS-03a: exact-action persistence is explicit");
+const unprovenRememberedPayload = buildDecisionPayload({
+  item: { ...BASE_REQUEST, exact_action_persistence_eligible: false },
+  action: "allow",
+  scope: "artifact",
+  reason: "approved in review",
+  persistExactAction: true,
+});
+assert(unprovenRememberedPayload.persist_policy === undefined, "T-AS-03b: unproven actions cannot be remembered");
+
+function ignoreScopeChange(): void {}
+
+function renderExactActionControl(eligible: boolean): string {
+  return renderToStaticMarkup(
+    createElement(ReviewScopeControls, {
+      commonScopeOptions: standardScopeChoicesForRequest(BASE_REQUEST, "allow"),
+      broaderScopeOptions: [],
+      advancedScopeOptions: [],
+      blockScopeOptions: [],
+      hasAllowScope: true,
+      taskCapabilityCopy: null,
+      exactActionPersistenceEligible: eligible,
+      rememberExactAction: false,
+      allowScope: "artifact",
+      blockScope: "artifact",
+      onAllowScopeChange: ignoreScopeChange,
+      onBlockScopeChange: ignoreScopeChange,
+      onRememberExactActionChange: ignoreScopeChange,
+    }),
+  );
+}
+
+assert(
+  renderExactActionControl(true).includes("Always allow this exact action"),
+  "T-AS-03c: eligible requests render the exact-action permission",
+);
+assert(
+  !renderExactActionControl(false).includes("Always allow this exact action"),
+  "T-AS-03d: unproven requests do not render a durable permission",
 );
 
 const blockPayload = buildDecisionPayload({
@@ -199,3 +249,5 @@ assert(
     "artifact,workspace,harness",
   "T-AS-21: standard allow scopes expose project and app when eligible",
 );
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";

--- a/dashboard/src/approval-scopes.ts
+++ b/dashboard/src/approval-scopes.ts
@@ -217,6 +217,7 @@ export function buildDecisionPayload(input: {
   action: "allow" | "block";
   scope: DecisionScope;
   reason: string;
+  persistExactAction?: boolean;
 }): {
   requestId: string;
   action: "allow" | "block";
@@ -225,6 +226,7 @@ export function buildDecisionPayload(input: {
   reason: string;
   scope_contract_version?: string;
   scope_contract_digest?: string;
+  persist_policy?: boolean;
 } {
   const contractVersion = input.item.scope_contract_version;
   const contractDigest = input.item.scope_contract_digest;
@@ -250,6 +252,12 @@ export function buildDecisionPayload(input: {
     scope: normalizedScope,
     workspace,
     reason: input.reason,
+    ...(input.action === "allow" &&
+    normalizedScope === "artifact" &&
+    input.persistExactAction === true &&
+    input.item.exact_action_persistence_eligible === true
+      ? { persist_policy: true }
+      : {}),
     ...(hasCompleteBinding
       ? {
           scope_contract_version: contractVersion,

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -182,6 +182,7 @@ export type GuardApprovalRequest = {
   recommended_scope_by_action?: GuardRecommendedScopesByAction;
   scope_restrictions?: string[];
   task_capability_eligibility?: GuardTaskCapabilityEligibility;
+  exact_action_persistence_eligible?: boolean;
   risk_headline?: string;
   risk_summary?: string;
   risk_signals?: string[];
@@ -260,6 +261,7 @@ export type GuardApprovalResolutionInput = {
   approval_gate_use_cooldown?: boolean;
   scope_contract_version?: string;
   scope_contract_digest?: string;
+  persist_policy?: boolean;
   mcp_grant_target?: GuardTemporaryMcpGrantTarget;
   mcp_grant_duration?: GuardTemporaryMcpGrantDuration;
   local_tool_grant_target?: GuardLocalToolGrantTarget;

--- a/dashboard/src/review-decision-card.tsx
+++ b/dashboard/src/review-decision-card.tsx
@@ -98,6 +98,7 @@ export function ReviewDecisionCard(props: {
   const [mcpGrantDuration, setMcpGrantDuration] = useState<GuardTemporaryMcpGrantDuration>("once");
   const [localToolGrantTarget, setLocalToolGrantTarget] = useState<GuardLocalToolGrantTarget>("capability");
   const [localToolGrantDuration, setLocalToolGrantDuration] = useState<GuardLocalToolGrantDuration>("once");
+  const [rememberExactAction, setRememberExactAction] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const allowButtonRef = useRef<HTMLButtonElement>(null);
   const availableScopeChoices = useMemo(
@@ -148,6 +149,7 @@ export function ReviewDecisionCard(props: {
       setUseCooldown(false);
       setPendingAction(null);
       setPendingContractKey(null);
+      setRememberExactAction(false);
       const nextTemporaryOptions = temporaryMcpApprovalOptions(item);
       if (nextTemporaryOptions !== null) {
         setMcpGrantTarget(defaultTemporaryMcpTarget(nextTemporaryOptions));
@@ -204,6 +206,7 @@ export function ReviewDecisionCard(props: {
             action,
             scope: requestedScope,
             reason: action === "allow" ? "approved in review" : "blocked in review",
+            persistExactAction: action === "allow" ? rememberExactAction : false,
           }),
           ...(includeGateFields && needsPassword ? { approval_password: approvalPassword } : {}),
           ...(includeGateFields && !needsPassword ? { approval_totp_code: approvalTotpCode } : {}),
@@ -232,6 +235,7 @@ export function ReviewDecisionCard(props: {
       item,
       allowScope,
       blockScope,
+      rememberExactAction,
       props.onResolve,
       props.approvalGate,
       approvalPassword,
@@ -378,6 +382,9 @@ export function ReviewDecisionCard(props: {
   const evidenceItems = buildEvidenceItems(item);
   const actionPresentation = guardActionPresentation(item.policy_action);
   let resolvedAllowButtonLabel = allowButtonLabel(allowScope);
+  if (rememberExactAction && allowScope === "artifact") {
+    resolvedAllowButtonLabel = "Approve and remember";
+  }
   if (temporaryMcpOptions !== null) {
     resolvedAllowButtonLabel = temporaryMcpAllowButtonLabel(mcpGrantDuration);
   } else if (localToolOptions !== null) {
@@ -498,11 +505,14 @@ export function ReviewDecisionCard(props: {
               blockScopeOptions={blockScopeOptions}
               hasAllowScope={hasAllowScope}
               taskCapabilityCopy={taskCapabilityCopy}
+              exactActionPersistenceEligible={item.exact_action_persistence_eligible === true}
+              rememberExactAction={rememberExactAction}
               allowScope={allowScope}
               blockScope={blockScope}
               showAllowScopes={temporaryMcpOptions === null && localToolOptions === null}
               onAllowScopeChange={setAllowScope}
               onBlockScopeChange={setBlockScope}
+              onRememberExactActionChange={setRememberExactAction}
             />
           </>
         )}

--- a/dashboard/src/review-scope-controls.tsx
+++ b/dashboard/src/review-scope-controls.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, type ChangeEvent } from "react";
 import { HiMiniKey } from "react-icons/hi2";
 import { SectionLabel } from "./approval-center-primitives";
 import type { ApprovalScopeChoice } from "./approval-scopes";
@@ -11,11 +11,14 @@ type ReviewScopeControlsProps = {
   blockScopeOptions: ApprovalScopeChoice[];
   hasAllowScope: boolean;
   taskCapabilityCopy: string | null;
+  exactActionPersistenceEligible: boolean;
+  rememberExactAction: boolean;
   allowScope: DecisionScope;
   blockScope: DecisionScope;
   showAllowScopes?: boolean;
   onAllowScopeChange: (scope: DecisionScope) => void;
   onBlockScopeChange: (scope: DecisionScope) => void;
+  onRememberExactActionChange: (checked: boolean) => void;
 };
 
 export function ReviewScopeControls(props: ReviewScopeControlsProps) {
@@ -38,6 +41,12 @@ export function ReviewScopeControls(props: ReviewScopeControlsProps) {
           />
         ))}
       </div>}
+      {showAllowScopes && props.exactActionPersistenceEligible && props.allowScope === "artifact" && (
+        <ExactActionPersistenceChoice
+          checked={props.rememberExactAction}
+          onChange={props.onRememberExactActionChange}
+        />
+      )}
       {showAllowScopes && props.broaderScopeOptions.length > 0 && (
         <details className="rounded-xl border border-brand-blue/15 bg-brand-blue/[0.03] p-3">
           <summary className="cursor-pointer select-none text-xs font-semibold uppercase tracking-[0.16em] text-brand-blue">
@@ -105,6 +114,32 @@ export function ReviewScopeControls(props: ReviewScopeControlsProps) {
         </details>
       )}
     </div>
+  );
+}
+
+function ExactActionPersistenceChoice(props: { checked: boolean; onChange: (checked: boolean) => void }) {
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      props.onChange(event.target.checked);
+    },
+    [props.onChange],
+  );
+
+  return (
+    <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-brand-blue/20 bg-brand-blue/[0.03] px-4 py-3">
+      <input
+        type="checkbox"
+        checked={props.checked}
+        onChange={handleChange}
+        className="mt-0.5 h-4 w-4 accent-brand-blue"
+      />
+      <span>
+        <span className="block text-sm font-medium text-brand-dark">Always allow this exact action</span>
+        <span className="mt-0.5 block text-xs text-muted-foreground">
+          Save only this exact command for this AI app. Changed commands still need review.
+        </span>
+      </span>
+    </label>
   );
 }
 

--- a/src/codex_plugin_scanner/guard/approval_scope_support.py
+++ b/src/codex_plugin_scanner/guard/approval_scope_support.py
@@ -232,14 +232,12 @@ def exact_action_allow_persistence_eligible(request: Mapping[str, object]) -> bo
     envelope = request.get("action_envelope_json")
     if isinstance(envelope, Mapping):
         typed_envelope = cast(Mapping[str, object], envelope)
-        raw_command_text = raw_command_text or _string_or_none(typed_envelope.get("command"))
-    return bool(
-        artifact_id
-        and artifact_hash
-        and artifact_hash != "unknown"
-        and action_identity
-        and raw_command_text
-    )
+        raw_command_text = (
+            raw_command_text
+            or _string_or_none(typed_envelope.get("raw_command_text"))
+            or _string_or_none(typed_envelope.get("command"))
+        )
+    return bool(artifact_id and artifact_hash and artifact_hash != "unknown" and action_identity and raw_command_text)
 
 
 def resolve_request_scope_selection(

--- a/src/codex_plugin_scanner/guard/approval_scope_support.py
+++ b/src/codex_plugin_scanner/guard/approval_scope_support.py
@@ -33,7 +33,7 @@ _SCOPED_APPROVAL_FAMILIES = frozenset(
 )
 
 APPROVAL_SCOPE_CONTRACT_VERSION_PREFIX: Final = "guard.approval-scopes.v"
-APPROVAL_SCOPE_CONTRACT_VERSION: Final = f"{APPROVAL_SCOPE_CONTRACT_VERSION_PREFIX}4"
+APPROVAL_SCOPE_CONTRACT_VERSION: Final = f"{APPROVAL_SCOPE_CONTRACT_VERSION_PREFIX}5"
 ResolutionAction = Literal["allow", "block"]
 
 
@@ -85,6 +85,7 @@ class ApprovalScopeContract:
     digest: str
     task_capability_eligible: bool = False
     task_capability_reason_codes: tuple[str, ...] = ("task_capability_not_enabled",)
+    exact_action_persistence_eligible: bool = False
     version: str = APPROVAL_SCOPE_CONTRACT_VERSION
 
     def to_dict(self) -> dict[str, object]:
@@ -104,6 +105,7 @@ class ApprovalScopeContract:
                 "eligible": self.task_capability_eligible,
                 "reason_codes": list(self.task_capability_reason_codes),
             },
+            "exact_action_persistence_eligible": self.exact_action_persistence_eligible,
         }
 
 
@@ -121,6 +123,7 @@ def request_scope_contract(request: Mapping[str, object]) -> ApprovalScopeContra
     block_scopes: list[DecisionScope] = list(artifact_scopes)
     trusted_family = _request_scoped_family_key(request)
     task_capability_eligible = _github_workflow_task_capability_eligible(request)
+    exact_action_persistence_eligible = exact_action_allow_persistence_eligible(request)
     task_capability_reason_codes = (
         ("exact_github_workflow_record",) if task_capability_eligible else ("task_capability_not_enabled",)
     )
@@ -151,6 +154,7 @@ def request_scope_contract(request: Mapping[str, object]) -> ApprovalScopeContra
         restrictions=restrictions_tuple,
         task_capability_eligible=task_capability_eligible,
         task_capability_reason_codes=task_capability_reason_codes,
+        exact_action_persistence_eligible=exact_action_persistence_eligible,
     )
     return ApprovalScopeContract(
         allow_scopes=allow_scopes,
@@ -161,6 +165,7 @@ def request_scope_contract(request: Mapping[str, object]) -> ApprovalScopeContra
         digest=digest,
         task_capability_eligible=task_capability_eligible,
         task_capability_reason_codes=task_capability_reason_codes,
+        exact_action_persistence_eligible=exact_action_persistence_eligible,
     )
 
 
@@ -211,6 +216,30 @@ def request_scope_contract_payload(request: Mapping[str, object]) -> dict[str, o
     if local_tool_approval is not None:
         payload["local_tool_approval"] = local_tool_approval
     return payload
+
+
+def exact_action_allow_persistence_eligible(request: Mapping[str, object]) -> bool:
+    """Return whether an artifact allow can be saved as one exact action."""
+
+    if _allow_is_non_overridable(request) or _string_or_none(request.get("artifact_type")) != "tool_action_request":
+        return False
+    if _request_scoped_family_key(request) != "family:tool-action":
+        return False
+    artifact_id = _string_or_none(request.get("artifact_id"))
+    artifact_hash = _string_or_none(request.get("artifact_hash"))
+    action_identity = _string_or_none(request.get("action_identity"))
+    raw_command_text = _string_or_none(request.get("raw_command_text"))
+    envelope = request.get("action_envelope_json")
+    if isinstance(envelope, Mapping):
+        typed_envelope = cast(Mapping[str, object], envelope)
+        raw_command_text = raw_command_text or _string_or_none(typed_envelope.get("command"))
+    return bool(
+        artifact_id
+        and artifact_hash
+        and artifact_hash != "unknown"
+        and action_identity
+        and raw_command_text
+    )
 
 
 def resolve_request_scope_selection(
@@ -394,6 +423,7 @@ def _scope_contract_digest(
     restrictions: tuple[str, ...],
     task_capability_eligible: bool = False,
     task_capability_reason_codes: tuple[str, ...] = ("task_capability_not_enabled",),
+    exact_action_persistence_eligible: bool = False,
 ) -> str:
     material = {
         "version": APPROVAL_SCOPE_CONTRACT_VERSION,
@@ -402,6 +432,7 @@ def _scope_contract_digest(
         "restrictions": restrictions,
         "task_capability_eligible": task_capability_eligible,
         "task_capability_reason_codes": task_capability_reason_codes,
+        "exact_action_persistence_eligible": exact_action_persistence_eligible,
         "request": {
             key: _json_boundary_value(request.get(key))
             for key in (

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -717,7 +717,11 @@ def apply_approval_resolution(
         if scope in {"artifact", "workspace", "harness", "global"}:
             scoped_artifact_id = request_artifact_id
     else:
-        artifact_runtime_exact_match_key = _artifact_scope_runtime_exact_match_key(request, scope)
+        artifact_runtime_exact_match_key = _artifact_scope_runtime_exact_match_key(
+            request,
+            scope,
+            include_envelope_command=persist_policy is True,
+        )
         if artifact_runtime_exact_match_key is not None:
             scoped_artifact_hash = artifact_runtime_exact_match_key
         broad_runtime_exact_match_key = _broad_runtime_exact_match_key(request, scope)
@@ -981,7 +985,12 @@ def _workspace_policy_artifact_keys(request: Mapping[str, object], scope: str) -
     return artifact_id, artifact_hash
 
 
-def _artifact_scope_runtime_exact_match_key(request: Mapping[str, object], scope: str) -> str | None:
+def _artifact_scope_runtime_exact_match_key(
+    request: Mapping[str, object],
+    scope: str,
+    *,
+    include_envelope_command: bool = False,
+) -> str | None:
     if scope != "artifact" or request.get("artifact_type") != "tool_action_request":
         return None
     artifact_id = request.get("artifact_id")
@@ -992,7 +1001,7 @@ def _artifact_scope_runtime_exact_match_key(request: Mapping[str, object], scope
         raw_command_text = (
             raw_command_text
             or _string_or_none(envelope.get("raw_command_text"))
-            or _string_or_none(envelope.get("command"))
+            or (_string_or_none(envelope.get("command")) if include_envelope_command else None)
         )
         if not isinstance(wrapper_chain, Sequence) or isinstance(wrapper_chain, str):
             wrapper_chain = envelope.get("wrapper_chain")

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -23,6 +23,7 @@ from .approval_gate import ApprovalGateGrant, ApprovalGateInput, require_approva
 from .approval_resolution import require_resolvable_approval_request
 from .approval_scope_support import (
     IneligibleApprovalScopeError,
+    exact_action_allow_persistence_eligible,
     package_request_portable_workspace_scope,
     request_scope_contract,
     request_scope_contract_payload,
@@ -680,13 +681,15 @@ def apply_approval_resolution(
         persist_policy = None
     elif action == "allow" and scope == "artifact" and persist_policy is True:
         if scope_contract_version is not None:
-            raise IneligibleApprovalScopeError(
-                "saved_allow_scope_ineligible",
-                request_scope_contract(request),
-                action=action,
-                requested_scope=scope,
-            )
-        persist_policy = None
+            if not exact_action_allow_persistence_eligible(request):
+                raise IneligibleApprovalScopeError(
+                    "saved_allow_scope_ineligible",
+                    request_scope_contract(request),
+                    action=action,
+                    requested_scope=scope,
+                )
+        else:
+            persist_policy = None
     workspace_artifact_id, workspace_artifact_hash = _workspace_policy_artifact_keys(request, scope)
     request_artifact_id = _string_or_none(request.get("artifact_id"))
     request_artifact_hash = _string_or_none(request.get("artifact_hash"))
@@ -986,7 +989,11 @@ def _artifact_scope_runtime_exact_match_key(request: Mapping[str, object], scope
     wrapper_chain = request.get("wrapper_chain")
     envelope = request.get("action_envelope_json")
     if isinstance(envelope, Mapping):
-        raw_command_text = raw_command_text or _string_or_none(envelope.get("raw_command_text"))
+        raw_command_text = (
+            raw_command_text
+            or _string_or_none(envelope.get("raw_command_text"))
+            or _string_or_none(envelope.get("command"))
+        )
         if not isinstance(wrapper_chain, Sequence) or isinstance(wrapper_chain, str):
             wrapper_chain = envelope.get("wrapper_chain")
     normalized_wrapper_chain = (

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13270,6 +13270,7 @@ function buildDecisionPayload(input) {
     scope: normalizedScope,
     workspace,
     reason: input.reason,
+    ...input.action === "allow" && normalizedScope === "artifact" && input.persistExactAction === true && input.item.exact_action_persistence_eligible === true ? { persist_policy: true } : {},
     ...hasCompleteBinding ? {
       scope_contract_version: contractVersion,
       scope_contract_digest: contractDigest
@@ -28352,6 +28353,13 @@ function ReviewScopeControls(props) {
       },
       choice.value
     )) }),
+    showAllowScopes && props.exactActionPersistenceEligible && props.allowScope === "artifact" && /* @__PURE__ */ jsxRuntimeExports.jsx(
+      ExactActionPersistenceChoice,
+      {
+        checked: props.rememberExactAction,
+        onChange: props.onRememberExactActionChange
+      }
+    ),
     showAllowScopes && props.broaderScopeOptions.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "rounded-xl border border-brand-blue/15 bg-brand-blue/[0.03] p-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: "cursor-pointer select-none text-xs font-semibold uppercase tracking-[0.16em] text-brand-blue", children: "Save for project or app" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-xs text-brand-dark/70", children: "These options save a decision that skips review for matching actions going forward. Choose the narrowest scope that fits what you meant to allow." }),
@@ -28394,6 +28402,29 @@ function ReviewScopeControls(props) {
         },
         choice.value
       )) })
+    ] })
+  ] });
+}
+function ExactActionPersistenceChoice(props) {
+  const handleChange = reactExports.useCallback(
+    (event) => {
+      props.onChange(event.target.checked);
+    },
+    [props.onChange]
+  );
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "flex cursor-pointer items-start gap-3 rounded-lg border border-brand-blue/20 bg-brand-blue/[0.03] px-4 py-3", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "input",
+      {
+        type: "checkbox",
+        checked: props.checked,
+        onChange: handleChange,
+        className: "mt-0.5 h-4 w-4 accent-brand-blue"
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "block text-sm font-medium text-brand-dark", children: "Always allow this exact action" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-0.5 block text-xs text-muted-foreground", children: "Save only this exact command for this AI app. Changed commands still need review." })
     ] })
   ] });
 }
@@ -28774,6 +28805,7 @@ function ReviewDecisionCard(props) {
   const [mcpGrantDuration, setMcpGrantDuration] = reactExports.useState("once");
   const [localToolGrantTarget, setLocalToolGrantTarget] = reactExports.useState("capability");
   const [localToolGrantDuration, setLocalToolGrantDuration] = reactExports.useState("once");
+  const [rememberExactAction, setRememberExactAction] = reactExports.useState(false);
   const timerRef = reactExports.useRef(null);
   const allowButtonRef = reactExports.useRef(null);
   const availableScopeChoices = reactExports.useMemo(
@@ -28821,6 +28853,7 @@ function ReviewDecisionCard(props) {
       setUseCooldown(false);
       setPendingAction(null);
       setPendingContractKey(null);
+      setRememberExactAction(false);
       const nextTemporaryOptions = temporaryMcpApprovalOptions(item);
       if (nextTemporaryOptions !== null) {
         setMcpGrantTarget(defaultTemporaryMcpTarget(nextTemporaryOptions));
@@ -28869,7 +28902,8 @@ function ReviewDecisionCard(props) {
             item,
             action,
             scope: requestedScope,
-            reason: action === "allow" ? "approved in review" : "blocked in review"
+            reason: action === "allow" ? "approved in review" : "blocked in review",
+            persistExactAction: action === "allow" ? rememberExactAction : false
           }),
           ...includeGateFields && needsPassword ? { approval_password: approvalPassword } : {},
           ...includeGateFields && !needsPassword ? { approval_totp_code: approvalTotpCode } : {},
@@ -28894,6 +28928,7 @@ function ReviewDecisionCard(props) {
       item,
       allowScope,
       blockScope,
+      rememberExactAction,
       props.onResolve,
       props.approvalGate,
       approvalPassword,
@@ -29027,6 +29062,9 @@ function ReviewDecisionCard(props) {
   const evidenceItems = buildEvidenceItems(item);
   const actionPresentation = guardActionPresentation(item.policy_action);
   let resolvedAllowButtonLabel = allowButtonLabel(allowScope);
+  if (rememberExactAction && allowScope === "artifact") {
+    resolvedAllowButtonLabel = "Approve and remember";
+  }
   if (temporaryMcpOptions !== null) {
     resolvedAllowButtonLabel = temporaryMcpAllowButtonLabel(mcpGrantDuration);
   } else if (localToolOptions !== null) {
@@ -29127,11 +29165,14 @@ function ReviewDecisionCard(props) {
             blockScopeOptions,
             hasAllowScope,
             taskCapabilityCopy,
+            exactActionPersistenceEligible: item.exact_action_persistence_eligible === true,
+            rememberExactAction,
             allowScope,
             blockScope,
             showAllowScopes: temporaryMcpOptions === null && localToolOptions === null,
             onAllowScopeChange: setAllowScope,
-            onBlockScopeChange: setBlockScope
+            onBlockScopeChange: setBlockScope,
+            onRememberExactActionChange: setRememberExactAction
           }
         )
       ] }),

--- a/tests/test_guard_approval_scope_contract.py
+++ b/tests/test_guard_approval_scope_contract.py
@@ -426,6 +426,17 @@ def test_v2_saved_artifact_allow_requires_exact_action_proof(tmp_path: Path) -> 
     assert response["error"] == "saved_allow_scope_ineligible"
 
 
+def test_exact_action_persistence_accepts_envelope_raw_command_text(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    request = replace(
+        _request("envelope-raw-command"),
+        action_envelope_json={"action_type": "shell_command", "raw_command_text": "echo test"},
+    )
+    row = _store_request(store, request)
+
+    assert request_scope_contract(row).exact_action_persistence_eligible is True
+
+
 def test_legacy_unknown_broad_deny_is_not_silently_narrowed(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     _store_request(

--- a/tests/test_guard_approval_scope_contract.py
+++ b/tests/test_guard_approval_scope_contract.py
@@ -356,22 +356,74 @@ def test_v2_ineligible_scope_returns_422_without_policy_or_resolution(tmp_path: 
     assert store.list_policy_decisions() == []
 
 
-def test_v2_saved_artifact_allow_is_rejected_as_ineligible(tmp_path: Path) -> None:
+def test_v2_saved_artifact_allow_persists_only_the_exact_action(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     row = _store_request(store, _request("saved-allow"))
     payload = {**_v2_selection(row, "artifact"), "persist_policy": True}
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
-        status, response = _post(daemon, "/v1/requests/saved-allow/approve", payload)
+        status, _response = _post(daemon, "/v1/requests/saved-allow/approve", payload)
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    stored = store.get_approval_request("saved-allow")
+    assert stored is not None
+    assert stored["status"] == "resolved"
+    decisions = store.list_policy_decisions()
+    assert len(decisions) == 1
+    assert decisions[0]["scope"] == "artifact"
+    assert decisions[0]["expires_at"] is None
+    same_action_context = runtime_tool_action_exact_match_context(
+        config_path="/workspace/repo/.guard/config.toml",
+        source_scope="project",
+        raw_command_text="echo test",
+    )
+    changed_action_context = runtime_tool_action_exact_match_context(
+        config_path="/workspace/repo/.guard/config.toml",
+        source_scope="project",
+        raw_command_text="echo changed",
+    )
+    assert (
+        store.resolve_policy_decision(
+            "codex",
+            "codex:project:tool-action:saved-allow",
+            "hash-retry",
+            runtime_exact_match_context=same_action_context,
+            consume_one_shot=False,
+        )
+        is not None
+    )
+    assert (
+        store.resolve_policy_decision(
+            "codex",
+            "codex:project:tool-action:saved-allow",
+            "hash-retry",
+            runtime_exact_match_context=changed_action_context,
+            consume_one_shot=False,
+        )
+        is None
+    )
+
+
+def test_v2_saved_artifact_allow_requires_exact_action_proof(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    request = replace(
+        _request("unproven-saved-allow"),
+        action_envelope_json={"action_type": "shell_command"},
+    )
+    row = _store_request(store, request)
+    payload = {**_v2_selection(row, "artifact"), "persist_policy": True}
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, response = _post(daemon, "/v1/requests/unproven-saved-allow/approve", payload)
     finally:
         daemon.stop()
 
     assert status == 422
     assert response["error"] == "saved_allow_scope_ineligible"
-    stored = store.get_approval_request("saved-allow")
-    assert stored is not None
-    assert stored["status"] == "pending"
 
 
 def test_legacy_unknown_broad_deny_is_not_silently_narrowed(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- expose proof-gated permanent approval for an exact tool action
- bind saved approvals to the canonical command context so changed commands still require review
- show an "Always allow this exact action" choice only when the daemon verifies sufficient identity and command proof

## Testing

- `uv run --no-sync pytest -q tests/test_guard_approval_scope_contract.py --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_approvals.py tests/test_guard_approval_reuse.py tests/test_guard_approval_policy_versions.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/approval_scope_support.py src/codex_plugin_scanner/guard/approvals.py tests/test_guard_approval_scope_contract.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/approval_scope_support.py src/codex_plugin_scanner/guard/approvals.py tests/test_guard_approval_scope_contract.py`
- `bun run test`
- `bun run build`
- `uv run --no-sync python tests/guard_command_decision_diff.py --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to always allow an eligible exact artifact action.
  * The option appears only for supported approvals and is excluded from blocked or unsupported actions.
  * Saved approvals now apply only to the exact approved action, preventing reuse for changed commands.

* **Bug Fixes**
  * Improved handling when command details are provided through alternate request data.
  * Added safeguards to reject exact-action persistence when eligibility cannot be verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->