### PR TITLE
feat(guard): package version-matched Rust runtime in Guard wheels

### DIFF
--- a/.github/workflows/native-wheel-ci.yml
+++ b/.github/workflows/native-wheel-ci.yml
@@ -1,0 +1,233 @@
+name: Native wheel CI
+
+on:
+  pull_request:
+    branches: [release/3.0]
+    paths:
+      - "rust/**"
+      - "scripts/build_native_hol_guard_wheel.py"
+      - "ci/native_runtime/test_native_hol_guard_wheel.py"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - ".github/workflows/native-wheel-ci.yml"
+  push:
+    branches: [release/3.0]
+    paths:
+      - "rust/**"
+      - "scripts/build_native_hol_guard_wheel.py"
+      - "ci/native_runtime/test_native_hol_guard_wheel.py"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - ".github/workflows/native-wheel-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-wheel-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-x64:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Run wheel-builder contracts
+        run: uv run --no-sync pytest ci/native_runtime/test_native_hol_guard_wheel.py --tb=short
+      - name: Install pinned Rust toolchain and musl target
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal
+          rustup default 1.88.0
+          rustup target add x86_64-unknown-linux-musl
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends musl-tools
+      - name: Build pure Python wheel
+        run: uv run --no-sync python -m build --wheel --outdir pure-dist
+      - name: Build static native runtime
+        env:
+          HOL_GUARD_BUILD_SHA: ${{ github.sha }}
+        run: |
+          VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          export HOL_GUARD_PACKAGE_VERSION="$VERSION"
+          cargo build --manifest-path rust/Cargo.toml --locked --release --target x86_64-unknown-linux-musl -p hol-guard-runtime
+          runtime="rust/target/x86_64-unknown-linux-musl/release/hol-guard-runtime"
+          LDD_OUTPUT=$(ldd "$runtime" 2>&1 || true)
+          if grep -Eq 'not a dynamic executable|statically linked' <<< "$LDD_OUTPUT"; then
+            echo "Runtime is static"
+          else
+            echo "Linux runtime must be statically linked" >&2
+            printf '%s\n' "$LDD_OUTPUT" >&2
+            exit 1
+          fi
+          "$runtime" self-test --json
+      - name: Assemble and install native wheel
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          runtime="rust/target/x86_64-unknown-linux-musl/release/hol-guard-runtime"
+          RULE_DIGEST=$("$runtime" capabilities --json | python -c 'import json,sys; print(json.load(sys.stdin)["rule_digest"])')
+          uv run --no-sync python scripts/build_native_hol_guard_wheel.py \
+            --wheel "pure-dist/hol_guard-${VERSION}-py3-none-any.whl" \
+            --runtime "$runtime" \
+            --output-dir native-dist \
+            --version "$VERSION" \
+            --platform-tag manylinux_2_17_x86_64 \
+            --target x86_64-unknown-linux-musl \
+            --source-sha "$SOURCE_SHA" \
+            --rule-digest "$RULE_DIGEST"
+          uv pip install --python .venv/bin/python --no-deps --force-reinstall native-dist/*.whl
+          HOL_GUARD_NATIVE=auto uv run --no-sync python - <<'PY'
+          from codex_plugin_scanner.guard.native_runtime import native_runtime_status
+          status = native_runtime_status()
+          assert status.available and status.compatible, status
+          assert status.reason == "native_ready"
+          assert status.capabilities is not None
+          print(status.capabilities)
+          PY
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: hol-guard-native-wheel-linux-x64
+          path: native-dist/*.whl
+          if-no-files-found: error
+
+  macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15-intel
+            platform_tag: macosx_13_0_x86_64
+            target: x86_64-apple-darwin
+            deployment_target: "13.0"
+          - runner: macos-15
+            platform_tag: macosx_11_0_arm64
+            target: aarch64-apple-darwin
+            deployment_target: "11.0"
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal
+          rustup default 1.88.0
+      - name: Build pure Python wheel
+        run: uv run --no-sync python -m build --wheel --outdir pure-dist
+      - name: Build native runtime
+        env:
+          HOL_GUARD_BUILD_SHA: ${{ github.sha }}
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
+        run: |
+          VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          export HOL_GUARD_PACKAGE_VERSION="$VERSION"
+          cargo build --manifest-path rust/Cargo.toml --locked --release -p hol-guard-runtime
+          rust/target/release/hol-guard-runtime self-test --json
+      - name: Assemble and install native wheel
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+          PLATFORM_TAG: ${{ matrix.platform_tag }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          runtime="rust/target/release/hol-guard-runtime"
+          RULE_DIGEST=$("$runtime" capabilities --json | python -c 'import json,sys; print(json.load(sys.stdin)["rule_digest"])')
+          uv run --no-sync python scripts/build_native_hol_guard_wheel.py \
+            --wheel "pure-dist/hol_guard-${VERSION}-py3-none-any.whl" \
+            --runtime "$runtime" \
+            --output-dir native-dist \
+            --version "$VERSION" \
+            --platform-tag "$PLATFORM_TAG" \
+            --target "$TARGET" \
+            --source-sha "$SOURCE_SHA" \
+            --rule-digest "$RULE_DIGEST"
+          uv pip install --python .venv/bin/python --no-deps --force-reinstall native-dist/*.whl
+          HOL_GUARD_NATIVE=auto uv run --no-sync python - <<'PY'
+          from codex_plugin_scanner.guard.native_runtime import native_runtime_status
+          status = native_runtime_status()
+          assert status.available and status.compatible, status
+          assert status.reason == "native_ready"
+          PY
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: hol-guard-native-wheel-${{ matrix.target }}
+          path: native-dist/*.whl
+          if-no-files-found: error
+
+  windows-x64:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Install pinned Rust toolchain
+        shell: pwsh
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal
+          rustup default 1.88.0
+      - name: Build pure Python wheel
+        run: uv run --no-sync python -m build --wheel --outdir pure-dist
+      - name: Build native runtime
+        shell: pwsh
+        env:
+          HOL_GUARD_BUILD_SHA: ${{ github.sha }}
+        run: |
+          $version = uv run --no-sync python scripts/sync_repo_version.py --check
+          $env:HOL_GUARD_PACKAGE_VERSION = $version.Trim()
+          cargo build --manifest-path rust/Cargo.toml --locked --release -p hol-guard-runtime
+          .\rust\target\release\hol-guard-runtime.exe self-test --json
+      - name: Assemble and install native wheel
+        shell: pwsh
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          $version = (uv run --no-sync python scripts/sync_repo_version.py --check).Trim()
+          $runtime = "rust\target\release\hol-guard-runtime.exe"
+          $caps = & $runtime capabilities --json | ConvertFrom-Json
+          uv run --no-sync python scripts/build_native_hol_guard_wheel.py `
+            --wheel "pure-dist\hol_guard-$version-py3-none-any.whl" `
+            --runtime $runtime `
+            --output-dir native-dist `
+            --version $version `
+            --platform-tag win_amd64 `
+            --target x86_64-pc-windows-msvc `
+            --source-sha $env:SOURCE_SHA `
+            --rule-digest $caps.rule_digest
+          $wheel = (Get-ChildItem native-dist\*.whl).FullName
+          uv pip install --python .venv\Scripts\python.exe --no-deps --force-reinstall $wheel
+          $env:HOL_GUARD_NATIVE = "auto"
+          uv run --no-sync python -c "from codex_plugin_scanner.guard.native_runtime import native_runtime_status; s=native_runtime_status(); assert s.available and s.compatible and s.reason == 'native_ready', s"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: hol-guard-native-wheel-windows-x64
+          path: native-dist/*.whl
+          if-no-files-found: error

--- a/ci/native_runtime/test_native_hol_guard_wheel.py
+++ b/ci/native_runtime/test_native_hol_guard_wheel.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import base64
+import csv
+import hashlib
+import io
+import json
+import os
+import stat
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.build_native_hol_guard_wheel import NativeWheelError, build_native_wheel
+
+_VERSION = "3.0.0a7"
+_SOURCE_SHA = "a" * 40
+_RULE_DIGEST = "b" * 64
+_PLATFORM_TAG = "manylinux_2_28_x86_64"
+_TARGET = "x86_64-unknown-linux-gnu"
+
+
+def _write_source_wheel(tmp_path: Path, *, version: str = _VERSION, unsafe_name: str | None = None) -> Path:
+    path = tmp_path / f"hol_guard-{version}-py3-none-any.whl"
+    dist_info = f"hol_guard-{version}.dist-info"
+    entries = {
+        "codex_plugin_scanner/__init__.py": b"__version__ = 'fixture'\n",
+        f"{dist_info}/METADATA": (
+            "Metadata-Version: 2.4\n"
+            "Name: hol-guard\n"
+            f"Version: {version}\n"
+            "\n"
+        ).encode(),
+        f"{dist_info}/WHEEL": (
+            "Wheel-Version: 1.0\n"
+            "Generator: test\n"
+            "Root-Is-Purelib: true\n"
+            "Tag: py3-none-any\n"
+        ).encode(),
+        f"{dist_info}/RECORD": b"",
+    }
+    if unsafe_name is not None:
+        entries[unsafe_name] = b"unsafe"
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name, content in entries.items():
+            archive.writestr(name, content)
+    return path
+
+
+def _write_runtime(tmp_path: Path) -> Path:
+    path = tmp_path / "hol-guard-runtime"
+    path.write_bytes(b"native-runtime-fixture-v1")
+    path.chmod(0o755)
+    return path
+
+
+def _record_digest(content: bytes) -> str:
+    encoded = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).rstrip(b"=").decode()
+    return f"sha256={encoded}"
+
+
+def _build(tmp_path: Path, *, wheel: Path | None = None, runtime: Path | None = None) -> Path:
+    return build_native_wheel(
+        source_wheel=wheel or _write_source_wheel(tmp_path),
+        runtime=runtime or _write_runtime(tmp_path),
+        output_dir=tmp_path / "native",
+        version=_VERSION,
+        platform_tag=_PLATFORM_TAG,
+        target=_TARGET,
+        source_sha=_SOURCE_SHA,
+        rule_digest=_RULE_DIGEST,
+    )
+
+
+def test_native_wheel_injects_runtime_manifest_and_valid_record(tmp_path: Path) -> None:
+    output = _build(tmp_path)
+    assert output.name == f"hol_guard-{_VERSION}-py3-none-{_PLATFORM_TAG}.whl"
+
+    with zipfile.ZipFile(output) as archive:
+        names = set(archive.namelist())
+        runtime_path = "codex_plugin_scanner/_native/hol-guard-runtime"
+        manifest_path = "codex_plugin_scanner/_native/runtime-manifest.json"
+        wheel_path = f"hol_guard-{_VERSION}.dist-info/WHEEL"
+        record_path = f"hol_guard-{_VERSION}.dist-info/RECORD"
+        assert runtime_path in names
+        assert manifest_path in names
+
+        wheel_text = archive.read(wheel_path).decode()
+        assert "Root-Is-Purelib: false" in wheel_text
+        assert f"Tag: py3-none-{_PLATFORM_TAG}" in wheel_text
+        assert "Tag: py3-none-any" not in wheel_text
+
+        runtime_bytes = archive.read(runtime_path)
+        manifest = json.loads(archive.read(manifest_path))
+        assert manifest == {
+            "package_version": _VERSION,
+            "platform_tag": _PLATFORM_TAG,
+            "protocol_version": 1,
+            "rule_digest": _RULE_DIGEST,
+            "runtime_sha256": hashlib.sha256(runtime_bytes).hexdigest(),
+            "runtime_size": len(runtime_bytes),
+            "schema": "hol-guard-native-runtime.v1",
+            "source_sha": _SOURCE_SHA,
+            "target": _TARGET,
+        }
+        runtime_mode = stat.S_IMODE(archive.getinfo(runtime_path).external_attr >> 16)
+        assert runtime_mode == 0o755
+
+        rows = list(csv.reader(io.StringIO(archive.read(record_path).decode())))
+        by_name = {row[0]: row[1:] for row in rows}
+        assert by_name[record_path] == ["", ""]
+        for name in names - {record_path}:
+            content = archive.read(name)
+            assert by_name[name] == [_record_digest(content), str(len(content))]
+
+
+def test_builder_does_not_modify_source_wheel(tmp_path: Path) -> None:
+    wheel = _write_source_wheel(tmp_path)
+    before = hashlib.sha256(wheel.read_bytes()).hexdigest()
+    _ = _build(tmp_path, wheel=wheel)
+    assert hashlib.sha256(wheel.read_bytes()).hexdigest() == before
+
+
+def test_builder_refuses_plugin_scanner_artifact(tmp_path: Path) -> None:
+    wheel = _write_source_wheel(tmp_path)
+    scanner_wheel = wheel.with_name(f"plugin_scanner-{_VERSION}-py3-none-any.whl")
+    wheel.rename(scanner_wheel)
+    with pytest.raises(NativeWheelError, match="expected pure hol-guard wheel"):
+        _build(tmp_path, wheel=scanner_wheel)
+
+
+def test_builder_rejects_archive_path_traversal(tmp_path: Path) -> None:
+    wheel = _write_source_wheel(tmp_path, unsafe_name="../escaped")
+    with pytest.raises(NativeWheelError, match="unsafe path"):
+        _build(tmp_path, wheel=wheel)
+
+
+def test_builder_rejects_source_version_mismatch(tmp_path: Path) -> None:
+    wheel = _write_source_wheel(tmp_path, version="3.0.0a6")
+    with pytest.raises(NativeWheelError, match="expected pure hol-guard wheel"):
+        _build(tmp_path, wheel=wheel)
+
+
+def test_builder_refuses_overwrite(tmp_path: Path) -> None:
+    wheel = _write_source_wheel(tmp_path)
+    runtime = _write_runtime(tmp_path)
+    _ = _build(tmp_path, wheel=wheel, runtime=runtime)
+    with pytest.raises(NativeWheelError, match="refusing to overwrite"):
+        _build(tmp_path, wheel=wheel, runtime=runtime)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink fixture uses POSIX executable semantics")
+def test_builder_rejects_symlink_runtime(tmp_path: Path) -> None:
+    target = _write_runtime(tmp_path)
+    link = tmp_path / "runtime-link"
+    link.symlink_to(target)
+    with pytest.raises(NativeWheelError, match="regular non-symlink"):
+        _build(tmp_path, runtime=link)

--- a/scripts/build_native_hol_guard_wheel.py
+++ b/scripts/build_native_hol_guard_wheel.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Build one platform-specific HOL Guard wheel from the verified pure wheel.
+
+The native runtime is injected into ``codex_plugin_scanner/_native``. The
+source wheel is never modified in place, and this builder refuses any project
+other than ``hol-guard``. It rewrites only wheel metadata required by the
+platform artifact plus RECORD hashes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import hashlib
+import io
+import json
+import os
+import re
+import stat
+import zipfile
+from dataclasses import dataclass
+from email.parser import BytesParser
+from pathlib import Path, PurePosixPath
+
+_MAX_RUNTIME_BYTES = 128 * 1024 * 1024
+_PLATFORM_TAG_RE = re.compile(r"^[A-Za-z0-9_.]+$")
+_SHA40_RE = re.compile(r"^[0-9a-f]{40}$")
+_SHA64_RE = re.compile(r"^[0-9a-f]{64}$")
+_NATIVE_DIR = "codex_plugin_scanner/_native"
+_RUNTIME_MANIFEST_PATH = f"{_NATIVE_DIR}/runtime-manifest.json"
+_DETERMINISTIC_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+
+
+class NativeWheelError(ValueError):
+    """Raised when a source artifact cannot safely become a native wheel."""
+
+
+@dataclass(frozen=True, slots=True)
+class SourceWheel:
+    path: Path
+    dist_info: str
+    metadata_path: str
+    wheel_path: str
+    record_path: str
+    entries: dict[str, bytes]
+    modes: dict[str, int]
+
+
+def _wheel_version_for_filename(version: str) -> str:
+    return version.replace("-", "_")
+
+
+def _safe_archive_path(name: str) -> bool:
+    if not name or "\\" in name:
+        return False
+    path = PurePosixPath(name)
+    return not path.is_absolute() and ".." not in path.parts and all(part not in {"", "."} for part in path.parts)
+
+
+def _entry_mode(info: zipfile.ZipInfo) -> int:
+    raw = info.external_attr >> 16
+    if raw and stat.S_ISLNK(raw):
+        raise NativeWheelError(f"source wheel contains a symlink entry: {info.filename}")
+    mode = stat.S_IMODE(raw) if raw else 0
+    return mode or 0o644
+
+
+def _load_source_wheel(path: Path, *, version: str) -> SourceWheel:
+    expected_name = f"hol_guard-{_wheel_version_for_filename(version)}-py3-none-any.whl"
+    if path.name != expected_name:
+        raise NativeWheelError(f"expected pure hol-guard wheel {expected_name}, got {path.name}")
+    if not path.is_file() or path.is_symlink():
+        raise NativeWheelError("source wheel must be a regular non-symlink file")
+
+    entries: dict[str, bytes] = {}
+    modes: dict[str, int] = {}
+    with zipfile.ZipFile(path, "r") as archive:
+        infos = archive.infolist()
+        names = [info.filename for info in infos if not info.is_dir()]
+        if len(names) != len(set(names)):
+            raise NativeWheelError("source wheel contains duplicate entries")
+        for info in infos:
+            if info.is_dir():
+                continue
+            if not _safe_archive_path(info.filename):
+                raise NativeWheelError(f"source wheel contains an unsafe path: {info.filename}")
+            entries[info.filename] = archive.read(info)
+            modes[info.filename] = _entry_mode(info)
+
+    wheel_paths = [name for name in entries if name.endswith(".dist-info/WHEEL")]
+    metadata_paths = [name for name in entries if name.endswith(".dist-info/METADATA")]
+    record_paths = [name for name in entries if name.endswith(".dist-info/RECORD")]
+    if len(wheel_paths) != 1 or len(metadata_paths) != 1 or len(record_paths) != 1:
+        raise NativeWheelError("source wheel must contain exactly one WHEEL, METADATA, and RECORD")
+
+    wheel_path = wheel_paths[0]
+    metadata_path = metadata_paths[0]
+    record_path = record_paths[0]
+    dist_info = wheel_path.rsplit("/", 1)[0]
+    if metadata_path.rsplit("/", 1)[0] != dist_info or record_path.rsplit("/", 1)[0] != dist_info:
+        raise NativeWheelError("source wheel dist-info metadata is inconsistent")
+
+    metadata = BytesParser().parsebytes(entries[metadata_path])
+    if metadata.get("Name") != "hol-guard" or metadata.get("Version") != version:
+        raise NativeWheelError("source wheel project identity or version does not match")
+
+    wheel_text = entries[wheel_path].decode("utf-8")
+    tags = [line.removeprefix("Tag:").strip() for line in wheel_text.splitlines() if line.startswith("Tag:")]
+    if tags != ["py3-none-any"]:
+        raise NativeWheelError("source wheel must be the canonical py3-none-any artifact")
+    if f"{_NATIVE_DIR}/hol-guard-runtime" in entries or f"{_NATIVE_DIR}/hol-guard-runtime.exe" in entries:
+        raise NativeWheelError("source wheel already contains a native runtime")
+
+    return SourceWheel(
+        path=path,
+        dist_info=dist_info,
+        metadata_path=metadata_path,
+        wheel_path=wheel_path,
+        record_path=record_path,
+        entries=entries,
+        modes=modes,
+    )
+
+
+def _load_runtime(path: Path) -> bytes:
+    if path.is_symlink() or not path.is_file():
+        raise NativeWheelError("runtime must be a regular non-symlink file")
+    metadata = path.stat()
+    if metadata.st_size <= 0 or metadata.st_size > _MAX_RUNTIME_BYTES:
+        raise NativeWheelError("runtime size is outside the accepted release bounds")
+    if os.name != "nt" and stat.S_IMODE(metadata.st_mode) & 0o022:
+        raise NativeWheelError("runtime is group/world writable")
+    return path.read_bytes()
+
+
+def _rewrite_wheel_metadata(raw: bytes, *, platform_tag: str) -> bytes:
+    lines = raw.decode("utf-8").splitlines()
+    rewritten = [
+        line
+        for line in lines
+        if not line.startswith("Root-Is-Purelib:") and not line.startswith("Tag:")
+    ]
+    rewritten.extend(["Root-Is-Purelib: false", f"Tag: py3-none-{platform_tag}"])
+    return ("\n".join(rewritten).rstrip() + "\n").encode("utf-8")
+
+
+def _record_hash(content: bytes) -> str:
+    digest = hashlib.sha256(content).digest()
+    encoded = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return f"sha256={encoded}"
+
+
+def _record_content(entries: dict[str, bytes], *, record_path: str) -> bytes:
+    output = io.StringIO(newline="")
+    writer = csv.writer(output, lineterminator="\n")
+    for name in sorted(entries):
+        if name == record_path:
+            continue
+        content = entries[name]
+        writer.writerow([name, _record_hash(content), str(len(content))])
+    writer.writerow([record_path, "", ""])
+    return output.getvalue().encode("utf-8")
+
+
+def _zip_info(name: str, *, mode: int) -> zipfile.ZipInfo:
+    info = zipfile.ZipInfo(name, date_time=_DETERMINISTIC_TIMESTAMP)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.create_system = 3
+    info.external_attr = (stat.S_IFREG | mode) << 16
+    return info
+
+
+def build_native_wheel(
+    *,
+    source_wheel: Path,
+    runtime: Path,
+    output_dir: Path,
+    version: str,
+    platform_tag: str,
+    target: str,
+    source_sha: str,
+    rule_digest: str,
+) -> Path:
+    """Return a new native HOL Guard wheel without changing the source wheel."""
+    if not version.strip():
+        raise NativeWheelError("package version is required")
+    if not _PLATFORM_TAG_RE.fullmatch(platform_tag):
+        raise NativeWheelError("invalid wheel platform tag")
+    if not target or any(character in target for character in "\\/\x00"):
+        raise NativeWheelError("invalid runtime target")
+    if not _SHA40_RE.fullmatch(source_sha):
+        raise NativeWheelError("source SHA must be a lowercase 40-character Git SHA")
+    if not _SHA64_RE.fullmatch(rule_digest):
+        raise NativeWheelError("rule digest must be a lowercase SHA-256 hex digest")
+
+    source = _load_source_wheel(source_wheel, version=version)
+    runtime_bytes = _load_runtime(runtime)
+    runtime_name = "hol-guard-runtime.exe" if platform_tag.startswith("win") else "hol-guard-runtime"
+    runtime_path = f"{_NATIVE_DIR}/{runtime_name}"
+
+    entries = dict(source.entries)
+    modes = dict(source.modes)
+    entries[source.wheel_path] = _rewrite_wheel_metadata(entries[source.wheel_path], platform_tag=platform_tag)
+    runtime_sha256 = hashlib.sha256(runtime_bytes).hexdigest()
+    manifest = {
+        "schema": "hol-guard-native-runtime.v1",
+        "protocol_version": 1,
+        "package_version": version,
+        "target": target,
+        "platform_tag": platform_tag,
+        "source_sha": source_sha,
+        "rule_digest": rule_digest,
+        "runtime_sha256": runtime_sha256,
+        "runtime_size": len(runtime_bytes),
+    }
+    entries[runtime_path] = runtime_bytes
+    entries[_RUNTIME_MANIFEST_PATH] = (json.dumps(manifest, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    modes[runtime_path] = 0o755
+    modes[_RUNTIME_MANIFEST_PATH] = 0o644
+    modes[source.wheel_path] = 0o644
+    entries[source.record_path] = _record_content(entries, record_path=source.record_path)
+    modes[source.record_path] = 0o644
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"hol_guard-{_wheel_version_for_filename(version)}-py3-none-{platform_tag}.whl"
+    if output_path.exists():
+        raise NativeWheelError(f"refusing to overwrite existing native wheel: {output_path}")
+
+    with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9) as archive:
+        for name in sorted(entries):
+            if not _safe_archive_path(name):
+                raise NativeWheelError(f"refusing unsafe output path: {name}")
+            archive.writestr(_zip_info(name, mode=modes.get(name, 0o644)), entries[name])
+    return output_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Inject the native runtime into a verified hol-guard wheel")
+    parser.add_argument("--wheel", type=Path, required=True)
+    parser.add_argument("--runtime", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--platform-tag", required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--rule-digest", required=True)
+    args = parser.parse_args()
+    output = build_native_wheel(
+        source_wheel=args.wheel,
+        runtime=args.runtime,
+        output_dir=args.output_dir,
+        version=args.version,
+        platform_tag=args.platform_tag,
+        target=args.target,
+        source_sha=args.source_sha,
+        rule_digest=args.rule_digest,
+    )
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds deterministic platform-wheel packaging for the version-matched Rust runtime while preserving `hol-guard` as the single public Python package.

- starts from the already verified pure `hol-guard` wheel
- injects only `codex_plugin_scanner/_native/hol-guard-runtime[.exe]` plus a non-secret provenance manifest
- changes wheel metadata to the exact platform tag and recomputes every `RECORD` hash/size
- refuses non-`hol-guard` artifacts, version mismatches, unsafe/duplicate archive paths, symlink or writable runtime inputs, existing native payloads, and output overwrite
- keeps `plugin-scanner` entirely outside the native packaging path
- preserves the pure-Python `hol-guard` wheel as the unsupported-platform fallback

## Verification

Dedicated native-wheel CI builds and installs Tier 1 Linux, macOS, and Windows wheel variants and validates manifest identity, executable placement, wheel metadata, RECORD integrity, source immutability, traversal rejection, version binding, overwrite refusal, and symlink-runtime rejection.

This PR does not enable native execution by default and does not alter the release PR.