### PR TITLE
fix(action): render markdown scan reports inline

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -44,7 +44,7 @@ inputs:
     required: false
     default: "ai-plugin-scanner"
   write_step_summary:
-    description: "Write a concise markdown summary to the GitHub Actions job summary"
+    description: "Write the full report inline for markdown scans, otherwise write a concise GitHub Actions job summary"
     required: false
     default: "true"
   registry_payload_output:
@@ -283,7 +283,7 @@ runs:
         BASELINE: ${{ inputs.baseline }}
         ONLINE: ${{ inputs.online }}
         UPLOAD_SARIF: ${{ inputs.upload_sarif }}
-        WRITE_STEP_SUMMARY: ${{ inputs.write_step_summary }}
+        WRITE_STEP_SUMMARY: ${{ inputs.write_step_summary == 'true' && inputs.format != 'markdown' }}
         REGISTRY_PAYLOAD_OUTPUT: ${{ inputs.registry_payload_output }}
         MIN_SCORE: ${{ inputs.min_score }}
         FAIL_ON: ${{ inputs.fail_on_severity }}
@@ -306,6 +306,20 @@ runs:
         PYTHONNOUSERSITE: "1"
         PYTHONSAFEPATH: "1"
       run: python3 -P -m codex_plugin_scanner.action_runner
+
+    - name: Publish Markdown report to job summary
+      if: ${{ inputs.write_step_summary == 'true' && inputs.mode == 'scan' && inputs.format == 'markdown' && steps.scan.outputs.report_path != '' }}
+      shell: bash
+      env:
+        REPORT_PATH: ${{ steps.scan.outputs.report_path }}
+      run: |
+        set -euo pipefail
+        if [ ! -s "$REPORT_PATH" ]; then
+          echo "Markdown report was requested for the job summary but was not generated: $REPORT_PATH" >&2
+          exit 1
+        fi
+        cat "$REPORT_PATH" >> "$GITHUB_STEP_SUMMARY"
+        printf '\n' >> "$GITHUB_STEP_SUMMARY"
 
     - name: Upload SARIF
       if: ${{ inputs.upload_sarif == 'true' && inputs.mode == 'scan' && steps.scan.outputs.report_path != '' }}

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12258,
-  "maximum_test_source_lines": 285500,
+  "maximum_test_source_lines": 285508,
   "schema_version": 1
 }

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -74,6 +74,7 @@ def test_action_steps_enable_python_safe_path() -> None:
     steps = parsed["runs"]["steps"]
     install_step = next(step for step in steps if step["name"] == "Install scanner")
     scan_step = next(step for step in steps if step["name"] == "Run scanner")
+    summary_step = next(step for step in steps if step["name"] == "Publish Markdown report to job summary")
 
     assert install_step["env"]["PYTHONNOUSERSITE"] == "1"
     assert install_step["env"]["PYTHONSAFEPATH"] == "1"
@@ -81,7 +82,14 @@ def test_action_steps_enable_python_safe_path() -> None:
     assert "python3 -P -m pip install" in install_step["run"]
     assert scan_step["env"]["PYTHONNOUSERSITE"] == "1"
     assert scan_step["env"]["PYTHONSAFEPATH"] == "1"
+    assert scan_step["env"]["WRITE_STEP_SUMMARY"] == (
+        "${{ inputs.write_step_summary == 'true' && inputs.format != 'markdown' }}"
+    )
     assert scan_step["run"] == "python3 -P -m codex_plugin_scanner.action_runner"
+    assert "inputs.format == 'markdown'" in summary_step["if"]
+    assert summary_step["env"]["REPORT_PATH"] == "${{ steps.scan.outputs.report_path }}"
+    assert 'if [ ! -s "$REPORT_PATH" ]; then' in summary_step["run"]
+    assert 'cat "$REPORT_PATH" >> "$GITHUB_STEP_SUMMARY"' in summary_step["run"]
 
 
 def test_python_safe_path_blocks_workspace_module_shadowing(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- render generated Markdown scan reports directly in the GitHub Actions job summary
- suppress the compact duplicate summary for `format: markdown`
- keep concise summary behavior unchanged for SARIF, JSON, and text modes
- fail clearly if a Markdown report was requested for the job summary but the report file is missing
- add action-bundle regression coverage for the summary publication step

This fixes the consumer behavior seen in `currencyguard-guard-pricing-plugin`, where the full Markdown report was only available as an artifact instead of being rendered in the Actions summary.