### PR TITLE
feat(guard): use resident Rust runtime for PostToolUse

### DIFF
--- a/.github/workflows/rust-runtime-differential.yml
+++ b/.github/workflows/rust-runtime-differential.yml
@@ -1,0 +1,63 @@
+name: Rust runtime differential
+
+on:
+  pull_request:
+    branches: [release/3.0]
+    paths:
+      - "rust/**"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/runtime/hook_*.py"
+      - "ci/native_runtime/test_guard_native_runtime_differential.py"
+      - ".github/workflows/rust-runtime-differential.yml"
+  push:
+    branches: [release/3.0]
+    paths:
+      - "rust/**"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/runtime/hook_*.py"
+      - "ci/native_runtime/test_guard_native_runtime_differential.py"
+      - ".github/workflows/rust-runtime-differential.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-runtime-differential-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  differential:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal
+          rustup default 1.88.0
+      - name: Build version-matched native runtime
+        env:
+          HOL_GUARD_BUILD_SHA: ${{ github.sha }}
+        run: |
+          VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          export HOL_GUARD_PACKAGE_VERSION="$VERSION"
+          cargo build --manifest-path rust/Cargo.toml --locked --release -p hol-guard-runtime
+          rust/target/release/hol-guard-runtime self-test --json
+      - name: Compare Python and Rust decisions
+        env:
+          HOL_GUARD_NATIVE: force
+          HOL_GUARD_NATIVE_BINARY: ${{ github.workspace }}/rust/target/release/hol-guard-runtime
+        run: uv run --no-sync pytest ci/native_runtime/test_guard_native_runtime_differential.py --tb=short

--- a/.github/workflows/rust-runtime.yml
+++ b/.github/workflows/rust-runtime.yml
@@ -6,16 +6,24 @@ on:
     paths:
       - "rust/**"
       - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py"
       - "src/codex_plugin_scanner/guard/daemon/hook_worker.py"
       - "tests/test_guard_native_runtime.py"
+      - "ci/native_runtime/test_guard_native_runtime_binary.py"
+      - "ci/native_runtime/test_guard_native_runtime_resident.py"
       - ".github/workflows/rust-runtime.yml"
   pull_request:
     branches: [release/3.0]
     paths:
       - "rust/**"
       - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py"
       - "src/codex_plugin_scanner/guard/daemon/hook_worker.py"
       - "tests/test_guard_native_runtime.py"
+      - "ci/native_runtime/test_guard_native_runtime_binary.py"
+      - "ci/native_runtime/test_guard_native_runtime_resident.py"
       - ".github/workflows/rust-runtime.yml"
   workflow_dispatch:
 
@@ -76,6 +84,59 @@ jobs:
           version: "0.9.26"
           enable-cache: true
       - run: uv sync --frozen --extra dev --python 3.12
-      - run: uv run --no-sync python -m ruff check src/codex_plugin_scanner/guard/native_runtime.py tests/test_guard_native_runtime.py
-      - run: uv run --no-sync python -m ruff format --check src/codex_plugin_scanner/guard/native_runtime.py
-      - run: uv run --no-sync pytest tests/test_guard_native_runtime.py tests/test_guard_hook_process_deadline_contract.py --tb=short
+      - name: Lint native Python boundary
+        run: >-
+          uv run --no-sync python -m ruff check
+          src/codex_plugin_scanner/guard/native_runtime.py
+          src/codex_plugin_scanner/guard/native_runtime_resident.py
+          tests/test_guard_native_runtime.py
+          ci/native_runtime/test_guard_native_runtime_binary.py
+          ci/native_runtime/test_guard_native_runtime_resident.py
+      - name: Format native Python boundary
+        run: >-
+          uv run --no-sync python -m ruff format --check
+          src/codex_plugin_scanner/guard/native_runtime.py
+          src/codex_plugin_scanner/guard/native_runtime_resident.py
+          tests/test_guard_native_runtime.py
+          ci/native_runtime/test_guard_native_runtime_binary.py
+          ci/native_runtime/test_guard_native_runtime_resident.py
+      - name: Run native Python boundary tests
+        run: >-
+          uv run --no-sync pytest
+          tests/test_guard_native_runtime.py
+          ci/native_runtime/test_guard_native_runtime_resident.py
+          tests/test_guard_hook_process_deadline_contract.py
+          --tb=short
+
+  resident-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal
+          rustup default 1.88.0
+      - name: Build version-matched runtime
+        env:
+          HOL_GUARD_BUILD_SHA: ${{ github.sha }}
+        run: |
+          VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          export HOL_GUARD_PACKAGE_VERSION="$VERSION"
+          cargo build --manifest-path rust/Cargo.toml --locked --release -p hol-guard-runtime
+          rust/target/release/hol-guard-runtime self-test --json
+      - name: Exercise real resident runtime
+        env:
+          HOL_GUARD_NATIVE: force
+          HOL_GUARD_NATIVE_BINARY: ${{ github.workspace }}/rust/target/release/hol-guard-runtime
+        run: uv run --no-sync pytest ci/native_runtime/test_guard_native_runtime_binary.py --tb=short

--- a/ci/native_runtime/test_guard_native_runtime_binary.py
+++ b/ci/native_runtime/test_guard_native_runtime_binary.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib.metadata
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.native_runtime import native_runtime_status, review_post_tool_native
+from codex_plugin_scanner.guard.native_runtime_resident import (
+    close_resident_native_runtimes,
+    resident_service_starts,
+)
+from codex_plugin_scanner.guard.runtime.hook_review_types import HookReviewRequest
+
+_NATIVE_BINARY = os.environ.get("HOL_GUARD_NATIVE_BINARY")
+pytestmark = pytest.mark.skipif(not _NATIVE_BINARY, reason="compiled native runtime is required")
+
+
+def _request(tmp_path: Path, text: str) -> HookReviewRequest:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(mode=0o700, exist_ok=True)
+    return HookReviewRequest(
+        harness="claude-code",
+        event_name="PostToolUse",
+        payload={
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Read",
+            "tool_response": [{"type": "text", "text": text}],
+        },
+        payload_kind="inline",
+        config_path=None,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+        guard_home=guard_home,
+        source_scope="project",
+        request_id="native-binary-proof",
+    )
+
+
+def _github_like_token() -> str:
+    prefix = "".join(("gh", "p_"))
+    return prefix + "c" * 30
+
+
+def test_compiled_native_runtime_reviews_and_reuses_resident_service(tmp_path: Path) -> None:
+    status = native_runtime_status()
+    assert status.available and status.compatible, status
+    assert status.identity is not None
+    assert status.capabilities is not None
+    assert status.capabilities.runtime_version == importlib.metadata.version("hol-guard")
+    assert "post-tool-inline-v1" in status.capabilities.features
+
+    with tempfile.TemporaryDirectory(prefix="hgr-", dir="/tmp" if os.name != "nt" else None) as short_tmp:
+        clean_request = _request(Path(short_tmp), "const value = 1;\n")
+        try:
+            clean = review_post_tool_native(clean_request, observe_mode=False)
+            assert clean is not None
+            assert clean.decision == "allow"
+            assert clean.reason_code == "output_scan_allow"
+
+            secret_request = _request(Path(short_tmp), _github_like_token())
+            secret = review_post_tool_native(secret_request, observe_mode=False)
+            assert secret is not None
+            assert secret.decision == "deny"
+            assert secret.reason_code == "output_secret_match"
+
+            if os.name != "nt":
+                assert (
+                    resident_service_starts(
+                        executable=status.identity.path,
+                        identity_sha256=status.identity.sha256,
+                        guard_home=clean_request.guard_home,
+                    )
+                    == 1
+                )
+        finally:
+            close_resident_native_runtimes()

--- a/ci/native_runtime/test_guard_native_runtime_differential.py
+++ b/ci/native_runtime/test_guard_native_runtime_differential.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.config import load_guard_config
+from codex_plugin_scanner.guard.native_runtime import parity_signature, review_post_tool_native
+from codex_plugin_scanner.guard.native_runtime_resident import close_resident_native_runtimes
+from codex_plugin_scanner.guard.runtime.hook_content_scanner import ContentScanner
+from codex_plugin_scanner.guard.runtime.hook_decision_cache import HookDecisionCache
+from codex_plugin_scanner.guard.runtime.hook_review_engine import HookReviewEngine
+from codex_plugin_scanner.guard.runtime.hook_review_types import HookReviewRequest, HookSourceFileRef
+from codex_plugin_scanner.guard.runtime.hook_source_read import sha256_text
+from codex_plugin_scanner.guard.store import GuardStore
+
+_NATIVE_BINARY = os.environ.get("HOL_GUARD_NATIVE_BINARY")
+pytestmark = pytest.mark.skipif(not _NATIVE_BINARY, reason="compiled native runtime is required")
+
+
+def _secret_token() -> str:
+    return "".join(("gh", "p_")) + "d" * 30
+
+
+def _engine(store: GuardStore) -> HookReviewEngine:
+    return HookReviewEngine(
+        store=store,
+        scanner=ContentScanner(),
+        cache=HookDecisionCache(store),
+        config_loader=lambda guard_home, workspace: load_guard_config(guard_home, workspace=workspace),
+    )
+
+
+def _inline_request(
+    *,
+    tmp_path: Path,
+    payload: dict[str, object],
+    request_id: str,
+) -> HookReviewRequest:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(mode=0o700, exist_ok=True)
+    return HookReviewRequest(
+        harness="claude-code",
+        event_name="PostToolUse",
+        payload={"hook_event_name": "PostToolUse", **payload},
+        payload_kind="inline",
+        config_path=None,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+        guard_home=guard_home,
+        source_scope="project",
+        request_id=request_id,
+        deadline_monotonic=time.monotonic() + 5.0,
+    )
+
+
+def _source_request(*, tmp_path: Path, relative_path: str, text: str, request_id: str) -> HookReviewRequest:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(mode=0o700, exist_ok=True)
+    path = tmp_path / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    source_ref = HookSourceFileRef(
+        version=1,
+        path=relative_path,
+        output_sha256=sha256_text(text),
+        output_chars=len(text),
+        tool_input_path=relative_path,
+    )
+    return HookReviewRequest(
+        harness="pi",
+        event_name="PostToolUse",
+        payload={
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": relative_path},
+            "guard_source_ref": {
+                "version": 1,
+                "path": relative_path,
+                "output_sha256": source_ref.output_sha256,
+                "output_chars": source_ref.output_chars,
+                "tool_input_path": relative_path,
+            },
+        },
+        payload_kind="source_file_ref",
+        config_path=None,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+        guard_home=guard_home,
+        source_scope="project",
+        source_ref=source_ref,
+        request_id=request_id,
+        deadline_monotonic=time.monotonic() + 5.0,
+    )
+
+
+def _assert_parity(request: HookReviewRequest) -> None:
+    store = GuardStore(request.guard_home)
+    python_response = _engine(store).review(request)
+    native_response = review_post_tool_native(request, observe_mode=False)
+    assert native_response is not None
+    assert parity_signature(native_response) == parity_signature(python_response), (
+        native_response,
+        python_response,
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "payload"),
+    [
+        ("clean-small", {"tool_response": [{"type": "text", "text": "const value = 1;\n"}]}),
+        ("empty", {"tool_response": ""}),
+        (
+            "multi-field-clean",
+            {"stdout": "build complete\n", "stderr": "", "result": [{"type": "text", "text": "ok"}]},
+        ),
+        (
+            "docs-placeholder",
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "docs/example.md"},
+                "tool_response": [{"type": "text", "text": "token = placeholder-only\n"}],
+            },
+        ),
+        (
+            "large-clean",
+            {"tool_response": [{"type": "text", "text": "const x = 1;\n" * 15_000}]},
+        ),
+    ],
+)
+def test_compiled_native_inline_allow_parity(tmp_path: Path, name: str, payload: dict[str, object]) -> None:
+    try:
+        _assert_parity(_inline_request(tmp_path=tmp_path, payload=payload, request_id=name))
+    finally:
+        close_resident_native_runtimes()
+
+
+def test_compiled_native_inline_secret_parity(tmp_path: Path) -> None:
+    try:
+        _assert_parity(
+            _inline_request(
+                tmp_path=tmp_path,
+                payload={"stdout": "ok", "stderr": _secret_token()},
+                request_id="inline-secret",
+            )
+        )
+    finally:
+        close_resident_native_runtimes()
+
+
+def test_compiled_native_clean_source_read_parity(tmp_path: Path) -> None:
+    try:
+        _assert_parity(
+            _source_request(
+                tmp_path=tmp_path,
+                relative_path="src/example.ts",
+                text="export const value = 1;\n",
+                request_id="source-clean",
+            )
+        )
+    finally:
+        close_resident_native_runtimes()
+
+
+def test_compiled_native_secret_source_read_parity(tmp_path: Path) -> None:
+    try:
+        _assert_parity(
+            _source_request(
+                tmp_path=tmp_path,
+                relative_path="src/private.ts",
+                text=f"export const value = '{_secret_token()}';\n",
+                request_id="source-secret",
+            )
+        )
+    finally:
+        close_resident_native_runtimes()

--- a/ci/native_runtime/test_guard_native_runtime_resident.py
+++ b/ci/native_runtime/test_guard_native_runtime_resident.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon.hook_worker import HookWorker
+from codex_plugin_scanner.guard.native_runtime_resident import (
+    close_resident_native_runtimes,
+    resident_native_request,
+    resident_service_starts,
+)
+from codex_plugin_scanner.guard.runtime.hook_review_types import HookReviewResponse
+from codex_plugin_scanner.guard.store import GuardStore
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="resident runtime currently uses owner-only Unix sockets")
+
+
+def _fake_runtime(path: Path) -> Path:
+    executable = path / "fake-native-runtime"
+    executable.write_text(
+        f"""#!{sys.executable}
+import socket
+import sys
+
+socket_path = sys.argv[3]
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+server.bind(socket_path)
+while True:
+    server.listen(8)
+    client, _ = server.accept()
+    with client:
+        header = client.recv(4)
+        if len(header) != 4:
+            continue
+        length = int.from_bytes(header, 'big')
+        remaining = length
+        while remaining:
+            chunk = client.recv(min(remaining, 65536))
+            if not chunk:
+                break
+            remaining -= len(chunk)
+        if remaining:
+            continue
+        response = b'{{"decision":"allow","model_output_action":"allow_original","notice":"none","reason_code":"ok"}}'
+        client.sendall(len(response).to_bytes(4, 'big') + response)
+""",
+        encoding="utf-8",
+    )
+    executable.chmod(0o700)
+    return executable
+
+
+def test_resident_runtime_reuses_one_contained_service() -> None:
+    with tempfile.TemporaryDirectory(prefix="hgr-", dir="/tmp") as short_tmp:
+        root = Path(short_tmp)
+        executable = _fake_runtime(root)
+        guard_home = root / "guard-home"
+        guard_home.mkdir(mode=0o700)
+        identity = "a" * 64
+        environment = {"HOME": str(root)}
+        try:
+            first = resident_native_request(
+                executable=executable,
+                identity_sha256=identity,
+                guard_home=guard_home,
+                environment=environment,
+                payload=b"{}",
+                timeout_seconds=1.0,
+            )
+            second = resident_native_request(
+                executable=executable,
+                identity_sha256=identity,
+                guard_home=guard_home,
+                environment=environment,
+                payload=b"{}",
+                timeout_seconds=1.0,
+            )
+            assert first == second
+            assert first is not None and b'"decision":"allow"' in first
+            assert (
+                resident_service_starts(
+                    executable=executable,
+                    identity_sha256=identity,
+                    guard_home=guard_home,
+                )
+                == 1
+            )
+            runtime_dir = guard_home / "native-runtime"
+            assert stat.S_IMODE(runtime_dir.stat().st_mode) == 0o700
+        finally:
+            close_resident_native_runtimes()
+
+        assert not any((guard_home / "native-runtime").glob("*.sock"))
+
+
+def test_resident_runtime_falls_back_for_overlong_socket_path(tmp_path: Path) -> None:
+    executable = _fake_runtime(tmp_path)
+    guard_home = tmp_path
+    for index in range(8):
+        guard_home = guard_home / (f"very-long-private-runtime-directory-{index}" * 2)
+    guard_home.mkdir(parents=True, mode=0o700)
+    try:
+        assert (
+            resident_native_request(
+                executable=executable,
+                identity_sha256="b" * 64,
+                guard_home=guard_home,
+                environment={"HOME": str(tmp_path)},
+                payload=b"{}",
+                timeout_seconds=0.25,
+            )
+            is None
+        )
+    finally:
+        close_resident_native_runtimes()
+
+
+def _allow_response(reason_code: str) -> HookReviewResponse:
+    return HookReviewResponse(
+        decision="allow",
+        reason=None,
+        model_output_action="allow_original",
+        notice="none",
+        reason_code=reason_code,
+        policy_action="allow",
+    )
+
+
+def test_hook_worker_auto_is_native_first(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    worker = HookWorker(store=store)
+    native_calls = 0
+
+    def fake_native(*args: object, **kwargs: object) -> HookReviewResponse:
+        nonlocal native_calls
+        native_calls += 1
+        return _allow_response("native_allow")
+
+    def fail_python(*args: object, **kwargs: object) -> HookReviewResponse:
+        raise AssertionError("Python engine should not run after an authoritative native result")
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "auto")
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.review_post_tool_native", fake_native)
+    monkeypatch.setattr(worker.engine, "review", fail_python)
+
+    result = worker.review_http_payload(
+        payload={"hook_event_name": "PostToolUse", "tool_response": "clean output"},
+        params={},
+        default_harness="claude-code",
+        home_dir=tmp_path,
+        guard_home=store.guard_home,
+        workspace=tmp_path,
+    )
+    assert native_calls == 1
+    assert result == {"policy_action": "allow", "hookSpecificOutput": {"hookEventName": "PostToolUse"}}
+
+
+def test_hook_worker_auto_falls_back_to_python(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    worker = HookWorker(store=store)
+    python_calls = 0
+
+    def fake_python(*args: object, **kwargs: object) -> HookReviewResponse:
+        nonlocal python_calls
+        python_calls += 1
+        return _allow_response("python_fallback")
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "auto")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_post_tool_native",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(worker.engine, "review", fake_python)
+
+    result = worker.review_http_payload(
+        payload={"hook_event_name": "PostToolUse", "tool_response": "clean output"},
+        params={},
+        default_harness="claude-code",
+        home_dir=tmp_path,
+        guard_home=store.guard_home,
+        workspace=tmp_path,
+    )
+    assert python_calls == 1
+    assert result["policy_action"] == "allow"
+
+
+def test_hook_worker_shadow_keeps_python_authoritative(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    worker = HookWorker(store=store)
+    native_calls = 0
+    python_calls = 0
+
+    def fake_python(*args: object, **kwargs: object) -> HookReviewResponse:
+        nonlocal python_calls
+        python_calls += 1
+        return _allow_response("python_authoritative")
+
+    def fake_native(*args: object, **kwargs: object) -> HookReviewResponse:
+        nonlocal native_calls
+        native_calls += 1
+        return HookReviewResponse(
+            decision="deny",
+            reason="native mismatch",
+            model_output_action="block",
+            notice="warning",
+            reason_code="native_deny",
+        )
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "shadow")
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.review_post_tool_native", fake_native)
+    monkeypatch.setattr(worker.engine, "review", fake_python)
+
+    result = worker.review_http_payload(
+        payload={"hook_event_name": "PostToolUse", "tool_response": "clean output"},
+        params={},
+        default_harness="claude-code",
+        home_dir=tmp_path,
+        guard_home=store.guard_home,
+        workspace=tmp_path,
+    )
+    assert python_calls == 1
+    assert native_calls == 1
+    assert result["policy_action"] == "allow"
+
+
+def test_hook_worker_shadow_ignores_native_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    worker = HookWorker(store=store)
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "shadow")
+    monkeypatch.setattr(worker.engine, "review", lambda *args, **kwargs: _allow_response("python_authoritative"))
+
+    def fail_native(*args: object, **kwargs: object) -> HookReviewResponse:
+        raise RuntimeError("synthetic native failure")
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.review_post_tool_native", fail_native)
+
+    result = worker.review_http_payload(
+        payload={"hook_event_name": "PostToolUse", "tool_response": "clean output"},
+        params={},
+        default_harness="claude-code",
+        home_dir=tmp_path,
+        guard_home=store.guard_home,
+        workspace=tmp_path,
+    )
+    assert result == {"policy_action": "allow", "hookSpecificOutput": {"hookEventName": "PostToolUse"}}

--- a/rust/crates/guard-runtime/src/main.rs
+++ b/rust/crates/guard-runtime/src/main.rs
@@ -16,6 +16,7 @@ const PACKAGE_VERSION: &str = match option_env!("HOL_GUARD_PACKAGE_VERSION") {
     Some(value) => value,
     None => env!("CARGO_PKG_VERSION"),
 };
+const MAX_RESIDENT_CONCURRENCY: usize = 16;
 
 fn capabilities() -> RuntimeCapabilitiesV1 {
     RuntimeCapabilitiesV1 {
@@ -29,6 +30,7 @@ fn capabilities() -> RuntimeCapabilitiesV1 {
             "post-tool-source-read-v1".into(),
             "oneshot-v1".into(),
             "framed-serve-v1".into(),
+            "bounded-concurrency-v1".into(),
         ],
     }
 }
@@ -69,6 +71,8 @@ fn serve(socket_path: &str) -> Result<(), String> {
     use std::os::unix::fs::PermissionsExt;
     use std::os::unix::net::{UnixListener, UnixStream};
     use std::path::Path;
+    use std::sync::{Arc, Condvar, Mutex};
+    use std::thread;
 
     fn handle(mut stream: UnixStream) -> Result<(), String> {
         let mut header = [0u8; 4];
@@ -104,13 +108,31 @@ fn serve(socket_path: &str) -> Result<(), String> {
     let listener = UnixListener::bind(path).map_err(|_| "native_socket_bind_failed".to_owned())?;
     fs::set_permissions(path, fs::Permissions::from_mode(0o600))
         .map_err(|_| "native_socket_permissions_failed".to_owned())?;
+
+    let permits = Arc::new((Mutex::new(MAX_RESIDENT_CONCURRENCY), Condvar::new()));
     for stream in listener.incoming() {
-        match stream {
-            Ok(stream) => {
-                let _ = handle(stream);
+        let stream = stream.map_err(|_| "native_socket_accept_failed".to_owned())?;
+        let thread_permits = Arc::clone(&permits);
+        {
+            let (lock, available) = &*thread_permits;
+            let mut remaining = lock
+                .lock()
+                .map_err(|_| "native_runtime_concurrency_poisoned".to_owned())?;
+            while *remaining == 0 {
+                remaining = available
+                    .wait(remaining)
+                    .map_err(|_| "native_runtime_concurrency_poisoned".to_owned())?;
             }
-            Err(_) => return Err("native_socket_accept_failed".into()),
+            *remaining -= 1;
         }
+        thread::spawn(move || {
+            let _ = handle(stream);
+            let (lock, available) = &*thread_permits;
+            if let Ok(mut remaining) = lock.lock() {
+                *remaining = (*remaining + 1).min(MAX_RESIDENT_CONCURRENCY);
+                available.notify_one();
+            }
+        });
     }
     Ok(())
 }

--- a/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
@@ -209,8 +209,14 @@ def run_isolated_hook_process(
     timeout_seconds: float,
     output_limit: int = _HOOK_SUBPROCESS_OUTPUT_LIMIT,
     allow_windows_breakaway: bool = False,
+    stop_event: threading.Event | None = None,
 ) -> BoundedHookProcessResult:
-    """Run one child with bounded input lifetime and combined output bytes."""
+    """Run one child with bounded input lifetime and combined output bytes.
+
+    ``stop_event`` lets a long-lived reviewed helper terminate through the same
+    process-group / Windows Job containment path used for deadlines. Existing
+    one-shot callers do not need to supply it.
+    """
 
     if _HOOK_PROCESS_CONTAINMENT_FAILED.is_set() and not _retry_quarantined_hook_processes():
         return BoundedHookProcessResult(None, "", False, False, containment_failed=True)
@@ -277,6 +283,9 @@ def run_isolated_hook_process(
     timed_out = False
     containment_confirmed = True
     while process.poll() is None:
+        if stop_event is not None and stop_event.is_set():
+            containment_confirmed = _kill_hook_process(process, windows_job)
+            break
         if output_limit_exceeded.is_set():
             containment_confirmed = _kill_hook_process(process, windows_job)
             break

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker.py
@@ -2,18 +2,21 @@
 
 This worker avoids Python startup/import cost and avoids calling the
 CLI path for normal daemon hooks. It builds a ``HookReviewRequest``
-from the HTTP payload and calls ``HookReviewEngine.review()``.
+from the HTTP payload and calls the configured local decision backend.
 
 Security:
 - Never lets unreviewed tool output reach the model.
 - Never falls back to legacy CLI after a worker exception for a
   request that supplied only ``guard_source_ref`` without full output.
 - Never calls ``run_guard_command()``.
+- Native authority is limited to PostToolUse and falls back to Python on
+  any unavailable, incompatible, timeout, transport, or invalid-response case.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, final
 
@@ -22,7 +25,7 @@ from ..cli.commands_support_command_activity import (
     record_post_hook_command_activity_best_effort,
 )
 from ..config import load_guard_config
-from ..native_runtime import choose_post_tool_response
+from ..native_runtime import native_mode, review_post_tool_native
 from ..runtime.hook_content_scanner import ContentScanner
 from ..runtime.hook_decision_cache import HookDecisionCache
 from ..runtime.hook_review_engine import HookReviewEngine
@@ -97,9 +100,10 @@ class HookWorker:
     ) -> dict[str, object]:
         """Review a hook HTTP payload and return harness JSON.
 
-        PostToolUse remains the only fast-path event. Python is always evaluated
-        while the native backend is off or shadowed; explicit auto/force modes
-        may select the version-matched native result after compatibility checks.
+        ``off`` keeps the Python engine authoritative. ``shadow`` evaluates
+        Python first and exercises native only as non-authoritative evidence.
+        ``auto`` and ``force`` try the native runtime first and invoke Python
+        only when native cannot produce a valid local result.
         """
         harness = self._runtime_harness(params) or default_harness
         event_name = self._hook_event_name(payload)
@@ -115,13 +119,26 @@ class HookWorker:
             workspace=workspace,
             deadline=deadline,
         )
-        python_response = self.engine.review(request)
-        config = self._load_config(guard_home, workspace)
-        response = choose_post_tool_response(
-            request,
-            python_response=python_response,
-            observe_mode=config.mode == "observe",
-        )
+        mode = native_mode()
+        if mode in {"auto", "force"}:
+            config = self._load_config(guard_home, workspace)
+            response = review_post_tool_native(
+                request,
+                observe_mode=config.mode == "observe",
+            )
+            if response is None:
+                response = self.engine.review(request)
+        else:
+            response = self.engine.review(request)
+            if mode == "shadow":
+                # Shadow evidence is explicitly non-authoritative. No native
+                # failure may replace or discard the completed Python result.
+                with suppress(Exception):
+                    _ = review_post_tool_native(
+                        request,
+                        observe_mode=response.observe_mode,
+                    )
+
         succeeded = hook_post_succeeded(event_name, payload)
         if self.activity_writer is not None:
             _ = self.activity_writer.submit_command_activity(

--- a/src/codex_plugin_scanner/guard/native_runtime.py
+++ b/src/codex_plugin_scanner/guard/native_runtime.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Literal, cast
 
 from .codex_hook_launch_runtime import run_isolated_hook_process
+from .native_runtime_resident import resident_native_request
 from .runtime.hook_review_types import HookReviewRequest, HookReviewResponse
 
 NativeMode = Literal["off", "shadow", "auto", "force"]
@@ -315,9 +316,28 @@ def review_post_tool_native(request: HookReviewRequest, *, observe_mode: bool) -
         "deadline_budget_ms": _deadline_budget_ms(request),
     }
     input_text = json.dumps(envelope, separators=(",", ":"), ensure_ascii=False)
-    if len(input_text.encode("utf-8")) > _MAX_REQUEST_BYTES:
+    encoded = input_text.encode("utf-8")
+    if len(encoded) > _MAX_REQUEST_BYTES:
         return None
     timeout_seconds = max(0.05, min(9.0, _deadline_budget_ms(request) / 1000.0))
+
+    resident_output = resident_native_request(
+        executable=status.identity.path,
+        identity_sha256=status.identity.sha256,
+        guard_home=request.guard_home,
+        environment=_isolated_environment(),
+        payload=encoded,
+        timeout_seconds=timeout_seconds,
+    )
+    if resident_output is not None:
+        try:
+            payload = json.loads(resident_output)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            payload = None
+        response = _response_from_payload(payload)
+        if response is not None:
+            return response
+
     output = _run_native_process(
         status.identity.path,
         ("hook", "--stdin"),

--- a/src/codex_plugin_scanner/guard/native_runtime_resident.py
+++ b/src/codex_plugin_scanner/guard/native_runtime_resident.py
@@ -1,0 +1,272 @@
+"""Resident local transport for the Rust PostToolUse runtime.
+
+The resident service is POSIX-only in this wave. It runs through Guard's
+existing contained process launcher, speaks a length-prefixed protocol over an
+owner-only Unix socket, and falls back to the one-shot native path on any
+startup, transport, or lifecycle failure.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import socket
+import stat
+import threading
+import time
+from collections.abc import Mapping
+from pathlib import Path
+
+from .codex_hook_launch_runtime import run_isolated_hook_process
+
+_MAX_REQUEST_BYTES = 6 * 1024 * 1024
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+_MAX_SOCKET_PATH_BYTES = 100
+_START_TIMEOUT_SECONDS = 0.4
+_SERVICE_LIFETIME_SECONDS = 7 * 24 * 60 * 60
+_SERVICE_OUTPUT_LIMIT = 64 * 1024
+
+
+class _ResidentService:
+    def __init__(
+        self,
+        *,
+        executable: Path,
+        identity_sha256: str,
+        guard_home: Path,
+        environment: Mapping[str, str],
+    ) -> None:
+        self.executable = executable
+        self.identity_sha256 = identity_sha256
+        self.guard_home = guard_home
+        self.environment = dict(environment)
+        self.socket_path = _resident_socket_path(guard_home, identity_sha256)
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._starts = 0
+
+    @property
+    def starts(self) -> int:
+        with self._lock:
+            return self._starts
+
+    def request(self, payload: bytes, *, timeout_seconds: float) -> bytes | None:
+        if self.socket_path is None or len(payload) > _MAX_REQUEST_BYTES or timeout_seconds <= 0:
+            return None
+        response = _send_request(self.socket_path, payload, timeout_seconds=min(timeout_seconds, 0.05))
+        if response is not None:
+            return response
+        if not self._ensure_started(timeout_seconds=min(timeout_seconds, _START_TIMEOUT_SECONDS)):
+            return None
+        return _send_request(self.socket_path, payload, timeout_seconds=timeout_seconds)
+
+    def _ensure_started(self, *, timeout_seconds: float) -> bool:
+        if self.socket_path is None or timeout_seconds <= 0:
+            return False
+        with self._lock:
+            thread = self._thread
+            if thread is None or not thread.is_alive():
+                self._stop_event = threading.Event()
+                thread = threading.Thread(
+                    target=self._run,
+                    name="hol-guard-native-runtime",
+                    daemon=True,
+                )
+                self._thread = thread
+                self._starts += 1
+                thread.start()
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            if self._socket_accepts_connections():
+                return True
+            with self._lock:
+                if self._thread is None or not self._thread.is_alive():
+                    return False
+            time.sleep(0.01)
+        return self._socket_accepts_connections()
+
+    def _socket_accepts_connections(self) -> bool:
+        if self.socket_path is None:
+            return False
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+                client.settimeout(0.025)
+                client.connect(str(self.socket_path))
+            return True
+        except OSError:
+            return False
+
+    def _run(self) -> None:
+        socket_path = self.socket_path
+        if socket_path is None:
+            return
+        _ = run_isolated_hook_process(
+            (str(self.executable), "serve", "--socket", str(socket_path)),
+            input_text="",
+            cwd=self.executable.parent,
+            environment=self.environment,
+            timeout_seconds=_SERVICE_LIFETIME_SECONDS,
+            output_limit=_SERVICE_OUTPUT_LIMIT,
+            stop_event=self._stop_event,
+        )
+
+    def close(self) -> None:
+        with self._lock:
+            self._stop_event.set()
+            thread = self._thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=1.5)
+        _unlink_owned_socket(self.socket_path)
+
+
+_SERVICES_LOCK = threading.Lock()
+_SERVICES: dict[tuple[str, str, str], _ResidentService] = {}
+
+
+def _private_runtime_dir(guard_home: Path) -> Path | None:
+    if os.name == "nt" or not hasattr(socket, "AF_UNIX"):
+        return None
+    try:
+        resolved_guard_home = guard_home.expanduser().resolve(strict=True)
+        guard_metadata = resolved_guard_home.lstat()
+        if stat.S_ISLNK(guard_metadata.st_mode) or not stat.S_ISDIR(guard_metadata.st_mode):
+            return None
+        runtime_dir = resolved_guard_home / "native-runtime"
+        runtime_dir.mkdir(mode=0o700, exist_ok=True)
+        metadata = runtime_dir.lstat()
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+            return None
+        current_uid = os.getuid() if hasattr(os, "getuid") else None
+        if current_uid is not None and getattr(metadata, "st_uid", current_uid) != current_uid:
+            return None
+        if stat.S_IMODE(metadata.st_mode) & 0o077:
+            runtime_dir.chmod(0o700)
+            metadata = runtime_dir.lstat()
+            if stat.S_IMODE(metadata.st_mode) & 0o077:
+                return None
+        return runtime_dir.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _resident_socket_path(guard_home: Path, identity_sha256: str) -> Path | None:
+    runtime_dir = _private_runtime_dir(guard_home)
+    if runtime_dir is None:
+        return None
+    suffix = identity_sha256[:16] if identity_sha256 else "unknown"
+    socket_path = runtime_dir / f"hook-v1-{suffix}.sock"
+    if len(os.fsencode(socket_path)) > _MAX_SOCKET_PATH_BYTES:
+        return None
+    return socket_path
+
+
+def _read_exact(client: socket.socket, length: int) -> bytes | None:
+    if length < 0:
+        return None
+    chunks: list[bytes] = []
+    remaining = length
+    while remaining:
+        chunk = client.recv(min(remaining, 64 * 1024))
+        if not chunk:
+            return None
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _send_request(socket_path: Path, payload: bytes, *, timeout_seconds: float) -> bytes | None:
+    if len(payload) > _MAX_REQUEST_BYTES or timeout_seconds <= 0:
+        return None
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(timeout_seconds)
+            client.connect(str(socket_path))
+            client.sendall(len(payload).to_bytes(4, "big") + payload)
+            header = _read_exact(client, 4)
+            if header is None:
+                return None
+            response_length = int.from_bytes(header, "big")
+            if response_length > _MAX_RESPONSE_BYTES:
+                return None
+            return _read_exact(client, response_length)
+    except (OSError, OverflowError):
+        return None
+
+
+def resident_native_request(
+    *,
+    executable: Path,
+    identity_sha256: str,
+    guard_home: Path,
+    environment: Mapping[str, str],
+    payload: bytes,
+    timeout_seconds: float,
+) -> bytes | None:
+    """Send one request to a resident native runtime, starting it lazily."""
+    if os.name == "nt" or not hasattr(socket, "AF_UNIX"):
+        return None
+    try:
+        resolved_executable = executable.resolve(strict=True)
+        resolved_guard_home = guard_home.expanduser().resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    key = (str(resolved_executable), identity_sha256, str(resolved_guard_home))
+    with _SERVICES_LOCK:
+        service = _SERVICES.get(key)
+        if service is None:
+            service = _ResidentService(
+                executable=resolved_executable,
+                identity_sha256=identity_sha256,
+                guard_home=resolved_guard_home,
+                environment=environment,
+            )
+            _SERVICES[key] = service
+    return service.request(payload, timeout_seconds=timeout_seconds)
+
+
+def resident_service_starts(*, executable: Path, identity_sha256: str, guard_home: Path) -> int:
+    """Return an aggregate-only lifecycle counter for tests and diagnostics."""
+    try:
+        key = (
+            str(executable.resolve(strict=True)),
+            identity_sha256,
+            str(guard_home.expanduser().resolve(strict=True)),
+        )
+    except (OSError, RuntimeError, ValueError):
+        return 0
+    with _SERVICES_LOCK:
+        service = _SERVICES.get(key)
+    return service.starts if service is not None else 0
+
+
+def close_resident_native_runtimes() -> None:
+    """Stop every resident runtime through the contained launcher path."""
+    with _SERVICES_LOCK:
+        services = list(_SERVICES.values())
+        _SERVICES.clear()
+    for service in services:
+        service.close()
+
+
+def _unlink_owned_socket(socket_path: Path | None) -> None:
+    if socket_path is None:
+        return
+    try:
+        metadata = socket_path.lstat()
+        if stat.S_ISSOCK(metadata.st_mode):
+            socket_path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
+
+atexit.register(close_resident_native_runtimes)
+
+
+__all__ = [
+    "close_resident_native_runtimes",
+    "resident_native_request",
+    "resident_service_starts",
+]


### PR DESCRIPTION
## Summary

This slice turns the Rust PostToolUse runtime into the actual performance path while keeping default rollout gated.

- `HOL_GUARD_NATIVE=auto|force` tries native first and skips the Python review engine after a valid native result
- any native unavailable/version/transport/timeout/invalid-response case falls back to the existing Python reference engine
- `shadow` remains Python-authoritative and exercises native only as non-authoritative evidence
- POSIX uses an owner-only Unix-socket resident runtime with bounded framed requests/responses
- resident process lifecycle reuses Guard's existing contained hook-process launcher, including controlled shutdown through the same process-group / Windows Job cleanup path
- the Rust server is capped at 16 concurrent requests
- Windows remains on the bounded native one-shot fallback in this slice; named-pipe residency remains separately gated

## Verification

Adds unit tests for resident reuse, private runtime directory/socket cleanup, long-path fallback, native-first authority, Python fallback and shadow authority. Dedicated real-binary CI compiles the Rust runtime with the Python package version, runs clean and generated secret-bearing PostToolUse requests, and proves one resident service is reused.

A separate differential gate executes the same synthetic PostToolUse corpus through Python and compiled Rust and requires exact parity for decision, model-output action, reason code, notice, policy action, reviewed hash and reviewed-excerpt hash. Current parity corpus covers clean/empty/multi-field/large inline output, generated secret output, documentation-placeholder context, and common workspace source reads.

## Deliberate gates still closed

Source default remains `HOL_GUARD_NATIVE=off`. External sibling-checkout/skill-path source-read parity, Windows named-pipe residency, broader differential/fuzz/race evidence, installed-wheel performance thresholds and rollback drills remain blockers for a separate default-`auto` release gate. This PR does not claim those are complete and does not enable native by default.