### PR TITLE
fix(guard): allow frozen daemon bootloader parent

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14152,
-  "maximum_test_source_lines": 312267,
+  "maximum_collected_cases": 14158,
+  "maximum_test_source_lines": 312377,
   "schema_version": 1
 }

--- a/scripts/mdm/hol-guard-entry.py
+++ b/scripts/mdm/hol-guard-entry.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
-from codex_plugin_scanner.cli import main
-from codex_plugin_scanner.guard.frozen_codex_runtime import (
-    install_frozen_codex_runtime,
-    run_frozen_internal_command,
-)
+from codex_plugin_scanner.guard.frozen_daemon_runtime import install_frozen_daemon_runtime
 
 if __name__ == "__main__":
+    install_frozen_daemon_runtime()
+
+    from codex_plugin_scanner.guard.frozen_codex_runtime import (
+        install_frozen_codex_runtime,
+        run_frozen_internal_command,
+    )
+
     install_frozen_codex_runtime()
     internal_exit_code = run_frozen_internal_command()
-    raise SystemExit(main() if internal_exit_code is None else internal_exit_code)
+    if internal_exit_code is not None:
+        raise SystemExit(internal_exit_code)
+
+    from codex_plugin_scanner.cli import main
+
+    raise SystemExit(main())

--- a/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
+++ b/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
@@ -1,0 +1,116 @@
+"""PyInstaller-specific Guard daemon runtime adaptations."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+from .daemon import manager
+
+_frozen_runtime_installed = False
+_frozen_runtime_fingerprint_cache: tuple[Path, str] | None = None
+
+
+def _trusted_frozen_executable() -> Path:
+    executable = Path(sys.executable).expanduser()
+    if not executable.is_absolute() or not executable.is_file():
+        raise RuntimeError("Frozen Guard daemon requires the signed Guard executable.")
+    try:
+        return executable.resolve(strict=True)
+    except (OSError, RuntimeError) as error:
+        raise RuntimeError("Frozen Guard daemon requires the signed Guard executable.") from error
+
+
+def _frozen_runtime_source_root() -> str:
+    """Use the stable one-file executable path instead of the temporary extraction root."""
+
+    return str(_trusted_frozen_executable())
+
+
+def _frozen_runtime_fingerprint() -> str:
+    """Bind daemon compatibility to the exact frozen executable bytes."""
+
+    global _frozen_runtime_fingerprint_cache
+    executable = _trusted_frozen_executable()
+    cached = _frozen_runtime_fingerprint_cache
+    if cached is not None and cached[0] == executable:
+        return cached[1]
+
+    digest = hashlib.sha256()
+    try:
+        with executable.open("rb") as handle:
+            while chunk := handle.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError as error:
+        raise RuntimeError("Frozen Guard daemon executable identity could not be read.") from error
+    fingerprint = digest.hexdigest()
+    _frozen_runtime_fingerprint_cache = (executable, fingerprint)
+    return fingerprint
+
+
+def _same_guard_home(left: Path, right: Path) -> bool:
+    try:
+        return left.resolve() == right.resolve()
+    except OSError:
+        return left == right
+
+
+def _trusted_frozen_bootloader_parent_pid(guard_home: Path) -> int | None:
+    """Return the proven PyInstaller one-file parent PID for this daemon child."""
+
+    if not bool(getattr(sys, "frozen", False)):
+        return None
+    current_pid = os.getpid()
+    parent_pid = os.getppid()
+    if parent_pid <= 1 or parent_pid == current_pid:
+        return None
+
+    command = manager._guard_daemon_command_for_pid(parent_pid)
+    if command is None:
+        return None
+    parts = manager._split_process_command(command)
+    if not parts or not manager._guard_daemon_command_parts_match(parts):
+        return None
+    command_guard_home = manager._guard_home_from_command_parts(parts)
+    if command_guard_home is None or not _same_guard_home(command_guard_home, guard_home):
+        return None
+
+    try:
+        current_executable = _trusted_frozen_executable()
+        parent_executable = Path(parts[0]).expanduser().resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+    if parent_executable != current_executable:
+        return None
+    return parent_pid
+
+
+def _filter_frozen_bootloader_parent(
+    guard_home: Path,
+    inventory: list[tuple[int, int]] | None,
+) -> list[tuple[int, int]] | None:
+    if inventory is None:
+        return None
+    parent_pid = _trusted_frozen_bootloader_parent_pid(guard_home)
+    if parent_pid is None:
+        return inventory
+    return [(pid, port) for pid, port in inventory if pid != parent_pid]
+
+
+def install_frozen_daemon_runtime() -> None:
+    """Install one-file daemon identity and process-inventory adaptations."""
+
+    global _frozen_runtime_installed
+    if not bool(getattr(sys, "frozen", False)) or _frozen_runtime_installed:
+        return
+    current_inventory = manager._guard_daemon_process_inventory_for_guard_home
+
+    def filtered_inventory(guard_home: Path) -> list[tuple[int, int]] | None:
+        return _filter_frozen_bootloader_parent(guard_home, current_inventory(guard_home))
+
+    manager._guard_daemon_process_inventory_for_guard_home = filtered_inventory
+    manager._current_guard_daemon_source_root = _frozen_runtime_source_root
+    manager._current_guard_daemon_runtime_fingerprint = _frozen_runtime_fingerprint
+    _frozen_runtime_installed = True

--- a/tests/test_guard_frozen_daemon_runtime.py
+++ b/tests/test_guard_frozen_daemon_runtime.py
@@ -1,0 +1,110 @@
+"""Frozen daemon process-inventory and runtime-identity coverage."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard import frozen_daemon_runtime
+from codex_plugin_scanner.guard.daemon import manager
+
+
+def _daemon_command(executable: Path, guard_home: Path, home: Path, *, port: int = 4781) -> str:
+    return (
+        f"{executable} daemon --serve --guard-home {guard_home} "
+        f"--home {home} --port {port}"
+    )
+
+
+def test_frozen_runtime_proves_same_executable_bootloader_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "hol-guard"
+    executable.write_bytes(b"guard")
+    home = tmp_path / "home"
+    guard_home = home / ".hol-guard"
+    guard_home.mkdir(parents=True)
+    command = _daemon_command(executable, guard_home, home)
+
+    monkeypatch.setattr(frozen_daemon_runtime.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(frozen_daemon_runtime.sys, "executable", str(executable))
+    monkeypatch.setattr(frozen_daemon_runtime.os, "getpid", lambda: 4243)
+    monkeypatch.setattr(frozen_daemon_runtime.os, "getppid", lambda: 4242)
+    monkeypatch.setattr(manager, "_guard_daemon_command_for_pid", lambda pid: command if pid == 4242 else None)
+
+    assert frozen_daemon_runtime._trusted_frozen_bootloader_parent_pid(guard_home) == 4242
+
+
+def test_frozen_runtime_rejects_different_parent_executable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "hol-guard"
+    executable.write_bytes(b"guard")
+    other_executable = tmp_path / "other-hol-guard"
+    other_executable.write_bytes(b"other")
+    home = tmp_path / "home"
+    guard_home = home / ".hol-guard"
+    guard_home.mkdir(parents=True)
+    command = _daemon_command(other_executable, guard_home, home)
+
+    monkeypatch.setattr(frozen_daemon_runtime.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(frozen_daemon_runtime.sys, "executable", str(executable))
+    monkeypatch.setattr(frozen_daemon_runtime.os, "getpid", lambda: 4243)
+    monkeypatch.setattr(frozen_daemon_runtime.os, "getppid", lambda: 4242)
+    monkeypatch.setattr(manager, "_guard_daemon_command_for_pid", lambda pid: command if pid == 4242 else None)
+
+    assert frozen_daemon_runtime._trusted_frozen_bootloader_parent_pid(guard_home) is None
+
+
+def test_frozen_inventory_filters_only_proven_bootloader_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / ".hol-guard"
+    monkeypatch.setattr(
+        frozen_daemon_runtime,
+        "_trusted_frozen_bootloader_parent_pid",
+        lambda _guard_home: 4242,
+    )
+
+    assert frozen_daemon_runtime._filter_frozen_bootloader_parent(
+        guard_home,
+        [(4242, 4781), (4243, 4781), (9000, 4782)],
+    ) == [(4243, 4781), (9000, 4782)]
+
+
+def test_frozen_runtime_source_root_uses_stable_executable_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "hol-guard"
+    executable.write_bytes(b"signed-core")
+    monkeypatch.setattr(frozen_daemon_runtime.sys, "executable", str(executable))
+
+    assert frozen_daemon_runtime._frozen_runtime_source_root() == str(executable.resolve())
+
+
+def test_frozen_runtime_fingerprint_binds_exact_executable_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "hol-guard"
+    payload = b"signed-core-bytes"
+    executable.write_bytes(payload)
+    monkeypatch.setattr(frozen_daemon_runtime.sys, "executable", str(executable))
+    monkeypatch.setattr(frozen_daemon_runtime, "_frozen_runtime_fingerprint_cache", None)
+
+    assert frozen_daemon_runtime._frozen_runtime_fingerprint() == hashlib.sha256(payload).hexdigest()
+
+
+def test_non_frozen_runtime_does_not_patch_daemon_inventory(monkeypatch: pytest.MonkeyPatch) -> None:
+    inventory = manager._guard_daemon_process_inventory_for_guard_home
+    monkeypatch.setattr(frozen_daemon_runtime.sys, "frozen", False, raising=False)
+
+    frozen_daemon_runtime.install_frozen_daemon_runtime()
+
+    assert manager._guard_daemon_process_inventory_for_guard_home is inventory


### PR DESCRIPTION
Fix the signed PyInstaller one-file Core sidecar daemon startup on macOS without weakening the generic daemon owner lock.

The frozen runtime handles both one-file process identity edges exposed by the packaged Desktop acceptance:
- It filters only a proven direct PyInstaller bootloader parent when the parent is the current OS parent, runs the exact same Guard daemon command for the exact same Guard home, and resolves to the exact current executable.
- It derives daemon runtime identity from the stable frozen executable path plus SHA-256 of the exact executable bytes, rather than the per-invocation temporary extraction directory.

Any unrelated matching process remains visible to the existing generic owner lock and is rejected as before. Source/non-frozen runtime identity remains unchanged.

Coverage adds six focused tests / 110 test-source lines. The ratchet is recomputed against the current release/3.0 baseline at 14158 collected cases / 312377 test-source lines.

Target: release/3.0 only. This does not merge release/3.0 into main.