### PR TITLE
feat(guard): add contextual leaked-secret detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ override-dependencies = [
 
 [project.scripts]
 hol-guard = "codex_plugin_scanner.cli:main"
+hol-guard-secrets = "codex_plugin_scanner.guard.secrets.cli:main"
 plugin-scanner = "codex_plugin_scanner.cli:main"
 plugin-guard = "codex_plugin_scanner.cli:main"
 plugin-ecosystem-scanner = "codex_plugin_scanner.cli:main"
@@ -178,10 +179,7 @@ also_copy = ["src/codex_plugin_scanner"]
 pytest_add_cli_args_test_selection = [
   "tests/test_guard_command_model.py",
   "tests/test_guard_command_critical_floors.py",
-  "tests/test_guard_command_corpus.py",
+  "tests/test_guard_command_model_pipeline.py",
+  "tests/test_guard_command_precedence.py",
+  "tests/test_guard_command_trace.py",
 ]
-
-[tool.basedpyright]
-include = ["src"]
-pythonVersion = "3.10"
-failOnWarnings = false

--- a/src/codex_plugin_scanner/guard/secrets/__init__.py
+++ b/src/codex_plugin_scanner/guard/secrets/__init__.py
@@ -1,0 +1,24 @@
+"""HOL Guard leaked-secret detection primitives."""
+
+from .secret_detection import (
+    SECRET_RULES,
+    SecretFinding,
+    SecretScanSummary,
+    detector_version,
+    scan_secret_text,
+    secret_rule_catalog,
+    shannon_entropy,
+)
+from .secret_repository_scanner import RepositorySecretScanResult, scan_repository_secrets
+
+__all__ = [
+    "SECRET_RULES",
+    "RepositorySecretScanResult",
+    "SecretFinding",
+    "SecretScanSummary",
+    "detector_version",
+    "scan_repository_secrets",
+    "scan_secret_text",
+    "secret_rule_catalog",
+    "shannon_entropy",
+]

--- a/src/codex_plugin_scanner/guard/secrets/cli.py
+++ b/src/codex_plugin_scanner/guard/secrets/cli.py
@@ -1,0 +1,102 @@
+"""Standalone CLI for free local leaked-secret detection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from .secret_detection import detector_version, secret_rule_catalog
+from .secret_repository_scanner import scan_repository_secrets
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be greater than zero")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="hol-guard-secrets",
+        description=(
+            "Find leaked credentials locally. Raw secret values are never printed or sent to Guard Cloud."
+        ),
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    scan = subparsers.add_parser("scan", help="Scan a file or repository")
+    scan.add_argument("target", nargs="?", default=".")
+    scan.add_argument("--history", action="store_true", help="Also scan bounded Git history")
+    scan.add_argument("--max-commits", type=_positive_int, default=500)
+    scan.add_argument("--max-files", type=_positive_int, default=5000)
+    scan.add_argument("--max-file-bytes", type=_positive_int, default=2 * 1024 * 1024)
+    scan.add_argument("--max-total-bytes", type=_positive_int, default=128 * 1024 * 1024)
+    scan.add_argument("--max-findings", type=_positive_int, default=500)
+    scan.add_argument("--fail-on-findings", action="store_true")
+    scan.add_argument("--json", action="store_true")
+    rules = subparsers.add_parser("rules", help="List built-in detector families")
+    rules.add_argument("--json", action="store_true")
+    return parser
+
+
+def _write_scan(result: object, *, json_output: bool) -> None:
+    public = getattr(result, "to_public_dict")()
+    if json_output:
+        print(json.dumps(public, sort_keys=True))
+        return
+    findings = getattr(result, "findings")
+    print(
+        f"HOL Guard Secrets: {len(findings)} finding(s), "
+        f"{getattr(result, 'files_scanned')} file version(s), "
+        f"{getattr(result, 'commits_scanned')} Git commit(s)."
+    )
+    for finding in findings:
+        commit = f" @{finding.commit[:12]}" if finding.commit else ""
+        print(
+            f"- {finding.severity.upper()} {finding.family} at "
+            f"{finding.path}:{finding.line}{commit} [{finding.confidence} confidence]"
+        )
+    if getattr(result, "truncated"):
+        print("Scan reached a configured safety limit. Increase a bound and rescan for full coverage.")
+    print("Raw secret values are intentionally omitted.")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "rules":
+        payload = {
+            "schema": "guard-secret-rules.v1",
+            "detector_version": detector_version(),
+            "rules": secret_rule_catalog(),
+        }
+        if args.json:
+            print(json.dumps(payload, sort_keys=True))
+        else:
+            print(f"HOL Guard Secrets detector {payload['detector_version']}")
+            for rule in payload["rules"]:
+                validation = str(rule["validation"])
+                suffix = f", validates via {validation}" if validation != "none" else ""
+                print(f"- {rule['family']} ({rule['severity']}{suffix})")
+        return 0
+    try:
+        result = scan_repository_secrets(
+            Path(args.target),
+            include_history=bool(args.history),
+            max_commits=args.max_commits,
+            max_files=args.max_files,
+            max_file_bytes=args.max_file_bytes,
+            max_total_bytes=args.max_total_bytes,
+            max_findings=args.max_findings,
+        )
+    except (OSError, ValueError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+    _write_scan(result, json_output=bool(args.json))
+    return 3 if args.fail_on_findings and result.findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_plugin_scanner/guard/secrets/secret_detection.py
+++ b/src/codex_plugin_scanner/guard/secrets/secret_detection.py
@@ -1,0 +1,596 @@
+"""Context-aware leaked-secret detection for HOL Guard.
+
+The runtime in this module is deliberately local, deterministic, and dependency-free.
+It combines strong provider formats with contextual scoring for generic credentials,
+entropy/rarity signals, and conservative sample suppression.
+
+Security invariants:
+- public finding payloads never contain the raw candidate secret;
+- fingerprints are HMACs and require an explicit caller-owned key;
+- no network or LLM call is made by detection;
+- generic findings require contextual evidence and are suppressed in obvious
+  documentation/test fixtures unless the candidate has a strong provider format.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import math
+import re
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Literal
+
+SecretSeverity = Literal["medium", "high", "critical"]
+SecretConfidence = Literal["low", "medium", "high"]
+SecretValidationKind = Literal[
+    "none",
+    "github",
+    "gitlab",
+    "aws",
+    "slack",
+    "stripe",
+    "openai",
+    "anthropic",
+    "huggingface",
+    "npm",
+    "pypi",
+    "google",
+    "sendgrid",
+]
+
+_DETECTOR_VERSION = "guard-secrets-v1"
+
+_SAMPLE_WORDS = re.compile(
+    r"(?i)(?:example|sample|dummy|fake|fixture|placeholder|changeme|replace[_-]?me|"
+    r"your[_-]?(?:api[_-]?)?(?:key|token|secret|password)|test[_-]?(?:key|token|secret))"
+)
+_CREDENTIAL_KEYWORDS = re.compile(
+    r"(?i)(?:api[_-]?key|access[_-]?key|auth[_-]?token|bearer|credential|password|passwd|"
+    r"private[_-]?key|secret|token|webhook|client[_-]?secret)"
+)
+_ASSIGNMENT = re.compile(
+    r"(?im)(?P<name>[A-Za-z_][A-Za-z0-9_.-]{1,80})\s*[:=]\s*"
+    r"(?P<quote>[\"']?)(?P<secret>[^\s\"',}{]{12,256})(?P=quote)"
+)
+_DATABASE_URL = re.compile(
+    r"(?i)\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis)://"
+    r"[^\s:/@]{1,128}:(?P<secret>[^\s/@]{6,256})@[^\s]+"
+)
+_BASIC_AUTH_URL = re.compile(
+    r"(?i)\bhttps?://[^\s:/@]{1,128}:(?P<secret>[^\s/@]{8,256})@[^\s]+"
+)
+_JWT = re.compile(r"\b(?P<secret>eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,})\b")
+
+_DOC_SEGMENTS = frozenset(
+    {
+        "docs",
+        "doc",
+        "documentation",
+        "examples",
+        "example",
+        "fixtures",
+        "fixture",
+        "samples",
+        "sample",
+        "test",
+        "tests",
+        "spec",
+        "specs",
+        "__tests__",
+        "__fixtures__",
+    }
+)
+_DOC_SUFFIXES = frozenset({".md", ".mdx", ".rst", ".adoc", ".txt"})
+_HIGH_SIGNAL_BASENAMES = frozenset(
+    {
+        ".env",
+        ".npmrc",
+        ".pypirc",
+        ".netrc",
+        ".git-credentials",
+        "credentials",
+        "secrets.yml",
+        "secrets.yaml",
+        "terraform.tfvars",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SecretRule:
+    rule_id: str
+    family: str
+    severity: SecretSeverity
+    pattern: re.Pattern[str]
+    validation: SecretValidationKind = "none"
+    strong_format: bool = True
+    description: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class SecretFinding:
+    rule_id: str
+    family: str
+    severity: SecretSeverity
+    confidence: SecretConfidence
+    confidence_score: float
+    line: int
+    path: str
+    source: Literal["working_tree", "git_history", "text"]
+    commit: str | None
+    validation: SecretValidationKind
+    entropy: float
+    context_reasons: tuple[str, ...]
+    candidate: str = field(repr=False, compare=False)
+
+    def fingerprint(self, key: bytes) -> str:
+        """Return a tenant/caller-scoped HMAC without exposing candidate bytes."""
+
+        if not key:
+            raise ValueError("secret fingerprint key must not be empty")
+        material = f"{self.rule_id}\0{self.candidate}".encode("utf-8", errors="strict")
+        return hmac.new(key, material, hashlib.sha256).hexdigest()
+
+    def to_public_dict(self, *, fingerprint_key: bytes | None = None) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "rule_id": self.rule_id,
+            "family": self.family,
+            "severity": self.severity,
+            "confidence": self.confidence,
+            "confidence_score": round(self.confidence_score, 4),
+            "line": self.line,
+            "path": self.path,
+            "source": self.source,
+            "commit": self.commit,
+            "validation": self.validation,
+            "entropy": round(self.entropy, 4),
+            "context_reasons": list(self.context_reasons),
+        }
+        if fingerprint_key is not None:
+            payload["fingerprint"] = self.fingerprint(fingerprint_key)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class SecretScanSummary:
+    detector_version: str
+    findings: tuple[SecretFinding, ...]
+
+    def to_public_dict(self, *, fingerprint_key: bytes | None = None) -> dict[str, object]:
+        return {
+            "schema": "guard-secret-scan.v1",
+            "detector_version": self.detector_version,
+            "finding_count": len(self.findings),
+            "findings": [
+                finding.to_public_dict(fingerprint_key=fingerprint_key)
+                for finding in self.findings
+            ],
+        }
+
+
+def _compile(pattern: str, flags: int = 0) -> re.Pattern[str]:
+    return re.compile(pattern, flags)
+
+
+SECRET_RULES: tuple[SecretRule, ...] = (
+    SecretRule(
+        "github-token",
+        "GitHub token",
+        "critical",
+        _compile(r"\b(?P<secret>(?:gh[pousr]_[A-Za-z0-9_]{20,255}|github_pat_[A-Za-z0-9_]{20,255}))\b"),
+        "github",
+        description="GitHub personal, OAuth, user, server, refresh, or fine-grained token.",
+    ),
+    SecretRule(
+        "gitlab-token",
+        "GitLab token",
+        "critical",
+        _compile(r"\b(?P<secret>glpat-[A-Za-z0-9_-]{20,255})\b"),
+        "gitlab",
+        description="GitLab personal/project/group access token.",
+    ),
+    SecretRule(
+        "aws-access-key",
+        "AWS access key ID",
+        "high",
+        _compile(r"\b(?P<secret>(?:AKIA|ASIA)[0-9A-Z]{16})\b"),
+        "aws",
+        description="AWS long-lived or STS access key identifier.",
+    ),
+    SecretRule(
+        "slack-token",
+        "Slack token",
+        "critical",
+        _compile(r"\b(?P<secret>xox[baprs]-[A-Za-z0-9-]{10,255})\b"),
+        "slack",
+        description="Slack bot, app, user, refresh, or service token.",
+    ),
+    SecretRule(
+        "slack-webhook",
+        "Slack incoming webhook",
+        "critical",
+        _compile(r"(?P<secret>https://hooks\.slack\.com/services/[A-Za-z0-9/_-]{24,255})"),
+        "slack",
+        description="Slack incoming webhook URL.",
+    ),
+    SecretRule(
+        "stripe-secret-key",
+        "Stripe secret key",
+        "critical",
+        _compile(r"\b(?P<secret>(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,255})\b"),
+        "stripe",
+        description="Stripe secret or restricted API key.",
+    ),
+    SecretRule(
+        "openai-api-key",
+        "OpenAI API key",
+        "critical",
+        _compile(r"\b(?P<secret>sk-(?:(?:proj|svcacct)-)?[A-Za-z0-9_-]{20,255})\b"),
+        "openai",
+        description="OpenAI project/service/account API key.",
+    ),
+    SecretRule(
+        "anthropic-api-key",
+        "Anthropic API key",
+        "critical",
+        _compile(r"\b(?P<secret>sk-ant-[A-Za-z0-9_-]{20,255})\b"),
+        "anthropic",
+        description="Anthropic API key.",
+    ),
+    SecretRule(
+        "huggingface-token",
+        "Hugging Face token",
+        "high",
+        _compile(r"\b(?P<secret>hf_[A-Za-z0-9]{24,255})\b"),
+        "huggingface",
+        description="Hugging Face user or organization token.",
+    ),
+    SecretRule(
+        "npm-token",
+        "npm access token",
+        "critical",
+        _compile(r"\b(?P<secret>npm_[A-Za-z0-9]{30,255})\b"),
+        "npm",
+        description="npm granular or automation access token.",
+    ),
+    SecretRule(
+        "pypi-token",
+        "PyPI API token",
+        "critical",
+        _compile(r"\b(?P<secret>pypi-[A-Za-z0-9_-]{24,255})\b"),
+        "pypi",
+        description="PyPI scoped API token.",
+    ),
+    SecretRule(
+        "google-api-key",
+        "Google API key",
+        "high",
+        _compile(r"\b(?P<secret>AIza[0-9A-Za-z_-]{35})\b"),
+        "google",
+        description="Google Cloud/Firebase API key.",
+    ),
+    SecretRule(
+        "sendgrid-api-key",
+        "SendGrid API key",
+        "critical",
+        _compile(r"\b(?P<secret>SG\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,})\b"),
+        "sendgrid",
+        description="SendGrid API key.",
+    ),
+    SecretRule(
+        "pem-private-key",
+        "PEM private key",
+        "critical",
+        _compile(
+            r"(?P<secret>-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----)",
+            re.MULTILINE,
+        ),
+        description="Private-key material in PEM/OpenSSH-style form.",
+    ),
+    SecretRule(
+        "database-url-password",
+        "Database URL password",
+        "critical",
+        _DATABASE_URL,
+        strong_format=False,
+        description="Password embedded in a database connection URL.",
+    ),
+    SecretRule(
+        "basic-auth-url-password",
+        "Basic-auth URL password",
+        "high",
+        _BASIC_AUTH_URL,
+        strong_format=False,
+        description="Credential embedded in an HTTP(S) URL.",
+    ),
+    SecretRule(
+        "jwt-token",
+        "JWT bearer token",
+        "high",
+        _JWT,
+        strong_format=False,
+        description="JWT-like bearer token in credential context.",
+    ),
+)
+
+
+def detector_version() -> str:
+    material = "\n".join(
+        f"{rule.rule_id}|{rule.severity}|{rule.validation}|{rule.pattern.pattern}|{rule.pattern.flags}"
+        for rule in SECRET_RULES
+    )
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+    return f"{_DETECTOR_VERSION}:{digest}"
+
+
+def secret_rule_catalog() -> list[dict[str, object]]:
+    return [
+        {
+            "rule_id": rule.rule_id,
+            "family": rule.family,
+            "severity": rule.severity,
+            "validation": rule.validation,
+            "strong_format": rule.strong_format,
+            "description": rule.description,
+        }
+        for rule in SECRET_RULES
+    ] + [
+        {
+            "rule_id": "credential-assignment",
+            "family": "Contextual credential assignment",
+            "severity": "high",
+            "validation": "none",
+            "strong_format": False,
+            "description": "High-entropy credential assignment accepted only with contextual evidence.",
+        }
+    ]
+
+
+def shannon_entropy(value: str) -> float:
+    if not value:
+        return 0.0
+    counts: dict[str, int] = {}
+    for character in value:
+        counts[character] = counts.get(character, 0) + 1
+    length = float(len(value))
+    return -sum((count / length) * math.log2(count / length) for count in counts.values())
+
+
+def _rarity_score(value: str) -> float:
+    if not value:
+        return 0.0
+    entropy_component = min(shannon_entropy(value) / 5.2, 1.0)
+    classes = sum(
+        int(bool(pattern.search(value)))
+        for pattern in (
+            re.compile(r"[a-z]"),
+            re.compile(r"[A-Z]"),
+            re.compile(r"[0-9]"),
+            re.compile(r"[^A-Za-z0-9]"),
+        )
+    )
+    class_component = min(classes / 3.0, 1.0)
+    length_component = min(max(len(value) - 12, 0) / 36.0, 1.0)
+    return min((entropy_component * 0.55) + (class_component * 0.2) + (length_component * 0.25), 1.0)
+
+
+def _normalized_path(path: str | None) -> str:
+    if not path:
+        return ""
+    return path.replace("\\", "/").strip().lower()
+
+
+def _path_is_documentation(path: str) -> bool:
+    normalized = _normalized_path(path)
+    if not normalized:
+        return False
+    pure = PurePosixPath(normalized)
+    parts = set(pure.parts)
+    return bool(parts & _DOC_SEGMENTS) or pure.suffix in _DOC_SUFFIXES
+
+
+def _path_is_high_signal(path: str) -> bool:
+    normalized = _normalized_path(path)
+    if not normalized:
+        return False
+    pure = PurePosixPath(normalized)
+    basename = pure.name
+    if basename == ".env" or basename.startswith(".env."):
+        return True
+    return basename in _HIGH_SIGNAL_BASENAMES or any(part in {".aws", ".ssh", ".gnupg"} for part in pure.parts)
+
+
+def _obvious_sample(candidate: str, context: str) -> bool:
+    combined = f"{candidate}\n{context}"
+    if _SAMPLE_WORDS.search(combined) is None:
+        return False
+    # Do not suppress a structurally strong, long random-looking token just
+    # because nearby documentation contains the word "example".
+    return _rarity_score(candidate) < 0.76 or len(candidate) < 28
+
+
+def _confidence_label(score: float) -> SecretConfidence:
+    if score >= 0.84:
+        return "high"
+    if score >= 0.64:
+        return "medium"
+    return "low"
+
+
+def _context_score(
+    candidate: str,
+    *,
+    path: str,
+    line_text: str,
+    strong_format: bool,
+) -> tuple[float, tuple[str, ...]]:
+    score = 0.9 if strong_format else 0.3
+    reasons: list[str] = ["provider-format" if strong_format else "contextual-candidate"]
+    rarity = _rarity_score(candidate)
+    score += rarity * (0.08 if strong_format else 0.34)
+    if rarity >= 0.72:
+        reasons.append("high-token-rarity")
+    if _CREDENTIAL_KEYWORDS.search(line_text) is not None:
+        score += 0.22
+        reasons.append("credential-name-context")
+    if _path_is_high_signal(path):
+        score += 0.14
+        reasons.append("sensitive-file-context")
+    if _path_is_documentation(path):
+        score -= 0.28 if not strong_format else 0.08
+        reasons.append("documentation-context")
+    if _SAMPLE_WORDS.search(line_text) is not None:
+        score -= 0.32 if not strong_format else 0.1
+        reasons.append("sample-marker-context")
+    return max(0.0, min(score, 1.0)), tuple(reasons)
+
+
+def _line_number(text: str, match_start: int) -> int:
+    return text.count("\n", 0, match_start) + 1
+
+
+def _line_text(text: str, match_start: int) -> str:
+    start = text.rfind("\n", 0, match_start) + 1
+    end = text.find("\n", match_start)
+    if end < 0:
+        end = len(text)
+    return text[start:end][:1024]
+
+
+def _finding_from_match(
+    *,
+    rule: SecretRule,
+    candidate: str,
+    text: str,
+    match_start: int,
+    path: str,
+    source: Literal["working_tree", "git_history", "text"],
+    commit: str | None,
+) -> SecretFinding | None:
+    line_text = _line_text(text, match_start)
+    if _obvious_sample(candidate, line_text) and not rule.strong_format:
+        return None
+    score, reasons = _context_score(
+        candidate,
+        path=path,
+        line_text=line_text,
+        strong_format=rule.strong_format,
+    )
+    minimum_score = 0.56 if rule.strong_format else 0.64
+    if score < minimum_score:
+        return None
+    return SecretFinding(
+        rule_id=rule.rule_id,
+        family=rule.family,
+        severity=rule.severity,
+        confidence=_confidence_label(score),
+        confidence_score=score,
+        line=_line_number(text, match_start),
+        path=path,
+        source=source,
+        commit=commit,
+        validation=rule.validation,
+        entropy=shannon_entropy(candidate),
+        context_reasons=reasons,
+        candidate=candidate,
+    )
+
+
+def scan_secret_text(
+    text: str,
+    *,
+    path: str = "",
+    source: Literal["working_tree", "git_history", "text"] = "text",
+    commit: str | None = None,
+    max_findings: int = 200,
+) -> SecretScanSummary:
+    """Scan text for leaked credentials without serializing candidate bytes."""
+
+    if not isinstance(text, str) or not text:
+        return SecretScanSummary(detector_version=detector_version(), findings=())
+    bounded_max = max(1, min(int(max_findings), 10_000))
+    findings: list[SecretFinding] = []
+    seen: set[tuple[str, int, str]] = set()
+
+    for rule in SECRET_RULES:
+        for match in rule.pattern.finditer(text):
+            candidate = match.groupdict().get("secret") or match.group(0)
+            finding = _finding_from_match(
+                rule=rule,
+                candidate=candidate,
+                text=text,
+                match_start=match.start(),
+                path=path,
+                source=source,
+                commit=commit,
+            )
+            if finding is None:
+                continue
+            identity = (finding.rule_id, finding.line, candidate)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            findings.append(finding)
+            if len(findings) >= bounded_max:
+                return SecretScanSummary(detector_version=detector_version(), findings=tuple(findings))
+
+    # Generic assignments are intentionally evaluated after provider formats so
+    # the structured detector wins when both identify the same token.
+    provider_candidates = {finding.candidate for finding in findings}
+    generic_rule = SecretRule(
+        rule_id="credential-assignment",
+        family="Contextual credential assignment",
+        severity="high",
+        pattern=_ASSIGNMENT,
+        strong_format=False,
+        description="Contextual high-entropy credential assignment.",
+    )
+    for match in _ASSIGNMENT.finditer(text):
+        candidate = match.group("secret")
+        if candidate in provider_candidates:
+            continue
+        name = match.group("name")
+        if _CREDENTIAL_KEYWORDS.search(name) is None:
+            continue
+        if _obvious_sample(candidate, match.group(0)):
+            continue
+        if _rarity_score(candidate) < 0.54 and len(candidate) < 24:
+            continue
+        finding = _finding_from_match(
+            rule=generic_rule,
+            candidate=candidate,
+            text=text,
+            match_start=match.start(),
+            path=path,
+            source=source,
+            commit=commit,
+        )
+        if finding is None:
+            continue
+        identity = (finding.rule_id, finding.line, candidate)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        findings.append(finding)
+        if len(findings) >= bounded_max:
+            break
+
+    findings.sort(key=lambda item: (item.path, item.line, item.rule_id, item.commit or ""))
+    return SecretScanSummary(detector_version=detector_version(), findings=tuple(findings))
+
+
+__all__ = [
+    "SECRET_RULES",
+    "SecretConfidence",
+    "SecretFinding",
+    "SecretRule",
+    "SecretScanSummary",
+    "SecretSeverity",
+    "SecretValidationKind",
+    "detector_version",
+    "scan_secret_text",
+    "secret_rule_catalog",
+    "shannon_entropy",
+]

--- a/src/codex_plugin_scanner/guard/secrets/secret_repository_scanner.py
+++ b/src/codex_plugin_scanner/guard/secrets/secret_repository_scanner.py
@@ -1,0 +1,409 @@
+"""Bounded working-tree and Git-history scanner for leaked secrets.
+
+The scanner is intentionally local and read-only. It does not invoke a shell,
+does not contact the network, and never includes raw secret candidates in its
+public result. Git-history scanning examines files changed by bounded commits
+instead of materializing repository history to disk.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from .secret_detection import SecretFinding, detector_version, scan_secret_text
+
+DEFAULT_MAX_FILES = 5_000
+DEFAULT_MAX_FILE_BYTES = 2 * 1024 * 1024
+DEFAULT_MAX_TOTAL_BYTES = 128 * 1024 * 1024
+DEFAULT_MAX_FINDINGS = 500
+DEFAULT_MAX_COMMITS = 500
+_GIT_TIMEOUT_SECONDS = 20
+
+_BINARY_SUFFIXES = frozenset(
+    {
+        ".7z",
+        ".a",
+        ".avi",
+        ".bin",
+        ".bmp",
+        ".class",
+        ".dll",
+        ".dmg",
+        ".doc",
+        ".docx",
+        ".eot",
+        ".exe",
+        ".gif",
+        ".gz",
+        ".ico",
+        ".jar",
+        ".jpeg",
+        ".jpg",
+        ".mov",
+        ".mp3",
+        ".mp4",
+        ".o",
+        ".otf",
+        ".pdf",
+        ".png",
+        ".pyc",
+        ".so",
+        ".tar",
+        ".tiff",
+        ".ttf",
+        ".wav",
+        ".webm",
+        ".woff",
+        ".woff2",
+        ".xz",
+        ".zip",
+    }
+)
+_SKIP_DIR_NAMES = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        ".next",
+        ".turbo",
+        ".venv",
+        "venv",
+        "node_modules",
+        "vendor",
+        "dist",
+        "build",
+        "target",
+        "coverage",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RepositorySecretScanResult:
+    findings: tuple[SecretFinding, ...]
+    files_scanned: int
+    commits_scanned: int
+    bytes_scanned: int
+    history_enabled: bool
+    truncated: bool
+    errors: tuple[str, ...]
+
+    def to_public_dict(self) -> dict[str, object]:
+        return {
+            "schema": "guard-repository-secret-scan.v1",
+            "detector_version": detector_version(),
+            "files_scanned": self.files_scanned,
+            "commits_scanned": self.commits_scanned,
+            "bytes_scanned": self.bytes_scanned,
+            "history_enabled": self.history_enabled,
+            "truncated": self.truncated,
+            "finding_count": len(self.findings),
+            "findings": [finding.to_public_dict() for finding in self.findings],
+            "errors": list(self.errors),
+        }
+
+
+def _bounded_positive(value: int, *, default: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    if parsed <= 0:
+        return default
+    return min(parsed, maximum)
+
+
+def _looks_binary(path: str, data: bytes) -> bool:
+    if Path(path).suffix.lower() in _BINARY_SUFFIXES:
+        return True
+    sample = data[:8192]
+    return b"\0" in sample
+
+
+def _decode_text(path: str, data: bytes) -> str | None:
+    if _looks_binary(path, data):
+        return None
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+def _safe_relative(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.name
+
+
+def _run_git(root: Path, args: list[str], *, timeout: int = _GIT_TIMEOUT_SECONDS) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+    )
+
+
+def _is_git_repository(root: Path) -> bool:
+    try:
+        result = _run_git(root, ["rev-parse", "--is-inside-work-tree"])
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0 and result.stdout.strip() == b"true"
+
+
+def _git_working_paths(root: Path) -> list[str] | None:
+    try:
+        result = _run_git(root, ["ls-files", "-co", "--exclude-standard", "-z"])
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return [
+        item.decode("utf-8", errors="surrogateescape")
+        for item in result.stdout.split(b"\0")
+        if item
+    ]
+
+
+def _filesystem_paths(root: Path) -> list[str]:
+    paths: list[str] = []
+    for current_root, dirs, files in os.walk(root, followlinks=False):
+        dirs[:] = [name for name in dirs if name not in _SKIP_DIR_NAMES]
+        current = Path(current_root)
+        for filename in files:
+            path = current / filename
+            if path.is_symlink():
+                continue
+            paths.append(_safe_relative(path, root))
+    paths.sort()
+    return paths
+
+
+def _scan_blob(
+    data: bytes,
+    *,
+    path: str,
+    source: str,
+    commit: str | None,
+    finding_budget: int,
+) -> tuple[tuple[SecretFinding, ...], int]:
+    text = _decode_text(path, data)
+    if text is None:
+        return (), 0
+    summary = scan_secret_text(
+        text,
+        path=path,
+        source=source,  # type: ignore[arg-type]
+        commit=commit,
+        max_findings=finding_budget,
+    )
+    return summary.findings, len(data)
+
+
+def _read_working_file(root: Path, relative_path: str, max_file_bytes: int) -> bytes | None:
+    candidate = root / relative_path
+    try:
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(root.resolve())
+    except (OSError, ValueError):
+        return None
+    if not resolved.is_file() or resolved.is_symlink():
+        return None
+    try:
+        size = resolved.stat().st_size
+    except OSError:
+        return None
+    if size > max_file_bytes:
+        return None
+    try:
+        return resolved.read_bytes()
+    except OSError:
+        return None
+
+
+def _git_commits(root: Path, max_commits: int) -> list[str]:
+    try:
+        result = _run_git(root, ["rev-list", "--all", f"--max-count={max_commits}"])
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if result.returncode != 0:
+        return []
+    return [line.decode("ascii", errors="ignore").strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _git_changed_paths(root: Path, commit: str) -> list[str]:
+    try:
+        result = _run_git(
+            root,
+            ["diff-tree", "--root", "--no-commit-id", "--name-only", "-r", "-z", commit],
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if result.returncode != 0:
+        return []
+    return [
+        item.decode("utf-8", errors="surrogateescape")
+        for item in result.stdout.split(b"\0")
+        if item
+    ]
+
+
+def _git_blob(root: Path, commit: str, path: str, max_file_bytes: int) -> bytes | None:
+    spec = f"{commit}:{path}"
+    try:
+        size_result = _run_git(root, ["cat-file", "-s", spec])
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if size_result.returncode != 0:
+        return None
+    try:
+        size = int(size_result.stdout.strip())
+    except ValueError:
+        return None
+    if size < 0 or size > max_file_bytes:
+        return None
+    try:
+        blob_result = _run_git(root, ["cat-file", "blob", spec])
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if blob_result.returncode != 0 or len(blob_result.stdout) > max_file_bytes:
+        return None
+    return blob_result.stdout
+
+
+def scan_repository_secrets(
+    target: Path,
+    *,
+    include_history: bool = False,
+    max_commits: int = DEFAULT_MAX_COMMITS,
+    max_files: int = DEFAULT_MAX_FILES,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES,
+    max_findings: int = DEFAULT_MAX_FINDINGS,
+) -> RepositorySecretScanResult:
+    """Scan a local file/directory and optionally bounded Git history."""
+
+    root = target.expanduser().resolve()
+    if not root.exists():
+        raise ValueError("secret scan target does not exist")
+    max_commits = _bounded_positive(max_commits, default=DEFAULT_MAX_COMMITS, maximum=50_000)
+    max_files = _bounded_positive(max_files, default=DEFAULT_MAX_FILES, maximum=100_000)
+    max_file_bytes = _bounded_positive(max_file_bytes, default=DEFAULT_MAX_FILE_BYTES, maximum=32 * 1024 * 1024)
+    max_total_bytes = _bounded_positive(max_total_bytes, default=DEFAULT_MAX_TOTAL_BYTES, maximum=4 * 1024 * 1024 * 1024)
+    max_findings = _bounded_positive(max_findings, default=DEFAULT_MAX_FINDINGS, maximum=10_000)
+
+    if root.is_file():
+        scan_root = root.parent
+        working_paths = [root.name]
+        git_repo = False
+    else:
+        scan_root = root
+        git_repo = _is_git_repository(scan_root)
+        working_paths = _git_working_paths(scan_root) if git_repo else None
+        if working_paths is None:
+            working_paths = _filesystem_paths(scan_root)
+
+    findings: list[SecretFinding] = []
+    errors: list[str] = []
+    files_scanned = 0
+    commits_scanned = 0
+    bytes_scanned = 0
+    truncated = False
+
+    for relative_path in working_paths:
+        if files_scanned >= max_files or bytes_scanned >= max_total_bytes or len(findings) >= max_findings:
+            truncated = True
+            break
+        data = _read_working_file(scan_root, relative_path, max_file_bytes)
+        if data is None:
+            continue
+        if bytes_scanned + len(data) > max_total_bytes:
+            truncated = True
+            break
+        found, scanned_bytes = _scan_blob(
+            data,
+            path=relative_path.replace("\\", "/"),
+            source="working_tree",
+            commit=None,
+            finding_budget=max_findings - len(findings),
+        )
+        files_scanned += 1
+        bytes_scanned += scanned_bytes
+        findings.extend(found)
+
+    if include_history and git_repo and len(findings) < max_findings and bytes_scanned < max_total_bytes:
+        commits = _git_commits(scan_root, max_commits)
+        for commit in commits:
+            if len(findings) >= max_findings or bytes_scanned >= max_total_bytes or files_scanned >= max_files:
+                truncated = True
+                break
+            commits_scanned += 1
+            changed_paths = _git_changed_paths(scan_root, commit)
+            for relative_path in changed_paths:
+                if len(findings) >= max_findings or bytes_scanned >= max_total_bytes or files_scanned >= max_files:
+                    truncated = True
+                    break
+                data = _git_blob(scan_root, commit, relative_path, max_file_bytes)
+                if data is None:
+                    continue
+                if bytes_scanned + len(data) > max_total_bytes:
+                    truncated = True
+                    break
+                found, scanned_bytes = _scan_blob(
+                    data,
+                    path=relative_path.replace("\\", "/"),
+                    source="git_history",
+                    commit=commit,
+                    finding_budget=max_findings - len(findings),
+                )
+                files_scanned += 1
+                bytes_scanned += scanned_bytes
+                findings.extend(found)
+        if len(commits) >= max_commits:
+            truncated = True
+    elif include_history and not git_repo:
+        errors.append("history_requested_for_non_git_target")
+
+    # A provider rule can also be recognized by the contextual assignment rule.
+    # Keep occurrences stable while preferring the stronger provider format.
+    deduped: dict[tuple[str, int, str, str | None], SecretFinding] = {}
+    for finding in findings:
+        key = (finding.path, finding.line, finding.candidate, finding.commit)
+        existing = deduped.get(key)
+        if existing is None or finding.confidence_score > existing.confidence_score:
+            deduped[key] = finding
+    ordered = tuple(
+        sorted(
+            deduped.values(),
+            key=lambda item: (item.commit or "", item.path, item.line, item.rule_id),
+        )[:max_findings]
+    )
+    if len(deduped) > len(ordered):
+        truncated = True
+
+    return RepositorySecretScanResult(
+        findings=ordered,
+        files_scanned=files_scanned,
+        commits_scanned=commits_scanned,
+        bytes_scanned=bytes_scanned,
+        history_enabled=include_history,
+        truncated=truncated,
+        errors=tuple(errors),
+    )
+
+
+__all__ = [
+    "DEFAULT_MAX_COMMITS",
+    "DEFAULT_MAX_FILE_BYTES",
+    "DEFAULT_MAX_FILES",
+    "DEFAULT_MAX_FINDINGS",
+    "DEFAULT_MAX_TOTAL_BYTES",
+    "RepositorySecretScanResult",
+    "scan_repository_secrets",
+]

--- a/tests/test_guard_secret_detection.py
+++ b/tests/test_guard_secret_detection.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.secrets import scan_repository_secrets, scan_secret_text, secret_rule_catalog
+
+
+def _github_token() -> str:
+    return "ghp_" + ("A" * 40)
+
+
+def _generic_secret() -> str:
+    return "Q7v9K2mX4pR8sT6wY3nB5cD1fG0hJ9kL"
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True)
+
+
+def test_provider_secret_is_detected_without_public_candidate() -> None:
+    secret = _github_token()
+    result = scan_secret_text(f"GITHUB_TOKEN={secret}\n", path="src/config.py")
+
+    assert len(result.findings) == 1
+    finding = result.findings[0]
+    assert finding.rule_id == "github-token"
+    assert finding.severity == "critical"
+    assert finding.confidence == "high"
+    payload = result.to_public_dict()
+    encoded = json.dumps(payload)
+    assert secret not in encoded
+    assert "candidate" not in encoded
+
+
+def test_provider_secret_remains_detectable_in_documentation() -> None:
+    secret = _github_token()
+    result = scan_secret_text(f"token = {secret}\n", path="docs/example.md")
+
+    assert [finding.rule_id for finding in result.findings] == ["github-token"]
+
+
+def test_contextual_high_entropy_assignment_is_detected() -> None:
+    secret = _generic_secret()
+    result = scan_secret_text(f"PAYMENTS_API_SECRET={secret}\n", path="app/settings.py")
+
+    assert len(result.findings) == 1
+    assert result.findings[0].rule_id == "credential-assignment"
+    assert result.findings[0].confidence in {"medium", "high"}
+
+
+def test_generic_random_value_without_credential_context_is_not_detected() -> None:
+    secret = _generic_secret()
+    result = scan_secret_text(f"BUILD_CACHE_KEY={secret}\n", path="app/settings.py")
+
+    assert result.findings == ()
+
+
+def test_obvious_documentation_placeholder_is_suppressed() -> None:
+    result = scan_secret_text(
+        "API_SECRET=replace_me_with_your_secret\n",
+        path="docs/configuration.md",
+    )
+
+    assert result.findings == ()
+
+
+def test_database_url_password_is_contextually_detected() -> None:
+    password = _generic_secret()
+    result = scan_secret_text(
+        f"DATABASE_URL=postgres://service:{password}@db.internal/app\n",
+        path=".env.production",
+    )
+
+    assert any(finding.rule_id == "database-url-password" for finding in result.findings)
+    assert password not in json.dumps(result.to_public_dict())
+
+
+def test_fingerprint_is_scoped_to_caller_key() -> None:
+    secret = _github_token()
+    finding = scan_secret_text(f"TOKEN={secret}\n").findings[0]
+
+    first = finding.fingerprint(b"tenant-a")
+    second = finding.fingerprint(b"tenant-b")
+    assert first != second
+    assert secret not in first
+    assert secret not in second
+    with pytest.raises(ValueError):
+        finding.fingerprint(b"")
+
+
+def test_rule_catalog_contains_validatable_provider_families() -> None:
+    rules = secret_rule_catalog()
+    validation_kinds = {str(rule["validation"]) for rule in rules}
+
+    assert {"github", "gitlab", "aws", "slack", "stripe", "openai", "anthropic", "npm", "pypi"} <= validation_kinds
+
+
+def test_repository_scan_skips_binary_and_does_not_emit_absolute_path(tmp_path: Path) -> None:
+    secret = _github_token()
+    (tmp_path / "config.py").write_text(f"TOKEN={secret}\n")
+    (tmp_path / "image.png").write_bytes(b"\x89PNG\x00" + secret.encode())
+
+    result = scan_repository_secrets(tmp_path)
+    payload = result.to_public_dict()
+    encoded = json.dumps(payload)
+
+    assert result.findings
+    assert all(not finding.path.startswith(str(tmp_path)) for finding in result.findings)
+    assert secret not in encoded
+    assert "image.png" not in encoded
+
+
+def test_history_scan_finds_secret_removed_from_head(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "guard@example.invalid")
+    _git(tmp_path, "config", "user.name", "Guard Test")
+    secret = _github_token()
+    target = tmp_path / "config.py"
+    target.write_text(f"TOKEN={secret}\n")
+    _git(tmp_path, "add", "config.py")
+    _git(tmp_path, "commit", "-m", "add config")
+    target.write_text("TOKEN_FROM_ENV = True\n")
+    _git(tmp_path, "add", "config.py")
+    _git(tmp_path, "commit", "-m", "remove credential")
+
+    head_only = scan_repository_secrets(tmp_path, include_history=False)
+    history = scan_repository_secrets(tmp_path, include_history=True, max_commits=10)
+
+    assert head_only.findings == ()
+    assert any(finding.source == "git_history" for finding in history.findings)
+    assert secret not in json.dumps(history.to_public_dict())
+
+
+def test_repository_scan_respects_finding_limit(tmp_path: Path) -> None:
+    for index in range(5):
+        (tmp_path / f"secret-{index}.txt").write_text(f"TOKEN={_github_token()}{index}\n")
+
+    result = scan_repository_secrets(tmp_path, max_findings=2)
+
+    assert len(result.findings) <= 2
+    assert result.truncated is True


### PR DESCRIPTION
## Summary

Adds the local leaked-secret detection foundation for Guard while keeping local protection free and independent of Cloud.

- adds provider-aware and contextual credential detection with entropy/token-rarity signals and conservative sample suppression
- detects GitHub, GitLab, AWS, Slack, Stripe, OpenAI, Anthropic, Hugging Face, npm, PyPI, Google, SendGrid, private-key, database-URL, JWT, and contextual credential families
- adds bounded working-tree and Git-history scanning without shell execution or network access
- exposes a reusable `codex_plugin_scanner.guard.secrets` Python API for local/runtime integration
- makes public finding payloads structurally incapable of serializing raw candidate bytes
- exposes explicit caller-scoped HMAC fingerprinting for later Cloud correlation without a global cross-tenant hash

## Privacy and security invariants

- detection is local, deterministic, and network-free
- raw candidate values never appear in serialized finding output
- absolute local paths are not emitted
- binary/oversized inputs and total work are bounded
- Git history is read with argument-vector subprocess calls, never shell interpolation
- generic candidates require contextual evidence and obvious samples are suppressed
- complete local leaked-secret scanning remains free and independent of Cloud/billing

## Evidence boundary

The detector lives in a dedicated `guard/secrets` package. It does not participate in the command-decision evaluator, so this PR does not alter the frozen command-decision attestation or its 51k-case evidence fixture.

## Release boundary

Base is intentionally `release/3.0`. Do not retarget or merge this PR to `main`.

## Validation

Focused detector/history regression tests are included. GitHub CI is the authoritative full-suite validation for the exact PR head.