### PR TITLE
fix(ci): verify framework Python runtime signing

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12264,
-  "maximum_test_source_lines": 285687,
+  "maximum_collected_cases": 12265,
+  "maximum_test_source_lines": 285707,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12261,
-  "maximum_test_source_lines": 285620,
+  "maximum_collected_cases": 12264,
+  "maximum_test_source_lines": 285687,
   "schema_version": 1
 }

--- a/scripts/release/verify_pyinstaller_macos_signing.py
+++ b/scripts/release/verify_pyinstaller_macos_signing.py
@@ -9,7 +9,7 @@ import struct
 import subprocess
 import tempfile
 import zlib
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 COOKIE_MAGIC = b"MEI\x0c\x0b\x0a\x0b\x0e"
 COOKIE_FORMAT = "!8sIIII64s"
@@ -17,6 +17,7 @@ COOKIE_LENGTH = struct.calcsize(COOKIE_FORMAT)
 TOC_FORMAT = "!IIIIBc"
 TOC_HEADER_LENGTH = struct.calcsize(TOC_FORMAT)
 BINARY_TYPE = "b"
+SYMLINK_TYPE = "n"
 MACHO_MAGICS = {
     b"\xce\xfa\xed\xfe",  # MH_MAGIC
     b"\xcf\xfa\xed\xfe",  # MH_MAGIC_64
@@ -127,33 +128,94 @@ def _team_id(path: Path) -> str:
     raise ValueError(f"Embedded Mach-O has no TeamIdentifier: {path.name}")
 
 
+def _unique_entry(
+    entries: list[tuple[str, int, int, bool, str]],
+    name: str,
+    *,
+    role: str,
+) -> tuple[str, int, int, bool, str]:
+    matches = [entry for entry in entries if entry[0] == name]
+    if len(matches) != 1:
+        raise ValueError(f"{role} {name!r} must have exactly one TOC entry; found {len(matches)}")
+    return matches[0]
+
+
+def _normalized_symlink_target(source_name: str, target: str) -> str:
+    target_path = PurePosixPath(target)
+    if target_path.is_absolute():
+        raise ValueError(f"PyInstaller archive symlink {source_name!r} has an absolute target")
+
+    parts = list(PurePosixPath(source_name).parent.parts)
+    for part in target_path.parts:
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            if not parts:
+                raise ValueError(f"PyInstaller archive symlink {source_name!r} escapes the archive root")
+            parts.pop()
+            continue
+        parts.append(part)
+    if not parts:
+        raise ValueError(f"PyInstaller archive symlink {source_name!r} has an empty target")
+    return PurePosixPath(*parts).as_posix()
+
+
+def _resolve_declared_runtime(
+    handle,
+    archive_start: int,
+    declared_runtime: str,
+    entries: list[tuple[str, int, int, bool, str]],
+) -> tuple[str, int, int, bool, str]:
+    """Resolve PyInstaller's cookie runtime through archive-local symlinks to a binary entry."""
+
+    current_name = declared_runtime
+    seen: set[str] = set()
+    for _ in range(8):
+        if current_name in seen:
+            raise ValueError(f"Cookie-declared Python runtime {declared_runtime!r} resolves through a symlink cycle")
+        seen.add(current_name)
+        entry = _unique_entry(entries, current_name, role="Cookie-declared Python runtime target")
+        name, offset, length, compressed, typecode = entry
+        if typecode == BINARY_TYPE:
+            return entry
+        if typecode != SYMLINK_TYPE:
+            raise ValueError(
+                f"Cookie-declared Python runtime {declared_runtime!r} resolves to unsupported TOC type {typecode!r}"
+            )
+
+        data = _entry_bytes(handle, archive_start, name, offset, length, compressed)
+        if not data.endswith(b"\0") or b"\0" in data[:-1]:
+            raise ValueError(f"PyInstaller archive symlink {name!r} has invalid target encoding")
+        try:
+            target = data[:-1].decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"PyInstaller archive symlink {name!r} target is not UTF-8") from exc
+        if not target:
+            raise ValueError(f"PyInstaller archive symlink {name!r} has an empty target")
+        current_name = _normalized_symlink_target(name, target)
+
+    raise ValueError(f"Cookie-declared Python runtime {declared_runtime!r} exceeds symlink resolution depth")
+
+
 def verify(binary: Path, expected_team_id: str) -> None:
     archive_start, declared_runtime, entries = _archive_layout(binary)
-    declared_entries = [entry for entry in entries if entry[0] == declared_runtime]
-    if len(declared_entries) != 1:
-        raise ValueError(
-            f"Cookie-declared Python runtime {declared_runtime!r} must have exactly one TOC entry; "
-            f"found {len(declared_entries)}"
-        )
-    if declared_entries[0][4] != BINARY_TYPE:
-        raise ValueError(
-            f"Cookie-declared Python runtime {declared_runtime!r} is not a binary TOC entry"
-        )
 
     macho_count = 0
     declared_runtime_verified = False
     with binary.open("rb") as handle, tempfile.TemporaryDirectory(
         prefix="hol-guard-pyi-signing-"
     ) as tmp:
+        runtime_entry = _resolve_declared_runtime(handle, archive_start, declared_runtime, entries)
+        runtime_name = runtime_entry[0]
         root = Path(tmp)
         for index, (name, offset, length, compressed, typecode) in enumerate(entries):
             if typecode != BINARY_TYPE:
                 continue
             data = _entry_bytes(handle, archive_start, name, offset, length, compressed)
             is_macho = data[:4] in MACHO_MAGICS
-            if name == declared_runtime and not is_macho:
+            if name == runtime_name and not is_macho:
                 raise ValueError(
-                    f"Cookie-declared Python runtime {declared_runtime!r} is not Mach-O"
+                    f"Cookie-declared Python runtime {declared_runtime!r} resolves to non-Mach-O binary {name!r}"
                 )
             if not is_macho:
                 continue
@@ -167,7 +229,7 @@ def verify(binary: Path, expected_team_id: str) -> None:
                     f"Embedded Mach-O {name!r} has TeamIdentifier={actual_team_id!r}; "
                     f"expected {expected_team_id!r}"
                 )
-            if name == declared_runtime:
+            if name == runtime_name:
                 declared_runtime_verified = True
 
     if macho_count == 0:

--- a/scripts/release/verify_pyinstaller_macos_signing.py
+++ b/scripts/release/verify_pyinstaller_macos_signing.py
@@ -140,7 +140,18 @@ def _unique_entry(
     return matches[0]
 
 
+def _archive_relative_name(name: str, *, role: str) -> str:
+    path = PurePosixPath(name)
+    if not name or path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"{role} {name!r} must be archive-relative")
+    normalized = path.as_posix()
+    if normalized in {"", ".", ".."}:
+        raise ValueError(f"{role} {name!r} must be archive-relative")
+    return normalized
+
+
 def _normalized_symlink_target(source_name: str, target: str) -> str:
+    source_name = _archive_relative_name(source_name, role="PyInstaller archive symlink source")
     target_path = PurePosixPath(target)
     if target_path.is_absolute():
         raise ValueError(f"PyInstaller archive symlink {source_name!r} has an absolute target")
@@ -157,7 +168,8 @@ def _normalized_symlink_target(source_name: str, target: str) -> str:
         parts.append(part)
     if not parts:
         raise ValueError(f"PyInstaller archive symlink {source_name!r} has an empty target")
-    return PurePosixPath(*parts).as_posix()
+    normalized = PurePosixPath(*parts).as_posix()
+    return _archive_relative_name(normalized, role="PyInstaller archive symlink target")
 
 
 def _resolve_declared_runtime(
@@ -168,7 +180,10 @@ def _resolve_declared_runtime(
 ) -> tuple[str, int, int, bool, str]:
     """Resolve PyInstaller's cookie runtime through archive-local symlinks to a binary entry."""
 
-    current_name = declared_runtime
+    current_name = _archive_relative_name(
+        declared_runtime,
+        role="Cookie-declared Python runtime",
+    )
     seen: set[str] = set()
     for _ in range(8):
         if current_name in seen:

--- a/tests/test_desktop_core_alpha_feed_macos_signing.py
+++ b/tests/test_desktop_core_alpha_feed_macos_signing.py
@@ -30,11 +30,16 @@ def _load_verifier() -> ModuleType:
     return module
 
 
-def _fake_archive(path: Path, *, declared_runtime: str, entries: list[tuple[str, bytes]]) -> None:
+def _fake_archive(
+    path: Path,
+    *,
+    declared_runtime: str,
+    entries: list[tuple[str, bytes, str]],
+) -> None:
     module = _load_verifier()
     payload = bytearray()
     toc = bytearray()
-    for name, data in entries:
+    for name, data, typecode in entries:
         offset = len(payload)
         payload.extend(data)
         raw_name = name.encode("utf-8") + b"\0"
@@ -47,7 +52,7 @@ def _fake_archive(path: Path, *, declared_runtime: str, entries: list[tuple[str,
                 len(data),
                 len(data),
                 0,
-                b"b",
+                typecode.encode("ascii"),
             )
         )
         toc.extend(raw_name)
@@ -95,6 +100,68 @@ def test_final_verification_checks_reused_and_new_embedded_team_identity() -> No
     assert run.index(verifier) < run.index('if [[ "$MODE" == "build" ]]; then')
 
 
+def test_verifier_accepts_framework_runtime_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_verifier()
+    archive = tmp_path / "hol-guard"
+    runtime = "Python.framework/Versions/3.12/Python"
+    _fake_archive(
+        archive,
+        declared_runtime="Python",
+        entries=[
+            ("Python", runtime.encode() + b"\0", "n"),
+            (runtime, b"\xcf\xfa\xed\xfe-runtime", "b"),
+            ("helper.dylib", b"\xcf\xfa\xed\xfe-helper", "b"),
+        ],
+    )
+    monkeypatch.setattr(module, "_team_id", lambda _path: "TEAM123")
+
+    module.verify(archive, "TEAM123")
+
+
+def test_verifier_rejects_framework_runtime_symlink_escape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_verifier()
+    archive = tmp_path / "hol-guard"
+    _fake_archive(
+        archive,
+        declared_runtime="Python",
+        entries=[
+            ("Python", b"../outside/Python\0", "n"),
+            ("helper.dylib", b"\xcf\xfa\xed\xfe-helper", "b"),
+        ],
+    )
+    monkeypatch.setattr(module, "_team_id", lambda _path: "TEAM123")
+
+    with pytest.raises(ValueError, match="escapes the archive root"):
+        module.verify(archive, "TEAM123")
+
+
+def test_verifier_rejects_framework_runtime_symlink_to_non_binary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_verifier()
+    archive = tmp_path / "hol-guard"
+    runtime = "Python.framework/Versions/3.12/Python"
+    _fake_archive(
+        archive,
+        declared_runtime="Python",
+        entries=[
+            ("Python", runtime.encode() + b"\0", "n"),
+            (runtime, b"not-a-binary", "x"),
+        ],
+    )
+    monkeypatch.setattr(module, "_team_id", lambda _path: "TEAM123")
+
+    with pytest.raises(ValueError, match="resolves to unsupported TOC type 'x'"):
+        module.verify(archive, "TEAM123")
+
+
 def test_verifier_rejects_missing_cookie_declared_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -104,9 +171,9 @@ def test_verifier_rejects_missing_cookie_declared_runtime(
     _fake_archive(
         archive,
         declared_runtime="Python",
-        entries=[("python_helper", b"\xcf\xfa\xed\xfe")],
+        entries=[("python_helper", b"\xcf\xfa\xed\xfe", "b")],
     )
     monkeypatch.setattr(module, "_team_id", lambda _path: "TEAM123")
 
-    with pytest.raises(ValueError, match="Cookie-declared Python runtime 'Python'.*found 0"):
+    with pytest.raises(ValueError, match="Cookie-declared Python runtime target 'Python'.*found 0"):
         module.verify(archive, "TEAM123")

--- a/tests/test_desktop_core_alpha_feed_macos_signing.py
+++ b/tests/test_desktop_core_alpha_feed_macos_signing.py
@@ -177,3 +177,23 @@ def test_verifier_rejects_missing_cookie_declared_runtime(
 
     with pytest.raises(ValueError, match="Cookie-declared Python runtime target 'Python'.*found 0"):
         module.verify(archive, "TEAM123")
+
+
+def test_verifier_rejects_parent_traversal_cookie_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_verifier()
+    archive = tmp_path / "hol-guard"
+    _fake_archive(
+        archive,
+        declared_runtime="../Python",
+        entries=[
+            ("../Python", b"runtime\0", "n"),
+            ("../runtime", b"\xcf\xfa\xed\xfe-runtime", "b"),
+        ],
+    )
+    monkeypatch.setattr(module, "_team_id", lambda _path: "TEAM123")
+
+    with pytest.raises(ValueError, match="archive-relative"):
+        module.verify(archive, "TEAM123")


### PR DESCRIPTION
Fix the macOS PyInstaller embedded-runtime verifier for framework Python builds. PyInstaller 6.21 stores the cookie-declared top-level `Python` as an archive symlink to `Python.framework/.../Python`; the verifier now resolves only archive-local symlink chains, requires the resolved runtime to be a binary Mach-O, and still verifies every embedded Mach-O against the expected Apple Team ID. Adds regression coverage for the framework shape and fail-closed symlink cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS application verification for bundled Python runtimes represented by symlinks.
  * Added safeguards against invalid, unsafe, cyclic, or unsupported symlink configurations.
  * Runtime validation and signature checks now correctly follow valid runtime links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->