### PR TITLE
fix(scanner): include complete findings in action summaries

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12238,
-  "maximum_test_source_lines": 285105,
+  "maximum_collected_cases": 12240,
+  "maximum_test_source_lines": 285212,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -21,7 +21,7 @@ from .github_reporting import (
     should_manage_pr_comment,
     upsert_pr_comment,
 )
-from .models import GRADE_LABELS, max_severity
+from .models import Finding, GRADE_LABELS, SEVERITY_ORDER, max_severity
 from .quality_artifact import build_quality_artifact, write_quality_artifact
 from .reporting import build_json_payload, format_markdown, format_sarif, should_fail_for_severity
 from .submission import (
@@ -175,6 +175,66 @@ def _render_lint_output(result, *, output_format: str, profile: str, policy_pass
     return "\n".join(lines)
 
 
+def _escape_step_summary_text(value: str) -> str:
+    """Normalize scanner-controlled text before embedding it in GitHub-flavored Markdown."""
+
+    text = " ".join(value.split())
+    for character in ("\\", "`", "*", "_", "[", "]", "<", ">"):
+        text = text.replace(character, f"\\{character}")
+    return text
+
+
+def _build_findings_summary_lines(findings: tuple[Finding, ...]) -> tuple[str, ...]:
+    """Render complete, deterministic finding details for the Actions job summary."""
+
+    ordered_findings = sorted(
+        findings,
+        key=lambda finding: (
+            -SEVERITY_ORDER[finding.severity],
+            finding.rule_id,
+            finding.file_path or "",
+            finding.line_number or 0,
+        ),
+    )
+    lines = ["", "### Finding details", ""]
+    if not ordered_findings:
+        lines.append("No findings detected.")
+        return tuple(lines)
+
+    for index, finding in enumerate(ordered_findings, start=1):
+        title = _escape_step_summary_text(finding.title)
+        rule_id = _escape_step_summary_text(finding.rule_id)
+        category = _escape_step_summary_text(finding.category)
+        source = _escape_step_summary_text(finding.source)
+        description = _escape_step_summary_text(finding.description)
+        remediation = (
+            _escape_step_summary_text(finding.remediation)
+            if finding.remediation
+            else "Not provided."
+        )
+        location = "Not provided."
+        if finding.file_path:
+            raw_location = finding.file_path
+            if finding.line_number is not None:
+                raw_location = f"{raw_location}:{finding.line_number}"
+            location = _escape_step_summary_text(raw_location)
+
+        lines.extend(
+            [
+                f"#### {index}. {finding.severity.value.upper()} - {title}",
+                "",
+                f"- Rule ID: {rule_id}",
+                f"- Category: {category}",
+                f"- Source: {source}",
+                f"- Location: {location}",
+                f"- Description: {description}",
+                f"- Remediation: {remediation}",
+                "",
+            ]
+        )
+    return tuple(lines)
+
+
 def _build_step_summary_lines(
     *,
     mode: str,
@@ -191,6 +251,7 @@ def _build_step_summary_lines(
     scope: str = "plugin",
     local_plugin_count: int | None = None,
     skipped_target_count: int | None = None,
+    findings: tuple[Finding, ...] = (),
 ) -> tuple[str, ...]:
     lines = ["## HOL AI Plugin Scanner", "", f"- Mode: {mode}"]
     lines.append(f"- Scope: {scope}")
@@ -215,6 +276,8 @@ def _build_step_summary_lines(
         lines.append(f"- Registry payload: `{registry_payload_path}`")
     if submission_issues:
         lines.append(f"- Submission issues: {', '.join(issue.url for issue in submission_issues)}")
+    if mode in {"scan", "lint", "submit"}:
+        lines.extend(_build_findings_summary_lines(findings))
     return tuple(lines)
 
 
@@ -302,6 +365,7 @@ def main() -> int:
     local_plugin_count: int | None = None
     skipped_target_count: int | None = None
     pr_comment_body = ""
+    summary_findings: tuple[Finding, ...] = ()
 
     def finish(return_code: int) -> int:
         output_values["report_path"] = report_path_value
@@ -354,6 +418,7 @@ def main() -> int:
                     scope=scan_scope,
                     local_plugin_count=local_plugin_count,
                     skipped_target_count=skipped_target_count,
+                    findings=summary_findings,
                 ),
             )
         output_values["action_exit_code"] = str(return_code)
@@ -383,6 +448,7 @@ def main() -> int:
             _config_path,
             _baseline_path,
         ) = _scan_with_policy(args, Path(plugin_dir).resolve())
+        summary_findings = result.findings
         scan_scope = getattr(result, "scope", "plugin")
         if scan_scope == "repository":
             local_plugin_count = len(result.plugin_results)

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -21,7 +21,7 @@ from .github_reporting import (
     should_manage_pr_comment,
     upsert_pr_comment,
 )
-from .models import Finding, GRADE_LABELS, SEVERITY_ORDER, max_severity
+from .models import GRADE_LABELS, SEVERITY_ORDER, Finding, max_severity
 from .quality_artifact import build_quality_artifact, write_quality_artifact
 from .reporting import build_json_payload, format_markdown, format_sarif, should_fail_for_severity
 from .submission import (

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -207,11 +207,9 @@ def _build_findings_summary_lines(findings: tuple[Finding, ...]) -> tuple[str, .
         category = _escape_step_summary_text(finding.category)
         source = _escape_step_summary_text(finding.source)
         description = _escape_step_summary_text(finding.description)
-        remediation = (
-            _escape_step_summary_text(finding.remediation)
-            if finding.remediation
-            else "Not provided."
-        )
+        remediation = "Not provided."
+        if finding.remediation:
+            remediation = _escape_step_summary_text(finding.remediation)
         location = "Not provided."
         if finding.file_path:
             raw_location = finding.file_path

--- a/tests/test_action_runner_step_summary_findings.py
+++ b/tests/test_action_runner_step_summary_findings.py
@@ -1,0 +1,107 @@
+"""Regression coverage for complete GitHub Actions finding summaries."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import codex_plugin_scanner.action_runner as action_runner
+from codex_plugin_scanner.models import Finding, ScanResult, Severity, build_severity_counts
+
+
+def test_scan_step_summary_includes_complete_finding_details(monkeypatch, tmp_path) -> None:
+    finding = Finding(
+        rule_id="TEST-INFO-001",
+        severity=Severity.INFO,
+        category="Security",
+        title="Informational scanner finding",
+        description="The scanner found a concrete issue that should be visible in the job summary.",
+        remediation="Apply the documented remediation and rerun the scanner.",
+        file_path="plugin/example.py",
+        line_number=42,
+        source="native",
+    )
+    findings = (finding,)
+    result = ScanResult(
+        score=97,
+        grade="A",
+        categories=(),
+        timestamp="2026-08-10T00:00:00Z",
+        plugin_dir=str(tmp_path),
+        findings=findings,
+        severity_counts=build_severity_counts(findings),
+    )
+    policy_eval = SimpleNamespace(policy_pass=True)
+
+    def _fake_scan(*_args, **_kwargs):
+        return result, result, "default", policy_eval, 97, None, None
+
+    report_path = tmp_path / "ai-plugin-scanner.sarif"
+    summary_path = tmp_path / "step-summary.md"
+    output_path = tmp_path / "github-output.txt"
+
+    monkeypatch.setattr(action_runner, "_scan_with_policy", _fake_scan)
+    monkeypatch.setenv("MODE", "scan")
+    monkeypatch.setenv("PLUGIN_DIR", str(tmp_path))
+    monkeypatch.setenv("FORMAT", "sarif")
+    monkeypatch.setenv("OUTPUT", str(report_path))
+    monkeypatch.setenv("UPLOAD_SARIF", "true")
+    monkeypatch.setenv("WRITE_STEP_SUMMARY", "true")
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+    monkeypatch.setenv("PR_COMMENT", "off")
+    monkeypatch.setenv("MIN_SCORE", "0")
+    monkeypatch.setenv("FAIL_ON", "none")
+    monkeypatch.setenv("CISCO_SCAN", "off")
+    monkeypatch.setenv("CISCO_POLICY", "balanced")
+    monkeypatch.setenv("SUBMISSION_ENABLED", "false")
+    monkeypatch.setenv("REGISTRY_PAYLOAD_OUTPUT", "")
+
+    exit_code = action_runner.main()
+
+    assert exit_code == 0
+    assert report_path.exists()
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "- Score: 97/100" in summary
+    assert "- Grade: A - Excellent" in summary
+    assert "- Max severity: info" in summary
+    assert "- Findings: 1" in summary
+    assert "### Finding details" in summary
+    assert "#### 1. INFO - Informational scanner finding" in summary
+    assert "- Rule ID: TEST-INFO-001" in summary
+    assert "- Category: Security" in summary
+    assert "- Source: native" in summary
+    assert "- Location: plugin/example.py:42" in summary
+    assert (
+        "- Description: The scanner found a concrete issue that should be visible in the job summary."
+        in summary
+    )
+    assert "- Remediation: Apply the documented remediation and rerun the scanner." in summary
+
+
+def test_finding_summary_orders_severity_and_escapes_markdown() -> None:
+    findings = (
+        Finding(
+            rule_id="INFO-1",
+            severity=Severity.INFO,
+            category="General",
+            title="Info finding",
+            description="Plain detail",
+        ),
+        Finding(
+            rule_id="CRIT-1",
+            severity=Severity.CRITICAL,
+            category="Security",
+            title="Unsafe <script> *title*",
+            description="Potential `code` injection",
+            file_path="plugin/[unsafe].py",
+            source="external",
+        ),
+    )
+
+    summary = "\n".join(action_runner._build_findings_summary_lines(findings))
+
+    assert summary.index("CRITICAL") < summary.index("INFO")
+    assert "Unsafe \\<script\\> \\*title\\*" in summary
+    assert "Potential \\`code\\` injection" in summary
+    assert "plugin/\\[unsafe\\].py" in summary
+    assert "- Remediation: Not provided." in summary


### PR DESCRIPTION
## Summary

- include every scanner finding in the GitHub Actions job summary instead of only aggregate score/count fields
- render severity, rule ID, category, source, file/line, description, and remediation
- order findings deterministically by severity and escape Markdown-sensitive content
- add regression coverage for the SARIF upload path and summary rendering

## Validation

CI and review feedback will be resolved before merge.