### PR TITLE
fix(guard): allow bounded workspace directory setup

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14212,
-  "maximum_test_source_lines": 312976,
+  "maximum_collected_cases": 14214,
+  "maximum_test_source_lines": 312978,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14197,
-  "maximum_test_source_lines": 312856,
+  "maximum_collected_cases": 14211,
+  "maximum_test_source_lines": 312919,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
@@ -41,6 +41,7 @@ from .interpreter_observers import (
 )
 from .request_artifacts import _candidate_command_texts
 from .request_models import ToolActionRequestMatch, _normalize_tool_name
+from .routine_directory_creation import is_safe_routine_directory_creation
 from .sensitive_read_pipeline import _runtime_read_root_texts
 from .shell_static_safety import _path_text_is_within_root_text
 from .shell_stdin_sources import (
@@ -105,6 +106,9 @@ def is_explicitly_benign_tool_action_request(
             found_benign_candidate = True
             continue
         if _looks_like_safe_existence_probe(stripped_command, cwd=cwd, home_dir=home_dir):
+            found_benign_candidate = True
+            continue
+        if is_safe_routine_directory_creation(stripped_command, cwd=cwd, home_dir=home_dir):
             found_benign_candidate = True
             continue
         if _looks_like_safe_cli_metadata_command(stripped_command, parts, cwd=cwd):

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/routine_directory_creation.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/routine_directory_creation.py
@@ -1,0 +1,73 @@
+"""Proof-gated classification for routine local directory creation."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+from ..secret_sensitivity import classify_secret_path
+
+_DYNAMIC_PATH_MARKERS = ("$", "`", "*", "?", "[", "]", "{", "}", "\x00")
+_SHELL_CONTROL_CHARACTERS = frozenset(";&|<>()")
+_PROTECTED_DIRECTORY_NAMES = frozenset({".aws", ".codex", ".docker", ".git", ".gnupg", ".hol-guard", ".kube", ".ssh"})
+
+
+def is_safe_routine_directory_creation(
+    command_text: str,
+    *,
+    cwd: Path | None,
+    home_dir: Path | None,
+) -> bool:
+    """Allow exact parents-only mkdir calls with bounded literal targets."""
+
+    try:
+        lexer = shlex.shlex(command_text, posix=True, punctuation_chars=";&|<>()")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        parts = list(lexer)
+    except ValueError:
+        return False
+    if len(parts) < 3 or parts[0] != "mkdir" or parts[1] not in {"-p", "--parents"}:
+        return False
+    targets = parts[2:]
+    if any(
+        target.startswith("-") or any(character in target for character in _SHELL_CONTROL_CHARACTERS)
+        for target in targets
+    ):
+        return False
+    if any(marker in target for target in targets for marker in _DYNAMIC_PATH_MARKERS):
+        return False
+    try:
+        allowed_roots = tuple(root.resolve() for root in (cwd, home_dir) if root is not None)
+        if not allowed_roots:
+            return False
+        for target in targets:
+            if target == "~":
+                if home_dir is None:
+                    return False
+                candidate = home_dir
+            elif target.startswith("~/"):
+                if home_dir is None:
+                    return False
+                candidate = home_dir / target[2:]
+            elif target.startswith("~"):
+                return False
+            else:
+                candidate = Path(target)
+            if not candidate.is_absolute():
+                if cwd is None or ".." in candidate.parts:
+                    return False
+                candidate = cwd / candidate
+            resolved = candidate.resolve(strict=False)
+            if not any(resolved.is_relative_to(root) for root in allowed_roots):
+                return False
+            if {part.casefold() for part in resolved.parts} & _PROTECTED_DIRECTORY_NAMES:
+                return False
+            if classify_secret_path(str(resolved), cwd=cwd, home_dir=home_dir) is not None:
+                return False
+    except (OSError, RuntimeError):
+        return False
+    return True
+
+
+__all__ = ["is_safe_routine_directory_creation"]

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/routine_directory_creation.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/routine_directory_creation.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from ..secret_sensitivity import classify_secret_path
 
 _DYNAMIC_PATH_MARKERS = ("$", "`", "*", "?", "[", "]", "{", "}", "\x00")
-_SHELL_CONTROL_CHARACTERS = frozenset(";&|<>()")
+_SHELL_CONTROL_CHARACTERS = frozenset(";&|<>()\r\n")
 _PROTECTED_DIRECTORY_NAMES = frozenset({".aws", ".codex", ".docker", ".git", ".gnupg", ".hol-guard", ".kube", ".ssh"})
 
 
@@ -20,6 +20,8 @@ def is_safe_routine_directory_creation(
 ) -> bool:
     """Allow exact parents-only mkdir calls with bounded literal targets."""
 
+    if "\n" in command_text or "\r" in command_text:
+        return False
     try:
         lexer = shlex.shlex(command_text, posix=True, punctuation_chars=";&|<>()")
         lexer.whitespace_split = True

--- a/tests/test_guard_safe_directory_creation.py
+++ b/tests/test_guard_safe_directory_creation.py
@@ -44,6 +44,8 @@ def test_literal_workspace_directory_creation_is_benign(tmp_path: Path) -> None:
         "mkdir -p /etc/guard-test",
         "mkdir -p $TARGET",
         "mkdir -p target; id",
+        "mkdir -p target\nid",
+        "mkdir -p target\rid",
         "mkdir -p target |& id",
         "mkdir -p target >> output.log",
         "mkdir -p target >& output.log",

--- a/tests/test_guard_safe_directory_creation.py
+++ b/tests/test_guard_safe_directory_creation.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.secret_file_requests import is_explicitly_benign_tool_action_request
+
+
+def _is_benign(command: str, *, cwd: Path, home: Path) -> bool:
+    return is_explicitly_benign_tool_action_request(
+        "Bash",
+        {"command": command},
+        cwd=cwd,
+        home_dir=home,
+    )
+
+
+def test_literal_workspace_directory_creation_is_benign(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    workspace = home / "projects" / "example"
+    workspace.mkdir(parents=True)
+
+    assert _is_benign("mkdir -p src assets .github/workflows", cwd=workspace, home=home)
+    assert _is_benign(
+        f'mkdir --parents "{home / "new project"}" {workspace / ".codex-plugin"}',
+        cwd=workspace,
+        home=home,
+    )
+    assert _is_benign(
+        "mkdir -p ~/new-project/assets ~/new-project/.github/workflows",
+        cwd=workspace,
+        home=home,
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "mkdir target",
+        "mkdir -m 700 target",
+        "mkdir -p --mode=700 target",
+        "mkdir -p ../outside",
+        "mkdir -p /etc/guard-test",
+        "mkdir -p $TARGET",
+        "mkdir -p target; id",
+        "mkdir -p target |& id",
+        "mkdir -p target >> output.log",
+        "mkdir -p target >& output.log",
+        "mkdir -p <(id)",
+        "mkdir -p ~/.ssh/guard-test",
+        "mkdir -p ~other/guard-test",
+    ),
+)
+def test_directory_creation_rejects_widened_dynamic_or_sensitive_targets(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    home = tmp_path / "home"
+    workspace = home / "projects" / "example"
+    workspace.mkdir(parents=True)
+
+    assert not _is_benign(command, cwd=workspace, home=home)


### PR DESCRIPTION
## Summary
- allow exact parents-only directory setup for literal targets bounded to the workspace or user home
- preserve review for sensitive authority directories, traversal, mode changes, substitutions, multiline commands, and shell control syntax
- refresh the branch against the current release line and remeasure the test-suite ratchet

## Testing
- `uv run --no-sync pytest -q tests/test_guard_safe_directory_creation.py tests/test_guard_standalone_git_routine.py tests/test_ci_test_suite_ratchet.py --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_surface_server.py::TestGuardSurfaceServer::test_guard_daemon_background_start_auto_stops_after_idle_timeout --tb=short` (three consecutive runs)
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py src/codex_plugin_scanner/guard/runtime/secret_file_request_services/routine_directory_creation.py tests/test_guard_safe_directory_creation.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py src/codex_plugin_scanner/guard/runtime/secret_file_request_services/routine_directory_creation.py tests/test_guard_safe_directory_creation.py`
- `uv run --no-sync basedpyright --level error src/codex_plugin_scanner/guard/runtime/secret_file_request_services/routine_directory_creation.py src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory <inventory-json>`
