### PR TITLE
fix(ci): sign embedded macOS Core runtime

### DIFF
--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -5,12 +5,15 @@ on:
     paths:
       - .github/workflows/desktop-core-alpha-feed.yml
       - tests/test_desktop_core_alpha_feed_security.py
+      - tests/test_desktop_core_alpha_feed_macos_signing.py
       - scripts/release/desktop_core_alpha_feed.py
+      - scripts/release/verify_pyinstaller_macos_signing.py
   push:
     branches: [main]
     paths:
       - .github/workflows/desktop-core-alpha-feed.yml
       - scripts/release/desktop_core_alpha_feed.py
+      - scripts/release/verify_pyinstaller_macos_signing.py
   schedule:
     - cron: "17 * * * *"
   workflow_dispatch:
@@ -248,48 +251,6 @@ jobs:
             --base "$BASE" --marker "$BASE.attested.json" --version "$CORE_VERSION" --source-commit "$SOURCE_SHA" \
             --source-tag "$CORE_TAG" --target "$RELEASE_TARGET" --apple-signing-identity "$APPLE_SIGNING_IDENTITY" \
             --apple-team-id "$APPLE_TEAM_ID"
-      - name: Build standalone Core executable
-        if: steps.release.outputs.available == 'true' && steps.existing.outputs.mode == 'build'
-        env:
-          CORE_VERSION: ${{ steps.release.outputs.version }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          SOURCE="$RUNNER_TEMP/hol-guard-core"
-          DIST="$RUNNER_TEMP/dist"
-          mkdir -p "$DIST" "$RUNNER_TEMP/pyinstaller" "$RUNNER_TEMP/spec"
-          uv sync --directory "$SOURCE" --frozen --extra mdm-build --python 3.12
-          (
-            cd "$SOURCE"
-            uv run --no-sync python scripts/sync_repo_version.py --version "$CORE_VERSION"
-            test "$(uv run --no-sync python scripts/sync_repo_version.py --check)" = "$CORE_VERSION"
-          )
-          uv sync --directory "$SOURCE" --frozen --extra mdm-build --python 3.12
-          git -C "$SOURCE" diff --check
-          while IFS= read -r changed_path; do
-            [[ -z "$changed_path" ]] && continue
-            case "$changed_path" in
-              pyproject.toml|src/codex_plugin_scanner/version.py|uv.lock) ;;
-              *) echo "Version stamping changed an unexpected Core file: $changed_path" >&2; exit 1 ;;
-            esac
-          done < <(git -C "$SOURCE" diff --name-only)
-          (
-            cd "$SOURCE"
-            uv run --no-sync pyinstaller --clean --noconfirm --onefile --name hol-guard \
-              --collect-submodules codex_plugin_scanner --collect-data codex_plugin_scanner \
-              --distpath "$DIST" --workpath "$RUNNER_TEMP/pyinstaller" --specpath "$RUNNER_TEMP/spec" \
-              scripts/mdm/hol-guard-entry.py
-          )
-          BUILT="$DIST/hol-guard"
-          ASSET="$DIST/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
-          chmod 0755 "$BUILT"
-          test "$("$BUILT" --version | sed -E 's/^hol-guard[[:space:]]+//')" = "$CORE_VERSION"
-          export HOL_GUARD_HOME="$RUNNER_TEMP/smoke-home"
-          mkdir -p "$HOL_GUARD_HOME"
-          "$BUILT" desktop bootstrap --json > "$RUNNER_TEMP/bootstrap.json"
-          python3 -I scripts/release/desktop_core_alpha_feed.py verify-bootstrap \
-            --payload "$RUNNER_TEMP/bootstrap.json" --version "$CORE_VERSION" --subject "Standalone Core"
-          mv "$BUILT" "$ASSET"
       - name: Import Apple signing identity
         if: steps.release.outputs.available == 'true'
         env:
@@ -328,6 +289,53 @@ jobs:
               raise SystemExit(f"Expected exactly one imported code-signing identity, found {len(matches)}")
           (root / "apple-signing-fingerprint.txt").write_text(matches[0].upper() + "\n", encoding="ascii")
           PY
+      - name: Build standalone Core executable
+        if: steps.release.outputs.available == 'true' && steps.existing.outputs.mode == 'build'
+        env:
+          CORE_VERSION: ${{ steps.release.outputs.version }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          SOURCE="$RUNNER_TEMP/hol-guard-core"
+          DIST="$RUNNER_TEMP/dist"
+          mkdir -p "$DIST" "$RUNNER_TEMP/pyinstaller" "$RUNNER_TEMP/spec"
+          uv sync --directory "$SOURCE" --frozen --extra mdm-build --python 3.12
+          (
+            cd "$SOURCE"
+            uv run --no-sync python scripts/sync_repo_version.py --version "$CORE_VERSION"
+            test "$(uv run --no-sync python scripts/sync_repo_version.py --check)" = "$CORE_VERSION"
+          )
+          uv sync --directory "$SOURCE" --frozen --extra mdm-build --python 3.12
+          git -C "$SOURCE" diff --check
+          while IFS= read -r changed_path; do
+            [[ -z "$changed_path" ]] && continue
+            case "$changed_path" in
+              pyproject.toml|src/codex_plugin_scanner/version.py|uv.lock) ;;
+              *) echo "Version stamping changed an unexpected Core file: $changed_path" >&2; exit 1 ;;
+            esac
+          done < <(git -C "$SOURCE" diff --name-only)
+          (
+            cd "$SOURCE"
+            uv run --no-sync pyinstaller --codesign-identity "$APPLE_SIGNING_IDENTITY" \
+              --clean --noconfirm --onefile --name hol-guard \
+              --collect-submodules codex_plugin_scanner --collect-data codex_plugin_scanner \
+              --distpath "$DIST" --workpath "$RUNNER_TEMP/pyinstaller" --specpath "$RUNNER_TEMP/spec" \
+              scripts/mdm/hol-guard-entry.py
+          )
+          BUILT="$DIST/hol-guard"
+          ASSET="$DIST/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
+          chmod 0755 "$BUILT"
+          python3 -I scripts/release/verify_pyinstaller_macos_signing.py \
+            --binary "$BUILT" --team-id "$APPLE_TEAM_ID"
+          test "$("$BUILT" --version | sed -E 's/^hol-guard[[:space:]]+//')" = "$CORE_VERSION"
+          export HOL_GUARD_HOME="$RUNNER_TEMP/smoke-home"
+          mkdir -p "$HOL_GUARD_HOME"
+          "$BUILT" desktop bootstrap --json > "$RUNNER_TEMP/bootstrap.json"
+          python3 -I scripts/release/desktop_core_alpha_feed.py verify-bootstrap \
+            --payload "$RUNNER_TEMP/bootstrap.json" --version "$CORE_VERSION" --subject "Standalone Core"
+          mv "$BUILT" "$ASSET"
       - name: Sign and notarize new Core sidecar
         if: steps.release.outputs.available == 'true' && steps.existing.outputs.mode == 'build'
         env:
@@ -342,6 +350,8 @@ jobs:
           BINARY="$RUNNER_TEMP/dist/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
           codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$BINARY"
           codesign --verify --deep --strict --verbose=2 "$BINARY"
+          python3 -I scripts/release/verify_pyinstaller_macos_signing.py \
+            --binary "$BINARY" --team-id "$APPLE_TEAM_ID"
           ditto -c -k --keepParent "$BINARY" "$RUNNER_TEMP/core-update-notary.zip"
           xcrun notarytool submit "$RUNNER_TEMP/core-update-notary.zip" \
             --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" \
@@ -381,6 +391,8 @@ jobs:
             | sed -E 's/^[^=]+=//; s/://g' | tr '[:lower:]' '[:upper:]')
           test -n "$EXPECTED_FINGERPRINT"
           test "$ACTUAL_FINGERPRINT" = "$EXPECTED_FINGERPRINT"
+          python3 -I scripts/release/verify_pyinstaller_macos_signing.py \
+            --binary "$BINARY" --team-id "$APPLE_TEAM_ID"
           if [[ "$MODE" == "build" ]]; then
             test -s "$RUNNER_TEMP/notary-result.json"
             jq -e '.status == "Accepted" and (.id | type == "string" and length > 0)' \

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12258,
-  "maximum_test_source_lines": 285508,
+  "maximum_collected_cases": 12261,
+  "maximum_test_source_lines": 285620,
   "schema_version": 1
 }

--- a/scripts/release/verify_pyinstaller_macos_signing.py
+++ b/scripts/release/verify_pyinstaller_macos_signing.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Verify that Mach-O binaries embedded in a PyInstaller onefile archive share one Apple Team ID."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import struct
+import subprocess
+import tempfile
+import zlib
+from pathlib import Path
+
+COOKIE_MAGIC = b"MEI\x0c\x0b\x0a\x0b\x0e"
+COOKIE_FORMAT = "!8sIIII64s"
+COOKIE_LENGTH = struct.calcsize(COOKIE_FORMAT)
+TOC_FORMAT = "!IIIIBc"
+TOC_HEADER_LENGTH = struct.calcsize(TOC_FORMAT)
+BINARY_TYPE = "b"
+MACHO_MAGICS = {
+    b"\xce\xfa\xed\xfe",  # MH_MAGIC
+    b"\xcf\xfa\xed\xfe",  # MH_MAGIC_64
+    b"\xfe\xed\xfa\xce",  # MH_CIGAM
+    b"\xfe\xed\xfa\xcf",  # MH_CIGAM_64
+    b"\xca\xfe\xba\xbe",  # FAT_MAGIC
+    b"\xca\xfe\xba\xbf",  # FAT_MAGIC_64
+    b"\xbe\xba\xfe\xca",  # FAT_CIGAM
+    b"\xbf\xba\xfe\xca",  # FAT_CIGAM_64
+}
+
+
+def _find_cookie(handle) -> int:
+    handle.seek(0, os.SEEK_END)
+    end = handle.tell()
+    chunk_size = 8192
+    while end >= len(COOKIE_MAGIC):
+        start = max(end - chunk_size, 0)
+        handle.seek(start)
+        chunk = handle.read(end - start)
+        pos = chunk.rfind(COOKIE_MAGIC)
+        if pos >= 0:
+            return start + pos
+        end = start + len(COOKIE_MAGIC) - 1
+    raise ValueError("PyInstaller CArchive cookie was not found")
+
+
+def _archive_layout(binary: Path) -> tuple[int, str, list[tuple[str, int, int, bool, str]]]:
+    with binary.open("rb") as handle:
+        cookie_offset = _find_cookie(handle)
+        handle.seek(cookie_offset)
+        cookie = handle.read(COOKIE_LENGTH)
+        if len(cookie) != COOKIE_LENGTH:
+            raise ValueError("Truncated PyInstaller CArchive cookie")
+        magic, archive_length, toc_offset, toc_length, _pyvers, raw_pylib_name = struct.unpack(
+            COOKIE_FORMAT, cookie
+        )
+        try:
+            pylib_name = raw_pylib_name.rstrip(b"\0").decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("PyInstaller CArchive Python runtime name is not UTF-8") from exc
+        if magic != COOKIE_MAGIC or not pylib_name:
+            raise ValueError("Invalid PyInstaller CArchive cookie")
+
+        archive_end = cookie_offset + COOKIE_LENGTH
+        archive_start = archive_end - archive_length
+        if archive_start < 0:
+            raise ValueError("Invalid PyInstaller CArchive length")
+        handle.seek(archive_start + toc_offset)
+        toc = handle.read(toc_length)
+        if len(toc) != toc_length:
+            raise ValueError("Truncated PyInstaller CArchive TOC")
+
+    entries: list[tuple[str, int, int, bool, str]] = []
+    cursor = 0
+    while cursor < len(toc):
+        header = toc[cursor : cursor + TOC_HEADER_LENGTH]
+        if len(header) != TOC_HEADER_LENGTH:
+            raise ValueError("Truncated PyInstaller TOC header")
+        entry_length, offset, length, _uncompressed, compressed, raw_typecode = struct.unpack(
+            TOC_FORMAT, header
+        )
+        name_length = entry_length - TOC_HEADER_LENGTH
+        if name_length <= 0 or cursor + entry_length > len(toc):
+            raise ValueError("Invalid PyInstaller TOC entry length")
+        raw_name = toc[
+            cursor + TOC_HEADER_LENGTH : cursor + TOC_HEADER_LENGTH + name_length
+        ]
+        try:
+            name = raw_name.rstrip(b"\0").decode("utf-8")
+            typecode = raw_typecode.decode("ascii")
+        except UnicodeDecodeError as exc:
+            raise ValueError("Invalid PyInstaller TOC text encoding") from exc
+        if not name:
+            raise ValueError("PyInstaller TOC entry has an empty name")
+        entries.append((name, offset, length, bool(compressed), typecode))
+        cursor += entry_length
+    return archive_start, pylib_name, entries
+
+
+def _entry_bytes(
+    handle,
+    archive_start: int,
+    name: str,
+    offset: int,
+    length: int,
+    compressed: bool,
+) -> bytes:
+    handle.seek(archive_start + offset)
+    data = handle.read(length)
+    if len(data) != length:
+        raise ValueError(f"Truncated PyInstaller binary entry: {name}")
+    return zlib.decompress(data) if compressed else data
+
+
+def _team_id(path: Path) -> str:
+    result = subprocess.run(
+        ["codesign", "--display", "--verbose=4", str(path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ValueError(f"Embedded Mach-O is not code signed: {path.name}: {result.stderr.strip()}")
+    for line in result.stderr.splitlines():
+        if line.startswith("TeamIdentifier="):
+            return line.split("=", 1)[1]
+    raise ValueError(f"Embedded Mach-O has no TeamIdentifier: {path.name}")
+
+
+def verify(binary: Path, expected_team_id: str) -> None:
+    archive_start, declared_runtime, entries = _archive_layout(binary)
+    declared_entries = [entry for entry in entries if entry[0] == declared_runtime]
+    if len(declared_entries) != 1:
+        raise ValueError(
+            f"Cookie-declared Python runtime {declared_runtime!r} must have exactly one TOC entry; "
+            f"found {len(declared_entries)}"
+        )
+    if declared_entries[0][4] != BINARY_TYPE:
+        raise ValueError(
+            f"Cookie-declared Python runtime {declared_runtime!r} is not a binary TOC entry"
+        )
+
+    macho_count = 0
+    declared_runtime_verified = False
+    with binary.open("rb") as handle, tempfile.TemporaryDirectory(
+        prefix="hol-guard-pyi-signing-"
+    ) as tmp:
+        root = Path(tmp)
+        for index, (name, offset, length, compressed, typecode) in enumerate(entries):
+            if typecode != BINARY_TYPE:
+                continue
+            data = _entry_bytes(handle, archive_start, name, offset, length, compressed)
+            is_macho = data[:4] in MACHO_MAGICS
+            if name == declared_runtime and not is_macho:
+                raise ValueError(
+                    f"Cookie-declared Python runtime {declared_runtime!r} is not Mach-O"
+                )
+            if not is_macho:
+                continue
+
+            macho_count += 1
+            extracted = root / f"{index:04d}-{Path(name).name or 'binary'}"
+            extracted.write_bytes(data)
+            actual_team_id = _team_id(extracted)
+            if actual_team_id != expected_team_id:
+                raise ValueError(
+                    f"Embedded Mach-O {name!r} has TeamIdentifier={actual_team_id!r}; "
+                    f"expected {expected_team_id!r}"
+                )
+            if name == declared_runtime:
+                declared_runtime_verified = True
+
+    if macho_count == 0:
+        raise ValueError("PyInstaller archive contained no Mach-O binary entries")
+    if not declared_runtime_verified:
+        raise ValueError(
+            f"Cookie-declared Python runtime {declared_runtime!r} was not signature-verified"
+        )
+    print(
+        f"verified {macho_count} embedded Mach-O binaries, including declared Python runtime "
+        f"{declared_runtime!r}, with TeamIdentifier={expected_team_id}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--team-id", required=True)
+    args = parser.parse_args()
+    if not args.binary.is_file():
+        raise SystemExit(f"Binary does not exist: {args.binary}")
+    if not args.team_id or any(ch.isspace() for ch in args.team_id):
+        raise SystemExit("team-id must be a non-empty token")
+    try:
+        verify(args.binary, args.team_id)
+    except (OSError, ValueError, zlib.error) as exc:
+        raise SystemExit(str(exc)) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_desktop_core_alpha_feed_macos_signing.py
+++ b/tests/test_desktop_core_alpha_feed_macos_signing.py
@@ -1,0 +1,112 @@
+"""Regression contracts for macOS PyInstaller signing in the Desktop Core feed."""
+
+from __future__ import annotations
+
+import importlib.util
+import struct
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "desktop-core-alpha-feed.yml"
+VERIFIER = ROOT / "scripts" / "release" / "verify_pyinstaller_macos_signing.py"
+
+
+def _publish_steps() -> list[dict[str, object]]:
+    payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = payload["jobs"]["publish-macos-arm64"]["steps"]
+    assert isinstance(steps, list)
+    return steps
+
+
+def _load_verifier() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("verify_pyinstaller_macos_signing", VERIFIER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_archive(path: Path, *, declared_runtime: str, entries: list[tuple[str, bytes]]) -> None:
+    module = _load_verifier()
+    payload = bytearray()
+    toc = bytearray()
+    for name, data in entries:
+        offset = len(payload)
+        payload.extend(data)
+        raw_name = name.encode("utf-8") + b"\0"
+        entry_length = module.TOC_HEADER_LENGTH + len(raw_name)
+        toc.extend(
+            struct.pack(
+                module.TOC_FORMAT,
+                entry_length,
+                offset,
+                len(data),
+                len(data),
+                0,
+                b"b",
+            )
+        )
+        toc.extend(raw_name)
+
+    raw_runtime = declared_runtime.encode("utf-8")
+    assert len(raw_runtime) < 64
+    cookie = struct.pack(
+        module.COOKIE_FORMAT,
+        module.COOKIE_MAGIC,
+        len(payload) + len(toc) + module.COOKIE_LENGTH,
+        len(payload),
+        len(toc),
+        312,
+        raw_runtime + (b"\0" * (64 - len(raw_runtime))),
+    )
+    path.write_bytes(bytes(payload) + bytes(toc) + cookie)
+
+
+def test_signing_identity_is_imported_before_pyinstaller_build() -> None:
+    steps = _publish_steps()
+    names = [step.get("name") for step in steps]
+    assert names.index("Import Apple signing identity") < names.index("Build standalone Core executable")
+
+    build = next(step for step in steps if step.get("name") == "Build standalone Core executable")
+    assert build["env"]["APPLE_SIGNING_IDENTITY"] == "${{ secrets.APPLE_SIGNING_IDENTITY }}"
+    assert build["env"]["APPLE_TEAM_ID"] == "${{ secrets.APPLE_TEAM_ID }}"
+    run = build["run"]
+    assert isinstance(run, str)
+    assert '--codesign-identity "$APPLE_SIGNING_IDENTITY"' in run
+    assert "verify_pyinstaller_macos_signing.py" in run
+    assert '--team-id "$APPLE_TEAM_ID"' in run
+
+
+def test_final_verification_checks_reused_and_new_embedded_team_identity() -> None:
+    steps = _publish_steps()
+    verify = next(
+        step
+        for step in steps
+        if step.get("name") == "Verify exact Apple identity, notarization, and Core contract"
+    )
+    run = verify["run"]
+    assert isinstance(run, str)
+    verifier = "python3 -I scripts/release/verify_pyinstaller_macos_signing.py"
+    assert verifier in run
+    assert run.index(verifier) < run.index('if [[ "$MODE" == "build" ]]; then')
+
+
+def test_verifier_rejects_missing_cookie_declared_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_verifier()
+    archive = tmp_path / "hol-guard"
+    _fake_archive(
+        archive,
+        declared_runtime="Python",
+        entries=[("python_helper", b"\xcf\xfa\xed\xfe")],
+    )
+    monkeypatch.setattr(module, "_team_id", lambda _path: "TEAM123")
+
+    with pytest.raises(ValueError, match="Cookie-declared Python runtime 'Python'.*found 0"):
+        module.verify(archive, "TEAM123")


### PR DESCRIPTION
Fixes the macOS Desktop Core sidecar signing boundary for PyInstaller one-file builds.

The Developer ID identity is now imported before PyInstaller runs and passed via `--codesign-identity`, so embedded Mach-O binaries, including the extracted Python runtime, are signed by the same Apple team as the outer executable. A fail-closed archive verifier inspects embedded Mach-O TeamIdentifiers before and after outer hardening/notarization.

Scope is limited to the privileged Desktop Core alpha feed and regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS desktop release signing and verification.
  - Release builds now consistently validate embedded components and Apple team identity throughout the packaging process.
  - Added safeguards to help prevent improperly signed or unverifiable macOS artifacts from being published.

- **Quality Improvements**
  - Expanded automated coverage for macOS signing, notarization, and final artifact validation.
  - Updated release quality thresholds to reflect the growing test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->