### PR TITLE
feat(guard): enforce Rust source path parity

### DIFF
--- a/.github/workflows/rust-runtime-differential.yml
+++ b/.github/workflows/rust-runtime-differential.yml
@@ -2,7 +2,6 @@ name: Rust runtime differential
 
 on:
   pull_request:
-    branches: [release/3.0]
     paths:
       - "rust/**"
       - "src/codex_plugin_scanner/guard/native_runtime.py"

--- a/ci/native_runtime/test_guard_native_runtime_differential.py
+++ b/ci/native_runtime/test_guard_native_runtime_differential.py
@@ -56,18 +56,31 @@ def _inline_request(
     )
 
 
-def _source_request(*, tmp_path: Path, relative_path: str, text: str, request_id: str) -> HookReviewRequest:
-    guard_home = tmp_path / "guard-home"
-    guard_home.mkdir(mode=0o700, exist_ok=True)
-    path = tmp_path / relative_path
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
+def _source_request(
+    *,
+    workspace: Path,
+    reference_path: str,
+    text: str,
+    request_id: str,
+    actual_path: Path | None = None,
+    home_dir: Path | None = None,
+    guard_home: Path | None = None,
+    write_file: bool = True,
+    external_allowed: bool = False,
+) -> HookReviewRequest:
+    home = home_dir or workspace
+    guard = guard_home or (home / "guard-home")
+    guard.mkdir(parents=True, mode=0o700, exist_ok=True)
+    path = actual_path or (workspace / reference_path)
+    if write_file:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
     source_ref = HookSourceFileRef(
         version=1,
-        path=relative_path,
+        path=reference_path,
         output_sha256=sha256_text(text),
         output_chars=len(text),
-        tool_input_path=relative_path,
+        tool_input_path=reference_path,
     )
     return HookReviewRequest(
         harness="pi",
@@ -75,21 +88,22 @@ def _source_request(*, tmp_path: Path, relative_path: str, text: str, request_id
         payload={
             "hook_event_name": "PostToolUse",
             "tool_name": "Read",
-            "tool_input": {"file_path": relative_path},
+            "tool_input": {"file_path": reference_path},
             "guard_source_ref": {
                 "version": 1,
-                "path": relative_path,
+                "path": reference_path,
                 "output_sha256": source_ref.output_sha256,
                 "output_chars": source_ref.output_chars,
-                "tool_input_path": relative_path,
+                "tool_input_path": reference_path,
             },
         },
         payload_kind="source_file_ref",
         config_path=None,
-        cwd=tmp_path,
-        home_dir=tmp_path,
-        guard_home=guard_home,
+        cwd=workspace,
+        home_dir=home,
+        guard_home=guard,
         source_scope="project",
+        source_ref_external_allowed=external_allowed,
         source_ref=source_ref,
         request_id=request_id,
         deadline_monotonic=time.monotonic() + 5.0,
@@ -154,8 +168,8 @@ def test_compiled_native_clean_source_read_parity(tmp_path: Path) -> None:
     try:
         _assert_parity(
             _source_request(
-                tmp_path=tmp_path,
-                relative_path="src/example.ts",
+                workspace=tmp_path,
+                reference_path="src/example.ts",
                 text="export const value = 1;\n",
                 request_id="source-clean",
             )
@@ -168,10 +182,138 @@ def test_compiled_native_secret_source_read_parity(tmp_path: Path) -> None:
     try:
         _assert_parity(
             _source_request(
-                tmp_path=tmp_path,
-                relative_path="src/private.ts",
+                workspace=tmp_path,
+                reference_path="src/private.ts",
                 text=f"export const value = '{_secret_token()}';\n",
                 request_id="source-secret",
+            )
+        )
+    finally:
+        close_resident_native_runtimes()
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "text"),
+    [
+        (".env", "SAFE_PLACEHOLDER=value\n"),
+        (".hidden/config.py", "VALUE = 1\n"),
+        ("credentials", "not-a-secret\n"),
+    ],
+)
+def test_compiled_native_rejected_workspace_source_path_parity(
+    tmp_path: Path,
+    relative_path: str,
+    text: str,
+) -> None:
+    try:
+        _assert_parity(
+            _source_request(
+                workspace=tmp_path,
+                reference_path=relative_path,
+                text=text,
+                request_id=f"source-rejected-{relative_path}",
+            )
+        )
+    finally:
+        close_resident_native_runtimes()
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "text"),
+    [
+        (".github/workflows/ci.yml", "name: ci\n"),
+        (".nvmrc", "20\n"),
+        ("docs/guide.md", "# Guide\n"),
+    ],
+)
+def test_compiled_native_allowed_workspace_source_path_parity(
+    tmp_path: Path,
+    relative_path: str,
+    text: str,
+) -> None:
+    try:
+        _assert_parity(
+            _source_request(
+                workspace=tmp_path,
+                reference_path=relative_path,
+                text=text,
+                request_id=f"source-allowed-{relative_path}",
+            )
+        )
+    finally:
+        close_resident_native_runtimes()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink source fixture is POSIX-only")
+def test_compiled_native_source_symlink_rejection_parity(tmp_path: Path) -> None:
+    source = tmp_path / "src" / "actual.ts"
+    source.parent.mkdir(parents=True)
+    text = "export const value = 1;\n"
+    source.write_text(text, encoding="utf-8")
+    link = source.with_name("link.ts")
+    link.symlink_to(source)
+    try:
+        _assert_parity(
+            _source_request(
+                workspace=tmp_path,
+                reference_path="src/link.ts",
+                actual_path=link,
+                text=text,
+                write_file=False,
+                request_id="source-symlink",
+            )
+        )
+    finally:
+        close_resident_native_runtimes()
+
+
+def test_compiled_native_external_sibling_checkout_source_parity(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    workspace = home / "workspace"
+    sibling = home / "sibling"
+    workspace.mkdir(parents=True)
+    (sibling / ".git").mkdir(parents=True)
+    source = sibling / "src" / "library.ts"
+    text = "export const library = true;\n"
+    source.parent.mkdir(parents=True)
+    source.write_text(text, encoding="utf-8")
+    try:
+        _assert_parity(
+            _source_request(
+                workspace=workspace,
+                reference_path=str(source),
+                actual_path=source,
+                text=text,
+                home_dir=home,
+                guard_home=home / "guard-home",
+                write_file=False,
+                external_allowed=True,
+                request_id="source-external-sibling",
+            )
+        )
+    finally:
+        close_resident_native_runtimes()
+
+
+def test_compiled_native_known_skill_source_parity(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    workspace = home / "workspace"
+    skill = home / ".codex" / "skills" / "example" / "SKILL.md"
+    workspace.mkdir(parents=True)
+    text = "# Example skill\n"
+    skill.parent.mkdir(parents=True)
+    skill.write_text(text, encoding="utf-8")
+    try:
+        _assert_parity(
+            _source_request(
+                workspace=workspace,
+                reference_path="skill://example",
+                actual_path=skill,
+                text=text,
+                home_dir=home,
+                guard_home=home / "guard-home",
+                write_file=False,
+                request_id="source-known-skill",
             )
         )
     finally:

--- a/rust/crates/guard-hook-core/src/lib.rs
+++ b/rust/crates/guard-hook-core/src/lib.rs
@@ -1,9 +1,14 @@
 #![forbid(unsafe_code)]
 
-use guard_contracts::{HookReviewResponseV1, HookSourceFileRefV1, NativeHookRequestV1, NATIVE_PROTOCOL_VERSION};
-use guard_rules::{MAX_CONTENT_ITEMS, MAX_DEPTH, MAX_OBJECT_KEYS, MAX_OUTPUT_CHARS, MAX_SCAN_BYTES, OUTPUT_TEXT_KEYS, PAYLOAD_OUTPUT_KEYS, REVIEWED_EXCERPT_CHARS};
+use guard_contracts::{
+    HookReviewResponseV1, HookSourceFileRefV1, NativeHookRequestV1, NATIVE_PROTOCOL_VERSION,
+};
+use guard_rules::{
+    MAX_CONTENT_ITEMS, MAX_DEPTH, MAX_OBJECT_KEYS, MAX_OUTPUT_CHARS, MAX_SCAN_BYTES,
+    OUTPUT_TEXT_KEYS, PAYLOAD_OUTPUT_KEYS, REVIEWED_EXCERPT_CHARS,
+};
 use guard_scanner::scan_text;
-use guard_secure_fs::{read_bounded, resolve_candidate, sensitive_path_family, source_like, SecureReadError};
+use guard_secure_fs::{classify_source_path, read_bounded, sensitive_path_family};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
@@ -33,7 +38,14 @@ fn collect_output_text(value: &Value) -> ExtractedOutput {
         *chars += text.chars().count();
     }
 
-    fn traverse(value: &Value, depth: usize, parts: &mut Vec<String>, chars: &mut usize, truncated: &mut bool, seen: &mut HashSet<usize>) {
+    fn traverse(
+        value: &Value,
+        depth: usize,
+        parts: &mut Vec<String>,
+        chars: &mut usize,
+        truncated: &mut bool,
+        seen: &mut HashSet<usize>,
+    ) {
         if *truncated {
             return;
         }
@@ -74,7 +86,9 @@ fn collect_output_text(value: &Value) -> ExtractedOutput {
                 }
                 let mut keys_seen = 0usize;
                 for key in OUTPUT_TEXT_KEYS {
-                    let Some(child) = record.get(*key) else { continue };
+                    let Some(child) = record.get(*key) else {
+                        continue;
+                    };
                     if keys_seen >= MAX_OBJECT_KEYS {
                         *truncated = true;
                         break;
@@ -96,12 +110,20 @@ fn collect_output_text(value: &Value) -> ExtractedOutput {
     let mut truncated = false;
     let mut seen = HashSet::new();
     traverse(value, 0, &mut parts, &mut chars, &mut truncated, &mut seen);
-    ExtractedOutput { text: parts.concat(), chars, truncated }
+    ExtractedOutput {
+        text: parts.concat(),
+        chars,
+        truncated,
+    }
 }
 
 pub fn extract_payload_output(payload: &Value) -> ExtractedOutput {
     let Some(record) = payload.as_object() else {
-        return ExtractedOutput { text: String::new(), chars: 0, truncated: false };
+        return ExtractedOutput {
+            text: String::new(),
+            chars: 0,
+            truncated: false,
+        };
     };
     let mut parts = Vec::new();
     let mut truncated = false;
@@ -119,19 +141,30 @@ pub fn extract_payload_output(payload: &Value) -> ExtractedOutput {
     if chars > MAX_OUTPUT_CHARS {
         truncated = true;
     }
-    ExtractedOutput { text: joined.chars().take(MAX_OUTPUT_CHARS).collect(), chars: chars.min(MAX_OUTPUT_CHARS), truncated }
+    ExtractedOutput {
+        text: joined.chars().take(MAX_OUTPUT_CHARS).collect(),
+        chars: chars.min(MAX_OUTPUT_CHARS),
+        truncated,
+    }
 }
 
 fn deadline(request: &NativeHookRequestV1) -> Option<Instant> {
-    request.deadline_budget_ms.map(|budget| Instant::now() + Duration::from_millis(budget.min(9_000)))
+    request
+        .deadline_budget_ms
+        .map(|budget| Instant::now() + Duration::from_millis(budget.min(9_000)))
 }
 
 fn source_ref(payload: &Value) -> Option<HookSourceFileRefV1> {
-    payload.get("guard_source_ref").and_then(|value| serde_json::from_value(value.clone()).ok())
+    payload
+        .get("guard_source_ref")
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
 }
 
 fn envelope_target(payload: &Value) -> Option<String> {
-    let input = payload.get("tool_input").or_else(|| payload.get("toolInput"))?.as_object()?;
+    let input = payload
+        .get("tool_input")
+        .or_else(|| payload.get("toolInput"))?
+        .as_object()?;
     for key in ["file_path", "path", "filePath"] {
         if let Some(value) = input.get(key).and_then(Value::as_str) {
             if !value.trim().is_empty() {
@@ -156,7 +189,8 @@ fn output_equivalent(text: &str, output_sha256: &str, output_chars: i64) -> bool
         return true;
     }
     if let Some(stripped) = text.strip_suffix('\n') {
-        return sha256_text(stripped) == output_sha256 && stripped.chars().count() == output_chars as usize;
+        return sha256_text(stripped) == output_sha256
+            && stripped.chars().count() == output_chars as usize;
     }
     false
 }
@@ -164,11 +198,24 @@ fn output_equivalent(text: &str, output_sha256: &str, output_chars: i64) -> bool
 fn local_samples_should_be_unsuppressed(path: &str) -> bool {
     let normalized = path.replace('\\', "/").to_ascii_lowercase();
     let parts: Vec<&str> = normalized.split('/').collect();
-    let docs = ["__fixtures__", "__tests__", "docs", "documentation", "examples", "fixtures", "samples", "spec", "test", "tests"];
+    let docs = [
+        "__fixtures__",
+        "__tests__",
+        "docs",
+        "documentation",
+        "examples",
+        "fixtures",
+        "samples",
+        "spec",
+        "test",
+        "tests",
+    ];
     if parts.iter().any(|part| docs.contains(part)) {
         return false;
     }
-    ![".adoc", ".md", ".mdx", ".rst", ".txt"].iter().any(|suffix| normalized.ends_with(suffix))
+    ![".adoc", ".md", ".mdx", ".rst", ".txt"]
+        .iter()
+        .any(|suffix| normalized.ends_with(suffix))
 }
 
 fn sensitive_reason(family: &str) -> &'static str {
@@ -190,57 +237,96 @@ fn sensitive_reason(family: &str) -> &'static str {
     }
 }
 
-fn review_source(request: &NativeHookRequestV1, source: &HookSourceFileRefV1) -> HookReviewResponseV1 {
+fn inconclusive_source() -> HookReviewResponseV1 {
+    // Python's source fast path retains detailed internal reason codes, but
+    // every non-risky proof failure falls back to the standard PostToolUse
+    // path. With a source-ref-only payload that public contract is a safe
+    // deny/block with `no_output_to_review`. Keep the Rust classifier details
+    // internal so native mode does not change observable reason semantics.
+    HookReviewResponseV1::deny(
+        "no_output_to_review",
+        "HOL Guard could not complete local hook review safely.",
+    )
+}
+
+fn review_source(
+    request: &NativeHookRequestV1,
+    source: &HookSourceFileRefV1,
+) -> HookReviewResponseV1 {
     if source.version != 1 {
-        return HookReviewResponseV1::deny("invalid_source_ref_version", "HOL Guard could not complete local hook review safely.");
+        return inconclusive_source();
     }
     if source.output_chars < 0 || source.output_chars > MAX_SCAN_BYTES as i64 {
-        return HookReviewResponseV1::deny("output_too_large", "HOL Guard could not complete local hook review safely.");
+        return inconclusive_source();
     }
-    if source.output_sha256.len() != 64 || !source.output_sha256.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        return HookReviewResponseV1::deny("invalid_output_hash", "HOL Guard could not complete local hook review safely.");
+    if source.output_sha256.len() != 64
+        || !source
+            .output_sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+    {
+        return inconclusive_source();
     }
     let Some(target) = envelope_target(&request.payload) else {
-        return HookReviewResponseV1::deny("unresolved_envelope_target", "HOL Guard could not complete local hook review safely.");
+        return inconclusive_source();
     };
     let candidate = source.tool_input_path.as_deref().unwrap_or(&source.path);
-    if candidate != target {
-        return HookReviewResponseV1::deny("source_ref_target_mismatch", "HOL Guard could not complete local hook review safely.");
-    }
-    let cwd = request.cwd.as_deref().map(Path::new);
+    let cwd = request
+        .cwd
+        .as_deref()
+        .map(Path::new)
+        .unwrap_or_else(|| Path::new("."));
     let home = Path::new(&request.home_dir);
-    let path = match resolve_candidate(candidate, cwd, home) {
-        Ok(path) => path,
-        Err(_) => return HookReviewResponseV1::deny("unresolved_path", "HOL Guard could not complete local hook review safely."),
-    };
-    if let Some((family, _)) = sensitive_path_family(&path) {
+    if let Some((family, _)) = sensitive_path_family(Path::new(candidate)) {
         return HookReviewResponseV1::deny("sensitive_path", sensitive_reason(family));
     }
-    if !source_like(&path) {
-        return HookReviewResponseV1::deny("not_source_like", "HOL Guard could not complete local hook review safely.");
+    let allow_external =
+        matches!(request.harness.as_str(), "pi" | "omp") && request.source_ref_external_allowed;
+    let candidate_decision = classify_source_path(candidate, cwd, Some(home), allow_external);
+    if !candidate_decision.allowed {
+        return inconclusive_source();
+    }
+    let target_decision = classify_source_path(&target, cwd, Some(home), allow_external);
+    if !target_decision.allowed {
+        return inconclusive_source();
+    }
+    let Some(path) = candidate_decision.resolved_path else {
+        return inconclusive_source();
+    };
+    let Some(target_path) = target_decision.resolved_path else {
+        return inconclusive_source();
+    };
+    if path != target_path {
+        return inconclusive_source();
     }
     let read = match read_bounded(&path, MAX_SCAN_BYTES) {
         Ok(read) => read,
-        Err(SecureReadError::TooLarge) => return HookReviewResponseV1::deny("source_file_too_large", "HOL Guard could not complete local hook review safely."),
-        Err(SecureReadError::Changed) => return HookReviewResponseV1::deny("source_stat_changed", "HOL Guard could not complete local hook review safely."),
-        Err(SecureReadError::SymlinkInPath) => return HookReviewResponseV1::deny("symlink_in_path", "HOL Guard could not complete local hook review safely."),
-        Err(_) => return HookReviewResponseV1::deny("read_failed", "HOL Guard could not complete local hook review safely."),
+        Err(_) => return inconclusive_source(),
     };
     if read.bytes.contains(&0) {
-        return HookReviewResponseV1::deny("binary_file", "HOL Guard could not complete local hook review safely.");
+        return inconclusive_source();
     }
     let Ok(text) = std::str::from_utf8(&read.bytes) else {
-        return HookReviewResponseV1::deny("invalid_utf8", "HOL Guard could not complete local hook review safely.");
+        return inconclusive_source();
     };
     if !output_equivalent(text, &source.output_sha256, source.output_chars) {
-        return HookReviewResponseV1::deny("output_mismatch", "HOL Guard could not complete local hook review safely.");
+        return inconclusive_source();
     }
-    let scan = scan_text(text, local_samples_should_be_unsuppressed(&source.path), true, MAX_SCAN_BYTES, deadline(request));
+    let scan = scan_text(
+        text,
+        local_samples_should_be_unsuppressed(&source.path),
+        true,
+        MAX_SCAN_BYTES,
+        deadline(request),
+    );
     if scan.budget_exhausted {
-        return HookReviewResponseV1::deny("scanner_budget_exhausted", "HOL Guard could not complete local hook review safely.");
+        return inconclusive_source();
     }
     if !scan.matches.is_empty() {
-        return HookReviewResponseV1::deny("source_secret_match", "HOL Guard blocked this output because it contains sensitive content.");
+        return HookReviewResponseV1::deny(
+            "source_secret_match",
+            "HOL Guard blocked this output because it contains sensitive content.",
+        );
     }
     let mut response = HookReviewResponseV1::allow("source_full_scan_allow");
     response.reviewed_output_sha256 = Some(source.output_sha256.clone());
@@ -249,7 +335,14 @@ fn review_source(request: &NativeHookRequestV1, source: &HookSourceFileRefV1) ->
 
 fn review_inline(request: &NativeHookRequestV1) -> HookReviewResponseV1 {
     let extracted = extract_payload_output(&request.payload);
-    let has_output_key = request.payload.as_object().is_some_and(|record: &Map<String, Value>| PAYLOAD_OUTPUT_KEYS.iter().any(|key| record.contains_key(*key)));
+    let has_output_key = request
+        .payload
+        .as_object()
+        .is_some_and(|record: &Map<String, Value>| {
+            PAYLOAD_OUTPUT_KEYS
+                .iter()
+                .any(|key| record.contains_key(*key))
+        });
     if extracted.text.is_empty() {
         if extracted.truncated {
             return HookReviewResponseV1::deny("output_too_large", "HOL Guard blocked this output because it could not be safely excerpted within local limits.");
@@ -257,36 +350,72 @@ fn review_inline(request: &NativeHookRequestV1) -> HookReviewResponseV1 {
         if has_output_key {
             return HookReviewResponseV1::allow("output_empty_allow");
         }
-        return HookReviewResponseV1::deny("no_output_to_review", "HOL Guard could not complete local hook review safely.");
+        return HookReviewResponseV1::deny(
+            "no_output_to_review",
+            "HOL Guard could not complete local hook review safely.",
+        );
     }
-    let local_content = envelope_target(&request.payload).is_some_and(|path| local_samples_should_be_unsuppressed(&path));
+    let local_content = envelope_target(&request.payload)
+        .is_some_and(|path| local_samples_should_be_unsuppressed(&path));
     if extracted.truncated {
-        let excerpt: String = extracted.text.chars().take(REVIEWED_EXCERPT_CHARS).collect();
-        let scan = scan_text(&excerpt, local_content, true, MAX_SCAN_BYTES, deadline(request));
+        let excerpt: String = extracted
+            .text
+            .chars()
+            .take(REVIEWED_EXCERPT_CHARS)
+            .collect();
+        let scan = scan_text(
+            &excerpt,
+            local_content,
+            true,
+            MAX_SCAN_BYTES,
+            deadline(request),
+        );
         if scan.budget_exhausted || !scan.matches.is_empty() {
             return HookReviewResponseV1::deny("output_too_large", "HOL Guard blocked this output because it could not be fully scanned within local limits.");
         }
         return HookReviewResponseV1::reviewed_excerpt("output_too_large", "HOL Guard returned a reviewed excerpt because the output was too large to scan in full within local limits.", excerpt);
     }
-    let scan = scan_text(&extracted.text, local_content, true, MAX_SCAN_BYTES, deadline(request));
+    let scan = scan_text(
+        &extracted.text,
+        local_content,
+        true,
+        MAX_SCAN_BYTES,
+        deadline(request),
+    );
     if scan.budget_exhausted {
-        return HookReviewResponseV1::deny("scanner_budget_exhausted", "HOL Guard could not complete local hook review safely.");
+        return HookReviewResponseV1::deny(
+            "scanner_budget_exhausted",
+            "HOL Guard could not complete local hook review safely.",
+        );
     }
     if !scan.matches.is_empty() {
-        return HookReviewResponseV1::deny("output_secret_match", "HOL Guard blocked this output because it contains sensitive content.");
+        return HookReviewResponseV1::deny(
+            "output_secret_match",
+            "HOL Guard blocked this output because it contains sensitive content.",
+        );
     }
     HookReviewResponseV1::allow("output_scan_allow")
 }
 
 pub fn review_post_tool(request: &NativeHookRequestV1) -> HookReviewResponseV1 {
     if request.protocol_version != NATIVE_PROTOCOL_VERSION {
-        return HookReviewResponseV1::deny("protocol_version_mismatch", "HOL Guard could not complete local hook review safely.");
+        return HookReviewResponseV1::deny(
+            "protocol_version_mismatch",
+            "HOL Guard could not complete local hook review safely.",
+        );
     }
     if request.event_name != "PostToolUse" {
-        return HookReviewResponseV1::deny("not_post_tool", "HOL Guard could not complete local hook review safely.");
+        return HookReviewResponseV1::deny(
+            "not_post_tool",
+            "HOL Guard could not complete local hook review safely.",
+        );
     }
     let source = source_ref(&request.payload);
-    let response = if let Some(source) = source.as_ref() { review_source(request, source) } else { review_inline(request) };
+    let response = if let Some(source) = source.as_ref() {
+        review_source(request, source)
+    } else {
+        review_inline(request)
+    };
     if request.observe_mode {
         let output_hash = source.map(|value| value.output_sha256);
         response.observed(output_hash)
@@ -328,7 +457,9 @@ mod tests {
 
     #[test]
     fn clean_inline_output_is_allowed() {
-        let response = review_post_tool(&request(json!({"tool_response": [{"type": "text", "text": "hello"}]})));
+        let response = review_post_tool(&request(
+            json!({"tool_response": [{"type": "text", "text": "hello"}]}),
+        ));
         assert_eq!(response.decision, "allow");
         assert_eq!(response.reason_code, "output_scan_allow");
     }
@@ -342,7 +473,9 @@ mod tests {
 
     #[test]
     fn stderr_is_scanned_even_when_stdout_exists() {
-        let response = review_post_tool(&request(json!({"stdout": "ok", "stderr": aws_like_access_key()})));
+        let response = review_post_tool(&request(
+            json!({"stdout": "ok", "stderr": aws_like_access_key()}),
+        ));
         assert_eq!(response.reason_code, "output_secret_match");
     }
 }

--- a/rust/crates/guard-secure-fs/src/lib.rs
+++ b/rust/crates/guard-secure-fs/src/lib.rs
@@ -11,6 +11,72 @@ use thiserror::Error;
 #[cfg(unix)]
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 
+const SOURCE_INSPECTION_PARTS: &[&str] = &[
+    "__tests__",
+    "app",
+    "constants",
+    "dashboard",
+    "docs",
+    "lib",
+    "packages",
+    "scripts",
+    "src",
+    "test",
+    "tests",
+    "workers",
+];
+const SOURCE_EXTENSIONS: &[&str] = &[
+    "c", "cc", "cpp", "css", "go", "h", "hpp", "html", "java", "js", "jsx", "json", "md", "mjs",
+    "py", "rs", "sh", "toml", "ts", "tsx", "yaml", "yml",
+];
+const BENIGN_SOURCE_DOTFILES: &[&str] = &[".nvmrc", ".worktrees"];
+const SENSITIVE_SEARCH_BASENAMES: &[&str] = &[
+    ".aws",
+    ".docker",
+    ".env",
+    ".git-credentials",
+    ".kube",
+    ".netrc",
+    ".npmrc",
+    ".pypirc",
+    ".ssh",
+    "credentials",
+    "id_rsa",
+];
+const EXTERNAL_SENSITIVE_PARTS: &[&str] = &[
+    ".aws",
+    ".docker",
+    ".env",
+    ".git-credentials",
+    ".kube",
+    ".netrc",
+    ".npmrc",
+    ".pypirc",
+    ".ssh",
+    "auth",
+    "authorization",
+    "credential",
+    "credentials",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "id_rsa",
+    "passwd",
+    "password",
+    "private-key",
+    "private_key",
+    "secret",
+    "secrets",
+    "token",
+    "tokens",
+];
+const KNOWN_SKILL_DOC_ROOTS: &[&str] = &[
+    ".codex/superpowers/skills",
+    ".codex/skills",
+    ".agents/skills",
+    ".claude/skills",
+];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileIdentity {
     pub dev: Option<u64>,
@@ -24,6 +90,31 @@ pub struct SecureRead {
     pub bytes: Vec<u8>,
     pub identity: FileIdentity,
     pub sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourcePathDecision {
+    pub allowed: bool,
+    pub reason_code: &'static str,
+    pub resolved_path: Option<PathBuf>,
+}
+
+impl SourcePathDecision {
+    fn allow(reason_code: &'static str, path: PathBuf) -> Self {
+        Self {
+            allowed: true,
+            reason_code,
+            resolved_path: Some(path),
+        }
+    }
+
+    fn deny(reason_code: &'static str) -> Self {
+        Self {
+            allowed: false,
+            reason_code,
+            resolved_path: None,
+        }
+    }
 }
 
 #[derive(Debug, Error)]
@@ -42,7 +133,11 @@ pub enum SecureReadError {
     Changed,
 }
 
-pub fn resolve_candidate(target: &str, cwd: Option<&Path>, home: &Path) -> Result<PathBuf, SecureReadError> {
+pub fn resolve_candidate(
+    target: &str,
+    cwd: Option<&Path>,
+    home: &Path,
+) -> Result<PathBuf, SecureReadError> {
     let stripped = target.trim().trim_matches(['\'', '"']);
     if stripped.is_empty() {
         return Err(SecureReadError::UnresolvedPath);
@@ -52,6 +147,9 @@ pub fn resolve_candidate(target: &str, cwd: Option<&Path>, home: &Path) -> Resul
     }
     if let Some(rest) = stripped.strip_prefix("~/") {
         return Ok(home.join(rest));
+    }
+    if stripped.starts_with('~') {
+        return Err(SecureReadError::UnresolvedPath);
     }
     let path = PathBuf::from(stripped);
     if path.is_absolute() {
@@ -63,12 +161,27 @@ pub fn resolve_candidate(target: &str, cwd: Option<&Path>, home: &Path) -> Resul
 pub fn contains_symlink_component(path: &Path) -> bool {
     let mut current = PathBuf::new();
     for component in path.components() {
-        match component {
-            Component::Prefix(prefix) => current.push(prefix.as_os_str()),
-            Component::RootDir => current.push(Path::new(std::path::MAIN_SEPARATOR_STR)),
+        let should_stat = match component {
+            Component::Prefix(prefix) => {
+                current.push(prefix.as_os_str());
+                false
+            }
+            Component::RootDir => {
+                current.push(Path::new(std::path::MAIN_SEPARATOR_STR));
+                false
+            }
             Component::CurDir => continue,
-            Component::ParentDir => current.push(".."),
-            Component::Normal(part) => current.push(part),
+            Component::ParentDir => {
+                current.push("..");
+                false
+            }
+            Component::Normal(part) => {
+                current.push(part);
+                true
+            }
+        };
+        if !should_stat {
+            continue;
         }
         match fs::symlink_metadata(&current) {
             Ok(metadata) if metadata.file_type().is_symlink() => return true,
@@ -90,7 +203,12 @@ fn identity(metadata: &Metadata) -> FileIdentity {
     let (dev, ino) = (Some(metadata.dev()), Some(metadata.ino()));
     #[cfg(not(unix))]
     let (dev, ino) = (None, None);
-    FileIdentity { dev, ino, size: metadata.len(), mtime_ns }
+    FileIdentity {
+        dev,
+        ino,
+        size: metadata.len(),
+        mtime_ns,
+    }
 }
 
 fn secure_open(path: &Path) -> io::Result<File> {
@@ -129,12 +247,297 @@ pub fn read_bounded(path: &Path, max_bytes: usize) -> Result<SecureRead, SecureR
     }
     let mut hasher = Sha256::new();
     hasher.update(&bytes);
-    Ok(SecureRead { bytes, identity: after, sha256: hex::encode(hasher.finalize()) })
+    Ok(SecureRead {
+        bytes,
+        identity: after,
+        sha256: hex::encode(hasher.finalize()),
+    })
+}
+
+fn lowered_parts(path: &Path) -> Vec<String> {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => Some(value.to_string_lossy().to_ascii_lowercase()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn hidden_parts_allowed(parts: &[String]) -> bool {
+    let hidden: Vec<&str> = parts
+        .iter()
+        .map(String::as_str)
+        .filter(|part| part.starts_with('.'))
+        .collect();
+    if hidden.is_empty()
+        || hidden
+            .iter()
+            .all(|part| BENIGN_SOURCE_DOTFILES.contains(part))
+    {
+        return true;
+    }
+    let workflow_prefix = parts
+        .windows(2)
+        .any(|window| window[0] == ".github" && window[1] == "workflows");
+    workflow_prefix && hidden == [".github"]
+}
+
+fn sensitive_external_filename(path: &Path) -> bool {
+    let filename = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let stem = path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if EXTERNAL_SENSITIVE_PARTS.contains(&filename.as_str())
+        || EXTERNAL_SENSITIVE_PARTS.contains(&stem.as_str())
+    {
+        return true;
+    }
+    stem.replace(['-', '.'], "_")
+        .split('_')
+        .any(|token| !token.is_empty() && EXTERNAL_SENSITIVE_PARTS.contains(&token))
+}
+
+fn source_shape_allowed(path: &Path, parts: &[String]) -> bool {
+    if parts
+        .iter()
+        .any(|part| SOURCE_INSPECTION_PARTS.contains(&part.as_str()))
+    {
+        return true;
+    }
+    if path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .is_some_and(|name| {
+            let lowered = name.to_ascii_lowercase();
+            BENIGN_SOURCE_DOTFILES.contains(&lowered.as_str())
+        })
+    {
+        return true;
+    }
+    path.extension()
+        .and_then(|value| value.to_str())
+        .map(str::to_ascii_lowercase)
+        .is_some_and(|suffix| SOURCE_EXTENSIONS.contains(&suffix.as_str()))
+}
+
+fn canonical_dir(path: &Path) -> Option<PathBuf> {
+    let canonical = fs::canonicalize(path).ok()?;
+    canonical.is_dir().then_some(canonical)
+}
+
+fn immediate_sibling_git_checkout(path: &Path, workspace: &Path) -> bool {
+    let parent = match workspace.parent() {
+        Some(parent) => parent,
+        None => return false,
+    };
+    let relative = match path.strip_prefix(parent) {
+        Ok(relative) => relative,
+        Err(_) => return false,
+    };
+    let Some(first) = relative.components().next() else {
+        return false;
+    };
+    let Component::Normal(first) = first else {
+        return false;
+    };
+    let checkout = parent.join(first);
+    if checkout == workspace {
+        return false;
+    }
+    let marker = checkout.join(".git");
+    match fs::symlink_metadata(&marker) {
+        Ok(metadata) => {
+            !metadata.file_type().is_symlink() && (metadata.is_file() || metadata.is_dir())
+        }
+        Err(_) => false,
+    }
+}
+
+fn known_skill_doc_path(target: &str, home: &Path) -> Option<PathBuf> {
+    if target
+        .chars()
+        .any(|character| matches!(character, '$' | '`' | '<' | '>' | '|' | ';' | '&'))
+    {
+        return None;
+    }
+    if let Some(skill_name) = target.strip_prefix("skill://") {
+        let skill_name = skill_name.trim().trim_matches(['\'', '"']);
+        let candidate = Path::new(skill_name);
+        if skill_name.is_empty()
+            || candidate.is_absolute()
+            || candidate
+                .components()
+                .any(|component| matches!(component, Component::ParentDir))
+        {
+            return None;
+        }
+        for root in KNOWN_SKILL_DOC_ROOTS {
+            let skill_dir = home.join(root).join(candidate);
+            let skill_file = skill_dir.join("SKILL.md");
+            let Ok(real_dir) = fs::canonicalize(&skill_dir) else {
+                continue;
+            };
+            let Ok(real_file) = fs::canonicalize(&skill_file) else {
+                continue;
+            };
+            if real_file.is_file() && real_file.starts_with(&real_dir) {
+                return Some(real_file);
+            }
+        }
+        return None;
+    }
+
+    let lexical = resolve_candidate(target, None, home).ok()?;
+    for root in KNOWN_SKILL_DOC_ROOTS {
+        let lexical_root = home.join(root);
+        if !lexical.starts_with(&lexical_root) || contains_symlink_component(&lexical) {
+            continue;
+        }
+        if let Ok(real) = fs::canonicalize(&lexical) {
+            return Some(real);
+        }
+    }
+    None
+}
+
+pub fn classify_source_path(
+    target: &str,
+    cwd: &Path,
+    home: Option<&Path>,
+    allow_external: bool,
+) -> SourcePathDecision {
+    let stripped = target.trim().trim_matches(['\'', '"']);
+    if stripped.is_empty() {
+        return SourcePathDecision::deny("empty_path");
+    }
+    if let Some(home) = home {
+        if let Some(skill_path) = known_skill_doc_path(stripped, home) {
+            return SourcePathDecision::allow("known_skill_doc_path", skill_path);
+        }
+        let safety = home.join(".hol-support").join("SAFETY.md");
+        if (stripped == "~/.hol-support/SAFETY.md" || Path::new(stripped) == safety)
+            && fs::symlink_metadata(&safety)
+                .is_ok_and(|metadata| metadata.is_file() && !metadata.file_type().is_symlink())
+        {
+            if let Ok(real) = fs::canonicalize(safety) {
+                return SourcePathDecision::allow("guard_safety_doc_path", real);
+            }
+        }
+    }
+    if stripped
+        .chars()
+        .any(|character| matches!(character, '*' | '?' | '{' | '}'))
+    {
+        return SourcePathDecision::deny("glob_pattern");
+    }
+
+    let Ok(workspace) = fs::canonicalize(cwd) else {
+        return SourcePathDecision::deny("unresolved_path");
+    };
+    let external_requested = Path::new(stripped).is_absolute() || stripped.starts_with("~/");
+    let home_for_resolution = home.unwrap_or_else(|| Path::new(""));
+    let Ok(lexical) = resolve_candidate(stripped, Some(&workspace), home_for_resolution) else {
+        return SourcePathDecision::deny("unresolved_path");
+    };
+
+    if contains_symlink_component(&lexical) {
+        return SourcePathDecision::deny("symlink_in_path");
+    }
+    let Ok(candidate) = fs::canonicalize(&lexical) else {
+        return SourcePathDecision::deny("external_target_not_readable");
+    };
+
+    let inside_workspace = candidate.starts_with(&workspace);
+    if !inside_workspace {
+        if !allow_external || !external_requested {
+            return SourcePathDecision::deny("absolute_path_outside_workspace");
+        }
+        let Some(home) = home.and_then(canonical_dir) else {
+            return SourcePathDecision::deny("external_home_unavailable");
+        };
+        if !candidate.starts_with(&home) {
+            return SourcePathDecision::deny("external_target_outside_home");
+        }
+        if !immediate_sibling_git_checkout(&candidate, &workspace) {
+            return SourcePathDecision::deny("external_target_not_sibling_git_checkout");
+        }
+        let parts = lowered_parts(&candidate);
+        if parts
+            .iter()
+            .any(|part| EXTERNAL_SENSITIVE_PARTS.contains(&part.as_str()))
+            || sensitive_external_filename(&candidate)
+        {
+            return SourcePathDecision::deny("sensitive_basename");
+        }
+        if !hidden_parts_allowed(&parts) {
+            return SourcePathDecision::deny("unsafe_hidden_dir");
+        }
+        if !source_shape_allowed(Path::new(stripped), &parts) {
+            return SourcePathDecision::deny("not_source_like");
+        }
+        return SourcePathDecision::allow("external_source_path", candidate);
+    }
+
+    let relative = match candidate.strip_prefix(&workspace) {
+        Ok(relative) => relative,
+        Err(_) => return SourcePathDecision::deny("resolved_outside_workspace"),
+    };
+    let parts = lowered_parts(relative);
+    if parts.is_empty() {
+        return SourcePathDecision::deny("empty_resolved_path");
+    }
+    if parts
+        .iter()
+        .any(|part| SENSITIVE_SEARCH_BASENAMES.contains(&part.as_str()))
+    {
+        return SourcePathDecision::deny("sensitive_basename");
+    }
+    if !hidden_parts_allowed(&parts) {
+        return SourcePathDecision::deny("unsafe_hidden_dir");
+    }
+    if !source_shape_allowed(relative, &parts) {
+        return SourcePathDecision::deny("not_source_like");
+    }
+    let reason = if parts
+        .first()
+        .is_some_and(|part| SOURCE_INSPECTION_PARTS.contains(&part.as_str()))
+    {
+        "source_prefix"
+    } else if parts
+        .iter()
+        .any(|part| SOURCE_INSPECTION_PARTS.contains(&part.as_str()))
+    {
+        "source_inspection_part"
+    } else if relative
+        .file_name()
+        .and_then(|value| value.to_str())
+        .is_some_and(|name| {
+            let lowered = name.to_ascii_lowercase();
+            BENIGN_SOURCE_DOTFILES.contains(&lowered.as_str())
+        })
+    {
+        "benign_source_dotfile"
+    } else {
+        "source_extension"
+    };
+    SourcePathDecision::allow(reason, candidate)
 }
 
 pub fn sensitive_path_family(path: &Path) -> Option<(&'static str, &'static str)> {
-    let normalized = path.to_string_lossy().replace('\\', "/").to_ascii_lowercase();
-    let parts: Vec<&str> = normalized.split('/').filter(|part| !part.is_empty()).collect();
+    let normalized = path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_ascii_lowercase();
+    let parts: Vec<&str> = normalized
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect();
     let basename = parts.last().copied().unwrap_or_default();
     if basename == ".env" || basename.starts_with(".env.") {
         return Some(("local .env file", "critical"));
@@ -152,16 +555,26 @@ pub fn sensitive_path_family(path: &Path) -> Option<(&'static str, &'static str)
     if let Some((_, family, sensitivity)) = direct.iter().find(|(name, _, _)| *name == basename) {
         return Some((*family, *sensitivity));
     }
-    if basename.contains("private-key") || basename.contains("private_key") || basename.contains("wallet-key") || basename.contains("wallet_key") {
+    if basename.contains("private-key")
+        || basename.contains("private_key")
+        || basename.contains("wallet-key")
+        || basename.contains("wallet_key")
+    {
         return Some(("wallet/private-key file", "critical"));
     }
-    if parts.windows(2).any(|window| window == [".aws", "credentials"]) {
+    if parts
+        .windows(2)
+        .any(|window| window == [".aws", "credentials"])
+    {
         return Some(("AWS shared credentials file", "high"));
     }
     if parts.windows(2).any(|window| window == [".aws", "config"]) {
         return Some(("AWS shared config file", "high"));
     }
-    if parts.windows(2).any(|window| window == [".docker", "config.json"]) {
+    if parts
+        .windows(2)
+        .any(|window| window == [".docker", "config.json"])
+    {
         return Some(("Docker client config", "high"));
     }
     if parts.windows(2).any(|window| window == [".kube", "config"]) {
@@ -171,7 +584,10 @@ pub fn sensitive_path_family(path: &Path) -> Option<(&'static str, &'static str)
         return Some(("GnuPG key material", "high"));
     }
     if let Some(index) = parts.iter().position(|part| *part == ".ssh") {
-        if parts.get(index + 1).is_some_and(|name| matches!(*name, "id_rsa" | "id_ed25519" | "id_ecdsa")) {
+        if parts
+            .get(index + 1)
+            .is_some_and(|name| matches!(*name, "id_rsa" | "id_ed25519" | "id_ecdsa"))
+        {
             return Some(("SSH private key", "critical"));
         }
         if parts.get(index + 1).is_some_and(|name| *name == "config") {
@@ -182,17 +598,15 @@ pub fn sensitive_path_family(path: &Path) -> Option<(&'static str, &'static str)
 }
 
 pub fn source_like(path: &Path) -> bool {
-    let normalized = path.to_string_lossy().replace('\\', "/").to_ascii_lowercase();
-    let parts: Vec<&str> = normalized.split('/').filter(|part| !part.is_empty()).collect();
-    if parts.iter().any(|part| matches!(*part, ".env" | ".ssh" | ".gnupg" | "credentials" | "secrets" | "tokens")) {
+    let parts = lowered_parts(path);
+    if parts
+        .iter()
+        .any(|part| SENSITIVE_SEARCH_BASENAMES.contains(&part.as_str()))
+        || !hidden_parts_allowed(&parts)
+    {
         return false;
     }
-    let source_parts = ["src", "lib", "app", "packages", "tests", "test", "docs", "spec", "examples", ".github"];
-    if parts.iter().any(|part| source_parts.contains(part)) {
-        return true;
-    }
-    let suffix = path.extension().and_then(|value| value.to_str()).unwrap_or_default().to_ascii_lowercase();
-    matches!(suffix.as_str(), "py" | "pyi" | "js" | "jsx" | "ts" | "tsx" | "rs" | "go" | "java" | "kt" | "rb" | "php" | "swift" | "c" | "h" | "cc" | "cpp" | "hpp" | "md" | "mdx" | "rst" | "txt" | "toml" | "yaml" | "yml" | "json")
+    source_shape_allowed(path, &parts)
 }
 
 #[cfg(test)]
@@ -200,9 +614,13 @@ mod tests {
     use super::*;
     use std::io::Write;
 
+    fn fixture_root(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("guard-secure-fs-{name}-{}", std::process::id()))
+    }
+
     #[test]
     fn bounded_read_hashes_regular_file() {
-        let dir = std::env::temp_dir().join(format!("guard-secure-fs-{}", std::process::id()));
+        let dir = fixture_root("read");
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("sample.rs");
         let mut file = File::create(&path).unwrap();
@@ -216,7 +634,100 @@ mod tests {
 
     #[test]
     fn sensitive_paths_are_classified() {
-        assert_eq!(sensitive_path_family(Path::new("/home/u/.aws/credentials")).unwrap().0, "AWS shared credentials file");
-        assert_eq!(sensitive_path_family(Path::new(".env.local")).unwrap().1, "critical");
+        assert_eq!(
+            sensitive_path_family(Path::new("/home/u/.aws/credentials"))
+                .unwrap()
+                .0,
+            "AWS shared credentials file"
+        );
+        assert_eq!(
+            sensitive_path_family(Path::new(".env.local")).unwrap().1,
+            "critical"
+        );
+    }
+
+    #[test]
+    fn source_classifier_rejects_hidden_sensitive_and_escape_paths() {
+        let root = fixture_root("classifier");
+        let home = root.join("home");
+        let workspace = home.join("workspace");
+        fs::create_dir_all(workspace.join("src")).unwrap();
+        fs::create_dir_all(workspace.join(".secret")).unwrap();
+        fs::write(workspace.join("src/main.rs"), "fn main() {}\n").unwrap();
+        fs::write(workspace.join(".secret/config.ts"), "value = 1\n").unwrap();
+        fs::write(workspace.join(".env"), "fixture=value\n").unwrap();
+
+        assert!(classify_source_path("src/main.rs", &workspace, Some(&home), false).allowed);
+        assert_eq!(
+            classify_source_path(".secret/config.ts", &workspace, Some(&home), false).reason_code,
+            "unsafe_hidden_dir"
+        );
+        assert_eq!(
+            classify_source_path(".env", &workspace, Some(&home), false).reason_code,
+            "sensitive_basename"
+        );
+        assert_eq!(
+            classify_source_path("../../outside.rs", &workspace, Some(&home), true).reason_code,
+            "external_target_not_readable"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_classifier_allows_workflow_and_sibling_git_source() {
+        let root = fixture_root("external");
+        let home = root.join("home");
+        let workspace = home.join("workspace");
+        let workflow = workspace.join(".github/workflows/publish.yml");
+        fs::create_dir_all(workflow.parent().unwrap()).unwrap();
+        fs::write(&workflow, "jobs: {}\n").unwrap();
+        let sibling = home.join("sibling");
+        let sibling_file = sibling.join("src/main.py");
+        fs::create_dir_all(sibling_file.parent().unwrap()).unwrap();
+        fs::create_dir_all(sibling.join(".git")).unwrap();
+        fs::write(&sibling_file, "value = 1\n").unwrap();
+
+        assert!(
+            classify_source_path(
+                ".github/workflows/publish.yml",
+                &workspace,
+                Some(&home),
+                false
+            )
+            .allowed
+        );
+        let external = classify_source_path(
+            sibling_file.to_str().unwrap(),
+            &workspace,
+            Some(&home),
+            true,
+        );
+        assert!(external.allowed);
+        assert_eq!(external.reason_code, "external_source_path");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn source_classifier_rejects_sensitive_external_filename_without_substring_false_positive() {
+        let root = fixture_root("external-sensitive");
+        let home = root.join("home");
+        let workspace = home.join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let sibling = home.join("sibling");
+        fs::create_dir_all(sibling.join(".git")).unwrap();
+        let sensitive = sibling.join("auth_token.ts");
+        let benign = sibling.join("authentication.ts");
+        fs::write(&sensitive, "value = 1\n").unwrap();
+        fs::write(&benign, "value = 1\n").unwrap();
+
+        assert_eq!(
+            classify_source_path(sensitive.to_str().unwrap(), &workspace, Some(&home), true)
+                .reason_code,
+            "sensitive_basename"
+        );
+        assert!(
+            classify_source_path(benign.to_str().unwrap(), &workspace, Some(&home), true).allowed
+        );
+        let _ = fs::remove_dir_all(root);
     }
 }


### PR DESCRIPTION
## Summary

Closes the remaining Rust/PostToolUse source-read parity gap against Python's authoritative source-path policy.

- ports workspace hidden/sensitive/source-shape checks into `guard-secure-fs`
- preserves explicitly allowed `.github/workflows`, `.nvmrc`, docs/source files, known `skill://` documents, and immediate sibling Git checkout reads
- rejects sensitive paths, hidden paths, unresolved paths, and symlink traversal fail closed
- mirrors Python's public source-proof fallback contract: only actual sensitive-path/secret findings surface risk-specific reasons; other failed source proofs fall back to `no_output_to_review`
- fixes Windows rooted-path handling so drive/root prefixes are not themselves lstat'ed as candidate path components
- keeps exact output hash/character verification, bounded reads, UTF-8 checks and local secret scanning

## Verification

The compiled Python/Rust differential corpus now includes clean/secret source reads, rejected `.env`/hidden/credentials paths, allowed workflow/dotfile/docs paths, POSIX symlink rejection, explicitly allowed sibling Git checkout reads, and known `skill://` documents. Exact public parity is required for decision, model-output action, reason code, notice, policy action and reviewed hashes.

The Rust differential workflow runs on stacked PRs as well as `release/3.0` so semantic drift is caught before merge.

## Rollout

`HOL_GUARD_NATIVE` remains `off` by default. This closes a source-read parity prerequisite but does not expand native authority by itself.