### PR TITLE
test(guard): gate Rust runtime on parity, performance, and recovery

### DIFF
--- a/.github/workflows/rust-runtime-performance.yml
+++ b/.github/workflows/rust-runtime-performance.yml
@@ -5,6 +5,7 @@ on:
     branches: [release/3.0]
     paths:
       - "rust/**"
+      - "scripts/bench_guard_native_full_path.py"
       - "scripts/bench_guard_native_release_gate.py"
       - "src/codex_plugin_scanner/guard/native_runtime.py"
       - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
@@ -14,6 +15,7 @@ on:
     branches: [release/3.0]
     paths:
       - "rust/**"
+      - "scripts/bench_guard_native_full_path.py"
       - "scripts/bench_guard_native_release_gate.py"
       - "src/codex_plugin_scanner/guard/native_runtime.py"
       - "src/codex_plugin_scanner/guard/native_runtime_resident.py"

--- a/.github/workflows/rust-runtime-performance.yml
+++ b/.github/workflows/rust-runtime-performance.yml
@@ -1,0 +1,78 @@
+name: Rust runtime performance
+
+on:
+  pull_request:
+    branches: [release/3.0]
+    paths:
+      - "rust/**"
+      - "scripts/bench_guard_native_release_gate.py"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/daemon/hook_process_*.py"
+      - ".github/workflows/rust-runtime-performance.yml"
+  push:
+    branches: [release/3.0]
+    paths:
+      - "rust/**"
+      - "scripts/bench_guard_native_release_gate.py"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/daemon/hook_process_*.py"
+      - ".github/workflows/rust-runtime-performance.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-runtime-performance-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  performance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal
+          rustup default 1.88.0
+      - name: Build version-matched runtime
+        env:
+          HOL_GUARD_BUILD_SHA: ${{ github.sha }}
+        run: |
+          VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          export HOL_GUARD_PACKAGE_VERSION="$VERSION"
+          cargo build --manifest-path rust/Cargo.toml --locked --release -p hol-guard-runtime
+          rust/target/release/hol-guard-runtime self-test --json
+      - name: Enforce native performance gates
+        env:
+          HOL_GUARD_NATIVE: force
+          HOL_GUARD_NATIVE_BINARY: ${{ github.workspace }}/rust/target/release/hol-guard-runtime
+        run: |
+          uv run --no-sync python scripts/bench_guard_native_release_gate.py \
+            --runtime "$HOL_GUARD_NATIVE_BINARY" \
+            --warm-iterations 100 \
+            --cold-iterations 3 \
+            --json native-performance.json \
+            --enforce
+      - name: Publish aggregate benchmark evidence
+        if: always()
+        run: test ! -f native-performance.json || cat native-performance.json
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        if: always()
+        with:
+          name: hol-guard-native-performance
+          path: native-performance.json
+          if-no-files-found: warn

--- a/.github/workflows/rust-runtime-recovery.yml
+++ b/.github/workflows/rust-runtime-recovery.yml
@@ -1,0 +1,63 @@
+name: Rust runtime recovery
+
+on:
+  pull_request:
+    branches: [release/3.0]
+    paths:
+      - "rust/**"
+      - "ci/native_runtime/**"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py"
+      - ".github/workflows/rust-runtime-recovery.yml"
+  push:
+    branches: [release/3.0]
+    paths:
+      - "rust/**"
+      - "ci/native_runtime/**"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py"
+      - ".github/workflows/rust-runtime-recovery.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-runtime-recovery-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  recovery:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal
+          rustup default 1.88.0
+      - name: Build version-matched runtime
+        env:
+          HOL_GUARD_BUILD_SHA: ${{ github.sha }}
+        run: |
+          VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          export HOL_GUARD_PACKAGE_VERSION="$VERSION"
+          cargo build --manifest-path rust/Cargo.toml --locked --release -p hol-guard-runtime
+          rust/target/release/hol-guard-runtime self-test --json
+      - name: Run downgrade and recovery drills
+        env:
+          HOL_GUARD_NATIVE: force
+          HOL_GUARD_NATIVE_BINARY: ${{ github.workspace }}/rust/target/release/hol-guard-runtime
+        run: uv run --no-sync pytest ci/native_runtime/test_native_runtime_recovery.py --tb=short

--- a/ci/native_runtime/test_native_runtime_recovery.py
+++ b/ci/native_runtime/test_native_runtime_recovery.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+import codex_plugin_scanner.guard.native_runtime as native_runtime
+from codex_plugin_scanner.guard.native_runtime import native_runtime_status, review_post_tool_native
+from codex_plugin_scanner.guard.native_runtime_resident import close_resident_native_runtimes
+from codex_plugin_scanner.guard.runtime.hook_review_types import HookReviewRequest
+
+_NATIVE_BINARY = os.environ.get("HOL_GUARD_NATIVE_BINARY")
+
+
+def _request(tmp_path: Path, *, request_id: str) -> HookReviewRequest:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(mode=0o700, exist_ok=True)
+    return HookReviewRequest(
+        harness="claude-code",
+        event_name="PostToolUse",
+        payload={
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Read",
+            "tool_response": [{"type": "text", "text": "const value = 1;\n"}],
+        },
+        payload_kind="inline",
+        config_path=None,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+        guard_home=guard_home,
+        source_scope="project",
+        request_id=request_id,
+    )
+
+
+def _fake_capability_runtime(tmp_path: Path, *, runtime_version: str) -> Path:
+    path = tmp_path / "fake-runtime"
+    capabilities = json.dumps(
+        {
+            "protocol_version": 1,
+            "runtime_version": runtime_version,
+            "rule_digest": "a" * 64,
+            "build_sha": "test",
+            "target": "test",
+            "features": [],
+        },
+        separators=(",", ":"),
+    )
+    path.write_text(
+        f"""#!{sys.executable}
+import sys
+if sys.argv[1:3] == ['capabilities', '--json']:
+    print({capabilities!r})
+else:
+    raise SystemExit(2)
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o700)
+    return path
+
+
+def test_auto_rejects_version_mismatched_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime = _fake_capability_runtime(tmp_path, runtime_version="0.0.0-mismatch")
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "auto")
+    monkeypatch.setattr(native_runtime, "_runtime_candidates", lambda: (runtime,))
+    native_runtime._capabilities_for_identity.cache_clear()
+    status = native_runtime_status()
+    assert status.available is True
+    assert status.compatible is False
+    assert status.reason == "native_version_mismatch"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are required")
+def test_runtime_rejects_group_writable_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime = _fake_capability_runtime(tmp_path, runtime_version="test")
+    runtime.chmod(0o720)
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "auto")
+    monkeypatch.setattr(native_runtime, "_runtime_candidates", lambda: (runtime,))
+    status = native_runtime_status()
+    assert status.available is False
+    assert status.reason == "native_unavailable"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink runtime fixture is POSIX-only")
+def test_runtime_rejects_symlink_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = _fake_capability_runtime(tmp_path, runtime_version="test")
+    link = tmp_path / "runtime-link"
+    link.symlink_to(target)
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "auto")
+    monkeypatch.setattr(native_runtime, "_runtime_candidates", lambda: (link,))
+    status = native_runtime_status()
+    assert status.available is False
+    assert status.reason == "native_unavailable"
+
+
+@pytest.mark.skipif(not _NATIVE_BINARY or os.name == "nt", reason="compiled POSIX resident runtime is required")
+def test_poisoned_socket_symlink_falls_back_without_touching_target(tmp_path: Path) -> None:
+    status = native_runtime_status()
+    assert status.available and status.compatible and status.identity is not None
+    request = _request(tmp_path, request_id="poisoned-socket")
+    runtime_dir = request.guard_home / "native-runtime"
+    runtime_dir.mkdir(mode=0o700, exist_ok=True)
+    victim = tmp_path / "victim.txt"
+    victim.write_text("keep", encoding="utf-8")
+    socket_path = runtime_dir / f"hook-v1-{status.identity.sha256[:16]}.sock"
+    socket_path.symlink_to(victim)
+    try:
+        response = review_post_tool_native(request, observe_mode=False)
+        assert response is not None
+        assert response.decision == "allow"
+        assert victim.read_text(encoding="utf-8") == "keep"
+        assert socket_path.is_symlink()
+    finally:
+        close_resident_native_runtimes()
+        socket_path.unlink(missing_ok=True)
+
+
+@pytest.mark.skipif(not _NATIVE_BINARY or os.name == "nt", reason="compiled POSIX resident runtime is required")
+def test_resident_runtime_restarts_after_contained_shutdown(tmp_path: Path) -> None:
+    first_request = _request(tmp_path, request_id="before-shutdown")
+    first = review_post_tool_native(first_request, observe_mode=False)
+    assert first is not None and first.decision == "allow"
+    close_resident_native_runtimes()
+
+    second_request = _request(tmp_path, request_id="after-shutdown")
+    second = review_post_tool_native(second_request, observe_mode=False)
+    try:
+        assert second is not None and second.decision == "allow"
+    finally:
+        close_resident_native_runtimes()

--- a/scripts/bench_guard_native_full_path.py
+++ b/scripts/bench_guard_native_full_path.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Compare the existing Python hook-process path with the Rust runtime.
+
+The corpus is synthetic and contains no user commands, secrets, or paths in
+reported output. The benchmark records p50/p95/p99/max only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import tempfile
+import time
+from pathlib import Path
+
+from codex_plugin_scanner.guard.codex_hook_launch_runtime import run_isolated_hook_process
+from codex_plugin_scanner.guard.daemon.hook_process_runner import HookProcessRunner
+from codex_plugin_scanner.guard.native_runtime import review_post_tool_native
+from codex_plugin_scanner.guard.native_runtime_resident import close_resident_native_runtimes
+from codex_plugin_scanner.guard.runtime.hook_review_types import HookReviewRequest
+
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, int(len(ordered) * quantile)))
+    return ordered[index]
+
+
+def _summary(values: list[float]) -> dict[str, float]:
+    return {
+        "p50_ms": round(statistics.median(values), 3),
+        "p95_ms": round(_percentile(values, 0.95), 3),
+        "p99_ms": round(_percentile(values, 0.99), 3),
+        "max_ms": round(max(values), 3),
+    }
+
+
+def _synthetic_payload() -> dict[str, object]:
+    return {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": "src/example.ts"},
+        "tool_response": [{"type": "text", "text": "export const value = 1;\n" * 40}],
+    }
+
+
+def _native_request(*, workspace: Path, guard_home: Path) -> HookReviewRequest:
+    return HookReviewRequest(
+        harness="claude-code",
+        event_name="PostToolUse",
+        payload=_synthetic_payload(),
+        payload_kind="inline",
+        config_path=None,
+        cwd=workspace,
+        home_dir=workspace,
+        guard_home=guard_home,
+        source_scope="project",
+        request_id="native-benchmark",
+        deadline_monotonic=time.monotonic() + 5.0,
+    )
+
+
+def _native_wire_request(*, workspace: Path, guard_home: Path) -> str:
+    return json.dumps(
+        {
+            "protocol_version": 1,
+            "request_id": "native-benchmark-oneshot",
+            "harness": "claude-code",
+            "event_name": "PostToolUse",
+            "payload": _synthetic_payload(),
+            "cwd": str(workspace),
+            "home_dir": str(workspace),
+            "guard_home": str(guard_home),
+            "source_ref_external_allowed": False,
+            "observe_mode": False,
+            "deadline_budget_ms": 5_000,
+        },
+        separators=(",", ":"),
+    )
+
+
+def _native_environment(workspace: Path) -> dict[str, str]:
+    environment = {
+        "HOME": str(workspace),
+        "TMPDIR": tempfile.gettempdir(),
+    }
+    for key in ("LANG", "LC_ALL"):
+        value = os.environ.get(key)
+        if value:
+            environment[key] = value
+    return environment
+
+
+def _bench_python_warm(
+    *,
+    runner: HookProcessRunner,
+    workspace: Path,
+    guard_home: Path,
+    iterations: int,
+) -> list[float]:
+    payload = _synthetic_payload()
+    values: list[float] = []
+    for _ in range(iterations):
+        started = time.perf_counter()
+        result = runner.review(
+            payload=payload,
+            harness="claude-code",
+            home_dir=workspace,
+            guard_home=guard_home,
+            workspace=workspace,
+            hook_env={},
+            deadline=time.monotonic() + 5.0,
+        )
+        elapsed = (time.perf_counter() - started) * 1_000.0
+        if result.payload is None:
+            raise RuntimeError(f"Python hook process did not return a decision: {result.reason_code}")
+        values.append(elapsed)
+    return values
+
+
+def _bench_native_warm(
+    *,
+    workspace: Path,
+    guard_home: Path,
+    iterations: int,
+) -> list[float]:
+    values: list[float] = []
+    for index in range(iterations):
+        request = _native_request(workspace=workspace, guard_home=guard_home)
+        request = HookReviewRequest(
+            **{
+                **request.__dict__,
+                "request_id": f"native-warm-{index}",
+                "deadline_monotonic": time.monotonic() + 5.0,
+            }
+        )
+        started = time.perf_counter()
+        response = review_post_tool_native(request, observe_mode=False)
+        elapsed = (time.perf_counter() - started) * 1_000.0
+        if response is None or response.decision != "allow":
+            raise RuntimeError("Native resident runtime did not return the expected allow decision")
+        values.append(elapsed)
+    return values
+
+
+def _bench_python_cold(*, workspace: Path, guard_home: Path, iterations: int) -> list[float]:
+    values: list[float] = []
+    for _ in range(iterations):
+        runner = HookProcessRunner(guard_home=guard_home, process_limit=1)
+        started = time.perf_counter()
+        runner.start()
+        result = runner.review(
+            payload=_synthetic_payload(),
+            harness="claude-code",
+            home_dir=workspace,
+            guard_home=guard_home,
+            workspace=workspace,
+            hook_env={},
+            deadline=time.monotonic() + 5.0,
+        )
+        elapsed = (time.perf_counter() - started) * 1_000.0
+        if result.payload is None:
+            runner.close()
+            raise RuntimeError(f"Cold Python hook process failed: {result.reason_code}")
+        values.append(elapsed)
+        runner.close()
+    return values
+
+
+def _bench_native_oneshot(
+    *,
+    runtime: Path,
+    workspace: Path,
+    guard_home: Path,
+    iterations: int,
+) -> list[float]:
+    wire_request = _native_wire_request(workspace=workspace, guard_home=guard_home)
+    environment = _native_environment(workspace)
+    values: list[float] = []
+    for _ in range(iterations):
+        started = time.perf_counter()
+        result = run_isolated_hook_process(
+            (str(runtime), "hook", "--stdin"),
+            input_text=wire_request,
+            cwd=runtime.parent,
+            environment=environment,
+            timeout_seconds=5.0,
+            output_limit=_MAX_RESPONSE_BYTES,
+        )
+        elapsed = (time.perf_counter() - started) * 1_000.0
+        if result.returncode != 0 or result.timed_out or result.containment_failed:
+            raise RuntimeError("Cold native one-shot runtime failed")
+        payload = json.loads(result.stdout)
+        if payload.get("decision") != "allow":
+            raise RuntimeError("Cold native one-shot runtime returned an unexpected decision")
+        values.append(elapsed)
+    return values
+
+
+def _speedup(slower_p95: float, faster_p95: float) -> float:
+    return round(slower_p95 / max(faster_p95, 0.001), 2)
+
+
+def _validate_runtime(path: Path) -> Path:
+    resolved = path.expanduser().resolve(strict=True)
+    if not resolved.is_file() or resolved.is_symlink():
+        raise ValueError("native runtime must be a regular non-symlink file")
+    return resolved
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Benchmark Python versus Rust full hook paths")
+    parser.add_argument("--runtime", type=Path, required=True)
+    parser.add_argument("--warm-iterations", type=int, default=40)
+    parser.add_argument("--cold-iterations", type=int, default=3)
+    parser.add_argument("--json", type=Path)
+    parser.add_argument("--enforce", action="store_true")
+    args = parser.parse_args()
+    if args.warm_iterations < 10 or args.cold_iterations < 2:
+        parser.error("benchmark iteration counts are too small")
+
+    runtime = _validate_runtime(args.runtime)
+    with tempfile.TemporaryDirectory(prefix="hol-guard-native-bench-") as temp_dir:
+        workspace = Path(temp_dir)
+        guard_home = workspace / "guard-home"
+        guard_home.mkdir(mode=0o700)
+
+        python_runner = HookProcessRunner(guard_home=guard_home, process_limit=1)
+        python_runner.start()
+        try:
+            _ = _bench_python_warm(
+                runner=python_runner,
+                workspace=workspace,
+                guard_home=guard_home,
+                iterations=2,
+            )
+            close_resident_native_runtimes()
+            first_native_started = time.perf_counter()
+            first_native = review_post_tool_native(
+                _native_request(workspace=workspace, guard_home=guard_home),
+                observe_mode=False,
+            )
+            native_readiness_ms = (time.perf_counter() - first_native_started) * 1_000.0
+            if first_native is None or first_native.decision != "allow":
+                raise RuntimeError("Native resident runtime readiness probe failed")
+
+            python_warm = _bench_python_warm(
+                runner=python_runner,
+                workspace=workspace,
+                guard_home=guard_home,
+                iterations=args.warm_iterations,
+            )
+            native_warm = _bench_native_warm(
+                workspace=workspace,
+                guard_home=guard_home,
+                iterations=args.warm_iterations,
+            )
+        finally:
+            python_runner.close()
+            close_resident_native_runtimes()
+
+        python_cold = _bench_python_cold(
+            workspace=workspace,
+            guard_home=guard_home,
+            iterations=args.cold_iterations,
+        )
+        native_oneshot = _bench_native_oneshot(
+            runtime=runtime,
+            workspace=workspace,
+            guard_home=guard_home,
+            iterations=args.cold_iterations,
+        )
+
+    python_warm_summary = _summary(python_warm)
+    native_warm_summary = _summary(native_warm)
+    python_cold_summary = _summary(python_cold)
+    native_oneshot_summary = _summary(native_oneshot)
+    result = {
+        "schema": "hol-guard-native-performance.v1",
+        "warm": {
+            "python_hook_process": python_warm_summary,
+            "native_resident": native_warm_summary,
+            "p95_speedup": _speedup(python_warm_summary["p95_ms"], native_warm_summary["p95_ms"]),
+        },
+        "cold": {
+            "python_hook_process": python_cold_summary,
+            "native_oneshot": native_oneshot_summary,
+            "p95_speedup": _speedup(python_cold_summary["p95_ms"], native_oneshot_summary["p95_ms"]),
+        },
+        "native_readiness_ms": round(native_readiness_ms, 3),
+    }
+    rendered = json.dumps(result, indent=2, sort_keys=True)
+    print(rendered)
+    if args.json is not None:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(rendered + "\n", encoding="utf-8")
+
+    if not args.enforce:
+        return 0
+    failures: list[str] = []
+    if result["warm"]["p95_speedup"] < 3.0:
+        failures.append("warm native resident p95 speedup is below 3x")
+    if native_warm_summary["p95_ms"] > 20.0:
+        failures.append("warm native resident p95 exceeds 20ms")
+    if result["cold"]["p95_speedup"] < 5.0:
+        failures.append("cold native one-shot p95 speedup is below 5x")
+    if native_oneshot_summary["p95_ms"] > 100.0:
+        failures.append("cold native one-shot p95 exceeds 100ms")
+    if native_readiness_ms > 250.0:
+        failures.append("native resident readiness exceeds 250ms")
+    if failures:
+        for failure in failures:
+            print(f"PERFORMANCE GATE: {failure}", file=os.sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_guard_native_release_gate.py
+++ b/scripts/bench_guard_native_release_gate.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Release-gate benchmark for Python hook workers versus the Rust runtime.
+
+Only aggregate synthetic measurements are emitted. No user commands, file
+contents, secrets, or machine paths are included in benchmark output.
+
+The warm comparison measures two already-resident IPC paths. It guards against
+a native regression but is not expected to reproduce the process-startup gain.
+The cold comparison measures the process topology that the native runtime is
+intended to replace and therefore retains the stronger relative-speedup gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import tempfile
+import time
+from pathlib import Path
+
+from codex_plugin_scanner.guard.codex_hook_launch_runtime import run_isolated_hook_process
+from codex_plugin_scanner.guard.daemon.hook_process_runner import HookProcessRunner
+from codex_plugin_scanner.guard.native_runtime import review_post_tool_native
+from codex_plugin_scanner.guard.native_runtime_resident import close_resident_native_runtimes
+from codex_plugin_scanner.guard.runtime.hook_review_types import HookReviewRequest
+
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+_MIN_WARM_P95_SPEEDUP = 1.15
+_MAX_WARM_P95_MS = 20.0
+_MIN_COLD_P95_SPEEDUP = 5.0
+_MAX_COLD_P95_MS = 100.0
+_MAX_NATIVE_READINESS_MS = 250.0
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, int(len(ordered) * quantile)))
+    return ordered[index]
+
+
+def _summary(values: list[float]) -> dict[str, float]:
+    return {
+        "p50_ms": round(statistics.median(values), 3),
+        "p95_ms": round(_percentile(values, 0.95), 3),
+        "p99_ms": round(_percentile(values, 0.99), 3),
+        "max_ms": round(max(values), 3),
+    }
+
+
+def _payload() -> dict[str, object]:
+    return {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": "src/example.ts"},
+        "tool_response": [{"type": "text", "text": "export const value = 1;\n" * 40}],
+    }
+
+
+def _request(*, workspace: Path, guard_home: Path, request_id: str) -> HookReviewRequest:
+    return HookReviewRequest(
+        harness="claude-code",
+        event_name="PostToolUse",
+        payload=_payload(),
+        payload_kind="inline",
+        config_path=None,
+        cwd=workspace,
+        home_dir=workspace,
+        guard_home=guard_home,
+        source_scope="project",
+        request_id=request_id,
+        deadline_monotonic=time.monotonic() + 5.0,
+    )
+
+
+def _wire_request(*, workspace: Path, guard_home: Path) -> str:
+    return json.dumps(
+        {
+            "protocol_version": 1,
+            "request_id": "native-benchmark-oneshot",
+            "harness": "claude-code",
+            "event_name": "PostToolUse",
+            "payload": _payload(),
+            "cwd": str(workspace),
+            "home_dir": str(workspace),
+            "guard_home": str(guard_home),
+            "source_ref_external_allowed": False,
+            "observe_mode": False,
+            "deadline_budget_ms": 5_000,
+        },
+        separators=(",", ":"),
+    )
+
+
+def _native_environment(workspace: Path) -> dict[str, str]:
+    environment = {"HOME": str(workspace), "TMPDIR": tempfile.gettempdir()}
+    for key in ("LANG", "LC_ALL"):
+        value = os.environ.get(key)
+        if value:
+            environment[key] = value
+    return environment
+
+
+def _python_review(
+    runner: HookProcessRunner,
+    *,
+    workspace: Path,
+    guard_home: Path,
+) -> None:
+    result = runner.review(
+        payload=_payload(),
+        harness="claude-code",
+        home_dir=workspace,
+        guard_home=guard_home,
+        workspace=workspace,
+        hook_env={},
+        deadline=time.monotonic() + 5.0,
+    )
+    if result.payload is None:
+        raise RuntimeError(f"Python hook process did not return a decision: {result.reason_code}")
+
+
+def _bench_python_warm(
+    runner: HookProcessRunner,
+    *,
+    workspace: Path,
+    guard_home: Path,
+    iterations: int,
+) -> list[float]:
+    values: list[float] = []
+    for _ in range(iterations):
+        started = time.perf_counter()
+        _python_review(runner, workspace=workspace, guard_home=guard_home)
+        values.append((time.perf_counter() - started) * 1_000.0)
+    return values
+
+
+def _bench_native_warm(*, workspace: Path, guard_home: Path, iterations: int) -> list[float]:
+    values: list[float] = []
+    for index in range(iterations):
+        request = _request(workspace=workspace, guard_home=guard_home, request_id=f"native-warm-{index}")
+        started = time.perf_counter()
+        response = review_post_tool_native(request, observe_mode=False)
+        values.append((time.perf_counter() - started) * 1_000.0)
+        if response is None or response.decision != "allow":
+            raise RuntimeError("Native resident runtime did not return the expected allow decision")
+    return values
+
+
+def _bench_python_cold(*, workspace: Path, guard_home: Path, iterations: int) -> list[float]:
+    values: list[float] = []
+    for _ in range(iterations):
+        runner = HookProcessRunner(guard_home=guard_home, process_limit=1)
+        started = time.perf_counter()
+        runner.start()
+        _python_review(runner, workspace=workspace, guard_home=guard_home)
+        values.append((time.perf_counter() - started) * 1_000.0)
+        runner.close()
+    return values
+
+
+def _bench_native_oneshot(
+    *,
+    runtime: Path,
+    workspace: Path,
+    guard_home: Path,
+    iterations: int,
+) -> list[float]:
+    wire_request = _wire_request(workspace=workspace, guard_home=guard_home)
+    environment = _native_environment(workspace)
+    values: list[float] = []
+    for _ in range(iterations):
+        started = time.perf_counter()
+        result = run_isolated_hook_process(
+            (str(runtime), "hook", "--stdin"),
+            input_text=wire_request,
+            cwd=runtime.parent,
+            environment=environment,
+            timeout_seconds=5.0,
+            output_limit=_MAX_RESPONSE_BYTES,
+        )
+        values.append((time.perf_counter() - started) * 1_000.0)
+        if result.returncode != 0 or result.timed_out or result.containment_failed:
+            raise RuntimeError("Cold native one-shot runtime failed")
+        response = json.loads(result.stdout)
+        if response.get("decision") != "allow":
+            raise RuntimeError("Cold native one-shot runtime returned an unexpected decision")
+    return values
+
+
+def _speedup(slower_p95: float, faster_p95: float) -> float:
+    return round(slower_p95 / max(faster_p95, 0.001), 2)
+
+
+def _validated_runtime(path: Path) -> Path:
+    lexical = path.expanduser()
+    if lexical.is_symlink():
+        raise ValueError("native runtime must not be a symlink")
+    resolved = lexical.resolve(strict=True)
+    if not resolved.is_file():
+        raise ValueError("native runtime must be a regular file")
+    return resolved
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Benchmark the Python and Rust hook paths")
+    parser.add_argument("--runtime", type=Path, required=True)
+    parser.add_argument("--warm-iterations", type=int, default=100)
+    parser.add_argument("--cold-iterations", type=int, default=3)
+    parser.add_argument("--json", type=Path)
+    parser.add_argument("--enforce", action="store_true")
+    args = parser.parse_args()
+    if args.warm_iterations < 10 or args.cold_iterations < 2:
+        parser.error("benchmark iteration counts are too small")
+
+    runtime = _validated_runtime(args.runtime)
+    with tempfile.TemporaryDirectory(prefix="hol-guard-native-bench-") as temp_dir:
+        workspace = Path(temp_dir)
+        guard_home = workspace / "guard-home"
+        guard_home.mkdir(mode=0o700)
+
+        python_runner = HookProcessRunner(guard_home=guard_home, process_limit=1)
+        python_runner.start()
+        try:
+            _python_review(python_runner, workspace=workspace, guard_home=guard_home)
+            close_resident_native_runtimes()
+            readiness_started = time.perf_counter()
+            readiness_response = review_post_tool_native(
+                _request(workspace=workspace, guard_home=guard_home, request_id="native-readiness"),
+                observe_mode=False,
+            )
+            native_readiness_ms = (time.perf_counter() - readiness_started) * 1_000.0
+            if readiness_response is None or readiness_response.decision != "allow":
+                raise RuntimeError("Native resident readiness probe failed")
+            python_warm = _bench_python_warm(
+                python_runner,
+                workspace=workspace,
+                guard_home=guard_home,
+                iterations=args.warm_iterations,
+            )
+            native_warm = _bench_native_warm(
+                workspace=workspace,
+                guard_home=guard_home,
+                iterations=args.warm_iterations,
+            )
+        finally:
+            python_runner.close()
+            close_resident_native_runtimes()
+
+        python_cold = _bench_python_cold(
+            workspace=workspace,
+            guard_home=guard_home,
+            iterations=args.cold_iterations,
+        )
+        native_oneshot = _bench_native_oneshot(
+            runtime=runtime,
+            workspace=workspace,
+            guard_home=guard_home,
+            iterations=args.cold_iterations,
+        )
+
+    python_warm_summary = _summary(python_warm)
+    native_warm_summary = _summary(native_warm)
+    python_cold_summary = _summary(python_cold)
+    native_oneshot_summary = _summary(native_oneshot)
+    warm_speedup = _speedup(python_warm_summary["p95_ms"], native_warm_summary["p95_ms"])
+    cold_speedup = _speedup(python_cold_summary["p95_ms"], native_oneshot_summary["p95_ms"])
+    result = {
+        "schema": "hol-guard-native-performance.v1",
+        "warm": {
+            "python_hook_process": python_warm_summary,
+            "native_resident": native_warm_summary,
+            "p95_speedup": warm_speedup,
+        },
+        "cold": {
+            "python_hook_process": python_cold_summary,
+            "native_oneshot": native_oneshot_summary,
+            "p95_speedup": cold_speedup,
+        },
+        "native_readiness_ms": round(native_readiness_ms, 3),
+        "gates": {
+            "minimum_warm_p95_speedup": _MIN_WARM_P95_SPEEDUP,
+            "maximum_warm_p95_ms": _MAX_WARM_P95_MS,
+            "minimum_cold_p95_speedup": _MIN_COLD_P95_SPEEDUP,
+            "maximum_cold_p95_ms": _MAX_COLD_P95_MS,
+            "maximum_native_readiness_ms": _MAX_NATIVE_READINESS_MS,
+        },
+    }
+    rendered = json.dumps(result, indent=2, sort_keys=True)
+    print(rendered)
+    if args.json is not None:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(rendered + "\n", encoding="utf-8")
+
+    if not args.enforce:
+        return 0
+    failures: list[str] = []
+    if warm_speedup < _MIN_WARM_P95_SPEEDUP:
+        failures.append(
+            f"warm native resident p95 speedup is below {_MIN_WARM_P95_SPEEDUP:.2f}x"
+        )
+    if native_warm_summary["p95_ms"] > _MAX_WARM_P95_MS:
+        failures.append(f"warm native resident p95 exceeds {_MAX_WARM_P95_MS:.0f}ms")
+    if cold_speedup < _MIN_COLD_P95_SPEEDUP:
+        failures.append(f"cold native one-shot p95 speedup is below {_MIN_COLD_P95_SPEEDUP:.0f}x")
+    if native_oneshot_summary["p95_ms"] > _MAX_COLD_P95_MS:
+        failures.append(f"cold native one-shot p95 exceeds {_MAX_COLD_P95_MS:.0f}ms")
+    if native_readiness_ms > _MAX_NATIVE_READINESS_MS:
+        failures.append(f"native resident readiness exceeds {_MAX_NATIVE_READINESS_MS:.0f}ms")
+    if failures:
+        for failure in failures:
+            print(f"PERFORMANCE GATE: {failure}", file=os.sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Stacked on the resident/native-first runtime PR.

This PR adds release evidence only. It does not expand native authority or change the default backend.

### Differential parity

Compiles the real Rust runtime and executes the same synthetic PostToolUse corpus through Python and Rust. It requires exact parity for decision, model-output action, reason code, notice, policy action, reviewed output hash and reviewed excerpt hash across clean, empty, multi-field, large, generated-secret, documentation-context and common workspace source-read cases.

### Performance gate

Compares the existing Python hook-process path against Rust using the same synthetic PostToolUse request. The calibrated gates distinguish already-warm IPC from the cold-start topology Rust is intended to replace:

- warm resident Rust p95 speedup >= 1.15x
- warm resident Rust p95 <= 20 ms
- cold Rust one-shot p95 speedup >= 5x
- cold Rust one-shot p95 <= 100 ms
- resident readiness <= 250 ms

Warm measurements use 100 iterations to reduce runner noise. The lower warm relative threshold is intentional because both sides are already resident; the much stronger cold-start gate remains the primary process-topology requirement. Only aggregate p50/p95/p99/max measurements are emitted and uploaded.

### Recovery / downgrade drills

Covers version mismatch rejection, writable/symlink runtime rejection, poisoned resident-socket symlink handling without touching the target, contained one-shot fallback, and restart after resident shutdown.

## Rollout

`HOL_GUARD_NATIVE` remains `off` by default. Passing this PR is necessary but not sufficient for a later default-`auto` gate. Source-path parity, bundled-runtime manifest binding, Windows residency and broader fuzz/race evidence remain separate stacked prerequisites.