### PR TITLE
fix(guard): handle frozen daemon paths with spaces

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 14175,
-  "maximum_test_source_lines": 312679,
+  "maximum_test_source_lines": 312680,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
+++ b/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
@@ -57,6 +57,22 @@ def _same_guard_home(left: Path, right: Path) -> bool:
         return left == right
 
 
+def _split_frozen_parent_command(command: str, executable: Path) -> list[str] | None:
+    """Preserve a trusted frozen executable path when POSIX ps drops argv quoting."""
+
+    executable_text = str(executable)
+    if os.name != "nt" and command.startswith(executable_text):
+        suffix = command[len(executable_text) :]
+        if not suffix:
+            return [executable_text]
+        if suffix[0].isspace():
+            tail = manager._split_process_command(suffix.lstrip())
+            if tail is None:
+                return None
+            return [executable_text, *tail]
+    return manager._split_process_command(command)
+
+
 def _trusted_frozen_bootloader_parent_pid(guard_home: Path) -> int | None:
     """Return the proven PyInstaller one-file parent PID for this daemon child."""
 
@@ -70,7 +86,11 @@ def _trusted_frozen_bootloader_parent_pid(guard_home: Path) -> int | None:
     command = manager._guard_daemon_command_for_pid(parent_pid)
     if command is None:
         return None
-    parts = manager._split_process_command(command)
+    try:
+        current_executable = _trusted_frozen_executable()
+    except RuntimeError:
+        return None
+    parts = _split_frozen_parent_command(command, current_executable)
     if not parts or not manager._guard_daemon_command_parts_match(parts):
         return None
     command_guard_home = manager._guard_home_from_command_parts(parts)
@@ -78,7 +98,6 @@ def _trusted_frozen_bootloader_parent_pid(guard_home: Path) -> int | None:
         return None
 
     try:
-        current_executable = _trusted_frozen_executable()
         parent_executable = Path(parts[0]).expanduser().resolve(strict=True)
     except (OSError, RuntimeError):
         return None

--- a/tests/test_guard_frozen_daemon_runtime.py
+++ b/tests/test_guard_frozen_daemon_runtime.py
@@ -22,7 +22,8 @@ def test_frozen_runtime_proves_same_executable_bootloader_parent(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    executable = tmp_path / "hol-guard"
+    executable = tmp_path / "Application Support" / "hol-guard"
+    executable.parent.mkdir()
     executable.write_bytes(b"guard")
     home = tmp_path / "home"
     guard_home = home / ".hol-guard"


### PR DESCRIPTION
## Summary
- preserve the exact trusted PyInstaller executable prefix when POSIX process listings render argv without quoting
- keep the existing parent-PID, daemon-command, Guard-home, and canonical executable checks intact
- exercise the existing frozen-parent regression with an `Application Support`-style executable path

## Why
HOL Guard Desktop installs managed Core under macOS `Library/Application Support/...`. The frozen daemon child validates its PyInstaller bootloader parent from `ps` command text. POSIX `shlex.split()` cannot recover an unquoted executable path containing spaces, so the valid bootloader parent was misclassified as a competing daemon and startup failed closed.

## Validation
- test-suite ratchet adjusted by exactly one test-source line; collected test count is unchanged
- target: `release/3.0` only; do not merge `release/3.0` into `main`