### PR TITLE
feat(guard): add shadow Rust command model

### DIFF
--- a/.github/workflows/rust-command-model-differential.yml
+++ b/.github/workflows/rust-command-model-differential.yml
@@ -1,0 +1,76 @@
+name: Rust command model differential
+
+on:
+  pull_request:
+    paths:
+      - "rust/Cargo.toml"
+      - "rust/Cargo.lock"
+      - "rust/crates/guard-command/**"
+      - "rust/crates/guard-runtime/**"
+      - "ci/native_runtime/test_command_model_differential.py"
+      - ".github/workflows/rust-command-model-differential.yml"
+  push:
+    branches: [release/3.0]
+    paths:
+      - "rust/Cargo.toml"
+      - "rust/Cargo.lock"
+      - "rust/crates/guard-command/**"
+      - "rust/crates/guard-runtime/**"
+      - "ci/native_runtime/test_command_model_differential.py"
+      - ".github/workflows/rust-command-model-differential.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-command-model-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  command-model:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal --component rustfmt --component clippy
+          rustup default 1.88.0
+      - name: Normalize changed Rust sources
+        run: |
+          rustfmt --edition 2021 rust/crates/guard-command/src/lib.rs rust/crates/guard-runtime/src/main.rs
+          git diff --check -- rust/crates/guard-command/src/lib.rs rust/crates/guard-runtime/src/main.rs
+      - name: Validate locked command workspace
+        run: |
+          cargo metadata --manifest-path rust/Cargo.toml --locked --format-version 1 --no-deps > /dev/null
+          cargo clippy --manifest-path rust/Cargo.toml --locked --workspace --all-targets -- -D warnings
+          cargo test --manifest-path rust/Cargo.toml --locked --workspace --all-targets
+      - name: Normalize and check Python differential harness
+        run: |
+          uv run --no-sync python -m ruff format ci/native_runtime/test_command_model_differential.py
+          uv run --no-sync python -m ruff check ci/native_runtime/test_command_model_differential.py
+          git diff --check -- ci/native_runtime/test_command_model_differential.py
+      - name: Build version-matched runtime
+        env:
+          HOL_GUARD_BUILD_SHA: ${{ github.sha }}
+        run: |
+          VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          export HOL_GUARD_PACKAGE_VERSION="$VERSION"
+          cargo build --manifest-path rust/Cargo.toml --locked --release -p hol-guard-runtime
+          rust/target/release/hol-guard-runtime self-test --json
+          rust/target/release/hol-guard-runtime rule-contract --json
+      - name: Compare Python and Rust command models
+        run: >-
+          uv run --no-sync python ci/native_runtime/test_command_model_differential.py
+          --binary "${{ github.workspace }}/rust/target/release/hol-guard-runtime"

--- a/ci/native_runtime/test_command_model_differential.py
+++ b/ci/native_runtime/test_command_model_differential.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Differential checks for the shadow-only Rust command model."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+from codex_plugin_scanner.guard.runtime.command_model import parse_shell_command
+
+EXACT_FIXTURES = (
+    "git status --short",
+    "printf 'hello world'",
+    "printf '' \"\"",
+    "FOO=bar PATH=/tmp tool --name 'two words'",
+    "A_B=one FOO='two words' tool ''",
+    "FOO=bar",
+    "printf 'a|b' | grep b",
+    "echo one && echo two",
+    "echo one || echo two",
+    "echo one; echo two",
+    "echo one\necho two",
+    "printf 'a&&b' 'a||b' 'a;b'",
+    r'printf "%s" "a\q" "a\$b" "a\"b" "a\\b"',
+    "echo foo\\\nbar",
+    "printf x\u00a0y",
+    r"printf escaped\ space",
+    r"printf \#not-a-comment",
+    "./tool --flag=value",
+)
+UNCERTAIN_FIXTURES = (
+    "echo $(uname)",
+    "echo `uname`",
+    "cat <<EOF",
+    "echo hello > out.txt",
+    "sleep 1 &",
+    "sudo rm -rf /tmp/example",
+    "env FOO=bar tool",
+    "time tool",
+    "stdbuf -o0 tool",
+    "sh -c 'rm -rf /tmp/example'",
+    "bash ./script.sh",
+    "eval 'rm -rf /tmp/example'",
+    "exec rm -rf /tmp/example",
+    "source ./script.sh",
+    ". ./script.sh",
+    "if true; then echo yes; fi",
+    "for item in one two; do echo \"$item\"; done",
+    "while true; do break; done",
+    "case \"$value\" in one) echo one;; esac",
+    "[[ -f Cargo.toml ]]",
+    "echo $'non-posix quote'",
+    'echo $"localized quote"',
+    "xargs rm -rf",
+    "parallel rm ::: one",
+    "find . -exec rm {} ;",
+    "(echo nested)",
+    "{ echo nested; }",
+    "echo 'unterminated",
+    "echo trailing\\",
+)
+
+
+def _native(binary: Path, command: str) -> dict[str, object]:
+    payload = json.dumps(
+        {
+            "command": command,
+            "dialect": "posix",
+            "transport": "shell_string",
+            "extraction_provenance": "guard-shell",
+        }
+    )
+    completed = subprocess.run(
+        [str(binary), "command-model", "--stdin"],
+        input=payload,
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=5,
+    )
+    return json.loads(completed.stdout)
+
+
+def _comparable(command: dict[str, object]) -> dict[str, object]:
+    return {
+        "normalized_text": command["normalized_text"],
+        "dialect": command["dialect"],
+        "transport": command["transport"],
+        "extraction_provenance": command["extraction_provenance"],
+        "wrapper_chain": command["wrapper_chain"],
+        "segments": command["segments"],
+        "confidence": command["confidence"],
+        "uncertainty_reason": command["uncertainty_reason"],
+        "path_overridden": command["path_overridden"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=Path, required=True)
+    args = parser.parse_args()
+
+    capabilities = subprocess.run(
+        [str(args.binary), "capabilities", "--json"],
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=5,
+    )
+    features = set(json.loads(capabilities.stdout)["features"])
+    assert "pre-tool-command-model-shadow-v1" in features
+
+    for fixture in EXACT_FIXTURES:
+        python_model = parse_shell_command(fixture).to_dict()
+        native_model = _native(args.binary, fixture)
+        assert python_model["confidence"] == "exact", fixture
+        assert native_model["confidence"] == "exact", fixture
+        assert _comparable(native_model) == _comparable(python_model), fixture
+
+    for fixture in UNCERTAIN_FIXTURES:
+        native_model = _native(args.binary, fixture)
+        assert native_model["confidence"] == "uncertain", fixture
+        assert native_model["segments"] == [], fixture
+        assert native_model["uncertainty_reason"], fixture
+
+    print(
+        json.dumps(
+            {
+                "exact_fixture_count": len(EXACT_FIXTURES),
+                "uncertain_fixture_count": len(UNCERTAIN_FIXTURES),
+                "status": "ok",
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -66,6 +66,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "guard-command"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "guard-contracts"
 version = "0.1.0"
 dependencies = [
@@ -142,6 +149,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 name = "hol-guard-runtime"
 version = "0.1.0"
 dependencies = [
+ "guard-command",
  "guard-contracts",
  "guard-hook-core",
  "guard-rule-contract",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/guard-command",
     "crates/guard-contracts",
     "crates/guard-rules",
     "crates/guard-scanner",

--- a/rust/crates/guard-command/Cargo.toml
+++ b/rust/crates/guard-command/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "guard-command"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde.workspace = true
+
+[lints]
+workspace = true

--- a/rust/crates/guard-command/README.md
+++ b/rust/crates/guard-command/README.md
@@ -1,0 +1,19 @@
+# guard-command
+
+`guard-command` is HOL Guard's side-effect-free native command model for the staged PreToolUse migration.
+
+## Current authority
+
+The crate is shadow-only. Python remains authoritative for PreToolUse policy decisions, approvals, receipts, and compatibility behavior.
+
+## Exact subset
+
+The `posix-simple-v1` parser may report `confidence = "exact"` only for bounded POSIX shell strings whose represented shell structure and tokenization match the Python reference model. The current exact subset covers ordinary argv-style commands, POSIX quoting and escaping, leading `NAME=value` assignments, PATH override detection, logical command groups, and pipelines.
+
+## Conservative boundary
+
+Command substitution, backticks, non-POSIX `$'...'` or `$"..."` quoting, heredocs, redirects, background jobs, shell control syntax, compound forms, transparent wrappers, nested shell evaluators, and command executors such as `xargs` are not partially interpreted. They return `confidence = "uncertain"` with no native segments until their semantics have dedicated parity tests.
+
+The parser never executes input, expands variables, resolves executables, reads shell startup files, or performs network I/O. Hard limits match the Python command model: 32 KiB command input, 128 segments, and 2,048 tokens.
+
+Native PreToolUse authority must not be enabled solely because this crate exists. Exact Python/Rust differential coverage and fail-closed hook integration are separate rollout gates.

--- a/rust/crates/guard-command/src/lib.rs
+++ b/rust/crates/guard-command/src/lib.rs
@@ -1,0 +1,615 @@
+#![forbid(unsafe_code)]
+
+use serde::{Deserialize, Serialize};
+
+pub const MAX_COMMAND_BYTES: usize = 32_768;
+pub const MAX_COMMAND_SEGMENTS: usize = 128;
+pub const MAX_COMMAND_TOKENS: usize = 2_048;
+
+fn default_dialect() -> String {
+    "posix".to_owned()
+}
+
+fn default_transport() -> String {
+    "shell_string".to_owned()
+}
+
+fn default_provenance() -> String {
+    "guard-shell".to_owned()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommandModelRequestV1 {
+    pub command: String,
+    #[serde(default = "default_dialect")]
+    pub dialect: String,
+    #[serde(default = "default_transport")]
+    pub transport: String,
+    #[serde(default = "default_provenance")]
+    pub extraction_provenance: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommandSpanV1 {
+    pub source: String,
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommandSegmentV1 {
+    pub text: String,
+    pub tokens: Vec<String>,
+    pub executable: Option<String>,
+    pub arguments: Vec<String>,
+    pub environment_names: Vec<String>,
+    pub wrapper_chain: Vec<String>,
+    pub path_overridden: bool,
+    pub execution_context: String,
+    pub pipeline_index: usize,
+    pub span: CommandSpanV1,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CanonicalCommandV1 {
+    pub normalized_text: String,
+    pub dialect: String,
+    pub transport: String,
+    pub extraction_provenance: String,
+    pub wrapper_chain: Vec<String>,
+    pub segments: Vec<CommandSegmentV1>,
+    pub confidence: String,
+    pub uncertainty_reason: Option<String>,
+    pub path_overridden: bool,
+    pub parser_profile: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Quote {
+    None,
+    Single,
+    Double,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RawSegment {
+    group_index: usize,
+    pipeline_index: usize,
+    start: usize,
+    end: usize,
+}
+
+pub fn parse_command(request: &CommandModelRequestV1) -> Result<CanonicalCommandV1, String> {
+    let raw = request.command.trim();
+    if raw.is_empty() {
+        return Err("command_text_empty".to_owned());
+    }
+    if request.dialect != "posix" || request.transport != "shell_string" {
+        return Ok(uncertain(request, raw, "unsupported_dialect_or_transport"));
+    }
+    if raw.chars().count() > MAX_COMMAND_BYTES || raw.len() > MAX_COMMAND_BYTES {
+        return Ok(uncertain(request, raw, "command_byte_limit_exceeded"));
+    }
+
+    let raw_segments = match split_execution_segments(raw) {
+        Ok(value) => value,
+        Err(reason) => return Ok(uncertain(request, raw, reason)),
+    };
+    if raw_segments.len() > MAX_COMMAND_SEGMENTS {
+        return Ok(uncertain(request, raw, "command_segment_limit_exceeded"));
+    }
+
+    let chars: Vec<char> = raw.chars().collect();
+    let mut segments = Vec::with_capacity(raw_segments.len());
+    let mut total_tokens = 0usize;
+    for raw_segment in raw_segments {
+        let text: String = chars[raw_segment.start..raw_segment.end].iter().collect();
+        let tokens = match shell_tokens(&text) {
+            Ok(value) => value,
+            Err(reason) => return Ok(uncertain(request, raw, reason)),
+        };
+        total_tokens = total_tokens.saturating_add(tokens.len());
+        if total_tokens > MAX_COMMAND_TOKENS {
+            return Ok(uncertain(request, raw, "command_token_limit_exceeded"));
+        }
+
+        let mut environment_names = Vec::new();
+        let mut executable_index = 0usize;
+        while executable_index < tokens.len() {
+            let Some(name) = assignment_name(&tokens[executable_index]) else {
+                break;
+            };
+            environment_names.push(name.to_owned());
+            executable_index += 1;
+        }
+        let executable = tokens.get(executable_index).cloned();
+        let arguments = if executable.is_some() {
+            tokens[executable_index + 1..].to_vec()
+        } else {
+            Vec::new()
+        };
+        if executable
+            .as_deref()
+            .is_some_and(is_shell_control_keyword)
+        {
+            return Ok(uncertain(request, raw, "compound_shell_not_yet_supported"));
+        }
+        if executable
+            .as_deref()
+            .is_some_and(is_transparent_wrapper)
+        {
+            return Ok(uncertain(
+                request,
+                raw,
+                "transparent_wrapper_not_yet_supported",
+            ));
+        }
+        if executable
+            .as_deref()
+            .is_some_and(|value| is_nested_command_executor(value, &arguments))
+        {
+            return Ok(uncertain(
+                request,
+                raw,
+                "nested_command_executor_not_yet_supported",
+            ));
+        }
+        let path_overridden = environment_names.iter().any(|name| name == "PATH");
+        segments.push(CommandSegmentV1 {
+            text,
+            tokens,
+            executable,
+            arguments,
+            environment_names,
+            wrapper_chain: Vec::new(),
+            path_overridden,
+            execution_context: format!("top:{}", raw_segment.group_index),
+            pipeline_index: raw_segment.pipeline_index,
+            span: CommandSpanV1 {
+                source: "normalized".to_owned(),
+                start: raw_segment.start,
+                end: raw_segment.end,
+            },
+        });
+    }
+
+    let path_overridden = segments.iter().any(|segment| segment.path_overridden);
+    Ok(CanonicalCommandV1 {
+        normalized_text: raw.to_owned(),
+        dialect: request.dialect.clone(),
+        transport: request.transport.clone(),
+        extraction_provenance: request.extraction_provenance.clone(),
+        wrapper_chain: Vec::new(),
+        segments,
+        confidence: "exact".to_owned(),
+        uncertainty_reason: None,
+        path_overridden,
+        parser_profile: "posix-simple-v1".to_owned(),
+    })
+}
+
+fn uncertain(request: &CommandModelRequestV1, raw: &str, reason: &str) -> CanonicalCommandV1 {
+    CanonicalCommandV1 {
+        normalized_text: raw.to_owned(),
+        dialect: request.dialect.clone(),
+        transport: request.transport.clone(),
+        extraction_provenance: request.extraction_provenance.clone(),
+        wrapper_chain: Vec::new(),
+        segments: Vec::new(),
+        confidence: "uncertain".to_owned(),
+        uncertainty_reason: Some(reason.to_owned()),
+        path_overridden: false,
+        parser_profile: "posix-simple-v1".to_owned(),
+    }
+}
+
+fn split_execution_segments(command: &str) -> Result<Vec<RawSegment>, &'static str> {
+    let chars: Vec<char> = command.chars().collect();
+    let mut quote = Quote::None;
+    let mut escaped = false;
+    let mut segments = Vec::new();
+    let mut segment_start = 0usize;
+    let mut group_index = 0usize;
+    let mut pipeline_index = 0usize;
+    let mut index = 0usize;
+
+    while index < chars.len() {
+        let current = chars[index];
+        if escaped {
+            escaped = false;
+            index += 1;
+            continue;
+        }
+        match quote {
+            Quote::Single => {
+                if current == '\'' {
+                    quote = Quote::None;
+                }
+                index += 1;
+                continue;
+            }
+            Quote::Double => {
+                if current == '"' {
+                    quote = Quote::None;
+                } else if current == '\\' {
+                    escaped = true;
+                } else if current == '`'
+                    || (current == '$' && chars.get(index + 1) == Some(&'('))
+                {
+                    return Err("command_substitution_not_yet_supported");
+                }
+                index += 1;
+                continue;
+            }
+            Quote::None => {}
+        }
+
+        match current {
+            '\'' => quote = Quote::Single,
+            '"' => quote = Quote::Double,
+            '\\' => escaped = true,
+            '`' => return Err("command_substitution_not_yet_supported"),
+            '$' if chars.get(index + 1) == Some(&'(') => {
+                return Err("command_substitution_not_yet_supported");
+            }
+            '$'
+                if chars
+                    .get(index + 1)
+                    .is_some_and(|next| *next == '\'' || *next == '"') =>
+            {
+                return Err("non_posix_quoting_not_yet_supported");
+            }
+            '<' | '>' => return Err("command_redirect_not_yet_supported"),
+            '(' | ')' | '{' | '}' => return Err("compound_shell_not_yet_supported"),
+            '&' => {
+                if chars.get(index + 1) != Some(&'&') {
+                    return Err("background_job_not_yet_supported");
+                }
+                push_segment(
+                    &chars,
+                    segment_start,
+                    index,
+                    group_index,
+                    pipeline_index,
+                    &mut segments,
+                )?;
+                index += 1;
+                segment_start = index + 1;
+                group_index += 1;
+                pipeline_index = 0;
+            }
+            '|' => {
+                let logical_or = chars.get(index + 1) == Some(&'|');
+                push_segment(
+                    &chars,
+                    segment_start,
+                    index,
+                    group_index,
+                    pipeline_index,
+                    &mut segments,
+                )?;
+                if logical_or {
+                    index += 1;
+                    group_index += 1;
+                    pipeline_index = 0;
+                } else {
+                    pipeline_index += 1;
+                }
+                segment_start = index + 1;
+            }
+            ';' | '\n' => {
+                push_segment(
+                    &chars,
+                    segment_start,
+                    index,
+                    group_index,
+                    pipeline_index,
+                    &mut segments,
+                )?;
+                segment_start = index + 1;
+                group_index += 1;
+                pipeline_index = 0;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    if quote != Quote::None || escaped {
+        return Err("malformed_shell_quoting");
+    }
+    push_segment(
+        &chars,
+        segment_start,
+        chars.len(),
+        group_index,
+        pipeline_index,
+        &mut segments,
+    )?;
+    if segments.is_empty() {
+        return Err("empty_command_segment");
+    }
+    Ok(segments)
+}
+
+fn push_segment(
+    chars: &[char],
+    start: usize,
+    end: usize,
+    group_index: usize,
+    pipeline_index: usize,
+    output: &mut Vec<RawSegment>,
+) -> Result<(), &'static str> {
+    let mut left = start;
+    let mut right = end;
+    while left < right && chars[left].is_whitespace() {
+        left += 1;
+    }
+    while right > left && chars[right - 1].is_whitespace() {
+        right -= 1;
+    }
+    if left == right {
+        return Err("empty_command_segment");
+    }
+    output.push(RawSegment {
+        group_index,
+        pipeline_index,
+        start: left,
+        end: right,
+    });
+    Ok(())
+}
+
+fn shell_tokens(command: &str) -> Result<Vec<String>, &'static str> {
+    let mut tokens = Vec::new();
+    let mut token = String::new();
+    let mut token_started = false;
+    let mut quote = Quote::None;
+    let mut escaped = false;
+
+    for current in command.chars() {
+        if escaped {
+            if quote == Quote::Double && current != '"' && current != '\\' {
+                token.push('\\');
+            }
+            token.push(current);
+            token_started = true;
+            escaped = false;
+            continue;
+        }
+        match quote {
+            Quote::Single => {
+                if current == '\'' {
+                    quote = Quote::None;
+                } else {
+                    token.push(current);
+                    token_started = true;
+                }
+            }
+            Quote::Double => {
+                if current == '"' {
+                    quote = Quote::None;
+                } else if current == '\\' {
+                    escaped = true;
+                    token_started = true;
+                } else {
+                    token.push(current);
+                    token_started = true;
+                }
+            }
+            Quote::None => match current {
+                '\'' => {
+                    quote = Quote::Single;
+                    token_started = true;
+                }
+                '"' => {
+                    quote = Quote::Double;
+                    token_started = true;
+                }
+                '\\' => {
+                    escaped = true;
+                    token_started = true;
+                }
+                value if is_shell_token_whitespace(value) => {
+                    if token_started {
+                        tokens.push(std::mem::take(&mut token));
+                        token_started = false;
+                    }
+                }
+                value => {
+                    token.push(value);
+                    token_started = true;
+                }
+            },
+        }
+    }
+    if quote != Quote::None || escaped {
+        return Err("malformed_shell_quoting");
+    }
+    if token_started {
+        tokens.push(token);
+    }
+    Ok(tokens)
+}
+
+fn is_shell_token_whitespace(value: char) -> bool {
+    matches!(value, ' ' | '\t' | '\r' | '\n')
+}
+
+fn assignment_name(token: &str) -> Option<&str> {
+    let (name, _value) = token.split_once('=')?;
+    let mut chars = name.chars();
+    let first = chars.next()?;
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        return None;
+    }
+    if !chars.all(|value| value == '_' || value.is_ascii_alphanumeric()) {
+        return None;
+    }
+    Some(name)
+}
+
+fn executable_basename(executable: &str) -> &str {
+    executable.rsplit('/').next().unwrap_or(executable)
+}
+
+fn is_shell_control_keyword(executable: &str) -> bool {
+    if executable.contains('/') {
+        return false;
+    }
+    matches!(
+        executable,
+        "!" | "[["
+            | "case"
+            | "coproc"
+            | "do"
+            | "done"
+            | "elif"
+            | "else"
+            | "esac"
+            | "fi"
+            | "for"
+            | "function"
+            | "if"
+            | "in"
+            | "select"
+            | "then"
+            | "until"
+            | "while"
+    )
+}
+
+fn is_transparent_wrapper(executable: &str) -> bool {
+    matches!(
+        executable_basename(executable),
+        "ash"
+            | "bash"
+            | "command"
+            | "dash"
+            | "doas"
+            | "env"
+            | "fish"
+            | "lean-ctx"
+            | "nice"
+            | "nohup"
+            | "setsid"
+            | "sh"
+            | "stdbuf"
+            | "sudo"
+            | "time"
+            | "timeout"
+            | "zsh"
+    )
+}
+
+fn is_nested_command_executor(executable: &str, arguments: &[String]) -> bool {
+    let basename = executable_basename(executable);
+    if matches!(basename, "." | "eval" | "exec" | "parallel" | "source" | "xargs") {
+        return true;
+    }
+    basename == "find"
+        && arguments
+            .iter()
+            .any(|argument| matches!(argument.as_str(), "-exec" | "-execdir" | "-ok" | "-okdir"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(command: &str) -> CommandModelRequestV1 {
+        CommandModelRequestV1 {
+            command: command.to_owned(),
+            dialect: default_dialect(),
+            transport: default_transport(),
+            extraction_provenance: default_provenance(),
+        }
+    }
+
+    #[test]
+    fn parses_simple_command_without_execution() {
+        let parsed = parse_command(&request("git status --short")).unwrap();
+        assert_eq!(parsed.confidence, "exact");
+        assert_eq!(parsed.segments.len(), 1);
+        assert_eq!(parsed.segments[0].executable.as_deref(), Some("git"));
+        assert_eq!(parsed.segments[0].arguments, ["status", "--short"]);
+        assert_eq!(parsed.segments[0].span.start, 0);
+        assert_eq!(parsed.segments[0].span.end, 18);
+    }
+
+    #[test]
+    fn preserves_quotes_environment_and_path_override() {
+        let parsed = parse_command(&request("FOO=bar PATH=/tmp tool --name 'two words'")).unwrap();
+        let segment = &parsed.segments[0];
+        assert_eq!(segment.environment_names, ["FOO", "PATH"]);
+        assert_eq!(segment.executable.as_deref(), Some("tool"));
+        assert_eq!(segment.arguments, ["--name", "two words"]);
+        assert!(segment.path_overridden);
+        assert!(parsed.path_overridden);
+    }
+
+    #[test]
+    fn matches_python_shlex_escape_and_whitespace_semantics() {
+        let parsed = parse_command(&request(
+            "printf \"%s\" \"a\\q\" \"a\\$b\" \"a\\\"b\" \"a\\\\b\" x\u{00a0}y",
+        ))
+        .unwrap();
+        assert_eq!(parsed.confidence, "exact");
+        assert_eq!(
+            parsed.segments[0].tokens,
+            [
+                "printf",
+                "%s",
+                "a\\q",
+                "a\\$b",
+                "a\"b",
+                "a\\b",
+                "x\u{00a0}y"
+            ]
+        );
+    }
+
+    #[test]
+    fn splits_pipeline_but_not_quoted_pipe() {
+        let parsed = parse_command(&request("printf 'a|b' | grep b")).unwrap();
+        assert_eq!(parsed.segments.len(), 2);
+        assert_eq!(parsed.segments[0].tokens, ["printf", "a|b"]);
+        assert_eq!(parsed.segments[0].pipeline_index, 0);
+        assert_eq!(parsed.segments[1].tokens, ["grep", "b"]);
+        assert_eq!(parsed.segments[1].pipeline_index, 1);
+    }
+
+    #[test]
+    fn marks_complex_shell_forms_uncertain_without_partial_segments() {
+        for command in [
+            "echo $(uname)",
+            "cat <<EOF",
+            "echo hello > out.txt",
+            "sleep 1 &",
+            "sudo rm -rf /tmp/example",
+            "sh -c 'rm -rf /tmp/example'",
+            "eval 'rm -rf /tmp/example'",
+            "if true; then echo yes; fi",
+            "[[ -f Cargo.toml ]]",
+            "echo $'non-posix quote'",
+            "xargs rm -rf",
+            "find . -exec rm {} ;",
+        ] {
+            let parsed = parse_command(&request(command)).unwrap();
+            assert_eq!(parsed.confidence, "uncertain", "{command}");
+            assert!(parsed.segments.is_empty(), "{command}");
+            assert!(parsed.uncertainty_reason.is_some(), "{command}");
+        }
+    }
+
+    #[test]
+    fn rejects_oversized_commands_without_partial_exact_parse() {
+        let parsed = parse_command(&request(&"x".repeat(MAX_COMMAND_BYTES + 1))).unwrap();
+        assert_eq!(parsed.confidence, "uncertain");
+        assert_eq!(
+            parsed.uncertainty_reason.as_deref(),
+            Some("command_byte_limit_exceeded")
+        );
+        assert!(parsed.segments.is_empty());
+    }
+}

--- a/rust/crates/guard-runtime/Cargo.toml
+++ b/rust/crates/guard-runtime/Cargo.toml
@@ -10,6 +10,7 @@ name = "hol-guard-runtime"
 path = "src/main.rs"
 
 [dependencies]
+guard-command = { path = "../guard-command" }
 guard-contracts = { path = "../guard-contracts" }
 guard-hook-core = { path = "../guard-hook-core" }
 guard-rule-contract = { path = "../guard-rule-contract" }

--- a/rust/crates/guard-runtime/src/main.rs
+++ b/rust/crates/guard-runtime/src/main.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+use guard_command::{parse_command, CommandModelRequestV1};
 use guard_contracts::{
     NativeHookRequestV1, RuntimeCapabilitiesV1, MAX_NATIVE_REQUEST_BYTES,
     MAX_NATIVE_RESPONSE_BYTES, NATIVE_PROTOCOL_VERSION,
@@ -32,6 +33,7 @@ fn capabilities() -> RuntimeCapabilitiesV1 {
             "framed-serve-v1".into(),
             "bounded-concurrency-v1".into(),
             "rule-contract-v2".into(),
+            "pre-tool-command-model-shadow-v1".into(),
         ],
     }
 }
@@ -48,12 +50,21 @@ fn read_stdin_bounded() -> Result<Vec<u8>, String> {
     Ok(bytes)
 }
 
-fn evaluate_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
+fn evaluate_hook_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
     let request: NativeHookRequestV1 =
         serde_json::from_slice(bytes).map_err(|_| "native_request_invalid_json".to_owned())?;
-    let response = review_post_tool(&request);
+    encode_response(&review_post_tool(&request))
+}
+
+fn evaluate_command_model_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let request: CommandModelRequestV1 = serde_json::from_slice(bytes)
+        .map_err(|_| "native_command_model_invalid_json".to_owned())?;
+    encode_response(&parse_command(&request)?)
+}
+
+fn encode_response<T: serde::Serialize>(value: &T) -> Result<Vec<u8>, String> {
     let encoded =
-        serde_json::to_vec(&response).map_err(|_| "native_response_encode_failed".to_owned())?;
+        serde_json::to_vec(value).map_err(|_| "native_response_encode_failed".to_owned())?;
     if encoded.len() > MAX_NATIVE_RESPONSE_BYTES {
         return Err("native_response_too_large".into());
     }
@@ -64,6 +75,16 @@ fn write_json<T: serde::Serialize>(value: &T) -> Result<(), String> {
     serde_json::to_writer(io::stdout().lock(), value)
         .map_err(|_| "native_response_encode_failed".to_owned())?;
     println!();
+    Ok(())
+}
+
+fn write_bytes_response(response: &[u8]) -> Result<(), String> {
+    io::stdout()
+        .write_all(response)
+        .map_err(|_| "native_response_write_failed".to_owned())?;
+    io::stdout()
+        .write_all(b"\n")
+        .map_err(|_| "native_response_write_failed".to_owned())?;
     Ok(())
 }
 
@@ -89,7 +110,7 @@ fn serve(socket_path: &str) -> Result<(), String> {
         stream
             .read_exact(&mut request)
             .map_err(|_| "native_frame_read_failed".to_owned())?;
-        let response = evaluate_bytes(&request)?;
+        let response = evaluate_hook_bytes(&request)?;
         stream
             .write_all(&(response.len() as u32).to_be_bytes())
             .map_err(|_| "native_frame_write_failed".to_owned())?;
@@ -164,18 +185,15 @@ fn run() -> Result<(), String> {
         }
         [command, flag] if command == "hook" && flag == "--stdin" => {
             let bytes = read_stdin_bounded()?;
-            let response = evaluate_bytes(&bytes)?;
-            io::stdout()
-                .write_all(&response)
-                .map_err(|_| "native_response_write_failed".to_owned())?;
-            io::stdout()
-                .write_all(b"\n")
-                .map_err(|_| "native_response_write_failed".to_owned())?;
-            Ok(())
+            write_bytes_response(&evaluate_hook_bytes(&bytes)?)
+        }
+        [command, flag] if command == "command-model" && flag == "--stdin" => {
+            let bytes = read_stdin_bounded()?;
+            write_bytes_response(&evaluate_command_model_bytes(&bytes)?)
         }
         [command, flag, path] if command == "serve" && flag == "--socket" => serve(path),
         _ => Err(
-            "usage: hol-guard-runtime capabilities --json | rule-contract --json | self-test --json | hook --stdin | serve --socket PATH"
+            "usage: hol-guard-runtime capabilities --json | rule-contract --json | self-test --json | hook --stdin | command-model --stdin | serve --socket PATH"
                 .into(),
         ),
     }


### PR DESCRIPTION
## Summary

Adds the first PreToolUse Rust migration slice without changing production authority, rebuilt on top of the exact native rule-implementation contract.

- introduces an `unsafe`-forbidden `guard-command` crate
- parses a deliberately bounded POSIX subset without shell execution
- models simple commands, quoting, environment prefixes, PATH override, logical command groups and pipelines
- marks substitutions, heredocs, redirects, background jobs, compound forms and transparent wrappers as explicitly `uncertain` instead of partially claiming exactness
- exposes `command-model --stdin` from the same version-matched `hol-guard-runtime` binary
- preserves `rule-contract-v2`, source-path parity, `guard-policy-snapshot`, and the existing PostToolUse runtime surface
- advertises `pre-tool-command-model-shadow-v1`
- uses a dedicated command-model differential workflow rather than modifying the merged PostToolUse differential gate
- differentially compares exact synthetic fixtures against Python's canonical command model
- requires unsupported fixtures to fail conservatively with no partial exact segments

## Rollout

Shadow/evidence only. Python remains authoritative for PreToolUse decisions, policy, approvals and receipts. This PR does not enable native PreToolUse blocking or allowing and does not change the default `HOL_GUARD_NATIVE=off` behavior.