### PR TITLE
fix(approvals): restore permanent MCP action trust

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14198,
-  "maximum_test_source_lines": 312913,
+  "maximum_collected_cases": 14203,
+  "maximum_test_source_lines": 313016,
   "schema_version": 1
 }

--- a/dashboard/src/review-scope-controls.tsx
+++ b/dashboard/src/review-scope-controls.tsx
@@ -134,7 +134,7 @@ function ExactActionPersistenceChoice(props: { checked: boolean; onChange: (chec
       <span>
         <span className="block text-sm font-medium text-brand-dark">Always allow this exact action</span>
         <span className="mt-0.5 block text-xs text-muted-foreground">
-          Save only this exact command for this AI app. Changed commands still need review.
+          Save only this exact action for this AI app. Changed actions still need review.
         </span>
       </span>
     </label>

--- a/src/codex_plugin_scanner/guard/approval_scope_support.py
+++ b/src/codex_plugin_scanner/guard/approval_scope_support.py
@@ -15,6 +15,7 @@ from .package_execution_context import (
     PackageExecutionContext,
     package_execution_context_from_scanner_evidence,
 )
+from .runtime.approval_context import parse_approval_context_token
 from .runtime.github_workflow_runtime import approval_record_from_approval_request
 from .temporary_mcp_approvals import temporary_mcp_approval_payload
 from .trusted_local_tools import local_tool_approval_payload
@@ -221,12 +222,21 @@ def request_scope_contract_payload(request: Mapping[str, object]) -> dict[str, o
 def exact_action_allow_persistence_eligible(request: Mapping[str, object]) -> bool:
     """Return whether an artifact allow can be saved as one exact action."""
 
-    if _allow_is_non_overridable(request) or _string_or_none(request.get("artifact_type")) != "tool_action_request":
+    if _allow_is_non_overridable(request):
+        return False
+    artifact_type = _string_or_none(request.get("artifact_type"))
+    artifact_id = _string_or_none(request.get("artifact_id"))
+    artifact_hash = _string_or_none(request.get("artifact_hash"))
+    if artifact_type == "tool_call":
+        return bool(
+            artifact_id
+            and parse_approval_context_token(artifact_hash) is not None
+            and _string_or_none(request.get("raw_command_text"))
+        )
+    if artifact_type != "tool_action_request":
         return False
     if _request_scoped_family_key(request) != "family:tool-action":
         return False
-    artifact_id = _string_or_none(request.get("artifact_id"))
-    artifact_hash = _string_or_none(request.get("artifact_hash"))
     action_identity = _string_or_none(request.get("action_identity"))
     raw_command_text = _string_or_none(request.get("raw_command_text"))
     envelope = request.get("action_envelope_json")

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -27972,7 +27972,7 @@ function ExactActionPersistenceChoice(props) {
     ),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "block text-sm font-medium text-brand-dark", children: "Always allow this exact action" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-0.5 block text-xs text-muted-foreground", children: "Save only this exact command for this AI app. Changed commands still need review." })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-0.5 block text-xs text-muted-foreground", children: "Save only this exact action for this AI app. Changed actions still need review." })
     ] })
   ] });
 }

--- a/tests/test_guard_approval_scope_contract.py
+++ b/tests/test_guard_approval_scope_contract.py
@@ -21,6 +21,7 @@ from codex_plugin_scanner.guard.approval_scope_support import (
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.models import GuardAction, GuardApprovalRequest
+from codex_plugin_scanner.guard.runtime.approval_context import build_approval_context_token
 from codex_plugin_scanner.guard.store import GuardStore, runtime_tool_action_exact_match_context
 
 
@@ -435,6 +436,108 @@ def test_exact_action_persistence_accepts_envelope_raw_command_text(tmp_path: Pa
     row = _store_request(store, request)
 
     assert request_scope_contract(row).exact_action_persistence_eligible is True
+
+
+def test_exact_action_persistence_accepts_context_bound_tool_call(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    context_token = build_approval_context_token(
+        identity={"server": "browser", "tool": "navigate"},
+        content={"url": "http://127.0.0.1:3000"},
+        capabilities={"risk_categories": ["browser_navigation"]},
+        policy={"action": "review"},
+        sandbox={"mode": "workspace-write"},
+    )
+    request = replace(
+        _request(
+            "context-bound-tool-call",
+            artifact_id="codex:runtime:global:browser:navigate",
+            artifact_type="tool_call",
+            artifact_hash=context_token,
+        ),
+        raw_command_text="navigate http://127.0.0.1:3000",
+    )
+    row = _store_request(store, request)
+
+    assert request_scope_contract(row).exact_action_persistence_eligible is True
+
+
+def test_v2_saved_tool_call_allow_remains_bound_to_exact_context(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    context_token = build_approval_context_token(
+        identity={"server": "browser", "tool": "navigate"},
+        content={"url": "http://127.0.0.1:3000"},
+        capabilities={"risk_categories": ["browser_navigation"]},
+        policy={"action": "review"},
+        sandbox={"mode": "workspace-write"},
+    )
+    artifact_id = "codex:runtime:global:browser:navigate"
+    request = replace(
+        _request(
+            "saved-tool-call",
+            artifact_id=artifact_id,
+            artifact_type="tool_call",
+            artifact_hash=context_token,
+        ),
+        raw_command_text="navigate http://127.0.0.1:3000",
+    )
+    row = _store_request(store, request)
+    payload = {**_v2_selection(row, "artifact"), "persist_policy": True}
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, response = _post(daemon, "/v1/requests/saved-tool-call/approve", payload)
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert response["applied_scope"] == "artifact"
+    decisions = store.list_policy_decisions()
+    assert len(decisions) == 1
+    assert decisions[0]["expires_at"] is None
+    assert (
+        store.resolve_policy(
+            "codex",
+            artifact_id,
+            context_token,
+            now="2026-07-19T00:01:00+00:00",
+            consume_one_shot=False,
+        )
+        == "allow"
+    )
+    changed_token = build_approval_context_token(
+        identity={"server": "browser", "tool": "navigate"},
+        content={"url": "https://example.com"},
+        capabilities={"risk_categories": ["browser_navigation"]},
+        policy={"action": "review"},
+        sandbox={"mode": "workspace-write"},
+    )
+    assert (
+        store.resolve_policy(
+            "codex",
+            artifact_id,
+            changed_token,
+            now="2026-07-19T00:02:00+00:00",
+            consume_one_shot=False,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("artifact_hash", ["unknown", "plain-hash", "guard-approval-context:v1:invalid"])
+def test_exact_action_persistence_rejects_unbound_tool_call(tmp_path: Path, artifact_hash: str) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    request = replace(
+        _request(
+            f"unbound-tool-call-{len(artifact_hash)}",
+            artifact_id="codex:runtime:global:browser:navigate",
+            artifact_type="tool_call",
+            artifact_hash=artifact_hash,
+        ),
+        raw_command_text="navigate http://127.0.0.1:3000",
+    )
+    row = _store_request(store, request)
+
+    assert request_scope_contract(row).exact_action_persistence_eligible is False
 
 
 def test_legacy_unknown_broad_deny_is_not_silently_narrowed(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- allow context-bound MCP tool calls to save a permanent exact-action decision
- keep malformed and changed action contexts subject to fresh review
- describe the saved scope consistently as an exact action

## Testing
- `uv run --no-sync pytest -q tests/test_guard_approval_scope_contract.py tests/test_guard_approval_reuse.py tests/test_guard_temporary_mcp_approvals.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/approval_scope_support.py tests/test_guard_approval_scope_contract.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/approval_scope_support.py tests/test_guard_approval_scope_contract.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/guard/approval_scope_support.py tests/test_guard_approval_scope_contract.py`
- `bun run test`
- `bun run build`
