### PR TITLE
fix(guard): isolate frozen daemon re-exec

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14251,
-  "maximum_test_source_lines": 313720,
+  "maximum_collected_cases": 14252,
+  "maximum_test_source_lines": 313734,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
+++ b/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
@@ -122,7 +122,15 @@ def install_frozen_daemon_runtime() -> None:
     """Install one-file daemon identity and process-inventory adaptations."""
 
     global _frozen_runtime_installed
-    if not bool(getattr(sys, "frozen", False)) or _frozen_runtime_installed:
+    if not bool(getattr(sys, "frozen", False)):
+        return
+
+    # A daemon is an independent invocation of the one-file executable. Force
+    # PyInstaller to create a fresh extraction root instead of treating it as a
+    # worker process that reuses the parent's private _MEI runtime directory.
+    os.environ["PYINSTALLER_RESET_ENVIRONMENT"] = "1"
+
+    if _frozen_runtime_installed:
         return
     current_inventory = manager._guard_daemon_process_inventory_for_guard_home
 

--- a/tests/test_guard_frozen_daemon_runtime.py
+++ b/tests/test_guard_frozen_daemon_runtime.py
@@ -102,10 +102,24 @@ def test_frozen_runtime_fingerprint_binds_exact_executable_bytes(
     assert frozen_daemon_runtime._frozen_runtime_fingerprint() == hashlib.sha256(payload).hexdigest()
 
 
+def test_frozen_runtime_forces_fresh_pyinstaller_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    inventory = manager._guard_daemon_process_inventory_for_guard_home
+    monkeypatch.setattr(frozen_daemon_runtime.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(frozen_daemon_runtime, "_frozen_runtime_installed", False)
+    monkeypatch.delenv("PYINSTALLER_RESET_ENVIRONMENT", raising=False)
+
+    frozen_daemon_runtime.install_frozen_daemon_runtime()
+
+    assert frozen_daemon_runtime.os.environ["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
+    monkeypatch.setattr(manager, "_guard_daemon_process_inventory_for_guard_home", inventory)
+
+
 def test_non_frozen_runtime_does_not_patch_daemon_inventory(monkeypatch: pytest.MonkeyPatch) -> None:
     inventory = manager._guard_daemon_process_inventory_for_guard_home
     monkeypatch.setattr(frozen_daemon_runtime.sys, "frozen", False, raising=False)
+    monkeypatch.delenv("PYINSTALLER_RESET_ENVIRONMENT", raising=False)
 
     frozen_daemon_runtime.install_frozen_daemon_runtime()
 
     assert manager._guard_daemon_process_inventory_for_guard_home is inventory
+    assert "PYINSTALLER_RESET_ENVIRONMENT" not in frozen_daemon_runtime.os.environ


### PR DESCRIPTION
Fix the macOS frozen Core daemon re-exec path used by Desktop. A frozen Guard process sets PyInstaller's reset marker before spawning independent same-executable daemon processes, preventing reuse of the parent one-file extraction runtime. Adds focused regression coverage and leaves non-frozen behavior unchanged.

This PR is temporarily stacked on `fix/desktop-core-pyinstaller-signing-release-3` so CI/review sees only the daemon fix. It will be retargeted to `release/3.0` after #2233 lands.