### PR TITLE
fix(guard): bind bundled Rust runtime identity

### DIFF
--- a/.github/workflows/rust-native-identity.yml
+++ b/.github/workflows/rust-native-identity.yml
@@ -1,0 +1,47 @@
+name: Native runtime identity
+
+on:
+  pull_request:
+    paths:
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "ci/native_runtime/test_native_runtime_manifest.py"
+      - "scripts/build_native_hol_guard_wheel.py"
+      - ".github/workflows/rust-native-identity.yml"
+  push:
+    branches: [release/3.0]
+    paths:
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "ci/native_runtime/test_native_runtime_manifest.py"
+      - "scripts/build_native_hol_guard_wheel.py"
+      - ".github/workflows/rust-native-identity.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-native-identity-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  identity-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Lint native identity boundary
+        run: |
+          uv run --no-sync python -m ruff check src/codex_plugin_scanner/guard/native_runtime.py ci/native_runtime/test_native_runtime_manifest.py
+          uv run --no-sync python -m ruff format --check src/codex_plugin_scanner/guard/native_runtime.py
+      - name: Run manifest identity contracts
+        run: uv run --no-sync pytest ci/native_runtime/test_native_runtime_manifest.py --tb=short

--- a/ci/native_runtime/test_native_runtime_manifest.py
+++ b/ci/native_runtime/test_native_runtime_manifest.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard import native_runtime
+
+
+def _runtime(tmp_path: Path, payload: bytes = b"native-runtime") -> native_runtime.NativeRuntimeIdentity:
+    runtime = tmp_path / ("hol-guard-runtime.exe" if os.name == "nt" else "hol-guard-runtime")
+    runtime.write_bytes(payload)
+    if os.name != "nt":
+        runtime.chmod(0o700)
+    metadata = runtime.stat()
+    return native_runtime.NativeRuntimeIdentity(
+        path=runtime.resolve(),
+        size=metadata.st_size,
+        mtime_ns=metadata.st_mtime_ns,
+        sha256=hashlib.sha256(payload).hexdigest(),
+    )
+
+
+def _manifest(identity: native_runtime.NativeRuntimeIdentity, **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema": "hol-guard-native-runtime.v1",
+        "protocol_version": 1,
+        "package_version": "3.0.0a1",
+        "target": "x86_64-unknown-linux-musl",
+        "platform_tag": "manylinux_2_17_x86_64",
+        "source_sha": "a" * 40,
+        "rule_digest": "b" * 64,
+        "runtime_sha256": identity.sha256,
+        "runtime_size": identity.size,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_manifest(identity: native_runtime.NativeRuntimeIdentity, payload: dict[str, object]) -> None:
+    path = identity.path.with_name("runtime-manifest.json")
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    if os.name != "nt":
+        path.chmod(0o600)
+
+
+def test_manifest_binds_exact_runtime_bytes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    identity = _runtime(tmp_path)
+    _write_manifest(identity, _manifest(identity))
+    monkeypatch.setattr(native_runtime, "_python_package_version", lambda: "3.0.0a1")
+
+    manifest, reason = native_runtime._manifest_for_bundled_identity(identity)
+
+    assert reason is None
+    assert manifest is not None
+    assert manifest.runtime_sha256 == identity.sha256
+    assert manifest.runtime_size == identity.size
+
+
+def test_manifest_rejects_runtime_digest_mismatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    identity = _runtime(tmp_path)
+    _write_manifest(identity, _manifest(identity, runtime_sha256="c" * 64))
+    monkeypatch.setattr(native_runtime, "_python_package_version", lambda: "3.0.0a1")
+
+    manifest, reason = native_runtime._manifest_for_bundled_identity(identity)
+
+    assert manifest is None
+    assert reason == "native_manifest_runtime_mismatch"
+
+
+def test_manifest_rejects_package_version_mismatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    identity = _runtime(tmp_path)
+    _write_manifest(identity, _manifest(identity, package_version="3.0.0a2"))
+    monkeypatch.setattr(native_runtime, "_python_package_version", lambda: "3.0.0a1")
+
+    manifest, reason = native_runtime._manifest_for_bundled_identity(identity)
+
+    assert manifest is None
+    assert reason == "native_manifest_version_mismatch"
+
+
+def test_auto_mode_does_not_consider_separate_runtime_distribution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    bundled = tmp_path / "_native" / ("hol-guard-runtime.exe" if os.name == "nt" else "hol-guard-runtime")
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "auto")
+    monkeypatch.delenv("HOL_GUARD_NATIVE_BINARY", raising=False)
+    monkeypatch.setattr(native_runtime, "_bundled_runtime_candidate", lambda: bundled)
+
+    def unexpected_distribution(_name: str) -> object:
+        raise AssertionError("automatic mode must not inspect a separately installed runtime distribution")
+
+    monkeypatch.setattr(native_runtime.importlib.metadata, "distribution", unexpected_distribution)
+
+    assert native_runtime._runtime_candidates() == (bundled,)
+
+
+def test_status_rejects_manifest_build_sha_mismatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    identity = _runtime(tmp_path)
+    _write_manifest(identity, _manifest(identity))
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "auto")
+    monkeypatch.setattr(native_runtime, "_bundled_runtime_candidate", lambda: identity.path)
+    monkeypatch.setattr(native_runtime, "_runtime_candidates", lambda: (identity.path,))
+    monkeypatch.setattr(native_runtime, "_validate_binary", lambda _path: identity)
+    monkeypatch.setattr(native_runtime, "_python_package_version", lambda: "3.0.0a1")
+    monkeypatch.setattr(
+        native_runtime,
+        "_capabilities_for_identity",
+        lambda *_args: native_runtime.NativeRuntimeCapabilities(
+            protocol_version=1,
+            runtime_version="3.0.0a1",
+            rule_digest="b" * 64,
+            build_sha="d" * 40,
+            target="x86_64-linux",
+            features=(),
+        ),
+    )
+
+    status = native_runtime.native_runtime_status()
+
+    assert status.available is True
+    assert status.compatible is False
+    assert status.reason == "native_manifest_build_mismatch"
+
+
+def test_status_accepts_fully_bound_manifest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    identity = _runtime(tmp_path)
+    _write_manifest(identity, _manifest(identity))
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "auto")
+    monkeypatch.setattr(native_runtime, "_bundled_runtime_candidate", lambda: identity.path)
+    monkeypatch.setattr(native_runtime, "_runtime_candidates", lambda: (identity.path,))
+    monkeypatch.setattr(native_runtime, "_validate_binary", lambda _path: identity)
+    monkeypatch.setattr(native_runtime, "_python_package_version", lambda: "3.0.0a1")
+    monkeypatch.setattr(
+        native_runtime,
+        "_capabilities_for_identity",
+        lambda *_args: native_runtime.NativeRuntimeCapabilities(
+            protocol_version=1,
+            runtime_version="3.0.0a1",
+            rule_digest="b" * 64,
+            build_sha="a" * 40,
+            target="x86_64-linux",
+            features=("post-tool-inline-v1",),
+        ),
+    )
+
+    status = native_runtime.native_runtime_status()
+
+    assert status.available is True
+    assert status.compatible is True
+    assert status.reason == "native_ready"
+
+
+def test_manifest_decoder_rejects_boolean_runtime_size() -> None:
+    payload = {
+        "schema": "hol-guard-native-runtime.v1",
+        "protocol_version": 1,
+        "package_version": "3.0.0a1",
+        "target": "x86_64-unknown-linux-musl",
+        "platform_tag": "manylinux_2_17_x86_64",
+        "source_sha": "a" * 40,
+        "rule_digest": "b" * 64,
+        "runtime_sha256": "c" * 64,
+        "runtime_size": True,
+    }
+    assert native_runtime._decode_runtime_manifest(payload) is None
+
+
+def test_manifest_rejects_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    if os.name == "nt":
+        pytest.skip("symlink permissions vary on Windows runners")
+    identity = _runtime(tmp_path)
+    real_manifest = tmp_path / "real-manifest.json"
+    real_manifest.write_text(json.dumps(_manifest(identity)), encoding="utf-8")
+    identity.path.with_name("runtime-manifest.json").symlink_to(real_manifest)
+    monkeypatch.setattr(native_runtime, "_python_package_version", lambda: "3.0.0a1")
+
+    manifest, reason = native_runtime._manifest_for_bundled_identity(identity)
+
+    assert manifest is None
+    assert reason == "native_manifest_invalid"

--- a/src/codex_plugin_scanner/guard/native_runtime.py
+++ b/src/codex_plugin_scanner/guard/native_runtime.py
@@ -26,6 +26,9 @@ NativeMode = Literal["off", "shadow", "auto", "force"]
 _NATIVE_PROTOCOL_VERSION = 1
 _NATIVE_BINARY_ENV = "HOL_GUARD_NATIVE_BINARY"
 _NATIVE_MODE_ENV = "HOL_GUARD_NATIVE"
+_NATIVE_MANIFEST_NAME = "runtime-manifest.json"
+_NATIVE_MANIFEST_SCHEMA = "hol-guard-native-runtime.v1"
+_MAX_MANIFEST_BYTES = 16 * 1024
 _MAX_REQUEST_BYTES = 6 * 1024 * 1024
 _MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 
@@ -46,6 +49,19 @@ class NativeRuntimeCapabilities:
     build_sha: str
     target: str
     features: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class NativeRuntimeManifest:
+    schema: str
+    protocol_version: int
+    package_version: str
+    target: str
+    platform_tag: str
+    source_sha: str
+    rule_digest: str
+    runtime_sha256: str
+    runtime_size: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,28 +88,30 @@ def _bundled_runtime_candidate() -> Path:
 
 
 def _runtime_candidates() -> tuple[Path, ...]:
+    mode = native_mode()
     candidates: list[Path] = []
     override = os.environ.get(_NATIVE_BINARY_ENV)
-    if override and native_mode() in {"shadow", "force"}:
+    if override and mode in {"shadow", "force"}:
         candidate = Path(override).expanduser()
         if candidate.is_absolute():
             candidates.append(candidate)
 
     candidates.append(_bundled_runtime_candidate())
 
-    # Developer compatibility: a separately installed runtime distribution
-    # may be used for shadow/force validation. Production packaging bundles
-    # the binary inside the hol-guard wheel and does not require this project.
-    try:
-        distribution = importlib.metadata.distribution("hol-guard-runtime")
-    except importlib.metadata.PackageNotFoundError:
-        distribution = None
-    if distribution is not None:
-        executable_names = {"hol-guard-runtime", "hol-guard-runtime.exe"}
-        for entry in distribution.files or ():
-            if Path(str(entry)).name not in executable_names:
-                continue
-            candidates.append(Path(str(distribution.locate_file(entry))))
+    # Developer compatibility: a separately installed runtime distribution is
+    # validation-only. Automatic production selection must use the runtime
+    # bundled inside the version-matched hol-guard wheel and its manifest.
+    if mode in {"shadow", "force"}:
+        try:
+            distribution = importlib.metadata.distribution("hol-guard-runtime")
+        except importlib.metadata.PackageNotFoundError:
+            distribution = None
+        if distribution is not None:
+            executable_names = {"hol-guard-runtime", "hol-guard-runtime.exe"}
+            for entry in distribution.files or ():
+                if Path(str(entry)).name not in executable_names:
+                    continue
+                candidates.append(Path(str(distribution.locate_file(entry))))
 
     unique: list[Path] = []
     seen: set[str] = set()
@@ -134,6 +152,95 @@ def _validate_binary(path: Path) -> NativeRuntimeIdentity | None:
         )
     except (OSError, RuntimeError, ValueError):
         return None
+
+
+def _is_lower_hex(value: str, length: int) -> bool:
+    return len(value) == length and all(character in "0123456789abcdef" for character in value)
+
+
+def _decode_runtime_manifest(payload: object) -> NativeRuntimeManifest | None:
+    if not isinstance(payload, dict):
+        return None
+    schema = payload.get("schema")
+    protocol_version = payload.get("protocol_version")
+    package_version = payload.get("package_version")
+    target = payload.get("target")
+    platform_tag = payload.get("platform_tag")
+    source_sha = payload.get("source_sha")
+    rule_digest = payload.get("rule_digest")
+    runtime_sha256 = payload.get("runtime_sha256")
+    runtime_size = payload.get("runtime_size")
+    if (
+        schema != _NATIVE_MANIFEST_SCHEMA
+        or protocol_version != _NATIVE_PROTOCOL_VERSION
+        or not isinstance(package_version, str)
+        or not package_version.strip()
+        or not isinstance(target, str)
+        or not target.strip()
+        or not isinstance(platform_tag, str)
+        or not platform_tag.strip()
+        or not isinstance(source_sha, str)
+        or not _is_lower_hex(source_sha, 40)
+        or not isinstance(rule_digest, str)
+        or not _is_lower_hex(rule_digest, 64)
+        or not isinstance(runtime_sha256, str)
+        or not _is_lower_hex(runtime_sha256, 64)
+        or not isinstance(runtime_size, int)
+        or isinstance(runtime_size, bool)
+        or runtime_size <= 0
+    ):
+        return None
+    return NativeRuntimeManifest(
+        schema=schema,
+        protocol_version=protocol_version,
+        package_version=package_version,
+        target=target,
+        platform_tag=platform_tag,
+        source_sha=source_sha,
+        rule_digest=rule_digest,
+        runtime_sha256=runtime_sha256,
+        runtime_size=runtime_size,
+    )
+
+
+def _manifest_for_bundled_identity(
+    identity: NativeRuntimeIdentity,
+) -> tuple[NativeRuntimeManifest | None, str | None]:
+    manifest_path = identity.path.with_name(_NATIVE_MANIFEST_NAME)
+    try:
+        metadata = manifest_path.lstat()
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+            return None, "native_manifest_invalid"
+        if metadata.st_size <= 0 or metadata.st_size > _MAX_MANIFEST_BYTES:
+            return None, "native_manifest_invalid"
+        if os.name != "nt":
+            if stat.S_IMODE(metadata.st_mode) & 0o022:
+                return None, "native_manifest_invalid"
+            current_uid = os.getuid() if hasattr(os, "getuid") else None
+            owner = getattr(metadata, "st_uid", current_uid)
+            if current_uid is not None and owner not in {0, current_uid}:
+                return None, "native_manifest_invalid"
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None, "native_manifest_missing"
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None, "native_manifest_invalid"
+    manifest = _decode_runtime_manifest(payload)
+    if manifest is None:
+        return None, "native_manifest_invalid"
+    if manifest.runtime_size != identity.size or manifest.runtime_sha256 != identity.sha256:
+        return None, "native_manifest_runtime_mismatch"
+    expected_version = _python_package_version()
+    if expected_version is not None and manifest.package_version != expected_version:
+        return None, "native_manifest_version_mismatch"
+    return manifest, None
+
+
+def _is_bundled_candidate(candidate: Path) -> bool:
+    try:
+        return candidate.expanduser().absolute() == _bundled_runtime_candidate().absolute()
+    except (OSError, RuntimeError, ValueError):
+        return False
 
 
 def _isolated_environment() -> dict[str, str]:
@@ -229,6 +336,17 @@ def native_runtime_status() -> NativeRuntimeStatus:
         identity = _validate_binary(candidate)
         if identity is None:
             continue
+        manifest: NativeRuntimeManifest | None = None
+        if _is_bundled_candidate(candidate):
+            manifest, manifest_error = _manifest_for_bundled_identity(identity)
+            if manifest_error is not None:
+                return NativeRuntimeStatus(
+                    mode=mode,
+                    available=True,
+                    compatible=False,
+                    reason=manifest_error,
+                    identity=identity,
+                )
         capabilities = _capabilities_for_identity(str(identity.path), identity.size, identity.mtime_ns, identity.sha256)
         if capabilities is None:
             continue
@@ -241,6 +359,26 @@ def native_runtime_status() -> NativeRuntimeStatus:
                 identity=identity,
                 capabilities=capabilities,
             )
+        if manifest is not None:
+            if capabilities.protocol_version != manifest.protocol_version:
+                reason = "native_manifest_protocol_mismatch"
+            elif capabilities.runtime_version != manifest.package_version:
+                reason = "native_manifest_version_mismatch"
+            elif capabilities.rule_digest != manifest.rule_digest:
+                reason = "native_manifest_rule_mismatch"
+            elif capabilities.build_sha != manifest.source_sha:
+                reason = "native_manifest_build_mismatch"
+            else:
+                reason = None
+            if reason is not None:
+                return NativeRuntimeStatus(
+                    mode=mode,
+                    available=True,
+                    compatible=False,
+                    reason=reason,
+                    identity=identity,
+                    capabilities=capabilities,
+                )
         expected_version = _python_package_version()
         version_compatible = expected_version is None or capabilities.runtime_version == expected_version
         compatible = version_compatible or mode in {"shadow", "force"}
@@ -389,6 +527,7 @@ def choose_post_tool_response(
 __all__ = [
     "NativeRuntimeCapabilities",
     "NativeRuntimeIdentity",
+    "NativeRuntimeManifest",
     "NativeRuntimeStatus",
     "choose_post_tool_response",
     "native_mode",


### PR DESCRIPTION
## Summary

Closes the native rollout gap between the packaged Rust binary and its wheel manifest.

- requires the bundled runtime to have a valid `runtime-manifest.json`
- binds manifest runtime SHA-256 and byte size to the exact executable bytes
- binds manifest package version to the installed `hol-guard` version
- binds Rust capabilities back to the manifest protocol version, exact rule digest, package version, and build/source SHA
- rejects missing, malformed, writable, symlinked, or mismatched bundled manifests
- prevents `auto` mode from selecting a separately installed developer runtime distribution
- preserves explicit developer overrides only for `shadow` and `force`
- adds dedicated manifest identity contracts outside the global pytest ratchet

## Rollout

This does not enable native execution by default. It strengthens the prerequisite checks that must pass before a bundled runtime can be considered `native_ready`.

## Verification

The stacked version passed native runtime identity, Rust runtime, differential, mutation differential, performance, recovery, native-wheel, Security Gates, CodeQL, and publication canary checks. This final PR targets `release/3.0` directly and contains only the three bundle-identity files.