### PR TITLE
fix(release): harden native wheel assembly

### DIFF
--- a/ci/native_runtime/test_native_hol_guard_wheel.py
+++ b/ci/native_runtime/test_native_hol_guard_wheel.py
@@ -7,11 +7,13 @@ import io
 import json
 import os
 import stat
+import subprocess
 import zipfile
 from pathlib import Path
 
 import pytest
 
+import scripts.build_native_hol_guard_wheel as wheel_builder
 from scripts.build_native_hol_guard_wheel import NativeWheelError, build_native_wheel
 
 _VERSION = "3.0.0a7"
@@ -21,7 +23,33 @@ _PLATFORM_TAG = "manylinux_2_28_x86_64"
 _TARGET = "x86_64-unknown-linux-gnu"
 
 
-def _write_source_wheel(tmp_path: Path, *, version: str = _VERSION, unsafe_name: str | None = None) -> Path:
+@pytest.fixture(autouse=True)
+def _stub_runtime_capabilities(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(args: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        del kwargs
+        payload = {
+            "protocol_version": 1,
+            "runtime_version": _VERSION,
+            "rule_digest": _RULE_DIGEST,
+            "build_sha": _SOURCE_SHA,
+        }
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            stdout=json.dumps(payload, separators=(",", ":")).encode(),
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(wheel_builder.subprocess, "run", fake_run)
+
+
+def _write_source_wheel(
+    tmp_path: Path,
+    *,
+    version: str = _VERSION,
+    unsafe_name: str | None = None,
+    extra_entries: dict[str, bytes] | None = None,
+) -> Path:
     path = tmp_path / f"hol_guard-{version}-py3-none-any.whl"
     dist_info = f"hol_guard-{version}.dist-info"
     entries = {
@@ -42,6 +70,8 @@ def _write_source_wheel(tmp_path: Path, *, version: str = _VERSION, unsafe_name:
     }
     if unsafe_name is not None:
         entries[unsafe_name] = b"unsafe"
+    if extra_entries is not None:
+        entries.update(extra_entries)
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         for name, content in entries.items():
             archive.writestr(name, content)
@@ -71,6 +101,32 @@ def _build(tmp_path: Path, *, wheel: Path | None = None, runtime: Path | None = 
         source_sha=_SOURCE_SHA,
         rule_digest=_RULE_DIGEST,
     )
+
+
+def _set_runtime_capabilities(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    protocol_version: int = 1,
+    runtime_version: str = _VERSION,
+    rule_digest: str = _RULE_DIGEST,
+    build_sha: str = _SOURCE_SHA,
+) -> None:
+    def fake_run(args: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        del kwargs
+        payload = {
+            "protocol_version": protocol_version,
+            "runtime_version": runtime_version,
+            "rule_digest": rule_digest,
+            "build_sha": build_sha,
+        }
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            stdout=json.dumps(payload, separators=(",", ":")).encode(),
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(wheel_builder.subprocess, "run", fake_run)
 
 
 def test_native_wheel_injects_runtime_manifest_and_valid_record(tmp_path: Path) -> None:
@@ -136,18 +192,84 @@ def test_builder_rejects_archive_path_traversal(tmp_path: Path) -> None:
         _build(tmp_path, wheel=wheel)
 
 
+def test_builder_rejects_noncanonical_archive_path(tmp_path: Path) -> None:
+    wheel = _write_source_wheel(tmp_path, unsafe_name="codex_plugin_scanner//payload.py")
+    with pytest.raises(NativeWheelError, match="unsafe path"):
+        _build(tmp_path, wheel=wheel)
+
+
+def test_builder_rejects_casefold_archive_collision(tmp_path: Path) -> None:
+    wheel = _write_source_wheel(
+        tmp_path,
+        extra_entries={"pkg/File.py": b"one", "pkg/file.py": b"two"},
+    )
+    with pytest.raises(NativeWheelError, match="canonical path collision"):
+        _build(tmp_path, wheel=wheel)
+
+
+def test_builder_rejects_oversized_archive_entry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(wheel_builder, "_MAX_SOURCE_ENTRY_BYTES", 256)
+    wheel = _write_source_wheel(
+        tmp_path,
+        extra_entries={"pkg/oversized.bin": b"x" * 257},
+    )
+    with pytest.raises(NativeWheelError, match="entry is too large"):
+        _build(tmp_path, wheel=wheel)
+
+
 def test_builder_rejects_source_version_mismatch(tmp_path: Path) -> None:
     wheel = _write_source_wheel(tmp_path, version="3.0.0a6")
     with pytest.raises(NativeWheelError, match="expected pure hol-guard wheel"):
         _build(tmp_path, wheel=wheel)
 
 
-def test_builder_refuses_overwrite(tmp_path: Path) -> None:
+def test_builder_refuses_overwrite_without_changing_existing_output(tmp_path: Path) -> None:
     wheel = _write_source_wheel(tmp_path)
     runtime = _write_runtime(tmp_path)
-    _ = _build(tmp_path, wheel=wheel, runtime=runtime)
+    output = _build(tmp_path, wheel=wheel, runtime=runtime)
+    before = output.read_bytes()
     with pytest.raises(NativeWheelError, match="refusing to overwrite"):
         _build(tmp_path, wheel=wheel, runtime=runtime)
+    assert output.read_bytes() == before
+
+
+def test_builder_rejects_runtime_rule_digest_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_runtime_capabilities(monkeypatch, rule_digest="c" * 64)
+    with pytest.raises(NativeWheelError, match="rule digest"):
+        _build(tmp_path)
+
+
+def test_builder_rejects_runtime_build_sha_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_runtime_capabilities(monkeypatch, build_sha="d" * 40)
+    with pytest.raises(NativeWheelError, match="build SHA"):
+        _build(tmp_path)
+
+
+def test_builder_rejects_runtime_version_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_runtime_capabilities(monkeypatch, runtime_version="3.0.0a6")
+    with pytest.raises(NativeWheelError, match="package version"):
+        _build(tmp_path)
+
+
+def test_builder_rejects_runtime_protocol_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_runtime_capabilities(monkeypatch, protocol_version=2)
+    with pytest.raises(NativeWheelError, match="protocol version"):
+        _build(tmp_path)
 
 
 @pytest.mark.skipif(os.name == "nt", reason="symlink fixture uses POSIX executable semantics")

--- a/scripts/build_native_hol_guard_wheel.py
+++ b/scripts/build_native_hol_guard_wheel.py
@@ -18,12 +18,20 @@ import json
 import os
 import re
 import stat
+import subprocess
+import unicodedata
 import zipfile
 from dataclasses import dataclass
 from email.parser import BytesParser
 from pathlib import Path, PurePosixPath
+from typing import BinaryIO
 
 _MAX_RUNTIME_BYTES = 128 * 1024 * 1024
+_MAX_SOURCE_WHEEL_BYTES = 256 * 1024 * 1024
+_MAX_SOURCE_ENTRY_BYTES = 64 * 1024 * 1024
+_MAX_SOURCE_UNCOMPRESSED_BYTES = 512 * 1024 * 1024
+_MAX_SOURCE_ENTRIES = 16_384
+_MAX_CAPABILITIES_BYTES = 64 * 1024
 _PLATFORM_TAG_RE = re.compile(r"^[A-Za-z0-9_.]+$")
 _SHA40_RE = re.compile(r"^[0-9a-f]{40}$")
 _SHA64_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -47,15 +55,38 @@ class SourceWheel:
     modes: dict[str, int]
 
 
+@dataclass(frozen=True, slots=True)
+class RuntimeCapabilities:
+    protocol_version: int
+    runtime_version: str
+    rule_digest: str
+    build_sha: str
+
+
 def _wheel_version_for_filename(version: str) -> str:
     return version.replace("-", "_")
 
 
 def _safe_archive_path(name: str) -> bool:
-    if not name or "\\" in name:
+    if (
+        not name
+        or "\\" in name
+        or "\x00" in name
+        or any(ord(character) < 0x20 for character in name)
+    ):
         return False
     path = PurePosixPath(name)
-    return not path.is_absolute() and ".." not in path.parts and all(part not in {"", "."} for part in path.parts)
+    if path.is_absolute() or ".." in path.parts or any(part in {"", "."} for part in path.parts):
+        return False
+    # Wheel member names are canonical POSIX paths. Reject repeated separators,
+    # dot segments, trailing separators, and other spellings that normalize to
+    # a different installed path.
+    return str(path) == name
+
+
+def _canonical_archive_key(name: str) -> str:
+    """Return a conservative collision key for case/Unicode-normalizing hosts."""
+    return unicodedata.normalize("NFC", name).casefold()
 
 
 def _entry_mode(info: zipfile.ZipInfo) -> int:
@@ -66,27 +97,100 @@ def _entry_mode(info: zipfile.ZipInfo) -> int:
     return mode or 0o644
 
 
+def _open_regular_file(path: Path, *, max_bytes: int, label: str) -> BinaryIO:
+    """Open one immutable-by-identity regular file without following POSIX symlinks."""
+    lexical = path.expanduser()
+    try:
+        before = lexical.lstat()
+    except OSError as exc:
+        raise NativeWheelError(f"{label} must be a regular non-symlink file") from exc
+    if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+        raise NativeWheelError(f"{label} must be a regular non-symlink file")
+    if before.st_size <= 0 or before.st_size > max_bytes:
+        raise NativeWheelError(f"{label} size is outside the accepted release bounds")
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(lexical, flags)
+    except OSError as exc:
+        raise NativeWheelError(f"{label} could not be opened safely") from exc
+    try:
+        opened = os.fstat(fd)
+        if not stat.S_ISREG(opened.st_mode) or opened.st_size != before.st_size:
+            raise NativeWheelError(f"{label} changed while being opened")
+        before_identity = (getattr(before, "st_dev", None), getattr(before, "st_ino", None))
+        opened_identity = (getattr(opened, "st_dev", None), getattr(opened, "st_ino", None))
+        identities_available = all(
+            value not in {None, 0}
+            for value in (*before_identity, *opened_identity)
+        )
+        if identities_available and before_identity != opened_identity:
+            raise NativeWheelError(f"{label} changed while being opened")
+        return os.fdopen(fd, "rb")
+    except Exception:
+        os.close(fd)
+        raise
+
+
+def _validate_source_archive_bounds(infos: list[zipfile.ZipInfo]) -> None:
+    files = [info for info in infos if not info.is_dir()]
+    if len(files) > _MAX_SOURCE_ENTRIES:
+        raise NativeWheelError("source wheel contains too many entries")
+    total_uncompressed = 0
+    for info in files:
+        if info.flag_bits & 0x1:
+            raise NativeWheelError(f"source wheel contains an encrypted entry: {info.filename}")
+        if info.file_size < 0 or info.file_size > _MAX_SOURCE_ENTRY_BYTES:
+            raise NativeWheelError(f"source wheel entry is too large: {info.filename}")
+        total_uncompressed += info.file_size
+        if total_uncompressed > _MAX_SOURCE_UNCOMPRESSED_BYTES:
+            raise NativeWheelError("source wheel uncompressed size exceeds the accepted release bound")
+
+
+def _read_zip_entry_bounded(archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> bytes:
+    content = bytearray()
+    try:
+        with archive.open(info, "r") as handle:
+            while True:
+                chunk = handle.read(min(64 * 1024, _MAX_SOURCE_ENTRY_BYTES + 1 - len(content)))
+                if not chunk:
+                    break
+                content.extend(chunk)
+                if len(content) > _MAX_SOURCE_ENTRY_BYTES or len(content) > info.file_size:
+                    raise NativeWheelError(f"source wheel entry expanded past its declared size: {info.filename}")
+    except (OSError, RuntimeError, zipfile.BadZipFile) as exc:
+        raise NativeWheelError(f"source wheel entry could not be read safely: {info.filename}") from exc
+    if len(content) != info.file_size:
+        raise NativeWheelError(f"source wheel entry size changed while reading: {info.filename}")
+    return bytes(content)
+
+
 def _load_source_wheel(path: Path, *, version: str) -> SourceWheel:
     expected_name = f"hol_guard-{_wheel_version_for_filename(version)}-py3-none-any.whl"
     if path.name != expected_name:
         raise NativeWheelError(f"expected pure hol-guard wheel {expected_name}, got {path.name}")
-    if not path.is_file() or path.is_symlink():
-        raise NativeWheelError("source wheel must be a regular non-symlink file")
 
     entries: dict[str, bytes] = {}
     modes: dict[str, int] = {}
-    with zipfile.ZipFile(path, "r") as archive:
-        infos = archive.infolist()
-        names = [info.filename for info in infos if not info.is_dir()]
-        if len(names) != len(set(names)):
-            raise NativeWheelError("source wheel contains duplicate entries")
-        for info in infos:
-            if info.is_dir():
-                continue
-            if not _safe_archive_path(info.filename):
-                raise NativeWheelError(f"source wheel contains an unsafe path: {info.filename}")
-            entries[info.filename] = archive.read(info)
-            modes[info.filename] = _entry_mode(info)
+    with _open_regular_file(path, max_bytes=_MAX_SOURCE_WHEEL_BYTES, label="source wheel") as source_file:
+        with zipfile.ZipFile(source_file, "r") as archive:
+            infos = archive.infolist()
+            _validate_source_archive_bounds(infos)
+            names = [info.filename for info in infos if not info.is_dir()]
+            if len(names) != len(set(names)):
+                raise NativeWheelError("source wheel contains duplicate entries")
+            canonical_names: set[str] = set()
+            for info in infos:
+                if info.is_dir():
+                    continue
+                if not _safe_archive_path(info.filename):
+                    raise NativeWheelError(f"source wheel contains an unsafe path: {info.filename}")
+                collision_key = _canonical_archive_key(info.filename)
+                if collision_key in canonical_names:
+                    raise NativeWheelError(f"source wheel contains a canonical path collision: {info.filename}")
+                canonical_names.add(collision_key)
+                entries[info.filename] = _read_zip_entry_bounded(archive, info)
+                modes[info.filename] = _entry_mode(info)
 
     wheel_paths = [name for name in entries if name.endswith(".dist-info/WHEEL")]
     metadata_paths = [name for name in entries if name.endswith(".dist-info/METADATA")]
@@ -106,11 +210,17 @@ def _load_source_wheel(path: Path, *, version: str) -> SourceWheel:
         raise NativeWheelError("source wheel project identity or version does not match")
 
     wheel_text = entries[wheel_path].decode("utf-8")
-    tags = [line.removeprefix("Tag:").strip() for line in wheel_text.splitlines() if line.startswith("Tag:")]
+    tags = [
+        line.removeprefix("Tag:").strip()
+        for line in wheel_text.splitlines()
+        if line.startswith("Tag:")
+    ]
     if tags != ["py3-none-any"]:
         raise NativeWheelError("source wheel must be the canonical py3-none-any artifact")
     if f"{_NATIVE_DIR}/hol-guard-runtime" in entries or f"{_NATIVE_DIR}/hol-guard-runtime.exe" in entries:
         raise NativeWheelError("source wheel already contains a native runtime")
+    if _RUNTIME_MANIFEST_PATH in entries:
+        raise NativeWheelError("source wheel already contains a native runtime manifest")
 
     return SourceWheel(
         path=path,
@@ -124,14 +234,104 @@ def _load_source_wheel(path: Path, *, version: str) -> SourceWheel:
 
 
 def _load_runtime(path: Path) -> bytes:
-    if path.is_symlink() or not path.is_file():
-        raise NativeWheelError("runtime must be a regular non-symlink file")
-    metadata = path.stat()
-    if metadata.st_size <= 0 or metadata.st_size > _MAX_RUNTIME_BYTES:
-        raise NativeWheelError("runtime size is outside the accepted release bounds")
-    if os.name != "nt" and stat.S_IMODE(metadata.st_mode) & 0o022:
-        raise NativeWheelError("runtime is group/world writable")
-    return path.read_bytes()
+    with _open_regular_file(path, max_bytes=_MAX_RUNTIME_BYTES, label="runtime") as handle:
+        metadata = os.fstat(handle.fileno())
+        if os.name != "nt":
+            mode = stat.S_IMODE(metadata.st_mode)
+            if mode & 0o022:
+                raise NativeWheelError("runtime is group/world writable")
+            if not mode & stat.S_IXUSR:
+                raise NativeWheelError("runtime is not owner-executable")
+        runtime = handle.read(_MAX_RUNTIME_BYTES + 1)
+        after = os.fstat(handle.fileno())
+        if len(runtime) > _MAX_RUNTIME_BYTES:
+            raise NativeWheelError("runtime size is outside the accepted release bounds")
+        if (metadata.st_size, metadata.st_mtime_ns) != (after.st_size, after.st_mtime_ns):
+            raise NativeWheelError("runtime changed while being read")
+        if len(runtime) != metadata.st_size:
+            raise NativeWheelError("runtime could not be read completely")
+        return runtime
+
+
+def _runtime_capabilities(path: Path) -> RuntimeCapabilities:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if key.upper()
+        in {
+            "COMSPEC",
+            "HOME",
+            "LANG",
+            "PATHEXT",
+            "SYSTEMROOT",
+            "TEMP",
+            "TMP",
+            "TMPDIR",
+            "USERPROFILE",
+            "WINDIR",
+        }
+        or key.upper().startswith("LC_")
+    }
+    try:
+        completed = subprocess.run(
+            (str(path.resolve(strict=True)), "capabilities", "--json"),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=5.0,
+            env=environment,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise NativeWheelError("runtime capabilities probe failed") from exc
+    if completed.returncode != 0 or len(completed.stdout) > _MAX_CAPABILITIES_BYTES:
+        raise NativeWheelError("runtime capabilities probe failed")
+    try:
+        payload = json.loads(completed.stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise NativeWheelError("runtime capabilities response is invalid") from exc
+    if not isinstance(payload, dict):
+        raise NativeWheelError("runtime capabilities response is invalid")
+    protocol_version = payload.get("protocol_version")
+    runtime_version = payload.get("runtime_version")
+    rule_digest = payload.get("rule_digest")
+    build_sha = payload.get("build_sha")
+    if (
+        not isinstance(protocol_version, int)
+        or not isinstance(runtime_version, str)
+        or not isinstance(rule_digest, str)
+        or not isinstance(build_sha, str)
+    ):
+        raise NativeWheelError("runtime capabilities response is invalid")
+    return RuntimeCapabilities(
+        protocol_version=protocol_version,
+        runtime_version=runtime_version,
+        rule_digest=rule_digest,
+        build_sha=build_sha,
+    )
+
+
+def _verify_runtime_provenance(
+    path: Path,
+    *,
+    version: str,
+    source_sha: str,
+    rule_digest: str,
+) -> bytes:
+    before = _load_runtime(path)
+    capabilities = _runtime_capabilities(path)
+    after = _load_runtime(path)
+    if not hashlib.sha256(before).digest() == hashlib.sha256(after).digest():
+        raise NativeWheelError("runtime changed during capabilities verification")
+    if capabilities.protocol_version != 1:
+        raise NativeWheelError("runtime protocol version does not match native wheel contract")
+    if capabilities.runtime_version != version:
+        raise NativeWheelError("runtime package version does not match native wheel version")
+    if capabilities.rule_digest != rule_digest:
+        raise NativeWheelError("runtime rule digest does not match requested manifest digest")
+    if capabilities.build_sha != source_sha:
+        raise NativeWheelError("runtime build SHA does not match requested source SHA")
+    return before
 
 
 def _rewrite_wheel_metadata(raw: bytes, *, platform_tag: str) -> bytes:
@@ -142,7 +342,7 @@ def _rewrite_wheel_metadata(raw: bytes, *, platform_tag: str) -> bytes:
         if not line.startswith("Root-Is-Purelib:") and not line.startswith("Tag:")
     ]
     rewritten.extend(["Root-Is-Purelib: false", f"Tag: py3-none-{platform_tag}"])
-    return ("\n".join(rewritten).rstrip() + "\n").encode("utf-8")
+    return ("\n".join(rewritten).rstrip("\n") + "\n").encode("utf-8")
 
 
 def _record_hash(content: bytes) -> str:
@@ -171,6 +371,39 @@ def _zip_info(name: str, *, mode: int) -> zipfile.ZipInfo:
     return info
 
 
+def _prepare_output_dir(output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    metadata = output_dir.lstat()
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise NativeWheelError("output directory must be a regular non-symlink directory")
+    return output_dir
+
+
+def _write_output_wheel_exclusive(
+    output_path: Path,
+    entries: dict[str, bytes],
+    modes: dict[str, int],
+) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
+    try:
+        fd = os.open(output_path, flags, 0o600)
+    except FileExistsError as exc:
+        raise NativeWheelError(f"refusing to overwrite existing native wheel: {output_path}") from exc
+    with os.fdopen(fd, "w+b") as output_file:
+        with zipfile.ZipFile(
+            output_file,
+            "w",
+            compression=zipfile.ZIP_DEFLATED,
+            compresslevel=9,
+        ) as archive:
+            for name in sorted(entries):
+                if not _safe_archive_path(name):
+                    raise NativeWheelError(f"refusing unsafe output path: {name}")
+                archive.writestr(_zip_info(name, mode=modes.get(name, 0o644)), entries[name])
+        output_file.flush()
+        os.fsync(output_file.fileno())
+
+
 def build_native_wheel(
     *,
     source_wheel: Path,
@@ -195,13 +428,21 @@ def build_native_wheel(
         raise NativeWheelError("rule digest must be a lowercase SHA-256 hex digest")
 
     source = _load_source_wheel(source_wheel, version=version)
-    runtime_bytes = _load_runtime(runtime)
+    runtime_bytes = _verify_runtime_provenance(
+        runtime,
+        version=version,
+        source_sha=source_sha,
+        rule_digest=rule_digest,
+    )
     runtime_name = "hol-guard-runtime.exe" if platform_tag.startswith("win") else "hol-guard-runtime"
     runtime_path = f"{_NATIVE_DIR}/{runtime_name}"
 
     entries = dict(source.entries)
     modes = dict(source.modes)
-    entries[source.wheel_path] = _rewrite_wheel_metadata(entries[source.wheel_path], platform_tag=platform_tag)
+    entries[source.wheel_path] = _rewrite_wheel_metadata(
+        entries[source.wheel_path],
+        platform_tag=platform_tag,
+    )
     runtime_sha256 = hashlib.sha256(runtime_bytes).hexdigest()
     manifest = {
         "schema": "hol-guard-native-runtime.v1",
@@ -215,23 +456,20 @@ def build_native_wheel(
         "runtime_size": len(runtime_bytes),
     }
     entries[runtime_path] = runtime_bytes
-    entries[_RUNTIME_MANIFEST_PATH] = (json.dumps(manifest, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    entries[_RUNTIME_MANIFEST_PATH] = (
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode()
     modes[runtime_path] = 0o755
     modes[_RUNTIME_MANIFEST_PATH] = 0o644
     modes[source.wheel_path] = 0o644
     entries[source.record_path] = _record_content(entries, record_path=source.record_path)
     modes[source.record_path] = 0o644
 
-    output_dir.mkdir(parents=True, exist_ok=True)
-    output_path = output_dir / f"hol_guard-{_wheel_version_for_filename(version)}-py3-none-{platform_tag}.whl"
-    if output_path.exists():
-        raise NativeWheelError(f"refusing to overwrite existing native wheel: {output_path}")
-
-    with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9) as archive:
-        for name in sorted(entries):
-            if not _safe_archive_path(name):
-                raise NativeWheelError(f"refusing unsafe output path: {name}")
-            archive.writestr(_zip_info(name, mode=modes.get(name, 0o644)), entries[name])
+    safe_output_dir = _prepare_output_dir(output_dir)
+    output_path = safe_output_dir / (
+        f"hol_guard-{_wheel_version_for_filename(version)}-py3-none-{platform_tag}.whl"
+    )
+    _write_output_wheel_exclusive(output_path, entries, modes)
     return output_path
 
 


### PR DESCRIPTION
## Summary

Closes the remaining native-wheel review gaps after the Rust runtime packaging foundation landed.

- rejects NUL/control characters, non-canonical archive paths, and case/Unicode path collisions
- enforces source-wheel file, entry-count, per-entry, and total-uncompressed bounds
- streams ZIP members through explicit decompression bounds rather than trusting one unbounded read
- requires regular non-symlink source/runtime inputs and owner-executable, non-writable POSIX runtime bytes
- probes the exact Rust runtime and requires protocol version, package version, rule digest, and build/source SHA to match the manifest inputs
- re-reads the runtime around the capability probe so the packaged bytes cannot silently change during provenance verification
- creates the final wheel with `O_EXCL` so an existing artifact is never truncated
- preserves existing output bytes on overwrite refusal
- keeps plugin-scanner outside this packaging path

## Verification

Adds focused contract coverage for path traversal/non-canonical names, casefold collisions, oversized ZIP members, runtime protocol/version/rule/source mismatches, overwrite integrity, source immutability, and symlink rejection. The existing cross-platform native-wheel workflow will also exercise the real compiled runtime capability probe.

This does not enable native execution by default and targets `release/3.0` only.