### PR TITLE
feat(guard): add native Secrets CLI and staged pre-commit scans

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14280,
-  "maximum_test_source_lines": 314269,
+  "maximum_collected_cases": 14292,
+  "maximum_test_source_lines": 314476,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -303,6 +303,10 @@ def _resolve_legacy_args(
 def main(argv: list[str] | None = None) -> int:
     program_name = Path(sys.argv[0]).name or "plugin-scanner"
     requested_argv = argv or sys.argv[1:]
+    if _is_hol_guard_program(program_name) and requested_argv and requested_argv[0] == "secrets":
+        from .guard.secrets.cli import main as secrets_main
+
+        return secrets_main(requested_argv[1:], program_name=f"{program_name} secrets")
     if _is_guard_program(program_name):
         program_mode = "guard"
     elif _is_hol_guard_program(program_name):

--- a/src/codex_plugin_scanner/guard/secrets/cli.py
+++ b/src/codex_plugin_scanner/guard/secrets/cli.py
@@ -1,4 +1,4 @@
-"""Standalone CLI for free local leaked-secret detection."""
+"""CLI for free local HOL Guard leaked-secret detection."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 
+from .precommit import install_precommit_hook, uninstall_precommit_hook
 from .secret_detection import detector_version, secret_rule_catalog
 from .secret_repository_scanner import (
     DEFAULT_MAX_COMMITS,
@@ -18,6 +19,7 @@ from .secret_repository_scanner import (
     RepositorySecretScanResult,
     scan_repository_secrets,
 )
+from .secret_staged_scanner import scan_staged_secrets
 
 
 def _positive_int(value: str) -> int:
@@ -27,24 +29,46 @@ def _positive_int(value: str) -> int:
     return parsed
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser(*, program_name: str = "hol-guard-secrets") -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="hol-guard-secrets",
-        description=("Find leaked credentials locally. Raw secret values are never printed or sent to Guard Cloud."),
+        prog=program_name,
+        description="Find leaked credentials locally. Raw secret values are never printed or sent to Guard Cloud.",
     )
-    subparsers = parser.add_subparsers(dest="command", required=True)
-    scan = subparsers.add_parser("scan", help="Scan a file or repository")
+    subparsers = parser.add_subparsers(
+        dest="command",
+        required=True,
+        metavar="{scan,rules,install-hook,uninstall-hook}",
+    )
+    scan = subparsers.add_parser("scan", help="Scan the working tree, staged index, or bounded Git history")
     scan.add_argument("target", nargs="?", default=".")
-    scan.add_argument("--history", action="store_true", help="Also scan bounded Git history")
+    scope = scan.add_mutually_exclusive_group()
+    scope.add_argument("--staged", action="store_true", help="Scan only content currently staged for commit")
+    scope.add_argument("--history", action="store_true", help="Scan the working tree plus bounded Git history")
     scan.add_argument("--max-commits", type=_positive_int, default=DEFAULT_MAX_COMMITS)
     scan.add_argument("--max-files", type=_positive_int, default=DEFAULT_MAX_FILES)
     scan.add_argument("--max-file-bytes", type=_positive_int, default=DEFAULT_MAX_FILE_BYTES)
     scan.add_argument("--max-total-bytes", type=_positive_int, default=DEFAULT_MAX_TOTAL_BYTES)
     scan.add_argument("--max-findings", type=_positive_int, default=DEFAULT_MAX_FINDINGS)
     scan.add_argument("--fail-on-findings", action="store_true")
-    scan.add_argument("--json", action="store_true")
+    scan.add_argument("--format", choices=("text", "json"), default="text")
+    scan.add_argument("--json", action="store_true", help="Compatibility alias for --format json")
+
     rules = subparsers.add_parser("rules", help="List built-in detector families")
     rules.add_argument("--json", action="store_true")
+
+    install_hook = subparsers.add_parser(
+        "install-hook",
+        help="Install a staged-secret pre-commit scan without overwriting an existing hook",
+    )
+    install_hook.add_argument("target", nargs="?", default=".")
+    install_hook.add_argument("--json", action="store_true")
+
+    uninstall_hook = subparsers.add_parser(
+        "uninstall-hook",
+        help="Remove the Guard-managed hook and restore any preserved user hook",
+    )
+    uninstall_hook.add_argument("target", nargs="?", default=".")
+    uninstall_hook.add_argument("--json", action="store_true")
     return parser
 
 
@@ -66,45 +90,95 @@ def _write_scan(result: RepositorySecretScanResult, *, json_output: bool) -> Non
             f"{finding.path}:{finding.line}{commit} [{finding.confidence} confidence]"
         )
     if result.truncated:
-        print("Scan reached a configured safety limit. Increase a bound and rescan for full coverage.")
+        print(
+            "Scan coverage is partial. Increase the configured bounds or resolve the "
+            "reported Git error before treating it as clean."
+        )
     for error in result.errors:
         print(f"Warning: {error}", file=sys.stderr)
     print("Raw secret values are intentionally omitted.")
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
-    if args.command == "rules":
-        rules = secret_rule_catalog()
-        payload = {
-            "schema": "guard-secret-rules.v1",
-            "detector_version": detector_version(),
-            "rules": rules,
-        }
-        if args.json:
-            print(json.dumps(payload, sort_keys=True))
-        else:
-            print(f"HOL Guard Secrets detector {payload['detector_version']}")
-            for rule in rules:
-                validation = str(rule["validation"])
-                suffix = f", validates via {validation}" if validation != "none" else ""
-                print(f"- {rule['family']} ({rule['severity']}{suffix})")
-        return 0
+def _run_scan(args: argparse.Namespace) -> int:
+    target = Path(args.target)
     try:
-        result = scan_repository_secrets(
-            Path(args.target),
-            include_history=bool(args.history),
-            max_commits=args.max_commits,
-            max_files=args.max_files,
-            max_file_bytes=args.max_file_bytes,
-            max_total_bytes=args.max_total_bytes,
-            max_findings=args.max_findings,
-        )
+        if bool(args.staged):
+            result = scan_staged_secrets(
+                target,
+                max_files=args.max_files,
+                max_file_bytes=args.max_file_bytes,
+                max_total_bytes=args.max_total_bytes,
+                max_findings=args.max_findings,
+            )
+        else:
+            result = scan_repository_secrets(
+                target,
+                include_history=bool(args.history),
+                max_commits=args.max_commits,
+                max_files=args.max_files,
+                max_file_bytes=args.max_file_bytes,
+                max_total_bytes=args.max_total_bytes,
+                max_findings=args.max_findings,
+            )
     except (OSError, ValueError) as error:
         print(f"Error: {error}", file=sys.stderr)
         return 2
-    _write_scan(result, json_output=bool(args.json))
+    _write_scan(result, json_output=bool(args.json) or args.format == "json")
+    if result.truncated or result.errors:
+        return 2
     return 3 if args.fail_on_findings and result.findings else 0
+
+
+def _run_rules(args: argparse.Namespace) -> int:
+    rules = secret_rule_catalog()
+    payload = {
+        "schema": "guard-secret-rules.v1",
+        "detector_version": detector_version(),
+        "rules": rules,
+    }
+    if args.json:
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print(f"HOL Guard Secrets detector {payload['detector_version']}")
+        for rule in rules:
+            validation = str(rule["validation"])
+            suffix = f", validates via {validation}" if validation != "none" else ""
+            print(f"- {rule['family']} ({rule['severity']}{suffix})")
+    return 0
+
+
+def _run_hook(args: argparse.Namespace, *, install: bool) -> int:
+    try:
+        result = install_precommit_hook(Path(args.target)) if install else uninstall_precommit_hook(Path(args.target))
+    except (OSError, ValueError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
+    payload = result.to_public_dict()
+    if args.json:
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        action = "installed" if install else "uninstalled"
+        print(f"HOL Guard Secrets pre-commit hook {action}: {result.status} ({result.hook})")
+        if result.chained_existing:
+            print("Existing pre-commit behavior is preserved and chained before the staged secret scan.")
+    return 0
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    program_name: str = "hol-guard-secrets",
+) -> int:
+    args = build_parser(program_name=program_name).parse_args(argv)
+    if args.command == "scan":
+        return _run_scan(args)
+    if args.command == "rules":
+        return _run_rules(args)
+    if args.command == "install-hook":
+        return _run_hook(args, install=True)
+    if args.command == "uninstall-hook":
+        return _run_hook(args, install=False)
+    return 2
 
 
 if __name__ == "__main__":

--- a/src/codex_plugin_scanner/guard/secrets/precommit.py
+++ b/src/codex_plugin_scanner/guard/secrets/precommit.py
@@ -1,0 +1,162 @@
+"""Non-destructive Git pre-commit integration for HOL Guard Secrets."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from .secret_repository_scanner import _run_git
+
+_MANAGED_MARKER = "# HOL_GUARD_SECRETS_PRE_COMMIT_V1"
+_BACKUP_NAME = "pre-commit.hol-guard-user"
+
+_MANAGED_HOOK = f"""#!/bin/sh
+{_MANAGED_MARKER}
+# Managed by `hol-guard secrets install-hook`. Do not place secrets in this file.
+hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+legacy="$hook_dir/{_BACKUP_NAME}"
+if [ -x "$legacy" ]; then
+  "$legacy" "$@"
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    exit "$status"
+  fi
+fi
+exec hol-guard secrets scan --staged --fail-on-findings
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class SecretsHookResult:
+    status: str
+    hook: str
+    chained_existing: bool
+
+    def to_public_dict(self) -> dict[str, object]:
+        return {
+            "schema": "guard-secrets-hook.v1",
+            "status": self.status,
+            "hook": self.hook,
+            "chained_existing": self.chained_existing,
+        }
+
+
+def _git_common_dir(root: Path) -> Path:
+    resolved = root.expanduser().resolve()
+    if not resolved.exists() or not resolved.is_dir():
+        raise ValueError("hook target must be an existing Git worktree directory")
+    try:
+        custom_hooks = _run_git(resolved, ["config", "--get", "core.hooksPath"])
+    except (OSError, subprocess.SubprocessError) as error:
+        raise ValueError("hook target is not a usable Git worktree") from error
+    if custom_hooks.returncode == 0 and custom_hooks.stdout.strip():
+        raise ValueError(
+            "custom core.hooksPath is configured; HOL Guard will not modify a shared or "
+            "custom hook directory automatically"
+        )
+    try:
+        result = _run_git(resolved, ["rev-parse", "--git-common-dir"])
+    except (OSError, subprocess.SubprocessError) as error:
+        raise ValueError("hook target is not a usable Git worktree") from error
+    if result.returncode != 0:
+        raise ValueError("hook target is not a usable Git worktree")
+    raw = result.stdout.decode("utf-8", errors="strict").strip()
+    if not raw:
+        raise ValueError("Git hook directory could not be resolved")
+    path = Path(raw)
+    return (path if path.is_absolute() else resolved / path).resolve()
+
+
+def _hook_paths(root: Path) -> tuple[Path, Path, str]:
+    hooks_dir = _git_common_dir(root) / "hooks"
+    return hooks_dir / "pre-commit", hooks_dir / _BACKUP_NAME, "git-hooks/pre-commit"
+
+
+def _is_managed_hook(path: Path) -> bool:
+    if not path.is_file():
+        return False
+    try:
+        prefix = path.read_text(encoding="utf-8", errors="replace")[:512]
+    except OSError:
+        return False
+    return _MANAGED_MARKER in prefix
+
+
+def install_precommit_hook(root: Path) -> SecretsHookResult:
+    """Install the managed hook while preserving any existing user hook."""
+
+    hook, backup, display = _hook_paths(root)
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    if _is_managed_hook(hook):
+        return SecretsHookResult(
+            status="already_installed",
+            hook=display,
+            chained_existing=backup.exists(),
+        )
+    if hook.exists() and backup.exists():
+        raise ValueError("refusing to replace pre-commit hook because the HOL Guard backup path already exists")
+
+    moved_existing = False
+    temp = hook.with_name(f".{hook.name}.hol-guard-{os.getpid()}.tmp")
+    try:
+        if hook.exists():
+            os.replace(hook, backup)
+            moved_existing = True
+        temp.write_text(_MANAGED_HOOK, encoding="utf-8", newline="\n")
+        temp.chmod(0o755)
+        os.replace(temp, hook)
+    except OSError as error:
+        try:
+            if temp.exists():
+                temp.unlink()
+            if moved_existing and backup.exists() and not hook.exists():
+                os.replace(backup, hook)
+        except OSError:
+            pass
+        raise ValueError("could not install HOL Guard Secrets pre-commit hook") from error
+
+    return SecretsHookResult(
+        status="installed",
+        hook=display,
+        chained_existing=backup.exists(),
+    )
+
+
+def uninstall_precommit_hook(root: Path) -> SecretsHookResult:
+    """Remove only the managed hook and restore a chained user hook exactly."""
+
+    hook, backup, display = _hook_paths(root)
+    if not hook.exists():
+        if backup.exists():
+            try:
+                os.replace(backup, hook)
+            except OSError as error:
+                raise ValueError("could not restore the preserved pre-commit hook") from error
+            return SecretsHookResult(status="restored", hook=display, chained_existing=True)
+        return SecretsHookResult(status="not_installed", hook=display, chained_existing=False)
+    if not _is_managed_hook(hook):
+        if backup.exists():
+            raise ValueError("refusing to overwrite a non-HOL-Guard pre-commit hook while a preserved backup exists")
+        return SecretsHookResult(status="not_installed", hook=display, chained_existing=False)
+
+    try:
+        hook.unlink()
+        restored = backup.exists()
+        if restored:
+            os.replace(backup, hook)
+    except OSError as error:
+        raise ValueError("could not uninstall HOL Guard Secrets pre-commit hook") from error
+    return SecretsHookResult(
+        status="restored" if restored else "uninstalled",
+        hook=display,
+        chained_existing=restored,
+    )
+
+
+__all__ = [
+    "SecretsHookResult",
+    "install_precommit_hook",
+    "uninstall_precommit_hook",
+]

--- a/src/codex_plugin_scanner/guard/secrets/secret_detection.py
+++ b/src/codex_plugin_scanner/guard/secrets/secret_detection.py
@@ -24,7 +24,7 @@ from typing import Literal, TypedDict
 
 SecretSeverity = Literal["medium", "high", "critical"]
 SecretConfidence = Literal["low", "medium", "high"]
-SecretScanSource = Literal["working_tree", "git_history", "text"]
+SecretScanSource = Literal["working_tree", "git_history", "text", "staged"]
 SecretValidationKind = Literal[
     "none",
     "github",

--- a/src/codex_plugin_scanner/guard/secrets/secret_staged_scanner.py
+++ b/src/codex_plugin_scanner/guard/secrets/secret_staged_scanner.py
@@ -1,0 +1,180 @@
+"""Bounded leaked-secret scanning for the Git staging index."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from .secret_detection import SecretFinding, SecretScanSource
+from .secret_repository_scanner import (
+    DEFAULT_MAX_FILE_BYTES,
+    DEFAULT_MAX_FILES,
+    DEFAULT_MAX_FINDINGS,
+    DEFAULT_MAX_TOTAL_BYTES,
+    RepositorySecretScanResult,
+    _bounded_positive,
+    _run_git,
+    _scan_blob,
+)
+
+
+def _git_repository_root(root: Path) -> Path | None:
+    try:
+        result = _run_git(root, ["rev-parse", "--show-toplevel"])
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    raw = result.stdout.decode("utf-8", errors="strict").strip()
+    if not raw:
+        return None
+    return Path(raw).resolve()
+
+
+def _git_staged_paths(root: Path) -> list[str] | None:
+    try:
+        result = _run_git(
+            root,
+            ["diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z", "--"],
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return [item.decode("utf-8", errors="surrogateescape") for item in result.stdout.split(b"\0") if item]
+
+
+def _git_staged_blob(root: Path, path: str, max_file_bytes: int) -> tuple[bytes | None, bool]:
+    spec = f":{path}"
+    try:
+        size_result = _run_git(root, ["cat-file", "-s", spec])
+    except (OSError, subprocess.SubprocessError):
+        return None, True
+    if size_result.returncode != 0:
+        return None, True
+    try:
+        size = int(size_result.stdout.strip())
+    except ValueError:
+        return None, True
+    if size < 0 or size > max_file_bytes:
+        return None, True
+    try:
+        blob_result = _run_git(root, ["cat-file", "blob", spec])
+    except (OSError, subprocess.SubprocessError):
+        return None, True
+    if blob_result.returncode != 0 or len(blob_result.stdout) > max_file_bytes:
+        return None, True
+    return blob_result.stdout, False
+
+
+def scan_staged_secrets(
+    target: Path,
+    *,
+    max_files: int = DEFAULT_MAX_FILES,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES,
+    max_findings: int = DEFAULT_MAX_FINDINGS,
+) -> RepositorySecretScanResult:
+    """Scan only content currently staged in a Git index.
+
+    The working tree is never read for candidate content. This makes the result
+    suitable for pre-commit enforcement even when unstaged edits differ from the
+    index that will actually be committed.
+    """
+
+    requested_root = target.expanduser().resolve()
+    if not requested_root.exists() or not requested_root.is_dir():
+        raise ValueError("staged secret scan target must be an existing directory")
+    root = _git_repository_root(requested_root)
+    if root is None:
+        return RepositorySecretScanResult(
+            findings=(),
+            files_scanned=0,
+            commits_scanned=0,
+            bytes_scanned=0,
+            history_enabled=False,
+            truncated=True,
+            errors=("git_staged_enumeration_failed",),
+        )
+
+    max_files = _bounded_positive(max_files, default=DEFAULT_MAX_FILES, maximum=100_000)
+    max_file_bytes = _bounded_positive(
+        max_file_bytes,
+        default=DEFAULT_MAX_FILE_BYTES,
+        maximum=32 * 1024 * 1024,
+    )
+    max_total_bytes = _bounded_positive(
+        max_total_bytes,
+        default=DEFAULT_MAX_TOTAL_BYTES,
+        maximum=4 * 1024 * 1024 * 1024,
+    )
+    max_findings = _bounded_positive(max_findings, default=DEFAULT_MAX_FINDINGS, maximum=10_000)
+
+    paths = _git_staged_paths(root)
+    if paths is None:
+        return RepositorySecretScanResult(
+            findings=(),
+            files_scanned=0,
+            commits_scanned=0,
+            bytes_scanned=0,
+            history_enabled=False,
+            truncated=True,
+            errors=("git_staged_enumeration_failed",),
+        )
+
+    findings: list[SecretFinding] = []
+    errors: set[str] = set()
+    files_scanned = 0
+    bytes_scanned = 0
+    truncated = False
+    staged_source: SecretScanSource = "staged"
+    for relative_path in paths:
+        if files_scanned >= max_files or bytes_scanned >= max_total_bytes or len(findings) >= max_findings:
+            truncated = True
+            break
+        data, incomplete_blob = _git_staged_blob(root, relative_path, max_file_bytes)
+        if incomplete_blob:
+            truncated = True
+            errors.add("git_staged_blob_unavailable_or_oversized")
+            continue
+        if data is None:
+            continue
+        if bytes_scanned + len(data) > max_total_bytes:
+            truncated = True
+            break
+        found, scanned_bytes = _scan_blob(
+            data,
+            path=relative_path.replace("\\", "/"),
+            source=staged_source,
+            commit=None,
+            finding_budget=max_findings - len(findings),
+        )
+        files_scanned += 1
+        bytes_scanned += scanned_bytes
+        findings.extend(found)
+        if len(findings) >= max_findings:
+            truncated = True
+            break
+
+    deduped: dict[tuple[str, int, str], SecretFinding] = {}
+    for finding in findings:
+        key = (finding.path, finding.line, finding.candidate)
+        existing = deduped.get(key)
+        if existing is None or finding.confidence_score > existing.confidence_score:
+            deduped[key] = finding
+    ordered = tuple(sorted(deduped.values(), key=lambda item: (item.path, item.line, item.rule_id))[:max_findings])
+    if len(deduped) > len(ordered):
+        truncated = True
+
+    return RepositorySecretScanResult(
+        findings=ordered,
+        files_scanned=files_scanned,
+        commits_scanned=0,
+        bytes_scanned=bytes_scanned,
+        history_enabled=False,
+        truncated=truncated,
+        errors=tuple(sorted(errors)),
+    )
+
+
+__all__ = ["scan_staged_secrets"]

--- a/tests/test_guard_secrets_native_cli.py
+++ b/tests/test_guard_secrets_native_cli.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner import cli as guard_cli
+from codex_plugin_scanner.guard.secrets.cli import main as standalone_secrets_main
+from codex_plugin_scanner.guard.secrets.precommit import install_precommit_hook, uninstall_precommit_hook
+from codex_plugin_scanner.guard.secrets.secret_staged_scanner import scan_staged_secrets
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True)
+
+
+def _init_repo(root: Path) -> None:
+    _git(root, "init")
+    _git(root, "config", "user.email", "guard@example.invalid")
+    _git(root, "config", "user.name", "Guard Test")
+
+
+def _github_token() -> str:
+    return "ghp_" + ("A" * 40)
+
+
+def _run_native(argv: list[str]) -> tuple[int, str, str]:
+    output = io.StringIO()
+    error = io.StringIO()
+    original_argv = guard_cli.sys.argv
+    try:
+        guard_cli.sys.argv = ["hol-guard"]
+        with contextlib.redirect_stdout(output), contextlib.redirect_stderr(error):
+            exit_code = guard_cli.main(argv)
+    finally:
+        guard_cli.sys.argv = original_argv
+    return exit_code, output.getvalue(), error.getvalue()
+
+
+def test_staged_scan_reads_index_not_unstaged_worktree(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    target = tmp_path / "config.env"
+    target.write_text("SAFE_VALUE=hello\n", encoding="utf-8")
+    _git(tmp_path, "add", "config.env")
+    secret = _github_token()
+    target.write_text(f"GITHUB_TOKEN={secret}\n", encoding="utf-8")
+
+    staged = scan_staged_secrets(tmp_path)
+    assert staged.findings == ()
+
+    _git(tmp_path, "add", "config.env")
+    staged_secret = scan_staged_secrets(tmp_path)
+    assert [finding.rule_id for finding in staged_secret.findings] == ["github-token"]
+    assert staged_secret.findings[0].source == "staged"
+    assert secret not in json.dumps(staged_secret.to_public_dict())
+
+
+def test_staged_scan_resolves_repository_root_from_nested_directory(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    nested = tmp_path / "packages" / "app"
+    nested.mkdir(parents=True)
+    (tmp_path / "config.env").write_text(f"GITHUB_TOKEN={_github_token()}\n", encoding="utf-8")
+    _git(tmp_path, "add", "config.env")
+
+    result = scan_staged_secrets(nested)
+
+    assert result.truncated is False
+    assert [finding.path for finding in result.findings] == ["config.env"]
+
+
+def test_staged_scan_non_git_target_is_explicitly_partial(tmp_path: Path) -> None:
+    result = scan_staged_secrets(tmp_path)
+
+    assert result.truncated is True
+    assert result.findings == ()
+    assert result.errors == ("git_staged_enumeration_failed",)
+
+
+def test_native_partial_staged_scan_returns_infrastructure_error(tmp_path: Path) -> None:
+    exit_code, output, error = _run_native(["secrets", "scan", str(tmp_path), "--staged"])
+
+    assert exit_code == 2
+    assert "Scan coverage is partial" in output
+    assert "finding(s)" in output
+    assert "git_staged_enumeration_failed" in error
+
+
+def test_standalone_partial_history_scan_returns_infrastructure_error(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = standalone_secrets_main(["scan", str(tmp_path), "--history"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "history_requested_for_non_git_target" in captured.err
+
+
+def test_native_rules_bypass_guard_parser(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_guard_parser(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("Guard parser must not initialize for local Secrets commands")
+
+    monkeypatch.setattr(guard_cli, "_build_parser", fail_guard_parser)
+    exit_code, output, error = _run_native(["secrets", "rules", "--json"])
+
+    assert exit_code == 0
+    assert error == ""
+    payload = json.loads(output)
+    assert payload["schema"] == "guard-secret-rules.v1"
+    assert any(rule["rule_id"] == "github-token" for rule in payload["rules"])
+
+
+def test_native_staged_scan_fails_on_findings_without_printing_secret(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    secret = _github_token()
+    (tmp_path / "config.env").write_text(f"GITHUB_TOKEN={secret}\n", encoding="utf-8")
+    _git(tmp_path, "add", "config.env")
+
+    exit_code, output, error = _run_native(
+        ["secrets", "scan", str(tmp_path), "--staged", "--fail-on-findings"]
+    )
+
+    assert exit_code == 3
+    assert error == ""
+    assert "GitHub token" in output
+    assert "config.env:1" in output
+    assert secret not in output
+
+
+def test_native_staged_json_reports_staged_source(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "config.env").write_text(f"TOKEN={_github_token()}\n", encoding="utf-8")
+    _git(tmp_path, "add", "config.env")
+
+    exit_code, output, error = _run_native(["secrets", "scan", str(tmp_path), "--staged", "--json"])
+
+    assert exit_code == 0
+    assert error == ""
+    payload = json.loads(output)
+    assert payload["finding_count"] == 1
+    assert payload["findings"][0]["source"] == "staged"
+    assert "candidate" not in output
+
+
+def test_precommit_install_is_idempotent(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+
+    first = install_precommit_hook(tmp_path)
+    second = install_precommit_hook(tmp_path)
+    hook = tmp_path / ".git" / "hooks" / "pre-commit"
+
+    assert first.status == "installed"
+    assert second.status == "already_installed"
+    assert first.chained_existing is False
+    content = hook.read_text(encoding="utf-8")
+    assert "HOL_GUARD_SECRETS_PRE_COMMIT_V1" in content
+    assert "hol-guard secrets scan --staged --fail-on-findings" in content
+    assert hook.stat().st_mode & 0o100
+
+
+def test_precommit_install_chains_and_uninstall_restores_existing_hook(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    hook = tmp_path / ".git" / "hooks" / "pre-commit"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    original = b"#!/bin/sh\necho existing-hook\n"
+    hook.write_bytes(original)
+    hook.chmod(0o755)
+
+    installed = install_precommit_hook(tmp_path)
+    backup = hook.with_name("pre-commit.hol-guard-user")
+    assert installed.chained_existing is True
+    assert backup.read_bytes() == original
+    assert "HOL_GUARD_SECRETS_PRE_COMMIT_V1" in hook.read_text(encoding="utf-8")
+
+    exit_code, output, error = _run_native(["secrets", "uninstall-hook", str(tmp_path)])
+    assert exit_code == 0
+    assert error == ""
+    assert "pre-commit hook uninstalled: restored" in output
+    assert hook.read_bytes() == original
+    assert hook.stat().st_mode & 0o100
+    assert not backup.exists()
+
+
+def test_precommit_install_refuses_custom_hooks_path(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _git(tmp_path, "config", "core.hooksPath", ".custom-hooks")
+
+    with pytest.raises(ValueError, match="custom core.hooksPath"):
+        install_precommit_hook(tmp_path)
+
+
+def test_precommit_uninstall_does_not_remove_foreign_hook(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    hook = tmp_path / ".git" / "hooks" / "pre-commit"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    original = b"#!/bin/sh\necho foreign\n"
+    hook.write_bytes(original)
+    hook.chmod(0o755)
+
+    result = uninstall_precommit_hook(tmp_path)
+
+    assert result.status == "not_installed"
+    assert hook.read_bytes() == original


### PR DESCRIPTION
## Summary

Makes HOL Guard Secrets a first-class offline `hol-guard` command surface on `release/3.0` while preserving the established attested `hol-guard = codex_plugin_scanner.cli:main` console entry point.

- add `hol-guard secrets scan` with working-tree, bounded-history, and staged-index modes
- staged mode reads Git index blobs, not unstaged working-tree content
- add `hol-guard secrets rules` for the built-in detector catalog
- add `hol-guard secrets install-hook` / `uninstall-hook`
- preserve and chain an existing pre-commit hook instead of overwriting it
- restore the original hook exactly on uninstall
- refuse automatic hook modification when custom `core.hooksPath` is configured
- dispatch `hol-guard secrets` inside the existing CLI before normal Guard parser/store initialization
- preserve Guard CLI runtime attestation and all existing non-Secrets command behavior
- make partial/incomplete scans return infrastructure-error exit code 2
- keep finding enforcement distinct at exit code 3

## Security / fail-honest behavior

- raw candidate values remain omitted from text and JSON output
- staged scans resolve the actual Git repository root and scan the final index content
- Git/index failures or bounded incomplete coverage never return a clean exit
- unavailable/oversized staged blobs mark coverage partial
- the managed hook runs any preserved user hook first, then scans the final staged state
- custom/shared hooks paths are not modified automatically
- local Secrets commands dispatch before normal Guard parser/store/cloud initialization

## Testing

Adds 12 focused tests covering staged index vs worktree correctness, nested worktree invocation, fail-honest partial exits, early offline dispatch, raw-value redaction, hook idempotency, existing-hook chaining/restoration, custom hooks-path refusal, and foreign-hook preservation. The test-suite ratchet advances by exactly 12 cases / 205 lines.

The final diff intentionally does not change the installed `hol-guard` entry-point target, so existing runtime attestation and packaged harness integrations remain compatible.

## Release boundary

Base is intentionally `release/3.0`. Do not retarget or merge this PR to `main`.