### PR TITLE
fix(approvals): restore permanent MCP action trust

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12232,
-  "maximum_test_source_lines": 284945,
+  "maximum_collected_cases": 12237,
+  "maximum_test_source_lines": 285048,
   "schema_version": 1
 }

--- a/dashboard/src/approval-scopes.test.ts
+++ b/dashboard/src/approval-scopes.test.ts
@@ -125,6 +125,27 @@ function renderExactActionControl(eligible: boolean): string {
   );
 }
 
+function renderExactActionControlWithTimedScopesHidden(): string {
+  return renderToStaticMarkup(
+    createElement(ReviewScopeControls, {
+      commonScopeOptions: standardScopeChoicesForRequest(BASE_REQUEST, "allow"),
+      broaderScopeOptions: [],
+      advancedScopeOptions: [],
+      blockScopeOptions: [],
+      hasAllowScope: true,
+      taskCapabilityCopy: null,
+      exactActionPersistenceEligible: true,
+      rememberExactAction: false,
+      allowScope: "artifact",
+      blockScope: "artifact",
+      showAllowScopes: false,
+      onAllowScopeChange: ignoreScopeChange,
+      onBlockScopeChange: ignoreScopeChange,
+      onRememberExactActionChange: ignoreScopeChange,
+    }),
+  );
+}
+
 assert(
   renderExactActionControl(true).includes("Always allow this exact action"),
   "T-AS-03c: eligible requests render the exact-action permission",
@@ -132,6 +153,10 @@ assert(
 assert(
   !renderExactActionControl(false).includes("Always allow this exact action"),
   "T-AS-03d: unproven requests do not render a durable permission",
+);
+assert(
+  renderExactActionControlWithTimedScopesHidden().includes("Always allow this exact action"),
+  "T-AS-03e: exact-action permission remains available beside bounded MCP choices",
 );
 
 const blockPayload = buildDecisionPayload({

--- a/dashboard/src/review-decision-card.tsx
+++ b/dashboard/src/review-decision-card.tsx
@@ -212,7 +212,12 @@ export function ReviewDecisionCard(props: {
           ...(includeGateFields && !needsPassword ? { approval_totp_code: approvalTotpCode } : {}),
           ...(includeGateFields ? { approval_gate_use_cooldown: useCooldown } : {}),
           ...(action === "allow"
-            ? buildTemporaryMcpResolutionFields(temporaryMcpOptions, mcpGrantTarget, mcpGrantDuration)
+            ? buildTemporaryMcpResolutionFields(
+                temporaryMcpOptions,
+                mcpGrantTarget,
+                mcpGrantDuration,
+                rememberExactAction,
+              )
             : {}),
           ...(action === "allow" && temporaryMcpOptions === null
             ? buildLocalToolResolutionFields(localToolOptions, localToolGrantTarget, localToolGrantDuration)
@@ -385,7 +390,7 @@ export function ReviewDecisionCard(props: {
   if (rememberExactAction && allowScope === "artifact") {
     resolvedAllowButtonLabel = "Approve and remember";
   }
-  if (temporaryMcpOptions !== null) {
+  if (temporaryMcpOptions !== null && !rememberExactAction) {
     resolvedAllowButtonLabel = temporaryMcpAllowButtonLabel(mcpGrantDuration);
   } else if (localToolOptions !== null) {
     resolvedAllowButtonLabel = localToolAllowButtonLabel(localToolGrantDuration);
@@ -477,7 +482,7 @@ export function ReviewDecisionCard(props: {
 
         {resolutionBlockReason === null && (
           <>
-            {temporaryMcpOptions !== null && (
+            {temporaryMcpOptions !== null && !rememberExactAction && (
               <TemporaryMcpApprovalControls
                 options={temporaryMcpOptions}
                 target={mcpGrantTarget}
@@ -505,7 +510,9 @@ export function ReviewDecisionCard(props: {
               blockScopeOptions={blockScopeOptions}
               hasAllowScope={hasAllowScope}
               taskCapabilityCopy={taskCapabilityCopy}
-              exactActionPersistenceEligible={item.exact_action_persistence_eligible === true}
+              exactActionPersistenceEligible={
+                item.exact_action_persistence_eligible === true && localToolOptions === null
+              }
               rememberExactAction={rememberExactAction}
               allowScope={allowScope}
               blockScope={blockScope}

--- a/dashboard/src/review-scope-controls.tsx
+++ b/dashboard/src/review-scope-controls.tsx
@@ -23,9 +23,10 @@ type ReviewScopeControlsProps = {
 
 export function ReviewScopeControls(props: ReviewScopeControlsProps) {
   const showAllowScopes = props.showAllowScopes !== false;
+  const showApprovalControls = showAllowScopes || props.exactActionPersistenceEligible;
   return (
     <div className="mt-6 space-y-2">
-      <SectionLabel>{showAllowScopes ? "Approval scope" : "Block scope"}</SectionLabel>
+      <SectionLabel>{showApprovalControls ? "Approval scope" : "Block scope"}</SectionLabel>
       {showAllowScopes && !props.hasAllowScope && (
         <p className="text-sm text-brand-attention" role="status">
           This action cannot be approved under its current Guard policy.
@@ -41,7 +42,7 @@ export function ReviewScopeControls(props: ReviewScopeControlsProps) {
           />
         ))}
       </div>}
-      {showAllowScopes && props.exactActionPersistenceEligible && props.allowScope === "artifact" && (
+      {props.exactActionPersistenceEligible && props.allowScope === "artifact" && (
         <ExactActionPersistenceChoice
           checked={props.rememberExactAction}
           onChange={props.onRememberExactActionChange}
@@ -136,7 +137,7 @@ function ExactActionPersistenceChoice(props: { checked: boolean; onChange: (chec
       <span>
         <span className="block text-sm font-medium text-brand-dark">Always allow this exact action</span>
         <span className="mt-0.5 block text-xs text-muted-foreground">
-          Save only this exact command for this AI app. Changed commands still need review.
+          Save only this exact action for this AI app. Changed actions still need review.
         </span>
       </span>
     </label>

--- a/dashboard/src/temporary-mcp-approval.test.tsx
+++ b/dashboard/src/temporary-mcp-approval.test.tsx
@@ -57,6 +57,10 @@ assert(
   Object.keys(buildTemporaryMcpResolutionFields(options, "category", "once")).length === 0,
   "one-time approval uses the existing exact one-shot path",
 );
+assert(
+  Object.keys(buildTemporaryMcpResolutionFields(options, "category", "1h", true)).length === 0,
+  "permanent exact-action approval never submits conflicting timed grant fields",
+);
 const refreshedOptions = {
   ...options,
   allowed_targets: ["exact"] as const,

--- a/dashboard/src/temporary-mcp-approval.ts
+++ b/dashboard/src/temporary-mcp-approval.ts
@@ -190,8 +190,10 @@ export function buildTemporaryMcpResolutionFields(
   options: TemporaryMcpApprovalOptions | null,
   target: GuardTemporaryMcpGrantTarget,
   duration: GuardTemporaryMcpGrantDuration,
+  persistExactAction = false,
 ): { mcp_grant_target: GuardTemporaryMcpGrantTarget; mcp_grant_duration: GuardTemporaryMcpGrantDuration } | Record<string, never> {
   if (
+    persistExactAction ||
     options === null ||
     duration === "once" ||
     !options.allowed_targets.includes(target) ||

--- a/src/codex_plugin_scanner/guard/approval_scope_support.py
+++ b/src/codex_plugin_scanner/guard/approval_scope_support.py
@@ -15,6 +15,7 @@ from .package_execution_context import (
     PackageExecutionContext,
     package_execution_context_from_scanner_evidence,
 )
+from .runtime.approval_context import parse_approval_context_token
 from .runtime.github_workflow_runtime import approval_record_from_approval_request
 from .temporary_mcp_approvals import temporary_mcp_approval_payload
 from .trusted_local_tools import local_tool_approval_payload
@@ -221,12 +222,21 @@ def request_scope_contract_payload(request: Mapping[str, object]) -> dict[str, o
 def exact_action_allow_persistence_eligible(request: Mapping[str, object]) -> bool:
     """Return whether an artifact allow can be saved as one exact action."""
 
-    if _allow_is_non_overridable(request) or _string_or_none(request.get("artifact_type")) != "tool_action_request":
+    if _allow_is_non_overridable(request):
+        return False
+    artifact_type = _string_or_none(request.get("artifact_type"))
+    artifact_id = _string_or_none(request.get("artifact_id"))
+    artifact_hash = _string_or_none(request.get("artifact_hash"))
+    if artifact_type == "tool_call":
+        return bool(
+            artifact_id
+            and parse_approval_context_token(artifact_hash) is not None
+            and _string_or_none(request.get("raw_command_text"))
+        )
+    if artifact_type != "tool_action_request":
         return False
     if _request_scoped_family_key(request) != "family:tool-action":
         return False
-    artifact_id = _string_or_none(request.get("artifact_id"))
-    artifact_hash = _string_or_none(request.get("artifact_hash"))
     action_identity = _string_or_none(request.get("action_identity"))
     raw_command_text = _string_or_none(request.get("raw_command_text"))
     envelope = request.get("action_envelope_json")

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -15561,8 +15561,8 @@ function temporaryMcpSummary(options, target, duration) {
   const coverage = target === "server" ? "Routine tools" : browserCapabilityLabel(options.category);
   return ["Allow", options.server_name, coverage, options.target_label, temporaryMcpDurationLabel(duration)].filter(nonEmpty$1).join(" · ");
 }
-function buildTemporaryMcpResolutionFields(options, target, duration) {
-  if (options === null || duration === "once" || !options.allowed_targets.includes(target) || !options.allowed_durations.includes(duration)) {
+function buildTemporaryMcpResolutionFields(options, target, duration, persistExactAction = false) {
+  if (persistExactAction || options === null || duration === "once" || !options.allowed_targets.includes(target) || !options.allowed_durations.includes(duration)) {
     return {};
   }
   return { mcp_grant_target: target, mcp_grant_duration: duration };
@@ -28341,8 +28341,9 @@ function ReviewCloudRecovery({ item }) {
 }
 function ReviewScopeControls(props) {
   const showAllowScopes = props.showAllowScopes !== false;
+  const showApprovalControls = showAllowScopes || props.exactActionPersistenceEligible;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-6 space-y-2", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: showAllowScopes ? "Approval scope" : "Block scope" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: showApprovalControls ? "Approval scope" : "Block scope" }),
     showAllowScopes && !props.hasAllowScope && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-attention", role: "status", children: "This action cannot be approved under its current Guard policy." }),
     showAllowScopes && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid grid-cols-1 gap-2 md:grid-cols-2", role: "radiogroup", "aria-label": "Allow scope selection", children: props.commonScopeOptions.map((choice) => /* @__PURE__ */ jsxRuntimeExports.jsx(
       ScopeChoiceButton,
@@ -28353,7 +28354,7 @@ function ReviewScopeControls(props) {
       },
       choice.value
     )) }),
-    showAllowScopes && props.exactActionPersistenceEligible && props.allowScope === "artifact" && /* @__PURE__ */ jsxRuntimeExports.jsx(
+    props.exactActionPersistenceEligible && props.allowScope === "artifact" && /* @__PURE__ */ jsxRuntimeExports.jsx(
       ExactActionPersistenceChoice,
       {
         checked: props.rememberExactAction,
@@ -28424,7 +28425,7 @@ function ExactActionPersistenceChoice(props) {
     ),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "block text-sm font-medium text-brand-dark", children: "Always allow this exact action" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-0.5 block text-xs text-muted-foreground", children: "Save only this exact command for this AI app. Changed commands still need review." })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-0.5 block text-xs text-muted-foreground", children: "Save only this exact action for this AI app. Changed actions still need review." })
     ] })
   ] });
 }
@@ -28908,7 +28909,12 @@ function ReviewDecisionCard(props) {
           ...includeGateFields && needsPassword ? { approval_password: approvalPassword } : {},
           ...includeGateFields && !needsPassword ? { approval_totp_code: approvalTotpCode } : {},
           ...includeGateFields ? { approval_gate_use_cooldown: useCooldown } : {},
-          ...action === "allow" ? buildTemporaryMcpResolutionFields(temporaryMcpOptions, mcpGrantTarget, mcpGrantDuration) : {},
+          ...action === "allow" ? buildTemporaryMcpResolutionFields(
+            temporaryMcpOptions,
+            mcpGrantTarget,
+            mcpGrantDuration,
+            rememberExactAction
+          ) : {},
           ...action === "allow" && temporaryMcpOptions === null ? buildLocalToolResolutionFields(localToolOptions, localToolGrantTarget, localToolGrantDuration) : {}
         });
         setResolved(action);
@@ -29065,7 +29071,7 @@ function ReviewDecisionCard(props) {
   if (rememberExactAction && allowScope === "artifact") {
     resolvedAllowButtonLabel = "Approve and remember";
   }
-  if (temporaryMcpOptions !== null) {
+  if (temporaryMcpOptions !== null && !rememberExactAction) {
     resolvedAllowButtonLabel = temporaryMcpAllowButtonLabel(mcpGrantDuration);
   } else if (localToolOptions !== null) {
     resolvedAllowButtonLabel = localToolAllowButtonLabel(localToolGrantDuration);
@@ -29135,7 +29141,7 @@ function ReviewDecisionCard(props) {
         showConsequences && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 rounded-xl border border-slate-200/70 bg-slate-50 p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: whatWouldHappen }) })
       ] }),
       resolutionBlockReason === null && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-        temporaryMcpOptions !== null && /* @__PURE__ */ jsxRuntimeExports.jsx(
+        temporaryMcpOptions !== null && !rememberExactAction && /* @__PURE__ */ jsxRuntimeExports.jsx(
           TemporaryMcpApprovalControls,
           {
             options: temporaryMcpOptions,
@@ -29165,7 +29171,7 @@ function ReviewDecisionCard(props) {
             blockScopeOptions,
             hasAllowScope,
             taskCapabilityCopy,
-            exactActionPersistenceEligible: item.exact_action_persistence_eligible === true,
+            exactActionPersistenceEligible: item.exact_action_persistence_eligible === true && localToolOptions === null,
             rememberExactAction,
             allowScope,
             blockScope,

--- a/tests/test_guard_approval_scope_contract.py
+++ b/tests/test_guard_approval_scope_contract.py
@@ -21,6 +21,7 @@ from codex_plugin_scanner.guard.approval_scope_support import (
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.models import GuardAction, GuardApprovalRequest
+from codex_plugin_scanner.guard.runtime.approval_context import build_approval_context_token
 from codex_plugin_scanner.guard.store import GuardStore, runtime_tool_action_exact_match_context
 
 
@@ -435,6 +436,108 @@ def test_exact_action_persistence_accepts_envelope_raw_command_text(tmp_path: Pa
     row = _store_request(store, request)
 
     assert request_scope_contract(row).exact_action_persistence_eligible is True
+
+
+def test_exact_action_persistence_accepts_context_bound_tool_call(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    context_token = build_approval_context_token(
+        identity={"server": "browser", "tool": "navigate"},
+        content={"url": "http://127.0.0.1:3000"},
+        capabilities={"risk_categories": ["browser_navigation"]},
+        policy={"action": "review"},
+        sandbox={"mode": "workspace-write"},
+    )
+    request = replace(
+        _request(
+            "context-bound-tool-call",
+            artifact_id="codex:runtime:global:browser:navigate",
+            artifact_type="tool_call",
+            artifact_hash=context_token,
+        ),
+        raw_command_text="navigate http://127.0.0.1:3000",
+    )
+    row = _store_request(store, request)
+
+    assert request_scope_contract(row).exact_action_persistence_eligible is True
+
+
+def test_v2_saved_tool_call_allow_remains_bound_to_exact_context(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    context_token = build_approval_context_token(
+        identity={"server": "browser", "tool": "navigate"},
+        content={"url": "http://127.0.0.1:3000"},
+        capabilities={"risk_categories": ["browser_navigation"]},
+        policy={"action": "review"},
+        sandbox={"mode": "workspace-write"},
+    )
+    artifact_id = "codex:runtime:global:browser:navigate"
+    request = replace(
+        _request(
+            "saved-tool-call",
+            artifact_id=artifact_id,
+            artifact_type="tool_call",
+            artifact_hash=context_token,
+        ),
+        raw_command_text="navigate http://127.0.0.1:3000",
+    )
+    row = _store_request(store, request)
+    payload = {**_v2_selection(row, "artifact"), "persist_policy": True}
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, response = _post(daemon, "/v1/requests/saved-tool-call/approve", payload)
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert response["applied_scope"] == "artifact"
+    decisions = store.list_policy_decisions()
+    assert len(decisions) == 1
+    assert decisions[0]["expires_at"] is None
+    assert (
+        store.resolve_policy(
+            "codex",
+            artifact_id,
+            context_token,
+            now="2026-07-19T00:01:00+00:00",
+            consume_one_shot=False,
+        )
+        == "allow"
+    )
+    changed_token = build_approval_context_token(
+        identity={"server": "browser", "tool": "navigate"},
+        content={"url": "https://example.com"},
+        capabilities={"risk_categories": ["browser_navigation"]},
+        policy={"action": "review"},
+        sandbox={"mode": "workspace-write"},
+    )
+    assert (
+        store.resolve_policy(
+            "codex",
+            artifact_id,
+            changed_token,
+            now="2026-07-19T00:02:00+00:00",
+            consume_one_shot=False,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("artifact_hash", ["unknown", "plain-hash", "guard-approval-context:v1:invalid"])
+def test_exact_action_persistence_rejects_unbound_tool_call(tmp_path: Path, artifact_hash: str) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    request = replace(
+        _request(
+            f"unbound-tool-call-{len(artifact_hash)}",
+            artifact_id="codex:runtime:global:browser:navigate",
+            artifact_type="tool_call",
+            artifact_hash=artifact_hash,
+        ),
+        raw_command_text="navigate http://127.0.0.1:3000",
+    )
+    row = _store_request(store, request)
+
+    assert request_scope_contract(row).exact_action_persistence_eligible is False
 
 
 def test_legacy_unknown_broad_deny_is_not_silently_narrowed(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- restore permanent exact-action approval for context-bound MCP tool calls
- keep timed MCP grants separate while changed identity, content, capabilities, policy, or sandbox context still requires review
- clarify the saved-action control and ship the rebuilt dashboard bundle

## Testing
- `uv run --no-sync pytest -q tests/test_guard_approval_scope_contract.py tests/test_guard_approval_reuse.py tests/test_guard_temporary_mcp_approvals.py --tb=short`
- `bun run test`
- `bun run build`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/approval_scope_support.py tests/test_guard_approval_scope_contract.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/approval_scope_support.py tests/test_guard_approval_scope_contract.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/approval_scope_support.py tests/test_guard_approval_scope_contract.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exact-action approval persistence for eligible tool actions.
  * Saved approvals now require the same approval context and action details.
  * Approval controls can display exact-action persistence even when broader scope options are hidden.
* **Bug Fixes**
  * Prevented temporary access grants from being created when an exact action is remembered.
  * Excluded local-tool approvals and invalid or incomplete requests from exact-action persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->