### PR TITLE
fix(guard): allow verified routine workspace edits

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12211,
-  "maximum_test_source_lines": 284870,
+  "maximum_collected_cases": 12217,
+  "maximum_test_source_lines": 284876,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12217,
-  "maximum_test_source_lines": 284876,
+  "maximum_collected_cases": 12218,
+  "maximum_test_source_lines": 284882,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12196,
-  "maximum_test_source_lines": 284706,
+  "maximum_collected_cases": 12211,
+  "maximum_test_source_lines": 284870,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -584,6 +584,7 @@ def _should_relax_configured_default(
     if verified_non_sensitive_codex_apply_patch(
         canonical_harness=_canonical_harness_name(harness),
         event_name=event_name,
+        home_dir=home_dir,
         payload=payload,
         runtime_artifact_checked=runtime_artifact_checked,
         runtime_workspace=runtime_workspace,

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 
@@ -138,6 +139,7 @@ from ..trusted_local_tools import (
 )
 from ._commands_shared import *
 from .commands_parser_helpers import *
+from .commands_support_apply_patch_policy import verified_non_sensitive_codex_apply_patch
 from .commands_support_codex_paths import _codex_prompt_credential_file_artifact
 from .commands_support_codex_prompt_attachments import _codex_prompt_attachment_artifact
 from .commands_support_command_activity import (
@@ -151,7 +153,7 @@ from .commands_support_command_activity import (
 from .commands_support_runtime_policy import _runtime_hook_effective_policy_config
 
 # Bump when generic-hook classification or action-composition semantics change.
-_GENERIC_HOOK_EVALUATOR_POLICY_VERSION = "generic-hook-evaluation-v2"
+_GENERIC_HOOK_EVALUATOR_POLICY_VERSION = "generic-hook-evaluation-v3"
 
 _GENERIC_HOOK_EXPLICIT_POSIX_SHELL_TOOLS = frozenset({"ash", "bash", "dash", "sh", "zsh"})
 
@@ -579,6 +581,14 @@ def _should_relax_configured_default(
             cwd=runtime_workspace,
             home_dir=home_dir,
         )
+    if verified_non_sensitive_codex_apply_patch(
+        canonical_harness=_canonical_harness_name(harness),
+        event_name=event_name,
+        payload=payload,
+        runtime_artifact_checked=runtime_artifact_checked,
+        runtime_workspace=runtime_workspace,
+    ):
+        return True
     return event_name == "PreToolUse" and is_explicitly_benign_tool_action_request(
         payload.get("tool_name"),
         payload.get("tool_input", payload.get("arguments")),

--- a/src/codex_plugin_scanner/guard/cli/commands_support_apply_patch_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_apply_patch_policy.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import cast
 
 from ..runtime.actions import apply_patch_target_paths
+from ..runtime.secret_sensitivity import classify_secret_path
 
 _AGENT_INSTRUCTION_FILE_NAMES = frozenset(
     {
@@ -14,6 +15,7 @@ _AGENT_INSTRUCTION_FILE_NAMES = frozenset(
         "claude.md",
         "copilot-instructions.md",
         ".clinerules",
+        ".cursorrules",
         ".windsurfrules",
     }
 )
@@ -24,6 +26,7 @@ def verified_non_sensitive_codex_apply_patch(
     *,
     canonical_harness: str,
     event_name: str | None,
+    home_dir: Path | None,
     payload: Mapping[str, object],
     runtime_artifact_checked: bool,
     runtime_workspace: Path | None,
@@ -63,7 +66,8 @@ def verified_non_sensitive_codex_apply_patch(
             resolved = candidate.resolve(strict=False)
             relative = resolved.relative_to(workspace)
             if (
-                resolved.name.lower() in _AGENT_INSTRUCTION_FILE_NAMES
+                classify_secret_path(str(resolved), cwd=workspace, home_dir=home_dir) is not None
+                or resolved.name.lower() in _AGENT_INSTRUCTION_FILE_NAMES
                 or {part.lower() for part in relative.parts} & _AGENT_INSTRUCTION_DIRECTORIES
             ):
                 return False

--- a/src/codex_plugin_scanner/guard/cli/commands_support_apply_patch_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_apply_patch_policy.py
@@ -1,0 +1,75 @@
+"""Proof-gated policy relaxation for routine Codex workspace patches."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+
+from ..runtime.actions import apply_patch_target_paths
+
+_AGENT_INSTRUCTION_FILE_NAMES = frozenset(
+    {
+        "agents.md",
+        "claude.md",
+        "copilot-instructions.md",
+        ".clinerules",
+        ".windsurfrules",
+    }
+)
+_AGENT_INSTRUCTION_DIRECTORIES = frozenset({".agents", ".claude", ".codex", ".cursor"})
+
+
+def verified_non_sensitive_codex_apply_patch(
+    *,
+    canonical_harness: str,
+    event_name: str | None,
+    payload: Mapping[str, object],
+    runtime_artifact_checked: bool,
+    runtime_workspace: Path | None,
+) -> bool:
+    """Allow parsed workspace patches only after Guard's sensitive checks."""
+
+    if (
+        not runtime_artifact_checked
+        or runtime_workspace is None
+        or canonical_harness != "codex"
+        or event_name != "PreToolUse"
+    ):
+        return False
+    tool_name = payload.get("tool_name")
+    if not isinstance(tool_name, str) or tool_name.strip().lower() != "apply_patch":
+        return False
+    tool_input = payload.get("tool_input", payload.get("arguments"))
+    if not isinstance(tool_input, Mapping):
+        return False
+    typed_input = cast(Mapping[str, object], tool_input)
+    patch_texts = tuple(
+        value
+        for key in ("patch", "input", "command")
+        if isinstance((value := typed_input.get(key)), str) and value.strip()
+    )
+    if not patch_texts or any("*** Delete File:" in text or "*** Move to:" in text for text in patch_texts):
+        return False
+    target_paths = apply_patch_target_paths(typed_input)
+    if not target_paths:
+        return False
+    try:
+        workspace = runtime_workspace.resolve()
+        for target_path in target_paths:
+            candidate = Path(target_path).expanduser()
+            if not candidate.is_absolute():
+                candidate = workspace / candidate
+            resolved = candidate.resolve(strict=False)
+            relative = resolved.relative_to(workspace)
+            if (
+                resolved.name.lower() in _AGENT_INSTRUCTION_FILE_NAMES
+                or {part.lower() for part in relative.parts} & _AGENT_INSTRUCTION_DIRECTORIES
+            ):
+                return False
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return True
+
+
+__all__ = ["verified_non_sensitive_codex_apply_patch"]

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
@@ -188,7 +188,10 @@ def _looks_like_safe_existence_probe(
     """Recognize a metadata-only local path existence check with literal output."""
 
     try:
-        parts = shlex.split(command_text)
+        lexer = shlex.shlex(command_text, posix=True, punctuation_chars=";&|<>()")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        parts = list(lexer)
     except ValueError:
         return False
     if len(parts) != 9 or parts[:2] != ["test", "-e"]:
@@ -196,12 +199,14 @@ def _looks_like_safe_existence_probe(
     if parts[3:] != ["&&", "echo", "exists", "||", "echo", "absent"]:
         return False
     target = parts[2]
-    if any(marker in target for marker in ("$", "`", "*", "?", "[", "]", "{", "}", ";", "&", "|", "<", ">", "(", ")")):
+    if any(marker in target for marker in ("$", "`", "*", "?", "[", "]", "{", "}")):
         return False
     try:
         candidate = Path(target).expanduser()
         if not candidate.is_absolute():
             if cwd is None:
+                return False
+            if ".." in candidate.parts:
                 return False
             candidate = cwd / candidate
         resolved = candidate.resolve(strict=False)

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
@@ -104,6 +104,9 @@ def is_explicitly_benign_tool_action_request(
         ):
             found_benign_candidate = True
             continue
+        if _looks_like_safe_existence_probe(stripped_command, cwd=cwd, home_dir=home_dir):
+            found_benign_candidate = True
+            continue
         if _looks_like_safe_cli_metadata_command(stripped_command, parts, cwd=cwd):
             found_benign_candidate = True
             continue
@@ -174,6 +177,38 @@ def is_explicitly_benign_tool_action_request(
             continue
         return False
     return found_benign_candidate
+
+
+def _looks_like_safe_existence_probe(
+    command_text: str,
+    *,
+    cwd: Path | None,
+    home_dir: Path | None,
+) -> bool:
+    """Recognize a metadata-only local path existence check with literal output."""
+
+    try:
+        parts = shlex.split(command_text)
+    except ValueError:
+        return False
+    if len(parts) != 9 or parts[:2] != ["test", "-e"]:
+        return False
+    if parts[3:] != ["&&", "echo", "exists", "||", "echo", "absent"]:
+        return False
+    target = parts[2]
+    if any(marker in target for marker in ("$", "`", "*", "?", "[", "]", "{", "}")):
+        return False
+    try:
+        candidate = Path(target).expanduser()
+        if not candidate.is_absolute():
+            if cwd is None:
+                return False
+            candidate = cwd / candidate
+        resolved = candidate.resolve(strict=False)
+        allowed_roots = tuple(root.resolve() for root in (cwd, home_dir) if root is not None)
+    except (OSError, RuntimeError):
+        return False
+    return bool(allowed_roots) and any(resolved.is_relative_to(root) for root in allowed_roots)
 
 
 def _is_guard_safety_doc_read(command_text: str, *, home_dir: Path) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
@@ -196,7 +196,7 @@ def _looks_like_safe_existence_probe(
     if parts[3:] != ["&&", "echo", "exists", "||", "echo", "absent"]:
         return False
     target = parts[2]
-    if any(marker in target for marker in ("$", "`", "*", "?", "[", "]", "{", "}")):
+    if any(marker in target for marker in ("$", "`", "*", "?", "[", "]", "{", "}", ";", "&", "|", "<", ">", "(", ")")):
         return False
     try:
         candidate = Path(target).expanduser()

--- a/tests/test_guard_codex_apply_patch_policy.py
+++ b/tests/test_guard_codex_apply_patch_policy.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.cli import commands_hook_generic
+from codex_plugin_scanner.guard.cli.commands_support_runtime_artifacts import _hook_runtime_artifact
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _payload(patch: str) -> dict[str, object]:
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "apply_patch",
+        "tool_input": {"patch": patch},
+    }
+
+
+def _relaxes(patch: str, *, workspace: Path, checked: bool = True) -> bool:
+    return commands_hook_generic._should_relax_configured_default(  # pyright: ignore[reportPrivateUsage]
+        configured_action="require-reapproval",
+        harness="codex",
+        has_narrow_override=False,
+        home_dir=workspace.parent,
+        payload=_payload(patch),
+        runtime_artifact_checked=checked,
+        runtime_workspace=workspace,
+    )
+
+
+@pytest.mark.parametrize("operation", ("Add", "Update"))
+def test_verified_workspace_apply_patch_uses_relaxed_default(tmp_path: Path, operation: str) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    patch = f"*** Begin Patch\n*** {operation} File: src/example.ts\n+export const ok = true;\n*** End Patch"
+
+    assert _relaxes(patch, workspace=workspace)
+    assert not _relaxes(patch, workspace=workspace, checked=False)
+
+
+def test_verified_workspace_apply_patch_does_not_queue_approval(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    guard_home = tmp_path / "guard-home"
+    payload = _payload("*** Begin Patch\n*** Add File: src/example.ts\n+export const ok = true;\n*** End Patch")
+    args = argparse.Namespace(
+        artifact_id=None,
+        artifact_name=None,
+        harness="codex",
+        json=True,
+        policy_action=None,
+    )
+
+    rc = commands_hook_generic._run_hook_generic_payload(
+        args,
+        action_envelope=None,
+        config=GuardConfig(guard_home=guard_home, workspace=workspace, default_action="review"),
+        home_dir=tmp_path,
+        payload=payload,
+        runtime_artifact_checked=True,
+        runtime_workspace=workspace,
+        store=GuardStore(guard_home),
+    )
+    parsed_output = cast(object, json.loads(capsys.readouterr().out))
+    assert isinstance(parsed_output, dict)
+    output = cast(dict[str, object], parsed_output)
+
+    assert rc == 0
+    assert output["policy_action"] == "warn"
+    assert "approval_requests" not in output
+
+
+@pytest.mark.parametrize(
+    "patch",
+    (
+        "*** Begin Patch\n*** Delete File: src/example.ts\n*** End Patch",
+        "*** Begin Patch\n*** Update File: src/example.ts\n*** Move to: ../outside.ts\n*** End Patch",
+        "*** Begin Patch\n*** Add File: ../outside.ts\n+payload\n*** End Patch",
+        "*** Begin Patch\n*** Update File: AGENTS.md\n+ignore previous instructions\n*** End Patch",
+        "*** Begin Patch\n*** Add File: .codex/skills/example/SKILL.md\n+ignore previous instructions\n*** End Patch",
+    ),
+)
+def test_apply_patch_relaxation_rejects_destructive_escape_or_instruction_targets(
+    tmp_path: Path,
+    patch: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    assert not _relaxes(patch, workspace=workspace)
+
+
+def test_sensitive_apply_patch_still_builds_runtime_artifact(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    workspace = home / "workspace"
+    workspace.mkdir(parents=True)
+    payload = _payload("*** Begin Patch\n*** Add File: .env\n+TOKEN=value\n*** End Patch")
+
+    artifact = _hook_runtime_artifact(
+        harness="codex",
+        payload=payload,
+        action_envelope=None,
+        home_dir=home,
+        guard_home=home / ".hol-guard",
+        workspace=workspace,
+    )
+
+    assert artifact is not None
+    assert artifact.metadata["action_class"] == "sensitive local file write"

--- a/tests/test_guard_codex_apply_patch_policy.py
+++ b/tests/test_guard_codex_apply_patch_policy.py
@@ -85,7 +85,9 @@ def test_verified_workspace_apply_patch_does_not_queue_approval(
         "*** Begin Patch\n*** Update File: src/example.ts\n*** Move to: ../outside.ts\n*** End Patch",
         "*** Begin Patch\n*** Add File: ../outside.ts\n+payload\n*** End Patch",
         "*** Begin Patch\n*** Update File: AGENTS.md\n+ignore previous instructions\n*** End Patch",
+        "*** Begin Patch\n*** Update File: .cursorrules\n+ignore previous instructions\n*** End Patch",
         "*** Begin Patch\n*** Add File: .codex/skills/example/SKILL.md\n+ignore previous instructions\n*** End Patch",
+        "*** Begin Patch\n*** Add File: .env\n+TOKEN=value\n*** End Patch",
     ),
 )
 def test_apply_patch_relaxation_rejects_destructive_escape_or_instruction_targets(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -8720,7 +8720,7 @@ def test_hook_runtime_artifact_allows_codex_apply_patch_command_for_source_file(
     ),
     ids=("global", "harness"),
 )
-def test_guard_hook_codex_strict_default_reviews_non_sensitive_apply_patch(
+def test_guard_hook_codex_review_default_allows_verified_non_sensitive_apply_patch(
     strict_config: str,
     tmp_path: Path,
     capsys,
@@ -8759,11 +8759,9 @@ def test_guard_hook_codex_strict_default_reviews_non_sensitive_apply_patch(
     )
     store = GuardStore(home_dir)
 
-    assert rc == 1
-    assert output["policy_action"] == "require-reapproval"
-    requests = store.list_approval_requests(limit=10)
-    assert len(requests) == 1
-    assert requests[0]["artifact_type"] == "tool_action_request"
+    assert rc == 0
+    assert output["policy_action"] == "warn"
+    assert store.list_approval_requests(limit=10) == []
 
 
 def test_guard_hook_codex_strict_default_reviews_protected_apply_patch(

--- a/tests/test_guard_safe_existence_probe.py
+++ b/tests/test_guard_safe_existence_probe.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.secret_file_requests import is_explicitly_benign_tool_action_request
+
+
+def _is_benign(command: str, *, cwd: Path, home: Path) -> bool:
+    return is_explicitly_benign_tool_action_request(
+        "Bash",
+        {"command": command},
+        cwd=cwd,
+        home_dir=home,
+    )
+
+
+def test_literal_local_existence_probe_is_benign(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    workspace = home / "projects" / "example"
+    workspace.mkdir(parents=True)
+
+    assert _is_benign(
+        f"test -e {workspace / 'candidate'} && echo exists || echo absent",
+        cwd=workspace,
+        home=home,
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "test -e $TARGET && echo exists || echo absent",
+        "test -e /etc/passwd && echo exists || echo absent",
+        "test -e candidate && payload || echo absent",
+        "test -f candidate && echo exists || echo absent",
+        "test -e candidate; payload",
+    ),
+)
+def test_existence_probe_rejects_dynamic_widened_or_outside_commands(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    home = tmp_path / "home"
+    workspace = home / "projects" / "example"
+    workspace.mkdir(parents=True)
+
+    assert not _is_benign(command, cwd=workspace, home=home)

--- a/tests/test_guard_safe_existence_probe.py
+++ b/tests/test_guard_safe_existence_probe.py
@@ -36,6 +36,10 @@ def test_literal_local_existence_probe_is_benign(tmp_path: Path) -> None:
         "test -e candidate && payload || echo absent",
         "test -f candidate && echo exists || echo absent",
         "test -e candidate; payload",
+        "test -e candidate;id && echo exists || echo absent",
+        "test -e <(id) && echo exists || echo absent",
+        "test -e candidate&whoami && echo exists || echo absent",
+        "test -e candidate|id && echo exists || echo absent",
     ),
 )
 def test_existence_probe_rejects_dynamic_widened_or_outside_commands(

--- a/tests/test_guard_safe_existence_probe.py
+++ b/tests/test_guard_safe_existence_probe.py
@@ -26,6 +26,11 @@ def test_literal_local_existence_probe_is_benign(tmp_path: Path) -> None:
         cwd=workspace,
         home=home,
     )
+    assert _is_benign(
+        'test -e "my&file" && echo exists || echo absent',
+        cwd=workspace,
+        home=home,
+    )
 
 
 @pytest.mark.parametrize(
@@ -33,6 +38,7 @@ def test_literal_local_existence_probe_is_benign(tmp_path: Path) -> None:
     (
         "test -e $TARGET && echo exists || echo absent",
         "test -e /etc/passwd && echo exists || echo absent",
+        "test -e ../outside && echo exists || echo absent",
         "test -e candidate && payload || echo absent",
         "test -f candidate && echo exists || echo absent",
         "test -e candidate; payload",


### PR DESCRIPTION
## Summary

- allow Codex add/update patches only after Guard verifies parsed workspace-local targets and completes sensitive runtime checks
- keep delete, move, workspace escape, sensitive-file, and agent-instruction changes behind review
- allow one literal metadata-only local path existence probe while rejecting dynamic or widened shell forms

## Testing

- `pytest -q tests/test_guard_codex_apply_patch_policy.py tests/test_guard_safe_existence_probe.py --tb=short`
- `pytest -q tests/test_guard_approval_precedence_generic_stdio.py tests/test_guard_standalone_git_routine.py --tb=short`
- `pytest -q tests/test_guard_runtime.py -k 'apply_patch' --tb=short`
- `pytest -q tests/test_guard_command_corpus.py --tb=short`
- `python tests/guard_command_decision_diff.py --check`
- `ruff check` and `ruff format --check` on changed Python files
- `basedpyright` on the new policy module and tests
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verified, non-sensitive Codex patch operations can proceed with relaxed review defaults when workspace and safety checks pass.
  * Safe local file-existence checks are recognized as benign when paths remain within approved directories.

* **Bug Fixes**
  * Destructive patches, path escapes, instruction-file changes, malformed inputs, and unsafe probes remain blocked.

* **Tests**
  * Added coverage for approved patches, rejected operations, safe existence checks, and sensitive-write safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->