### PR TITLE
fix(hooks): honor repository context for safe fetches

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14197,
-  "maximum_test_source_lines": 312856,
+  "maximum_collected_cases": 14198,
+  "maximum_test_source_lines": 312913,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5764,9 +5764,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             )
             guard_home = self._validated_hook_guard_home(self._optional_string(params.get("guard-home", [None])[-1]))
             workspace_query = self._normalized_hook_workspace_string(params.get("workspace", [None])[-1])
-            workspace_candidate = (
-                workspace_query if "workspace" in params else self._optional_string(payload.get("cwd"))
-            )
+            payload_workspace = self._normalized_hook_workspace_string(payload.get("cwd"))
+            workspace_candidate = payload_workspace if payload_workspace is not None else workspace_query
             workspace = self._validated_hook_directory_string(
                 "workspace",
                 workspace_candidate,

--- a/tests/test_codex_daemon_hook_bridge.py
+++ b/tests/test_codex_daemon_hook_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import subprocess
 import sys
 import threading
 from http.server import HTTPServer
@@ -456,3 +457,59 @@ def test_bridge_real_daemon_emits_schema_exact_post_tool_response(
         assert response == {"hookSpecificOutput": {"hookEventName": "PostToolUse"}}
     else:
         assert response["continue"] is False
+
+
+def test_bridge_real_daemon_prefers_payload_cwd_for_verified_git_fetch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    configured_workspace = tmp_path / "projects"
+    repository = configured_workspace / "example"
+    repository.mkdir(parents=True)
+    _ = subprocess.run(["git", "init", "--quiet", str(repository)], check=True)
+    _ = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repository),
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example/project.git",
+        ],
+        check=True,
+    )
+    daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
+    daemon.start()
+    config = _bridge_config(guard_home, daemon.port)
+    config["query"] = urlencode(
+        {
+            "guard-home": str(guard_home),
+            "home": str(tmp_path),
+            "workspace": str(configured_workspace),
+        }
+    )
+    config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(
+            json.dumps(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "git fetch origin main"},
+                    "cwd": str(repository),
+                }
+            )
+        ),
+    )
+
+    try:
+        exit_code = bridge.main(**config)
+    finally:
+        daemon.stop()
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == {}


### PR DESCRIPTION
## Summary
- prefer the validated per-action working directory over the install-time workspace when reviewing Codex hooks
- preserve verified safe Git fetch behavior while retaining existing checks for executable configuration and mutating fetch syntax
- add an authenticated bridge-to-daemon regression for repository-scoped fetches

## Testing
- `uv run --no-sync pytest -q tests/test_guard_standalone_git_routine.py tests/test_codex_daemon_hook_bridge.py tests/test_ci_test_suite_ratchet.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_codex_daemon_hook_bridge.py tests/test_guard_standalone_git_routine.py tests/test_ci_test_suite_ratchet.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/daemon/server.py tests/test_codex_daemon_hook_bridge.py tests/test_guard_standalone_git_routine.py tests/test_ci_test_suite_ratchet.py`
- `uv run --no-sync basedpyright --level error src/codex_plugin_scanner/guard/daemon/server.py`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory <inventory-json>`
