### PR TITLE
fix(guard): preserve watch-only inbox visibility

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14219,
-  "maximum_test_source_lines": 313081,
+  "maximum_collected_cases": 14225,
+  "maximum_test_source_lines": 313296,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -447,6 +447,7 @@ def queue_blocked_approvals(
     store: GuardStore,
     approval_center_url: str,
     now: str | None = None,
+    notify: bool = True,
     redaction_level: str = "full",
 ) -> list[dict[str, object]]:
     timestamp = now or _now()
@@ -578,7 +579,8 @@ def queue_blocked_approvals(
             )
         if created_new_request:
             _record_created_event(store, request, timestamp)
-        _notify_pending_approval(store=store, request=request)
+        if notify:
+            _notify_pending_approval(store=store, request=request)
         request_payload = store.get_approval_request(persisted_request_id)
         if request_payload is None:
             raise RuntimeError(f"Persisted approval request not found: {persisted_request_id}")

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
@@ -37,6 +37,7 @@ from .commands_support_command_activity import (
     command_activity_was_prompted,
     record_pre_hook_command_activity_best_effort,
 )
+from .commands_support_observe_queue import queue_observe_mode_request
 
 
 def _record_copilot_pre_activity(
@@ -151,6 +152,7 @@ def _run_hook_copilot_pretool(
     decision_scanner_evidence = _copilot_tool_decision_scanner_evidence(decision)
     saved_policy_blocks = decision.saved_action == "block"
     now = _now()
+    observed_policy_action: GuardAction | None = None
     if config.mode == "observe" and policy_action not in {"allow", "warn"}:
         observed_policy_action = policy_action
         observe_mode_evidence: dict[str, object] = {
@@ -160,6 +162,19 @@ def _run_hook_copilot_pretool(
         }
         decision_scanner_evidence = (*decision_scanner_evidence, observe_mode_evidence)
         policy_action = "allow"
+    if config.mode == "observe":
+        queue_observe_mode_request(
+            action_envelope=action_envelope,
+            artifact=runtime_artifact,
+            artifact_hash=runtime_artifact_hash,
+            changed_fields=("runtime_tool_call", *decision.signals),
+            executable_action=policy_action,
+            observed_policy_action=observed_policy_action or policy_action,
+            redaction_level=config.receipt_redaction_level,
+            risk_summary=decision.summary,
+            scanner_evidence=decision_scanner_evidence,
+            store=store,
+        )
     # Copilot review/reapproval continues to PermissionRequest, which owns that
     # activity. PreToolUse records only decisions that terminate at this stage.
     if policy_action in {"allow", "warn"}:
@@ -324,6 +339,7 @@ def _run_hook_copilot_permission_request(
         response_payload["approval_reuse"] = approval_reuse
     if decision_scanner_evidence:
         response_payload["scanner_evidence"] = list(decision_scanner_evidence)
+    observed_policy_action: GuardAction | None = None
     if config.mode == "observe" and policy_action not in {"allow", "warn"}:
         observed_policy_action = policy_action
         response_payload["approval_requests"] = []
@@ -339,6 +355,19 @@ def _run_hook_copilot_permission_request(
         response_payload["scanner_evidence"] = list(decision_scanner_evidence)
         policy_action = "allow"
         response_payload["policy_action"] = "allow"
+    if config.mode == "observe":
+        queue_observe_mode_request(
+            action_envelope=action_envelope,
+            artifact=runtime_artifact,
+            artifact_hash=runtime_artifact_hash,
+            changed_fields=("runtime_tool_call", *decision.signals),
+            executable_action=policy_action,
+            observed_policy_action=observed_policy_action or policy_action,
+            redaction_level=config.receipt_redaction_level,
+            risk_summary=decision.summary,
+            scanner_evidence=decision_scanner_evidence,
+            store=store,
+        )
     if policy_action in {"allow", "warn"}:
         receipt = allow_tool_call(
             store=store,

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -71,6 +71,23 @@ def _string_list(value: object | None) -> list[str]:
     return [str(item) for item in value if isinstance(item, str) and item.strip()]
 
 
+def _observed_action_detail(
+    command_text: str | None,
+    *,
+    action_envelope: GuardActionEnvelope | None,
+    home_dir: Path | None,
+) -> str | None:
+    command_detail = _command_detail(command_text, home_dir=home_dir)
+    if command_detail is not None or action_envelope is None:
+        return command_detail
+    tool_name = action_envelope.tool_name
+    if not isinstance(tool_name, str) or not tool_name.strip():
+        return None
+    target_summary = " ".join(action_envelope.target_paths)
+    detail = f"{tool_name.strip()} {target_summary}" if target_summary else tool_name.strip()
+    return _command_detail(detail, home_dir=home_dir)
+
+
 if TYPE_CHECKING:
     from ._commands_shared import (
         _HOOK_DAEMON_FAIL_MODES,
@@ -150,6 +167,7 @@ from .commands_support_command_activity import (
     record_post_hook_command_activity_best_effort,
     record_pre_hook_command_activity_best_effort,
 )
+from .commands_support_observe_queue import queue_observe_mode_request
 from .commands_support_runtime_policy import _runtime_hook_effective_policy_config
 
 # Bump when generic-hook classification or action-composition semantics change.
@@ -1066,6 +1084,41 @@ def _run_hook_generic_payload(
             output_stream=output_stream,
         )
         return 0
+    if config.mode == "observe" and hook_is_pre_event(hook_event_name):
+        inbox_policy_action = observed_policy_action or policy_action
+        observed_artifact = GuardArtifact(
+            artifact_id=artifact_id,
+            name=artifact_name,
+            harness=args.harness,
+            artifact_type="tool_action_request",
+            source_scope="project",
+            config_path=str(runtime_workspace) if runtime_workspace is not None else "",
+            command=_observed_action_detail(
+                command_text,
+                action_envelope=action_envelope,
+                home_dir=home_dir,
+            ),
+            metadata={
+                "action_class": "observed tool action",
+                "request_summary": "Guard recorded what watch-only mode would have stopped.",
+            },
+        )
+        queue_observe_mode_request(
+            action_envelope=action_envelope,
+            artifact=observed_artifact,
+            artifact_hash=runtime_artifact_hash,
+            changed_fields=changed_capabilities or ["tool_action"],
+            executable_action=policy_action,
+            observed_policy_action=inbox_policy_action,
+            redaction_level=config.receipt_redaction_level,
+            risk_summary=(
+                "Watch-only mode allowed an action that current policy would stop."
+                if observed_policy_action is not None
+                else "Watch-only mode recorded this action without blocking it."
+            ),
+            scanner_evidence=scanner_evidence,
+            store=store,
+        )
     if (
         hook_is_pre_event(hook_event_name)
         and policy_action in {"review", "require-reapproval"}

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_review.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_review.py
@@ -58,6 +58,7 @@ from .commands_hook_runtime_state import (
     set_runtime_artifact_hook_final_action,
 )
 from .commands_parser_helpers import *
+from .commands_support_observe_queue import queue_observe_mode_request
 
 _OBSERVE_EXECUTION_SOURCE_FIELDS = (
     "current_config_action",
@@ -108,6 +109,8 @@ def _review_runtime_artifact_hook(
     event_name = state.event_name
     package_evaluation = state.package_evaluation
     policy_action = state.policy_action
+    if not is_guard_action(policy_action):
+        return None
     response_payload = state.response_payload
     risk_summary = state.risk_summary
     runtime_artifact = state.runtime_artifact
@@ -123,6 +126,7 @@ def _review_runtime_artifact_hook(
         guard_payload=response_payload,
     )
     observe_mode = config.mode == "observe"
+    observe_request_queued = False
     terminal_action = policy_action in {
         "block",
         "sandbox-required",
@@ -143,6 +147,19 @@ def _review_runtime_artifact_hook(
         if observe_mode:
             response_payload["approval_requests"] = []
             observed_policy_action = policy_action
+            queue_observe_mode_request(
+                action_envelope=action_envelope,
+                artifact=runtime_artifact,
+                artifact_hash=runtime_artifact_hash,
+                changed_fields=changed_capabilities,
+                executable_action=_observe_mode_executable_action(state),
+                observed_policy_action=observed_policy_action,
+                redaction_level=config.receipt_redaction_level,
+                risk_summary=risk_summary,
+                scanner_evidence=scanner_evidence_payload,
+                store=store,
+            )
+            observe_request_queued = True
             set_runtime_artifact_hook_final_action(
                 state,
                 _observe_mode_executable_action(state),
@@ -369,6 +386,19 @@ def _review_runtime_artifact_hook(
                 managed_install=managed_install,
             )
             _localize_pending_approval_copy(response_payload, harness=args.harness)
+    if observe_mode and event_name == "PreToolUse" and not observe_request_queued:
+        queue_observe_mode_request(
+            action_envelope=action_envelope,
+            artifact=runtime_artifact,
+            artifact_hash=runtime_artifact_hash,
+            changed_fields=changed_capabilities,
+            executable_action=policy_action,
+            observed_policy_action=policy_action,
+            redaction_level=config.receipt_redaction_level,
+            risk_summary=risk_summary,
+            scanner_evidence=scanner_evidence_payload,
+            store=store,
+        )
     state.action_envelope = action_envelope
     state.browser_approval_daemon_client = locals().get("browser_approval_daemon_client")
     state.policy_action = policy_action

--- a/src/codex_plugin_scanner/guard/cli/commands_support_observe_queue.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_observe_queue.py
@@ -1,0 +1,80 @@
+"""Non-blocking Inbox persistence for watch-only hook decisions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from ..approvals import queue_blocked_approvals
+from ..daemon.manager import guard_daemon_url_for_home
+from ..models import GuardAction, GuardArtifact, HarnessDetection
+from ..runtime.actions import GuardActionEnvelope
+from ..store import GuardStore
+
+
+def queue_observe_mode_request(
+    *,
+    action_envelope: GuardActionEnvelope | None,
+    artifact: GuardArtifact,
+    artifact_hash: str,
+    changed_fields: Sequence[str],
+    executable_action: GuardAction,
+    observed_policy_action: GuardAction,
+    redaction_level: str,
+    risk_summary: str | None,
+    scanner_evidence: Sequence[Mapping[str, object]],
+    store: GuardStore,
+) -> list[dict[str, object]]:
+    """Queue retrospective review without changing the executable decision."""
+
+    review_action: GuardAction = (
+        observed_policy_action if observed_policy_action in {"review", "require-reapproval"} else "require-reapproval"
+    )
+    queue_envelope = action_envelope.with_pre_execution_result(None) if action_envelope is not None else None
+    evidence = [dict(item) for item in scanner_evidence]
+    evidence.append(
+        {
+            "source": "observe_mode_inbox",
+            "observed_policy_action": observed_policy_action,
+            "queued_policy_action": review_action,
+            "authoritative_action": executable_action,
+        }
+    )
+    try:
+        approval_center_url = guard_daemon_url_for_home(store.guard_home)
+        return queue_blocked_approvals(
+            detection=HarnessDetection(
+                harness=artifact.harness,
+                installed=True,
+                command_available=True,
+                config_paths=(artifact.config_path,),
+                artifacts=(artifact,),
+            ),
+            evaluation={
+                "artifacts": [
+                    {
+                        "artifact_id": artifact.artifact_id,
+                        "artifact_name": artifact.name,
+                        "artifact_hash": artifact_hash,
+                        "artifact_type": artifact.artifact_type,
+                        "source_scope": artifact.source_scope,
+                        "config_path": artifact.config_path,
+                        "policy_action": review_action,
+                        "changed_fields": list(changed_fields),
+                        "launch_target": artifact.command,
+                        "risk_summary": risk_summary,
+                        "action_envelope_json": queue_envelope.to_dict() if queue_envelope is not None else None,
+                        "scanner_evidence": evidence,
+                    }
+                ]
+            },
+            store=store,
+            approval_center_url=approval_center_url,
+            notify=False,
+            redaction_level=redaction_level,
+        )
+    except Exception:
+        # Watch-only telemetry must never alter the executable hook decision.
+        return []
+
+
+__all__ = ["queue_observe_mode_request"]

--- a/tests/test_guard_approval_precedence_generic_stdio.py
+++ b/tests/test_guard_approval_precedence_generic_stdio.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard import approvals as approvals_module
 from codex_plugin_scanner.guard.cli import commands_hook_generic
 from codex_plugin_scanner.guard.cli import commands_support as guard_commands_module
 from codex_plugin_scanner.guard.cli.commands_hook_generic import (
@@ -410,6 +411,11 @@ def test_generic_hook_observe_mode_records_block_without_enforcing_it(
     monkeypatch: pytest.MonkeyPatch,
     event_name: str,
 ) -> None:
+    monkeypatch.setattr(
+        approvals_module,
+        "_notify_pending_approval",
+        lambda **_kwargs: pytest.fail("watch-only persistence must stay silent"),
+    )
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     store = GuardStore(tmp_path / "guard-home")
@@ -451,6 +457,16 @@ def test_generic_hook_observe_mode_records_block_without_enforcing_it(
     if event_name == "PreToolUse":
         assert recorded_activity["policy_action"] == "allow"
         assert recorded_activity["prompted"] is False
+        pending = store.list_approval_requests(limit=10)
+        assert len(pending) == 1
+        assert pending[0]["policy_action"] == "require-reapproval"
+        assert pending[0]["scanner_evidence"][-1] == {
+            "source": "observe_mode_inbox",
+            "observed_policy_action": "block",
+            "queued_policy_action": "require-reapproval",
+            "authoritative_action": "allow",
+        }
+        assert "approval_requests" not in output
 
 
 def test_codex_pretool_observe_mode_persists_observed_decision_evidence(

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -5437,7 +5437,7 @@ curl --data-binary @"$1" http://127.0.0.1:8787/guard-canary
         assert pending[0]["policy_action"] == "require-reapproval"
         assert pending[0]["scanner_evidence"][-1] == {
             "source": "observe_mode_inbox",
-            "observed_policy_action": "require-reapproval",
+            "observed_policy_action": "block",
             "queued_policy_action": "require-reapproval",
             "authoritative_action": "allow",
         }

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -5433,7 +5433,14 @@ curl --data-binary @"$1" http://127.0.0.1:8787/guard-canary
         assert rc == 0
         assert captured.out == ""
         pending = store.list_approval_requests(limit=5)
-        assert pending == []
+        assert len(pending) == 1
+        assert pending[0]["policy_action"] == "require-reapproval"
+        assert pending[0]["scanner_evidence"][-1] == {
+            "source": "observe_mode_inbox",
+            "observed_policy_action": "require-reapproval",
+            "queued_policy_action": "require-reapproval",
+            "authoritative_action": "allow",
+        }
 
     def test_guard_codex_pretooluse_returns_without_browser_wait_for_secret_exfil(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_codex_apply_patch_policy.py
+++ b/tests/test_guard_codex_apply_patch_policy.py
@@ -7,9 +7,11 @@ from typing import cast
 
 import pytest
 
-from codex_plugin_scanner.guard.cli import commands_hook_generic
+from codex_plugin_scanner.guard.cli import commands_hook_generic, commands_support_observe_queue
+from codex_plugin_scanner.guard.cli.commands_support_hook_payload import _hook_action_envelope
 from codex_plugin_scanner.guard.cli.commands_support_runtime_artifacts import _hook_runtime_artifact
 from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.models import GuardAction, GuardArtifact
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -43,6 +45,19 @@ def test_verified_workspace_apply_patch_uses_relaxed_default(tmp_path: Path, ope
     assert not _relaxes(patch, workspace=workspace, checked=False)
 
 
+def test_verified_workspace_apply_patch_allows_plugin_metadata_bundle(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    patch = f"""*** Begin Patch
+*** Add File: {workspace}/.codex-plugin/plugin.json
++{{"name":"example-plugin","mcpServers":"./.mcp.json"}}
+*** Add File: {workspace}/.mcp.json
++{{"mcpServers":{{"example":{{"type":"http","url":"https://api.example.com/mcp"}}}}}}
+*** End Patch"""
+
+    assert _relaxes(patch, workspace=workspace)
+
+
 def test_verified_workspace_apply_patch_does_not_queue_approval(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -59,9 +74,15 @@ def test_verified_workspace_apply_patch_does_not_queue_approval(
         policy_action=None,
     )
 
+    action_envelope = _hook_action_envelope(
+        harness="codex",
+        payload=payload,
+        home_dir=tmp_path,
+        workspace=workspace,
+    )
     rc = commands_hook_generic._run_hook_generic_payload(
         args,
-        action_envelope=None,
+        action_envelope=action_envelope,
         config=GuardConfig(guard_home=guard_home, workspace=workspace, default_action="review"),
         home_dir=tmp_path,
         payload=payload,
@@ -76,6 +97,149 @@ def test_verified_workspace_apply_patch_does_not_queue_approval(
     assert rc == 0
     assert output["policy_action"] == "warn"
     assert "approval_requests" not in output
+
+
+@pytest.mark.parametrize(("default_action", "expected_action"), (("review", "warn"), ("allow", "allow")))
+def test_watch_only_workspace_apply_patch_is_visible_without_blocking(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    default_action: str,
+    expected_action: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    guard_home = tmp_path / "guard-home"
+    payload = _payload(
+        f"""*** Begin Patch
+*** Add File: {workspace}/.codex-plugin/plugin.json
++{{"name":"example-plugin","mcpServers":"./.mcp.json"}}
+*** Add File: {workspace}/.mcp.json
++{{"mcpServers":{{"example":{{"type":"http","url":"https://api.example.com/mcp"}}}}}}
+*** End Patch"""
+    )
+    payload["approval_requests"] = []
+    args = argparse.Namespace(
+        artifact_id=None,
+        artifact_name=None,
+        harness="codex",
+        json=True,
+        policy_action=None,
+    )
+    store = GuardStore(guard_home)
+    action_envelope = _hook_action_envelope(
+        harness="codex",
+        payload=payload,
+        home_dir=tmp_path,
+        workspace=workspace,
+    )
+
+    rc = commands_hook_generic._run_hook_generic_payload(
+        args,
+        action_envelope=action_envelope,
+        config=GuardConfig(
+            guard_home=guard_home,
+            workspace=workspace,
+            default_action=default_action,
+            mode="observe",
+        ),
+        home_dir=tmp_path,
+        payload=payload,
+        runtime_artifact_checked=True,
+        runtime_workspace=workspace,
+        store=store,
+    )
+    output = cast(dict[str, object], json.loads(capsys.readouterr().out))
+
+    assert rc == 0
+    assert output["policy_action"] == expected_action
+    assert "approval_requests" not in output
+    pending = store.list_approval_requests(limit=10)
+    assert len(pending) == 1
+    assert pending[0]["policy_action"] == "require-reapproval"
+    assert pending[0]["launch_target"] == ("apply_patch ~.../plugin.json ~.../.mcp.json")
+    assert pending[0]["scanner_evidence"][-1]["authoritative_action"] == expected_action
+    assert pending[0]["action_envelope_json"]["pre_execution_result"] is None
+
+
+def test_watch_only_inbox_failure_never_changes_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = GuardArtifact(
+        artifact_id="observe-failure",
+        name="apply_patch",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(tmp_path),
+        command="apply_patch src/example.py",
+    )
+    monkeypatch.setattr(
+        commands_support_observe_queue,
+        "queue_blocked_approvals",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("storage unavailable")),
+    )
+
+    queued = commands_support_observe_queue.queue_observe_mode_request(
+        action_envelope=None,
+        artifact=artifact,
+        artifact_hash="observe-failure-hash",
+        changed_fields=("tool_action",),
+        executable_action="allow",
+        observed_policy_action="allow",
+        redaction_level="full",
+        risk_summary="Routine action",
+        scanner_evidence=(),
+        store=GuardStore(tmp_path / "guard-home"),
+    )
+
+    assert queued == []
+
+
+@pytest.mark.parametrize("executable_action", ("allow", "warn"))
+def test_watch_only_inbox_accepts_stamped_runtime_envelope(
+    tmp_path: Path,
+    executable_action: GuardAction,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    payload = _payload("*** Begin Patch\n*** Add File: example.py\n+value = 1\n*** End Patch")
+    action_envelope = _hook_action_envelope(
+        harness="codex",
+        payload=payload,
+        home_dir=tmp_path,
+        workspace=workspace,
+    )
+    assert action_envelope is not None
+    artifact = GuardArtifact(
+        artifact_id=f"stamped-{executable_action}",
+        name="apply_patch",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace),
+        command="apply_patch example.py",
+    )
+    store = GuardStore(tmp_path / "guard-home")
+
+    queued = commands_support_observe_queue.queue_observe_mode_request(
+        action_envelope=action_envelope.with_pre_execution_result(executable_action),
+        artifact=artifact,
+        artifact_hash=f"stamped-{executable_action}-hash",
+        changed_fields=("tool_action",),
+        executable_action=executable_action,
+        observed_policy_action=executable_action,
+        redaction_level="full",
+        risk_summary="Routine action",
+        scanner_evidence=(),
+        store=store,
+    )
+
+    assert len(queued) == 1
+    pending = store.list_approval_requests(limit=10)
+    assert len(pending) == 1
+    assert pending[0]["action_envelope_json"]["pre_execution_result"] is None
+    assert pending[0]["scanner_evidence"][-1]["authoritative_action"] == executable_action
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_hook_saved_block_terminal.py
+++ b/tests/test_guard_hook_saved_block_terminal.py
@@ -157,6 +157,7 @@ def test_runtime_review_observe_mode_records_saved_block_without_enforcing_it(
     monkeypatch.setattr(runtime_review, "ensure_guard_daemon", _fail_queue)
     monkeypatch.setattr(runtime_review, "queue_blocked_approvals", _fail_queue)
 
+    store = GuardStore(context.guard_home)
     result = runtime_review._review_runtime_artifact_hook(
         state,
         _copilot_args(),
@@ -165,7 +166,7 @@ def test_runtime_review_observe_mode_records_saved_block_without_enforcing_it(
         guard_home=context.guard_home,
         managed_install=None,
         payload={"hook_event_name": "PreToolUse", "tool_name": "dangerous_delete"},
-        store=GuardStore(context.guard_home),
+        store=store,
         workspace=context.workspace_dir,
     )
 
@@ -176,7 +177,7 @@ def test_runtime_review_observe_mode_records_saved_block_without_enforcing_it(
     assert emitted_actions == []
 
 
-def test_runtime_review_observe_mode_allows_fresh_block_without_approval_queue(
+def test_runtime_review_observe_mode_allows_fresh_block_with_retrospective_queue(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -207,6 +208,7 @@ def test_runtime_review_observe_mode_allows_fresh_block_without_approval_queue(
     monkeypatch.setattr(runtime_review, "ensure_guard_daemon", _fail_queue)
     monkeypatch.setattr(runtime_review, "queue_blocked_approvals", _fail_queue)
 
+    store = GuardStore(context.guard_home)
     result = runtime_review._review_runtime_artifact_hook(
         state,
         _copilot_args(json_output=True),
@@ -215,7 +217,7 @@ def test_runtime_review_observe_mode_allows_fresh_block_without_approval_queue(
         guard_home=context.guard_home,
         managed_install=None,
         payload={"hook_event_name": "PreToolUse", "tool_name": "dangerous_delete"},
-        store=GuardStore(context.guard_home),
+        store=store,
         workspace=context.workspace_dir,
     )
 
@@ -232,6 +234,15 @@ def test_runtime_review_observe_mode_allows_fresh_block_without_approval_queue(
     assert "allows" in str(state.response_payload["why_now"]).lower()
     assert state.decision_v2_payload["action"] == "allow"
     assert state.receipt.policy_decision == "allow"
+    pending = store.list_approval_requests(limit=10)
+    assert len(pending) == 1
+    assert pending[0]["policy_action"] == "require-reapproval"
+    assert pending[0]["scanner_evidence"][-1] == {
+        "source": "observe_mode_inbox",
+        "observed_policy_action": "block",
+        "queued_policy_action": "require-reapproval",
+        "authoritative_action": "allow",
+    }
 
 
 def test_runtime_final_action_rewrites_package_copy_and_preserves_observation(
@@ -361,6 +372,7 @@ def test_runtime_observe_mode_preserves_executable_package_warning(
     monkeypatch.setattr(runtime_review, "load_guard_surface_daemon_client", _fail_queue)
     monkeypatch.setattr(runtime_review, "queue_blocked_approvals", _fail_queue)
 
+    store = GuardStore(context.guard_home)
     result = runtime_review._review_runtime_artifact_hook(
         state,
         _copilot_args(json_output=True),
@@ -369,7 +381,7 @@ def test_runtime_observe_mode_preserves_executable_package_warning(
         guard_home=context.guard_home,
         managed_install=None,
         payload={"hook_event_name": "PreToolUse", "tool_name": "dangerous_delete"},
-        store=GuardStore(context.guard_home),
+        store=store,
         workspace=context.workspace_dir,
     )
 
@@ -378,6 +390,9 @@ def test_runtime_observe_mode_preserves_executable_package_warning(
     assert state.policy_action == "warn"
     assert state.response_payload["policy_action"] == "warn"
     assert state.response_payload["approval_requests"] == []
+    pending = store.list_approval_requests(limit=10)
+    assert len(pending) == 1
+    assert pending[0]["scanner_evidence"][-1]["authoritative_action"] == "warn"
     assert state.response_payload["observed_policy_action"] == "review"
     assert state.decision_v2_payload["guard_action"] == "warn"
     assert state.receipt.policy_decision == "warn"
@@ -432,7 +447,9 @@ def test_copilot_pretool_observe_mode_records_saved_block_without_enforcing_it(
     receipt = store.list_receipts(limit=1)[0]
     assert receipt["policy_decision"] == "allow"
     assert _receipt_reuse_evidence(store) == {"source": "approval_reuse", **approval_reuse}
-    assert store.list_approval_requests(limit=10) == []
+    pending = store.list_approval_requests(limit=10)
+    assert len(pending) == 1
+    assert pending[0]["policy_action"] == "require-reapproval"
 
 
 def test_copilot_permission_request_observe_mode_does_not_enforce_saved_block(
@@ -478,7 +495,9 @@ def test_copilot_permission_request_observe_mode_does_not_enforce_saved_block(
     receipt = store.list_receipts(limit=1)[0]
     assert receipt["policy_decision"] == "allow"
     assert _receipt_reuse_evidence(store)["reason_code"] == "approval_reuse_saved_block"
-    assert store.list_approval_requests(limit=10) == []
+    pending = store.list_approval_requests(limit=10)
+    assert len(pending) == 1
+    assert pending[0]["policy_action"] == "require-reapproval"
 
 
 def test_copilot_permission_request_fresh_block_is_terminal_and_never_queued(
@@ -558,7 +577,7 @@ def test_copilot_saved_allow_is_explained_in_native_response_and_allow_receipt(
 
 
 @pytest.mark.parametrize("flow", ("pretool", "permission-request"))
-def test_copilot_observe_mode_allows_fresh_block_without_approval_queue(
+def test_copilot_observe_mode_allows_fresh_block_with_retrospective_queue(
     flow: str,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -606,3 +625,12 @@ def test_copilot_observe_mode_allows_fresh_block_without_approval_queue(
     scanner_evidence = receipt["scanner_evidence"]
     assert isinstance(scanner_evidence, list)
     assert not any(item.get("source") == "approval_reuse" for item in scanner_evidence if isinstance(item, dict))
+    pending = store.list_approval_requests(limit=10)
+    assert len(pending) == 1
+    assert pending[0]["policy_action"] == "require-reapproval"
+    assert pending[0]["scanner_evidence"][-1] == {
+        "source": "observe_mode_inbox",
+        "observed_policy_action": "block",
+        "queued_policy_action": "require-reapproval",
+        "authoritative_action": "allow",
+    }


### PR DESCRIPTION
## Summary
- retain watch-only pre-tool actions in the Inbox without blocking execution
- keep retrospective recording notification-free and independent of daemon startup
- preserve release-specific policy evidence while forwarding the reviewed main behavior

## Testing
- `uv run --no-sync pytest -q tests/test_guard_codex_apply_patch_policy.py tests/test_guard_hook_saved_block_terminal.py tests/test_guard_approval_precedence_generic_stdio.py tests/test_guard_cli.py::TestGuardCli::test_guard_codex_hook_observe_mode_does_not_pause_risky_tool_use tests/test_guard_hook_process_runner.py::test_scheduler_and_runner_complete_48_routine_reviews_without_capacity_denial --tb=short`
- `uv run --no-sync ruff check <changed Python files>`
- `uv run --no-sync ruff format --check <changed Python files>`
- `uv run --no-sync basedpyright --level error <changed hook modules>`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory <generated inventory>`
- `python tests/guard_command_decision_diff.py --check`
